### PR TITLE
chore: Ignore .ipynb_checkpoints in pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,4 +101,5 @@ exclude = [
     "**/__pycache__",
     ".git",
     "**/.venv",
+    "**/.ipynb_checkpoints",
 ]


### PR DESCRIPTION
Ignore `.ipynb_checkpoints`, otherwise `make test` fails.
