### PR TITLE
enhance(dag): include all dependencies of the planned subgraph

### DIFF
--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -76,16 +76,17 @@ def test_topological_sort():
 
 @patch("etl.steps.parse_step")
 def test_selection_selects_children(parse_step):
-    "When you pick a step, it should rebuild everything that depends on that step."
+    """When you pick a step, it should rebuild everything that depends on that step
+    and all dependencies of those steps"""
     parse_step.side_effect = lambda name, _: DummyStep(name)
 
-    dag = {"a": ["b", "c"], "d": ["a"]}
+    dag = {"a": ["b", "c"], "d": ["a"], "e": ["b"]}
 
     # selecting "c" should cause "c" -> "a" -> "d" to all be selected
     #                            "b" to be ignored
     steps = compile_steps(dag, ["c"], [])
-    assert len(steps) == 3
-    assert set(s.path for s in steps) == {"c", "a", "d"}
+    assert len(steps) == 4
+    assert set(s.path for s in steps) == {"b", "c", "a", "d"}
 
 
 @patch("etl.steps.parse_step")


### PR DESCRIPTION
After computing the subgraph, include their dependencies as well. This needed a couple of performance improvements to make this reasonably fast - caching walden catalog and checking steps dirtiness in parallel (requests from `GithubStep` were slowing it down).