### PR TITLE
chore(jupytext)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ wikipedia = "^1.4.0"
 pandas = "^1.4.0"
 numpy = "^1.22.1"
 pydantic = "^1.9.0"
+jupytext = "^1.13.7"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
In some pipelines, especially complex ones, it makes sense to use modules (`.py`) instead of notebooks, but it would be great to still be able to leverage the power of Jupyter Notebooks.

[jupytext](https://github.com/mwouts/jupytext) is a nice way to interact with plain text (i.e. `.py`) using Jupyter Notebooks.