### PR TITLE
fix(grapher): get dataset checksum by shortName instead of name

### DIFF
--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -247,7 +247,7 @@ def fetch_db_checksum(dataset: catalog.Dataset) -> Optional[str]:
             """
             SELECT sourceChecksum
             FROM datasets
-            WHERE name=%s
+            WHERE shortName=%s
             """,
             [dataset.metadata.short_name],
         )


### PR DESCRIPTION
`GrapherStep.is_dirty` didn't work because it was fetching datasets by `name` which changed to `shortName` recently.