### PR TITLE
📜 docs: styiling improvements

### DIFF
--- a/docs/assets/site-logo.svg
+++ b/docs/assets/site-logo.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 399.89 202.97">
+  <defs>
+    <style>
+      .cls-1 {
+        letter-spacing: -.02em;
+      }
+
+      .cls-2 {
+        font-family: Lato-Regular, Lato;
+        font-size: 80px;
+      }
+
+      .cls-2, .cls-3 {
+        fill: #fff;
+      }
+
+      .cls-4 {
+        letter-spacing: 0em;
+      }
+
+      .cls-5 {
+        letter-spacing: 0em;
+      }
+
+      .cls-6 {
+        letter-spacing: -.01em;
+      }
+
+      .cls-7 {
+        letter-spacing: -.06em;
+      }
+
+      .cls-8 {
+        letter-spacing: -.01em;
+      }
+    </style>
+  </defs>
+  <rect class="cls-3" y="172.97" width="399.89" height="30"/>
+  <text class="cls-2" transform="translate(12.66 68.66)"><tspan class="cls-5" x="0" y="0">O</tspan><tspan x="63.44" y="0">u</tspan><tspan class="cls-1" x="108.04" y="0">r</tspan><tspan class="cls-6" x="135.48" y="0"> </tspan><tspan class="cls-7" x="154.88" y="0">W</tspan><tspan x="233.2" y="0">orld</tspan><tspan x="59.78" y="80">in </tspan><tspan class="cls-8" x="144.1" y="80">D</tspan><tspan class="cls-4" x="203.9" y="80">a</tspan><tspan x="243.14" y="80">ta</tspan></text>
+</svg>

--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -4,7 +4,7 @@ Our documentation is built using `mkdocs`, which renders markdown files into HTM
 
 The markdown files powering the documentation are in the same repository, under the [`docs/`](https://github.com/owid/etl/tree/master/docs) directory. Along with this file, there is the [`mkdocs.yml`](https://github.com/owid/etl/tree/master/mkdocs.yml) configuration file, which organizes the markdown files hierarchically, sets the site theme, and much more.
 
-!!! warning "Whenever you do substantiall changes to the ETL project, make sure that this is reflected in the documentation"
+!!! warning "Whenever you do substantial changes to the ETL project, make sure that this is reflected in the documentation"
     That is, whenever you are working on a project and you create a pull request, make sure that the documentation still makes sense with your changes. If necessary, adapt it in the same PR.
 
 
@@ -15,12 +15,12 @@ To preview the documentation on your local machine, run
 mkdocs serve
 ```
 
-and go to localhost:8000.
+and go to [localhost:8000](http://localhost:8000).
 
 Now, you can test this by modifying one of the files in `docs/` and see how this is reflected automatically on the local site.
 
 ### Adding a new entry
-To add a new entry, simply create a markdown file in the `docs/` directory (or a directory that falls under it). Next, if you want this entry to be listed in the navigation bar, you'l need to add a reference to the file in the `mkdocs.yml` file.
+To add a new entry, simply create a markdown file in the `docs/` directory (or a directory that falls under it). Next, if you want this entry to be listed in the navigation bar, you'll need to add a reference to the file in the `mkdocs.yml` file.
 
 ### Pull request
 Once you are happy with your documentation tweaks, make sure to create a pull request so that others can review your text.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: OWID data pipeline
+site_name: ETL documentation
 
 repo_name: owid/etl
 repo_url: https://github.com/owid/etl
@@ -65,16 +65,21 @@ nav:
 theme:
   # logo: assets/logo.png
   favicon: assets/images/favicon.png
+  # icon:
+    # logo: material/library-outline
+  logo: "assets/site-logo.svg"
   palette:
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
+      primary: blue-grey
       toggle:
         icon: material/brightness-7
         name: Switch to dark mode
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
+      primary: blue-grey
       toggle:
         icon: material/brightness-4
         name: Switch to light mode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: ETL documentation
+site_name: Data pipeline
 
 repo_name: owid/etl
 repo_url: https://github.com/owid/etl


### PR DESCRIPTION
The motivation for these changes is the fact that we are now linking users from our site to this documentation. In particular, we use the button "Read about our data pipeline" in data pages to link users to https://docs.owid.io/projects/etl.


**Main changes**:

- Change the navigation menu colour.
- Change site name.
- Changed default logo; now use OWID's.
- Fix minor typos.

**Preview changes**
Run 

```
mkdocs serve
```

from the project top directory.

**Currently**:

![image](https://github.com/owid/etl/assets/18101289/a8f75082-2b79-4dde-9df7-423ba5859307)


**After changes**:

![image](https://github.com/owid/etl/assets/18101289/62c3c7d7-f5a2-45aa-aca1-b331f573e68a)
