### PR TITLE
enhance: generate CSVs for backported data

### DIFF
--- a/etl/backport_helpers.py
+++ b/etl/backport_helpers.py
@@ -137,6 +137,7 @@ def create_dataset(dest_dir: str, short_name: str) -> Dataset:
         if "year" in t.columns:
             t = t.rename(columns={"year": "year_"})
 
-        ds.add(t)
+        # add CSV to the format list, for re-consumption in explorers
+        ds.add(t, formats=["feather", "parquet", "csv"])
 
     return ds


### PR DESCRIPTION
We would like to be able to use backported variables in explorers. Currently we do this in one of two ways. We either:

- Create an ETL step for the explorer that generates CSVs
- Link to a CSV from the auto-generated `owid-datasets` repo that Grapher publishes

This PR adds a third way, by publishing all backported data in CSV format.
