### PR TITLE
:tada: upload data to R2 instead of S3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,9 @@ DB_PASS=grapher
 DB_PORT=3307
 DB_HOST=127.0.0.1
 
+R2_ACCESS_KEY=xxx
+R2_SECRET_KEY=xxx
+R2_ENDPOINT_URL=https://078fcdfed9955087315dd86792e71a7e.r2.cloudflarestorage.com
+
 # optional
 # BUGSNAG_API_KEY

--- a/backport/datasync/datasync.py
+++ b/backport/datasync/datasync.py
@@ -170,8 +170,8 @@ def _sync_variable_data_metadata(engine: Engine, variable_id: int, dry_run: bool
 
         if not dry_run:
             # upload data and metadata to S3
-            data_path = upload_gzip_dict(var_data, variable.s3_data_path(), private)
-            metadata_path = upload_gzip_dict(var_metadata, variable.s3_metadata_path(), private)
+            data_path = upload_gzip_dict(var_data, variable.s3_data_path(), private, r2=True)
+            metadata_path = upload_gzip_dict(var_metadata, variable.s3_metadata_path(), private, r2=True)
 
             # update dataPath and metadataPath of a variable if different
             if variable.dataPath != data_path or variable.metadataPath != metadata_path:
@@ -183,13 +183,19 @@ def _sync_variable_data_metadata(engine: Engine, variable_id: int, dry_run: bool
     log.info("datasync.upload", t=f"{time.time() - t:.2f}s", variable_id=variable_id)
 
 
-def upload_gzip_dict(d: Dict[str, Any], s3_path: str, private: bool = False) -> str:
+def upload_gzip_dict(d: Dict[str, Any], s3_path: str, private: bool = False, r2: bool = False) -> str:
     """Upload compressed dictionary to S3 and return its URL."""
     body_gzip = gzip.compress(json.dumps(d, default=str).encode())  # type: ignore
 
     bucket, key = s3_utils.s3_bucket_key(s3_path)
 
-    client = connect_s3_cached()
+    client = connect_s3_cached(r2=r2)
+
+    if r2:
+        assert not private, "r2 does not support private files yet"
+        extra_args = {}
+    else:
+        extra_args = {"ACL": "private" if private else "public-read"}
 
     for attempt in Retrying(
         wait=wait_exponential(min=5, max=100),
@@ -203,14 +209,20 @@ def upload_gzip_dict(d: Dict[str, Any], s3_path: str, private: bool = False) -> 
                 Key=key,
                 ContentEncoding="gzip",
                 ContentType="application/json",
-                ACL="private" if private else "public-read",
+                **extra_args,
             )
 
     # bucket owid-catalog is behind Cloudflare
     if bucket == "owid-catalog":
         return f"https://catalog.ourworldindata.org/{key}"
-    else:
+    elif bucket == "owid-api":
+        return f"https://api.ourworldindata.org/{key}"
+    elif bucket == "owid-api-staging":
+        return f"https://api-staging.owid.io/{key}"
+    elif not r2:
         return f"https://{bucket}.nyc3.digitaloceanspaces.com/{key}"
+    else:
+        raise NotImplementedError()
 
 
 @dataclass_json

--- a/etl/config.py
+++ b/etl/config.py
@@ -30,6 +30,12 @@ S3_HOST = "nyc3.digitaloceanspaces.com"
 S3_ACCESS_KEY = env.get("OWID_ACCESS_KEY")
 S3_SECRET_KEY = env.get("OWID_SECRET_KEY")
 
+# publishing to R2 public data catalog
+R2_REGION_NAME = "auto"
+R2_ENDPOINT_URL = env.get("R2_ENDPOINT_URL")
+R2_ACCESS_KEY = env.get("R2_ACCESS_KEY")
+R2_SECRET_KEY = env.get("R2_SECRET_KEY")
+
 # publishing to grapher's MySQL db
 GRAPHER_USER_ID = env.get("GRAPHER_USER_ID")
 DB_NAME = env.get("DB_NAME", "grapher")
@@ -43,14 +49,12 @@ def get_username():
     return pwd.getpwuid(os.getuid())[0]
 
 
-# if running against live or staging, use s3://owid-catalog that has CDN
-# otherwise use s3://owid-test/baked-variables/<username> for local development
-# it might be better to save things locally instead of S3, but that would require
-# a lot of changes to the codebase (and even grapher one)
-if DB_NAME in ("live_grapher", "staging_grapher"):
-    DEFAULT_BAKED_VARIABLES_PATH = f"s3://owid-catalog/baked-variables/{DB_NAME}"
+# if running against live, use s3://owid-api, otherwise use s3://owid-api-staging
+# Cloudflare workers running on https://api.ourworldindata.org/ and https://api-staging.owid.io/ will use them
+if DB_NAME == "live_grapher":
+    DEFAULT_BAKED_VARIABLES_PATH = "s3://owid-api/v1/indicators"
 else:
-    DEFAULT_BAKED_VARIABLES_PATH = f"s3://owid-test/baked-variables/{get_username()}"
+    DEFAULT_BAKED_VARIABLES_PATH = f"s3://owid-api-staging/{get_username()}/v1/indicators"
 BAKED_VARIABLES_PATH = env.get("BAKED_VARIABLES_PATH", DEFAULT_BAKED_VARIABLES_PATH)
 
 # run ETL steps with debugger on exception

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -247,7 +247,7 @@ def upsert_table(
 
         # process and upload data to S3
         var_data = variable_data(df)
-        data_path = upload_gzip_dict(var_data, variable.s3_data_path())
+        data_path = upload_gzip_dict(var_data, variable.s3_data_path(), r2=True)
 
         # we need to commit changes because we use SQL command in `variable_metadata`. We wouldn't
         # have to if we used ORM instead
@@ -256,7 +256,7 @@ def upsert_table(
 
         # process and upload metadata to S3
         var_metadata = variable_metadata(engine, variable_id, df)
-        metadata_path = upload_gzip_dict(var_metadata, variable.s3_metadata_path())
+        metadata_path = upload_gzip_dict(var_metadata, variable.s3_metadata_path(), r2=True)
 
         variable.dataPath = data_path
         variable.metadataPath = metadata_path

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -868,13 +868,13 @@ class Variable(SQLModel, table=True):
 
     def s3_data_path(self) -> str:
         """Path to S3 with data in JSON format for Grapher. Typically
-        s3://owid-catalog/baked-variables/live_grapher/data/123.json."""
-        return f"{config.BAKED_VARIABLES_PATH}/data/{self.id}.json"
+        s3://owid-api/v1/indicators/123.data.json."""
+        return f"{config.BAKED_VARIABLES_PATH}/{self.id}.data.json"
 
     def s3_metadata_path(self) -> str:
         """Path to S3 with metadata in JSON format for Grapher. Typically
-        s3://owid-catalog/baked-variables/live_grapher/metadata/123.json."""
-        return f"{config.BAKED_VARIABLES_PATH}/metadata/{self.id}.json"
+        s3://owid-api/v1/indicators/123.metadata.json."""
+        return f"{config.BAKED_VARIABLES_PATH}/{self.id}.metadata.json"
 
 
 class ChartDimensions(SQLModel, table=True):


### PR DESCRIPTION
When running --grapher step, upload data to R2 rather than to S3. Note that catalog is still published to S3 (R2 migration is likely planned at some point,  there's [even PR](https://github.com/owid/etl/pull/583) that supports publishing to R2).

After this change, everyone will have to setup extra .env variables
```
R2_ACCESS_KEY=xxx
R2_SECRET_KEY=xxx
R2_ENDPOINT_URL=https://078fcdfed9955087315dd86792e71a7e.r2.cloudflarestorage.com
```
It'd keep working if people still push to S3 because there's a fallback in Cloudflare worker, but the sooner we start pushing to R2 the better.

## Checklist for Data API
* [x] merge [MySQL paths migration](https://github.com/owid/owid-grapher/pull/2315)
* [x] set R2 credentials on `etl-prod-1` and `etl-staging-1` servers
* [ ] inform others to set R2 credentials
* [x] merge this PR
* [ ] reset all checksums in live DB to trigger update with `update datasets set sourceChecksum = 'refresh' where sourceChecksum is not null;` (do it overnight)
* [ ] (manually upsert [datasets](https://github.com/owid/ops/blob/main/templates/etl-prod/etl-prod.sh#L89) that are excluded from automatic deploy)
* [ ] enable backup of R2 buckets