### PR TITLE
fix: include walden metadata in data freshness check

### DIFF
--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -403,10 +403,6 @@ class WaldenStep(Step):
 
         checksum = hashlib.md5(",".join(inputs).encode("utf8")).hexdigest()
 
-        if not checksum:
-            raise Exception(
-                f"no md5 checksum available for walden dataset: {self.path}"
-            )
         return checksum
 
     @property

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -391,8 +391,13 @@ class WaldenStep(Step):
         return True
 
     def checksum_output(self) -> str:
-        inputs: List[str] = [
+        if not self._walden_dataset.md5:
+            raise Exception(f"walden dataset is missing checksum: {self}")
+
+        inputs = [
+            # the contents of the dataset
             self._walden_dataset.md5,
+            # the metadata describing the dataset
             files.checksum_file(self._walden_dataset.index_path),
         ]
 

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -391,7 +391,13 @@ class WaldenStep(Step):
         return True
 
     def checksum_output(self) -> str:
-        checksum: str = cast(str, self._walden_dataset.md5)
+        inputs: List[str] = [
+            self._walden_dataset.md5,
+            files.checksum_file(self._walden_dataset.index_path),
+        ]
+
+        checksum = hashlib.md5(",".join(inputs).encode("utf8")).hexdigest()
+
         if not checksum:
             raise Exception(
                 f"no md5 checksum available for walden dataset: {self.path}"


### PR DESCRIPTION
Resolves #95.

When you decide if data from Walden has changed, consider not only the data file but the metadata itself. This way, if you change the dataset name or description, it will ripple through the ETL and be copied as necessary to downstream datasets.
