### PR TITLE
feature(open-numbers): fast table loading and cleaning

### DIFF
--- a/etl/steps/open_numbers.py
+++ b/etl/steps/open_numbers.py
@@ -20,10 +20,9 @@ import frictionless
 import pandas as pd
 import structlog
 from frictionless.exception import FrictionlessException
-from owid.catalog import Dataset, Table, utils
+from owid.catalog import Dataset, Table, Variable, utils
 from owid.catalog.meta import Source
 
-from etl import data_helpers
 from etl.git import GithubRepo
 from etl.paths import REFERENCE_DATASET
 
@@ -208,7 +207,7 @@ GM_TO_OWID_ISO_CODES = {
 }
 
 
-def iso_gm2owid(ds):
+def iso_gm2owid(ds: Variable) -> Variable:
     # Load reference OWID country file
     reference_dataset = Dataset(REFERENCE_DATASET)
     countries_regions = reference_dataset["countries_regions"]

--- a/etl/steps/open_numbers.py
+++ b/etl/steps/open_numbers.py
@@ -250,7 +250,7 @@ def fast_table_clean(dataset: Dataset, table_name: str) -> Table:
         raise Exception(f"Table must have 3 columns (including original indices). Instead it has {ncols} columns.")
     if "geo" not in df.columns:
         if "global" in df.columns:
-            raise KeyError("This is a global dataset! Does not have column 'geo' but 'globall instead.")
+            raise KeyError("This is a global dataset! Does not have column 'geo' but 'global' instead.")
         raise KeyError(f"Table should have column named 'geo'! Found columns are {df.columns}.")
     if "time" not in df.columns:
         raise KeyError(f"Table should have column named 'time'! Found columns are {df.columns}.")

--- a/etl/steps/open_numbers.py
+++ b/etl/steps/open_numbers.py
@@ -18,11 +18,16 @@ from typing import Dict, List, Tuple, cast
 
 import frictionless
 import pandas as pd
+import structlog
 from frictionless.exception import FrictionlessException
 from owid.catalog import Dataset, Table, utils
 from owid.catalog.meta import Source
 
+from etl import data_helpers
 from etl.git import GithubRepo
+from etl.paths import REFERENCE_DATASET
+
+log = structlog.get_logger()
 
 
 def run(dest_dir: str) -> None:
@@ -195,3 +200,74 @@ def parse_name(name: str) -> Tuple[str, str]:
 
 def norm_primary_key(primary_key: List[str]) -> List[str]:
     return [k if k != "global" else "geo" for k in primary_key]
+
+
+GM_TO_OWID_ISO_CODES = {
+    "KOS": "OWID_KOS",
+    "NLD_CURACAO": "CUW",
+}
+
+
+def iso_gm2owid(ds):
+    # Load reference OWID country file
+    reference_dataset = Dataset(REFERENCE_DATASET)
+    countries_regions = reference_dataset["countries_regions"]
+    # Standardize
+    mapping = {**GM_TO_OWID_ISO_CODES, **countries_regions["name"]}
+    return ds.str.upper().map(mapping)
+
+
+def fast_table_clean(dataset: Dataset, table_name: str) -> Table:
+    """Load and clean an open number's table from a dataset.
+
+    This function resets the indices, maps Open Number's codes to OWID country names, checks columns and standardizes their names.
+
+    Parameters
+    ----------
+    ds: Dataset
+        Open number's dataset
+    table_name: str
+        Table name in `dataset`
+    Returns
+    -------
+    t: Table
+        Cleaned table.
+
+    Raises
+    ------
+        Exception: If table shape is not as expected.
+        KeyError: If columns are missing.
+
+    Usage:
+        >>> from owid.catalog import Dataset
+        >>> from etl.paths import DATA_DIR
+        >>> from etl.steps.open_numbers import on_table_clean_fast
+        >>> d = Dataset(DATA_DIR / "open_numbers/open_numbers/latest/open_numbers__world_development_indicators")
+        >>> df = on_table_clean_fast(d, "it_net_user_zs")
+    """
+    df = dataset[table_name].reset_index()
+    # Sanity checks
+    if (ncols := df.shape[1]) != 3:
+        raise Exception(f"Table must have 3 columns (including original indices). Instead it has {ncols} columns.")
+    if "geo" not in df.columns:
+        if "global" in df.columns:
+            raise KeyError("This is a global dataset! Does not have column 'geo' but 'globall instead.")
+        raise KeyError(f"Table should have column named 'geo'! Found columns are {df.columns}.")
+    if "time" not in df.columns:
+        raise KeyError(f"Table should have column named 'time'! Found columns are {df.columns}.")
+    if table_name not in df.columns:
+        raise KeyError(
+            f"Table should have column with the metric of interest (same name as the table): '{table_name}'! Found"
+            f" columns are {df.columns}."
+        )
+    # First clean
+    df = df.rename(
+        columns={
+            "time": "year",
+        }
+    ).assign(country=iso_gm2owid(df.geo))
+    countries_missing = df.loc[df.country.isna(), "geo"].unique().tolist()
+    log.warning(f"Countries missing (listed by Gapminder code): {', '.join(countries_missing)}")
+
+    df = df.dropna(subset=["country"]).drop(["geo"], axis=1)
+    return df[["country", "year", table_name]]


### PR DESCRIPTION
Added function `fast_table_clean` to `etl.steps.open_numbers` module.

This function resets the indices, maps Open Number's codes to OWID country names, checks columns and standardizes their names.

The idea is that does some minor data transformations that can come in handy when loading Open Number's tables (e.g. to combine with other tables).


### Example usage
```python
>>> from owid.catalog import Dataset
>>> from etl.paths import DATA_DIR
>>> from etl.steps.open_numbers import fast_table_clean
>>> d = Dataset(DATA_DIR / "open_numbers/open_numbers/latest/open_numbers__world_development_indicators")
>>> d["it_net_user_zs"].head()  # uncleaned
          it_net_user_zs
geo time                
abw 1990             0.0
    1991             0.0
    1992             0.0
    1993             0.0
    1994             0.0
>>> df = fast_table_clean(d, "it_net_user_zs")
>>> df.head()  # cleaned
  country  year  it_net_user_zs
0   Aruba  1990             0.0
1   Aruba  1991             0.0
2   Aruba  1992             0.0
3   Aruba  1993             0.0
4   Aruba  1994             0.0
```