### PR TITLE
fix(backport): fix missing owid_data_url in backported datasets

### DIFF
--- a/backport/backport.py
+++ b/backport/backport.py
@@ -32,7 +32,9 @@ engine = get_engine()
 walden_catalog = WaldenCatalog()
 
 
-def _walden_values_metadata(ds: GrapherDatasetModel, short_name: str) -> WaldenDataset:
+def _walden_values_metadata(
+    ds: GrapherDatasetModel, short_name: str, public: bool
+) -> WaldenDataset:
     """Create walden dataset for grapher dataset values.
     These datasets are not meant for direct consumption from the catalog, but rather
     for postprocessing in etl.
@@ -48,14 +50,15 @@ def _walden_values_metadata(ds: GrapherDatasetModel, short_name: str) -> WaldenD
         url=f"https://owid.cloud/admin/datasets/{ds.id}",
         publication_date="latest",
         file_extension="feather",
+        is_public=public,
     )
 
 
 def _walden_config_metadata(
-    ds: GrapherDatasetModel, short_name: str, origin_md5: str
+    ds: GrapherDatasetModel, short_name: str, origin_md5: str, public: bool
 ) -> WaldenDataset:
     """Create walden dataset for grapher dataset variables and metadata."""
-    config = _walden_values_metadata(ds, short_name)
+    config = _walden_values_metadata(ds, short_name, public)
     config.short_name = short_name + "_config"
     config.name = f"Grapher metadata for {short_name}"
     config.file_extension = "json"
@@ -224,7 +227,7 @@ def backport(
     lg.info("backport.upload_config", upload=upload, dry_run=dry_run, public=public)
     _upload_config_to_walden(
         config,
-        _walden_config_metadata(ds, short_name, md5_config),
+        _walden_config_metadata(ds, short_name, md5_config, public),
         dry_run,
         upload,
         public=public,
@@ -242,7 +245,7 @@ def backport(
     )
     _upload_values_to_walden(
         df,
-        _walden_values_metadata(ds, short_name),
+        _walden_values_metadata(ds, short_name, public),
         dry_run,
         upload,
         public=public,

--- a/backport/backport.py
+++ b/backport/backport.py
@@ -159,6 +159,11 @@ def _needs_update(ds: GrapherDatasetModel, short_name: str, md5_config: str) -> 
         # datasets not found in catalog
         return True
 
+    # fastrack does not upload data to S3 and leaves owid_data_url empty, if we find
+    # such a dataset, we backport and upload it again
+    if not walden_ds.owid_data_url:
+        return True
+
     # compare checksums
     if walden_ds.origin_md5 == md5_config:
         # then check dataEditedAt field

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -94,7 +94,6 @@ def bulk_backport(
             )
             backport_step(
                 dataset_id=ds_row.id,
-                short_name=ds_row.short_name,
                 dry_run=dry_run,
                 upload=upload,
                 force=force,
@@ -159,7 +158,7 @@ def _active_datasets_names(engine: Engine) -> set[str]:
     active_datasets_df = _active_datasets(engine)
     names = set(
         active_datasets_df.apply(
-            lambda r: utils.create_short_name(r.short_name, r.id), axis=1
+            lambda r: utils.create_short_name(r.id, r.name), axis=1
         )
     )
     return {n + "_config" for n in names} | {n + "_values" for n in names}

--- a/backport/fasttrack.py
+++ b/backport/fasttrack.py
@@ -6,7 +6,6 @@ from typing import cast
 import click
 import pandas as pd
 import structlog
-from owid.catalog.utils import underscore
 from owid.walden import CATALOG as WALDEN_CATALOG
 from sqlalchemy.engine import Engine
 
@@ -128,14 +127,13 @@ def _backport_datasets_to_walden(df: pd.DataFrame, dry_run: bool, force: bool) -
     """Add datasets to local walden if missing or checksums are out of date; on prod, a cron job will commit."""
     # NOTE: we are not commiting changes to walden repo, this could be problematic
     # if the other processes are trying to rebase the repo
-    # NOTE: we are not uploading files to walden S3 bucket, this will be done during periodic
-    # etl run
+    # NOTE: we are not uploading files to walden S3 bucket and hence leaving owid_data_url attribute empty, these
+    # files will be uploaded during periodic backport run
     log.info("backport_dataset_to_walden.start")
     with concurrent.futures.ThreadPoolExecutor() as executor:
         executor.map(
             lambda r: backport(
                 dataset_id=r.dataset_id,
-                short_name=underscore(r.dataset_name),
                 dry_run=dry_run,
                 force=force,
                 upload=False,

--- a/backport/utils.py
+++ b/backport/utils.py
@@ -1,13 +1,10 @@
-from typing import Optional
-
-from owid.catalog.utils import validate_underscore
+from owid.catalog.utils import underscore
 
 
-def create_short_name(short_name: Optional[str], dataset_id: int) -> str:
+def create_short_name(dataset_id: int, dataset_name: str) -> str:
     """Create sensible short name for dataset."""
-    validate_underscore(short_name, "short-name")
     # prepend dataset id to short name
-    return f"dataset_{dataset_id}_{short_name}"
+    return f"dataset_{dataset_id}_{underscore(dataset_name)}"
 
 
 def extract_id_from_short_name(short_name: str) -> int:

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -3,11 +3,11 @@ import json
 from typing import Any, Dict, Optional
 
 import pandas as pd
+import structlog
 from pydantic import BaseModel
 from sqlalchemy.engine import Engine
 from sqlmodel import JSON, Column, Field, Session, SQLModel, select
 from sqlmodel.sql.expression import Select, SelectOfScalar
-import structlog
 
 
 log = structlog.get_logger()


### PR DESCRIPTION
Fastrack is backporting datasets only locally and does not upload them to Walden, hence the missing `owid_data_url`. Periodic backport runs need to find those datasets and upload them before commiting to Walden.