### PR TITLE
fix(unwpp): add CF variant to population, variable units

### DIFF
--- a/etl/steps/data/garden/un/2022-07-11/un_wpp.meta.yml
+++ b/etl/steps/data/garden/un/2022-07-11/un_wpp.meta.yml
@@ -11,54 +11,54 @@ tables:
     variables:
       birth_rate:
         title: Birth rate
-        short_unit: ‰
-        unit: Births per 1,000 population
+        short_unit: births per 1,000 population
+        unit: births per 1,000 population
         description: Number of births over a given period divided by the person-years lived by the population over that period.
       births:
         title: Births
-        short_unit:
-        unit: Persons
+        short_unit: births
+        unit: births
         description: Number of births over a given period. Refers to live births for annual civil calendar years from 1 January to 31 December.
         display:
           conversionFactor: 1
       child_mortality_rate:
         title: Child mortality rate
         short_unit: "%"
-        unit: Percentage
+        unit: "%"
         description: Number of deaths under age 5 over a given period. Refers to annual civil calendar years from 1 January to 31 December.
         display:
           conversionFactor: 1
       death_rate:
         title: Death rate
-        short_unit: ‰
-        unit: Deaths per 1,000 population
+        short_unit: deaths per 1,000 population
+        unit: deaths per 1,000 population
         description: Number of deaths over a given period divided by the person-years lived by the population over that period.
       deaths:
         title: Deaths
-        short_unit:
-        unit: Persons
+        short_unit: deaths
+        unit: deaths
         description: Number of deaths over a given period. Refers to annual civil calendar years from 1 January to 31 December.
         display:
           conversionFactor: 1
       dependency_ratio_child:
         title: Child dependency ratio
         short_unit: "%"
-        unit: Percentage
+        unit: "%"
         description: The ratio of the population under age 15 (e.g., 0-14) to the number of persons of working age 15-64 (e.g., 15-64). It is expressed as number of dependants per 100 persons of working age (e.g., 25-64). Data are presented for different age categories.
       dependency_ratio_old:
         title: Old-age dependency ratio
         short_unit: "%"
-        unit: Percentage
+        unit: "%"
         description: The ratio of the population aged 65 and over (e.g., 65+) to the number of persons of working age 15-64 (e.g., 15-64). It is expressed as number of dependants per 100 persons of working age (e.g., 25-64). Data are presented for different age categories.
       dependency_ratio_total:
         title: Total dependency ratio
         short_unit: "%"
-        unit: Percentage
+        unit: "%"
         description: The ratio of the sum of the population under age 15 (e.g., 0-14) and that aged 65 and over (e.g., 65+) to the number of persons of working age 15-64 (e.g., 15-64). It is expressed as number of dependants per 100 persons of working age (e.g., 25-64). Data are presented for different age categories.
       fertility_rate:
         title: Fertility rate
-        short_unit:
-        unit: Children per woman
+        short_unit: live births per woman
+        unit: live births per woman
         description: |
           The average number of live births a hypothetical cohort of women would have at the end of their
           reproductive period if they were subject during their whole lives to the fertility rates of a given period and
@@ -66,26 +66,26 @@ tables:
       growth_natural_rate:
         title: Natural growth rate
         short_unit: "%"
-        unit: Percentage
+        unit: "%"
         description: Crude birth rate minus the crude death rate. Represents the portion of population growth (or decline) determined exclusively by births and deaths.
         display:
           conversionFactor: 1
       growth_rate:
         title: Growth rate
         short_unit: "%"
-        unit: Percentage
+        unit: "%"
         description: Average exponential rate of growth of the population over a given period. It is calculated as ln(P2/P1)/n where P1 and P2 are the populations on 1 January of subsequent years, and n is the length of the period between t1 and t2 (n=1 for annual data).
         display:
           conversionFactor: 1
       infant_mortality_rate:
         title: Infant mortality rate
         short_unit: "%"
-        unit: Percentage
+        unit: "%"
         description: Probability of dying between birth and exact age 1.
       life_expectancy:
         title: Life expectancy
         short_unit: years
-        unit: Years
+        unit: years
         description: The average number of remaining years of life expected by a hypothetical cohort of individuals who already reached age x and would be subject during the remainder of their lives to the mortality rates of a given period.
       median_age:
         title: Median age
@@ -94,44 +94,44 @@ tables:
         description: Age that divides the population in two parts of equal size, that is, there are as many persons with ages above the median as there are with ages below the median.
       net_migration:
         title: Net migration
-        short_unit: persons
-        unit: Persons
+        short_unit: migrants
+        unit: migrants
         description: Net number of migrants, that is, the number of immigrants minus the number of emigrants.
       net_migration_rate:
         title: Net migration rate
-        short_unit:
-        unit: Migrants per 1,000 population
+        short_unit: migrants per 1,000 population
+        unit: migrants per 1,000 population
         description: The number of immigrants minus the number of emigrants over a period, divided by the person-years lived by the population of the receiving country over that period.
       population:
         title: Population
-        short_unit:
-        unit: Persons
+        short_unit: persons
+        unit: persons
         description: De facto population in a country, area or region as of 1 July of the year indicated.
         display:
           conversionFactor: 1
       population_broad:
         title: Population by broad age group
-        short_unit:
-        unit: Persons
+        short_unit: persons
+        unit: persons
         description: De facto population in a country, area or region as of 1 July of the year indicated. Figures are presented in thousands. Alternative metric to 'population', used for different (and groader) age groups.
         display:
           conversionFactor: 1
       population_change:
         title: Population change
-        short_unit:
-        unit: Persons
+        short_unit: persons
+        unit: persons
         description: Population increment over a period, that is, the difference between the population at the end of the period and that at the beginning of the period. Refers to calendar years from 1 July to 30 June.
         display:
           conversionFactor: 1
       population_density:
         title: Population density
-        short_unit:
-        unit: Persons per square kilometer
+        short_unit: persons per square kilometer
+        unit: persons per square kilometer
         description: Population per square Kilometer as of 1 July.
       sex_ratio:
         title: Sex ratio
-        short_unit:
-        unit: Males per 100 females
+        short_unit: males per 100 females
+        unit: males per 100 females
         description: Number of males per 100 females in the population.
       # gdp:
       #   title: GDP

--- a/etl/steps/data/meadow/un/2022-07-11/un_wpp.py
+++ b/etl/steps/data/meadow/un/2022-07-11/un_wpp.py
@@ -46,7 +46,7 @@ def _load_population(tmp_dir: str) -> pd.DataFrame:
         "ParentID": "category",
         "Location": "category",
         "VarID": CategoricalDtype(categories=["2", "3", "4"]),
-        "Variant": CategoricalDtype(categories=["Medium", "High", "Low"]),
+        "Variant": CategoricalDtype(categories=["Medium", "High", "Low", "Constant fertility"]),
         "Time": "uint16",
         "MidPeriod": "uint16",
         "AgeGrp": "category",


### PR DESCRIPTION
This PR adds:

- Constant Fertility variant scenario for metric `population`.
- Corrects and improves the units for all dataset variables.

Solves #520 