### PR TITLE
fix(grapher_import): add threadlock for source upserts

### DIFF
--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -549,15 +549,18 @@ class GrapherStep(Step):
             dataset.metadata.sources,
         )
 
+        tables = step_module.get_grapher_tables(dataset)  # type: ignore
+        upsert = lambda t: upsert_table(t, dataset_upsert_results)
+
         # insert data in parallel, this speeds it up considerably and is even faster than loading
         # data with LOAD DATA INFILE
-        with concurrent.futures.ThreadPoolExecutor(max_workers=GRAPHER_INSERT_WORKERS) as executor:
-            variable_upsert_results = list(
-                executor.map(
-                    lambda table: upsert_table(table, dataset_upsert_results),
-                    step_module.get_grapher_tables(dataset),  # type: ignore
-                )
-            )
+        if GRAPHER_INSERT_WORKERS > 1:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=GRAPHER_INSERT_WORKERS) as executor:
+                results = executor.map(upsert, tables)
+        else:
+            results = map(upsert, tables)
+
+        variable_upsert_results = list(results)
 
         # Cleanup all ghost variables and sources that weren't upserted
         # NOTE: we can't just remove all dataset variables before starting this step because

--- a/etl/steps/grapher/worldbank_wdi/2022-05-26/wdi.py
+++ b/etl/steps/grapher/worldbank_wdi/2022-05-26/wdi.py
@@ -24,6 +24,7 @@ def get_grapher_dataset() -> Dataset:
     dataset = Dataset(DATA_DIR / f"garden/{namespace}/{version}/{fname}")
     # short_name should include dataset name and version
     dataset.metadata.short_name = f"{dataset.metadata.short_name}__{version.replace('-', '_')}"
+    dataset.metadata.version = version
 
     return dataset
 


### PR DESCRIPTION
Fix for https://github.com/owid/etl/issues/421

Add thread lock with its own DB connection to source upserts. The separate connection means sources inserts won't be rolled back, but that's not a big deal as we're removing ghost sources later.