### PR TITLE
:hammer: enforce strict mode for new datasets

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -272,7 +272,8 @@ def _detect_strictness_level(step: Step, strict: Optional[bool] = None) -> bool:
         return False
 
     # now it depends on the version
-    return step.version == "latest" or step.version >= config.STRICT_AFTER
+    # TODO fix the "latest" cases as well
+    return step.version != "latest" and step.version >= config.STRICT_AFTER
 
 
 @contextmanager

--- a/etl/command.py
+++ b/etl/command.py
@@ -7,15 +7,17 @@ import re
 import resource
 import sys
 import time
+from contextlib import contextmanager
+from os import environ
 from pathlib import Path
-from typing import Any, Callable, List, Optional, Set
+from typing import Any, Callable, Iterator, List, Optional, Set
 
 import click
 from ipdb import launch_ipdb_on_exception
 
 from etl import config, paths
 from etl.snapshot import snapshot_catalog
-from etl.steps import DAG, compile_steps, load_dag, select_dirty_steps
+from etl.steps import DAG, DataStep, Step, compile_steps, load_dag, select_dirty_steps
 
 config.enable_bugsnag()
 
@@ -69,6 +71,12 @@ LIMIT_NOFILE = 4096
     help="Thread workers to parallelize which steps need rebuilding (steps execution is not parallelized)",
     default=5,
 )
+@click.option(
+    "--strict/--no-strict",
+    is_flag=True,
+    help="Force strict or lax validation on DAG steps, e.g. checks for primary keys in data steps.",
+    default=None,
+)
 @click.argument("steps", nargs=-1)
 def main_cli(
     steps: List[str],
@@ -84,6 +92,7 @@ def main_cli(
     exclude: Optional[str] = None,
     dag_path: Path = paths.DEFAULT_DAG_FILE,
     workers: int = 5,
+    strict: Optional[bool] = None,
 ) -> None:
     _update_open_file_limit()
 
@@ -103,6 +112,7 @@ def main_cli(
         exclude=exclude,
         dag_path=dag_path,
         workers=workers,
+        strict=strict,
     )
 
     # propagate workers to grapher upserts
@@ -132,6 +142,7 @@ def main(
     exclude: Optional[str] = None,
     dag_path: Path = paths.DEFAULT_DAG_FILE,
     workers: int = 5,
+    strict: Optional[bool] = None,
 ) -> None:
     """
     Execute all ETL steps listed in dag file.
@@ -155,6 +166,7 @@ def main(
         only=only,
         excludes=excludes,
         workers=workers,
+        strict=strict,
     )
 
 
@@ -203,6 +215,7 @@ def run_dag(
     only: bool = False,
     excludes: Optional[List[str]] = None,
     workers: int = 1,
+    strict: Optional[bool] = None,
 ) -> None:
     """
     Run the selected steps, and anything that needs updating based on them. An empty
@@ -242,9 +255,39 @@ def run_dag(
     for i, step in enumerate(steps, 1):
         print(f"{i}. {step}...")
         if not dry_run:
-            time_taken = timed_run(lambda: step.run())
-            click.echo(f"{click.style('OK', fg='blue')} ({time_taken:.0f}s)")
-            print()
+            strict = _detect_strictness_level(step, strict)
+            with strictness_level(strict):
+                time_taken = timed_run(lambda: step.run())
+                click.echo(f"{click.style('OK', fg='blue')} ({time_taken:.0f}s)")
+                print()
+
+
+def _detect_strictness_level(step: Step, strict: Optional[bool] = None) -> bool:
+    # honour the command-line argument over anything else
+    if strict is not None:
+        return strict
+
+    # only data steps can be strict, and only after meadow
+    if not isinstance(step, DataStep) or step.channel in ("meadow", "open_numbers"):
+        return False
+
+    # now it depends on the version
+    return step.version == "latest" or step.version >= config.STRICT_AFTER
+
+
+@contextmanager
+def strictness_level(strict: bool) -> Iterator[None]:
+    # start from a clean slate
+    if "OWID_STRICT" in environ:
+        del environ["OWID_STRICT"]
+
+    if strict:
+        # enable strict mode
+        environ["OWID_STRICT"] = "true"
+
+    yield
+
+    # no need to clean up
 
 
 def timed_run(f: Callable[[], Any]) -> float:

--- a/etl/config.py
+++ b/etl/config.py
@@ -70,6 +70,9 @@ MAX_VIRTUAL_MEMORY_LINUX = 32 * 2**30  # 32 GB
 # increment this to force a full rebuild of all datasets
 ETL_EPOCH = 2
 
+# any garden or grapher dataset after this date will have strict mode enabled
+STRICT_AFTER = "2023-06-25"
+
 
 def enable_bugsnag() -> None:
     BUGSNAG_API_KEY = env.get("BUGSNAG_API_KEY")

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -111,11 +111,11 @@ class Dataset:
         if not table.primary_key:
             if "OWID_STRICT" in environ:
                 raise PrimaryKeyMissing(
-                    f"Table `{table.metadata.short_name}` does not have a primary_key set -- please use set_index() to indicate dimensions"
+                    f"Table `{table.metadata.short_name}` does not have a primary_key -- please use t.set_index([col, ...], verify_integrity=True) to indicate dimensions before saving"
                 )
             else:
                 warnings.warn(
-                    f"Table `{table.metadata.short_name}` does not have a primary_key set -- please use set_index() to indicate dimensions"
+                    f"Table `{table.metadata.short_name}` does not have a primary_key -- please use t.set_index([col, ...], verify_integrity=True) to indicate dimensions before saving"
                 )
 
         if not table.index.is_unique and "OWID_STRICT" in environ:

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -53,9 +53,10 @@ def test_detect_strictness():
         step = DataStep(f"{channel}/_/2023-06-01/_", [])
         assert _detect_strictness_level(step)
 
-        # strict channel using "latest"
+        # lax channel using "latest"
+        # TODO: make this strict once the data passes
         step = DataStep(f"{channel}/_/latest/_", [])
-        assert _detect_strictness_level(step)
+        assert not _detect_strictness_level(step)
 
 
 def get_all_steps(filename: Union[str, Path] = paths.DEFAULT_DAG_FILE) -> List[Step]:

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -7,8 +7,10 @@ Check the integrity of the DAG.
 """
 from pathlib import Path
 from typing import List, Union
+from unittest.mock import patch
 
 from etl import paths
+from etl.command import _detect_strictness_level
 from etl.steps import DataStep, Step, WaldenStep, compile_steps, load_dag
 
 
@@ -32,6 +34,28 @@ def test_all_data_steps_have_code():
 def test_sub_dag_import():
     # Ensure that sub-dag is imported from separate file
     assert any(["sub_dag_step" in step for step in load_dag("tests/data/dag.yml")]), "sub-dag steps not found"
+
+
+@patch("etl.config.STRICT_AFTER", "2023-06-01")
+def test_detect_strictness():
+    for channel in ["meadow", "open_numbers"]:
+        # lax channel with date after STRICT_AFTER
+        step = DataStep(f"{channel}/_/2023-06-01/_", [])
+        assert not _detect_strictness_level(step)
+
+    channels = ["garden", "grapher"]
+    for channel in channels:
+        # strict channel with date before STRICT_AFTER
+        step = DataStep(f"{channel}/_/2023-05-30/_", [])
+        assert not _detect_strictness_level(step)
+
+        # strict channel with date after STRICT_AFTER
+        step = DataStep(f"{channel}/_/2023-06-01/_", [])
+        assert _detect_strictness_level(step)
+
+        # strict channel using "latest"
+        step = DataStep(f"{channel}/_/latest/_", [])
+        assert _detect_strictness_level(step)
 
 
 def get_all_steps(filename: Union[str, Path] = paths.DEFAULT_DAG_FILE) -> List[Step]:


### PR DESCRIPTION
Enable strict mode by default for all `garden` and `grapher` datasets, where `version` is `latest` or after `2023-06-25`.

Strict mode for now means the following:

- Every table must have a primary key
- Every primary key must uniquely identify a row

If either of these criteria fail then the step will refuse to build.

When building the ETL manually, you can override the default setting by running `etl --strict` or `etl --no-strict`.

## Todo

- [x] Enable strict mode checks when the criteria matches
- [x] Ensure current ETL passes all these checks
