### PR TITLE
Add `downstream` option for `etl`, and turn off by default

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -37,6 +37,11 @@ THREADPOOL_WORKERS = 5
     is_flag=True,
     help="Add steps for backporting OWID datasets",
 )
+@click.option(
+    "--downstream",
+    is_flag=True,
+    help="Include downstream dependencies (steps that depend on the included steps)"
+)
 @click.option("--exclude", help="Comma-separated patterns to exclude")
 @click.option(
     "--dag-path",
@@ -50,6 +55,7 @@ THREADPOOL_WORKERS = 5
     help="Thread workers to parallelize which steps need rebuilding (steps execution is not parallelized)",
     default=5,
 )
+
 @click.argument("steps", nargs=-1)
 def main(
     steps: List[str],
@@ -58,6 +64,7 @@ def main(
     private: bool = False,
     grapher: bool = False,
     backport: bool = False,
+    downstream: bool = False,
     exclude: Optional[str] = None,
     dag_path: Path = paths.DAG_FILE,
     workers: int = 5,
@@ -85,6 +92,7 @@ def main(
         force=force,
         private=private,
         include_grapher=grapher,
+        downstream=downstream,
         excludes=excludes,
         workers=workers,
     )
@@ -107,6 +115,7 @@ def run_dag(
     force: bool = False,
     private: bool = False,
     include_grapher: bool = False,
+    downstream: bool = False,
     excludes: Optional[List[str]] = None,
     workers: int = 1,
 ) -> None:
@@ -126,7 +135,7 @@ def run_dag(
     if not private:
         excludes.append("-private://")
 
-    steps = compile_steps(dag, includes, excludes)
+    steps = compile_steps(dag, includes, excludes, downstream=downstream)
 
     if not force:
         print("Detecting which steps need rebuilding...")

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -53,7 +53,7 @@ DAG = Dict[str, Any]
 
 
 def compile_steps(
-    dag: DAG, includes: Optional[List[str]] = None, excludes: Optional[List[str]] = None
+    dag: DAG, includes: Optional[List[str]] = None, excludes: Optional[List[str]] = None, downstream: bool = False,
 ) -> List["Step"]:
     """
     Return the list of steps which, if executed in order, mean that every
@@ -63,21 +63,21 @@ def compile_steps(
     excludes = excludes or []
 
     # make sure each step runs after its dependencies
-    steps = to_dependency_order(dag, includes, excludes)
+    steps = to_dependency_order(dag, includes, excludes, downstream=downstream)
 
     # parse the steps into Python objects
     return [parse_step(name, dag) for name in steps]
 
 
 def to_dependency_order(
-    dag: DAG, includes: List[str], excludes: List[str]
+    dag: DAG, includes: List[str], excludes: List[str], downstream: bool = False,
 ) -> List[str]:
     """
     Organize the steps in dependency order with a topological sort. In other words,
     the resulting list of steps is a valid ordering of steps such that no step is run
     before the steps it depends on. Note: this ordering is not necessarily unique.
     """
-    subgraph = filter_to_subgraph(dag, includes) if includes else dag
+    subgraph = filter_to_subgraph(dag, includes, downstream=downstream) if includes else dag
     in_order = list(graphlib.TopologicalSorter(subgraph).static_order())
 
     # filter out explicit excludes
@@ -89,13 +89,13 @@ def to_dependency_order(
 
 
 def filter_to_subgraph(
-    graph: Graph, includes: Iterable[str], incl_forward: bool = True
+    graph: Graph, includes: Iterable[str], downstream: bool = False
 ) -> Graph:
     """
     Filter the full graph to only the included nodes, and all their dependencies.
 
-    If the incl_forward flag is true, also include "forward dependencies" (dependents),
-    and their own (backward) dependencies.
+    If the downstream flag is true, also include downstream dependencies (ie steps
+    that depend on the included steps), as well as their OWN dependencies.
 
     Assumes that the graph is organized dependent -> dependency (A -> B means A is
     dependent on B).
@@ -105,7 +105,7 @@ def filter_to_subgraph(
         s for s in all_steps if any(re.findall(pattern, s) for pattern in includes)
     }
 
-    if incl_forward:
+    if downstream:
         # Reverse the graph to find all nodes dependent on included nodes (forward deps)
         forward_deps = set(traverse(reverse_graph(graph), included))
         included = included.union(forward_deps)

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -83,31 +83,16 @@ def test_dependency_filtering():
         "c": {"b", "d"},
         "b": {"a"},
     }
-    assert filter_to_subgraph(dag, ["b"]) == {
+    assert filter_to_subgraph(dag, ["b"], downstream=True) == {
         "d": set(),
         "c": {"b", "d"},
         "b": {"a"},
         "a": set(),
     }
-    assert filter_to_subgraph(dag, ["b"], incl_forward=False) == {
+    assert filter_to_subgraph(dag, ["b"], downstream=False) == {
         "b": {"a"},
         "a": set(),
     }
-
-
-@patch("etl.steps.parse_step")
-def test_selection_selects_children(parse_step):
-    """When you pick a step, it should rebuild everything that depends on that step
-    and all dependencies of those steps"""
-    parse_step.side_effect = lambda name, _: DummyStep(name)
-
-    dag = {"a": ["b", "c"], "d": ["a"], "e": ["b"]}
-
-    # selecting "c" should cause "c" -> "a" -> "d" to all be selected
-    #                            "b" to be ignored
-    steps = compile_steps(dag, ["c"], [])
-    assert len(steps) == 4
-    assert set(s.path for s in steps) == {"b", "c", "a", "d"}
 
 
 @patch("etl.steps.parse_step")


### PR DESCRIPTION
You can now use `--downstream` to include downstream ("forward") dependencies. Previously downstream dependencies were included by default, now they are not.