### PR TITLE
refactor(grapher steps): make adapt functions implicit

### DIFF
--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -98,7 +98,7 @@ def annotate_table(
     return table
 
 
-def yield_wide_table(
+def _yield_wide_table(
     table: catalog.Table,
     na_action: Literal["drop", "raise"] = "raise",
     dim_titles: Optional[List[str]] = None,
@@ -236,7 +236,7 @@ def _assert_long_table(table: catalog.Table) -> None:
     ), "Values in column `meta` must be either instances of `catalog.VariableMeta` or null"
 
 
-def yield_long_table(
+def _yield_long_table(
     table: catalog.Table,
     annot: Optional[Annotation] = None,
     dim_titles: Optional[List[str]] = None,
@@ -267,7 +267,7 @@ def yield_long_table(
         if annot:
             t = annotate_table(t, annot, missing_col="ignore")
 
-        yield from yield_wide_table(cast(catalog.Table, t), dim_titles=dim_titles)
+        yield from _yield_wide_table(cast(catalog.Table, t), dim_titles=dim_titles)
 
 
 def long_to_wide_tables(
@@ -300,16 +300,16 @@ def long_to_wide_tables(
         yield cast(catalog.Table, t)
 
 
-def _get_entities_from_countries_regions() -> Dict[str, int]:
+def _get_entities_from_countries_regions(by: Literal["name", "code"] = "name") -> Dict[str, int]:
     reference_dataset = catalog.Dataset(REFERENCE_DATASET)
-    countries_regions = reference_dataset["countries_regions"]
-    return cast(Dict[str, int], countries_regions.set_index("name")["legacy_entity_id"])
+    countries_regions = reference_dataset["countries_regions"].reset_index()
+    return cast(Dict[str, int], countries_regions.set_index(by)["legacy_entity_id"])
 
 
-def _get_entities_from_db(countries: Set[str]) -> Dict[str, int]:
-    q = "select id as entity_id, name from entities where name in %(names)s"
+def _get_entities_from_db(countries: Set[str], by: Literal["name", "code"]) -> Dict[str, int]:
+    q = f"select id as entity_id, {by} from entities where {by} in %(names)s"
     df = pd.read_sql(q, get_engine(), params={"names": list(countries)})
-    return cast(Dict[str, int], df.set_index("name").entity_id.to_dict())
+    return cast(Dict[str, int], df.set_index(by).entity_id.to_dict())
 
 
 def _get_and_create_entities_in_db(countries: Set[str]) -> Dict[str, int]:
@@ -324,24 +324,27 @@ def country_to_entity_id(
     fill_from_db: bool = True,
     create_entities: bool = False,
     errors: Literal["raise", "ignore", "warn"] = "raise",
+    by: Literal["name", "code"] = "name",
 ) -> pd.Series:
     """Convert country name to grapher entity_id. Most of countries should be in countries_regions.csv,
     however some regions could be only in `entities` table in MySQL or doesn't exist at all.
     :param fill_from_db: if True, fill missing countries from `entities` table
     :param create_entities: if True, create missing countries in `entities` table
     :param errors: how to handle missing countries
+    :param by: use `name` if you use country names, `code` if you use ISO codes
     """
     # get entities from countries_regions.csv
-    entity_id = country.map(_get_entities_from_countries_regions())
+    entity_id = country.map(_get_entities_from_countries_regions(by=by))
 
     # fill entities from DB
     if entity_id.isnull().any() and fill_from_db:
         ix = entity_id.isnull()
-        entity_id[ix] = country[ix].map(_get_entities_from_db(set(country[ix])))
+        entity_id[ix] = country[ix].map(_get_entities_from_db(set(country[ix]), by=by))
 
     # create entities in DB
     if entity_id.isnull().any() and create_entities:
         assert fill_from_db, "fill_from_db must be True to create entities"
+        assert by == "name", "create_entities works only with `by='name'`"
         ix = entity_id.isnull()
         entity_id[ix] = country[ix].map(_get_and_create_entities_in_db(set(country[ix])))
 
@@ -425,10 +428,11 @@ def combine_metadata_sources(sources: List[catalog.Source]) -> catalog.Source:
     return default_source
 
 
-def adapt_dataset_metadata_for_grapher(
+def _adapt_dataset_metadata_for_grapher(
     metadata: catalog.DatasetMeta,
 ) -> catalog.DatasetMeta:
-    """Adapt metadata of a garden dataset to be used in a grapher step.
+    """Adapt metadata of a garden dataset to be used in a grapher step. This function
+    is not meant to be run explicitly, but by default in the grapher step.
 
     Parameters
     ----------
@@ -457,10 +461,11 @@ def adapt_dataset_metadata_for_grapher(
     return metadata
 
 
-def adapt_table_for_grapher(
+def _adapt_table_for_grapher(
     table: catalog.Table, country_col: str = "country", year_col: str = "year"
 ) -> catalog.Table:
-    """Adapt table (from a garden dataset) to be used in a grapher step.
+    """Adapt table (from a garden dataset) to be used in a grapher step. This function
+    is not meant to be run explicitly, but by default in the grapher step.
 
     Parameters
     ----------
@@ -478,10 +483,13 @@ def adapt_table_for_grapher(
 
     """
     table = deepcopy(table)
-    # Grapher needs a column entity id, that is constructed based on the unique entity names in the database.
-    table["entity_id"] = country_to_entity_id(table[country_col], create_entities=True)
-    table = table.drop(columns=[country_col]).rename(columns={year_col: "year"})
-    table = table.set_index(["entity_id", "year"])
+    if "entity_id" not in table.index.names and "year" not in table.index.names:
+        # Grapher needs a column entity id, that is constructed based on the unique entity names in the database.
+        table["entity_id"] = country_to_entity_id(table[country_col], create_entities=True)
+        table = table.drop(columns=[country_col]).rename(columns={year_col: "year"})
+        table = table.set_index(["entity_id", "year"])
+    else:
+        assert {"entity_id", "year"} <= set(table.index.names)
 
     # Ensure the default source of each column includes the description of the table (since that is the description that
     # will appear in grapher on the SOURCES tab).

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -49,7 +49,9 @@ INT_TYPES = (
 # once we switch to catalogPath, no data will be upserted to data_values
 BLACKLIST_DATASETS_DATA_VALUES_UPSERTS = [
     "gbd_cause",
+    "gbd_risk",
     "gbd_prevalence",
+    "gbd_child_mortality",
 ]
 
 
@@ -253,8 +255,7 @@ def upsert_table(
 
     if table.metadata.dataset.short_name not in BLACKLIST_DATASETS_DATA_VALUES_UPSERTS:
         insert_to_data_values(df)
-
-    log.info("upsert_table.upserted_data_values", size=len(table))
+        log.info("upsert_table.upserted_data_values", size=len(table))
 
     return VariableUpsertResult(variable.id, source_id)
 

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -517,6 +517,8 @@ class GrapherStep(Step):
         # save dataset to grapher DB
         dataset = self.dataset
 
+        dataset.metadata = gh._adapt_dataset_metadata_for_grapher(dataset.metadata)
+
         dataset_upsert_results = upsert_dataset(
             dataset,
             dataset.metadata.namespace,
@@ -531,8 +533,10 @@ class GrapherStep(Step):
         for table in dataset:
             catalog_path = f"{self.path}/{table.metadata.short_name}"
 
+            table = gh._adapt_table_for_grapher(table)
+
             # generate table with entity_id, year and value for every column
-            tables = gh.yield_wide_table(table, na_action="drop")
+            tables = gh._yield_wide_table(table, na_action="drop")
             upsert = lambda t: upsert_table(  # noqa: E731
                 t,
                 dataset_upsert_results,
@@ -557,7 +561,7 @@ class GrapherStep(Step):
         set_dataset_checksum(dataset_upsert_results.dataset_id, self.data_step.checksum_input())
 
     def checksum_output(self) -> str:
-        raise NotImplementedError("UpsertStep should not be used as an input")
+        raise NotImplementedError("GrapherStep should not be used as an input")
 
     @classmethod
     def _cleanup_ghost_resources(

--- a/etl/steps/data/garden/un_sdg/2022-07-07/un_sdg.country_mapping.json
+++ b/etl/steps/data/garden/un_sdg/2022-07-07/un_sdg.country_mapping.json
@@ -280,5 +280,5 @@
   "Europe": "Europe (UN)",
   "Least Developed Countries (LDCs)": "Least Developed Countries (LDCs)",
   "Developing regions": "Developing regions",
-  "Small island developing States (SIDS)": "Small island developing States (SIDS)"
+  "Small island developing States (SIDS)": "Small Island Developing States (SIDS)"
 }

--- a/etl/steps/data/garden/who/2021-07-01/ghe.ipynb
+++ b/etl/steps/data/garden/who/2021-07-01/ghe.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": [
      "parameters"
@@ -291,11 +291,8 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "bfee9b694fe04c946c13f91f59877f323f209df7eaba52b3079ace55470be701"
-  },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3.9.13 ('.venv': poetry)",
    "language": "python",
    "name": "python3"
   },
@@ -309,7 +306,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.9.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "844e7496ece5f279b92e860ee31795b4810a8e6a6d9b1dd318e3a60c64167b55"
+   }
   }
  },
  "nbformat": 4,

--- a/etl/steps/grapher/bp/2022-07-14/energy_mix.py
+++ b/etl/steps/grapher/bp/2022-07-14/energy_mix.py
@@ -1,10 +1,8 @@
 """Grapher step for BP's energy mix 2022 dataset.
-
 """
 
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 DATASET_PATH = DATA_DIR / "garden" / "bp" / "2022-07-14" / "energy_mix"
@@ -12,9 +10,9 @@ DATASET_PATH = DATA_DIR / "garden" / "bp" / "2022-07-14" / "energy_mix"
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     # There is only one table in the dataset, with the same name as the dataset.
     table = garden_dataset[garden_dataset.table_names[0]].reset_index().drop(columns=["country_code"])
-    dataset.add(gh.adapt_table_for_grapher(table))
+    dataset.add(table)
     dataset.save()

--- a/etl/steps/grapher/bp/2022-07-14/statistical_review.py
+++ b/etl/steps/grapher/bp/2022-07-14/statistical_review.py
@@ -1,10 +1,8 @@
 """Grapher step for BP's statistical review 2022 dataset.
-
 """
 
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 DATASET_PATH = DATA_DIR / "garden" / "bp" / "2022-07-14" / "statistical_review"
@@ -12,9 +10,9 @@ DATASET_PATH = DATA_DIR / "garden" / "bp" / "2022-07-14" / "statistical_review"
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     # There is only one table in the dataset, with the same name as the dataset.
     table = garden_dataset[garden_dataset.table_names[0]].reset_index().drop(columns=["country_code"])
-    dataset.add(gh.adapt_table_for_grapher(table))
+    dataset.add(table)
     dataset.save()

--- a/etl/steps/grapher/bp/2022-09-19/fossil_fuel_reserves_production_ratio.py
+++ b/etl/steps/grapher/bp/2022-09-19/fossil_fuel_reserves_production_ratio.py
@@ -1,7 +1,6 @@
 from owid import catalog
 from shared import CURRENT_DIR
 
-from etl import grapher_helpers as gh
 from etl.helpers import Names
 
 DATASET_SHORT_NAME = "fossil_fuel_reserves_production_ratio"
@@ -10,10 +9,9 @@ N = Names(str(CURRENT_DIR / DATASET_SHORT_NAME))
 
 def run(dest_dir: str) -> None:
     # Create new grapher dataset.
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(N.garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, N.garden_dataset.metadata)
     # Prepare table for grapher.
     table = N.garden_dataset[DATASET_SHORT_NAME].reset_index()
-    table = gh.adapt_table_for_grapher(table)
     # Add table and save dataset.
     dataset.add(table)
     dataset.save()

--- a/etl/steps/grapher/cait/2022-08-10/all_ghg_emissions.py
+++ b/etl/steps/grapher/cait/2022-08-10/all_ghg_emissions.py
@@ -1,6 +1,5 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 from .shared import GARDEN_DATASET_VERSION, NAMESPACE
@@ -15,7 +14,7 @@ DATASET_PATH = DATA_DIR / "garden" / NAMESPACE / GARDEN_DATASET_VERSION / "ghg_e
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     ####################################################################################################################
     # Grapher seems to be taking the name from the dataset instead of the table.
@@ -23,8 +22,6 @@ def run(dest_dir: str) -> None:
     dataset.metadata.title = GRAPHER_DATASET_TITLE
     dataset.metadata.short_name = TABLE_NAME
     ####################################################################################################################
-
-    dataset.metadata = gh.adapt_dataset_metadata_for_grapher(dataset.metadata)
 
     dataset.save()
 
@@ -38,5 +35,4 @@ def run(dest_dir: str) -> None:
             table[column].metadata.short_unit = "t"
             table[column].metadata.display["conversionFactor"] = 1e6
             table[column].metadata.description = table[column].metadata.description.replace("million tonnes", "tonnes")
-    table = gh.adapt_table_for_grapher(table)
     dataset.add(table)

--- a/etl/steps/grapher/cait/2022-08-10/ch4_emissions.py
+++ b/etl/steps/grapher/cait/2022-08-10/ch4_emissions.py
@@ -1,6 +1,5 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 from .shared import GARDEN_DATASET_VERSION, NAMESPACE
@@ -15,7 +14,7 @@ DATASET_PATH = DATA_DIR / "garden" / NAMESPACE / GARDEN_DATASET_VERSION / "ghg_e
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     ####################################################################################################################
     # Grapher seems to be taking the name from the dataset instead of the table.
@@ -23,8 +22,6 @@ def run(dest_dir: str) -> None:
     dataset.metadata.title = GRAPHER_DATASET_TITLE
     dataset.metadata.short_name = TABLE_NAME
     ####################################################################################################################
-
-    dataset.metadata = gh.adapt_dataset_metadata_for_grapher(dataset.metadata)
 
     dataset.save()
 
@@ -38,5 +35,4 @@ def run(dest_dir: str) -> None:
             table[column].metadata.short_unit = "t"
             table[column].metadata.display["conversionFactor"] = 1e6
             table[column].metadata.description = table[column].metadata.description.replace("million tonnes", "tonnes")
-    table = gh.adapt_table_for_grapher(table)
     dataset.add(table)

--- a/etl/steps/grapher/cait/2022-08-10/co2_emissions.py
+++ b/etl/steps/grapher/cait/2022-08-10/co2_emissions.py
@@ -1,6 +1,5 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 from .shared import GARDEN_DATASET_VERSION, NAMESPACE
@@ -15,7 +14,7 @@ DATASET_PATH = DATA_DIR / "garden" / NAMESPACE / GARDEN_DATASET_VERSION / "ghg_e
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     ####################################################################################################################
     # Grapher seems to be taking the name from the dataset instead of the table.
@@ -23,8 +22,6 @@ def run(dest_dir: str) -> None:
     dataset.metadata.title = GRAPHER_DATASET_TITLE
     dataset.metadata.short_name = TABLE_NAME
     ####################################################################################################################
-
-    dataset.metadata = gh.adapt_dataset_metadata_for_grapher(dataset.metadata)
 
     dataset.save()
 
@@ -38,5 +35,4 @@ def run(dest_dir: str) -> None:
             table[column].metadata.short_unit = "t"
             table[column].metadata.display["conversionFactor"] = 1e6
             table[column].metadata.description = table[column].metadata.description.replace("million tonnes", "tonnes")
-    table = gh.adapt_table_for_grapher(table)
     dataset.add(table)

--- a/etl/steps/grapher/cait/2022-08-10/n2o_emissions.py
+++ b/etl/steps/grapher/cait/2022-08-10/n2o_emissions.py
@@ -1,6 +1,5 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 from .shared import GARDEN_DATASET_VERSION, NAMESPACE
@@ -15,7 +14,7 @@ DATASET_PATH = DATA_DIR / "garden" / NAMESPACE / GARDEN_DATASET_VERSION / "ghg_e
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     ####################################################################################################################
     # Grapher seems to be taking the name from the dataset instead of the table.
@@ -23,8 +22,6 @@ def run(dest_dir: str) -> None:
     dataset.metadata.title = GRAPHER_DATASET_TITLE
     dataset.metadata.short_name = TABLE_NAME
     ####################################################################################################################
-
-    dataset.metadata = gh.adapt_dataset_metadata_for_grapher(dataset.metadata)
 
     dataset.save()
 
@@ -38,5 +35,4 @@ def run(dest_dir: str) -> None:
             table[column].metadata.short_unit = "t"
             table[column].metadata.display["conversionFactor"] = 1e6
             table[column].metadata.description = table[column].metadata.description.replace("million tonnes", "tonnes")
-    table = gh.adapt_table_for_grapher(table)
     dataset.add(table)

--- a/etl/steps/grapher/dummy/2020-01-01/dummy.py
+++ b/etl/steps/grapher/dummy/2020-01-01/dummy.py
@@ -1,18 +1,14 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.helpers import Names
 
 N = Names(__file__)
 
 
 def run(dest_dir: str) -> None:
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(N.garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, N.garden_dataset.metadata)
 
     table = N.garden_dataset["dummy"]
-
-    # convert `country` into `entity_id`
-    table = gh.adapt_table_for_grapher(table)
 
     # optionally set additional dimensions
     # table = table.set_index(["sex", "income_group"], append=True)

--- a/etl/steps/grapher/energy/2022-07-20/fossil_fuel_production.py
+++ b/etl/steps/grapher/energy/2022-07-20/fossil_fuel_production.py
@@ -1,10 +1,8 @@
 """Grapher step for the fossil fuel production dataset.
-
 """
 
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 DATASET_PATH = DATA_DIR / "garden" / "energy" / "2022-07-20" / "fossil_fuel_production"
@@ -12,9 +10,9 @@ DATASET_PATH = DATA_DIR / "garden" / "energy" / "2022-07-20" / "fossil_fuel_prod
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     # There is only one table in the dataset, with the same name as the dataset.
     table = garden_dataset[garden_dataset.table_names[0]].reset_index()
-    dataset.add(gh.adapt_table_for_grapher(table))
+    dataset.add(table)
     dataset.save()

--- a/etl/steps/grapher/energy/2022-07-29/primary_energy_consumption.py
+++ b/etl/steps/grapher/energy/2022-07-29/primary_energy_consumption.py
@@ -1,10 +1,8 @@
 """Grapher step for the primary energy consumption dataset.
-
 """
 
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 # Path to garden dataset to be loaded.
@@ -13,9 +11,9 @@ DATASET_PATH = DATA_DIR / "garden" / "energy" / "2022-07-29" / "primary_energy_c
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     # There is only one table in the dataset, with the same name as the dataset.
     table = garden_dataset[garden_dataset.table_names[0]].reset_index().drop(columns=["gdp", "population", "source"])
-    dataset.add(gh.adapt_table_for_grapher(table))
+    dataset.add(table)
     dataset.save()

--- a/etl/steps/grapher/energy/2022-08-03/electricity_mix.py
+++ b/etl/steps/grapher/energy/2022-08-03/electricity_mix.py
@@ -1,10 +1,8 @@
 """Grapher step for the Electricity Mix (BP & Ember, 2022) dataset.
-
 """
 
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 # Path to garden dataset to be loaded.
@@ -13,9 +11,9 @@ DATASET_PATH = DATA_DIR / "garden" / "energy" / "2022-08-03" / "electricity_mix"
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     # There is only one table in the dataset, with the same name as the dataset.
     table = garden_dataset[garden_dataset.table_names[0]].reset_index().drop(columns=["population"])
-    dataset.add(gh.adapt_table_for_grapher(table))
+    dataset.add(table)
     dataset.save()

--- a/etl/steps/grapher/energy/2022-09-09/global_primary_energy.py
+++ b/etl/steps/grapher/energy/2022-09-09/global_primary_energy.py
@@ -1,6 +1,5 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 # Path to garden dataset to be loaded.
@@ -9,11 +8,10 @@ DATASET_PATH = DATA_DIR / "garden" / "energy" / "2022-09-09" / "global_primary_e
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     # There is only one table in the dataset, with the same name as the dataset.
     table = garden_dataset[garden_dataset.table_names[0]].reset_index().drop(columns=["data_source"])
-    table = gh.adapt_table_for_grapher(table)
 
     dataset.add(table)
     dataset.save()

--- a/etl/steps/grapher/faostat/2022-05-17/shared.py
+++ b/etl/steps/grapher/faostat/2022-05-17/shared.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pandas as pd
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR, STEP_DIR
 
 
@@ -43,9 +42,6 @@ def get_grapher_dataset_from_file_name(file_path: str) -> catalog.Dataset:
     # Load latest garden dataset.
     dataset = catalog.Dataset(garden_data_dir)
 
-    # Adapt dataset metadata to grapher requirements.
-    dataset.metadata = gh.adapt_dataset_metadata_for_grapher(dataset.metadata)
-
     # Some datasets have " - FAO (YYYY)" at the end, and some others do not.
     # For consistency, remove that ending of the title, and add something consistent across all datasets.
     dataset.metadata.title = dataset.metadata.title.split(" - FAO (")[0] + f" (FAO, {grapher_version})"
@@ -75,5 +71,4 @@ def get_grapher_table(dataset: catalog.Dataset) -> catalog.Table:
     assert len(flat_table_names) == 1
     table = dataset[flat_table_names[0]].reset_index().drop(columns=["area_code"])
 
-    # Adapt table to grapher requirements.
-    return gh.adapt_table_for_grapher(table=table)
+    return table

--- a/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
+++ b/etl/steps/grapher/ggdc/2020-10-01/ggdc_maddison.py
@@ -1,17 +1,14 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.helpers import Names
 
 N = Names(__file__)
 
 
 def run(dest_dir: str) -> None:
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(N.garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, N.garden_dataset.metadata)
     dataset.save()
 
     table = N.garden_dataset["maddison_gdp"].reset_index()
 
-    table = gh.adapt_table_for_grapher(table[["country", "year", "gdp", "gdp_per_capita", "population"]])
-
-    dataset.add(table)
+    dataset.add(table[["country", "year", "gdp", "gdp_per_capita", "population"]])

--- a/etl/steps/grapher/ihme_gbd/2019/gbd_cause.py
+++ b/etl/steps/grapher/ihme_gbd/2019/gbd_cause.py
@@ -1,6 +1,5 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.helpers import Names
 
 from .gbd_tools import run_wrapper

--- a/etl/steps/grapher/ihme_gbd/2019/gbd_cause.py
+++ b/etl/steps/grapher/ihme_gbd/2019/gbd_cause.py
@@ -10,7 +10,7 @@ N = Names(__file__)
 
 def run(dest_dir: str) -> None:
     garden_dataset = N.garden_dataset
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
     dataset.save()
 
     run_wrapper(garden_dataset=garden_dataset, dataset=dataset, dims=["sex", "age", "cause"])

--- a/etl/steps/grapher/ihme_gbd/2019/gbd_child_mortality.py
+++ b/etl/steps/grapher/ihme_gbd/2019/gbd_child_mortality.py
@@ -1,6 +1,5 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.helpers import Names
 
 from .gbd_tools import run_wrapper
@@ -10,7 +9,7 @@ N = Names(__file__)
 
 def run(dest_dir: str) -> None:
     garden_dataset = N.garden_dataset
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
     dataset.save()
 
     run_wrapper(garden_dataset=garden_dataset, dataset=dataset, dims=["sex", "age", "cause"])

--- a/etl/steps/grapher/ihme_gbd/2019/gbd_prevalence.py
+++ b/etl/steps/grapher/ihme_gbd/2019/gbd_prevalence.py
@@ -1,6 +1,5 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.helpers import Names
 
 from .gbd_tools import run_wrapper
@@ -10,7 +9,7 @@ N = Names(__file__)
 
 def run(dest_dir: str) -> None:
     garden_dataset = N.garden_dataset
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
     dataset.save()
 
     run_wrapper(garden_dataset=garden_dataset, dataset=dataset, dims=["sex", "age", "cause"])

--- a/etl/steps/grapher/ihme_gbd/2019/gbd_risk.py
+++ b/etl/steps/grapher/ihme_gbd/2019/gbd_risk.py
@@ -1,6 +1,5 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.helpers import Names
 
 from .gbd_tools import run_wrapper
@@ -10,7 +9,7 @@ N = Names(__file__)
 
 def run(dest_dir: str) -> None:
     garden_dataset = N.garden_dataset
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
     dataset.save()
 
     run_wrapper(garden_dataset=garden_dataset, dataset=dataset, dims=["sex", "age", "cause", "rei"])

--- a/etl/steps/grapher/ihme_gbd/2019/gbd_tools.py
+++ b/etl/steps/grapher/ihme_gbd/2019/gbd_tools.py
@@ -33,13 +33,11 @@ def run_wrapper(garden_dataset: Dataset, dataset: Dataset, dims: List[str]) -> N
 
         tab.reset_index(inplace=True)
 
-        # NOTE: we no longer need `create_var_name`, variable names will be created automatically from dimensions
         tab["age"] = map_age(tab["age"])
 
-        # create entity_id from country
-        tab = gh.adapt_table_for_grapher(tab)
-
         # add more dimensions
-        tab = tab.set_index(dims, append=True)
+        tab.set_index(dims, inplace=True)
+
+        __import__("ipdb").set_trace()
 
         dataset.add(tab)

--- a/etl/steps/grapher/ihme_gbd/2019/gbd_tools.py
+++ b/etl/steps/grapher/ihme_gbd/2019/gbd_tools.py
@@ -4,8 +4,6 @@ import pandas as pd
 from owid.catalog import Dataset
 from structlog import get_logger
 
-from etl import grapher_helpers as gh
-
 log = get_logger()
 
 
@@ -20,12 +18,6 @@ def map_age(age: pd.Series) -> pd.Series:
 
 
 def run_wrapper(garden_dataset: Dataset, dataset: Dataset, dims: List[str]) -> None:
-    # variables_in_charts = get_variables_used_in_charts(old_dataset_name)
-
-    # NOTE: it was `Global Burden of Disease Study (2019) - Deaths and DALYs` originally
-    # all variables will inherit this source from dataset
-    # dataset.metadata.sources = [Source(name="Global Burden of Disease Study (2019) - Deaths and DALYs")]
-
     # add tables to dataset
     tables = garden_dataset.table_names
     for table in tables:
@@ -37,7 +29,5 @@ def run_wrapper(garden_dataset: Dataset, dataset: Dataset, dims: List[str]) -> N
 
         # add more dimensions
         tab.set_index(dims, inplace=True)
-
-        __import__("ipdb").set_trace()
 
         dataset.add(tab)

--- a/etl/steps/grapher/owid/latest/key_indicators.py
+++ b/etl/steps/grapher/owid/latest/key_indicators.py
@@ -4,7 +4,6 @@ from typing import Any, List
 import numpy as np
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 KEY_INDICATORS_GARDEN = DATA_DIR / "garden/owid/latest/key_indicators"
@@ -15,7 +14,7 @@ def run(dest_dir: str) -> None:
     # NOTE: this generates shortName `population_density__owid_latest`, perhaps we should keep it as `population_density`
     # and create unique constraint on (shortName, version, namespace) instead of just (shortName, namespace)
     garden_dataset = catalog.Dataset(KEY_INDICATORS_GARDEN)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     # Get population table
     table = garden_dataset["population"].reset_index()
@@ -25,16 +24,13 @@ def run(dest_dir: str) -> None:
     # table["population_historical"] = deepcopy(table["population"])
     # table["population_projection"] = deepcopy(table["population"])
     # Add population table to dataset
-    table = gh.adapt_table_for_grapher(table)
     dataset.add(table)
 
     # Add land area table to dataset
-    table = gh.adapt_table_for_grapher(garden_dataset["land_area"].reset_index())
-    dataset.add(table)
+    dataset.add(garden_dataset["land_area"].reset_index())
 
     # Add population density table to dataset
-    table = gh.adapt_table_for_grapher(garden_dataset["population_density"].reset_index())
-    dataset.add(table)
+    dataset.add(garden_dataset["population_density"].reset_index())
 
     # Save dataset
     dataset.save()

--- a/etl/steps/grapher/owid/latest/population_density.py
+++ b/etl/steps/grapher/owid/latest/population_density.py
@@ -1,6 +1,5 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.helpers import Names
 
 N = Names(__file__)
@@ -9,9 +8,9 @@ N = Names(__file__)
 def run(dest_dir: str) -> None:
     # NOTE: this generates shortName `population_density__owid_latest`, perhaps we should keep it as `population_density`
     # and create unique constraint on (shortName, version, namespace) instead of just (shortName, namespace)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(N.garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, N.garden_dataset.metadata)
     dataset.save()
 
-    table = gh.adapt_table_for_grapher(N.garden_dataset["population_density"].reset_index())
+    table = N.garden_dataset["population_density"].reset_index()
 
     dataset.add(table)

--- a/etl/steps/grapher/un/2022-07-11/un_wpp.py
+++ b/etl/steps/grapher/un/2022-07-11/un_wpp.py
@@ -17,7 +17,7 @@ log = structlog.get_logger()
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATA_DIR / "garden" / NAMESPACE / VERSION / FNAME)
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
     dataset.save()
 
     # Get table (in appropriate format)

--- a/etl/steps/grapher/un_sdg/2022-07-07/un_sdg.py
+++ b/etl/steps/grapher/un_sdg/2022-07-07/un_sdg.py
@@ -28,7 +28,7 @@ NAMESPACE = Path(__file__).parent.parent.stem
 
 def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATA_DIR / f"garden/{NAMESPACE}/{VERSION}/{FNAME}")
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
     dataset.save()
 
     # add tables to dataset

--- a/etl/steps/grapher/who/2021-07-01/ghe.py
+++ b/etl/steps/grapher/who/2021-07-01/ghe.py
@@ -1,17 +1,13 @@
-import copy
-
-import pandas as pd
 from owid import catalog
 
 from etl import grapher_helpers as gh
 from etl.helpers import Names
-from etl.paths import REFERENCE_DATASET
 
 N = Names(__file__)
 
 
 def run(dest_dir: str) -> None:
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(N.garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, N.garden_dataset.metadata)
     dataset.save()
 
     table = N.garden_dataset["estimates"]
@@ -45,33 +41,10 @@ def run(dest_dir: str) -> None:
             f"GHE table to transform to grapher did not contain the expected columns but instead had: {list(table.columns)}"
         )
 
-    # Get the legacy_entity_id from the country_code via the countries_regions dimension table
-    reference_dataset = catalog.Dataset(REFERENCE_DATASET)
-    countries_regions = reference_dataset["countries_regions"]
-
-    orig_table = copy.deepcopy(table)
-
-    # TODO: update `gh.adapt_table_for_grapher(table)` to support country codes
-    # and reuse it
-    table = orig_table.merge(
-        right=countries_regions[["legacy_entity_id"]],
-        how="left",
-        left_on="country_code",
-        right_index=True,
-        validate="m:1",
-    )
-    table.metadata = orig_table.metadata
-
-    # Add entity_id, drop country_code
     table.reset_index(inplace=True)
-    df = pd.DataFrame(table)
-    table["year"] = df["year"].astype(int)
-    table["entity_id"] = df["legacy_entity_id"].astype(int)
-    table.drop("country_code", axis="columns", inplace=True)
-    table.set_index(
-        ["entity_id", "year", "ghe_cause_title", "sex_code", "agegroup_code"],
-        inplace=True,
-    )
+    table["entity_id"] = gh.country_to_entity_id(table["country_code"], by="code")
+    table = table.drop(["country_code"], axis=1)
+    table = table.set_index(["entity_id", "year", "ghe_cause_title", "sex_code", "agegroup_code"])
 
     table.update_metadata_from_yaml(N.metadata_path, "estimates")
 

--- a/etl/steps/grapher/worldbank_wdi/2022-05-26/wdi.py
+++ b/etl/steps/grapher/worldbank_wdi/2022-05-26/wdi.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import structlog
 from owid.catalog import Dataset
 
-from etl import grapher_helpers as gh
 from etl.paths import DATA_DIR
 
 log = structlog.get_logger()
@@ -23,7 +22,4 @@ def run(dest_dir: str) -> None:
     assert len(table.metadata.primary_key) == 2
 
     table.reset_index(inplace=True)
-    table["entity_id"] = gh.country_to_entity_id(table["country"], create_entities=True)
-    table = table.drop(columns=["country"]).set_index(["year", "entity_id"])
-
     dataset.add(table)

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -5,10 +5,10 @@ from owid.catalog import DatasetMeta, Source, Table, TableMeta, VariableMeta
 
 from etl.grapher_helpers import (
     _ensure_source_per_variable,
+    _yield_long_table,
+    _yield_wide_table,
     combine_metadata_sources,
     contains_inf,
-    yield_long_table,
-    yield_wide_table,
 )
 
 
@@ -56,7 +56,7 @@ def test_yield_wide_table_with_dimensions():
     table = Table(df.set_index(["entity_id", "year", "age"]))
     table.deaths.metadata.unit = "people"
     table.deaths.metadata.title = "Deaths"
-    grapher_tables = list(yield_wide_table(table, dim_titles=["Age group"]))
+    grapher_tables = list(_yield_wide_table(table, dim_titles=["Age group"]))
 
     t = grapher_tables[0]
     assert t.columns[0] == "deaths__age_10_18"
@@ -82,7 +82,7 @@ def test_yield_long_table_with_dimensions():
         }
     ).set_index(["year", "entity_id", "sex"])
     table = Table(long, metadata=TableMeta(dataset=DatasetMeta(sources=[Source()])))
-    grapher_tables = list(yield_long_table(table, dim_titles=["Sex"]))
+    grapher_tables = list(_yield_long_table(table, dim_titles=["Sex"]))
 
     t = grapher_tables[0]
     assert t.columns[0] == "births__sex_female"
@@ -117,7 +117,7 @@ def test_yield_long_table_with_dimensions_error():
     ).set_index(["year", "entity_id", "sex"])
     table = Table(long)  # no metadata with sources
     with pytest.raises(AssertionError):
-        _ = list(yield_long_table(table, dim_titles=["Sex"]))
+        _ = list(_yield_long_table(table, dim_titles=["Sex"]))
 
 
 def test_contains_inf():

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -3,13 +3,7 @@ import pandas as pd
 import pytest
 from owid.catalog import DatasetMeta, Source, Table, TableMeta, VariableMeta
 
-from etl.grapher_helpers import (
-    _ensure_source_per_variable,
-    _yield_long_table,
-    _yield_wide_table,
-    combine_metadata_sources,
-    contains_inf,
-)
+from etl import grapher_helpers as gh
 
 
 def test_yield_wide_table():
@@ -25,7 +19,7 @@ def test_yield_wide_table():
     table._1.metadata.unit = "kg"
     table.a__pct.metadata.unit = "pct"
 
-    tables = list(yield_wide_table(table))
+    tables = list(gh._yield_wide_table(table))
 
     assert tables[0].reset_index().to_dict(orient="list") == {
         "_1": [1, 2, 3],
@@ -56,7 +50,7 @@ def test_yield_wide_table_with_dimensions():
     table = Table(df.set_index(["entity_id", "year", "age"]))
     table.deaths.metadata.unit = "people"
     table.deaths.metadata.title = "Deaths"
-    grapher_tables = list(_yield_wide_table(table, dim_titles=["Age group"]))
+    grapher_tables = list(gh._yield_wide_table(table, dim_titles=["Age group"]))
 
     t = grapher_tables[0]
     assert t.columns[0] == "deaths__age_10_18"
@@ -82,7 +76,7 @@ def test_yield_long_table_with_dimensions():
         }
     ).set_index(["year", "entity_id", "sex"])
     table = Table(long, metadata=TableMeta(dataset=DatasetMeta(sources=[Source()])))
-    grapher_tables = list(_yield_long_table(table, dim_titles=["Sex"]))
+    grapher_tables = list(gh._yield_long_table(table, dim_titles=["Sex"]))
 
     t = grapher_tables[0]
     assert t.columns[0] == "births__sex_female"
@@ -117,15 +111,15 @@ def test_yield_long_table_with_dimensions_error():
     ).set_index(["year", "entity_id", "sex"])
     table = Table(long)  # no metadata with sources
     with pytest.raises(AssertionError):
-        _ = list(_yield_long_table(table, dim_titles=["Sex"]))
+        _ = list(gh._yield_long_table(table, dim_titles=["Sex"]))
 
 
 def test_contains_inf():
-    assert contains_inf(pd.Series([1, np.inf]))
-    assert not contains_inf(pd.Series([1, 2]))
-    assert not contains_inf(pd.Series(["a", 2]))
-    assert not contains_inf(pd.Series(["a", "b"]))
-    assert not contains_inf(pd.Series(["a", "b"]).astype("category"))
+    assert gh.contains_inf(pd.Series([1, np.inf]))
+    assert not gh.contains_inf(pd.Series([1, 2]))
+    assert not gh.contains_inf(pd.Series(["a", 2]))
+    assert not gh.contains_inf(pd.Series(["a", "b"]))
+    assert not gh.contains_inf(pd.Series(["a", "b"]).astype("category"))
 
 
 def test_ensure_source_per_variable_multiple_sources():
@@ -146,7 +140,7 @@ def test_ensure_source_per_variable_multiple_sources():
         Source(name="s1", description="s1 description"),
         Source(name="s2", description="s2 description"),
     ]
-    new_table = _ensure_source_per_variable(table)
+    new_table = gh._ensure_source_per_variable(table)
     assert len(new_table.deaths.metadata.sources) == 1
     source = new_table.deaths.metadata.sources[0]
     assert source.name == "s1; s2"
@@ -154,7 +148,7 @@ def test_ensure_source_per_variable_multiple_sources():
 
     # no sources
     table.deaths.metadata.sources = []
-    new_table = _ensure_source_per_variable(table)
+    new_table = gh._ensure_source_per_variable(table)
     assert len(new_table.deaths.metadata.sources) == 1
     source = new_table.deaths.metadata.sources[0]
     assert source.name == "s3"
@@ -162,7 +156,7 @@ def test_ensure_source_per_variable_multiple_sources():
 
     # sources have no description, but table has
     table.deaths.metadata.sources = [Source(name="s1")]
-    new_table = _ensure_source_per_variable(table)
+    new_table = gh._ensure_source_per_variable(table)
     assert len(new_table.deaths.metadata.sources) == 1
     source = new_table.deaths.metadata.sources[0]
     assert source.name == "s1"
@@ -174,9 +168,54 @@ def test_combine_metadata_sources():
         Source(name="s1", description="s1 description"),
         Source(name="s2", description="s2 description"),
     ]
-    source = combine_metadata_sources(sources)
+    source = gh.combine_metadata_sources(sources)
     assert source.name == "s1; s2"
     assert source.description == "s1 description\ns2 description"
 
     # make sure we haven't modified original sources
     assert sources[0].name == "s1"
+
+
+def _sample_table() -> Table:
+    table = Table(
+        pd.DataFrame(
+            {
+                "deaths": [0, 1],
+                "year": [2019, 2020],
+                "entity_id": [1, 1],
+                "sex": ["female", "male"],
+            }
+        )
+    )
+    table.metadata.dataset = DatasetMeta(
+        description="Dataset description", sources=[Source(name="s3", description="s3 description")]
+    )
+    table.metadata.description = "Table description"
+    return table
+
+
+def test_adapt_table_for_grapher_multiindex():
+    table = _sample_table()
+    out_table = gh._adapt_table_for_grapher(table)
+    assert out_table.index.names == ["entity_id", "year"]
+    assert out_table.columns.tolist() == ["deaths", "sex"]
+
+    table = _sample_table().set_index(["entity_id", "year", "sex"])
+    out_table = gh._adapt_table_for_grapher(table)
+    assert out_table.index.names == ["entity_id", "year", "sex"]
+    assert out_table.columns.tolist() == ["deaths"]
+
+    table = _sample_table().set_index(["sex"])
+    out_table = gh._adapt_table_for_grapher(table)
+    assert out_table.index.names == ["entity_id", "year", "sex"]
+    assert out_table.columns.tolist() == ["deaths"]
+
+
+def test_adapt_table_for_grapher_multiindex_with_country():
+    table = _sample_table().set_index("sex")
+    table["country"] = ["France", "Poland"]
+    del table["entity_id"]
+
+    out_table = gh._adapt_table_for_grapher(table)
+    assert out_table.index.names == ["entity_id", "year", "sex"]
+    assert out_table.columns.tolist() == ["deaths"]

--- a/walkthrough/grapher_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
+++ b/walkthrough/grapher_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
@@ -1,18 +1,14 @@
 from owid import catalog
 
-from etl import grapher_helpers as gh
 from etl.helpers import Names
 
 N = Names(__file__)
 
 
 def run(dest_dir: str) -> None:
-    dataset = catalog.Dataset.create_empty(dest_dir, gh.adapt_dataset_metadata_for_grapher(N.garden_dataset.metadata))
+    dataset = catalog.Dataset.create_empty(dest_dir, N.garden_dataset.metadata)
 
     table = N.garden_dataset["{{cookiecutter.short_name}}"]
-
-    # convert `country` into `entity_id`
-    table = gh.adapt_table_for_grapher(table)
 
     # optionally set additional dimensions
     # table = table.set_index(["sex", "income_group"], append=True)


### PR DESCRIPTION
Move functions `adapt_dataset_metadata_for_grapher` and `adapt_table_for_grapher` to the step that upserts data into DB. Remove those functions from all existing steps.

`country_to_entity_id` has been modified to work with country codes.

This moves creating entities, which need access to MySQL, to the upsert step. In the future we'd want all steps from channels meadow - garden - grapher to work without access to MySQL. There are still a few steps that use `country_to_entity_id` in the grapher channel, but that'll be fixed in the next PR.