### PR TITLE
enhance: Repack dataframes into smaller types

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9]
+        python-version: ["3.9", "3.10"]
 
     runs-on: ubuntu-latest
 

--- a/etl/frames.py
+++ b/etl/frames.py
@@ -3,27 +3,32 @@
 #  etl
 #
 
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 import numpy as np
 import pandas as pd
 
 
-def repack_frame(df: pd.DataFrame, remap: Dict[str, str]) -> None:
+def repack_frame(df: pd.DataFrame, remap: Optional[Dict[str, str]] = None) -> None:
     """
     Convert the DataFrame's columns to the most compact types possible.
     Rename columns if necessary during the repacking. The column renames
     work even if the column is part of the index.
     """
+    remap = remap or {}
+
+    # unwind the primary key
     if len(df.index.names) == 1 and not df.index.names[0]:
         primary_key = []
     else:
         primary_key = cast(List[str], df.index.names)
         df.reset_index(inplace=True)
 
+    # repack each column into the best dtype we can give it
     for col in df.columns:
         df[col] = repack_series(df[col])
 
+    # remap all column names, including those in the primary key
     for from_, to_ in remap.items():
         if from_ in df.columns:
             df.rename(columns={from_: to_}, inplace=True)
@@ -31,20 +36,21 @@ def repack_frame(df: pd.DataFrame, remap: Dict[str, str]) -> None:
 
     assert all(df[col].dtype != "object" for col in df.columns)
 
+    # set the primary key back again
     if primary_key:
         df.set_index(primary_key, inplace=True)
 
 
 def repack_series(s: pd.Series) -> pd.Series:
-    # only repack object columns
-    if s.dtype not in (np.object_, np.float64):
-        return s
+    if s.dtype.name in ("Int64", "int64"):
+        return shrink_integer(s)
 
-    for strategy in [to_int, to_float, to_category]:
-        try:
-            return strategy(s)
-        except (ValueError, TypeError):
-            continue
+    if s.dtype in (np.object_, np.float64):
+        for strategy in [to_int, to_float, to_category]:
+            try:
+                return strategy(s)
+            except (ValueError, TypeError):
+                continue
 
     return s
 
@@ -59,13 +65,41 @@ def to_int(s: pd.Series) -> pd.Series:
     if not series_eq(v, s, cast=float):
         raise ValueError()
 
-    return v
+    # it's an integer, now pack it smaller
+    return shrink_integer(v)
+
+
+def shrink_integer(s: pd.Series) -> pd.Series:
+    """
+    Take an Int64 series and make it as small as possible.
+    """
+    assert s.dtype.name in ("Int64", "int64")
+
+    if s.isnull().any():
+        if s.min() < 0:
+            series = ["Int32", "Int16", "Int8"]
+        else:
+            series = ["UInt32", "UInt16", "UInt8"]
+    else:
+        if s.min() < 0:
+            series = ["int32", "int16", "int8"]
+        else:
+            series = ["uint32", "uint16", "uint8"]
+
+    for dtype in series:
+        v = s.astype(dtype)
+        if not (v == s).all():
+            break
+
+        s = v
+
+    return s
 
 
 def to_float(s: pd.Series) -> pd.Series:
     v = cast(pd.Series, s.astype("float64"))
 
-    if not series_eq(v, s, cast=float):
+    if not series_eq(s, v, float):
         raise ValueError()
 
     return v

--- a/etl/frames.py
+++ b/etl/frames.py
@@ -45,7 +45,7 @@ def repack_series(s: pd.Series) -> pd.Series:
     if s.dtype.name in ("Int64", "int64"):
         return shrink_integer(s)
 
-    if s.dtype in (np.object_, np.float64):
+    if s.dtype.name in ("object", "float64", "Float64"):
         for strategy in [to_int, to_float, to_category]:
             try:
                 return strategy(s)

--- a/etl/frames.py
+++ b/etl/frames.py
@@ -91,7 +91,7 @@ def shrink_integer(s: pd.Series) -> pd.Series:
         if not (v == s).all():
             break
 
-        s = v
+        s = cast(pd.Series, v)
 
     return s
 
@@ -99,7 +99,7 @@ def shrink_integer(s: pd.Series) -> pd.Series:
 def to_float(s: pd.Series) -> pd.Series:
     options = ["float32", "float64"]
     for dtype in options:
-        v = s.astype(dtype)
+        v = cast(pd.Series, s.astype(dtype))
 
         if series_eq(s, v, float):
             return v
@@ -124,7 +124,7 @@ def series_eq(
     NaN != NaN, we want missing or null values to be reported as equal to each
     other.
     """
-    if len(lhs) != len(rhs) or (lhs.isnull() != rhs.isnull()).all():
+    if len(lhs) != len(rhs) or (lhs.isnull() != rhs.isnull()).any():  # type: ignore
         return False
 
     lhs_values = lhs.dropna().apply(cast)

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -22,7 +22,7 @@ def test_repack_non_object_columns():
     frames.repack_frame(df2, {})
 
     assert df2.myint.dtype.name == "uint8"
-    assert df2.myfloat.dtype.name == "float64"
+    assert df2.myfloat.dtype.name == "float32"
     assert_frame_equal(df, df2, check_dtype=False)
 
 
@@ -39,10 +39,9 @@ def test_repack_object_columns():
     df_repack = df.copy()
 
     frames.repack_frame(df_repack, {})
-
-    for col in df_repack.columns:
-        assert (df_repack[col].isnull() == df[col].isnull()).all()
-        assert (df_repack[col].dropna() == df[col].dropna()).all()
+    assert df_repack.myint.dtype.name == "UInt8"
+    assert df_repack.myfloat.dtype.name == "float32"
+    assert df_repack.mycat.dtype.name == "category"
 
 
 def test_repack_integer_strings():
@@ -54,7 +53,7 @@ def test_repack_integer_strings():
 def test_repack_float_strings():
     s = pd.Series(["10", "22.2", "30"])
     v = frames.repack_series(s)
-    assert v.dtype.name == "float64"
+    assert v.dtype.name == "float32"
 
 
 def test_repack_int8_boundaries():
@@ -155,11 +154,11 @@ def test_repack_float_to_int():
     assert v.dtype == "UInt8"
 
 
-def test_repack_float_object_to_float64():
+def test_repack_float_object_to_float32():
     s = pd.Series([1, 2, None, 3.3], dtype="object")
 
     v = frames.repack_series(s)
-    assert v.dtype == "float64"
+    assert v.dtype == "float32"
 
 
 def test_repack_category():

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -45,6 +45,97 @@ def test_repack_object_columns():
         assert (df_repack[col].dropna() == df[col].dropna()).all()
 
 
+def test_repack_integer_strings():
+    s = pd.Series(["1", "2", "3", None])
+    v = frames.repack_series(s)
+    assert v.dtype.name == "UInt8"
+
+
+def test_repack_float_strings():
+    s = pd.Series(["10", "22.2", "30"])
+    v = frames.repack_series(s)
+    assert v.dtype.name == "float64"
+
+
+def test_repack_int8_boundaries():
+    s = pd.Series([0, -1])
+    info = np.iinfo(np.int8)
+
+    # check the lower boundary
+    s[0] = info.min
+    assert frames.repack_series(s).dtype.name == "int8"
+    s[0] -= 1
+    assert frames.repack_series(s).dtype.name == "int16"
+
+    # check the upper boundary
+    s[0] = info.max
+    assert frames.repack_series(s).dtype.name == "int8"
+    s[0] += 1
+    assert frames.repack_series(s).dtype.name == "int16"
+
+
+def test_repack_int16_boundaries():
+    s = pd.Series([0, -1])
+    info = np.iinfo(np.int16)
+
+    # check the lower boundary
+    s[0] = info.min
+    assert frames.repack_series(s).dtype.name == "int16"
+    s[0] -= 1
+    assert frames.repack_series(s).dtype.name == "int32"
+
+    # check the upper boundary
+    s[0] = info.max
+    assert frames.repack_series(s).dtype.name == "int16"
+    s[0] += 1
+    assert frames.repack_series(s).dtype.name == "int32"
+
+
+def test_repack_int32_boundaries():
+    s = pd.Series([0, -1])
+    info = np.iinfo(np.int32)
+
+    # check the lower boundary
+    s[0] = info.min
+    assert frames.repack_series(s).dtype.name == "int32"
+    s[0] -= 1
+    assert frames.repack_series(s).dtype.name == "int64"
+
+    # check the upper boundary
+    s[0] = info.max
+    assert frames.repack_series(s).dtype.name == "int32"
+    s[0] += 1
+    assert frames.repack_series(s).dtype.name == "int64"
+
+
+def test_repack_uint_boundaries():
+    s = pd.Series([0])
+    # uint8
+    info = np.iinfo(np.uint8)
+    s[0] = info.max
+    assert frames.repack_series(s).dtypes.name == "uint8"
+
+    s[0] += 1
+    assert frames.repack_series(s).dtypes.name == "uint16"
+
+    # uint16
+    info = np.iinfo(np.uint16)
+    s[0] = info.max
+    assert frames.repack_series(s).dtypes.name == "uint16"
+
+    s[0] += 1
+    assert frames.repack_series(s).dtypes.name == "uint32"
+
+    # uint32
+    info = np.iinfo(np.uint32)
+    s[0] = info.max
+    assert frames.repack_series(s).dtypes.name == "uint32"
+
+    # we don't bother using uint64, we just use int64
+    s[0] += 1
+    assert frames.repack_series(s).dtypes.name == "int64"
+
+
 def test_repack_int():
     s = cast(pd.Series, pd.Series([1, 2, None, 3]).astype("object"))
     v = frames.repack_series(s)


### PR DESCRIPTION
Today, our largest feather file is 269MB, and consists only of integers and floats, both 64 bits wide by default.

This PR improves packing of integers and floats into smaller types, e.g. `int8` and `float32`, making them much more compact on disk.