### PR TITLE
Restrict long-term wheat yields dataset to European countries

### DIFF
--- a/dag/agriculture.yml
+++ b/dag/agriculture.yml
@@ -1,6 +1,6 @@
 steps:
   #
-  # Long-term wheat yields.
+  # Long-term wheat yields in Europe.
   #
   data://garden/agriculture/2023-04-20/long_term_wheat_yields:
     - data://garden/papers/2023-04-20/bayliss_smith_wanmali_1984

--- a/etl/steps/data/garden/agriculture/2023-04-20/long_term_wheat_yields.meta.yml
+++ b/etl/steps/data/garden/agriculture/2023-04-20/long_term_wheat_yields.meta.yml
@@ -1,9 +1,9 @@
 dataset:
   title: Long-term wheat yields (agriculture, 2023)
   description: |
-    This dataset combines data from two key sources:
+    This dataset combines data for European countries from two key sources:
+    + Data from prior to 1961 is sourced from Table 1.2 of Understanding Green Revolutions, by Bayliss-Smith & Wanmali (1984).
     + Wheat yields from 1961 onwards are as reported by the Food and Agricultural Organization of the United Nations.
-    + Data for European countries from prior to 1961 is sourced from Table 1.2 of Understanding Green Revolutions, by Bayliss-Smith & Wanmali (1984).
 
     All values of yield have been converted to tonnes per hectare.
 

--- a/etl/steps/data/garden/agriculture/2023-04-20/long_term_wheat_yields.py
+++ b/etl/steps/data/garden/agriculture/2023-04-20/long_term_wheat_yields.py
@@ -47,8 +47,11 @@ def run(dest_dir: str) -> None:
     # Process data.
     #
     # Select the relevant item and element from faostat data.
+    # Also, select only countries that appear in the Bayliss-Smith & Wanmali (1984) dataset.
     df_qcl = df_qcl[
-        (df_qcl["item_code"] == ITEM_CODE_FOR_WHEAT) & (df_qcl["element_code"] == ELEMENT_CODE_FOR_YIELD)
+        (df_qcl["item_code"] == ITEM_CODE_FOR_WHEAT)
+        & (df_qcl["element_code"] == ELEMENT_CODE_FOR_YIELD)
+        & (df_qcl["country"].isin(df_bayliss["country"].unique()))
     ].reset_index(drop=True)
 
     # Sanity check.


### PR DESCRIPTION
Restrict long-term wheat yields dataset to European countries (since otherwise data for all other countries is redundant with FAOSTAT QCL).
