### PR TITLE
fix(bp): Fix metadata in BP statistical review

### DIFF
--- a/etl/steps/data/garden/bp/2022-07-14/statistical_review.py
+++ b/etl/steps/data/garden/bp/2022-07-14/statistical_review.py
@@ -373,4 +373,8 @@ def run(dest_dir: str) -> None:
 
     # Add table to the dataset.
     table.metadata.title = dataset.metadata.title
+    table.metadata.description = dataset.metadata.description
+    table.metadata.dataset = dataset.metadata
+    table.metadata.short_name = dataset.metadata.short_name
+    table.metadata.primary_key = list(table.index.names)
     dataset.add(table, repack=True)


### PR DESCRIPTION
I put back some lines that were removed from the garden step of the BP statistical review dataset. In theory they are not necessary, but in practice they are (maybe not all of them?). For example, if I don't add `table.metadata.dataset = dataset.metadata`, the `table.metadata.dataset` is incomplete, and this is needed in the grapher step, because it contains the description that appears in the SOURCES tab for a particular variable.