### PR TITLE
docs: init submodule before installing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ You need to install the following:
 
 We use `poetry` to manage the virtual environment for the project, and you'll typically do your work within that virtual environment.
 
-1. Run `poetry install`, which creates a virtual environment in `.venv` using `make`
-2. Activate the virtual env with `poetry shell`
+1. Run `git submodule update --init`
+2. Run `poetry install`, which creates a virtual environment in `.venv` using `make`
+3. Activate the virtual env with `poetry shell`
 
 ### Example commands
 

--- a/README.md
+++ b/README.md
@@ -28,22 +28,21 @@ api --> jupyter[Jupyter notebooks]
 classDef focus stroke-width:4px
 ```
 
-## Getting started
+## Environment setup
 
-### Installations
+### Dependencies
 
 You need to install the following:
 
-* Python 3.9+. Guide for all platforms [here](https://realpython.com/installing-python/). If you are using multiple different versions of Python on your machine, you may want to use `pyenv` to manage them (instructions [here](https://github.com/pyenv/pyenv)).
-* `poetry`, for managing dependencies, virtual envs, and packages. Installation guide [here](https://python-poetry.org/docs/#installation).
-* `make`. You likely already have this, but otherwise it can be installed using your usual package manager (e.g. on Mac, `brew install make`).
-* MYSQL client (and Python dev headers). If you don't have this already,
-  * On Ubuntu: `sudo apt install python3.9-dev mysql-client`
-  * On Mac: `brew install mysql-client`
-* AWS CLI and you should have an `~/.aws/config` file configured so that you can upload to walden etc.
+- Python 3.9+. Guide for all platforms [here](https://realpython.com/installing-python/). If you are using multiple different versions of Python on your machine, you may want to use `pyenv` to manage them (instructions [here](https://github.com/pyenv/pyenv)).
+- `poetry`, for managing dependencies, virtual envs, and packages. Installation guide [here](https://python-poetry.org/docs/#installation).
+- `make`. You likely already have this, but otherwise it can be installed using your usual package manager (e.g. on Mac, `brew install make`).
+- MYSQL client (and Python dev headers). If you don't have this already,
+  - On Ubuntu: `sudo apt install python3.9-dev mysql-client`
+  - On Mac: `brew install mysql-client`
+- AWS CLI and you should have an `~/.aws/config` file configured so that you can upload to walden etc.
 
-
-### Creating and using the virtual environment
+### Installation
 
 We use `poetry` to manage the virtual environment for the project, and you'll typically do your work within that virtual environment.
 
@@ -51,15 +50,17 @@ We use `poetry` to manage the virtual environment for the project, and you'll ty
 2. Run `poetry install`, which creates a virtual environment in `.venv` using `make`
 3. Activate the virtual env with `poetry shell`
 
-### Example commands
-
 To run all the checks and make sure you have everything set up correctly, try
 
 ```
 make test
 ```
+
 if `make test` fails report it in #data-architecture or #tech-issues. The `etl` is undergoing constant development so it may not be your local setup causing `make test` to fail and therefore shouldn't stop you progressing to the next step.
 
+## Example commands
+
+### Build specific datasets
 
 To run a subset of examples, you can try (for example)
 
@@ -77,6 +78,8 @@ These will generate files in `./data` directory according to their recipes in `.
 
 Scripts in `./etl/steps/data/examples/examples/latest` showcase basic functionality and can help you get started (mainly `script_example.py`).
 
+### Build all known tables
+
 You can also build all known data tables into the `data/` folder with:
 
 ```
@@ -85,9 +88,9 @@ poetry run etl
 
 However, processing all the datasets will take a long time and memory.
 
-*Note*: `poetry run` runs commands from within the virtual environment. You can also activate it with `poetry shell` and then simply run `etl ...`.
+_Note_: `poetry run` runs commands from within the virtual environment. You can also activate it with `poetry shell` and then simply run `etl ...`.
 
-### Creating the pipeline of a new dataset
+## Creating the pipeline of a new dataset
 
 You can start an interactive walkthrough that will guide you through all the steps of creating a new dataset. Start it with
 
@@ -110,39 +113,39 @@ is being added to `etl`, or the date when the source data was released or update
 0. Activate the virtual environment (running `poetry shell`).
 1. **Create a new branch in the `walden` submodule**.
 2. **Create an ingest script** (e.g. `etl/vendor/walden/ingests/example_institution.py`) to download the data from its
-original source and upload it as a new data snapshot into the S3 `walden` bucket.
-This step can also be done manually (although it is preferable to do it via script, to have a record of how the data was
-obtained, and to be able to repeat the process in the future, for instance if another version of the data is released).
-Keep in mind that, if there is additional metadata, it should also be ingested into `walden` as part of the snapshot.
-If the data is in a single file for which you have a download link, this script may not be required: you can add
-this link directly in the index file (see next point). There is guidance on how to upload to `walden` manually in the [`walden` README](https://github.com/owid/walden#manually).
+   original source and upload it as a new data snapshot into the S3 `walden` bucket.
+   This step can also be done manually (although it is preferable to do it via script, to have a record of how the data was
+   obtained, and to be able to repeat the process in the future, for instance if another version of the data is released).
+   Keep in mind that, if there is additional metadata, it should also be ingested into `walden` as part of the snapshot.
+   If the data is in a single file for which you have a download link, this script may not be required: you can add
+   this link directly in the index file (see next point). There is guidance on how to upload to `walden` manually in the [`walden` README](https://github.com/owid/walden#manually).
 3. **Create an index file** `etl/vendor/walden/index/example_institution/YYYY-MM-DD/example_dataset.json` for the new
-dataset.
-You can simply copy another existing index file and adapt its content.
-This can be done manually, or, alternatively, the ingest script can also write one (or multiple) index files.
+   dataset.
+   You can simply copy another existing index file and adapt its content.
+   This can be done manually, or, alternatively, the ingest script can also write one (or multiple) index files.
 4. **Run `make test` in `walden`** and make changes to ensure the new files in the repository have the right style and structure.
 5. **Create a pull request** to merge the new branch with the master branch in `walden`. When getting started with the `etl` you should request a code review from a more experienced `etl` user.
-7. **Create a new branch in `etl`**.
-8. **Create a new `meadow` step file** (e.g. `etl/etl/steps/data/meadow/example_institution/YYYY-MM-DD/example_dataset.py`).
-The step must contain a `run(dest_dir)` function that loads data from the `walden` bucket in S3 and creates a dataset
-(a `catalog.Dataset` object) with one or more tables (`catalog.Table` objects) containing the raw data.
-Keep in mind that both the dataset and its table(s) should contain metadata. Additionally, all of the column names must be snake case before uploading to `meadow`. There is a function in the `owid.catalog.utils` module that will do this for you: `tb = underscore_table(Table(full_df))`.
+6. **Create a new branch in `etl`**.
+7. **Create a new `meadow` step file** (e.g. `etl/etl/steps/data/meadow/example_institution/YYYY-MM-DD/example_dataset.py`).
+   The step must contain a `run(dest_dir)` function that loads data from the `walden` bucket in S3 and creates a dataset
+   (a `catalog.Dataset` object) with one or more tables (`catalog.Table` objects) containing the raw data.
+   Keep in mind that both the dataset and its table(s) should contain metadata. Additionally, all of the column names must be snake case before uploading to `meadow`. There is a function in the `owid.catalog.utils` module that will do this for you: `tb = underscore_table(Table(full_df))`.
 8. **Add the new meadow step to the dag**, including its dependencies.
-9. **Run `make test` in `etl`** and  ensure the step runs well. To run the step: `etl data://meadow/example_institution/YYYY-MM-DD/example_dataset`
+9. **Run `make test` in `etl`** and ensure the step runs well. To run the step: `etl data://meadow/example_institution/YYYY-MM-DD/example_dataset`
 10. **Create a new garden step** (e.g. `etl/etl/steps/data/garden/example_institution/YYYY-MM-DD/example_dataset.py`).
-The step must contain a `run(dest_dir)` function that loads data from the last `meadow` step, processes the data and
-creates a dataset with one or more tables and the necessary metadata.
-Country names must be harmonized (for which the `harmonize` tool of `etl` can be used).
-Add plenty of assertions and sanity checks to the step (if possible, compare the data with its previous version and
-check for abrupt changes).
+    The step must contain a `run(dest_dir)` function that loads data from the last `meadow` step, processes the data and
+    creates a dataset with one or more tables and the necessary metadata.
+    Country names must be harmonized (for which the `harmonize` tool of `etl` can be used).
+    Add plenty of assertions and sanity checks to the step (if possible, compare the data with its previous version and
+    check for abrupt changes).
 11. **Add the new garden step to the dag**, including its dependencies.
-12. **Run `make test` in `etl`** and  ensure the step runs well.
+12. **Run `make test` in `etl`** and ensure the step runs well.
 13. **Create a new grapher step** (e.g. `etl/etl/steps/grapher/example_institution/YYYY-MM-DD/example_dataset.py`).
-The step must contain a `get_grapher_dataset()` function and a `get_grapher_tables()` function.
-To test the step, you can run it on the grapher `staging` database, or using
-[a local grapher](https://github.com/owid/owid-grapher/blob/master/docs/docker-compose-mysql.md).
+    The step must contain a `get_grapher_dataset()` function and a `get_grapher_tables()` function.
+    To test the step, you can run it on the grapher `staging` database, or using
+    [a local grapher](https://github.com/owid/owid-grapher/blob/master/docs/docker-compose-mysql.md).
 14. **Create a pull request** to merge the new branch with the master branch in `etl`.
-At this point, some further editing of the step files may be required before merging the branch with master.
+    At this point, some further editing of the step files may be required before merging the branch with master.
 
 ## Reporting problems
 
@@ -370,7 +373,6 @@ etl --backport
 
 (or `etl backport --backport`). This will transform original datasets from long format to wide format, optimize their data types, convert metadata and add them to the catalog. Then you can run `publish` to publish the datasets as usual.
 
-
 ### Fasttrack
 
 Fastrack is a service that polls grapher database for dataset updates and backports them as fast as possible. When it detects a change it will:
@@ -380,7 +382,6 @@ Fastrack is a service that polls grapher database for dataset updates and backpo
 3. Publish new ETL catalog to S3
 
 All these steps have been optimized to run in a few seconds (except of huge datasets) and make them available through [data-api](https://github.com/owid/data-api).
-
 
 ## Staging
 


### PR DESCRIPTION
I ran into this and someone else did too – when setting up for the first time, we need to init the submodules before attempting to install all dependencies with poetry.

I'm not sure if this should instead point to a `make` step, since that initializes submodules:

https://github.com/owid/etl/blob/a9e96f2b6f5d0f97c1b054a69aa9525b79d4d024/Makefile#L38-L41