### PR TITLE
fix(WaldenStep): compare checksums in is_dirty

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -227,7 +227,9 @@ def run_dag(
 
     if not force:
         print("Detecting which steps need rebuilding...")
+        start_time = time.time()
         steps = select_dirty_steps(steps, workers)
+        click.echo(f"{click.style('OK', fg='blue')} ({time.time() - start_time:.0f}s)")
 
     if not steps:
         print("All datasets up to date!")

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -444,7 +444,13 @@ class WaldenStep(Step):
         self._walden_dataset.ensure_downloaded(quiet=True)
 
     def is_dirty(self) -> bool:
-        return not Path(self._walden_dataset.local_path).exists()
+        if not Path(self._walden_dataset.local_path).exists():
+            return True
+
+        if files.checksum_file(self._walden_dataset.local_path) != self._walden_dataset.md5:
+            return True
+
+        return False
 
     def has_existing_data(self) -> bool:
         return True


### PR DESCRIPTION
Fix for https://github.com/owid/etl/issues/552

[PR in walden](https://github.com/owid/walden/pull/91)

`WaldenStep` should also compare checksums before using file from cache. However, this is computationally expensive so we use runtime cache with filename as a key. (Using mtime of files plus filename would be also possible, but is it necessary over one run of ETL?)