### PR TITLE
data(maddison): Production export of the Maddison dataset data

### DIFF
--- a/dag.yml
+++ b/dag.yml
@@ -73,6 +73,9 @@ steps:
   data://garden/ggdc/2020-10-01/ggdc_maddison:
     - walden://ggdc/2020-10-01/ggdc_maddison
 
+  grapher://ggdc/2020-10-01/ggdc_maddison:
+    - data://garden/ggdc/2020-10-01/ggdc_maddison
+
   #
   #  Backported data
   #

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -10,6 +10,8 @@ from typing import Optional, Dict, Literal, cast, List, Any
 from pydantic import BaseModel
 
 from etl.paths import DATA_DIR
+from etl.db import get_connection
+from etl.db_utils import DBUtils
 
 
 # TODO: remove if it turns out to be useless for real examples
@@ -177,6 +179,13 @@ def country_to_entity_id(
         return cast(pd.Series, entity_id.astype("Int64"))
     else:
         return cast(pd.Series, entity_id.astype(int))
+
+
+def get_or_create_entity(name: str) -> int:
+    cursor = get_connection().cursor()
+    db = DBUtils(cursor)
+    print(name)
+    return db.get_or_create_entity(name)
 
 
 def _unique(x: List[Any]) -> List[Any]:

--- a/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
+++ b/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
@@ -1,0 +1,29 @@
+dataset:
+  sources:
+    -
+      name: Maddison Project Database 2020 (Bolt and van Zanden (2020))
+      published_by: Bolt, Jutta and Jan Luiten van Zanden (2020), “Maddison style estimates of the evolution of the world economy. A new 2020 update
+      publisher_source: |
+        The Maddison Project Database is based on the work of many researchers that have produced estimates of
+        economic growth for individual countries. The full list of sources for this historical data is given for each country below.
+
+tables:
+  maddison_gdp:
+    variables:
+      population:
+        title: Population
+        unit: people
+      gdp:
+        title: GDP
+        short_unit: $
+        unit: 2011 int-$
+        description: Gross domestic product measured in international-$ using 2011 prices to adjust for price changes over time (inflation) and price differences between countries. Calculated by multiplying GDP per capita with population.
+        display:
+          entityAnnotationsMap: "Western Offshoots: United States, Canada, Australia and New Zealand"
+      gdp_per_capita:
+        title: GDP per capita
+        short_unit: $
+        unit: 2011 int-$
+        description: Gross domestic product measured in international-$ using 2011 prices to adjust for price changes over time (inflation) and price differences between countries. Calculated by multiplying GDP per capita with population.
+        display:
+          entityAnnotationsMap: "Western Offshoots: United States, Canada, Australia and New Zealand"

--- a/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
+++ b/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
@@ -23,17 +23,7 @@ def get_grapher_dataset() -> catalog.Dataset:
 def get_grapher_tables(dataset: catalog.Dataset) -> Iterable[catalog.Table]:
     table = dataset["maddison_gdp"].reset_index()
 
-    table["entity_id"] = gh.country_to_entity_id(table["country"], errors="warn")
-
-    # TODO: this is really slow, create a separate batch query and nice helper in grapher_helpers
-    # get the remaining entities directly from the DB
-    ix = table.entity_id.isnull()
-    country_entity_id_map = {
-        country: gh.get_or_create_entity(country)
-        for country in set(table.loc[ix, "country"])
-    }
-    table.loc[ix, "entity_id"] = table.loc[ix, "country"].map(country_entity_id_map)
-    assert table.entity_id.notnull().all()
+    table["entity_id"] = gh.country_to_entity_id(table["country"])
 
     table.dropna(subset=["gdp"], inplace=True)
 

--- a/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
+++ b/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
@@ -25,11 +25,17 @@ def get_grapher_tables(dataset: catalog.Dataset) -> Iterable[catalog.Table]:
 
     table["entity_id"] = gh.country_to_entity_id(table["country"], errors="warn")
 
-    # unmapped countries
-    # TODO: should be automatically added in upsert, but are they?
-    # {'South and South-East Asia', 'Western Offshoots', 'Eastern Europe', 'Western Europe',
-    # 'Latin America', 'Sub-Sahara Africa', 'East Asia', 'Middle East'}
-    table.dropna(subset=["entity_id", "gdp"], inplace=True)
+    # TODO: this is really slow, create a separate batch query and nice helper in grapher_helpers
+    # get the remaining entities directly from the DB
+    ix = table.entity_id.isnull()
+    country_entity_id_map = {
+        country: gh.get_or_create_entity(country)
+        for country in set(table.loc[ix, "country"])
+    }
+    table.loc[ix, "entity_id"] = table.loc[ix, "country"].map(country_entity_id_map)
+    assert table.entity_id.notnull().all()
+
+    table.dropna(subset=["gdp"], inplace=True)
 
     table = table.set_index(["entity_id", "year"])[
         ["gdp", "gdp_per_capita", "population"]

--- a/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
+++ b/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
@@ -1,0 +1,38 @@
+from owid import catalog
+from collections.abc import Iterable
+
+from etl.paths import DATA_DIR
+from etl import grapher_helpers as gh
+
+
+def get_grapher_dataset() -> catalog.Dataset:
+    dataset = catalog.Dataset(
+        DATA_DIR / "garden" / "ggdc" / "2020-10-01" / "ggdc_maddison"
+    )
+    # short_name should include dataset name and version
+    dataset.metadata.short_name = "ggdc_maddison__2020_10_01"
+
+    # move description to source as that is what is shown in grapher
+    # (dataset.description would be displayed under `Internal notes` in the admin UI otherwise)
+    dataset.metadata.sources[0].description = dataset.metadata.description
+    dataset.metadata.description = ""
+
+    return dataset
+
+
+def get_grapher_tables(dataset: catalog.Dataset) -> Iterable[catalog.Table]:
+    table = dataset["maddison_gdp"].reset_index()
+
+    table["entity_id"] = gh.country_to_entity_id(table["country"], errors="warn")
+
+    # unmapped countries
+    # TODO: should be automatically added in upsert, but are they?
+    # {'South and South-East Asia', 'Western Offshoots', 'Eastern Europe', 'Western Europe',
+    # 'Latin America', 'Sub-Sahara Africa', 'East Asia', 'Middle East'}
+    table.dropna(subset=["entity_id", "gdp"], inplace=True)
+
+    table = table.set_index(["entity_id", "year"])[
+        ["gdp", "gdp_per_capita", "population"]
+    ]
+
+    yield from gh.yield_wide_table(table)

--- a/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
+++ b/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
@@ -25,10 +25,8 @@ def get_grapher_tables(dataset: catalog.Dataset) -> Iterable[catalog.Table]:
 
     table["entity_id"] = gh.country_to_entity_id(table["country"])
 
-    table.dropna(subset=["gdp"], inplace=True)
-
     table = table.set_index(["entity_id", "year"])[
         ["gdp", "gdp_per_capita", "population"]
     ]
 
-    yield from gh.yield_wide_table(table)
+    yield from gh.yield_wide_table(table, na_action="drop")


### PR DESCRIPTION
Import Maddison dataset from ETL into grapher. This was done in way to have metadata parity with the old version of Maddison. Here's the [old one](https://staging.owid.cloud/admin/datasets/5219) on staging vs the [new one](https://staging.owid.cloud/admin/datasets/5566) for comparison.

There's one "trick" where we map `Dataset.description` to `Source[0].description` to make it work with the grapher model. It's explicit in the code, but we may decide to make it implicit. Metadata is loaded from YAML file using helper methods, but that one might be also improved in the future.

(There's still [one part](https://github.com/owid/etl/pull/144/files#diff-066f8606fbd0d1ebf10c166179474f38f8c508d55ecdb232b1c81b9530fa13f5R28) I need to improve, but that shouldn't prevent review)