### PR TITLE
docs(match_variables): fix arg description

### DIFF
--- a/etl/match_variables_from_two_versions_of_a_dataset.py
+++ b/etl/match_variables_from_two_versions_of_a_dataset.py
@@ -390,9 +390,8 @@ def main(
     type=str,
     default=N_MAX_SUGGESTIONS,
     help=(
-        "Name of similarity function to use when fuzzy matching variables."
-        f" Default: {SIMILARITY_NAME}. Available methods:"
-        f" {', '.join(list(SIMILARITY_NAMES))}."
+        "Number of suggestions to show per old variable. That is, for every old"
+        " variable at most [--max-suggestions] suggestions will be listed."
     ),
 )
 def main_cli(


### PR DESCRIPTION
Correct description for `max-suggestions` argument of command `etl-match-variables` (introduced in #386)