### PR TITLE
fix(grapher): fix dimensions when yielding long or wide table to grapher

### DIFF
--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -171,7 +171,7 @@ def yield_wide_table(
                 )
                 tab[short_name].metadata.title = title_with_dims
             else:
-                title_with_dims = None  # type: ignore
+                title_with_dims = None
 
             log.info(
                 "yield_wide_table.create_variable",

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -164,6 +164,7 @@ def yield_wide_table(
             tab = tab.rename(columns={column: short_name})
 
             # Add dimensions to title (which will be used as variable name in grapher)
+            title_with_dims: Optional[str]
             if tab[short_name].metadata.title:
                 title_with_dims = _title_column_and_dimensions(
                     tab[short_name].metadata.title, dims, dim_titles

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -104,6 +104,7 @@ def annotate_table(
 def yield_wide_table(
     table: catalog.Table,
     na_action: Literal["drop", "raise"] = "raise",
+    dim_titles: Optional[List[str]] = None,
 ) -> Iterable[catalog.Table]:
     """We have 5 dimensions but graphers data model can only handle 2 (year and entityId). This means
     we have to iterate all combinations of the remaining 3 dimensions and create a new variable for
@@ -112,6 +113,8 @@ def yield_wide_table(
 
     :param na_action: grapher does not support missing values, you can either drop them using this argument
         or raise an exception
+    :param dim_titles: Custom names to use for the dimensions, if not provided, the default names will be used.
+        Dimension title will be used to create variable name, e.g. `Deaths - Age: 10-18` instead of `Deaths - age: 10-18`
     """
     # Validation
     if "year" not in table.primary_key:
@@ -124,6 +127,12 @@ def yield_wide_table(
                 raise ValueError(f"Column `{col}` contains missing values")
 
     dim_names = [k for k in table.primary_key if k not in ("year", "entity_id")]
+    if dim_titles:
+        assert len(dim_names) == len(
+            dim_titles
+        ), "`dim_titles` must be the same length as your index without year and entity_id"
+    else:
+        dim_titles = dim_names
 
     if dim_names:
         grouped = table.groupby(dim_names, as_index=False)
@@ -132,14 +141,11 @@ def yield_wide_table(
         grouped = [([], table)]
 
     for dims, table_to_yield in grouped:
+        dims = [dims] if isinstance(dims, str) else dims
+
         # Now iterate over every column in the original dataset and export the
         # subset of data that we prepared above
         for column in table_to_yield.columns:
-            # Add column and dimensions as short_name
-            table_to_yield.metadata.short_name = _slugify_column_and_dimensions(
-                column, dims
-            )
-
             # Safety check to see if the metadata is still intact
             assert (
                 table_to_yield[column].metadata.unit is not None
@@ -152,13 +158,44 @@ def yield_wide_table(
                 else table_to_yield
             )
 
-            print(f"Yielding table {tab.metadata.short_name}")
+            # Create underscored name of a new column from the combination of column and dimensions
+            short_name = _slugify_column_and_dimensions(column, dims, dim_names)
 
-            yield tab.reset_index().set_index(["entity_id", "year"])[[column]]
+            # Add dimensions to title (which will be used as variable name in grapher)
+            title_with_dims = _title_column_and_dimensions(
+                table_to_yield[column].metadata.title, dims, dim_titles
+            )
+
+            # set new metadata with dimensions
+            tab.metadata.short_name = short_name
+            tab = tab.rename(columns={column: short_name})
+            tab[short_name].metadata.title = title_with_dims
+
+            print(f"Yielding table {short_name} with title {title_with_dims}")
+
+            yield tab.reset_index().set_index(["entity_id", "year"])[[short_name]]
 
 
-def _slugify_column_and_dimensions(column: str, dims: List[str]) -> str:
-    slug = slugify.slugify("__".join([column] + list(dims)), separator="_")
+def _title_column_and_dimensions(
+    title: str, dims: List[str], dim_names: List[str]
+) -> str:
+    """Create new title from column title and dimensions.
+    For instance `Deaths`, ["age", "sex"], ["10-18", "male"] will be converted into
+    Deaths - age: 10-18 - sex: male
+    """
+    dims = [f"{dim_name}: {dim}" for dim, dim_name in zip(dims, dim_names)]
+
+    return " - ".join([title] + dims)
+
+
+def _slugify_column_and_dimensions(
+    column: str, dims: List[str], dim_names: List[str]
+) -> str:
+    # add dimension names to dimensions
+    dims = [f"{dim_name}_{dim}" for dim, dim_name in zip(dims, dim_names)]
+
+    # underscore everything, separate dimensions & column with double __
+    slug = "__".join([slugify.slugify(n, separator="_") for n in [column] + list(dims)])
 
     # slugify would strip the leading underscore, put it back in that case
     if column.startswith("_"):
@@ -168,12 +205,17 @@ def _slugify_column_and_dimensions(column: str, dims: List[str]) -> str:
 
 
 def yield_long_table(
-    table: catalog.Table, annot: Optional[Annotation] = None
+    table: catalog.Table,
+    annot: Optional[Annotation] = None,
+    dim_titles: Optional[List[str]] = None,
 ) -> Iterable[catalog.Table]:
     """Yield from long table with the following columns:
     - variable: short variable name (needs to be underscored)
     - value: variable value
     - meta: either VariableMeta object or null in every row
+
+    :param dim_titles: Custom names to use for the dimensions, if not provided, the default names will be used.
+        Dimension title will be used to create variable name, e.g. `Deaths - Age: 10-18` instead of `Deaths - age: 10-18`
     """
     assert set(table.columns) == {
         "variable",
@@ -198,9 +240,7 @@ def yield_long_table(
         if annot:
             t = annotate_table(t, annot, missing_col="ignore")
 
-        t = t.drop(["variable", "meta"], axis=1, errors="ignore")
-
-        yield from yield_wide_table(cast(catalog.Table, t))
+        yield from yield_wide_table(cast(catalog.Table, t), dim_titles=dim_titles)
 
 
 def _get_entities_from_countries_regions() -> Dict[str, int]:

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -173,7 +173,11 @@ def yield_wide_table(
             else:
                 title_with_dims = None  # type: ignore
 
-            log.info("yield_wide_table", short_name=short_name, title=title_with_dims)
+            log.info(
+                "yield_wide_table.create_variable",
+                short_name=short_name,
+                title=title_with_dims,
+            )
 
             yield tab.reset_index().set_index(["entity_id", "year"])[[short_name]]
 

--- a/etl/steps/grapher/who/2021-07-01/ghe.py
+++ b/etl/steps/grapher/who/2021-07-01/ghe.py
@@ -89,5 +89,7 @@ def get_grapher_tables(dataset: catalog.Dataset) -> Iterable[catalog.Table]:
     # Sanity check
     for column in columns_to_export:
         assert table[column].metadata.unit is not None, "Unit should not be None here!"
+        # Use short names as titles
+        table[column].metadata.title = column
 
     yield from gh.yield_wide_table(table[columns_to_export], na_action="drop")

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
-from owid.catalog import Table
-from etl.grapher_helpers import yield_wide_table
+from owid.catalog import Table, VariableMeta
+from etl.grapher_helpers import yield_wide_table, yield_long_table
 
 
 def test_yield_wide_table():
@@ -15,5 +15,65 @@ def test_yield_wide_table():
     table = Table(df.set_index(["entity_id", "year"]))
     table._1.metadata.unit = "kg"
     grapher_tab = list(yield_wide_table(table))[0]
-    assert grapher_tab.to_dict() == {"_1": {(1, 2019): 1, (2, 2020): 2, (3, 2021): 3}}
+    assert grapher_tab.reset_index().to_dict(orient="list") == {
+        "_1": [1, 2, 3],
+        "entity_id": [1, 2, 3],
+        "year": [2019, 2020, 2021],
+    }
     assert grapher_tab.metadata.short_name == "_1"
+
+
+def test_yield_wide_table_with_dimensions():
+    df = pd.DataFrame(
+        {
+            "year": [2019, 2019, 2019],
+            "entity_id": [1, 1, 1],
+            "age": ["10-18", "19-25", "19-25"],
+            "deaths": [1, 2, 3],
+        }
+    )
+    table = Table(df.set_index(["entity_id", "year", "age"]))
+    table.deaths.metadata.unit = "people"
+    table.deaths.metadata.title = "Deaths"
+    grapher_tables = list(yield_wide_table(table, dim_titles=["Age group"]))
+
+    t = grapher_tables[0]
+    assert t.columns[0] == "deaths__age_10_18"
+    assert t[t.columns[0]].metadata.title == "Deaths - Age group: 10-18"
+
+    t = grapher_tables[1]
+    assert t.columns[0] == "deaths__age_19_25"
+    assert t[t.columns[0]].metadata.title == "Deaths - Age group: 19-25"
+
+
+def test_yield_long_table_with_dimensions():
+    deaths_meta = VariableMeta(title="Deaths", unit="people")
+    births_meta = VariableMeta(title="Births", unit="people")
+
+    long = pd.DataFrame(
+        {
+            "year": [2019, 2019, 2019, 2019],
+            "entity_id": [1, 1, 1, 1],
+            "variable": ["deaths", "deaths", "births", "births"],
+            "meta": [deaths_meta, deaths_meta, births_meta, births_meta],
+            "value": [1, 2, 3, 4],
+            "sex": ["male", "female", "male", "female"],
+        }
+    ).set_index(["year", "entity_id", "sex"])
+    grapher_tables = list(yield_long_table(Table(long), dim_titles=["Sex"]))
+
+    t = grapher_tables[0]
+    assert t.columns[0] == "births__sex_female"
+    assert t[t.columns[0]].metadata.title == "Births - Sex: female"
+
+    t = grapher_tables[1]
+    assert t.columns[0] == "births__sex_male"
+    assert t[t.columns[0]].metadata.title == "Births - Sex: male"
+
+    t = grapher_tables[2]
+    assert t.columns[0] == "deaths__sex_female"
+    assert t[t.columns[0]].metadata.title == "Deaths - Sex: female"
+
+    t = grapher_tables[3]
+    assert t.columns[0] == "deaths__sex_male"
+    assert t[t.columns[0]].metadata.title == "Deaths - Sex: male"


### PR DESCRIPTION
Helper functions for yielding tables for grapher don't work well with dimensions. They don't support titles and had bugs in creating short names.

This PR adds the following functionality:
* Title (= variable name in grapher) is now created automatically from the original title and dimensions. For instance variable `deaths` with dimensions `age group` and `sex` would be converted into `deaths - age group: 10-18 - sex: male`. It also supports new argument `dim_titles` for custom dimension naming, e.g. `Deaths - Age group: 10-18 - Sex: male` in this case
* Short names are created similarly to title, though they're not used for anything in grapher yet
* Adds test coverage for yielding wide and long tables (see unit tests for toy examples)

`yield_long_table` groups table by variable and then yields `yield_wide_table` for every such group.