### PR TITLE
Change number of decimal places for Luxembourg Income Study

### DIFF
--- a/etl/steps/data/garden/lis/2023-01-18/shared.py
+++ b/etl/steps/data/garden/lis/2023-01-18/shared.py
@@ -12,7 +12,7 @@ var_dict = {
         "description": "This is the mean income or consumption per year within the {pct_dict[pct]['decile10']} (tenth of the population).",
         "unit": "international-$ in 2017 prices",
         "short_unit": "$",
-        "numDecimalPlaces": 1,
+        "numDecimalPlaces": 2,
     },
     "share": {
         "title": "Share",
@@ -26,14 +26,14 @@ var_dict = {
         "description": "This is the level of income or consumption per year below which {str(pct)}% of the population falls.",
         "unit": "international-$ in 2017 prices",
         "short_unit": "$",
-        "numDecimalPlaces": 1,
+        "numDecimalPlaces": 2,
     },
     "avg_shortfall": {
         "title": "Average shortfall ($)",
         "description": "This is the amount of money that would be theoretically needed to lift the incomes of all people in poverty up to the poverty line of {povline}, averaged across the population in poverty.",
         "unit": "international-$ in 2017 prices",
         "short_unit": "$",
-        "numDecimalPlaces": 1,
+        "numDecimalPlaces": 2,
     },
     "headcount": {
         "title": "Number in poverty",
@@ -68,7 +68,7 @@ var_dict = {
         "description": "This is the amount of money that would be theoretically needed to lift the incomes of all people in poverty up to {povline}.",
         "unit": "international-$ in 2017 prices",
         "short_unit": "$",
-        "numDecimalPlaces": 1,
+        "numDecimalPlaces": 2,
     },
     "gini": {
         "title": "Gini coefficient",
@@ -82,14 +82,14 @@ var_dict = {
         "description": "Mean income or consumption.",
         "unit": "international-$ in 2017 prices",
         "short_unit": "$",
-        "numDecimalPlaces": 1,
+        "numDecimalPlaces": 2,
     },
     "median": {
         "title": "Median",
         "description": "Median income or consumption.",
         "unit": "international-$ in 2017 prices",
         "short_unit": "$",
-        "numDecimalPlaces": 1,
+        "numDecimalPlaces": 2,
     },
     "palma_ratio": {
         "title": "Palma ratio",

--- a/etl/steps/data/meadow/democracy/2023-03-02/vdem.meta.yml
+++ b/etl/steps/data/meadow/democracy/2023-03-02/vdem.meta.yml
@@ -1285,6 +1285,8 @@ tables:
           It is based on the V-Dem variable v2x_genpp_codehigh, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.
       popw_wom_pol_par_vdem_low_owid:
         description: |-
           The variable denotes the lower-bound estimate of the extent to which women are represented in the legislature and have an equal share of political power, weighted by population.
@@ -1292,6 +1294,8 @@ tables:
           It is based on the V-Dem variable v2x_genpp_codelow, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.
       popw_wom_pol_par_vdem_owid:
         description: |-
           The variable denotes the best estimate of the extent to which women are represented in the legislature and have an equal share of political power, weighted by population.
@@ -1299,6 +1303,8 @@ tables:
           It is based on the V-Dem variable v2x_genpp, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.
       priv_libs_vdem_high_owid:
         description: |-
           The variable denotes the upper-bound estimate of  the extent to which people are free from forced labor, have property rights, and enjoy the freedoms of movement and religion.

--- a/etl/steps/data/meadow/democracy/2023-03-02/vdem.meta.yml
+++ b/etl/steps/data/meadow/democracy/2023-03-02/vdem.meta.yml
@@ -1583,6 +1583,8 @@ tables:
           It is based on the V-Dem variable v2x_genpp_codehigh, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.
       wom_pol_par_vdem_low_owid:
         description: |-
           The variable denotes the lower-bound estimate of the extent to which women are represented in the legislature and have an equal share of political power.
@@ -1590,6 +1592,8 @@ tables:
           It is based on the V-Dem variable v2x_genpp_codelow, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.
       wom_pol_par_vdem_owid:
         description: |-
           The variable denotes the best estimate of the extent to which women are represented in the legislature and have an equal share of political power.
@@ -1597,3 +1601,5 @@ tables:
           It is based on the V-Dem variable v2x_genpp, and we expand it to cover more years for some countries.
 
           The variable ranges from 0 to 1 (most equal).
+
+          Many countries in recent years receive high scores even though they are far from equal participation because the index scores them relative to the historical average across countries.


### PR DESCRIPTION
Monetary values had one decimal place. Changed to two.