### PR TITLE
Implement is_dirty check for GrapherStep

### DIFF
--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -246,7 +246,7 @@ def fetch_db_checksum(dataset: catalog.Dataset) -> Optional[str]:
             FROM datasets
             WHERE name=%s
             """,
-            [dataset.metadata.short_name]
+            [dataset.metadata.short_name],
         )
         return None if source_checksum is None else source_checksum[0]
 

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -242,7 +242,7 @@ def fetch_db_checksum(dataset: catalog.Dataset) -> Optional[str]:
     with open_db() as db:
         source_checksum = db.fetch_one_or_none(
             """
-            SELECT sourceChecksum 
+            SELECT sourceChecksum
             FROM datasets
             WHERE name=%s
             """,

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 import json
 import os
 import pandas as pd
-from typing import Dict, List, cast
+from typing import Dict, List, cast, Optional
 from contextlib import contextmanager
 from collections.abc import Generator
 
@@ -232,6 +232,23 @@ def upsert_table(
         logger.info(f"Upserted {len(table)} datapoints.")
 
         return VariableUpsertResult(db_variable_id, source_id)
+
+
+def fetch_db_checksum(dataset: catalog.Dataset) -> Optional[str]:
+    """
+    Fetch the latest source checksum associated with a given dataset in the db. Can be compared
+    with the current source checksum to determine whether the db is up-to-date.
+    """
+    with open_db() as db:
+        source_checksum = db.fetch_one_or_none(
+            """
+            SELECT sourceChecksum 
+            FROM datasets
+            WHERE name=%s
+            """,
+            [dataset.metadata.short_name]
+        )
+        return None if source_checksum is None else source_checksum[0]
 
 
 def cleanup_ghost_variables(dataset_id: int, upserted_variable_ids: List[int]) -> None:


### PR DESCRIPTION
#94 

With https://github.com/owid/etl/pull/208, we began writing the latest input checksum to grapher db. Now, we use that checksum to verify if the grapher db data is up-to-date, by implementing `GrapherStep#is_dirty`.