### PR TITLE
enhance(backport): add entity_id and entity_code to dataframe index

### DIFF
--- a/backport/backport.py
+++ b/backport/backport.py
@@ -64,8 +64,6 @@ def _walden_config_metadata(
 
 def _load_values(engine: Engine, variable_ids: list[int]) -> pd.DataFrame:
     """Get data values of a variable."""
-    # NOTE: loading entity_name and variable_name is perhaps unnecessary, consider removing it
-    # to speed up loading
     q = """
     select
         d.entityId as entity_id,
@@ -73,6 +71,7 @@ def _load_values(engine: Engine, variable_ids: list[int]) -> pd.DataFrame:
         -- it would be more efficient to load entity name and variable name separately and
         -- then join it before uploading to walden
         e.name as entity_name,
+        e.code as entity_code,
         v.name as variable_name,
         d.year,
         d.value as value
@@ -94,6 +93,7 @@ def _load_values(engine: Engine, variable_ids: list[int]) -> pd.DataFrame:
             "variable_name": "category",
             "entity_id": "category",
             "entity_name": "category",
+            "entity_code": "category",
         }
     )
 

--- a/etl/backport_helpers.py
+++ b/etl/backport_helpers.py
@@ -35,7 +35,9 @@ def create_wide_table(
     # convert to wide format
     long_mem_usage_mb = values.memory_usage().sum() / 1e6
     df = values.pivot(
-        index=["entity_name", "year"], columns="variable_name", values="value"
+        index=["year", "entity_name", "entity_id", "entity_code"],
+        columns="variable_name",
+        values="value",
     )
 
     # report compression ratio if the file is larger than >1MB


### PR DESCRIPTION
Add `entity_id` and `entity_code` to index for backported datasets. This will be useful for the API.

Alternatives are:

* keep it as column instead of having it in multiindex
* keeping the `entity_name -> entity_id` mapping in metadata
* `entity_name` as categorical variable with category codes being entity ids

Keeping it all in multiindex is probably the best though.