### PR TITLE
fix(steps): run notebook with proper working directory

### DIFF
--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -399,6 +399,7 @@ class DataStep(Step):
                     progress_bar=False,
                     stdout_file=ostream,
                     stderr_file=ostream,
+                    cwd=notebook_path.parent.as_posix(),
                 )
 
 

--- a/etl/steps/data/examples/examples/latest/jupytext_example.py
+++ b/etl/steps/data/examples/examples/latest/jupytext_example.py
@@ -9,7 +9,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.11.2
 #   kernelspec:
-#     display_name: 'Python 3.9.12 (''.venv'': poetry)'
+#     display_name: 'Python 3.9.13 (''.venv'': poetry)'
 #     language: python
 #     name: python3
 # ---

--- a/etl/steps/data/examples/examples/latest/notebook_example.ipynb
+++ b/etl/steps/data/examples/examples/latest/notebook_example.ipynb
@@ -103,7 +103,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.13"
   },
   "orig_nbformat": 4,
   "vscode": {


### PR DESCRIPTION
Previously we weren't able to import modules from the same directory as notebook (e.g. `from shared import ...`). This sets working directory correctly.