### PR TITLE
enhance: match_variables command

### DIFF
--- a/etl/db.py
+++ b/etl/db.py
@@ -2,7 +2,9 @@ import traceback
 from collections.abc import Generator
 from contextlib import contextmanager
 from urllib.parse import quote
+from typing import Any
 
+import pandas as pd
 import MySQLdb
 import structlog
 from sqlalchemy import create_engine
@@ -56,3 +58,72 @@ def open_db() -> Generator[DBUtils, None, None]:
             cursor.close()
         if connection:
             connection.close()
+
+
+def get_dataset_id(db_conn: MySQLdb.Connection, dataset_name: str) -> Any:
+    """Get the dataset ID of a specific dataset name from database.
+
+    If more than one dataset is found for the same name, or if no dataset is found, an error is raised.
+
+    Parameters
+    ----------
+    db_conn : MySQLdb.Connection
+        Connection to database.
+    dataset_name : str
+        Dataset name.
+
+    Returns
+    -------
+    dataset_id : int
+        Dataset ID.
+
+    """
+    query = f"""
+        SELECT id
+        FROM datasets
+        WHERE name = '{dataset_name}'
+    """
+    with db_conn.cursor() as cursor:
+        cursor.execute(query)
+        result = cursor.fetchall()
+
+    assert len(result) == 1, f"Ambiguous or unknown dataset name '{dataset_name}'"
+    dataset_id = result[0][0]
+
+    return dataset_id
+
+
+def get_variables_in_dataset(
+    db_conn: MySQLdb.Connection, dataset_id: int, only_used_in_charts: bool = False
+) -> Any:
+    """Get all variables data for a specific dataset ID from database.
+
+    Parameters
+    ----------
+    db_conn : pymysql.connections.Connection
+    dataset_id : int
+        Dataset ID.
+    only_used_in_charts : bool
+        True to select variables only if they have been used in at least one chart. False to select all variables.
+
+    Returns
+    -------
+    variables_data : pd.DataFrame
+        Variables data for considered dataset.
+
+    """
+    query = f"""
+        SELECT *
+        FROM variables
+        WHERE datasetId = {dataset_id}
+    """
+    if only_used_in_charts:
+        query += """
+            AND id IN (
+                SELECT DISTINCT variableId
+                FROM chart_dimensions
+            )
+        """
+    variables_data = pd.read_sql(query, con=db_conn)
+
+    return variables_data

--- a/etl/db.py
+++ b/etl/db.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from urllib.parse import quote
 from typing import Any
+import warnings
 
 import pandas as pd
 import MySQLdb
@@ -124,6 +125,7 @@ def get_variables_in_dataset(
                 FROM chart_dimensions
             )
         """
-    variables_data = pd.read_sql(query, con=db_conn)
-
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', UserWarning)
+        variables_data = pd.read_sql(query, con=db_conn)
     return variables_data

--- a/etl/db.py
+++ b/etl/db.py
@@ -126,6 +126,6 @@ def get_variables_in_dataset(
             )
         """
     with warnings.catch_warnings():
-        warnings.simplefilter('ignore', UserWarning)
+        warnings.simplefilter("ignore", UserWarning)
         variables_data = pd.read_sql(query, con=db_conn)
     return variables_data

--- a/etl/match_variables_from_two_versions_of_a_dataset.py
+++ b/etl/match_variables_from_two_versions_of_a_dataset.py
@@ -36,7 +36,7 @@ SIMILARITY_NAMES = {
 }
 
 
-def get_similarity_function(similarity_name: str) -> Callable[[str, str], int]:
+def get_similarity_function(similarity_name: str) -> Any:
     """Return a similarity function given its name.
 
     Parameters
@@ -200,7 +200,9 @@ def map_old_and_new_variables(
         new_name = missing_new.loc[suggested_index]["name_new"]
 
         # Display comparison.
-        click.secho(f"\nVARIABLE {count}/{num_variables}", bold=True, bg="white", fg="black")
+        click.secho(
+            f"\nVARIABLE {count}/{num_variables}", bold=True, bg="white", fg="black"
+        )
         _display_compared_variables(
             old_name=old_name,
             new_name=new_name,
@@ -394,13 +396,13 @@ def main(
     ),
 )
 def main_cli(
-    old_dataset_name,
-    new_dataset_name,
-    add_identical_pairs,
-    similarity_name,
-    output_file,
-    max_suggestions,
-):
+    old_dataset_name: str,
+    new_dataset_name: str,
+    output_file: str,
+    add_identical_pairs: bool,
+    similarity_name: str,
+    max_suggestions: int,
+) -> None:
     main(
         old_dataset_name=old_dataset_name,
         new_dataset_name=new_dataset_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ fasttrack = 'backport.fasttrack:fasttrack'
 walkthrough = 'walkthrough.cli:cli'
 run_python_step = 'etl.run_python_step:main'
 compare = 'etl.compare:cli'
+etl-match-variables = 'etl.match_variables_from_two_versions_of_a_dataset:main_cli'
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Improvements on the match variables script

- Prettify the menu with variable options (using `click` and colouring)
- Changed `argparse` for `click` to manage executable
- Created command `etl-match-variables` to run the script
- Removed unused code
- Moved database-specific functions to `etl.db`
- Added argument `--max-suggestions`, to select an arbitrary number of new variables to be displayed



**Test the code**
1. Install the library: `poetry install`
2. Run `etl-match-variables --help`

The library might need a patch upgrade (0.1.1)