### PR TITLE
Add new variables for World Inequality Database

### DIFF
--- a/etl/steps/data/garden/wid/2023-01-27/shared.py
+++ b/etl/steps/data/garden/wid/2023-01-27/shared.py
@@ -190,7 +190,12 @@ pct_dict = {
         "decile10_extra": "Top 0.001%",
     },
     "p0p50": {"decile10": "Bottom 50%", "decile9": "Bottom 50%", "thr_number": "", "decile10_extra": "Bottom 50%"},
-    "p90p99": {"decile10": "9th decile - top 99%", "decile9": "", "thr_number": "", "decile10_extra": "People between the 9oth and 99th percentiles"},
+    "p90p99": {
+        "decile10": "9th decile - top 99%",
+        "decile9": "",
+        "thr_number": "",
+        "decile10_extra": "People between the 9oth and 99th percentiles",
+    },
 }
 
 

--- a/etl/steps/data/garden/wid/2023-01-27/shared.py
+++ b/etl/steps/data/garden/wid/2023-01-27/shared.py
@@ -190,6 +190,7 @@ pct_dict = {
         "decile10_extra": "Top 0.001%",
     },
     "p0p50": {"decile10": "Bottom 50%", "decile9": "Bottom 50%", "thr_number": "", "decile10_extra": "Bottom 50%"},
+    "p90p99": {"decile10": "9th decile - top 99%", "decile9": "", "thr_number": "", "decile10_extra": "People between the 9oth and 99th percentiles"},
 }
 
 

--- a/etl/steps/data/garden/wid/2023-01-27/shared.py
+++ b/etl/steps/data/garden/wid/2023-01-27/shared.py
@@ -191,10 +191,10 @@ pct_dict = {
     },
     "p0p50": {"decile10": "Bottom 50%", "decile9": "Bottom 50%", "thr_number": "", "decile10_extra": "Bottom 50%"},
     "p90p99": {
-        "decile10": "9th decile - top 99%",
+        "decile10": "Between 90th and 99th percentiles%",
         "decile9": "",
         "thr_number": "",
-        "decile10_extra": "People between the 9oth and 99th percentiles",
+        "decile10_extra": "People between the 90th and 99th percentiles",
     },
 }
 

--- a/etl/steps/data/garden/wid/2023-01-27/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2023-01-27/world_inequality_database.meta.yml
@@ -81,7 +81,7 @@ dataset:
   sources:
     - name: World Inequality Database (WID.world) (2023)
       url: https://wid.world/
-      date_accessed: "2023-03-29"
+      date_accessed: "2023-06-12"
       publication_year: 2023
       published_by: World Inequality Database (WID), https://wid.world
       publisher_source: National income surveys, tax records and national accounts

--- a/snapshots/wid/2023-01-27/wid_indices.do
+++ b/snapshots/wid/2023-01-27/wid_indices.do
@@ -14,7 +14,7 @@ HOW TO EXECUTE:
 
 1. Open this do-file in a local installation of Stata (execution time: ~5-10 minutes)
 2. It generates one file, wid_indices_992j.csv, which needs to be imported as a snapshot in the ETL, as
-	python snapshots/wid/2023-01-27/world_inequality_database.py --path-to-file wid_indices_992j.csv
+	python snapshots/wid/2023-01-27/world_inequality_database.py --path-to-file snapshots/wid/2023-01-27/wid_indices_992j.csv
 
 	(Change the date for future updates)
 
@@ -103,6 +103,7 @@ drop p0p100_thr*
 local var_names pretax posttax_nat posttax_dis wealth
 
 *Calculate ratios for each variable + create a duplicate variable for median
+* Also, generate a variable for the share between p90 and p99 and recalculate p50p90_share, because their components are more available.
 foreach var in `var_names' {
 
 	gen palma_ratio_`var' = p90p100_share_`var' / (p0p50_share_`var' - p40p50_share_`var')
@@ -112,8 +113,12 @@ foreach var in `var_names' {
 	gen p90_p10_ratio_`var' = p90p100_thr_`var' / p10p20_thr_`var'
 	gen p90_p50_ratio_`var' = p90p100_thr_`var' / p50p60_thr_`var'
 	gen p50_p10_ratio_`var' = p50p60_thr_`var' / p10p20_thr_`var'
-	
+
 	gen median_`var' = p50p60_thr_`var'
+
+	gen p90p99_share_`var' = p90p100_share_`var' - p99p100_share_`var'
+
+	replace p50p90_share_`var' = p50p60_share_`var' + p60p70_share_`var' + p70p80_share_`var' + p80p90_share_`var'
 
 }
 

--- a/snapshots/wid/2023-01-27/world_inequality_database.csv.dvc
+++ b/snapshots/wid/2023-01-27/world_inequality_database.csv.dvc
@@ -11,7 +11,7 @@ meta:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-03-29
+  date_accessed: 2023-06-12
   is_public: true
   description: |
     The World Inequality Database (WID) is an extensive database on the distribution of income and wealth, both between and within countries. It is primarily maintained by the World Inequality Lab (WIL), located at the Paris School of Economics (PSE). But it is fundamentally the result of a coordinated, collaborative effort involving hundreds of researchers throughout the world over the past twenty years.
@@ -83,6 +83,6 @@ meta:
     More information is available at https://wid.world/methodology/
 wdir: ../../../data/snapshots/wid/2023-01-27
 outs:
-- md5: 8d10049a8b3c5180729f755376a365e9
-  size: 10221168
+- md5: d0fa7c81ec3bd788e577fdd70a4115e0
+  size: 10406082
   path: world_inequality_database.csv


### PR DESCRIPTION
Minor edit: Include the income share between the 90th and 99th percentiles (to construct stacked area charts) and recalculate the share of the middle 40% (because their components have a wider time rage than the variable p50p90 for share).

This is for charts in the all charts block of the new [inequality topic page](https://github.com/owid/owid-issues/issues/784). 