### PR TITLE
:bug: un: remove sint maarten inaccurate estimates

### DIFF
--- a/etl/steps/data/garden/un/2022-07-11/un_wpp/__init__.py
+++ b/etl/steps/data/garden/un/2022-07-11/un_wpp/__init__.py
@@ -123,9 +123,6 @@ def run(dest_dir: str) -> None:
     # merge main df
     log.info("Merging tables...")
     df = merge_dfs([df_population, df_fertility, df_demographics, df_depratio, df_deaths])
-    # Remove Sint Maarten
-    log.info("Removing country due to inconsistencies...")
-    df = df.loc[~df.index.get_level_values("location").isin(["Sint Maarten (Dutch part)"])]
     # create tables
     log.info("Transforming DataFrame into Table...")
     table_long = df_to_table(

--- a/etl/steps/data/garden/un/2022-07-11/un_wpp/__init__.py
+++ b/etl/steps/data/garden/un/2022-07-11/un_wpp/__init__.py
@@ -125,7 +125,7 @@ def run(dest_dir: str) -> None:
     df = merge_dfs([df_population, df_fertility, df_demographics, df_depratio, df_deaths])
     # Remove Sint Maarten
     log.info("Removing country due to inconsistencies...")
-    df = df.loc[~df.index.get_level_values("location").isin(["SXM"])]
+    df = df.loc[~df.index.get_level_values("location").isin(["Sint Maarten (Dutch part)"])]
     # create tables
     log.info("Transforming DataFrame into Table...")
     table_long = df_to_table(

--- a/etl/steps/data/garden/un/2022-07-11/un_wpp/population.py
+++ b/etl/steps/data/garden/un/2022-07-11/un_wpp/population.py
@@ -110,7 +110,13 @@ def remove_outliers(df: pd.DataFrame) -> pd.DataFrame:
     So far, detected ones are:
         - Sex ratio for Sint Maarten
     """
-    df = df.loc[~((df["location"] == "Sint Maarten (Dutch part)") & (df["metric"] == "sex_ratio") & (df["age"].isin(["5", "10", "30", "40"])))]
+    df = df.loc[
+        ~(
+            (df["location"] == "Sint Maarten (Dutch part)")
+            & (df["metric"] == "sex_ratio")
+            & (df["age"].isin(["5", "10", "30", "40"]))
+        )
+    ]
     return df
 
 

--- a/etl/steps/data/garden/un/2022-07-11/un_wpp/population.py
+++ b/etl/steps/data/garden/un/2022-07-11/un_wpp/population.py
@@ -79,6 +79,8 @@ def process(df: pd.DataFrame, country_std: str) -> Tuple[pd.DataFrame, pd.DataFr
     df_base = process_base(df, country_std)
     # Add metrics
     df = add_metrics(df_base.copy())
+    # Remove potential outliers
+    df = remove_outliers(df)
     return df_base, df
 
 
@@ -99,6 +101,16 @@ def add_metrics(df: pd.DataFrame) -> pd.DataFrame:
     # Remove infs
     msk = np.isinf(df["value"])
     df.loc[msk, "value"] = np.nan
+    return df
+
+
+def remove_outliers(df: pd.DataFrame) -> pd.DataFrame:
+    """Remove outliers from the population table.
+
+    So far, detected ones are:
+        - Sex ratio for Sint Maarten
+    """
+    df = df.loc[~((df["location"] == "Sint Maarten (Dutch part)") & (df["metric"] == "sex_ratio") & (df["age"].isin(["5", "10", "30", "40"])))]
     return df
 
 


### PR DESCRIPTION
We were trying to filter Sint Maarten before but using the ISO code. Instead, we should be using the complete country name.

TODO: review "natural_disasters" pipeline, seems to sanity check the countries in un_wpp. Now that Sint Maarten is missing, it fails.