### PR TITLE
:hammer: Support strict primary key enforcement

### DIFF
--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -8,7 +8,7 @@ import shutil
 import warnings
 from dataclasses import dataclass
 from glob import glob
-from os import mkdir
+from os import environ, mkdir
 from os.path import join
 from pathlib import Path
 from typing import Any, Iterator, List, Literal, Optional, Union
@@ -107,6 +107,12 @@ class Dataset:
                 warnings.warn(
                     f"Table `{table.metadata.short_name}` from dataset `{self.metadata.short_name}` has non-unique index"
                 )
+
+        if not table.primary_key:
+            if "OWID_STRICT" in environ:
+                raise PrimaryKeyMissing(f"Table `{table.metadata.short_name}` does not have a primary_key set")
+            else:
+                warnings.warn(f"Table `{table.metadata.short_name}` does not have a primary_key set")
 
         # check Float64 and Int64 columns for np.nan
         for col, dtype in table.dtypes.items():
@@ -281,3 +287,7 @@ def checksum_file(filename: str) -> Any:
             chunk = istream.read(chunk_size)
 
     return checksum
+
+
+class PrimaryKeyMissing(Exception):
+    pass

--- a/lib/catalog/tests/test_datasets.py
+++ b/lib/catalog/tests/test_datasets.py
@@ -3,6 +3,7 @@
 #
 
 import json
+import os
 import random
 import shutil
 import tempfile
@@ -12,11 +13,13 @@ from os import rmdir
 from os.path import exists, join
 from pathlib import Path
 from typing import Any, Iterator, Optional, Union
+from unittest.mock import patch
 
 import pytest
 import yaml
 
 from owid.catalog import Dataset, DatasetMeta
+from owid.catalog.datasets import PrimaryKeyMissing
 
 from .mocking import mock
 from .test_tables import mock_table
@@ -102,6 +105,26 @@ def test_add_table():
         assert t2.metadata.primary_key == t.metadata.primary_key
         assert t2.equals_table(t)
         assert t2.metadata.dataset == ds.metadata
+
+
+@patch.dict(os.environ, {})
+def test_add_table_without_primary_key():
+    t = mock_table().reset_index()
+
+    with temp_dataset_dir() as dirname:
+        ds = Dataset.create_empty(dirname)
+        with pytest.warns(UserWarning):
+            ds.add(t)
+
+
+@patch.dict(os.environ, {"OWID_STRICT": "1"})
+def test_add_table_without_primary_key_strict_mode():
+    t = mock_table().reset_index()
+
+    with temp_dataset_dir() as dirname:
+        ds = Dataset.create_empty(dirname)
+        with pytest.raises(PrimaryKeyMissing):
+            ds.add(t)
 
 
 def test_add_table_csv():


### PR DESCRIPTION
This change causes a warning to happen any time you save a table without a primary key. It also allows a strict mode in which the warning becomes an exception.

## Motivation

We are trying to move more metadata to the indicator level. The dimensions an indicator has is a really important piece of metadata that is make or break for automatically collecting, indexing and reusing the indicators.

## How it will be used

The Buildkite tasks that build production data and do the nightly full build will not be run in strict mode. However, PRs will be run in strict mode. This is to avoid any downtime for the ETL, whilst strongly encouraging future changes to have a primary key.
