### PR TITLE
data(snapshot): add conflict datasets from spreadsheets

### DIFF
--- a/snapshots/conflicts/2023-01-09/bouthoul_carrere_1978.csv.dvc
+++ b/snapshots/conflicts/2023-01-09/bouthoul_carrere_1978.csv.dvc
@@ -1,0 +1,70 @@
+meta:
+  namespace: conflicts
+  short_name: bouthoul_carrere
+  name: A list of the 366 major armed conflicts of the period 1740 - 1974
+  source_name: Bouthoul and Carrere (1978)
+  publication_year: 1978
+  publication_date: 1978-07-01
+  url: https://www.jstor.org/stable/23609587
+  source_data_url: https://docs.google.com/spreadsheets/d/1JXkz05kb_gkGXuvdnI21B6lhHIVZJD5BaiEOZi8mqRk/edit?usp=sharing
+  file_extension: csv
+  license_url: https://about.jstor.org/terms/
+  license_name: JSTOR
+  date_accessed: 2023-01-09
+  is_public: true
+  description: >-
+    What years and countries are covered? 1740–1974, worldwide
+
+      - "List of all major armed conflicts – domestic and international – for the
+    period 1740 - 1974" (Bouthoul et al. 1978: 83)
+
+
+    Which conflicts are covered?
+
+      - Major armed conflicts, domestic and international.
+
+      - "Only those conflicts were included which satisfied at least one of the following
+    six quantitative criteria and could 
+      therefore be considered as 'major armed conflicts', wars and revolutions being
+    the most representative ones." (Bouthoul et al. 1978: 83).
+
+      - 'Major': more than one state, affected a large area, lasted longer than one
+    year, killed more than 1,000, or had important results,
+      such as regime change or independence; "Those six criteria were: a. undertaken
+    by more than one state, b. Affected a space larger 
+      than one province or a capital, c. lasted longer than one year, d. Was of great
+    intensity (more than 1,000 killed)[...], e. Had important 
+      internal results (secession or regime change), f. Had important international
+    results (annexation or independence, emergence or 
+      disappearance of a state" (Bouthoul et al. 1978: 83).
+
+      - "The list thus includes the following types of conflicts: foreign and civil
+    wars, occupations by force (e.g. Austria, 1938), 
+      military penetrations, revolutions, uprisings and insurrections, massacres and
+    genocide, and other violent troubles with important 
+      consequences." (Bouthoul et al. 1978: 83-84).
+
+      - "Conflicts preceded by an asterisk are classified as "inter-state" conflicts
+    in the authors' investigation." (Bouthoul et al. 1978: 84).
+
+
+    Which deaths and casualties are covered?
+
+      - Deaths; military and civilian combined; direct and indirect combined
+
+      - "Number of killed, military and civilian, on account of the conflict (operations,
+    massacres, epidemies and famines directly linked to the 
+      conflict) (order of magnitude, e.g. 60,000). In view of the difficulty of obtaining
+    precise figures, the ones given indicate orders of magnitude" 
+      (Bouthoul et al. 1978: 84).
+
+    How did we construct our source spreadsheet?
+
+      - We identified conflicts as well as deaths from the list in their article.
+
+      - We excluded conflicts without deaths.
+wdir: ../../../data/snapshots/conflicts/2023-01-09
+outs:
+- md5: d0b1416eade865e82e5f935f1c641610
+  size: 46668
+  path: bouthoul_carrere_1978.csv

--- a/snapshots/conflicts/2023-01-09/bouthoul_carrere_1978.py
+++ b/snapshots/conflicts/2023-01-09/bouthoul_carrere_1978.py
@@ -1,7 +1,9 @@
-"""Get our manually curated dataset.
+"""Get our manually curated dataset into Snapshot.
 
-This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
-at https://docs.google.com/spreadsheets/d/1JXkz05kb_gkGXuvdnI21B6lhHIVZJD5BaiEOZi8mqRk/edit?usp=sharing."""
+We maintain a manually curated transcription of the data from Bouthoul and Carrere (1978) in a Google Spreadsheet.
+Then, port this file to Snapshot. To obtain this file, download it as a CSV from
+https://docs.google.com/spreadsheets/d/1JXkz05kb_gkGXuvdnI21B6lhHIVZJD5BaiEOZi8mqRk/edit?usp=sharing and use
+it with the `--path-to-file` argument."""
 
 from pathlib import Path
 

--- a/snapshots/conflicts/2023-01-09/bouthoul_carrere_1978.py
+++ b/snapshots/conflicts/2023-01-09/bouthoul_carrere_1978.py
@@ -1,0 +1,35 @@
+"""Get our manually curated dataset.
+
+This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
+at https://docs.google.com/spreadsheets/d/1JXkz05kb_gkGXuvdnI21B6lhHIVZJD5BaiEOZi8mqRk/edit?usp=sharing."""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+SNAPSHOT_VERSION = "2023-01-09"
+
+
+@click.command()
+@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(path_to_file: str, upload: bool) -> None:
+    # Create new snapshot.
+    snap = Snapshot(f"conflicts/{SNAPSHOT_VERSION}/bouthoul_carrere_1978.csv")
+    # Ensure destination folder exists.
+    snap.path.parent.mkdir(exist_ok=True, parents=True)
+    # Copy local data file to snapshots data folder.
+    snap.path.write_bytes(Path(path_to_file).read_bytes())
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/conflicts/2023-01-09/clodfelter_2017.csv.dvc
+++ b/snapshots/conflicts/2023-01-09/clodfelter_2017.csv.dvc
@@ -1,0 +1,178 @@
+meta:
+  namespace: conflicts
+  short_name: clodfelter_2017
+  name: 'Warfare and Armed Conflicts: A Statistical Encyclopedia of Casualty and Other
+    Figures, 1492-2015, 4th ed.'
+  source_name: Clodfelter (2017)
+  publication_year: 2017
+  publication_date: 2017-04-24
+  url: https://books.google.es/books/about/Warfare_and_Armed_Conflicts.html?id=kNzCDgAAQBAJ&redir_esc=y
+  source_data_url: https://docs.google.com/spreadsheets/d/1Evc5VP2Ra3Lb2_GoV8LjMaJcFoCzlUwslY-TFtC_fB4/edit?usp=sharing
+  file_extension: csv
+  license_url: https://mcfarlandbooks.com/product/warfare-and-armed-conflicts/
+  license_name: McFarland, 2017
+  date_accessed: 2023-01-09
+  is_public: true
+  description: >-
+    What years and countries are covered? 1492 – 2015
+
+
+    Which conflicts are covered? Wars, domestic and international
+
+      - 1492 chosen because data before even more flawed: "Because of the paucity
+    of even remotely reliable statistics before the Renaissance, 
+      this volume employs as its starting point the epical year of 1492" (Clodfelter
+    2017: 1).
+
+      - "I have attempted to include every war, major or minor, for which there exist
+    statistics—international wars and civil wars,
+      internationalized civil wars, limited wars and unlimited wars, border wars and
+    miniwars—as well as those less organized and 
+      less sustained, or wholly one-sided outbreaks of mass human violence—riots,
+    revolutions, massacres, bloodbaths, and pogroms, 
+      (or those conflicts, such as the U.S. Civil Rights Movement, in which only one
+    side was armed and violent and the other 
+      determinedly non-violent)" (Clodfelter 2017: 1-2).
+
+
+    Which deaths and casualties are covered?
+
+      - Deaths and casualties; military and civilian combined; direct and indirect
+    combined.
+      
+      - Deaths and casualties from battle: "KIA for killed-in-action; DOW for died
+    of wounds; WIA for wounded-in-action; MIA for missing-in-action; 
+      POW for prisoner of war. In many instances, because of a lack of accurate information
+    about the number who died of wounds subsequent to the 
+      battle or who died from fratricide or other causes directly or indirectly attributable
+    to hostile fire, KIA is employed as a catch-all 
+      designation for lack of more precise data. Where more appropriate, the term
+    "battle deaths" is used" (Clodfelter 2017: xix-xx).
+      
+      - Deaths from disease included: "Of course, a very large proportion of the dead
+    shown in these sets of figures were not killed in battle but 
+      died as a result of infections arising from wounds or disease. Until the great
+    medical advances of the late nineteenth century and of the 
+      twentieth century, nearly as many men did after the guns had fallen silent as
+    had been killed in the heat and smoke of battle" 
+      (Clodfelter 2017: 6).
+      
+      - "Until the twentieth century a soldier marching off to war had a far greater
+    chance of dying for his cause or country because of disease than 
+      through enemy fire. The proportion of disease deaths to combat deaths (including
+    those who died of wounds) was almost always at least 3:1, even 
+      in the healthiest of climates" (Clodfelter 2017: 6).
+      
+      - No deaths or casualties threshold: "It is, of course, beyond the scope of
+    a work such as this to include the losses of every single battle 
+      for which someone has bothered to take and record a count of casualties. [...]
+    It is obvious that I must establish some kind of minimum 
+      cut-off figure for the toll of the battles of, say, World War I's Western Front
+    or World War II's Russian Front, while setting a different 
+      criterion when recording the losses suffered in the actions of a great many
+    lesser wars. If I were to arbitrarily conform to a figure of 
+      50,000 or even 25,000 total casualties incurred, below which I would not bother
+    to include a battle in this survey, this work would 
+      ignore a great many of the important battles of history" (Clodfelter 2017: 2).
+      
+      - One-sided violence included: "I have attempted to include every war, major
+    or minor, for which there exist statistics [...] as well as those 
+      less organized and less sustained, or wholly one-sided outbreaks of mass human
+    violence—riots, revolutions, massacres, bloodbaths, and pogroms, 
+      (or those conflicts, such as the U.S. Civil Rights Movement, in which only one
+    side was armed and violent and the other determinedly 
+      non-violent)" (Clodfelter 2017: 1-2).
+      
+      - Numbers do not necessarily add up across categories: "Figures in tables organized
+    by year or unit do not always conform strictly to other 
+      cumulative counts or estimates due to variables in the methodology and dating
+    of the counts" (Clodfelter 2017: xx).
+      
+      - Data quality low because lives lost were not valued: "Body counts were not
+    important in earlier centuries, particularly the seventeenth and 
+      eighteenth, the era of siege warfare. In those centuries the magnitude of victory
+    was often calculated as much on fortresses or cities 
+      captured and war materiel seized as on casualties inflicted" (Clodfelter 2017:
+    4).
+      
+      - "The ratio of killed to wounded also remained fairly constant up to World
+    War I. For every 10 men killed usually another 35 were wounded" 
+      (Clodfelter 2017: 4).
+      
+      - Sometimes several estimates are given: "Usually a single set of figures is
+    presented in this work, but in some cases, for the sake of 
+      comparison, conflicting counts are given. The abbreviation "n.a." (not available)
+    is used when no reliable data were found." (Clodfelter 2017: xix).
+
+
+    How did he construct the data?
+
+      - Data quality as good as can be, but flawed: "I have employed official and
+    supposedly authoritative sources wherever available, have sought 
+      statistics from both sides in each war to evaluate the inevitably conflicting
+    claims, and have tried to verify the numbers reported on 
+      the battlefield with the records of the various medical corps and military surgeon-general
+    reports. But for all my efforts at cutting 
+      through the exaggeration, propaganda, and outright mendacity with which the
+    statistics of warfare are weighted, it must still be admitted 
+      that every quantity in this work may legitimately be questioned" (Clodfelter
+    2017: xix).
+      
+      - Data quality lower for earlier years and for countries outside Europe: "Usually
+    the longer the battle and the larger the battlefield, 
+      the more uncertain the numbers involved. Generally also, the reliability of
+    battlefield figures decreases the further back one goes in 
+      history and the further one travels from the Western industrial world. Numerical
+    precision in warfare, even in the West, was rare prior 
+      to the Age of the Enlightenment. Every battlefield statistic can be no more
+    than an educated guess" (Clodfelter 2017: xix).
+      
+      - Data is still informative: "But there are precise numbers in the documentation
+    of warfare—tens of thousands of them. It is unnecessary 
+      to reject them all because a few seem unlikely or even impossible, and round
+    off all battlefield numbers" (Clodfelter 2017: xix).
+      
+      - Data quality for European countries is better (but a troubling way of expressing
+    that): "In some cases, exact numbers are stated for one 
+      side in a conflict while estimated figures are given for the opposing side.
+    This is due to the progression in statistical accuracy of the 
+      one side and lack of such for the other. This is particularly characteristic
+    of the colonial conflicts of the late eighteenth through the 
+      early twentieth centuries, when the more technologically advanced Western armies
+    battled the forces of Africa and Asia whose cultures cared 
+      little for statistical precision" (Clodfelter 2017: xix).
+      
+      - Data quality is better if war was relatively small, brief, and clear geography
+    and timeline: "The dependability of statistical accuracy 
+      rises with battles of relatively small scope, brief duration, and distinct boundaries
+    in geography and chronology" (Clodfelter 2017: xix).
+      
+      - Worked to reconcile differing sources: "Where generally reliable, but conflicting,
+    sources exist for the same battle or war, the origin 
+      of each source has been investigated to determine the more accurate of the two"
+    (Clodfelter 2017: xix).
+
+
+    How did we construct our source spreadsheet?
+
+      - We identified conflicts as well as deaths and casualties based on the conflict
+    narratives in his book.
+      
+      - We seem to have almost exclusively coded conflicts until the early 19th century;
+    among the coded conflicts, the latest start date is 1831.
+      
+      - We erred on the side of caution, such as by excluding estimates referring
+    to 'dead, wounded, or missing in action'.
+      
+      - In some cases, we used overall estimates of deaths instead of adding up more
+    specific death types.
+      
+      - We have two source spreadsheets: they include the same information, but whereas
+    one provides more information in the 'notes' column, the 
+      other follows the structure common for the other datasets of one conflict per
+    row.
+wdir: ../../../data/snapshots/conflicts/2023-01-09
+outs:
+- md5: 3d352b60ea0bf89d81061ffdb6db9322
+  size: 41745
+  path: clodfelter_2017.csv

--- a/snapshots/conflicts/2023-01-09/clodfelter_2017.py
+++ b/snapshots/conflicts/2023-01-09/clodfelter_2017.py
@@ -1,8 +1,9 @@
-"""Get our manually curated dataset.
+"""Get our manually curated dataset into Snapshot.
 
-This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
-at https://docs.google.com/spreadsheets/d/1Evc5VP2Ra3Lb2_GoV8LjMaJcFoCzlUwslY-TFtC_fB4/edit?usp=sharing."""
-
+We maintain a manually curated transcription of the data from Dunnigan and Clodfelter (2017) in a Google Spreadsheet.
+Then, port this file to Snapshot. To obtain this file, download it as a CSV from
+https://docs.google.com/spreadsheets/d/1Evc5VP2Ra3Lb2_GoV8LjMaJcFoCzlUwslY-TFtC_fB4/edit?usp=sharing and use
+it with the `--path-to-file` argument."""
 
 from pathlib import Path
 

--- a/snapshots/conflicts/2023-01-09/clodfelter_2017.py
+++ b/snapshots/conflicts/2023-01-09/clodfelter_2017.py
@@ -1,0 +1,36 @@
+"""Get our manually curated dataset.
+
+This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
+at https://docs.google.com/spreadsheets/d/1Evc5VP2Ra3Lb2_GoV8LjMaJcFoCzlUwslY-TFtC_fB4/edit?usp=sharing."""
+
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+SNAPSHOT_VERSION = "2023-01-09"
+
+
+@click.command()
+@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(path_to_file: str, upload: bool) -> None:
+    # Create new snapshot.
+    snap = Snapshot(f"conflicts/{SNAPSHOT_VERSION}/clodfelter_2017.csv")
+    # Ensure destination folder exists.
+    snap.path.parent.mkdir(exist_ok=True, parents=True)
+    # Copy local data file to snapshots data folder.
+    snap.path.write_bytes(Path(path_to_file).read_bytes())
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/conflicts/2023-01-09/dunnigan_martel_1987.csv.dvc
+++ b/snapshots/conflicts/2023-01-09/dunnigan_martel_1987.csv.dvc
@@ -1,0 +1,120 @@
+meta:
+  namespace: conflicts
+  short_name: dunnigan_martel_1987
+  name: How to stop a war (1987)
+  source_name: Dunnigan and Martel (1987)
+  publication_year: 1987
+  publication_date: 1987-10-01
+  url: https://books.google.es/books/about/How_to_Stop_a_War.html?id=lg7cAAAAMAAJ
+  source_data_url: https://docs.google.com/spreadsheets/d/13XJbTXryll5VqhtmbutMLCbb3pgjEtofk3o2dJG29Aw/edit?usp=sharing
+  file_extension: csv
+  license_url:
+  license_name: Doubleday (1987)
+  date_accessed: 2023-01-09
+  is_public: true
+  description: >-
+    What years and countries are covered?
+      
+      - "Wars that occurred during the last two hundred years" (Dunnigan and Martel
+    1987: 6).
+
+      - 1786-1987  (Dunnigan and Martel 1987: 207, 250)
+
+
+    Which conflicts are covered?
+      
+      - "War is organized violence caused by national governments" (Dunnigan and Martel
+    1987: 11).
+      
+      - "Traditional Wars. [...] Two nations gather up their armed forces and go after
+    each other" (Dunnigan and Martel 1987: 11).
+      
+      - "Colonial Wars. A broad category of conflicts best described as a major power
+    going to war with a significantly weaker power on the 
+      defender's own territory. This does not always involve actual colonies, just
+    big guys beating up on little guys. 
+      [The major distinguishing characteristic is the great disparity in military
+    power between the two combatants. [...] What is most important 
+      about this type of war is that only one side, the major power, can escalate
+    the war to include nuclear weapons or other combat between 
+      superpowers" (Dunnigan and Martel 1987: 11).
+      
+      - "Civil Wars. A nation at war with itself, with both sides deploying armed
+    forces. This category includes insurrections, separatist movements, 
+      persistent terrorism and rebellions in general" (Dunnigan and Martel 1987: 11-12).
+      
+      - "Civil Terrors. A nation goes to war against its own people. Many of these
+    wars are very similar to civil wars, except that the "rebels" are 
+      not organized well, if at all. [...] The most prominent examples are the Stalinist
+    Terror in Russia during the 1930s, the Communist Terror in 
+      China during the 1950s [...]" (Dunnigan and Martel 1987: 12).
+      
+      - "Began: Year in which the war began. Sometimes it differs from the official
+    starting date. We used the date at which hostilities or 
+      large-scale unrest began" (Dunnigan and Martel 1987: 180).
+      
+      - "We categorized wars into the following groups: C— Civil terror[;] R—Social
+    revolution[;] S—Secessionist movement[;] T—Territorial conflict" 
+      (Dunnigan and Martel 1987: 184).
+
+
+    Which deaths and casualties are covered?
+      
+      - Probably deaths; military and civilian combined; direct and indirect combined.
+      
+      - "Losses: Military and civilian" (Dunnigan and Martel 1987: 185).
+      
+      - "Keep in mind that it is often difficult to separate them. A further complication
+    is that civilian losses are often not noted in histories" 
+      (Dunnigan and Martel 1987: 185).
+      
+      - 'Losses' used, which probably means deaths: "nearly half the deaths in all
+    wars" made up by the Napoleonic Wars, the Taiping Rebellion, and 
+      the World Wars — which is half of all the losses of the 163 million they list.
+
+
+    How did they construct the data?
+      
+      - "our information was collected for each participant of the war" (Dunnigan
+    and Martel 1987: 6).
+      
+      - "One source that was quite useful is The Encyclopedia of Military History
+    (New York: Harper & Row, 1977) by R. E. Dupuy and T. N. Dupuy. 
+      The detailed accounts of wars provided a starting point for identifying wars"
+    (Dunnigan and Martel 1987: 275).
+      
+      - "An important reference was The Wages of War, 1819-1965 (New York: John Wiley
+    & Sons, 1972) by J. David Singer and Melvin Small. [...] It 
+      is also a good source of data on the size of the combat forces for each nation,
+    and estimates of the casualties. Singer and Small, however, 
+      tend to generate statistics of dubious value, such as battle deaths per month
+    of the war" (Dunnigan and Martel 1987: 275).
+      
+      - "There is considerable uncertainty about the number of people who are killed
+    in a given war, especially as one proceeds further into the past" 
+      (Dunnigan and Martel 1987: 275).
+      
+      - "Some other sources for data on combat casualties are Statistics of Deadly
+    Quarrels (Pittsburgh: Boxwood Press, 1960) by Lewis Frye Richardson; 
+      Social and Cultural Dynamics (New York: American Book, 1937) by Pitirim A. Sorokin;
+    Losses of Life in Modern Wars (London: Oxford University, 
+      1916) by Gaston Bodart; Losses of Life Caused by War (London: Oxford University,
+    1920) by Vedel and Petersen. Military Balance (Letchford,
+      England: The Garden City Press Ltd., 1985), which is published annually by the
+    International Institute for Strategic Studies, is a good source 
+      for the size of armed forces in the contemporary period" (Dunnigan and Martel
+    1987: 276).
+
+    How did we construct it?
+      
+      - We used to access the book here; the access since seems to have become restricted,
+    we have purchased a used copy; the quotes above are from 
+      that copy.
+      
+      - We extracted conflicts as well as deaths and casualties from the list in their
+    book, starting at page 207.
+wdir: ../../../data/snapshots/conflicts/2023-01-09
+outs:
+- md5: 5ab165a63ccfdec62b72d3bddf114497
+  size: 150480
+  path: dunnigan_martel_1987.csv

--- a/snapshots/conflicts/2023-01-09/dunnigan_martel_1987.py
+++ b/snapshots/conflicts/2023-01-09/dunnigan_martel_1987.py
@@ -1,0 +1,35 @@
+"""Get our manually curated dataset.
+
+This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
+at https://docs.google.com/spreadsheets/d/13XJbTXryll5VqhtmbutMLCbb3pgjEtofk3o2dJG29Aw/edit?usp=sharing."""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+SNAPSHOT_VERSION = "2023-01-09"
+
+
+@click.command()
+@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(path_to_file: str, upload: bool) -> None:
+    # Create new snapshot.
+    snap = Snapshot(f"conflicts/{SNAPSHOT_VERSION}/dunnigan_martel_1987.csv")
+    # Ensure destination folder exists.
+    snap.path.parent.mkdir(exist_ok=True, parents=True)
+    # Copy local data file to snapshots data folder.
+    snap.path.write_bytes(Path(path_to_file).read_bytes())
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/conflicts/2023-01-09/dunnigan_martel_1987.py
+++ b/snapshots/conflicts/2023-01-09/dunnigan_martel_1987.py
@@ -1,7 +1,9 @@
-"""Get our manually curated dataset.
+"""Get our manually curated dataset into Snapshot.
 
-This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
-at https://docs.google.com/spreadsheets/d/13XJbTXryll5VqhtmbutMLCbb3pgjEtofk3o2dJG29Aw/edit?usp=sharing."""
+We maintain a manually curated transcription of the data from Dunnigan and Martel (1987) in a Google Spreadsheet.
+Then, port this file to Snapshot. To obtain this file, download it as a CSV from
+https://docs.google.com/spreadsheets/d/13XJbTXryll5VqhtmbutMLCbb3pgjEtofk3o2dJG29Aw/edit?usp=sharing and use
+it with the `--path-to-file` argument."""
 
 from pathlib import Path
 

--- a/snapshots/conflicts/2023-01-09/eckhardt_1991.csv.dvc
+++ b/snapshots/conflicts/2023-01-09/eckhardt_1991.csv.dvc
@@ -1,0 +1,63 @@
+meta:
+  namespace: conflicts
+  short_name: eckhardt_1991
+  name: Wars and War-Related Deaths, 1500-1990 - Eckhardt (1991)
+  source_name: Eckhardt (1991)
+  publication_year: 1991
+  publication_date: 1991-01-01
+  url: https://ruthsivard.com/wmse91.html
+  source_data_url: https://docs.google.com/spreadsheets/d/1vI5zTU5r7LNjG8AcH0ZIoCNEjMIo68Rn6pqwarVAQ-Q/edit?usp=sharing
+  file_extension: csv
+  license_url:
+  license_name: World Priorities
+  date_accessed: 2023-01-09
+  is_public: true
+  description: >-
+    What years and countries are covered? 1500 – 1990.
+
+
+    Which conflicts are covered? War, domestic or international, involving at least
+    one state.
+
+      - Threshold for a war: "War—any armed conflict involving one or more governments
+    and causing the death of 1,000 or more people per year" 
+      (Eckhardt 1991: 25).
+
+      - "Location refer to country which was principal battleground, except for two
+    World Wars for which location refers to participating country" 
+      (Eckhardt 1991: 25).
+
+      - Also included: "Intervention—overt military action by foreign forces, at the
+    invitation of the government in power" (Eckhardt 1991: 25).
+
+      - Also included: "Invasion—armed attack by foreign country, including air attack
+    without land invasion" (Eckhardt 1991: 25).
+
+
+    Which deaths and casualties are covered? Deaths; total, military, or civilian;
+
+      
+      - "War-Related Deaths" (Eckhardt 1991: 22).
+      
+      - "Civilian [—] Military [—] Total" (Eckhardt 1991: 22).
+      
+      - "Incomplete; breakdown of civilian and military deaths not available in all
+    cases" (Eckhardt 1991: 25).
+      
+      - "World War area-wide deaths are in addition to those which could be located
+    by country, and are shown under the country of origin" 
+      (Eckhardt 1991: 25).
+
+
+    How did we construct it?
+
+      - We extracted conflicts as well as deaths and casualties from the list in this
+    book.
+      - There seems to be an affordable used edition available in the UK that we could
+    buy if we wanted more information; alternatively, 
+      this book by Eckhardt may have more details in chapter 9.
+wdir: ../../../data/snapshots/conflicts/2023-01-09
+outs:
+- md5: ef6af27bf85a82675f41a9e4423b6120
+  size: 103932
+  path: eckhardt_1991.csv

--- a/snapshots/conflicts/2023-01-09/eckhardt_1991.py
+++ b/snapshots/conflicts/2023-01-09/eckhardt_1991.py
@@ -1,7 +1,9 @@
-"""Get our manually curated dataset.
+"""Get our manually curated dataset into Snapshot.
 
-This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
-at https://docs.google.com/spreadsheets/d/1vI5zTU5r7LNjG8AcH0ZIoCNEjMIo68Rn6pqwarVAQ-Q/edit?usp=sharing."""
+We maintain a manually curated transcription of the data from Eckhardt (1991) in a Google Spreadsheet.
+Then, port this file to Snapshot. To obtain this file, download it as a CSV from
+https://docs.google.com/spreadsheets/d/1vI5zTU5r7LNjG8AcH0ZIoCNEjMIo68Rn6pqwarVAQ-Q/edit?usp=sharing and use
+it with the `--path-to-file` argument."""
 
 from pathlib import Path
 

--- a/snapshots/conflicts/2023-01-09/eckhardt_1991.py
+++ b/snapshots/conflicts/2023-01-09/eckhardt_1991.py
@@ -1,0 +1,35 @@
+"""Get our manually curated dataset.
+
+This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
+at https://docs.google.com/spreadsheets/d/1vI5zTU5r7LNjG8AcH0ZIoCNEjMIo68Rn6pqwarVAQ-Q/edit?usp=sharing."""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+SNAPSHOT_VERSION = "2023-01-09"
+
+
+@click.command()
+@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(path_to_file: str, upload: bool) -> None:
+    # Create new snapshot.
+    snap = Snapshot(f"conflicts/{SNAPSHOT_VERSION}/eckhardt_1991.csv")
+    # Ensure destination folder exists.
+    snap.path.parent.mkdir(exist_ok=True, parents=True)
+    # Copy local data file to snapshots data folder.
+    snap.path.write_bytes(Path(path_to_file).read_bytes())
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/conflicts/2023-01-09/orae_1985.csv.dvc
+++ b/snapshots/conflicts/2023-01-09/orae_1985.csv.dvc
@@ -1,0 +1,147 @@
+meta:
+  namespace: conflicts
+  short_name: orae_1985
+  name: ORAE Report 95 - National Defence of Canada (1985)
+  source_name: National Defence of Canada (1985)
+  publication_year: 1985
+  publication_date: 1985-11-01
+  url: https://books.google.es/books/about/Major_Armed_Conflict.html?id=Xce_PwAACAAJ&redir_esc=y
+  source_data_url: https://docs.google.com/spreadsheets/d/1GIB-8ZPNXqTATwHU4ZDavKz0iJoiOg2UROfoRz43kQY/edit#gid=1251805698
+  file_extension: csv
+  license_url:
+  license_name: Department of National Defence, Canada, Operational Research and Analysis
+    Establishment, 1985
+  date_accessed: 2023-01-09
+  is_public: true
+  description: >-
+    What years and countries are covered? 1720–1985, worldwide.
+      
+      - "190 nations for the years 1720 to 1985" (ORAE 1985: 12).
+      
+      - "The nation list is so large because it includes nations that have ceased
+    to exist today" (ORAE 1985: 12).
+      
+      - "all identifiable wars and conflicts that have taken place since 1720" (ORAE
+    1985: i).
+      
+      - Coverage start was chosen because modern age begins then: "The 260-year time
+    period was chosen because it covers the development of 
+      modern war and conflict" (ORAE 1985: 12-13).
+
+
+    Which conflicts are covered?
+
+      - Major armed conflicts involving at least one state, domestic and international.
+      
+      - Definition of major armed conflict: "It was originally defined as "An event
+    where one or more nations or actors used armed force against 
+      another nation or actor. The violent actions must result in significant casualties""
+    (ORAE 1985: 13).
+      
+      - One state has to be involved: "there are certain types of conflict which the
+    definition should exclude, for example, isolated terrorist acts, 
+      gang warfare not involving a national government, changes of government by bloodless
+    coup, riots controlled by police without military support, 
+      etc. Most of these can be excluded by setting the requirement that in a conflict
+    at least one nation must be involved; the other participants may 
+      be actors" (ORAE 1985: 14).
+      
+      - Different types of conflict: "Major armed conflicts may include: international
+    wars, civil wars, guerilla wars, limited wars, nuclear wars, 
+      colonial wars, revolutions, occupation by force, massacres (if committed for
+    or against a government), violent civil disorders with military 
+      involvement, coups d'état (where armed resistance or attack is involved), military
+    revolts, wars for independence, etc. Specifically, the 
+      following typology of conflict modes has been utilized in the Compendium: 1.
+    Conventional Interstate 2. Unconventional Interstate 3. Internal 
+      with Significant External Involvement 4. Primarily Internal 5. Colonial 6. Imperial
+    7. Cold War Crisis[.] The definitions, criteria and 
+      assumptions of these modes are discussed in Annex A: Guide to the Variable list"
+    (ORAE 1985: 14).
+      
+      - "Seven modes of conflict have been identified [...] The most important are
+    "Primarily Internal" Conflict – 230 cases, and "Conventional 
+      Interstate Conflict" – 164 cases" (ORAE 1985: 1).
+      
+      - "However, since the appearance of mode 7, Cold War Crisis, may be unexpected,
+    it should be explained that a cold war crisis is really a 
+      substitute for a major armed conflict, or a major armed conflict that doesn't
+    happen. It is a new development in the nature of conflict and 
+      seems best regarded as a major conflict that is resolved peaceably. Such cases
+    are, therefore, included whether or not there were many 
+      casualties or even any at all. They do not occur before 1945" (ORAE 1985: 14-15).
+      
+      - Casualty numbers unnecessary to be included: "Moreover, in a large number
+    of cases there is no reliable record of the number of casualties' 
+      these cases have not been excluded if they appeared to meet the other requirements
+    for a major conflict" (ORAE 1985: 14).
+      
+      - "a total of 654 conflicts [...] deaths are recorded for only 504 of the cases"
+    (ORAE 1985: 1).
+
+    Which deaths and casualties are covered? Deaths; military and civilian combined
+
+      - "This report has attempted to identify the total casualties (deaths) associated
+    with each conflict, both military and civilian, but it 
+      should be noted that there are inconsistencies and inaccuracies in the data"
+    (ORAE 1985: 18).
+      
+      - "DEATHS - the sum of the deaths in all the nations actively involved in each
+    conflict which can be related to that conflict. 
+      There is some inconsistency in the data because Singer and Small include only
+    battle deaths while Bouthoul and Carrière [sic] include 
+      both military and civilian deaths. An effort has been made to include the casualties
+    for both civilians and military that were a result 
+      of the armed conflict. When there is no figure available, the deaths are listed
+    as ‘0'" (ORAE 1985: A7).
+      
+      - Direct and indirect deaths combined because one source is Singer and Small
+    (i.e. early Correlates of War)
+
+
+    How did they construct the data?
+
+      - "This research project is based upon an approach to the study of war and conflict
+    largely begun by Quincy Wright in A Study of War (1942) 
+      and Lewis F. Richardson in Statistics of Deadly Quarrels (1960)" (ORAE 1985:
+    10).
+      
+      - The data of Bouthoul and Carrère (1976) served as an important secondary source"
+    (ORAE 1985: 12).
+      
+      - Singer and Small (i.e. early Correlates of War) used as one source: "There
+    is some inconsistency in the data because Singer and Small 
+      include only battle deaths" (ORAE 1985: A7).
+      
+      - "In this Annex [B] each conflict is listed in order of starting date and a
+    number of basic facts describing the conflicts are given. 
+      [...] They relate to the when, where, why of the conflict and who is involved"
+    (ORAE 1985: 4).
+      
+      - "each conflict case has been subjected to the same formally-defined and operationalized
+    variables. These include: date, region, participants 
+      (i.e. nations and actors), committer, location, intervenor, magnitude, combatants,
+    deaths (both military and civilian), type of force employed,
+       issues and outcomes" (ORAE 1985: 15).
+      
+      - War duration precise to the month: "the duration statistics are not refined
+    to days and the shortest war is, therefore, one month" 
+      (ORAE 1985: 33).
+      
+      - War within one year assumed to have lasted six months: "When a conflict was
+    identified by only the year during which it occurred, the 
+      assumption was made that the conflict began mid-year and lasted six months"
+    (ORAE 1985: A1).
+
+
+    How did we construct our source spreadsheet?
+
+      - We identified conflicts as well as deaths and casualties from appendix B1
+    in their report.
+
+      - We excluded conflicts with 0 deaths.
+wdir: ../../../data/snapshots/conflicts/2023-01-09
+outs:
+- md5: ebe21d08d52544800ffdfdb2b9ceec62
+  size: 81484
+  path: orae_1985.csv

--- a/snapshots/conflicts/2023-01-09/orae_1985.py
+++ b/snapshots/conflicts/2023-01-09/orae_1985.py
@@ -1,0 +1,35 @@
+"""Get our manually curated dataset.
+
+This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
+at https://docs.google.com/spreadsheets/d/1GIB-8ZPNXqTATwHU4ZDavKz0iJoiOg2UROfoRz43kQY/edit?usp=sharing."""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+SNAPSHOT_VERSION = "2023-01-09"
+
+
+@click.command()
+@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(path_to_file: str, upload: bool) -> None:
+    # Create new snapshot.
+    snap = Snapshot(f"conflicts/{SNAPSHOT_VERSION}/orae_1985.csv")
+    # Ensure destination folder exists.
+    snap.path.parent.mkdir(exist_ok=True, parents=True)
+    # Copy local data file to snapshots data folder.
+    snap.path.write_bytes(Path(path_to_file).read_bytes())
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/conflicts/2023-01-09/orae_1985.py
+++ b/snapshots/conflicts/2023-01-09/orae_1985.py
@@ -1,7 +1,9 @@
-"""Get our manually curated dataset.
+"""Get our manually curated dataset into Snapshot.
 
-This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
-at https://docs.google.com/spreadsheets/d/1GIB-8ZPNXqTATwHU4ZDavKz0iJoiOg2UROfoRz43kQY/edit?usp=sharing."""
+We maintain a manually curated transcription of the data from ORAE (1985) in a Google Spreadsheet.
+Then, port this file to Snapshot. To obtain this file, download it as a CSV from
+https://docs.google.com/spreadsheets/d/1GIB-8ZPNXqTATwHU4ZDavKz0iJoiOg2UROfoRz43kQY/edit?usp=sharing and use
+it with the `--path-to-file` argument."""
 
 from pathlib import Path
 

--- a/snapshots/conflicts/2023-01-09/sorokin_1937.csv.dvc
+++ b/snapshots/conflicts/2023-01-09/sorokin_1937.csv.dvc
@@ -1,0 +1,90 @@
+meta:
+  namespace: conflicts
+  short_name: sorokin_1937
+  name: 'Social and cultural dynamics. Volume III: Fluctuation of Social Relationships,
+    War, and Revolution (1937)'
+  source_name: Sorokin (1937)
+  publication_year: 1937
+  publication_date: 1937-12-01
+  url: https://doi.org/10.2307/2143975
+  source_data_url: https://docs.google.com/spreadsheets/d/1Xo5e8aiFJnmv_aasFXU8MtzizSU0LxiysoUuErEJx3Q/edit?usp=sharing
+  file_extension: csv
+  license_url: https://about.jstor.org/terms/
+  license_name: JSTOR
+  date_accessed: 2023-01-09
+  is_public: true
+  description: >-
+    What years and countries are covered? 12th-20th century, 11 European countries
+      
+      - "We have taken almost all the known wars of Greece, Rome, Austria, Germany,
+    England, France, the Netherlands, Spain, Italy, Russia, and 
+      Poland and Lithuania from the periods indicated in the subsequent tables (Chapter
+    Ten and Eleven) to the present time, or, in the case of 
+      Greece and Rome, to the loss of Greek independence and to the so-called "end
+    of the Western Roman Empire," respectively" (Sorokin 1937: 283).
+      
+      - "for Greece, for Rome, and for nine other European countries" (Sorokin 1937:
+    286).
+      
+      - "From the twelfth to the twentieth century" (Sorokin 1937: 286).
+      
+      - 976 for France to 1925 (Sorokin 1937: 306-307).
+
+
+    Which conflicts are covered? Wars
+
+
+    Which deaths and casualties are covered? Direct military casualties
+
+      - Casualties, military, direct: "This study deals precisely with these three
+    quantitative elements of war: the strength of the army, 
+      the number of casualties (killed and wounded), and the duration of each of the
+    wars studied. No other aspect of the war phenomena is 
+      studied, not the economic losses, nor the morbidity and mortality of the civilian
+    population, nor anything else" (Sorokin 1937: 282).
+      
+      - "general losses up to 47,000 [...] but mainly from sickness, therefore not
+    included" (Sorokin 1937: 552).
+      
+      - Casualties are sometimes estimated based on army sizes and war duration: "Likewise,
+    the total number of the casualties in a given war means 
+      the typical per cent of the casualties in regard to the strength of the army
+    multiplied by the number of years during which the war lasted" 
+      (Sorokin 1937: 284).
+      
+      - War casualties sometimes estimated using annual casualties: "the total number
+    of the casualties for each given war is obtained, either by 
+      multiplication of the typical per cent of the casualties by the number of years,
+    or by putting down the actual data which exist in regard 
+      to this item for a given war as a whole" (Sorokin 1937: 284).
+      
+      - Data quality is rough: "This means that the figures given for each period
+    are aimed not so much to lay down the actual number of the 
+      mobilized or killed and wounded as to obtain a rough measuring device to see
+    the comparative increase or de- crease of war from period 
+      to period" (Sorokin 1937: 285).
+
+
+    How did he construct the data?
+
+      - "The actual data are taken from authoritative historical sources, often ably
+    summarized and elaborated by various special historical 
+      works like the often-quoted works of Delbruck, Bodart, and various encyclopedias
+    of war and military science" (Sorokin 1937: 285).
+
+
+    How did we construct our spreadsheet?
+
+      - We accessed the book, the relevant methodological section starts on page
+    282, the detailed descriptions of wars and deaths starts on 
+      page 543.
+
+      - We extracted deaths and casualties from Sorokin's numbers on which participant
+    suffered which losses during any given conflict; Sorokin 
+      often does not provide estimates for all participants of a given conflict.
+
+wdir: ../../../data/snapshots/conflicts/2023-01-09
+outs:
+- md5: 62db4de77391db49dca0ee88c989f6e9
+  size: 115599
+  path: sorokin_1937.csv

--- a/snapshots/conflicts/2023-01-09/sorokin_1937.py
+++ b/snapshots/conflicts/2023-01-09/sorokin_1937.py
@@ -1,0 +1,35 @@
+"""Get our manually curated dataset.
+
+This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
+at https://docs.google.com/spreadsheets/d/1Xo5e8aiFJnmv_aasFXU8MtzizSU0LxiysoUuErEJx3Q/edit?usp=sharing."""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+SNAPSHOT_VERSION = "2023-01-09"
+
+
+@click.command()
+@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(path_to_file: str, upload: bool) -> None:
+    # Create new snapshot.
+    snap = Snapshot(f"conflicts/{SNAPSHOT_VERSION}/sorokin_1937.csv")
+    # Ensure destination folder exists.
+    snap.path.parent.mkdir(exist_ok=True, parents=True)
+    # Copy local data file to snapshots data folder.
+    snap.path.write_bytes(Path(path_to_file).read_bytes())
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/conflicts/2023-01-09/sorokin_1937.py
+++ b/snapshots/conflicts/2023-01-09/sorokin_1937.py
@@ -1,7 +1,9 @@
-"""Get our manually curated dataset.
+"""Get our manually curated dataset into Snapshot.
 
-This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
-at https://docs.google.com/spreadsheets/d/1Xo5e8aiFJnmv_aasFXU8MtzizSU0LxiysoUuErEJx3Q/edit?usp=sharing."""
+We maintain a manually curated transcription of the data from Sorokin (1937) in a Google Spreadsheet.
+Then, port this file to Snapshot. To obtain this file, download it as a CSV from
+https://docs.google.com/spreadsheets/d/1Xo5e8aiFJnmv_aasFXU8MtzizSU0LxiysoUuErEJx3Q/edit?usp=sharing and use
+it with the `--path-to-file` argument."""
 
 from pathlib import Path
 

--- a/snapshots/conflicts/2023-01-09/sutton_1971.csv.dvc
+++ b/snapshots/conflicts/2023-01-09/sutton_1971.csv.dvc
@@ -1,0 +1,60 @@
+meta:
+  namespace: conflicts
+  short_name: sutton_1971
+  name: Wars and revolutions - Hoover Institution (1971)
+  source_name: Sutton, Hoover Institution (1971)
+  publication_year: 1971
+  publication_date:
+  url: https://searchworks.stanford.edu/view/3023823
+  source_data_url: https://docs.google.com/spreadsheets/d/1egViYkL0TXcGVCm_MFdJ98nYmQpOO54vdlUxG-4bwBM/edit?usp=sharing
+  file_extension: csv
+  license_url:
+  license_name: Unknown
+  date_accessed: 2023-01-09
+  is_public: true
+  description: |
+    What years and countries are covered? 1820-1970, worldwide
+      
+      - "All conflict resulting in more than 20 killed where certain basic facts can be determined is listed; the first volume includes the period 
+      1820 to 1900, and the second volume the period 1900 to 1970" (Sutton 1972: 9).
+      
+      - "It does provide for the first time a complete empirical base for conflict in the nineteenth century; this was my primary objective" 
+      (Sutton 1972: 7).
+      
+      - The list of wars and revolution starts with the year 1800 and lists eight conflicts before 1820 (Sutton 1972: 269)
+
+
+    Which conflicts are covered? Conflicts with more than 20 deaths, domestic and international
+      
+      - "All conflict resulting in more than 20 killed where certain basic facts can be determined is listed" (Sutton 1972: 9)
+
+
+    Which deaths and casualties are covered? Deaths
+      
+      - "The "Killed" column has three subdivisions: the "number killed for…" columns refers to the number killed from the participant country. 
+      This is followed by a "total for the incidents" figure i.e. number killed for participants combined. In a civil war these two columns are 
+      the same. In an "external" war the figures are different (except when one participant has no casualties)" (Sutton 1972: 15).
+
+
+    How did he construct the data?
+      - "The sources used and cited under each country listing are incomplete. It would require, in many cases, a bibliography longer than the 
+      tabulated data. Only more significant sources are cited. Further, the following standard works were consulted for all countries and 
+      citations are not repeated below the country listings: [Richardson 1960; Sorokin nd; Wright 1965]" (Sutton 1972: 10).
+
+
+    How did we construct our spreadsheet?
+      
+      - We only coded the conflicts for Sutton's manuscript on the 19th century, not for his manuscript on the years 1900–1972
+      
+      - We identified conflicts with the tables by region and country (pages 16-268) and the list of wars and revolutions in Appendix Three 
+      (pages 269-301).
+      
+      - We identified deaths with the "Killed — Total for the incident" column in the tables by country; if the value was missing, but there was 
+      an estimate for the main participant, we added a note.
+      
+      - We also copied any of his notes that numbers were 'estimated' or 'suspect'
+wdir: ../../../data/snapshots/conflicts/2023-01-09
+outs:
+- md5: 478d9301b194525a227243df1b5b2a28
+  size: 125790
+  path: sutton_1971.csv

--- a/snapshots/conflicts/2023-01-09/sutton_1971.py
+++ b/snapshots/conflicts/2023-01-09/sutton_1971.py
@@ -1,0 +1,35 @@
+"""Get our manually curated dataset.
+
+This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
+at https://docs.google.com/spreadsheets/d/1Xo5e8aiFJnmv_aasFXU8MtzizSU0LxiysoUuErEJx3Q/edit?usp=sharing."""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+SNAPSHOT_VERSION = "2023-01-09"
+
+
+@click.command()
+@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(path_to_file: str, upload: bool) -> None:
+    # Create new snapshot.
+    snap = Snapshot(f"conflicts/{SNAPSHOT_VERSION}/sutton_1971.csv")
+    # Ensure destination folder exists.
+    snap.path.parent.mkdir(exist_ok=True, parents=True)
+    # Copy local data file to snapshots data folder.
+    snap.path.write_bytes(Path(path_to_file).read_bytes())
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/conflicts/2023-01-09/sutton_1971.py
+++ b/snapshots/conflicts/2023-01-09/sutton_1971.py
@@ -1,7 +1,9 @@
-"""Get our manually curated dataset.
+"""Get our manually curated dataset into Snapshot.
 
-This dataset was obtained by examining the data provided by the source, and transcribing it into a Google Spreadsheet. It can be found
-at https://docs.google.com/spreadsheets/d/1Xo5e8aiFJnmv_aasFXU8MtzizSU0LxiysoUuErEJx3Q/edit?usp=sharing."""
+We maintain a manually curated transcription of the data from Sutton (1971) in a Google Spreadsheet.
+Then, port this file to Snapshot. To obtain this file, download it as a CSV from
+https://docs.google.com/spreadsheets/d/1Xo5e8aiFJnmv_aasFXU8MtzizSU0LxiysoUuErEJx3Q/edit?usp=sharing and use
+it with the `--path-to-file` argument."""
 
 from pathlib import Path
 


### PR DESCRIPTION
This PR adds several conflict datasets to Snapshot. To this end, I have created a new namespace: `conflicts`.

These datasets were previously manipulated and saved in [Google Drive](https://docs.google.com/spreadsheets/d/1lh4Ra3TaLt10ZRL4-C16--X1Zu4atofQO5iLwSBuOEY/edit#gid=1175422923). Here, we download these files from Google Drive and port them to Snapshots.

I have added [technical notes](https://docs.google.com/document/d/1aoBrW5UXkFNCZVM18teD9nYWcQH82_y5-uqeEH9c30E/edit#) to the corresponding dataset metadata.