### PR TITLE
feat(emdat): Add natural disasters explorer step

### DIFF
--- a/dag.yml
+++ b/dag.yml
@@ -217,6 +217,9 @@ steps:
   # The following dataset has only global data, and entity corresponds to the type of disaster.
   data://grapher/emdat/2022-11-24/natural_disasters_global_by_type:
     - data://garden/emdat/2022-11-24/natural_disasters
+  # Natural disasters explorer.
+  data://explorers/emdat/2022-12-07/natural_disasters:
+    - data://garden/emdat/2022-11-24/natural_disasters
 
   # Country profiles - overview
   data://garden/country_profile/2022/overview:

--- a/etl/steps/data/explorers/emdat/2022-12-07/natural_disasters.py
+++ b/etl/steps/data/explorers/emdat/2022-12-07/natural_disasters.py
@@ -1,0 +1,91 @@
+"""Natural disasters explorer data step.
+
+Loads the latest EM-DAT natural_disasters data from garden and stores a table (as a csv file) for yearly data, and
+another for decadal data.
+
+"""
+
+from copy import deepcopy
+
+from owid import catalog
+
+from etl.paths import DATA_DIR
+
+# NOTE: Some of the columns in the output files are not used by the explorer, consider removing them.
+# For now, we'll ensure all of the old columns are present, to avoid any possible issues.
+DISASTER_TYPE_RENAMING = {
+    "all_disasters": "all_disasters",
+    "drought": "drought",
+    "earthquake": "earthquake",
+    "extreme_temperature": "temperature",
+    "flood": "flood",
+    "fog": "fog",
+    "glacial_lake_outburst": "glacial_lake",
+    "landslide": "landslide",
+    "dry_mass_movement": "mass_movement",
+    "extreme_weather": "storm",
+    "volcanic_activity": "volcanic",
+    "wildfire": "wildfire",
+}
+
+
+def create_wide_tables(table: catalog.Table) -> catalog.Table:
+    # Adapt disaster type names to match those in the old explorer files.
+    table = table.reset_index()
+    table["type"] = table["type"].replace(DISASTER_TYPE_RENAMING)
+
+    # Create wide dataframes.
+    table_wide = table.pivot(index=["country", "year"], columns="type")
+
+    # Flatten column indexes and rename columns to match the old names in explorer.
+    table_wide.columns = [
+        f"{column}_{subcolumn}".replace("per_100k_people", "rate_per_100k")
+        .replace("total_dead", "deaths")
+        .replace("total_damages_per_gdp", "total_damages_pct_gdp")
+        for column, subcolumn in table_wide.columns
+    ]
+
+    # Remove unnecessary columns.
+    table_wide = table_wide[
+        [
+            column
+            for column in table_wide.columns
+            if not column.startswith(
+                ("gdp_", "n_events_", "population_", "insured_damages_per_gdp", "reconstruction_costs_per_gdp_")
+            )
+            if column
+            not in [
+                "affected_rate_per_100k_glacial_lake",
+                "homeless_rate_per_100k_glacial_lake",
+                "total_damages_pct_gdp_fog",
+            ]
+        ]
+    ]
+
+    # Adapt table to the format for explorer files.
+    table_wide = table_wide.reset_index()
+
+    return table_wide
+
+
+def run(dest_dir: str) -> None:
+    # Load the latest dataset from garden.
+    dataset_garden_latest_dir = sorted((DATA_DIR / "garden" / "emdat").glob("*/natural_disasters"))[-1]
+    dataset_garden = catalog.Dataset(dataset_garden_latest_dir)
+
+    # Load tables with yearly and decadal data.
+    table_yearly = dataset_garden["natural_disasters_yearly"]
+    table_decade = dataset_garden["natural_disasters_decadal"]
+
+    # Create wide tables adapted to the old format in explorers.
+    table_yearly_wide = create_wide_tables(table=table_yearly)
+    table_decade_wide = create_wide_tables(table=table_decade)
+
+    # Initialize a new grapher dataset and add dataset metadata.
+    dataset = catalog.Dataset.create_empty(dest_dir)
+    dataset.metadata = deepcopy(dataset_garden.metadata)
+    dataset.save()
+
+    # Add tables to dataset. Force publication in csv.
+    dataset.add(table_yearly_wide, formats=["csv"])
+    dataset.add(table_decade_wide, formats=["csv"])

--- a/etl/steps/data/explorers/emdat/2022-12-07/natural_disasters.py
+++ b/etl/steps/data/explorers/emdat/2022-12-07/natural_disasters.py
@@ -3,6 +3,16 @@
 Loads the latest EM-DAT natural_disasters data from garden and stores a table (as a csv file) for yearly data, and
 another for decadal data.
 
+NOTES:
+* Some of the columns in the output files are not used by the explorer (but they appear in the "Sort by" dropdown menu),
+  consider removing them. For now, we'll ensure all of the old columns are present, to avoid any possible issues.
+* Most charts in the explorer are generated from the data in the files, but 3 of them are directly linked to grapher
+  charts, namely:
+  "All disasters (by type) - Deaths - Decadal average - false"
+  "All disasters (by type) - Deaths - Decadal average - true"
+  "All disasters (by type) - Economic damages (% GDP) - Decadal average - false"
+  At some point it would be good to let the explorer take all the data from files.
+
 """
 
 from copy import deepcopy
@@ -11,8 +21,7 @@ from owid import catalog
 
 from etl.paths import DATA_DIR
 
-# NOTE: Some of the columns in the output files are not used by the explorer, consider removing them.
-# For now, we'll ensure all of the old columns are present, to avoid any possible issues.
+# Mapping of old to new disaster type names.
 DISASTER_TYPE_RENAMING = {
     "all_disasters": "all_disasters",
     "drought": "drought",

--- a/etl/steps/data/explorers/emdat/2022-12-07/natural_disasters.py
+++ b/etl/steps/data/explorers/emdat/2022-12-07/natural_disasters.py
@@ -39,6 +39,9 @@ DISASTER_TYPE_RENAMING = {
 
 
 def create_wide_tables(table: catalog.Table) -> catalog.Table:
+    """Convert input table from long to wide format, and adjust column names to adjust to the old names in the files
+    used by the explorer.
+    """
     # Adapt disaster type names to match those in the old explorer files.
     table = table.reset_index()
     table["type"] = table["type"].replace(DISASTER_TYPE_RENAMING)


### PR DESCRIPTION
Add natural disasters explorer step, which simply takes the annual/decadal tables from garden, and exports two tables with the same columns as those needed in the explorer.
