### PR TITLE
fix(cmd): unnecessary squeeze (solves #534)

### DIFF
--- a/etl/variable_mapping_translate.py
+++ b/etl/variable_mapping_translate.py
@@ -230,7 +230,7 @@ def _merge_dfs(df_old: pd.DataFrame, df_new: pd.DataFrame, mapping: Dict[str, st
     return df
 
 
-def build_mapping_from_df(sql: Engine, df: pd.DataFrame) -> Dict[str, str]:
+def build_mapping_from_df(sql: Engine, df: pd.DataFrame) -> Dict[Any, Any]:
     """_summary_
 
     Parameters
@@ -249,7 +249,7 @@ def build_mapping_from_df(sql: Engine, df: pd.DataFrame) -> Dict[str, str]:
     df_new = _build_individual_df(sql, df, "name_new", "dataset_name_new")
     # Merge into single df
     df = _merge_dfs_old_new(df_old, df_new)
-    dix: Dict[str, str] = df.set_index("id_old")["id_new"].squeeze().to_dict()
+    dix: Dict[Any, Any] = df.set_index("id_old")["id_new"].to_dict()
     return dix
 
 
@@ -302,3 +302,7 @@ def _sanity_check(sql: Engine, mapping: Dict[str, str]) -> None:
 
     # successfull message
     log.info("Sanity check passed.")
+
+
+if __name__ == "__main__":
+    main_cli()


### PR DESCRIPTION
There was an unnecessary call to `pd.Series.squeeze`. 

Most of the time, it would squeeze a Series of length > 1, and would not complain (as it leaves the object unchanged). However, if the Series was from length 1, it would return a scalar, and subsequent operations would fail. An example of this is #534.