### PR TITLE
enhance(steps): add shared modules to checksum

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -23,8 +23,6 @@ config.enable_bugsnag()
 
 WALDEN_NAMESPACE = os.environ.get("WALDEN_NAMESPACE", "backport")
 
-THREADPOOL_WORKERS = 5
-
 # if the number of open files allowed is less than this, increase it
 LIMIT_NOFILE = 5000
 
@@ -111,8 +109,14 @@ def main_cli(
         workers=workers,
     )
 
+    # propagate workers to grapher upserts
+    if workers == 1:
+        config.GRAPHER_INSERT_WORKERS = 1
+
     if ipdb:
         config.IPDB_ENABLED = True
+        config.GRAPHER_INSERT_WORKERS = 1
+        kwargs["workers"] = 1
         with launch_ipdb_on_exception():
             main(**kwargs)  # type: ignore
     else:

--- a/etl/config.py
+++ b/etl/config.py
@@ -37,6 +37,10 @@ DB_PASS = env.get("DB_PASS", "")
 # run ETL steps with debugger on exception
 IPDB_ENABLED = False
 
+# number of workers for grapher inserts
+# NOTE: this will soon be deprecated after we get rid of data_values
+GRAPHER_INSERT_WORKERS = int(env.get("GRAPHER_WORKERS", 10))
+
 
 def enable_bugsnag() -> None:
     BUGSNAG_API_KEY = env.get("BUGSNAG_API_KEY")

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -45,8 +45,6 @@ from etl.helpers import get_etag
 Graph = Dict[str, Set[str]]
 DAG = Dict[str, Any]
 
-GRAPHER_INSERT_WORKERS = int(os.environ.get("GRAPHER_INSERT_WORKERS", 10))
-
 
 def compile_steps(
     dag: DAG,
@@ -545,8 +543,8 @@ class GrapherStep(Step):
             # insert data in parallel, this speeds it up considerably and is even faster than loading
             # data with LOAD DATA INFILE
             # TODO: remove threads once we get rid of inserts into data_values
-            if GRAPHER_INSERT_WORKERS > 1:
-                with concurrent.futures.ThreadPoolExecutor(max_workers=GRAPHER_INSERT_WORKERS) as executor:
+            if config.GRAPHER_INSERT_WORKERS > 1:
+                with concurrent.futures.ThreadPoolExecutor(max_workers=config.GRAPHER_INSERT_WORKERS) as executor:
                     results = executor.map(upsert, tables)
             else:
                 results = map(upsert, tables)
@@ -579,7 +577,7 @@ class GrapherStep(Step):
         cleanup_ghost_variables(
             dataset_upsert_results.dataset_id,
             upserted_variable_ids,
-            workers=GRAPHER_INSERT_WORKERS,
+            workers=config.GRAPHER_INSERT_WORKERS,
         )
         cleanup_ghost_sources(dataset_upsert_results.dataset_id, upserted_source_ids)
 

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -358,10 +358,12 @@ class DataStep(Step):
 
     def _step_files(self) -> List[str]:
         "Return a list of code files defining this step."
+        # if dataset is a folder, use all its files
         if self._search_path.is_dir():
             return [p.as_posix() for p in files.walk(self._search_path)]
 
-        return glob(self._search_path.as_posix() + ".*")
+        # if a dataset is a single file, use [dataset].py and shared* files
+        return glob(self._search_path.as_posix() + ".*") + glob((self._search_path.parent / "shared*").as_posix())
 
     @property
     def _search_path(self) -> Path:


### PR DESCRIPTION
Partial fix for https://github.com/owid/etl/issues/466

## Problem

If you make any changes to `shared.py` (e.g. in `faostat/`), its checksum won't change and running `etl faostat_fs` is gonna tell you `All datasets up to date!` even though its recipe has changed.

Locally you can get around this by using `--force --only`, but once you push it to production, etl on our server won't rebuild the dataset.

ETL only looks for changes in `[dataset].py` or if you use directory `[dataset]/*` it looks for all changes in that directory (this would be best, but it would mean creating many redundant directories e.g. for faostat).

## Solution

In addition to files above, look for changes in all `shared*` files (`shared.py`).

We could also got with directories and have symlinks for shared files, but that might be an overkill compared to this heuristic.