### PR TITLE
fix(grapher): move country_to_entity_id from grapher steps and keep only country column

### DIFF
--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -11,6 +11,7 @@ import structlog
 import yaml
 from owid import catalog
 from owid.catalog.utils import underscore
+from owid.datautils import dataframes
 from pydantic import BaseModel
 
 from etl.db import get_connection, get_engine
@@ -319,6 +320,13 @@ def _get_and_create_entities_in_db(countries: Set[str]) -> Dict[str, int]:
     return {name: db.get_or_create_entity(name) for name in countries}
 
 
+def country_code_to_country(country_code: pd.Series) -> pd.Series:
+    """Convert country code to country name."""
+    reference_dataset = catalog.Dataset(REFERENCE_DATASET)
+    code_to_country = reference_dataset["countries_regions"]["name"].to_dict()
+    return dataframes.map_series(country_code, code_to_country, warn_on_missing_mappings=True)
+
+
 def country_to_entity_id(
     country: pd.Series,
     fill_from_db: bool = True,
@@ -328,6 +336,10 @@ def country_to_entity_id(
 ) -> pd.Series:
     """Convert country name to grapher entity_id. Most of countries should be in countries_regions.csv,
     however some regions could be only in `entities` table in MySQL or doesn't exist at all.
+
+    This function should not be used from ETL steps, conversion to entity_id is done automatically
+    when upserting to database.
+
     :param fill_from_db: if True, fill missing countries from `entities` table
     :param create_entities: if True, create missing countries in `entities` table
     :param errors: how to handle missing countries
@@ -498,13 +510,12 @@ def _adapt_table_for_grapher(
     if table.index.names != [None]:
         table = table.reset_index()
 
-    assert "year" in table.columns
+    assert {"year", country_col} <= set(table.columns)
+    assert "entity_id" not in table.columns
 
-    if "entity_id" not in table.columns:
-        assert country_col in table.columns
-        # Grapher needs a column entity id, that is constructed based on the unique entity names in the database.
-        table["entity_id"] = country_to_entity_id(table[country_col], create_entities=True)
-        table = table.drop(columns=[country_col]).rename(columns={year_col: "year"})
+    # Grapher needs a column entity id, that is constructed based on the unique entity names in the database.
+    table["entity_id"] = country_to_entity_id(table[country_col], create_entities=True)
+    table = table.drop(columns=[country_col]).rename(columns={year_col: "year"})
 
     table = table.set_index(["entity_id", "year"] + dim_names)
 

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -324,7 +324,7 @@ def country_code_to_country(country_code: pd.Series) -> pd.Series:
     """Convert country code to country name."""
     reference_dataset = catalog.Dataset(REFERENCE_DATASET)
     code_to_country = reference_dataset["countries_regions"]["name"].to_dict()
-    return dataframes.map_series(country_code, code_to_country, warn_on_missing_mappings=True)
+    return cast(pd.Series, dataframes.map_series(country_code, code_to_country, warn_on_missing_mappings=True))
 
 
 def country_to_entity_id(

--- a/etl/steps/grapher/un/2022-07-11/un_wpp.py
+++ b/etl/steps/grapher/un/2022-07-11/un_wpp.py
@@ -38,15 +38,10 @@ def run(dest_dir: str) -> None:
 def _get_shaped_table(dataset: catalog.Dataset) -> catalog.Table:
     table = dataset[TNAME].reset_index()
 
-    # grapher needs a column entity id, that is constructed based on the unique entity names in the database
-    table["entity_id"] = gh.country_to_entity_id(table["location"], create_entities=True)
-
     # use entity_id and year as indexes in grapher
-    table = table.set_index(["entity_id", "year", "sex", "age", "variant"])[["metric", "value"]].rename(
-        columns={
-            "metric": "variable",
-        }
-    )
+    table = table.rename(columns={"location": "country", "metric": "variable"}).set_index(
+        ["country", "year", "sex", "age", "variant"]
+    )[["variable", "value"]]
     return table
 
 

--- a/etl/steps/grapher/un_sdg/2022-07-07/un_sdg.py
+++ b/etl/steps/grapher/un_sdg/2022-07-07/un_sdg.py
@@ -106,8 +106,7 @@ def add_metadata_and_prepare_for_grapher(df_gr: pd.DataFrame, walden_ds: WaldenD
     df_gr = df_gr[["country", "year", "value", "variable", "meta"]].copy()
     # convert integer values to int but round float to 2 decimal places, string remain as string
     df_gr["value"] = df_gr["value"].apply(value_convert)
-    df_gr["entity_id"] = gh.country_to_entity_id(df_gr["country"], create_entities=True)
-    df_gr = df_gr.drop(columns=["country"]).set_index(["year", "entity_id"])
+    df_gr = df_gr.set_index(["year", "country"])
 
     return Table(df_gr)
 

--- a/etl/steps/grapher/who/2021-07-01/ghe.py
+++ b/etl/steps/grapher/who/2021-07-01/ghe.py
@@ -55,9 +55,9 @@ def run(dest_dir: str) -> None:
         .round({"deaths": 0, "deaths_rate": 2, "deaths_100k": 2, "daly": 2, "daly_rate": 2, "daly_100k": 2})
     )
     table["deaths"] = table["deaths"].astype(int)
-    table["entity_id"] = gh.country_to_entity_id(table["country_code"], by="code")
+    table["country"] = gh.country_code_to_country(table["country_code"])
     table = table.drop(["country_code"], axis=1)
-    table = table.set_index(["entity_id", "year", "ghe_cause_title", "sex_code", "agegroup_code"])
+    table = table.set_index(["country", "year", "ghe_cause_title", "sex_code", "agegroup_code"])
 
     table.update_metadata_from_yaml(N.metadata_path, "estimates")
 

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -182,7 +182,7 @@ def _sample_table() -> Table:
             {
                 "deaths": [0, 1],
                 "year": [2019, 2020],
-                "entity_id": [1, 1],
+                "country": ["France", "Poland"],
                 "sex": ["female", "male"],
             }
         )
@@ -200,22 +200,12 @@ def test_adapt_table_for_grapher_multiindex():
     assert out_table.index.names == ["entity_id", "year"]
     assert out_table.columns.tolist() == ["deaths", "sex"]
 
-    table = _sample_table().set_index(["entity_id", "year", "sex"])
+    table = _sample_table().set_index(["country", "year", "sex"])
     out_table = gh._adapt_table_for_grapher(table)
     assert out_table.index.names == ["entity_id", "year", "sex"]
     assert out_table.columns.tolist() == ["deaths"]
 
     table = _sample_table().set_index(["sex"])
-    out_table = gh._adapt_table_for_grapher(table)
-    assert out_table.index.names == ["entity_id", "year", "sex"]
-    assert out_table.columns.tolist() == ["deaths"]
-
-
-def test_adapt_table_for_grapher_multiindex_with_country():
-    table = _sample_table().set_index("sex")
-    table["country"] = ["France", "Poland"]
-    del table["entity_id"]
-
     out_table = gh._adapt_table_for_grapher(table)
     assert out_table.index.names == ["entity_id", "year", "sex"]
     assert out_table.columns.tolist() == ["deaths"]


### PR DESCRIPTION
Grapher steps should work without MySQL, since `country_to_entity_id` is trying to create entities in MySQL, we have to get rid of it in grapher steps and leave just country there.