### PR TITLE
fix: isolate python steps by running them in a separate process

### DIFF
--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -3,13 +3,10 @@
 #  etl
 #
 
-import re
-import sys
+from concurrent.futures import ProcessPoolExecutor
 import tempfile
-from collections.abc import Generator
 from contextlib import contextmanager
-from pathlib import Path
-from typing import Any, Iterator, List, cast
+from typing import Any, Iterator, List, cast, Callable
 
 import requests
 
@@ -54,3 +51,11 @@ def _get_github_branches(org: str, repo: str) -> List[Any]:
         raise Exception("reached single page limit, should paginate request")
 
     return branches
+
+
+def run_isolated(f: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """
+    Run a function in a separate process.
+    """
+    with ProcessPoolExecutor(1) as executor:
+        return executor.submit(f, *args, **kwargs).result()

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -54,32 +54,3 @@ def _get_github_branches(org: str, repo: str) -> List[Any]:
         raise Exception("reached single page limit, should paginate request")
 
     return branches
-
-
-@contextmanager
-def isolated_env(
-    working_dir: Path, keep_modules: str = r"openpyxl|pyarrow|lxml|PIL"
-) -> Generator[None, None, None]:
-    """Add given directory to pythonpath, run code in context, and
-    then remove from pythonpath and unimport modules imported in context.
-
-    Note that unimporting modules means they'll have to be imported again, but
-    it has minimal impact on performance (ms).
-
-    :param keep_modules: regex of modules to keep imported
-    """
-    # add module dir to pythonpath
-    sys.path.append(working_dir.as_posix())
-
-    # remember modules that were imported before
-    imported_modules = set(sys.modules.keys())
-
-    yield
-
-    # unimport modules imported during execution unless they match `keep_modules`
-    for module_name in set(sys.modules.keys()) - imported_modules:
-        if not re.search(keep_modules, module_name):
-            sys.modules.pop(module_name)
-
-    # remove module dir from pythonpath
-    sys.path.remove(working_dir.as_posix())

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -3,10 +3,9 @@
 #  etl
 #
 
-from concurrent.futures import ProcessPoolExecutor
 import tempfile
 from contextlib import contextmanager
-from typing import Any, Iterator, List, cast, Callable
+from typing import Any, Iterator, List, cast
 
 import requests
 
@@ -51,11 +50,3 @@ def _get_github_branches(org: str, repo: str) -> List[Any]:
         raise Exception("reached single page limit, should paginate request")
 
     return branches
-
-
-def run_isolated(f: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-    """
-    Run a function in a separate process.
-    """
-    with ProcessPoolExecutor(1) as executor:
-        return executor.submit(f, *args, **kwargs).result()

--- a/etl/run_python_step.py
+++ b/etl/run_python_step.py
@@ -17,8 +17,8 @@ def main(uri: str, dest_dir: str) -> None:
     Import and run a specific step of the ETL. Meant to be ran as
     a subprocess by the main `etl` command.
     """
-    if not uri.startswith("data://"):
-        raise ValueError("URI must start with data://")
+    if not uri.startswith("data://") and not uri.startswith("data-private://"):
+        raise ValueError("Only data:// or data-private:// URIs are supported")
 
     path = uri.split("//", 1)[1]
 

--- a/etl/run_python_step.py
+++ b/etl/run_python_step.py
@@ -12,7 +12,7 @@ from etl.paths import STEP_DIR, BASE_PACKAGE
 @click.command()
 @click.argument("uri")
 @click.argument("dest_dir")
-def main(uri: str, dest_dir: str):
+def main(uri: str, dest_dir: str) -> None:
     """
     Import and run a specific step of the ETL. Meant to be ran as
     a subprocess by the main `etl` command.

--- a/etl/run_python_step.py
+++ b/etl/run_python_step.py
@@ -1,0 +1,47 @@
+#
+#  run_python_step
+#
+
+from importlib import import_module
+import click
+import sys
+
+from etl.paths import STEP_DIR, BASE_PACKAGE
+
+
+@click.command()
+@click.argument("uri")
+@click.argument("dest_dir")
+def main(uri: str, dest_dir: str):
+    """
+    Import and run a specific step of the ETL. Meant to be ran as
+    a subprocess by the main `etl` command.
+    """
+    if not uri.startswith("data://"):
+        raise ValueError("URI must start with data://")
+
+    path = uri.split("//", 1)[1]
+
+    _import_and_run(path, dest_dir)
+
+
+def _import_and_run(path: str, dest_dir: str) -> None:
+    # ensure that the module search path includes the script
+    module_dir = (STEP_DIR / "data" / path).parent
+    sys.path.append(module_dir.as_posix())
+
+    # import the module
+    module_path = path.replace("/", ".")
+    import_path = f"{BASE_PACKAGE}.steps.data.{module_path}"
+    module = import_module(import_path)
+
+    # check it matches the expected interface
+    if not hasattr(module, "run"):
+        raise Exception(f'no run() method defined for module "{module}"')
+
+    # run the step itself
+    module.run(dest_dir)  # type: ignore
+
+
+if __name__ == "__main__":
+    main()

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -7,7 +7,6 @@ import graphlib
 import hashlib
 import re
 import subprocess
-import sys
 import tempfile
 import types
 import warnings

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -36,7 +36,7 @@ from etl.grapher_import import (
     upsert_dataset,
     upsert_table,
 )
-from etl.helpers import get_etag
+from etl.helpers import get_etag, run_isolated
 
 Graph = Dict[str, Set[str]]
 DAG = Dict[str, Any]
@@ -369,8 +369,7 @@ class DataStep(Step):
         module_path = self.path.lstrip("/").replace("/", ".")
 
         # isolate the python step in a new process to avoid any bleed-over between steps
-        with concurrent.futures.ProcessPoolExecutor(1) as executor:
-            executor.submit(_run_python_data_step, module_path, self._dest_dir).result()
+        run_isolated(_run_python_data_step, module_path, self._dest_dir)
 
     def _run_notebook(self) -> None:
         "Run a parameterised Jupyter notebook."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ backport = 'backport.backport:backport_cli'
 bulk_backport = 'backport.bulk_backport:bulk_backport'
 fasttrack = 'backport.fasttrack:fasttrack'
 walkthrough = 'walkthrough.cli:cli'
+run_python_step = 'etl.run_python_step:main'
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,8 +2,6 @@
 #  test_helpers.py
 #
 
-import pytest
-
 from etl import helpers
 
 
@@ -11,35 +9,9 @@ from etl import helpers
 #     sha = helpers.get_latest_github_sha("owid", "owid-grapher", "master")
 #     assert re.match("^[0-9a-f]+$", sha)
 
-MY_SPECIAL_VAR: int = 1
-
 
 def test_get_etag():
     etag = helpers.get_etag(
         "https://raw.githubusercontent.com/owid/owid-grapher/master/README.md"
     )
     assert etag
-
-
-def test_run_isolated(tmp_path):
-    # isolated process gets its own copy
-    assert helpers.run_isolated(_example_function) == 2
-    assert helpers.run_isolated(_example_function) == 2
-    assert helpers.run_isolated(_example_function) == 2
-
-
-def test_run_isolated_failure():
-    with pytest.raises(Exception):
-        helpers.run_isolated(_example_failure)
-
-
-def _example_function() -> int:
-    global MY_SPECIAL_VAR
-
-    MY_SPECIAL_VAR += 1
-
-    return MY_SPECIAL_VAR
-
-
-def _example_failure() -> None:
-    raise Exception("durian in coffee")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,13 +3,15 @@
 #
 
 import pytest
-import sys
+
 from etl import helpers
 
 
 # def test_get_github_sha():
 #     sha = helpers.get_latest_github_sha("owid", "owid-grapher", "master")
 #     assert re.match("^[0-9a-f]+$", sha)
+
+MY_SPECIAL_VAR: int = 1
 
 
 def test_get_etag():
@@ -19,18 +21,28 @@ def test_get_etag():
     assert etag
 
 
-def test_isolated_env(tmp_path):
-    (tmp_path / "shared.py").write_text("A = 1; import test_abc")
-    (tmp_path / "test_abc.py").write_text("B = 1")
+def test_run_isolated(tmp_path):
+    # local process mutates the global
+    assert _example_function() == 2
+    assert _example_function() == 3
 
-    with helpers.isolated_env(tmp_path):
-        import shared
+    # isolated process gets its own copy
+    assert helpers.run_isolated(_example_function) == 2
+    assert helpers.run_isolated(_example_function) == 2
 
-        assert shared.A == 1
-        assert shared.test_abc.B == 1
-        assert "test_abc" in sys.modules.keys()
 
-    with pytest.raises(ModuleNotFoundError):
-        import shared
+def test_run_isolated_failure():
+    with pytest.raises(Exception):
+        helpers.run_isolated(_example_failure)
 
-    assert "test_abc" not in sys.modules.keys()
+
+def _example_function() -> int:
+    global MY_SPECIAL_VAR
+
+    MY_SPECIAL_VAR += 1
+
+    return MY_SPECIAL_VAR
+
+
+def _example_failure() -> None:
+    raise Exception("durian in coffee")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -22,11 +22,8 @@ def test_get_etag():
 
 
 def test_run_isolated(tmp_path):
-    # local process mutates the global
-    assert _example_function() == 2
-    assert _example_function() == 3
-
     # isolated process gets its own copy
+    assert helpers.run_isolated(_example_function) == 2
     assert helpers.run_isolated(_example_function) == 2
     assert helpers.run_isolated(_example_function) == 2
 


### PR DESCRIPTION
Fixes #333

Remove the module import hacking, and instead use a separate process when running a python module.
