### PR TITLE
Fix/food explorer v1

### DIFF
--- a/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
+++ b/etl/steps/data/garden/explorers/2021/food_explorer.ipynb
@@ -2438,7 +2438,7 @@
    "source": [
     "# Check missing fields\n",
     "cols_missing = [f for f, v in fields.items() if v.description == \"\"]\n",
-    "assert cols_missing == [\n",
+    "cols_missing_check = {\n",
     "    \"exports__tonnes\",\n",
     "    \"imports__tonnes\",\n",
     "    \"producing_or_slaughtered_animals__animals\",\n",
@@ -2450,7 +2450,8 @@
     "    \"food_available_for_consumption__protein_g_per_day__per_capita\",\n",
     "    \"imports__tonnes__per_capita\",\n",
     "    \"producing_or_slaughtered_animals__animals__per_capita\",\n",
-    "]"
+    "}\n",
+    "assert set(cols_missing) == cols_missing_check"
    ]
   },
   {


### PR DESCRIPTION
There was a bug in production due to an assertion error:

```
To github.com-walden:owid/walden.git
 03cd1d6..b94cd7f master -> master
Traceback (most recent call last):
 File "/home/owid/etl/.venv/bin/etl", line 5, in <module>
 main()
 File "/home/owid/etl/.venv/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
 return self.main(*args, **kwargs)
 File "/home/owid/etl/.venv/lib/python3.9/site-packages/click/core.py", line 1055, in main
 rv = self.invoke(ctx)
 File "/home/owid/etl/.venv/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
 return ctx.invoke(self.callback, **ctx.params)
 File "/home/owid/etl/.venv/lib/python3.9/site-packages/click/core.py", line 760, in invoke
 return __callback(*args, **kwargs)
 File "/home/owid/etl/etl/command.py", line 81, in main
 run_dag(
 File "/home/owid/etl/etl/command.py", line 143, in run_dag
 time_taken = timed_run(lambda: step.run())
 File "/home/owid/etl/etl/command.py", line 150, in timed_run
 f()
 File "/home/owid/etl/etl/command.py", line 143, in <lambda>
 time_taken = timed_run(lambda: step.run())
 File "/home/owid/etl/etl/steps/__init__.py", line 318, in run
 self._run_notebook()
 File "/home/owid/etl/etl/steps/__init__.py", line 420, in _run_notebook
 pm.execute_notebook(
 File "/home/owid/etl/.venv/lib/python3.9/site-packages/papermill/execute.py", line 122, in execute_notebook
 raise_for_execution_errors(nb, output_path)
 File "/home/owid/etl/.venv/lib/python3.9/site-packages/papermill/execute.py", line 234, in raise_for_execution_errors
 raise error
papermill.exceptions.PapermillExecutionError: 
---------------------------------------------------------------------------
Exception encountered at "In [105]":
---------------------------------------------------------------------------
AssertionError Traceback (most recent call last)
/tmp/ipykernel_3970802/1840104696.py in <cell line: 3>()
 1 # Check missing fields
 2 cols_missing = [f for f, v in fields.items() if v.description == ""]
----> 3 assert cols_missing == [
 4 "exports__tonnes",
 5 "imports__tonnes",

AssertionError: 
```

This assertion happened in the baking of the metadata fields. In particular, it was checking that the metrics with missing descriptions in the source (there are some for which no description is provided) hadn't changed. However, it was doing this by comparing two lists. Instead, now it compares these using two sets, as the column order is not relevant!

Running ETL worked on my end:

```
~ .venv/bin/etl food_explorer                    
Detecting which steps need rebuilding...
Running 1 steps:
1. data://garden/explorers/2021/food_explorer...
OK (140s)
```