### PR TITLE
:bug: set latest date_accessed for excess mortality

### DIFF
--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/__init__.py
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/__init__.py
@@ -54,6 +54,22 @@ def run(dest_dir: str) -> None:
     # Update dataset and table metadata using the adjacent yaml file.
     ds_garden.update_metadata(paths.metadata_path)
 
+    # NOTE: ideally we wouldn't define sources in YAML, but inherit them from snapshots
+    # setting date_accessed is a workaround
+    # Get latest date_accessed from all sources and use it for variables and dataset.
+    max_date_accessed = max(
+        ds_hmd.metadata.sources[0].date_accessed,  # type: ignore
+        ds_wmd.metadata.sources[0].date_accessed,  # type: ignore
+        ds_kobak.metadata.sources[0].date_accessed,  # type: ignore
+    )
+    for col in tb_garden.columns:
+        for source in tb_garden[col].metadata.sources:
+            source.date_accessed = max_date_accessed
+
+    # Add date_accessed to dataset metadata.
+    for source in ds_garden.metadata.sources:
+        source.date_accessed = max_date_accessed
+
     # Save changes in the new garden dataset.
     ds_garden.save()
 

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/__init__.py
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/__init__.py
@@ -9,7 +9,7 @@ This step merges the two datasets into one single dataset, combining metrics fro
 from owid.catalog import Dataset, Table
 from structlog import get_logger
 
-from etl.helpers import PathFinder
+from etl.helpers import PathFinder, create_dataset
 
 from .input import build_df
 from .process import process_df
@@ -42,33 +42,17 @@ def run(dest_dir: str) -> None:
     # Create a new table with the processed data.
     tb_garden = Table(df, short_name=paths.short_name)
 
-    #
-    # Save outputs.
-    #
-    # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = Dataset.create_empty(dest_dir)
+    # Create dataset
+    ds_garden = create_dataset(dest_dir, tables=[tb_garden])
 
-    # Add table of processed data to the new dataset.
-    ds_garden.add(tb_garden)
+    # Add all sources from dependencies to dataset
+    ds_garden.metadata.sources = ds_hmd.metadata.sources + ds_wmd.metadata.sources + ds_kobak.metadata.sources
 
-    # Update dataset and table metadata using the adjacent yaml file.
-    ds_garden.update_metadata(paths.metadata_path)
-
-    # NOTE: ideally we wouldn't define sources in YAML, but inherit them from snapshots
-    # setting date_accessed is a workaround
-    # Get latest date_accessed from all sources and use it for variables and dataset.
-    max_date_accessed = max(
-        ds_hmd.metadata.sources[0].date_accessed,  # type: ignore
-        ds_wmd.metadata.sources[0].date_accessed,  # type: ignore
-        ds_kobak.metadata.sources[0].date_accessed,  # type: ignore
-    )
+    # Source in YAML file only have name, load them from dataset.
+    tb_garden = ds_garden[paths.short_name]  # need to reload it to get updated metadata
+    source_by_name = {source.name: source for source in ds_garden.metadata.sources}
     for col in tb_garden.columns:
-        for source in tb_garden[col].metadata.sources:
-            source.date_accessed = max_date_accessed
-
-    # Add date_accessed to dataset metadata.
-    for source in ds_garden.metadata.sources:
-        source.date_accessed = max_date_accessed
+        tb_garden[col].metadata.sources = [source_by_name[source.name] for source in tb_garden[col].metadata.sources]
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml
@@ -1,33 +1,3 @@
-all_sources:
-  - source_hmd: &source-hmd
-      name: Human Mortality Database (2023)
-      published_by:
-        HMD. Human Mortality Database. Max Planck Institute for Demographic
-        Research (Germany), University of California, Berkeley (USA), and French Institute
-        for Demographic Studies (France). Available at www.mortality.org.
-      url: https://www.mortality.org/Data/STMF
-      publication_date: "2023-04-21"
-      publication_year: 2023
-      source_data_url: https://www.mortality.org/File/GetDocument/Public/STMF/Outputs/stmf.csv
-  - source_wmd: &source-wmd
-      name: World Mortality Dataset (2023)
-      published_by:
-        Karlinsky & Kobak 2021, Tracking excess mortality across countries
-        during the COVID-19 pandemic with the World Mortality Dataset, eLife https://doi.org/10.7554/eLife.69336
-      url: https://github.com/akarlinsky/world_mortality/
-      source_data_url: https://raw.githubusercontent.com/akarlinsky/world_mortality/main/world_mortality.csv
-      publication_date: "2021-06-30"
-      publication_year: 2021
-  - source_xm_kk: &source-xm_kk
-      name: World Mortality Dataset (2023)
-      published_by:
-        Karlinsky & Kobak, 2021, Tracking excess mortality across countries
-        during the COVID-19 pandemic with the World Mortality Dataset. eLife 10:e69336.
-        https://elifesciences.org/articles/69336
-      url: https://github.com/dkobak/excess-mortality
-      publication_date: "2021-06-30"
-      publication_year: 2021
-
 all_licenses:
   - license_hmd: &license-hmd
       name: Creative Commons BY 4.0
@@ -40,8 +10,6 @@ all_licenses:
       url: https://github.com/dkobak/excess-mortality/blob/main/LICENSE
 
 dataset:
-  namespace: excess_mortality
-  short_name: excess_mortality
   title: Excess Mortality (various sources)
   description: |-
     All-cause mortality data is from the Human Mortality Database (HMD) Short-term Mortality Fluctuations project and the World Mortality Dataset (WMD). Both sources are updated weekly.
@@ -59,15 +27,10 @@ dataset:
     For a more detailed description of the HMD data, including week date definitions, the coverage (of individuals, locations, and time), whether dates are for death occurrence or registration, the original national source information, and important caveats, see the HMD metadata file at https://www.mortality.org/Public/STMF_DOC/STMFmetadata.pdf.
 
     For a more detailed description of the WMD data, including original source information, see their GitHub page at https://github.com/akarlinsky/world_mortality.
-  version: latest
   licenses:
     - *license-hmd
     - *license-wmd
     - *license-xm_kk
-  sources:
-    - *source-hmd
-    - *source-wmd
-    - *source-xm_kk
 
 tables:
   excess_mortality:
@@ -89,8 +52,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       p_avg_0_14:
         title: p_avg_0_14
         # title: Excess mortality P-scores (5-year average baseline, 0–14)
@@ -107,8 +70,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       p_avg_15_64:
         title: p_avg_15_64
         # title: Excess mortality P-scores (5-year average baseline, 15–64)
@@ -125,8 +88,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       p_avg_65_74:
         title: p_avg_65_74
         # title: Excess mortality P-scores (5-year average baseline, 65–74)
@@ -143,8 +106,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       p_avg_75_84:
         title: p_avg_75_84
         # title: Excess mortality P-scores (5-year average baseline, 75–84)
@@ -161,8 +124,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       p_avg_85p:
         title: p_avg_85p
         # title: Excess mortality P-scores (5-year average baseline, 85+)
@@ -179,8 +142,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
 
       # p_proj_*
       p_proj_all_ages:
@@ -200,9 +163,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       p_proj_0_14:
         title: p_proj_0_14
         # title: Excess mortality P-scores (projected baseline, 0–14)
@@ -220,9 +183,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       p_proj_15_64:
         title: p_proj_15_64
         # title: Excess mortality P-scores (projected baseline, 15–64)
@@ -240,9 +203,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       p_proj_65_74:
         title: p_proj_65_74
         # title: Excess mortality P-scores (projected baseline, 65–74)
@@ -260,9 +223,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       p_proj_75_84:
         title: p_proj_75_84
         # title: Excess mortality P-scores (projected baseline, 75–84)
@@ -280,9 +243,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       p_proj_85p:
         title: p_proj_85p
         # title: Excess mortality P-scores (projected baseline, 85+)
@@ -300,9 +263,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
 
       # deaths_*_all_ages
       deaths_2010_all_ages:
@@ -314,8 +277,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2011_all_ages:
         title: deaths_2011_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
@@ -325,8 +288,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2012_all_ages:
         title: deaths_2012_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
@@ -336,8 +299,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2013_all_ages:
         title: deaths_2013_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
@@ -347,8 +310,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2014_all_ages:
         title: deaths_2014_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
@@ -358,8 +321,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-wmd
-          - *source-hmd
+          - name: World Mortality Dataset (2023)
+          - name: Human Mortality Database (2023)
       deaths_2015_all_ages:
         title: deaths_2015_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
@@ -374,8 +337,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2016_all_ages:
         title: deaths_2016_all_ages
         # title: Number of deaths (weekly or monthly, 2016)
@@ -390,8 +353,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2017_all_ages:
         title: deaths_2017_all_ages
         # title: Number of deaths (weekly or monthly, 2017)
@@ -406,8 +369,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2018_all_ages:
         title: deaths_2018_all_ages
         # title: Number of deaths (weekly or monthly, 2018)
@@ -422,8 +385,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2019_all_ages:
         title: deaths_2019_all_ages
         # title: Number of deaths (weekly or monthly, 2019)
@@ -438,8 +401,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2020_all_ages:
         title: deaths_2020_all_ages
         # title: Number of deaths (weekly or monthly, 2020)
@@ -454,8 +417,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2021_all_ages:
         title: deaths_2021_all_ages
         # title: Number of deaths (weekly or monthly, 2021)
@@ -470,8 +433,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2022_all_ages:
         title: deaths_2022_all_ages
         # title: Number of deaths (weekly or monthly, 2022)
@@ -486,8 +449,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_2023_all_ages:
         title: deaths_2023_all_ages
         # title: Number of deaths (weekly or monthly, 2022)
@@ -502,8 +465,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       deaths_since_2020_all_ages:
         title: deaths_since_2020_all_ages
         # title: Number of deaths (weekly or monthly, 2020–2022)
@@ -518,8 +481,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
 
       # other metrics
       excess_proj_all_ages:
@@ -536,9 +499,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       excess_per_million_proj_all_ages:
         title: excess_per_million_proj_all_ages
         # title: Excess deaths per million people (projected, all ages)
@@ -553,9 +516,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       average_deaths_2015_2019_all_ages:
         title: average_deaths_2015_2019_all_ages
         # title: Average number of deaths (2015–2019, all ages)
@@ -569,8 +532,8 @@ tables:
           - *license-hmd
           - *license-wmd
         sources:
-          - *source-hmd
-          - *source-wmd
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
       projected_deaths_since_2020_all_ages:
         title: projected_deaths_since_2020_all_ages
         # title: Projected number of deaths (2020–2022, all ages)
@@ -585,7 +548,7 @@ tables:
         licenses:
           - *license-xm_kk
         sources:
-          - *source-xm_kk
+          - name: Karlinsky and Kobak (2021)
       cum_excess_proj_all_ages:
         title: cum_excess_proj_all_ages
         # title: Cumulative excess of deaths (projected, all ages)
@@ -601,9 +564,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       cum_proj_deaths_all_ages:
         title: cum_proj_deaths_all_ages
         # title: Cumulative number of deaths (projected, all ages)
@@ -616,7 +579,7 @@ tables:
         licenses:
           - *license-xm_kk
         sources:
-          - *source-xm_kk
+          - name: Karlinsky and Kobak (2021)
       cum_p_proj_all_ages:
         title: cum_p_proj_all_ages
         # title: Cumulative p-score (projected, all ages)
@@ -634,9 +597,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       cum_excess_per_million_proj_all_ages:
         title: cum_excess_per_million_proj_all_ages
         # title: Cumulative excess deaths per million people (projected, all ages)
@@ -652,9 +615,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       # auxiliary columns
       time:
         title: Time
@@ -667,9 +630,9 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)
       time_unit:
         title: Time unit
         unit: ""
@@ -681,6 +644,6 @@ tables:
           - *license-wmd
           - *license-xm_kk
         sources:
-          - *source-hmd
-          - *source-wmd
-          - *source-xm_kk
+          - name: Human Mortality Database (2023)
+          - name: World Mortality Dataset (2023)
+          - name: Karlinsky and Kobak (2021)

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml
@@ -6,7 +6,6 @@ all_sources:
         Research (Germany), University of California, Berkeley (USA), and French Institute
         for Demographic Studies (France). Available at www.mortality.org.
       url: https://www.mortality.org/Data/STMF
-      date_accessed: "2023-04-24"
       publication_date: "2023-04-21"
       publication_year: 2023
       source_data_url: https://www.mortality.org/File/GetDocument/Public/STMF/Outputs/stmf.csv
@@ -17,7 +16,6 @@ all_sources:
         during the COVID-19 pandemic with the World Mortality Dataset, eLife https://doi.org/10.7554/eLife.69336
       url: https://github.com/akarlinsky/world_mortality/
       source_data_url: https://raw.githubusercontent.com/akarlinsky/world_mortality/main/world_mortality.csv
-      date_accessed: "2023-04-24"
       publication_date: "2021-06-30"
       publication_year: 2021
   - source_xm_kk: &source-xm_kk
@@ -27,7 +25,6 @@ all_sources:
         during the COVID-19 pandemic with the World Mortality Dataset. eLife 10:e69336.
         https://elifesciences.org/articles/69336
       url: https://github.com/dkobak/excess-mortality
-      date_accessed: "2023-04-24"
       publication_date: "2021-06-30"
       publication_year: 2021
 

--- a/snapshots/excess_mortality/latest/hmd_stmf.csv.dvc
+++ b/snapshots/excess_mortality/latest/hmd_stmf.csv.dvc
@@ -14,7 +14,7 @@ meta:
     For citing STMF data, please follow the HMD data citation guidelines (https://www.mortality.org/Research/CitationGuidelines).
 
     HMD provides an online STMF visualization toolkit (https://mpidr.shinyapps.io/stmortality).
-  source_name: HMD
+  source_name: Human Mortality Database (2023)
   url: https://www.mortality.org/Data/STMF
   source_published_by: HMD. Human Mortality Database. Max Planck Institute for Demographic
     Research (Germany), University of California, Berkeley (USA), and French Institute

--- a/snapshots/excess_mortality/latest/wmd.csv.dvc
+++ b/snapshots/excess_mortality/latest/wmd.csv.dvc
@@ -14,11 +14,11 @@ meta:
     For the list of sources that they use, please go to https://github.com/akarlinsky/world_mortality/#sou rces.
 
     Published paper available at https://elifesciences.org/articles/69336.
-  source_name: Karlinsky and Kobak (2021)
+  source_name: World Mortality Dataset (2023)
   url: https://github.com/akarlinsky/world_mortality/
   source_published_by: Karlinsky & Kobak 2021, Tracking excess mortality across countries
     during the COVID-19 pandemic with the World Mortality Dataset, eLife https://doi.org/10.7554/eLife.69336
-  source_data_url: 
+  source_data_url:
     https://raw.githubusercontent.com/akarlinsky/world_mortality/main/world_mortality.csv
   license_url: https://github.com/akarlinsky/world_mortality/blob/main/LICENSE
   license_name: MIT License


### PR DESCRIPTION
Having fixed `date_accessed: "2023-04-24"` in YAML metadata was preventing updates of excess mortality in the covid repo. This is a hotfix that sets `date_accessed` of all sources to the latest one.

Proper fix would involve propagating sources from snapshots through channels instead of defining them in YAML metadata. It'd be better to wait for metadata updates we're working on though and @pabloarosado way of propagating metadata (this would be a good proof of concept).