### PR TITLE
enhance: make exceptions clearer when a step fails

### DIFF
--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -415,7 +415,13 @@ class DataStep(Step):
             ]
         )
 
-        subprocess.check_call(args)
+        try:
+            subprocess.check_call(args)
+        except subprocess.CalledProcessError:
+            # swallow this exception and just exit -- the important stack trace
+            # will already have been printed to stderr
+            print(f'\nCOMMAND: {" ".join(args)}', file=sys.stderr)
+            sys.exit(1)
 
     def _run_notebook(self) -> None:
         "Run a parameterised Jupyter notebook."


### PR DESCRIPTION
Currently, you get two exceptions when a step fails:

1. The real exception, the reason for failure
2. A `CalledProcessError` from `subprocess`

This PR removes the second one, which is not very helpful, so that you can focus on the first one.

## Before

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/lars/Documents/owid/etl/etl/run_python_step.py", line 34, in main
    _import_and_run(path, dest_dir)
  File "/Users/lars/Documents/owid/etl/etl/run_python_step.py", line 52, in _import_and_run
    module.run(dest_dir)
  File "/Users/lars/Documents/owid/etl/etl/steps/data/meadow/papers/2022-11-04/riley_2005/__init__.py", line 49, in run
    check_expected_data(local_file)
  File "/Users/lars/Documents/owid/etl/etl/steps/data/meadow/papers/2022-11-04/riley_2005/__init__.py", line 75, in check_expected_data
    pdfReader = PyPDF2.PdfFileReader(f)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/PyPDF2/_reader.py", line 1974, in __init__
    deprecation_with_replacement("PdfFileReader", "PdfReader", "3.0.0")
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/PyPDF2/_utils.py", line 369, in deprecation_with_replacement
    deprecation(DEPR_MSG_HAPPENED.format(old_name, removed_in, new_name))
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/PyPDF2/_utils.py", line 351, in deprecation
    raise DeprecationError(msg)
PyPDF2.errors.DeprecationError: PdfFileReader is deprecated and was removed in PyPDF2 3.0.0. Use PdfReader instead.
2023-01-09 12:29:37,636 - [bugsnag] WARNING - No API key configured, couldn't notify
Traceback (most recent call last):
  File "/Users/lars/Documents/owid/etl/.venv/bin/etl", line 6, in <module>
    sys.exit(main_cli())
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/lars/Documents/owid/etl/etl/command.py", line 119, in main_cli
    main(**kwargs)  # type: ignore
  File "/Users/lars/Documents/owid/etl/etl/command.py", line 147, in main
    run_dag(
  File "/Users/lars/Documents/owid/etl/etl/command.py", line 245, in run_dag
    time_taken = timed_run(lambda: step.run())
  File "/Users/lars/Documents/owid/etl/etl/command.py", line 252, in timed_run
    f()
  File "/Users/lars/Documents/owid/etl/etl/command.py", line 245, in <lambda>
    time_taken = timed_run(lambda: step.run())
  File "/Users/lars/Documents/owid/etl/etl/steps/__init__.py", line 300, in run
    self._run_py()
  File "/Users/lars/Documents/owid/etl/etl/steps/__init__.py", line 418, in _run_py
    subprocess.check_call(args)
  File "/Users/lars/.pyenv/versions/3.10.7/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['poetry', 'run', 'run_python_step', 'data://meadow/papers/2022-11-04/riley_2005', '/Users/lars/Documents/owid/etl/data/meadow/papers/2022-11-04/riley_2005']' returned non-zero exit status 1.
```

## After

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/lars/Documents/owid/etl/etl/run_python_step.py", line 34, in main
    _import_and_run(path, dest_dir)
  File "/Users/lars/Documents/owid/etl/etl/run_python_step.py", line 52, in _import_and_run
    module.run(dest_dir)
  File "/Users/lars/Documents/owid/etl/etl/steps/data/meadow/papers/2022-11-04/riley_2005/__init__.py", line 49, in run
    check_expected_data(local_file)
  File "/Users/lars/Documents/owid/etl/etl/steps/data/meadow/papers/2022-11-04/riley_2005/__init__.py", line 75, in check_expected_data
    pdfReader = PyPDF2.PdfFileReader(f)
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/PyPDF2/_reader.py", line 1974, in __init__
    deprecation_with_replacement("PdfFileReader", "PdfReader", "3.0.0")
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/PyPDF2/_utils.py", line 369, in deprecation_with_replacement
    deprecation(DEPR_MSG_HAPPENED.format(old_name, removed_in, new_name))
  File "/Users/lars/Documents/owid/etl/.venv/lib/python3.10/site-packages/PyPDF2/_utils.py", line 351, in deprecation
    raise DeprecationError(msg)
PyPDF2.errors.DeprecationError: PdfFileReader is deprecated and was removed in PyPDF2 3.0.0. Use PdfReader instead.

COMMAND: poetry run run_python_step data://meadow/papers/2022-11-04/riley_2005 /Users/lars/Documents/owid/etl/data/meadow/papers/2022-11-04/riley_2005
```