### PR TITLE
WIP: enhance(dvc): improve DVC performance

### DIFF
--- a/.dvcignore
+++ b/.dvcignore
@@ -9,3 +9,6 @@ vendor/
 .cachedir/
 .venv/
 !data/snapshots/
+# this folder contains thousands of .dvc files which slows it down, we dynamically comment it when working with
+# backported snapshots (see _unignore_backports)
+snapshots/backport/


### PR DESCRIPTION
Our DVC commands are pretty slow at the moment, even simple command such as `dvc pull data/snapshots/emdat/2022-11-24/natural_disasters.xlsx` takes ~8s. This is because DVC is [not optimised for our use case](https://github.com/iterative/dvc/issues/8768#issue-1521107079) with thousands of DVC files. They've labeled it as a bug, but it's not clear when is this gonna be fixed.

Temporary solution is to add `snapshots/backports` to `.dvcignore` which makes most of DVC files. Then we dynamically modify it when we work with backported snapshots. This makes DVC run under 1s for non-backported files which is noticeable in `etl` runs and also in fast-track when uploading snapshots.