### PR TITLE
enhance(wt-charts): use new backend version by default

### DIFF
--- a/etl/chart_revision/cli.py
+++ b/etl/chart_revision/cli.py
@@ -12,6 +12,8 @@ import click
 from rich_click.rich_command import RichCommand
 from structlog import get_logger
 
+# TBD
+from etl.chart_revision.deprecated import ChartRevisionSuggester
 from etl.chart_revision.revision import (
     get_charts_to_update,
     submit_revisions_to_grapher,
@@ -27,9 +29,15 @@ log = get_logger()
     type=str,
 )
 @click.option("--revision-reason", default=None, help="Assign a reason for the suggested chart revision.")
-def main_cli(mapping_file: str, revision_reason: str) -> None:
+@click.option("-o", "--old-version", is_flag=True, help="Use old backend version.")
+def main_cli(mapping_file: str, revision_reason: str, old_version: str) -> None:
     try:
-        main(mapping_file, revision_reason)
+        if old_version:
+            suggester = ChartRevisionSuggester.from_json(mapping_file, revision_reason)
+            suggester.suggest()
+        else:
+            main(mapping_file, revision_reason)
+
     except Exception as e:
         log.error(e)
         if DEBUG:

--- a/etl/chart_revision/deprecated.py
+++ b/etl/chart_revision/deprecated.py
@@ -1,4 +1,6 @@
-"""Generate chart revisions in Grapher using MAPPING_FILE JSON file.
+"""[This submodule will be deprecated, replaced by etl.chart_revision.cli]
+
+Generate chart revisions in Grapher using MAPPING_FILE JSON file.
 
 MAPPING_FILE is a JSON file with old_variable_id -> new_variable_id pairs. E.g. {2032: 147395, 2033: 147396, ...}.
 
@@ -12,15 +14,12 @@ import traceback
 from copy import deepcopy
 from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple, Union, cast
 
-import click
 import pandas as pd
 import simplejson as json
 import structlog
 from MySQLdb import IntegrityError
-from rich_click.rich_command import RichCommand
 from tqdm import tqdm
 
-from etl.chart_revision.cli import main as main_exp
 from etl.config import DEBUG, GRAPHER_USER_ID
 from etl.db import open_db
 from etl.grapher_helpers import IntRange
@@ -30,26 +29,6 @@ MSGTypes = Literal["error", "warning", "info", "success"]
 
 # The maximum length of the suggested revision reason can't exceed the maximum length specified by the datatype "suggestedReason" in grapher.suggested_chart_revisions table.
 SUGGESTED_REASON_MAX_LENGTH = 512
-
-
-@click.command(cls=RichCommand, help=__doc__)
-@click.argument(
-    "mapping-file",
-    type=str,
-)
-@click.option("--revision-reason", default=None, help="Assign a reason for the suggested chart revision.")
-@click.option("-e", "--experimental", is_flag=True, help="Enable experimental mode.")
-def main_cli(mapping_file: str, revision_reason: str, experimental: bool) -> None:
-    try:
-        if experimental:
-            main_exp(mapping_file, revision_reason)
-        else:
-            suggester = ChartRevisionSuggester.from_json(mapping_file, revision_reason)
-            suggester.suggest()
-    except Exception as e:
-        log.error(e)
-        if DEBUG:
-            traceback.print_exc()
 
 
 class ChartRevisionSuggester:

--- a/walkthrough/charts.py
+++ b/walkthrough/charts.py
@@ -295,7 +295,7 @@ class Navigation:
                     options=["Use old version"],
                     value=[],
                     name="old_version",
-                    help_text="Currently using latest version. Check to use old version!",
+                    help_text="Currently using latest backend version. Check to use old version!",
                 ),
             ],
         )


### PR DESCRIPTION
By default, `walkthrough charts` and `etl-chart-suggester` will now use the new backend version. Previously, new version was optional (see #776).

To use old (legacy) version, use:

```
etl-chart-suggester MAPPING.json -o
```

or in walkthrough check "Use old version":

![image](https://user-images.githubusercontent.com/18101289/214114113-fb35363c-26ed-4ee6-9059-855414fae59b.png)

---
Good enough review would be to test `walkthrough charts` for some datasets locally and see that it makes sense.
