### PR TITLE
enhance(grapher_import): upsert to S3 in addition to data_values

### DIFF
--- a/backport/datasync/data_metadata.py
+++ b/backport/datasync/data_metadata.py
@@ -46,6 +46,10 @@ def variable_data_df_from_s3(engine: Engine, data_path: str) -> pd.DataFrame:
     if df.empty:
         return empty_df
 
+    return add_entity_code_and_name(engine, df)
+
+
+def add_entity_code_and_name(engine: Engine, df: pd.DataFrame) -> pd.DataFrame:
     # add entities from DB
     q = """
     SELECT
@@ -56,9 +60,7 @@ def variable_data_df_from_s3(engine: Engine, data_path: str) -> pd.DataFrame:
     WHERE id in %(entity_ids)s
     """
     entities = pd.read_sql(q, engine, params={"entity_ids": df["entityId"].tolist()})
-    df = df.merge(entities, on="entityId")
-
-    return df
+    return df.merge(entities, on="entityId")
 
 
 def variable_data(data_df: pd.DataFrame) -> Dict[str, Any]:

--- a/etl/config.py
+++ b/etl/config.py
@@ -7,6 +7,8 @@ The environment variables and settings here are for publishing options, they're
 only important for OWID staff.
 """
 
+import os
+import pwd
 from os import environ as env
 
 import bugsnag
@@ -33,6 +35,21 @@ DB_HOST = env.get("DB_HOST", "localhost")
 DB_PORT = int(env.get("DB_PORT", "3306"))
 DB_USER = env.get("DB_USER", "root")
 DB_PASS = env.get("DB_PASS", "")
+
+
+def get_username():
+    return pwd.getpwuid(os.getuid())[0]
+
+
+# if running against live or staging, use s3://owid-catalog that has CDN
+# otherwise use s3://owid-test/baked-variables/<username> for local development
+# it might be better to save things locally instead of S3, but that would require
+# a lot of changes to the codebase (and even grapher one)
+if DB_NAME in ("live_grapher", "staging_grapher"):
+    DEFAULT_BAKED_VARIABLES_PATH = f"s3://owid-catalog/baked-variables/{DB_NAME}"
+else:
+    DEFAULT_BAKED_VARIABLES_PATH = f"s3://owid-test/baked-variables/{get_username()}"
+BAKED_VARIABLES_PATH = env.get("BAKED_VARIABLES_PATH", DEFAULT_BAKED_VARIABLES_PATH)
 
 # run ETL steps with debugger on exception
 IPDB_ENABLED = False

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -55,7 +55,8 @@ JSON = _JSON(none_as_null=True)
 
 def get_engine() -> _FutureEngine:
     return create_engine(
-        f"mysql://{config.DB_USER}:{quote(config.DB_PASS)}@{config.DB_HOST}:{config.DB_PORT}/{config.DB_NAME}"
+        f"mysql://{config.DB_USER}:{quote(config.DB_PASS)}@{config.DB_HOST}:{config.DB_PORT}/{config.DB_NAME}",
+        future=False,
     )
 
 
@@ -803,6 +804,16 @@ class Variable(SQLModel, table=True):
     @classmethod
     def load_variable(cls, session: Session, variable_id: int) -> "Variable":
         return session.exec(select(cls).where(cls.id == variable_id)).one()
+
+    def s3_data_path(self) -> str:
+        """Path to S3 with data in JSON format for Grapher. Typically
+        s3://owid-catalog/baked-variables/live_grapher/data/123.json."""
+        return f"{config.BAKED_VARIABLES_PATH}/data/{self.id}.json"
+
+    def s3_metadata_path(self) -> str:
+        """Path to S3 with metadata in JSON format for Grapher. Typically
+        s3://owid-catalog/baked-variables/live_grapher/metadata/123.json."""
+        return f"{config.BAKED_VARIABLES_PATH}/metadata/{self.id}.json"
 
 
 class ChartDimensions(SQLModel, table=True):


### PR DESCRIPTION
When running `etl --grapher`, push to S3 in addition to upserting to `data_values`. Stop syncing datasets from ETL in `datasync` service. After we make sure loading data from S3 works well, we can remove upserting to data_values and prune all ETL datasets from there. That should make `data_values` significantly smaller and give us better visibility into what's writing there and still needs to be migrated.

Running `ENV=.env.prod etl ... --grapher` now does the following:

1. Upsert to `data_values`
2. Upload data to https://catalog.ourworldindata.org/baked-variables/live_grapher/data/[variable_id].json (and metadata)
3. Set `dataPath` and `metadataPath` of all upserted variables
4. (Skip `datasync`)

Grapher admin will fetch data and metadata from S3 instead of data_values.

Note that we're **pushing to S3** even when running locally (to bucket `s3://owid-test`). That could slow things down a bit. If this becomes too annoying I can add option to have local variables catalog on disk (it'd make sense to do it as a separate PR anyway as it needs also changes to grapher codebase).

Shortly after this gets merged and tried out, there'll be another PR that removes upserting to `data_values`.