### PR TITLE
draft: use checksum in walden backports instead of latest

### DIFF
--- a/backport/backport.py
+++ b/backport/backport.py
@@ -16,7 +16,7 @@ from etl import config
 from etl import grapher_model as gm
 from etl.backport_helpers import GrapherConfig
 from etl.db import get_engine
-from etl.files import checksum_str, checksum_file
+from etl.files import checksum_file, checksum_str
 
 from . import utils
 


### PR DESCRIPTION
See: https://github.com/owid/etl/issues/257

Currently when backporting, we overwrite previous versions of the dataset. This changes the checksum, which basically means that every current copy of the ETL anywhere on any machine now is currently invalid, and will fail to handle this backport step without an explicit code update.

This breaks a pretty big contract of the ETL, namely that it is repeatable.

**Principle:** the ETL should not break because of a side-effect happening on a remote machine; the previous and next versions of the ETL should live side-by-side and both work

This change moves us from overwriting the previous backport to appending it, by using the md5 of the data instead of "latest" in the path.

It doesn't yet solve the problem of how we deal with having multiple copies around.
