### PR TITLE
chore: add --ipdb option to enter debugger on failure

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -95,6 +95,7 @@ def main_cli(
     )
 
     if ipdb:
+        config.IPDB_ENABLED = True
         with launch_ipdb_on_exception():
             main(**kwargs)  # type: ignore
     else:

--- a/etl/command.py
+++ b/etl/command.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Callable, List, Optional
 
 import click
+from ipdb import launch_ipdb_on_exception
 from owid.walden import CATALOG as WALDEN_CATALOG
 from owid.walden import Catalog as WaldenCatalog
 
@@ -33,6 +34,7 @@ LIMIT_NOFILE = 5000
 @click.option("--force", is_flag=True, help="Redo a step even if it appears done and up-to-date")
 @click.option("--private", is_flag=True, help="Execute private steps")
 @click.option("--grapher", is_flag=True, help="Publish changes to grapher (OWID staff only)")
+@click.option("--ipdb", is_flag=True, help="Run the debugger on uncaught exceptions")
 @click.option(
     "--backport",
     is_flag=True,
@@ -69,6 +71,7 @@ def main_cli(
     private: bool = False,
     grapher: bool = False,
     backport: bool = False,
+    ipdb: bool = False,
     downstream: bool = False,
     only: bool = False,
     exclude: Optional[str] = None,
@@ -76,7 +79,8 @@ def main_cli(
     workers: int = 5,
 ) -> None:
     _update_open_file_limit()
-    return main(
+
+    kwargs = dict(
         steps=steps,
         dry_run=dry_run,
         force=force,
@@ -89,6 +93,12 @@ def main_cli(
         dag_path=dag_path,
         workers=workers,
     )
+
+    if ipdb:
+        with launch_ipdb_on_exception():
+            main(**kwargs)  # type: ignore
+    else:
+        main(**kwargs)  # type: ignore
 
 
 def main(

--- a/etl/config.py
+++ b/etl/config.py
@@ -32,6 +32,9 @@ DB_PORT = int(env.get("DB_PORT", "3306"))
 DB_USER = env.get("DB_USER", "root")
 DB_PASS = env.get("DB_PASS", "")
 
+# run ETL steps with debugger on exception
+IPDB_ENABLED = False
+
 
 def enable_bugsnag() -> None:
     BUGSNAG_API_KEY = env.get("BUGSNAG_API_KEY")

--- a/etl/run_python_step.py
+++ b/etl/run_python_step.py
@@ -4,8 +4,10 @@
 
 import sys
 from importlib import import_module
+from typing import Optional
 
 import click
+from ipdb import launch_ipdb_on_exception
 
 from etl.paths import BASE_PACKAGE, STEP_DIR
 
@@ -13,7 +15,8 @@ from etl.paths import BASE_PACKAGE, STEP_DIR
 @click.command()
 @click.argument("uri")
 @click.argument("dest_dir")
-def main(uri: str, dest_dir: str) -> None:
+@click.option("--ipdb", is_flag=True)
+def main(uri: str, dest_dir: str, ipdb: Optional[bool]) -> None:
     """
     Import and run a specific step of the ETL. Meant to be ran as
     a subprocess by the main `etl` command.
@@ -23,7 +26,11 @@ def main(uri: str, dest_dir: str) -> None:
 
     path = uri.split("//", 1)[1]
 
-    _import_and_run(path, dest_dir)
+    if ipdb:
+        with launch_ipdb_on_exception():
+            _import_and_run(path, dest_dir)
+    else:
+        _import_and_run(path, dest_dir)
 
 
 def _import_and_run(path: str, dest_dir: str) -> None:

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -29,7 +29,7 @@ with warnings.catch_warnings():
 from owid import catalog, walden
 from owid.walden import CATALOG as WALDEN_CATALOG
 
-from etl import backport_helpers, files, git, paths
+from etl import backport_helpers, config, files, git, paths
 from etl.grapher_import import (
     cleanup_ghost_sources,
     cleanup_ghost_variables,
@@ -358,13 +358,15 @@ class DataStep(Step):
         """
         # use a subprocess to isolate each step from the others, and avoid state bleeding
         # between them
-        subprocess.check_call(
-            [
-                f"{paths.BASE_DIR}/.venv/bin/run_python_step",
-                str(self),
-                self._dest_dir.as_posix(),
-            ]
-        )
+        args = [
+            f"{paths.BASE_DIR}/.venv/bin/run_python_step",
+            str(self),
+            self._dest_dir.as_posix(),
+        ]
+        if config.IPDB_ENABLED:
+            args[1:1] = ["--ipdb"]
+
+        subprocess.check_call(args)
 
     def _run_notebook(self) -> None:
         "Run a parameterised Jupyter notebook."


### PR DESCRIPTION
This non-essential flag makes it easier to check where something is going wrong. If you run the `etl` command but add `--ipdb`, it will enter the debugger on failure, regardless of whether you are in normal ETL code or within a Python ETL step.

- Adds a global variable to `etl.config` indicating whether the debugger should be triggered on exceptions
- Adds `--ipdb` options to both the `etl` command and the `run_python_step` command
