### PR TITLE
fix: change name of the source for LIS

### DIFF
--- a/etl/steps/data/garden/lis/2023-01-18/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2023-01-18/luxembourg_income_study.meta.yml
@@ -51,7 +51,7 @@ dataset:
     All LIS income and consumption variables are originally reported in annual amounts and in units of the national currency in use today. In Our World in Data, we use international-$ in 2017 prices to account for inflation and for differences in the cost of living between countries. LIS provides conversion tables in its platform.
   version: "2023-01-18"
   sources:
-    - name: Luxembourg Income Study (LIS) (2023)
+    - name: Luxembourg Income Study (2023)
       url: https://www.lisdatacenter.org/our-data/lis-database/
       date_accessed: "2023-06-21"
       publication_date: "2023-06-21"


### PR DESCRIPTION
Another minor change, removing the acronym for LIS in the source name