### PR TITLE
style(black): format code as pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: local
+  hooks:
+    - id: format
+      name: format
+      entry: make format
+      language: system


### PR DESCRIPTION
Fix CI and make sure `make format` runs as a pre-commit hook to avoid these styling bugs in the future. (linting and isort could be added as a pre-commit hook too)