### PR TITLE
enhance(open_numbers): parallelise table imports

### DIFF
--- a/etl/steps/open_numbers.py
+++ b/etl/steps/open_numbers.py
@@ -56,10 +56,15 @@ def run(dest_dir: str) -> None:
     # copy tables one by one
     with ProcessPoolExecutor() as executor:
         for short_name, resources in resource_map.items():
-            executor.submit(add_resource, ds, short_name, resources)
+            executor.submit(add_resource, ds, repo, short_name, resources)
 
 
-def add_resource(ds: Dataset, short_name: str, resources: List[frictionless.Resource]):
+def add_resource(
+    ds: Dataset,
+    repo: GithubRepo,
+    short_name: str,
+    resources: List[frictionless.Resource],
+) -> None:
     print(f"- {short_name}")
     if len(resources) > 1:
         df = load_all_resources(repo.cache_dir, resources)

--- a/etl/steps/open_numbers.py
+++ b/etl/steps/open_numbers.py
@@ -66,28 +66,37 @@ def add_resource(
     resources: List[frictionless.Resource],
 ) -> None:
     print(f"- {short_name}")
-    if len(resources) > 1:
-        df = load_all_resources(repo.cache_dir, resources)
-    else:
-        (resource,) = resources
-        try:
-            df = resource.to_pandas()
+    try:
+        if len(resources) > 1:
+            df = load_and_combine(repo.cache_dir, resources)
+        else:
+            df = load_table(resources[0])
 
-        except FrictionlessException:
-            # see: https://github.com/owid/etl/issues/36
-            print("  ERROR: skipping")
-            return
-
-        # use smaller, more accurate column types that minimise space
-        if "global" in df.columns:
-            df["geo"] = df.pop("global")
+    except FrictionlessException:
+        # see: https://github.com/owid/etl/issues/36
+        print("  ERROR: skipping")
+        return
 
     t = Table(df)
     t.metadata.short_name = short_name
-    ds.add(utils.underscore_table(t))
+
+    # adapt the table name and its column names to our naming convention
+    t = utils.underscore_table(t)
+
+    ds.add(t)
 
 
-def load_all_resources(
+def load_table(resource: frictionless.Resource) -> pd.DataFrame:
+    df = cast(pd.DataFrame, resource.to_pandas())
+
+    # use smaller, more accurate column types that minimise space
+    if "global" in df.columns:
+        df["geo"] = df.pop("global")
+
+    return df
+
+
+def load_and_combine(
     path: Path, resources: List[frictionless.Resource]
 ) -> pd.DataFrame:
     first = True

--- a/etl/steps/open_numbers.py
+++ b/etl/steps/open_numbers.py
@@ -8,7 +8,7 @@ Convert repositories with data in DDF format to OWID's Dataset and Table
 format.
 """
 
-from concurrent.futures import ProcessPoolExecutor
+from multiprocessing import Pool
 from pathlib import Path
 from typing import Dict, List, Tuple, cast
 import hashlib
@@ -54,9 +54,12 @@ def run(dest_dir: str) -> None:
     resource_map = remap_names(package.resources)
 
     # copy tables one by one
-    with ProcessPoolExecutor() as executor:
-        for short_name, resources in resource_map.items():
-            executor.submit(add_resource, ds, repo, short_name, resources)
+    with Pool() as pool:
+        args = [
+            (ds, repo, short_name, resources)
+            for short_name, resources in resource_map.items()
+        ]
+        pool.starmap(add_resource, args)
 
 
 def add_resource(


### PR DESCRIPTION
Several open_numbers datasets are large, and importing them can take a long time when done table by table.

This PR parallelises each open_numbers dataset import, whilst leaving the overall process serial.

## Benchmarks

On a 10-core M1 Max, running `rm -f data/open_numbers; etl open_numbers`

Before: `2352.86s user 130.22s system 99% cpu 41:35.25 total`
After: `4143.78s user 554.04s system 654% cpu 11:57.23 total` (3.5x faster)