### PR TITLE
feature(backport): Perform a once-off bulk backport of the full dataset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 include default.mk
 
-SRC = etl tests
+SRC = etl backport tests
 
 help:
 	@echo 'Available commands:'

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Datasets from our production grapher database can be backported to ETL catalog. 
 bulk_backport
 ```
 
-(specify `--limit` to make it process only a subset of datasets). It goes through all public datasets with at least one variable used in a chart and uploads them to Walden catalog (or skip them if they're already there and have the same checksum). If you set `--dry-run` flag, it will only persist the datasets locally. **You need S3 credentials to upload them to Walden.**
+(specify `--limit` to make it process only a subset of datasets). It goes through all public datasets with at least one variable used in a chart and uploads them to Walden catalog (or skip them if they're already there and have the same checksum). If you set `--skip-upload` flag, it will only persist the datasets locally. **You need S3 credentials to upload them to Walden.**
 
 Note that you still have to commit those updates to [Walden index](https://github.com/owid/walden/tree/master/owid/walden/index), otherwise others won't be able to rerun the ETL. (If you don't commit them, running `etl` and `publish` steps will still work for you in your local repository, but not for others).
 

--- a/README.md
+++ b/README.md
@@ -220,3 +220,24 @@ etl --private
 reindex
 publish --private
 ```
+
+
+## Backporting
+
+Datasets from our production grapher database can be backported to ETL catalog. The first step is getting them to Walden using
+
+```
+bulk_backport
+```
+
+(specify `--limit` to make it process only a subset of datasets). It goes through all public datasets with at least one variable used in a chart and uploads them to Walden catalog (or skip them if they're already there and have the same checksum). If you set `--dry-run` flag, it will only persist the datasets locally. **You need S3 credentials to upload them to Walden.**
+
+Note that you still have to commit those updates to [Walden index](https://github.com/owid/walden/tree/master/owid/walden/index), otherwise others won't be able to rerun the ETL. (If you don't commit them, running `etl` and `publish` steps will still work for you in your local repository, but not for others).
+
+Backported walden datasets can be processed with ETL using
+
+```
+etl --backport
+```
+
+(or `etl backport --backport`). This will transform original datasets from long format to wide format, optimize their data types, convert metadata and add them to the catalog. Then you can run `publish` to publish the datasets as usual.

--- a/backport/backport.py
+++ b/backport/backport.py
@@ -43,7 +43,7 @@ def _walden_values_metadata(ds: GrapherDatasetModel, short_name: str) -> WaldenD
         name=ds.name,
         date_accessed=dt.datetime.utcnow().isoformat(),
         description=ds.description,
-        source_name="Our World in Data",
+        source_name="Our World in Data catalog backport",
         url=f"https://owid.cloud/admin/datasets/{ds.id}",
         publication_date="latest",
         file_extension="feather",
@@ -228,7 +228,9 @@ def backport(
     lg.info("backport.loading_values", variables=variable_ids)
     df = _load_values(engine, variable_ids)
     lg.info("backport.upload_values", size=len(df))
-    _upload_values_to_walden(df, _walden_values_metadata(ds, short_name), dry_run, upload)
+    _upload_values_to_walden(
+        df, _walden_values_metadata(ds, short_name), dry_run, upload
+    )
 
     lg.info("backport.finished")
 

--- a/backport/backport.py
+++ b/backport/backport.py
@@ -93,6 +93,11 @@ def _load_values(engine: Engine, variable_ids: list[int]) -> pd.DataFrame:
             "entity_name": "category",
         }
     )
+
+    # special case for empty dataframes (would fail otherwise when saving to feather)
+    if df.empty:
+        df = df.reset_index(drop=True)
+
     return df
 
 

--- a/backport/backport.py
+++ b/backport/backport.py
@@ -27,6 +27,9 @@ log = structlog.get_logger()
 
 engine = get_engine()
 
+# preload walden catalog to improve performance (initializing the catalog takes a while)
+walden_catalog = WaldenCatalog()
+
 
 def _walden_values_metadata(ds: GrapherDatasetModel, short_name: str) -> WaldenDataset:
     """Create walden dataset for grapher dataset values.
@@ -138,7 +141,7 @@ def _upload_values_to_walden(
 
 def _checksum_match(short_name: str, md5: str) -> bool:
     try:
-        walden_ds = WaldenCatalog().find_one(short_name=short_name)
+        walden_ds = walden_catalog.find_one(short_name=short_name)
     except KeyError:
         # datasets not found in catalog
         return False
@@ -147,7 +150,7 @@ def _checksum_match(short_name: str, md5: str) -> bool:
 
 
 def _walden_timestamp(short_name: str) -> dt.datetime:
-    t = WaldenCatalog().find_one(short_name=short_name).date_accessed
+    t = walden_catalog.find_one(short_name=short_name).date_accessed
     return cast(dt.datetime, pd.to_datetime(t))
 
 

--- a/backport/backport.py
+++ b/backport/backport.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
-import time
-from typing import Optional
+import datetime as dt
+from typing import Optional, cast
 
 import click
 import pandas as pd
@@ -14,34 +14,36 @@ from sqlalchemy.engine import Engine
 
 from etl.db import get_engine
 from etl.files import checksum_str
-from etl.grapher_model import (GrapherConfig, GrapherDatasetModel,
-                               GrapherSourceModel, GrapherVariableModel)
+from etl.grapher_model import (
+    GrapherConfig,
+    GrapherDatasetModel,
+    GrapherSourceModel,
+    GrapherVariableModel,
+)
 
 WALDEN_NAMESPACE = os.environ.get("WALDEN_NAMESPACE", "backport")
 
 log = structlog.get_logger()
 
+engine = get_engine()
 
-def _walden_values_metadata(
-    ds: GrapherDatasetModel, short_name: str, origin_md5: str
-) -> WaldenDataset:
+
+def _walden_values_metadata(ds: GrapherDatasetModel, short_name: str) -> WaldenDataset:
     """Create walden dataset for grapher dataset values.
     These datasets are not meant for direct consumption from the catalog, but rather
     for postprocessing in etl.
     :param short_name: short name of the dataset in catalog
-    :param origin_md5: MD5 hash of data values in grapher used to decide whether to recompute
-        or not in the next run
     """
     return WaldenDataset(
         namespace=WALDEN_NAMESPACE,
         short_name=f"{short_name}_values",
         name=ds.name,
+        date_accessed=dt.datetime.utcnow().isoformat(),
         description=ds.description,
         source_name="Our World in Data",
         url=f"https://owid.cloud/admin/datasets/{ds.id}",
         publication_date="latest",
         file_extension="feather",
-        origin_md5=origin_md5,
     )
 
 
@@ -49,10 +51,11 @@ def _walden_config_metadata(
     ds: GrapherDatasetModel, short_name: str, origin_md5: str
 ) -> WaldenDataset:
     """Create walden dataset for grapher dataset variables and metadata."""
-    config = _walden_values_metadata(ds, short_name, origin_md5)
+    config = _walden_values_metadata(ds, short_name)
     config.short_name = short_name + "_config"
     config.name = f"Grapher metadata for {short_name}"
     config.file_extension = "json"
+    config.origin_md5 = origin_md5
     return config
 
 
@@ -60,7 +63,7 @@ def _load_values(engine: Engine, variable_ids: list[int]) -> pd.DataFrame:
     """Get data values of a variable."""
     # NOTE: loading entity_name and variable_name is perhaps unnecessary, consider removing it
     # to speed up loading
-    q = f"""
+    q = """
     select
         d.entityId as entity_id,
         d.variableId as variable_id,
@@ -128,73 +131,96 @@ def _upload_values_to_walden(
             add_to_catalog(meta, f.name, upload=True)
 
 
-def _content_hash_values(engine: Engine, variable_ids: list[int]) -> str:
-    """Get content hash of values for given variables. This version is quite slow,
-    processing WBI dataset (7.7M data values) takes 33s.
-
-    An alternative to checking content sum of all data values would be creating a
-    changelog table for variables that would get updated by MySQL trigger whenever
-    a data value is updated. (or adding a column to existing variables table)
-
-    An example (taken from https://stackoverflow.com/questions/4753878/how-to-program-a-mysql-trigger-to-insert-row-into-another-table)
-    ```
-    delimiter #
-    create trigger variable_changelog_trig after insert on data_values
-    for each row
-    begin
-        insert into variable_changelog (variableId, updatedAt) values (variableId, NOW())
-        on duplicate key update
-            updatedAt = VALUES(updatedAt)
-    end#
-    ```
-
-    However, this might be quite inefficient for large data values. Better solution would be to
-    update variable `updatedAt` column on app level whenever its data value is updated.
-    """
-    q = """
-    SELECT MD5(
-        GROUP_CONCAT(
-            CONCAT_WS('#',value,year,entityId,variableId) SEPARATOR '##'
-        )
-    ) FROM data_values
-    where variableId in %(variable_ids)s
-    order by year, entityId, variableId
-    """
-    log.info("backport.content_hash_values.start", variable_ids=variable_ids)
-    t = time.time()
-    content_hash = engine.execute(q, variable_ids=variable_ids).first()[0]
-    assert content_hash is not None
-    log.info("backport.content_hash_values.end", hash=content_hash, t=time.time() - t)
-    return content_hash
-
-
-def _checksums_match(short_name: str, md5_config: str, md5_values: str) -> bool:
+def _checksum_match(short_name: str, md5: str) -> bool:
     try:
-        walden_ds_config = WaldenCatalog().find_one(short_name=f"{short_name}_config")
-        walden_ds_values = WaldenCatalog().find_one(short_name=f"{short_name}_values")
+        walden_ds = WaldenCatalog().find_one(short_name=short_name)
     except KeyError:
         # datasets not found in catalog
         return False
 
-    return (
-        walden_ds_config.origin_md5 == md5_config
-        and walden_ds_values.origin_md5 == md5_values
-    )
+    return (walden_ds.origin_md5 or "") == md5
+
+
+def _walden_timestamp(short_name: str) -> dt.datetime:
+    t = WaldenCatalog().find_one(short_name=short_name).date_accessed
+    return cast(dt.datetime, pd.to_datetime(t))
 
 
 def _create_short_name(
-    short_name: Optional[str], dataset_id: int, variable_id: int
+    short_name: Optional[str], dataset_id: int, variable_id: Optional[int]
 ) -> str:
     """Create sensible short name for dataset."""
     if short_name:
         validate_underscore(short_name, "short-name")
         # prepend dataset id to short name
-        return f"{dataset_id}_{short_name}"
+        return f"dataset_{dataset_id}_{short_name}"
     else:
         if variable_id:
-            return f"{dataset_id}_{variable_id}"
+            return f"dataset_{dataset_id}_{variable_id}"
         else:
-            return str(dataset_id)
+            return f"dataset_{dataset_id}"
+
+
+def backport(
+    dataset_id: int,
+    variable_id: Optional[int] = None,
+    short_name: Optional[str] = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> None:
+    lg = log.bind(dataset_id=dataset_id)
+
+    # get data from database
+    lg.info("backport.loading_dataset")
+    ds = GrapherDatasetModel.load_dataset(engine, dataset_id)
+    lg.info("backport.loading_variable", variable_id=variable_id or "all")
+    if variable_id:
+        vars = [GrapherVariableModel.load_variable(engine, variable_id)]
+    else:
+        # load all variables from a dataset
+        vars = GrapherDatasetModel.load_variables_for_dataset(engine, dataset_id)
+    variable_ids = [v.id for v in vars]
+
+    # get sources for dataset and all variables
+    lg.info("backport.loading_sources")
+    sources = GrapherSourceModel.load_sources(
+        engine, dataset_id=ds.id, variable_ids=variable_ids
+    )
+
+    short_name = _create_short_name(short_name, dataset_id, variable_id)
+
+    config = _load_config(ds, vars, sources)
+
+    # get checksums of config
+    md5_config = checksum_str(config.json(sort_keys=True, indent=0))
+
+    if not force:
+        # first check config checksum
+        if _checksum_match(f"{short_name}_config", md5_config):
+            # then check dataEditedAt field
+            if ds.dataEditedAt < _walden_timestamp(f"{short_name}_config"):
+                lg.info(
+                    "backport.skip", short_name=short_name, reason="checksums match"
+                )
+                return
+            else:
+                # since `dataEditedAt` is part of config, its checksum should change and _checksum_match
+                # should return False... if this is not the case, something is wrong
+                raise AssertionError("This should never happen")
+
+    # upload config to walden
+    lg.info("backport.upload_config")
+    _upload_config_to_walden(
+        config, _walden_config_metadata(ds, short_name, md5_config), dry_run
+    )
+
+    # upload values to walden
+    lg.info("backport.loading_values", variables=variable_ids)
+    df = _load_values(engine, variable_ids)
+    lg.info("backport.upload_values", size=len(df))
+    _upload_values_to_walden(df, _walden_values_metadata(ds, short_name), dry_run)
+
+    lg.info("backport.finished")
 
 
 @click.command()
@@ -215,60 +241,20 @@ def _create_short_name(
     type=bool,
     help="Do not add dataset to a catalog on dry-run",
 )
-def backport(
+def backport_cli(
     dataset_id: int,
-    variable_id: int,
-    short_name: str,
-    force: bool,
-    dry_run: bool,
+    variable_id: Optional[int] = None,
+    short_name: Optional[str] = None,
+    force: bool = False,
+    dry_run: bool = False,
 ) -> None:
-    engine = get_engine()
-
-    # get data from database
-    log.info("backport.loading_dataset", dataset_id=dataset_id)
-    ds = GrapherDatasetModel.load_dataset(engine, dataset_id)
-    log.info("backport.loading_variable", variable_id=variable_id or "all")
-    if variable_id:
-        vars = [GrapherVariableModel.load_variable(engine, variable_id)]
-    else:
-        # load all variables from a dataset
-        vars = GrapherDatasetModel.load_variables_for_dataset(engine, dataset_id)
-    variable_ids = [v.id for v in vars]
-
-    # get sources for dataset and all variables
-    sources = GrapherSourceModel.load_sources(
-        engine, dataset_id=ds.id, variable_ids=variable_ids
+    return backport(
+        dataset_id,
+        variable_id,
+        short_name,
+        force,
+        dry_run,
     )
-
-    short_name = _create_short_name(short_name, dataset_id, variable_id)
-
-    config = _load_config(ds, vars, sources)
-
-    # get checksums of config and values
-    md5_config = checksum_str(config.json(sort_keys=True, indent=0))
-    md5_values = _content_hash_values(engine, variable_ids)
-
-    # if checksums of data and config are identical, skip upload
-    if not force:
-        if _checksums_match(short_name, md5_config, md5_values):
-            log.info("backport.skip", short_name=short_name, reason="checksums match")
-            return
-
-    # upload config to walden
-    log.info("backport.upload_config")
-    _upload_config_to_walden(
-        config, _walden_config_metadata(ds, short_name, md5_config), dry_run
-    )
-
-    # upload values to walden
-    log.info("backport.loading_values", variables=variable_ids)
-    df = _load_values(engine, variable_ids)
-    log.info("backport.upload_values", size=len(df))
-    _upload_values_to_walden(
-        df, _walden_values_metadata(ds, short_name, md5_values), dry_run
-    )
-
-    log.info("backport.finished")
 
 
 if __name__ == "__main__":
@@ -276,4 +262,4 @@ if __name__ == "__main__":
     #   backport --dataset-id 5426 --variable-id 244087 --name political_regimes --dry-run --force
     #   or entire dataset
     #   backport --dataset-id 5426 --short-name political_regimes --force
-    backport()
+    backport_cli()

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -1,0 +1,67 @@
+import click
+import pandas as pd
+import structlog
+from owid.catalog.utils import underscore
+
+from etl.db import get_engine
+
+from .backport import backport
+
+log = structlog.get_logger()
+
+
+@click.command()
+@click.option("--dataset-ids", "-d", type=int, multiple=True)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    type=bool,
+    help="Do not add dataset to a catalog on dry-run",
+)
+@click.option(
+    "--limit",
+    default=1000000,
+    type=int,
+)
+def bulk_backport(dataset_ids: list[int], dry_run: bool, limit: int) -> None:
+    engine = get_engine()
+
+    q = """
+    select id, name, dataEditedAt, metadataEditedAt from datasets
+    where not isPrivate
+        and id in (
+            select distinct v.datasetId from chart_dimensions as cd
+            join variables as v on cd.variableId = v.id
+        )
+    order by rand()
+    limit %(limit)s
+    """
+    df = pd.read_sql(q, engine, params={"limit": limit})
+
+    if dataset_ids:
+        df = df[df.id.isin(dataset_ids)]
+
+    df["short_name"] = df.name.map(underscore)
+
+    log.info("bulk_backport.start", n=len(df))
+
+    for i, ds in enumerate(df.itertuples()):
+        log.info(
+            "bulk_backport",
+            dataset_id=ds.id,
+            name=ds.name,
+            progress=f"{i + 1}/{len(df)}",
+        )
+        backport(
+            dataset_id=ds.id,
+            short_name=ds.short_name,
+            dry_run=dry_run,
+        )
+
+    log.info("bulk_backport.finished")
+
+
+if __name__ == "__main__":
+    # Example (run against staging DB):
+    #   bulk_backport -d 20 -d 21 -d 5426 --dry-run
+    bulk_backport()

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -23,7 +23,13 @@ log = structlog.get_logger()
     default=1000000,
     type=int,
 )
-def bulk_backport(dataset_ids: list[int], dry_run: bool, limit: int) -> None:
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Walden",
+)
+def bulk_backport(dataset_ids: list[int], dry_run: bool, limit: int, upload: bool) -> None:
     engine = get_engine()
 
     q = """
@@ -56,6 +62,7 @@ def bulk_backport(dataset_ids: list[int], dry_run: bool, limit: int) -> None:
             dataset_id=ds.id,
             short_name=ds.short_name,
             dry_run=dry_run,
+            upload=upload,
         )
 
     log.info("bulk_backport.finished")

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -29,7 +29,9 @@ log = structlog.get_logger()
     type=bool,
     help="Upload dataset to Walden",
 )
-def bulk_backport(dataset_ids: list[int], dry_run: bool, limit: int, upload: bool) -> None:
+def bulk_backport(
+    dataset_ids: list[int], dry_run: bool, limit: int, upload: bool
+) -> None:
     engine = get_engine()
 
     q = """

--- a/dag.yml
+++ b/dag.yml
@@ -72,7 +72,6 @@ steps:
     - data://meadow/wb/2021-07-01/wb_income
   data://garden/ggdc/2020-10-01/ggdc_maddison:
     - walden://ggdc/2020-10-01/ggdc_maddison
-
   grapher://ggdc/2020-10-01/ggdc_maddison:
     - data://garden/ggdc/2020-10-01/ggdc_maddison
 

--- a/etl/backport_helpers.py
+++ b/etl/backport_helpers.py
@@ -1,24 +1,64 @@
 from typing import cast
 
+import structlog
 import pandas as pd
 from owid.catalog import Dataset, Table
 from owid.catalog.utils import underscore_table
-from owid.walden import Catalog
+from owid.walden import Catalog as WaldenCatalog
 
 from etl.grapher_model import GrapherConfig
 from etl.steps.data.converters import convert_grapher_dataset, convert_grapher_variable
 
 
+from owid.catalog import VariableMeta
+
+
+log = structlog.get_logger()
+
+
 def load_values(short_name: str) -> pd.DataFrame:
-    walden_ds = Catalog().find_one(short_name=f"{short_name}_values")
+    walden_ds = WaldenCatalog().find_one(short_name=f"{short_name}_values")
     local_path = walden_ds.ensure_downloaded()
     return cast(pd.DataFrame, pd.read_feather(local_path))
 
 
 def load_config(short_name: str) -> GrapherConfig:
-    walden_ds = Catalog().find_one(short_name=f"{short_name}_config")
+    walden_ds = WaldenCatalog().find_one(short_name=f"{short_name}_config")
     local_path = walden_ds.ensure_downloaded()
     return GrapherConfig.parse_file(local_path)
+
+
+def create_wide_table(
+    values: pd.DataFrame, short_name: str, config: GrapherConfig
+) -> Table:
+    """Convert backported table from long to wide format."""
+    # convert to wide format
+    long_mem_usage_mb = values.memory_usage().sum() / 1e6
+    df = values.pivot(
+        index=["entity_name", "year"], columns="variable_name", values="value"
+    )
+
+    # report compression ratio if the file is larger than >1MB
+    # NOTE: memory usage can further drop later after repack_frame is called
+    wide_mem_usage_mb = df.memory_usage().sum() / 1e6
+    if wide_mem_usage_mb > 1:
+        log.info(
+            "create_wide_table",
+            short_name=short_name,
+            wide_mb=wide_mem_usage_mb,
+            long_mb=long_mem_usage_mb,
+            compression=f"{wide_mem_usage_mb / long_mem_usage_mb:.1%}",
+        )
+
+    # TODO: what about Table metadata? should I reuse what I have in a dataset?
+    t = Table(df)
+    t.metadata.short_name = short_name
+
+    # add variables metadata
+    for col in t.columns:
+        t[col].metadata = get_metadata_for_variable_name(config, col)
+
+    return underscore_table(t)
 
 
 def create_dataset(dest_dir: str, short_name: str) -> Dataset:
@@ -27,35 +67,67 @@ def create_dataset(dest_dir: str, short_name: str) -> Dataset:
     values = load_values(short_name)
     config = load_config(short_name)
 
-    # find sources belonging to this dataset
-    ds_sources = [s for s in config.sources if s.datasetId == config.dataset.id]
+    # put sources belonging to a dataset but not to a variable into dataset metadata
+    variable_source_ids = {v.sourceId for v in config.variables}
+    ds_sources = [
+        s
+        for s in config.sources
+        if s.datasetId == config.dataset.id and s.id not in variable_source_ids
+    ]
 
     # create dataset with metadata
     ds = Dataset.create_empty(
         dest_dir, convert_grapher_dataset(config.dataset, ds_sources, short_name)
     )
 
-    # convert to wide format
-    df = values.pivot(
-        index=["entity_name", "year"], columns="variable_name", values="value"
-    )
+    # in rare cases when wide table would be too sparse, we keep the dataset in long format
+    n_variables = len(set(values.variable_id))
+    wide_size = n_variables * len(set(values.entity_id))
+    long_size = len(values)
 
-    # convert to float all columns we can
-    for col in df.columns:
-        df[col] = df[col].astype(float, errors="ignore")
+    tables = []
 
-    # TODO: what about Table metadata? should I reuse what I have in a dataset?
-    t = Table(df)
-    t.metadata.short_name = short_name
+    if wide_size >= 1e6 and wide_size / long_size > 0.5:
+        # log.info(
+        #     "create_dataset.long_format", short_name=short_name, wide_size=wide_size
+        # )
+        # # keep config in additional_info for later use
+        # ds.metadata.additional_info["grapher_config"] = config.dict()
 
-    # add variables metadata
-    for col in df.columns:
-        variable = [v for v in config.variables if v.name == col][0]
-        variable_source = [s for s in config.sources if s.id == variable.sourceId][0]
-        df[col].metadata = convert_grapher_variable(
-            variable,
-            variable_source,
-        )
+        # t = Table(values)
+        # t.metadata.short_name = short_name
+        # tables.append(t)
 
-    ds.add(underscore_table(t))
+        # group it by 1000 variables
+        import numpy as np
+
+        for variable_ids in np.array_split(
+            values.variable_id.unique().sort_values(), n_variables / 1000
+        ):
+            chunk = values.loc[values.variable_id.isin(variable_ids)]
+            t = create_wide_table(
+                chunk,
+                f"variable_ids_{variable_ids.min()}_to_{variable_ids.max()}",
+                config,
+            )
+            tables.append(t)
+    else:
+        t = create_wide_table(values, short_name, config)
+        tables.append(t)
+
+    # create tables
+    for t in tables:
+        ds.add(t)
+
     return ds
+
+
+def get_metadata_for_variable_name(
+    config: GrapherConfig, variable_name: str
+) -> VariableMeta:
+    variable = [v for v in config.variables if v.name == variable_name][0]
+    variable_source = [s for s in config.sources if s.id == variable.sourceId][0]
+    return convert_grapher_variable(
+        variable,
+        variable_source,
+    )

--- a/etl/command.py
+++ b/etl/command.py
@@ -35,7 +35,7 @@ THREADPOOL_WORKERS = 5
 @click.option(
     "--backport",
     is_flag=True,
-    help="Add steps for backporting OWID datasets (OWID staff only)",
+    help="Add steps for backporting OWID datasets",
 )
 @click.option("--exclude", help="Comma-separated patterns to exclude")
 @click.option(
@@ -58,7 +58,7 @@ def main(
     """
     Execute all ETL steps listed in dag.yaml
     """
-    if grapher or backport:
+    if grapher:
         sanity_check_db_settings()
 
     # Load our graph of steps and the things they depend on

--- a/etl/publish.py
+++ b/etl/publish.py
@@ -72,6 +72,7 @@ def sync_catalog_to_s3(
         print(f"Catalog's channel {channel} is up to date!")
         return
 
+    print(f"Syncing datasets from channel {channel}")
     sync_datasets(s3, bucket, catalog, channel, dry_run=dry_run)
     if not dry_run:
         update_catalog(s3, bucket, catalog, channel)

--- a/etl/steps/data/backport/owid/latest/political_regimes.py
+++ b/etl/steps/data/backport/owid/latest/political_regimes.py
@@ -1,9 +1,0 @@
-from etl.backport_helpers import create_dataset
-
-
-def run(dest_dir: str) -> None:
-    create_dataset(dest_dir, "5426_political_regimes").save()
-
-
-if __name__ == "__main__":
-    run("/tmp/5426_political_regimes")

--- a/etl/steps/data/backport/owid/latest/wdi_world_bank.py
+++ b/etl/steps/data/backport/owid/latest/wdi_world_bank.py
@@ -1,9 +1,0 @@
-from etl.backport_helpers import create_dataset
-
-
-def run(dest_dir: str) -> None:
-    create_dataset(dest_dir, "5357_wdi_world_bank").save()
-
-
-if __name__ == "__main__":
-    run("/tmp/5357_wdi_world_bank")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1252,7 +1252,6 @@ pyarrow = "^7.0.0"
 pytest-cov = "^2.12.1"
 PyYAML = "^5.4.1"
 requests = "^2.26.0"
-structlog = "^21.5.0"
 Unidecode = "^1.3.4"
 
 [package.source]
@@ -2343,6 +2342,19 @@ beautifulsoup4 = "*"
 requests = ">=2.0.0,<3.0.0"
 
 [[package]]
+name = "xlrd"
+version = "2.0.1"
+description = "Library for developers to extract data from Microsoft Excel (tm) .xls spreadsheet files"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.extras]
+build = ["wheel", "twine"]
+docs = ["sphinx"]
+test = ["pytest", "pytest-cov"]
+
+[[package]]
 name = "xlsxwriter"
 version = "3.0.3"
 description = "A Python module for creating Excel XLSX files."
@@ -3416,26 +3428,18 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
@@ -3864,6 +3868,10 @@ widgetsnbextension = [
 ]
 wikipedia = [
     {file = "wikipedia-1.4.0.tar.gz", hash = "sha256:db0fad1829fdd441b1852306e9856398204dc0786d2996dd2e0c8bb8e26133b2"},
+]
+xlrd = [
+    {file = "xlrd-2.0.1-py2.py3-none-any.whl", hash = "sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd"},
+    {file = "xlrd-2.0.1.tar.gz", hash = "sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88"},
 ]
 xlsxwriter = [
     {file = "XlsxWriter-3.0.3-py3-none-any.whl", hash = "sha256:df0aefe5137478d206847eccf9f114715e42aaea077e6a48d0e8a2152e983010"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -2342,19 +2342,6 @@ beautifulsoup4 = "*"
 requests = ">=2.0.0,<3.0.0"
 
 [[package]]
-name = "xlrd"
-version = "2.0.1"
-description = "Library for developers to extract data from Microsoft Excel (tm) .xls spreadsheet files"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
-
-[package.extras]
-build = ["wheel", "twine"]
-docs = ["sphinx"]
-test = ["pytest", "pytest-cov"]
-
-[[package]]
 name = "xlsxwriter"
 version = "3.0.3"
 description = "A Python module for creating Excel XLSX files."
@@ -3868,10 +3855,6 @@ widgetsnbextension = [
 ]
 wikipedia = [
     {file = "wikipedia-1.4.0.tar.gz", hash = "sha256:db0fad1829fdd441b1852306e9856398204dc0786d2996dd2e0c8bb8e26133b2"},
-]
-xlrd = [
-    {file = "xlrd-2.0.1-py2.py3-none-any.whl", hash = "sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd"},
-    {file = "xlrd-2.0.1.tar.gz", hash = "sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88"},
 ]
 xlsxwriter = [
     {file = "XlsxWriter-3.0.3-py3-none-any.whl", hash = "sha256:df0aefe5137478d206847eccf9f114715e42aaea077e6a48d0e8a2152e983010"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ etl = 'etl.command:main'
 reindex = 'etl.reindex:reindex'
 publish = 'etl.publish:publish'
 harmonize = 'etl.harmonize:harmonize'
-backport = 'backport.backport:backport'
+backport = 'backport.backport:backport_cli'
+bulk_backport = 'backport.bulk_backport:bulk_backport'
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -40,6 +41,7 @@ structlog = "^21.5.0"
 sqlmodel = "^0.0.6"
 rich = "^12.1.0"
 owid-datautils = {git = "https://github.com/owid/data-utils-py.git", rev = "v0.4.0-alpha"}
+xlrd = "^2.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ structlog = "^21.5.0"
 sqlmodel = "^0.0.6"
 rich = "^12.1.0"
 owid-datautils = {git = "https://github.com/owid/data-utils-py.git", rev = "v0.4.0-alpha"}
-xlrd = "^2.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
Add command `bulk_backport` that calls `backport` for backporting all datasets that are used in at least one chart and are not private to Walden. Next, flag `--backport` creates `Backport` steps for all backported datasets found in Walden. That step aligns grapher metadata with ETL metadata and yields a wide-table (~~or long-table in rare cases~~) with all columns from the backported dataset.

I've tested it on two cases - creating World Bank Indicators from backported data and for getting SDG indicators into ETL catalog.

Datasets & tables are currently named like `dataset_5438_global_health_observatory__world_health_organization__2021_12`. We have [an issue](https://github.com/owid/etl/issues/167) for making them prettier.

### Long vs wide tables

~~The initial plan was to convert every dataset to a wide `Table`, but it turned out there are a few datasets for which wide format wouldn't be effective (creating extremely sparse >4GB dataframes). I tried a few things - sparse dataframes, hardcoded steps for those datasets, better compression, ... but none of them worked well so I ended up keeping the table in long format and added helper function `create_wide_table` to convert them on-demand after pre-filtering (useful for SDG dataset). If this works for us we can wrap this functionality in a new `LongTable` class with `to_wide_table` method.~~

Running [some benchmarks](https://github.com/owid/notebooks/blob/main/MojmirVinkler/2022-04-27%20Wide%20vs%20long%20format.ipynb) showed that long format is much less efficient than wide format. There are a few exception (extremely sparse datasets) that were autogenerated, but rather than supporting another format I've just split it into tables with 1000 variables. In the future we can revisit those datasets and split them logically into tables in the generating script.

### Removed content-hash

Since field `dataEditedAt` is reliable, there's no need for calculating content hash of all values. Instead, we only calculate checksum of all metadata (which includes `dataEditedAt`).

### Performance

Checksum comparison takes ~1s per dataset (we have 800 datasets in total), this could be speeded up by async / threading, but it's ok for now IMHO.