### PR TITLE
format(homicide): fixing homicide long run metadata

### DIFF
--- a/etl/steps/data/garden/homicide/2023-01-03/homicide_long_run_omm.meta.yml
+++ b/etl/steps/data/garden/homicide/2023-01-03/homicide_long_run_omm.meta.yml
@@ -30,8 +30,14 @@ tables:
           This variable is a combination of homicide rate estimates from Eisner (2014) and the WHO Mortality Database (2022). For the following countries we use Eisner (2014) before the given date and the WHO Mortality Database for all later datapoints:
 
           * 1950: France, Ireland, Netherlands
+
+
           * 1951: Italy, Spain, Sweden, Switzerland
+
+
           * 1954: Belgium
+
+          
           * 1990: Germany
         
           


### PR DESCRIPTION
Adding in some white space to the bullet points on source tab.