### PR TITLE
data(population-density): add OMM dataset

### DIFF
--- a/dag/demography.yml
+++ b/dag/demography.yml
@@ -21,6 +21,12 @@ steps:
     - data://meadow/demography/2023-04-07/population_education_wittgenstein
   data://grapher/demography/2023-04-07/population_education_wittgenstein:
     - data://garden/demography/2023-04-07/population_education_wittgenstein
+  # Population density
+  data://garden/demography/2023-04-14/population_density:
+    - data://garden/demography/2023-03-31/population
+    - data://garden/faostat/2023-02-22/faostat_rl
+  data://grapher/demography/2023-04-14/population_density:
+    - data://garden/demography/2023-04-14/population_density
 
   # Life expectancy
   ## Meadow

--- a/etl/steps/data/garden/demography/2023-03-31/population/meta.yml
+++ b/etl/steps/data/garden/demography/2023-03-31/population/meta.yml
@@ -11,8 +11,6 @@ dataset:
     some countries outside of this year period. E.g. it provides data for "Svalbard and Jan Mayen" (until 2017) and "Netherlands Antilles" (until 2010).
     • Gapminder (Systema Globalis): Covers the period 1555-2008. It complements the dataset with former countries and other data points not present in the other sources.
 
-    For a more detailed description, please refer to the field "source" in table "population".
-
   version: "2022-12-08"
   sources: &population-sources
     - name: Gapminder (2022)
@@ -36,6 +34,15 @@ dataset:
       published_by: Gapminder (Systema Globalis)
       url: https://github.com/open-numbers/ddf--gapminder--systema_globalis
       date_accessed: 2022-12-12
+  licenses:
+    - name: Creative Commons BY 4.0
+      url: https://docs.google.com/document/d/1-RmthhS2EPMK_HIpnPctcXpB0n7ADSWnXa5Hb3PxNq4/edit?usp=sharing
+    - name: CC BY 3.0 IGO
+      url: http://creativecommons.org/licenses/by/3.0/igo/
+    - name: CC BY 3.0
+      url: https://dataportaal.pbl.nl/downloads/HYDE/HYDE3.2/readme_release_HYDE3.2.1.txt
+    - name: Creative Commons BY 4.0
+      url: https://creativecommons.org/licenses/by/4.0/
 tables:
   population:
     title: Population (various sources)

--- a/etl/steps/data/garden/demography/2023-04-14/population_density.meta.yml
+++ b/etl/steps/data/garden/demography/2023-04-14/population_density.meta.yml
@@ -1,0 +1,2 @@
+dataset: {}
+tables: {}

--- a/etl/steps/data/garden/demography/2023-04-14/population_density.py
+++ b/etl/steps/data/garden/demography/2023-04-14/population_density.py
@@ -1,0 +1,135 @@
+"""Build population density OMM dataset.
+
+This dataset is built using our population OMM dataset and the land area given by FAOSTAT (RL):
+
+    `population_density = population / land_area`
+"""
+
+import pandas as pd
+from owid.catalog import Dataset, DatasetMeta, Table, VariableMeta
+from structlog import get_logger
+
+from etl.helpers import PathFinder, create_dataset
+
+log = get_logger()
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    log.info("population_density: start")
+
+    #
+    # Load inputs.
+    #
+    # Load dependency datasets.
+    ds_population: Dataset = paths.load_dependency("population")
+    ds_land_area: Dataset = paths.load_dependency("faostat_rl")
+
+    # Read relevant tables
+    tb_population = ds_population["population"]
+    tb_land_area = ds_land_area["faostat_rl_flat"]
+
+    #
+    # Process data.
+    #
+    tb = make_table(tb_population, tb_land_area)
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(
+        dest_dir,
+        tables=[tb],
+        default_metadata=build_metadata(ds_population, ds_land_area),
+    )
+    # Save changes in the new garden dataset.
+    ds_garden.save()
+
+    log.info("population_density: end")
+
+
+def make_table(tb_population: Table, tb_land_area: Table) -> Table:
+    """Create a table with population density data."""
+    # Dataframe population
+    df_population = pd.DataFrame(tb_population).reset_index()
+    # Dataframe land area
+    log.info("population_density: process land area datafame")
+    column_area = "land_area__00006601__area__005110__hectares"
+    df_land_area = (
+        pd.DataFrame(tb_land_area)[[column_area]]
+        .reset_index()
+        .rename(columns={column_area: "area"})
+        .sort_values(["country", "year"])
+        .drop_duplicates(subset=["country"], keep="last")
+        .drop(columns=["year"])
+    )
+
+    # Merge dataframes
+    log.info("population_density: merge dataframes")
+    df = df_population.merge(df_land_area, on="country", how="inner")
+    # Drop NaN (no data for area)
+    df = df.dropna(subset=["area"])
+    # Estimate population density as population / land_area(in km2)
+    df["population_density"] = df["population"] / (0.01 * df["area"])  # 0.01 to convert from hectare to km2
+    # Rename column source -> source_population
+    df = df.rename(columns={"source": "source_population"})
+    # Select relevant columns, order them, set index
+    df = df[["country", "year", "population_density", "source_population"]].set_index(["country", "year"]).sort_index()
+
+    # Build table
+    log.info("population_density: build table")
+    tb = Table(df, short_name=paths.short_name)
+
+    # Define variable metadata
+    log.info("population_density: define variable metadata")
+    tb.population_density.metadata = VariableMeta(
+        title="Population density",
+        description=(
+            "Population density estimated by Our World in Data using population estimates from multiple sources "
+            "and land area estimates by the Food and Agriculture Organization of the United Nations. We obtain it"
+            "by dividing the population estimates by the land area estimates.\n\n"
+            + tb_population.population.metadata.description
+        ),
+        unit="people per km²",
+    )
+    tb.source_population.metadata = VariableMeta(
+        title="Source (population)",
+        description=(
+            "Name of the source of the population estimate for a specific data point (country-year). The name includes a short name of the source and a link."
+        ),
+        unit="",
+    )
+    return tb
+
+
+def build_metadata(ds_population: Dataset, ds_land_area: Dataset) -> DatasetMeta:
+    """Generate metadata for the dataset based on the metadata from `ds_population` and `ds_land_area`.
+
+    Parameters
+    ----------
+    ds_population : Dataset
+        Dataset with population estimates.
+    ds_land_area : Dataset
+        Dataset with land area estimates.
+
+    Returns
+    -------
+    DatasetMeta
+        Dataset metadata.
+    """
+    log.info("population_density: add metadata")
+    return DatasetMeta(
+        channel=paths.channel,
+        namespace=paths.namespace,
+        short_name=paths.short_name,
+        title="Population density (various sources, 2023.1)",
+        description=(
+            "Population density is obtained by dividing population by land area.\n\n"
+            + ds_population.metadata.description
+        ),
+        sources=ds_population.metadata.sources + ds_land_area.metadata.sources,
+        licenses=ds_population.metadata.licenses + ds_land_area.metadata.licenses,
+    )

--- a/etl/steps/data/garden/demography/2023-04-14/population_density.py
+++ b/etl/steps/data/garden/demography/2023-04-14/population_density.py
@@ -56,6 +56,7 @@ def make_table(tb_population: Table, tb_land_area: Table) -> Table:
     # Dataframe population
     df_population = pd.DataFrame(tb_population).reset_index()
     # Dataframe land area
+    # We use land area of countries as they are defined today (latest reported value)
     log.info("population_density: process land area datafame")
     column_area = "land_area__00006601__area__005110__hectares"
     df_land_area = (
@@ -73,7 +74,7 @@ def make_table(tb_population: Table, tb_land_area: Table) -> Table:
     # Drop NaN (no data for area)
     df = df.dropna(subset=["area"])
     # Estimate population density as population / land_area(in km2)
-    df["population_density"] = df["population"] / (0.01 * df["area"])  # 0.01 to convert from hectare to km2
+    df["population_density"] = df["population"] / (0.01 * df["area"])  # 0.01 to convert from hectares to km2
     # Rename column source -> source_population
     df = df.rename(columns={"source": "source_population"})
     # Select relevant columns, order them, set index

--- a/etl/steps/data/grapher/demography/2023-04-14/population_density.py
+++ b/etl/steps/data/grapher/demography/2023-04-14/population_density.py
@@ -1,0 +1,36 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from owid.catalog import Dataset
+
+from etl.helpers import PathFinder, create_dataset, grapher_checks
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden: Dataset = paths.load_dependency("population_density")
+
+    # Read table from garden dataset.
+    tb_garden = ds_garden["population_density"]
+
+    #
+    # Process data.
+    #
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
+    #
+    # Checks.
+    #
+    grapher_checks(ds_grapher)
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()


### PR DESCRIPTION
### Summary
- Creates garden and grapher datasets for our `population density` OMM.
- We estimate it as `population / land area`, where
  - `population`: from our OMM dataset.
  - `land area`: from FAOSTAT RL dataset.
- Minor metadata adjustments to `population` OMM: Add licenses.
- Metadata for `population density` is mostly inherited from `population`.

### What about `key_indicators`?
This PR makes `key_indicators` no longer required:
- population metrics can be found in the population OMM dataset.
- population density metrics can be found in the population density OMM dataset.
- land area metric can be found in FAOSTAT RL dataset.

I sanity-checked, and differences with `key_indicators` are neglectable.

<details>
    <summary>Show sanity check code</summary>

  ```python
import pandas as pd
from owid.catalog import Dataset
from etl.paths import DATA_DIR

# Load datasets
ds1 = Dataset(
    DATA_DIR
    / "garden"
    / "demography"
    / "2023-04-14"
    / "population_density"
)
ds2 = Dataset(
    DATA_DIR
    / "garden"
    / "owid"
    / "latest"
    / "key_indicators"
)

# Get dataframes
df1 = ds1["population_density"][["population_density"]].reset_index()
df2 = ds2["population_density"][["population_density"]].reset_index()

# Obtain error
df = df1.merge(df2, on=["country", "year"], how="outer", suffixes=("_new", "_old"))
df = pd.DataFrame(df)
df["error"] = df.population_density_new-df.population_density_old
df["error_relative"] = 100 * df["error"] / df["population_density_new"]

# Display 60 exampels with largest error
df.sort_values("error_relative").head(60)
```
</details>

The next step would be to use this `population_density` in `key_indicators`, instead of estimating it there too. On the longer run, we should refactor those recipes that rely on `key_indicators`.