### PR TITLE
enhance(grapher_helpers): combine sources of variables

### DIFF
--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -368,27 +368,25 @@ def _unique(x: List[Any]) -> List[Any]:
     return list(dict.fromkeys(x))
 
 
-def combine_metadata_sources(metadata: catalog.DatasetMeta) -> catalog.DatasetMeta:
-    """Combine each of the attributes in the sources of a dataset's metadata, and assign them to the first source, since
+def combine_metadata_sources(sources: List[catalog.Source]) -> catalog.Source:
+    """Combine each of the attributes in the sources and assign them to the first source, since
     that is the only source that grapher will read.
 
     Parameters
     ----------
-    metadata : catalog.DatasetMeta
-        Dataset metadata.
+    sources : List[Source]
+        List of sources to combine.
 
     Returns
     -------
-    metadata : catalog.DatasetMeta
-        Dataset metadata, after combining its sources.
+    source : catalog.Source
+        Combined source.
 
     """
-    metadata = deepcopy(metadata)
-
-    assert len(metadata.sources) >= 1, "Dataset needs to have at least one source in metadata."
+    assert len(sources) >= 1, "Dataset needs to have at least one source in metadata."
 
     # Define the 'default_source', which will be the one where all sources' attributes are combined.
-    default_source = metadata.sources[0]
+    default_source = sources[0]
     # Attributes to combine from sources.
     attributes = [
         "name",
@@ -405,14 +403,8 @@ def combine_metadata_sources(metadata: catalog.DatasetMeta) -> catalog.DatasetMe
     # Combine sources' attributes into the first source (which is the only one that grapher will interpret).
     for attribute in attributes:
         # Gather non-empty values from each source for current attribute.
-        values = _unique(
-            [getattr(source, attribute) for source in metadata.sources if getattr(source, attribute) is not None]
-        )
+        values = _unique([getattr(source, attribute) for source in sources if getattr(source, attribute) is not None])
         if attribute == "description":
-            if metadata.description is not None:
-                # Add the dataset description as if it was a source's description.
-                values = [metadata.description] + values
-
             # Descriptions are usually long, so it is better so put together descriptions from different sources in
             # separate lines.
             combined_value = "\n".join(values)
@@ -430,10 +422,7 @@ def combine_metadata_sources(metadata: catalog.DatasetMeta) -> catalog.DatasetMe
 
         setattr(default_source, attribute, combined_value)
 
-    # Remove other sources and keep only the default one.
-    metadata.sources = [default_source]
-
-    return metadata
+    return default_source
 
 
 def adapt_dataset_metadata_for_grapher(
@@ -453,7 +442,11 @@ def adapt_dataset_metadata_for_grapher(
 
     """
     # Combine metadata sources into one.
-    metadata = combine_metadata_sources(metadata)
+    metadata.sources = [combine_metadata_sources(metadata.sources)]
+
+    # Add the dataset description as if it was a source's description.
+    if metadata.description is not None:
+        metadata.sources[0].description = metadata.description + "\n" + metadata.sources[0].description
 
     # Empty dataset description (otherwise it will appear in `Internal notes` in the admin UI).
     metadata.description = ""
@@ -495,13 +488,35 @@ def adapt_table_for_grapher(
 
 
 def _ensure_source_per_variable(table: catalog.Table) -> catalog.Table:
+    assert table.metadata.dataset
+    dataset_meta = table.metadata.dataset
     for column in table.columns:
         if len(table[column].metadata.sources) == 0:
             # Take the metadata sources from the dataset's metadata (after combining them into one).
-            table[column].metadata.sources = combine_metadata_sources(table.metadata.dataset).sources
-        if table[column].metadata.sources[0].description is None:
-            # Add the table description to the first source, so that it is displayed on the SOURCES tab.
-            table[column].metadata.sources[0].description = table.metadata.description
+            assert (
+                len(dataset_meta.sources) > 0
+            ), f"If column `{column}` has no sources, dataset must have at least one."
+            source = combine_metadata_sources(dataset_meta.sources)
+
+            # Add the dataset description as if it was a source's description.
+            if dataset_meta.description is not None:
+                source.description = dataset_meta.description + "\n" + source.description
+        else:
+            sources: List[catalog.Source] = table[column].metadata.sources
+
+            if len(sources) > 1:
+                # Combine multiple sources into one.
+                # NOTE: dataset description is not included in the combined source
+                source = combine_metadata_sources(sources)
+            else:
+                source = sources[0]
+
+            if source.description is None:
+                # Use table description if sources don't have their own
+                source.description = table.metadata.description
+
+        table[column].metadata.sources = [source]
+
     return table
 
 

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -446,7 +446,10 @@ def adapt_dataset_metadata_for_grapher(
 
     # Add the dataset description as if it was a source's description.
     if metadata.description is not None:
-        metadata.sources[0].description = metadata.description + "\n" + metadata.sources[0].description
+        if metadata.sources[0].description:
+            metadata.sources[0].description = metadata.description + "\n" + metadata.sources[0].description
+        else:
+            metadata.sources[0].description = metadata.description
 
     # Empty dataset description (otherwise it will appear in `Internal notes` in the admin UI).
     metadata.description = ""
@@ -491,7 +494,8 @@ def _ensure_source_per_variable(table: catalog.Table) -> catalog.Table:
     assert table.metadata.dataset
     dataset_meta = table.metadata.dataset
     for column in table.columns:
-        if len(table[column].metadata.sources) == 0:
+        variable_meta: catalog.VariableMeta = table[column].metadata
+        if len(variable_meta.sources) == 0:
             # Take the metadata sources from the dataset's metadata (after combining them into one).
             assert (
                 len(dataset_meta.sources) > 0
@@ -500,7 +504,10 @@ def _ensure_source_per_variable(table: catalog.Table) -> catalog.Table:
 
             # Add the dataset description as if it was a source's description.
             if dataset_meta.description is not None:
-                source.description = dataset_meta.description + "\n" + source.description
+                if source.description:
+                    source.description = dataset_meta.description + "\n" + source.description
+                else:
+                    source.description = dataset_meta.description
         else:
             sources: List[catalog.Source] = table[column].metadata.sources
 
@@ -513,7 +520,11 @@ def _ensure_source_per_variable(table: catalog.Table) -> catalog.Table:
 
             if source.description is None:
                 # Use table description if sources don't have their own
-                source.description = table.metadata.description
+                if table.metadata.description:
+                    source.description = table.metadata.description
+                # Or dataset description if sources don't have their own
+                else:
+                    source.description = dataset_meta.description
 
         table[column].metadata.sources = [source]
 

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -3,7 +3,12 @@ import pandas as pd
 import pytest
 from owid.catalog import DatasetMeta, Source, Table, TableMeta, VariableMeta
 
-from etl.grapher_helpers import contains_inf, yield_long_table, yield_wide_table
+from etl.grapher_helpers import (
+    _ensure_source_per_variable,
+    contains_inf,
+    yield_long_table,
+    yield_wide_table,
+)
 
 
 def test_yield_wide_table():
@@ -107,3 +112,44 @@ def test_contains_inf():
     assert not contains_inf(pd.Series(["a", 2]))
     assert not contains_inf(pd.Series(["a", "b"]))
     assert not contains_inf(pd.Series(["a", "b"]).astype("category"))
+
+
+def test_ensure_source_per_variable_multiple_sources():
+    table = Table(
+        pd.DataFrame(
+            {
+                "deaths": [0, 1],
+            }
+        )
+    )
+    table.metadata.dataset = DatasetMeta(
+        description="Dataset description", sources=[Source(name="s3", description="s3 description")]
+    )
+    table.metadata.description = "Table description"
+
+    # multiple sources
+    table.deaths.metadata.sources = [
+        Source(name="s1", description="s1 description"),
+        Source(name="s2", description="s2 description"),
+    ]
+    new_table = _ensure_source_per_variable(table)
+    assert len(new_table.deaths.metadata.sources) == 1
+    source = new_table.deaths.metadata.sources[0]
+    assert source.name == "s1 ; s2"
+    assert source.description == "s1 description\ns2 description"
+
+    # no sources
+    table.deaths.metadata.sources = []
+    new_table = _ensure_source_per_variable(table)
+    assert len(new_table.deaths.metadata.sources) == 1
+    source = new_table.deaths.metadata.sources[0]
+    assert source.name == "s3"
+    assert source.description == "Dataset description\ns3 description"
+
+    # sources have no description, but table has
+    table.deaths.metadata.sources = [Source(name="s1")]
+    new_table = _ensure_source_per_variable(table)
+    assert len(new_table.deaths.metadata.sources) == 1
+    source = new_table.deaths.metadata.sources[0]
+    assert source.name == "s1"
+    assert source.description == "Table description"


### PR DESCRIPTION
If table contains variable with multiple sources, combine them into a single source ready for upsert to grapher.

I've also slightly refactored `combine_metadata_sources` as `adapt_*` methods will be soon applied to all datasets by default. I haven't changed the original logic, but to be honest I find it quite confusing how we make description fallbacks to dataset description or table description. I couldn't think of a better solution though.

@pabloarosado are you fine with the existing fallback logic? If yes then I'd say we go ahead and keep it like that until we either find it problematic or design a better schema for sources.

