### PR TITLE
fix(dag): replace non-existing wb/2022/wb_gender version by wb/2022-10-29/wb_gender

### DIFF
--- a/dag.yml
+++ b/dag.yml
@@ -48,7 +48,7 @@ steps:
   data://meadow/wb/2021-07-01/wb_income:
     - walden://wb/2021-07-01/wb_income
   data://meadow/wb/2022/wb_gender:
-    - walden://wb/2022/wb_gender
+    - walden://wb/2022-10-29/wb_gender
   data://garden/wb/2021-07-01/wb_income:
     - data://meadow/wb/2021-07-01/wb_income
   data://garden/ggdc/2020-10-01/ggdc_maddison:

--- a/etl/steps/data/meadow/wb/2022/wb_gender.py
+++ b/etl/steps/data/meadow/wb/2022/wb_gender.py
@@ -236,7 +236,7 @@ def add_tables_to_ds(ds: Dataset, df: pd.DataFrame, metadata: pd.DataFrame) -> D
 def run(dest_dir: str) -> None:
     """Run pipeline."""
     # Load data and metadata
-    walden_ds = walden.Catalog().find_one("wb", "2022", "wb_gender")
+    walden_ds = walden.Catalog().find_one("wb", "2022-10-29", "wb_gender")
     df, metadata = load_data_from_walden(walden_ds)
     # Format metadata
     metadata = metadata.pipe(format_metadata)


### PR DESCRIPTION
Hotfix for non-existing `walden://wb/2022/wb_gender`. @lucasrodes do you remember what happened here? Did you manually remove the old 2022 version from walden or was it something else that could have done it?