### PR TITLE
Add Poverty and Inequality Platform to explorer (+ LIS update)

### DIFF
--- a/etl/steps/data/explorers/poverty_inequality/2023-03-01/poverty_inequality.py
+++ b/etl/steps/data/explorers/poverty_inequality/2023-03-01/poverty_inequality.py
@@ -1,7 +1,8 @@
-"""World Inequality Database explorer data step.
+"""
 
-Loads the latest WID data from garden and stores a table (as a csv file).
-It also includes the LIS and WID datasets combined for a comparison explorer.
+Loads the latest WID and LIS data from garden and stores a table (as a csv file) to use for a comparison explorer.
+It also loads World Bank Poverty and Inequality Platform (PIP) data, currently outside the ETL (notebooks repo).
+This data will be replaced in May 2023 by a PIP step inside the ETL
 
 """
 
@@ -13,19 +14,82 @@ from etl.helpers import PathFinder, create_dataset
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
+# Get path of PIP csv file
+PIP_PATH = "https://raw.githubusercontent.com/owid/notebooks/main/BetterDataDocs/JoeHasell/PIP/data/ppp_2017/final/OWID_internal_upload/explorer_database/inc_or_cons/poverty_inc_or_cons.csv"
+
+# Function to load and clean PIP data (will dissapear when PIP steps are created)
+def add_pip_data(PIP_PATH: str):
+    # Load PIP data
+    tb_pip = pd.read_csv(PIP_PATH)
+
+    # Rename country and year vars
+    rename_list = {"Entity": "country", "Year": "year"}
+    tb_pip = tb_pip.rename(columns=rename_list)
+
+    # Drop welfare variables not used in the explorers
+    drop_list = ["above", "poverty_severity", "watts", "stacked"]
+
+    for var in drop_list:
+        tb_pip = tb_pip[tb_pip.columns.drop(list(tb_pip.filter(like=var)))]
+
+    # Addittional variables to drop from PIP
+    drop_list = [
+        "survey_year",
+        "survey_comparability",
+        "comparable_spell",
+        "distribution_type",
+        "estimation_type",
+        "cpi",
+        "ppp",
+        "reporting_gdp",
+        "reporting_pce",
+        "mld",
+        "polarization",
+    ]
+
+    tb_pip = tb_pip.drop(columns=drop_list)
+
+    # Rename regional aggregations
+    regions_dict = {
+        "Sub-Saharan Africa": "Sub-Saharan Africa (PIP)",
+        "Europe and Central Asia": "Europe and Central Asia (PIP)",
+        "High income countries": "High income countries (PIP)",
+        "Latin America and the Caribbean": "Latin America and the Caribbean (PIP)",
+        "South Asia": "South Asia (PIP)",
+        "Middle East and North Africa": "Middle East and North Africa (PIP)",
+        "East Asia and Pacific": "East Asia and Pacific (PIP)",
+    }
+
+    tb_pip["country"] = tb_pip["country"].replace(regions_dict)
+
+    return tb_pip
+
 
 def run(dest_dir: str) -> None:
 
     # Load WID explorer step
     ds_wid: Dataset = paths.load_dependency("world_inequality_database")
-    tb_wid = ds_wid["world_inequality_database"]
+    tb_wid = ds_wid["world_inequality_database"].reset_index()
 
     # Load LIS explorer step
     ds_lis: Dataset = paths.load_dependency("luxembourg_income_study")
-    tb_lis = ds_lis["luxembourg_income_study"]
+    tb_lis = ds_lis["luxembourg_income_study"].reset_index()
 
-    # Merge both explorer datasets and assign a short name
+    # Load PIP data
+    tb_pip = add_pip_data(PIP_PATH)
+
+    # Merge explorer datasets and assign a short name
     tb_explorer = pd.merge(tb_wid, tb_lis, on=["country", "year"], how="outer", validate="one_to_one")
+    tb_explorer = pd.merge(
+        tb_explorer,
+        tb_pip,
+        on=["country", "year"],
+        how="outer",
+        validate="one_to_one",
+    )
+
+    # Verify index and sort
+    tb_explorer = tb_explorer.set_index(["country", "year"], verify_integrity=True).sort_index()
 
     tb_explorer.metadata.short_name = "poverty_inequality"
 

--- a/etl/steps/data/garden/lis/2023-01-18/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2023-01-18/luxembourg_income_study.meta.yml
@@ -3,7 +3,7 @@
 dataset:
   namespace: lis
   short_name: luxembourg_income_study
-  title: Luxembourg Income Study (LIS, 2022)
+  title: Luxembourg Income Study (LIS, 2023)
   description: |-
     The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from about 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.
 
@@ -27,14 +27,14 @@ dataset:
     Person-level adjusted weights are used when generating income indicators for the total population. This means that survey data is adjusted to the population by multiplying the household weight by the number of household members (HWGT*NHHMEM).
   version: "2023-01-18"
   sources:
-    - name: Luxembourg Income Study (LIS) (2022)
+    - name: Luxembourg Income Study (LIS) (2023)
       url: https://www.lisdatacenter.org/our-data/lis-database/
-      date_accessed: "2023-02-27"
-      publication_date: "2022-12-15"
-      publication_year: 2022
+      date_accessed: "2023-03-14"
+      publication_date: "2023-03-14"
+      publication_year: 2023
       published_by:
         Luxembourg Income Study (LIS) Database, http://www.lisdatacenter.org
-        (multiple countries; 1967-2021). Luxembourg, LIS.
+        (multiple countries; 1967-2020). Luxembourg, LIS.
       publisher_source: National income surveys
 tables:
   luxembourg_income_study:

--- a/etl/steps/data/meadow/wid/2023-01-27/world_inequality_database.py
+++ b/etl/steps/data/meadow/wid/2023-01-27/world_inequality_database.py
@@ -47,7 +47,7 @@ iso2_missing = {
     "QW": "West Asia (WID)",
     "QX": "Western Europe (WID)",
     "QY": "European Union (WID)",
-    "WO": "World (WID)",
+    "WO": "World",
     "XA": "Asia (excluding Middle East) (WID)",
     "XB": "North America and Oceania (WID)",
     "XF": "Sub-Saharan Africa (WID)",

--- a/snapshots/lis/2023-01-18/lis_abs_poverty.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_abs_poverty.csv.dvc
@@ -1,19 +1,19 @@
 meta:
   namespace: lis
   short_name: lis_abs_poverty
-  name: Luxembourg Income Study - Absolute poverty (LIS, 2022)
+  name: Luxembourg Income Study - Absolute poverty (LIS, 2023)
   version: 2023-01-18
-  publication_year: 2022
-  publication_date: 2022-12-13
+  publication_year: 2023
+  publication_date: 2023-03-14
   source_name: Luxembourg Income Study (LIS)
   source_published_by: Luxembourg Income Study (LIS) Database, http://www.lisdatacenter.org
-    (multiple countries; 1967-2021). Luxembourg, LIS.
+    (multiple countries; 1967-2020). Luxembourg, LIS.
   url: https://www.lisdatacenter.org/our-data/lis-database/
   source_data_url:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-01-18
+  date_accessed: 2023-03-14
   is_public: true
   description: |
     The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from about 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.
@@ -21,6 +21,6 @@ meta:
     Harmonized into a common framework, LIS datasets contain household- and person-level data on labor income, capital income, pensions, public social benefits (excl. pensions) and private transfers, as well as taxes and contributions, demography, employment, and expenditures.
 wdir: ../../../data/snapshots/lis/2023-01-18
 outs:
-- md5: 3e7227f7774f57038d2bee2a729d7992
-  size: 2403388
+- md5: 598bcfecb6656ba83035580256996f57
+  size: 2575292
   path: lis_abs_poverty.csv

--- a/snapshots/lis/2023-01-18/lis_distribution.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_distribution.csv.dvc
@@ -1,19 +1,19 @@
 meta:
   namespace: lis
   short_name: lis_distribution
-  name: Luxembourg Income Study - Distributional variables (LIS, 2022)
+  name: Luxembourg Income Study - Distributional variables (LIS, 2023)
   version: 2023-01-18
-  publication_year: 2022
-  publication_date: 2022-12-13
+  publication_year: 2023
+  publication_date: 2023-03-14
   source_name: Luxembourg Income Study (LIS)
   source_published_by: Luxembourg Income Study (LIS) Database, http://www.lisdatacenter.org
-    (multiple countries; 1967-2021). Luxembourg, LIS.
+    (multiple countries; 1967-2020). Luxembourg, LIS.
   url: https://www.lisdatacenter.org/our-data/lis-database/
   source_data_url:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-01-18
+  date_accessed: 2023-03-14
   is_public: true
   description: |
     The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from about 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.
@@ -21,6 +21,6 @@ meta:
     Harmonized into a common framework, LIS datasets contain household- and person-level data on labor income, capital income, pensions, public social benefits (excl. pensions) and private transfers, as well as taxes and contributions, demography, employment, and expenditures.
 wdir: ../../../data/snapshots/lis/2023-01-18
 outs:
-- md5: a5501dfe0f8872307f5fdd6625c5d5bc
-  size: 1925117
+- md5: 177002237fe8b16d42bf7b8672236af4
+  size: 2063565
   path: lis_distribution.csv

--- a/snapshots/lis/2023-01-18/lis_keyvars.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_keyvars.csv.dvc
@@ -1,19 +1,19 @@
 meta:
   namespace: lis
   short_name: lis_keyvars
-  name: Luxembourg Income Study - Key variables (LIS, 2022)
+  name: Luxembourg Income Study - Key variables (LIS, 2023)
   version: 2023-01-18
-  publication_year: 2022
-  publication_date: 2022-12-13
+  publication_year: 2023
+  publication_date: 2023-03-14
   source_name: Luxembourg Income Study (LIS)
   source_published_by: Luxembourg Income Study (LIS) Database, http://www.lisdatacenter.org
-    (multiple countries; 1967-2021). Luxembourg, LIS.
+    (multiple countries; 1967-2020). Luxembourg, LIS.
   url: https://www.lisdatacenter.org/our-data/lis-database/
   source_data_url:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-01-18
+  date_accessed: 2023-03-14
   is_public: true
   description: |
     The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from about 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.
@@ -21,6 +21,6 @@ meta:
     Harmonized into a common framework, LIS datasets contain household- and person-level data on labor income, capital income, pensions, public social benefits (excl. pensions) and private transfers, as well as taxes and contributions, demography, employment, and expenditures.
 wdir: ../../../data/snapshots/lis/2023-01-18
 outs:
-- md5: d05f9d54050086938ea2a209a37736a5
-  size: 878602
+- md5: 846211e9ba49eec6dc849d72190e0796
+  size: 940486
   path: lis_keyvars.csv


### PR DESCRIPTION
I have introduced a temporal update for the `poverty_inequality` `explorers` step: As the World Bank Poverty and Inequality Platform (PIP) dataset is currently outside the ETL we decided to merge the current version of the exported dataset (in the notebooks repo) to both LIS and WID explorers datasets to create a [comparison data explorer](https://github.com/owid/owid-issues/issues/983).

This is a temporary solution because I plan to move PIP to the ETL [in May](https://github.com/owid/data-research-roadmap/#pablo-a-gantt-chart)

There is also a [2023 LIS update](https://www.lisdatacenter.org/news-and-events/2023-spring-data-splash/) that I include