### PR TITLE
✨ underscore: format camelCase fields as snake_case

### DIFF
--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -86,6 +86,7 @@ def create_dataset(
     tables: Iterable[catalog.Table],
     default_metadata: Optional[Union[SnapshotMeta, catalog.DatasetMeta]] = None,
     underscore_table: bool = True,
+    camel_to_snake: bool = False,
     formats: List[FileFormat] = DEFAULT_FORMATS,
 ) -> catalog.Dataset:
     """Create a dataset and add a list of tables. The dataset metadata is inferred from
@@ -100,6 +101,7 @@ def create_dataset(
     :param tables: A list of tables to add to the dataset.
     :param default_metadata: The default metadata to use for the dataset, could be either SnapshotMeta or DatasetMeta.
     :param underscore_table: Whether to underscore the table name before adding it to the dataset.
+    :param camel_to_snake: Whether to convert camel case to snake case for the table name.
 
     Usage:
         ds = create_dataset(dest_dir, [table_a, table_b], default_metadata=snap.metadata)
@@ -115,7 +117,7 @@ def create_dataset(
     # add tables to dataset
     for table in tables:
         if underscore_table:
-            table = catalog.utils.underscore_table(table)
+            table = catalog.utils.underscore_table(table, camel_to_snake=camel_to_snake)
         ds.add(table, formats=formats)
 
     # set metadata from dest_dir

--- a/lib/catalog/owid/catalog/utils.py
+++ b/lib/catalog/owid/catalog/utils.py
@@ -19,15 +19,33 @@ def underscore(name: None, validate: bool = True) -> None:
     ...
 
 
-def underscore(name: Optional[str], validate: bool = True) -> Optional[str]:
+def underscore(name: Optional[str], validate: bool = True, camel_to_snake: bool = False) -> Optional[str]:
     """Convert arbitrary string to under_score. This was fine tuned on WDI bank column names.
     This function might evolve in the future, so make sure to have your use cases in tests
     or rather underscore your columns yourself.
+
+    Parameters
+    ----------
+    name : str
+        String to format.
+    validate: bool, optional
+        Whether to validate that the string is under_score. Defaults to True.
+    camel_to_snake: bool, optional
+        Whether to convert camelCase to snake_case. Defaults to False.
+
+    Returns
+    -------
+    str:
+        String using snake_case formatting.
     """
     if name is None:
         return None
 
     orig_name = name
+
+    # camelCase to snake_case
+    if camel_to_snake:
+        name = _camel_to_snake(name)
 
     name = (
         name.replace(" ", "_")
@@ -97,6 +115,28 @@ def underscore(name: Optional[str], validate: bool = True) -> Optional[str]:
         validate_underscore(name, f"`{orig_name}`")
 
     return name
+
+def _camel_to_snake(name: str) -> str:
+    """Convert string camelCase to snake_case.
+
+    Reference: https://stackoverflow.com/a/1176023/5056599 CC BY-SA 4.0
+
+    Example:
+    >>> _camel_to_snake('camelCase')
+    'camel_case'
+
+    Parameters
+    ----------
+    name : str
+        String using camelCase formatting.
+
+    Returns
+    -------
+    str:
+        String using snake_case formatting.
+    """
+    name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
+    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
 
 
 def _resolve_collisions(

--- a/lib/catalog/owid/catalog/utils.py
+++ b/lib/catalog/owid/catalog/utils.py
@@ -170,14 +170,27 @@ def underscore_table(
     t: Table,
     collision: Literal["raise", "rename", "ignore"] = "raise",
     inplace: bool = False,
+    camel_to_snake: bool = False,
 ) -> Table:
     """Convert column and index names to underscore. In extremely rare cases
     two columns might have the same underscored version. Use `collision` param
-    to control whether to raise an error or append numbered suffix."""
+    to control whether to raise an error or append numbered suffix.
+
+    Parameters
+    ----------
+    t : Table
+        Table to underscore.
+    collision : Literal["raise", "rename", "ignore"], optional
+        How to handle collisions, by default "raise".
+    inplace : bool, optional
+        Whether to modify the table in place, by default False.
+    camel_to_snake : bool, optional
+        Whether to convert strings camelCase to snake_case, by default False.
+    """
     orig_cols = t.columns
 
     # underscore columns and resolve collisions
-    new_cols = pd.Index([underscore(c) for c in t.columns])
+    new_cols = pd.Index([underscore(c, camel_to_snake=camel_to_snake) for c in t.columns])
     new_cols = _resolve_collisions(orig_cols, new_cols, collision)
 
     columns_map = {c_old: c_new for c_old, c_new in zip(orig_cols, new_cols)}
@@ -186,9 +199,9 @@ def underscore_table(
     else:
         t = t.rename(columns=columns_map)
 
-    t.index.names = [underscore(e) for e in t.index.names]
+    t.index.names = [underscore(e, camel_to_snake=camel_to_snake) for e in t.index.names]
     t.metadata.primary_key = t.primary_key
-    t.metadata.short_name = underscore(t.metadata.short_name)
+    t.metadata.short_name = underscore(t.metadata.short_name, camel_to_snake=camel_to_snake)
 
     # put original names as titles into metadata by default
     for c_old, c_new in columns_map.items():

--- a/lib/catalog/owid/catalog/utils.py
+++ b/lib/catalog/owid/catalog/utils.py
@@ -10,12 +10,12 @@ from .variables import Variable
 
 
 @overload
-def underscore(name: str, validate: bool = True) -> str:
+def underscore(name: str, validate: bool = True, camel_to_snake: bool = False) -> str:
     ...
 
 
 @overload
-def underscore(name: None, validate: bool = True) -> None:
+def underscore(name: None, validate: bool = True, camel_to_snake: bool = False) -> None:
     ...
 
 

--- a/lib/catalog/owid/catalog/utils.py
+++ b/lib/catalog/owid/catalog/utils.py
@@ -116,6 +116,7 @@ def underscore(name: Optional[str], validate: bool = True, camel_to_snake: bool 
 
     return name
 
+
 def _camel_to_snake(name: str) -> str:
     """Convert string camelCase to snake_case.
 
@@ -135,8 +136,8 @@ def _camel_to_snake(name: str) -> str:
     str:
         String using snake_case formatting.
     """
-    name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', name).lower()
+    name = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", name).lower()
 
 
 def _resolve_collisions(

--- a/lib/catalog/tests/test_utils.py
+++ b/lib/catalog/tests/test_utils.py
@@ -1,6 +1,5 @@
 import pandas as pd
 import pytest
-
 from owid.catalog import Table
 from owid.catalog.utils import underscore, underscore_table
 
@@ -84,7 +83,7 @@ def test_underscore():
     )
 
     # camelCase to snake_case
-    assert underscore("camelCase") == "camelCase"
+    assert underscore("camelCase") == "camelcase"
     assert underscore("camelcase", camel_to_snake=True) == "camelcase"
     assert underscore("camelCase", camel_to_snake=True) == "camel_case"
     assert underscore("CamelCase", camel_to_snake=True) == "camel_case"

--- a/lib/catalog/tests/test_utils.py
+++ b/lib/catalog/tests/test_utils.py
@@ -83,6 +83,14 @@ def test_underscore():
         == "cost_of_basic_needs_approach__share_of_population_below_poverty_line"
     )
 
+    # camelCase to snake_case
+    assert (underscore("camelCase") == "camelCase")
+    assert (underscore("camelcase", camel_to_snake=True) == "camelcase")
+    assert (underscore("camelCase", camel_to_snake=True) == "camel_case")
+    assert (underscore("CamelCase", camel_to_snake=True) == "camel_case")
+    assert (underscore("CAMELCase", camel_to_snake=True) == "camel_case")
+    assert (underscore("camelCase1", camel_to_snake=True) == "camel_case1")
+    assert (underscore("camelCase_1", camel_to_snake=True) == "camel_case_1")
 
 def test_underscore_table():
     df = pd.DataFrame({"A": [1, 2, 3]})

--- a/lib/catalog/tests/test_utils.py
+++ b/lib/catalog/tests/test_utils.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+
 from owid.catalog import Table
 from owid.catalog.utils import underscore, underscore_table
 

--- a/lib/catalog/tests/test_utils.py
+++ b/lib/catalog/tests/test_utils.py
@@ -84,13 +84,14 @@ def test_underscore():
     )
 
     # camelCase to snake_case
-    assert (underscore("camelCase") == "camelCase")
-    assert (underscore("camelcase", camel_to_snake=True) == "camelcase")
-    assert (underscore("camelCase", camel_to_snake=True) == "camel_case")
-    assert (underscore("CamelCase", camel_to_snake=True) == "camel_case")
-    assert (underscore("CAMELCase", camel_to_snake=True) == "camel_case")
-    assert (underscore("camelCase1", camel_to_snake=True) == "camel_case1")
-    assert (underscore("camelCase_1", camel_to_snake=True) == "camel_case_1")
+    assert underscore("camelCase") == "camelCase"
+    assert underscore("camelcase", camel_to_snake=True) == "camelcase"
+    assert underscore("camelCase", camel_to_snake=True) == "camel_case"
+    assert underscore("CamelCase", camel_to_snake=True) == "camel_case"
+    assert underscore("CAMELCase", camel_to_snake=True) == "camel_case"
+    assert underscore("camelCase1", camel_to_snake=True) == "camel_case1"
+    assert underscore("camelCase_1", camel_to_snake=True) == "camel_case_1"
+
 
 def test_underscore_table():
     df = pd.DataFrame({"A": [1, 2, 3]})


### PR DESCRIPTION
It is often the case that the source codes their fields using `camelCase`. In such instances, we want to preserve the token separation with a `_` instead of a "lower- to upper-case" change.

An example:

- Currently: `numberOfParticipants` → `numberofparticipants`
- New: `numberOfParticipants` → `number_of_participants`

To this end, I've slightly modified our function `underscore` to perform camelCase to snake_case formatting. This is only triggered if the argument `camel_to_snake` is True. By default, this argument is set to False so we don't break any of the pipelines (i.e. some metadata files might expect the older formatting).