### PR TITLE
feature(backport): full backport of private data

### DIFF
--- a/backport/backport.py
+++ b/backport/backport.py
@@ -164,21 +164,15 @@ def _create_short_name(
     short_name: Optional[str], dataset_id: int, variable_id: Optional[int]
 ) -> str:
     """Create sensible short name for dataset."""
-    if short_name:
-        validate_underscore(short_name, "short-name")
-        # prepend dataset id to short name
-        return f"dataset_{dataset_id}_{short_name}"
-    else:
-        if variable_id:
-            return f"dataset_{dataset_id}_{variable_id}"
-        else:
-            return f"dataset_{dataset_id}"
+    validate_underscore(short_name, "short-name")
+    # prepend dataset id to short name
+    return f"dataset_{dataset_id}_{short_name}"
 
 
 def backport(
     dataset_id: int,
+    short_name: str,
     variable_id: Optional[int] = None,
-    short_name: Optional[str] = None,
     force: bool = False,
     dry_run: bool = False,
     upload: bool = True,
@@ -252,10 +246,13 @@ def backport(
 
 
 @click.command()
-@click.option("--dataset-id", type=int)
+@click.option("--dataset-id", type=int, required=True)
 @click.option("--variable-id", type=int)
 @click.option(
-    "--short-name", type=str, help="Short name of a dataset, must be under_score"
+    "--short-name",
+    type=str,
+    help="Short name of a dataset, must be under_score",
+    required=True,
 )
 @click.option(
     "--force/--no-force",
@@ -277,16 +274,16 @@ def backport(
 )
 def backport_cli(
     dataset_id: int,
+    short_name: str,
     variable_id: Optional[int] = None,
-    short_name: Optional[str] = None,
     force: bool = False,
     dry_run: bool = False,
     upload: bool = True,
 ) -> None:
     return backport(
         dataset_id,
-        variable_id,
         short_name,
+        variable_id,
         force,
         dry_run,
         upload,

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -29,8 +29,14 @@ log = structlog.get_logger()
     type=bool,
     help="Upload dataset to Walden",
 )
+@click.option(
+    "--force/--no-force",
+    default=False,
+    type=bool,
+    help="Force overwrite even if checksums match",
+)
 def bulk_backport(
-    dataset_ids: list[int], dry_run: bool, limit: int, upload: bool
+    dataset_ids: list[int], dry_run: bool, limit: int, upload: bool, force: bool
 ) -> None:
     engine = get_engine()
 
@@ -67,6 +73,7 @@ def bulk_backport(
             short_name=ds.short_name,
             dry_run=dry_run,
             upload=upload,
+            force=force,
         )
 
     log.info("bulk_backport.finished")

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -35,12 +35,13 @@ def bulk_backport(
     engine = get_engine()
 
     q = """
-    select id, name, dataEditedAt, metadataEditedAt from datasets
-    where not isPrivate
-        and id in (
-            select distinct v.datasetId from chart_dimensions as cd
-            join variables as v on cd.variableId = v.id
-        )
+    select
+        id, name, dataEditedAt, metadataEditedAt, isPrivate
+    from datasets
+    where id in (
+        select distinct v.datasetId from chart_dimensions as cd
+        join variables as v on cd.variableId = v.id
+    )
     order by rand()
     limit %(limit)s
     """
@@ -58,6 +59,7 @@ def bulk_backport(
             "bulk_backport",
             dataset_id=ds.id,
             name=ds.name,
+            private=ds.isPrivate,
             progress=f"{i + 1}/{len(df)}",
         )
         backport(

--- a/dag.yml
+++ b/dag.yml
@@ -91,7 +91,7 @@ steps:
   # private steps that require S3 access keys for private walden
   data-private://examples/private/2022-03-08/private_example:
     # NOTE: this dataset is public as we don't have any private data yet
-    - walden-private://faostat/2022-02-10/faostat_metadata
+    - walden-private://ggdc/2020-10-01/ggdc_maddison
     - data://garden/reference
 
 # Sub-dags to import

--- a/etl/command.py
+++ b/etl/command.py
@@ -166,10 +166,12 @@ def _backporting_steps() -> DAG:
     for ds in WaldenCatalog().find(namespace=WALDEN_NAMESPACE):
         # two files are generated for each dataset, skip one
         if ds.short_name.endswith("_values"):
+            private_suffix = "" if ds.is_public else "-private"
+
             short_name = ds.short_name.replace("_values", "")
-            dag[f"backport://backport/owid/latest/{short_name}"] = {
-                f"walden://{ds.namespace}/latest/{short_name}_values",
-                f"walden://{ds.namespace}/latest/{short_name}_config",
+            dag[f"backport{private_suffix}://backport/owid/latest/{short_name}"] = {
+                f"walden{private_suffix}://{ds.namespace}/latest/{short_name}_values",
+                f"walden{private_suffix}://{ds.namespace}/latest/{short_name}_config",
             }
 
     return dag

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -264,6 +264,9 @@ def parse_step(step_name: str, dag: Dict[str, Any]) -> "Step":
     elif step_type == "grapher-private":
         step = GrapherStepPrivate(path, dependencies)
 
+    elif step_type == "backport-private":
+        step = BackportStepPrivate(path, dependencies)
+
     else:
         raise Exception(f"no recipe for executing step: {step_name}")
 
@@ -696,6 +699,9 @@ class BackportStep(DataStep):
 class DataStepPrivate(DataStep):
     is_public = False
 
+    def __str__(self) -> str:
+        return f"data-private://{self.path}"
+
     def after_run(self) -> None:
         """Make dataset private"""
         ds = catalog.Dataset(self._dest_dir.as_posix())
@@ -706,9 +712,22 @@ class DataStepPrivate(DataStep):
 class WaldenStepPrivate(WaldenStep):
     is_public = False
 
+    def __str__(self) -> str:
+        return f"walden-private://{self.path}"
+
 
 class GrapherStepPrivate(GrapherStep):
     is_public = False
+
+    def __str__(self) -> str:
+        return f"grapher-private://{self.path}"
+
+
+class BackportStepPrivate(BackportStep):
+    is_public = False
+
+    def __str__(self) -> str:
+        return f"backport-private://{self.path}"
 
 
 def select_dirty_steps(steps: List[Step], max_workers: int) -> List[Step]:

--- a/etl/steps/data/examples/jupytext/jupytext_example.py
+++ b/etl/steps/data/examples/jupytext/jupytext_example.py
@@ -34,6 +34,7 @@ df = df.dropna(subset=["Income group"]).rename(
 def run(dest_dir: str) -> None:
     ds = Dataset.create_empty(dest_dir)
     ds.metadata.short_name = "jupytext_example"
+    ds.metadata.namespace = "examples"
 
     # use module-level variables
     t = Table(df.reset_index(drop=True))

--- a/etl/steps/data/examples/private/2022-03-08/private_example.py
+++ b/etl/steps/data/examples/private/2022-03-08/private_example.py
@@ -3,11 +3,12 @@ from owid.catalog import Dataset, Table
 from owid.walden import Catalog
 
 from etl.steps.data.converters import convert_walden_metadata
+from owid.catalog.utils import underscore_table
 
 
 def run(dest_dir: str) -> None:
-    walden_ds = Catalog().find_one("private", "2021", "private_test")
-    df = pd.read_csv(walden_ds.ensure_downloaded())
+    walden_ds = Catalog().find_one("ggdc", "2020-10-01", "ggdc_maddison")
+    df = pd.read_excel(walden_ds.ensure_downloaded())
 
     ds = Dataset.create_empty(dest_dir)
     ds.metadata = convert_walden_metadata(walden_ds)
@@ -17,5 +18,5 @@ def run(dest_dir: str) -> None:
     t.metadata.title = ds.metadata.title
     t.metadata.description = ds.metadata.description
 
-    ds.add(t)
+    ds.add(underscore_table(t))
     ds.save()

--- a/etl/steps/data/examples/script/script_example.py
+++ b/etl/steps/data/examples/script/script_example.py
@@ -35,6 +35,7 @@ def run(dest_dir: str) -> None:
 
     ds = Dataset.create_empty(dest_dir)
     ds.metadata.short_name = "dataset_example"
+    ds.metadata.namespace = "examples"
 
     t = Table(df.reset_index(drop=True))
     t.metadata.short_name = "table_example"

--- a/etl/steps/data/examples/vs_code_cells/vs_code_cells_example.py
+++ b/etl/steps/data/examples/vs_code_cells/vs_code_cells_example.py
@@ -24,6 +24,7 @@ df = df[df.a > 1]
 def run(dest_dir: str) -> None:
     ds = Dataset.create_empty(dest_dir)
     ds.metadata.short_name = "vs_code_cells_example"
+    ds.metadata.namespace = "examples"
 
     # use module-level variables
     t = Table(df.reset_index(drop=True))


### PR DESCRIPTION
Previously only public datasets were backported. This PR adds support for private datasets that are uploaded without public visibility to Walden and then processed in ETL and uploaded as private to our catalog.