### PR TITLE
fix(datasync): variable name collision

### DIFF
--- a/backport/datasync/datasync.py
+++ b/backport/datasync/datasync.py
@@ -160,9 +160,8 @@ def _sync_variable_data_metadata(engine: Engine, variable_id: int, dry_run: bool
         # NOTE: if metadata changes, we still reupload even data to S3, this is quite inefficient, but
         #   this entire script is a temporary solution until everything is uploaded directly from ETL
         if variable_df.empty:
-            with Session(engine) as session:
-                assert variable.dataPath
-                variable_df = variable_data_df_from_s3(engine, variable.dataPath)
+            assert variable.dataPath
+            variable_df = variable_data_df_from_s3(engine, variable.dataPath)
 
         var_data = variable_data(variable_df)
         var_metadata = variable_metadata(engine, variable_id, variable_df)


### PR DESCRIPTION
There was an unnecessary session created which name collided with another session. Removing it fixes some `sqlalchemy.exc.InvalidRequestError` errors.