### PR TITLE
chore(datautils): bump to version 0.5.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2419,14 +2419,14 @@ files = [
 
 [[package]]
 name = "ipywidgets"
-version = "8.0.3"
+version = "8.0.4"
 description = "Jupyter interactive widgets"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ipywidgets-8.0.3-py3-none-any.whl", hash = "sha256:db7dd35fb1217636cbdbe0ba0bd2216d91a7695cb28b5c1dca17e62cd51378de"},
-    {file = "ipywidgets-8.0.3.tar.gz", hash = "sha256:2ec50df8538a1d4ddd5d454830d010922ad1015e81ac23efb27c0908bbc1eece"},
+    {file = "ipywidgets-8.0.4-py3-none-any.whl", hash = "sha256:ebb195e743b16c3947fe8827190fb87b4d00979c0fbf685afe4d2c4927059fa1"},
+    {file = "ipywidgets-8.0.4.tar.gz", hash = "sha256:c0005a77a47d77889cafed892b58e33b4a2a96712154404c6548ec22272811ea"},
 ]
 
 [package.dependencies]
@@ -2877,14 +2877,14 @@ typing = ["mypy (>=0.990)"]
 
 [[package]]
 name = "jupyterlab-widgets"
-version = "3.0.4"
+version = "3.0.5"
 description = "Jupyter interactive widgets for JupyterLab"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jupyterlab_widgets-3.0.4-py3-none-any.whl", hash = "sha256:4c9275daa6d20fc96c3aea45756ece7110850d035b0b93a6a40e918016b927da"},
-    {file = "jupyterlab_widgets-3.0.4.tar.gz", hash = "sha256:9a568e022b8bb53ab23291f6ddb52f8002b789c2c5763378cbc882be1d619be8"},
+    {file = "jupyterlab_widgets-3.0.5-py3-none-any.whl", hash = "sha256:a04a42e50231b355b7087e16a818f541e53589f7647144ea0344c4bf16f300e5"},
+    {file = "jupyterlab_widgets-3.0.5.tar.gz", hash = "sha256:eeaecdeaf6c03afc960ddae201ced88d5979b4ca9c3891bcb8f6631af705f5ef"},
 ]
 
 [[package]]
@@ -3772,11 +3772,11 @@ et-xmlfile = "*"
 
 [[package]]
 name = "owid-catalog"
-version = "0.3.3"
+version = "0.3.4"
 description = "Core data types used by OWID for managing data."
 category = "main"
 optional = false
-python-versions = "^3.8"
+python-versions = "^3.8.1"
 files = []
 develop = true
 
@@ -3785,6 +3785,7 @@ boto3 = "^1.21.13"
 dataclasses-json = "^0.5.6"
 ipdb = "^0.13.9"
 jsonschema = "^3.2.0"
+owid-repack = "^0.1.1"
 pandas = "^1.3.3"
 pandas-stubs = "^1.2.0"
 pyarrow = "^10.0.1"
@@ -3800,7 +3801,7 @@ url = "vendor/owid-catalog-py"
 
 [[package]]
 name = "owid-datautils"
-version = "0.5.0"
+version = "0.5.2"
 description = "Data utils library by the Data Team at Our World in Data"
 category = "main"
 optional = false
@@ -3814,7 +3815,7 @@ colorama = "^0.4.4"
 gdown = "^4.5.2"
 gsheets = "^0.6.1"
 mypy-boto3-s3 = "^1.21.23"
-owid-catalog = "^0.3.2"
+owid-catalog = "^0.3.4"
 pandas = "^1.3.3"
 pydrive2 = "^1.15.0"
 structlog = "^21.5.0"
@@ -3822,8 +3823,8 @@ structlog = "^21.5.0"
 [package.source]
 type = "git"
 url = "https://github.com/owid/owid-datautils-py.git"
-reference = "v0.5.1-alpha"
-resolved_reference = "a635ed97fda5f4f3083f367853d268efbe6a29eb"
+reference = "v0.5.2-alpha"
+resolved_reference = "0bed883fbe5c0bd1a01d624d245da92deacaa75a"
 
 [[package]]
 name = "owid-repack"
@@ -6319,7 +6320,7 @@ click = "^8.0.1"
 dataclasses-json = "^0.5.4"
 jsonschema = "^3.2.0"
 openpyxl = "^3.0.9"
-owid-datautils = {git = "https://github.com/owid/owid-datautils-py.git", tag = "v0.5.1-alpha"}
+owid-datautils = {git = "https://github.com/owid/owid-datautils-py.git", tag = "v0.5.2-alpha"}
 owid-repack = "^0.1.1"
 pandas = "^1.3.4"
 pyrsistent = "^0.19.1"
@@ -6432,14 +6433,14 @@ test = ["websockets"]
 
 [[package]]
 name = "widgetsnbextension"
-version = "4.0.4"
+version = "4.0.5"
 description = "Jupyter interactive widgets for Jupyter Notebook"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "widgetsnbextension-4.0.4-py3-none-any.whl", hash = "sha256:fa0e840719ec95dd2ec85c3a48913f1a0c29d323eacbcdb0b29bfed0cc6da678"},
-    {file = "widgetsnbextension-4.0.4.tar.gz", hash = "sha256:44c69f18237af0f610557d6c1c7ef76853f5856a0e604c0a517f2320566bb775"},
+    {file = "widgetsnbextension-4.0.5-py3-none-any.whl", hash = "sha256:eaaaf434fb9b08bd197b2a14ffe45ddb5ac3897593d43c69287091e5f3147bf7"},
+    {file = "widgetsnbextension-4.0.5.tar.gz", hash = "sha256:003f716d930d385be3fd9de42dd9bf008e30053f73bddde235d14fbeaeff19af"},
 ]
 
 [[package]]
@@ -6685,4 +6686,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "8a2b9c9c91d0a3f9e536ed300831a1fe9d219b38d19e52b51cfb82f856c6d1b0"
+content-hash = "11ec0b992d9b6f66616dcbeaf0c330a8ebd4d20b91eb3bd62fd80743816a5201"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ fasttrack = 'fasttrack.cli:cli'
 run_python_step = 'etl.run_python_step:main'
 compare = 'etl.compare:cli'
 generate_graph = 'etl.to_graphviz:to_graphviz'
-etl-match-variables = 'etl.match_variables_from_two_versions_of_a_dataset:main_cli'
+etl-match-variables = 'etl.match_variables:main_cli'
 etl-translate-varmap = 'etl.variable_mapping_translate:main_cli'
 etl-chart-suggester = 'etl.chart_revision_suggester:main_cli'
 etl-metadata-export = 'etl.metadata_export:cli'
@@ -50,7 +50,7 @@ pydantic = "^1.9.0"
 structlog = "^21.5.0"
 sqlmodel = "^0.0.6"
 rich = "^12.1.0"
-owid-datautils = {git = "https://github.com/owid/owid-datautils-py.git", tag = "v0.5.1-alpha"}
+owid-datautils = {git = "https://github.com/owid/owid-datautils-py.git", tag = "v0.5.2-alpha"}
 fuzzywuzzy = "^0.18.0"
 rich-click = "^1.5.1"
 tenacity = "^8.0.1"
@@ -58,9 +58,10 @@ simplejson = "^3.17.6"
 bugsnag = "^4.2.1"
 xlrd = "^2.0.1"
 PyPDF2 = "^2.11.1"
-dvc = {extras = ["s3"], version = "^2.38.1"}
+dvc = {extras = ["s3"], version = "^2.36.0"}
 "ruamel.yaml" = "^0.17.21"
-owid-repack = "^0.1.1"
+# pinned pathspec is necessary for DVC until this issue gets resolved https://github.com/iterative/dvc/issues/8217
+pathspec = "0.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"
@@ -84,9 +85,6 @@ sphinx-rtd-theme = "^1.0.0"
 sphinxcontrib-mermaid = "^0.7.1"
 pyright = "^1.1.277"
 types-PyYAML = "^6.0.12"
-
-[tool.poetry.group.dev.dependencies]
-hydra-core = "^1.3.0"
 
 [tool.black]
 exclude = ".ipynb_checkpoints|walkthrough/.*_cookiecutter|.*playground.*.ipynb"


### PR DESCRIPTION
I was getting this error:


```
Because etl depends on walden (0.1.0) @ file:///Users/lucasrodes/repos/etl/vendor/walden which depends on owid-datautils (0.5.2) @ git+https://github.com/owid/owid-datautils-py.git@v0.5.2-alpha, owid-datautils is required.
So, because etl depends on owid-datautils (0.5.0) @ git+https://github.com/owid/owid-datautils-py.git@v0.5.1-alpha, version solving failed.
```

It seems that `etl` relies on `walden==0.1.0` and `datautils==0.5.1`. But `walden==0.1.0` relies on `datautils==0.5.2`. We might want to change etl dependencies so that it depends on `datautils==0.5.2`, to avoid such errors.