### PR TITLE
fix(steps): proper private dependencies for grapher

### DIFF
--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -219,9 +219,6 @@ def parse_step(step_name: str, dag: Dict[str, Any]) -> "Step":
     elif step_type == "walden-private":
         step = WaldenStepPrivate(path)
 
-    elif step_type == "grapher-private":
-        step = GrapherStepPrivate(path, dependencies)
-
     elif step_type == "backport-private":
         step = BackportStepPrivate(path, dependencies)
 
@@ -697,13 +694,6 @@ class WaldenStepPrivate(WaldenStep):
 
     def __str__(self) -> str:
         return f"walden-private://{self.path}"
-
-
-class GrapherStepPrivate(GrapherStep):
-    is_public = False
-
-    def __str__(self) -> str:
-        return f"grapher-private://{self.path}"
 
 
 class BackportStepPrivate(PrivateMixin, BackportStep):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -27,11 +27,21 @@ def test_validate_private_steps(dag):
     cmd._validate_private_steps(dag)
 
     # public step with private dependency should raise an error
-    dag = dict(
+    new_dag = dict(
         dag,
         **{
             "data://c": {"data-private://d"},
         }
     )
     with pytest.raises(ValueError):
-        cmd._validate_private_steps(dag)
+        cmd._validate_private_steps(new_dag)
+
+    # private grapher step should not raise an error even if
+    # it is using private dependency
+    new_dag = dict(
+        dag,
+        **{
+            "grapher://c": {"data-private://a"},
+        }
+    )
+    cmd._validate_private_steps(new_dag)


### PR DESCRIPTION
Enable pushing to grapher from private datasets. This supports DAGs such as

```
grapher://grapher/gcp/2022-11-11/global_carbon_budget
  - data-private://grapher/gcp/2022-11-11/global_carbon_budget
```

that are run with `etl ... --private --grapher`. It shouldn't raise validation error any more. `grapher-private://` step got also removed as it didn't make any sense (grapher database is always _private_).

@pabloarosado can you merge it yourself if you approve it?