### PR TITLE
enhance(population): use un wpp 2022

### DIFF
--- a/dag.yml
+++ b/dag.yml
@@ -10,7 +10,7 @@ steps:
   data://garden/owid/latest/key_indicators:
     - data://garden/hyde/2017/baseline
     - data://garden/gapminder/2019-12-10/population
-    - data://garden/un/2019/un_wpp
+    - data://garden/un/2022-07-11/un_wpp
     - data://garden/wb/2021-07-01/wb_income
     - data://open_numbers/open_numbers/latest/open_numbers__world_development_indicators
     - data://garden/reference
@@ -117,11 +117,11 @@ steps:
   # Emissions - CO2 dataset (2022).
   #
   data://garden/emissions/2022-08-26/owid_co2:
-  - backport://backport/owid/latest/dataset_5582_global_carbon_budget__global_carbon_project__v2021
-  - data://garden/cait/2022-08-10/ghg_emissions_by_sector
-  - data://garden/energy/2022-07-29/primary_energy_consumption
-  - data://garden/owid/latest/key_indicators
-  - data://garden/ggdc/2020-10-01/ggdc_maddison
+    - backport://backport/owid/latest/dataset_5582_global_carbon_budget__global_carbon_project__v2021
+    - data://garden/cait/2022-08-10/ghg_emissions_by_sector
+    - data://garden/energy/2022-07-29/primary_energy_consumption
+    - data://garden/owid/latest/key_indicators
+    - data://garden/ggdc/2020-10-01/ggdc_maddison
 
   grapher://un_sdg/2022-07-07/un_sdg:
     - data://garden/un_sdg/2022-07-07/un_sdg

--- a/etl/steps/data/garden/owid/latest/key_indicators/table_population.meta.yml
+++ b/etl/steps/data/garden/owid/latest/key_indicators/table_population.meta.yml
@@ -8,23 +8,20 @@ tables:
     variables:
       population:
         title: Population
-        description: Population by country, available from 1800 to 2021 based on Gapminder data, HYDE, and UN Population Division (2019) estimates.
+        description: Population by country, available from 1800 to 2021 based on Gapminder data, HYDE, and UN Population Division (2022) estimates.
         display:
           name: Population
           includeInTable: true
         sources:
-          -
-            name: Gapminder (v6)
+          - name: Gapminder (v6)
             published_by: Gapminder (v6)
             url: https://www.gapminder.org/data/documentation/gd003/
             date_accessed: October 8, 2021
-          -
-            name: UN (2019)
-            published_by: United Nations Population Division (2019)
+          - name: UN (2022)
+            published_by: United Nations - Population Division (2022)
             url: https://population.un.org/wpp/Download/Standard/Population/
-            date_accessed: October 8, 2021
-          -
-            name: HYDE (v3.2)
+            date_accessed: September 9, 2022
+          - name: HYDE (v3.2)
             published_by: HYDE (v3.2)
             url: https://dataportaal.pbl.nl/downloads/HYDE/
             date_accessed: October 8, 2021

--- a/etl/steps/data/garden/owid/latest/key_indicators/table_population.py
+++ b/etl/steps/data/garden/owid/latest/key_indicators/table_population.py
@@ -135,7 +135,22 @@ def load_unwpp() -> pd.DataFrame:
     )
 
     # Remove special regions
-    df = df[~df.country.isin(["Northern America", "Latin America & Caribbean"])]
+    df = df[
+        ~df.country.isin(
+            [
+                "Northern America",
+                "Latin America & Caribbean",
+                "Land-locked developing countries (LLDC)",
+                "Latin America and the Caribbean",
+                "Least developed countries",
+                "Less developed regions",
+                "Less developed regions, excluding China",
+                "Less developed regions, excluding least developed countries",
+                "More developed regions",
+                "Small island developing states (SIDS)",
+            ]
+        )
+    ]
 
     # Check no (country, year) duplicates
     assert df.groupby(["country", "year"]).population.count().max() == 1

--- a/etl/steps/data/garden/owid/latest/key_indicators/table_population.py
+++ b/etl/steps/data/garden/owid/latest/key_indicators/table_population.py
@@ -13,8 +13,8 @@ from pathlib import Path
 from typing import List, cast
 
 import pandas as pd
-from pandas.api.types import CategoricalDtype
 from owid.catalog import Dataset, Table
+from pandas.api.types import CategoricalDtype
 
 from etl import data_helpers
 from etl.paths import DATA_DIR

--- a/etl/steps/data/garden/owid/latest/key_indicators/table_population.py
+++ b/etl/steps/data/garden/owid/latest/key_indicators/table_population.py
@@ -134,6 +134,9 @@ def load_unwpp() -> pd.DataFrame:
         .reset_index(drop=True)
     )
 
+    # Remove special regions
+    df = df[~df.country.isin(["Northern America", "Latin America & Caribbean"])]
+
     # Check no (country, year) duplicates
     assert df.groupby(["country", "year"]).population.count().max() == 1
     return cast(pd.DataFrame, df)

--- a/etl/steps/data/garden/owid/latest/key_indicators/table_population.py
+++ b/etl/steps/data/garden/owid/latest/key_indicators/table_population.py
@@ -148,6 +148,10 @@ def load_unwpp() -> pd.DataFrame:
                 "Less developed regions, excluding least developed countries",
                 "More developed regions",
                 "Small island developing states (SIDS)",
+                "High-income countries",
+                "Low-income countries",
+                "Lower-middle-income countries",
+                "Upper-middle-income countries",
             ]
         )
     ]


### PR DESCRIPTION
Switch to UN WPP 2022 revision population for data starting from 1950:

New countries (only UN data, i.e. > 1950 year):
- Kosovo
- Guernsey
- Jersey

Deleted:
- Channel Islands (now Guernsey and Jersey)
- Melanesia, Polynesia (not countries)