### PR TITLE
FIX: Fix data reports for regions, temporary fix FBSC and add new products

### DIFF
--- a/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 222,
+   "execution_count": 1,
    "id": "6f35e10c-ecda-4c86-8783-56992f6f855e",
    "metadata": {
     "tags": [
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 223,
+   "execution_count": 2,
    "id": "2319d18c-fc2f-49d5-be71-c55bc7676a8b",
    "metadata": {},
    "outputs": [],
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 224,
+   "execution_count": 3,
    "id": "5674d02f-c7cd-4ef8-a28d-a64ddcc4caa3",
    "metadata": {},
    "outputs": [],
@@ -97,7 +97,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 225,
+   "execution_count": 4,
    "id": "a5769436-dfed-466b-9108-d534c59b7acd",
    "metadata": {},
    "outputs": [],
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 226,
+   "execution_count": 5,
    "id": "2edc462f-3dec-46c7-8d99-e89242fc38e4",
    "metadata": {},
    "outputs": [],
@@ -136,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 227,
+   "execution_count": 6,
    "id": "944a7d5d-48ec-4700-8795-e360245252c8",
    "metadata": {},
    "outputs": [],
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 228,
+   "execution_count": 7,
    "id": "e88461fe-c796-4cd2-8007-dadb141e01c6",
    "metadata": {},
    "outputs": [
@@ -258,7 +258,7 @@
        "4  Armenia        221          5312  1996    M   <NA>"
       ]
      },
-     "execution_count": 228,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 229,
+   "execution_count": 8,
    "id": "2a7f2ffb-ea32-4628-b070-affa5ea29a72",
    "metadata": {},
    "outputs": [
@@ -370,7 +370,7 @@
        "4  Armenia       2901           664  2018   Fc  2997.0"
       ]
      },
-     "execution_count": 229,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -395,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 230,
+   "execution_count": 9,
    "id": "8ec594e6-8bce-462a-bc6b-f0f619cc5478",
    "metadata": {},
    "outputs": [],
@@ -422,7 +422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 231,
+   "execution_count": 10,
    "id": "f467850f-4088-4d09-a467-a9860ddb81fa",
    "metadata": {},
    "outputs": [
@@ -467,7 +467,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 232,
+   "execution_count": 11,
    "id": "62537795-b1bd-4495-b221-3a20a3c575b8",
    "metadata": {},
    "outputs": [
@@ -554,7 +554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": 12,
    "id": "f5da2eda-1fca-47d0-9bd3-7da00c99d562",
    "metadata": {},
    "outputs": [],
@@ -588,7 +588,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 234,
+   "execution_count": 13,
    "id": "dbb64782-3fe5-4ac4-a59c-013f1221ed16",
    "metadata": {},
    "outputs": [
@@ -608,7 +608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 235,
+   "execution_count": 14,
    "id": "30c748ef-2016-4738-9304-cbffd1c6d172",
    "metadata": {},
    "outputs": [
@@ -643,7 +643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 236,
+   "execution_count": 15,
    "id": "61681c4f-0585-48c6-85d1-1adf9586d3f7",
    "metadata": {},
    "outputs": [],
@@ -661,7 +661,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 237,
+   "execution_count": 16,
    "id": "55e5e095-b849-4fac-b731-bd78a6e16952",
    "metadata": {},
    "outputs": [
@@ -687,7 +687,7 @@
        "Name: Item Code, dtype: int64"
       ]
      },
-     "execution_count": 237,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -699,7 +699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 238,
+   "execution_count": 17,
    "id": "cd067c44-bc63-4d05-af0e-0fc6f7ae3373",
    "metadata": {},
    "outputs": [
@@ -727,7 +727,7 @@
        "Name: Item Code, dtype: int64"
       ]
      },
-     "execution_count": 238,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -750,7 +750,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 239,
+   "execution_count": 18,
    "id": "2d78ddb6-1100-4658-8043-44964e869a9b",
    "metadata": {},
    "outputs": [],
@@ -765,7 +765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 240,
+   "execution_count": 19,
    "id": "53bbe8b1-9f74-4af1-ad37-1df1e262edb5",
    "metadata": {},
    "outputs": [],
@@ -778,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 241,
+   "execution_count": 20,
    "id": "e9f5471b-a00e-4996-894c-6d8709bb3713",
    "metadata": {},
    "outputs": [
@@ -926,7 +926,7 @@
        "      <td>Production</td>\n",
        "      <td>tonnes</td>\n",
        "      <td>tonnes</td>\n",
-       "      <td>996973</td>\n",
+       "      <td>1074200</td>\n",
        "      <td>QCL</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -935,7 +935,7 @@
        "      <td>Area harvested</td>\n",
        "      <td>ha</td>\n",
        "      <td>hectares</td>\n",
-       "      <td>539828</td>\n",
+       "      <td>586119</td>\n",
        "      <td>QCL</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -944,7 +944,7 @@
        "      <td>Yield</td>\n",
        "      <td>hg/ha</td>\n",
        "      <td>hectograms per hectare</td>\n",
-       "      <td>534847</td>\n",
+       "      <td>581076</td>\n",
        "      <td>QCL</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -953,7 +953,7 @@
        "      <td>Producing Animals/Slaughtered</td>\n",
        "      <td>Head</td>\n",
        "      <td>head</td>\n",
-       "      <td>149439</td>\n",
+       "      <td>155804</td>\n",
        "      <td>QCL</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -962,7 +962,7 @@
        "      <td>Stocks</td>\n",
        "      <td>Head</td>\n",
        "      <td>head</td>\n",
-       "      <td>86112</td>\n",
+       "      <td>89812</td>\n",
        "      <td>QCL</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -978,11 +978,11 @@
        "0   5111                         Stocks    Head                    head   \n",
        "\n",
        "    number_occurrences dataset  \n",
-       "13              996973     QCL  \n",
-       "3               539828     QCL  \n",
-       "9               534847     QCL  \n",
-       "5               149439     QCL  \n",
-       "0                86112     QCL  "
+       "13             1074200     QCL  \n",
+       "3               586119     QCL  \n",
+       "9               581076     QCL  \n",
+       "5               155804     QCL  \n",
+       "0                89812     QCL  "
       ]
      },
      "execution_count": 24,
@@ -1243,7 +1243,7 @@
        "      <td>1765</td>\n",
        "      <td>Meat, Total</td>\n",
        "      <td>Group</td>\n",
-       "      <td>11055</td>\n",
+       "      <td>11367</td>\n",
        "      <td>QCL</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1251,7 +1251,7 @@
        "      <td>1738</td>\n",
        "      <td>Fruit Primary</td>\n",
        "      <td>Group</td>\n",
-       "      <td>10909</td>\n",
+       "      <td>11221</td>\n",
        "      <td>QCL</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1259,7 +1259,7 @@
        "      <td>1057</td>\n",
        "      <td>Chickens</td>\n",
        "      <td>None</td>\n",
-       "      <td>10893</td>\n",
+       "      <td>11205</td>\n",
        "      <td>QCL</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1267,7 +1267,7 @@
        "      <td>1808</td>\n",
        "      <td>Meat, Poultry</td>\n",
        "      <td>Group</td>\n",
-       "      <td>10883</td>\n",
+       "      <td>11195</td>\n",
        "      <td>QCL</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1275,7 +1275,7 @@
        "      <td>1058</td>\n",
        "      <td>Meat, chicken</td>\n",
        "      <td>None</td>\n",
-       "      <td>10883</td>\n",
+       "      <td>11195</td>\n",
        "      <td>QCL</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -1284,11 +1284,11 @@
       ],
       "text/plain": [
        "   code           name   type number_occurences dataset\n",
-       "0  1765    Meat, Total  Group             11055     QCL\n",
-       "1  1738  Fruit Primary  Group             10909     QCL\n",
-       "2  1057       Chickens   None             10893     QCL\n",
-       "3  1808  Meat, Poultry  Group             10883     QCL\n",
-       "4  1058  Meat, chicken   None             10883     QCL"
+       "0  1765    Meat, Total  Group             11367     QCL\n",
+       "1  1738  Fruit Primary  Group             11221     QCL\n",
+       "2  1057       Chickens   None             11205     QCL\n",
+       "3  1808  Meat, Poultry  Group             11195     QCL\n",
+       "4  1058  Meat, chicken   None             11195     QCL"
       ]
      },
      "execution_count": 30,
@@ -1339,7 +1339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 242,
+   "execution_count": 32,
    "id": "f9fd878f-47ca-4569-8bb4-f764f1244d4e",
    "metadata": {},
    "outputs": [],
@@ -1362,7 +1362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 243,
+   "execution_count": 33,
    "id": "2be4a477-197a-411d-8d52-d103036cf54b",
    "metadata": {},
    "outputs": [
@@ -1697,7 +1697,7 @@
        "5417       0.1000  "
       ]
      },
-     "execution_count": 243,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1717,7 +1717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 244,
+   "execution_count": 34,
    "id": "8a980add-06d6-4b8d-96b0-be53678bd3f0",
    "metadata": {},
    "outputs": [],
@@ -1737,7 +1737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 245,
+   "execution_count": 35,
    "id": "2c30000a-40bd-4a97-a99e-775127cb49ac",
    "metadata": {},
    "outputs": [],
@@ -1757,7 +1757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 246,
+   "execution_count": 36,
    "id": "180ca094-27f3-4b26-828b-8f8e8a11feaf",
    "metadata": {},
    "outputs": [],
@@ -1779,7 +1779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 247,
+   "execution_count": 37,
    "id": "06553ff8-56e3-4c03-8e01-ec36c172c637",
    "metadata": {},
    "outputs": [],
@@ -1798,7 +1798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 248,
+   "execution_count": 38,
    "id": "aa7c11c6-d286-4c42-9612-105db99d32f3",
    "metadata": {},
    "outputs": [],
@@ -1810,7 +1810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 249,
+   "execution_count": 39,
    "id": "e8ec1808-8715-4473-b129-98434c4eadd7",
    "metadata": {},
    "outputs": [
@@ -1912,7 +1912,7 @@
        "                      1965                0.9723                  <NA>  "
       ]
      },
-     "execution_count": 249,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1935,7 +1935,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 250,
+   "execution_count": 40,
    "id": "1b564750-ee04-48d2-85c3-7c0c00c351b3",
    "metadata": {},
    "outputs": [],
@@ -1955,7 +1955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 251,
+   "execution_count": 41,
    "id": "fe7f4012-4b80-41a1-8cf0-d83d887d6014",
    "metadata": {},
    "outputs": [
@@ -1974,7 +1974,7 @@
        " 572: 'Avocados'}"
       ]
      },
-     "execution_count": 251,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1993,7 +1993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 252,
+   "execution_count": 42,
    "id": "af18fe34-5475-4dd6-b285-2e2dd2d3ae04",
    "metadata": {},
    "outputs": [
@@ -2068,7 +2068,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 253,
+   "execution_count": 43,
    "id": "0eb99ea9-2457-4d22-ae23-52d15f71e4ad",
    "metadata": {},
    "outputs": [],
@@ -2094,7 +2094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 254,
+   "execution_count": 44,
    "id": "2c68a20f-e46f-4aa8-8ba9-4ec010839468",
    "metadata": {},
    "outputs": [],
@@ -2111,7 +2111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 255,
+   "execution_count": 45,
    "id": "7c9e522f-7a57-44c3-918a-a519ca9464f8",
    "metadata": {},
    "outputs": [],
@@ -2133,7 +2133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 368,
+   "execution_count": 46,
    "id": "82898260-9b51-49bd-a23b-8a289abc7dcd",
    "metadata": {},
    "outputs": [],
@@ -2144,7 +2144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 369,
+   "execution_count": 47,
    "id": "9c473b45-e1b6-4f54-9746-2b8ccf0c7e7d",
    "metadata": {},
    "outputs": [
@@ -2166,7 +2166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 370,
+   "execution_count": 48,
    "id": "2adc3d98-4d00-45f3-97a1-c261bbf554b1",
    "metadata": {},
    "outputs": [
@@ -2186,7 +2186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 371,
+   "execution_count": 50,
    "id": "cd65eb08-512a-4656-9856-692689944978",
    "metadata": {},
    "outputs": [
@@ -2428,7 +2428,7 @@
        "                    1979                                                NaN             "
       ]
      },
-     "execution_count": 371,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2457,7 +2457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 372,
+   "execution_count": 51,
    "id": "0bae636c-79f3-44bc-ad2f-f4f3fe4c4744",
    "metadata": {},
    "outputs": [],
@@ -2484,7 +2484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 373,
+   "execution_count": 52,
    "id": "917c1d6a-cd66-4e91-827e-641c6720f19f",
    "metadata": {},
    "outputs": [],
@@ -2496,7 +2496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 374,
+   "execution_count": 53,
    "id": "0f7949cc-12df-4ae3-bd8a-82c0c2f151f7",
    "metadata": {},
    "outputs": [
@@ -2504,7 +2504,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Missing 17 countries: {'Czechoslovakia', 'USSR', 'Niue', 'Yugoslavia', 'Macao', 'Asia', 'Polynesia', 'Tokelau', 'Oceania', 'Eritrea and Ethiopia', 'Cook Islands', 'Bermuda', 'Serbia and Montenegro', 'Melanesia', 'Europe', 'French Polynesia', 'Africa'}\n",
+      "Missing 17 countries: {'Cook Islands', 'Niue', 'USSR', 'Czechoslovakia', 'Melanesia', 'Tokelau', 'French Polynesia', 'Eritrea and Ethiopia', 'Serbia and Montenegro', 'Bermuda', 'Yugoslavia', 'Macao', 'Polynesia', 'Oceania', 'Europe', 'Africa', 'Asia'}\n",
       "Decrease of 9% rows\n"
      ]
     }
@@ -2535,7 +2535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 375,
+   "execution_count": 54,
    "id": "7b391137-2642-45f7-bedc-34dbc8a33710",
    "metadata": {},
    "outputs": [],
@@ -2571,7 +2571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 376,
+   "execution_count": 55,
    "id": "02921d82-0454-4c1a-837a-0c615b7b94a0",
    "metadata": {},
    "outputs": [],
@@ -2610,7 +2610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 377,
+   "execution_count": 56,
    "id": "d2b4a30b-fba6-434b-84ed-bf556ae74146",
    "metadata": {},
    "outputs": [],
@@ -2629,7 +2629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 378,
+   "execution_count": 57,
    "id": "980cecc4-5c3b-4c09-90b9-5e2d5873eda8",
    "metadata": {},
    "outputs": [],
@@ -2652,7 +2652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 379,
+   "execution_count": 58,
    "id": "c4eca576-ca7d-44cd-8def-9f5232a93fa7",
    "metadata": {},
    "outputs": [],
@@ -2672,7 +2672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 380,
+   "execution_count": 59,
    "id": "2c9543c5-f007-4c23-adda-ee9caa9ced11",
    "metadata": {},
    "outputs": [
@@ -2714,7 +2714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 381,
+   "execution_count": 60,
    "id": "cba5d1b2-7c08-4cf3-ab72-7215e9dc14d2",
    "metadata": {},
    "outputs": [],
@@ -2733,7 +2733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 396,
+   "execution_count": 61,
    "id": "a24ccaa0-36c4-4c25-9991-a51fb5a04827",
    "metadata": {},
    "outputs": [],
@@ -2759,7 +2759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 398,
+   "execution_count": 62,
    "id": "ca4b04f6-2bdf-42cb-95c7-f30b21db6158",
    "metadata": {},
    "outputs": [],
@@ -2778,7 +2778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 399,
+   "execution_count": 63,
    "id": "0ba04bbd-8650-4dbe-9797-4512f599ae7d",
    "metadata": {},
    "outputs": [
@@ -2802,7 +2802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 400,
+   "execution_count": 64,
    "id": "45bb6107-13df-43ce-b7d2-be58a8a56fdd",
    "metadata": {},
    "outputs": [],
@@ -2822,7 +2822,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 401,
+   "execution_count": 65,
    "id": "38505ff2-c5ff-4c29-8a19-57231652ef2d",
    "metadata": {},
    "outputs": [],
@@ -2835,12 +2835,12 @@
    "id": "235e4733-e137-476a-920b-bf0bfc97d0e6",
    "metadata": {},
    "source": [
-    "### Set index"
+    "#### Set index"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 402,
+   "execution_count": 66,
    "id": "a2eae09b-a6f3-4b4e-94e8-bbbb35cd4ed1",
    "metadata": {},
    "outputs": [],
@@ -2876,7 +2876,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 403,
+   "execution_count": 67,
    "id": "5e11a2df-9018-4db6-a741-c8e23f7fcc74",
    "metadata": {},
    "outputs": [],
@@ -2886,7 +2886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 404,
+   "execution_count": 68,
    "id": "063d7187-b99d-4c17-a726-d9e44a59806b",
    "metadata": {},
    "outputs": [],
@@ -2925,7 +2925,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 405,
+   "execution_count": 69,
    "id": "97bedabf-2d57-4789-9466-a66ac2f28aba",
    "metadata": {},
    "outputs": [],
@@ -2954,7 +2954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 406,
+   "execution_count": 70,
    "id": "f2711acb-c700-4ce9-89f5-6fbbf7c9a4f6",
    "metadata": {},
    "outputs": [
@@ -3192,7 +3192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 407,
+   "execution_count": 71,
    "id": "0042dcdd-2cc2-460b-9523-e3167bcaef2b",
    "metadata": {},
    "outputs": [
@@ -3222,7 +3222,7 @@
    "id": "6b391ff9-3fc7-44ce-a292-0b0c83e792d5",
    "metadata": {},
    "source": [
-    "The biggest is 1.5MB (csv), we should be ok ✓ "
+    "The biggest is 1.7MB (csv), we should be ok ✓ "
    ]
   },
   {

--- a/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
@@ -1339,7 +1339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 21,
    "id": "f9fd878f-47ca-4569-8bb4-f764f1244d4e",
    "metadata": {},
    "outputs": [],
@@ -1362,7 +1362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 22,
    "id": "2be4a477-197a-411d-8d52-d103036cf54b",
    "metadata": {},
    "outputs": [
@@ -1697,7 +1697,7 @@
        "5417       0.1000  "
       ]
      },
-     "execution_count": 33,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1717,7 +1717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 23,
    "id": "8a980add-06d6-4b8d-96b0-be53678bd3f0",
    "metadata": {},
    "outputs": [],
@@ -1737,7 +1737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 24,
    "id": "2c30000a-40bd-4a97-a99e-775127cb49ac",
    "metadata": {},
    "outputs": [],
@@ -1757,7 +1757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 25,
    "id": "180ca094-27f3-4b26-828b-8f8e8a11feaf",
    "metadata": {},
    "outputs": [],
@@ -1779,7 +1779,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 26,
    "id": "06553ff8-56e3-4c03-8e01-ec36c172c637",
    "metadata": {},
    "outputs": [],
@@ -1798,7 +1798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 27,
    "id": "aa7c11c6-d286-4c42-9612-105db99d32f3",
    "metadata": {},
    "outputs": [],
@@ -1810,7 +1810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 28,
    "id": "e8ec1808-8715-4473-b129-98434c4eadd7",
    "metadata": {},
    "outputs": [
@@ -1912,7 +1912,7 @@
        "                      1965                0.9723                  <NA>  "
       ]
      },
-     "execution_count": 39,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1935,7 +1935,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 29,
    "id": "1b564750-ee04-48d2-85c3-7c0c00c351b3",
    "metadata": {},
    "outputs": [],
@@ -1955,7 +1955,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 30,
    "id": "fe7f4012-4b80-41a1-8cf0-d83d887d6014",
    "metadata": {},
    "outputs": [
@@ -1974,7 +1974,7 @@
        " 572: 'Avocados'}"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1993,7 +1993,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 33,
    "id": "af18fe34-5475-4dd6-b285-2e2dd2d3ae04",
    "metadata": {},
    "outputs": [
@@ -2068,7 +2068,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 34,
    "id": "0eb99ea9-2457-4d22-ae23-52d15f71e4ad",
    "metadata": {},
    "outputs": [],
@@ -2094,7 +2094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 35,
    "id": "2c68a20f-e46f-4aa8-8ba9-4ec010839468",
    "metadata": {},
    "outputs": [],
@@ -2111,7 +2111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 36,
    "id": "7c9e522f-7a57-44c3-918a-a519ca9464f8",
    "metadata": {},
    "outputs": [],
@@ -2133,7 +2133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 39,
    "id": "82898260-9b51-49bd-a23b-8a289abc7dcd",
    "metadata": {},
    "outputs": [],
@@ -2144,7 +2144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 40,
    "id": "9c473b45-e1b6-4f54-9746-2b8ccf0c7e7d",
    "metadata": {},
    "outputs": [
@@ -2153,8 +2153,8 @@
      "output_type": "stream",
      "text": [
       "QCL // shape: (1032796, 4) / not-NaN: 1939848\n",
-      "FBSC // shape: (532258, 11) / not-NaN: 4162507\n",
-      "FE // shape: (1292607, 15) / not-NaN: 6102355\n"
+      "FBSC // shape: (541771, 11) / not-NaN: 4191046\n",
+      "FE // shape: (1302120, 15) / not-NaN: 6130894\n"
      ]
     }
    ],
@@ -2166,7 +2166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 41,
    "id": "2adc3d98-4d00-45f3-97a1-c261bbf554b1",
    "metadata": {},
    "outputs": [
@@ -2174,7 +2174,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FE (after NaN-drop): (1106720, 15)\n"
+      "FE (after NaN-drop): (1116233, 15)\n"
      ]
     }
    ],
@@ -2186,7 +2186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 42,
    "id": "cd65eb08-512a-4656-9856-692689944978",
    "metadata": {},
    "outputs": [
@@ -2194,7 +2194,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(1106720, 15)\n"
+      "(1116233, 15)\n"
      ]
     },
     {
@@ -2428,7 +2428,7 @@
        "                    1979                                                NaN             "
       ]
      },
-     "execution_count": 50,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2457,7 +2457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 43,
    "id": "0bae636c-79f3-44bc-ad2f-f4f3fe4c4744",
    "metadata": {},
    "outputs": [],
@@ -2484,7 +2484,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 44,
    "id": "917c1d6a-cd66-4e91-827e-641c6720f19f",
    "metadata": {},
    "outputs": [],
@@ -2496,7 +2496,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 45,
    "id": "0f7949cc-12df-4ae3-bd8a-82c0c2f151f7",
    "metadata": {},
    "outputs": [
@@ -2504,7 +2504,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Missing 17 countries: {'Cook Islands', 'Niue', 'USSR', 'Czechoslovakia', 'Melanesia', 'Tokelau', 'French Polynesia', 'Eritrea and Ethiopia', 'Serbia and Montenegro', 'Bermuda', 'Yugoslavia', 'Macao', 'Polynesia', 'Oceania', 'Europe', 'Africa', 'Asia'}\n",
+      "Missing 17 countries: {'Oceania', 'Yugoslavia', 'Europe', 'Asia', 'French Polynesia', 'Tokelau', 'Niue', 'Eritrea and Ethiopia', 'Bermuda', 'Cook Islands', 'Melanesia', 'Macao', 'USSR', 'Serbia and Montenegro', 'Polynesia', 'Africa', 'Czechoslovakia'}\n",
       "Decrease of 9% rows\n"
      ]
     }
@@ -2535,7 +2535,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 46,
    "id": "7b391137-2642-45f7-bedc-34dbc8a33710",
    "metadata": {},
    "outputs": [],
@@ -2571,7 +2571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 47,
    "id": "02921d82-0454-4c1a-837a-0c615b7b94a0",
    "metadata": {},
    "outputs": [],
@@ -2610,7 +2610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 48,
    "id": "d2b4a30b-fba6-434b-84ed-bf556ae74146",
    "metadata": {},
    "outputs": [],
@@ -2629,7 +2629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 49,
    "id": "980cecc4-5c3b-4c09-90b9-5e2d5873eda8",
    "metadata": {},
    "outputs": [],
@@ -2640,9 +2640,9 @@
     "    if columns_aggregate is not None:\n",
     "        df_regions = df_regions.groupby(columns_index, as_index=False)[\n",
     "            columns_aggregate\n",
-    "        ].sum()\n",
+    "        ].sum(min_count=1)\n",
     "    else:\n",
-    "        df_regions = df_regions.groupby(columns_index, as_index=False).sum()\n",
+    "        df_regions = df_regions.groupby(columns_index, as_index=False).sum(min_count=1)\n",
     "    # Only keep new regions\n",
     "    msk = df_regions[column_location].isin(set(mapping.values()))\n",
     "    df_regions = df_regions.loc[msk]\n",
@@ -2652,7 +2652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 50,
    "id": "c4eca576-ca7d-44cd-8def-9f5232a93fa7",
    "metadata": {},
    "outputs": [],
@@ -2672,7 +2672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 51,
    "id": "2c9543c5-f007-4c23-adda-ee9caa9ced11",
    "metadata": {},
    "outputs": [
@@ -2680,9 +2680,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.09% increase in rows\n",
-      "5.85% increase in rows\n",
-      "4.08% increase in rows\n"
+      "1.08% increase in rows\n",
+      "5.83% increase in rows\n",
+      "4.07% increase in rows\n"
      ]
     }
    ],
@@ -2714,7 +2714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 52,
    "id": "cba5d1b2-7c08-4cf3-ab72-7215e9dc14d2",
    "metadata": {},
    "outputs": [],
@@ -2733,7 +2733,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 53,
    "id": "a24ccaa0-36c4-4c25-9991-a51fb5a04827",
    "metadata": {},
    "outputs": [],
@@ -2759,7 +2759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 54,
    "id": "ca4b04f6-2bdf-42cb-95c7-f30b21db6158",
    "metadata": {},
    "outputs": [],
@@ -2778,7 +2778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 55,
    "id": "0ba04bbd-8650-4dbe-9797-4512f599ae7d",
    "metadata": {},
    "outputs": [
@@ -2802,7 +2802,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 56,
    "id": "45bb6107-13df-43ce-b7d2-be58a8a56fdd",
    "metadata": {},
    "outputs": [],
@@ -2822,7 +2822,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 57,
    "id": "38505ff2-c5ff-4c29-8a19-57231652ef2d",
    "metadata": {},
    "outputs": [],
@@ -2840,7 +2840,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 58,
    "id": "a2eae09b-a6f3-4b4e-94e8-bbbb35cd4ed1",
    "metadata": {},
    "outputs": [],
@@ -2876,7 +2876,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 59,
    "id": "5e11a2df-9018-4db6-a741-c8e23f7fcc74",
    "metadata": {},
    "outputs": [],
@@ -2886,7 +2886,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 60,
    "id": "063d7187-b99d-4c17-a726-d9e44a59806b",
    "metadata": {},
    "outputs": [],
@@ -2925,7 +2925,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 61,
    "id": "97bedabf-2d57-4789-9466-a66ac2f28aba",
    "metadata": {},
    "outputs": [],
@@ -2954,7 +2954,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 62,
    "id": "f2711acb-c700-4ce9-89f5-6fbbf7c9a4f6",
    "metadata": {},
    "outputs": [
@@ -3145,6 +3145,7 @@
       "Tea --> tea.csv\n",
       "Tobacco --> tobacco.csv\n",
       "Tomatoes --> tomatoes.csv\n",
+      "Total --> total.csv\n",
       "Treenuts --> treenuts.csv\n",
       "Vegetables --> vegetables.csv\n",
       "Walnuts --> walnuts.csv\n",
@@ -3192,7 +3193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 63,
    "id": "0042dcdd-2cc2-460b-9523-e3167bcaef2b",
    "metadata": {},
    "outputs": [

--- a/etl/steps/data/garden/explorers/2021/food_explorer.items.std.csv
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.items.std.csv
@@ -148,7 +148,7 @@ code,name,type,number_occurences,dataset,name_standardised,Description
 1016,Goats,,10331,QCL,Goats,"Capra spp.. See 866. Includes Hircus, Ibex, Nubiana, Pyrenaica, Tibetana, Kashmir and Angora."
 549,Gooseberries,,940,QCL,,"Ribes grossularia. Trade data may sometimes include black, white or red currants."
 103,"Grain, mixed",,1391,QCL,Mixed grains,"A mixture of cereal species that are sown and harvested together. The mixture wheat/rye is known as meslin, but in trade is usually classified with wheat."
-2901,Grand Total,Group,9513,FBSC,,
+2901,Grand Total,Group,9513,FBSC,Total,
 507,Grapefruit (inc. pomelos),,4613,QCL,Grapefruit,Citrus maxima; C. grandis; C. paradisi.
 2613,Grapefruit and products,,8854,FBSC,Grapefruit,"Default composition: 507 Grapefruit (inc. pomelos), 509 Juice, grapefruit, 510 Juice, grapefruit, concentrated"
 560,Grapes,,4684,QCL,Grapes,Vitis vinifera. Includes both table and wine grapes.

--- a/etl/steps/data/garden/explorers/2021/food_explorer.items.std.csv
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.items.std.csv
@@ -315,7 +315,7 @@ code,name,type,number_occurences,dataset,name_standardised,Description
 489,Plantains and others,,3125,QCL,Plantains,Musa paradisiaca. Generally known as a cooking banana. Data should be reported excluding the weight of the central stalk.
 536,Plums and sloes,,4356,QCL,Plums,"Greengage, mirabelle, damson (Prunus domestica); sloe (P. spinosa)."
 296,Poppy seed,,886,QCL,Poppy seeds,"Papaver somniferum. The source of opium, poppy seeds are also used in baking and confectionery."
-116,Potatoes,,8444,QCL,,"Solanum tuberosum Irish potato. A seasonal crop grown in temperate zones all over the world, but primarily in the northern hemisphere."
+116,Potatoes,,8444,QCL,Potatoes,"Solanum tuberosum Irish potato. A seasonal crop grown in temperate zones all over the world, but primarily in the northern hemisphere."
 2531,Potatoes and products,,9518,FBSC,Potatoes,"Default composition: 116 Potatoes, 117 Flour, potatoes, 118 Potatoes, frozen, 119 Starch, potatoes, 121 Tapioca, potatoes"
 2029,Poultry Birds,Group,10863,QCL,Poultry,
 2734,Poultry Meat,,9518,FBSC,"Meat, poultry","Default composition: 1058 Meat, chicken, 1060 Fat, liver prepared (foie gras), 1061 Meat, chicken, canned, 1069 Meat, duck, 1073 Meat, goose and guinea fowl, 1080 Meat, turkey"

--- a/etl/steps/data/garden/faostat/2021-04-09/faostat_fbsc.ipynb
+++ b/etl/steps/data/garden/faostat/2021-04-09/faostat_fbsc.ipynb
@@ -22,7 +22,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 74,
    "id": "ec98d59c",
    "metadata": {
     "tags": [
@@ -47,7 +47,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 75,
    "id": "7a13d99e-cb34-4dee-a702-be026f2fa3a7",
    "metadata": {},
    "outputs": [],
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 76,
    "id": "273b21f5-48c3-49ed-a486-7cfd1c7cb8f0",
    "metadata": {},
    "outputs": [],
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 77,
    "id": "134ea32a-77b4-4e4c-af5c-400f6edd5866",
    "metadata": {},
    "outputs": [],
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 78,
    "id": "5553eb58-fd10-4a93-9356-859121b7bed0",
    "metadata": {
     "tags": []
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 79,
    "id": "e9a67fe4-ca1e-4e73-b667-6cef8cc573b2",
    "metadata": {},
    "outputs": [
@@ -206,7 +206,7 @@
        "                                 2018 *     1000 persons  37172.0"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 79,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 80,
    "id": "7ccf0bed-0e52-4bb3-be88-3fa80e0f48b8",
    "metadata": {},
    "outputs": [
@@ -315,7 +315,7 @@
        "                                 1965 NaN   1000 persons  9765.0"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -355,7 +355,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 81,
    "id": "e2e5f421-db02-4e5a-9d92-0d146b19d491",
    "metadata": {},
    "outputs": [],
@@ -372,7 +372,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 82,
    "id": "449e3f54-c3d5-4bb1-a0d0-73ae4a887f64",
    "metadata": {},
    "outputs": [],
@@ -396,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 83,
    "id": "66501a75-5725-42fc-b68b-8e22a3c7a49e",
    "metadata": {},
    "outputs": [],
@@ -407,7 +407,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 84,
    "id": "dd6fb699-b4d2-4f4d-a330-7e350e5fa3b2",
    "metadata": {},
    "outputs": [
@@ -442,7 +442,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 85,
    "id": "b005a93e-3821-4a79-8447-ccc4fd08cc92",
    "metadata": {},
    "outputs": [],
@@ -464,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 133,
    "id": "7b5ac5cb-a2bf-4149-9a0c-f70086f96f7c",
    "metadata": {},
    "outputs": [],
@@ -476,7 +476,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 134,
+   "id": "df394cda-49f0-4bec-b31d-d072b1aab123",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Temporary fixes\n",
+    "fbsh_item[\"Item\"] = fbsh_item[\"Item\"].astype(str)\n",
+    "assert (\n",
+    "    fbsh_item.loc[[[2919, 2625], [2901, 2625], [2903, 2625]], \"Item\"] == \"Fruits, other\"\n",
+    ").all()\n",
+    "fbsh_item.loc[[[2919, 2625], [2901, 2625], [2903, 2625]], \"Item\"] = \"Fruits, Other\"\n",
+    "assert (\n",
+    "    fbsh_item.loc[[[2918, 2605], [2901, 2605], [2903, 2605]], \"Item\"]\n",
+    "    == \"Vegetables, other\"\n",
+    ").all()\n",
+    "fbsh_item.loc[[[2918, 2605], [2901, 2605], [2903, 2605]], \"Item\"] = \"Vegetables, Other\"\n",
+    "fbsh_item[\"Item\"] = fbsh_item[\"Item\"].astype(\"category\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 135,
    "id": "8e5c87a3-3897-499c-9aea-2cf6454165ff",
    "metadata": {},
    "outputs": [],
@@ -501,7 +522,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 136,
    "id": "a24645e7-bcd3-4ea2-91e2-9780651e4874",
    "metadata": {},
    "outputs": [],
@@ -513,7 +534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 137,
    "id": "e5220bbf-a755-4d5b-846b-537b068b1f05",
    "metadata": {},
    "outputs": [
@@ -550,7 +571,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 140,
    "id": "275b7491-2e31-45a5-a48b-dbd3f93cb314",
    "metadata": {},
    "outputs": [],
@@ -562,7 +583,9 @@
   {
    "cell_type": "markdown",
    "id": "dbe512c5-9038-4afa-a0f9-2395e6d45669",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "source": [
     "#### `Element`\n",
     "We see that two items were introduced in FBS (not present in FBSH): `Residuals` and `Tourist consumption`."
@@ -570,7 +593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 141,
    "id": "605ca9e7-5f13-40c8-9d8c-b6b388b6fbb4",
    "metadata": {},
    "outputs": [],
@@ -582,7 +605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 144,
    "id": "49d1ba9e-c419-4568-828f-abbc73b5edef",
    "metadata": {},
    "outputs": [
@@ -617,7 +640,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 145,
    "id": "ac64c512-3e2b-4b08-97e3-437e24b56519",
    "metadata": {},
    "outputs": [],
@@ -629,7 +652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 151,
    "id": "c093dc21-525e-4839-be5b-f202c807fa5a",
    "metadata": {},
    "outputs": [],
@@ -638,8 +661,7 @@
     "x = fbs_element.merge(fbsh_element, left_index=True, right_index=True)\n",
     "assert (x.Element_x.astype(str) == x.Element_y.astype(str)).all()\n",
     "assert (x.Unit_x.astype(str) == x.Unit_y.astype(str)).all()\n",
-    "msk = x.Description_x.astype(str) != x.Description_y.astype(str)\n",
-    "assert x.loc[msk].index == 5301"
+    "assert (x.Description_x.astype(str) == x.Description_y.astype(str)).all()"
    ]
   },
   {
@@ -664,7 +686,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 152,
    "id": "92809a3c-490e-4a58-9628-21bff768f6fd",
    "metadata": {},
    "outputs": [
@@ -673,7 +695,7 @@
      "output_type": "stream",
      "text": [
       "- FBSH but not FBS: {nan, 'SD', 'F'}\n",
-      "- FBS but not FBSH: {'Im', '*'}\n"
+      "- FBS but not FBSH: {'*', 'Im'}\n"
      ]
     }
    ],
@@ -691,7 +713,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 153,
    "id": "b5bfc929-2f78-4a27-9a0c-0395cddf30ef",
    "metadata": {},
    "outputs": [
@@ -707,7 +729,7 @@
        "Name: Flag, dtype: int64"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 153,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -718,7 +740,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 154,
    "id": "d865d23d-6ca5-4b4d-b131-e1402ecb92da",
    "metadata": {},
    "outputs": [
@@ -733,7 +755,7 @@
        "Name: Flag, dtype: int64"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 154,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -769,7 +791,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 155,
    "id": "09c4e2f7-6aa5-4146-9e0a-aeacc879734e",
    "metadata": {},
    "outputs": [],
@@ -790,7 +812,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 156,
    "id": "66f3e32f-82d5-45d6-9dda-ba7b3aef4915",
    "metadata": {},
    "outputs": [],
@@ -801,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 157,
    "id": "4a9550f7-c4e4-4e87-a5c7-8045e51cce27",
    "metadata": {},
    "outputs": [
@@ -829,7 +851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 158,
    "id": "6187dae0-6333-4910-b0d2-4dd54114a6c8",
    "metadata": {},
    "outputs": [],
@@ -848,7 +870,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 159,
    "id": "c1c2e31a-dc5c-40aa-8309-c7f5d37a79e0",
    "metadata": {},
    "outputs": [],
@@ -860,7 +882,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 189,
    "id": "be235d1a-4e8a-4acc-9d56-9f124353b4f0",
    "metadata": {},
    "outputs": [],
@@ -870,28 +892,90 @@
     "b = fbsh_item.index\n",
     "c = fbsc_item.index\n",
     "\n",
-    "assert [cc for cc in c if cc not in a] == [\n",
-    "    (2905, 2805),\n",
-    "    (2901, 2556),\n",
-    "    (2901, 2805),\n",
-    "    (2913, 2556),\n",
-    "    (2903, 2556),\n",
-    "    (2903, 2805),\n",
-    "]\n",
+    "assert not {cc for cc in c if cc not in a}.difference(\n",
+    "    {\n",
+    "        (2905, 2805),\n",
+    "        (2901, 2805),\n",
+    "        (2903, 2805),\n",
+    "        (2901, 2556),\n",
+    "        (2913, 2556),\n",
+    "        (2903, 2556),\n",
+    "        (2960, 2769),\n",
+    "    }\n",
+    ")\n",
     "\n",
-    "assert [cc for cc in c if cc not in b] == [\n",
-    "    (2905, 2807),\n",
-    "    (2901, 2552),\n",
-    "    (2901, 2807),\n",
-    "    (2913, 2552),\n",
-    "    (2903, 2552),\n",
-    "    (2903, 2807),\n",
-    "]"
+    "assert not {cc for cc in c if cc not in b}.difference(\n",
+    "    {\n",
+    "        (2905, 2807),\n",
+    "        (2901, 2807),\n",
+    "        (2903, 2807),\n",
+    "        (2901, 2552),\n",
+    "        (2913, 2552),\n",
+    "        (2903, 2552),\n",
+    "        (2961, 2769),\n",
+    "    }\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 187,
+   "id": "6401adf5-d9c7-4d45-94c2-97e18cc52533",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Item Group              Fish, Seafood\n",
+       "Item          Aquatic Animals, Others\n",
+       "Factor                              1\n",
+       "HS Code                              \n",
+       "HS07 Code                            \n",
+       "HS12 Code                            \n",
+       "CPC Code                        S2769\n",
+       "Name: (2960, 2769), dtype: object"
+      ]
+     },
+     "execution_count": 187,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# fbsh_item.loc[2960, 2769]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 188,
+   "id": "bbf2f8dd-ff44-4c94-8a9d-5789c72d2330",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Item Group    Aquatic Products, Other\n",
+       "Item          Aquatic Animals, Others\n",
+       "Factor                              1\n",
+       "HS Code                              \n",
+       "HS07 Code                            \n",
+       "HS12 Code                            \n",
+       "CPC Code                             \n",
+       "Name: (2961, 2769), dtype: object"
+      ]
+     },
+     "execution_count": 188,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# fbs_item.loc[2961, 2769]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 190,
    "id": "7d3beea4-c7a0-4771-ba7d-da4e73689c93",
    "metadata": {},
    "outputs": [],
@@ -910,7 +994,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 191,
    "id": "8c900886-ca25-407b-a102-662a7bf106fa",
    "metadata": {},
    "outputs": [],
@@ -922,7 +1006,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 192,
    "id": "0a11e3cd-07a2-4c35-96cb-cb4ab424a733",
    "metadata": {},
    "outputs": [],
@@ -945,7 +1029,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 193,
    "id": "ac368715-7c07-4788-a1aa-1f7c284c8893",
    "metadata": {},
    "outputs": [],
@@ -973,7 +1057,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 194,
    "id": "edbccbda-e226-40df-8b22-a6574331d0eb",
    "metadata": {},
    "outputs": [],
@@ -983,7 +1067,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 195,
    "id": "a7133574-bcff-48af-9c5a-dd3950759c35",
    "metadata": {},
    "outputs": [],
@@ -999,7 +1083,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 196,
    "id": "320bed95-f461-4a8a-8d15-956bc7f98ec6",
    "metadata": {},
    "outputs": [],
@@ -1010,7 +1094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 197,
    "id": "a8430241-3bd2-4253-b641-be3706cee654",
    "metadata": {},
    "outputs": [],
@@ -1031,7 +1115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 198,
    "id": "28e82671-58d7-4751-b15d-387d44dfdd09",
    "metadata": {},
    "outputs": [],
@@ -1057,7 +1141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 199,
    "id": "e06c09d4-ccd0-4aec-a51d-65e18bab2814",
    "metadata": {},
    "outputs": [
@@ -1143,7 +1227,7 @@
        "                                                                                  2018 Fc    2997.0"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 199,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1171,7 +1255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 200,
    "id": "bec146ab-3f8d-432e-b51b-0e03b247febb",
    "metadata": {},
    "outputs": [],
@@ -1181,7 +1265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 201,
    "id": "92f8a6a6-5610-4769-a64e-0452e4fcbe23",
    "metadata": {},
    "outputs": [],
@@ -1211,7 +1295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 202,
    "id": "ac66fe58-5dbd-4445-b255-c7d4f2ce91bf",
    "metadata": {},
    "outputs": [],
@@ -1221,7 +1305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 203,
    "id": "2d01fe85-7479-445a-b69c-4266d911f992",
    "metadata": {},
    "outputs": [],
@@ -1233,7 +1317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 204,
    "id": "f3df32ca-fcd9-40de-9ee7-6ce65a04737f",
    "metadata": {},
    "outputs": [],
@@ -1252,7 +1336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 205,
    "id": "08c11810-9fc1-4512-bcb4-edecbfaa8aac",
    "metadata": {},
    "outputs": [],

--- a/etl/steps/data/meadow/faostat/2017-12-11/faostat_fbsh.ipynb
+++ b/etl/steps/data/meadow/faostat/2017-12-11/faostat_fbsh.ipynb
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "id": "cb82ba2d-d979-4d9b-a75c-60933c0200e5",
    "metadata": {},
    "outputs": [],
@@ -122,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "id": "b0673ef5-f156-40fa-8f95-6f07fd2beda7",
    "metadata": {},
    "outputs": [
@@ -132,7 +132,7 @@
        "Dataset(path='/tmp/faostat_fbsh', metadata=DatasetMeta(namespace='faostat', short_name='faostat_FBSH', title='Food Balance: Food Balances (-2013, old methodology and population) - FAO (2017)', description=\"Food Balance Sheet presents a comprehensive picture of the pattern of a country's food supply during a specified reference period. The food balance sheet shows for each food item - i.e. each primary commodity and a number of processed commodities potentially available for human consumption - the sources of supply and its utilization. The total quantity of foodstuffs produced in a country added to the total quantity imported and adjusted to any change in stocks that may have occurred since the beginning of the reference period gives the supply available during that period. On the utilization side a distinction is made between the quantities exported, fed to livestock, used for seed, put to manufacture for food use and non-food uses, losses during storage and transportation, and food supplies available for human consumption. The per caput supply of each such food item available for human consumption is then obtained by dividing the respective quantity by the related data on the population actually partaking of it. Data on per caput food supplies are expressed in terms of quantity and - by applying appropriate food composition factors for all primary and processed products - also in terms of caloric value and protein and fat content.\", sources=[Source(name='Food and Agriculture Organization of the United Nations', description=None, url='http://www.fao.org/faostat/en/#data', source_data_url='http://fenixservices.fao.org/faostat/static/bulkdownloads/FoodBalanceSheetsHistoric_E_All_Data_(Normalized).zip', owid_data_url='https://walden.nyc3.digitaloceanspaces.com/faostat/2017-12-11/faostat_FBSH.zip', date_accessed='2021-10-28', publication_date='2017-12-11', publication_year=2017)], licenses=[License(name='CC BY-NC-SA 3.0 IGO', url='http://www.fao.org/contact-us/terms/db-terms-of-use/en')], source_checksum=None))"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -147,12 +147,12 @@
    "metadata": {},
    "source": [
     "## Metadata\n",
-    "_To be moved into Walden_"
+    "_This part should be moved into Walden_"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "id": "05dac71e-53e3-49c2-9341-9b255ad7afc6",
    "metadata": {},
    "outputs": [],
@@ -183,21 +183,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "id": "8cad4800-12d8-4186-920d-da437da24450",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "meta_item\n",
-      "meta_area\n",
-      "meta_element\n",
-      "meta_unit\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for data_ in data_extra:\n",
     "    metadata = requests.get(data_[\"url\"]).json()\n",
@@ -218,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "id": "acf856cf",
    "metadata": {},
    "outputs": [],
@@ -228,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "id": "22addbd7",
    "metadata": {},
    "outputs": [
@@ -238,7 +227,7 @@
        "'FoodBalanceSheetsHistoric_E_All_Data_(Normalized).csv'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -262,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 11,
    "id": "242e2d84",
    "metadata": {},
    "outputs": [],
@@ -272,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "id": "eaca5a43",
    "metadata": {},
    "outputs": [
@@ -401,7 +390,7 @@
        "4  Total Population - Both sexes       1965  1965  1000 persons  9765.0  NaN  "
       ]
      },
-     "execution_count": 17,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -430,7 +419,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 13,
    "id": "ac7e3f10",
    "metadata": {},
    "outputs": [
@@ -451,7 +440,7 @@
        "dtype: bool"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -463,7 +452,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 14,
    "id": "57865d6f",
    "metadata": {},
    "outputs": [],
@@ -485,7 +474,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 15,
    "id": "01ecf866-2087-45e0-8818-2e92082dc415",
    "metadata": {},
    "outputs": [],
@@ -505,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 16,
    "id": "68fe610d-8122-4d66-8cd1-17caee07e0ce",
    "metadata": {},
    "outputs": [],
@@ -515,7 +504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 17,
    "id": "c7efd5d6",
    "metadata": {},
    "outputs": [],
@@ -529,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 18,
    "id": "319c5966-62aa-407a-8301-26ca640e5aa5",
    "metadata": {},
    "outputs": [
@@ -619,7 +608,7 @@
        "                                 1965 NaN   1000 persons  9765.0"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -638,7 +627,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 19,
    "id": "48d148f5",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
_UPDATES_
- Add new products: 
    - `Total`: Only available for FBSC metrics. 
    - `Potatoes`: Include QCL metrics (FBSC were already included).

_FIXES_
- `NaN` values for regions: For some years, all countries within a region (continent, income group) have missing data for some metrics. In such cases, the corresponding regions should report `NaN` (missing values), instead of `0` (currently)
- Temporary fix for FBSC product names (new metadata release was published by FAO)*


---
*Currently, metadata coming from FAO API is being ingested at the _meadow_ stage and not in Walden. This prevents us from having a complete snapshot of the source data. Also, it may lead to _out of sync_ scenarios where data and metadata are not aligned. In the near future, we want to move this (API calls) to Walden instead.