### PR TITLE
fix(data): fix failing grapher upsert steps

### DIFF
--- a/etl/compare.py
+++ b/etl/compare.py
@@ -324,7 +324,7 @@ def read_variables_from_db(env_path: str, namespace: str, version: str, dataset:
     )
 
     # drop uninteresting columns
-    df = df.drop(["updatedAt", "createdAt"], axis=1)
+    df = df.drop(["updatedAt", "createdAt", "dataPath", "metadataPath", "catalogPath"], axis=1)
 
     return cast(pd.DataFrame, df)
 

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -26,6 +26,8 @@ import yaml
 from dvc.dvcfile import Dvcfile
 from dvc.repo import Repo
 
+from etl.db import get_engine
+
 # smother deprecation warnings by papermill
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
@@ -693,8 +695,11 @@ class GrapherStep(Step):
 
         dataset.metadata = gh._adapt_dataset_metadata_for_grapher(dataset.metadata)
 
+        engine = get_engine()
+
         assert dataset.metadata.namespace
         dataset_upsert_results = upsert_dataset(
+            engine,
             dataset,
             dataset.metadata.namespace,
             dataset.metadata.sources,
@@ -713,6 +718,7 @@ class GrapherStep(Step):
             # generate table with entity_id, year and value for every column
             tables = gh._yield_wide_table(table, na_action="drop")
             upsert = lambda t: upsert_table(  # noqa: E731
+                engine,
                 t,
                 dataset_upsert_results,
                 catalog_path=catalog_path,

--- a/etl/steps/data/garden/un_sdg/2022-07-07/un_sdg.py
+++ b/etl/steps/data/garden/un_sdg/2022-07-07/un_sdg.py
@@ -86,6 +86,7 @@ def create_tables(original_df: pd.DataFrame) -> List[pd.DataFrame]:
     dim_description = get_dimension_description()
     init_dimensions = list(dim_description.keys())
     init_dimensions = list(set(init_dimensions).intersection(list(original_df.columns)))
+    init_dimensions = sorted(init_dimensions)
     init_non_dimensions = list([c for c in original_df.columns if c not in set(init_dimensions)])
 
     all_series = original_df.groupby(["indicator", "seriescode"])
@@ -282,7 +283,7 @@ def manual_clean_data(df: pd.DataFrame) -> pd.DataFrame:
         ],
     )
     # Dropping average marine acidity as we don't have a way to visualise it
-    df = df[~df["seriescode"].isin(["ER_OAW_MNACD", "EN_REF_WASCOL"])]
+    df = df[~df["seriescode"].isin(["ER_OAW_MNACD"])]
     df = df.drop(["level_0", "index"], axis=1, errors="ignore")
 
     return df

--- a/etl/steps/data/grapher/energy/2022-07-29/primary_energy_consumption.py
+++ b/etl/steps/data/grapher/energy/2022-07-29/primary_energy_consumption.py
@@ -13,6 +13,9 @@ def run(dest_dir: str) -> None:
     garden_dataset = catalog.Dataset(DATASET_PATH)
     dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
+    # Backward compatibility
+    dataset.metadata.title = "Primary energy consumption (BP & EIA, 2022a)"
+
     # There is only one table in the dataset, with the same name as the dataset.
     table = garden_dataset[garden_dataset.table_names[0]].reset_index().drop(columns=["gdp", "population", "source"])
     dataset.add(table)

--- a/etl/steps/data/grapher/energy/2022-07-29/primary_energy_consumption.py
+++ b/etl/steps/data/grapher/energy/2022-07-29/primary_energy_consumption.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
 
     # Backward compatibility
-    dataset.metadata.title = "Primary energy consumption (BP & EIA, 2022a)"
+    dataset.metadata.title = "Primary energy consumption (BP & EIA, 2022 archive)"
 
     # There is only one table in the dataset, with the same name as the dataset.
     table = garden_dataset[garden_dataset.table_names[0]].reset_index().drop(columns=["gdp", "population", "source"])


### PR DESCRIPTION
Couple of minor fixes needed to run `etl grapher --grapher` successfully on staging / live. This is a prerequisite to automated deploys.

It also fixes bug with excessive number of open connections (by using shared engine).

In addition to changes in this PR, I'll have to run the following SQLs against live DB (should be harmless)

```
update datasets set shortName = 'global_carbon_budget_additional'
where name = 'Global Carbon Budget (Global Carbon Project, v2021b)' and shortName = 'global_carbon_budget_global';

update datasets set name = 'United Nations Office on Drugs and Crime - Intentional Homicides'
where name = 'United Nations Office on Drugs and Crime - Intentional Homicides (2022)' and version = '2023-01-04';
```