### PR TITLE
Update Luxembourg Income Study dataset with correction to US data

### DIFF
--- a/etl/steps/data/garden/lis/2023-01-18/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2023-01-18/luxembourg_income_study.meta.yml
@@ -53,8 +53,8 @@ dataset:
   sources:
     - name: Luxembourg Income Study (LIS) (2023)
       url: https://www.lisdatacenter.org/our-data/lis-database/
-      date_accessed: "2023-06-14"
-      publication_date: "2023-06-14"
+      date_accessed: "2023-06-21"
+      publication_date: "2023-06-21"
       publication_year: 2023
       published_by:
         Luxembourg Income Study (LIS) Database, http://www.lisdatacenter.org

--- a/snapshots/lis/2023-01-18/lis_abs_poverty.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_abs_poverty.csv.dvc
@@ -21,6 +21,6 @@ meta:
     Harmonized into a common framework, LIS datasets contain household- and person-level data on labor income, capital income, pensions, public social benefits (excl. pensions) and private transfers, as well as taxes and contributions, demography, employment, and expenditures.
 wdir: ../../../data/snapshots/lis/2023-01-18
 outs:
-- md5: 9346d6ef2d0c8728535c57a95a26b3af
+- md5: 3d7c9b46640d8b8ae237e3bbefcd87f5
   size: 3381940
   path: lis_abs_poverty.csv

--- a/snapshots/lis/2023-01-18/lis_abs_poverty.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_abs_poverty.csv.dvc
@@ -4,7 +4,7 @@ meta:
   name: Luxembourg Income Study - Absolute poverty (LIS, 2023)
   version: 2023-01-18
   publication_year: 2023
-  publication_date: 2023-06-14
+  publication_date: 2023-06-21
   source_name: Luxembourg Income Study (LIS)
   source_published_by: Luxembourg Income Study (LIS) Database, http://www.lisdatacenter.org
     (multiple countries; 1967-2021). Luxembourg, LIS.
@@ -13,7 +13,7 @@ meta:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-06-14
+  date_accessed: 2023-06-21
   is_public: true
   description: |
     The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from about 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.

--- a/snapshots/lis/2023-01-18/lis_distribution.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_distribution.csv.dvc
@@ -21,6 +21,6 @@ meta:
     Harmonized into a common framework, LIS datasets contain household- and person-level data on labor income, capital income, pensions, public social benefits (excl. pensions) and private transfers, as well as taxes and contributions, demography, employment, and expenditures.
 wdir: ../../../data/snapshots/lis/2023-01-18
 outs:
-- md5: 8894d5cb89c151f6570f99b09974c74e
+- md5: e7b0864e7dc983563106cd954bed6b84
   size: 2171521
   path: lis_distribution.csv

--- a/snapshots/lis/2023-01-18/lis_distribution.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_distribution.csv.dvc
@@ -4,7 +4,7 @@ meta:
   name: Luxembourg Income Study - Distributional variables (LIS, 2023)
   version: 2023-01-18
   publication_year: 2023
-  publication_date: 2023-06-14
+  publication_date: 2023-06-21
   source_name: Luxembourg Income Study (LIS)
   source_published_by: Luxembourg Income Study (LIS) Database, http://www.lisdatacenter.org
     (multiple countries; 1967-2021). Luxembourg, LIS.
@@ -13,7 +13,7 @@ meta:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-06-14
+  date_accessed: 2023-06-21
   is_public: true
   description: |
     The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from about 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.

--- a/snapshots/lis/2023-01-18/lis_keyvars.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_keyvars.csv.dvc
@@ -21,6 +21,6 @@ meta:
     Harmonized into a common framework, LIS datasets contain household- and person-level data on labor income, capital income, pensions, public social benefits (excl. pensions) and private transfers, as well as taxes and contributions, demography, employment, and expenditures.
 wdir: ../../../data/snapshots/lis/2023-01-18
 outs:
-- md5: 2edd694daad3a921e55c37b2e05b7cbe
+- md5: 841bb72f917a7e0e252d5659e967f0d4
   size: 990378
   path: lis_keyvars.csv

--- a/snapshots/lis/2023-01-18/lis_keyvars.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_keyvars.csv.dvc
@@ -4,7 +4,7 @@ meta:
   name: Luxembourg Income Study - Key variables (LIS, 2023)
   version: 2023-01-18
   publication_year: 2023
-  publication_date: 2023-06-14
+  publication_date: 2023-06-21
   source_name: Luxembourg Income Study (LIS)
   source_published_by: Luxembourg Income Study (LIS) Database, http://www.lisdatacenter.org
     (multiple countries; 1967-2021). Luxembourg, LIS.
@@ -13,7 +13,7 @@ meta:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-06-14
+  date_accessed: 2023-06-21
   is_public: true
   description: |
     The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from about 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.


### PR DESCRIPTION
Update of the LIS dataset, because of a correction on US data for 2021, which has [_a major impact on poverty and inequality indicators_](https://www.lisdatacenter.org/news-and-events/the-us21-dataset-has-been-corrected/).

Part of the [inequality topic page](https://github.com/owid/owid-issues/issues/784).