### PR TITLE
fix(geo): fix circular dependency of population dataset

### DIFF
--- a/dag/demography.yml
+++ b/dag/demography.yml
@@ -4,6 +4,7 @@ steps:
     - data://garden/papers/2022-11-04/riley_2005
     - data://garden/un/2022-07-11/un_wpp
     - data://garden/hmd/2022-11-04/life_tables
+    - data://garden/owid/latest/key_indicators
 
   data://grapher/demography/2022-11-30/life_expectancy:
     - data://garden/demography/2022-11-30/life_expectancy

--- a/dag/emissions.yml
+++ b/dag/emissions.yml
@@ -7,6 +7,7 @@ steps:
   data://garden/cait/2022-08-10/ghg_emissions_by_sector:
     - data://meadow/cait/2022-08-10/ghg_emissions_by_sector
     - data://garden/reference
+    - data://garden/owid/latest/key_indicators
   data://grapher/cait/2022-08-10/all_ghg_emissions:
     - data://garden/cait/2022-08-10/ghg_emissions_by_sector
   data://grapher/cait/2022-08-10/ch4_emissions:

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -258,6 +258,7 @@ steps:
     - snapshot://health/2022-12-28/deaths_karlinsky.csv
   data://garden/health/2022-12-28/deaths_karlinsky:
     - data://meadow/health/2022-12-28/deaths_karlinsky
+    - data://garden/owid/latest/key_indicators
   data://grapher/health/2022-12-28/deaths_karlinsky:
     - data://garden/health/2022-12-28/deaths_karlinsky
 

--- a/etl/data_helpers/geo.py
+++ b/etl/data_helpers/geo.py
@@ -221,6 +221,7 @@ def add_region_aggregates(
     year_col: str = "year",
     aggregations: Optional[Dict[str, Any]] = None,
     keep_original_region_with_suffix: Optional[str] = None,
+    population: Optional[pd.DataFrame] = None,
 ) -> pd.DataFrame:
     """Add data for regions (e.g. income groups or continents) to a dataset.
 
@@ -272,6 +273,8 @@ def add_region_aggregates(
         If None, original data for region will be replaced by aggregate data constructed by this function. If not None,
         original data for region will be kept, with the same name, but having suffix keep_original_region_with_suffix
         added to its name.
+    population : pd.DataFrame or None
+        Population dataset, or None, to load it from owid catalog.
 
     Returns
     -------
@@ -289,6 +292,7 @@ def add_region_aggregates(
         # List countries that should present in the data (since they are expected to contribute the most).
         countries_that_must_have_data = list_countries_in_region_that_must_have_data(
             region=region,
+            population=population,
         )
 
     # If aggregations are not defined for each variable, assume 'sum'.

--- a/etl/steps/data/garden/demography/2022-12-08/population/__init__.py
+++ b/etl/steps/data/garden/demography/2022-12-08/population/__init__.py
@@ -169,7 +169,7 @@ def add_regions(df: pd.DataFrame) -> pd.DataFrame:
 
     # re-estimate region aggregates
     for region in regions:
-        df = geo.add_region_aggregates(df=df, region=region)
+        df = geo.add_region_aggregates(df=df, region=region, population=df)
 
     # add sources back
     # these are only added to countries, not aggregates


### PR DESCRIPTION
Merging [geo refactoring](https://github.com/owid/etl/pull/761#issuecomment-1378946768) introduced circular dependency of population dataset on itself. Step `data://garden/demography/2022-12-08/population` calls function `add_region_aggregates` calls  `list_countries_in_region_that_must_have_data` which tries to load population table from `data://garden/owid/latest/key_indicators` (that doesn't exist yet). Since we know population in `demography/2022-12-08/population`, the easiest fix is to pass it explicitly as a parameter for region calculation.

There might be a better solution, this is just a hotfix. @pabloarosado feel free to suggest a better one.

In addition, I've also added `data://garden/owid/latest/key_indicators` as dependencies to steps that use `geo.add_population_to_dataframe` function.

(To replicate the bug you can run:)
1. `rm -Rf data/garden/owid/latest/key_indicators` 
2. `etl data://garden/health/2022-12-28/deaths_karlinsky`