### PR TITLE
fix(smil): Fix duplicated sources in metadata

### DIFF
--- a/etl/steps/data/garden/smil/2017-01-01/global_primary_energy.meta.yml
+++ b/etl/steps/data/garden/smil/2017-01-01/global_primary_energy.meta.yml
@@ -1,9 +1,3 @@
-dataset:
-  sources:
-     -
-       name: Global Primary Energy (Smil, 2017)
-       published_by: "Vaclav Smil (2017), Energy Transitions: Global and National Perspectives, 2nd edition, Appendix A"
-
 tables:
   global_primary_energy:
     variables:

--- a/etl/steps/data/garden/smil/2017-01-01/global_primary_energy.py
+++ b/etl/steps/data/garden/smil/2017-01-01/global_primary_energy.py
@@ -29,7 +29,17 @@ def run(dest_dir: str) -> None:
     tb_garden = tb_garden[sorted(tb_garden.columns)].sort_index()
 
     # Update metadata using yaml file.
-    ds_garden.metadata.update_from_yaml(N.metadata_path)
+    ####################################################################################################################
+    # Temporary solution: At the moment, 'published_by' cannot be added to walden metadata.
+    # I could add a new source to the yaml file in this step (with the appropriate 'published_by') and use
+    # > ds_garden.metadata.update_from_yaml(N.metadata_path)
+    # but this would keep the original source (without 'published_by') and add a new one (with 'published_by').
+    # Therefore, for the moment the only solution I see is to manually input the 'published_by' field here.
+    # Alternatively, I could ignore the metadata from walden and add all the relevant metadata in this step's yaml file.
+    ds_garden.metadata.sources[
+        0
+    ].published_by = "Vaclav Smil (2017), Energy Transitions: Global and National Perspectives, 2nd edition, Appendix A"
+    ####################################################################################################################
     tb_garden.update_metadata_from_yaml(N.metadata_path, "global_primary_energy")
 
     # Add table to dataset.


### PR DESCRIPTION
The source for Smil data was duplicated in the `smil/2017-01-01/global_primary_energy` dataset. I have solved in manually with a temporary solution.
@Marigold if you want feel free to create an issue about this (I guess you understand better than me what the root issue is).