### PR TITLE
fix(grapher): use original column names in grapher upsert

### DIFF
--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -696,7 +696,14 @@ class Variable(SQLModel, table=True):
         cls = self.__class__
         q = select(cls).where(
             # old variables don't have a shortName, but can be identified with `name`
-            or_(cls.shortName == self.shortName, cls.shortName.is_(None)),  # type: ignore
+            or_(
+                cls.shortName == self.shortName,
+                # NOTE: we used to slugify shortName which replaced double underscore by a single underscore
+                # this was a bug, we should have kept the double underscore
+                # match even those variables and correct their shortName
+                cls.shortName == self.shortName.replace("__", "_"),
+                cls.shortName.is_(None),  # type: ignore
+            ),
             cls.name == self.name,
             cls.datasetId == self.datasetId,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ boto3 = "^1.18.54"
 awscli = "^1.20.54"
 Unidecode = "^1.3.2"
 python-dotenv = "^0.19.0"
-python-slugify = {extras = ["unidecode"], version = "^5.0.2"}
 # NOTE: the version is currently fixed, but we should update as soon as https://github.com/frictionlessdata/frictionless-py/issues/1143
 #   gets resolved
 frictionless = {version = "4.38.0", extras = ["pandas"]}

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -12,17 +12,30 @@ def test_yield_wide_table():
             "year": [2019, 2020, 2021],
             "entity_id": [1, 2, 3],
             "_1": [1, 2, 3],
+            "a__pct": [1, 2, 3],
         }
     )
     table = Table(df.set_index(["entity_id", "year"]))
     table._1.metadata.unit = "kg"
-    grapher_tab = list(yield_wide_table(table))[0]
-    assert grapher_tab.reset_index().to_dict(orient="list") == {
+    table.a__pct.metadata.unit = "pct"
+
+    tables = list(yield_wide_table(table))
+
+    assert tables[0].reset_index().to_dict(orient="list") == {
         "_1": [1, 2, 3],
         "entity_id": [1, 2, 3],
         "year": [2019, 2020, 2021],
     }
-    assert grapher_tab.metadata.short_name == "_1"
+    assert tables[0].metadata.short_name == "_1"
+    assert tables[0]["_1"].metadata.unit == "kg"
+
+    assert tables[1].reset_index().to_dict(orient="list") == {
+        "a__pct": [1, 2, 3],
+        "entity_id": [1, 2, 3],
+        "year": [2019, 2020, 2021],
+    }
+    assert tables[1].metadata.short_name == "a__pct"
+    assert tables[1]["a__pct"].metadata.unit == "pct"
 
 
 def test_yield_wide_table_with_dimensions():


### PR DESCRIPTION
Fixes https://github.com/owid/etl/issues/487#issuecomment-1252863212

Previously we were `slugify`-ing variable short names before upserting to grapher. This converted double underscore to a single underscore which led to unintended effects. In this PR we don't transform column names (since they are already underscored), only dimension names if necessary.

To avoid collisions when doing upserts, we match variables on either short name or short name with single underscore. This should eventually fix (i.e. put back original double underscore) all variables in grapher.

(I could also re-upsert all grapher datasets into grapher. Would it be perhaps safer?)