### PR TITLE
fix(dag): reference to reference dataset

### DIFF
--- a/dag_files/dag_emissions.yml
+++ b/dag_files/dag_emissions.yml
@@ -6,6 +6,7 @@ steps:
     - walden://cait/2022-08-10/cait_ghg_emissions
   data://garden/cait/2022-08-10/ghg_emissions_by_sector:
     - data://meadow/cait/2022-08-10/ghg_emissions_by_sector
+    - data://garden/reference
   data://grapher/cait/2022-08-10/all_ghg_emissions:
     - data://garden/cait/2022-08-10/ghg_emissions_by_sector
   data://grapher/cait/2022-08-10/ch4_emissions:

--- a/dag_files/dag_energy.yml
+++ b/dag_files/dag_energy.yml
@@ -6,6 +6,7 @@ steps:
   data://garden/bp/2022-07-11/statistical_review:
     - backport://backport/owid/latest/dataset_5347_statistical_review_of_world_energy__bp__2021
     - data://garden/owid/latest/key_indicators
+    - data://garden/reference
   #
   # BP - Statistical review 2022.
   #
@@ -18,6 +19,7 @@ steps:
     - data://garden/bp/2022-07-11/statistical_review
     - data://garden/owid/latest/key_indicators
     - data://garden/wb/2021-07-01/wb_income
+    - data://garden/reference
   data://grapher/bp/2022-07-14/statistical_review:
     - data://garden/bp/2022-07-14/statistical_review
   #
@@ -36,6 +38,7 @@ steps:
     - walden://shift/2022-07-18/fossil_fuel_production
   data://garden/shift/2022-07-18/fossil_fuel_production:
     - data://meadow/shift/2022-07-18/fossil_fuel_production
+    - data://garden/reference
   #
   # Energy - Fossil Fuel Production 2022.
   #
@@ -53,6 +56,7 @@ steps:
   data://garden/eia/2022-07-27/energy_consumption:
     - data://meadow/eia/2022-07-27/energy_consumption
     - data://garden/owid/latest/key_indicators
+    - data://garden/reference
   #
   # Energy - Primary energy consumption 2022.
   #
@@ -71,6 +75,7 @@ steps:
   data://garden/ember/2022-08-01/global_electricity_review:
     - data://meadow/ember/2022-08-01/global_electricity_review
     - data://garden/owid/latest/key_indicators
+    - data://garden/reference
   #
   # Ember - European electricity review 2022.
   #


### PR DESCRIPTION
I just added a reference to `data://garden/reference` for those garden datasets that may require it.

@pabloarosado realised that whenever we use `owid.datautils.geo.add_region_aggregates` function, a link to the reference dataset should be added to the corresponding ETL step. This is because this function makes use of its table `countries_regions`.