### PR TITLE
fix(makefile): make test should work on the first run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ watch: .venv
 	git submodule update --init
 	touch $@
 
-.venv: pyproject.toml poetry.toml poetry.lock .submodule-init vendor/*/*
+.venv: pyproject.toml poetry.toml poetry.lock .submodule-init
 	@echo '==> Installing packages'
 	poetry install
 	touch $@


### PR DESCRIPTION
Currently running `make test` ends up with an error and needs to be run again to make it work

```
==> Initialising submodules
git submodule update --init
Submodule 'vendor/owid-catalog-py' (https://github.com/owid/owid-catalog-py) registered for path 'vendor/owid-catalog-py'
Submodule 'vendor/walden' (https://github.com/owid/walden) registered for path 'vendor/walden'
Cloning into '/Users/mojmir/projects/etl4/vendor/owid-catalog-py'...
Cloning into '/Users/mojmir/projects/etl4/vendor/walden'...
Submodule path 'vendor/owid-catalog-py': checked out '8801c7b19f37d0429bb05441a4961098620aec76'
Submodule path 'vendor/walden': checked out 'e8c88db79b2ac8e3f49aaa95a6802a5b4b3849f3'
touch .submodule-init
make: *** No rule to make target `vendor/owid-catalog-py/*', needed by `.venv'.  Stop.
```

I'm not an expert on makefiles, but it's probably something with the wildcard. Since we already have file `.submodule-init` signalling submodules are ready, we can just remove `vendor/*/*` from prerequisites.