### PR TITLE
fix: massive parquet file for faostat_food_explorer

### DIFF
--- a/etl/steps/data/garden/faostat/2022-05-17/faostat_food_explorer.py
+++ b/etl/steps/data/garden/faostat/2022-05-17/faostat_food_explorer.py
@@ -478,6 +478,6 @@ def run(dest_dir: str) -> None:
     table = catalog.utils.underscore_table(table)
     # Add metadata for the table.
     table.metadata.short_name = "all_products"
-    table.metadata.primary_key = list(table.index)
+    table.metadata.primary_key = list(table.index.names)
     # Add table to dataset.
     explorer_dataset.add(table)


### PR DESCRIPTION
Fixes #363

A typo in the table metadata for the `faostat_food_explorer` dataset caused the entire multi-index to be serialised into the metadata, instead of just the names of the columns.

Fixing the primary key field for this dataset to just store the names of the columns reduces the parquet file's size from 187M to 61M, much closer to the feather file.

The feather file was not affected since it follows a different code path.
