### PR TITLE
enhance(fasttrack): add instructions for importing large CSVs

### DIFF
--- a/fasttrack/cli.py
+++ b/fasttrack/cli.py
@@ -197,6 +197,12 @@ def app(dummy_data: bool, commit: bool) -> None:
             contents=[po.put_markdown(f.read())],
         )
 
+    with open(CURRENT_DIR / "instructions_large_csv.md", "r") as f:
+        walkthrough_utils.put_widget(
+            title=po.put_html("<b>Instructions for importing large CSV file</b>"),
+            contents=[po.put_markdown(f.read())],
+        )
+
     data, meta, sheets_url, form, snapshot_dict = _load_data_and_meta(dummies)
 
     fast_import = FasttrackImport(data, meta, sheets_url, form.is_private, snapshot_dict)

--- a/fasttrack/instructions_large_csv.md
+++ b/fasttrack/instructions_large_csv.md
@@ -1,0 +1,13 @@
+## Importing large CSV
+
+If your dataset is too big to fit into Google Sheets (your CSV has >20mb), you can instead upload it somewhere else and tell fasttrack to import it from there.
+
+1. Follow `Instructions for importing Google Sheet` to create a new dataset, but don't paste any data there and delete `data` and `raw_data` sheets.
+
+2. Upload your CSV to a public URL. This could be Google Drive to [OWID Fast-track -> datasets](https://drive.google.com/drive/folders/1OeK3wsNnaHFCOTQlxHjqgZuFS9gvPhaI?usp=share_link) folder or it could be S3.
+
+3. Instead of having data in Google Sheets, you will have a link to your CSV in `dataset_meta` sheet in `data_url` field.
+
+4. Get the URL of your CSV. For example, if you uploaded it to Google Drive, you can get the URL by right-clicking on the file and selecting `Get shareable link`. The URL should look something like this: `https://drive.google.com/file/d/1--xdZuBFD1ZgM_8e4frydCheab6KBgnU/view?usp=sharing`. Paste this URL into that `data_url` field.
+
+5. Paste link of your Google Sheets just like you'd do in `Instructions for importing Google Sheet`

--- a/fasttrack/sheets.py
+++ b/fasttrack/sheets.py
@@ -22,18 +22,20 @@ class PartialSnapshotMeta(BaseModel):
     license_name: Optional[str]
 
 
-def import_google_sheets(url: str) -> Dict[str, Any]:
-    # these IDs are taken from template sheet
-    SHEET_TO_GID = {
-        "data": 409110122,
-        "variables_meta": 777328216,
-        "dataset_meta": 1719161864,
-        "sources_meta": 1399503534,
-    }
+# these IDs are taken from template sheet, they will be different if someone
+# creates a new sheet from scratch and use those names
+SHEET_TO_GID = {
+    "data": 409110122,
+    "variables_meta": 777328216,
+    "dataset_meta": 1719161864,
+    "sources_meta": 1399503534,
+}
 
+
+def import_google_sheets(url: str) -> Dict[str, Any]:
     # read dataset first to check if we're using data_url instead of data sheet
     dataset_meta = pd.read_csv(f"{url}&gid={SHEET_TO_GID['dataset_meta']}", header=None)
-    data_url = dataset_meta.set_index(0)[1].to_dict().get("data_url") or f"{url}&gid={SHEET_TO_GID['data']}"
+    data_url = _get_data_url(dataset_meta, url)
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
         data_future = executor.submit(lambda x: pd.read_csv(x), data_url)
@@ -158,3 +160,18 @@ def _move_keys_to_the_end(d: Dict[str, Any], keys: List[str]) -> None:
 
 def _prune_empty(d: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in d.items() if v and not pd.isnull(v)}
+
+
+def _get_data_url(dataset_meta: pd.DataFrame, url: str) -> str:
+    """Get data url from dataset_meta field or use data sheet if dataset_meta is empty."""
+    data_url = dataset_meta.set_index(0)[1].to_dict().get("data_url")
+
+    if data_url:
+        # files on Google Drive need modified link for downloading raw csv
+        if "drive.google.com" in data_url:
+            data_url = data_url.replace("file/d/", "uc?id=").replace("/view?usp=share_link", "&export=download")
+    else:
+        # use data sheet
+        data_url = f"{url}&gid={SHEET_TO_GID['data']}"
+
+    return data_url


### PR DESCRIPTION
Add instructions for importing large CSVs to fast-track and make it work with Google Drive URLs. We are already using this feature, but the documentation was not available.