### PR TITLE
:honeybee: Reduce import overhead of etl.helpers

### DIFF
--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -27,20 +27,10 @@ from owid import catalog
 from owid.walden import CATALOG as WALDEN_CATALOG
 from owid.walden import Dataset as WaldenDataset
 
-from etl import backport_helpers, config, files, git
+from etl import config, files, git
 from etl import grapher_helpers as gh
 from etl import paths
 from etl.db import get_engine
-from etl.grapher_import import (
-    DatasetUpsertResult,
-    VariableUpsertResult,
-    cleanup_ghost_sources,
-    cleanup_ghost_variables,
-    fetch_db_checksum,
-    set_dataset_checksum_and_editedAt,
-    upsert_dataset,
-    upsert_table,
-)
 from etl.snapshot import _unignore_backports
 
 log = structlog.get_logger()
@@ -653,14 +643,18 @@ class GrapherStep(Step):
         return self.data_step._output_dataset
 
     def is_dirty(self) -> bool:
+        import etl.grapher_import as gi
+
         if self.data_step.is_dirty():
             return True
 
         # dataset exists, but it is possible that we haven't inserted everything into DB
         dataset = self.dataset
-        return fetch_db_checksum(dataset) != self.data_step.checksum_input()
+        return gi.fetch_db_checksum(dataset) != self.data_step.checksum_input()
 
     def run(self) -> None:
+        import etl.grapher_import as gi
+
         # save dataset to grapher DB
         dataset = self.dataset
 
@@ -669,7 +663,7 @@ class GrapherStep(Step):
         engine = get_engine()
 
         assert dataset.metadata.namespace
-        dataset_upsert_results = upsert_dataset(
+        dataset_upsert_results = gi.upsert_dataset(
             engine,
             dataset,
             dataset.metadata.namespace,
@@ -688,7 +682,7 @@ class GrapherStep(Step):
 
             # generate table with entity_id, year and value for every column
             tables = gh._yield_wide_table(table, na_action="drop")
-            upsert = lambda t: upsert_table(  # noqa: E731
+            upsert = lambda t: gi.upsert_table(  # noqa: E731
                 engine,
                 t,
                 dataset_upsert_results,
@@ -709,32 +703,36 @@ class GrapherStep(Step):
         self._cleanup_ghost_resources(dataset_upsert_results, variable_upsert_results)
 
         # set checksum and updatedAt timestamps after all data got inserted
-        set_dataset_checksum_and_editedAt(dataset_upsert_results.dataset_id, self.data_step.checksum_input())
+        gi.set_dataset_checksum_and_editedAt(dataset_upsert_results.dataset_id, self.data_step.checksum_input())
 
     def checksum_output(self) -> str:
         raise NotImplementedError("GrapherStep should not be used as an input")
 
     @classmethod
     def _cleanup_ghost_resources(
-        cls, dataset_upsert_results: DatasetUpsertResult, variable_upsert_results: List[VariableUpsertResult]
+        cls,
+        dataset_upsert_results,
+        variable_upsert_results: List[Any],
     ) -> None:
         """
         Cleanup all ghost variables and sources that weren't upserted
         NOTE: we can't just remove all dataset variables before starting this step because
         there could be charts that use them and we can't remove and recreate with a new ID
         """
+        import etl.grapher_import as gi
+
         upserted_variable_ids = [r.variable_id for r in variable_upsert_results]
         upserted_source_ids = list(dataset_upsert_results.source_ids.values()) + [
             r.source_id for r in variable_upsert_results
         ]
         # Try to cleanup ghost variables, but make sure to raise an error if they are used
         # in any chart
-        cleanup_ghost_variables(
+        gi.cleanup_ghost_variables(
             dataset_upsert_results.dataset_id,
             upserted_variable_ids,
             workers=config.GRAPHER_INSERT_WORKERS,
         )
-        cleanup_ghost_sources(dataset_upsert_results.dataset_id, upserted_source_ids)
+        gi.cleanup_ghost_sources(dataset_upsert_results.dataset_id, upserted_source_ids)
 
 
 @dataclass
@@ -804,6 +802,8 @@ class BackportStep(DataStep):
         return f"backport://{self.path}"
 
     def run(self) -> None:
+        from etl import backport_helpers
+
         # make sure the enclosing folder is there
         self._dest_dir.parent.mkdir(parents=True, exist_ok=True)
 

--- a/lib/catalog/owid/catalog/s3_utils.py
+++ b/lib/catalog/owid/catalog/s3_utils.py
@@ -8,7 +8,6 @@ from os import path
 from typing import Any, Tuple
 from urllib.parse import urlparse
 
-import boto3
 from botocore.exceptions import ClientError
 
 SPACES_ENDPOINT = "https://nyc3.digitaloceanspaces.com"
@@ -72,6 +71,8 @@ def download(s3_url: str, filename: str, quiet: bool = False) -> None:
 
 def connect() -> Any:
     "Return a connection to Walden's DigitalOcean space."
+    import boto3
+
     check_for_default_profile()
 
     session = boto3.Session(profile_name=AWS_PROFILE)

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -13,7 +13,6 @@ from typing import Any, Dict, List, Literal, Optional, Union, cast, overload
 import pandas as pd
 import pyarrow
 import pyarrow.parquet as pq
-import requests
 import structlog
 import yaml
 from owid.repack import repack_frame
@@ -322,6 +321,8 @@ class Table(pd.DataFrame):
 
     @staticmethod
     def _read_metadata(data_path: str) -> Dict[str, Any]:
+        import requests
+
         metadata_path = splitext(data_path)[0] + ".meta.json"
 
         if metadata_path.startswith("http"):

--- a/lib/datautils/owid/datautils/dataframes.py
+++ b/lib/datautils/owid/datautils/dataframes.py
@@ -5,10 +5,9 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
 import pandas as pd
-from pandas.api.types import union_categoricals
-from owid.datautils.io.df import to_file as to_file_
-
 from owid.datautils.common import ExceptionFromDocstring, warn_on_list_of_entities
+from owid.datautils.io.df import to_file as to_file_
+from pandas.api.types import union_categoricals
 
 
 # Backwards compatibility

--- a/lib/datautils/owid/datautils/decorators.py
+++ b/lib/datautils/owid/datautils/decorators.py
@@ -2,10 +2,11 @@
 
 
 import functools
-from owid.datautils.web import download_file_from_url
-from owid.datautils.s3 import S3
 import tempfile
-from typing import Callable, Any, Optional
+from typing import Any, Callable, Optional
+
+from owid.datautils.s3 import S3
+from owid.datautils.web import download_file_from_url
 
 
 def enable_file_download(path_arg_name: Optional[str] = None) -> Callable[[Any], Any]:

--- a/lib/datautils/owid/datautils/format/__init__.py
+++ b/lib/datautils/owid/datautils/format/__init__.py
@@ -1,7 +1,6 @@
 """Utils for the processing of different data formats."""
 from owid.datautils.format.numbers import format_number
 
-
 __all__ = [
     "format_number",
 ]

--- a/lib/datautils/owid/datautils/format/numbers.py
+++ b/lib/datautils/owid/datautils/format/numbers.py
@@ -1,6 +1,6 @@
 """Numeric formatting."""
 import re
-from typing import Union, Any, Dict, Set
+from typing import Any, Dict, Set, Union
 
 
 class IntegerNumber:

--- a/lib/datautils/owid/datautils/google/__init__.py
+++ b/lib/datautils/owid/datautils/google/__init__.py
@@ -1,7 +1,6 @@
 """Google utils."""
 from owid.datautils.google.api import GoogleApi
 
-
 __all__ = [
     "GoogleApi",
 ]

--- a/lib/datautils/owid/datautils/google/api.py
+++ b/lib/datautils/owid/datautils/google/api.py
@@ -2,10 +2,6 @@
 from typing import Any, Optional
 
 import gdown
-from pydrive2.auth import GoogleAuth
-from pydrive2.drive import GoogleDrive
-from pydrive2.files import GoogleDriveFileList
-
 from owid.datautils.google.config import (
     CLIENT_SECRETS_PATH,
     CREDENTIALS_PATH,
@@ -14,6 +10,9 @@ from owid.datautils.google.config import (
     is_google_config_init,
 )
 from owid.datautils.google.sheets import GSheetsApi
+from pydrive2.auth import GoogleAuth
+from pydrive2.drive import GoogleDrive
+from pydrive2.files import GoogleDriveFileList
 
 
 class GoogleApi:

--- a/lib/datautils/owid/datautils/google/sheets.py
+++ b/lib/datautils/owid/datautils/google/sheets.py
@@ -1,11 +1,11 @@
 """Google Sheet utils."""
 import os
-from typing import Union, Any, Optional
+from typing import Any, Optional, Union
+
+import pandas as pd
 from gsheets import Sheets
 from gsheets.models import SpreadSheet, WorkSheet
-
 from owid.datautils.google.config import CLIENT_SECRETS_PATH, CREDENTIALS_PATH
-import pandas as pd
 
 
 class GSheetsApi:

--- a/lib/datautils/owid/datautils/io/__init__.py
+++ b/lib/datautils/owid/datautils/io/__init__.py
@@ -1,8 +1,8 @@
 """Input/Output methods."""
 from owid.datautils.io.archive import decompress_file
-from owid.datautils.io.df import from_file as df_from_file, to_file as df_to_file
+from owid.datautils.io.df import from_file as df_from_file
+from owid.datautils.io.df import to_file as df_to_file
 from owid.datautils.io.json import load_json, save_json
-
 
 __all__ = [
     "decompress_file",

--- a/lib/datautils/owid/datautils/io/archive.py
+++ b/lib/datautils/owid/datautils/io/archive.py
@@ -1,8 +1,8 @@
 """Input/Output functions for local files."""
 
+import tarfile
 import zipfile
 from pathlib import Path
-import tarfile
 from typing import Union
 
 from owid.datautils.decorators import enable_file_download

--- a/lib/datautils/owid/datautils/io/df.py
+++ b/lib/datautils/owid/datautils/io/df.py
@@ -1,11 +1,10 @@
 """DataFrame io operations."""
 import inspect
 from pathlib import Path
+from typing import Any, List, Optional, Union
 
 import pandas as pd
 from owid.datautils.decorators import enable_file_download
-from typing import Any, Optional, Union, List
-
 
 COMPRESSION_SUPPORTED = ["gz", "bz2", "zip", "xz", "zst", "tar"]
 

--- a/lib/datautils/owid/datautils/s3.py
+++ b/lib/datautils/owid/datautils/s3.py
@@ -1,17 +1,15 @@
 """S3 utils."""
 
-import os
 import json
+import os
 import tempfile
 from os import path
-from typing import Union, Tuple, Any, List
-from mypy_boto3_s3 import S3Client
+from typing import Any, List, Tuple, Union
+from urllib.parse import urlparse
 
 import pandas as pd
-import boto3
-from urllib.parse import urlparse
-from botocore.exceptions import ClientError
 import structlog
+from botocore.exceptions import ClientError
 
 logger = structlog.get_logger()
 
@@ -30,8 +28,10 @@ class S3:
     def __init__(self, profile_name: str = AWS_PROFILE) -> None:
         self.client = self.connect(profile_name)
 
-    def connect(self, profile_name: str = AWS_PROFILE) -> S3Client:
+    def connect(self, profile_name: str = AWS_PROFILE) -> Any:
         """Return a connection to Walden's DigitalOcean space."""
+        import boto3
+
         check_for_aws_profile(profile_name)
 
         session = boto3.Session(profile_name=profile_name)
@@ -58,9 +58,7 @@ class S3:
             s3_path += "/"
 
         bucket_name, s3_file = s3_path_to_bucket_key(s3_path)
-        objects_request = self.client.list_objects_v2(
-            Bucket=bucket_name, Prefix=s3_file
-        )
+        objects_request = self.client.list_objects_v2(Bucket=bucket_name, Prefix=s3_file)
 
         if objects_request["KeyCount"] == 0:
             return []
@@ -111,9 +109,7 @@ class S3:
         # Upload
         extra_args = {"ACL": "public-read"} if public else {}
         try:
-            self.client.upload_file(
-                local_path, bucket_name, s3_file, ExtraArgs=extra_args
-            )
+            self.client.upload_file(local_path, bucket_name, s3_file, ExtraArgs=extra_args)
         except ClientError as e:
             logger.error(e)
             raise UploadError(e)
@@ -158,9 +154,7 @@ class S3:
 
         return
 
-    def obj_to_s3(
-        self, obj: S3_OBJECT, s3_path: str, public: bool = False, **kwargs: Any
-    ) -> None:
+    def obj_to_s3(self, obj: S3_OBJECT, s3_path: str, public: bool = False, **kwargs: Any) -> None:
         """Upload an object to S3, as a file.
 
         Parameters
@@ -192,13 +186,9 @@ class S3:
                 if s3_path.endswith(".csv") or s3_path.endswith(".zip"):
                     obj.to_csv(output_path, index=False, **kwargs)
                 elif s3_path.endswith(".xls") or s3_path.endswith(".xlsx"):
-                    obj.to_excel(
-                        output_path, index=False, engine="xlsxwriter", **kwargs
-                    )
+                    obj.to_excel(output_path, index=False, engine="xlsxwriter", **kwargs)
                 else:
-                    raise ValueError(
-                        "pd.DataFrame must be exported to either CSV or XLS/XLSX!"
-                    )
+                    raise ValueError("pd.DataFrame must be exported to either CSV or XLS/XLSX!")
             else:
                 raise ValueError(
                     f"Type of `obj` is not supported ({type(obj).__name__}). Supported"
@@ -283,9 +273,7 @@ aws_secret_access_key = ...
     return
 
 
-def obj_to_s3(
-    data: S3_OBJECT, s3_path: str, public: bool = False, **kwargs: Any
-) -> None:
+def obj_to_s3(data: S3_OBJECT, s3_path: str, public: bool = False, **kwargs: Any) -> None:
     """See S3.obj_to_s3."""
     s3 = S3()
     return s3.obj_to_s3(data, s3_path, public, **kwargs)

--- a/lib/datautils/owid/datautils/s3.py
+++ b/lib/datautils/owid/datautils/s3.py
@@ -58,7 +58,9 @@ class S3:
             s3_path += "/"
 
         bucket_name, s3_file = s3_path_to_bucket_key(s3_path)
-        objects_request = self.client.list_objects_v2(Bucket=bucket_name, Prefix=s3_file)
+        objects_request = self.client.list_objects_v2(
+            Bucket=bucket_name, Prefix=s3_file
+        )
 
         if objects_request["KeyCount"] == 0:
             return []
@@ -109,7 +111,9 @@ class S3:
         # Upload
         extra_args = {"ACL": "public-read"} if public else {}
         try:
-            self.client.upload_file(local_path, bucket_name, s3_file, ExtraArgs=extra_args)
+            self.client.upload_file(
+                local_path, bucket_name, s3_file, ExtraArgs=extra_args
+            )
         except ClientError as e:
             logger.error(e)
             raise UploadError(e)
@@ -154,7 +158,9 @@ class S3:
 
         return
 
-    def obj_to_s3(self, obj: S3_OBJECT, s3_path: str, public: bool = False, **kwargs: Any) -> None:
+    def obj_to_s3(
+        self, obj: S3_OBJECT, s3_path: str, public: bool = False, **kwargs: Any
+    ) -> None:
         """Upload an object to S3, as a file.
 
         Parameters
@@ -186,9 +192,13 @@ class S3:
                 if s3_path.endswith(".csv") or s3_path.endswith(".zip"):
                     obj.to_csv(output_path, index=False, **kwargs)
                 elif s3_path.endswith(".xls") or s3_path.endswith(".xlsx"):
-                    obj.to_excel(output_path, index=False, engine="xlsxwriter", **kwargs)
+                    obj.to_excel(
+                        output_path, index=False, engine="xlsxwriter", **kwargs
+                    )
                 else:
-                    raise ValueError("pd.DataFrame must be exported to either CSV or XLS/XLSX!")
+                    raise ValueError(
+                        "pd.DataFrame must be exported to either CSV or XLS/XLSX!"
+                    )
             else:
                 raise ValueError(
                     f"Type of `obj` is not supported ({type(obj).__name__}). Supported"
@@ -273,7 +283,9 @@ aws_secret_access_key = ...
     return
 
 
-def obj_to_s3(data: S3_OBJECT, s3_path: str, public: bool = False, **kwargs: Any) -> None:
+def obj_to_s3(
+    data: S3_OBJECT, s3_path: str, public: bool = False, **kwargs: Any
+) -> None:
     """See S3.obj_to_s3."""
     s3 = S3()
     return s3.obj_to_s3(data, s3_path, public, **kwargs)

--- a/lib/walden/owid/walden/owid_cache.py
+++ b/lib/walden/owid/walden/owid_cache.py
@@ -11,9 +11,7 @@ from os import path
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
-import boto3
 from botocore.exceptions import ClientError
-
 from owid.walden.ui import bail, log
 
 from .files import ChecksumDoesNotMatch, checksum
@@ -104,6 +102,8 @@ def download(s3_url: str, filename: str, expected_md5: Optional[str] = None, qui
 
 def connect():
     "Return a connection to Walden's DigitalOcean space."
+    import boto3
+
     check_for_default_profile()
 
     session = boto3.Session(profile_name=AWS_PROFILE)

--- a/lib/walden/owid/walden/owid_cache.py
+++ b/lib/walden/owid/walden/owid_cache.py
@@ -12,6 +12,7 @@ from typing import Optional, Tuple
 from urllib.parse import urlparse
 
 from botocore.exceptions import ClientError
+
 from owid.walden.ui import bail, log
 
 from .files import ChecksumDoesNotMatch, checksum


### PR DESCRIPTION
Reduce by about 40% the import time for `etl.helpers`, which by convention we're importing on all new steps, by lazy loading modules that might not be used.

Changes:

- :honeybee: only lazy dvc and papermill on demand
- :honeybee: lazy load boto3
- :honeybee: lazy load requests and grapher helpers

Benchmark with `time etl data://grapher/fasttrack/ --force --only`:

- 10.2s before the change
- 7.8s with lazy loading (~25% faster)