### PR TITLE
feat(wid): Add median data as a separate variable

### DIFF
--- a/etl/steps/data/garden/wid/2023-01-27/shared.py
+++ b/etl/steps/data/garden/wid/2023-01-27/shared.py
@@ -49,6 +49,13 @@ var_dict = {
         "short_unit": "$",
         "numDecimalPlaces": 1,
     },
+    "median": {
+        "title": "Median",
+        "description": "Median income or wealth.",
+        "unit": "international-$ in 2021 prices",
+        "short_unit": "$",
+        "numDecimalPlaces": 1,
+    },
     "palma_ratio": {
         "title": "Palma ratio",
         "description": "The Palma ratio is the share of total income or wealth of the top 10% divided by the share of the bottom 40%.",

--- a/etl/steps/data/garden/wid/2023-01-27/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2023-01-27/world_inequality_database.meta.yml
@@ -79,7 +79,7 @@ dataset:
   sources:
     - name: World Inequality Database (WID.world) (2023)
       url: https://wid.world/
-      date_accessed: "2023-03-09"
+      date_accessed: "2023-03-29"
       publication_year: 2023
       published_by: World Inequality Database (WID), https://wid.world
       publisher_source: National income surveys, tax records and national accounts

--- a/snapshots/wid/2023-01-27/wid_indices.do
+++ b/snapshots/wid/2023-01-27/wid_indices.do
@@ -102,7 +102,7 @@ drop p0p100_thr*
 *Define each income/wealth variable
 local var_names pretax posttax_nat posttax_dis wealth
 
-*Calculate ratios for each variable
+*Calculate ratios for each variable + create a duplicate variable for median
 foreach var in `var_names' {
 
 	gen palma_ratio_`var' = p90p100_share_`var' / (p0p50_share_`var' - p40p50_share_`var')
@@ -112,11 +112,13 @@ foreach var in `var_names' {
 	gen p90_p10_ratio_`var' = p90p100_thr_`var' / p10p20_thr_`var'
 	gen p90_p50_ratio_`var' = p90p100_thr_`var' / p50p60_thr_`var'
 	gen p50_p10_ratio_`var' = p50p60_thr_`var' / p10p20_thr_`var'
+	
+	gen median_`var' = p50p60_thr_`var'
 
 }
 
 *Order variables according to different variable groups
-order country year *gini_pretax *gini*dis *gini*nat *gini_wealth *_ratio*pretax *_ratio*dis *_ratio*nat *_ratio*wealth *share_pretax *share*dis *share*nat *share_wealth *avg_pretax *avg*dis *avg*nat *avg_wealth *thr_pretax *thr*dis *thr*nat *thr_wealth
+order country year *gini_pretax *gini*dis *gini*nat *gini_wealth *_ratio*pretax *_ratio*dis *_ratio*nat *_ratio*wealth *share_pretax *share*dis *share*nat *share_wealth *avg_pretax *avg*dis *avg*nat *avg_wealth *thr_pretax *thr*dis *thr*nat *thr_wealth median*
 
 *Sort country and year
 sort country year

--- a/snapshots/wid/2023-01-27/world_inequality_database.csv.dvc
+++ b/snapshots/wid/2023-01-27/world_inequality_database.csv.dvc
@@ -11,7 +11,7 @@ meta:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-03-09
+  date_accessed: 2023-03-29
   is_public: true
   description: |
     The World Inequality Database (WID) is an extensive database on the distribution of income and wealth, both between and within countries. It is primarily maintained by the World Inequality Lab (WIL), located at the Paris School of Economics (PSE). But it is fundamentally the result of a coordinated, collaborative effort involving hundreds of researchers throughout the world over the past twenty years.
@@ -83,6 +83,6 @@ meta:
     More information is available at https://wid.world/methodology/
 wdir: ../../../data/snapshots/wid/2023-01-27
 outs:
-- md5: 9ea02397e0c9a39b7eeab2f0a0b1ccbf
-  size: 10533575
+- md5: 8d10049a8b3c5180729f755376a365e9
+  size: 10221168
   path: world_inequality_database.csv


### PR DESCRIPTION
Although the median is included among the WID variables (as a `p50p60_thr` variable), when I create explorers I need a median variable and a 5th percentile threshold with different names to be shown in comparisons with PIP and LIS. See more information about the explorers [here](https://github.com/owid/owid-issues/issues/983).

This is a minor change; it only adds four new variables and their metadata.