### PR TITLE
enhance(walkthrough): various improvements

### DIFF
--- a/etl/metadata_export.py
+++ b/etl/metadata_export.py
@@ -1,0 +1,104 @@
+import os
+from typing import Any, Dict, cast
+
+import click
+import yaml
+from owid.catalog import Dataset
+
+
+@click.command(help=__doc__)
+@click.argument(
+    "path",
+    type=click.Path(),
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(),
+    help="Save output into YAML file",
+)
+def cli(
+    path: str,
+    output: str,
+) -> None:
+    """Export dataset & tables & columns metadata in YAML format. This
+    is useful for generating *.meta.yml files that can be later manually edited.
+
+    Usage:
+        etl-metadata-export data/garden/ggdc/2020-10-01/ggdc_maddison -o etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
+    """
+    meta_str = metadata_export(str(path))
+    if output:
+        os.makedirs(os.path.dirname(output), exist_ok=True)
+        with open(output, "w") as f:
+            f.write(meta_str)
+    else:
+        print(meta_str)
+
+
+def metadata_export(
+    path: str,
+) -> str:
+    ds = Dataset(path)
+
+    ds_meta = ds.metadata.to_dict()
+
+    # transform dataset metadata
+    for source in ds_meta["sources"]:
+        _prune_empty(source)
+
+    for license in ds_meta.get("licenses", []):
+        _prune_empty(license)
+
+    ds_meta.pop("is_public")
+    ds_meta.pop("source_checksum")
+    # move sources at the end
+    ds_meta["sources"] = ds_meta.pop("sources")
+
+    # transform tables metadata
+    tb_meta = {}
+    for tab in ds:
+        t = tab.metadata.to_dict()
+        t.pop("short_name")
+        t.pop("dataset")
+        t.pop("primary_key", None)
+
+        # transform variables metadata
+        t["variables"] = {}
+        for col in tab.columns:
+            if col in ("country", "year"):
+                continue
+            variable = tab[col].metadata.to_dict()
+
+            # add required units
+            variable.setdefault("short_unit", "")
+            variable.setdefault("unit", "")
+
+            for source in variable.get("sources", []):
+                _prune_empty(source)
+
+            # move sources at the end
+            if "sources" in variable:
+                variable["sources"] = variable.pop("sources")
+
+            t["variables"][col] = variable
+
+        tb_meta[tab.metadata.short_name] = t
+
+    final = {
+        "dataset": ds_meta,
+        "tables": tb_meta,
+    }
+
+    return cast(str, yaml.dump(final, sort_keys=False, allow_unicode=True))
+
+
+def _prune_empty(d: Dict[str, Any]) -> None:
+    """Remove empty values from dict."""
+    for k, v in list(d.items()):
+        if not v:
+            del d[k]
+
+
+if __name__ == "__main__":
+    cli()

--- a/etl/steps/data/converters.py
+++ b/etl/steps/data/converters.py
@@ -30,7 +30,7 @@ def convert_walden_metadata(wd: WaldenDataset) -> DatasetMeta:
                 publication_year=wd.publication_year,
             )
         ],
-        licenses=[License(name=wd.license_name, url=wd.license_url)],
+        licenses=[License(name=wd.license_name, url=wd.license_url)] if wd.license_name or wd.license_url else [],
     )
 
 

--- a/etl/steps/data/meadow/dummy/2020-01-01/dummy.py
+++ b/etl/steps/data/meadow/dummy/2020-01-01/dummy.py
@@ -5,6 +5,7 @@ from owid.walden import Catalog as WaldenCatalog
 from structlog import get_logger
 
 from etl.helpers import Names
+from etl.paths import DATA_DIR, REFERENCE_DATASET
 from etl.steps.data.converters import convert_walden_metadata
 
 log = get_logger()
@@ -13,11 +14,14 @@ log = get_logger()
 N = Names(__file__)
 
 
+
 def run(dest_dir: str) -> None:
     log.info("dummy.start")
 
     # retrieve raw data from walden
-    walden_ds = WaldenCatalog().find_one(namespace="dummy", short_name="dummy", version="2020-01-01")
+    walden_ds = WaldenCatalog().find_one(
+        namespace="dummy", short_name="dummy", version="2020-01-01"
+    )
     local_file = walden_ds.ensure_downloaded()
 
     df = pd.read_excel(local_file, sheet_name="Full data")
@@ -40,10 +44,10 @@ def run(dest_dir: str) -> None:
 
     # underscore all table columns
     tb = underscore_table(tb)
-
-    ds.metadata.update_from_yaml(N.metadata_path, if_source_exists="replace")
+    
+    ds.metadata.update_from_yaml(N.metadata_path)
     tb.update_metadata_from_yaml(N.metadata_path, "dummy")
-
+    
     # add table to a dataset
     ds.add(tb)
 

--- a/etl/steps/data/meadow/dummy/2020-01-01/dummy.py
+++ b/etl/steps/data/meadow/dummy/2020-01-01/dummy.py
@@ -5,7 +5,6 @@ from owid.walden import Catalog as WaldenCatalog
 from structlog import get_logger
 
 from etl.helpers import Names
-from etl.paths import DATA_DIR, REFERENCE_DATASET
 from etl.steps.data.converters import convert_walden_metadata
 
 log = get_logger()

--- a/etl/steps/data/meadow/dummy/2020-01-01/dummy.py
+++ b/etl/steps/data/meadow/dummy/2020-01-01/dummy.py
@@ -14,14 +14,11 @@ log = get_logger()
 N = Names(__file__)
 
 
-
 def run(dest_dir: str) -> None:
     log.info("dummy.start")
 
     # retrieve raw data from walden
-    walden_ds = WaldenCatalog().find_one(
-        namespace="dummy", short_name="dummy", version="2020-01-01"
-    )
+    walden_ds = WaldenCatalog().find_one(namespace="dummy", short_name="dummy", version="2020-01-01")
     local_file = walden_ds.ensure_downloaded()
 
     df = pd.read_excel(local_file, sheet_name="Full data")
@@ -44,10 +41,10 @@ def run(dest_dir: str) -> None:
 
     # underscore all table columns
     tb = underscore_table(tb)
-    
-    ds.metadata.update_from_yaml(N.metadata_path)
+
+    ds.metadata.update_from_yaml(N.metadata_path, if_source_exists="replace")
     tb.update_metadata_from_yaml(N.metadata_path, "dummy")
-    
+
     # add table to a dataset
     ds.add(tb)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ generate_graph = 'etl.to_graphviz:to_graphviz'
 etl-match-variables = 'etl.match_variables_from_two_versions_of_a_dataset:main_cli'
 etl-translate-varmap = 'etl.variable_mapping_translate:main_cli'
 etl-chart-suggester = 'etl.chart_revision_suggester:main_cli'
+etl-metadata-export = 'etl.metadata_export:cli'
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/walkthrough/cli.py
+++ b/walkthrough/cli.py
@@ -26,7 +26,12 @@ PHASES = Literal["walden", "meadow", "garden", "grapher"]
     is_flag=True,
     help="Prefill form with dummy data, useful for development",
 )
-def cli(phase: Iterable[PHASES], run_checks: bool, dummy_data: bool) -> None:
+@click.option(
+    "--auto-open/--no-auto-open",
+    is_flag=True,
+    help="Auto open browser on port 8082",
+)
+def cli(phase: Iterable[PHASES], run_checks: bool, dummy_data: bool, auto_open: bool) -> None:
     print("Walkthrough has been opened at http://localhost:8082/")
     if phase == "walden":
         phase_func = walden.app
@@ -43,7 +48,7 @@ def cli(phase: Iterable[PHASES], run_checks: bool, dummy_data: bool) -> None:
         lambda: phase_func(run_checks=run_checks, dummy_data=dummy_data),
         port=8082,
         debug=True,
-        auto_open_webbrowser=True,
+        auto_open_webbrowser=auto_open,
     )
 
 

--- a/walkthrough/cli.py
+++ b/walkthrough/cli.py
@@ -29,6 +29,7 @@ PHASES = Literal["walden", "meadow", "garden", "grapher"]
 @click.option(
     "--auto-open/--no-auto-open",
     is_flag=True,
+    default=True,
     help="Auto open browser on port 8082",
 )
 def cli(phase: Iterable[PHASES], run_checks: bool, dummy_data: bool, auto_open: bool) -> None:

--- a/walkthrough/garden.py
+++ b/walkthrough/garden.py
@@ -55,15 +55,6 @@ def app(run_checks: bool, dummy_data: bool) -> None:
         "Options",
         [
             pi.input(
-                "Short name",
-                name="short_name",
-                placeholder="ggdc_maddison",
-                required=True,
-                value=dummies.get("short_name"),
-                validate=utils.validate_short_name,
-                help_text="Underscored short name",
-            ),
-            pi.input(
                 "Namespace",
                 name="namespace",
                 placeholder="ggdc",
@@ -76,6 +67,15 @@ def app(run_checks: bool, dummy_data: bool) -> None:
                 placeholder="2020",
                 required=True,
                 value=dummies.get("version"),
+            ),
+            pi.input(
+                "Short name",
+                name="short_name",
+                placeholder="ggdc_maddison",
+                required=True,
+                value=dummies.get("short_name"),
+                validate=utils.validate_short_name,
+                help_text="Underscored short name",
             ),
             pi.checkbox(
                 "Additional Options",

--- a/walkthrough/garden.py
+++ b/walkthrough/garden.py
@@ -158,9 +158,9 @@ def app(run_checks: bool, dummy_data: bool) -> None:
     poetry run etl data://garden/{form.namespace}/{form.version}/{form.short_name}
     ```
 
-2. Generated notebook `{notebook_path.relative_to(ETL_DIR)}` can be used to examine the dataset output interactively.
+2. (Optional) Generated notebook `{notebook_path.relative_to(ETL_DIR)}` can be used to examine the dataset output interactively.
 
-3. Loading the dataset is also possible with this snippet:
+3. (Optional) Loading the dataset is also possible with this snippet:
 
     ```python
     from owid.catalog import Dataset
@@ -172,9 +172,21 @@ def app(run_checks: bool, dummy_data: bool) -> None:
     df = ds["{form.short_name}"]
     ```
 
-4. Create a branch in [Walden](https://github.com/owid/walden) and [ETL](https://github.com/owid/etl) repositories, get it reviewed and merged.
+4. (Optional) Generate metadata file `{form.short_name}.meta.yml` from your dataset with
 
-5. Once your changes are merged, your steps will be run automatically by our server and published to the OWID catalog. Once that is finished, it can be found by anyone using:
+    ```
+    poetry run etl-metadata-export data/garden/{form.namespace}/{form.version}/{form.short_name} -o etl/steps/data/garden/{form.namespace}/{form.version}/{form.short_name}.meta.yml
+    ```
+
+    then manual edit it and rerun the step again with
+
+    ```
+    poetry run etl data://garden/{form.namespace}/{form.version}/{form.short_name}
+    ```
+
+5. Create a branch in [Walden](https://github.com/owid/walden) and [ETL](https://github.com/owid/etl) repositories, get it reviewed and merged.
+
+6. Once your changes are merged, your steps will be run automatically by our server and published to the OWID catalog. Once that is finished, it can be found by anyone using:
 
     ```python
     from owid.catalog import find_one
@@ -183,7 +195,7 @@ def app(run_checks: bool, dummy_data: bool) -> None:
     print(tab.head())
     ```
 
-6. If you are an internal OWID member and want to push data to our Grapher DB, continue with `poetry run walkthrough grapher`
+7. If you are an internal OWID member and want to push data to our Grapher DB, continue with `poetry run walkthrough grapher`
 
 ## Generated files
 """

--- a/walkthrough/grapher.py
+++ b/walkthrough/grapher.py
@@ -53,15 +53,6 @@ def app(run_checks: bool, dummy_data: bool) -> None:
         "Options",
         [
             pi.input(
-                "Short name",
-                name="short_name",
-                placeholder="ggdc_maddison",
-                required=True,
-                value=dummies.get("short_name"),
-                validate=utils.validate_short_name,
-                help_text="Underscored short name",
-            ),
-            pi.input(
                 "Namespace",
                 name="namespace",
                 placeholder="ggdc",
@@ -74,6 +65,15 @@ def app(run_checks: bool, dummy_data: bool) -> None:
                 placeholder="2020",
                 required=True,
                 value=dummies.get("version"),
+            ),
+            pi.input(
+                "Short name",
+                name="short_name",
+                placeholder="ggdc_maddison",
+                required=True,
+                value=dummies.get("short_name"),
+                validate=utils.validate_short_name,
+                help_text="Underscored short name",
             ),
             pi.checkbox(
                 "Additional Options",

--- a/walkthrough/meadow.py
+++ b/walkthrough/meadow.py
@@ -167,9 +167,9 @@ def app(run_checks: bool, dummy_data: bool) -> None:
     poetry run etl data://meadow/{form.namespace}/{form.version}/{form.short_name}
     ```
 
-2. Generated notebook `{notebook_path.relative_to(ETL_DIR)}` can be used to examine the dataset output interactively.
+2. (Optional) Generated notebook `{notebook_path.relative_to(ETL_DIR)}` can be used to examine the dataset output interactively.
 
-3. Loading the dataset is also possible with this snippet:
+3. (Optional) Loading the dataset is also possible with this snippet:
 
     ```python
     from owid.catalog import Dataset
@@ -181,7 +181,19 @@ def app(run_checks: bool, dummy_data: bool) -> None:
     df = ds["{form.short_name}"]
     ```
 
-4. Exit the process and run next step with `poetry run walkthrough garden`
+4. (Optional) Generate metadata file `{form.short_name}.meta.yml` from your dataset with
+
+    ```
+    poetry run etl-metadata-export data/meadow/{form.namespace}/{form.version}/{form.short_name} -o etl/steps/data/meadow/{form.namespace}/{form.version}/{form.short_name}.meta.yml
+    ```
+
+    then manual edit it and rerun the step again with
+
+    ```
+    poetry run etl data://meadow/{form.namespace}/{form.version}/{form.short_name}
+    ```
+
+5. Exit the process and run next step with `poetry run walkthrough garden`
 
 ## Generated files
 """

--- a/walkthrough/meadow.py
+++ b/walkthrough/meadow.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import os
 import shutil
 import tempfile
@@ -62,15 +63,6 @@ def app(run_checks: bool, dummy_data: bool) -> None:
         "Options",
         [
             pi.input(
-                "Short name",
-                name="short_name",
-                placeholder="ggdc_maddison",
-                required=True,
-                value=dummies.get("short_name"),
-                validate=utils.validate_short_name,
-                help_text="Underscored short name",
-            ),
-            pi.input(
                 "Namespace",
                 name="namespace",
                 placeholder="ggdc",
@@ -80,17 +72,26 @@ def app(run_checks: bool, dummy_data: bool) -> None:
             pi.input(
                 "Version",
                 name="version",
-                placeholder="2020",
+                placeholder=str(dt.date.today()),
                 required=True,
-                value=dummies.get("version"),
+                value=dummies.get("version", str(dt.date.today())),
             ),
             pi.input(
                 "Walden version",
                 name="walden_version",
-                placeholder="2020",
+                placeholder=str(dt.date.today()),
                 required=True,
-                value=dummies.get("version"),
+                value=dummies.get("version", str(dt.date.today())),
                 help_text="Usually same as Version",
+            ),
+            pi.input(
+                "Short name",
+                name="short_name",
+                placeholder="ggdc_maddison",
+                required=True,
+                value=dummies.get("short_name"),
+                validate=utils.validate_short_name,
+                help_text="Underscored short name",
             ),
             pi.checkbox(
                 "Additional Options",

--- a/walkthrough/meadow_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
+++ b/walkthrough/meadow_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
@@ -55,7 +55,7 @@ def run(dest_dir: str) -> None:
     # underscore all table columns
     tb = underscore_table(tb)
     {% if cookiecutter.include_metadata_yaml == "True" %}
-    ds.metadata.update_from_yaml(N.metadata_path)
+    ds.metadata.update_from_yaml(N.metadata_path, if_source_exists="replace")
     tb.update_metadata_from_yaml(N.metadata_path, "{{cookiecutter.short_name}}")
     {% endif %}
     # add table to a dataset

--- a/walkthrough/walden_cookiecutter/cookiecutter.json
+++ b/walkthrough/walden_cookiecutter/cookiecutter.json
@@ -2,6 +2,7 @@
     "directory_name": "",
     "short_name": "",
     "namespace": "",
+    "walden_version": "",
     "name": "",
     "source_name": "",
     "publication_year": "",


### PR DESCRIPTION
Implemented some ideas from https://github.com/owid/etl/issues/294

* CLI `etl-metadata-export` that creates a `*.meta.yml` file from a dataset, this is recommended in walkthrough, but could be used outside it too (@pabloarosado is this helpful? Any ideas how to make it more useful?)
* Add `version` field to walden
* Rearrange fields to be in order `namespace-version-short name`
* Ingestion scripts generated in `institution/version` folder

Does it make sense to generate `*.meta.yml` for meadow or should we only encourage to do it on garden level?