### PR TITLE
data(regions): rename East Timor back to Timor to stay consistent with ETL & grapher

### DIFF
--- a/etl/steps/data/garden/regions/2023-01-01/regions.yml
+++ b/etl/steps/data/garden/regions/2023-01-01/regions.yml
@@ -472,7 +472,7 @@
     - "DEU"
 
 - code: "TLS"
-  name: "East Timor"
+  name: "Timor"
   aliases:
     - "East Timor"
     - "Timor-Leste"


### PR DESCRIPTION
`regions.yml` with East Timor is inconsistent with `countries_regions.csv` with Timor. That prevents us from region [centralisation in grapher](https://github.com/owid/owid-grapher/pull/2135). We have a migration prepared that would rename Timor -> East Timor, but that might take time and we want to unblock the grapher PR first.