### PR TITLE
feature(datadiff): CLI for checking differences between two catalogs

### DIFF
--- a/etl/compare.py
+++ b/etl/compare.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 
 import click
 import pandas as pd
+import rich
 from dotenv import dotenv_values
 from owid import catalog
 from owid.repack import repack_frame
@@ -79,6 +80,7 @@ def diff_print(
     show_values: bool,
     show_shared: bool,
     truncate_lists_at: int,
+    print: Any = rich.print,
 ) -> int:
     """Runs the comparison and prints the differences, then return exit code."""
     diff = tempcompare.HighLevelDiff(df1, df2, absolute_tolerance, relative_tolerance)

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -114,7 +114,7 @@ class DatasetDiff:
 
                     if changed:
                         self.p(f"\t\t[yellow]~ Column [b]{col}[/b] (changed [u]{' & '.join(changed)}[/u])")
-                        if self.verbose:
+                        if self.verbose and meta_diff:
                             self.p(_dict_diff(col_a_meta, col_b_meta, tabs=4))
                     else:
                         # do not print identical columns
@@ -285,7 +285,12 @@ def _match_dataset(path_to_ds: Dict[str, Any], path: str) -> Optional[Dataset]:
                 candidates.append(k)
 
         if candidates:
-            return path_to_ds[max(candidates)]
+            latest_version = max(candidates)
+            # make sure we don't compare to newer version
+            if latest_version < path:
+                return path_to_ds[latest_version]
+            else:
+                return None
         else:
             return None
 

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -264,7 +264,7 @@ def _dict_diff(dict_a: Dict[str, Any], dict_b: Dict[str, Any], tabs) -> str:
     lines = [line for line in lines if not line.startswith("  ")]
 
     # add color
-    lines = ["[violet]" + line for line in lines if not l.startswith("  ")]
+    lines = ["[violet]" + line for line in lines]
 
     # add tabs
     return "\t" * tabs + "".join(lines).replace("\n", "\n" + "\t" * tabs).rstrip()

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -264,7 +264,7 @@ def _dict_diff(dict_a: Dict[str, Any], dict_b: Dict[str, Any], tabs) -> str:
     lines = [line for line in lines if not line.startswith("  ")]
 
     # add color
-    lines = ["[violet]" + l for l in lines if not l.startswith("  ")]
+    lines = ["[violet]" + line for line in lines if not l.startswith("  ")]
 
     # add tabs
     return "\t" * tabs + "".join(lines).replace("\n", "\n" + "\t" * tabs).rstrip()

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -256,10 +256,10 @@ def cli(
 
 def _dict_diff(dict_a: Dict[str, Any], dict_b: Dict[str, Any], tabs) -> str:
     """Convert dictionaries into YAML and compare them using difflib. Return colored diff as a string."""
-    meta_a = yaml_dump(dict_a).splitlines(keepends=True)  # type: ignore
-    meta_b = yaml_dump(dict_b).splitlines(keepends=True)  # type: ignore
+    meta_a = yaml_dump(dict_a)
+    meta_b = yaml_dump(dict_b)
 
-    lines = difflib.ndiff(meta_a, meta_b)
+    lines = difflib.ndiff(meta_a.splitlines(keepends=True), meta_b.splitlines(keepends=True))  # type: ignore
     # do not print lines that are identical
     lines = [line for line in lines if not line.startswith("  ")]
 

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -1,0 +1,275 @@
+import os
+import re
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+import requests
+import rich
+import rich_click as click
+import structlog
+from deepdiff import DeepDiff
+from owid.catalog import Dataset, DatasetMeta, LocalCatalog, RemoteCatalog, Table, find
+from owid.catalog.catalogs import CHANNEL, OWID_CATALOG_URI
+from rich.console import Console
+
+log = structlog.get_logger()
+
+
+class DatasetDiff:
+    def __init__(self, ds_a: Optional[Dataset], ds_b: Optional[Dataset], print: Callable = rich.print):
+        assert ds_a or ds_b, "At least one Dataset must be provided"
+        self.ds_a = ds_a
+        self.ds_b = ds_b
+        self.p = print
+
+    def _diff_datasets(self, ds_a: Optional[Dataset], ds_b: Optional[Dataset]):
+        if ds_a and ds_b:
+            ds_short_name = ds_a.metadata.short_name
+            assert ds_short_name
+
+            # compare dataset metadata
+            diff = DeepDiff(_dataset_metadata_dict(ds_a), _dataset_metadata_dict(ds_b))
+            if diff:
+                self.p(f"[yellow]~ Dataset [b]{dataset_uri(ds_a)}[/b]")
+                # self.p(diff)
+            else:
+                self.p(f"[white]= Dataset [b]{dataset_uri(ds_a)}[/b]")
+        elif ds_a:
+            self.p(f"[red]- Dataset [b]{dataset_uri(ds_a)}[/b]")
+        elif ds_b:
+            self.p(f"[green]+ Dataset [b]{dataset_uri(ds_b)}[/b]")
+
+    def _diff_tables(self, ds_a: Dataset, ds_b: Dataset, table_name: str):
+        if table_name not in ds_b.table_names:
+            self.p(f"\t[red]- Table [b]{table_name}[/b]")
+            for col in ds_a[table_name].columns:
+                self.p(f"\t\t[red]- Column [b]{col}[/b]")
+        elif table_name not in ds_a.table_names:
+            self.p(f"\t[green]+ Table [b]{table_name}[/b]")
+            for col in ds_b[table_name].columns:
+                self.p(f"\t\t[green]+ Column [b]{col}[/b]")
+        else:
+            table_a = ds_a[table_name].reset_index()
+            table_b = ds_b[table_name].reset_index()
+
+            # compare table metadata
+            diff = DeepDiff(_table_metadata_dict(table_a), _table_metadata_dict(table_b))
+            if diff:
+                self.p(f"\t[yellow]~ Table [b]{table_name}[/b]")
+                # self.p(diff)
+            else:
+                self.p(f"\t[white]= Table [b]{table_name}[/b]")
+
+            # compare columns
+            for col in sorted(set(table_a.columns) | set(table_b.columns)):
+                if col not in table_a.columns:
+                    self.p(f"\t\t[green]+ Column [b]{col}[/b]")
+                elif col not in table_b.columns:
+                    self.p(f"\t\t[red]- Column [b]{col}[/b]")
+                else:
+                    col_a = table_a[col]
+                    col_b = table_b[col]
+                    shape_diff = col_a.shape != col_b.shape
+                    if not shape_diff:
+                        data_diff = not col_a.equals(col_b)
+                    else:
+                        data_diff = False
+                    meta_diff = DeepDiff(col_a.metadata.to_dict(), col_b.metadata.to_dict())
+
+                    changed = (
+                        (["data"] if data_diff else [])
+                        + (["metadata"] if meta_diff else [])
+                        + (["shape"] if shape_diff else [])
+                    )
+
+                    if changed:
+                        self.p(f"\t\t[yellow]~ Column [b]{col}[/b] (changed [u]{' & '.join(changed)}[/u])")
+                    else:
+                        # do not print identical columns
+                        pass
+
+    def summary(self):
+        self._diff_datasets(self.ds_a, self.ds_b)
+
+        if self.ds_a and self.ds_b:
+            for table_name in set(self.ds_a.table_names) | set(self.ds_b.table_names):
+                self._diff_tables(self.ds_a, self.ds_b, table_name)
+
+
+@click.command(help=__doc__)
+@click.argument(
+    "path-a",
+    type=click.Path(),
+)
+@click.argument(
+    "path-b",
+    type=click.Path(),
+)
+@click.option(
+    "--channel",
+    "-c",
+    multiple=True,
+    type=click.Choice(CHANNEL.__args__),
+    default=["garden", "meadow", "grapher"],
+    help="Compare only selected channel (subfolder of data/), compare only meadow, garden and grapher by default",
+)
+@click.option(
+    "--include",
+    type=str,
+    help="Compare only datasets matching pattern",
+)
+@click.option(
+    "--exclude",
+    "-e",
+    type=str,
+    help="Exclude datasets matching pattern",
+)
+def cli(
+    path_a: str,
+    path_b: str,
+    channel: Iterable[CHANNEL],
+    include: Optional[str],
+    exclude: Optional[str],
+) -> None:
+    """TODO
+
+    Usage:
+        etl-datadiff data/ other/ -c garden --include maddison
+    """
+    console = Console(tab_size=2)
+
+    console.print(
+        "[b]Legend[/b]: [green]+New[/green]  [yellow]~Modified[/yellow]  [red]-Removed[/red]  [white]=Identical[/white]\n"
+    )
+
+    path_to_ds_a = _local_catalog_datasets(path_a, channels=channel, include=include, exclude=exclude)
+
+    if path_b == "REMOTE":
+        assert include, "You have to filter with --include when comparing with remote catalog"
+        path_to_ds_b = _remote_catalog_datasets(channels=channel, include=include, exclude=exclude)
+    else:
+        path_to_ds_b = _local_catalog_datasets(path_b, channels=channel, include=include, exclude=exclude)
+
+    any_diff = False
+
+    for path in set(path_to_ds_a.keys()) | set(path_to_ds_b.keys()):
+        ds_a = path_to_ds_a.get(path)
+        ds_b = path_to_ds_b.get(path)
+
+        if ds_a and ds_b and ds_a.metadata.source_checksum == ds_b.metadata.source_checksum:
+            # skip if they have the same source checksum, note that we're not comparing checksum of actual data
+            # to improve performance. Source checksum should be enough
+            continue
+
+        lines = []
+        differ = DatasetDiff(ds_a, ds_b, print=lambda x: lines.append(x))
+        differ.summary()
+
+        for line in lines:
+            console.print(line)
+
+        if any("~" in line for line in lines):
+            any_diff = True
+
+    exit(1 if any_diff else 0)
+
+
+def _table_metadata_dict(tab: Table) -> Dict[str, Any]:
+    d = tab.metadata.to_dict()
+
+    # add columns
+    d["columns"] = {}
+    for col in tab.columns:
+        d["columns"][col] = tab[col].metadata.to_dict()
+
+    del d["dataset"]
+    return d
+
+
+def _dataset_metadata_dict(ds: Dataset) -> Dict[str, Any]:
+    d = ds.metadata.to_dict()
+    del d["source_checksum"]
+    return d
+
+
+def _local_catalog_datasets(
+    catalog_path: str, channels: Iterable[CHANNEL], include: Optional[str], exclude: Optional[str]
+) -> Dict[str, Dataset]:
+    """Return a mapping from dataset path to Dataset object"""
+    lc_a = LocalCatalog(catalog_path, channels=channels)
+    datasets = []
+    for chan in lc_a.channels:
+        datasets += list(lc_a.iter_datasets(chan, include=include))
+        # TODO: channel should be in DatasetMeta by default
+        for ds in datasets:
+            ds.metadata.channel = chan
+
+    # keep only relative path of dataset
+    mapping = {str(Path(ds.path).relative_to(catalog_path)): ds for ds in datasets}
+
+    if exclude:
+        re_exclude = re.compile(exclude)
+        mapping = {path: ds for path, ds in mapping.items() if not re_exclude.search(path)}
+
+    return mapping
+
+
+class RemoteDataset:
+    """Dataset from remote catalog with the same interface as Dataset."""
+
+    def __init__(self, dataset_meta: DatasetMeta, table_names: List[str]):
+        self.metadata = dataset_meta
+        self.table_names = table_names
+
+    def __getitem__(self, name: str) -> Table:
+        tables = find(
+            table=name,
+            namespace=self.metadata.namespace,
+            version=self.metadata.version,
+            dataset=self.metadata.short_name,
+            channels=[self.metadata.channel],  # type: ignore
+        )
+
+        tables = tables[tables.channel == self.metadata.channel]  # type: ignore
+
+        return tables.load()
+
+
+def _remote_catalog_datasets(channels: Iterable[CHANNEL], include: str, exclude: Optional[str]) -> Dict[str, Dataset]:
+    """Return a mapping from dataset path to Dataset object"""
+    rc = RemoteCatalog(channels=channels)
+    frame = rc.frame
+
+    frame["ds_paths"] = frame["path"].map(os.path.dirname)
+    ds_paths = frame["ds_paths"]
+
+    if include:
+        ds_paths = ds_paths[ds_paths.str.contains(include)]
+
+    if exclude:
+        ds_paths = ds_paths[~ds_paths.str.contains(exclude)]
+
+    ds_paths = set(ds_paths)
+
+    if len(ds_paths) >= 10:
+        log.warning(f"Fetching {len(ds_paths)} datasets from the remote catalog, this may get slow...")
+
+    mapping = {}
+    for path in ds_paths:
+        uri = f"{OWID_CATALOG_URI}{path}/index.json"
+        ds_meta = DatasetMeta(**requests.get(uri).json())
+        # TODO: channel should be in DatasetMeta by default
+        ds_meta.channel = path.split("/")[0]  # type: ignore
+        table_names = frame.loc[frame["ds_paths"] == path, "table"].tolist()
+        mapping[path] = RemoteDataset(ds_meta, table_names)
+
+    return mapping
+
+
+def dataset_uri(ds: Dataset) -> str:
+    assert hasattr(ds.metadata, "channel"), "Dataset metadata should have channel attribute"
+    return f"{ds.metadata.channel}/{ds.metadata.namespace}/{ds.metadata.version}/{ds.metadata.short_name}"  # type: ignore
+
+
+if __name__ == "__main__":
+    cli()

--- a/etl/metadata_export.py
+++ b/etl/metadata_export.py
@@ -1,7 +1,7 @@
 import os
 from typing import Any, Dict
 
-import click
+import rich_click as click
 from owid.catalog import Dataset
 
 from etl.files import yaml_dump

--- a/etl/steps/data/garden/emdat/2022-11-24/natural_disasters.py
+++ b/etl/steps/data/garden/emdat/2022-11-24/natural_disasters.py
@@ -682,7 +682,7 @@ def run(dest_dir: str) -> None:
 
     # Ensure all column names are snake, lower case.
     tb_garden = catalog.Table(df, short_name="natural_disasters_yearly", underscore=True)
-    decade_tb_garden = catalog.Table(df, short_name="natural_disasters_decadal", underscore=True)
+    decade_tb_garden = catalog.Table(decade_df, short_name="natural_disasters_decadal", underscore=True)
 
     # Add tables to dataset
     ds_garden.add(tb_garden)

--- a/etl/steps/data/garden/emdat/2022-11-24/natural_disasters.py
+++ b/etl/steps/data/garden/emdat/2022-11-24/natural_disasters.py
@@ -682,7 +682,7 @@ def run(dest_dir: str) -> None:
 
     # Ensure all column names are snake, lower case.
     tb_garden = catalog.Table(df, short_name="natural_disasters_yearly", underscore=True)
-    decade_tb_garden = catalog.Table(decade_df, short_name="natural_disasters_decadal", underscore=True)
+    decade_tb_garden = catalog.Table(df, short_name="natural_disasters_decadal", underscore=True)
 
     # Add tables to dataset
     ds_garden.add(tb_garden)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1218,6 +1218,24 @@ files = [
 ]
 
 [[package]]
+name = "deepdiff"
+version = "6.2.2"
+description = "Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "deepdiff-6.2.2-py3-none-any.whl", hash = "sha256:dea62316741f86c1d8e946f47c4c21386788457c898a495a5e6b0ccdcd76d9b6"},
+    {file = "deepdiff-6.2.2.tar.gz", hash = "sha256:d04d997a68bf8bea01f8a97395877314ef5c2131d8f57bba2295f3adda725282"},
+]
+
+[package.dependencies]
+ordered-set = ">=4.0.2,<4.2.0"
+
+[package.extras]
+cli = ["click (==8.1.3)", "pyyaml (==6.0)"]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 description = "XML bomb protection for Python stdlib modules"
@@ -3769,6 +3787,21 @@ files = [
 
 [package.dependencies]
 et-xmlfile = "*"
+
+[[package]]
+name = "ordered-set"
+version = "4.1.0"
+description = "An OrderedSet is a custom MutableSet that remembers its order, so that every"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ordered-set-4.1.0.tar.gz", hash = "sha256:694a8e44c87657c59292ede72891eb91d34131f6531463aab3009191c77364a8"},
+    {file = "ordered_set-4.1.0-py3-none-any.whl", hash = "sha256:046e1132c71fcf3330438a539928932caf51ddbc582496833e23de611de14562"},
+]
+
+[package.extras]
+dev = ["black", "mypy", "pytest"]
 
 [[package]]
 name = "owid-catalog"
@@ -6685,4 +6718,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8a2b9c9c91d0a3f9e536ed300831a1fe9d219b38d19e52b51cfb82f856c6d1b0"
+content-hash = "fd3e5c9f89f1584831c11a3846ecf375921dbb6caeb3222d6f23ec8b182d812a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ etl-match-variables = 'etl.match_variables:main_cli'
 etl-translate-varmap = 'etl.variable_mapping_translate:main_cli'
 etl-chart-suggester = 'etl.chart_revision_suggester:main_cli'
 etl-metadata-export = 'etl.metadata_export:cli'
+etl-datadiff = 'etl.datadiff:cli'
 
 [tool.poetry.dependencies]
 python = "^3.9"
@@ -61,6 +62,7 @@ PyPDF2 = "^2.11.1"
 dvc = {extras = ["s3"], version = "^2.38.1"}
 "ruamel.yaml" = "^0.17.21"
 owid-repack = "^0.1.1"
+deepdiff = "^6.2.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -1,0 +1,37 @@
+import pandas as pd
+from owid.catalog import Dataset, DatasetMeta, Table
+
+from etl.datadiff import DatasetDiff
+
+
+def test_DatasetDiff_summary(tmp_path):
+    (tmp_path / "catalog_a").mkdir()
+    (tmp_path / "catalog_b").mkdir()
+
+    ds_meta_a = DatasetMeta(namespace="n", version="v", short_name="ds", source_checksum="1")
+    ds_a = Dataset.create_empty(tmp_path / "catalog_a" / "ds", ds_meta_a)
+    ds_a.metadata.channel = "garden"  # type: ignore
+
+    ds_meta_b = DatasetMeta(namespace="n", version="v", short_name="ds", source_checksum="2")
+    ds_b = Dataset.create_empty(tmp_path / "catalog_b" / "ds", ds_meta_b)
+    ds_b.metadata.channel = "garden"  # type: ignore
+
+    tab_a = Table(pd.DataFrame({"a": [1, 2]}), short_name="tab")
+    tab_a.metadata.description = "tab"
+
+    tab_b = Table(pd.DataFrame({"a": [1, 3], "b": ["a", "b"]}), short_name="tab")
+    tab_b["a"].metadata.description = "col a"
+
+    ds_a.add(tab_a)
+    ds_b.add(tab_b)
+
+    out = []
+    differ = DatasetDiff(ds_a, ds_b, print=lambda x: out.append(x))
+    differ.summary()
+
+    assert set(out) == {
+        "[white]= Dataset [b]garden/n/v/ds[/b]",
+        "\t[yellow]~ Table [b]tab[/b]",
+        "\t\t[yellow]~ Column [b]a[/b] (changed [u]data & metadata[/u])",
+        "\t\t[green]+ Column [b]b[/b]",
+    }

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -29,9 +29,9 @@ def test_DatasetDiff_summary(tmp_path):
     differ = DatasetDiff(ds_a, ds_b, print=lambda x: out.append(x))
     differ.summary()
 
-    assert set(out) == {
+    assert out == [
         "[white]= Dataset [b]garden/n/v/ds[/b]",
-        "\t[yellow]~ Table [b]tab[/b]",
+        "\t[yellow]~ Table [b]tab[/b] (changed [u]metadata[/u])",
         "\t\t[yellow]~ Column [b]a[/b] (changed [u]data & metadata[/u])",
         "\t\t[green]+ Column [b]b[/b]",
-    }
+    ]


### PR DESCRIPTION
Find differences between two catalogs (either two local catalogs or local and remote) and summarise them in a pretty format. It can be run locally, but it's gonna be used primarily in Buildkite as a separate pipeline to let us know what has changed.

I'm using `source_checksum` to find candidates for comparison. This works ok in most cases, but it's not gonna catch cases where ETL core code or dependencies (like new pandas version) changed. (This could be solved by adding ETL version to checksum calculation and increment whenever we do non-step change that we need to check... like pandas upgrade).

This originally leveraged `compare` tool that we have for comparing two datasets, but I've changed it to simple summary because the output was too long and messy in our CI. Devs can run `compare` on their own locals if they want more detailed summary.

Two use cases already wait for this PR - changing `str` to `string` to [get rid of warnings](https://github.com/owid/etl/pull/700) and pandas update. After we merge this, I'll update Buildkite to run this for all PRs.

Screenshot of Buildkite output for the case where I mistakenly used wrong dataframe when refactoring. This would have shown it wasn't safe.

<img width="626" alt="image" src="https://user-images.githubusercontent.com/1550888/209121036-24a9a1f0-b8b3-405c-b54c-a3fc63c88910.png">

### Future features

Meant for future PRs after we verify this concept

* `verbose` mode that would also print the actual differences (this could run in CI too, so we'd have both summary and detailed difference)
* adding `version` to ETL which is gonna be part of `source_checksum` calculation
* Dataset should have `channel` in metadata... it complicates my life a bit here
* New datasets should be compared against their older version