### PR TITLE
fix(walkthrough): load population and reference datasets in garden step

### DIFF
--- a/walkthrough/garden.py
+++ b/walkthrough/garden.py
@@ -123,17 +123,13 @@ def app(run_checks: bool, dummy_data: bool) -> None:
     private_suffix = "-private" if form.is_private else ""
 
     if form.add_to_dag:
-        deps = [
-            f"data{private_suffix}://meadow/{form.namespace}/{form.meadow_version}/{form.short_name}"
-        ]
+        deps = [f"data{private_suffix}://meadow/{form.namespace}/{form.meadow_version}/{form.short_name}"]
         if form.load_population:
             deps.append(utils.DATASET_POPULATION_URI)
         if form.load_countries_regions:
             deps.append(utils.DATASET_REFERENCE_URI)
         dag_content = utils.add_to_dag(
-            {
-                f"data{private_suffix}://garden/{form.namespace}/{form.version}/{form.short_name}": deps
-            }
+            {f"data{private_suffix}://garden/{form.namespace}/{form.version}/{form.short_name}": deps}
         )
     else:
         dag_content = ""

--- a/walkthrough/garden.py
+++ b/walkthrough/garden.py
@@ -25,6 +25,8 @@ class Options(Enum):
     ADD_TO_DAG = "Add steps into dag.yml file"
     INCLUDE_METADATA_YAML = "Include *.meta.yaml file with metadata"
     GENERATE_NOTEBOOK = "Generate playground notebook"
+    LOAD_COUNTRIES_REGIONS = "Load countries regions in the script"
+    LOAD_POPULATION = "Load population in the script"
     IS_PRIVATE = "Make dataset private"
 
 
@@ -35,6 +37,8 @@ class GardenForm(BaseModel):
     version: str
     meadow_version: str
     add_to_dag: bool
+    load_countries_regions: bool
+    load_population: bool
     include_metadata_yaml: bool
     generate_notebook: bool
     is_private: bool
@@ -43,6 +47,8 @@ class GardenForm(BaseModel):
         options = data.pop("options")
         data["add_to_dag"] = Options.ADD_TO_DAG.value in options
         data["include_metadata_yaml"] = Options.INCLUDE_METADATA_YAML.value in options
+        data["load_countries_regions"] = Options.LOAD_COUNTRIES_REGIONS.value in options
+        data["load_population"] = Options.LOAD_POPULATION.value in options
         data["generate_notebook"] = Options.GENERATE_NOTEBOOK.value in options
         data["is_private"] = Options.IS_PRIVATE.value in options
         super().__init__(**data)
@@ -96,6 +102,8 @@ def app(run_checks: bool, dummy_data: bool) -> None:
                     Options.ADD_TO_DAG.value,
                     Options.INCLUDE_METADATA_YAML.value,
                     Options.GENERATE_NOTEBOOK.value,
+                    Options.LOAD_COUNTRIES_REGIONS.value,
+                    Options.LOAD_POPULATION.value,
                     Options.IS_PRIVATE.value,
                 ],
                 name="options",
@@ -115,11 +123,16 @@ def app(run_checks: bool, dummy_data: bool) -> None:
     private_suffix = "-private" if form.is_private else ""
 
     if form.add_to_dag:
+        deps = [
+            f"data{private_suffix}://meadow/{form.namespace}/{form.meadow_version}/{form.short_name}"
+        ]
+        if form.load_population:
+            deps.append(utils.DATASET_POPULATION_URI)
+        if form.load_countries_regions:
+            deps.append(utils.DATASET_REFERENCE_URI)
         dag_content = utils.add_to_dag(
             {
-                f"data{private_suffix}://garden/{form.namespace}/{form.version}/{form.short_name}": [
-                    f"data{private_suffix}://meadow/{form.namespace}/{form.meadow_version}/{form.short_name}"
-                ]
+                f"data{private_suffix}://garden/{form.namespace}/{form.version}/{form.short_name}": deps
             }
         )
     else:

--- a/walkthrough/meadow.py
+++ b/walkthrough/meadow.py
@@ -17,6 +17,7 @@ CURRENT_DIR = Path(__file__).parent
 ETL_DIR = Path(etl.__file__).parent.parent
 DEFAULT_EXTENSION = "csv"
 
+
 class Options(Enum):
 
     ADD_TO_DAG = "Add steps into dag/walkthrough.yaml file"
@@ -40,7 +41,7 @@ class MeadowForm(BaseModel):
     def __init__(self, **data: Any) -> None:
         options = data.pop("options")
         print(1, data["snapshot_file_extension"])
-        if (ext := data.pop("snapshot_file_extension") != ""):
+        if ext := data.pop("snapshot_file_extension") != "":
             data["snapshot_file_extension"] = ext
         else:
             data["snapshot_file_extension"] = DEFAULT_EXTENSION

--- a/walkthrough/meadow.py
+++ b/walkthrough/meadow.py
@@ -22,8 +22,6 @@ class Options(Enum):
     ADD_TO_DAG = "Add steps into dag/walkthrough.yaml file"
     INCLUDE_METADATA_YAML = "Include *.meta.yaml file with metadata"
     GENERATE_NOTEBOOK = "Generate playground notebook"
-    LOAD_COUNTRIES_REGIONS = "Load countries regions in the script"
-    LOAD_POPULATION = "Load population in the script"
     IS_PRIVATE = "Make dataset private"
 
 
@@ -35,8 +33,6 @@ class MeadowForm(BaseModel):
     snapshot_version: str
     snapshot_file_extension: str
     add_to_dag: bool
-    load_countries_regions: bool
-    load_population: bool
     generate_notebook: bool
     include_metadata_yaml: bool
     is_private: bool
@@ -45,8 +41,6 @@ class MeadowForm(BaseModel):
         options = data.pop("options")
         data["add_to_dag"] = Options.ADD_TO_DAG.value in options
         data["include_metadata_yaml"] = Options.INCLUDE_METADATA_YAML.value in options
-        data["load_countries_regions"] = Options.LOAD_COUNTRIES_REGIONS.value in options
-        data["load_population"] = Options.LOAD_POPULATION.value in options
         data["generate_notebook"] = Options.GENERATE_NOTEBOOK.value in options
         data["is_private"] = Options.IS_PRIVATE.value in options
         super().__init__(**data)
@@ -107,14 +101,12 @@ def app(run_checks: bool, dummy_data: bool) -> None:
                     Options.ADD_TO_DAG.value,
                     Options.INCLUDE_METADATA_YAML.value,
                     Options.GENERATE_NOTEBOOK.value,
-                    Options.LOAD_COUNTRIES_REGIONS.value,
-                    Options.LOAD_POPULATION.value,
                     Options.IS_PRIVATE.value,
                 ],
                 name="options",
                 value=[
                     Options.ADD_TO_DAG.value,
-                    Options.INCLUDE_METADATA_YAML.value,
+                    # Options.INCLUDE_METADATA_YAML.value,
                     Options.GENERATE_NOTEBOOK.value,
                 ],
             ),
@@ -125,15 +117,12 @@ def app(run_checks: bool, dummy_data: bool) -> None:
     private_suffix = "-private" if form.is_private else ""
 
     if form.add_to_dag:
-        deps = [
-            f"snapshot{private_suffix}://{form.namespace}/{form.snapshot_version}/{form.short_name}.{form.snapshot_file_extension}"
-        ]
-        if form.load_population:
-            deps.append("data://garden/owid/latest/key_indicators")
-        if form.load_countries_regions:
-            deps.append("data://garden/reference")
         dag_content = utils.add_to_dag(
-            {f"data{private_suffix}://meadow/{form.namespace}/{form.version}/{form.short_name}": deps}
+            {
+                f"data{private_suffix}://meadow/{form.namespace}/{form.version}/{form.short_name}": [
+                    f"snapshot{private_suffix}://{form.namespace}/{form.snapshot_version}/{form.short_name}.{form.snapshot_file_extension}",
+                ]
+            }
         )
     else:
         dag_content = ""

--- a/walkthrough/utils.py
+++ b/walkthrough/utils.py
@@ -17,6 +17,8 @@ from etl.steps import DAG
 
 DAG_WALKTHROUGH_PATH = DAG_DIR / "walkthrough.yml"
 WALDEN_INGEST_DIR = Path(walden.__file__).parent.parent.parent / "ingests"
+DATASET_POPULATION_URI = "data://garden/demography/2023-03-31/population"
+DATASET_REFERENCE_URI = "data://garden/reference"
 
 DUMMY_DATA = {
     "namespace": "dummy",

--- a/walkthrough/utils.py
+++ b/walkthrough/utils.py
@@ -18,6 +18,7 @@ from etl.steps import DAG
 DAG_WALKTHROUGH_PATH = DAG_DIR / "walkthrough.yml"
 WALDEN_INGEST_DIR = Path(walden.__file__).parent.parent.parent / "ingests"
 
+# Load latest population version
 POPULATION_LATEST_VERSION = (
     sorted((STEP_DIR / "data/garden/demography").glob("*/population/"))[-1].as_posix().split("/")[-2]
 )

--- a/walkthrough/utils.py
+++ b/walkthrough/utils.py
@@ -17,7 +17,11 @@ from etl.steps import DAG
 
 DAG_WALKTHROUGH_PATH = DAG_DIR / "walkthrough.yml"
 WALDEN_INGEST_DIR = Path(walden.__file__).parent.parent.parent / "ingests"
-DATASET_POPULATION_URI = "data://garden/demography/2023-03-31/population"
+
+POPULATION_LATEST_VERSION = (
+    sorted((STEP_DIR / "data/garden/demography").glob("*/population/"))[-1].as_posix().split("/")[-2]
+)
+DATASET_POPULATION_URI = f"data://garden/demography/{POPULATION_LATEST_VERSION}/population"
 DATASET_REFERENCE_URI = "data://garden/reference"
 
 DUMMY_DATA = {


### PR DESCRIPTION
Previously, `walkthrough` allowed users to add our population and reference datasets as dependencies to our DAG _only_ in the meadow step. However, these datasets should not be listed as dependencies in any meadow step. Instead, they should be used in Garden.

This PR:

- Allows users to add population and reference datasets as dependencies in a Garden step from `walkthrough` interface. It removes these options from the Meadow step, as these should not be used there.
- Updates the population dataset used by default to the latest available one: `data://garden/demography/2023-03-31/population`

---
related to https://github.com/owid/etl/issues/1003
tagged you both, @pabloarosado @paarriagadap ー but one review should suffice I think.