### PR TITLE
fix(docs): wrong url

### DIFF
--- a/docs/overrides/404.html
+++ b/docs/overrides/404.html
@@ -1,0 +1,25 @@
+<!--
+  Copyright (c) 2016-2023 Martin Donath <martin.donath@squidfunk.com>
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to
+  deal in the Software without restriction, including without limitation the
+  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  sell copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+-->
+
+{% extends "main.html" %}
+
+<!-- Content -->
+{% block content %}
+  <h1>404 - Page not found</h1>
+{% endblock %}

--- a/docs/tutorials/adding-data/manual.md
+++ b/docs/tutorials/adding-data/manual.md
@@ -1,7 +1,7 @@
 # Manually add a dataset to the ETL
 ## Get set up
 
-Before you begin, make sure you've set up the ETL as described in [Getting Started](../getting-started/index.md).
+Before you begin, make sure you've set up the ETL as described in [Getting Started](../../getting-started/index.md).
 
 ## Adding steps to the ETL
 

--- a/docs/tutorials/adding-data/walkthrough.md
+++ b/docs/tutorials/adding-data/walkthrough.md
@@ -1,7 +1,14 @@
 # Using the interactive walkthrough
 
 The walkthrough is an interactive web UI for setting up the different ETL steps. It creates the base files to help you
-create the recipe for a dataset. It currently supports the following stages:
+create the recipe for a dataset.
+
+## Get set up
+
+Before you begin, make sure you've set up the ETL as described in [Getting Started](../../getting-started/index.md).
+
+## Walkthrough options
+The walkthrough currently supports the following stages:
 
 | Option      | Description                                                                                                   |
 | ----------- | ------------------------------------------------------------------------------------------------------------- |
@@ -26,10 +33,6 @@ Options:
   --port INTEGER                Application port
   --help                        Show this message and exit.
 ```
-
-## Get set up
-
-Before you begin, make sure you've set up the ETL as described in [Getting Started](../getting-started/index.md).
 
 ## Start the walkthrough
 


### PR DESCRIPTION
The following pages had the wrong URL embedded in the "Getting started" reference. This was first raised in https://github.com/owid/etl/issues/1046.

- https://docs.owid.io/projects/etl/en/latest/tutorials/adding-data/walkthrough/
- https://docs.owid.io/projects/etl/en/latest/tutorials/adding-data/manual/