### PR TITLE
enhance(.env): allow custom .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ data/*
 data/garden/*
 !data/garden/reference/
 .env
+.env.*
 *.dot
 *.pdf
 pyrightconfig.json

--- a/etl/config.py
+++ b/etl/config.py
@@ -12,7 +12,9 @@ from os import environ as env
 import bugsnag
 from dotenv import load_dotenv
 
-load_dotenv()
+ENV_FILE = env.get("ENV", ".env")
+
+load_dotenv(ENV_FILE)
 
 DEBUG = env.get("DEBUG") == "True"
 


### PR DESCRIPTION
Currently when I run grapher steps on staging on production I change my envs in `.env` file and then change it back. This could be dangerous if I forget to do so and then test against production envs in `.env`. Running `ENV=.env.production etl ...` instead is much more flagrant.

(I don't think that `dotenv` supports setting env file from environment or does it?)