### PR TITLE
feature(catalog): split catalog into channels

### DIFF
--- a/etl/publish.py
+++ b/etl/publish.py
@@ -6,6 +6,7 @@
 import re
 import sys
 from typing import Any, Dict, Iterator, Optional, cast
+from collections.abc import Iterable
 from urllib.error import HTTPError
 from pathlib import Path
 
@@ -36,7 +37,9 @@ class CannotPublish(Exception):
     default=CHANNEL.__args__,
     help="Publish only selected channel (subfolder of data/), push all by default",
 )
-def publish(dry_run: bool, private: bool, bucket: str, channel: tuple[CHANNEL]) -> None:
+def publish(
+    dry_run: bool, private: bool, bucket: str, channel: Iterable[CHANNEL]
+) -> None:
     """
     Publish the generated data catalog to S3.
     """

--- a/etl/reindex.py
+++ b/etl/reindex.py
@@ -6,14 +6,21 @@
 import click
 from pathlib import Path
 
-from owid.catalog import LocalCatalog
+from owid.catalog import LocalCatalog, CHANNEL
 
 from etl.paths import DATA_DIR
 
 
 @click.command()
-def reindex() -> None:
-    LocalCatalog(Path(DATA_DIR)).reindex()
+@click.option(
+    "--channel",
+    "-c",
+    multiple=True,
+    type=click.Choice(CHANNEL.__args__),
+    help="Reindex only selected channel (subfolder of data/), reindex all by default",
+)
+def reindex(channel: tuple[CHANNEL]) -> None:
+    LocalCatalog(Path(DATA_DIR), channels=channel).reindex()
 
 
 if __name__ == "__main__":

--- a/etl/reindex.py
+++ b/etl/reindex.py
@@ -5,6 +5,7 @@
 
 import click
 from pathlib import Path
+from collections.abc import Iterable
 
 from owid.catalog import LocalCatalog, CHANNEL
 
@@ -17,9 +18,10 @@ from etl.paths import DATA_DIR
     "-c",
     multiple=True,
     type=click.Choice(CHANNEL.__args__),
+    default=CHANNEL.__args__,
     help="Reindex only selected channel (subfolder of data/), reindex all by default",
 )
-def reindex(channel: tuple[CHANNEL]) -> None:
+def reindex(channel: Iterable[CHANNEL]) -> None:
     LocalCatalog(Path(DATA_DIR), channels=channel).reindex()
 
 


### PR DESCRIPTION
Core PR in [owid-catalog-py](https://github.com/owid/owid-catalog-py/pull/35)

Split our catalog into multiple channels to make finding garden datasets easier and more efficient. By default we only read `garden` channel which is really small (17 datasets with ~30kb index). Other channels like `open_numbers` or `backport` have much larger indexes (>MBs) and take longer time to reindex & publish.