### PR TITLE
fix(walkthrough): add some fields to metaata to make dummy dataset from walkthrough work

### DIFF
--- a/etl/steps/data/garden/dummy/2020-01-01/dummy.meta.yml
+++ b/etl/steps/data/garden/dummy/2020-01-01/dummy.meta.yml
@@ -1,35 +1,21 @@
 all_sources:
-  - source_testing: &source-testing
-      name: # TO BE FILLED. Example: Testing Short Citation
-      published_by: # TO BE FILLED (if different to short citation). Example: Testing Full Citation
-      url: # TO BE FILLED. Example: https://url_of_testing_source.com/
-      date_accessed: # TO BE FILLED. Example: 2023-01-01
-      publication_date: # TO BE FILLED. Example: 2023-01-01
-      publication_year: # TO BE FILLED (if publication_date is not given). Example: 2023
-      # description: Source description.
-
+- source_testing: &source-testing
+    name: Dummy source
+    published_by:
+    url:
+    date_accessed:
+    publication_date:
+    publication_year:
 dataset:
-  title: # TO BE FILLED. Example: Testing Dataset Name (Institution, 2023)
-  namespace: dummy
-  short_name: dummy
-  version: 2020-01-01
-  # description: Dataset description.
+  title: Dummy dataset
   licenses:
-    - name: # TO BE FILLED. Example: Testing License Name
-      url: # TO BE FILLED. Example: https://url_of_testing_source.com/license
+  - name:
+    url:
   sources:
-    - *source-testing
+  - *source-testing
 
 tables:
   dummy:
     variables:
-      # testing_variable:
-      #   title: Testing variable title
-      #   unit: arbitrary units
-      #   short_unit: au
-      #   description: Full description of testing variable.
-      #   sources:
-      #     - *source-testing
-      #   display:
-      #     entityAnnotationsMap: Test annotation
-      #     numDecimalPlaces: 0
+      dummy_variable:
+        unit: dummy unit

--- a/etl/steps/data/meadow/dummy/2020-01-01/dummy.meta.yml
+++ b/etl/steps/data/meadow/dummy/2020-01-01/dummy.meta.yml
@@ -10,9 +10,6 @@ all_sources:
 
 dataset:
   title: # TO BE FILLED. Example: Testing Dataset Name (Institution, 2023)
-  namespace: dummy
-  short_name: dummy
-  version: 2020-01-01
   # description: Dataset description.
   licenses:
     - name: # TO BE FILLED. Example: Testing License Name

--- a/walkthrough/garden.py
+++ b/walkthrough/garden.py
@@ -4,6 +4,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+import ruamel.yaml
 from owid.catalog import Dataset
 from pydantic import BaseModel
 from pywebio import input as pi
@@ -136,6 +137,9 @@ def app(run_checks: bool, dummy_data: bool) -> None:
     if not form.include_metadata_yaml:
         os.remove(metadata_path)
 
+    if dummies:
+        _fill_dummy_metadata_yaml(metadata_path)
+
     po.put_markdown(
         f"""
 ## Next steps
@@ -223,3 +227,17 @@ def _check_dataset_in_meadow(form: GardenForm) -> None:
     except FileNotFoundError:
         # raise a warning, but continue
         po.put_warning(po.put_markdown(f"Dataset not found in Meadow, have you run ```\n{cmd}\n```?"))
+
+
+def _fill_dummy_metadata_yaml(metadata_path: Path) -> None:
+    """Fill dummy metadata yaml file with some dummy values. Only useful when
+    --dummy-data is used. We need this to avoid errors in `walkthrough grapher --dummy-data`."""
+    with open(metadata_path, "r") as f:
+        doc = ruamel.yaml.load(f, Loader=ruamel.yaml.RoundTripLoader)
+
+    doc["dataset"]["title"] = "Dummy dataset"
+    doc["tables"]["dummy"]["variables"] = {"dummy_variable": {"unit": "dummy unit"}}
+    doc["all_sources"][0]["source_testing"]["name"] = "Dummy source"
+
+    with open(metadata_path, "w") as f:
+        ruamel.yaml.dump(doc, f, Dumper=ruamel.yaml.RoundTripDumper)


### PR DESCRIPTION
Before this `walkthrough grapher --dummy-data` generated grapher dataset that was raising error about missing properties like title. This PR adds missing metadata when we use flag `--dummy-data`.

(I could have fixed just the dummy dataset, but someone would have overwritten it soon anyway, so it's better to fix it when being generated)