### PR TITLE
tqdm should write to stdout

### DIFF
--- a/etl/steps/data/explorer/owid/latest/food_explorer.py
+++ b/etl/steps/data/explorer/owid/latest/food_explorer.py
@@ -6,6 +6,7 @@ NOTE: It will overwrite csv files inside "data/explorer/owid/latest/food_explore
 
 """
 
+import sys
 from copy import deepcopy
 
 from owid import catalog
@@ -72,7 +73,7 @@ def run(dest_dir: str) -> None:
     # List all products in table
     products = sorted(table_garden.index.get_level_values("product").unique().tolist())
 
-    for product in tqdm(products):
+    for product in tqdm(products, file=sys.stdout):
         # Save a table (as a separate csv file) for each food product.
         table_product = table_garden.loc[product].copy()
         # Update table metadata.

--- a/etl/steps/data/garden/faostat/2022-05-17/faostat_metadata.py
+++ b/etl/steps/data/garden/faostat/2022-05-17/faostat_metadata.py
@@ -36,6 +36,7 @@ mapping in the data is the correct one (except possibly in the examples mentione
 
 from copy import deepcopy
 from typing import List
+import sys
 
 import pandas as pd
 from owid import catalog
@@ -469,7 +470,7 @@ def run(dest_dir: str) -> None:
                                 "fao_unit": [], "fao_unit_short_name": []})
 
     # Gather all variables from the latest version of each meadow dataset.
-    for dataset_short_name in tqdm(dataset_short_names):
+    for dataset_short_name in tqdm(dataset_short_names, file=sys.stdout):
         # Load latest meadow table for current dataset.
         table = load_latest_data_table_for_dataset(dataset_short_name=dataset_short_name)
 

--- a/etl/steps/data/garden/faostat/2022-05-17/faostat_metadata.py
+++ b/etl/steps/data/garden/faostat/2022-05-17/faostat_metadata.py
@@ -34,9 +34,9 @@ mapping in the data is the correct one (except possibly in the examples mentione
 
 """
 
+import sys
 from copy import deepcopy
 from typing import List
-import sys
 
 import pandas as pd
 from owid import catalog

--- a/etl/steps/data/garden/faostat/2022-05-17/shared.py
+++ b/etl/steps/data/garden/faostat/2022-05-17/shared.py
@@ -17,6 +17,7 @@ NOTES:
 """
 
 import json
+import sys
 import warnings
 from copy import deepcopy
 from pathlib import Path
@@ -629,7 +630,7 @@ def add_regions(data, aggregations):
                                                       if value == unique_value]).tolist()
                              for unique_value in aggregations.values()}
 
-    for region in tqdm(REGIONS_TO_ADD):
+    for region in tqdm(REGIONS_TO_ADD, file=sys.stdout):
         countries_in_region = _list_countries_in_region(region, countries_regions=countries_regions)
         region_code = REGIONS_TO_ADD[region]["area_code"]
         region_population = population[population["country"] == region][["year", "population"]].reset_index(drop=True)


### PR DESCRIPTION
`tqdm` writes to stderr by default which is then displayed in our `#analytics-errors` channel as error. Make it write to stdout instead