### PR TITLE
refactor(etl): replace data_values table with values from S3

### DIFF
--- a/backport/datasync/data_metadata.py
+++ b/backport/datasync/data_metadata.py
@@ -188,6 +188,7 @@ def _is_float(x):
 def _convert_strings_to_numeric(lst: List[str]) -> List[Union[int, float, str]]:
     result = []
     for item in lst:
+        assert isinstance(item, str)
         try:
             num = float(item)
             if num.is_integer():

--- a/backport/datasync/data_metadata.py
+++ b/backport/datasync/data_metadata.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import json
 from typing import Any, Dict, List, Union
 from urllib.error import HTTPError
@@ -23,22 +24,30 @@ def variable_data_df_from_mysql(engine: Engine, variable_id: int) -> pd.DataFram
     return pd.read_sql(q, engine, params={"variable_id": variable_id})
 
 
-def variable_data_df_from_s3(engine: Engine, data_path: str) -> pd.DataFrame:
-    empty_df = pd.DataFrame(columns=["entityId", "entityName", "entityCode", "year", "value"])
+def _fetch_data_df_from_s3(data_path: str):
     try:
-        df = pd.read_json(data_path).rename(
-            columns={
-                "entities": "entityId",
-                "values": "value",
-                "years": "year",
-            }
+        variable_id = int(data_path.split("/")[-1].replace(".json", ""))
+        return (
+            pd.read_json(data_path)
+            .rename(
+                columns={
+                    "entities": "entityId",
+                    "values": "value",
+                    "years": "year",
+                }
+            )
+            .assign(variableId=variable_id)
         )
     # no data on S3 in dataPath
     except HTTPError:
-        return empty_df
+        return pd.DataFrame(columns=["variableId", "entityId", "year", "value"])
 
-    if df.empty:
-        return empty_df
+
+def variable_data_df_from_s3(engine: Engine, data_paths: List[str], workers: int = 1) -> pd.DataFrame:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+        results = list(executor.map(lambda data_path: _fetch_data_df_from_s3(data_path), data_paths))
+
+    df = pd.concat(results)
 
     # we work with strings and convert to specific types later
     df["value"] = df["value"].astype(str)

--- a/backport/datasync/datasync.py
+++ b/backport/datasync/datasync.py
@@ -163,7 +163,7 @@ def _sync_variable_data_metadata(engine: Engine, variable_id: int, dry_run: bool
         #   this entire script is a temporary solution until everything is uploaded directly from ETL
         if variable_df.empty:
             assert variable.dataPath
-            variable_df = variable_data_df_from_s3(engine, variable.dataPath)
+            variable_df = variable_data_df_from_s3(engine, [variable.dataPath])
 
         var_data = variable_data(variable_df)
         var_metadata = variable_metadata(engine, variable_id, variable_df)

--- a/etl/chart_revision/deprecated.py
+++ b/etl/chart_revision/deprecated.py
@@ -394,6 +394,7 @@ class ChartRevisionSuggester:
         with open_db() as db:
             all_var_ids = list(self.old_var_id2new_var_id.keys()) + list(self.old_var_id2new_var_id.values())
             variable_ids_str = ",".join([str(_id) for _id in all_var_ids])
+            raise NotImplementedError("data_values was deprecated")
             rows = db.fetch_many(
                 f"""
                 SELECT variableId, MIN(year) AS minYear, MAX(year) AS maxYear

--- a/etl/chart_revision/variables.py
+++ b/etl/chart_revision/variables.py
@@ -53,6 +53,7 @@ class VariablesUpdate:
     def _get_metadata_from_db(self) -> List["VariableMetadata"]:
         """Get metadata for all variables in the update."""
         # build query
+        # TODO: fix me!!! use values from S3 instead
         query = """
             SELECT variableId, MIN(year) AS minYear, MAX(year) AS maxYear
             FROM data_values

--- a/etl/chart_revision/variables.py
+++ b/etl/chart_revision/variables.py
@@ -56,7 +56,7 @@ class VariablesUpdate:
 
         # get min and max year for each variable
         df_var_years = (
-            df_var_years.groupby("variableId", as_index=False)
+            df_var_years.groupby("variableId")
             .year.agg(["min", "max"])
             .rename(columns={"min": "minYear", "max": "maxYear"})
         )

--- a/etl/compare.py
+++ b/etl/compare.py
@@ -367,7 +367,6 @@ def read_values_from_s3(env_path: str, namespace: str, version: str, dataset: st
     FROM variables as v
     JOIN datasets as d ON v.datasetId = d.id
     WHERE d.version = %(version)s and d.namespace = %(namespace)s and d.shortName = %(dataset)s
-    limit 1
     """
     vf = pd.read_sql(
         q,

--- a/etl/compare.py
+++ b/etl/compare.py
@@ -357,6 +357,7 @@ def read_sources_from_db(env_path: str, namespace: str, version: str, dataset: s
 def read_data_values_from_db(env_path: str, namespace: str, version: str, dataset: str) -> pd.DataFrame:
     engine = get_engine(dotenv_values(env_path))
 
+    # TODO: fix this!
     q = """
     SELECT
         dv.*,

--- a/etl/compare.py
+++ b/etl/compare.py
@@ -18,6 +18,7 @@ from rich_click.rich_group import RichGroup
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
+from backport.datasync.data_metadata import variable_data_df_from_s3
 from etl import tempcompare
 
 
@@ -200,7 +201,7 @@ def etl_catalog(
     help="Path to .env file with remote database credentials.",
     default=".env",
 )
-@click.option("--data-values", is_flag=True, help="Compare data_values table.")
+@click.option("--values", is_flag=True, help="Compare values from S3.")
 @click.pass_context
 def grapher(
     ctx: click.core.Context,
@@ -209,18 +210,18 @@ def grapher(
     dataset: str,
     remote_env: str,
     local_env: str,
-    data_values: bool,
+    values: bool,
 ) -> None:
     """
     Compare a dataset in the local database with the remote database.
 
-    It compares dataset and variables metadata, and optionally the data_values table with --data-values flag
+    It compares dataset and variables metadata, and optionally the values from S3 with --values flag
     (which can be both CPU and memory heavy). It does the comparison in the same way as the etl-catalog command.
 
     The exit code is always 0 even if dataframes are different.
 
     Example usage:
-        compare  --show-values grapher ggdc 2020-10-01 ggdc_maddison__2020_10_01 --data-values
+        compare  --show-values grapher ggdc 2020-10-01 ggdc_maddison__2020_10_01 --values
     """
     remote_dataset_df = read_dataset_from_db(remote_env, namespace, version, dataset)
     local_dataset_df = read_dataset_from_db(local_env, namespace, version, dataset)
@@ -266,9 +267,9 @@ def grapher(
         **ctx.obj,
     )
 
-    if data_values:
-        remote_data_values_df = read_data_values_from_db(remote_env, namespace, version, dataset)
-        local_data_values_df = read_data_values_from_db(local_env, namespace, version, dataset)
+    if values:
+        remote_data_values_df = read_values_from_s3(remote_env, namespace, version, dataset)
+        local_data_values_df = read_values_from_s3(local_env, namespace, version, dataset)
 
         print("\n[magenta]=== Comparing data_values ===[/magenta]")
         diff_print(
@@ -354,25 +355,31 @@ def read_sources_from_db(env_path: str, namespace: str, version: str, dataset: s
     return cast(pd.DataFrame, df)
 
 
-def read_data_values_from_db(env_path: str, namespace: str, version: str, dataset: str) -> pd.DataFrame:
+def read_values_from_s3(env_path: str, namespace: str, version: str, dataset: str) -> pd.DataFrame:
     engine = get_engine(dotenv_values(env_path))
 
-    # TODO: fix this!
+    # get variables
     q = """
     SELECT
-        dv.*,
+        v.id as variableId,
+        v.dataPath,
         v.name as variable
-    FROM data_values as dv
-    JOIN variables as v ON dv.variableId = v.id
+    FROM variables as v
     JOIN datasets as d ON v.datasetId = d.id
     WHERE d.version = %(version)s and d.namespace = %(namespace)s and d.shortName = %(dataset)s
+    limit 1
     """
-
-    df = pd.read_sql(
+    vf = pd.read_sql(
         q,
         engine,
         params={"version": version, "namespace": namespace, "dataset": dataset},
     )
+
+    # read them from S3
+    df = variable_data_df_from_s3(engine, vf.dataPath.tolist(), workers=10)
+
+    # add variable name
+    df = df.merge(vf[["variableId", "variable"]], on="variableId")
 
     # pivot table for easier comparison
     df = df.pivot(index=["year", "entityId"], columns="variable", values="value")

--- a/etl/config.py
+++ b/etl/config.py
@@ -55,7 +55,6 @@ BAKED_VARIABLES_PATH = env.get("BAKED_VARIABLES_PATH", DEFAULT_BAKED_VARIABLES_P
 IPDB_ENABLED = False
 
 # number of workers for grapher inserts
-# NOTE: this will soon be deprecated after we get rid of data_values
 GRAPHER_INSERT_WORKERS = int(env.get("GRAPHER_WORKERS", 10))
 
 # forbid any individual step from consuming more than this much memory

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -269,7 +269,7 @@ def cli(
         "[b]Hint[/b]: Run this locally with [cyan][b]etl-datadiff REMOTE data/ --include yourdataset --verbose[/b][/cyan]"
     )
     console.print(
-        "[b]Hint[/b]: Get detailed comparison with [cyan][b]compare --show-values channel namespace version short_name --data-values[/b][/cyan]"
+        "[b]Hint[/b]: Get detailed comparison with [cyan][b]compare --show-values channel namespace version short_name --values[/b][/cyan]"
     )
     exit(1 if any_diff else 0)
 

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -241,9 +241,10 @@ def upsert_table(
         variable_id = variable.id
         assert variable_id
 
-        session.commit()
+        df = table.rename(columns={column_name: "value", "entity_id": "entityId"})
 
-        df = table.rename(columns={column_name: "value", "entity_id": "entityId"}).assign(variableId=variable_id)
+        # following functions assume that `value` is string
+        df["value"] = df["value"].astype(str)
 
         # NOTE: we could prefetch all entities in advance, but it's not a bottleneck as it takes
         # less than 10ms per variable
@@ -256,7 +257,6 @@ def upsert_table(
         data_path = upload_gzip_dict(var_data, variable.s3_data_path())
         metadata_path = upload_gzip_dict(var_metadata, variable.s3_metadata_path())
 
-        variable = gm.Variable.load_variable(session, variable_id)
         variable.dataPath = data_path
         variable.metadataPath = metadata_path
         session.add(variable)

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -9,7 +9,6 @@ Usage:
     >>> import_dataset.main(dataset_dir, dataset_namespace)
 """
 
-import concurrent.futures
 import datetime
 import os
 from dataclasses import dataclass
@@ -20,10 +19,8 @@ import pandas as pd
 import structlog
 from owid import catalog
 from owid.catalog import utils
-from sqlalchemy import Integer, String
 from sqlalchemy.engine.base import Engine
-from sqlmodel import Session, delete, select, update
-from tenacity import retry, stop
+from sqlmodel import Session, select, update
 
 from backport.datasync.data_metadata import (
     add_entity_code_and_name,
@@ -51,16 +48,6 @@ INT_TYPES = (
     "uint64",
     "Int64",
 )
-
-# exclude the following datasets from upserting into data_values table as they
-# are too large
-# once we switch to catalogPath, no data will be upserted to data_values
-BLACKLIST_DATASETS_DATA_VALUES_UPSERTS = [
-    "gbd_cause",
-    "gbd_risk",
-    "gbd_prevalence",
-    "gbd_child_mortality",
-]
 
 
 @dataclass
@@ -256,20 +243,7 @@ def upsert_table(
 
         session.commit()
 
-        # delete its data if there is any
-        # TODO: once we stop upserting to data_values, prune all ETL datasets from data_values
-        # and remove these lines
-        q = delete(gm.DataValues).where(gm.DataValues.variableId == variable_id)
-        session.execute(q)
-        session.commit()
-
         df = table.rename(columns={column_name: "value", "entity_id": "entityId"}).assign(variableId=variable_id)
-
-        # TODO: once we verify that uploading to S3 works, stop upserting to data_values and remove these
-        # lines together with function insert_to_data_values
-        if table.metadata.dataset.short_name not in BLACKLIST_DATASETS_DATA_VALUES_UPSERTS:
-            insert_to_data_values(engine, df)
-            log.info("upsert_table.upserted_data_values", size=len(table), varible_id=variable_id)
 
         # NOTE: we could prefetch all entities in advance, but it's not a bottleneck as it takes
         # less than 10ms per variable
@@ -366,12 +340,6 @@ def cleanup_ghost_variables(dataset_id: int, upserted_variable_ids: List[int], w
             rows = pd.DataFrame(rows, columns=["chartId", "variableId"])
             raise ValueError(f"Variables used in charts will not be deleted automatically:\n{rows}")
 
-        # first delete data_values
-        # NOTE: deleting 100 variables takes ~30s with 10 workers with threading
-        # and about ~3mins when deleting them in batch
-        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-            list(executor.map(_delete_variable_from_data_values, variable_ids_to_delete))
-
         # then variables themselves with related data in other tables
         db.cursor.execute(
             """
@@ -393,16 +361,6 @@ def cleanup_ghost_variables(dataset_id: int, upserted_variable_ids: List[int], w
         )
 
 
-def _delete_variable_from_data_values(variable_id: int) -> None:
-    with open_db() as db:
-        db.cursor.execute(
-            """
-                    DELETE FROM data_values WHERE variableId = %(variable_id)s
-                """,
-            {"variable_id": variable_id},
-        )
-
-
 def cleanup_ghost_sources(dataset_id: int, upserted_source_ids: List[int]) -> None:
     """Remove all leftover sources that didn't get upserted into DB during grapher step.
     This could happen when you rename or delete sources.
@@ -418,26 +376,3 @@ def cleanup_ghost_sources(dataset_id: int, upserted_source_ids: List[int]) -> No
         )
         if db.cursor.rowcount > 0:
             log.warning(f"Deleted {db.cursor.rowcount} ghost sources")
-
-
-@retry(stop=stop.stop_after_attempt(3))
-def insert_to_data_values(engine: Engine, df: pd.DataFrame) -> None:
-    """Insert data into data_values table. Retry in case we get Deadlock error."""
-    # value will be converted to string in MySQL, we need to do it beforehand otherwise
-    # it's gonna assume it is float64 and mess up precision for smaller types
-    df.value = df.value.astype(str)
-
-    # insert data to data_values using pandas which is both faster and doesn't raise
-    # deadlocks
-    df.to_sql(
-        "data_values",
-        engine,
-        if_exists="append",
-        index=False,
-        dtype={
-            "value": String(255),
-            "year": Integer(),
-            "entityId": Integer(),
-            "variableId": Integer(),
-        },
-    )

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -849,6 +849,7 @@ t_country_latest_data = Table(
 )
 
 
+# data_values table is gonna be deprecated!
 class DataValues(SQLModel, table=True):
     __tablename__: str = "data_values"  # type: ignore
     __table_args__ = (

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -727,7 +727,6 @@ class GrapherStep(Step):
 
             # insert data in parallel, this speeds it up considerably and is even faster than loading
             # data with LOAD DATA INFILE
-            # TODO: remove threads once we get rid of inserts into data_values
             if config.GRAPHER_INSERT_WORKERS > 1:
                 with concurrent.futures.ThreadPoolExecutor(max_workers=config.GRAPHER_INSERT_WORKERS) as executor:
                     results = executor.map(upsert, tables)

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -7,6 +7,7 @@ from backport.datasync.data_metadata import (
     _convert_strings_to_numeric,
     _infer_variable_type,
     variable_data,
+    variable_data_df_from_s3,
     variable_metadata,
 )
 from etl.db import get_engine
@@ -122,6 +123,27 @@ def test_variable_data():
         "values": [-2, 1, 2.1, "UK", 9800000000],
         "years": [-10000, -10000, -10000, -10000, -10000],
     }
+
+
+def test_variable_data_df_from_s3():
+    engine = mock.Mock()
+    entities = pd.DataFrame(
+        {
+            "entityId": [1],
+            "entityName": ["UK"],
+            "entityCode": ["GBR"],
+        }
+    )
+    s3_data = pd.DataFrame({"entities": [1, 1], "values": ["a", 2], "years": [2000, 2001]})
+
+    with mock.patch("pandas.read_sql", return_value=entities):
+        with mock.patch("pandas.read_json", return_value=s3_data):
+            df = variable_data_df_from_s3(engine, ["123.json"])
+
+    assert df.to_dict(orient="records") == [
+        {"entityId": 1, "value": "a", "year": 2000, "variableId": 123, "entityName": "UK", "entityCode": "GBR"},
+        {"entityId": 1, "value": "2", "year": 2001, "variableId": 123, "entityName": "UK", "entityCode": "GBR"},
+    ]
 
 
 def test_infer_variable_type():

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -162,5 +162,5 @@ def test_convert_strings_to_numeric():
     assert r == [-2, 1, 2.1, "UK", 9800000000]
     assert [type(x) for x in r] == [int, int, float, str, int]
 
-    with pytest.raises(TypeError):
+    with pytest.raises(AssertionError):
         r = _convert_strings_to_numeric([None, "UK"])  # type: ignore

--- a/walkthrough/grapher.md
+++ b/walkthrough/grapher.md
@@ -6,4 +6,4 @@
 
 Grapher step is the last phase before upserting the dataset into the database. It works in the same way as the other steps, but the transformations made there are meant to get the data ready for the database (and not be consumed by users of catalog).
 
-After the dataset is generated using the standard `etl` command, we can run `etl ... --grapher` which will load the dataset and its tables and upsert them into `datasets`, `variables` and `data_values` tables in the database.
+After the dataset is generated using the standard `etl` command, we can run `etl ... --grapher` which will load the dataset and its tables and upsert them into `datasets`, `variables` and S3.


### PR DESCRIPTION
Stop upserting values to `data_values` table. Adapt `compare` and `etl-chart-suggester` to fetch data from S3 instead of `data_values`. `data_values` remains only in datasync and backporting now (we won't need them once all data go through ETL).