### PR TITLE
fix(grapher): fix grapher inserts

### DIFF
--- a/etl/db_utils.py
+++ b/etl/db_utils.py
@@ -169,22 +169,21 @@ class DBUtils:
         namespace: str,
         user_id: int,
         tag_id: Optional[int] = None,
-        source_checksum: Optional[str] = None,
         description: str = "This is a dataset imported by the automated fetcher",
     ) -> int:
         operation = self.upsert_one(
             """
             INSERT INTO datasets
-                (shortName, name, version, description, namespace, sourceChecksum, createdAt, createdByUserId, updatedAt, metadataEditedAt, metadataEditedByUserId, dataEditedAt, dataEditedByUserId)
+                (shortName, name, version, description, namespace, createdAt, createdByUserId, updatedAt, metadataEditedAt, metadataEditedByUserId, dataEditedAt, dataEditedByUserId)
             VALUES
-                (%s, %s, %s, %s, %s, %s, NOW(), %s, NOW(), NOW(), %s, NOW(), %s)
+                (%s, %s, %s, %s, %s, NOW(), %s, NOW(), NOW(), %s, NOW(), %s)
             ON DUPLICATE KEY UPDATE
                 shortName = VALUES(shortName),
                 name = VALUES(name),
                 version = VALUES(version),
                 description = VALUES(description),
                 namespace = VALUES(namespace),
-                sourceChecksum = VALUES(sourceChecksum),
+                sourceChecksum = NULL,
                 updatedAt = VALUES(updatedAt),
                 metadataEditedAt = VALUES(metadataEditedAt),
                 metadataEditedByUserId = VALUES(metadataEditedByUserId),
@@ -197,7 +196,6 @@ class DBUtils:
                 version,
                 description,
                 namespace,
-                source_checksum,
                 user_id,
                 user_id,
                 user_id,

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -149,12 +149,11 @@ def yield_wide_table(
                 table_to_yield[column].metadata.unit is not None
             ), f"Unit for column {column} should not be None here!"
 
+            # Select only one column and dimensions for performance
+            tab = table_to_yield[[column]]
+
             # Drop NA values
-            tab = (
-                table_to_yield.dropna(subset=[column])
-                if na_action == "drop"
-                else table_to_yield
-            )
+            tab = tab.dropna() if na_action == "drop" else table_to_yield
 
             # Create underscored name of a new column from the combination of column and dimensions
             short_name = _slugify_column_and_dimensions(column, dims, dim_names)
@@ -179,6 +178,7 @@ def yield_wide_table(
                 title=title_with_dims,
             )
 
+            # Keep only entity_id and year in index
             yield tab.reset_index().set_index(["entity_id", "year"])[[short_name]]
 
 

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -52,10 +52,7 @@ class VariableUpsertResult:
 
 
 def upsert_dataset(
-    dataset: catalog.Dataset,
-    namespace: str,
-    sources: List[catalog.meta.Source],
-    source_checksum: str,
+    dataset: catalog.Dataset, namespace: str, sources: List[catalog.meta.Source]
 ) -> DatasetUpsertResult:
     assert dataset.metadata.short_name, "Dataset must have a short_name"
     assert dataset.metadata.version, "Dataset must have a version"
@@ -90,7 +87,6 @@ def upsert_dataset(
             dataset.metadata.version,
             namespace,
             int(cast(str, config.GRAPHER_USER_ID)),
-            source_checksum=source_checksum,
             description=dataset.metadata.description or "",
         )
         log.info(
@@ -267,15 +263,15 @@ def fetch_db_checksum(dataset: catalog.Dataset) -> Optional[str]:
         return None if source_checksum is None else source_checksum[0]
 
 
-def set_dataset_checksum_to_null(dataset_id: int) -> None:
+def set_dataset_checksum(dataset_id: int, checksum: str) -> None:
     with open_db() as db:
         db.cursor.execute(
             """
             UPDATE datasets
-            SET sourceChecksum = NULL
+            SET sourceChecksum = %s
             WHERE id=%s
         """,
-            [dataset_id],
+            [checksum, dataset_id],
         )
 
 

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -592,7 +592,9 @@ class GrapherStep(Step):
         # Try to cleanup ghost variables, but make sure to raise an error if they are used
         # in any chart
         cleanup_ghost_variables(
-            dataset_upsert_results.dataset_id, upserted_variable_ids
+            dataset_upsert_results.dataset_id,
+            upserted_variable_ids,
+            workers=GRAPHER_INSERT_WORKERS,
         )
         cleanup_ghost_sources(dataset_upsert_results.dataset_id, upserted_source_ids)
 

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -34,7 +34,7 @@ from etl.grapher_import import (
     cleanup_ghost_sources,
     cleanup_ghost_variables,
     fetch_db_checksum,
-    set_dataset_checksum_to_null,
+    set_dataset_checksum,
     upsert_dataset,
     upsert_table,
 )
@@ -43,7 +43,7 @@ from etl.helpers import get_etag
 Graph = Dict[str, Set[str]]
 DAG = Dict[str, Any]
 
-GRAPHER_INSERT_WORKERS = int(os.environ.get("GRAPHER_INSERT_WORKERS", 20))
+GRAPHER_INSERT_WORKERS = int(os.environ.get("GRAPHER_INSERT_WORKERS", 10))
 
 
 def compile_steps(
@@ -568,24 +568,19 @@ class GrapherStep(Step):
             dataset,
             dataset.metadata.namespace,
             dataset.metadata.sources,
-            self.checksum_input(),
         )
-        try:
-            # insert data in parallel, this speeds it up considerably and is even faster than loading
-            # data with LOAD DATA INFILE
-            with concurrent.futures.ThreadPoolExecutor(
-                max_workers=GRAPHER_INSERT_WORKERS
-            ) as executor:
-                variable_upsert_results = executor.map(
+
+        # insert data in parallel, this speeds it up considerably and is even faster than loading
+        # data with LOAD DATA INFILE
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=GRAPHER_INSERT_WORKERS
+        ) as executor:
+            variable_upsert_results = list(
+                executor.map(
                     lambda table: upsert_table(table, dataset_upsert_results),
                     step_module.get_grapher_tables(dataset),  # type: ignore
                 )
-
-        except Exception as e:
-            # dataset has been already inserted into DB with checksum, make it null again so that the
-            # step remains dirty
-            set_dataset_checksum_to_null(dataset_upsert_results.dataset_id)
-            raise e
+            )
 
         # Cleanup all ghost variables and sources that weren't upserted
         # NOTE: we can't just remove all dataset variables before starting this step because
@@ -600,6 +595,9 @@ class GrapherStep(Step):
             dataset_upsert_results.dataset_id, upserted_variable_ids
         )
         cleanup_ghost_sources(dataset_upsert_results.dataset_id, upserted_source_ids)
+
+        # set checksum after all data got inserted
+        set_dataset_checksum(dataset_upsert_results.dataset_id, self.checksum_input())
 
     def _get_step_module(self) -> types.ModuleType:
         module_path = self.path.lstrip("/").replace("/", ".")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ exclude = ".ipynb_checkpoints|walkthrough/.*_cookiecutter"
 
 [tool.isort]
 profile = "black"
+extend_skip = [".ipynb_checkpoints"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
* there is a bug that labels grapher step as complete if inserts into DB fail
* fix performance bottleneck in `yield_wide_table`
* lower default grapher connections to 10
* run variable deletion in parallel