### PR TITLE
enhance(datadiff): improve performance

### DIFF
--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -68,8 +68,16 @@ class DatasetDiff:
             for col in ds_b[table_name].columns:
                 self.p(f"\t\t[green]+ Column [b]{col}[/b]")
         else:
-            table_a = _sort_index(ds_a[table_name]).reset_index()
-            table_b = _sort_index(ds_b[table_name]).reset_index()
+            table_a = ds_a[table_name]
+            table_b = ds_b[table_name]
+
+            # only sort index if different to avoid unnecessary sorting for huge datasets such as ghe
+            if not _index_equals(table_a, table_b):
+                table_a = _sort_index(table_a)
+                table_b = _sort_index(table_b)
+
+            table_a = table_a.reset_index()
+            table_b = table_b.reset_index()
 
             # compare table metadata
             diff = _dict_diff(_table_metadata_dict(table_a), _table_metadata_dict(table_b), tabs=3)
@@ -259,6 +267,14 @@ def cli(
         "[b]Hint[/b]: Get detailed comparison with [cyan][b]compare --show-values channel namespace version short_name --data-values[/b][/cyan]"
     )
     exit(1 if any_diff else 0)
+
+
+def _index_equals(table_a: pd.DataFrame, table_b: pd.DataFrame, sample: int = 1000) -> bool:
+    """Check if two tables have the same index. Sample both tables to speed up the check."""
+    return (
+        table_a.sample(min(len(table_a), sample), random_state=0).index
+        == table_b.sample(min(len(table_b), sample), random_state=0).index
+    ).all()  # type: ignore
 
 
 def _dict_diff(dict_a: Dict[str, Any], dict_b: Dict[str, Any], tabs) -> str:

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -271,10 +271,14 @@ def cli(
 
 def _index_equals(table_a: pd.DataFrame, table_b: pd.DataFrame, sample: int = 1000) -> bool:
     """Check if two tables have the same index. Sample both tables to speed up the check."""
-    return (
-        table_a.sample(min(len(table_a), sample), random_state=0).index
-        == table_b.sample(min(len(table_b), sample), random_state=0).index
-    ).all()  # type: ignore
+    if len(table_a) < sample and len(table_b) < sample:
+        index_a = table_a.index
+        index_b = table_b.index
+    else:
+        index_a = table_a.sample(sample, random_state=0).index
+        index_b = table_b.sample(sample, random_state=0).index
+
+    return (index_a == index_b).all()  # type: ignore
 
 
 def _dict_diff(dict_a: Dict[str, Any], dict_b: Dict[str, Any], tabs) -> str:

--- a/etl/files.py
+++ b/etl/files.py
@@ -31,7 +31,7 @@ class RuntimeCache:
     def __getitem__(self, key: str) -> str:
         return self._cache[key]
 
-    def add(self, key: str, value: str) -> None:
+    def add(self, key: str, value: Any) -> None:
         if key not in self._locks:
             self._locks[key] = Lock()
 

--- a/etl/files.py
+++ b/etl/files.py
@@ -14,9 +14,36 @@ from yaml.dumper import Dumper
 
 from etl.paths import BASE_DIR
 
-# runtime cache, we need locks because we usually run it in threads
-cache_md5: Dict[str, str] = {}
-cache_md5_locks: Dict[str, Lock] = {}
+
+class RuntimeCache:
+    """Runtime cache, we need locks because we usually run it in threads."""
+
+    _cache: Dict[str, str]
+    _locks: Dict[str, Lock]
+
+    def __init__(self):
+        self._cache = {}
+        self._locks = {}
+
+    def __contains__(self, key):
+        return key in self._cache
+
+    def __getitem__(self, key: str) -> str:
+        return self._cache[key]
+
+    def add(self, key: str, value: str) -> None:
+        if key not in self._locks:
+            self._locks[key] = Lock()
+
+        with self._locks[key]:
+            self._cache[key] = value
+
+    def clear(self) -> None:
+        self._cache = {}
+        self._locks = {}
+
+
+CACHE_CHECKSUM_FILE = RuntimeCache()
 
 
 def checksum_file_nocache(filename: Union[str, Path]) -> str:
@@ -37,13 +64,10 @@ def checksum_file(filename: Union[str, Path]) -> str:
     if isinstance(filename, Path):
         filename = filename.as_posix()
 
-    if filename not in cache_md5:
-        cache_md5_locks[filename] = Lock()
+    if filename not in CACHE_CHECKSUM_FILE:
+        CACHE_CHECKSUM_FILE.add(filename, checksum_file_nocache(filename))
 
-        with cache_md5_locks[filename]:
-            cache_md5[filename] = checksum_file_nocache(filename)
-
-    return cache_md5[filename]
+    return CACHE_CHECKSUM_FILE[filename]
 
 
 def checksum_str(s: str) -> str:

--- a/etl/steps/data/garden/country_profile/2022/overview.py
+++ b/etl/steps/data/garden/country_profile/2022/overview.py
@@ -98,7 +98,8 @@ def run(dest_dir: str) -> None:
 
                 # Add combined tables to the new dataset.
                 tb_combined = tb_combined.reset_index()
-                ds_garden.add(tb_combined, formats=["csv"])
+                # Save also as a csv format for the website
+                ds_garden.add(tb_combined, formats=["csv", "feather", "parquet"])
 
 
 def get_population() -> pd.DataFrame:

--- a/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
+++ b/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
@@ -23,6 +23,7 @@ tables:
         display:
           entityAnnotationsMap: "Western Offshoots: United States, Canada, Australia and New Zealand"
           numDecimalPlaces: 0
+
       gdp_per_capita:
         title: GDP per capita
         short_unit: $

--- a/etl/steps/data/garden/hmd/2022-11-04/life_tables.py
+++ b/etl/steps/data/garden/hmd/2022-11-04/life_tables.py
@@ -46,7 +46,7 @@ def make_table(ds_meadow: Dataset, table_name: str) -> Table:
     log.info(f"Building table {table_name}...")
 
     # Country management
-    tb_garden = ds_meadow[table_name].reset_index()
+    tb_garden = ds_meadow[table_name].reset_index(drop=True)
     tb_garden = clean_countries(tb_garden)
     tb_garden = tb_garden.set_index(["country", "year", "age"], verify_integrity=True)
 

--- a/etl/tempcompare.py
+++ b/etl/tempcompare.py
@@ -97,6 +97,8 @@ def df_equals(
     assert all(df1.columns == df2.columns), "Columns must be the same"
     assert all(df1.index == df2.index), "Indices must be the same"
 
+    df1, df2 = df1.copy(deep=False), df2.copy(deep=False)
+
     # Union categories of categorical columns to enable comparison
     for col in df1.columns:
         if df1[col].dtype == "category":

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -18,7 +18,6 @@ from owid.catalog import Dataset
 
 from etl import paths
 from etl.steps import (
-    CACHE_IS_DIRTY,
     BackportStepPrivate,
     DataStep,
     DataStepPrivate,
@@ -62,11 +61,9 @@ def test_data_step_becomes_dirty_when_pandas_version_changes():
             d = DataStep(step_name, [])
             assert d.is_dirty()
             d.run()
-            CACHE_IS_DIRTY.clear()
             assert not d.is_dirty()
 
             pd.__version__ += ".test"  # type: ignore
-            CACHE_IS_DIRTY.clear()
             assert d.is_dirty()
 
     finally:

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -18,6 +18,7 @@ from owid.catalog import Dataset
 
 from etl import paths
 from etl.steps import (
+    CACHE_IS_DIRTY,
     BackportStepPrivate,
     DataStep,
     DataStepPrivate,
@@ -61,9 +62,11 @@ def test_data_step_becomes_dirty_when_pandas_version_changes():
             d = DataStep(step_name, [])
             assert d.is_dirty()
             d.run()
+            CACHE_IS_DIRTY.clear()
             assert not d.is_dirty()
 
             pd.__version__ += ".test"  # type: ignore
+            CACHE_IS_DIRTY.clear()
             assert d.is_dirty()
 
     finally:


### PR DESCRIPTION
* improve performance of `datadiff` so that running `etl-datadiff REMOTE data/ --include "garden" --verbose` runs in reasonable time (it could still take an hour or so if your bandwidth is slow)
* avoid recomputing dependencies checksums by caching them, this speeds up `etl garden` by 3x or so
* save country profiles as other formats to make them available in the catalog