### PR TITLE
✨ fix errors in chart config

### DIFF
--- a/etl/chart_revision/v2/schema.py
+++ b/etl/chart_revision/v2/schema.py
@@ -109,11 +109,10 @@ def fix_errors_in_schema(config: Dict[str, Any]) -> Dict[str, Any]:
             if "variableId" not in config_new["map"]:
                 config_new["map"]["variableId"] = config_new["map"]["columnSlug"]
             del config_new["map"]["columnSlug"]
-    if "properties" in config_new:
-        if ("timelineMaxTime" in config_new["properties"]) and (config_new["properties"]["timelineMaxTime"] is None):
-            del config_new["properties"]["timelineMaxTime"]
-        if ("timelineMinTime" in config_new["properties"]) and (config_new["properties"]["timelineMinTime"] is None):
-            del config_new["properties"]["timelineMinTime"]
+    if ("timelineMaxTime" in config_new) and (config_new["timelineMaxTime"] is None):
+        del config_new["properties"]["timelineMaxTime"]
+    if ("timelineMinTime" in config_new) and (config_new["timelineMinTime"] is None):
+        del config_new["properties"]["timelineMinTime"]
     return config_new
 
 

--- a/etl/chart_revision/v2/schema.py
+++ b/etl/chart_revision/v2/schema.py
@@ -109,6 +109,11 @@ def migrate_to_latest_schema(config: Dict[str, Any]) -> Dict[str, Any]:
             if "variableId" not in config_new["map"]:
                 config_new["map"]["variableId"] = config_new["map"]["columnSlug"]
             del config_new["map"]["columnSlug"]
+    if "properties" in config_new:
+        if ("timelineMaxTime" in config_new["properties"]) and (config_new["properties"]["timelineMaxTime"] is None):
+            del config_new["properties"]["timelineMaxTime"]
+        if ("timelineMinTime" in config_new["properties"]) and (config_new["properties"]["timelineMinTime"] is None):
+            del config_new["properties"]["timelineMinTime"]
     return config_new
 
 

--- a/etl/chart_revision/v2/schema.py
+++ b/etl/chart_revision/v2/schema.py
@@ -99,7 +99,7 @@ def validate_chart_config_and_set_defaults(
     return config_new
 
 
-def migrate_to_latest_schema(config: Dict[str, Any]) -> Dict[str, Any]:
+def fix_errors_in_schema(config: Dict[str, Any]) -> Dict[str, Any]:
     """Fix common errors in schema and tries to catch up with latest schema version."""
     config_new = copy.deepcopy(config)
     # Remove map.columnSlug. This should be map.variableId instead.

--- a/etl/chart_revision/v2/updaters/variable_update.py
+++ b/etl/chart_revision/v2/updaters/variable_update.py
@@ -14,8 +14,8 @@ import etl.grapher_model as gm
 from backport.datasync.data_metadata import variable_data_df_from_s3
 from etl.chart_revision.v2.base import ChartUpdater
 from etl.chart_revision.v2.schema import (
+    fix_errors_in_schema,
     get_schema_chart_config,
-    migrate_to_latest_schema,
     validate_chart_config_and_remove_defaults,
     validate_chart_config_and_set_defaults,
 )
@@ -148,7 +148,7 @@ class ChartVariableUpdater(ChartUpdater):
         """Run the chart variable updater."""
         log.info("variable_update: updating configuration")
         # Validate the configuration of the chart and add default values
-        config_new = migrate_to_latest_schema(config)
+        config_new = fix_errors_in_schema(config)
         config_new = validate_chart_config_and_set_defaults(config_new, self.schema)
         # Update map configuration
         config_new = self.update_config_map(


### PR DESCRIPTION
Corrects the case when either `properties.timelineMaxTime` or `properties.timelineMinTime` is set to `None` by removing the field.