### PR TITLE
fix(gbd): reduce memory peak usage

### DIFF
--- a/etl/steps/data/meadow/ihme_gbd/2019/shared.py
+++ b/etl/steps/data/meadow/ihme_gbd/2019/shared.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
 import pandas as pd
+import pyarrow.compute as pc
 from owid.catalog import Dataset, Table, TableMeta
 from owid.catalog.utils import underscore_table
 from owid.walden import Catalog as WaldenCatalog
+from pyarrow import feather
 
 from etl.steps.data.converters import convert_walden_metadata
 
@@ -27,18 +29,28 @@ def clean_data(df: pd.DataFrame) -> pd.DataFrame:
             columns=["measure_id", "location_id", "sex_id", "age_id", "cause_id", "metric_id"],
             errors="ignore",
         )
-        .drop_duplicates()
+        .drop_duplicates(subset=["measure", "sex", "age", "cause", "metric", "year"])
     )
+
+
+def read_and_clean_data(local_file: str) -> pd.DataFrame:
+    """Reading the entire data at once and cleaning consumes too much memory (drop_duplicates
+    is the culprit). So we read the data in chunks and clean each chunk separately."""
+    arrow_table = feather.read_table(local_file)
+
+    dfs = []
+    for metric_name in ("Percent", "Number", "Rate"):
+        dfs.append(clean_data(arrow_table.filter(pc.equal(arrow_table["metric_name"], metric_name)).to_pandas()))
+
+    return pd.concat(dfs)
 
 
 def run_wrapper(dataset: Path, metadata_path: Path, namespace: Path, version: Path, dest_dir: str) -> None:
     # retrieve raw data from walden
     walden_ds = WaldenCatalog().find_one(namespace=namespace, short_name=dataset, version=version)
     local_file = walden_ds.ensure_downloaded()
-    df = pd.read_feather(local_file)
 
-    # clean and transform data
-    df = clean_data(df)
+    df = read_and_clean_data(local_file)
 
     # create new dataset and reuse walden metadata
     ds = Dataset.create_empty(dest_dir)


### PR DESCRIPTION
Meadow gbd step needs too much memory - apparently because `drop_duplicates` is such a memory intensive function. I've tried several approaches, but the only one that worked was processing feather file in chunks (one metric per chunk) and cleaning them separately.

This was really painful process, one more reason to get a bigger machine (cc @larsyencken).