### PR TITLE
enhance(walkthrough): fix bug, add field in Grapher step

### DIFF
--- a/walkthrough/grapher.py
+++ b/walkthrough/grapher.py
@@ -78,6 +78,14 @@ def app(run_checks: bool, dummy_data: bool) -> None:
                 validate=utils.validate_short_name,
                 help_text="Underscored dataset short name. Example: natural_disasters",
             ),
+            pi.input(
+                "Garden dataset version",
+                name="garden_version",
+                placeholder=str(dt.date.today()),
+                required=True,
+                value=dummies.get("version", str(dt.date.today())),
+                help_text="Version of the garden dataset (by default, the current date, or exceptionally the publication date).",
+            ),
             pi.checkbox(
                 "Additional Options",
                 options=[
@@ -99,7 +107,7 @@ def app(run_checks: bool, dummy_data: bool) -> None:
         dag_content = utils.add_to_dag(
             {
                 f"data{private_suffix}://grapher/{form.namespace}/{form.version}/{form.short_name}": [
-                    f"data{private_suffix}://garden/{form.namespace}/{form.version}/{form.short_name}"
+                    f"data{private_suffix}://garden/{form.namespace}/{form.garden_version}/{form.short_name}"
                 ]
             }
         )

--- a/walkthrough/grapher.py
+++ b/walkthrough/grapher.py
@@ -27,6 +27,7 @@ class GrapherForm(BaseModel):
     short_name: str
     namespace: str
     version: str
+    garden_version: str
     add_to_dag: bool
     is_private: bool
 

--- a/walkthrough/grapher_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
+++ b/walkthrough/grapher_cookiecutter/{{cookiecutter.directory_name}}/{{cookiecutter.short_name}}.py
@@ -31,7 +31,7 @@ def run(dest_dir: str) -> None:
     #
     # Checks.
     #
-    grapher_checks(ds_garden)
+    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()


### PR DESCRIPTION
Only affects Grapher step:

- Minor bug in Grapher template: `ds_garden` was used instead of `ds_grapher` when running sanity checks.
- It was assumed that Garden dataset version was the same as Grapher's. I have added an extra field to allow users to define different versions for each step. We are currently doing this in the Garden step for Meadow/Garden.