### PR TITLE
fix(etl): use DEFAULT_DAG_FILE everywhere

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -22,11 +22,6 @@ config.enable_bugsnag()
 # if the number of open files allowed is less than this, increase it
 LIMIT_NOFILE = 4096
 
-# DAG file to use by default.
-# Use paths.DAG_ARCHIVE_FILE to load the complete dag, with active and archive steps.
-# Otherwise use paths.DAG_FILE to load only active steps, ignoring archive ones.
-DEFAULT_DAG_FILE = paths.DAG_ARCHIVE_FILE
-
 
 @click.command()
 @click.option("--dry-run", is_flag=True, help="Only print the steps that would be run")
@@ -66,7 +61,7 @@ DEFAULT_DAG_FILE = paths.DAG_ARCHIVE_FILE
     "--dag-path",
     type=click.Path(exists=True),
     help="Path to DAG yaml file",
-    default=DEFAULT_DAG_FILE,
+    default=paths.DEFAULT_DAG_FILE,
 )
 @click.option(
     "--workers",
@@ -87,7 +82,7 @@ def main_cli(
     downstream: bool = False,
     only: bool = False,
     exclude: Optional[str] = None,
-    dag_path: Path = DEFAULT_DAG_FILE,
+    dag_path: Path = paths.DEFAULT_DAG_FILE,
     workers: int = 5,
 ) -> None:
     _update_open_file_limit()
@@ -135,7 +130,7 @@ def main(
     downstream: bool = False,
     only: bool = False,
     exclude: Optional[str] = None,
-    dag_path: Path = DEFAULT_DAG_FILE,
+    dag_path: Path = paths.DEFAULT_DAG_FILE,
     workers: int = 5,
 ) -> None:
     """

--- a/etl/paths.py
+++ b/etl/paths.py
@@ -12,3 +12,8 @@ REFERENCE_DATASET = DATA_DIR / "garden" / "reference"
 
 # NOTE: this is useful when your steps are defined in a different package
 BASE_PACKAGE = os.environ.get("BASE_PACKAGE", "etl")
+
+# DAG file to use by default.
+# Use paths.DAG_ARCHIVE_FILE to load the complete dag, with active and archive steps.
+# Otherwise use paths.DAG_FILE to load only active steps, ignoring archive ones.
+DEFAULT_DAG_FILE = DAG_ARCHIVE_FILE

--- a/etl/prune.py
+++ b/etl/prune.py
@@ -23,7 +23,7 @@ EXCLUDE_STEP_TYPES = ("grapher", "walden", "walden-private", "github")
     "--dag-path",
     type=click.Path(exists=True),
     help="Path to DAG yaml file",
-    default=paths.DAG_FILE,
+    default=paths.DEFAULT_DAG_FILE,
 )
 @click.option(
     "--data-dir",
@@ -42,7 +42,7 @@ def prune_cli(
 
 
 def prune(
-    dag_path: Path = paths.DAG_FILE,
+    dag_path: Path = paths.DEFAULT_DAG_FILE,
     data_dir: Path = paths.DATA_DIR,
     dry_run: bool = False,
 ) -> None:

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -145,7 +145,7 @@ def traverse(graph: Graph, nodes: Set[str]) -> Graph:
     return dict(reachable)
 
 
-def load_dag(filename: Union[str, Path] = paths.DAG_FILE) -> Dict[str, Any]:
+def load_dag(filename: Union[str, Path] = paths.DEFAULT_DAG_FILE) -> Dict[str, Any]:
     return _load_dag(filename, {})
 
 

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -34,7 +34,7 @@ def test_sub_dag_import():
     assert any(["sub_dag_step" in step for step in load_dag("tests/data/dag.yml")]), "sub-dag steps not found"
 
 
-def get_all_steps(filename: Union[str, Path] = paths.DAG_FILE) -> List[Step]:
+def get_all_steps(filename: Union[str, Path] = paths.DEFAULT_DAG_FILE) -> List[Step]:
     dag = load_dag(filename)
     steps = compile_steps(dag, [])
     return steps

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -61,7 +61,7 @@ def rename_steps_in_dag(dag, prefix):
 
 
 def create_mock_version_tracker(dag):
-    def mock_load_dag(filename=paths.DAG_FILE):
+    def mock_load_dag(filename=paths.DEFAULT_DAG_FILE):
         # This function mimics load_dag, but using a custom dag.
         _dag = dag["steps"].copy()
         if filename == paths.DAG_ARCHIVE_FILE:


### PR DESCRIPTION
Some steps were not building because `load_dag` was using `DAG_FILE` and not `DEFAULT_DAG_FILE`. This is a bit confusing, it would be better do the [leap of faith](https://github.com/owid/etl/pull/799#discussion_r1090485357), avoid using `DEFAULT_DAG_FILE` and use just `DAG_FILE` & `DAG_ARCHIVE_FILE`