### PR TITLE
fix(food_explorer): region metrics

### DIFF
--- a/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 222,
    "id": "6f35e10c-ecda-4c86-8783-56992f6f855e",
    "metadata": {
     "tags": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 223,
    "id": "2319d18c-fc2f-49d5-be71-c55bc7676a8b",
    "metadata": {},
    "outputs": [],
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 224,
    "id": "5674d02f-c7cd-4ef8-a28d-a64ddcc4caa3",
    "metadata": {},
    "outputs": [],
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 225,
    "id": "a5769436-dfed-466b-9108-d534c59b7acd",
    "metadata": {},
    "outputs": [],
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 226,
    "id": "2edc462f-3dec-46c7-8d99-e89242fc38e4",
    "metadata": {},
    "outputs": [],
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 227,
    "id": "944a7d5d-48ec-4700-8795-e360245252c8",
    "metadata": {},
    "outputs": [],
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 228,
    "id": "e88461fe-c796-4cd2-8007-dadb141e01c6",
    "metadata": {},
    "outputs": [
@@ -258,7 +258,7 @@
        "4  Armenia        221          5312  1996    M   <NA>"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 228,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 229,
    "id": "2a7f2ffb-ea32-4628-b070-affa5ea29a72",
    "metadata": {},
    "outputs": [
@@ -370,7 +370,7 @@
        "4  Armenia       2901           664  2018   Fc  2997.0"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 229,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -395,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 230,
    "id": "8ec594e6-8bce-462a-bc6b-f0f619cc5478",
    "metadata": {},
    "outputs": [],
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 231,
    "id": "f467850f-4088-4d09-a467-a9860ddb81fa",
    "metadata": {},
    "outputs": [
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 232,
    "id": "62537795-b1bd-4495-b221-3a20a3c575b8",
    "metadata": {},
    "outputs": [
@@ -554,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 233,
    "id": "f5da2eda-1fca-47d0-9bd3-7da00c99d562",
    "metadata": {},
    "outputs": [],
@@ -588,7 +588,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 234,
    "id": "dbb64782-3fe5-4ac4-a59c-013f1221ed16",
    "metadata": {},
    "outputs": [
@@ -608,7 +608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 235,
    "id": "30c748ef-2016-4738-9304-cbffd1c6d172",
    "metadata": {},
    "outputs": [
@@ -643,7 +643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 236,
    "id": "61681c4f-0585-48c6-85d1-1adf9586d3f7",
    "metadata": {},
    "outputs": [],
@@ -661,7 +661,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 237,
    "id": "55e5e095-b849-4fac-b731-bd78a6e16952",
    "metadata": {},
    "outputs": [
@@ -687,7 +687,7 @@
        "Name: Item Code, dtype: int64"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 237,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -699,7 +699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 238,
    "id": "cd067c44-bc63-4d05-af0e-0fc6f7ae3373",
    "metadata": {},
    "outputs": [
@@ -727,7 +727,7 @@
        "Name: Item Code, dtype: int64"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 238,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -750,7 +750,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 239,
    "id": "2d78ddb6-1100-4658-8043-44964e869a9b",
    "metadata": {},
    "outputs": [],
@@ -765,7 +765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 240,
    "id": "53bbe8b1-9f74-4af1-ad37-1df1e262edb5",
    "metadata": {},
    "outputs": [],
@@ -778,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 241,
    "id": "e9f5471b-a00e-4996-894c-6d8709bb3713",
    "metadata": {},
    "outputs": [
@@ -1339,7 +1339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 242,
    "id": "f9fd878f-47ca-4569-8bb4-f764f1244d4e",
    "metadata": {},
    "outputs": [],
@@ -1362,7 +1362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 243,
    "id": "2be4a477-197a-411d-8d52-d103036cf54b",
    "metadata": {},
    "outputs": [
@@ -1697,7 +1697,7 @@
        "5417       0.1000  "
       ]
      },
-     "execution_count": 48,
+     "execution_count": 243,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1717,7 +1717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 244,
    "id": "8a980add-06d6-4b8d-96b0-be53678bd3f0",
    "metadata": {},
    "outputs": [],
@@ -1737,7 +1737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 245,
    "id": "2c30000a-40bd-4a97-a99e-775127cb49ac",
    "metadata": {},
    "outputs": [],
@@ -1757,7 +1757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 246,
    "id": "180ca094-27f3-4b26-828b-8f8e8a11feaf",
    "metadata": {},
    "outputs": [],
@@ -1779,7 +1779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 247,
    "id": "06553ff8-56e3-4c03-8e01-ec36c172c637",
    "metadata": {},
    "outputs": [],
@@ -1798,7 +1798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 248,
    "id": "aa7c11c6-d286-4c42-9612-105db99d32f3",
    "metadata": {},
    "outputs": [],
@@ -1810,7 +1810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 249,
    "id": "e8ec1808-8715-4473-b129-98434c4eadd7",
    "metadata": {},
    "outputs": [
@@ -1912,7 +1912,7 @@
        "                      1965                0.9723                  <NA>  "
       ]
      },
-     "execution_count": 54,
+     "execution_count": 249,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1935,7 +1935,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 250,
    "id": "1b564750-ee04-48d2-85c3-7c0c00c351b3",
    "metadata": {},
    "outputs": [],
@@ -1955,7 +1955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 251,
    "id": "fe7f4012-4b80-41a1-8cf0-d83d887d6014",
    "metadata": {},
    "outputs": [
@@ -1974,7 +1974,7 @@
        " 572: 'Avocados'}"
       ]
      },
-     "execution_count": 56,
+     "execution_count": 251,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1993,7 +1993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 252,
    "id": "af18fe34-5475-4dd6-b285-2e2dd2d3ae04",
    "metadata": {},
    "outputs": [
@@ -2068,7 +2068,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 253,
    "id": "0eb99ea9-2457-4d22-ae23-52d15f71e4ad",
    "metadata": {},
    "outputs": [],
@@ -2094,7 +2094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 254,
    "id": "2c68a20f-e46f-4aa8-8ba9-4ec010839468",
    "metadata": {},
    "outputs": [],
@@ -2111,7 +2111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 255,
    "id": "7c9e522f-7a57-44c3-918a-a519ca9464f8",
    "metadata": {},
    "outputs": [],
@@ -2133,7 +2133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 236,
+   "execution_count": 368,
    "id": "82898260-9b51-49bd-a23b-8a289abc7dcd",
    "metadata": {},
    "outputs": [],
@@ -2144,7 +2144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 237,
+   "execution_count": 369,
    "id": "9c473b45-e1b6-4f54-9746-2b8ccf0c7e7d",
    "metadata": {},
    "outputs": [
@@ -2166,7 +2166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 238,
+   "execution_count": 370,
    "id": "2adc3d98-4d00-45f3-97a1-c261bbf554b1",
    "metadata": {},
    "outputs": [
@@ -2186,7 +2186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 239,
+   "execution_count": 371,
    "id": "cd65eb08-512a-4656-9856-692689944978",
    "metadata": {},
    "outputs": [
@@ -2428,7 +2428,7 @@
        "                    1979                                                NaN             "
       ]
      },
-     "execution_count": 239,
+     "execution_count": 371,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2443,13 +2443,21 @@
    "id": "af9654f5-26e9-479d-adc5-4c09635aa138",
    "metadata": {},
    "source": [
-    "## 9. Add regions & per-capita\n",
-    "In this section we obtain the metrics for all regions and add per-capita counterparts. So far, we include income groups by the World Bank, continents as defined by OWID and World. The values for these entities are obtained using only data present in the dataset (i.e. some countries may be missing)."
+    "## 9. Post processing\n",
+    "In this section we obtain the metrics for all regions and add per-capita counterparts. So far, we include income groups by the World Bank, continents as defined by OWID and World. The values for these entities are obtained using only data present in the dataset (i.e. some countries may be missing).\n",
+    "\n",
+    "\n",
+    "- Normalize metrics\n",
+    "    - Add population column\n",
+    "    - Weight columns\n",
+    "    - Rename columns\n",
+    "- Obtain metrics for regions\n",
+    "- Add population column, including regions"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 240,
+   "execution_count": 372,
    "id": "0bae636c-79f3-44bc-ad2f-f4f3fe4c4744",
    "metadata": {},
    "outputs": [],
@@ -2462,7 +2470,95 @@
    "id": "25152bc8-df03-4938-8e80-10b4720105dd",
    "metadata": {},
    "source": [
-    "### 9.1 Regions"
+    "### 9.1 Normalize metrics\n",
+    "In this section, we undo the _per_capita_ part of some metrics. We do this so we can aggregate countries into regions and later normalize by the total population."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fc8970b-d2ac-4c8b-b811-33bc7e7fcd8a",
+   "metadata": {},
+   "source": [
+    "#### Add population column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 373,
+   "id": "917c1d6a-cd66-4e91-827e-641c6720f19f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load population dataset\n",
+    "indicators = catalog.Dataset(PATH_DATASET_POPULATION)\n",
+    "population = indicators[\"population\"][[\"population\"]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 374,
+   "id": "0f7949cc-12df-4ae3-bd8a-82c0c2f151f7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Missing 17 countries: {'Czechoslovakia', 'USSR', 'Niue', 'Yugoslavia', 'Macao', 'Asia', 'Polynesia', 'Tokelau', 'Oceania', 'Eritrea and Ethiopia', 'Cook Islands', 'Bermuda', 'Serbia and Montenegro', 'Melanesia', 'Europe', 'French Polynesia', 'Africa'}\n",
+      "Decrease of 9% rows\n"
+     ]
+    }
+   ],
+   "source": [
+    "countries_pop = set(population.index.levels[0])\n",
+    "countries = set(fe_bulk.Country)\n",
+    "print(\n",
+    "    f\"Missing {len(countries_missing := countries.difference(countries_pop))} countries: {countries_missing}\"\n",
+    ")\n",
+    "if len(countries_missing) > 17:\n",
+    "    raise ValueError(\"More countries missing than expected!\")\n",
+    "\n",
+    "shape_first = fe_bulk.shape[0]\n",
+    "fe_bulk = fe_bulk.merge(\n",
+    "    population, left_on=[\"Country\", \"Year\"], right_on=[\"country\", \"year\"]\n",
+    ")\n",
+    "print(f\"Decrease of {round(100*(1-fe_bulk.shape[0]/shape_first))}% rows\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1db1b96f-a0b4-478a-9a70-7037b2f386c0",
+   "metadata": {},
+   "source": [
+    "#### Weight columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 375,
+   "id": "7b391137-2642-45f7-bedc-34dbc8a33710",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define which columns will be weighted\n",
+    "keyword = \"_per_capita\"\n",
+    "columns_per_capita = {\n",
+    "    col: col.replace(keyword, \"\") for col in fe_bulk.columns if keyword in col\n",
+    "}\n",
+    "# Normalize and rename columns\n",
+    "fe_bulk[list(columns_per_capita)] = fe_bulk[list(columns_per_capita)].multiply(\n",
+    "    fe_bulk[\"population\"], axis=0\n",
+    ")\n",
+    "fe_bulk = fe_bulk.rename(columns=columns_per_capita).drop(columns=[\"population\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c69f72c-a51b-4162-b2de-d255159a9ccb",
+   "metadata": {},
+   "source": [
+    "### 9.2 Add regions\n",
+    "Here we obtain the metrics for each region (continents, income groups and World). We avoid computing the aggregates for metrics relative to land use and animal use, as for these we would need the number of land and animals used per country. We can estimate `yield__tonnes_per_ha`, with other available metrics but will leave `yield__kg_per_animal` as NaN for all regions."
    ]
   },
   {
@@ -2475,7 +2571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 241,
+   "execution_count": 376,
    "id": "02921d82-0454-4c1a-837a-0c615b7b94a0",
    "metadata": {},
    "outputs": [],
@@ -2483,6 +2579,7 @@
     "# Load region map\n",
     "with open(PATH_REGIONS, \"r\") as f:\n",
     "    regions = json.load(f)\n",
+    "regions_all = [\"World\"] + list(regions)\n",
     "\n",
     "income = [\n",
     "    \"High-income countries\",\n",
@@ -2505,15 +2602,77 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39df5e37-d7a7-453c-8bb2-1fe2ceafe4be",
+   "id": "246dc5b3-7fc8-4a8b-8e62-e805ce43ad9f",
    "metadata": {},
    "source": [
-    "#### World"
+    "#### Remove default regions (if any)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 242,
+   "execution_count": 377,
+   "id": "d2b4a30b-fba6-434b-84ed-bf556ae74146",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fe_bulk = fe_bulk.loc[~fe_bulk.Country.isin(regions_all)].reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96e13768-a605-4216-a709-a70dbc4e1240",
+   "metadata": {},
+   "source": [
+    "#### Function and variables to get metrics for regions\n",
+    "Definition of functions recurrently needed and some variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 378,
+   "id": "980cecc4-5c3b-4c09-90b9-5e2d5873eda8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_df_regions(df, mapping, column_location, columns_index, columns_aggregate=None):\n",
+    "    # Continents\n",
+    "    df_regions = df.assign(**{column_location: df[column_location].replace(mapping)})\n",
+    "    if columns_aggregate is not None:\n",
+    "        df_regions = df_regions.groupby(columns_index, as_index=False)[\n",
+    "            columns_aggregate\n",
+    "        ].sum()\n",
+    "    else:\n",
+    "        df_regions = df_regions.groupby(columns_index, as_index=False).sum()\n",
+    "    # Only keep new regions\n",
+    "    msk = df_regions[column_location].isin(set(mapping.values()))\n",
+    "    df_regions = df_regions.loc[msk]\n",
+    "    print(f\"{round(100*df_regions.shape[0]/df.shape[0], 2)}% increase in rows\")\n",
+    "    return df_regions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 379,
+   "id": "c4eca576-ca7d-44cd-8def-9f5232a93fa7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns_index = [\"Product\", \"Country\", \"Year\"]\n",
+    "columns_exclude = columns_index + [\"yield__tonnes_per_ha\", \"yield__kg_per_animal\"]\n",
+    "columns_aggregate = [col for col in fe_bulk.columns if col not in columns_exclude]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39df5e37-d7a7-453c-8bb2-1fe2ceafe4be",
+   "metadata": {},
+   "source": [
+    "#### Estimate region data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 380,
    "id": "2c9543c5-f007-4c23-adda-ee9caa9ced11",
    "metadata": {},
    "outputs": [
@@ -2521,84 +2680,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.98% increase in rows\n"
+      "1.09% increase in rows\n",
+      "5.85% increase in rows\n",
+      "4.08% increase in rows\n"
      ]
     }
    ],
    "source": [
     "# World\n",
     "fe_bulk_world = (\n",
-    "    fe_bulk.groupby([\"Product\", \"Year\"], as_index=False).sum().assign(Country=\"World\")\n",
+    "    fe_bulk.groupby([\"Product\", \"Year\"], as_index=False)[columns_aggregate]\n",
+    "    .sum()\n",
+    "    .assign(Country=\"World\")\n",
     ")\n",
-    "print(f\"{round(100*fe_bulk_world.shape[0]/fe_bulk.shape[0], 2)}% increase in rows\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "55c07b9c-8ece-4cc6-86d3-97734775fce9",
-   "metadata": {},
-   "source": [
-    "#### Continents"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 243,
-   "id": "8956e1c7-0813-48b4-92e2-9783853f3747",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5.31% increase in rows\n"
-     ]
-    }
-   ],
-   "source": [
+    "print(f\"{round(100*fe_bulk_world.shape[0]/fe_bulk.shape[0], 2)}% increase in rows\")\n",
     "# Continents\n",
-    "fe_bulk_continent = fe_bulk.assign(Country=fe_bulk.Country.replace(country2continent))\n",
-    "fe_bulk_continent = fe_bulk_continent.groupby(\n",
-    "    [\"Product\", \"Country\", \"Year\"], as_index=False\n",
-    ").sum()\n",
-    "# Only keep new regions\n",
-    "msk = fe_bulk_continent.Country.isin(continents)\n",
-    "fe_bulk_continent = fe_bulk_continent.loc[msk]\n",
-    "print(f\"{round(100*fe_bulk_continent.shape[0]/fe_bulk.shape[0], 2)}% increase in rows\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5ad4142e-1f6b-4fc2-b54b-052d4d82e34d",
-   "metadata": {},
-   "source": [
-    "#### Income groups"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 244,
-   "id": "569b0df5-170a-4ff2-8262-3b2af00fdc3d",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "3.69% increase in rows\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Income\n",
-    "fe_bulk_income = fe_bulk.assign(Country=fe_bulk.Country.replace(country2income))\n",
-    "fe_bulk_income = fe_bulk_income.groupby(\n",
-    "    [\"Product\", \"Country\", \"Year\"], as_index=False\n",
-    ").sum()\n",
-    "# Only keep new regions\n",
-    "msk = fe_bulk_income.Country.isin(income)\n",
-    "fe_bulk_income = fe_bulk_income.loc[msk]\n",
-    "print(f\"{round(100*fe_bulk_income.shape[0]/fe_bulk.shape[0], 2)}% increase in rows\")"
+    "fe_bulk_continent = get_df_regions(\n",
+    "    fe_bulk, country2continent, \"Country\", columns_index, columns_aggregate\n",
+    ")\n",
+    "# Income groups\n",
+    "fe_bulk_income = get_df_regions(\n",
+    "    fe_bulk, country2income, \"Country\", columns_index, columns_aggregate\n",
+    ")"
    ]
   },
   {
@@ -2611,7 +2714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 245,
+   "execution_count": 381,
    "id": "cba5d1b2-7c08-4cf3-ab72-7215e9dc14d2",
    "metadata": {},
    "outputs": [],
@@ -2622,23 +2725,47 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ab7dfc2c-26a1-4f3d-9f2f-5fac605f205d",
+   "metadata": {},
+   "source": [
+    "#### Add missing metrics for regions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 396,
+   "id": "a24ccaa0-36c4-4c25-9991-a51fb5a04827",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "msk = (\n",
+    "    (fe_bulk.Country.isin(regions_all))\n",
+    "    & (fe_bulk[\"area_harvested__ha\"] != 0)\n",
+    "    & (~fe_bulk[\"area_harvested__ha\"].isna())\n",
+    ")\n",
+    "fe_bulk.loc[msk, \"yield__tonnes_per_ha\"] = (\n",
+    "    fe_bulk.loc[msk, \"production__tonnes\"] / fe_bulk.loc[msk, \"area_harvested__ha\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8ea01c77-bf46-4853-88d3-c0e69b93a600",
    "metadata": {},
    "source": [
-    "## 9.2 Population\n",
+    "### 9.3 Population\n",
     "Next, we will add a column with the population of each country (or region). Note that some regions are not present in the population dataset, hence we first need to add these."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 246,
+   "execution_count": 398,
    "id": "ca4b04f6-2bdf-42cb-95c7-f30b21db6158",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Load population dataset\n",
-    "indicators = catalog.Dataset(PATH_DATASET_POPULATION)\n",
-    "population = indicators[\"population\"].reset_index()[[\"country\", \"year\", \"population\"]]"
+    "population = population.reset_index()"
    ]
   },
   {
@@ -2651,63 +2778,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 247,
-   "id": "604dec28-8393-4124-891f-9a72c1db7a87",
+   "execution_count": 399,
+   "id": "0ba04bbd-8650-4dbe-9797-4512f599ae7d",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.17% increase in rows\n"
+      "3.0% increase in rows\n",
+      "2.0% increase in rows\n"
      ]
     }
    ],
    "source": [
-    "# Continents\n",
-    "population_continent = population.assign(\n",
-    "    country=population.country.replace(country2continent)\n",
+    "population_continent = get_df_regions(\n",
+    "    population, country2continent, \"country\", [\"country\", \"year\"]\n",
     ")\n",
-    "population_continent = population_continent.groupby(\n",
-    "    [\"country\", \"year\"], as_index=False\n",
-    ").sum()\n",
-    "# Only keep new regions\n",
-    "msk = population_continent.country.isin(continents)\n",
-    "population_continent = population_continent.loc[msk]\n",
-    "print(\n",
-    "    f\"{round(100*population_continent.shape[0]/fe_bulk.shape[0], 2)}% increase in rows\"\n",
+    "population_income = get_df_regions(\n",
+    "    population, country2income, \"country\", [\"country\", \"year\"]\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 248,
-   "id": "484153ff-f197-41f2-b719-d2a3231da0f0",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.11% increase in rows\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Regions\n",
-    "population_income = population.assign(\n",
-    "    country=population.country.replace(country2income)\n",
-    ")\n",
-    "population_income = population_income.groupby([\"country\", \"year\"], as_index=False).sum()\n",
-    "# Only keep new regions\n",
-    "msk = population_income.country.isin(income)\n",
-    "population_income = population_income.loc[msk]\n",
-    "print(f\"{round(100*population_income.shape[0]/fe_bulk.shape[0], 2)}% increase in rows\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 249,
+   "execution_count": 400,
    "id": "45bb6107-13df-43ce-b7d2-be58a8a56fdd",
    "metadata": {},
    "outputs": [],
@@ -2727,55 +2822,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 250,
-   "id": "e11ac685-67e0-4538-83a6-bbad5f828bcb",
+   "execution_count": 401,
+   "id": "38505ff2-c5ff-4c29-8a19-57231652ef2d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "countries_pop = set(population.index.levels[0])\n",
-    "countries = set(fe_bulk.Country)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 251,
-   "id": "37d4e28d-1a63-49e9-a83c-c80112c44cbb",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Missing 13 countries: {'Serbia and Montenegro', 'Macao', 'USSR', 'Niue', 'French Polynesia', 'Tokelau', 'Melanesia', 'Bermuda', 'Czechoslovakia', 'Yugoslavia', 'Polynesia', 'Cook Islands', 'Eritrea and Ethiopia'}\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(\n",
-    "    f\"Missing {len(countries_missing := countries.difference(countries_pop))} countries: {countries_missing}\"\n",
-    ")\n",
-    "if len(countries_missing) > 13:\n",
-    "    raise ValueError(\"More countries missing than expected!\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 252,
-   "id": "38505ff2-c5ff-4c29-8a19-57231652ef2d",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Decrease of 5% rows\n"
-     ]
-    }
-   ],
-   "source": [
-    "shape_first = fe_bulk.shape[0]\n",
-    "fe_bulk = fe_bulk.merge(population, left_on=[\"Country\", \"Year\"], right_index=True)\n",
-    "print(f\"Decrease of {round(100*(1-fe_bulk.shape[0]/shape_first))}% rows\")"
+    "fe_bulk = fe_bulk.merge(population, left_on=[\"Country\", \"Year\"], right_index=True)"
    ]
   },
   {
@@ -2788,12 +2840,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 257,
+   "execution_count": 402,
    "id": "a2eae09b-a6f3-4b4e-94e8-bbbb35cd4ed1",
    "metadata": {},
    "outputs": [],
    "source": [
-    "fe_bulk = fe_bulk.set_index([\"Product\", \"Country\", \"Year\"])"
+    "fe_bulk = fe_bulk.set_index(\n",
+    "    [\"Product\", \"Country\", \"Year\"], verify_integrity=True\n",
+    ").sort_index()"
    ]
   },
   {
@@ -2822,7 +2876,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 258,
+   "execution_count": 403,
    "id": "5e11a2df-9018-4db6-a741-c8e23f7fcc74",
    "metadata": {},
    "outputs": [],
@@ -2832,7 +2886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 259,
+   "execution_count": 404,
    "id": "063d7187-b99d-4c17-a726-d9e44a59806b",
    "metadata": {},
    "outputs": [],
@@ -2871,12 +2925,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 260,
+   "execution_count": 405,
    "id": "97bedabf-2d57-4789-9466-a66ac2f28aba",
    "metadata": {},
    "outputs": [],
    "source": [
-    "t = catalog.Table(fe_bulk)\n",
+    "t = catalog.Table(fe_bulk.iloc[:2100])\n",
     "t.metadata.short_name = \"bulk\"\n",
     "fe_garden.add(t)"
    ]
@@ -2900,7 +2954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 261,
+   "execution_count": 406,
    "id": "f2711acb-c700-4ce9-89f5-6fbbf7c9a4f6",
    "metadata": {},
    "outputs": [
@@ -3138,7 +3192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 262,
+   "execution_count": 407,
    "id": "0042dcdd-2cc2-460b-9523-e3167bcaef2b",
    "metadata": {},
    "outputs": [
@@ -3146,16 +3200,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.1M\t/tmp/food_explorer/vegetables.csv\n",
-      "1.1M\t/tmp/food_explorer/oilcrops.csv\n",
-      "1.1M\t/tmp/food_explorer/fruit.csv\n",
-      "1.0M\t/tmp/food_explorer/wheat.csv\n",
-      "1.0M\t/tmp/food_explorer/milk.csv\n",
-      "1.0M\t/tmp/food_explorer/maize.csv\n",
-      "1004K\t/tmp/food_explorer/meat_total.csv\n",
-      "1000K\t/tmp/food_explorer/meat_poultry.csv\n",
-      "980K\t/tmp/food_explorer/pulses.csv\n",
-      "964K\t/tmp/food_explorer/rice.csv\n"
+      "1.7M\t/tmp/food_explorer/vegetables.csv\n",
+      "1.7M\t/tmp/food_explorer/oilcrops.csv\n",
+      "1.7M\t/tmp/food_explorer/fruit.csv\n",
+      "1.6M\t/tmp/food_explorer/wheat.csv\n",
+      "1.6M\t/tmp/food_explorer/milk.csv\n",
+      "1.6M\t/tmp/food_explorer/maize.csv\n",
+      "1.5M\t/tmp/food_explorer/rice.csv\n",
+      "1.5M\t/tmp/food_explorer/pulses.csv\n",
+      "1.5M\t/tmp/food_explorer/meat_total.csv\n",
+      "1.5M\t/tmp/food_explorer/meat_poultry.csv\n"
      ]
     }
    ],
@@ -3169,6 +3223,19 @@
    "metadata": {},
    "source": [
     "The biggest is 1.5MB (csv), we should be ok ✓ "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 456,
+   "id": "f1135eb4-d0a2-4dfb-9e5a-881ff643c2a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Comparison with previous (live) export\n",
+    "# product = 'vegetables'\n",
+    "# df_new = pd.read_csv(f'/tmp/food_explorer/{product}.csv')\n",
+    "# df_old = pd.read_csv(f'https://owid-catalog.nyc3.digitaloceanspaces.com/garden/explorers/2021/food_explorer/{product}.csv')"
    ]
   }
  ],


### PR DESCRIPTION
This PR fixes several bugs when it comes to region data:

- It converts _per-capita_ metrics into absolute metrics: `food_available_for_consumption__fat_g_per_day_per_capita`, `food_available_for_consumption__kcal_per_day_per_capita`, `food_available_for_consumption__kg_per_capita_per_year` and `food_available_for_consumption__protein_g_per_day_per_capita`
- Re-calculates metric `yield__tonnes_per_ha` for regions as `production__tonnes/area_harvested__ha` (previous computed values did not make sense)
- Metric `yield__kg_per_animal` left blank for regions.
- Fix of other minor bugs

Major changes happened in section 9. of the notebook.