### PR TITLE
feature(data_parity): compare metadata

### DIFF
--- a/backport/datasync/datasync.py
+++ b/backport/datasync/datasync.py
@@ -38,6 +38,7 @@ config.enable_bugsnag()
 
 @click.command(help=__doc__)
 @click.option("--dataset-ids", "-d", type=int, multiple=True)
+@click.option("--variable-ids", "-v", type=int, multiple=True)
 @click.option(
     "--dt-start",
     type=click.DateTime(),
@@ -63,6 +64,7 @@ config.enable_bugsnag()
 )
 def cli(
     dataset_ids: tuple[int],
+    variable_ids: tuple[int],
     dt_start: dt.datetime,
     dry_run: bool,
     force: bool,
@@ -126,7 +128,7 @@ def cli(
 
         log.info("datasync.start", dataset_id=ds.id, progress=progress)
 
-        variable_ids = _load_variable_ids(engine, ds.id)
+        ds_variable_ids = variable_ids or _load_variable_ids(engine, ds.id)
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
             results = executor.map(
@@ -136,14 +138,14 @@ def cli(
                     dry_run=dry_run,
                     private=ds.isPrivate,
                 ),
-                variable_ids,
+                ds_variable_ids,
             )
 
             # raise errors from futures, otherwise they'd fail silently
             list(results)
 
-        # add file to S3
-        if not dry_run:
+        # add file to S3 if not dry run or not syncing specific variables
+        if not dry_run and not variable_ids:
             ds.save_to_s3(client)
 
         log.info("datasync.end", dataset_id=ds.id)
@@ -171,11 +173,12 @@ def _sync_variable_data_metadata(engine: Engine, variable_id: int, dry_run: bool
             data_path = upload_gzip_dict(var_data, variable.s3_data_path(), private)
             metadata_path = upload_gzip_dict(var_metadata, variable.s3_metadata_path(), private)
 
-            # update dataPath and metadataPath of a variable
-            variable.dataPath = data_path
-            variable.metadataPath = metadata_path
-            session.add(variable)
-            session.commit()
+            # update dataPath and metadataPath of a variable if different
+            if variable.dataPath != data_path or variable.metadataPath != metadata_path:
+                variable.dataPath = data_path
+                variable.metadataPath = metadata_path
+                session.add(variable)
+                session.commit()
 
     log.info("datasync.upload", t=f"{time.time() - t:.2f}s", variable_id=variable_id)
 
@@ -215,6 +218,7 @@ class DatasetSync:
     id: int
     dataEditedAt: dt.datetime
     metadataEditedAt: dt.datetime
+    variablesEditedAt: dt.datetime
     isPrivate: bool
     sourceChecksum: str
 
@@ -231,6 +235,10 @@ class DatasetSync:
         d = json.loads(a["Body"].read().decode())
         d["dataEditedAt"] = dt.datetime.utcfromtimestamp(d["dataEditedAt"] / 1000)
         d["metadataEditedAt"] = dt.datetime.utcfromtimestamp(d["metadataEditedAt"] / 1000)
+        if "variablesEditedAt" in d:
+            d["variablesEditedAt"] = dt.datetime.utcfromtimestamp(d["variablesEditedAt"] / 1000)
+        else:
+            d["variablesEditedAt"] = d["metadataEditedAt"]
         d.pop("name", None)
         return cls(**d)
 
@@ -248,7 +256,11 @@ class DatasetSync:
         # compare timestamps of the latest update (we don't have sourceChecksum for all datasets)
         # NOTE: we rebake both data and metadata even if only one has changed. This is a bit inefficient, but should
         # not matter much since dataset updates are rare.
-        if self.dataEditedAt == ds.dataEditedAt and self.metadataEditedAt == ds.metadataEditedAt:
+        if (
+            self.dataEditedAt == ds.dataEditedAt
+            and self.metadataEditedAt == ds.metadataEditedAt
+            and self.variablesEditedAt == ds.variablesEditedAt
+        ):
             # checksums should match if dataEditedAt match
             assert self.sourceChecksum is None or ds.sourceChecksum is None or self.sourceChecksum == ds.sourceChecksum
             return True
@@ -269,24 +281,32 @@ def _load_variable_ids(engine: Engine, dataset_id: int) -> List[int]:
 
 def _load_datasets(engine: Engine, dataset_ids: tuple[int], dt_start: Optional[dt.datetime]) -> List[DatasetSync]:
     if dataset_ids:
-        where = "id in %(dataset_ids)s"
+        where = "d.id in %(dataset_ids)s"
+        having = "1 = 1"
     elif dt_start:
         # datasets with shortName come from ETL and are already synced
         # we don't use sourceChecksum because that one is set only after the dataset is fully upserted
-        where = "shortName is null and dataEditedAt > %(dt_start)s or metadataEditedAt > %(dt_start)s"
+        where = "d.shortName is null and v.shortName is null"
+        having = "dataEditedAt > %(dt_start)s or metadataEditedAt > %(dt_start)s or variablesEditedAt > %(dt_start)s"
+
     else:
         raise ValueError("Either dataset_ids or dt_start must be specified")
 
     q = f"""
     select
-        id,
-        dataEditedAt,
-        metadataEditedAt,
+        MAX(d.id) as id,
+        MAX(d.dataEditedAt) as dataEditedAt,
+        MAX(d.metadataEditedAt) as metadataEditedAt,
         -- we save all variables as public for now to have them available in grapher
         false as isPrivate,
-        sourceChecksum
-    from datasets
+        MAX(d.sourceChecksum) as sourceChecksum,
+        -- latest updated variable
+        MAX(v.updatedAt) as variablesEditedAt
+    from datasets as d
+    join variables as v on v.datasetId = d.id
     where {where}
+    group by d.id
+    having {having}
     """
     df = pd.read_sql(
         q,
@@ -302,6 +322,7 @@ def _load_datasets(engine: Engine, dataset_ids: tuple[int], dt_start: Optional[d
     for ds in ds_dicts:
         ds["dataEditedAt"] = ds["dataEditedAt"].to_pydatetime()
         ds["metadataEditedAt"] = ds["metadataEditedAt"].to_pydatetime()
+        ds["variablesEditedAt"] = ds["variablesEditedAt"].to_pydatetime()
 
     return [DatasetSync(**d) for d in ds_dicts]
 

--- a/scripts/data_parity.py
+++ b/scripts/data_parity.py
@@ -1,11 +1,13 @@
 import gzip
 import json
+import random
 from pathlib import Path
 from typing import List
 
 import click
 import pandas as pd
 import structlog
+from deepdiff import DeepDiff
 
 from etl.db import get_engine
 
@@ -33,6 +35,9 @@ def data_parity_cli(s3_path: Path, baked_path: Path, variables: List[int]) -> No
     Then run this script:
 
         ENV=.env.prod python scripts/data_parity.py playground/s3-live/ playground/baked-live/
+
+    I've been having trouble with `aws s3 sync` not syncing refreshed files, so it might be safer to redownload the
+    entire directory or at least problematic variables.
     """
     s3_path = Path(s3_path)
     baked_path = Path(baked_path)
@@ -42,41 +47,92 @@ def data_parity_cli(s3_path: Path, baked_path: Path, variables: List[int]) -> No
     else:
         vars_in_charts = _variables_in_charts()
 
+    random.shuffle(vars_in_charts)
+
     for var_id in vars_in_charts:
-        p = Path(baked_path / f"data/{var_id}.json")
-
-        # read live site
-        try:
-            with open(p) as f:
-                live = _parse(f.read())
-        except FileNotFoundError:
-            log.warning("File not found on live", path=p)
-            continue
-
-        # read s3
-        p = Path(s3_path / f"data/{var_id}.json")
-        try:
-            with gzip.open(p, "rb") as f:
-                raw = f.read().decode()
-                s3 = _parse(raw)
-        except FileNotFoundError:
-            log.warning("File not found on S3", path=p)
-            continue
-
-        if s3 != live:
-            if len(s3) != len(live):
-                log.warning("S3 and live have different length", s3_len=len(s3), live_len=len(live), var_id=var_id)
-            else:
-                # iterate through all values
-                for i in range(len(s3)):
-                    if s3[i] != live[i]:
-                        log.warning("S3 and live have different values", s3=s3[i], live=live[i], var_id=var_id)
-                        break
+        _compare_data(baked_path, s3_path, var_id)
+        _compare_metadata(baked_path, s3_path, var_id)
 
 
-def _parse(js):
+def _compare_metadata(baked_path: Path, s3_path: Path, var_id: int) -> None:
+    # read live site
+    p = Path(baked_path / f"metadata/{var_id}.json")
+    try:
+        with open(p) as f:
+            live_data = _parse_metadata(f.read())
+    except FileNotFoundError:
+        log.warning("File not found on live", path=p)
+        return
+
+    # read s3
+    p = Path(s3_path / f"metadata/{var_id}.json")
+    try:
+        with gzip.open(p, "rb") as f:
+            raw = f.read().decode()
+            s3_data = _parse_metadata(raw)
+    except FileNotFoundError:
+        log.warning("File not found on S3", path=p)
+        return
+
+    # remove dimensions for now
+    s3_data.pop("dimensions")
+    live_data.pop("dimensions")
+
+    if s3_data != live_data:
+        diff = DeepDiff(s3_data, live_data)
+        log.warning("S3 and live have different metadata", var_id=var_id, dataset_id=live_data["datasetId"], diff=diff)
+
+
+def _compare_data(baked_path: Path, s3_path: Path, var_id: int) -> None:
+    # read live site
+    p = Path(baked_path / f"data/{var_id}.json")
+    try:
+        with open(p) as f:
+            live_data = _parse_data(f.read())
+    except FileNotFoundError:
+        log.warning("File not found on live", path=p)
+        return
+
+    # read s3
+    p = Path(s3_path / f"data/{var_id}.json")
+    try:
+        with gzip.open(p, "rb") as f:
+            raw = f.read().decode()
+            s3_data = _parse_data(raw)
+    except FileNotFoundError:
+        log.warning("File not found on S3", path=p)
+        return
+
+    if s3_data != live_data:
+        if len(s3_data) != len(live_data):
+            log.warning(
+                "S3 and live have different length", s3_len=len(s3_data), live_len=len(live_data), var_id=var_id
+            )
+        else:
+            # iterate through all values
+            for i in range(len(s3_data)):
+                if s3_data[i] != live_data[i]:
+                    log.warning("S3 and live have different values", s3=s3_data[i], live=live_data[i], var_id=var_id)
+                    break
+
+
+def _parse_data(js):
     x = json.loads(js)
     return sorted(zip(x["entities"], x["years"], x["values"]))
+
+
+def _parse_metadata(js):
+    x = json.loads(js)
+
+    # type on live is not computed correctly, but we're not using it anyway
+    x.pop("type")
+
+    # does not have to match
+    x.pop("updatedAt")
+    x.pop("dataPath", None)
+    x.pop("metadataPath", None)
+
+    return x
 
 
 def _variables_in_charts() -> List[int]:


### PR DESCRIPTION
Compare metadata in `data_parity.py` script in addition to data. There's one [inconsistency](https://github.com/owid/owid-grapher/issues/1927), but we're not using that field so it's not a blocker. I've also found that `datasync` can't rely just on `dataEditedAt` and `metadataEditedAt` in case someone changes variable metadata. This PR also fixes that.