### PR TITLE
fix(sdg): backport WDI dataset that comes originally from ETL

### DIFF
--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -130,8 +130,8 @@ def _active_datasets(
         -- or be used in DAG or specified in CLI
         or id in %(dataset_ids)s
     )
-    -- and must not come from ETL
-    and sourceChecksum is null
+    -- and must not come from ETL, unless they're in DAG
+    and (sourceChecksum is null or id in %(dataset_ids)s)
     -- and must not be archived
     and not isArchived
     order by rand()

--- a/dag.yml
+++ b/dag.yml
@@ -77,6 +77,8 @@ steps:
     - backport://backport/owid/latest/dataset_5201_forest_land__deforestation_and_change__fao__2020
     - backport://backport/owid/latest/dataset_70_population__gapminder__hyde__and__un
     - backport://backport/owid/latest/dataset_792_investment__credit_to_agriculture__fao__2017
+    # wdi__2022_05_26 is a dataset that comes from grapher `grapher://worldbank_wdi/2022-05-26/wdi` step, this might cause circular
+    # dependency and we should instead use garden dataset (which does not have proper metadata yet unfortunately)
     - backport://backport/owid/latest/dataset_5637_wdi__2022_05_26
     - backport://backport/owid/latest/dataset_560_world_development_indicators__social_protection__and__labor
     - backport://backport/owid/latest/dataset_943_sexual_violence__unicef__2017

--- a/etl/steps/data/garden/sdg/latest/generate_sdg_mapping.ipynb
+++ b/etl/steps/data/garden/sdg/latest/generate_sdg_mapping.ipynb
@@ -190,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.13"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
This problem breaks ETL and started happening after we added checksum to WDI dataset which then stopped being imported.

It's a bit of a hotfix before we [do it properly](https://github.com/owid/etl/issues/329).