### PR TITLE
chore: limit steps to 16G of memory on Linux

### DIFF
--- a/etl/config.py
+++ b/etl/config.py
@@ -41,6 +41,10 @@ IPDB_ENABLED = False
 # NOTE: this will soon be deprecated after we get rid of data_values
 GRAPHER_INSERT_WORKERS = int(env.get("GRAPHER_WORKERS", 10))
 
+# forbid any individual step from consuming more than this much memory
+# (only enforced on Linux)
+MAX_VIRTUAL_MEMORY_LINUX = 10 * 2**30  # 10 GB
+
 
 def enable_bugsnag() -> None:
     BUGSNAG_API_KEY = env.get("BUGSNAG_API_KEY")

--- a/etl/config.py
+++ b/etl/config.py
@@ -43,7 +43,7 @@ GRAPHER_INSERT_WORKERS = int(env.get("GRAPHER_WORKERS", 10))
 
 # forbid any individual step from consuming more than this much memory
 # (only enforced on Linux)
-MAX_VIRTUAL_MEMORY_LINUX = 10 * 2**30  # 10 GB
+MAX_VIRTUAL_MEMORY_LINUX = 16 * 2**30  # 16 GB
 
 
 def enable_bugsnag() -> None:

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -8,6 +8,7 @@ import hashlib
 import os
 import re
 import subprocess
+import sys
 import tempfile
 import warnings
 from collections import defaultdict
@@ -378,7 +379,13 @@ class DataStep(Step):
         """
         # use a subprocess to isolate each step from the others, and avoid state bleeding
         # between them
-        args = ["poetry", "run", "run_python_step"]
+        args = []
+
+        if sys.platform == "linux":
+            args.extend(["prlimit", f"--as={config.MAX_VIRTUAL_MEMORY_LINUX}"])
+
+        args.extend(["poetry", "run", "run_python_step"])
+
         if config.IPDB_ENABLED:
             args.append("--ipdb")
 


### PR DESCRIPTION
Use `prlimit` on Linux to limit steps to 16G of virtual memory.

We want the ETL to run correctly on machines with 16GB of memory, of which not all can be dedicated to the ETL. We also want to be able to potentially parallelise steps in future.

By setting this limit, we force expensive steps to break predictably on Linux rather than have them sometimes work and sometimes not depending on other factors.

## Why 16GB?

16GB is a memory size that's increasingly the default for data work on laptops and reasonably priced cloud servers, so that's the default we choose here.

Conveniently, all our current work fits into 16GB of memory, so merging this constraint will only cause future memory-intensive work to fail rather than existing work.