### PR TITLE
feature(grapher): stop upserting to data_values table

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ _Internal OWID staff only_
 
 Grapher step writes metadata to mysql and stores data as parquet files in the grapher channel. Admin still uses two ways of loading data - from table `data_values` for manually uploaded datasets and now from bucket `owid-catalog` in S3 (proxied by https://owid-catalog.nyc3.digitaloceanspaces.com/) for ETL datasets.
 
-During local development your data isn't yet in S3 catalog, but is stored in your local catalog. You have to the following env variable to `owid-grapher/.env`
+During local development your data isn't yet in S3 catalog, but is stored in your local catalog. You have to add the following env variable to `owid-grapher/.env`
 
 ```
 CATALOG_PATH=/path/to/etl/data


### PR DESCRIPTION
Stop upserting to `data_values` table now that data in admin is loaded directly from parquet files in grapher channel.

Adding `CATALOG_PATH=/path/to/etl/data` to `owid-grapher/.env` is needed for local development (see README).