### PR TITLE
Add compare tool

### DIFF
--- a/etl/compare.py
+++ b/etl/compare.py
@@ -1,0 +1,251 @@
+#
+#  compare.py
+#
+
+from pathlib import Path
+import click
+from rich_click import RichCommand, RichGroup
+from rich import print
+from typing import cast
+import pandas as pd
+from etl import tempcompare
+from owid import catalog
+
+
+@click.group(cls=RichGroup)
+def cli():
+    """Compare two dataframes, both structurally and the values.
+
+    This tool loads two dataframes, either from the local ETL and the remote catalog
+    or just from two different files. It compares the columns, index columns and index values (row indices) as
+    sets between the two dataframes and outputs the differences. Finally it compares the values of the overlapping
+    columns and rows with the given threshold values for absolute and relative tolerance.
+
+    The exit code is 0 if the dataframes are equal, 1 if there is an error loading the dataframes, 2 if the dataframes
+    are structurally equal but are otherwise different, 3 if the dataframes have different structure and/or different values.
+    """
+    pass
+
+
+def diff_print_and_exit(
+    df1: pd.DataFrame,
+    df2: pd.DataFrame,
+    df1_label: str,
+    df2_label: str,
+    absolute_tolerance: float,
+    relative_tolerance: float,
+    show_values: bool,
+    show_shared: bool,
+    truncate_lists_at: int,
+):
+    """Runs the comparison and prints the differences, then exits with the appropriate exit code."""
+    diff = tempcompare.DataFrameHighLevelDiff(
+        df1, df2, absolute_tolerance, relative_tolerance
+    )
+    if diff.are_equal:
+        print("[green]Dataframes are equal (within the given thresholds)[/green]")
+        exit(0)
+    else:
+        lines = diff.get_description_lines_for_diff(
+            df1_label,
+            df2_label,
+            use_color_tags=True,
+            preview_different_dataframe_values=show_values,
+            show_shared=show_shared,
+            truncate_lists_longer_than=truncate_lists_at,
+        )
+        for line in lines:
+            print(line)
+        if diff.are_structurally_equal:
+            exit(2)
+        else:
+            exit(3)
+
+
+@cli.command(cls=RichCommand)
+@click.argument("channel")
+@click.argument("namespace")
+@click.argument("dataset")
+@click.argument("table")
+@click.option(
+    "--absolute-tolerance",
+    default=0.00000001,
+    show_default=True,
+    help="The absolute tolerance for floating point comparisons.",
+)
+@click.option(
+    "--relative-tolerance",
+    default=0.05,
+    show_default=True,
+    help="The relative tolerance for floating point comparisons.",
+)
+@click.option(
+    "--show-values/--hide-values",
+    default=False,
+    show_default=True,
+    help="Show a preview of the values where the dataframes are different.",
+)
+@click.option(
+    "--show-shared/--hide-shared",
+    default=False,
+    show_default=True,
+    help="Show the structural overlap of the two dataframes (shared columns, index columns and index values).",
+)
+@click.option(
+    "--truncate-lists-at",
+    default=20,
+    show_default=True,
+    help="Print truncated lists if they are longer than the given length.",
+)
+def etl_catalog(
+    channel: str,
+    namespace: str,
+    dataset: str,
+    table: str,
+    absolute_tolerance: float,
+    relative_tolerance: float,
+    show_values: bool,
+    show_shared: bool,
+    truncate_lists_at: int,
+) -> None:
+    """
+    Compare a table in the local catalog with the one in the remote catalog.
+
+    It compares the columns, index columns and index values (row indices) as
+    sets between the two dataframes and outputs the differences. Finally it compares the values of the overlapping
+    columns and rows with the given threshold values for absolute and relative tolerance.
+
+    The exit code is 0 if the dataframes are equal, 1 if there is an error loading the dataframes, 2 if the dataframes
+    are structurally equal but are otherwise different, 3 if the dataframes have different structure and/or different values.
+    """
+    try:
+        remote_df = catalog.find_one(table=table, namespace=namespace, dataset=dataset, channels=[cast(catalog.CHANNEL, channel)])  # type: ignore
+        local_catalog = catalog.LocalCatalog("data")
+        local_df = local_catalog.find_one(
+            table=table,
+            namespace=namespace,
+            dataset=dataset,
+            channel=cast(catalog.CHANNEL, channel),
+        )
+    except Exception as e:
+        print(e)
+        exit(1)
+
+    diff_print_and_exit(remote_df, local_df, "remote", "local", absolute_tolerance, relative_tolerance, show_values, show_shared, truncate_lists_at)
+
+
+def load_table(path_str: str) -> catalog.Table:
+    """Loads a Table (dataframe + metadata) from a path."""
+    path = Path(path_str)
+    if not path.exists():
+        raise Exception("File does not exist: " + path_str)
+
+    if path.suffix.lower() == ".feather":
+        return catalog.tables.Table.read_feather(path_str)
+    elif path.suffix.lower() == ".csv":
+        return catalog.tables.Table.read_csv(path_str)
+    else:
+        raise Exception("Unknown file format: " + path_str)
+
+
+def load_dataframe(path_str: str) -> pd.DataFrame:
+    """Loads a DataFrame from a path."""
+    path = Path(path_str)
+    if not path.exists():
+        raise Exception("File does not exist: " + path_str)
+
+    if path.suffix.lower() == ".feather":
+        return pd.read_feather(path_str)
+    elif path.suffix.lower() == ".csv":
+        return pd.read_csv(path_str)
+    elif path.suffix.lower() == ".parquet":
+        return pd.read_parquet(path_str)
+    else:
+        raise Exception("Unknown file format: " + path_str)
+
+
+@cli.command(cls=RichCommand)
+@click.argument("dataframe1")
+@click.argument("dataframe2")
+@click.option(
+    "--absolute-tolerance",
+    default=0.00000001,
+    show_default=True,
+    help="The absolute tolerance for floating point comparisons.",
+)
+@click.option(
+    "--relative-tolerance",
+    default=0.05,
+    show_default=True,
+    help="The relative tolerance for floating point comparisons.",
+)
+@click.option(
+    "--show-values/--hide-values",
+    default=False,
+    show_default=True,
+    help="Show a preview of the values where the dataframes are different.",
+)
+@click.option(
+    "--show-shared/--hide-shared",
+    default=False,
+    show_default=True,
+    help="Show the structural overlap of the two dataframes (shared columns, index columns and index values).",
+)
+@click.option(
+    "--truncate-lists-at",
+    default=20,
+    show_default=True,
+    help="Print truncated lists if they are longer than the given length.",
+)
+def dataframes(
+    dataframe1: str,
+    dataframe2: str,
+    absolute_tolerance: float,
+    relative_tolerance: float,
+    show_values: bool,
+    show_shared: bool,
+    truncate_lists_at: int,
+) -> None:
+    """
+    Compare two dataframes given as paths.
+
+    It compares the columns, index columns and index values (row indices) as
+    sets between the two dataframes and outputs the differences. Finally it compares the values of the overlapping
+    columns and rows with the given threshold values for absolute and relative tolerance.
+
+    The exit code is 0 if the dataframes are equal, 1 if there is an error loading the dataframes, 2 if the dataframes
+    are structurally equal but are otherwise different, 3 if the dataframes have different structure and/or different values.
+    """
+    df1: pd.DataFrame
+    df2: pd.DataFrame
+    try:
+        df1 = load_table(dataframe1)
+    except Exception as e:
+        print(
+            f"[yellow]Reading {dataframe1} as table with metadata failed, trying to read as plain dataframe[/yellow]"
+        )
+        try:
+            df1 = load_dataframe(dataframe1)
+        except Exception as e:
+            print(f"[red]Reading {dataframe1} as dataframe failed[/red]")
+            print(e)
+            exit(1)
+
+    try:
+        df2 = load_table(dataframe2)
+    except Exception as e:
+        print(
+            f"[yellow]Reading {dataframe2} as table with metadata failed, trying to read as plain dataframe[/yellow]"
+        )
+        try:
+            df2 = load_dataframe(dataframe2)
+        except Exception as e:
+            print(f"[red]Reading {dataframe2} as dataframe failed[/red]")
+            print(e)
+            exit(1)
+
+    diff_print_and_exit(df1, df2, "dataframe1", "dataframe2", absolute_tolerance, relative_tolerance, show_values, show_shared, truncate_lists_at)
+
+
+if __name__ == "__main__":
+    cli()

--- a/etl/compare.py
+++ b/etl/compare.py
@@ -218,6 +218,7 @@ def dataframes(
     """
     df1: pd.DataFrame
     df2: pd.DataFrame
+    print("🦸 OWID's friendly dataframe comparision tool - at your service! 🦸")
     try:
         df1 = load_table(dataframe1)
     except Exception as e:

--- a/etl/compare.py
+++ b/etl/compare.py
@@ -131,7 +131,17 @@ def etl_catalog(
         print(e)
         exit(1)
 
-    diff_print_and_exit(remote_df, local_df, "remote", "local", absolute_tolerance, relative_tolerance, show_values, show_shared, truncate_lists_at)
+    diff_print_and_exit(
+        remote_df,
+        local_df,
+        "remote",
+        "local",
+        absolute_tolerance,
+        relative_tolerance,
+        show_values,
+        show_shared,
+        truncate_lists_at,
+    )
 
 
 def load_table(path_str: str) -> catalog.Table:
@@ -221,7 +231,7 @@ def dataframes(
     print("🦸 OWID's friendly dataframe comparision tool - at your service! 🦸")
     try:
         df1 = load_table(dataframe1)
-    except Exception as e:
+    except Exception:
         print(
             f"[yellow]Reading {dataframe1} as table with metadata failed, trying to read as plain dataframe[/yellow]"
         )
@@ -234,7 +244,7 @@ def dataframes(
 
     try:
         df2 = load_table(dataframe2)
-    except Exception as e:
+    except Exception:
         print(
             f"[yellow]Reading {dataframe2} as table with metadata failed, trying to read as plain dataframe[/yellow]"
         )
@@ -245,7 +255,17 @@ def dataframes(
             print(e)
             exit(1)
 
-    diff_print_and_exit(df1, df2, "dataframe1", "dataframe2", absolute_tolerance, relative_tolerance, show_values, show_shared, truncate_lists_at)
+    diff_print_and_exit(
+        df1,
+        df2,
+        "dataframe1",
+        "dataframe2",
+        absolute_tolerance,
+        relative_tolerance,
+        show_values,
+        show_shared,
+        truncate_lists_at,
+    )
 
 
 if __name__ == "__main__":

--- a/etl/tempcompare.py
+++ b/etl/tempcompare.py
@@ -1,0 +1,433 @@
+from typing import Callable, Generator, Iterable
+import pandas as pd
+from typing import List, Optional, Any
+import numpy as np
+
+# ######## Note - this file will be moved to owid-catalog-py before the branch is merged ##############
+
+def get_list_description_with_max_length(items: List[Any], max_items: int = 20) -> str:
+    if len(items) > max_items:
+        return (
+            f"[{len(items)} items] "
+            + f'{", ".join(str(item) for item in items[:int(max_items/2)])} ... {", ".join(str(item) for item in items[-int(max_items/2):])}'
+        )
+    else:
+        return ", ".join(str(item) for item in items)
+
+
+def yield_list_lines(
+            description: str, items: Iterable[Any]
+        ) -> Generator[str, None, None]:
+            sublines = [item for item in items]
+            if len(sublines) > 1:
+                yield f"{description}:"
+                for subline in sublines:
+                    if subline != "":
+                        yield f"  {subline}"
+            elif len(sublines) == 1:
+                yield f"{description}: {sublines[0]}"
+
+
+def get_compact_list_description(
+    items_iterable: Iterable[Any], tuple_headers: List[str] = [], max_items: int = 20
+) -> Generator[str, None, None]:
+    """Returns a compact desription of a list.
+
+    If the list is numeric and monotonic then it gets compacted into a range like 2000-2015. If
+    the list contains tuples then the tuples are deconstructed into their components and the
+    components are compacted individually.
+    """
+    items = set(items_iterable)
+    if not items:
+        yield "[]"
+    elif all(isinstance(item, int) for item in items):
+        sorted_items = sorted(items)
+        if len(items) == 1:
+            yield str(sorted_items[0])
+        if len(items) == 2:
+            yield f"{sorted_items[0]}, {sorted_items[1]}"
+        if len(items) > 2:
+            if len(items) == sorted_items[-1] - sorted_items[0]:
+                yield f"{sorted_items[0]}-{sorted_items[-1]}"
+            else:
+                yield get_list_description_with_max_length(sorted_items, max_items)
+    elif all(isinstance(item, tuple) for item in items):
+        transposed = zip(*items)
+        lines = [
+            line for item in transposed for line in get_compact_list_description(item)
+        ]
+        if len(tuple_headers) == len(lines):
+            yield from (
+                f"{header}: {line}" for header, line in zip(tuple_headers, lines)
+            )
+        else:
+            yield from lines
+    else:
+        sorted_items = sorted(items)
+        yield get_list_description_with_max_length(sorted_items, max_items)
+
+
+def yield_formatted_if_not_empty(
+    item: Any, format_function: Callable[[Any], Generator[str, None, None]], fallback_message: str = ""
+) -> Generator[str, None, None]:
+    """Yield an item formatted with the given function if it is not empty."""
+    if item is not None and any(item):
+        yield from format_function(item)
+    elif fallback_message != "":
+        yield fallback_message
+
+class DataFrameHighLevelDiff:
+    """Class for comparing two dataframes.
+
+    It assumes that all nans are identical, and compares floats by means of certain absolute and relative tolerances.
+    Construct this class by passing two dataframes of possibly different shape. Then check the are_structurally_equal
+    property to see if the column and row sets of the two dataframes match and/or check the are_equal flag to also
+    check for equality of values.
+
+    For cases where there is a difference, various member fields on this class give indications of what is different
+    (e.g. columns missing in dataframe 1 or 2, index values missing in dataframe 1 or 2, etc.).
+
+    Parameters
+    ----------
+    df1 : pd.DataFrame
+        First dataframe.
+    df2 : pd.DataFrame
+        Second dataframe.
+    absolute_tolerance : float
+        Absolute tolerance to assume in the comparison of each cell in the dataframes. A value a of an element in df1 is
+        considered equal to the corresponding element b at the same position in df2, if:
+        abs(a - b) <= absolute_tolerance
+    relative_tolerance : float
+        Relative tolerance to assume in the comparison of each cell in the dataframes. A value a of an element in df1 is
+        considered equal to the corresponding element b at the same position in df2, if:
+        abs(a - b) / abs(b) <= relative_tolerance
+
+    """
+
+    df1: pd.DataFrame
+    df2: pd.DataFrame
+    columns_missing_in_df1: List[str]
+    columns_missing_in_df2: List[str]
+    columns_shared: List[str]
+    index_columns_missing_in_df1: List[str]
+    index_columns_missing_in_df2: List[str]
+    index_columns_shared: List[str]
+    index_values_missing_in_df1: pd.Index
+    index_values_missing_in_df2: pd.Index
+    index_values_shared: pd.Index
+    duplicate_index_values_in_df1: pd.Series
+    duplicate_index_values_in_df2: pd.Series
+    value_differences: Optional[pd.DataFrame] = None
+
+
+    def __init__(
+        self,
+        df1: pd.DataFrame,
+        df2: pd.DataFrame,
+        absolute_tolerance: float,
+        relative_tolerance: float,
+    ):
+        self.df1 = df1
+        self.df2 = df2
+        self.absolute_tolerance = absolute_tolerance
+        self.relative_tolerance = relative_tolerance
+        self.diff()
+
+    @property
+    def value_differences_count(self) -> int:
+        if self.value_differences is None:
+            return 0
+        else:
+            return self.value_differences.sum().sum()
+
+    @property
+    def columns_with_differences(self) -> Any:
+        """Return the columns that are different in the two dataframes.
+
+        This will be an array of index values. If the index is a MultiIndex, the index values will be tuples.
+        """
+        if self.value_differences is None:
+            return pd.array([])
+        return self.value_differences.columns.values
+
+    @property
+    def rows_with_differences(self) -> Any:
+        """Return the row indices that are different in the two dataframes.
+
+        This will be an array of index values. If the index is a MultiIndex, the index values will be tuples.
+        """
+        if self.value_differences is None:
+            return pd.array([])
+        return self.value_differences.index.values
+
+    def diff(self) -> None:
+        """Diff the two dataframes.
+
+        This can be a somewhat slow operation
+        """
+        df1_columns_set = set(self.df1.columns)
+        df2_columns_set = set(self.df2.columns)
+        self.columns_missing_in_df1 = sorted(df2_columns_set - df1_columns_set)
+        self.columns_missing_in_df2 = sorted(df1_columns_set - df2_columns_set)
+        self.columns_shared = sorted(df1_columns_set.intersection(df2_columns_set))
+
+        df1_index_names = set(self.df1.index.names)
+        df2_index_names = set(self.df2.index.names)
+        self.index_columns_missing_in_df1 = sorted(df2_index_names - df1_index_names)
+        self.index_columns_missing_in_df2 = sorted(df1_index_names - df2_index_names)
+        self.index_columns_shared = sorted(df1_index_names.intersection(df2_index_names))
+
+        self.index_values_missing_in_df1 = self.df2.index.difference(self.df1.index)
+        self.index_values_missing_in_df2 = self.df1.index.difference(self.df2.index)
+        self.index_values_shared = self.df2.index.intersection(self.df1.index)
+        self.duplicate_index_values_in_df1 = self.df1[
+            self.df1.index.duplicated()
+        ].index.values
+        self.duplicate_index_values_in_df2 = self.df2[
+            self.df2.index.duplicated()
+        ].index.values
+
+        # Now we calculate the value differences in the intersection of the two dataframes.
+        if self.columns_shared and any(self.index_values_shared):
+            df1_intersected = self.df1.loc[self.index_values_shared, list(self.columns_shared)]
+            df2_intersected = self.df2.loc[self.index_values_shared, list(self.columns_shared)]
+            # We don't use the compare function here from above because it builds a new
+            # dataframe and we want to leave indices intact so we can know which rows and columns
+            # were different once we drop the ones with no differences
+            diffs = df1_intersected.eq(df2_intersected)
+
+            # Eq above does not take tolerance into account so compare again with tolerance
+            # for columns that are numeric. this could probably be sped up with a check on any on
+            # the column first but would have to be benchmarked
+            for col in diffs.columns:
+                if (df1_intersected[col].dtype in (object, "category")) or (
+                    df2_intersected[col].dtype in (object, "category")
+                ):
+                    # Apply a direct comparison for strings or categories
+                    pass
+                else:
+                    # For numeric data, consider them equal within certain absolute and relative tolerances.
+                    compared_values = np.isclose(
+                        df1_intersected[col].values,
+                        df2_intersected[col].values,
+                        atol=self.absolute_tolerance,
+                        rtol=self.relative_tolerance,
+                    )
+                    # Treat nans as equal.
+                    compared_values[
+                        pd.isnull(df1_intersected[col].values)
+                        & pd.isnull(df2_intersected[col].values)
+                    ] = True
+                    diffs[col] = compared_values
+
+            # We now have a dataframe with the same shape and indices as df1 and df2, filled with
+            # True where the values are the same. We want to use true for different values, so invert
+            # element-wise now
+            diffs = ~diffs
+
+            if diffs.empty:
+                self.value_differences = None
+            else:
+                # Get a copy of diffs with all rows dropped where all values in a row are False
+                # (i.e. where df1 and df2 have identical values for all columns)
+                rows_with_diffs = diffs[diffs.any(axis=1)]
+                if rows_with_diffs.empty or not rows_with_diffs.any().any():
+                    self.value_differences = None
+                else:
+                    # Now figure out all columns where there is at least one difference
+                    columns_with_diffs = diffs.any(axis=0)
+                    if not columns_with_diffs.any():
+                        self.value_differences = None
+                    else:
+                        # Here we drop the columns that did not have differences. We are left with a dataframe
+                        # with the original indices and only the rows and columns let with differences.
+                        self.value_differences = rows_with_diffs.loc[
+                            :, columns_with_diffs
+                        ]
+
+    @property
+    def are_structurally_equal(self) -> bool:
+        """Check if the two dataframes are structurally equal (i.e. same columns, same index values, ...)."""
+        return not (
+            any(self.columns_missing_in_df1)
+            or any(self.columns_missing_in_df2)
+            or any(self.index_columns_missing_in_df1)
+            or any(self.index_columns_missing_in_df2)
+            or any(self.index_values_missing_in_df1)
+            or any(self.index_values_missing_in_df2)
+            or any(self.duplicate_index_values_in_df1)
+            or any(self.duplicate_index_values_in_df2)
+        )
+
+    @property
+    def are_equal(self) -> bool:
+        """Check if the two dataframes are equal, both structurally and cell-wise."""
+        return self.are_structurally_equal and self.value_differences is None
+
+    @property
+    def are_overlapping_values_equal(self) -> bool:
+        """Check if the values within the overlapping columns and rows of the two dataframes are equal."""
+        return self.value_differences is None
+
+    @property
+    def df1_value_differences(self) -> Optional[pd.DataFrame]:
+        """Returns a sliced version of df1 that contains only the columns and rows that differ from df2 (but with the
+        original values from df1)."""
+        if self.value_differences is None:
+            return None
+        return self.df1.loc[
+            self.value_differences.index, self.value_differences.columns
+        ]
+
+    @property
+    def df2_value_differences(self) -> Optional[pd.DataFrame]:
+        """Returns a sliced version of df2 that contains only the columns and rows that differ from df1 (but with the
+        original values from df2)."""
+        if self.value_differences is None:
+            return None
+        return self.df2.loc[
+            self.value_differences.index, self.value_differences.columns
+        ]
+
+    def get_description_lines_for_diff(
+        self,
+        df1_label: str,
+        df2_label: str,
+        use_color_tags: bool = False,
+        preview_different_dataframe_values: bool = False,
+        show_shared: bool = False,
+        truncate_lists_longer_than: int = 20,
+    ) -> Generator[str, None, None]:
+        red, red_end = ("[red]", "[/red]") if use_color_tags else ("", "")
+        green, green_end = ("[green]", "[/green]") if use_color_tags else ("", "")
+        blue, blue_end = ("[blue]", "[/blue]") if use_color_tags else ("", "")
+
+        if self.are_equal:
+            yield (f"{green}{df1_label} is equal to {df2_label}{green_end}")
+        else:
+            yield (f"{red}{df1_label} is not equal to {df2_label}{red_end}")
+
+            if self.are_structurally_equal:
+                yield (f"The structure is {green}identical{green_end}")
+            else:
+                yield (f"The structure is {red}different{red_end}")
+                if show_shared:
+                    yield from yield_formatted_if_not_empty(
+                        self.columns_shared,
+                        lambda item: yield_list_lines(
+                            f"{blue}Shared columns{blue_end}",
+                            get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                        ),
+                        f"{red}No shared columns{red_end}",
+                    )
+                yield from yield_formatted_if_not_empty(
+                    self.columns_missing_in_df1,
+                    lambda item: yield_list_lines(
+                        f"Columns missing in {df1_label}",
+                        get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                    ),
+                )
+                yield from yield_formatted_if_not_empty(
+                    self.columns_missing_in_df2,
+                    lambda item: yield_list_lines(
+                        f"Columns missing in {df2_label}",
+                        get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                    ),
+                )
+                if show_shared:
+                    yield from yield_formatted_if_not_empty(
+                        self.index_columns_shared,
+                        lambda item: yield_list_lines(
+                            f"{blue}Shared index columns{blue_end}",
+                            get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                        ),
+                        f"{red}No shared index columns{red_end}",
+                    )
+                yield from yield_formatted_if_not_empty(
+                    self.index_columns_missing_in_df1,
+                    lambda item: yield_list_lines(
+                        f"Index columns missing in {df1_label}",
+                        get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                    ),
+                )
+                yield from yield_formatted_if_not_empty(
+                    self.index_columns_missing_in_df2,
+                    lambda item: yield_list_lines(
+                        f"Index columns missing in {df2_label}",
+                        get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                    ),
+                )
+                if show_shared:
+                    yield from yield_formatted_if_not_empty(
+                        self.index_values_shared,
+                        lambda item: yield_list_lines(
+                            f"{blue}Shared index values{blue_end}",
+                            get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                        ),
+                        f"{red}No shared index values{red_end}",
+                    )
+                yield from yield_formatted_if_not_empty(
+                    self.index_values_missing_in_df1,
+                    lambda item: yield_list_lines(
+                        f"Index values missing in {df1_label}",
+                        get_compact_list_description(item, self.df1.index.names, max_items=truncate_lists_longer_than),
+                    ),
+                )
+                yield from yield_formatted_if_not_empty(
+                    self.index_values_missing_in_df2,
+                    lambda item: yield_list_lines(
+                        f"Index values missing in {df2_label}",
+                        get_compact_list_description(item, self.df2.index.names, max_items=truncate_lists_longer_than),
+                    ),
+                )
+                yield from yield_formatted_if_not_empty(
+                    self.duplicate_index_values_in_df1,
+                    lambda item: yield_list_lines(
+                        f"Duplicate index values in {df1_label}",
+                        get_compact_list_description(item, self.df1.index.names, max_items=truncate_lists_longer_than),
+                    ),
+                )
+                yield from yield_formatted_if_not_empty(
+                    self.duplicate_index_values_in_df2,
+                    lambda item: yield_list_lines(
+                        f"Duplicate index values in {df2_label}",
+                        get_compact_list_description(item, self.df2.index.names, max_items=truncate_lists_longer_than),
+                    ),
+                )
+
+            if self.value_differences is not None:
+                yield (f"Values in the shared columns/rows are {red}different{red_end}. ({self.value_differences_count} different cells)")
+                yield from yield_formatted_if_not_empty(
+                    self.columns_with_differences,
+                    lambda item: yield_list_lines(
+                        f"Columns with diffs", get_compact_list_description(item, max_items=truncate_lists_longer_than)
+                    ),
+                )
+                yield from yield_formatted_if_not_empty(
+                    self.rows_with_differences,
+                    lambda item: yield_list_lines(
+                        f"Rows with diffs",
+                        get_compact_list_description(item, self.df1.index.names, max_items=truncate_lists_longer_than),
+                    ),
+                )
+
+        if preview_different_dataframe_values:
+            if self.columns_shared and self.index_values_shared:
+                yield f"Values with differences in {df1_label}:"
+                yield (
+                    str(
+                        self.df1.loc[
+                            self.value_differences.index, self.value_differences.columns
+                        ]
+                    )
+                )
+                yield f"Values with differences in {df2_label}:"
+                yield (
+                    str(
+                        self.df2.loc[
+                            self.value_differences.index, self.value_differences.columns
+                        ]
+                    )
+                )
+            else:
+                yield f"The datasets have no overlapping columns/rows."

--- a/etl/tempcompare.py
+++ b/etl/tempcompare.py
@@ -303,9 +303,9 @@ class DataFrameHighLevelDiff:
         blue, blue_end = ("[blue]", "[/blue]") if use_color_tags else ("", "")
 
         if self.are_equal:
-            yield (f"{green}{df1_label} is equal to {df2_label}{green_end}")
+            yield (f"{green}{df1_label} == {df2_label}{green_end}")
         else:
-            yield (f"{red}{df1_label} is not equal to {df2_label}{red_end}")
+            yield (f"{red}{df1_label} ≠ {df2_label}{red_end}")
 
             if self.are_structurally_equal:
                 yield (f"The structure is {green}identical{green_end}")
@@ -320,6 +320,10 @@ class DataFrameHighLevelDiff:
                         ),
                         f"{red}No shared columns{red_end}",
                     )
+                elif len(self.columns_shared) == 0:
+                    # Warn about no shared columns even if show_shared is not set
+                    yield f"{red}No shared columns{red_end}"
+
                 yield from yield_formatted_if_not_empty(
                     self.columns_missing_in_df1,
                     lambda item: yield_list_lines(

--- a/etl/tempcompare.py
+++ b/etl/tempcompare.py
@@ -5,6 +5,7 @@ import numpy as np
 
 # ######## Note - this file will be moved to owid-catalog-py before the branch is merged ##############
 
+
 def get_list_description_with_max_length(items: List[Any], max_items: int = 20) -> str:
     if len(items) > max_items:
         return (
@@ -16,16 +17,16 @@ def get_list_description_with_max_length(items: List[Any], max_items: int = 20) 
 
 
 def yield_list_lines(
-            description: str, items: Iterable[Any]
-        ) -> Generator[str, None, None]:
-            sublines = [item for item in items]
-            if len(sublines) > 1:
-                yield f"{description}:"
-                for subline in sublines:
-                    if subline != "":
-                        yield f"  {subline}"
-            elif len(sublines) == 1:
-                yield f"{description}: {sublines[0]}"
+    description: str, items: Iterable[Any]
+) -> Generator[str, None, None]:
+    sublines = [item for item in items]
+    if len(sublines) > 1:
+        yield f"{description}:"
+        for subline in sublines:
+            if subline != "":
+                yield f"  {subline}"
+    elif len(sublines) == 1:
+        yield f"{description}: {sublines[0]}"
 
 
 def get_compact_list_description(
@@ -68,13 +69,16 @@ def get_compact_list_description(
 
 
 def yield_formatted_if_not_empty(
-    item: Any, format_function: Callable[[Any], Generator[str, None, None]], fallback_message: str = ""
+    item: Any,
+    format_function: Callable[[Any], Generator[str, None, None]],
+    fallback_message: str = "",
 ) -> Generator[str, None, None]:
     """Yield an item formatted with the given function if it is not empty."""
     if item is not None and any(item):
         yield from format_function(item)
     elif fallback_message != "":
         yield fallback_message
+
 
 class DataFrameHighLevelDiff:
     """Class for comparing two dataframes.
@@ -118,7 +122,6 @@ class DataFrameHighLevelDiff:
     duplicate_index_values_in_df1: pd.Series
     duplicate_index_values_in_df2: pd.Series
     value_differences: Optional[pd.DataFrame] = None
-
 
     def __init__(
         self,
@@ -175,7 +178,9 @@ class DataFrameHighLevelDiff:
         df2_index_names = set(self.df2.index.names)
         self.index_columns_missing_in_df1 = sorted(df2_index_names - df1_index_names)
         self.index_columns_missing_in_df2 = sorted(df1_index_names - df2_index_names)
-        self.index_columns_shared = sorted(df1_index_names.intersection(df2_index_names))
+        self.index_columns_shared = sorted(
+            df1_index_names.intersection(df2_index_names)
+        )
 
         self.index_values_missing_in_df1 = self.df2.index.difference(self.df1.index)
         self.index_values_missing_in_df2 = self.df1.index.difference(self.df2.index)
@@ -189,8 +194,12 @@ class DataFrameHighLevelDiff:
 
         # Now we calculate the value differences in the intersection of the two dataframes.
         if self.columns_shared and any(self.index_values_shared):
-            df1_intersected = self.df1.loc[self.index_values_shared, list(self.columns_shared)]
-            df2_intersected = self.df2.loc[self.index_values_shared, list(self.columns_shared)]
+            df1_intersected = self.df1.loc[
+                self.index_values_shared, list(self.columns_shared)
+            ]
+            df2_intersected = self.df2.loc[
+                self.index_values_shared, list(self.columns_shared)
+            ]
             # We don't use the compare function here from above because it builds a new
             # dataframe and we want to leave indices intact so we can know which rows and columns
             # were different once we drop the ones with no differences
@@ -316,7 +325,9 @@ class DataFrameHighLevelDiff:
                         self.columns_shared,
                         lambda item: yield_list_lines(
                             f"{blue}Shared columns{blue_end}",
-                            get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                            get_compact_list_description(
+                                item, max_items=truncate_lists_longer_than
+                            ),
                         ),
                         f"{red}No shared columns{red_end}",
                     )
@@ -328,14 +339,18 @@ class DataFrameHighLevelDiff:
                     self.columns_missing_in_df1,
                     lambda item: yield_list_lines(
                         f"Columns missing in {df1_label}",
-                        get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                        get_compact_list_description(
+                            item, max_items=truncate_lists_longer_than
+                        ),
                     ),
                 )
                 yield from yield_formatted_if_not_empty(
                     self.columns_missing_in_df2,
                     lambda item: yield_list_lines(
                         f"Columns missing in {df2_label}",
-                        get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                        get_compact_list_description(
+                            item, max_items=truncate_lists_longer_than
+                        ),
                     ),
                 )
                 if show_shared:
@@ -343,7 +358,9 @@ class DataFrameHighLevelDiff:
                         self.index_columns_shared,
                         lambda item: yield_list_lines(
                             f"{blue}Shared index columns{blue_end}",
-                            get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                            get_compact_list_description(
+                                item, max_items=truncate_lists_longer_than
+                            ),
                         ),
                         f"{red}No shared index columns{red_end}",
                     )
@@ -351,14 +368,18 @@ class DataFrameHighLevelDiff:
                     self.index_columns_missing_in_df1,
                     lambda item: yield_list_lines(
                         f"Index columns missing in {df1_label}",
-                        get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                        get_compact_list_description(
+                            item, max_items=truncate_lists_longer_than
+                        ),
                     ),
                 )
                 yield from yield_formatted_if_not_empty(
                     self.index_columns_missing_in_df2,
                     lambda item: yield_list_lines(
                         f"Index columns missing in {df2_label}",
-                        get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                        get_compact_list_description(
+                            item, max_items=truncate_lists_longer_than
+                        ),
                     ),
                 )
                 if show_shared:
@@ -366,7 +387,9 @@ class DataFrameHighLevelDiff:
                         self.index_values_shared,
                         lambda item: yield_list_lines(
                             f"{blue}Shared index values{blue_end}",
-                            get_compact_list_description(item, max_items=truncate_lists_longer_than),
+                            get_compact_list_description(
+                                item, max_items=truncate_lists_longer_than
+                            ),
                         ),
                         f"{red}No shared index values{red_end}",
                     )
@@ -374,44 +397,69 @@ class DataFrameHighLevelDiff:
                     self.index_values_missing_in_df1,
                     lambda item: yield_list_lines(
                         f"Index values missing in {df1_label}",
-                        get_compact_list_description(item, self.df1.index.names, max_items=truncate_lists_longer_than),
+                        get_compact_list_description(
+                            item,
+                            self.df1.index.names,
+                            max_items=truncate_lists_longer_than,
+                        ),
                     ),
                 )
                 yield from yield_formatted_if_not_empty(
                     self.index_values_missing_in_df2,
                     lambda item: yield_list_lines(
                         f"Index values missing in {df2_label}",
-                        get_compact_list_description(item, self.df2.index.names, max_items=truncate_lists_longer_than),
+                        get_compact_list_description(
+                            item,
+                            self.df2.index.names,
+                            max_items=truncate_lists_longer_than,
+                        ),
                     ),
                 )
                 yield from yield_formatted_if_not_empty(
                     self.duplicate_index_values_in_df1,
                     lambda item: yield_list_lines(
                         f"Duplicate index values in {df1_label}",
-                        get_compact_list_description(item, self.df1.index.names, max_items=truncate_lists_longer_than),
+                        get_compact_list_description(
+                            item,
+                            self.df1.index.names,
+                            max_items=truncate_lists_longer_than,
+                        ),
                     ),
                 )
                 yield from yield_formatted_if_not_empty(
                     self.duplicate_index_values_in_df2,
                     lambda item: yield_list_lines(
                         f"Duplicate index values in {df2_label}",
-                        get_compact_list_description(item, self.df2.index.names, max_items=truncate_lists_longer_than),
+                        get_compact_list_description(
+                            item,
+                            self.df2.index.names,
+                            max_items=truncate_lists_longer_than,
+                        ),
                     ),
                 )
 
             if self.value_differences is not None:
-                yield (f"Values in the shared columns/rows are {red}different{red_end}. ({self.value_differences_count} different cells)")
+                yield (
+                    f"Values in the shared columns/rows are {red}different{red_end}. ({self.value_differences_count} different cells)"
+                )
                 yield from yield_formatted_if_not_empty(
                     self.columns_with_differences,
                     lambda item: yield_list_lines(
-                        f"Columns with diffs", get_compact_list_description(item, max_items=truncate_lists_longer_than)
+                        "Columns with diffs",
+                        get_compact_list_description(
+                            item, max_items=truncate_lists_longer_than
+                        ),
                     ),
                 )
                 yield from yield_formatted_if_not_empty(
                     self.rows_with_differences,
                     lambda item: yield_list_lines(
-                        f"Rows with diffs",
-                        get_compact_list_description(item, self.df1.index.names, max_items=truncate_lists_longer_than),
+                        "Rows with diffs",
+                        get_compact_list_description(
+                            item,
+                            self.df1.index.names,
+                            max_items=truncate_lists_longer_than,
+                        ),
                     ),
                 )
 
@@ -434,4 +482,4 @@ class DataFrameHighLevelDiff:
                     )
                 )
             else:
-                yield f"The datasets have no overlapping columns/rows."
+                yield "The datasets have no overlapping columns/rows."

--- a/poetry.lock
+++ b/poetry.lock
@@ -94,28 +94,28 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.4.0"
+version = "22.1.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "awscli"
-version = "1.25.32"
+version = "1.25.42"
 description = "Universal Command Line Environment for AWS."
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = "1.27.32"
+botocore = "1.27.42"
 colorama = ">=0.2.5,<0.4.5"
 docutils = ">=0.10,<0.17"
 PyYAML = ">=3.10,<5.5"
@@ -209,14 +209,14 @@ dev = ["build (==0.8.0)", "flake8 (==4.0.1)", "hashin (==0.17.0)", "pip-tools (=
 
 [[package]]
 name = "boto3"
-version = "1.24.32"
+version = "1.24.42"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.27.32,<1.28.0"
+botocore = ">=1.27.42,<1.28.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -225,7 +225,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.27.32"
+version = "1.27.42"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -923,7 +923,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "jupytext"
-version = "1.14.0"
+version = "1.14.1"
 description = "Jupyter notebooks as Markdown documents, Julia, Python or R scripts"
 category = "dev"
 optional = false
@@ -1106,11 +1106,11 @@ python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
 
 [[package]]
 name = "mypy-boto3-s3"
-version = "1.24.0"
-description = "Type annotations for boto3.S3 1.24.0 service generated with mypy-boto3-builder 7.6.1"
+version = "1.24.36.post1"
+description = "Type annotations for boto3.S3 1.24.36 service generated with mypy-boto3-builder 7.10.0"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 typing-extensions = ">=4.1.0"
@@ -1853,7 +1853,7 @@ test = ["pytest-qt", "pytest-cov (>=3.0.0)", "pytest (>=6,!=7.0.0,!=7.0.1)"]
 
 [[package]]
 name = "rdflib"
-version = "6.1.1"
+version = "6.2.0"
 description = "RDFLib is a Python library for working with RDF, a simple yet powerful language for representing information."
 category = "main"
 optional = false
@@ -1864,13 +1864,16 @@ isodate = "*"
 pyparsing = "*"
 
 [package.extras]
-docs = ["sphinx (<5)", "sphinxcontrib-apidoc"]
+berkeleydb = ["berkeleydb"]
+dev = ["black (==22.6.0)", "flake8", "isort", "mypy", "pep8-naming", "types-setuptools", "flakeheaven"]
+docs = ["myst-parser", "sphinx (<6)", "sphinxcontrib-apidoc", "sphinxcontrib-kroki", "sphinx-autodoc-typehints"]
 html = ["html5lib"]
-tests = ["berkeleydb", "html5lib", "networkx", "pytest", "pytest-cov", "pytest-subtests"]
+networkx = ["networkx"]
+tests = ["html5lib", "pytest", "pytest-cov"]
 
 [[package]]
 name = "regex"
-version = "2022.7.9"
+version = "2022.7.25"
 description = "Alternative regular expression module, to replace re."
 category = "main"
 optional = false
@@ -1919,6 +1922,22 @@ pygments = ">=2.6.0,<3.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
+
+[[package]]
+name = "rich-click"
+version = "1.5.1"
+description = "Format click help output nicely with rich"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=7"
+rich = ">=10.7.0"
+
+[package.extras]
+dev = ["pre-commit"]
+typer = ["typer (>=0.4)"]
 
 [[package]]
 name = "rsa"
@@ -2321,7 +2340,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "urllib3"
-version = "1.26.10"
+version = "1.26.11"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -2373,6 +2392,8 @@ click = "^8.0.1"
 dataclasses-json = "^0.5.4"
 jsonschema = "^3.2.0"
 openpyxl = "^3.0.9"
+owid-catalog = "^0.2.9"
+owid-datautils = {git = "https://github.com/owid/data-utils-py.git", rev = "v0.4.4-alpha"}
 pandas = "^1.3.4"
 requests = "^2.26.0"
 rich = "^12.1.0"
@@ -2469,7 +2490,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "45a91cbdef0891c074f260049096f6ad96af4d713a6e43d63b662ea9c5d22dd0"
+content-hash = "04e116e553a1a77b7428616bda973b00d840923eee9f58d04db21f87fb5467b7"
 
 [metadata.files]
 ansiwrap = [
@@ -2523,8 +2544,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
 ]
 attrs = [
-    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
-    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
+    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
 ]
 awscli = []
 babel = []
@@ -3411,10 +3432,7 @@ pyzmq = [
 ]
 qtconsole = []
 qtpy = []
-rdflib = [
-    {file = "rdflib-6.1.1-py3-none-any.whl", hash = "sha256:fc81cef513cd552d471f2926141396b633207109d0154c8e77926222c70367fe"},
-    {file = "rdflib-6.1.1.tar.gz", hash = "sha256:8dbfa0af2990b98471dacbc936d6494c997ede92fd8ed693fb84ee700ef6f754"},
-]
+rdflib = []
 regex = []
 requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
@@ -3428,6 +3446,7 @@ rich = [
     {file = "rich-12.5.1-py3-none-any.whl", hash = "sha256:2eb4e6894cde1e017976d2975ac210ef515d7548bc595ba20e195fb9628acdeb"},
     {file = "rich-12.5.1.tar.gz", hash = "sha256:63a5c5ce3673d3d5fbbf23cd87e11ab84b6b451436f1b7f19ec54b6bc36ed7ca"},
 ]
+rich-click = []
 rsa = [
     {file = "rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2"},
     {file = "rsa-4.7.2.tar.gz", hash = "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"},
@@ -3593,7 +3612,10 @@ unidecode = [
     {file = "Unidecode-1.3.4-py3-none-any.whl", hash = "sha256:afa04efcdd818a93237574791be9b2817d7077c25a068b00f8cff7baa4e59257"},
     {file = "Unidecode-1.3.4.tar.gz", hash = "sha256:8e4352fb93d5a735c788110d2e7ac8e8031eb06ccbfe8d324ab71735015f9342"},
 ]
-urllib3 = []
+urllib3 = [
+    {file = "urllib3-1.26.11-py2.py3-none-any.whl", hash = "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc"},
+    {file = "urllib3-1.26.11.tar.gz", hash = "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"},
+]
 user-agents = []
 validators = []
 walden = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ bulk_backport = 'backport.bulk_backport:bulk_backport'
 fasttrack = 'backport.fasttrack:fasttrack'
 walkthrough = 'walkthrough.cli:cli'
 run_python_step = 'etl.run_python_step:main'
+compare = 'etl.compare:cli'
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -49,6 +50,7 @@ rich = "^12.1.0"
 owid-datautils = {git = "https://github.com/owid/data-utils-py.git", rev = "v0.4.4-alpha"}
 fuzzywuzzy = "^0.18.0"
 mistune = "^2.0.4"
+rich-click = "^1.5.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"


### PR DESCRIPTION
This PR implements the first version of a compare CLI that allows easy comparison of either arbitrary dataframes (feather, csv, parquet) or etl files (in that case against the version currently uploaded in the production catalog). Much of the logic for the diffing lives in the data-utils-py repo and is managed in this PR: https://github.com/owid/data-utils-py/pull/29 . 

This PR currently includes a temporary copy of the new HighlevelDiff class for development. It will be removed here and imported from data-utils-py when the PR over there is merged.