### PR TITLE
Improve harmonize countries

### DIFF
--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -351,7 +351,7 @@ def _dataset_metadata_dict(ds: Dataset) -> Dict[str, Any]:
     if "sources" in d:
         d["sources"] = sorted(d["sources"], key=lambda x: x["name"])
 
-    del d["source_checksum"]
+    d.pop("source_checksum", None)
     return d
 
 
@@ -385,6 +385,10 @@ def _remote_catalog_datasets(channels: Iterable[CHANNEL], include: str, exclude:
     frame = rc.frame
 
     frame["ds_paths"] = frame["path"].map(os.path.dirname)
+
+    # only compare public datasets
+    frame = frame[frame.is_public]
+
     ds_paths = frame["ds_paths"]
 
     if include:

--- a/etl/steps/data/garden/dummy/2020-01-01/dummy.py
+++ b/etl/steps/data/garden/dummy/2020-01-01/dummy.py
@@ -48,6 +48,9 @@ def run(dest_dir: str) -> None:
     # Add table of processed data to the new dataset.
     ds_garden.add(tb_garden)
 
+    # Update dataset and table metadata using the adjacent yaml file.
+    ds_garden.update_metadata(paths.metadata_path)
+
     # Save changes in the new garden dataset.
     ds_garden.save()
 

--- a/etl/steps/data/garden/dummy/2020-01-01/dummy.py
+++ b/etl/steps/data/garden/dummy/2020-01-01/dummy.py
@@ -1,8 +1,5 @@
 """Load a meadow dataset and create a garden dataset."""
 
-import json
-from typing import List, cast
-
 import pandas as pd
 from owid.catalog import Dataset, Table
 from structlog import get_logger
@@ -34,11 +31,10 @@ def run(dest_dir: str) -> None:
     #
     # Process data.
     #
-    log.info("dummy.exclude_countries")
-    df = exclude_countries(df)
-
     log.info("dummy.harmonize_countries")
-    df = harmonize_countries(df)
+    df = geo.harmonize_countries(
+        df=df, countries_file=paths.country_mapping_path, excluded_countries_file=paths.excluded_countries_path
+    )
 
     # Create a new table with the processed data.
     tb_garden = Table(df, like=tb_meadow)
@@ -52,38 +48,7 @@ def run(dest_dir: str) -> None:
     # Add table of processed data to the new dataset.
     ds_garden.add(tb_garden)
 
-    # Update dataset and table metadata using the adjacent yaml file.
-    ds_garden.update_metadata(paths.metadata_path)
-
     # Save changes in the new garden dataset.
     ds_garden.save()
 
     log.info("dummy.end")
-
-
-def load_excluded_countries() -> List[str]:
-    with open(paths.excluded_countries_path, "r") as f:
-        data = json.load(f)
-        assert isinstance(data, list)
-    return data
-
-
-def exclude_countries(df: pd.DataFrame) -> pd.DataFrame:
-    excluded_countries = load_excluded_countries()
-    return cast(pd.DataFrame, df.loc[~df.country.isin(excluded_countries)])
-
-
-def harmonize_countries(df: pd.DataFrame) -> pd.DataFrame:
-    unharmonized_countries = df["country"]
-    df = geo.harmonize_countries(df=df, countries_file=str(paths.country_mapping_path))
-
-    missing_countries = set(unharmonized_countries[df.country.isnull()])
-    if any(missing_countries):
-        raise RuntimeError(
-            "The following raw country names have not been harmonized. "
-            f"Please: (a) edit {paths.country_mapping_path} to include these country "
-            f"names; or (b) add them to {paths.excluded_countries_path}."
-            f"Raw country names: {missing_countries}"
-        )
-
-    return df

--- a/tests/data_helpers/test_geo.py
+++ b/tests/data_helpers/test_geo.py
@@ -4,6 +4,7 @@
 
 import json
 import unittest
+import warnings
 from unittest.mock import mock_open, patch
 
 import numpy as np
@@ -17,6 +18,11 @@ mock_countries = {
     "country_02": "Country 2",
     "country_03": "Country 3",
 }
+
+mock_excluded_countries = [
+    "country_05",
+    "country_06",
+]
 
 mock_population = pd.DataFrame(
     {
@@ -40,6 +46,21 @@ mock_income_groups = pd.DataFrame(
         "income_group": ["Income group 1", "Income group 1", "Income group 2"],
     }
 )
+
+
+def mock_opens(filename, _):
+    # This function mocks opening a file with path given by filename, and returns custom content for that file.
+    mock_files_content = {
+        "MOCK_COUNTRIES_FILE": mock_countries,
+        "MOCK_EXCLUDED_COUNTRIES_FILE": mock_excluded_countries,
+    }
+    if filename in mock_files_content:
+        content = mock_files_content[filename]
+    else:
+        raise FileNotFoundError(filename)
+    file_object = mock_open(read_data=json.dumps(content)).return_value
+
+    return file_object
 
 
 def mock_population_load(*args, **kwargs):
@@ -138,14 +159,14 @@ class TestAddPopulationToDataframe:
             geo.add_population_to_dataframe(df=df_in, warn_on_missing_countries=True).equals(df_out)
 
 
-@patch("builtins.open", new_callable=mock_open, read_data=json.dumps(mock_countries))
+@patch("builtins.open", new=mock_opens)
 class TestHarmonizeCountries:
-    def test_one_country_unchanged_and_another_changed(self, _):
+    def test_one_country_unchanged_and_another_changed(self):
         df_in = pd.DataFrame({"country": ["Country 1", "country_02"], "some_variable": [1, 2]})
         df_out = pd.DataFrame({"country": ["Country 1", "Country 2"], "some_variable": [1, 2]})
         assert geo.harmonize_countries(
             df=df_in,
-            countries_file="IGNORED",
+            countries_file="MOCK_COUNTRIES_FILE",
             warn_on_unused_countries=False,
             warn_on_missing_countries=False,
         ).equals(df_out)
@@ -153,17 +174,17 @@ class TestHarmonizeCountries:
         # input dataframe is unchanged
         assert df_in.country.tolist() == ["Country 1", "country_02"]
 
-    def test_one_country_unchanged_and_another_unknown(self, _):
+    def test_one_country_unchanged_and_another_unknown(self):
         df_in = pd.DataFrame({"country": ["Country 1", "country_04"], "some_variable": [1, 2]})
         df_out = pd.DataFrame({"country": ["Country 1", "country_04"], "some_variable": [1, 2]})
         assert geo.harmonize_countries(
             df=df_in,
-            countries_file="IGNORED",
+            countries_file="MOCK_COUNTRIES_FILE",
             warn_on_unused_countries=False,
             warn_on_missing_countries=False,
         ).equals(df_out)
 
-    def test_two_unknown_countries_made_nan(self, _):
+    def test_two_unknown_countries_made_nan(self):
         df_in = pd.DataFrame({"country": ["Country 1", "country_04"], "some_variable": [1, 2]})
         df_out = pd.DataFrame({"country": [np.nan, np.nan], "some_variable": [1, 2]})
         df_out["country"] = df_out["country"].astype(object)
@@ -171,60 +192,60 @@ class TestHarmonizeCountries:
             df1=df_out,
             df2=geo.harmonize_countries(
                 df=df_in,
-                countries_file="IGNORED",
+                countries_file="MOCK_COUNTRIES_FILE",
                 make_missing_countries_nan=True,
                 warn_on_unused_countries=False,
                 warn_on_missing_countries=False,
             ),
         )[0]
 
-    def test_one_unknown_country_made_nan_and_a_known_country_changed(self, _):
+    def test_one_unknown_country_made_nan_and_a_known_country_changed(self):
         df_in = pd.DataFrame({"country": ["Country 1", "country_02"], "some_variable": [1, 2]})
         df_out = pd.DataFrame({"country": [np.nan, "Country 2"], "some_variable": [1, 2]})
         assert dataframes.are_equal(
             df1=df_out,
             df2=geo.harmonize_countries(
                 df=df_in,
-                countries_file="IGNORED",
+                countries_file="MOCK_COUNTRIES_FILE",
                 make_missing_countries_nan=True,
                 warn_on_unused_countries=False,
                 warn_on_missing_countries=False,
             ),
         )[0]
 
-    def test_on_dataframe_with_no_countries(self, _):
+    def test_on_dataframe_with_no_countries(self):
         df_in = pd.DataFrame({"country": []})
         df_out = pd.DataFrame({"country": []})
         df_out["country"] = df_out["country"].astype(object)
         assert dataframes.are_equal(
             df1=df_out,
-            df2=geo.harmonize_countries(df=df_in, countries_file="IGNORED", warn_on_unused_countries=False),
+            df2=geo.harmonize_countries(df=df_in, countries_file="MOCK_COUNTRIES_FILE", warn_on_unused_countries=False),
         )[0]
 
-    def test_change_country_column_name(self, _):
+    def test_change_country_column_name(self):
         df_in = pd.DataFrame({"Country": ["country_02"]})
         df_out = pd.DataFrame({"Country": ["Country 2"]})
         assert dataframes.are_equal(
             df1=df_out,
             df2=geo.harmonize_countries(
                 df=df_in,
-                countries_file="IGNORED",
+                countries_file="MOCK_COUNTRIES_FILE",
                 country_col="Country",
                 warn_on_unused_countries=False,
             ),
         )[0]
 
-    def test_warn_on_unused_mappings(self, _):
+    def test_warn_on_unused_mappings(self):
         df_in = pd.DataFrame({"country": ["country_02"], "some_variable": [1]})
         with warns(UserWarning, match="unused"):
             geo.harmonize_countries(
                 df=df_in,
-                countries_file="IGNORED",
+                countries_file="MOCK_COUNTRIES_FILE",
                 warn_on_unused_countries=True,
                 warn_on_missing_countries=True,
             )
 
-    def test_warn_on_countries_missing_in_mapping(self, _):
+    def test_warn_on_countries_missing_in_mapping(self):
         df_in = pd.DataFrame(
             {
                 "country": ["country_02", "country_03", "country_04"],
@@ -234,7 +255,71 @@ class TestHarmonizeCountries:
         with warns(UserWarning, match="missing"):
             geo.harmonize_countries(
                 df=df_in,
-                countries_file="IGNORED",
+                countries_file="MOCK_COUNTRIES_FILE",
+                warn_on_unused_countries=True,
+                warn_on_missing_countries=True,
+            )
+
+    def test_all_countries_excluded(self):
+        df_in = pd.DataFrame({"country": ["country_05", "country_06"], "some_variable": [1, 2]})
+        df_out = pd.DataFrame({"country": [], "some_variable": []}).astype({"country": str, "some_variable": int})
+        assert geo.harmonize_countries(
+            df=df_in,
+            countries_file="MOCK_COUNTRIES_FILE",
+            excluded_countries_file="MOCK_EXCLUDED_COUNTRIES_FILE",
+            warn_on_unused_countries=False,
+            warn_on_missing_countries=False,
+        ).equals(df_out)
+
+    def test_one_country_harmonized_and_one_excluded(self):
+        df_in = pd.DataFrame({"country": ["country_02", "country_05"], "some_variable": [1, 2]})
+        df_out = pd.DataFrame({"country": ["Country 2"], "some_variable": [1]})
+        assert geo.harmonize_countries(
+            df=df_in,
+            countries_file="MOCK_COUNTRIES_FILE",
+            excluded_countries_file="MOCK_EXCLUDED_COUNTRIES_FILE",
+            warn_on_unused_countries=False,
+            warn_on_missing_countries=False,
+        ).equals(df_out)
+
+    def test_one_country_left_equal_one_harmonized_and_one_excluded(self):
+        df_in = pd.DataFrame({"country": ["country_01", "country_02", "country_05"], "some_variable": [1, 2, 3]})
+        df_out = pd.DataFrame({"country": ["country_01", "Country 2"], "some_variable": [1, 2]})
+        assert geo.harmonize_countries(
+            df=df_in,
+            countries_file="MOCK_COUNTRIES_FILE",
+            excluded_countries_file="MOCK_EXCLUDED_COUNTRIES_FILE",
+            warn_on_unused_countries=False,
+            warn_on_missing_countries=False,
+        ).equals(df_out)
+
+    def test_warn_on_unknown_excluded_countries(self):
+        # Since excluded countries contains "country_05" and "country_06", which are not contained in df_in, a warning
+        # should be raised.
+        df_in = pd.DataFrame({"country": ["country_02", "country_03"], "some_variable": [1, 2]})
+        with warns(UserWarning, match="Unknown"):
+            geo.harmonize_countries(
+                df=df_in,
+                countries_file="MOCK_COUNTRIES_FILE",
+                excluded_countries_file="MOCK_EXCLUDED_COUNTRIES_FILE",
+                warn_on_unused_countries=False,
+                warn_on_missing_countries=False,
+            )
+
+    def test_no_warning_after_excluding_country(self):
+        # Ensure no warning is raised because:
+        # * All countries in excluded countries are included in data.
+        # * All countries in data are included in countries mapping.
+        # * All countries in countries mapping are used.
+        df_in = pd.DataFrame(
+            {"country": ["country_02", "country_03", "country_05", "country_06"], "some_variable": [1, 2, 3, 4]}
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            geo.harmonize_countries(
+                df=df_in,
+                countries_file="MOCK_COUNTRIES_FILE",
+                excluded_countries_file="MOCK_EXCLUDED_COUNTRIES_FILE",
                 warn_on_unused_countries=True,
                 warn_on_missing_countries=True,
             )

--- a/tests/data_helpers/test_geo.py
+++ b/tests/data_helpers/test_geo.py
@@ -8,8 +8,10 @@ from unittest.mock import mock_open, patch
 
 import numpy as np
 import pandas as pd
-from owid.datautils import dataframes, geo
+from owid.datautils import dataframes
 from pytest import warns
+
+from etl.data_helpers import geo
 
 mock_countries = {
     "country_02": "Country 2",
@@ -44,7 +46,7 @@ def mock_population_load(*args, **kwargs):
     return mock_population
 
 
-@patch.object(geo.catalog.catalogs.CatalogMixin, "__getitem__", mock_population_load)
+@patch.object(geo, "_load_population", mock_population_load)
 class TestAddPopulationToDataframe:
     def test_all_countries_and_years_in_population(self):
         df_in = pd.DataFrame({"country": ["Country 2", "Country 1"], "year": [2019, 2021]})

--- a/walkthrough/garden_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
+++ b/walkthrough/garden_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
@@ -1,8 +1,5 @@
 """Load a meadow dataset and create a garden dataset."""
 
-import json
-from typing import List, cast
-
 import pandas as pd
 from owid.catalog import Dataset, Table
 from structlog import get_logger
@@ -34,11 +31,10 @@ def run(dest_dir: str) -> None:
     #
     # Process data.
     #
-    log.info("{{cookiecutter.short_name}}.exclude_countries")
-    df = exclude_countries(df)
-
     log.info("{{cookiecutter.short_name}}.harmonize_countries")
-    df = harmonize_countries(df)
+    df = geo.harmonize_countries(
+        df=df, countries_file=paths.country_mapping_path, excluded_countries_file=paths.excluded_countries_path
+    )
 
     # Create a new table with the processed data.
     tb_garden = Table(df, like=tb_meadow)
@@ -61,31 +57,3 @@ def run(dest_dir: str) -> None:
     ds_garden.save()
 
     log.info("{{cookiecutter.short_name}}.end")
-
-
-def load_excluded_countries() -> List[str]:
-    with open(paths.excluded_countries_path, "r") as f:
-        data = json.load(f)
-        assert isinstance(data, list)
-    return data
-
-
-def exclude_countries(df: pd.DataFrame) -> pd.DataFrame:
-    excluded_countries = load_excluded_countries()
-    return cast(pd.DataFrame, df.loc[~df.country.isin(excluded_countries)])
-
-
-def harmonize_countries(df: pd.DataFrame) -> pd.DataFrame:
-    unharmonized_countries = df["country"]
-    df = geo.harmonize_countries(df=df, countries_file=str(paths.country_mapping_path))
-
-    missing_countries = set(unharmonized_countries[df.country.isnull()])
-    if any(missing_countries):
-        raise RuntimeError(
-            "The following raw country names have not been harmonized. "
-            f"Please: (a) edit {paths.country_mapping_path} to include these country "
-            f"names; or (b) add them to {paths.excluded_countries_path}."
-            f"Raw country names: {missing_countries}"
-        )
-
-    return df


### PR DESCRIPTION
* Generalize `etl.data_helpers.harmonize_countries` so that it can ingest a path to a file of excluded country names.
* Change tests to load `geo` from `etl.data_helpers` instead of `owid.datautils`.
* Add new tests for `harmonize_countries`.
* Simplify walkthrough garden to use the new `harmonize_countries`.
* Reformat garden dummy step.
