### PR TITLE
enhance(yaml): add yaml_dump for proper writing of multi-line strings

### DIFF
--- a/etl/metadata_export.py
+++ b/etl/metadata_export.py
@@ -1,9 +1,10 @@
 import os
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 import click
-import yaml
 from owid.catalog import Dataset
+
+from etl.files import yaml_dump
 
 
 @click.command(help=__doc__)
@@ -90,7 +91,7 @@ def metadata_export(
         "tables": tb_meta,
     }
 
-    return cast(str, yaml.dump(final, sort_keys=False, allow_unicode=True))
+    return yaml_dump(final)  # type: ignore
 
 
 def _prune_empty(d: Dict[str, Any]) -> None:

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -15,6 +15,7 @@ from owid.datautils import dataframes
 from owid.walden import files
 
 from etl import paths
+from etl.files import yaml_dump
 
 dvc = Repo(paths.BASE_DIR)
 
@@ -138,7 +139,7 @@ class SnapshotMeta:
     def save(self) -> None:
         self.path.parent.mkdir(exist_ok=True, parents=True)
         with open(self.path, "w") as ostream:
-            yaml.dump({"meta": self.to_dict()}, ostream)
+            yaml_dump({"meta": self.to_dict()}, ostream)
 
     @property
     def uri(self):

--- a/fasttrack/yaml_meta.py
+++ b/fasttrack/yaml_meta.py
@@ -1,8 +1,9 @@
 import datetime as dt
 from typing import Any, List, Optional, Union
 
-import yaml
 from pydantic import BaseModel, Extra, Field
+
+from etl.files import yaml_dump
 
 
 class YAMLSourceMeta(BaseModel):
@@ -61,5 +62,5 @@ class YAMLMeta(BaseModel):
     dataset: YAMLDatasetMeta
     tables: dict[str, YAMLTableMeta]
 
-    def to_yaml(self):
-        return yaml.dump(self.dict(exclude_none=True, exclude_unset=True), sort_keys=False, allow_unicode=True)
+    def to_yaml(self) -> str:
+        return yaml_dump(self.dict(exclude_none=True, exclude_unset=True))  # type: ignore

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -10,3 +10,23 @@ def test_walk_ignore_set(tmp_path):
 
     outfiles = files.walk(tmp_path)
     assert [f.name for f in outfiles] == ["test.py"]
+
+
+def test_yaml_dump():
+    d = {"a": "Multi-line\nstring\n with whitespaces!", "b": "One-liner", "c": {"nested": {"d": ["\nline  \n"]}}}
+
+    out = files.yaml_dump(d)
+    print(out)
+    assert (
+        out
+        == """a: |-
+  Multi-line
+  string
+  with whitespaces!
+b: One-liner
+c:
+  nested:
+    d:
+    - line
+"""
+    )


### PR DESCRIPTION
Dumping strings to YAML were sometimes producing weird single-line strings full of `\n` newline characters. Turned out it was caused by non-stripped lines in multi-line strings. This PR fixes that and creates consistent function for dumping dictionaries to YAML format.