### PR TITLE
fix(faostat): Fix wrong use of fillna with fao unit short name

### DIFF
--- a/etl/steps/data/garden/faostat/2022-05-17/faostat_metadata.py
+++ b/etl/steps/data/garden/faostat/2022-05-17/faostat_metadata.py
@@ -470,7 +470,7 @@ def create_elements_dataframe_for_domain(
         .sort_values(["fao_unit_short_name"])
         .reset_index(drop=True)
     )
-    elements_from_data["fao_unit"] = elements_from_data["fao_unit"].fillna("fao_unit_short_name")
+    elements_from_data["fao_unit"] = elements_from_data["fao_unit"].fillna(elements_from_data["fao_unit_short_name"])
 
     # Sanity checks:
 


### PR DESCRIPTION
Silly bug: I was filling missing short units with "fao_unit_short_names" instead of the actual value of the unit short names.
