### PR TITLE
feat(helpers): Add formats to create_dataset, so that it can be used …

### DIFF
--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -14,6 +14,7 @@ import requests
 import structlog
 from owid import catalog
 from owid.catalog import CHANNEL
+from owid.catalog.datasets import DEFAULT_FORMATS, FileFormat
 from owid.datautils.common import ExceptionFromDocstring
 from owid.walden import Catalog as WaldenCatalog
 from owid.walden import Dataset as WaldenDataset
@@ -67,6 +68,7 @@ def create_dataset(
     tables: Iterable[catalog.Table],
     default_metadata: Optional[Union[SnapshotMeta, catalog.DatasetMeta]] = None,
     underscore_table: bool = True,
+    formats: List[FileFormat] = DEFAULT_FORMATS,
 ) -> catalog.Dataset:
     """Create a dataset and add a list of tables. The dataset metadata is inferred from
     default_metadata and the dest_dir (which is in the form `channel/namespace/version/short_name`).
@@ -96,7 +98,7 @@ def create_dataset(
     for table in tables:
         if underscore_table:
             table = catalog.utils.underscore_table(table)
-        ds.add(table)
+        ds.add(table, formats=formats)
 
     # set metadata from dest_dir
     pattern = (


### PR DESCRIPTION
Add `formats` to `create_dataset` function from `etl.helpers`, so that it can be used in explorer steps.

Given that Pablo A is currently working on an explorer step, I thought it would be good to fix this (since explorer steps are not that commonly used).

This PR should fix: https://github.com/owid/etl/issues/825