### PR TITLE
feat(grapher_helpers): Ensure short and long sources citation ends in a period

### DIFF
--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -335,7 +335,7 @@ def combine_metadata_sources(sources: List[catalog.Source]) -> catalog.Source:
 
         # Ensure combined source names (short and long versions) end in a period.
         if ((attribute == "name") or (attribute == "published_by")) and not combined_value.endswith("."):
-            combined_value += '.'
+            combined_value += "."
 
         # Instead of leaving an empty string, make any empty field None.
         if combined_value == "":

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -333,13 +333,14 @@ def combine_metadata_sources(sources: List[catalog.Source]) -> catalog.Source:
             # For any other attribute, values from different sources can be in the same line, separated by ;.
             combined_value = "; ".join(values)
 
-        # Ensure combined source names (short and long versions) end in a period.
-        if ((attribute == "name") or (attribute == "published_by")) and not combined_value.endswith("."):
-            combined_value += "."
-
         # Instead of leaving an empty string, make any empty field None.
         if combined_value == "":
             combined_value = None  # type: ignore
+
+        # Ensure combined source names (short and long versions) end in a period.
+        if ((attribute == "name") or (attribute == "published_by")) and (combined_value is not None):
+            if not combined_value.endswith("."):
+                combined_value += "."
 
         setattr(default_source, attribute, combined_value)
 

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -333,6 +333,10 @@ def combine_metadata_sources(sources: List[catalog.Source]) -> catalog.Source:
             # For any other attribute, values from different sources can be in the same line, separated by ;.
             combined_value = "; ".join(values)
 
+        # Ensure combined source names (short and long versions) end in a period.
+        if ((attribute == "name") or (attribute == "published_by")) and not combined_value.endswith("."):
+            combined_value += '.'
+
         # Instead of leaving an empty string, make any empty field None.
         if combined_value == "":
             combined_value = None  # type: ignore

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -117,7 +117,7 @@ def test_ensure_source_per_variable_multiple_sources():
     new_table = gh._ensure_source_per_variable(table)
     assert len(new_table.deaths.metadata.sources) == 1
     source = new_table.deaths.metadata.sources[0]
-    assert source.name == "s1; s2"
+    assert source.name == "s1; s2."
     assert source.description == "s1 description\ns2 description"
 
     # no sources
@@ -125,7 +125,7 @@ def test_ensure_source_per_variable_multiple_sources():
     new_table = gh._ensure_source_per_variable(table)
     assert len(new_table.deaths.metadata.sources) == 1
     source = new_table.deaths.metadata.sources[0]
-    assert source.name == "s3"
+    assert source.name == "s3."
     assert source.description == "Dataset description\ns3 description"
 
     # sources have no description, but table has
@@ -143,7 +143,7 @@ def test_combine_metadata_sources():
         Source(name="s2", description="s2 description"),
     ]
     source = gh.combine_metadata_sources(sources)
-    assert source.name == "s1; s2"
+    assert source.name == "s1; s2."
     assert source.description == "s1 description\ns2 description"
 
     # make sure we haven't modified original sources


### PR DESCRIPTION
So far we have not been consistent about whether sources short/long citations end in a period.
This PR ensures that the ETL grapher step adds a '.' at the end of the source name and `published_by` fields.
