### PR TITLE
feat(un_wpp): add 100+ age group for `deaths`

### DIFF
--- a/etl/steps/data/garden/un/2022-07-11/un_wpp/deaths.py
+++ b/etl/steps/data/garden/un/2022-07-11/un_wpp/deaths.py
@@ -91,6 +91,8 @@ def add_age_groups(df: pd.DataFrame) -> pd.DataFrame:
         as_index=False,
         observed=True,
     ).sum()
+    # 100+ age group
+    df_100 = df[df.age == "100+"].copy()
     # Merge all age groups
-    df = pd.concat([df_0, df_1_4, df_5, df_10], ignore_index=True)
+    df = pd.concat([df_0, df_1_4, df_5, df_10, df_100], ignore_index=True)
     return df


### PR DESCRIPTION
@fiona asked if we could have the 100+ year group for [this chart](https://ourworldindata.org/grapher/deaths-by-age-group?country=~OWID_WRL). So the ‘Deaths - Sex: all - Age: 100+ - Variant: estimates’ variable.

Issue tracked in https://github.com/owid/owid-issues/issues/648