### PR TITLE
feature(step): add new static:// step to add static files to catalog

### DIFF
--- a/.dvcignore
+++ b/.dvcignore
@@ -8,4 +8,11 @@ tests/
 vendor/
 .cachedir/
 .venv/
+.github
+__pycache__/
+
 !data/snapshots/
+
+# temporary for static step
+!etl/steps/data/**/*.csv
+!etl/steps/data/**/*.csv.dvc

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -292,6 +292,10 @@ steps:
   data://grapher/fasttrack/2023-01-03/long_term_homicide_rates_in_europe:
     - snapshot://fasttrack/2023-01-03/long_term_homicide_rates_in_europe.csv
 
+  # Gravitational waves
+  data://grapher/technology/2023-01-05/gravitational_waves:
+    - snapshot://technology/2023-01-05/gravitational_waves.csv
+
 # Sub-dags to import
 include:
   - dag/open_numbers.yml

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -296,6 +296,9 @@ steps:
   data://grapher/technology/2023-01-05/gravitational_waves:
     - snapshot://technology/2023-01-05/gravitational_waves.csv
 
+  # Gravitational waves with the new static step
+  static://grapher/technology/2023-01-06/gravitational_waves.csv:
+
 # Sub-dags to import
 include:
   - dag/open_numbers.yml

--- a/etl/steps/data/grapher/technology/2023-01-05/gravitational_waves.meta.yml
+++ b/etl/steps/data/grapher/technology/2023-01-05/gravitational_waves.meta.yml
@@ -1,0 +1,8 @@
+dataset: {}
+
+tables:
+  gravitational_waves:
+    variables:
+      cumulative_gwt:
+        title: Cumulative gravitational wave transients
+        unit: Gravitational wave transients

--- a/etl/steps/data/grapher/technology/2023-01-05/gravitational_waves.py
+++ b/etl/steps/data/grapher/technology/2023-01-05/gravitational_waves.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from owid.catalog import Dataset, Table
+
+from etl.helpers import Names
+from etl.snapshot import Snapshot
+from etl.steps.data.converters import convert_snapshot_metadata
+
+N = Names(__file__)
+
+
+def run(dest_dir: str) -> None:
+    snap = Snapshot("technology/2023-01-05/gravitational_waves.csv")
+    df = pd.read_csv(snap.path)
+
+    # Initialise dataset.
+    ds = Dataset.create_empty(dest_dir, metadata=convert_snapshot_metadata(snap.metadata))
+
+    # In case events are recorded multiple times
+    # we keep only the earliest GPS time for each commonName
+    df = df.groupby("commonName", as_index=False).GPS.min()
+
+    # Origin for GPS time is on 1980-01-06
+    df["time"] = pd.to_datetime(df["GPS"], unit="s", origin="1980-01-06", utc=True)
+
+    # Count events by year, and calculate the cumsum
+    df["year"] = df["time"].dt.year
+    df = df.groupby("year").size().reset_index(name="N")
+    df["cumulative_gwt"] = df["N"].cumsum()
+
+    # Add entity and select columns
+    df = df.assign(entity="World")[["entity", "year", "cumulative_gwt"]]
+
+    # Add table and save dataset
+    ds.add(Table(df, short_name="gravitational_waves"))
+    ds.update_metadata(N.metadata_path)
+    ds.save()

--- a/etl/steps/data/grapher/technology/2023-01-06/.gitignore
+++ b/etl/steps/data/grapher/technology/2023-01-06/.gitignore
@@ -1,0 +1,1 @@
+/gravitational_waves.csv

--- a/etl/steps/data/grapher/technology/2023-01-06/gravitational_waves.csv.dvc
+++ b/etl/steps/data/grapher/technology/2023-01-06/gravitational_waves.csv.dvc
@@ -1,0 +1,4 @@
+outs:
+- md5: dc733adf31f5616f57bf3c80bba6f56b
+  size: 82
+  path: gravitational_waves.csv

--- a/etl/steps/data/grapher/technology/2023-01-06/gravitational_waves.meta.yml
+++ b/etl/steps/data/grapher/technology/2023-01-06/gravitational_waves.meta.yml
@@ -1,0 +1,18 @@
+dataset:
+  sources:
+    - name: Gravitational Wave Open Science Center (2023)
+      url: https://www.gw-openscience.org/eventapi/html/GWTC/
+      description: |
+        The Gravitational Wave Open Science Center (GWOSC) provides public access to gravitational-wave data. This data is collected by LIGO, Virgo, GEO600, and KAGRA, which are all large-scale physics experiments designed and constructed to observe gravitational waves.
+
+        The GWTC (Gravitational Wave Transient Catalog) is a cumulative set of gravitational wave transients maintained by GWOSC. It contains confidently-detected gravitational wave observations.
+
+        The sources notes that this catalog is only updated periodically, and may not contain recently-published events.
+      publication_year: 2023
+
+tables:
+  gravitational_waves:
+    variables:
+      cumulative_gwt:
+        title: Cumulative gravitational wave transients
+        unit: Gravitational wave transients

--- a/etl/steps/data/grapher/technology/2023-01-06/script.py
+++ b/etl/steps/data/grapher/technology/2023-01-06/script.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pandas as pd
+
+CURRENT_DIR = Path(__file__).parent
+
+
+def main():
+
+    df = pd.read_csv("https://www.gw-openscience.org/eventapi/csv/GWTC/")
+
+    # In case events are recorded multiple times
+    # we keep only the earliest GPS time for each commonName
+    df = df.groupby("commonName", as_index=False).GPS.min()
+
+    # Origin for GPS time is on 1980-01-06
+    df["time"] = pd.to_datetime(df["GPS"], unit="s", origin="1980-01-06", utc=True)
+
+    # Count events by year, and calculate the cumsum
+    df["year"] = df["time"].dt.year
+    df = df.groupby("year").size().reset_index(name="N")
+    df["cumulative_gwt"] = df["N"].cumsum()
+
+    # Add entity and select columns
+    df = df.assign(entity="World")[["entity", "year", "cumulative_gwt"]]
+
+    df.to_csv(CURRENT_DIR / "gravitational_waves.csv", index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/technology/2023-01-05/gravitational_waves.csv.dvc
+++ b/snapshots/technology/2023-01-05/gravitational_waves.csv.dvc
@@ -1,0 +1,23 @@
+meta:
+  namespace: technology
+  short_name: gravitational_waves
+  name: Gravitational wave transients (GWOSC)
+  description: |
+    The Gravitational Wave Open Science Center (GWOSC) provides public access to gravitational-wave data. This data is collected by LIGO, Virgo, GEO600, and KAGRA, which are all large-scale physics experiments designed and constructed to observe gravitational waves.
+
+    The GWTC (Gravitational Wave Transient Catalog) is a cumulative set of gravitational wave transients maintained by GWOSC. It contains confidently-detected gravitational wave observations.
+
+    The sources notes that this catalog is only updated periodically, and may not contain recently-published events.
+  source_name: Gravitational Wave Open Science Center (2023)
+  url: https://www.gw-openscience.org/eventapi/html/GWTC/
+  source_data_url: https://www.gw-openscience.org/eventapi/html/GWTC/
+  file_extension: csv
+  date_accessed: '2023-01-05'
+  is_public: true
+  version: '2023-01-05'
+  publication_year: 2023
+wdir: ../../../data/snapshots/technology/2023-01-05
+outs:
+- md5: 3393a66f008daeff96db5be2c6f81f4e
+  size: 501472
+  path: gravitational_waves.csv

--- a/snapshots/technology/2023-01-05/gravitational_waves.py
+++ b/snapshots/technology/2023-01-05/gravitational_waves.py
@@ -1,0 +1,24 @@
+"""This script should be manually adapted and executed on the event of an update of the Maddison Project Database.
+
+"""
+
+import click
+
+from etl.snapshot import Snapshot
+
+
+@click.command()
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(upload: bool) -> None:
+    snap = Snapshot("technology/2023-01-05/gravitational_waves.csv")
+    snap.download_from_source()
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We've [recently discussed](https://owid.slack.com/archives/C0193RW5E2J/p1672916983670529) what's the easiest way how to get CSV file into MySQL through ETL. Here's a [python script](https://github.com/owid/notebooks/tree/main/EdouardMathieu/gravitational_waves) that generates the data

There are a few ways how to currently do it:

1. **CSV import** in admin - that's gonna get the data into MySQL, but not to ETL
2. **Fast-track** - copy your data, fill metadata and then import it through fast-track (sample [spreadsheet](https://docs.google.com/spreadsheets/d/1NKoZMe6bkXMS29mORNw3o25cENx3MnpYFJk2y3cWXOc/edit?usp=sharing))
3. **Walkthrough** - go through all walkthrough steps and create snapshot & meadow & garden & grapher
4. **Code** - if you know ETL, you should be able to create Snapshot and grapher step

I've tried all of them. Honestly, I understand why people are still using CSV import. Other than that, **fast-track** was the most straightforward to use, although creating a google sheet just for the sake of this small dataset and having my script push data there (or copy&paste manually every time I make a change) is a bit annoying.

Using walkthrough is an overkill for such a dataset and putting together code from the top of my head was hard, even for me! (it took me ~30 mins with debugging typos and such) I guess that only power-users are able to use `etl` at the moment.

[This commit](https://github.com/owid/etl/pull/742/commits/f564ff26688c47e77cda7aaa457384f849691ac7) shows how complex is it to do it at the moment just with code.

I've also experimented with a new approach - let **users generate csv however they like, add it to DVC (= keep it locally, but don't commit to git) and add metadata in YAML**.

In more detail - users would generate csv file using whatever tools they like (python, R, stata) and **add it to S3** with DVC (so it's kind of a snapshot). Then we add a special `static://` step that loads the snapshot, **add metadata** from YAML file and save it as a dataset (that will live in a catalog and could be sent to grapher DB). Here are the steps I made (all in [this commit](https://github.com/owid/etl/pull/742/commits/a134ece23b6f82af6fba055b55f19a3da4e7b2c9)):

1. Create folder `etl/steps/data/grapher/technology/2023-01-06`
2. Copy `script.py` there that generates file `gravitational_waves.csv` (note the script doesn't use ETL at all and it could be R script as well)
3. Run `dvc add etl/steps/data/grapher/technology/2023-01-06/gravitational_waves.csv` to automatically move the file to S3 and only leave the placeholder `gravitational_waves.csv.dvc` in git
4. Add file `gravitational_waves.meta.yml` with metadata
5. Add line `static://grapher/technology/2023-01-06/gravitational_waves.csv:` to DAG
6. Run `etl grapher/technology/2023-01-06/gravitational_waves.csv` to build it (or with `--grapher` flag to upload it to grapher DB)

## Questions

### How is this `static://` from running my script as part of snapshot?

It's pretty similar. The `script.py` could be run as part of snapshot and we'd have just a very simple `grapher` step that would copy snapshot and add metadata. We would need to fill in snapshot metadata and it would make using non-python scripts more challenging.