### PR TITLE
Migrate backporting from walden to snapshots

### DIFF
--- a/.dvcignore
+++ b/.dvcignore
@@ -4,9 +4,8 @@
 walkthrough/
 etl/
 data/
-!data/snapshots/
 tests/
-backport/
 vendor/
 .cachedir/
 .venv/
+!data/snapshots/

--- a/backport/bulk_backport.py
+++ b/backport/bulk_backport.py
@@ -5,11 +5,11 @@ import click
 import pandas as pd
 import structlog
 from owid.catalog.utils import underscore
-from owid.walden import Catalog as WaldenCatalog
 from sqlalchemy.engine import Engine
 
 from etl import config
 from etl.db import get_engine
+from etl.snapshot import snapshot_catalog
 from etl.steps import load_dag
 
 from . import utils
@@ -37,7 +37,7 @@ log = structlog.get_logger()
     "--upload/--skip-upload",
     default=True,
     type=bool,
-    help="Upload dataset to Walden",
+    help="Upload dataset to S3",
 )
 @click.option(
     "--force/--no-force",
@@ -49,13 +49,7 @@ log = structlog.get_logger()
     "--prune/--no-prune",
     default=False,
     type=bool,
-    help="Prune datasets from local walden that are not in DB anymore",
-)
-@click.option(
-    "--prune-remote/--no-prune-remote",
-    default=False,
-    type=bool,
-    help="Prune datasets from remote walden that are not in DB anymore",
+    help="Prune datasets from local snapshots that are not in DB anymore",
 )
 @click.option(
     "--backport/--skip-backport",
@@ -70,12 +64,8 @@ def bulk_backport(
     upload: bool,
     force: bool,
     prune: bool,
-    prune_remote: bool,
     backport: bool,
 ) -> None:
-    if prune_remote:
-        assert prune, "--prune-remote must be used together with --prune flag"
-
     engine = get_engine()
 
     if backport:
@@ -103,7 +93,7 @@ def bulk_backport(
             )
 
     if prune:
-        _prune_walden_datasets(engine, dataset_ids, dry_run, prune_remote)
+        _prune_snapshots(engine, dataset_ids, dry_run)
 
     log.info("bulk_backport.finished")
 
@@ -161,31 +151,30 @@ def _active_datasets_names(engine: Engine) -> set[str]:
     return {n + "_config" for n in names} | {n + "_values" for n in names}
 
 
-def _prune_walden_datasets(engine: Engine, dataset_ids: tuple[int], dry_run: bool, prune_remote: bool) -> None:
+def _prune_snapshots(engine: Engine, dataset_ids: tuple[int], dry_run: bool) -> None:
     active_dataset_names = _active_datasets_names(engine)
 
-    walden_catalog = WaldenCatalog()
-    datasets = walden_catalog.find(namespace="backport")
+    # load all backport snapshots
+    snapshots = snapshot_catalog("backport/.*")
 
     # if given dataset ids, only prune those
     if dataset_ids:
-        datasets = [ds for ds in datasets if utils.extract_id_from_short_name(ds.short_name) in dataset_ids]
+        snapshots = [
+            snap for snap in snapshots if utils.extract_id_from_short_name(snap.metadata.short_name) in dataset_ids
+        ]
 
     # datasets that are not among active datasets
     # NOTE: it is important to compare not just dataset id, but the whole name as dataset name
     # can be changed by the user
-    datasets_to_delete = [ds for ds in datasets if ds.short_name not in active_dataset_names]
+    snapshots_to_delete = [snap for snap in snapshots if snap.metadata.short_name not in active_dataset_names]
 
-    log.info("bulk_backport.delete", n=len(datasets_to_delete))
+    log.info("bulk_backport.delete", n=len(snapshots_to_delete))
 
-    for ds in datasets_to_delete:
-        log.info("bulk_backport.delete_dataset", short_name=ds.short_name)
+    for snap in snapshots_to_delete:
+        log.info("bulk_backport.delete_dataset", short_name=snap.metadata.short_name)
 
-        # delete it from local and remote catalog
         if not dry_run:
-            ds.delete()
-            if prune_remote:
-                ds.delete_from_remote()
+            snap.delete_local()
 
 
 def _backported_ids_in_dag() -> list[int]:

--- a/backport/fastback.py
+++ b/backport/fastback.py
@@ -1,3 +1,6 @@
+# WARNING: fast-back is currently disabled and might be deprecated. We've decided to go with fast-track approach
+# that would let authors create datasets in ETL rather than going back and forth with backports.
+
 import concurrent.futures
 import datetime as dt
 import time

--- a/etl/steps/data/garden/sdg/latest/generate_sdg_mapping.ipynb
+++ b/etl/steps/data/garden/sdg/latest/generate_sdg_mapping.ipynb
@@ -204,7 +204,7 @@
     {
      "data": {
       "text/plain": [
-       "'ENV=.env.prod bulk_backport -d 5782 -d 5201 -d 1886 -d 1861 -d 5599 -d 5821 -d 1047 -d 5520 -d 5362 -d 943 -d 5546 -d 115 -d 5676 -d 829 -d 1070 -d 792 -d 5637 -d 1857 -d 5774 -d 3093 -d 5332 -d 5575 -d 5669 -d 5593 -d 5712'"
+       "'ENV=.env.prod bulk_backport -d 5712 -d 829 -d 5669 -d 1886 -d 5332 -d 5520 -d 792 -d 5782 -d 3093 -d 1857 -d 5599 -d 5593 -d 5201 -d 5546 -d 5774 -d 1047 -d 5575 -d 5362 -d 115 -d 5637 -d 5821 -d 1861 -d 1070 -d 5676 -d 943'"
       ]
      },
      "execution_count": 9,
@@ -219,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +265,7 @@
    ],
    "source": [
     "# dependencies for DAG file\n",
-    "print(\"\\n\".join([f\"- backport://backport/owid/latest/{n}\" for n in sorted(list(set(df[\"dataset_name\"])))]))"
+    "print(\"\\n\".join([f\"- snapshot://backport/latest/{n}\" for n in sorted(list(set(df[\"dataset_name\"])))]))"
    ]
   },
   {

--- a/snapshots/backport/latest/dataset_1047_world_bank_gender_statistics__gender_config.json.dvc
+++ b/snapshots/backport/latest/dataset_1047_world_bank_gender_statistics__gender_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:23:30.925935
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_1047_world_bank_gender_statistics__gender
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1047_world_bank_gender_statistics__gender_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1047
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: cc51a67b51d3f69b5f9337861ba11b41
+  size: 350935
+  path: dataset_1047_world_bank_gender_statistics__gender_config.json

--- a/snapshots/backport/latest/dataset_1047_world_bank_gender_statistics__gender_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_1047_world_bank_gender_statistics__gender_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:23:34.130368
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: World Bank Gender Statistics - Gender
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1047_world_bank_gender_statistics__gender_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1047
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 37aa1f52d397ea28d893b4bbe6f01c8e
+  size: 126690
+  path: dataset_1047_world_bank_gender_statistics__gender_values.feather

--- a/snapshots/backport/latest/dataset_1070_statistical_capacity_indicator__sci__world_bank_data_on_statistical_capacity_config.json.dvc
+++ b/snapshots/backport/latest/dataset_1070_statistical_capacity_indicator__sci__world_bank_data_on_statistical_capacity_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:24:43.808121
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_1070_statistical_capacity_indicator__sci__world_bank_data_on_statistical_capacity
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1070_statistical_capacity_indicator__sci__world_bank_data_on_statistical_capacity_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1070
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: e0fb9e784d1180e212ac0a8c5862cf83
+  size: 47634
+  path: dataset_1070_statistical_capacity_indicator__sci__world_bank_data_on_statistical_capacity_config.json

--- a/snapshots/backport/latest/dataset_1070_statistical_capacity_indicator__sci__world_bank_data_on_statistical_capacity_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_1070_statistical_capacity_indicator__sci__world_bank_data_on_statistical_capacity_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:24:49.764625
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: Statistical Capacity Indicator (SCI) - World Bank Data on Statistical Capacity
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1070_statistical_capacity_indicator__sci__world_bank_data_on_statistical_capacity_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1070
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: db1e72ba1d77b7ef9f83b25c082c319d
+  size: 48738
+  path: dataset_1070_statistical_capacity_indicator__sci__world_bank_data_on_statistical_capacity_values.feather

--- a/snapshots/backport/latest/dataset_115_countries_continents_config.json.dvc
+++ b/snapshots/backport/latest/dataset_115_countries_continents_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:38:36.571421
+  description: Continents each country belongs to. Good one.
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_115_countries_continents
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_115_countries_continents_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/115
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 22020e9c2c83a860f82c9485626615f0
+  size: 1266
+  path: dataset_115_countries_continents_config.json

--- a/snapshots/backport/latest/dataset_115_countries_continents_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_115_countries_continents_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:38:38.611121
+  description: Continents each country belongs to. Good one.
+  file_extension: feather
+  is_public: true
+  name: Countries Continents
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_115_countries_continents_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/115
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 14456789ef9a4b4dcebffbabfd644e62
+  size: 16162
+  path: dataset_115_countries_continents_values.feather

--- a/snapshots/backport/latest/dataset_1857_employment_config.json.dvc
+++ b/snapshots/backport/latest/dataset_1857_employment_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:27:12.740132
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_1857_employment
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1857_employment_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1857
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 4c7b94d3b9bbd4a9460b46baa4d65ce7
+  size: 46547
+  path: dataset_1857_employment_config.json

--- a/snapshots/backport/latest/dataset_1857_employment_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_1857_employment_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:27:17.746742
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: Employment
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1857_employment_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1857
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 795a1a1609024f8ac8b08fb78b671fda
+  size: 694274
+  path: dataset_1857_employment_values.feather

--- a/snapshots/backport/latest/dataset_1861_earnings_and_labour_cost_config.json.dvc
+++ b/snapshots/backport/latest/dataset_1861_earnings_and_labour_cost_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:38:18.426592
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_1861_earnings_and_labour_cost
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1861_earnings_and_labour_cost_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1861
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 981ef7801100fe435795d59b283546fb
+  size: 26628
+  path: dataset_1861_earnings_and_labour_cost_config.json

--- a/snapshots/backport/latest/dataset_1861_earnings_and_labour_cost_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_1861_earnings_and_labour_cost_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:38:21.445766
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: Earnings and labour cost
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1861_earnings_and_labour_cost_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1861
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 2c39e44f40a2e087d7664110177ada6c
+  size: 123690
+  path: dataset_1861_earnings_and_labour_cost_values.feather

--- a/snapshots/backport/latest/dataset_1886_minimum_reading_and_maths_proficiency__gem_report__2017_8_config.json.dvc
+++ b/snapshots/backport/latest/dataset_1886_minimum_reading_and_maths_proficiency__gem_report__2017_8_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:27:00.485327
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_1886_minimum_reading_and_maths_proficiency__gem_report__2017_8
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1886_minimum_reading_and_maths_proficiency__gem_report__2017_8_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1886
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 8f75a90b1c8e6ebeb99d120a7cf31dc2
+  size: 6859
+  path: dataset_1886_minimum_reading_and_maths_proficiency__gem_report__2017_8_config.json

--- a/snapshots/backport/latest/dataset_1886_minimum_reading_and_maths_proficiency__gem_report__2017_8_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_1886_minimum_reading_and_maths_proficiency__gem_report__2017_8_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:27:02.298327
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Minimum reading and maths proficiency (GEM Report (2017/8))
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1886_minimum_reading_and_maths_proficiency__gem_report__2017_8_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1886
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 3ce933be3599200cfe16311d02c5c727
+  size: 10498
+  path: dataset_1886_minimum_reading_and_maths_proficiency__gem_report__2017_8_values.feather

--- a/snapshots/backport/latest/dataset_1892_life_expectancy__riley__2005__clio_infra__2015__and_un__2019_config.json.dvc
+++ b/snapshots/backport/latest/dataset_1892_life_expectancy__riley__2005__clio_infra__2015__and_un__2019_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:50:19.506470
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_1892_life_expectancy__riley__2005__clio_infra__2015__and_un__2019
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1892_life_expectancy__riley__2005__clio_infra__2015__and_un__2019_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1892
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 7f07e99d21f310a16928ca72872337d7
+  size: 3787
+  path: dataset_1892_life_expectancy__riley__2005__clio_infra__2015__and_un__2019_config.json

--- a/snapshots/backport/latest/dataset_1892_life_expectancy__riley__2005__clio_infra__2015__and_un__2019_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_1892_life_expectancy__riley__2005__clio_infra__2015__and_un__2019_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:50:22.037366
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Life expectancy - Riley (2005), Clio Infra (2015), and UN (2019)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_1892_life_expectancy__riley__2005__clio_infra__2015__and_un__2019_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/1892
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 2e9dd079415ed109f8516d113648666b
+  size: 109218
+  path: dataset_1892_life_expectancy__riley__2005__clio_infra__2015__and_un__2019_values.feather

--- a/snapshots/backport/latest/dataset_2710_child_mortality_rates__selected_gapminder__v10__2017_config.json.dvc
+++ b/snapshots/backport/latest/dataset_2710_child_mortality_rates__selected_gapminder__v10__2017_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:51:56.217884
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_2710_child_mortality_rates__selected_gapminder__v10__2017
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_2710_child_mortality_rates__selected_gapminder__v10__2017_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/2710
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: fd4ac3df404a08c17890b7fcff86e917
+  size: 3568
+  path: dataset_2710_child_mortality_rates__selected_gapminder__v10__2017_config.json

--- a/snapshots/backport/latest/dataset_2710_child_mortality_rates__selected_gapminder__v10__2017_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_2710_child_mortality_rates__selected_gapminder__v10__2017_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:51:58.537835
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Child Mortality Rates (Selected Gapminder, v10) (2017)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_2710_child_mortality_rates__selected_gapminder__v10__2017_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/2710
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: ca47b13afa6121f987b2457cc867c68d
+  size: 70610
+  path: dataset_2710_child_mortality_rates__selected_gapminder__v10__2017_values.feather

--- a/snapshots/backport/latest/dataset_3093_economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018_config.json.dvc
+++ b/snapshots/backport/latest/dataset_3093_economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:31:59.256325
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_3093_economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_3093_economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/3093
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 6b9a857d40b1461f6b4d36a4c26c264e
+  size: 5692
+  path: dataset_3093_economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018_config.json

--- a/snapshots/backport/latest/dataset_3093_economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_3093_economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:32:02.204263
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Economic losses from disasters as a share of GDP (Pielke, 2018)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_3093_economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/3093
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 7c39c44e41d7dc19751f8d3c4098c64b
+  size: 6954
+  path: dataset_3093_economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018_values.feather

--- a/snapshots/backport/latest/dataset_4129_years_of_schooling__based_on_lee_lee__2016__barro_lee__2018__and_undp__2018_config.json.dvc
+++ b/snapshots/backport/latest/dataset_4129_years_of_schooling__based_on_lee_lee__2016__barro_lee__2018__and_undp__2018_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:51:51.562004
+  description: ''
+  file_extension: json
+  is_public: false
+  name: Grapher metadata for dataset_4129_years_of_schooling__based_on_lee_lee__2016__barro_lee__2018__and_undp__2018
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_4129_years_of_schooling__based_on_lee_lee__2016__barro_lee__2018__and_undp__2018_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/4129
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 4650754f904b75fabdcf80e342316392
+  size: 2564
+  path: dataset_4129_years_of_schooling__based_on_lee_lee__2016__barro_lee__2018__and_undp__2018_config.json

--- a/snapshots/backport/latest/dataset_4129_years_of_schooling__based_on_lee_lee__2016__barro_lee__2018__and_undp__2018_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_4129_years_of_schooling__based_on_lee_lee__2016__barro_lee__2018__and_undp__2018_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:51:53.801251
+  description: ''
+  file_extension: feather
+  is_public: false
+  name: Years of Schooling - based on Lee-Lee (2016), Barro-Lee (2018); and UNDP (2018)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_4129_years_of_schooling__based_on_lee_lee__2016__barro_lee__2018__and_undp__2018_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/4129
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 11ecc3cbfcc373b27d51f366d2aa31e4
+  size: 35650
+  path: dataset_4129_years_of_schooling__based_on_lee_lee__2016__barro_lee__2018__and_undp__2018_values.feather

--- a/snapshots/backport/latest/dataset_5201_forest_land__deforestation_and_change__fao__2020_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5201_forest_land__deforestation_and_change__fao__2020_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:27:07.953322
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5201_forest_land__deforestation_and_change__fao__2020
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5201_forest_land__deforestation_and_change__fao__2020_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5201
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 262afac06b5db428dca54eb2a233bd0e
+  size: 11789
+  path: dataset_5201_forest_land__deforestation_and_change__fao__2020_config.json

--- a/snapshots/backport/latest/dataset_5201_forest_land__deforestation_and_change__fao__2020_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5201_forest_land__deforestation_and_change__fao__2020_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:27:10.172577
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Forest land, deforestation and change (FAO, 2020)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5201_forest_land__deforestation_and_change__fao__2020_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5201
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: ab5f9fc0fbceb5538b0e12e0c5523cf1
+  size: 213626
+  path: dataset_5201_forest_land__deforestation_and_change__fao__2020_values.feather

--- a/snapshots/backport/latest/dataset_5332_water_and_sanitation__who_wash__2021_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5332_water_and_sanitation__who_wash__2021_config.json.dvc
@@ -1,0 +1,19 @@
+meta:
+  date_accessed: 2022-11-29 16:38:24.184724
+  description: "Data cleaned using this script: https://github.com/owid/notebooks/blob/main/FionaSpooner/WASH/cleaning_who_wash_data.Rmd\n\
+    \nScript removes erroneous negative values and rounds data to appropriate number\
+    \ of decimal places, 0 for integer, 2 otherwise. "
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5332_water_and_sanitation__who_wash__2021
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5332_water_and_sanitation__who_wash__2021_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5332
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: a5324e8e946cc44d043f4d14ff3ffb64
+  size: 47034
+  path: dataset_5332_water_and_sanitation__who_wash__2021_config.json

--- a/snapshots/backport/latest/dataset_5332_water_and_sanitation__who_wash__2021_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5332_water_and_sanitation__who_wash__2021_values.feather.dvc
@@ -1,0 +1,19 @@
+meta:
+  date_accessed: 2022-11-29 16:38:32.959988
+  description: "Data cleaned using this script: https://github.com/owid/notebooks/blob/main/FionaSpooner/WASH/cleaning_who_wash_data.Rmd\n\
+    \nScript removes erroneous negative values and rounds data to appropriate number\
+    \ of decimal places, 0 for integer, 2 otherwise. "
+  file_extension: feather
+  is_public: true
+  name: Water and Sanitation (WHO WASH, 2021)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5332_water_and_sanitation__who_wash__2021_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5332
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: e030d3d1128f676f787921dec495a3b4
+  size: 1618266
+  path: dataset_5332_water_and_sanitation__who_wash__2021_values.feather

--- a/snapshots/backport/latest/dataset_5347_statistical_review_of_world_energy__bp__2021_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5347_statistical_review_of_world_energy__bp__2021_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:48:54.946599
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5347_statistical_review_of_world_energy__bp__2021
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5347_statistical_review_of_world_energy__bp__2021_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5347
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: b0ab04fa5a19f80314178ef4e8c81c73
+  size: 64441
+  path: dataset_5347_statistical_review_of_world_energy__bp__2021_config.json

--- a/snapshots/backport/latest/dataset_5347_statistical_review_of_world_energy__bp__2021_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5347_statistical_review_of_world_energy__bp__2021_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:49:02.027097
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: Statistical Review of World Energy - BP (2021)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5347_statistical_review_of_world_energy__bp__2021_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5347
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 847c48a00a483f7be1fd5ba24a9fc1fb
+  size: 1613202
+  path: dataset_5347_statistical_review_of_world_energy__bp__2021_values.feather

--- a/snapshots/backport/latest/dataset_5362_world_bank_edstats_2020_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5362_world_bank_edstats_2020_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:29:23.911925
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5362_world_bank_edstats_2020
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5362_world_bank_edstats_2020_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5362
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 878b03e2857038680c828f5854257b88
+  size: 3672418
+  path: dataset_5362_world_bank_edstats_2020_config.json

--- a/snapshots/backport/latest/dataset_5362_world_bank_edstats_2020_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5362_world_bank_edstats_2020_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:31:38.217929
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: World Bank EdStats 2020
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5362_world_bank_edstats_2020_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5362
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 73ef7f90786a384eec78401b9adba5f3
+  size: 27762802
+  path: dataset_5362_world_bank_edstats_2020_values.feather

--- a/snapshots/backport/latest/dataset_5520_united_nations_sustainable_development_goals__united_nations__2022_02_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5520_united_nations_sustainable_development_goals__united_nations__2022_02_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:19:19.367184
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5520_united_nations_sustainable_development_goals__united_nations__2022_02
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5520_united_nations_sustainable_development_goals__united_nations__2022_02_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5520
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: cc72121739db8152a73e90ae208864e3
+  size: 4540753
+  path: dataset_5520_united_nations_sustainable_development_goals__united_nations__2022_02_config.json

--- a/snapshots/backport/latest/dataset_5520_united_nations_sustainable_development_goals__united_nations__2022_02_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5520_united_nations_sustainable_development_goals__united_nations__2022_02_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:20:38.673382
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: United Nations Sustainable Development Goals - United Nations (2022-02)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5520_united_nations_sustainable_development_goals__united_nations__2022_02_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5520
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 2b9a7c5e2329615e26700c680146648f
+  size: 10266946
+  path: dataset_5520_united_nations_sustainable_development_goals__united_nations__2022_02_values.feather

--- a/snapshots/backport/latest/dataset_5546_democracy__lexical_index_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5546_democracy__lexical_index_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:34:47.120850
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5546_democracy__lexical_index
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5546_democracy__lexical_index_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5546
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 074abe26846675f65f9c3a41dc23380d
+  size: 37350
+  path: dataset_5546_democracy__lexical_index_config.json

--- a/snapshots/backport/latest/dataset_5546_democracy__lexical_index_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5546_democracy__lexical_index_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:34:57.040056
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Democracy - Lexical Index
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5546_democracy__lexical_index_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5546
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 0fdcb221309cb94302558a2d87087688
+  size: 2592730
+  path: dataset_5546_democracy__lexical_index_values.feather

--- a/snapshots/backport/latest/dataset_5575_united_nations_sustainable_development_goals__united_nations__2022_04_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5575_united_nations_sustainable_development_goals__united_nations__2022_04_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:25:19.498698
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5575_united_nations_sustainable_development_goals__united_nations__2022_04
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5575_united_nations_sustainable_development_goals__united_nations__2022_04_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5575
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 7c61d62920d4ff837e48f32f0f05c5e9
+  size: 4311060
+  path: dataset_5575_united_nations_sustainable_development_goals__united_nations__2022_04_config.json

--- a/snapshots/backport/latest/dataset_5575_united_nations_sustainable_development_goals__united_nations__2022_04_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5575_united_nations_sustainable_development_goals__united_nations__2022_04_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:26:44.221932
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: United Nations Sustainable Development Goals - United Nations (2022-04)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5575_united_nations_sustainable_development_goals__united_nations__2022_04_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5575
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: cb7cef5ed3c2ae7e5571da76b14f73de
+  size: 19472002
+  path: dataset_5575_united_nations_sustainable_development_goals__united_nations__2022_04_values.feather

--- a/snapshots/backport/latest/dataset_5593_ihme__global_burden_of_disease__risk_factors__institute_for_health_metrics_and_evaluation__2022_04_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5593_ihme__global_burden_of_disease__risk_factors__institute_for_health_metrics_and_evaluation__2022_04_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:23:36.726861
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5593_ihme__global_burden_of_disease__risk_factors__institute_for_health_metrics_and_evaluation__2022_04
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5593_ihme__global_burden_of_disease__risk_factors__institute_for_health_metrics_and_evaluation__2022_04_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5593
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 34c5d31149d71a201393a764d69181a6
+  size: 145746
+  path: dataset_5593_ihme__global_burden_of_disease__risk_factors__institute_for_health_metrics_and_evaluation__2022_04_config.json

--- a/snapshots/backport/latest/dataset_5593_ihme__global_burden_of_disease__risk_factors__institute_for_health_metrics_and_evaluation__2022_04_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5593_ihme__global_burden_of_disease__risk_factors__institute_for_health_metrics_and_evaluation__2022_04_values.feather.dvc
@@ -1,0 +1,18 @@
+meta:
+  date_accessed: 2022-11-29 16:24:36.352020
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: IHME - Global Burden of Disease - Risk Factors - Institute for Health Metrics
+    and Evaluation  (2022-04)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5593_ihme__global_burden_of_disease__risk_factors__institute_for_health_metrics_and_evaluation__2022_04_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5593
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: f2e3445f501922b3d9df6d2bf3695209
+  size: 6510266
+  path: dataset_5593_ihme__global_burden_of_disease__risk_factors__institute_for_health_metrics_and_evaluation__2022_04_values.feather

--- a/snapshots/backport/latest/dataset_5599_ihme__global_burden_of_disease__deaths_and_dalys__institute_for_health_metrics_and_evaluation__2022_04_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5599_ihme__global_burden_of_disease__deaths_and_dalys__institute_for_health_metrics_and_evaluation__2022_04_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:32:04.694495
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5599_ihme__global_burden_of_disease__deaths_and_dalys__institute_for_health_metrics_and_evaluation__2022_04
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5599_ihme__global_burden_of_disease__deaths_and_dalys__institute_for_health_metrics_and_evaluation__2022_04_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5599
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 595766893107c142ca33daf10ad4af7f
+  size: 381287
+  path: dataset_5599_ihme__global_burden_of_disease__deaths_and_dalys__institute_for_health_metrics_and_evaluation__2022_04_config.json

--- a/snapshots/backport/latest/dataset_5599_ihme__global_burden_of_disease__deaths_and_dalys__institute_for_health_metrics_and_evaluation__2022_04_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5599_ihme__global_burden_of_disease__deaths_and_dalys__institute_for_health_metrics_and_evaluation__2022_04_values.feather.dvc
@@ -1,0 +1,18 @@
+meta:
+  date_accessed: 2022-11-29 16:34:28.233227
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: IHME - Global Burden of Disease - Deaths and DALYs - Institute for Health
+    Metrics and Evaluation  (2022-04)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5599_ihme__global_burden_of_disease__deaths_and_dalys__institute_for_health_metrics_and_evaluation__2022_04_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5599
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: ad25a9862efc68af6daaf3ea44bdf194
+  size: 18850514
+  path: dataset_5599_ihme__global_burden_of_disease__deaths_and_dalys__institute_for_health_metrics_and_evaluation__2022_04_values.feather

--- a/snapshots/backport/latest/dataset_5600_democracy_and_human_rights__owid_based_on_varieties_of_democracy__v12__and_regimes_of_the_world_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5600_democracy_and_human_rights__owid_based_on_varieties_of_democracy__v12__and_regimes_of_the_world_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:50:26.763991
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5600_democracy_and_human_rights__owid_based_on_varieties_of_democracy__v12__and_regimes_of_the_world
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5600_democracy_and_human_rights__owid_based_on_varieties_of_democracy__v12__and_regimes_of_the_world_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5600
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 962d6b4f06fc22097c734711f565b7f1
+  size: 158630
+  path: dataset_5600_democracy_and_human_rights__owid_based_on_varieties_of_democracy__v12__and_regimes_of_the_world_config.json

--- a/snapshots/backport/latest/dataset_5600_democracy_and_human_rights__owid_based_on_varieties_of_democracy__v12__and_regimes_of_the_world_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5600_democracy_and_human_rights__owid_based_on_varieties_of_democracy__v12__and_regimes_of_the_world_values.feather.dvc
@@ -1,0 +1,18 @@
+meta:
+  date_accessed: 2022-11-29 16:51:35.219027
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Democracy and Human rights - OWID based on Varieties of Democracy (v12) and
+    Regimes of the World
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5600_democracy_and_human_rights__owid_based_on_varieties_of_democracy__v12__and_regimes_of_the_world_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5600
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 3b1724cf75a6a447eab91c73261c7bdd
+  size: 19541946
+  path: dataset_5600_democracy_and_human_rights__owid_based_on_varieties_of_democracy__v12__and_regimes_of_the_world_values.feather

--- a/snapshots/backport/latest/dataset_5637_world_development_indicators__world_bank__2022_05_26_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5637_world_development_indicators__world_bank__2022_05_26_config.json.dvc
@@ -1,0 +1,20 @@
+meta:
+  date_accessed: 2022-11-29 16:35:02.196291
+  description: The World Development Indicators (WDI) is the primary World Bank collection
+    of development indicators, compiled from officially-recognized international sources.
+    It presents the most current and accurate global development data available, and
+    includes national, regional and global estimates.
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5637_world_development_indicators__world_bank__2022_05_26
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5637_world_development_indicators__world_bank__2022_05_26_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5637
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 9d2de0433759755146db27cb2794a236
+  size: 3278485
+  path: dataset_5637_world_development_indicators__world_bank__2022_05_26_config.json

--- a/snapshots/backport/latest/dataset_5637_world_development_indicators__world_bank__2022_05_26_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5637_world_development_indicators__world_bank__2022_05_26_values.feather.dvc
@@ -1,0 +1,20 @@
+meta:
+  date_accessed: 2022-11-29 16:37:53.385446
+  description: The World Development Indicators (WDI) is the primary World Bank collection
+    of development indicators, compiled from officially-recognized international sources.
+    It presents the most current and accurate global development data available, and
+    includes national, regional and global estimates.
+  file_extension: feather
+  is_public: true
+  name: World Development Indicators - World Bank (2022.05.26)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5637_world_development_indicators__world_bank__2022_05_26_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5637
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 5c3680309390cb0e154cfb7f973649f5
+  size: 38826322
+  path: dataset_5637_world_development_indicators__world_bank__2022_05_26_values.feather

--- a/snapshots/backport/latest/dataset_5650_statistical_review_of_world_energy__bp__2022_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5650_statistical_review_of_world_energy__bp__2022_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:17:42.649938
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5650_statistical_review_of_world_energy__bp__2022
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5650_statistical_review_of_world_energy__bp__2022_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5650
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 6d278cd45dee1573c705d724f61408a6
+  size: 63970
+  path: dataset_5650_statistical_review_of_world_energy__bp__2022_config.json

--- a/snapshots/backport/latest/dataset_5650_statistical_review_of_world_energy__bp__2022_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5650_statistical_review_of_world_energy__bp__2022_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:17:55.729325
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: Statistical Review of World Energy - BP (2022)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5650_statistical_review_of_world_energy__bp__2022_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5650
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: b0eb30e4ba0a5d7ff22878c675a6bf54
+  size: 1684138
+  path: dataset_5650_statistical_review_of_world_energy__bp__2022_values.feather

--- a/snapshots/backport/latest/dataset_5669_un_sdg__2022_07_07_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5669_un_sdg__2022_07_07_config.json.dvc
@@ -1,0 +1,19 @@
+meta:
+  date_accessed: 2022-11-29 16:27:24.791867
+  description: The United Nations Sustainable Development Goal (SDG) dataset is the
+    primary collection of data tracking progress towards the SDG indicators, compiled
+    from officially-recognized international sources.
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5669_un_sdg__2022_07_07
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5669_un_sdg__2022_07_07_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5669
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 7f6dbb476acf4be9b668d834d99258fd
+  size: 8556149
+  path: dataset_5669_un_sdg__2022_07_07_config.json

--- a/snapshots/backport/latest/dataset_5669_un_sdg__2022_07_07_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5669_un_sdg__2022_07_07_values.feather.dvc
@@ -1,0 +1,19 @@
+meta:
+  date_accessed: 2022-11-29 16:29:05.264063
+  description: The United Nations Sustainable Development Goal (SDG) dataset is the
+    primary collection of data tracking progress towards the SDG indicators, compiled
+    from officially-recognized international sources.
+  file_extension: feather
+  is_public: true
+  name: un_sdg__2022_07_07
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5669_un_sdg__2022_07_07_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5669
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: c5b6ee44a91a2f2ca04de432fd9e3e81
+  size: 21921834
+  path: dataset_5669_un_sdg__2022_07_07_values.feather

--- a/snapshots/backport/latest/dataset_5676_global_health_observatory__world_health_organization__2022_08_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5676_global_health_observatory__world_health_organization__2022_08_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:20:47.348974
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5676_global_health_observatory__world_health_organization__2022_08
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5676_global_health_observatory__world_health_organization__2022_08_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5676
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: c76f1460a173966dfd766a85c4686eb1
+  size: 10068008
+  path: dataset_5676_global_health_observatory__world_health_organization__2022_08_config.json

--- a/snapshots/backport/latest/dataset_5676_global_health_observatory__world_health_organization__2022_08_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5676_global_health_observatory__world_health_organization__2022_08_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:23:06.193306
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: Global Health Observatory - World Health Organization (2022.08)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5676_global_health_observatory__world_health_organization__2022_08_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5676
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 67a5ff7a226d1bd4be412e6c0a0228e4
+  size: 31580722
+  path: dataset_5676_global_health_observatory__world_health_organization__2022_08_values.feather

--- a/snapshots/backport/latest/dataset_5712_food_security__suite_of_food_security_indicators__fao__2022_05_17_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5712_food_security__suite_of_food_security_indicators__fao__2022_05_17_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:24:53.348117
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5712_food_security__suite_of_food_security_indicators__fao__2022_05_17
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5712_food_security__suite_of_food_security_indicators__fao__2022_05_17_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5712
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: a3d463ef91600ff3e286b9d40fc36b25
+  size: 54378
+  path: dataset_5712_food_security__suite_of_food_security_indicators__fao__2022_05_17_config.json

--- a/snapshots/backport/latest/dataset_5712_food_security__suite_of_food_security_indicators__fao__2022_05_17_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5712_food_security__suite_of_food_security_indicators__fao__2022_05_17_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:25:02.962652
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: 'Food Security: Suite of Food Security Indicators (FAO, 2022-05-17)'
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5712_food_security__suite_of_food_security_indicators__fao__2022_05_17_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5712
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 79e01b1a621f2d3b2b03117d1085de97
+  size: 485042
+  path: dataset_5712_food_security__suite_of_food_security_indicators__fao__2022_05_17_values.feather

--- a/snapshots/backport/latest/dataset_5757_multidimensional_poverty_index__mpi__2022__current_estimates_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5757_multidimensional_poverty_index__mpi__2022__current_estimates_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:25:13.346213
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5757_multidimensional_poverty_index__mpi__2022__current_estimates
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5757_multidimensional_poverty_index__mpi__2022__current_estimates_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5757
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 9fefc3cd910669c9004c5d5c266cfeec
+  size: 43627
+  path: dataset_5757_multidimensional_poverty_index__mpi__2022__current_estimates_config.json

--- a/snapshots/backport/latest/dataset_5757_multidimensional_poverty_index__mpi__2022__current_estimates_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5757_multidimensional_poverty_index__mpi__2022__current_estimates_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:25:15.442990
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Multidimensional Poverty Index (MPI) 2022 – Current estimates
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5757_multidimensional_poverty_index__mpi__2022__current_estimates_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5757
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 31b4de5cb86c39b783b6857dd64cba35
+  size: 19650
+  path: dataset_5757_multidimensional_poverty_index__mpi__2022__current_estimates_values.feather

--- a/snapshots/backport/latest/dataset_5774_key_indicators_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5774_key_indicators_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 18:37:56.767319
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5774_key_indicators
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5774_key_indicators_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5774
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 1d06eed3ae1006a3ccf3dcb06e4abb2a
+  size: 12114
+  path: dataset_5774_key_indicators_config.json

--- a/snapshots/backport/latest/dataset_5774_key_indicators_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5774_key_indicators_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 18:38:19.585470
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Key Indicators
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5774_key_indicators_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5774
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 08279876aa387cd13393d0eb94f0046b
+  size: 1457986
+  path: dataset_5774_key_indicators_values.feather

--- a/snapshots/backport/latest/dataset_5782_who_immunization_data__2022_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5782_who_immunization_data__2022_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-30 12:28:03.956589
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5782_who_immunization_data__2022
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5782_who_immunization_data__2022_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5782
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: e4dd809d8a9a51ddc5226c2338c34ad6
+  size: 25966
+  path: dataset_5782_who_immunization_data__2022_config.json

--- a/snapshots/backport/latest/dataset_5782_who_immunization_data__2022_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5782_who_immunization_data__2022_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-30 12:28:10.909534
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: WHO Immunization Data (2022)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5782_who_immunization_data__2022_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5782
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 2de2c9aa3df9e3e6e949fd16e6c92e80
+  size: 784466
+  path: dataset_5782_who_immunization_data__2022_values.feather

--- a/snapshots/backport/latest/dataset_581_daily_supply_of_calories_per_person__owid_based_on_un_fao__and__historical_sources_config.json.dvc
+++ b/snapshots/backport/latest/dataset_581_daily_supply_of_calories_per_person__owid_based_on_un_fao__and__historical_sources_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:51:45.832274
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_581_daily_supply_of_calories_per_person__owid_based_on_un_fao__and__historical_sources
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_581_daily_supply_of_calories_per_person__owid_based_on_un_fao__and__historical_sources_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/581
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 731c07ea9d295c1f7f20532fa401b121
+  size: 2299
+  path: dataset_581_daily_supply_of_calories_per_person__owid_based_on_un_fao__and__historical_sources_config.json

--- a/snapshots/backport/latest/dataset_581_daily_supply_of_calories_per_person__owid_based_on_un_fao__and__historical_sources_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_581_daily_supply_of_calories_per_person__owid_based_on_un_fao__and__historical_sources_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:51:48.124613
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Daily supply of calories per person (OWID based on UN FAO & historical sources)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_581_daily_supply_of_calories_per_person__owid_based_on_un_fao__and__historical_sources_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/581
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 87b34f7d75f677160ef030a26c8b73b7
+  size: 51546
+  path: dataset_581_daily_supply_of_calories_per_person__owid_based_on_un_fao__and__historical_sources_values.feather

--- a/snapshots/backport/latest/dataset_5821_gender_statistics__world_bank__2022_10_29_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5821_gender_statistics__world_bank__2022_10_29_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-30 12:30:09.352580
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_5821_gender_statistics__world_bank__2022_10_29
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5821_gender_statistics__world_bank__2022_10_29_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5821
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: d4828c91303555a6fa915386ddbc0a16
+  size: 1182114
+  path: dataset_5821_gender_statistics__world_bank__2022_10_29_config.json

--- a/snapshots/backport/latest/dataset_5821_gender_statistics__world_bank__2022_10_29_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5821_gender_statistics__world_bank__2022_10_29_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-30 12:31:30.886546
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Gender Statistics - World Bank (2022-10-29)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_5821_gender_statistics__world_bank__2022_10_29_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/5821
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: dcf34d401463a4473c9dac1b20d0b937
+  size: 14253346
+  path: dataset_5821_gender_statistics__world_bank__2022_10_29_values.feather

--- a/snapshots/backport/latest/dataset_792_investment__credit_to_agriculture__fao__2017_config.json.dvc
+++ b/snapshots/backport/latest/dataset_792_investment__credit_to_agriculture__fao__2017_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:19:08.533946
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_792_investment__credit_to_agriculture__fao__2017
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_792_investment__credit_to_agriculture__fao__2017_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/792
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 9f6883d16a456d3b2e062203028864d4
+  size: 4346
+  path: dataset_792_investment__credit_to_agriculture__fao__2017_config.json

--- a/snapshots/backport/latest/dataset_792_investment__credit_to_agriculture__fao__2017_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_792_investment__credit_to_agriculture__fao__2017_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:19:14.640351
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: 'Investment: Credit to Agriculture - FAO (2017)'
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_792_investment__credit_to_agriculture__fao__2017_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/792
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: ae7a287af9ad558ad9abceacf1b99fd3
+  size: 85162
+  path: dataset_792_investment__credit_to_agriculture__fao__2017_values.feather

--- a/snapshots/backport/latest/dataset_829_food_security__suite_of_food_security_indicators__fao__2017_config.json.dvc
+++ b/snapshots/backport/latest/dataset_829_food_security__suite_of_food_security_indicators__fao__2017_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:25:06.178910
+  description: This is a dataset imported by the automated fetcher
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_829_food_security__suite_of_food_security_indicators__fao__2017
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_829_food_security__suite_of_food_security_indicators__fao__2017_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/829
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 6f800ead5b45be8a4dade2371ac078e1
+  size: 47062
+  path: dataset_829_food_security__suite_of_food_security_indicators__fao__2017_config.json

--- a/snapshots/backport/latest/dataset_829_food_security__suite_of_food_security_indicators__fao__2017_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_829_food_security__suite_of_food_security_indicators__fao__2017_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:25:10.830860
+  description: This is a dataset imported by the automated fetcher
+  file_extension: feather
+  is_public: true
+  name: 'Food Security: Suite of Food Security Indicators - FAO (2017)'
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_829_food_security__suite_of_food_security_indicators__fao__2017_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/829
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: 7743ef00f1d2589d76ea4f0508bf9f37
+  size: 232810
+  path: dataset_829_food_security__suite_of_food_security_indicators__fao__2017_values.feather

--- a/snapshots/backport/latest/dataset_943_sexual_violence__unicef__2017_config.json.dvc
+++ b/snapshots/backport/latest/dataset_943_sexual_violence__unicef__2017_config.json.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:27:04.252435
+  description: ''
+  file_extension: json
+  is_public: true
+  name: Grapher metadata for dataset_943_sexual_violence__unicef__2017
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_943_sexual_violence__unicef__2017_config
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/943
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: d59bcf3bb0d859f9526e371d67b65e68
+  size: 2778
+  path: dataset_943_sexual_violence__unicef__2017_config.json

--- a/snapshots/backport/latest/dataset_943_sexual_violence__unicef__2017_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_943_sexual_violence__unicef__2017_values.feather.dvc
@@ -1,0 +1,17 @@
+meta:
+  date_accessed: 2022-11-29 16:27:06.004500
+  description: ''
+  file_extension: feather
+  is_public: true
+  name: Sexual Violence – UNICEF (2017)
+  namespace: backport
+  publication_date: latest
+  short_name: dataset_943_sexual_violence__unicef__2017_values
+  source_name: Our World in Data catalog backport
+  url: https://owid.cloud/admin/datasets/943
+  version: latest
+wdir: ../../../data/snapshots/backport/latest
+outs:
+- md5: c501dc780090a111dac31eeb5ed15a46
+  size: 7826
+  path: dataset_943_sexual_violence__unicef__2017_values.feather


### PR DESCRIPTION
Migrate backports from Walden to Snapshots. This migration slightly simplifies the logic and prevents checksum conflicts that have been occasionally happening.

Related PR in analytics https://github.com/owid/analytics/pull/64 (this will be further tested).

## How to review

Backporting logic hasn't changed and snapshots have only simplified things (e.g. we're not using special `origin_md5` field on walden dataset anymore because it's already part of snapshot). We're still generating one JSON for config and one feather for data, only the way we access them has changed (used to be `WaldenDataset` now it is `SnapshotMeta` and `Snapshot` objects). Additionally, I've added `workers` argument to backporting to make it faster (checking all backports used to take >1min which was annoying).

Files in `snapshots/backport/latest` were generated by `bulk_backport` and contain all backports needed by ETL. No need to review them.

To test it backporting you can run `bulk_backport -d 1892` and to test ETL you can run `etl data://garden/country_profile/2022/overview --dry-run` (and see `snapshot://` steps there).