### PR TITLE
:hammer: Replace snapshot fields by source and license

### DIFF
--- a/backport/backport.py
+++ b/backport/backport.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 import click
 import pandas as pd
 import structlog
+from owid.catalog import Source
 from sqlalchemy.engine import Engine
 from sqlmodel import Session
 
@@ -174,12 +175,14 @@ def _snapshot_values_metadata(ds: gm.Dataset, short_name: str, public: bool) -> 
         short_name=f"{short_name}_values",
         version="latest",
         name=ds.name,
-        date_accessed=dt.datetime.utcnow(),
         description=ds.description,
-        source_name="Our World in Data catalog backport",
-        source_published_by="Our World in Data catalog backport",
-        url=f"https://owid.cloud/admin/datasets/{ds.id}",
-        publication_date="latest",
+        source=Source(
+            name="Our World in Data catalog backport",
+            published_by="Our World in Data catalog backport",
+            url=f"https://owid.cloud/admin/datasets/{ds.id}",
+            publication_date="latest",
+            date_accessed=dt.datetime.utcnow(),
+        ),
         file_extension="feather",
         is_public=public,
     )

--- a/etl/scripts/faostat/create_new_snapshots.py
+++ b/etl/scripts/faostat/create_new_snapshots.py
@@ -120,17 +120,22 @@ class FAODataset:
             "short_name": self.short_name,
             "name": (f"{self._dataset_metadata['DatasetName']} - FAO" f" ({self.publication_year})"),
             "description": self._dataset_metadata["DatasetDescription"],
-            "source_name": SOURCE_NAME,
-            "source_published_by": SOURCE_NAME,
-            "publication_year": self.publication_year,
-            "publication_date": str(self.publication_date),
-            "date_accessed": VERSION,
+            "source": {
+                "name": SOURCE_NAME,
+                "description": self._dataset_metadata["DatasetDescription"],
+                "published_by": SOURCE_NAME,
+                "publication_year": self.publication_year,
+                "publication_date": str(self.publication_date),
+                "date_accessed": VERSION,
+                "source_data_url": self.source_data_url,
+            },
             "version": VERSION,
             "url": f"{FAO_DATA_URL}/{self._dataset_metadata['DatasetCode']}",
-            "source_data_url": self.source_data_url,
             "file_extension": "zip",
-            "license_url": LICENSE_URL,
-            "license_name": LICENSE_NAME,
+            "license": {
+                "name": LICENSE_NAME,
+                "url": LICENSE_URL,
+            },
             "is_public": True,
         }
 
@@ -183,7 +188,7 @@ def is_dataset_already_up_to_date(
     """
     dataset_up_to_date = False
     for snapshot in existing_snapshots:
-        snapshot_source_data_url = snapshot.metadata.source_data_url
+        snapshot_source_data_url = snapshot.metadata.source.source_data_url
         snapshot_date_accessed = parser.parse(str(snapshot.metadata.date_accessed)).date()
         if (snapshot_source_data_url == source_data_url) and (snapshot_date_accessed > source_modification_date):
             dataset_up_to_date = True
@@ -207,17 +212,21 @@ class FAOAdditionalMetadata:
             "short_name": f"{NAMESPACE}_metadata",
             "name": f"Metadata and identifiers - FAO ({self.publication_year})",
             "description": "Metadata and identifiers used in FAO datasets",
-            "source_name": SOURCE_NAME,
-            "source_published_by": SOURCE_NAME,
-            "publication_year": self.publication_year,
-            "publication_date": str(self.publication_date),
-            "date_accessed": VERSION,
+            "source": {
+                "name": SOURCE_NAME,
+                "published_by": SOURCE_NAME,
+                "publication_year": self.publication_year,
+                "publication_date": str(self.publication_date),
+                "date_accessed": VERSION,
+                "source_data_url": None,
+            },
             "version": VERSION,
             "url": FAO_DATA_URL,
-            "source_data_url": None,
             "file_extension": "json",
-            "license_url": LICENSE_URL,
-            "license_name": LICENSE_NAME,
+            "license": {
+                "name": LICENSE_NAME,
+                "url": LICENSE_URL,
+            },
             "is_public": True,
         }
 

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -1,4 +1,3 @@
-import datetime as dt
 import json
 import re
 import shutil
@@ -6,7 +5,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 import yaml
@@ -79,9 +78,9 @@ class Snapshot:
 
     def download_from_source(self) -> None:
         """Download file from source_data_url."""
-        assert self.metadata.source_data_url, "source_data_url is not set"
+        assert self.metadata.source.source_data_url, "source_data_url is not set"
         self.path.parent.mkdir(exist_ok=True, parents=True)
-        files.download(self.metadata.source_data_url, str(self.path))
+        files.download(self.metadata.source.source_data_url, str(self.path))
 
     def dvc_add(self, upload: bool) -> None:
         """Add file to DVC and upload to S3."""
@@ -115,22 +114,8 @@ class Snapshot:
                         "short_name": self.metadata.short_name,
                         "title": self.metadata.name,
                         "version": self.metadata.version,
-                        "sources": [
-                            Source(
-                                name=self.metadata.source_name,
-                                published_by=self.metadata.source_published_by,
-                                source_data_url=self.metadata.source_data_url,
-                                url=self.metadata.url,
-                                date_accessed=self.metadata.date_accessed,
-                                publication_date=str(self.metadata.publication_date)
-                                if self.metadata.publication_date
-                                else None,
-                                publication_year=self.metadata.publication_year,
-                            )
-                        ],
-                        "licenses": [License(name=self.metadata.license_name, url=self.metadata.license_url)]
-                        if self.metadata.license_name or self.metadata.license_url
-                        else [],
+                        "sources": [self.metadata.source],
+                        "licenses": [self.metadata.license],
                     }
                 ),
             }
@@ -150,30 +135,16 @@ class SnapshotMeta:
     # how to get the data file
     file_extension: str
 
-    # usually today
-    date_accessed: dt.date
-
     # fields that are meant to be shown to humans
     name: str
     description: str
-    source_name: str  # Short source citation.
-    url: str
-    source_published_by: Optional[str] = None  # Full source citation.
 
-    # URL with file, use `download_and_create(metadata)` for uploading to walden
-    source_data_url: Optional[str] = None
+    source: Source
+    license: Optional[License] = None
 
-    # license
-    # NOTE: license_url should be ideally required, but we don't have it for backported datasets
-    # so we have to relax this condition
-    license_url: Optional[str] = None
-    license_name: Optional[str] = None
     access_notes: Optional[str] = None
 
     is_public: Optional[bool] = True
-
-    publication_year: Optional[int] = None
-    publication_date: Union[Optional[dt.date], Literal["latest"]] = None
 
     outs: Any = None
 
@@ -234,6 +205,27 @@ class SnapshotMeta:
                 meta["short_name"] = _parse_snapshot_path(Path(filename))[2]
             if "file_extension" not in meta:
                 meta["file_extension"] = _parse_snapshot_path(Path(filename))[3]
+
+            # convert legacy fields to source
+            if "source" not in meta:
+                publication_date = meta.pop("publication_date", None)
+                meta["source"] = Source(
+                    name=meta.pop("source_name", None),
+                    description=meta.get("description", None),
+                    published_by=meta.pop("source_published_by", None),
+                    source_data_url=meta.pop("source_data_url", None),
+                    url=meta.pop("url", None),
+                    date_accessed=meta.pop("date_accessed", None),
+                    publication_date=str(publication_date) if publication_date else None,
+                    publication_year=meta.pop("publication_year", None),
+                )
+
+            if "license" not in meta:
+                if "license_name" in meta or "license_url" in meta:
+                    meta["license"] = License(
+                        name=meta.pop("license_name", None),
+                        url=meta.pop("license_url", None),
+                    )
 
             return cls.from_dict(dict(**meta, outs=yml.get("outs", [])))
 

--- a/etl/steps/data/converters.py
+++ b/etl/steps/data/converters.py
@@ -45,23 +45,8 @@ def convert_snapshot_metadata(snap: SnapshotMeta) -> DatasetMeta:
         title=snap.name,
         version=snap.version,
         description=snap.description,
-        sources=[
-            Source(
-                name=snap.source_name,  # Short source citation.
-                published_by=snap.source_published_by,  # Full source citation.
-                description=snap.description,
-                url=snap.url,
-                source_data_url=snap.source_data_url,
-                # XXX owid_data_url is not a thing for snapshots, but it could be possibly added
-                # owid_data_url=snap.owid_data_url,
-                date_accessed=snap.date_accessed,
-                publication_date=str(snap.publication_date) if snap.publication_date else None,
-                publication_year=snap.publication_year,
-            )
-        ],
-        licenses=[License(name=snap.license_name, url=snap.license_url)]
-        if snap.license_name or snap.license_url
-        else [],
+        sources=[snap.source],
+        licenses=[snap.license] if snap.license else [],
     )
 
 

--- a/lib/walden/ingests/un_sdg.py
+++ b/lib/walden/ingests/un_sdg.py
@@ -11,9 +11,10 @@ import numpy as np
 import pandas as pd
 import requests
 import yaml
+from structlog import get_logger
+
 from owid.walden import add_to_catalog
 from owid.walden.catalog import Dataset
-from structlog import get_logger
 
 BASE_URL = "https://unstats.un.org/sdgapi"
 log = get_logger()

--- a/lib/walden/ingests/un_sdg.py
+++ b/lib/walden/ingests/un_sdg.py
@@ -11,10 +11,9 @@ import numpy as np
 import pandas as pd
 import requests
 import yaml
-from structlog import get_logger
-
 from owid.walden import add_to_catalog
 from owid.walden.catalog import Dataset
+from structlog import get_logger
 
 BASE_URL = "https://unstats.un.org/sdgapi"
 log = get_logger()
@@ -226,7 +225,6 @@ def dimensions_description() -> dict:
 
 
 def get_goal_codes() -> List[int]:
-
     # retrieves all goal codes
     url = f"{BASE_URL}/v1/sdg/Goal/List"
     res = requests.get(url)

--- a/snapshots/excess_mortality/latest/hmd_stmf.py
+++ b/snapshots/excess_mortality/latest/hmd_stmf.py
@@ -40,9 +40,9 @@ def modify_metadata(snap: Snapshot) -> Snapshot:
     snap.metadata.date_accessed = date.today()
     # Set publication date
     publication_date = _get_publication_date()
-    snap.metadata.publication_date = publication_date
+    snap.metadata.source.publication_date = publication_date
     # Set publication year
-    snap.metadata.publication_year = publication_date.year
+    snap.metadata.source.publication_year = publication_date.year
     # Save
     snap.metadata.save()
     return snap

--- a/snapshots/un/2023-01-24/un_sdg.py
+++ b/snapshots/un/2023-01-24/un_sdg.py
@@ -64,7 +64,7 @@ def main(upload: bool) -> None:
         add_snapshot("un/2023-01-24/un_sdg_dimension.json", filename=dim_file, upload=upload)  # type: ignore
 
         # fetch the file locally
-        assert metadata.source_data_url is not None
+        assert metadata.source.source_data_url is not None
         log.info("Downloading data...")
         all_data = download_data(snap)
         log.info("Adding data to catalog...")
@@ -76,9 +76,9 @@ def create_metadata(snap: Snapshot) -> SnapshotMeta:
     meta = snap.metadata
     meta_update = load_external_metadata()
     meta.name = meta_update["name"]
-    meta.publication_year = meta_update["publication_year"]
-    meta.publication_date = meta_update["publication_date"]
-    meta.date_accessed = dt.datetime.now().date()
+    meta.source.publication_year = meta_update["publication_year"]
+    meta.source.publication_date = meta_update["publication_date"]
+    meta.source.date_accessed = str(dt.datetime.now().date())
     return meta
 
 
@@ -105,7 +105,7 @@ def load_external_metadata() -> dict:
 def download_data(snap: Snapshot) -> pd.DataFrame:
     # retrieves all goal codes
     print("Retrieving SDG goal codes...")
-    url = f"{snap.metadata.source_data_url}/v1/sdg/Goal/List"
+    url = f"{snap.metadata.source.source_data_url}/v1/sdg/Goal/List"
     res = requests.get(url)
     assert res.ok
 
@@ -114,14 +114,14 @@ def download_data(snap: Snapshot) -> pd.DataFrame:
 
     # retrieves all area codes
     print("Retrieving area codes...")
-    url = f"{snap.metadata.source_data_url}/v1/sdg/GeoArea/List"
+    url = f"{snap.metadata.source.source_data_url}/v1/sdg/GeoArea/List"
     res = requests.get(url)
     assert res.ok
     areas = res.json()
     area_codes = [str(area["geoAreaCode"]) for area in areas]
     # retrieves csv with data for all codes and areas
     print("Retrieving data...")
-    url = f"{snap.metadata.source_data_url}/v1/sdg/Goal/DataCSV"
+    url = f"{snap.metadata.source.source_data_url}/v1/sdg/Goal/DataCSV"
     all_data = []
     for goal in goal_codes:
         content = download_file(url=url, goal=goal, area_codes=area_codes, max_retries=MAX_RETRIES)
@@ -193,7 +193,7 @@ def attributes_description(snap: Snapshot) -> Dict[Any, Any]:
     goal_codes = get_goal_codes(snap)
     a = []
     for goal in goal_codes:
-        url = f"{snap.metadata.source_data_url}/v1/sdg/Goal/{goal}/Attributes"
+        url = f"{snap.metadata.source.source_data_url}/v1/sdg/Goal/{goal}/Attributes"
         res = requests.get(url)
         assert res.ok
         attr = res.json()
@@ -215,7 +215,7 @@ def dimensions_description(snap: Snapshot) -> dict:
     goal_codes = get_goal_codes(snap)
     d = []
     for goal in goal_codes:
-        url = f"{snap.metadata.source_data_url}/v1/sdg/Goal/{goal}/Dimensions"
+        url = f"{snap.metadata.source.source_data_url}/v1/sdg/Goal/{goal}/Dimensions"
         res = requests.get(url)
         assert res.ok
         dims = res.json()
@@ -236,9 +236,8 @@ def dimensions_description(snap: Snapshot) -> dict:
 
 
 def get_goal_codes(snap: Snapshot) -> List[int]:
-
     # retrieves all goal codes
-    url = f"{snap.metadata.source_data_url}/v1/sdg/Goal/List"
+    url = f"{snap.metadata.source.source_data_url}/v1/sdg/Goal/List"
     res = requests.get(url)
     assert res.ok
     goals = res.json()

--- a/snapshots/worldbank_wdi/2023-05-29/wdi.py
+++ b/snapshots/worldbank_wdi/2023-05-29/wdi.py
@@ -8,6 +8,7 @@ import click
 import requests
 import structlog
 from bs4 import BeautifulSoup
+from owid.catalog import License
 
 from etl.snapshot import Snapshot
 
@@ -52,7 +53,7 @@ def load_external_metadata() -> dict:
         "description": description,
         "publication_year": pub_date.year,
         "publication_date": pub_date,
-        "license_name": meta_orig.get("constraints").get("license").get("license_id"),
+        "license": License(name=meta_orig.get("constraints").get("license").get("license_id")),
     }
     return meta
 


### PR DESCRIPTION
Fields in `SnapshotMeta` like `source_published_by` are just flattened Source and License. Working with Sources and Licenses directly makes further changes to metadata easier.

I've been initially thinking about editing all snapshot YAML files and adding `source:` and `license:` entries there, but that'd be probably too much. To avoid that I'm converting those YAML fields to Source object on load.