### PR TITLE
fix(un_wpp): remove unused s3 connection from un_wpp explorer

### DIFF
--- a/etl/steps/data/explorers/un/2022/un_wpp.py
+++ b/etl/steps/data/explorers/un/2022/un_wpp.py
@@ -5,14 +5,12 @@ from typing import Any, List
 
 import pandas as pd
 from owid import catalog
-from owid.datautils.io.s3 import S3
 from tqdm.auto import tqdm
 
 from etl.paths import DATA_DIR
 
 YEAR_SPLIT = 2022
 no_dim_keyword = "full"
-s3 = S3()
 
 
 def _load_dataset() -> catalog.Dataset:


### PR DESCRIPTION
The connection was unused, but meant that the explorer build failed for the general public due to missing credentials.

Discovered in a full rebuild: https://buildkite.com/our-world-in-data/etl-nightly-public-build-from-scratch/builds/2#01838dde-2288-4cbe-affa-d8e34aa2a1b5
