### PR TITLE
Update OECD Income Distribution Database

### DIFF
--- a/snapshots/oecd/2023-06-06/income_distribution_database.csv.dvc
+++ b/snapshots/oecd/2023-06-06/income_distribution_database.csv.dvc
@@ -1,17 +1,17 @@
 meta:
   namespace: oecd
   short_name: income_distribution_database
-  name: Income Distribution Database - Inequality (OECD, 2022)
+  name: Income Distribution Database - Inequality (OECD, 2023)
   version: '2023-06-06'
-  publication_date: '2022-10-27'
-  source_name: OECD Income Distribution Database (2022)
-  source_published_by: OECD (2022). Income Distribution Database, https://www.oecd.org/social/income-distribution-database.htm
+  publication_date: '2023-06-08'
+  source_name: OECD Income Distribution Database (2023)
+  source_published_by: OECD (2023). Income Distribution Database, https://www.oecd.org/social/income-distribution-database.htm
   url: https://www.oecd.org/social/income-distribution-database.htm
   source_data_url:
   file_extension: csv
   license_url: https://www.oecd.org/termsandconditions/
   license_name: OECD Terms and Conditions
-  date_accessed: 2023-06-06
+  date_accessed: 2023-06-23
   is_public: true
   description: |
     The OECD Income Distribution database (IDD) has been developed to benchmark and monitor countries’ performance in the field of income inequality and poverty. It contains a number of standardised indicators based on the central concept of “equivalised household disposable income”, i.e. the total income received by the households less the current taxes and transfers they pay, adjusted for household size with an equivalence scale. While household income is only one of the factors shaping people’s economic well-being, it is also the one for which comparable data for all OECD countries are most common. Income distribution has a long-standing tradition among household-level statistics, with regular data collections going back to the 1980s (and sometimes earlier) in many OECD countries.
@@ -21,6 +21,6 @@ meta:
     Small changes in estimates between years should be treated with caution as they may not be statistically significant.
 wdir: ../../../data/snapshots/oecd/2023-06-06
 outs:
-- md5: 65fdd8eafa6b941e4315116cb2956095
-  size: 1021835
+- md5: 475da98f3f67e8a349af4114dcae2125
+  size: 1026173
   path: income_distribution_database.csv


### PR DESCRIPTION
Update the inequality data for the [OECD IDD](https://stats.oecd.org//Index.aspx?QueryId=123861#), which was updated from the source two days after [I ingested it into the ETL](https://github.com/owid/etl/pull/1190).

Dataset update issue [here](https://github.com/owid/owid-issues/issues/646).