### PR TITLE
enhance(open_numbers): make the biggest dataset more memory efficient

### DIFF
--- a/etl/run_python_step.py
+++ b/etl/run_python_step.py
@@ -9,6 +9,7 @@ from typing import Optional
 import click
 from ipdb import launch_ipdb_on_exception
 
+from etl import config
 from etl.paths import BASE_PACKAGE, STEP_DIR
 
 
@@ -28,6 +29,7 @@ def main(uri: str, dest_dir: str, ipdb: Optional[bool]) -> None:
 
     if ipdb:
         with launch_ipdb_on_exception():
+            config.IPDB_ENABLED = True
             _import_and_run(path, dest_dir)
     else:
         _import_and_run(path, dest_dir)

--- a/etl/steps/open_numbers.py
+++ b/etl/steps/open_numbers.py
@@ -114,7 +114,7 @@ def load_and_combine(path: Path, resources: List[frictionless.Resource]) -> pd.D
     primary_key: List[str]
 
     with tempfile.NamedTemporaryFile(suffix=".csv") as f:
-        inferred_dtypes = _write_mega_csv(path, resources, f)
+        primary_key, inferred_dtypes = _write_mega_csv(path, resources, f)
 
         # ignore mixed type warnings
         with warnings.catch_warnings():
@@ -177,7 +177,7 @@ def _write_mega_csv(
 
     f.flush()
 
-    if not first:
+    if first:
         raise Exception("No resources found")
 
     return primary_key, inferred_dtypes  # type: ignore
@@ -185,7 +185,7 @@ def _write_mega_csv(
 
 def remap_names(
     resources: List[frictionless.Resource],
-) -> Dict[str, frictionless.Resource]:
+) -> Dict[str, List[frictionless.Resource]]:
     "Short names must be unique, so fix name collisions."
     rows = []
     for resource in resources:


### PR DESCRIPTION
Make open numbers steps more memory efficient for the largest datasets such as IHME. This is motivated by out-of-memory errors that can unpredictably happen on `analytics`, which has 16GB memory and no swap.

## Todo

- [x] Patch mega csv building to use inferred data types
- [ ] Successfully rebuild with this branch
- [ ] Confirm integrity of rebuilt data by comparing to data catalog