### PR TITLE
fix(helpers): fix paths in PathFinder

### DIFF
--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -101,6 +101,10 @@ class PathFinder:
         if not self.f.as_posix().startswith(paths.STEP_DIR.as_posix()):
             raise CurrentFileMustBeAStep
 
+        # It could be either called from a module with short_name.py or __init__.py inside short_name/ dir.
+        if len(self.f.relative_to(paths.STEP_DIR).parts) == 6:
+            self.f = self.f.parent
+
         # Current step should be in the dag.
         if self.step not in DAG:
             raise CurrentStepMustBeInDag
@@ -123,19 +127,23 @@ class PathFinder:
 
     @property
     def country_mapping_path(self) -> Path:
-        return self.f.parent / (self.short_name + ".countries.json")
+        return self.directory / (self.short_name + ".countries.json")
 
     @property
     def excluded_countries_path(self) -> Path:
-        return self.f.parent / (self.short_name + ".excluded_countries.json")
+        return self.directory / (self.short_name + ".excluded_countries.json")
 
     @property
     def metadata_path(self) -> Path:
-        return self.f.parent / (self.short_name + ".meta.yml")
+        return self.directory / (self.short_name + ".meta.yml")
 
     @property
     def directory(self) -> Path:
-        return self.f.parent
+        # If the current file is a directory, it's a step with multiple files.
+        if self.f.is_dir():
+            return self.f
+        else:
+            return self.f.parent
 
     @property
     def meadow_dataset(self) -> catalog.Dataset:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,6 @@
+from etl import paths
+from etl.helpers import PathFinder
+
 #
 #  test_helpers.py
 #
@@ -5,3 +8,26 @@
 # def test_get_github_sha():
 #     sha = helpers.get_latest_github_sha("owid", "owid-grapher", "master")
 #     assert re.match("^[0-9a-f]+$", sha)
+
+
+def test_PathFinder_paths():
+    def _assert(pf):
+        assert pf.channel == "meadow"
+        assert pf.namespace == "papers"
+        assert pf.version == "2022-11-03"
+        assert pf.short_name == "zijdeman_et_al_2015"
+
+    # saved as short_name/__init__.py
+    pf = PathFinder(str(paths.STEP_DIR / "data/meadow/papers/2022-11-03/zijdeman_et_al_2015/__init__.py"))
+    _assert(pf)
+    assert pf.directory == paths.STEP_DIR / "data/meadow/papers/2022-11-03/zijdeman_et_al_2015"
+
+    # saved as short_name/anymodule.py
+    pf = PathFinder(str(paths.STEP_DIR / "data/meadow/papers/2022-11-03/zijdeman_et_al_2015/anymodule.py"))
+    _assert(pf)
+    assert pf.directory == paths.STEP_DIR / "data/meadow/papers/2022-11-03/zijdeman_et_al_2015"
+
+    # saved as short_name.py
+    pf = PathFinder(str(paths.STEP_DIR / "data/meadow/papers/2022-11-03/zijdeman_et_al_2015.py"))
+    _assert(pf)
+    assert pf.directory == paths.STEP_DIR / "data/meadow/papers/2022-11-03"


### PR DESCRIPTION
`PathFinder` wasn't working for steps that were using `version/short_name/` directory instead of `version/short_name.py` module. This fixes it and adds some tests.