### PR TITLE
fix(ozone): metadata

### DIFF
--- a/etl/steps/data/garden/nasa/2023-03-06/ozone_hole_area.meta.yml
+++ b/etl/steps/data/garden/nasa/2023-03-06/ozone_hole_area.meta.yml
@@ -50,10 +50,10 @@ tables:
         short_unit: "km²"
         unit: "square kilometres"
         description: |
-          Ozone hole area mean (07 September -- 13 October) for each year.
+          Ozone hole area mean (07 September - 13 October) for each year.
       mean_hole_concentration:
         title: Mean daily concentration
         short_unit: "DU"
         unit: "Dobson Units (DU)"
         description: |
-          Minimum ozone (21 September -- 16 October) for each year.
+          Minimum ozone (21 September - 16 October) for each year.

--- a/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.meta.yml
+++ b/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.meta.yml
@@ -40,8 +40,8 @@ tables:
         description: |
           Consumption of various controlled substances. These include Bromochloromethane (BCM), Carbon Tetrachloride (CTC), Chlorofluorocarbons (CFCs), Hydrobromofluorocarbons (HBFCs), Hydrochlorofluorocarbons (HCFCs), Hydrofluorocarbons (HFCs), Methyl Bromide (MB), Methyl Chloroform (TCA) and Other Fully Halogenated CFCs.
 
-          We assign zero to missing values for a givent (year, country, chemical) triple.
-        short_unit: "ODP tonnes"
+          We assign zero to missing values for a given (year, country, chemical) triple. This is due to technical reasons, so that we are able to plot this variable using our Grapher stacked are charts.
+        short_unit: "tonnes"
         unit: "ODP tonnes"
         display:
           numDecimalPlaces: 1

--- a/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.meta.yml
+++ b/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.meta.yml
@@ -45,3 +45,11 @@ tables:
         unit: "ODP tonnes"
         display:
           numDecimalPlaces: 1
+      consumption_rel_1986:
+        title: Consumption of controlled substance (relative to 1986)
+        description: |
+          Consumption of various controlled substances. These include Bromochloromethane (BCM), Carbon Tetrachloride (CTC), Chlorofluorocarbons (CFCs), Hydrobromofluorocarbons (HBFCs), Hydrochlorofluorocarbons (HCFCs), Hydrofluorocarbons (HFCs), Methyl Bromide (MB), Methyl Chloroform (TCA) and Other Fully Halogenated CFCs.
+
+          This is measured as an index relative to emissions in the year 1986 (1986 = 100).
+        display:
+          numDecimalPlaces: 1

--- a/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.meta.yml
+++ b/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.meta.yml
@@ -51,5 +51,6 @@ tables:
           Consumption of various controlled substances. These include Bromochloromethane (BCM), Carbon Tetrachloride (CTC), Chlorofluorocarbons (CFCs), Hydrobromofluorocarbons (HBFCs), Hydrochlorofluorocarbons (HCFCs), Hydrofluorocarbons (HFCs), Methyl Bromide (MB), Methyl Chloroform (TCA) and Other Fully Halogenated CFCs.
 
           This is measured as an index relative to emissions in the year 1986 (1986 = 100).
+        unit: ""
         display:
           numDecimalPlaces: 1

--- a/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.py
+++ b/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.py
@@ -177,7 +177,13 @@ def add_consumption_zerofilled(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def add_consumption_rel_1986(df: pd.DataFrame) -> pd.DataFrame:
-    df_1986 = df[df["year"] == 1986]
+    """Add column with ratio of consumption to 1986 consumption."""
+    # Initial columns and new column names
+    columns = list(df.columns)
+    new_col = "consumption_rel_1986"
+    # Get consumption in 1986, where it is not zero
+    df_1986 = df[(df["year"] == 1986) & (df["consumption"] > 0)]
+    # Merge and estimate ratio
     df = df.merge(df_1986, on=["country", "chemical"], suffixes=("", "_1986"), how="left")
-    df["consumption_rel_1986"] = (100 * df["consumption"] / df["consumption_1986"]).round(2)
-    return df
+    df[new_col] = (100 * df["consumption"] / df["consumption_1986"]).round(2)
+    return df[columns + [new_col]]

--- a/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.py
+++ b/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.py
@@ -187,3 +187,23 @@ def add_consumption_rel_1986(df: pd.DataFrame) -> pd.DataFrame:
     df = df.merge(df_1986, on=["country", "chemical"], suffixes=("", "_1986"), how="left")
     df[new_col] = (100 * df["consumption"] / df["consumption_1986"]).round(2)
     return df[columns + [new_col]]
+
+
+def remove_last_year_for_regions(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove datapoint for latest available year in regions.
+
+    Data for latest year for regions is usually an underestimate, because just a subset of countries have reported data."""
+    REGIONS = [
+        "Africa",
+        "Asia",
+        "Europe",
+        "European Union (27)",
+        "European Union (28)",
+        "North America",
+        "Oceania",
+        "South America",
+        "World",
+    ]
+    last_year = df["year"].max()
+    df = df[~((df["year"] == last_year) & (df["country"].isin(REGIONS)))]
+    return df

--- a/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.py
+++ b/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.py
@@ -75,6 +75,8 @@ def df_to_table(df: pd.DataFrame) -> Table:
     df = pd.concat([df, df_total], ignore_index=True).sort_values(["country", "year", "chemical"])
     # Add zero-filled column
     df = add_consumption_zerofilled(df)
+    # Add consumption relative to 1986
+    df = add_consumption_rel_1986(df)
     # Set indices
     df = df.set_index(["country", "year", "chemical"])
     # Drop NaNs and set dtype
@@ -171,4 +173,11 @@ def add_consumption_zerofilled(df: pd.DataFrame) -> pd.DataFrame:
     df = df.pivot(index=id_vars, columns=[var_name], values=value_name).reset_index()
     df = df.melt(id_vars=id_vars, var_name=var_name, value_name=value_name)
     df["consumption_zf"] = df["consumption"].fillna(0)
+    return df
+
+
+def add_consumption_rel_1986(df: pd.DataFrame) -> pd.DataFrame:
+    df_1986 = df[df["year"] == 1986]
+    df = df.merge(df_1986, on=["country", "chemical"], suffixes=("", "_1986"), how="left")
+    df["consumption_rel_1986"] = (100 * df["consumption"] / df["consumption_1986"]).round(2)
     return df


### PR DESCRIPTION
This PR:

- Improves metadata for datasets:
  - [Ozone hole area and concentration (NASA, 2023)](https://owid.cloud/admin/datasets/5912)
  - [Consumption of controlled substances (UNEP, 2023)](https://owid.cloud/admin/datasets/5925)
- Adds a new variable, `consumption_rel_1986`, which normalizes the variable `consumption` value so that it equals 100 for the year 1986. This should allow us to update this chart: https://ourworldindata.org/grapher/ozone-depleting-substances-index