### PR TITLE
data: Add global mobile money dataset from GSMA

### DIFF
--- a/dag/walkthrough.yml
+++ b/dag/walkthrough.yml
@@ -8,3 +8,5 @@ steps:
   - data://garden/dummy/2020-01-01/dummy
   data://explorers/dummy/2020-01-01/dummy:
   - data://garden/dummy/2020-01-01/dummy
+  data://meadow/technology/2023-03-06/mobile_money:
+  - snapshot://technology/2023-03-06/mobile_money.xlsx

--- a/dag/walkthrough.yml
+++ b/dag/walkthrough.yml
@@ -10,3 +10,5 @@ steps:
   - data://garden/dummy/2020-01-01/dummy
   data://meadow/technology/2023-03-06/mobile_money:
   - snapshot://technology/2023-03-06/mobile_money.xlsx
+  data://garden/technology/2023-03-06/mobile_money:
+  - data://meadow/technology/2023-03-06/mobile_money

--- a/etl/steps/data/garden/technology/2023-03-06/mobile_money.meta.yml
+++ b/etl/steps/data/garden/technology/2023-03-06/mobile_money.meta.yml
@@ -1,0 +1,33 @@
+dataset:
+  namespace: technology
+  short_name: mobile_money
+  title: Global Mobile Money Dataset (GSMA, 2022)
+  description: |-
+    The Global Mobile Money Dataset is a set of global metrics for the mobile money industry based on data collected and analyzed by the GSMA Mobile Money program.
+
+    The GSMA Mobile Money program considers services that meet the following definitions:
+
+    • The service must be available to the unbanked, e.g., people who do not have access to a formal account at a financial institution.
+    • The service must offer at least one of the following services: Storage of value; Domestic or international transfer; mobile payment, including bill payment, bulk disbursement, and merchant payment.
+    • The service must offer a network of physical transactional points outside bank branches and ATMs, making the service widely accessible to everyone.
+    • The service must offer an interface for initiating transactions for agents or customers that is available on mobile devices.
+    • Mobile banking services that offer the mobile phone as just another channel to access a traditional banking product are not included.
+    • Payment services linked to a traditional banking product or credit cards, such as Apple Pay and Google Wallet, are not included.
+  sources:
+    - name: GSMA (2022)
+      url: https://www.gsma.com/mobilemoneymetrics/#global
+      source_data_url: https://www.gsma.com/mobilemoneymetrics/wp-content/uploads/2022/05/Global_Mobile_Money_Dataset_new.xlsx
+      date_accessed: '2023-03-06'
+      publication_date: '2022-05-01'
+      publication_year: 2022
+      published_by: GSMA
+tables:
+  mobile_money:
+    variables:
+      active_accounts_90d:
+        title: 'Active accounts (90 day)'
+        short_unit: ''
+        unit: 'active accounts'
+        description: "The number of customer accounts that have been used to perform at least one P2P payment, bill payment, bulk payment, cash in to account, cash out from account, merchant payments, international remittances or airtime top up from account during at least 90 days prior to end of the indicated months. Balance inquiries, PIN resets, and other transactions that do not involve the movement of value do not qualify a customer account as active."
+        display:
+          numDecimalPlaces: 0

--- a/etl/steps/data/garden/technology/2023-03-06/mobile_money.py
+++ b/etl/steps/data/garden/technology/2023-03-06/mobile_money.py
@@ -1,0 +1,69 @@
+"""Load a meadow dataset and create a garden dataset."""
+
+import pandas as pd
+from owid.catalog import Dataset, Table
+from structlog import get_logger
+
+from etl.data_helpers import geo
+from etl.helpers import PathFinder, create_dataset
+
+log = get_logger()
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    log.info("mobile_money.start")
+
+    #
+    # Load inputs.
+    #
+    # Load meadow dataset.
+    ds_meadow: Dataset = paths.load_dependency("mobile_money")
+
+    # Read table from meadow dataset.
+    tb_meadow = ds_meadow["mobile_money"]
+
+    # Create a dataframe with data from the table.
+    df = pd.DataFrame(tb_meadow)
+
+    #
+    # Process data.
+    #
+
+    # Select top-level regions
+    df = df[
+        df.entity.isin(
+            [
+                "East Asia and Pacific",
+                "Europe and Central Asia",
+                "Latin America and the Caribbean",
+                "South Asia",
+                "Middle East and North Africa",
+                "Sub-Saharan Africa",
+            ]
+        )
+    ]
+
+    # Exclude NAs and 0s
+    df = df[df.active_accounts_90d > 0].dropna()
+
+    # For each region, keep the latest data point in each year
+    df = df.sort_values("year")
+    df["year"] = df.year.dt.year
+    df = df.groupby(["entity", "year"], as_index=False).tail(1).reset_index(drop=True)
+
+    # Create a new table with the processed data.
+    tb_garden = Table(df, like=tb_meadow)
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_meadow.metadata)
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()
+
+    log.info("mobile_money.end")

--- a/etl/steps/data/meadow/technology/2023-03-06/mobile_money.meta.yml
+++ b/etl/steps/data/meadow/technology/2023-03-06/mobile_money.meta.yml
@@ -1,0 +1,33 @@
+dataset:
+  namespace: technology
+  short_name: mobile_money
+  title: Global Mobile Money Dataset (GSMA, 2022)
+  description: |-
+    The Global Mobile Money Dataset is a set of global metrics for the mobile money industry based on data collected and analyzed by the GSMA Mobile Money program.
+
+    The GSMA Mobile Money program considers services that meet the following definitions:
+
+    • The service must be available to the unbanked, e.g., people who do not have access to a formal account at a financial institution.
+    • The service must offer at least one of the following services: Storage of value; Domestic or international transfer; mobile payment, including bill payment, bulk disbursement, and merchant payment.
+    • The service must offer a network of physical transactional points outside bank branches and ATMs, making the service widely accessible to everyone.
+    • The service must offer an interface for initiating transactions for agents or customers that is available on mobile devices.
+    • Mobile banking services that offer the mobile phone as just another channel to access a traditional banking product are not included.
+    • Payment services linked to a traditional banking product or credit cards, such as Apple Pay and Google Wallet, are not included.
+  sources:
+    - name: GSMA (2022)
+      url: https://www.gsma.com/mobilemoneymetrics/#global
+      source_data_url: https://www.gsma.com/mobilemoneymetrics/wp-content/uploads/2022/05/Global_Mobile_Money_Dataset_new.xlsx
+      date_accessed: '2023-03-06'
+      publication_date: '2022-05-01'
+      publication_year: 2022
+      published_by: GSMA
+tables:
+  mobile_money:
+    variables:
+      active_accounts_90d:
+        title: 'Active accounts (90 day)'
+        short_unit: ''
+        unit: 'active accounts'
+        description: "The number of customer accounts that have been used to perform at least one P2P payment, bill payment, bulk payment, cash in to account, cash out from account, merchant payments, international remittances or airtime top up from account during at least 90 days prior to end of the indicated months. Balance inquiries, PIN resets, and other transactions that do not involve the movement of value do not qualify a customer account as active."
+        display:
+          numDecimalPlaces: 0

--- a/etl/steps/data/meadow/technology/2023-03-06/mobile_money.py
+++ b/etl/steps/data/meadow/technology/2023-03-06/mobile_money.py
@@ -1,0 +1,46 @@
+"""Load a snapshot and create a meadow dataset."""
+
+import pandas as pd
+from owid.catalog import Table
+from structlog import get_logger
+
+from etl.helpers import PathFinder, create_dataset
+from etl.snapshot import Snapshot
+
+# Initialize logger.
+log = get_logger()
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    log.info("mobile_money.start")
+
+    #
+    # Load inputs.
+    #
+    # Retrieve snapshot.
+    snap: Snapshot = paths.load_dependency("mobile_money.xlsx")
+
+    # Load data from snapshot.
+    df = pd.read_excel(snap.path, sheet_name="Accounts", usecols="B:BK", skiprows=25, nrows=16)
+
+    # Reshape to tidy format and rename cols
+    df = df.melt(id_vars="Regions", var_name="year", value_name="active_accounts_90d").rename(
+        columns={"Regions": "entity"}
+    )
+
+    # Create a new table and ensure all columns are snake-case.
+    tb = Table(df, short_name=paths.short_name, underscore=True)
+
+    #
+    # Save outputs.
+    #
+    # Create a new meadow dataset with the same metadata as the snapshot.
+    ds_meadow = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
+
+    # Save changes in the new garden dataset.
+    ds_meadow.save()
+
+    log.info("mobile_money.end")

--- a/snapshots/technology/2023-03-06/mobile_money.py
+++ b/snapshots/technology/2023-03-06/mobile_money.py
@@ -1,0 +1,36 @@
+"""Script to create a snapshot of dataset 'Global Mobile Money Dataset (GSMA, 2022)'."""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+# Version for current snapshot dataset.
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+
+@click.command()
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+def main(path_to_file: str, upload: bool) -> None:
+    # Create a new snapshot.
+    snap = Snapshot(f"technology/{SNAPSHOT_VERSION}/mobile_money.xlsx")
+
+    # Ensure destination folder exists.
+    snap.path.parent.mkdir(exist_ok=True, parents=True)
+
+    # Copy local data file to snapshots data folder.
+    snap.path.write_bytes(Path(path_to_file).read_bytes())
+
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/technology/2023-03-06/mobile_money.xlsx.dvc
+++ b/snapshots/technology/2023-03-06/mobile_money.xlsx.dvc
@@ -1,0 +1,32 @@
+meta:
+  namespace: technology
+  short_name: mobile_money
+  name: Global Mobile Money Dataset (GSMA, 2022)
+  version: 2023-03-06
+  publication_year: 2022
+  publication_date: 2022-03-01
+  source_name: GSMA (2022)
+  source_published_by: GSMA
+  url: https://www.gsma.com/mobilemoneymetrics/#global
+  source_data_url: https://www.gsma.com/mobilemoneymetrics/wp-content/uploads/2022/05/Global_Mobile_Money_Dataset_new.xlsx
+  file_extension: xlsx
+  license_url:
+  license_name:
+  date_accessed: 2023-03-06
+  is_public: true
+  description: |
+    The Global Mobile Money Dataset is a set of global metrics for the mobile money industry based on data collected and analyzed by the GSMA Mobile Money program.
+
+    The GSMA Mobile Money program considers services that meet the following definitions:
+
+    • The service must be available to the unbanked, e.g., people who do not have access to a formal account at a financial institution.
+    • The service must offer at least one of the following services: Storage of value; Domestic or international transfer; mobile payment, including bill payment, bulk disbursement, and merchant payment.
+    • The service must offer a network of physical transactional points outside bank branches and ATMs, making the service widely accessible to everyone.
+    • The service must offer an interface for initiating transactions for agents or customers that is available on mobile devices.
+    • Mobile banking services that offer the mobile phone as just another channel to access a traditional banking product are not included.
+    • Payment services linked to a traditional banking product or credit cards, such as Apple Pay and Google Wallet, are not included.
+wdir: ../../../data/snapshots/technology/2023-03-06
+outs:
+- md5: 242c9d84456f3f9721433ba8c106efaf
+  size: 963586
+  path: mobile_money.xlsx


### PR DESCRIPTION
This adds snapshots, meadow, and garden steps for the global mobile money dataset from GSMA (previously version [here](https://owid.cloud/admin/datasets/1015) in Grapher).

It's a tiny dataset where we do very little to the data. But I haven't added to the ETL myself before, so it'd be great if (at least) one of @Marigold @pabloarosado @spoonerf could review the PR. Thanks :) 