### PR TITLE
WIP: enhance(steps): check that different sources have different names

### DIFF
--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -114,6 +114,8 @@ def yield_wide_table(
     :param dim_titles: Custom names to use for the dimensions, if not provided, the default names will be used.
         Dimension title will be used to create variable name, e.g. `Deaths - Age: 10-18` instead of `Deaths - age: 10-18`
     """
+    assert table.columns.value_counts().max() == 1, "Table columns are not unique"
+
     # Validation
     if "year" not in table.primary_key:
         raise Exception("Table is missing `year` primary key")


### PR DESCRIPTION
Validation for https://github.com/owid/etl/issues/348

When iterating over tables from `get_grapher_tables` we keep a dictionary of `source.name -> source hash` and check that there aren't two sources with the same name, but different contents. This is done with generator (let me know if this is overkill, but the code was cleaner). If this was the case, sources would be overwritten (over-upserted) and user wouldn't even notice.