### PR TITLE
Create explorer step for Luxembourg Income Study

### DIFF
--- a/dag/main.yml
+++ b/dag/main.yml
@@ -269,6 +269,8 @@ steps:
     - data://meadow/lis/2023-01-18/luxembourg_income_study
   data://grapher/lis/2023-01-18/luxembourg_income_study:
     - data://garden/lis/2023-01-18/luxembourg_income_study
+  data://explorers/lis/2023-01-18/luxembourg_income_study:
+    - data://garden/lis/2023-01-18/luxembourg_income_study
 
   # World Inequality Database
   data://meadow/wid/2023-01-27/world_inequality_database:

--- a/etl/steps/data/explorers/lis/2023-01-18/luxembourg_income_study.py
+++ b/etl/steps/data/explorers/lis/2023-01-18/luxembourg_income_study.py
@@ -1,0 +1,24 @@
+"""Luxembourg Income Study explorer data step.
+
+Loads the latest LIS data from garden and stores a table (as a csv file).
+"""
+
+from owid.catalog import Dataset
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+
+    # Load garden dataset.
+    ds_garden: Dataset = paths.load_dependency("luxembourg_income_study")
+
+    # Read table from garden dataset.
+    tb_garden = ds_garden["luxembourg_income_study"]
+
+    # Create explorer dataset, with garden table and metadata in csv format
+    ds_explorer = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata, formats=["csv"])
+    ds_explorer.save()


### PR DESCRIPTION
Create explorer step for Luxembourg Income Study. It follows the same structure as [WID](https://github.com/owid/etl/blob/master/etl/steps/data/explorers/wid/2023-01-27/world_inequality_database.py).