### PR TITLE
884 data update near surface temperature met office hadley centre

### DIFF
--- a/dag/main.yml
+++ b/dag/main.yml
@@ -250,6 +250,10 @@ steps:
     - snapshot://met_office_hadley_centre/2023-01-02/near_surface_temperature_global.csv
     - snapshot://met_office_hadley_centre/2023-01-02/near_surface_temperature_northern_hemisphere.csv
     - snapshot://met_office_hadley_centre/2023-01-02/near_surface_temperature_southern_hemisphere.csv
+  data://meadow/met_office_hadley_centre/2023-01-17/near_surface_temperature:
+    - snapshot://met_office_hadley_centre/2023-01-17/near_surface_temperature_global.csv
+    - snapshot://met_office_hadley_centre/2023-01-17/near_surface_temperature_northern_hemisphere.csv
+    - snapshot://met_office_hadley_centre/2023-01-17/near_surface_temperature_southern_hemisphere.csv
   data://garden/met_office_hadley_centre/2023-01-02/near_surface_temperature:
     - data://meadow/met_office_hadley_centre/2023-01-02/near_surface_temperature
   data://grapher/met_office_hadley_centre/2023-01-02/near_surface_temperature:

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -256,8 +256,12 @@ steps:
     - snapshot://met_office_hadley_centre/2023-01-17/near_surface_temperature_southern_hemisphere.csv
   data://garden/met_office_hadley_centre/2023-01-02/near_surface_temperature:
     - data://meadow/met_office_hadley_centre/2023-01-02/near_surface_temperature
+  data://garden/met_office_hadley_centre/2023-01-17/near_surface_temperature:
+    - data://meadow/met_office_hadley_centre/2023-01-17/near_surface_temperature
   data://grapher/met_office_hadley_centre/2023-01-02/near_surface_temperature:
     - data://garden/met_office_hadley_centre/2023-01-02/near_surface_temperature
+  data://grapher/met_office_hadley_centre/2023-01-17/near_surface_temperature:
+    - data://garden/met_office_hadley_centre/2023-01-17/near_surface_temperature
 
   # Long-term homicide rates in Europe - Eisner (2014)
   data://grapher/fasttrack/2023-01-03/long_term_homicide_rates_in_europe:

--- a/etl/steps/data/garden/met_office_hadley_centre/2023-01-17/near_surface_temperature.meta.yml
+++ b/etl/steps/data/garden/met_office_hadley_centre/2023-01-17/near_surface_temperature.meta.yml
@@ -1,0 +1,22 @@
+dataset:
+  title: Near-surface temperature anomaly (Met Office Hadley Centre, 2022)
+
+tables:
+  near_surface_temperature:
+    variables:
+      temperature_anomaly:
+        title: Global average temperature anomaly relative to 1961-1990
+        short_unit: °C
+        unit: degrees Celsius
+        description: |
+          Annual average temperature anomaly (relative to 1961-90).
+
+          The global mean has been calculated by averaging anomalies for northern and southern hemispheres.
+      upper_limit:
+        title: Upper bound (95% confidence interval) of the annual temperature anomaly
+        short_unit: °C
+        unit: degrees Celsius
+      lower_limit:
+        title: Lower bound (95% confidence interval) of the annual temperature anomaly
+        short_unit: °C
+        unit: degrees Celsius

--- a/etl/steps/data/garden/met_office_hadley_centre/2023-01-17/near_surface_temperature.meta.yml
+++ b/etl/steps/data/garden/met_office_hadley_centre/2023-01-17/near_surface_temperature.meta.yml
@@ -1,5 +1,6 @@
 dataset:
-  title: Near-surface temperature anomaly (Met Office Hadley Centre, 2022)
+  title: Near-surface temperature anomaly (Met Office Hadley Centre, 2022b)
+  description: ""
 
 tables:
   near_surface_temperature:

--- a/etl/steps/data/garden/met_office_hadley_centre/2023-01-17/near_surface_temperature.meta.yml
+++ b/etl/steps/data/garden/met_office_hadley_centre/2023-01-17/near_surface_temperature.meta.yml
@@ -1,5 +1,5 @@
 dataset:
-  title: Near-surface temperature anomaly (Met Office Hadley Centre, 2022b)
+  title: Near-surface temperature anomaly (Met Office Hadley Centre, 2023)
   description: ""
 
 tables:

--- a/etl/steps/data/garden/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
+++ b/etl/steps/data/garden/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
@@ -1,0 +1,52 @@
+"""Load a meadow dataset and create a garden dataset."""
+
+import pandas as pd
+from owid.catalog import Dataset, Table
+from structlog import get_logger
+
+from etl.data_helpers import geo
+from etl.helpers import PathFinder
+
+log = get_logger()
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    log.info("near_surface_temperature.start")
+
+    #
+    # Load inputs.
+    #
+    # Load meadow dataset.
+    ds_meadow: Dataset = paths.load_dependency("near_surface_temperature")
+
+    # Read table from meadow dataset.
+    tb_meadow = ds_meadow["near_surface_temperature"]
+
+    # Create a dataframe with data from the table.
+    df = pd.DataFrame(tb_meadow)
+
+    #
+    # Process data.
+    #
+    # Create a new table with the processed data.
+    tb_garden = Table(df, like=tb_meadow)
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = Dataset.create_empty(dest_dir, metadata=ds_meadow.metadata)
+
+    # Add table of processed data to the new dataset.
+    ds_garden.add(tb_garden)
+
+    # Update dataset and table metadata using the adjacent yaml file.
+    ds_garden.update_metadata(paths.metadata_path)
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()
+
+    log.info("near_surface_temperature.end")

--- a/etl/steps/data/garden/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
+++ b/etl/steps/data/garden/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
@@ -4,7 +4,6 @@ import pandas as pd
 from owid.catalog import Dataset, Table
 from structlog import get_logger
 
-from etl.data_helpers import geo
 from etl.helpers import PathFinder
 
 log = get_logger()

--- a/etl/steps/data/grapher/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
+++ b/etl/steps/data/grapher/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
@@ -1,0 +1,38 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from owid.catalog import Dataset
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden: Dataset = paths.load_dependency("near_surface_temperature")
+
+    # Read table from garden dataset.
+    tb_garden = ds_garden["near_surface_temperature"].reset_index()
+
+    # For compatibility with grapher, change the name of "region" column to "country".
+    tb_garden = tb_garden.rename(columns={"region": "country"})
+
+    #
+    # Process data.
+    #
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = Dataset.create_empty(dest_dir, ds_garden.metadata)
+
+    # Add table of processed data to the new dataset.
+    ds_grapher.add(tb_garden)
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()

--- a/etl/steps/data/meadow/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
+++ b/etl/steps/data/meadow/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
@@ -5,7 +5,6 @@ from owid.catalog import Dataset, Table
 from structlog import get_logger
 
 from etl.helpers import PathFinder
-from etl.snapshot import Snapshot
 from etl.steps.data.converters import convert_snapshot_metadata
 
 # Initialize logger.

--- a/etl/steps/data/meadow/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
+++ b/etl/steps/data/meadow/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
@@ -1,0 +1,81 @@
+"""Load a snapshot and create a meadow dataset."""
+
+import pandas as pd
+from owid.catalog import Dataset, Table
+from structlog import get_logger
+
+from etl.helpers import PathFinder
+from etl.snapshot import Snapshot
+from etl.steps.data.converters import convert_snapshot_metadata
+
+# Initialize logger.
+log = get_logger()
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+# Columns to select and how to name them.
+COLUMNS = {
+    # Additional column.
+    "region": "region",
+    # Original column names and new names.
+    "Time": "year",
+    "Anomaly (deg C)": "temperature_anomaly",
+    "Lower confidence limit (2.5%)": "lower_limit",
+    "Upper confidence limit (97.5%)": "upper_limit",
+}
+
+# Names of snapshot files.
+REGION_FILE_NAMES = {
+    "Global": "near_surface_temperature_global.csv",
+    "Northern hemisphere": "near_surface_temperature_northern_hemisphere.csv",
+    "Southern hemisphere": "near_surface_temperature_southern_hemisphere.csv",
+}
+
+
+def run(dest_dir: str) -> None:
+    log.info("near_surface_temperature.start")
+
+    #
+    # Load inputs.
+    #
+    # Retrieve snapshots.
+    snapshots = {
+        region: paths.load_dependency(file_name)
+        for region, file_name in REGION_FILE_NAMES.items()
+    }
+
+    # Load data from snapshots.
+    df = pd.concat(
+        [pd.read_csv(snapshot.path).assign(**{"region": region}) for region, snapshot in snapshots.items()],
+        ignore_index=True,
+    )
+
+    #
+    # Process data.
+    #
+    # Select and rename required columns.
+    df = df.rename(columns=COLUMNS, errors="raise")[COLUMNS.values()]
+
+    # Set an appropriate index and sort conveniently.
+    df = df.set_index(["region", "year"], verify_integrity=True).sort_index()
+
+    # Create a new table and ensure all columns are snake-case.
+    tb = Table(df, short_name=paths.short_name, underscore=True)
+
+    #
+    # Save outputs.
+    #
+    # Create a new meadow dataset with the same metadata as the snapshot.
+    ds_meadow = Dataset.create_empty(dest_dir, metadata=convert_snapshot_metadata(snapshots["Global"].metadata))
+
+    # Ensure the version of the new dataset corresponds to the version of current step.
+    ds_meadow.metadata.version = paths.version
+
+    # Add the new table to the meadow dataset.
+    ds_meadow.add(tb)
+
+    # Save changes in the new garden dataset.
+    ds_meadow.save()
+
+    log.info("near_surface_temperature.end")

--- a/etl/steps/data/meadow/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
+++ b/etl/steps/data/meadow/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
@@ -65,7 +65,8 @@ def run(dest_dir: str) -> None:
     # Create a new meadow dataset with the same metadata as the snapshot.
     ds_meadow = Dataset.create_empty(dest_dir, metadata=convert_snapshot_metadata(snapshots["Global"].metadata))
 
-    # Ensure the version of the new dataset corresponds to the version of current step.
+    # Ensure the short name and version of the new dataset correspond to the ones of the current step.
+    ds_meadow.metadata.short_name = paths.short_name
     ds_meadow.metadata.version = paths.version
 
     # Add the new table to the meadow dataset.

--- a/etl/steps/data/meadow/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
+++ b/etl/steps/data/meadow/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
@@ -40,10 +40,7 @@ def run(dest_dir: str) -> None:
     # Load inputs.
     #
     # Retrieve snapshots.
-    snapshots = {
-        region: paths.load_dependency(file_name)
-        for region, file_name in REGION_FILE_NAMES.items()
-    }
+    snapshots = {region: paths.load_dependency(file_name) for region, file_name in REGION_FILE_NAMES.items()}
 
     # Load data from snapshots.
     df = pd.concat(

--- a/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
+++ b/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature.py
@@ -1,0 +1,36 @@
+"""Ingest snapshot of the HadCRUT5 near surface temperature dataset (temperature anomaly) by Met Office Hadley Centre.
+
+The HadCRUT5 near surface temperature data set is produced by blending data from the CRUTEM5 surface air temperature
+dataset and the HadSST4 sea-surface temperature dataset.
+"""
+
+import pathlib
+
+import click
+
+from etl.snapshot import Snapshot
+
+SNAPSHOT_VERSION = pathlib.Path(__file__).parent.name
+FILE_NAMES = [
+    "near_surface_temperature_global.csv",
+    "near_surface_temperature_northern_hemisphere.csv",
+    "near_surface_temperature_southern_hemisphere.csv",
+]
+
+
+@click.command()
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(upload: bool) -> None:
+    for file_name in FILE_NAMES:
+        snap = Snapshot(f"met_office_hadley_centre/{SNAPSHOT_VERSION}/{file_name}")
+        snap.download_from_source()
+        snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_global.csv.dvc
+++ b/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_global.csv.dvc
@@ -1,8 +1,10 @@
 meta:
   namespace: met_office_hadley_centre
   short_name: near_surface_temperature_global
-  name: HadCRUT5 near surface temperature
+  name: HadCRUT5 near surface temperature - Global
   source_name: Met Office Hadley Centre
+  source_published_by: |
+    Morice, C.P., J.J. Kennedy, N.A. Rayner, J.P. Winn, E. Hogan, R.E. Killick, R.J.H. Dunn, T.J. Osborn, P.D. Jones and I.R. Simpson (in press) An updated assessment of near-surface temperature change from 1850: the HadCRUT5 dataset. Journal of Geophysical Research (Atmospheres) doi:10.1029/2019JD032361 (supporting information).
   publication_year: 2022
   publication_date:
   url: https://www.metoffice.gov.uk/hadobs/hadcrut5/
@@ -14,6 +16,10 @@ meta:
   is_public: true
   description: |
     The HadCRUT5 near surface temperature data set is produced by blending data from the CRUTEM5 surface air temperature dataset and the HadSST4 sea-surface temperature dataset.
+
+    Temperature anomalies are based on the HadCRUT5 near-surface temperature dataset as published by the Met Office Hadley Centre. Temperature anomalies are given in degrees celsius relative to the average temperature over the period 1961-1990.
+
+    These are available for the Northern Hemisphere and the Southern Hemisphere. The global mean has been calculated by averaging anomalies for northern and southern hemispheres.
 wdir: ../../../data/snapshots/met_office_hadley_centre/2023-01-17
 outs:
 - md5: 5213f73d541be3d45e6d9fc9c4d8c664

--- a/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_global.csv.dvc
+++ b/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_global.csv.dvc
@@ -1,0 +1,21 @@
+meta:
+  namespace: met_office_hadley_centre
+  short_name: near_surface_temperature_global
+  name: HadCRUT5 near surface temperature
+  source_name: Met Office Hadley Centre
+  publication_year: 2022
+  publication_date:
+  url: https://www.metoffice.gov.uk/hadobs/hadcrut5/
+  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.global.annual.csv
+  file_extension: csv
+  license_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/terms_and_conditions.html
+  license_name: Open Government License v3
+  date_accessed: 2023-01-17
+  is_public: true
+  description: |
+    The HadCRUT5 near surface temperature data set is produced by blending data from the CRUTEM5 surface air temperature dataset and the HadSST4 sea-surface temperature dataset.
+wdir: ../../../data/snapshots/met_office_hadley_centre/2023-01-17
+outs:
+- md5: 5213f73d541be3d45e6d9fc9c4d8c664
+  size: 6910
+  path: near_surface_temperature_global.csv

--- a/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_northern_hemisphere.csv.dvc
+++ b/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_northern_hemisphere.csv.dvc
@@ -1,0 +1,21 @@
+meta:
+  namespace: met_office_hadley_centre
+  short_name: near_surface_temperature_northern_hemisphere
+  name: HadCRUT5 near surface temperature
+  source_name: Met Office Hadley Centre
+  publication_year: 2022
+  publication_date:
+  url: https://www.metoffice.gov.uk/hadobs/hadcrut5/
+  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.northern_hemisphere.annual.csv
+  file_extension: csv
+  license_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/terms_and_conditions.html
+  license_name: Open Government License v3
+  date_accessed: 2023-01-17
+  is_public: true
+  description: |
+    The HadCRUT5 near surface temperature data set is produced by blending data from the CRUTEM5 surface air temperature dataset and the HadSST4 sea-surface temperature dataset.
+wdir: ../../../data/snapshots/met_office_hadley_centre/2023-01-17
+outs:
+- md5: 633a7e29c17cf96a669c5561da9172eb
+  size: 6892
+  path: near_surface_temperature_northern_hemisphere.csv

--- a/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_northern_hemisphere.csv.dvc
+++ b/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_northern_hemisphere.csv.dvc
@@ -8,7 +8,7 @@ meta:
   publication_year: 2022
   publication_date:
   url: https://www.metoffice.gov.uk/hadobs/hadcrut5/
-  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.global.annual.csv
+  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.northern_hemisphere.annual.csv
   file_extension: csv
   license_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/terms_and_conditions.html
   license_name: Open Government License v3
@@ -22,6 +22,6 @@ meta:
     These are available for the Northern Hemisphere and the Southern Hemisphere. The global mean has been calculated by averaging anomalies for northern and southern hemispheres.
 wdir: ../../../data/snapshots/met_office_hadley_centre/2023-01-17
 outs:
-- md5: 5213f73d541be3d45e6d9fc9c4d8c664
-  size: 6910
+- md5: 633a7e29c17cf96a669c5561da9172eb
+  size: 6892
   path: near_surface_temperature_northern_hemisphere.csv

--- a/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_northern_hemisphere.csv.dvc
+++ b/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_northern_hemisphere.csv.dvc
@@ -1,12 +1,14 @@
 meta:
   namespace: met_office_hadley_centre
   short_name: near_surface_temperature_northern_hemisphere
-  name: HadCRUT5 near surface temperature
+  name: HadCRUT5 near surface temperature - Northern hemisphere
   source_name: Met Office Hadley Centre
+  source_published_by: |
+    Morice, C.P., J.J. Kennedy, N.A. Rayner, J.P. Winn, E. Hogan, R.E. Killick, R.J.H. Dunn, T.J. Osborn, P.D. Jones and I.R. Simpson (in press) An updated assessment of near-surface temperature change from 1850: the HadCRUT5 dataset. Journal of Geophysical Research (Atmospheres) doi:10.1029/2019JD032361 (supporting information).
   publication_year: 2022
   publication_date:
   url: https://www.metoffice.gov.uk/hadobs/hadcrut5/
-  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.northern_hemisphere.annual.csv
+  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.global.annual.csv
   file_extension: csv
   license_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/terms_and_conditions.html
   license_name: Open Government License v3
@@ -14,8 +16,12 @@ meta:
   is_public: true
   description: |
     The HadCRUT5 near surface temperature data set is produced by blending data from the CRUTEM5 surface air temperature dataset and the HadSST4 sea-surface temperature dataset.
+
+    Temperature anomalies are based on the HadCRUT5 near-surface temperature dataset as published by the Met Office Hadley Centre. Temperature anomalies are given in degrees celsius relative to the average temperature over the period 1961-1990.
+
+    These are available for the Northern Hemisphere and the Southern Hemisphere. The global mean has been calculated by averaging anomalies for northern and southern hemispheres.
 wdir: ../../../data/snapshots/met_office_hadley_centre/2023-01-17
 outs:
-- md5: 633a7e29c17cf96a669c5561da9172eb
-  size: 6892
+- md5: 5213f73d541be3d45e6d9fc9c4d8c664
+  size: 6910
   path: near_surface_temperature_northern_hemisphere.csv

--- a/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_southern_hemisphere.csv.dvc
+++ b/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_southern_hemisphere.csv.dvc
@@ -1,0 +1,21 @@
+meta:
+  namespace: met_office_hadley_centre
+  short_name: near_surface_temperature_southern_hemisphere
+  name: HadCRUT5 near surface temperature
+  source_name: Met Office Hadley Centre
+  publication_year: 2022
+  publication_date:
+  url: https://www.metoffice.gov.uk/hadobs/hadcrut5/
+  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.southern_hemisphere.annual.csv
+  file_extension: csv
+  license_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/terms_and_conditions.html
+  license_name: Open Government License v3
+  date_accessed: 2023-01-17
+  is_public: true
+  description: |
+    The HadCRUT5 near surface temperature data set is produced by blending data from the CRUTEM5 surface air temperature dataset and the HadSST4 sea-surface temperature dataset.
+wdir: ../../../data/snapshots/met_office_hadley_centre/2023-01-17
+outs:
+- md5: a3fcf801fe1e279ffb0b0b124701b5c6
+  size: 6891
+  path: near_surface_temperature_southern_hemisphere.csv

--- a/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_southern_hemisphere.csv.dvc
+++ b/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_southern_hemisphere.csv.dvc
@@ -8,7 +8,7 @@ meta:
   publication_year: 2022
   publication_date:
   url: https://www.metoffice.gov.uk/hadobs/hadcrut5/
-  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.global.annual.csv
+  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.southern_hemisphere.annual.csv
   file_extension: csv
   license_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/terms_and_conditions.html
   license_name: Open Government License v3
@@ -22,6 +22,6 @@ meta:
     These are available for the Northern Hemisphere and the Southern Hemisphere. The global mean has been calculated by averaging anomalies for northern and southern hemispheres.
 wdir: ../../../data/snapshots/met_office_hadley_centre/2023-01-17
 outs:
-- md5: 5213f73d541be3d45e6d9fc9c4d8c664
-  size: 6910
+- md5: a3fcf801fe1e279ffb0b0b124701b5c6
+  size: 6891
   path: near_surface_temperature_southern_hemisphere.csv

--- a/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_southern_hemisphere.csv.dvc
+++ b/snapshots/met_office_hadley_centre/2023-01-17/near_surface_temperature_southern_hemisphere.csv.dvc
@@ -1,12 +1,14 @@
 meta:
   namespace: met_office_hadley_centre
   short_name: near_surface_temperature_southern_hemisphere
-  name: HadCRUT5 near surface temperature
+  name: HadCRUT5 near surface temperature - Southern hemisphere
   source_name: Met Office Hadley Centre
+  source_published_by: |
+    Morice, C.P., J.J. Kennedy, N.A. Rayner, J.P. Winn, E. Hogan, R.E. Killick, R.J.H. Dunn, T.J. Osborn, P.D. Jones and I.R. Simpson (in press) An updated assessment of near-surface temperature change from 1850: the HadCRUT5 dataset. Journal of Geophysical Research (Atmospheres) doi:10.1029/2019JD032361 (supporting information).
   publication_year: 2022
   publication_date:
   url: https://www.metoffice.gov.uk/hadobs/hadcrut5/
-  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.southern_hemisphere.annual.csv
+  source_data_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/data/current/analysis/diagnostics/HadCRUT.5.0.1.0.analysis.summary_series.global.annual.csv
   file_extension: csv
   license_url: https://www.metoffice.gov.uk/hadobs/hadcrut5/terms_and_conditions.html
   license_name: Open Government License v3
@@ -14,8 +16,12 @@ meta:
   is_public: true
   description: |
     The HadCRUT5 near surface temperature data set is produced by blending data from the CRUTEM5 surface air temperature dataset and the HadSST4 sea-surface temperature dataset.
+
+    Temperature anomalies are based on the HadCRUT5 near-surface temperature dataset as published by the Met Office Hadley Centre. Temperature anomalies are given in degrees celsius relative to the average temperature over the period 1961-1990.
+
+    These are available for the Northern Hemisphere and the Southern Hemisphere. The global mean has been calculated by averaging anomalies for northern and southern hemispheres.
 wdir: ../../../data/snapshots/met_office_hadley_centre/2023-01-17
 outs:
-- md5: a3fcf801fe1e279ffb0b0b124701b5c6
-  size: 6891
+- md5: 5213f73d541be3d45e6d9fc9c4d8c664
+  size: 6910
   path: near_surface_temperature_southern_hemisphere.csv


### PR DESCRIPTION
I updated this dataset (which didn't really need an update) just to adapt it to the new walkthrough workflow and to see if everything works well. Nothing has changed with respect to the previous steps, so there's no need to review the steps.

Everything went well, except for one small issue: Initially, in the garden metadata, I only had:
```yaml
dataset:
  title: Near-surface temperature anomaly (Met Office Hadley Centre, 2022b)
```
Given that all metadata was well defined since the snapshot step. However, on grapher admin I saw that the datset description (which shows in the SOURCES tab) was duplicated. That's why I had to include `description: ""`. I think this happens because, when transferring the ETL grapher step to grapher, the sources' description are appended to the dataset description.

I think in general it's good to concatenate dataset description and sources' description, except in this kind of scenarios. The only downside is that it creates an extra line at the beginning of the description. @Marigold do you think there's a better solution? Thanks.