### PR TITLE
refactor: Remove old, unnecessary FAOSTAT steps from dag

### DIFF
--- a/dag_files/dag_faostat.yml
+++ b/dag_files/dag_faostat.yml
@@ -1,31 +1,5 @@
 steps:
   #
-  # FAOSTAT meadow steps for previous versions
-  #
-  data://meadow/faostat/2022-02-10/faostat_metadata:
-    - walden://faostat/2022-02-10/faostat_metadata
-  data://meadow/faostat/2017-12-11/faostat_fbsh:
-    - walden://faostat/2017-12-11/faostat_FBSH
-  data://meadow/faostat/2021-03-18/faostat_qcl:
-    - walden://faostat/2021-03-18/faostat_QCL
-  data://meadow/faostat/2021-04-09/faostat_fbs:
-    - walden://faostat/2021-04-09/faostat_FBS
-  #
-  # FAOSTAT garden steps for previous versions
-  #
-  data://garden/faostat/2021-03-18/faostat_qcl:
-    - data://meadow/faostat/2021-03-18/faostat_qcl
-    - data://meadow/faostat/2022-02-10/faostat_metadata
-  data://garden/faostat/2021-04-09/faostat_fbsc:
-    - data://meadow/faostat/2017-12-11/faostat_fbsh
-    - data://meadow/faostat/2021-04-09/faostat_fbs
-    - data://meadow/faostat/2022-02-10/faostat_metadata
-  data://explorers/owid/2021/food_explorer:
-    - data://garden/faostat/2021-03-18/faostat_qcl
-    - data://garden/faostat/2021-04-09/faostat_fbsc
-    - data://garden/owid/latest/key_indicators
-    - data://open_numbers/open_numbers/latest/gapminder__systema_globalis
-  #
   # FAOSTAT meadow steps for version 2022-05-17
   #
   data://meadow/faostat/2022-05-17/faostat_ef:


### PR DESCRIPTION
Every now and then we have issues with some of the old FAOSTAT steps, which used to be necessary for the global food explorer, but now they are not used anywhere.

This PR removes those old steps from the dag.
