### PR TITLE
data(health): fix description of Wellcome Global Monitor 2020

### DIFF
--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -368,7 +368,11 @@ def _adapt_dataset_metadata_for_grapher(
     # Add the dataset description as if it was a source's description.
     if metadata.description is not None:
         if metadata.sources[0].description:
-            if metadata.sources[0].description != metadata.description:
+            # If descriptions are not subsets of each other (or equal), add them together
+            if (
+                metadata.sources[0].description not in metadata.description
+                and metadata.description not in metadata.sources[0].description
+            ):
                 metadata.sources[0].description = metadata.description + "\n" + metadata.sources[0].description
         else:
             metadata.sources[0].description = metadata.description

--- a/etl/steps/data/garden/health/2023-04-18/wgm_mental_health.py
+++ b/etl/steps/data/garden/health/2023-04-18/wgm_mental_health.py
@@ -62,12 +62,13 @@ def run(dest_dir: str) -> None:
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
     ds_garden = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_meadow.metadata)
-    ds_garden.update_metadata(paths.metadata_path)
+
     # Add explanation to dataset description
-    ds_garden.metadata.description += (
+    ds_garden.metadata.sources[0].description += (
         "\n\nNote 1: Data for answers where the demographic group had less than 100 participants are filtered out."
         "\n\nNote 2: Empty answers have been filtered out. Empty answers may appear because the question was not applicable to the respondent or the respondent did not answer the question."
     )
+
     # Save changes in the new garden dataset.
     ds_garden.save()
 


### PR DESCRIPTION
In grapher we assemble **source** description (which is shown in admin as dataset description 🤦 dataset description is not shown anywhere in grapher) from **dataset description + source description** if and only if they're different. However, if someone appends something to e.g. source description, we'd have duplicate paragraphs in the output. Change it so that it uses both descriptions only if one is not subset of another.

Also remove `ds_garden.update_metadata(paths.metadata_path)` which is already part of `create_dataset`.