### PR TITLE
Multi-format support including parquet

### DIFF
--- a/etl/harmonize.py
+++ b/etl/harmonize.py
@@ -286,7 +286,7 @@ def save_alias(name: str, alias: str) -> None:
 
     # pack up and save
     rc.loc[rc.name == name, "aliases"] = json.dumps(sorted(aliases))
-    ref.add(rc, "csv")
+    ref.add(rc, formats=["csv"])
 
 
 def print_mapping(region: str, name: str) -> None:

--- a/etl/publish.py
+++ b/etl/publish.py
@@ -14,9 +14,11 @@ import concurrent.futures
 import click
 import boto3
 from botocore.client import ClientError
-import pandas as pd
+from owid.catalog.catalogs import INDEX_FORMATS
+from owid.catalog.datasets import FileFormat
 
 from owid.catalog import LocalCatalog, CHANNEL
+from owid.catalog.helpers import read_frame
 
 from etl import config, files
 from etl.paths import DATA_DIR
@@ -71,11 +73,13 @@ def publish(
 
 
 def sanity_checks(catalog: Path, channel: CHANNEL) -> None:
-    if not (catalog / _channel_path(channel)).exists():
-        print(
-            "ERROR: catalog has not been indexed, refusing to publish", file=sys.stderr
-        )
-        sys.exit(1)
+    for format in INDEX_FORMATS:
+        if not (catalog / _channel_path(channel, format)).exists():
+            print(
+                "ERROR: catalog has not been fully indexed, refusing to publish",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
 
 def sync_catalog_to_s3(
@@ -97,8 +101,10 @@ def is_catalog_up_to_date(
 ) -> bool:
     """The catalog file is synced last -- if it is the same as our local one, then all the remote
     files will be the same as our local ones too."""
-    remote = get_remote_checksum(s3, bucket, _channel_path(channel).as_posix())
-    local = files.checksum_file(catalog / _channel_path(channel))
+    # note: we only check the md5 of the first index format, not all of them
+    format = INDEX_FORMATS[0]
+    remote = get_remote_checksum(s3, bucket, _channel_path(channel, format).as_posix())
+    local = files.checksum_file(catalog / _channel_path(channel, format))
     return remote == local
 
 
@@ -225,13 +231,14 @@ def delete_dataset(s3: Any, bucket: str, relative_path: str) -> None:
 
 
 def update_catalog(s3: Any, bucket: str, catalog: Path, channel: CHANNEL) -> None:
-    catalog_filename = catalog / _channel_path(channel)
-    s3.upload_file(
-        catalog_filename.as_posix(),
-        bucket,
-        _channel_path(channel).as_posix(),
-        ExtraArgs={"ACL": "public-read"},
-    )
+    for format in INDEX_FORMATS:
+        catalog_filename = catalog / _channel_path(channel, format)
+        s3.upload_file(
+            catalog_filename.as_posix(),
+            bucket,
+            _channel_path(channel, format).as_posix(),
+            ExtraArgs={"ACL": "public-read"},
+        )
 
     s3.upload_file(
         (catalog / "catalog.meta.json").as_posix(),
@@ -243,10 +250,10 @@ def update_catalog(s3: Any, bucket: str, catalog: Path, channel: CHANNEL) -> Non
 
 def get_published_checksums(bucket: str, channel: CHANNEL) -> Dict[str, str]:
     "Get the checksum of every dataset that's been published."
+    format = INDEX_FORMATS[0]
+    uri = f"https://{bucket}.{config.S3_HOST}/{_channel_path(channel, format)}"
     try:
-        existing = pd.read_feather(
-            f"https://{bucket}.{config.S3_HOST}/{_channel_path(channel)}"
-        )
+        existing = read_frame(uri)
         existing["path"] = existing["path"].apply(lambda p: p.rsplit("/", 1)[0])
         existing = (
             existing[["path", "checksum"]]
@@ -284,8 +291,8 @@ def connect_s3() -> Any:
     )
 
 
-def _channel_path(channel: CHANNEL) -> Path:
-    return Path(f"catalog-{channel}.feather")
+def _channel_path(channel: CHANNEL, format: FileFormat) -> Path:
+    return Path(f"catalog-{channel}.{format}")
 
 
 if __name__ == "__main__":

--- a/etl/scripts/countries-regions/08-metadata.ipynb
+++ b/etl/scripts/countries-regions/08-metadata.ipynb
@@ -408,7 +408,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds.add(countries_regions, format=\"csv\")"
+    "ds.add(countries_regions, formats=[\"csv\"])"
    ]
   },
   {

--- a/etl/scripts/sex/01-create-table.ipynb
+++ b/etl/scripts/sex/01-create-table.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds.add(table, \"csv\")"
+    "ds.add(table, formats=[\"csv\"])"
    ]
   }
  ],

--- a/etl/steps/data/explorers/owid/2021/food_explorer.py
+++ b/etl/steps/data/explorers/owid/2021/food_explorer.py
@@ -1468,7 +1468,9 @@ def run(dest_dir: str) -> None:
 
     # Add products
     for _, t in tables_products.items():
-        fe_garden.add(t, format="csv")  # <-- note we choose CSV format here
+        fe_garden.add(
+            t, formats=["csv", "feather", "parquet"]
+        )  # <-- note we include CSV format here
 
 
 # %% [markdown]

--- a/etl/steps/data/explorers/owid/latest/food_explorer.py
+++ b/etl/steps/data/explorers/owid/latest/food_explorer.py
@@ -93,5 +93,5 @@ def run(dest_dir: str) -> None:
             .replace("__", "_")
             .replace("_e_g_", "_eg_")
         )
-        # Add table to dataset.
-        dataset.add(table_product, format="csv")
+        # Add table to dataset. Force publication in csv.
+        dataset.add(table_product, formats=["csv", "feather", "parquet"])


### PR DESCRIPTION
Fixes #332

This change enables support for co-publishing in `feather` and `parquet` formats. The `parquet` format includes the full table metadata inside the Parquet schema. At this time, `csv` was disabled by default since it would 50x the catalog size.

The motivation for this was to support quick (or even, lazy) DuckDB indexing for the API.

## Updates

- Code forcing an output format is updated, in particular `reference/countries_regions` and `**/food_explorer` (`ds.add(t, format='csv') --> ds.add(t, formats=['csv'])`).
- Channels are reindexed in parquet as well as feather
- Publishing co-publishes parquet indexes

## After merging

This PR only causes newly rebuilt datasets will get published this way. A full forced rebuild of the ETL is recommended to generate the first batch of `parquet` files.
