### PR TITLE
doc: add an example .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# for local development with grapher
+GRAPHER_USER_ID=1
+
+DB_USER=grapher
+DB_NAME=grapher
+DB_PASS=grapher
+DB_PORT=3307
+DB_HOST=127.0.0.1


### PR DESCRIPTION
The file is only required if you are doing trial exports to grapher in your local dev environment. It's designed to match .env settings in dev grapher.