### PR TITLE
:hammer: Remove further parquet generation

### DIFF
--- a/etl/steps/data/garden/country_profile/2022/overview.py
+++ b/etl/steps/data/garden/country_profile/2022/overview.py
@@ -89,7 +89,7 @@ def run(dest_dir: str) -> None:
                 # Add combined tables to the new dataset.
                 tb_combined = tb_combined.reset_index()
                 # Save also as a csv format for the website
-                ds_garden.add(tb_combined, formats=["csv", "feather", "parquet"])
+                ds_garden.add(tb_combined, formats=["csv", "feather"])
 
 
 def get_population() -> pd.DataFrame:

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality_economist/__init__.py
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality_economist/__init__.py
@@ -26,9 +26,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the snapshot.
-    ds_garden = create_dataset(
-        dest_dir, tables=[tb], default_metadata=ds_meadow.metadata, formats=["csv", "parquet", "feather"]
-    )
+    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata, formats=["csv", "feather"])
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/lib/catalog/owid/catalog/catalogs.py
+++ b/lib/catalog/owid/catalog/catalogs.py
@@ -37,7 +37,7 @@ S3_OWID_URI = "s3://owid-catalog"
 REMOTE_CATALOG: Optional["RemoteCatalog"] = None
 
 # what formats should we for our index of available datasets?
-INDEX_FORMATS: List[FileFormat] = ["feather", "parquet"]
+INDEX_FORMATS: List[FileFormat] = ["feather"]
 
 
 class CatalogMixin:


### PR DESCRIPTION
Remove the residual places where Parquet gets generated in our catalog:

- :hammer: remove parquet generation for the catalog index
- :hammer: disable parquet support for specific datasets
