### PR TITLE
data(population): population to grapher

### DIFF
--- a/dag.yml
+++ b/dag.yml
@@ -80,6 +80,8 @@ steps:
     - data://meadow/worldbank_wdi/2022-05-26/wdi
   grapher://worldbank_wdi/2022-05-26/wdi:
     - data://garden/worldbank_wdi/2022-05-26/wdi
+  grapher://owid/latest/population_density:
+    - data://garden/owid/latest/population_density
 
   data://garden/sdg/latest/sdg:
     - backport://backport/owid/latest/dataset_563_world_development_indicators__health

--- a/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.py
+++ b/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.py
@@ -248,6 +248,8 @@ def run(dest_dir: str) -> None:
     t.update_metadata_from_yaml(meta_path, "maddison_gdp")
     ds.metadata.description = ADDITIONAL_DESCRIPTION + ds.metadata.description
 
+    assert len(ds.metadata.sources) == 1
+
     # Add table to current dataset.
     ds.add(t)
 

--- a/etl/steps/data/garden/owid/latest/key_indicators/table_population.meta.yml
+++ b/etl/steps/data/garden/owid/latest/key_indicators/table_population.meta.yml
@@ -1,0 +1,30 @@
+tables:
+  population:
+    title: Population (Gapminder, HYDE & UN)
+    description: |
+      Our World in Data builds and maintains a long-run dataset on population by country, region, and for the world, based on three key sources: HYDE, Gapminder, and the UN World Population Prospects.
+      You can find more information on these sources and how our time series is constructed on this page: <a href="https://ourworldindata.org/population-sources">What sources do we rely on for population estimates?</a>'
+
+    variables:
+      population:
+        title: Population
+        description: Population by country, available from 1800 to 2021 based on Gapminder data, HYDE, and UN Population Division (2019) estimates.
+        display:
+          name: Population
+          includeInTable: true
+        sources:
+          -
+            name: Gapminder (v6)
+            published_by: Gapminder (v6)
+            url: https://www.gapminder.org/data/documentation/gd003/
+            date_accessed: October 8, 2021
+          -
+            name: UN (2019)
+            published_by: United Nations Population Division (2019)
+            url: https://population.un.org/wpp/Download/Standard/Population/
+            date_accessed: October 8, 2021
+          -
+            name: HYDE (v3.2)
+            published_by: HYDE (v3.2)
+            url: https://dataportaal.pbl.nl/downloads/HYDE/
+            date_accessed: October 8, 2021

--- a/etl/steps/data/garden/owid/latest/key_indicators/table_population.py
+++ b/etl/steps/data/garden/owid/latest/key_indicators/table_population.py
@@ -14,7 +14,7 @@ from typing import cast, List
 
 import pandas as pd
 
-from owid.catalog import Dataset, Table, Source
+from owid.catalog import Dataset, Table
 from etl.paths import DATA_DIR
 from etl import data_helpers
 
@@ -35,34 +35,7 @@ def make_table() -> Table:
         .pipe(prepare_dataset)
     )
 
-    sources = [
-        Source(
-            name="Gapminder (v6)",
-            url="https://www.gapminder.org/data/documentation/gd003/",
-            date_accessed="October 8, 2021",
-        ),
-        Source(
-            name="UN (2019)",
-            url="https://population.un.org/wpp/Download/Standard/Population/",
-            date_accessed="October 8, 2021",
-        ),
-        Source(
-            name="HYDE (v3.2)",
-            url="https://dataportaal.pbl.nl/downloads/HYDE/",
-            date_accessed="October 8, 2021",
-        ),
-    ]
-
-    # table metadata
-    t.metadata.short_name = "population"
-    t.metadata.title = "Population (Gapminder, HYDE & UN)"
-    t.metadata.description = 'Our World in Data builds and maintains a long-run dataset on population by country, region, and for the world, based on three key sources: HYDE, Gapminder, and the UN World Population Prospects. You can find more information on these sources and how our time series is constructed on this page: <a href="https://ourworldindata.org/population-sources">What sources do we rely on for population estimates?</a>'
-
-    # variables metadata (variable 72 in grapher)
-    t.population.metadata.title = "Population"
-    t.population.metadata.sources = sources
-    t.population.metadata.description = "Population by country, available from 1800 to 2021 based on Gapminder data, HYDE, and UN Population Division (2019) estimates."
-    t.population.metadata.display = {"name": "Population", "includeInTable": True}
+    t.update_metadata_from_yaml(DIR_PATH / "table_population.meta.yml", "population")
 
     return t
 

--- a/etl/steps/data/garden/owid/latest/population_density/__init__.py
+++ b/etl/steps/data/garden/owid/latest/population_density/__init__.py
@@ -11,8 +11,9 @@ https://github.com/owid/notebooks/blob/main/EdouardMathieu/omm_population_densit
 
 import pandas as pd
 from typing import cast
+from pathlib import Path
 
-from owid.catalog import Dataset, DatasetMeta, Table, Variable, Source, VariableMeta
+from owid.catalog import Dataset, Table, Source
 
 from etl.paths import DATA_DIR
 
@@ -69,36 +70,12 @@ def load_sources() -> list[Source]:
 
 def run(dest_dir: str) -> None:
     ds = Dataset.create_empty(dest_dir)
+    meta_path = Path(__file__).parent / "population_density.meta.yml"
+    ds.metadata.update_from_yaml(meta_path)
+    ds.metadata.sources = load_sources()
+
     t = make_table()
-
-    # add metadata, use values from variable 123 in grapher
-    ds.metadata = DatasetMeta(
-        namespace="owid",
-        short_name="population_density",
-        title="Population density (World Bank, Gapminder, HYDE & UN)",
-        sources=load_sources(),
-    )
-    t.metadata.short_name = "population_density"
-    t.metadata.description = """
-    Our World in Data builds and maintains a long-run dataset on population by country, region, and for the world, based on three key sources: HYDE, Gapminder, and the UN World Population Prospects. This combines historical population estimates with median scenario projections to 2100. You can find more information on these sources and how our time series is constructed on this page: <a href="https://ourworldindata.org/population-sources">What sources do we rely on for population estimates?</a>\n\nWe combine this population dataset with the <a href="https://ourworldindata.org/grapher/land-area-km">land area estimates published by the World Bank</a>, to produce a long-run dataset of population density.\n\nIn all sources that we rely on, population estimates and land area estimates are based on today’s geographical borders.'
-    """.strip()
-
-    # variable metadata (id 123 in grapher)
-    t.population_density.metadata = VariableMeta(
-        title="population_density",
-        display={
-            "name": "Population density",
-            "unit": "people per km²",
-            "includeInTable": True,
-        },
-    )
+    t.update_metadata_from_yaml(meta_path, "population_density")
 
     ds.add(t)
     ds.save()
-
-
-def set_variable_metadata(v: Variable, meta: VariableMeta) -> None:
-    """Set Metadata on a variable.
-    TODO: make this a method of the Variable class
-    """
-    v._fields[v.checked_name] = meta

--- a/etl/steps/data/garden/owid/latest/population_density/population_density.meta.yml
+++ b/etl/steps/data/garden/owid/latest/population_density/population_density.meta.yml
@@ -1,0 +1,20 @@
+dataset:
+  short_name: population_density
+  namespace: owid
+  title: Population density (World Bank, Gapminder, HYDE & UN)
+  description: |
+    Our World in Data builds and maintains a long-run dataset on population by country, region, and for the world, based on three key sources: HYDE, Gapminder, and the UN World Population Prospects. This combines historical population estimates with median scenario projections to 2100. You can find more information on these sources and how our time series is constructed on this page: <a href="https://ourworldindata.org/population-sources">What sources do we rely on for population estimates?</a>
+
+    We combine this population dataset with the <a href="https://ourworldindata.org/grapher/land-area-km">land area estimates published by the World Bank</a>, to produce a long-run dataset of population density.
+
+    In all sources that we rely on, population estimates and land area estimates are based on today’s geographical borders.
+
+tables:
+  population_density:
+    variables:
+      population_density:
+        title: Population density
+        display:
+          title: Population density
+          unit: people per km²
+          includeInTable: true

--- a/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
+++ b/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
@@ -10,6 +10,7 @@ def get_grapher_dataset() -> catalog.Dataset:
     dataset = catalog.Dataset(
         DATA_DIR / "garden" / "ggdc" / "2020-10-01" / "ggdc_maddison"
     )
+    assert len(dataset.metadata.sources) == 1
     # short_name should include dataset name and version
     dataset.metadata.short_name = "ggdc_maddison__2020_10_01"
 

--- a/etl/steps/grapher/owid/latest/population_density.py
+++ b/etl/steps/grapher/owid/latest/population_density.py
@@ -1,0 +1,32 @@
+from owid import catalog
+from collections.abc import Iterable
+
+from etl.paths import DATA_DIR
+from etl import grapher_helpers as gh
+
+
+def get_grapher_dataset() -> catalog.Dataset:
+    dataset = catalog.Dataset(DATA_DIR / "garden/owid/latest/population_density")
+
+    # grapher does not allow multiple sources
+    source = gh.join_sources(dataset.metadata.sources)
+
+    # move description to source as that is what is shown in grapher
+    # (dataset.description would be displayed under `Internal notes` in the admin UI otherwise)
+    source.description = dataset.metadata.description
+
+    dataset.metadata.sources = [source]
+
+    return dataset
+
+
+def get_grapher_tables(dataset: catalog.Dataset) -> Iterable[catalog.Table]:
+    table = dataset["population_density"].reset_index()
+
+    table = (
+        table.assign(entity_id=gh.country_to_entity_id(table["country"])).set_index(
+            ["entity_id", "year"],
+        )
+    )[["population_density"]]
+
+    yield from gh.yield_wide_table(table)


### PR DESCRIPTION
Export population density dataset to grapher. This is not currently used in production by any other datasets, but it simplifies metadata for population with YAML files and it could be useful in the future. (And I could finally close the [original issue](https://github.com/owid/etl/issues/141))