### PR TITLE
:hammer: raise strict mode error for non-unique index

### DIFF
--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -110,9 +110,18 @@ class Dataset:
 
         if not table.primary_key:
             if "OWID_STRICT" in environ:
-                raise PrimaryKeyMissing(f"Table `{table.metadata.short_name}` does not have a primary_key set")
+                raise PrimaryKeyMissing(
+                    f"Table `{table.metadata.short_name}` does not have a primary_key set -- please use set_index() to indicate dimensions"
+                )
             else:
-                warnings.warn(f"Table `{table.metadata.short_name}` does not have a primary_key set")
+                warnings.warn(
+                    f"Table `{table.metadata.short_name}` does not have a primary_key set -- please use set_index() to indicate dimensions"
+                )
+
+        if not table.index.is_unique and "OWID_STRICT" in environ:
+            raise NonUniqueIndex(
+                f"Table `{table.metadata.short_name}` has duplicate values in the index -- could you have made a mistake?"
+            )
 
         # check Float64 and Int64 columns for np.nan
         for col, dtype in table.dtypes.items():
@@ -290,4 +299,8 @@ def checksum_file(filename: str) -> Any:
 
 
 class PrimaryKeyMissing(Exception):
+    pass
+
+
+class NonUniqueIndex(Exception):
     pass

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -119,8 +119,10 @@ class Dataset:
                 )
 
         if not table.index.is_unique and "OWID_STRICT" in environ:
+            [(k, dups)] = table.index.value_counts().head(1).to_dict().items()
             raise NonUniqueIndex(
-                f"Table `{table.metadata.short_name}` has duplicate values in the index -- could you have made a mistake?"
+                f"Table `{table.metadata.short_name}` has duplicate values in the index -- could you have made a mistake?\n\n"
+                f"e.g. key {k} is repeated {dups} times in the index"
             )
 
         # check Float64 and Int64 columns for np.nan

--- a/lib/catalog/tests/test_datasets.py
+++ b/lib/catalog/tests/test_datasets.py
@@ -15,11 +15,12 @@ from pathlib import Path
 from typing import Any, Iterator, Optional, Union
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 import yaml
 
-from owid.catalog import Dataset, DatasetMeta
-from owid.catalog.datasets import PrimaryKeyMissing
+from owid.catalog import Dataset, DatasetMeta, Table
+from owid.catalog.datasets import NonUniqueIndex, PrimaryKeyMissing
 
 from .mocking import mock
 from .test_tables import mock_table
@@ -124,6 +125,16 @@ def test_add_table_without_primary_key_strict_mode():
     with temp_dataset_dir() as dirname:
         ds = Dataset.create_empty(dirname)
         with pytest.raises(PrimaryKeyMissing):
+            ds.add(t)
+
+
+@patch.dict(os.environ, {"OWID_STRICT": "1"})
+def test_add_table_without_unique_index():
+    t = Table(pd.DataFrame({"a": [1, 1], "b": [1, 2]}).set_index("a"))
+
+    with temp_dataset_dir() as dirname:
+        ds = Dataset.create_empty(dirname)
+        with pytest.raises(NonUniqueIndex):
             ds.add(t)
 
 


### PR DESCRIPTION
Usually when an index is not unique, you haven't properly specified the dimensions of the data or done roll-ups that you need to.

We would enforce this for new PRs only.
