### PR TITLE
Write source checksum to new db column

### DIFF
--- a/etl/db_utils.py
+++ b/etl/db_utils.py
@@ -166,25 +166,27 @@ class DBUtils:
         namespace: str,
         user_id: int,
         tag_id: Optional[int] = None,
+        source_checksum: Optional[str] = None,
         description: str = "This is a dataset imported by the automated fetcher",
     ) -> int:
         operation = self.upsert_one(
             """
             INSERT INTO datasets
-                (name, description, namespace, createdAt, createdByUserId, updatedAt, metadataEditedAt, metadataEditedByUserId, dataEditedAt, dataEditedByUserId)
+                (name, description, namespace, sourceChecksum, createdAt, createdByUserId, updatedAt, metadataEditedAt, metadataEditedByUserId, dataEditedAt, dataEditedByUserId)
             VALUES
-                (%s, %s, %s, NOW(), %s, NOW(), NOW(), %s, NOW(), %s)
+                (%s, %s, %s, %s, NOW(), %s, NOW(), NOW(), %s, NOW(), %s)
             ON DUPLICATE KEY UPDATE
                 name = VALUES(name),
                 description = VALUES(description),
                 namespace = VALUES(namespace),
+                sourceChecksum = VALUES(sourceChecksum),
                 updatedAt = VALUES(updatedAt),
                 metadataEditedAt = VALUES(metadataEditedAt),
                 metadataEditedByUserId = VALUES(metadataEditedByUserId),
                 dataEditedAt = VALUES(dataEditedAt),
                 dataEditedByUserId = VALUES(dataEditedByUserId)
         """,
-            [name, description, namespace, user_id, user_id, user_id],
+            [name, description, namespace, source_checksum, user_id, user_id, user_id],
         )
         (v,) = self.fetch_one(
             """

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -54,7 +54,7 @@ class VariableUpsertResult:
 
 
 def upsert_dataset(
-    dataset: catalog.Dataset, namespace: str, sources: List[catalog.meta.Source]
+    dataset: catalog.Dataset, namespace: str, sources: List[catalog.meta.Source], source_checksum: str
 ) -> DatasetUpsertResult:
     utils.validate_underscore(dataset.metadata.short_name, "Dataset's short_name")
 
@@ -78,7 +78,7 @@ def upsert_dataset(
             dataset.metadata.short_name,
             namespace,
             int(cast(str, config.GRAPHER_USER_ID)),
-            source_checksum=dataset.metadata.source_checksum,
+            source_checksum=source_checksum,
             description=dataset.metadata.description or "",
         )
 

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -78,6 +78,7 @@ def upsert_dataset(
             dataset.metadata.short_name,
             namespace,
             int(cast(str, config.GRAPHER_USER_ID)),
+            source_checksum=dataset.metadata.source_checksum,
             description=dataset.metadata.description or "",
         )
 

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -54,7 +54,10 @@ class VariableUpsertResult:
 
 
 def upsert_dataset(
-    dataset: catalog.Dataset, namespace: str, sources: List[catalog.meta.Source], source_checksum: str
+    dataset: catalog.Dataset,
+    namespace: str,
+    sources: List[catalog.meta.Source],
+    source_checksum: str,
 ) -> DatasetUpsertResult:
     utils.validate_underscore(dataset.metadata.short_name, "Dataset's short_name")
 

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -594,7 +594,10 @@ class GrapherStep(Step):
         # data steps
         dataset = step_module.get_grapher_dataset()  # type: ignore
         dataset_upsert_results = upsert_dataset(
-            dataset, dataset.metadata.namespace, dataset.metadata.sources, self.checksum_input()
+            dataset,
+            dataset.metadata.namespace,
+            dataset.metadata.sources,
+            self.checksum_input(),
         )
         variable_upsert_results = [
             upsert_table(table, dataset_upsert_results)

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -594,7 +594,7 @@ class GrapherStep(Step):
         # data steps
         dataset = step_module.get_grapher_dataset()  # type: ignore
         dataset_upsert_results = upsert_dataset(
-            dataset, dataset.metadata.namespace, dataset.metadata.sources
+            dataset, dataset.metadata.namespace, dataset.metadata.sources, self.checksum_input()
         )
         variable_upsert_results = [
             upsert_table(table, dataset_upsert_results)


### PR DESCRIPTION
#94 

When a dataset is loaded into grapher, write the source checksum. This allows us to compare with the checksums in ETL to determine whether grapher is out-of-date.

Prerequisite:
- [ ] Migration to add `sourceChecksum` db column