### PR TITLE
enhance(chart_revision): error message, simplified API

### DIFF
--- a/etl/chart_revision/cli.py
+++ b/etl/chart_revision/cli.py
@@ -14,10 +14,7 @@ from structlog import get_logger
 
 # TBD
 from etl.chart_revision.deprecated import ChartRevisionSuggester
-from etl.chart_revision.revision import (
-    get_charts_to_update,
-    submit_revisions_to_grapher,
-)
+from etl.chart_revision.revision import create_and_submit_charts_revisions
 from etl.config import DEBUG
 
 log = get_logger()
@@ -49,10 +46,4 @@ def main(mapping_file: str, revision_reason: Optional[str] = None):
     with open(mapping_file, "r") as f:
         variable_mapping = json.load(f)
         variable_mapping = {int(k): int(v) for k, v in variable_mapping.items()}
-    # Get revisions to be done
-    chart_revisions = get_charts_to_update(variable_mapping)
-    # Update chart configs
-    for chart_revision in chart_revisions:
-        _ = chart_revision.bake(revision_reason)
-    # Submit revisions to Grapher
-    submit_revisions_to_grapher(chart_revisions)
+    create_and_submit_charts_revisions(variable_mapping, revision_reason)


### PR DESCRIPTION
- Improves a slightly confusing error message.
- Simplifies the submission of chart revisions with the new function `create_and_submit_charts_revisions`. This aims to improve the experience of users that want to submit chart revisions programmatically. In such cases, users have a dictionary mapping old to new variable IDs and want to use this to create and submit the necessary chart revisions.