### PR TITLE
enhance(etl): improve ETL performance

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,7 +65,8 @@ jobs:
           cd vendor/owid-catalog-py
           make test
 
-      - name: walden tests
-        run: |
-          cd vendor/walden
-          make test
+      # walden was replaced by snapshots and is not actively developed
+      # - name: walden tests
+      #   run: |
+      #     cd vendor/walden
+      #     make test

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -17,7 +17,7 @@ steps:
   data://garden/gapminder/2019-12-10/population:
     - data://meadow/gapminder/2019-12-10/population
   data://meadow/un/2022-07-11/un_wpp:
-    - walden://un/2022-07-11/un_wpp
+    - snapshot://un/2022-07-11/un_wpp.zip
   data://garden/un/2022-07-11/un_wpp:
     - data://meadow/un/2022-07-11/un_wpp
   data://explorers/un/2022/un_wpp:

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -339,7 +339,8 @@ def _dataset_metadata_dict(ds: Dataset) -> Dict[str, Any]:
     d = ds.metadata.to_dict()
 
     # sort sources by name
-    d["sources"] = sorted(d["sources"], key=lambda x: x["name"])
+    if "sources" in d:
+        d["sources"] = sorted(d["sources"], key=lambda x: x["name"])
 
     del d["source_checksum"]
     return d

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -54,6 +54,10 @@ class DatasetDiff:
             self.p(f"[red]- Dataset [b]{dataset_uri(ds_a)}[/b]")
         elif ds_b:
             self.p(f"[green]+ Dataset [b]{dataset_uri(ds_b)}[/b]")
+            for table_name in ds_b.table_names:
+                self.p(f"\t[green]+ Table [b]{table_name}[/b]")
+                for col in ds_b[table_name].columns:
+                    self.p(f"\t\t[green]+ Column [b]{col}[/b]")
 
     def _diff_tables(self, ds_a: Dataset, ds_b: Dataset, table_name: str):
         if table_name not in ds_b.table_names:

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -139,7 +139,7 @@ class RemoteDataset:
         tables = find(
             table=name,
             namespace=self.metadata.namespace,
-            version=self.metadata.version,
+            version=str(self.metadata.version),
             dataset=self.metadata.short_name,
             channels=[self.metadata.channel],  # type: ignore
         )
@@ -337,6 +337,10 @@ def _table_metadata_dict(tab: Table) -> Dict[str, Any]:
 def _dataset_metadata_dict(ds: Dataset) -> Dict[str, Any]:
     """Extract metadata from Dataset object, prune and and return it as a dictionary"""
     d = ds.metadata.to_dict()
+
+    # sort sources by name
+    d["sources"] = sorted(d["sources"], key=lambda x: x["name"])
+
     del d["source_checksum"]
     return d
 

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -2,7 +2,7 @@ import difflib
 import os
 import re
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 import pandas as pd
 import requests

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -150,6 +150,9 @@ class RemoteDataset:
 
         tables = tables[tables.channel == self.metadata.channel]  # type: ignore
 
+        # find matches substrings, we have to further filter it
+        tables = tables[tables.table == name]
+
         return tables.load()
 
 

--- a/etl/steps/data/meadow/un/2022-07-11/un_wpp.py
+++ b/etl/steps/data/meadow/un/2022-07-11/un_wpp.py
@@ -3,21 +3,16 @@ import tempfile
 import zipfile
 from typing import Any, List, Optional, Tuple
 
-import owid.walden as walden
 import pandas as pd
 from owid.catalog import Dataset, Table, utils
 from pandas.api.types import CategoricalDtype
 
-from etl.steps.data.converters import convert_walden_metadata
+from etl.snapshot import Snapshot
+from etl.steps.data.converters import convert_snapshot_metadata
 
 
-def load_walden_ds() -> walden.catalog.Dataset:
-    walden_ds = walden.Catalog().find_one("un", "2022-07-11", "un_wpp")
-    return walden_ds
-
-
-def extract_data(walden_ds: walden.catalog.Dataset, output_dir: str) -> None:
-    z = zipfile.ZipFile(walden_ds.local_path)
+def extract_data(snap: Snapshot, output_dir: str) -> None:
+    z = zipfile.ZipFile(snap.path)
     z.extractall(output_dir)
 
 
@@ -360,9 +355,9 @@ def _sanity_checks(
     return df
 
 
-def init_dataset(dest_dir: str, walden_ds: walden.Dataset) -> Dataset:
+def init_dataset(dest_dir: str, snap: Snapshot) -> Dataset:
     ds = Dataset.create_empty(dest_dir)
-    ds.metadata = convert_walden_metadata(walden_ds)
+    ds.metadata = convert_snapshot_metadata(snap.metadata)
     ds.metadata.short_name = "un_wpp"
     ds.save()
     return ds
@@ -393,9 +388,9 @@ def add_tables_to_ds(
 
 def run(dest_dir: str) -> None:
     # Load
-    walden_ds = load_walden_ds()
+    snap = Snapshot("un/2022-07-11/un_wpp.zip")
     with tempfile.TemporaryDirectory() as tmp_dir:
-        extract_data(walden_ds, tmp_dir)
+        extract_data(snap, tmp_dir)
         (
             df_population,
             df_fertility,
@@ -408,6 +403,6 @@ def run(dest_dir: str) -> None:
         df_population, df_fertility, df_demographics, df_depratio, df_deaths
     )
     # Initiate dataset
-    ds = init_dataset(dest_dir, walden_ds)
+    ds = init_dataset(dest_dir, snap)
     # Add tables to dataset
     ds = add_tables_to_ds(ds, df_population, df_fertility, df_demographics, df_depratio, df_deaths)

--- a/etl/tempcompare.py
+++ b/etl/tempcompare.py
@@ -94,10 +94,8 @@ def df_equals(
     assert all(df1.columns == df2.columns), "Columns must be the same"
     assert all(df1.index == df2.index), "Indices must be the same"
 
-    columns = df1.columns
-
     # Union categories of categorical columns to enable comparison
-    for col in columns:
+    for col in df1.columns:
         if df1[col].dtype == "category":
             uc = union_categoricals([df1[col], df2[col]])
             for df in [df1, df2]:
@@ -119,9 +117,20 @@ def df_equals(
             # Apply a direct comparison for datetimes
             pass
         else:
-            # Comparison does not work for Int64
+            # Comparison does not work for certain types
             for df in [df1, df2]:
-                if df[col].dtype in ("Int64", "UInt64", "Int32", "UInt32", "Int16", "UInt16", "Int8", "UInt8"):
+                if df[col].dtype in (
+                    "Int64",
+                    "UInt64",
+                    "Float32",
+                    "Float16",
+                    "Int32",
+                    "UInt32",
+                    "Int16",
+                    "UInt16",
+                    "Int8",
+                    "UInt8",
+                ):
                     df[col] = df[col].astype(float)
 
             # For numeric data, consider them equal within certain absolute and relative tolerances.

--- a/etl/tempcompare.py
+++ b/etl/tempcompare.py
@@ -83,13 +83,14 @@ def sample_from_dataframe(df: pd.DataFrame, **kwargs: Any) -> pd.DataFrame:
     return cast(pd.DataFrame, df.sample(**kwargs).sort_index())
 
 
-def df_diff(
+def df_equals(
     df1,
     df2,
     absolute_tolerance: float = 1e-08,
     relative_tolerance: float = 1e-05,
 ) -> pd.DataFrame:
-    """Compare two dataframes and return a dataframe with the differences."""
+    """Compare two dataframes and return a boolean dataframe with True
+    if values are the same or within tolerance."""
     assert all(df1.columns == df2.columns), "Columns must be the same"
     assert all(df1.index == df2.index), "Indices must be the same"
 
@@ -250,7 +251,7 @@ class HighLevelDiff:
             df1_intersected = self.df1.loc[self.index_values_shared, list(self.columns_shared)]
             df2_intersected = self.df2.loc[self.index_values_shared, list(self.columns_shared)]
 
-            diffs = df_diff(
+            diffs = df_equals(
                 df1_intersected,
                 df2_intersected,
                 absolute_tolerance=self.absolute_tolerance,

--- a/snapshots/un/2022-07-11/un_wpp.zip.dvc
+++ b/snapshots/un/2022-07-11/un_wpp.zip.dvc
@@ -1,0 +1,25 @@
+meta:
+  namespace: un
+  short_name: un_wpp
+  name: World Population Prospects - UN (2022)
+  description: World Population Prospects 2022 is the 27th edition of the official
+    estimates and projections of the global population that have been published by
+    the United Nations since 1951. The estimates are based on all available sources
+    of data on population size and levels of fertility, mortality and international
+    migration for 237 countries or areas. More details at https://population.un.org/wpp/Publications/.
+  source_name: United Nations, Department of Economic and Social Affairs, Population
+    Division (2022)
+  url: https://population.un.org/wpp/Download/
+  file_extension: zip
+  date_accessed: '2022-09-09'
+  license_url: http://creativecommons.org/licenses/by/3.0/igo/
+  license_name: CC BY 3.0 IGO
+  is_public: true
+  version: '2022-07-11'
+  publication_year: 2022
+  publication_date: '2022-07-11'
+wdir: ../../../data/snapshots/un/2022-07-11
+outs:
+- md5: e49634a6a64f5b290d2f3a56837b44a1
+  size: 672744484
+  path: un_wpp.zip


### PR DESCRIPTION
* stop running `walden tests` now that we use snapshots (takes ~1.5min in CI)
* migrate `un/2022-07-11/un_wpp` to snapshot (speeds up certain `etl` runs by the factor of 10x)

(better to wait for `datadiff` to make sure un_wpp hasn't changed)