### PR TITLE
fix(faostat): Fill missing FAOSTAT unit names with unit short names

### DIFF
--- a/etl/steps/data/garden/faostat/2022-05-17/faostat_metadata.py
+++ b/etl/steps/data/garden/faostat/2022-05-17/faostat_metadata.py
@@ -470,7 +470,7 @@ def create_elements_dataframe_for_domain(
         .sort_values(["fao_unit_short_name"])
         .reset_index(drop=True)
     )
-    elements_from_data["fao_unit"] = elements_from_data["fao_unit"].fillna("")
+    elements_from_data["fao_unit"] = elements_from_data["fao_unit"].fillna("fao_unit_short_name")
 
     # Sanity checks:
 


### PR DESCRIPTION
In datasets `faostat_ek`, `faostat_qv`, and `faostat_sdgb`, some units were empty. This led to variables in the flattened dataset (and therefore variables in grapher) having names like `item | item code || element | element code || `.
But in all cases, when unit was missing, unit short name was given. So I have filled unit names with unit short names in those cases.
