### PR TITLE
fix(slug): separate variable name and dimensions by __

### DIFF
--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -158,7 +158,7 @@ def yield_wide_table(
 
 
 def _slugify_column_and_dimensions(column: str, dims: List[str]) -> str:
-    slug = slugify.slugify("__".join([column] + list(dims)), separator="_")
+    slug = "__".join([column] + list(dims))
 
     # slugify would strip the leading underscore, put it back in that case
     if column.startswith("_"):

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -158,7 +158,11 @@ def yield_wide_table(
 
 def _slugify_column_and_dimensions(column: str, dims: List[str]) -> str:
     if dims:
-        slug = "__".join([column] + [str(dims)])
+        if isinstance(dims, (list, tuple)):
+            dims = [str(d) for d in dims]
+        else:
+            dims = [str(dims)]
+        slug = "__".join([column] + dims)
     else:
         slug = column
     # slugify would strip the leading underscore, put it back in that case

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -17,3 +17,19 @@ def test_yield_wide_table():
     grapher_tab = list(yield_wide_table(table))[0]
     assert grapher_tab.to_dict() == {"_1": {(1, 2019): 1, (2, 2020): 2, (3, 2021): 3}}
     assert grapher_tab.metadata.short_name == "_1"
+
+
+def test_yield_wide_table_2():
+    df = pd.DataFrame(
+        {
+            "year": [2019, 2020, 2021],
+            "entity_id": [1, 2, 3],
+            "metric_name": [1, 2, 3],
+            "age": [10, 11, 12],
+        }
+    )
+    table = Table(df.set_index(["entity_id", "year", "age"]))
+    table.metric_name.metadata.unit = "kg"
+    grapher_tab = list(yield_wide_table(table))[0]
+    # assert grapher_tab.to_dict() == {"_1": {(1, 2019): 1, (2, 2020): 2, (3, 2021): 3}}
+    assert grapher_tab.metadata.short_name == "metric_name__12"

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -33,3 +33,20 @@ def test_yield_wide_table_2():
     grapher_tab = list(yield_wide_table(table))[0]
     # assert grapher_tab.to_dict() == {"_1": {(1, 2019): 1, (2, 2020): 2, (3, 2021): 3}}
     assert grapher_tab.metadata.short_name == "metric_name__12"
+
+
+def test_yield_wide_table_3():
+    df = pd.DataFrame(
+        {
+            "year": [2019, 2020, 2021],
+            "entity_id": [1, 2, 3],
+            "metric_name": [1, 2, 3],
+            "age": [10, 10, 10],
+            "sex": ["all", "all", "all"],
+        }
+    )
+    table = Table(df.set_index(["entity_id", "year", "age", "sex"]))
+    table.metric_name.metadata.unit = "kg"
+    grapher_tab = list(yield_wide_table(table))[0]
+    # assert grapher_tab.to_dict() == {"_1": {(1, 2019): 1, (2, 2020): 2, (3, 2021): 3}}
+    assert grapher_tab.metadata.short_name == "metric_name__10__all"


### PR DESCRIPTION
Separating by `__` (double underscore) the dimensions so that they can be differentiated from metric/dimension names.