### PR TITLE
:bug: switch key_indicators from datautils.geo to data_helpers.geo

### DIFF
--- a/etl/data_helpers/geo.py
+++ b/etl/data_helpers/geo.py
@@ -35,6 +35,7 @@ NUM_ALLOWED_NANS_PER_YEAR = None
 DATASET_KEY_INDICATORS = DATA_DIR / "garden" / "owid" / "latest" / "key_indicators"
 TNAME_KEY_INDICATORS = "population"
 # Path to Key Indicators dataset
+# TODO: we should update it to latest garden/wb/*/income_groups dataset
 DATASET_WB_INCOME = DATA_DIR / "garden" / "wb" / "2021-07-01" / "wb_income"
 TNAME_WB_INCOME = "wb_income_group"
 
@@ -157,12 +158,15 @@ def list_countries_in_region_that_must_have_data(
         Countries that are expected to have the largest contribution.
 
     """
+    # TODO: we should be passing countries_regions explicitly and get rid of `_load_countries_regions`
     if countries_regions is None:
         countries_regions = _load_countries_regions()
 
+    # TODO: we should be passing population explicitly and get rid of `_load_population`
     if population is None:
         population = _load_population()
 
+    # TODO: we should be passing income groups explicitly and get rid of `_load_income_groups`
     if income_groups is None:
         income_groups = _load_income_groups().reset_index()
 

--- a/etl/harmonize.py
+++ b/etl/harmonize.py
@@ -15,7 +15,7 @@ import pandas as pd
 from owid.catalog import Dataset
 from rapidfuzz import process
 
-from etl.paths import LATEST_REGIONS_DATASET_PATH, LATEST_REGIONS_REGIONS_YML
+from etl.paths import LATEST_REGIONS_DATASET_PATH, LATEST_REGIONS_YML
 
 
 @click.command()
@@ -270,10 +270,10 @@ def save_alias_to_regions_yaml(name: str, alias: str) -> None:
     Save alias to regions.yml definitions. It doesn't modify original formatting of the file, but assumes
     that `alias` is always the last element in the region block.
     """
-    with open(LATEST_REGIONS_REGIONS_YML, "r") as f:
+    with open(LATEST_REGIONS_YML, "r") as f:
         yaml_content = f.read()
 
-    with open(LATEST_REGIONS_REGIONS_YML, "w") as f:
+    with open(LATEST_REGIONS_YML, "w") as f:
         f.write(_add_alias_to_regions(yaml_content, name, alias))
 
 
@@ -297,7 +297,7 @@ def _add_alias_to_regions(yaml_content, target_name, new_alias):
             aliases = f'  aliases:\n    - "{new_alias}"\n'
             yaml_content = yaml_content[: match.end()] + aliases + yaml_content[match.end() :]
     else:
-        raise ValueError(f"Could not find region {target_name} in {LATEST_REGIONS_REGIONS_YML}")
+        raise ValueError(f"Could not find region {target_name} in {LATEST_REGIONS_YML}")
 
     return yaml_content
 

--- a/etl/paths.py
+++ b/etl/paths.py
@@ -10,11 +10,13 @@ SNAPSHOTS_DIR = BASE_DIR / "snapshots"
 STEP_DIR = BASE_DIR / "etl" / "steps"
 
 # Regions paths
-LATEST_REGIONS_REGIONS_YML = sorted((STEP_DIR / "data/garden/regions/").glob("*/regions.yml"))[-1]
-LATEST_REGIONS_DATASET_PATH = BASE_DIR / LATEST_REGIONS_REGIONS_YML.relative_to(STEP_DIR).with_suffix("")
+LATEST_REGIONS_VERSION = sorted((STEP_DIR / "data/garden/regions/").glob("*/regions.yml"))[-1].parts[-2]
+LATEST_REGIONS_YML = STEP_DIR / "data/garden/regions" / LATEST_REGIONS_VERSION / "regions.yml"
+LATEST_REGIONS_DATASET_PATH = BASE_DIR / "data/garden/regions" / LATEST_REGIONS_VERSION / "regions"
 
 # WB Income
-LATEST_INCOME_DATASET_PATH = BASE_DIR / LATEST_REGIONS_REGIONS_YML.relative_to(STEP_DIR).with_suffix("")
+LATEST_INCOME_VERSION = sorted((STEP_DIR / "data/garden/wb/").glob("*/income_groups.py"))[-1].parts[-2]
+LATEST_INCOME_DATASET_PATH = BASE_DIR / "data/garden/wb" / LATEST_INCOME_VERSION / "income_groups"
 
 # NOTE: this is useful when your steps are defined in a different package
 BASE_PACKAGE = os.environ.get("BASE_PACKAGE", "etl")

--- a/etl/steps/data/garden/owid/latest/key_indicators/__init__.py
+++ b/etl/steps/data/garden/owid/latest/key_indicators/__init__.py
@@ -2,7 +2,7 @@
 #  __init__.py
 #  owid/latest/key_indicators
 #
-from owid.catalog import Dataset, DatasetMeta, Source, Table
+from owid.catalog import Dataset, DatasetMeta, Source
 from structlog import get_logger
 
 from etl.steps.data.garden.owid.latest.key_indicators import (
@@ -30,14 +30,18 @@ def run(dest_dir: str) -> None:
     # Add main tables
     log.info("key_indicators: add tables")
     sources = []
-    table_modules = [table_land_area, table_population]
-    for module in table_modules:
-        t: Table = module.make_table()
-        ds.add(t)
-        # Collect sources from variables
-        sources.extend([source for col in t.columns for source in t[col].metadata.sources])
 
-    # Add derived table
+    # Add population
+    t = table_population.make_table()
+    ds.add(t)
+    sources.extend([source for col in t.columns for source in t[col].metadata.sources])
+
+    # Add land area
+    t = table_land_area.make_table(ds)
+    ds.add(t)
+    sources.extend([source for col in t.columns for source in t[col].metadata.sources])
+
+    # Add population density
     t = table_population_density.make_table(ds)
     ds.add(t)
     sources.extend([source for col in t.columns for source in t[col].metadata.sources])

--- a/etl/steps/data/garden/owid/latest/key_indicators/table_land_area.py
+++ b/etl/steps/data/garden/owid/latest/key_indicators/table_land_area.py
@@ -10,7 +10,7 @@ from etl.steps.data.garden.owid.latest.key_indicators.utils import add_regions
 DIR_PATH = Path(__file__).parent
 
 
-def load_land_area() -> Table:
+def load_land_area(ds: Dataset) -> Table:
     d = Dataset(DATA_DIR / "open_numbers/open_numbers/latest/open_numbers__world_development_indicators")
     table = d["ag_lnd_totl_k2"]
 
@@ -29,7 +29,7 @@ def load_land_area() -> Table:
         .assign(country=table.geo.str.upper().map(countries_regions["name"]))
         .dropna(subset=["country"])
         .drop(["geo"], axis=1)
-        .pipe(add_regions)
+        .pipe(add_regions, population=ds["population"].reset_index())
         .pipe(add_world)
     )
 
@@ -61,8 +61,8 @@ def add_world(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def make_table() -> Table:
-    t = load_land_area()
+def make_table(ds: Dataset) -> Table:
+    t = load_land_area(ds)
     t.update_metadata_from_yaml(DIR_PATH / "key_indicators.meta.yml", "land_area")
 
     # variable ID 147839 in grapher

--- a/etl/steps/data/garden/owid/latest/key_indicators/utils.py
+++ b/etl/steps/data/garden/owid/latest/key_indicators/utils.py
@@ -1,9 +1,10 @@
 """Utils for key_indicators module."""
 import pandas as pd
-from owid.datautils import geo
+
+from etl.data_helpers import geo
 
 
-def add_regions(df: pd.DataFrame) -> pd.DataFrame:
+def add_regions(df: pd.DataFrame, population: pd.DataFrame) -> pd.DataFrame:
     """Add continents and income groups."""
     regions = [
         "Europe",
@@ -20,5 +21,8 @@ def add_regions(df: pd.DataFrame) -> pd.DataFrame:
     ]
     df = df.loc[-df.country.isin(regions)]
     for region in regions:
-        df = geo.add_region_aggregates(df=df, region=region)
+        # TODO: this should be ideally
+        # countries_in_region = geo.list_members_of_region(region=region, ds_regions=ds_regions, ds_income_groups=ds_income_groups)
+        # df = geo.add_region_aggregates(df=df, region=region, countries_in_region=countries_in_region, population=population)
+        df = geo.add_region_aggregates(df=df, region=region, population=population)
     return df


### PR DESCRIPTION
Key indicators were still using `from owid.datautils import geo` instead of `from etl.data_helpers import geo` which caused problems for nightly build. Fix this dependency by passing population directly.

@pabloarosado is this the right time to remove `geo` module from `datautils` package? Or do we want to keep it there for some reason?