### PR TITLE
enhance(grapher): improve upserts to grapher, do not leave ghost variables and sources

### DIFF
--- a/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
+++ b/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
@@ -22,6 +22,7 @@ tables:
         description: Gross domestic product measured in international-$ using 2011 prices to adjust for price changes over time (inflation) and price differences between countries. Calculated by multiplying GDP per capita with population.
         display:
           entityAnnotationsMap: "Western Offshoots: United States, Canada, Australia and New Zealand"
+          numDecimalPlaces: 0
       gdp_per_capita:
         title: GDP per capita
         short_unit: $
@@ -29,3 +30,4 @@ tables:
         description:
         display:
           entityAnnotationsMap: "Western Offshoots: United States, Canada, Australia and New Zealand"
+          numDecimalPlaces: 0


### PR DESCRIPTION
## Problem

Running `etl grapher://... --grapher` automatically creates all objects in grapher. Variables and sources are upserted to grapher by matching on their `name`. So if you rename a variable, `etl` will create a new one and leave the old one in the DB 
(with the same datasetId). We should delete old renamed variables.

Another issue is that grapher data model needs exactly one source per variable, so we need to make sure we're not inserting multiple sources per variable.

## Solution

Cleanup ghost variables and sources after every `GrapherStep`. We just need to be careful not to remove variables that are already used in charts.

## Questions

1. `Dataset` can also have a single source, but does it make sense to insert it grapher? AFAIK it's not used by anything (or is it?) so I don't see a point inserting it there. We should only insert sources for Variables. Dataset's metadata shown in admin is (confusingly) taken from the first source found in grapher for that dataset. This works fine when all variables have the same single source, but if variables have different sources then you'd be able to edit only the first one from admin.

2. Cleaning ghost variables & sources could use some tests. However, unit tests with mocked `cursor.execute` wouldn't be very useful. On the other hand, creating integration tests with sqlite might be too much... (I've tested it extensively on staging). Moreover, the entire `db_utils.py` could use some refactoring (and possibly ORM), but we can do it in the future