### PR TITLE
enhance(wt-charts): use new backend version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ compare = 'etl.compare:cli'
 generate_graph = 'etl.to_graphviz:to_graphviz'
 etl-match-variables = 'etl.match_variables:main_cli'
 etl-translate-varmap = 'etl.variable_mapping_translate:main_cli'
-etl-chart-suggester = 'etl.chart_revision_suggester:main_cli'
+etl-chart-suggester = 'etl.chart_revision.cli:main_cli'
 etl-metadata-export = 'etl.metadata_export:cli'
 etl-datadiff = 'etl.datadiff:cli'
 


### PR DESCRIPTION
For some reason I forgot to change the function called in the `etl-chart-suggester` command tool. The web app client is already using the new backend version