### PR TITLE
:lipstick: Give catalog objects rich html versions

### DIFF
--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -77,6 +77,9 @@ class License:
     def from_dict(d: Dict[str, Any]) -> "License":
         ...
 
+    def __bool__(self):
+        return bool(self.name or self.url)
+
 
 @pruned_json
 @dataclass_json
@@ -112,6 +115,17 @@ class VariableMeta:
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "VariableMeta":
         ...
+
+    def _repr_html_(self):
+        # Render a nice display of the table metadata
+        record = self.to_dict()
+        return """
+             <h2 style="margin-bottom: 0em"><pre>{}</pre></h2>
+             <p style="font-variant: small-caps; font-family: sans-serif; font-size: 1.5em; color: grey; margin-top: -0.2em; margin-bottom: 0.2em">variable meta</p>
+             {}
+        """.format(
+            getattr(self, "_name", None), to_html(record)
+        )
 
 
 @pruned_json
@@ -244,7 +258,7 @@ class TableMeta:
         short_name = record.pop("short_name")
         return """
              <h2 style="margin-bottom: 0em"><pre>{}</pre></h2>
-             <p style="font-variant: small-caps; font-family: sans-serif; font-size: 170%; color: grey; margin-top: -0.2em;">metadata</p>
+             <p style="font-variant: small-caps; font-family: sans-serif; font-size: 1.5em; color: grey; margin-top: -0.2em; margin-bottom: 0.2em">table meta</p>
              {}
         """.format(
             short_name, to_html(record)

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -237,3 +237,43 @@ class TableMeta:
     @staticmethod
     def from_dict(dict: Dict[str, Any]) -> "TableMeta":
         ...
+
+    def _repr_html_(self):
+        # Render a nice display of the table metadata
+        record = self.to_dict()
+        short_name = record.pop("short_name")
+        return """
+             <h2 style="margin-bottom: 0em"><pre>{}</pre></h2>
+             <p style="font-variant: small-caps; font-family: sans-serif; font-size: 170%; color: grey; margin-top: -0.2em;">metadata</p>
+             {}
+        """.format(
+            short_name, to_html(record)
+        )
+
+
+def to_html(record: Any) -> Optional[str]:
+    if isinstance(record, dict):
+        rows = []
+        for k, v in record.items():
+            if not v:
+                continue
+            v_str = to_html(v)
+            rows.append(
+                """<tr><th style="text-align: right; font-family: sans-serif; vertical-align: top; padding: 0.2em 1em;"><strong>{}</strong></th><td style="text-align: left; padding: 0.2em 1em;">{}</td></tr>""".format(
+                    k, v_str
+                )
+            )
+        return '<table style="margin: 0em"><tbody>{}</tbody></table>'.format("".join(rows))
+
+    elif isinstance(record, list):
+        record = list(filter(None, record))
+        if not record:
+            return None
+
+        rows = []
+        for item in record:
+            rows.append("<li>{}</li>".format(to_html(item)))
+        return '<ul style="text-align: left; margin-top: 0em; margin-bottom: 0em">{}</ul>'.format("".join(rows))
+
+    else:
+        return str(record)

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -530,3 +530,13 @@ class Table(pd.DataFrame):
                 t._fields[k] = dataclasses.replace(v)
                 t._fields[k].sources = [dataclasses.replace(s) for s in v.sources]
         return t  # type: ignore
+
+    def _repr_html_(self):
+        html = super()._repr_html_()
+        return """
+             <h2 style="margin-bottom: 0em"><pre>{}</pre></h2>
+             <p style="font-variant: small-caps; font-size: 1.2em; color: grey; margin-top: 0em; margin-bottom: 0.1em">DATA</p>
+             {}
+        """.format(
+            self.metadata.short_name, html
+        )

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -535,7 +535,7 @@ class Table(pd.DataFrame):
         html = super()._repr_html_()
         return """
              <h2 style="margin-bottom: 0em"><pre>{}</pre></h2>
-             <p style="font-variant: small-caps; font-size: 1.2em; color: grey; margin-top: 0em; margin-bottom: 0.1em">DATA</p>
+             <p style="font-variant: small-caps; font-size: 1.5em; font-family: sans-serif; color: grey; margin-top: -0.2em; margin-bottom: 0.2em">table</p>
              {}
         """.format(
             self.metadata.short_name, html

--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -75,7 +75,12 @@ class Variable(pd.Series):
 
     @property
     def metadata(self) -> VariableMeta:
-        return self._fields[self.checked_name]
+        vm = self._fields[self.checked_name]
+
+        # pass this as a hidden attribute to the metadata object for display only
+        vm._name = self.name  # type: ignore
+
+        return vm
 
     @metadata.setter
     def metadata(self, meta: VariableMeta) -> None:
@@ -86,6 +91,16 @@ class Variable(pd.Series):
         v = super().astype(*args, **kwargs)
         v.name = self.name
         return cast(Variable, v)
+
+    def _repr_html_(self):
+        html = str(self)
+        return """
+             <h2 style="margin-bottom: 0em"><pre>{}</pre></h2>
+             <p style="font-variant: small-caps; font-size: 1.5em; font-family: sans-serif; color: grey; margin-top: -0.2em; margin-bottom: 0.2em">variable</p>
+             <pre>{}</pre>
+        """.format(
+            self.name, html
+        )
 
 
 # dynamically add all metadata properties to the class


### PR DESCRIPTION
We work in notebooks often, but today metadata is horrific to view in notebooks.

This PR adds rich HTML display of metadata to make it easier to read, and also adds a title to make it easier to distinguish a `Table` from a `DataFrame` and a `Variable` from a `Series`.

Before and after comparison: https://gist.github.com/larsyencken/5c9aedaaacba4f593d1b18d797cc2c00

It uses a completely generic approach that doesn't know anything about the metadata fields, so it will work just as well when new fields become available.
