### PR TITLE
fix(datasync): fix datasync types

### DIFF
--- a/backport/datasync/data_metadata.py
+++ b/backport/datasync/data_metadata.py
@@ -1,8 +1,7 @@
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List, Union
 from urllib.error import HTTPError
 
-import numpy as np
 import pandas as pd
 from sqlalchemy.engine import Engine
 
@@ -21,12 +20,7 @@ def variable_data_df_from_mysql(engine: Engine, variable_id: int) -> pd.DataFram
     ORDER BY
         year ASC
     """
-    df = pd.read_sql(q, engine, params={"variable_id": variable_id})
-
-    # convert from string to numerical type if possible
-    df["value"] = _convert_strings_to_numeric(df["value"])
-
-    return df
+    return pd.read_sql(q, engine, params={"variable_id": variable_id})
 
 
 def variable_data_df_from_s3(engine: Engine, data_path: str) -> pd.DataFrame:
@@ -71,7 +65,9 @@ def variable_data(data_df: pd.DataFrame) -> Dict[str, Any]:
             "year": "years",
         }
     )
-    return data_df[["values", "years", "entities"]].to_dict(orient="list")  # type: ignore
+    data = data_df[["values", "years", "entities"]].to_dict(orient="list")
+    data["values"] = _convert_strings_to_numeric(data["values"])
+    return data  # type: ignore
 
 
 def variable_metadata(engine: Engine, variable_id: int, variable_data: pd.DataFrame) -> Dict[str, Any]:
@@ -174,24 +170,17 @@ def _infer_variable_type(values: pd.Series) -> str:
             return "mixed"
 
 
-def _convert_strings_to_numeric(values: pd.Series) -> pd.Series:
-    assert values.map(lambda s: isinstance(s, str)).all(), "values must be strings"
-    assert values.notnull().all(), "values must not contain nulls"
-
-    values = values.replace("nan", np.nan)
-
-    # raises ValueError if any value is not numeric or float
-    try:
-        return values.map(int)
-    except ValueError:
-        pass
-    # perhaps they're all floats
-    try:
-        return values.map(float)
-    except ValueError:
-        pass
-    # otherwise return them as strings
-    return values
+def _convert_strings_to_numeric(lst: List[str]) -> List[Union[int, float, str]]:
+    result = []
+    for item in lst:
+        try:
+            num = float(item)
+            if num.is_integer():
+                num = int(num)
+        except ValueError:
+            num = item
+        result.append(num)
+    return result
 
 
 def _omit_nullable_values(d: dict) -> dict:

--- a/backport/datasync/data_metadata.py
+++ b/backport/datasync/data_metadata.py
@@ -164,10 +164,19 @@ def _infer_variable_type(values: pd.Series) -> str:
         else:
             raise NotImplementedError()
     except ValueError:
-        if values.map(lambda s: isinstance(s, str)).all():
-            return "string"
-        else:
+        if values.map(_is_float).any():
             return "mixed"
+        else:
+            return "string"
+
+
+def _is_float(x):
+    try:
+        float(x)
+    except ValueError:
+        return False
+    else:
+        return True
 
 
 def _convert_strings_to_numeric(lst: List[str]) -> List[Union[int, float, str]]:

--- a/backport/datasync/data_metadata.py
+++ b/backport/datasync/data_metadata.py
@@ -154,6 +154,9 @@ def variable_metadata(engine: Engine, variable_id: int, variable_data: pd.DataFr
 def _infer_variable_type(values: pd.Series) -> str:
     # data_values does not contain null values
     assert values.notnull().all(), "values must not contain nulls"
+    assert values.map(lambda x: isinstance(x, str)).all(), "only works for strings"
+    if values.empty:
+        return "mixed"
     try:
         values = pd.to_numeric(values)
         inferred_type = pd.api.types.infer_dtype(values)

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -125,15 +125,14 @@ def test_variable_data():
 
 
 def test_infer_variable_type():
-    assert _infer_variable_type(pd.Series([1, 2])) == "int"
-    assert _infer_variable_type(pd.Series([1, 2.5])) == "float"
-    assert _infer_variable_type(pd.Series([1, 2.5, "c"])) == "mixed"
-    assert _infer_variable_type(pd.Series(["a", "b", "c"])) == "string"
-
     assert _infer_variable_type(pd.Series(["1", "2"])) == "int"
-    assert _infer_variable_type(pd.Series(["1", 2])) == "int"
-    assert _infer_variable_type(pd.Series(["1", 2, "3.5"])) == "float"
-    assert _infer_variable_type(pd.Series(["1", 2, "3.5", "a"])) == "mixed"
+    assert _infer_variable_type(pd.Series(["1", "2.1"])) == "float"
+    assert _infer_variable_type(pd.Series(["1", "2.0"])) == "float"
+    assert _infer_variable_type(pd.Series(["1", "2.0", "a"])) == "mixed"
+    assert _infer_variable_type(pd.Series(["1", "a"])) == "mixed"
+    assert _infer_variable_type(pd.Series(["1.1", "a"])) == "mixed"
+    assert _infer_variable_type(pd.Series(["a", "NA"])) == "string"
+    assert _infer_variable_type(pd.Series([], dtype=object)) == "mixed"
 
 
 def test_convert_strings_to_numeric():

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pandas as pd
+import pytest
 
 from backport.datasync.data_metadata import (
     _convert_strings_to_numeric,
@@ -117,6 +118,9 @@ def test_infer_variable_type():
 
 
 def test_convert_strings_to_numeric():
-    assert _convert_strings_to_numeric(pd.Series(["1", "2.1", "UK"])).to_list() == ["1", "2.1", "UK"]
-    assert _convert_strings_to_numeric(pd.Series(["1", "2"])).to_list() == [1, 2]
-    assert _convert_strings_to_numeric(pd.Series(["1", "2.5"])).to_list() == [1, 2.5]
+    r = _convert_strings_to_numeric(["-2", "1", "2.1", "UK", "9.8e+09"])
+    assert r == [-2, 1, 2.1, "UK", 9800000000]
+    assert [type(x) for x in r] == [int, int, float, str, int]
+
+    with pytest.raises(TypeError):
+        r = _convert_strings_to_numeric([None, "UK"])  # type: ignore

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -6,6 +6,7 @@ import pytest
 from backport.datasync.data_metadata import (
     _convert_strings_to_numeric,
     _infer_variable_type,
+    variable_data,
     variable_metadata,
 )
 from etl.db import get_engine
@@ -15,7 +16,7 @@ def test_variable_metadata():
     engine = get_engine()
     variable_df = pd.DataFrame(
         {
-            "value": [0.008, 0.038, 0.022, 0.031, 0.056],
+            "value": ["0.008", "0.038", "0.022", "0.031", "NA"],
             "year": [-10000, -10000, -10000, -10000, -10000],
             "entityId": [273, 275, 276, 277, 294],
             "entityName": ["Africa", "Asia", "Europe", "Oceania", "North America"],
@@ -72,7 +73,7 @@ def test_variable_metadata():
         "shortName": "population_density",
         "catalogPath": "grapher/owid/latest/key_indicators/population_density",
         "datasetName": "Key Indicators",
-        "type": "float",
+        "type": "mixed",
         "nonRedistributable": False,
         "display": {
             "name": "Population density",
@@ -102,6 +103,24 @@ def test_variable_metadata():
                 ]
             },
         },
+    }
+
+
+def test_variable_data():
+    data_df = pd.DataFrame(
+        {
+            "value": ["-2", "1", "2.1", "UK", "9.8e+09"],
+            "year": [-10000, -10000, -10000, -10000, -10000],
+            "entityId": [273, 275, 276, 277, 294],
+            "entityName": ["Africa", "Asia", "Europe", "Oceania", "North America"],
+            "entityCode": [None, None, None, None, None],
+        }
+    )
+
+    assert variable_data(data_df) == {
+        "entities": [273, 275, 276, 277, 294],
+        "values": [-2, 1, 2.1, "UK", 9800000000],
+        "years": [-10000, -10000, -10000, -10000, -10000],
     }
 
 


### PR DESCRIPTION
Grapher data JSON files uses mixed types, but datasync uses consistent type, i.e. grapher values
```
{"values: {1, 2.5, "NA"}}
```
get incorrectly converted to strings by datasync as
```
{"values: {"1", "2.5", "NA"}}
```

This causes issues in plotting charts. Once we merge this change, we'll have to datasync all datasets with wrong types. I have a local comparison script that detects those datasets and eventually ensures 1:1 match between S3 and baked data files.