### PR TITLE
enhance(etl): use non-archive DAG file by default

### DIFF
--- a/etl/paths.py
+++ b/etl/paths.py
@@ -16,4 +16,4 @@ BASE_PACKAGE = os.environ.get("BASE_PACKAGE", "etl")
 # DAG file to use by default.
 # Use paths.DAG_ARCHIVE_FILE to load the complete dag, with active and archive steps.
 # Otherwise use paths.DAG_FILE to load only active steps, ignoring archive ones.
-DEFAULT_DAG_FILE = DAG_ARCHIVE_FILE
+DEFAULT_DAG_FILE = DAG_FILE


### PR DESCRIPTION
Steps archival works pretty well in my opinion. I think it's time to start excluding archived steps by default.

(I thought we were excluding them already which bit me recently)