### PR TITLE
Update long-run UK electricity dataset and archive old datasets

### DIFF
--- a/dag/archive/energy.yml
+++ b/dag/archive/energy.yml
@@ -2,6 +2,12 @@ steps:
   #
   # BP - Statistical review 2022.
   #
+  data://garden/bp/2022-07-14/statistical_review:
+    - backport://backport/owid/latest/dataset_5650_statistical_review_of_world_energy__bp__2022
+    - data://garden/bp/2022-07-11/statistical_review
+    - data://garden/owid/latest/key_indicators
+    - data://garden/wb/2021-07-01/wb_income
+    - data://garden/regions/2023-01-01/regions
   data://grapher/bp/2022-07-14/statistical_review:
     - data://garden/bp/2022-07-14/statistical_review
   #
@@ -180,3 +186,71 @@ steps:
     - data://garden/demography/2022-12-08/population
     - data://garden/ggdc/2020-10-01/ggdc_maddison
     - data://garden/regions/2023-01-01/regions
+  #
+  # Ember - Yearly electricity data 2023.
+  #
+  data://meadow/ember/2023-02-20/yearly_electricity:
+    - snapshot://ember/2023-02-20/yearly_electricity.csv
+  data://garden/ember/2023-02-20/yearly_electricity:
+    - data://meadow/ember/2023-02-20/yearly_electricity
+    - data://garden/demography/2022-12-08/population
+    - data://garden/wb/2021-07-01/wb_income
+    - data://garden/regions/2023-01-01/regions
+  #
+  # Ember - Combined electricity 2023.
+  #
+  # We still use EER 2022 for data from 1990-1999, which is not included in the 2023 version.
+  data://garden/ember/2023-02-20/combined_electricity:
+    - data://garden/ember/2022-08-01/european_electricity_review
+    - data://garden/ember/2023-02-20/yearly_electricity
+  #
+  # Energy - Electricity mix (BP & Ember, 2023).
+  #
+  data://garden/energy/2023-02-20/electricity_mix:
+    - data://garden/bp/2022-12-28/statistical_review
+    - data://garden/ember/2023-02-20/combined_electricity
+    - data://garden/demography/2022-12-08/population
+  data://grapher/energy/2023-02-20/electricity_mix:
+    - data://garden/energy/2023-02-20/electricity_mix
+  #
+  # Energy - Fossil Fuel Production 2023.
+  #
+  data://garden/energy/2023-02-20/fossil_fuel_production:
+    - data://garden/bp/2022-12-28/statistical_review
+    - data://garden/shift/2022-07-18/fossil_fuel_production
+    - data://garden/demography/2022-12-08/population
+  data://grapher/energy/2023-02-20/fossil_fuel_production:
+    - data://garden/energy/2023-02-20/fossil_fuel_production
+  #
+  # Energy - Primary energy consumption 2023.
+  #
+  data://garden/energy/2023-02-20/primary_energy_consumption:
+    - data://garden/bp/2022-12-28/statistical_review
+    - data://garden/eia/2022-07-27/energy_consumption
+    - data://garden/ggdc/2020-10-01/ggdc_maddison
+    - data://garden/demography/2022-12-08/population
+  data://grapher/energy/2023-02-20/primary_energy_consumption:
+    - data://garden/energy/2023-02-20/primary_energy_consumption
+  #
+  # Energy - Global primary energy (2023).
+  #
+  data://garden/energy/2023-02-20/global_primary_energy:
+    - data://garden/smil/2017-01-01/global_primary_energy
+    - data://garden/bp/2022-12-28/statistical_review
+  data://grapher/energy/2023-02-20/global_primary_energy:
+    - data://garden/energy/2023-02-20/global_primary_energy
+  #
+  # Energy - UK historical electricity (2023).
+  #
+  data://garden/energy/2023-02-20/uk_historical_electricity:
+    - data://garden/uk_beis/2022-07-28/uk_historical_electricity
+    - data://garden/energy/2023-02-20/electricity_mix
+  data://grapher/energy/2023-02-20/uk_historical_electricity:
+    - data://garden/energy/2023-02-20/uk_historical_electricity
+  #
+  # BP - Energy mix (2022).
+  #
+  data://garden/bp/2022-07-14/energy_mix:
+    - data://garden/bp/2022-07-14/statistical_review
+    - data://garden/owid/latest/key_indicators
+    - data://garden/wb/2021-07-01/wb_income

--- a/dag/emissions.yml
+++ b/dag/emissions.yml
@@ -23,7 +23,7 @@ steps:
     - data://garden/emissions/2023-05-02/national_contributions
     - data://garden/gcp/2023-04-28/global_carbon_budget
     - data://garden/cait/2022-08-10/ghg_emissions_by_sector
-    - data://garden/energy/2023-02-20/primary_energy_consumption
+    - data://garden/energy/2023-06-01/primary_energy_consumption
     - data://garden/demography/2022-12-08/population
     - data://garden/ggdc/2020-10-01/ggdc_maddison
     - data://garden/regions/2023-01-01/regions
@@ -50,7 +50,7 @@ steps:
   data://garden/gcp/2023-04-28/global_carbon_budget:
     - data://meadow/gcp/2023-04-28/global_carbon_budget
     # Loaded to calculate emissions per unit energy.
-    - data://garden/energy/2023-02-20/primary_energy_consumption
+    - data://garden/energy/2023-06-01/primary_energy_consumption
     # Loaded to calculate emissions per GDP.
     - data://garden/ggdc/2020-10-01/ggdc_maddison
     # Loaded to create per-capita variables.

--- a/dag/energy.yml
+++ b/dag/energy.yml
@@ -154,11 +154,11 @@ steps:
   #
   # Energy - UK historical electricity (2023).
   #
-  data://garden/energy/2023-02-20/uk_historical_electricity:
+  data://garden/energy/2023-06-01/uk_historical_electricity:
     - data://garden/uk_beis/2022-07-28/uk_historical_electricity
-    - data://garden/energy/2023-02-20/electricity_mix
-  data://grapher/energy/2023-02-20/uk_historical_electricity:
-    - data://garden/energy/2023-02-20/uk_historical_electricity
+    - data://garden/energy/2023-06-01/electricity_mix
+  data://grapher/energy/2023-06-01/uk_historical_electricity:
+    - data://garden/energy/2023-06-01/uk_historical_electricity
   #
   # IRENA - Renewable power generation costs (2022).
   #
@@ -214,68 +214,5 @@ steps:
 
   ######################################################################################################################
   # Older versions to be archived once they are not used by any other steps.
-  data://garden/bp/2022-07-14/statistical_review:
-    - backport://backport/owid/latest/dataset_5650_statistical_review_of_world_energy__bp__2022
-    - data://garden/bp/2022-07-11/statistical_review
-    - data://garden/owid/latest/key_indicators
-    - data://garden/wb/2021-07-01/wb_income
-    - data://garden/regions/2023-01-01/regions
-  data://garden/bp/2022-07-14/energy_mix:
-    - data://garden/bp/2022-07-14/statistical_review
-    - data://garden/owid/latest/key_indicators
-    - data://garden/wb/2021-07-01/wb_income
-  #
-  # Ember - Yearly electricity data 2023.
-  #
-  data://meadow/ember/2023-02-20/yearly_electricity:
-    - snapshot://ember/2023-02-20/yearly_electricity.csv
-  data://garden/ember/2023-02-20/yearly_electricity:
-    - data://meadow/ember/2023-02-20/yearly_electricity
-    - data://garden/demography/2022-12-08/population
-    - data://garden/wb/2021-07-01/wb_income
-    - data://garden/regions/2023-01-01/regions
-  #
-  # Ember - Combined electricity 2023.
-  #
-  # We still use EER 2022 for data from 1990-1999, which is not included in the 2023 version.
-  data://garden/ember/2023-02-20/combined_electricity:
-    - data://garden/ember/2022-08-01/european_electricity_review
-    - data://garden/ember/2023-02-20/yearly_electricity
-  #
-  # Energy - Electricity mix (BP & Ember, 2023).
-  #
-  data://garden/energy/2023-02-20/electricity_mix:
-    - data://garden/bp/2022-12-28/statistical_review
-    - data://garden/ember/2023-02-20/combined_electricity
-    - data://garden/demography/2022-12-08/population
-  data://grapher/energy/2023-02-20/electricity_mix:
-    - data://garden/energy/2023-02-20/electricity_mix
-  #
-  # Energy - Fossil Fuel Production 2023.
-  #
-  data://garden/energy/2023-02-20/fossil_fuel_production:
-    - data://garden/bp/2022-12-28/statistical_review
-    - data://garden/shift/2022-07-18/fossil_fuel_production
-    - data://garden/demography/2022-12-08/population
-  data://grapher/energy/2023-02-20/fossil_fuel_production:
-    - data://garden/energy/2023-02-20/fossil_fuel_production
-  #
-  # Energy - Primary energy consumption 2023.
-  #
-  data://garden/energy/2023-02-20/primary_energy_consumption:
-    - data://garden/bp/2022-12-28/statistical_review
-    - data://garden/eia/2022-07-27/energy_consumption
-    - data://garden/ggdc/2020-10-01/ggdc_maddison
-    - data://garden/demography/2022-12-08/population
-  data://grapher/energy/2023-02-20/primary_energy_consumption:
-    - data://garden/energy/2023-02-20/primary_energy_consumption
-  #
-  # Energy - Global primary energy (2023).
-  #
-  data://garden/energy/2023-02-20/global_primary_energy:
-    - data://garden/smil/2017-01-01/global_primary_energy
-    - data://garden/bp/2022-12-28/statistical_review
-  data://grapher/energy/2023-02-20/global_primary_energy:
-    - data://garden/energy/2023-02-20/global_primary_energy
 
   ######################################################################################################################

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -205,8 +205,7 @@ steps:
     - data://garden/regions/2023-01-01/regions
     - data://garden/gcp/2023-04-28/global_carbon_budget
     - data://garden/democracy/2023-03-02/vdem
-    # The following step is not the latest version available.
-    - data://garden/bp/2022-07-14/energy_mix
+    - data://garden/bp/2023-02-20/energy_mix
     - data://garden/worldbank_wdi/2022-05-26/wdi
 
   # Global GDP in the long run

--- a/etl/steps/data/garden/energy/2023-06-01/uk_historical_electricity.meta.yml
+++ b/etl/steps/data/garden/energy/2023-06-01/uk_historical_electricity.meta.yml
@@ -1,0 +1,93 @@
+dataset:
+  title: UK historical electricity (DUKES, 2023b)
+  description: |
+    All data prior to 1985 (and prior to 1965 in the case of renewables), is sourced from <a href="https://www.gov.uk/government/statistics/electricity-chapter-5-digest-of-united-kingdom-energy-statistics-dukes">the Digest of UK Energy Statistics (DUKES), published by the UK's Department for Business, Energy & Industrial Strategy</a>.
+
+    All other data is sourced from the <a href="https://www.bp.com/en/global/corporate/energy-economics/statistical-review-of-world-energy.html">BP's Statistical Review of World Energy</a> and <a href="https://ember-climate.org/data-catalogue/yearly-electricity-data/">Ember's Yearly Electricity Data</a>. Where data from BP is available for a given year, we rely on it as the primary source. We then supplement this with data from Ember where data from BP is not available.
+  # sources:
+  #   -
+  #     name: Digest of UK Energy Statistics
+  #     published_by: UK's Department for Business, Energy & Industrial Strategy
+  #     date_accessed: 2022-09-21
+  #     url: https://www.gov.uk/government/statistical-data-sets/historical-electricity-data
+  #   -
+  #     name: BP Statistical Review of World Energy
+  #     published_by: BP Statistical Review of World Energy
+  #     date_accessed: 2022-07-08
+  #     url: https://www.bp.com/en/global/corporate/energy-economics/statistical-review-of-world-energy.html
+  #   -
+  #     name: Ember's Yearly Electricity Data
+  #     published_by: Ember
+  #     publication_year: 2023
+  #     date_accessed: 2023-02-20
+  #     url: https://ember-climate.org/data-catalogue/yearly-electricity-data/
+  #   -
+  #     name: Ember's European Electricity Review
+  #     published_by: Ember
+  #     publication_year: 2022
+  #     date_accessed: 2022-08-01
+  #     url: https://ember-climate.org/insights/research/european-electricity-review-2022/
+
+tables:
+  uk_historical_electricity:
+    variables:
+      coal_generation:
+        title: Electricity generation from coal
+        short_unit: TWh
+        unit: terawatt-hours
+        display:
+          name: Coal
+      oil_generation:
+        title: Electricity generation from oil
+        short_unit: TWh
+        unit: terawatt-hours
+        display:
+          name: Oil
+      gas_generation:
+        title: Electricity generation from gas
+        short_unit: TWh
+        unit: terawatt-hours
+        display:
+          name: Natural gas
+      nuclear_generation:
+        title: Electricity generation from nuclear
+        short_unit: TWh
+        unit: terawatt-hours
+        display:
+          name: Nuclear
+      hydro_generation:
+        title: Electricity generation from hydropower
+        short_unit: TWh
+        unit: terawatt-hours
+        display:
+          name: Hydropower
+      solar_generation:
+        title: Electricity generation from solar
+        short_unit: TWh
+        unit: terawatt-hours
+        display:
+          name: Solar
+      wind_generation:
+        title: Electricity generation from wind
+        short_unit: TWh
+        unit: terawatt-hours
+        display:
+          name: Wind
+      other_renewables_generation:
+        title: Electricity generation from other renewables
+        short_unit: TWh
+        unit: terawatt-hours
+        display:
+          name: Other renewables
+      total_generation:
+        title: Total electricity generation
+        short_unit: TWh
+        unit: terawatt-hours
+        display:
+          name: Total electricity generation
+      net_imports:
+        title: Net electricity imports
+        short_unit: TWh
+        unit: terawatt-hours
+        display:
+          name: Net electricity imports

--- a/etl/steps/data/garden/energy/2023-06-01/uk_historical_electricity.py
+++ b/etl/steps/data/garden/energy/2023-06-01/uk_historical_electricity.py
@@ -1,0 +1,190 @@
+"""Combine UK BEIS' historical electricity with our electricity mix dataset (by BP & Ember) to obtain a long-run
+electricity mix in the UK.
+
+"""
+
+import numpy as np
+from owid.catalog import Dataset, Table
+from owid.datautils import dataframes
+
+from etl.helpers import PathFinder, create_dataset_with_combined_metadata
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def prepare_electricity_mix_data(tb_elec: Table) -> Table:
+    """Select necessary columns from the electricity mix, and select rows corresponding to the UK.
+
+    Parameters
+    ----------
+    tb_elec : Table
+        Data from the main table of the electricity mix dataset.
+
+    Returns
+    -------
+    tb_elec : Table
+        Selected columns and rows from the electricity mix data.
+
+    """
+    tb_elec = tb_elec.copy()
+
+    # Select columns and rename them conveniently.
+    elec_columns = {
+        "country": "country",
+        "year": "year",
+        "coal_generation__twh": "coal_generation",
+        "gas_generation__twh": "gas_generation",
+        "oil_generation__twh": "oil_generation",
+        "hydro_generation__twh": "hydro_generation",
+        "nuclear_generation__twh": "nuclear_generation",
+        "other_renewables_including_bioenergy_generation__twh": "other_renewables_generation",
+        "solar_generation__twh": "solar_generation",
+        "total_generation__twh": "total_generation",
+        "wind_generation__twh": "wind_generation",
+        "total_net_imports__twh": "net_imports",
+    }
+
+    # Select necessary columns from electricity mix dataset.
+    tb_elec = tb_elec[list(elec_columns)].rename(columns=elec_columns)
+
+    # Select UK data from Ember dataset.
+    tb_elec = tb_elec[tb_elec["country"] == "United Kingdom"].reset_index(drop=True)
+
+    return tb_elec
+
+
+def prepare_beis_data(tb_beis: Table) -> Table:
+    """Select (and rename) columns from the UK historical electricity data from BEIS.
+
+    Parameters
+    ----------
+    tb_beis : Table
+        Combined data for UK historical electricity data from BEIS.
+
+    Returns
+    -------
+    tb_beis : Table
+        Selected columns from the UK historical electricity data.
+
+    """
+    tb_beis = tb_beis.copy()
+
+    # Select columns and rename them conveniently.
+    beis_columns = {
+        "country": "country",
+        "year": "year",
+        "coal": "coal_generation",
+        "oil": "oil_generation",
+        "electricity_generation": "total_generation",
+        "gas": "gas_generation",
+        "hydro": "hydro_generation",
+        "nuclear": "nuclear_generation",
+        "net_imports": "net_imports",
+        "implied_efficiency": "implied_efficiency",
+        "wind_and_solar": "wind_and_solar_generation",
+    }
+    tb_beis = tb_beis[list(beis_columns)].rename(columns=beis_columns)
+
+    return tb_beis
+
+
+def combine_beis_and_electricity_mix_data(tb_beis: Table, tb_elec: Table) -> Table:
+    """Combine BEIS data on UK historical electricity with the electricity mix data (after having selected rows for only
+    the UK).
+
+    There are different processing steps done to the data, see comments below in the code.
+
+    Parameters
+    ----------
+    tb_beis : Table
+        Selected data from BEIS on UK historical electricity.
+    tb_elec : Table
+        Selected data from the electricity mix (after having selected rows for the UK).
+
+    Returns
+    -------
+    tb_combined : Table
+        Combined and processed data with a verified index.
+
+    """
+    # In the BEIS dataset, wind and solar are given as one joined variable.
+    # Check if we can ignore it (since it's better to have the two sources separately).
+    # Find the earliest year informed in the electricity mix for solar or wind generation.
+    solar_or_wind_first_year = tb_elec[tb_elec["wind_generation"].notnull() | tb_elec["solar_generation"].notnull()][
+        "year"
+    ].min()
+    # Now check that, prior to that year, all generation from solar and wind was zero.
+    assert tb_beis[tb_beis["year"] < solar_or_wind_first_year]["wind_and_solar_generation"].fillna(0).max() == 0
+    # Therefore, since wind and solar is always zero (prior to the beginning of the electricity mix data)
+    # we can ignore this column from the BEIS dataset.
+    tb_beis = tb_beis.drop(columns=["wind_and_solar_generation"])
+    # And create two columns of zeros for wind and solar.
+    tb_beis["solar_generation"] = 0
+    tb_beis["wind_generation"] = 0
+    # Similarly, given that in the BEIS dataset there is no data about other renewable sources (apart from hydro, solar
+    # and wind), we can assume that the contribution from other renewables is zero.
+    tb_beis["other_renewables_generation"] = 0
+    # And ensure these new columns do not have any values after the electricity mix data begins.
+    tb_beis.loc[
+        tb_beis["year"] >= solar_or_wind_first_year,
+        ["solar_generation", "wind_generation", "other_renewables_generation"],
+    ] = np.nan
+
+    # BEIS data on fuel input gives raw energy, but we want electricity generation (which is less, given the
+    # inefficiencies of the process of burning fossil fuels).
+    # They also include a variable on "implied efficiency", which they obtain by dividing the input energy by the total
+    # electricity generation.
+    # We multiply the raw energy by the efficiency to have an estimate of the electricity generated by each fossil fuel.
+    # This only affects data prior to the beginning of the electricity mix's data (which is 1965 for renewables and
+    # nuclear, and 1985 for the rest).
+    for source in ["coal", "oil", "gas"]:
+        tb_beis[f"{source}_generation"] *= tb_beis["implied_efficiency"]
+
+    # Drop other unnecessary columns.
+    tb_beis = tb_beis.drop(columns=["implied_efficiency"])
+
+    # Combine BEIS and electricity mix data.
+    tb_combined = dataframes.combine_two_overlapping_dataframes(
+        df1=tb_elec, df2=tb_beis, index_columns=["country", "year"]
+    )
+
+    # Add an index and sort conveniently.
+    tb_combined = tb_combined.set_index(["country", "year"]).sort_index().sort_index(axis=1)
+
+    return tb_combined
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load data.
+    #
+    # Load BEIS dataset and read its main table.
+    ds_beis: Dataset = paths.load_dependency("uk_historical_electricity")
+    tb_beis = ds_beis["uk_historical_electricity"].reset_index()
+
+    # Load electricity mix dataset and read its main table.
+    ds_elec: Dataset = paths.load_dependency("electricity_mix")
+    tb_elec = ds_elec["electricity_mix"].reset_index()
+
+    #
+    # Process data.
+    #
+    # Prepare electricity mix data.
+    tb_elec = prepare_electricity_mix_data(tb_elec=tb_elec)
+
+    # Prepare BEIS data.
+    tb_beis = prepare_beis_data(tb_beis=tb_beis)
+
+    # Combine BEIS and electricity mix data.
+    tb_combined = combine_beis_and_electricity_mix_data(tb_beis=tb_beis, tb_elec=tb_elec)
+
+    # Update combined table name.
+    tb_combined.metadata.short_name = paths.short_name
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset.
+    ds_garden = create_dataset_with_combined_metadata(dest_dir, datasets=[ds_beis, ds_elec], tables=[tb_combined])
+    ds_garden.save()

--- a/etl/steps/data/grapher/energy/2023-06-01/uk_historical_electricity.py
+++ b/etl/steps/data/grapher/energy/2023-06-01/uk_historical_electricity.py
@@ -1,0 +1,32 @@
+"""Grapher step for the UK historical electricity dataset.
+"""
+from copy import deepcopy
+
+from owid.catalog import Dataset
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load data.
+    #
+    # Load garden dataset and read its main table.
+    ds_garden: Dataset = paths.load_dependency("uk_historical_electricity")
+    tb_garden = ds_garden["uk_historical_electricity"]
+
+    # Create variable filling missing values with zeros (to allow visualization of stacked area charts in grapher).
+    for column in tb_garden.columns:
+        new_column = f"{column}_zero_filled"
+        tb_garden[new_column] = tb_garden[column].fillna(0)
+        tb_garden[new_column].metadata = deepcopy(tb_garden[column].metadata)
+        tb_garden[new_column].metadata.title = tb_garden[column].metadata.title + " (zero filled)"
+
+    #
+    # Save outputs.
+    #
+    ds_grapher = create_dataset(dest_dir=dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
+    ds_grapher.save()


### PR DESCRIPTION
Created new garden and grapher steps for the long-run UK electricity dataset (with only minor changes with respect to the previous version), and archived unnecessary steps.
NOTE: I changed one of the dependencies of the country profiles dataset, but the data should not be affected.