### PR TITLE
enhance(backport): prune inactive datasets from walden

### DIFF
--- a/backport/backport.py
+++ b/backport/backport.py
@@ -1,12 +1,11 @@
+import datetime as dt
 import os
 import tempfile
-import datetime as dt
 from typing import Optional, cast
 
 import click
 import pandas as pd
 import structlog
-from owid.catalog.utils import validate_underscore
 from owid.walden import Catalog as WaldenCatalog
 from owid.walden.catalog import Dataset as WaldenDataset
 from owid.walden.ingest import add_to_catalog
@@ -20,6 +19,8 @@ from etl.grapher_model import (
     GrapherSourceModel,
     GrapherVariableModel,
 )
+
+from . import utils
 
 WALDEN_NAMESPACE = os.environ.get("WALDEN_NAMESPACE", "backport")
 
@@ -160,15 +161,6 @@ def _walden_timestamp(short_name: str) -> dt.datetime:
     return cast(dt.datetime, pd.to_datetime(t))
 
 
-def _create_short_name(
-    short_name: Optional[str], dataset_id: int, variable_id: Optional[int]
-) -> str:
-    """Create sensible short name for dataset."""
-    validate_underscore(short_name, "short-name")
-    # prepend dataset id to short name
-    return f"dataset_{dataset_id}_{short_name}"
-
-
 def backport(
     dataset_id: int,
     short_name: str,
@@ -196,7 +188,7 @@ def backport(
         engine, dataset_id=ds.id, variable_ids=variable_ids
     )
 
-    short_name = _create_short_name(short_name, dataset_id, variable_id)
+    short_name = utils.create_short_name(short_name, dataset_id)
 
     config = _load_config(ds, vars, sources)
 

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -1,13 +1,17 @@
 import re
+from typing import Any, cast
 
 import click
 import pandas as pd
 import structlog
 from owid.catalog.utils import underscore
+from owid.walden import Catalog as WaldenCatalog
+from sqlalchemy.engine import Engine
 
 from etl.db import get_engine
 from etl.steps import load_dag
 
+from . import utils
 from .backport import backport
 
 log = structlog.get_logger()
@@ -38,10 +42,72 @@ log = structlog.get_logger()
     type=bool,
     help="Force overwrite even if checksums match",
 )
+@click.option(
+    "--prune/--no-prune",
+    default=False,
+    type=bool,
+    help="Prune datasets from walden that are not in DB anymore",
+)
 def bulk_backport(
-    dataset_ids: list[int], dry_run: bool, limit: int, upload: bool, force: bool
+    dataset_ids: list[int],
+    dry_run: bool,
+    limit: int,
+    upload: bool,
+    force: bool,
+    prune: bool,
 ) -> None:
     engine = get_engine()
+
+    df = _active_datasets(engine, limit=limit)
+
+    if dataset_ids:
+        df = df.loc[df.id.isin(dataset_ids)]
+
+    df["short_name"] = df.name.map(underscore)
+
+    log.info("bulk_backport.start", n=len(df))
+
+    ds_row: Any
+    for i, ds_row in enumerate(df.itertuples()):
+        log.info(
+            "bulk_backport",
+            dataset_id=ds_row.id,
+            name=ds_row.name,
+            private=ds_row.isPrivate,
+            progress=f"{i + 1}/{len(df)}",
+        )
+        backport(
+            dataset_id=ds_row.id,
+            short_name=ds_row.short_name,
+            dry_run=dry_run,
+            upload=upload,
+            force=force,
+        )
+
+    if prune:
+        _prune_walden_datasets(engine, dry_run)
+
+    log.info("bulk_backport.finished")
+
+
+def _backported_ids_in_dag() -> list[int]:
+    """Get all backported dataset ids used in DAG. This is helpful if someone uses backported
+    dataset without any charts."""
+    dag = load_dag()
+
+    all_steps = list(dag.keys()) + [x for vals in dag.values() for x in vals]
+
+    out = set()
+    for s in all_steps:
+        match = re.search(r"backport\/owid\/latest\/dataset_(\d+)_", s)
+        if match:
+            out.add(int(match.group(1)))
+
+    return list(out)
+
+
+def _active_datasets(engine: Engine, limit: int = 1000000) -> pd.DataFrame:
+    """Return dataframe of datasets with at least one chart that should be backported."""
 
     dag_backported_ids = _backported_ids_in_dag()
 
@@ -65,6 +131,8 @@ def bulk_backport(
     )
     -- and must not come from ETL
     and sourceChecksum is null
+    -- and must not be archived
+    and not isArchived
     order by rand()
     limit %(limit)s
     """
@@ -78,47 +146,29 @@ def bulk_backport(
         engine,
         params={"limit": limit, "dataset_ids": dag_backported_ids},
     )
-
-    if dataset_ids:
-        df = df[df.id.isin(dataset_ids)]
-
-    df["short_name"] = df.name.map(underscore)
-
-    log.info("bulk_backport.start", n=len(df))
-
-    for i, ds in enumerate(df.itertuples()):
-        log.info(
-            "bulk_backport",
-            dataset_id=ds.id,
-            name=ds.name,
-            private=ds.isPrivate,
-            progress=f"{i + 1}/{len(df)}",
-        )
-        backport(
-            dataset_id=ds.id,
-            short_name=ds.short_name,
-            dry_run=dry_run,
-            upload=upload,
-            force=force,
-        )
-
-    log.info("bulk_backport.finished")
+    return cast(df, pd.read_sql(q, engine, params={"limit": limit}))
 
 
-def _backported_ids_in_dag() -> list[int]:
-    """Get all backported dataset ids used in DAG. This is helpful if someone uses backported
-    dataset without any charts."""
-    dag = load_dag()
+def _prune_walden_datasets(engine: Engine, dry_run: bool) -> None:
+    active_dataset_ids = set(_active_datasets(engine)["id"])
 
-    all_steps = list(dag.keys()) + [x for vals in dag.values() for x in vals]
+    walden_catalog = WaldenCatalog()
 
-    out = set()
-    for s in all_steps:
-        match = re.search(r"backport\/owid\/latest\/dataset_(\d+)_", s)
-        if match:
-            out.add(int(match.group(1)))
+    datasets_to_delete = [
+        ds
+        for ds in walden_catalog.find(namespace="backport")
+        if utils.extract_id_from_short_name(ds.short_name) not in active_dataset_ids
+    ]
 
-    return list(out)
+    log.info("bulk_backport.delete", n=len(datasets_to_delete))
+
+    for ds in datasets_to_delete:
+        log.info("bulk_backport.delete_dataset", short_name=ds.short_name)
+
+        # delete it from local and remote catalog
+        if not dry_run:
+            ds.delete()
+            ds.delete_from_remote()
 
 
 if __name__ == "__main__":

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -121,7 +121,7 @@ def _active_datasets(engine: Engine, limit: int = 1000000) -> pd.DataFrame:
             select distinct v.datasetId from chart_dimensions as cd
             join variables as v on cd.variableId = v.id
         )
-        -- or be used in DAG
+        -- or be used in DAG or specified in CLI
         or id in %(dataset_ids)s
     )
     -- and must not come from ETL
@@ -135,7 +135,10 @@ def _active_datasets(engine: Engine, limit: int = 1000000) -> pd.DataFrame:
     df = pd.read_sql(
         q,
         engine,
-        params={"limit": limit, "dataset_ids": dag_backported_ids},
+        params={
+            "limit": limit,
+            "dataset_ids": dag_backported_ids + (list(dataset_ids) or []),
+        },
     )
     return cast(pd.DataFrame, df)
 

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -85,6 +85,7 @@ def bulk_backport(
         )
 
     if prune:
+        assert not dataset_ids, "Pruning cannot be used together with dataset-ids"
         _prune_walden_datasets(engine, dry_run)
 
     log.info("bulk_backport.finished")
@@ -121,16 +122,12 @@ def _active_datasets(engine: Engine, limit: int = 1000000) -> pd.DataFrame:
     limit %(limit)s
     """
 
-    # ignore limit if using dataset ids
-    if dataset_ids:
-        limit = 1000000
-
     df = pd.read_sql(
         q,
         engine,
         params={"limit": limit, "dataset_ids": dag_backported_ids},
     )
-    return cast(df, pd.read_sql(q, engine, params={"limit": limit}))
+    return cast(pd.DataFrame, df)
 
 
 def _prune_walden_datasets(engine: Engine, dry_run: bool) -> None:

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -90,22 +90,6 @@ def bulk_backport(
     log.info("bulk_backport.finished")
 
 
-def _backported_ids_in_dag() -> list[int]:
-    """Get all backported dataset ids used in DAG. This is helpful if someone uses backported
-    dataset without any charts."""
-    dag = load_dag()
-
-    all_steps = list(dag.keys()) + [x for vals in dag.values() for x in vals]
-
-    out = set()
-    for s in all_steps:
-        match = re.search(r"backport\/owid\/latest\/dataset_(\d+)_", s)
-        if match:
-            out.add(int(match.group(1)))
-
-    return list(out)
-
-
 def _active_datasets(engine: Engine, limit: int = 1000000) -> pd.DataFrame:
     """Return dataframe of datasets with at least one chart that should be backported."""
 
@@ -169,6 +153,22 @@ def _prune_walden_datasets(engine: Engine, dry_run: bool) -> None:
         if not dry_run:
             ds.delete()
             ds.delete_from_remote()
+
+
+def _backported_ids_in_dag() -> list[int]:
+    """Get all backported dataset ids used in DAG. This is helpful if someone uses backported
+    dataset without any charts."""
+    dag = load_dag()
+
+    all_steps = list(dag.keys()) + [x for vals in dag.values() for x in vals]
+
+    out = set()
+    for s in all_steps:
+        match = re.search(r"backport\/owid\/latest\/dataset_(\d+)_", s)
+        if match:
+            out.add(int(match.group(1)))
+
+    return list(out)
 
 
 if __name__ == "__main__":

--- a/backport/utils.py
+++ b/backport/utils.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+from owid.catalog.utils import validate_underscore
+
+
+def create_short_name(short_name: Optional[str], dataset_id: int) -> str:
+    """Create sensible short name for dataset."""
+    validate_underscore(short_name, "short-name")
+    # prepend dataset id to short name
+    return f"dataset_{dataset_id}_{short_name}"
+
+
+def extract_id_from_short_name(short_name: str) -> int:
+    return int(short_name.split("_")[1])


### PR DESCRIPTION
If dataset is archived or deleted from DB, it will still be saved in walden index (local index) and walden S3 bucket. This PR adds `bulk_backport --prune` command that deletes those datasets. This is meant to be run from production server and commited to walden as soon as the backport finishes (so that catalog in S3 and walden commits are out-of-sync as short time as possible).