### PR TITLE
fix(ember): Update links to Ember Global Electricity Review

### DIFF
--- a/etl/steps/data/garden/ember/2022-08-01/combined_electricity_review.meta.yml
+++ b/etl/steps/data/garden/ember/2022-08-01/combined_electricity_review.meta.yml
@@ -11,7 +11,7 @@ dataset:
       published_by: Ember
       publication_year: 2022
       date_accessed: 2022-08-01
-      url: https://ember-climate.org/data/data-catalogue/yearly-electricity-data/
+      url: https://ember-climate.org/data-catalogue/yearly-electricity-data/
     -
       name: Our World in Data based on Ember's European Electricity Review (2022).
       published_by: Ember

--- a/etl/steps/data/garden/ember/2022-08-01/global_electricity_review.meta.yml
+++ b/etl/steps/data/garden/ember/2022-08-01/global_electricity_review.meta.yml
@@ -18,7 +18,7 @@ dataset:
       published_by: Ember
       publication_year: 2022
       date_accessed: 2022-08-01
-      url: https://ember-climate.org/data/data-catalogue/yearly-electricity-data/
+      url: https://ember-climate.org/data-catalogue/yearly-electricity-data/
 
 tables:
   capacity:

--- a/etl/steps/data/garden/energy/2022-08-03/electricity_mix.meta.yml
+++ b/etl/steps/data/garden/energy/2022-08-03/electricity_mix.meta.yml
@@ -7,7 +7,7 @@ dataset:
   description: |
     Data is compiled by Our World in Data based on three main sources:
     – <a href="https://www.bp.com/en/global/corporate/energy-economics/statistical-review-of-world-energy.html">BP Statistical Review of World Energy</a>.
-    – <a href="https://ember-climate.org/data/data-catalogue/yearly-electricity-data/">Ember Global Electricity Review (2022)</a>.
+    – <a href="https://ember-climate.org/data-catalogue/yearly-electricity-data/">Ember Global Electricity Review (2022)</a>.
     – <a href="https://ember-climate.org/insights/research/european-electricity-review-2022/">Ember European Electricity Review (2022)</a>.
 
     Ember compile their global dataset from various sources including:
@@ -73,7 +73,7 @@ dataset:
       published_by: Ember
       publication_year: 2022
       date_accessed: 2022-08-01
-      url: https://ember-climate.org/data/data-catalogue/yearly-electricity-data/
+      url: https://ember-climate.org/data-catalogue/yearly-electricity-data/
     -
       name: Our World in Data based on Ember's European Electricity Review (2022)
       published_by: Ember

--- a/etl/steps/data/garden/energy/2022-09-22/uk_historical_electricity.meta.yml
+++ b/etl/steps/data/garden/energy/2022-09-22/uk_historical_electricity.meta.yml
@@ -24,7 +24,7 @@ dataset:
       published_by: Ember
       publication_year: 2022
       date_accessed: 2022-08-01
-      url: https://ember-climate.org/data/data-catalogue/yearly-electricity-data/
+      url: https://ember-climate.org/data-catalogue/yearly-electricity-data/
     -
       name: Ember's European Electricity Review
       published_by: Ember


### PR DESCRIPTION
Ember has changed their URL's, so this PR updates all mentions of their Global Electricity Review.

I haven't changed Walden, I suppose it makes sense to keep the old snapshot as it was at the time, and on the next release I will adapt the ingest script and metadata.
