### PR TITLE
Fix(food_explorer): Team feedback

### DIFF
--- a/etl/steps/data/garden/explorers/2021/food_explorer.elements.std.csv
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.elements.std.csv
@@ -12,8 +12,8 @@ code,name,unit,unit_description,number_occurrences,Dataset,name_standardised,uni
 5123,Losses,1000 tonnes,thousand tonnes,339465,FBSC,Waste,tonnes,1.00E+03
 5154,Other uses (non-food),1000 tonnes,thousand tonnes,418035,FBSC,Other uses,tonnes,1.00E+03
 5131,Processing,1000 tonnes,thousand tonnes,199001,FBSC,,,
-5321,Producing Animals/Slaughtered,1000 Head,thousand head,35354,QCL,,,
-5320,Producing Animals/Slaughtered,Head,head,149439,QCL,,,
+5321,Producing Animals/Slaughtered,1000 Head,thousand head,35354,QCL,Animals slaughtered,animals,1000
+5320,Producing Animals/Slaughtered,Head,head,149439,QCL,Animals slaughtered,animals,1
 5513,Production,1000 No,thousand number,13174,QCL,,,
 5510,Production,tonnes,tonnes,996973,QCL,Production,tonnes,1
 5511,Production,1000 tonnes,thousand tonnes,683798,FBSC,,,

--- a/etl/steps/data/garden/explorers/2021/food_explorer.elements.std.csv
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.elements.std.csv
@@ -9,7 +9,7 @@ code,name,unit,unit_description,number_occurrences,Dataset,name_standardised,uni
 645,Food supply quantity (kg/capita/yr),kg,kilograms,966185,FBSC,Food available for consumption,kg_per_capita_per_year,1
 5611,Import Quantity,1000 tonnes,thousand tonnes,1008063,FBSC,Imports,tonnes,1.00E+03
 5313,Laying,1000 Head,thousand head,23081,QCL,,,
-5123,Losses,1000 tonnes,thousand tonnes,339465,FBSC,Waste,tonnes,1.00E+03
+5123,Losses,1000 tonnes,thousand tonnes,339465,FBSC,Waste in Supply Chain,tonnes,1.00E+03
 5154,Other uses (non-food),1000 tonnes,thousand tonnes,418035,FBSC,Other uses,tonnes,1.00E+03
 5131,Processing,1000 tonnes,thousand tonnes,199001,FBSC,,,
 5321,Producing Animals/Slaughtered,1000 Head,thousand head,35354,QCL,Animals slaughtered,animals,1000

--- a/etl/steps/data/garden/explorers/2021/food_explorer.elements.std.csv
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.elements.std.csv
@@ -12,8 +12,8 @@ code,name,unit,unit_description,number_occurrences,Dataset,name_standardised,uni
 5123,Losses,1000 tonnes,thousand tonnes,339465,FBSC,Waste in Supply Chain,tonnes,1.00E+03
 5154,Other uses (non-food),1000 tonnes,thousand tonnes,418035,FBSC,Other uses,tonnes,1.00E+03
 5131,Processing,1000 tonnes,thousand tonnes,199001,FBSC,,,
-5321,Producing Animals/Slaughtered,1000 Head,thousand head,35354,QCL,Animals slaughtered,animals,1000
-5320,Producing Animals/Slaughtered,Head,head,149439,QCL,Animals slaughtered,animals,1
+5321,Producing Animals/Slaughtered,1000 Head,thousand head,35354,QCL,Producing or slaughtered animals,animals,1000
+5320,Producing Animals/Slaughtered,Head,head,149439,QCL,Producing or slaughtered animals,animals,1
 5513,Production,1000 No,thousand number,13174,QCL,,,
 5510,Production,tonnes,tonnes,996973,QCL,Production,tonnes,1
 5511,Production,1000 tonnes,thousand tonnes,683798,FBSC,,,

--- a/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
@@ -1339,7 +1339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "id": "f9fd878f-47ca-4569-8bb4-f764f1244d4e",
    "metadata": {},
    "outputs": [],
@@ -1362,7 +1362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "id": "2be4a477-197a-411d-8d52-d103036cf54b",
    "metadata": {},
    "outputs": [
@@ -1515,7 +1515,7 @@
        "      <td>thousand tonnes</td>\n",
        "      <td>339465</td>\n",
        "      <td>FBSC</td>\n",
-       "      <td>Waste</td>\n",
+       "      <td>Waste in Supply Chain</td>\n",
        "      <td>tonnes</td>\n",
        "      <td>1000.0000</td>\n",
        "    </tr>\n",
@@ -1691,7 +1691,7 @@
        "664   Food available for consumption                kcal_per_day_per_capita   \n",
        "645   Food available for consumption                 kg_per_capita_per_year   \n",
        "5611                         Imports                                 tonnes   \n",
-       "5123                           Waste                                 tonnes   \n",
+       "5123           Waste in Supply Chain                                 tonnes   \n",
        "5154                      Other uses                                 tonnes   \n",
        "5321             Animals slaughtered                                animals   \n",
        "5320             Animals slaughtered                                animals   \n",
@@ -1727,7 +1727,7 @@
        "5417       0.1000  "
       ]
      },
-     "execution_count": 24,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1747,7 +1747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "id": "8a980add-06d6-4b8d-96b0-be53678bd3f0",
    "metadata": {},
    "outputs": [],
@@ -1767,7 +1767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "id": "2c30000a-40bd-4a97-a99e-775127cb49ac",
    "metadata": {},
    "outputs": [],
@@ -1791,7 +1791,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "id": "45399108-669d-4771-a55e-84af45544cc4",
    "metadata": {},
    "outputs": [],
@@ -1818,7 +1818,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 26,
    "id": "06553ff8-56e3-4c03-8e01-ec36c172c637",
    "metadata": {},
    "outputs": [],
@@ -1837,7 +1837,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 27,
    "id": "aa7c11c6-d286-4c42-9612-105db99d32f3",
    "metadata": {},
    "outputs": [],
@@ -1849,7 +1849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "id": "e8ec1808-8715-4473-b129-98434c4eadd7",
    "metadata": {},
    "outputs": [
@@ -1966,7 +1966,7 @@
        "                      1965                  <NA>  "
       ]
      },
-     "execution_count": 30,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1989,7 +1989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 29,
    "id": "1b564750-ee04-48d2-85c3-7c0c00c351b3",
    "metadata": {},
    "outputs": [],
@@ -2009,7 +2009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 30,
    "id": "fe7f4012-4b80-41a1-8cf0-d83d887d6014",
    "metadata": {},
    "outputs": [
@@ -2028,7 +2028,7 @@
        " 572: 'Avocados'}"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2047,7 +2047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 31,
    "id": "af18fe34-5475-4dd6-b285-2e2dd2d3ae04",
    "metadata": {},
    "outputs": [
@@ -2055,60 +2055,59 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "There are 52 fused products:\n",
+      "There are 51 fused products:\n",
       " name\n",
-      "Apples                        [515, 2617]\n",
-      "Bananas                       [486, 2615]\n",
-      "Barley                         [44, 2513]\n",
-      "Beans, dry                    [2546, 176]\n",
-      "Cassava                       [125, 2532]\n",
-      "Chillies and peppers, dry     [689, 2641]\n",
-      "Coconut oil                   [2578, 252]\n",
-      "Cottonseed                    [329, 2559]\n",
-      "Cottonseed oil                [2575, 331]\n",
-      "Dates                         [577, 2619]\n",
-      "Eggs                         [2949, 1783]\n",
-      "Fruit                        [1738, 2919]\n",
-      "Grapefruit                    [507, 2613]\n",
-      "Groundnut oil                 [2572, 244]\n",
-      "Groundnuts                    [2556, 242]\n",
-      "Honey                        [2745, 1182]\n",
-      "Lemons and limes              [497, 2612]\n",
-      "Maize                          [56, 2514]\n",
-      "Maize oil                      [2582, 60]\n",
-      "Meat, Total                  [2943, 1765]\n",
-      "Meat, poultry                [1808, 2734]\n",
-      "Milk                         [2948, 1780]\n",
-      "Millet                         [79, 2517]\n",
-      "Oilcrops                     [1731, 2913]\n",
-      "Olive oil                     [261, 2580]\n",
-      "Olives                        [260, 2563]\n",
-      "Onions                        [2602, 403]\n",
-      "Oranges                       [490, 2611]\n",
-      "Palm kernel oil               [258, 2576]\n",
-      "Palm kernels                  [256, 2562]\n",
-      "Peas, dry                     [2547, 187]\n",
-      "Pepper                        [2640, 687]\n",
-      "Plantains                     [2616, 489]\n",
-      "Potatoes                      [116, 2531]\n",
-      "Pulses                       [2911, 1726]\n",
-      "Rice                           [2805, 27]\n",
-      "Rye                            [71, 2515]\n",
-      "Sesame oil                    [290, 2579]\n",
-      "Sesame seed                   [289, 2561]\n",
-      "Sorghum                        [83, 2518]\n",
-      "Soybean oil                   [237, 2571]\n",
-      "Soybeans                      [2555, 236]\n",
-      "Sugar beet                    [157, 2537]\n",
-      "Sugar cane                    [156, 2536]\n",
-      "Sugar crops                  [2908, 1723]\n",
-      "Sunflower oil                 [268, 2573]\n",
-      "Sunflower seed                [267, 2557]\n",
-      "Sweet potatoes                [122, 2533]\n",
-      "Tomatoes                      [388, 2601]\n",
-      "Vegetables                   [2918, 1735]\n",
-      "Wheat                          [15, 2511]\n",
-      "Yams                          [137, 2535]\n",
+      "Apples               [515, 2617]\n",
+      "Bananas              [486, 2615]\n",
+      "Barley                [44, 2513]\n",
+      "Beans, dry           [2546, 176]\n",
+      "Cassava              [125, 2532]\n",
+      "Coconut oil          [2578, 252]\n",
+      "Cottonseed           [329, 2559]\n",
+      "Cottonseed oil       [2575, 331]\n",
+      "Dates                [577, 2619]\n",
+      "Eggs                [2949, 1783]\n",
+      "Fruit               [1738, 2919]\n",
+      "Grapefruit           [507, 2613]\n",
+      "Groundnut oil        [2572, 244]\n",
+      "Groundnuts           [2556, 242]\n",
+      "Honey               [2745, 1182]\n",
+      "Lemons and limes     [497, 2612]\n",
+      "Maize                 [56, 2514]\n",
+      "Maize oil             [2582, 60]\n",
+      "Meat, Total         [2943, 1765]\n",
+      "Meat, poultry       [1808, 2734]\n",
+      "Milk                [2948, 1780]\n",
+      "Millet                [79, 2517]\n",
+      "Oilcrops            [1731, 2913]\n",
+      "Olive oil            [261, 2580]\n",
+      "Olives               [260, 2563]\n",
+      "Onions               [2602, 403]\n",
+      "Oranges              [490, 2611]\n",
+      "Palm kernel oil      [258, 2576]\n",
+      "Palm kernels         [256, 2562]\n",
+      "Peas, dry            [2547, 187]\n",
+      "Pepper               [2640, 687]\n",
+      "Plantains            [2616, 489]\n",
+      "Potatoes             [116, 2531]\n",
+      "Pulses              [2911, 1726]\n",
+      "Rice                  [2805, 27]\n",
+      "Rye                   [71, 2515]\n",
+      "Sesame oil           [290, 2579]\n",
+      "Sesame seed          [289, 2561]\n",
+      "Sorghum               [83, 2518]\n",
+      "Soybean oil          [237, 2571]\n",
+      "Soybeans             [2555, 236]\n",
+      "Sugar beet           [157, 2537]\n",
+      "Sugar cane           [156, 2536]\n",
+      "Sugar crops         [2908, 1723]\n",
+      "Sunflower oil        [268, 2573]\n",
+      "Sunflower seed       [267, 2557]\n",
+      "Sweet potatoes       [122, 2533]\n",
+      "Tomatoes             [388, 2601]\n",
+      "Vegetables          [2918, 1735]\n",
+      "Wheat                 [15, 2511]\n",
+      "Yams                 [137, 2535]\n",
       "Name: index, dtype: object\n"
      ]
     }
@@ -2123,7 +2122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 32,
    "id": "0eb99ea9-2457-4d22-ae23-52d15f71e4ad",
    "metadata": {},
    "outputs": [],
@@ -2149,7 +2148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 33,
    "id": "2c68a20f-e46f-4aa8-8ba9-4ec010839468",
    "metadata": {},
    "outputs": [],
@@ -2166,7 +2165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 34,
    "id": "7c9e522f-7a57-44c3-918a-a519ca9464f8",
    "metadata": {},
    "outputs": [],
@@ -2188,7 +2187,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 341,
+   "execution_count": 35,
    "id": "82898260-9b51-49bd-a23b-8a289abc7dcd",
    "metadata": {},
    "outputs": [],
@@ -2199,7 +2198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 342,
+   "execution_count": 36,
    "id": "9c473b45-e1b6-4f54-9746-2b8ccf0c7e7d",
    "metadata": {},
    "outputs": [
@@ -2207,9 +2206,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "QCL // shape: (1029659, 5) / not-NaN: 2123392\n",
+      "QCL // shape: (1022499, 5) / not-NaN: 2105281\n",
       "FBSC // shape: (560802, 11) / not-NaN: 4364188\n",
-      "FE // shape: (1310361, 16) / not-NaN: 6487580\n"
+      "FE // shape: (1306764, 16) / not-NaN: 6469469\n"
      ]
     }
    ],
@@ -2221,7 +2220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 343,
+   "execution_count": 37,
    "id": "2adc3d98-4d00-45f3-97a1-c261bbf554b1",
    "metadata": {},
    "outputs": [
@@ -2229,7 +2228,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FE (after NaN-drop): (1125968, 16)\n"
+      "FE (after NaN-drop): (1123024, 16)\n"
      ]
     }
    ],
@@ -2241,7 +2240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 344,
+   "execution_count": 38,
    "id": "cd65eb08-512a-4656-9856-692689944978",
    "metadata": {},
    "outputs": [
@@ -2249,7 +2248,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(1125968, 16)\n"
+      "(1123024, 16)\n"
      ]
     },
     {
@@ -2288,7 +2287,7 @@
        "      <th>food_available_for_consumption__kcal_per_day_per_capita</th>\n",
        "      <th>food_available_for_consumption__kg_per_capita_per_year</th>\n",
        "      <th>imports__tonnes</th>\n",
-       "      <th>waste__tonnes</th>\n",
+       "      <th>waste_in_supply_chain__tonnes</th>\n",
        "      <th>other_uses__tonnes</th>\n",
        "      <th>food_available_for_consumption__protein_g_per_day_per_capita</th>\n",
        "    </tr>\n",
@@ -2481,13 +2480,21 @@
        "                    1978                                                NaN        \n",
        "                    1979                                                NaN        \n",
        "\n",
-       "Element Code              imports__tonnes  waste__tonnes  other_uses__tonnes  \\\n",
-       "Product Country     Year                                                       \n",
-       "Almonds Afghanistan 1975              NaN            NaN                 NaN   \n",
-       "                    1976              NaN            NaN                 NaN   \n",
-       "                    1977              NaN            NaN                 NaN   \n",
-       "                    1978              NaN            NaN                 NaN   \n",
-       "                    1979              NaN            NaN                 NaN   \n",
+       "Element Code              imports__tonnes  waste_in_supply_chain__tonnes  \\\n",
+       "Product Country     Year                                                   \n",
+       "Almonds Afghanistan 1975              NaN                            NaN   \n",
+       "                    1976              NaN                            NaN   \n",
+       "                    1977              NaN                            NaN   \n",
+       "                    1978              NaN                            NaN   \n",
+       "                    1979              NaN                            NaN   \n",
+       "\n",
+       "Element Code              other_uses__tonnes  \\\n",
+       "Product Country     Year                       \n",
+       "Almonds Afghanistan 1975                 NaN   \n",
+       "                    1976                 NaN   \n",
+       "                    1977                 NaN   \n",
+       "                    1978                 NaN   \n",
+       "                    1979                 NaN   \n",
        "\n",
        "Element Code              food_available_for_consumption__protein_g_per_day_per_capita  \n",
        "Product Country     Year                                                                \n",
@@ -2498,7 +2505,7 @@
        "                    1979                                                NaN             "
       ]
      },
-     "execution_count": 344,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2527,7 +2534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 345,
+   "execution_count": 39,
    "id": "0bae636c-79f3-44bc-ad2f-f4f3fe4c4744",
    "metadata": {},
    "outputs": [],
@@ -2554,7 +2561,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 346,
+   "execution_count": 40,
    "id": "917c1d6a-cd66-4e91-827e-641c6720f19f",
    "metadata": {},
    "outputs": [],
@@ -2566,7 +2573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 347,
+   "execution_count": 41,
    "id": "0f7949cc-12df-4ae3-bd8a-82c0c2f151f7",
    "metadata": {},
    "outputs": [
@@ -2574,7 +2581,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Missing 17 countries: {'USSR', 'Polynesia', 'Yugoslavia', 'Asia', 'Europe', 'Melanesia', 'Serbia and Montenegro', 'Czechoslovakia', 'Niue', 'Africa', 'Cook Islands', 'Oceania', 'French Polynesia', 'Tokelau', 'Macao', 'Eritrea and Ethiopia', 'Bermuda'}\n",
+      "Missing 17 countries: {'Niue', 'French Polynesia', 'Czechoslovakia', 'Asia', 'USSR', 'Macao', 'Serbia and Montenegro', 'Africa', 'Oceania', 'Eritrea and Ethiopia', 'Cook Islands', 'Yugoslavia', 'Tokelau', 'Europe', 'Melanesia', 'Bermuda', 'Polynesia'}\n",
       "Decrease of 9% rows\n"
      ]
     }
@@ -2605,7 +2612,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 348,
+   "execution_count": 42,
    "id": "7b391137-2642-45f7-bedc-34dbc8a33710",
    "metadata": {},
    "outputs": [],
@@ -2641,7 +2648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 349,
+   "execution_count": 43,
    "id": "02921d82-0454-4c1a-837a-0c615b7b94a0",
    "metadata": {},
    "outputs": [],
@@ -2680,7 +2687,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 350,
+   "execution_count": 44,
    "id": "d2b4a30b-fba6-434b-84ed-bf556ae74146",
    "metadata": {},
    "outputs": [],
@@ -2699,7 +2706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 351,
+   "execution_count": 45,
    "id": "980cecc4-5c3b-4c09-90b9-5e2d5873eda8",
    "metadata": {},
    "outputs": [],
@@ -2722,7 +2729,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 352,
+   "execution_count": 46,
    "id": "c4eca576-ca7d-44cd-8def-9f5232a93fa7",
    "metadata": {},
    "outputs": [],
@@ -2742,7 +2749,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 353,
+   "execution_count": 47,
    "id": "2c9543c5-f007-4c23-adda-ee9caa9ced11",
    "metadata": {},
    "outputs": [
@@ -2752,7 +2759,7 @@
      "text": [
       "1.07% increase in rows\n",
       "5.79% increase in rows\n",
-      "4.04% increase in rows\n"
+      "4.02% increase in rows\n"
      ]
     }
    ],
@@ -2784,7 +2791,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 354,
+   "execution_count": 48,
    "id": "cba5d1b2-7c08-4cf3-ab72-7215e9dc14d2",
    "metadata": {},
    "outputs": [],
@@ -2803,7 +2810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 355,
+   "execution_count": 49,
    "id": "a24ccaa0-36c4-4c25-9991-a51fb5a04827",
    "metadata": {},
    "outputs": [],
@@ -2829,7 +2836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 356,
+   "execution_count": 50,
    "id": "ca4b04f6-2bdf-42cb-95c7-f30b21db6158",
    "metadata": {},
    "outputs": [],
@@ -2848,7 +2855,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 357,
+   "execution_count": 51,
    "id": "0ba04bbd-8650-4dbe-9797-4512f599ae7d",
    "metadata": {},
    "outputs": [
@@ -2872,7 +2879,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 358,
+   "execution_count": 52,
    "id": "45bb6107-13df-43ce-b7d2-be58a8a56fdd",
    "metadata": {},
    "outputs": [],
@@ -2892,7 +2899,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 359,
+   "execution_count": 53,
    "id": "38505ff2-c5ff-4c29-8a19-57231652ef2d",
    "metadata": {},
    "outputs": [],
@@ -2910,7 +2917,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 360,
+   "execution_count": 54,
    "id": "a2eae09b-a6f3-4b4e-94e8-bbbb35cd4ed1",
    "metadata": {},
    "outputs": [],
@@ -2941,7 +2948,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 361,
+   "execution_count": 55,
    "id": "0425a7d7-c007-4513-a58f-5cde33af7711",
    "metadata": {},
    "outputs": [
@@ -2961,7 +2968,7 @@
        "Name: food_available_for_consumption__kcal_per_day, dtype: float64"
       ]
      },
-     "execution_count": 361,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2976,7 +2983,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 362,
+   "execution_count": 56,
    "id": "9427afb2-b765-4019-9056-af14ab3ed983",
    "metadata": {},
    "outputs": [],

--- a/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
@@ -1339,7 +1339,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "id": "f9fd878f-47ca-4569-8bb4-f764f1244d4e",
    "metadata": {},
    "outputs": [],
@@ -1362,7 +1362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "2be4a477-197a-411d-8d52-d103036cf54b",
    "metadata": {},
    "outputs": [
@@ -1531,6 +1531,28 @@
        "      <td>1000.0000</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>5321</th>\n",
+       "      <td>Producing Animals/Slaughtered</td>\n",
+       "      <td>1000 Head</td>\n",
+       "      <td>thousand head</td>\n",
+       "      <td>35354</td>\n",
+       "      <td>QCL</td>\n",
+       "      <td>Animals slaughtered</td>\n",
+       "      <td>animals</td>\n",
+       "      <td>1000.0000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5320</th>\n",
+       "      <td>Producing Animals/Slaughtered</td>\n",
+       "      <td>Head</td>\n",
+       "      <td>head</td>\n",
+       "      <td>149439</td>\n",
+       "      <td>QCL</td>\n",
+       "      <td>Animals slaughtered</td>\n",
+       "      <td>animals</td>\n",
+       "      <td>1.0000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>5510</th>\n",
        "      <td>Production</td>\n",
        "      <td>tonnes</td>\n",
@@ -1625,6 +1647,8 @@
        "5611                         Import Quantity      1000 tonnes   \n",
        "5123                                  Losses      1000 tonnes   \n",
        "5154                   Other uses (non-food)      1000 tonnes   \n",
+       "5321           Producing Animals/Slaughtered        1000 Head   \n",
+       "5320           Producing Animals/Slaughtered             Head   \n",
        "5510                              Production           tonnes   \n",
        "674   Protein supply quantity (g/capita/day)     g/capita/day   \n",
        "5410                                   Yield         100mg/An   \n",
@@ -1646,6 +1670,8 @@
        "5611                 thousand tonnes             1008063    FBSC   \n",
        "5123                 thousand tonnes              339465    FBSC   \n",
        "5154                 thousand tonnes              418035    FBSC   \n",
+       "5321                   thousand head               35354     QCL   \n",
+       "5320                            head              149439     QCL   \n",
        "5510                          tonnes              996973     QCL   \n",
        "674         grams per capita per day              868087    FBSC   \n",
        "5410       100 milligrams per animal               23088     QCL   \n",
@@ -1667,6 +1693,8 @@
        "5611                         Imports                                 tonnes   \n",
        "5123                           Waste                                 tonnes   \n",
        "5154                      Other uses                                 tonnes   \n",
+       "5321             Animals slaughtered                                animals   \n",
+       "5320             Animals slaughtered                                animals   \n",
        "5510                      Production                                 tonnes   \n",
        "674   Food available for consumption           protein_g_per_day_per_capita   \n",
        "5410                           Yield                          kg_per_animal   \n",
@@ -1688,6 +1716,8 @@
        "5611    1000.0000  \n",
        "5123    1000.0000  \n",
        "5154    1000.0000  \n",
+       "5321    1000.0000  \n",
+       "5320       1.0000  \n",
        "5510       1.0000  \n",
        "674        1.0000  \n",
        "5410       0.0001  \n",
@@ -1697,7 +1727,7 @@
        "5417       0.1000  "
       ]
      },
-     "execution_count": 22,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1717,7 +1747,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "id": "8a980add-06d6-4b8d-96b0-be53678bd3f0",
    "metadata": {},
    "outputs": [],
@@ -1737,7 +1767,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "id": "2c30000a-40bd-4a97-a99e-775127cb49ac",
    "metadata": {},
    "outputs": [],
@@ -1752,21 +1782,30 @@
    "id": "24fee009-0f47-43ed-833a-c33d7507d8f3",
    "metadata": {},
    "source": [
-    "Next, we merge codes 5417, 5420, 5424 and 5410 into a single one. As previously highlighted, all of them are mapped to the same (name, unit) tupple."
+    "Next, we merge codes into single codes:\n",
+    "- **Yield**: `5417, 5420, 5424, 5410 ---> 5417` (QCL)\n",
+    "- **Animals slaughtered**: `5320, 5321 ---> 5320` (QCL)\n",
+    "\n",
+    "As previously highlighted, all of them are mapped to the same (name, unit) tupple."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "id": "180ca094-27f3-4b26-828b-8f8e8a11feaf",
+   "execution_count": 27,
+   "id": "45399108-669d-4771-a55e-84af45544cc4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Merge 5417,5420,5424,5410 --> 5417\n",
-    "qcl_bulk[5417] = qcl_bulk[5417].fillna(\n",
-    "    qcl_bulk[5420].fillna(qcl_bulk[5424].fillna(qcl_bulk[5410]))\n",
-    ")\n",
-    "qcl_bulk = qcl_bulk.drop(columns=[5420, 5424, 5410])"
+    "# QCL\n",
+    "item_code_merge = {\n",
+    "    5417: [5420, 5424, 5410],\n",
+    "    5320: [5321],\n",
+    "}\n",
+    "items_drop = [ii for i in item_code_merge.values() for ii in i]\n",
+    "for code_new, codes_old in item_code_merge.items():\n",
+    "    for code_old in codes_old:\n",
+    "        qcl_bulk[code_new] = qcl_bulk[code_new].fillna(qcl_bulk[code_old])\n",
+    "qcl_bulk = qcl_bulk.drop(columns=items_drop)"
    ]
   },
   {
@@ -1779,7 +1818,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "id": "06553ff8-56e3-4c03-8e01-ec36c172c637",
    "metadata": {},
    "outputs": [],
@@ -1798,7 +1837,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "id": "aa7c11c6-d286-4c42-9612-105db99d32f3",
    "metadata": {},
    "outputs": [],
@@ -1810,7 +1849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "id": "e8ec1808-8715-4473-b129-98434c4eadd7",
    "metadata": {},
    "outputs": [
@@ -1838,6 +1877,7 @@
        "      <th></th>\n",
        "      <th>Element Code</th>\n",
        "      <th>area_harvested__ha</th>\n",
+       "      <th>animals_slaughtered__animals</th>\n",
        "      <th>production__tonnes</th>\n",
        "      <th>yield__tonnes_per_ha</th>\n",
        "      <th>yield__kg_per_animal</th>\n",
@@ -1850,6 +1890,7 @@
        "      <th></th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
+       "      <th></th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1858,6 +1899,7 @@
        "      <th rowspan=\"5\" valign=\"top\">15</th>\n",
        "      <th>1961</th>\n",
        "      <td>2230000.0</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>2279000.0</td>\n",
        "      <td>1.022</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1865,6 +1907,7 @@
        "    <tr>\n",
        "      <th>1962</th>\n",
        "      <td>2341000.0</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>2279000.0</td>\n",
        "      <td>0.9735</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1872,6 +1915,7 @@
        "    <tr>\n",
        "      <th>1963</th>\n",
        "      <td>2341000.0</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>1947000.0</td>\n",
        "      <td>0.8317</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1879,6 +1923,7 @@
        "    <tr>\n",
        "      <th>1964</th>\n",
        "      <td>2345000.0</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>2230000.0</td>\n",
        "      <td>0.951</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1886,6 +1931,7 @@
        "    <tr>\n",
        "      <th>1965</th>\n",
        "      <td>2347000.0</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>2282000.0</td>\n",
        "      <td>0.9723</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -1895,24 +1941,32 @@
        "</div>"
       ],
       "text/plain": [
-       "Element Code                area_harvested__ha  production__tonnes  \\\n",
-       "Country     Item Code Year                                           \n",
-       "Afghanistan 15        1961           2230000.0           2279000.0   \n",
-       "                      1962           2341000.0           2279000.0   \n",
-       "                      1963           2341000.0           1947000.0   \n",
-       "                      1964           2345000.0           2230000.0   \n",
-       "                      1965           2347000.0           2282000.0   \n",
+       "Element Code                area_harvested__ha  animals_slaughtered__animals  \\\n",
+       "Country     Item Code Year                                                     \n",
+       "Afghanistan 15        1961           2230000.0                          <NA>   \n",
+       "                      1962           2341000.0                          <NA>   \n",
+       "                      1963           2341000.0                          <NA>   \n",
+       "                      1964           2345000.0                          <NA>   \n",
+       "                      1965           2347000.0                          <NA>   \n",
        "\n",
-       "Element Code                yield__tonnes_per_ha  yield__kg_per_animal  \n",
-       "Country     Item Code Year                                              \n",
-       "Afghanistan 15        1961                 1.022                  <NA>  \n",
-       "                      1962                0.9735                  <NA>  \n",
-       "                      1963                0.8317                  <NA>  \n",
-       "                      1964                 0.951                  <NA>  \n",
-       "                      1965                0.9723                  <NA>  "
+       "Element Code                production__tonnes  yield__tonnes_per_ha  \\\n",
+       "Country     Item Code Year                                             \n",
+       "Afghanistan 15        1961           2279000.0                 1.022   \n",
+       "                      1962           2279000.0                0.9735   \n",
+       "                      1963           1947000.0                0.8317   \n",
+       "                      1964           2230000.0                 0.951   \n",
+       "                      1965           2282000.0                0.9723   \n",
+       "\n",
+       "Element Code                yield__kg_per_animal  \n",
+       "Country     Item Code Year                        \n",
+       "Afghanistan 15        1961                  <NA>  \n",
+       "                      1962                  <NA>  \n",
+       "                      1963                  <NA>  \n",
+       "                      1964                  <NA>  \n",
+       "                      1965                  <NA>  "
       ]
      },
-     "execution_count": 28,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1935,7 +1989,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 32,
    "id": "1b564750-ee04-48d2-85c3-7c0c00c351b3",
    "metadata": {},
    "outputs": [],
@@ -1955,7 +2009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 33,
    "id": "fe7f4012-4b80-41a1-8cf0-d83d887d6014",
    "metadata": {},
    "outputs": [
@@ -1974,7 +2028,7 @@
        " 572: 'Avocados'}"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1993,7 +2047,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 34,
    "id": "af18fe34-5475-4dd6-b285-2e2dd2d3ae04",
    "metadata": {},
    "outputs": [
@@ -2001,7 +2055,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "There are 51 fused products:\n",
+      "There are 52 fused products:\n",
       " name\n",
       "Apples                        [515, 2617]\n",
       "Bananas                       [486, 2615]\n",
@@ -2036,6 +2090,7 @@
       "Peas, dry                     [2547, 187]\n",
       "Pepper                        [2640, 687]\n",
       "Plantains                     [2616, 489]\n",
+      "Potatoes                      [116, 2531]\n",
       "Pulses                       [2911, 1726]\n",
       "Rice                           [2805, 27]\n",
       "Rye                            [71, 2515]\n",
@@ -2068,7 +2123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 35,
    "id": "0eb99ea9-2457-4d22-ae23-52d15f71e4ad",
    "metadata": {},
    "outputs": [],
@@ -2094,7 +2149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 36,
    "id": "2c68a20f-e46f-4aa8-8ba9-4ec010839468",
    "metadata": {},
    "outputs": [],
@@ -2111,7 +2166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 37,
    "id": "7c9e522f-7a57-44c3-918a-a519ca9464f8",
    "metadata": {},
    "outputs": [],
@@ -2133,7 +2188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 341,
    "id": "82898260-9b51-49bd-a23b-8a289abc7dcd",
    "metadata": {},
    "outputs": [],
@@ -2144,7 +2199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 342,
    "id": "9c473b45-e1b6-4f54-9746-2b8ccf0c7e7d",
    "metadata": {},
    "outputs": [
@@ -2152,9 +2207,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "QCL // shape: (1032796, 4) / not-NaN: 1939848\n",
-      "FBSC // shape: (541771, 11) / not-NaN: 4191046\n",
-      "FE // shape: (1302120, 15) / not-NaN: 6130894\n"
+      "QCL // shape: (1029659, 5) / not-NaN: 2123392\n",
+      "FBSC // shape: (560802, 11) / not-NaN: 4364188\n",
+      "FE // shape: (1310361, 16) / not-NaN: 6487580\n"
      ]
     }
    ],
@@ -2166,7 +2221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 343,
    "id": "2adc3d98-4d00-45f3-97a1-c261bbf554b1",
    "metadata": {},
    "outputs": [
@@ -2174,7 +2229,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FE (after NaN-drop): (1116233, 15)\n"
+      "FE (after NaN-drop): (1125968, 16)\n"
      ]
     }
    ],
@@ -2186,7 +2241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 344,
    "id": "cd65eb08-512a-4656-9856-692689944978",
    "metadata": {},
    "outputs": [
@@ -2194,7 +2249,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(1116233, 15)\n"
+      "(1125968, 16)\n"
      ]
     },
     {
@@ -2221,6 +2276,7 @@
        "      <th></th>\n",
        "      <th>Element Code</th>\n",
        "      <th>area_harvested__ha</th>\n",
+       "      <th>animals_slaughtered__animals</th>\n",
        "      <th>production__tonnes</th>\n",
        "      <th>yield__tonnes_per_ha</th>\n",
        "      <th>yield__kg_per_animal</th>\n",
@@ -2255,6 +2311,7 @@
        "      <th></th>\n",
        "      <th></th>\n",
        "      <th></th>\n",
+       "      <th></th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -2263,6 +2320,7 @@
        "      <th rowspan=\"5\" valign=\"top\">Afghanistan</th>\n",
        "      <th>1975</th>\n",
        "      <td>0.0</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>0.0</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -2281,6 +2339,7 @@
        "    <tr>\n",
        "      <th>1976</th>\n",
        "      <td>5900.0</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>9800.0</td>\n",
        "      <td>1.661</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -2299,6 +2358,7 @@
        "    <tr>\n",
        "      <th>1977</th>\n",
        "      <td>6000.0</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>9000.0</td>\n",
        "      <td>1.5</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -2317,6 +2377,7 @@
        "    <tr>\n",
        "      <th>1978</th>\n",
        "      <td>6000.0</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>12000.0</td>\n",
        "      <td>2.0</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -2335,6 +2396,7 @@
        "    <tr>\n",
        "      <th>1979</th>\n",
        "      <td>6000.0</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
        "      <td>10500.0</td>\n",
        "      <td>1.75</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -2355,29 +2417,37 @@
        "</div>"
       ],
       "text/plain": [
-       "Element Code              area_harvested__ha  production__tonnes  \\\n",
-       "Product Country     Year                                           \n",
-       "Almonds Afghanistan 1975                 0.0                 0.0   \n",
-       "                    1976              5900.0              9800.0   \n",
-       "                    1977              6000.0              9000.0   \n",
-       "                    1978              6000.0             12000.0   \n",
-       "                    1979              6000.0             10500.0   \n",
+       "Element Code              area_harvested__ha  animals_slaughtered__animals  \\\n",
+       "Product Country     Year                                                     \n",
+       "Almonds Afghanistan 1975                 0.0                          <NA>   \n",
+       "                    1976              5900.0                          <NA>   \n",
+       "                    1977              6000.0                          <NA>   \n",
+       "                    1978              6000.0                          <NA>   \n",
+       "                    1979              6000.0                          <NA>   \n",
        "\n",
-       "Element Code              yield__tonnes_per_ha  yield__kg_per_animal  \\\n",
-       "Product Country     Year                                               \n",
-       "Almonds Afghanistan 1975                  <NA>                  <NA>   \n",
-       "                    1976                 1.661                  <NA>   \n",
-       "                    1977                   1.5                  <NA>   \n",
-       "                    1978                   2.0                  <NA>   \n",
-       "                    1979                  1.75                  <NA>   \n",
-       "\n",
-       "Element Code              domestic_supply__tonnes  exports__tonnes  \\\n",
+       "Element Code              production__tonnes  yield__tonnes_per_ha  \\\n",
        "Product Country     Year                                             \n",
-       "Almonds Afghanistan 1975                      NaN              NaN   \n",
-       "                    1976                      NaN              NaN   \n",
-       "                    1977                      NaN              NaN   \n",
-       "                    1978                      NaN              NaN   \n",
-       "                    1979                      NaN              NaN   \n",
+       "Almonds Afghanistan 1975                 0.0                  <NA>   \n",
+       "                    1976              9800.0                 1.661   \n",
+       "                    1977              9000.0                   1.5   \n",
+       "                    1978             12000.0                   2.0   \n",
+       "                    1979             10500.0                  1.75   \n",
+       "\n",
+       "Element Code              yield__kg_per_animal  domestic_supply__tonnes  \\\n",
+       "Product Country     Year                                                  \n",
+       "Almonds Afghanistan 1975                  <NA>                      NaN   \n",
+       "                    1976                  <NA>                      NaN   \n",
+       "                    1977                  <NA>                      NaN   \n",
+       "                    1978                  <NA>                      NaN   \n",
+       "                    1979                  <NA>                      NaN   \n",
+       "\n",
+       "Element Code              exports__tonnes  \\\n",
+       "Product Country     Year                    \n",
+       "Almonds Afghanistan 1975              NaN   \n",
+       "                    1976              NaN   \n",
+       "                    1977              NaN   \n",
+       "                    1978              NaN   \n",
+       "                    1979              NaN   \n",
        "\n",
        "Element Code              food_available_for_consumption__fat_g_per_day_per_capita  \\\n",
        "Product Country     Year                                                             \n",
@@ -2428,7 +2498,7 @@
        "                    1979                                                NaN             "
       ]
      },
-     "execution_count": 42,
+     "execution_count": 344,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2457,7 +2527,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 345,
    "id": "0bae636c-79f3-44bc-ad2f-f4f3fe4c4744",
    "metadata": {},
    "outputs": [],
@@ -2484,7 +2554,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 346,
    "id": "917c1d6a-cd66-4e91-827e-641c6720f19f",
    "metadata": {},
    "outputs": [],
@@ -2496,7 +2566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 347,
    "id": "0f7949cc-12df-4ae3-bd8a-82c0c2f151f7",
    "metadata": {},
    "outputs": [
@@ -2504,7 +2574,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Missing 17 countries: {'Oceania', 'Yugoslavia', 'Europe', 'Asia', 'French Polynesia', 'Tokelau', 'Niue', 'Eritrea and Ethiopia', 'Bermuda', 'Cook Islands', 'Melanesia', 'Macao', 'USSR', 'Serbia and Montenegro', 'Polynesia', 'Africa', 'Czechoslovakia'}\n",
+      "Missing 17 countries: {'USSR', 'Polynesia', 'Yugoslavia', 'Asia', 'Europe', 'Melanesia', 'Serbia and Montenegro', 'Czechoslovakia', 'Niue', 'Africa', 'Cook Islands', 'Oceania', 'French Polynesia', 'Tokelau', 'Macao', 'Eritrea and Ethiopia', 'Bermuda'}\n",
       "Decrease of 9% rows\n"
      ]
     }
@@ -2535,7 +2605,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 348,
    "id": "7b391137-2642-45f7-bedc-34dbc8a33710",
    "metadata": {},
    "outputs": [],
@@ -2571,7 +2641,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 349,
    "id": "02921d82-0454-4c1a-837a-0c615b7b94a0",
    "metadata": {},
    "outputs": [],
@@ -2610,7 +2680,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 350,
    "id": "d2b4a30b-fba6-434b-84ed-bf556ae74146",
    "metadata": {},
    "outputs": [],
@@ -2629,7 +2699,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 351,
    "id": "980cecc4-5c3b-4c09-90b9-5e2d5873eda8",
    "metadata": {},
    "outputs": [],
@@ -2652,7 +2722,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 352,
    "id": "c4eca576-ca7d-44cd-8def-9f5232a93fa7",
    "metadata": {},
    "outputs": [],
@@ -2672,7 +2742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 353,
    "id": "2c9543c5-f007-4c23-adda-ee9caa9ced11",
    "metadata": {},
    "outputs": [
@@ -2680,9 +2750,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1.08% increase in rows\n",
-      "5.83% increase in rows\n",
-      "4.07% increase in rows\n"
+      "1.07% increase in rows\n",
+      "5.79% increase in rows\n",
+      "4.04% increase in rows\n"
      ]
     }
    ],
@@ -2714,7 +2784,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 354,
    "id": "cba5d1b2-7c08-4cf3-ab72-7215e9dc14d2",
    "metadata": {},
    "outputs": [],
@@ -2733,7 +2803,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 355,
    "id": "a24ccaa0-36c4-4c25-9991-a51fb5a04827",
    "metadata": {},
    "outputs": [],
@@ -2759,7 +2829,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 356,
    "id": "ca4b04f6-2bdf-42cb-95c7-f30b21db6158",
    "metadata": {},
    "outputs": [],
@@ -2778,7 +2848,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 357,
    "id": "0ba04bbd-8650-4dbe-9797-4512f599ae7d",
    "metadata": {},
    "outputs": [
@@ -2802,7 +2872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 358,
    "id": "45bb6107-13df-43ce-b7d2-be58a8a56fdd",
    "metadata": {},
    "outputs": [],
@@ -2822,7 +2892,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 359,
    "id": "38505ff2-c5ff-4c29-8a19-57231652ef2d",
    "metadata": {},
    "outputs": [],
@@ -2840,7 +2910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 360,
    "id": "a2eae09b-a6f3-4b4e-94e8-bbbb35cd4ed1",
    "metadata": {},
    "outputs": [],
@@ -2848,6 +2918,76 @@
     "fe_bulk = fe_bulk.set_index(\n",
     "    [\"Product\", \"Country\", \"Year\"], verify_integrity=True\n",
     ").sort_index()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd15470f-e366-458c-92e1-a0c94896ab72",
+   "metadata": {},
+   "source": [
+    "### 9.4 Value checks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "accc91b5-f61e-4fc7-b16b-21b3703f10f2",
+   "metadata": {},
+   "source": [
+    "#### Remove values for _food_available_for_consumption__kcal_per_day_per_capita_\n",
+    "We remove values for metric `food_available_for_consumption__kcal_per_day_per_capita` whenever they seem wrong. Our criteria is to find out if for a given `(item,country)` this metric only has few values. We define _few_ as below a pre-defined threshold `th`.\n",
+    "\n",
+    "Note, here removing means assigning `NaN` to this metric for the rows considered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 361,
+   "id": "0425a7d7-c007-4513-a58f-5cde33af7711",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "58    0.481601\n",
+       "1     0.617113\n",
+       "27    0.673045\n",
+       "2     0.693749\n",
+       "26    0.710529\n",
+       "19    0.724070\n",
+       "13    0.737023\n",
+       "5     0.748602\n",
+       "3     0.759886\n",
+       "7     0.769797\n",
+       "Name: food_available_for_consumption__kcal_per_day, dtype: float64"
+      ]
+     },
+     "execution_count": 361,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Overview of the distribution of different metric values\n",
+    "res = fe_bulk.groupby(\n",
+    "    [fe_bulk.index.get_level_values(0), fe_bulk.index.get_level_values(1)]\n",
+    ").food_available_for_consumption__kcal_per_day.nunique()\n",
+    "res[res != 0].value_counts(normalize=True).cumsum().head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 362,
+   "id": "9427afb2-b765-4019-9056-af14ab3ed983",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get valid (item,country)\n",
+    "threshold = 5\n",
+    "idx_keep = res[res < threshold].index\n",
+    "# Assign NaNs\n",
+    "index_2 = pd.Index([i[:2] for i in fe_bulk.index])\n",
+    "msk = index_2.isin(idx_keep)\n",
+    "fe_bulk.loc[msk, \"food_available_for_consumption__kcal_per_day\"] = pd.NA"
    ]
   },
   {
@@ -2876,7 +3016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 57,
    "id": "5e11a2df-9018-4db6-a741-c8e23f7fcc74",
    "metadata": {},
    "outputs": [],
@@ -2886,7 +3026,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 58,
    "id": "063d7187-b99d-4c17-a726-d9e44a59806b",
    "metadata": {},
    "outputs": [],
@@ -2925,7 +3065,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 59,
    "id": "97bedabf-2d57-4789-9466-a66ac2f28aba",
    "metadata": {},
    "outputs": [],
@@ -2954,7 +3094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 60,
    "id": "f2711acb-c700-4ce9-89f5-6fbbf7c9a4f6",
    "metadata": {},
    "outputs": [
@@ -3021,6 +3161,7 @@
       "Fat, pigs --> fat_pigs.csv\n",
       "Fat, sheep --> fat_sheep.csv\n",
       "Fibre crops --> fibre_crops.csv\n",
+      "Fish and seafood --> fish_and_seafood.csv\n",
       "Flax fibre --> flax_fibre.csv\n",
       "Fruit --> fruit.csv\n",
       "Garlic --> garlic.csv\n",
@@ -3049,9 +3190,9 @@
       "Margarine --> margarine.csv\n",
       "Meat, Total --> meat_total.csv\n",
       "Meat, ass --> meat_ass.csv\n",
+      "Meat, beef --> meat_beef.csv\n",
       "Meat, buffalo --> meat_buffalo.csv\n",
       "Meat, camel --> meat_camel.csv\n",
-      "Meat, cattle --> meat_cattle.csv\n",
       "Meat, chicken --> meat_chicken.csv\n",
       "Meat, duck --> meat_duck.csv\n",
       "Meat, game --> meat_game.csv\n",
@@ -3059,7 +3200,6 @@
       "Meat, goose and guinea fowl --> meat_goose_and_guinea_fowl.csv\n",
       "Meat, horse --> meat_horse.csv\n",
       "Meat, mule --> meat_mule.csv\n",
-      "Meat, other birds --> meat_other_birds.csv\n",
       "Meat, other camelids --> meat_other_camelids.csv\n",
       "Meat, other rodents --> meat_other_rodents.csv\n",
       "Meat, pig --> meat_pig.csv\n",
@@ -3193,7 +3333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 61,
    "id": "0042dcdd-2cc2-460b-9523-e3167bcaef2b",
    "metadata": {},
    "outputs": [
@@ -3209,8 +3349,8 @@
       "1.6M\t/tmp/food_explorer/maize.csv\n",
       "1.5M\t/tmp/food_explorer/rice.csv\n",
       "1.5M\t/tmp/food_explorer/pulses.csv\n",
-      "1.5M\t/tmp/food_explorer/meat_total.csv\n",
-      "1.5M\t/tmp/food_explorer/meat_poultry.csv\n"
+      "1.5M\t/tmp/food_explorer/potatoes.csv\n",
+      "1.5M\t/tmp/food_explorer/meat_total.csv\n"
      ]
     }
    ],

--- a/etl/steps/data/garden/explorers/2021/food_explorer.items.std.csv
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.items.std.csv
@@ -77,8 +77,8 @@ code,name,type,number_occurences,dataset,name_standardised,Description
 191,Chick peas,,3022,QCL,Chickpeas,"Chickpea, Bengal gram, garbanzos (Cicer arietinum)."
 1057,Chickens,,10893,QCL,Chickens,Fowl (Gallus domesticus); Guinea fowl (Numida meleagris. Domesticated birds only. Data are expressed in thousands.
 459,Chicory roots,,901,QCL,,Horium intybus; C. sativum. Unroasted chicory roots.
-689,"Chillies and peppers, dry",,3835,QCL,"Chillies and peppers, dry","Red and cayenne pepper, paprika, chillies (Capsicum frutescens; C. annuum); allspice, Jamaica pepper (Pimenta officinalis). Uncrushed or unground fresh pimentos are considered to be vegetables."
-401,"Chillies and peppers, green",,6435,QCL,"Chillies and peppers, green","Capsicum annuum; C. fructescens; Pimenta officinalis. Production data exclude crops cultivated explicitly as spices. In contrast, trade data include these crops, provided they are fresh, uncrushed and unground."
+689,"Chillies and peppers, dry",,3835,QCL,"Chillies and peppers","Red and cayenne pepper, paprika, chillies (Capsicum frutescens; C. annuum); allspice, Jamaica pepper (Pimenta officinalis). Uncrushed or unground fresh pimentos are considered to be vegetables."
+401,"Chillies and peppers, green",,6435,QCL,,"Capsicum annuum; C. fructescens; Pimenta officinalis. Production data exclude crops cultivated explicitly as spices. In contrast, trade data include these crops, provided they are fresh, uncrushed and unground."
 693,Cinnamon (cannella),,661,QCL,,"Ceylon cinnamon (Cinnamomum zeylanicum); Chinese, common cinnamon, cassia (C. cassia). The inner bark of young branches of certain trees of the Laurus family. Includes cinnamon- tree flowers, cinnamon fruit and cinnamon waste (chips), whether whole, crushed or ground."
 1804,"Citrus Fruit, Total",Group,7917,QCL,Citrus Fruit,
 2614,"Citrus, Other",,8725,FBSC,,"Default composition: 512 Fruit, citrus nes, 513 Juice, citrus, single strength, 514 Juice, citrus, concentrated"
@@ -209,8 +209,8 @@ code,name,type,number_occurences,dataset,name_standardised,Description
 1097,"Meat, horse",,4230,QCL,"Meat, horse","Fresh, chilled or frozen."
 1111,"Meat, mule",,120,QCL,"Meat, mule","Fresh, chilled or frozen."
 2735,"Meat, Other",,9518,FBSC,,"Default composition: 1089 Meat, bird nes, 1097 Meat, horse, 1108 Meat, ass, 1111 Meat, mule, 1127 Meat, camel, 1141 Meat, rabbit, 1151 Meat, other rodents, 1158 Meat, other camelids, 1163 Meat, game, 1164 Meat, dried nes, 1166 Meat, nes, 1172 Meat, nes, preparations, 1176 Snails, not sea"
-1158,"Meat, other camelids",,118,QCL,"Meat, other camelids","Fresh, chilled or frozen."
-1151,"Meat, other rodents",,118,QCL,"Meat, other rodents","Fresh, chilled or frozen."
+1158,"Meat, other camelids",,118,QCL,,"Fresh, chilled or frozen."
+1151,"Meat, other rodents",,118,QCL,,"Fresh, chilled or frozen."
 1035,"Meat, pig",,9926,QCL,"Meat, pig","Meat, with the bone in, of domestic or wild pigs (e.g. wild boars),whether fresh, chilled or frozen."
 1808,"Meat, Poultry",Group,10883,QCL,"Meat, poultry",
 1141,"Meat, rabbit",,3034,QCL,"Meat, rabbit","Fresh, chilled or frozen. May include hare meat."
@@ -307,7 +307,7 @@ code,name,type,number_occurences,dataset,name_standardised,Description
 197,Pigeon peas,,1386,QCL,Pigeon peas,"Pigeon pea, cajan pea, Congo bean (Cajanus cajan)."
 2733,Pigmeat,,9402,FBSC,Pork,"Default composition: 1035 Meat, pig, 1038 Meat, pork, 1039 Bacon and ham, 1041 Meat, pig sausages, 1042 Meat, pig, preparations"
 1034,Pigs,,9856,QCL,Pigs,Domestic pig (Sus domestica); wild boar (Sus scrofa). See 866. Excludes non-domesticated wild boars.
-2641,Pimento,,8809,FBSC,"Chillies and peppers, dry","Default composition: 689 Chillies and peppers, dry"
+2641,Pimento,,8809,FBSC,"Chillies and peppers","Default composition: 689 Chillies and peppers, dry"
 574,Pineapples,,5131,QCL,,Ananas comosus; A. sativ. Trade figures may include dried pineapples.
 2618,Pineapples and products,,9212,FBSC,Pineapples,"Default composition: 574 Pineapples, 575 Pineapples canned, 576 Juice, pineapple, 580 Juice, pineapple, concentrated"
 223,Pistachios,,1082,QCL,Pistachios,Pistacia vera. Produced mainly in the Near East and the United States.

--- a/etl/steps/data/garden/explorers/2021/food_explorer.items.std.csv
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.items.std.csv
@@ -35,7 +35,7 @@ code,name,type,number_occurences,dataset,name_standardised,Description
 2658,"Beverages, Alcoholic",,9518,FBSC,,"Default composition: 634 Beverages, distilled alcoholic"
 2657,"Beverages, Fermented",,9040,FBSC,,"Default composition: 26 Beverages, fermented wheat, 39 Beverages, fermented rice, 66 Beer of maize, 82 Beer of millet, 86 Beer of sorghum, 517 Cider etc"
 552,Blueberries,,1464,QCL,Blueberries,"European blueberry, wild bilberry, whortleberry (Vaccinium myrtillus); American blueberry (V. corymbosum). Trade data may include cranberries, myrtle berries and other fruits of the genus Vaccinium."
-2731,Bovine Meat,,9518,FBSC,,"Default composition: 867 Meat, cattle, 870 Meat, cattle, boneless (beef & veal), 872 Meat, beef, dried, salted, smoked, 873 Meat, extracts, 874 Meat, beef and veal sausages, 875 Meat, beef, preparations, 876 Meat, beef, canned, 877 Meat, homogenized preparations, 947 Meat, buffalo"
+2731,Bovine Meat,,9518,FBSC,"Meat, beef","Default composition: 867 Meat, cattle, 870 Meat, cattle, boneless (beef & veal), 872 Meat, beef, dried, salted, smoked, 873 Meat, extracts, 874 Meat, beef and veal sausages, 875 Meat, beef, preparations, 876 Meat, beef, canned, 877 Meat, homogenized preparations, 947 Meat, buffalo"
 216,"Brazil nuts, with shell",,306,QCL,"Brazil nuts, with shell","Brazil, Para or cream nut (Bertholletia excelsa)."
 181,"Broad beans, horse beans, dry",,3285,QCL,Broad beans,Vicia faba: horse-bean (var. equina); broad bean (var. major); field bean (var. minor).
 89,Buckwheat,,1397,QCL,Buckwheat,"Fagopyrum esculentum (Polygonaceae). A minor cereal cultivated primarily in northern regions. Buckwheat is considered a cereal, although it does not belong to the gramineous family."
@@ -128,7 +128,7 @@ code,name,type,number_occurences,dataset,name_standardised,Description
 569,Figs,,2735,QCL,,Ficus carica.
 2781,"Fish, Body Oil",,8754,FBSC,,"Default composition: 1509 Frwt Bdy Oil, 1522 Dmrs Bdy Oil, 1535 Pelg Bdy Oil, 1548 Marn Bdy Oil, 1582 Aq M Oils"
 2782,"Fish, Liver Oil",,8065,FBSC,,"Default composition: 1510 Frwt Lvr Oil, 1523 Demersal Liver Oils, 1536 Pelg Lvr Oil, 1549 Marine nes Liver Oils"
-2960,"Fish, Seafood",Group,9513,FBSC,,
+2960,"Fish, Seafood",Group,9513,FBSC,Fish and seafood,
 773,Flax fibre and tow,,1729,QCL,Flax fibre,"Broken, scutched, hackled etc. but not spun. Traditionally, FAO has used this commodity to identify production in its raw state; in reality, the primary agricultural product is the commodity 771, which can either be used for the production of fibre or for other purposes."
 94,Fonio,,590,QCL,,Digitaria spp.: fonio or findi (D. exilis); black fonio or hungry rice (D. iburua). A minor cereal of importance only in West Africa where it is eaten in place of rice during famines. The seeds are cooked by steaming the whole grain.
 2761,Freshwater Fish,,9528,FBSC,,"Default composition: 1501 Frwtr Diad F, 1502 Frwtr Fz Whl, 1503 Frwtr Fillet, 1504 Frwtr Fz Flt, 1505 Frwtr Cured, 1506 Frwtr Canned, 1507 Frwtr Pr nes, 1508 Frwtr Meals"
@@ -197,10 +197,10 @@ code,name,type,number_occurences,dataset,name_standardised,Description
 1166,Meat nes,,2858,QCL,,"Including frog legs, marine mammals, etc. Some countries includeunder this heading meats that are listed above, but which are notreported separately. Fresh, chilled or frozen."
 2768,"Meat, Aquatic Mammals",,174,FBSC,,"Default composition: 1580 Aq M Meat, 1583 Aq M Prep Ns"
 1108,"Meat, ass",,507,QCL,"Meat, ass","Fresh, chilled or frozen."
-1089,"Meat, bird nes",,639,QCL,"Meat, other birds","Fresh, chilled or frozen."
+1089,"Meat, bird nes",,639,QCL,,"Fresh, chilled or frozen."
 947,"Meat, buffalo",,1714,QCL,"Meat, buffalo","Fresh, chilled or frozen, with bone in or boneless."
 1127,"Meat, camel",,1949,QCL,"Meat, camel","Fresh, chilled or frozen."
-867,"Meat, cattle",,10735,QCL,"Meat, cattle","Meat of bovine animals, fresh, chilled or frozen, with bone in. Commontrade names are beef and veal."
+867,"Meat, cattle",,10735,QCL,,"Meat of bovine animals, fresh, chilled or frozen, with bone in. Commontrade names are beef and veal."
 1058,"Meat, chicken",,10883,QCL,"Meat, chicken","Fresh, chilled or frozen. May include all types of poultry meat ifnational statistics do not report separate data."
 1069,"Meat, duck",,4604,QCL,"Meat, duck","Fresh, chilled or frozen."
 1163,"Meat, game",,3390,QCL,"Meat, game","Meat and offals of wild animals, whether fresh, chilled or frozen."


### PR DESCRIPTION
- Add FBSC's metrics for `Meat, beef`, `Fish and seafood`
- Remove products `Meat, other birds`, `Meat, cattle`, `Meat, other camelids`, `Meat, other rodents`
- Redefine product `Chillies and peppers`
- Add metric `Producing or slaughtered animals`
- Rename metric `Waste -> Waste in supply chain`
- Remove values when `food_available_for_consumption__fat_g_per_day` shows irregularities