### PR TITLE
Add description to women political empowerment index

### DIFF
--- a/etl/steps/data/meadow/democracy/2023-03-02/vdem.meta.yml
+++ b/etl/steps/data/meadow/democracy/2023-03-02/vdem.meta.yml
@@ -1285,6 +1285,8 @@ tables:
           It is based on the V-Dem variable v2x_genpp_codehigh, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.
       popw_wom_pol_par_vdem_low_owid:
         description: |-
           The variable denotes the lower-bound estimate of the extent to which women are represented in the legislature and have an equal share of political power, weighted by population.
@@ -1292,6 +1294,8 @@ tables:
           It is based on the V-Dem variable v2x_genpp_codelow, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.
       popw_wom_pol_par_vdem_owid:
         description: |-
           The variable denotes the best estimate of the extent to which women are represented in the legislature and have an equal share of political power, weighted by population.
@@ -1299,6 +1303,8 @@ tables:
           It is based on the V-Dem variable v2x_genpp, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.
       priv_libs_vdem_high_owid:
         description: |-
           The variable denotes the upper-bound estimate of  the extent to which people are free from forced labor, have property rights, and enjoy the freedoms of movement and religion.

--- a/etl/steps/data/meadow/democracy/2023-03-02/vdem.meta.yml
+++ b/etl/steps/data/meadow/democracy/2023-03-02/vdem.meta.yml
@@ -1583,6 +1583,8 @@ tables:
           It is based on the V-Dem variable v2x_genpp_codehigh, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.
       wom_pol_par_vdem_low_owid:
         description: |-
           The variable denotes the lower-bound estimate of the extent to which women are represented in the legislature and have an equal share of political power.
@@ -1590,6 +1592,8 @@ tables:
           It is based on the V-Dem variable v2x_genpp_codelow, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.
       wom_pol_par_vdem_owid:
         description: |-
           The variable denotes the best estimate of the extent to which women are represented in the legislature and have an equal share of political power.
@@ -1597,3 +1601,5 @@ tables:
           It is based on the V-Dem variable v2x_genpp, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.


### PR DESCRIPTION
Add the text

> Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.

That is in the footnote of the [chart about Women's Political Participation Index](https://owid.cloud/admin/charts/6379/edit)

We needed to do this before advertising the [Women's Rights topic page](https://github.com/owid/owid-issues/issues/1044)