### PR TITLE
:hammer: Remove parquet autogeneration

### DIFF
--- a/etl/config.py
+++ b/etl/config.py
@@ -67,6 +67,9 @@ GRAPHER_INSERT_WORKERS = int(env.get("GRAPHER_WORKERS", 40))
 # (only enforced on Linux)
 MAX_VIRTUAL_MEMORY_LINUX = 32 * 2**30  # 20 GB
 
+# increment this to force a full rebuild of all datasets
+ETL_EPOCH = 1
+
 
 def enable_bugsnag() -> None:
     BUGSNAG_API_KEY = env.get("BUGSNAG_API_KEY")

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -409,7 +409,7 @@ class DataStep(Step):
             # the pandas library is so important to the output that we include it in the checksum
             "__pandas__": pd.__version__,
             # if the epoch changes, rebuild everything
-            # "__etl_epoch__": str(config.ETL_EPOCH),
+            "__etl_epoch__": str(config.ETL_EPOCH),
         }
         for d in self.dependencies:
             checksums[d.path] = d.checksum_output()

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -408,6 +408,8 @@ class DataStep(Step):
         checksums = {
             # the pandas library is so important to the output that we include it in the checksum
             "__pandas__": pd.__version__,
+            # if the epoch changes, rebuild everything
+            # "__etl_epoch__": str(config.ETL_EPOCH),
         }
         for d in self.dependencies:
             checksums[d.path] = d.checksum_output()

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -28,7 +28,7 @@ FileFormat = Literal["csv", "feather", "parquet"]
 SUPPORTED_FORMATS: List[FileFormat] = ["feather", "parquet", "csv"]
 
 # the formats we generate by default
-DEFAULT_FORMATS: List[FileFormat] = ["feather", "parquet"]
+DEFAULT_FORMATS: List[FileFormat] = ["feather"]
 
 # the format we use by default if we only need one
 PREFERRED_FORMAT: FileFormat = "feather"

--- a/lib/catalog/tests/test_datasets.py
+++ b/lib/catalog/tests/test_datasets.py
@@ -84,7 +84,6 @@ def test_add_table():
         # check that it's really on disk
         table_files = [
             join(dirname, t.metadata.checked_name + ".feather"),
-            join(dirname, t.metadata.checked_name + ".parquet"),
             join(dirname, t.metadata.checked_name + ".meta.json"),
         ]
         for filename in table_files:


### PR DESCRIPTION
We would like to have an API with support for many formats, including Parquet.

Previously we took the approach that the `data/` folder had an identical folder structure to the API, so we co-generated Parquet files for every dataset. Now we would like a different approach where we build a more compact catalog, then have a bake step for the API that generates secondary formats.

This PR drops Parquet autogeneration from every step, which will speed them up and reduce the size of the `data-catalog` repo going forward. It also adds a new counter that you can increment to trigger a full ETL rebuild. The counter is turned off, but would be enabled to actually deploy this feature and prune parquet from the catalog.
