### PR TITLE
enhance(snapshots): use Cloudflare cdn for accessing public snapshots

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -4,6 +4,9 @@
     url = s3://owid-catalog/snapshots
     endpointurl = https://nyc3.digitaloceanspaces.com
     acl = public-read
+['remote "public-read"']
+    # Use Cloudflare CDN for pulling public data (also users won't need AWS config)
+    url = https://catalog.ourworldindata.org/snapshots
 ['remote "private"']
     url = s3://owid-catalog/snapshots-private
     endpointurl = https://nyc3.digitaloceanspaces.com

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -75,7 +75,7 @@ class Snapshot:
 
     @property
     def _dvc_remote(self):
-        return "public" if self.metadata.is_public else "private"
+        return "public-read" if self.metadata.is_public else "private"
 
 
 @pruned_json

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -520,7 +520,7 @@ class SnapshotStep(Step):
         return f"snapshot://{self.path}"
 
     def run(self) -> None:
-        DVC_REPO.pull(self._path, remote="public", force=True)
+        DVC_REPO.pull(self._path, remote="public-read", force=True)
 
     def is_dirty(self) -> bool:
         # check if the snapshot has been added to DVC


### PR DESCRIPTION
ETL users without AWS config (any config, not necessarily ours) couldn't pull snapshots and got weird DVC error. Make DVC pull public files from https://catalog.ourworldindata.org/snapshots instead of S3. Using CDN also speeds up access and reduce bandwidth costs.