### PR TITLE
enhance(walkthrough): typos, use data_helpers

### DIFF
--- a/snapshots/aviation_safety_network/2022-10-14/aviation_statistics.py
+++ b/snapshots/aviation_safety_network/2022-10-14/aviation_statistics.py
@@ -38,7 +38,7 @@ COLUMNS = {
     "--upload/--skip-upload",
     default=True,
     type=bool,
-    help="Upload dataset to Walden",
+    help="Upload dataset to Snapshot",
 )
 def main(upload: bool) -> None:
     # Load raw data from a specific sheet.

--- a/snapshots/dummy/2020-01-01/dummy.py
+++ b/snapshots/dummy/2020-01-01/dummy.py
@@ -14,7 +14,7 @@ CURRENT_DIR = pathlib.Path(__file__).parent
     "--upload/--skip-upload",
     default=True,
     type=bool,
-    help="Upload dataset to Walden",
+    help="Upload dataset to Snapshot",
 )
 def main(upload: bool) -> None:
     snap = Snapshot("dummy/2020-01-01/dummy.xlsx")

--- a/snapshots/ggdc/2020-10-01/ggdc_maddison.py
+++ b/snapshots/ggdc/2020-10-01/ggdc_maddison.py
@@ -12,7 +12,7 @@ from etl.snapshot import Snapshot
     "--upload/--skip-upload",
     default=True,
     type=bool,
-    help="Upload dataset to Walden",
+    help="Upload dataset to Snapshot",
 )
 def main(upload: bool) -> None:
     snap = Snapshot("ggdc/2020-10-01/ggdc_maddison.xlsx")

--- a/snapshots/hmd/2022-12-07/hmd.py
+++ b/snapshots/hmd/2022-12-07/hmd.py
@@ -22,7 +22,7 @@ SNAPSHOT_VERSION = "2022-12-07"
     "--upload/--skip-upload",
     default=True,
     type=bool,
-    help="Upload dataset to Walden",
+    help="Upload dataset to Snapshot",
 )
 def main(path_to_file: str, upload: bool) -> None:
     # Create new snapshot.

--- a/snapshots/hyde/2017/baseline.py
+++ b/snapshots/hyde/2017/baseline.py
@@ -8,7 +8,7 @@ from etl.snapshot import Snapshot
     "--upload/--skip-upload",
     default=True,
     type=bool,
-    help="Upload dataset to Walden",
+    help="Upload dataset to Snapshot",
 )
 def main(upload: bool) -> None:
     snap = Snapshot("hyde/2017/baseline.zip")

--- a/snapshots/hyde/2017/general_files.py
+++ b/snapshots/hyde/2017/general_files.py
@@ -8,7 +8,7 @@ from etl.snapshot import Snapshot
     "--upload/--skip-upload",
     default=True,
     type=bool,
-    help="Upload dataset to Walden",
+    help="Upload dataset to Snapshot",
 )
 def main(upload: bool) -> None:
     snap = Snapshot("hyde/2017/general_files.zip")

--- a/snapshots/un/2022-11-29/undp_hdr.py
+++ b/snapshots/un/2022-11-29/undp_hdr.py
@@ -20,7 +20,7 @@ CURRENT_DIR = pathlib.Path(__file__).parent
     "--upload/--skip-upload",
     default=True,
     type=bool,
-    help="Upload dataset to Walden",
+    help="Upload dataset to Snapshot",
 )
 def main(upload: bool) -> None:
     # Data

--- a/walkthrough/garden_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
+++ b/walkthrough/garden_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
@@ -3,9 +3,9 @@ from typing import List, cast
 
 import pandas as pd
 from owid.catalog import Dataset, Table
-from owid.datautils import geo
 from structlog import get_logger
 
+from etl.data_helpers import geo
 from etl.helpers import Names
 from etl.paths import DATA_DIR
 

--- a/walkthrough/snapshot_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
+++ b/walkthrough/snapshot_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
@@ -14,7 +14,7 @@ CURRENT_DIR = pathlib.Path(__file__).parent
     "--upload/--skip-upload",
     default=True,
     type=bool,
-    help="Upload dataset to Walden",
+    help="Upload dataset to Snapshot",
 )
 def main(upload: bool) -> None:
     snap = Snapshot(


### PR DESCRIPTION
This PR solves a typo in `walkthrough meadow` step, which wrongly had the help text as "Upload dataset to Walden" instead of "Upload dataset to Snapshot".

Also, changed python script template for Garden, so it uses `etl.data_helpers.geo` instead of `owid.datautils.geo`.