### PR TITLE
Add fertilizers data

### DIFF
--- a/dag/faostat.yml
+++ b/dag/faostat.yml
@@ -306,6 +306,7 @@ steps:
     - data://garden/faostat/2023-02-22/faostat_qcl
     - data://garden/faostat/2023-02-22/faostat_sdgb
     - data://garden/faostat/2023-02-22/faostat_fbsc
+    - data://garden/faostat/2023-02-22/faostat_ef
   #
   # FAOSTAT grapher step for additional variables for version 2023-02-22
   #

--- a/etl/steps/data/garden/faostat/2023-02-22/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2023-02-22/additional_variables.meta.yml
@@ -206,3 +206,50 @@ tables:
         unit: "grams per day per capita"
         short_unit: "g"
         description: *macronutrient_composition_variable_description
+  fertilizers:
+    variables:
+      nitrogen_per_cropland:
+        title: Nitrogen use per area of cropland
+        unit: kilograms per hectare
+        short_unit: kg/ha
+        description: 
+      phosphate_per_cropland:
+        title: Phosphate use per area of cropland
+        unit: kilograms per hectare
+        short_unit: kg/ha
+        description: 
+      potash_per_cropland:
+        title: Potash use per area of cropland
+        unit: kilograms per hectare
+        short_unit: kg/ha
+        description: 
+      all_fertilizers_per_cropland:
+        title: All fertilizers use per area of cropland
+        unit: kilograms per hectare
+        short_unit: kg/ha
+        description: 
+      cropland:
+        title: Area of cropland
+        unit: hectares
+        short_unit: ha
+        description: 
+      nitrogen_use:
+        title: Nitrogen use
+        unit: tonnes
+        short_unit: t
+        description: 
+      phosphate_use:
+        title: Phosphate use
+        unit: tonnes
+        short_unit: t
+        description: 
+      potash_use:
+        title: Potash use
+        unit: tonnes
+        short_unit: t
+        description: 
+      all_fertilizers_use:
+        title: All fertilizers use
+        unit: tonnes
+        short_unit: t
+        description: 

--- a/etl/steps/data/garden/faostat/2023-02-22/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2023-02-22/additional_variables.meta.yml
@@ -212,44 +212,53 @@ tables:
         title: Nitrogen use per area of cropland
         unit: kilograms per hectare
         short_unit: kg/ha
-        description: 
+        description: |
+          Nutrient nitrogen (N) from all fertilizer products per area of cropland, which corresponds to the sum of arable land and permanent crops.
       phosphate_per_cropland:
         title: Phosphate use per area of cropland
         unit: kilograms per hectare
         short_unit: kg/ha
-        description: 
+        description: |
+           Nutrient phosphate (P2O5) from all fertilizer products per area of cropland, which corresponds to the sum of arable land and permanent crops.
       potash_per_cropland:
         title: Potash use per area of cropland
         unit: kilograms per hectare
         short_unit: kg/ha
-        description: 
+        description: |
+          Nutrient potash (K2O) from all fertilizer products per area of cropland, which corresponds to the sum of arable land and permanent crops.
       all_fertilizers_per_cropland:
         title: All fertilizers use per area of cropland
         unit: kilograms per hectare
         short_unit: kg/ha
-        description: 
+        description: |
+          Agricultural use of all fertilizer products (including nitrogenous, potash, and phosphate fertilizers) per area of cropland, which corresponds to the sum of arable land and permanent crops.
       cropland:
         title: Area of cropland
         unit: hectares
         short_unit: ha
         description: 
+          Surface area of cropland, which corresponds to the sum of arable land and permanent crops.
       nitrogen_use:
         title: Nitrogen use
         unit: tonnes
         short_unit: t
-        description: 
+        description: |
+          Agricultural use of nutrient nitrogen (N) from all fertilizer products.
       phosphate_use:
         title: Phosphate use
         unit: tonnes
         short_unit: t
-        description: 
+        description: |
+          Agricultural use of nutrient phosphate (P2O5) from all fertilizer products.
       potash_use:
         title: Potash use
         unit: tonnes
         short_unit: t
-        description: 
+        description: |
+          Agricultural use of nutrient potash (K2O) from all fertilizer products.
       all_fertilizers_use:
         title: All fertilizers use
         unit: tonnes
         short_unit: t
-        description: 
+        description: |
+          Agricultural use from all fertilizer products (including nitrogenous, potash, and phosphate fertilizers).

--- a/etl/steps/data/grapher/faostat/2023-02-22/additional_variables.py
+++ b/etl/steps/data/grapher/faostat/2023-02-22/additional_variables.py
@@ -22,6 +22,7 @@ def run(dest_dir: str) -> None:
     tb_land_spared_by_increased_crop_yields = ds_garden["land_spared_by_increased_crop_yields"]
     tb_food_available_for_consumption = ds_garden["food_available_for_consumption"]
     tb_macronutrient_compositions = ds_garden["macronutrient_compositions"]
+    tb_fertilizers = ds_garden["fertilizers"]
 
     #
     # Process data.
@@ -53,6 +54,7 @@ def run(dest_dir: str) -> None:
             tb_land_spared_by_increased_crop_yields,
             tb_food_available_for_consumption,
             tb_macronutrient_compositions,
+            tb_fertilizers,
         ],
         default_metadata=ds_garden.metadata,
     )


### PR DESCRIPTION
In [the fertilizers' data explorer](https://ourworldindata.org/explorers/fertilizers), the data for total fertilizers per area of cropland was inconsistent with the data for each of the individual fertilizers per area of cropland. The reason is that, for the former, "cropland" meant "arable land", whereas for the latter, "cropland" meant "arable land plus permanent crops".

To fix the inconsistency, I added a new variable for all fertilizers per area of cropland (meaning arable land plus permanent crops). Additionally, I added variables for total use of each of the fertilizers (which were not included in the explorer and may now be included, if we find them useful).

This PR fixes https://github.com/owid/owid-issues/issues/996