### PR TITLE
fix(flu): raise an error when creating snapshot if CSV cannot be parsed

### DIFF
--- a/snapshots/who/latest/fluid.csv.dvc
+++ b/snapshots/who/latest/fluid.csv.dvc
@@ -20,6 +20,6 @@ meta:
     The platform accommodates both qualitative and quantitative data which facilitates the tracking of global trends, spread, intensity, and impact of influenza. These data are made freely available to health policy makers in order to assist them in making informed decisions regarding the management of influenza.
 wdir: ../../../data/snapshots/who/latest
 outs:
-- md5: b14ff0947487a8c2c1873615047244ac
-  size: 132692254
+- md5: 1d6e7dc65dad7436f77b43158842d5e4
+  size: 132684775
   path: fluid.csv

--- a/snapshots/who/latest/fluid.py
+++ b/snapshots/who/latest/fluid.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import click
+import pandas as pd
 
 from etl.snapshot import Snapshot
 
@@ -23,6 +24,14 @@ def main(upload: bool) -> None:
 
     # Download data from source.
     snap.download_from_source()
+
+    # Try reading the csv, we sometimes get error invalid CSV with error
+    # ParserError: Error tokenizing data. C error: Expected 49 fields in line 50053, saw 56
+    # if this fails, don't upload the file
+    pd.read_csv(snap.path)
+
+    # Snapshot should have at least 100mb, otherwise something went wrong
+    assert snap.path.stat().st_size > 100 * 2**20, "Snapshot file must have at least 100mb"
 
     # Add file to DVC and upload to S3.
     snap.dvc_add(upload=upload)

--- a/snapshots/who/latest/flunet.py
+++ b/snapshots/who/latest/flunet.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import click
+import pandas as pd
 
 from etl.snapshot import Snapshot
 
@@ -23,6 +24,13 @@ def main(upload: bool) -> None:
 
     # Download data from source.
     snap.download_from_source()
+
+    # Try reading the csv, we sometimes get error invalid CSV with error
+    # if this fails, don't upload the file
+    pd.read_csv(snap.path)
+
+    # Snapshot should have at least 20mb, otherwise something went wrong
+    assert snap.path.stat().st_size > 20 * 2**20, "Snapshot file must have at least 20mb"
 
     # Add file to DVC and upload to S3.
     snap.dvc_add(upload=upload)


### PR DESCRIPTION
Make sure we're not updating snapshots that are not working. This should hotfix https://github.com/owid/etl/issues/925 until we either decide what to do or until provider fixes their data. It also rolls back fluid to the latest working file.

It has also checks on CSV size since sometimes we're getting valid files which are [however much smaller](https://github.com/owid/etl/issues/925#issuecomment-1470365608).