### PR TITLE
enhance(backport): keep entity_id in multiindex

### DIFF
--- a/etl/backport_helpers.py
+++ b/etl/backport_helpers.py
@@ -35,7 +35,9 @@ def create_wide_table(
     # convert to wide format
     long_mem_usage_mb = values.memory_usage().sum() / 1e6
     df = values.pivot(
-        index=["entity_name", "year"], columns="variable_name", values="value"
+        index=["entity_name", "entity_id", "year"],
+        columns="variable_name",
+        values="value",
     )
 
     # report compression ratio if the file is larger than >1MB

--- a/etl/backport_helpers.py
+++ b/etl/backport_helpers.py
@@ -33,6 +33,7 @@ def create_wide_table(
 ) -> Table:
     """Convert backported table from long to wide format."""
     # convert to wide format
+    # NOTE: we keep both entity_name and entity_id
     long_mem_usage_mb = values.memory_usage().sum() / 1e6
     df = values.pivot(
         index=["entity_name", "entity_id", "year"],


### PR DESCRIPTION
Keep `entity_id` in multiindex which will be useful for [TBD]. Alternatives are:

1. keep it as column instead of having it in multiindex
2. keeping the `entity_name -> entity_id` mapping in metadata
3. `entity_name` as categorical variable with category codes being entity ids