### PR TITLE
fix(files): ignore __pycache__ when walking files

### DIFF
--- a/etl/files.py
+++ b/etl/files.py
@@ -32,10 +32,10 @@ def walk(folder: Path, ignore_set: Set[str] = {"__pycache__", ".ipynb_checkpoint
     paths = []
     for p in folder.iterdir():
         if p.is_dir():
-            paths.extend(walk(p))
+            if p.name not in ignore_set:
+                paths.extend(walk(p, ignore_set=ignore_set))
             continue
-
-        if p.name not in ignore_set:
+        else:
             paths.append(p)
 
     return paths

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,12 @@
+from etl import files
+
+
+def test_walk_ignore_set(tmp_path):
+    (tmp_path / "test.py").write_text("test")
+
+    d = tmp_path / "__pycache__"
+    d.mkdir()
+    (d / "cache.py").write_text("test")
+
+    outfiles = files.walk(tmp_path)
+    assert [f.name for f in outfiles] == ["test.py"]


### PR DESCRIPTION
Fix for https://github.com/owid/etl/issues/527

There was a bug that didn't ignore `__pycache__` which is why our checksums were different on different machines. `files.walk` is being used for [calculating checksums](https://github.com/owid/etl/blob/master/etl/steps/__init__.py#L361).