### PR TITLE
fix: Remove wrong market income calculations for LIS

### DIFF
--- a/etl/steps/data/garden/lis/2023-01-18/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2023-01-18/luxembourg_income_study.meta.yml
@@ -53,7 +53,7 @@ dataset:
   sources:
     - name: Luxembourg Income Study (2023)
       url: https://www.lisdatacenter.org/our-data/lis-database/
-      date_accessed: "2023-06-21"
+      date_accessed: "2023-07-02"
       publication_date: "2023-06-21"
       publication_year: 2023
       published_by:

--- a/snapshots/lis/2023-01-18/lis_abs_poverty.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_abs_poverty.csv.dvc
@@ -13,7 +13,7 @@ meta:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-06-21
+  date_accessed: 2023-07-02
   is_public: true
   description: |
     The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from about 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.
@@ -21,6 +21,6 @@ meta:
     Harmonized into a common framework, LIS datasets contain household- and person-level data on labor income, capital income, pensions, public social benefits (excl. pensions) and private transfers, as well as taxes and contributions, demography, employment, and expenditures.
 wdir: ../../../data/snapshots/lis/2023-01-18
 outs:
-- md5: 3d7c9b46640d8b8ae237e3bbefcd87f5
-  size: 3381940
+- md5: 5a7c2b3068ccbaba6bebbe4544655256
+  size: 3298740
   path: lis_abs_poverty.csv

--- a/snapshots/lis/2023-01-18/lis_distribution.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_distribution.csv.dvc
@@ -13,7 +13,7 @@ meta:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-06-21
+  date_accessed: 2023-07-02
   is_public: true
   description: |
     The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from about 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.
@@ -21,6 +21,6 @@ meta:
     Harmonized into a common framework, LIS datasets contain household- and person-level data on labor income, capital income, pensions, public social benefits (excl. pensions) and private transfers, as well as taxes and contributions, demography, employment, and expenditures.
 wdir: ../../../data/snapshots/lis/2023-01-18
 outs:
-- md5: e7b0864e7dc983563106cd954bed6b84
-  size: 2171521
+- md5: 63c4d0ef9e146d1581c4869c728b01ee
+  size: 2123681
   path: lis_distribution.csv

--- a/snapshots/lis/2023-01-18/lis_keyvars.csv.dvc
+++ b/snapshots/lis/2023-01-18/lis_keyvars.csv.dvc
@@ -13,7 +13,7 @@ meta:
   file_extension: csv
   license_url:
   license_name:
-  date_accessed: 2023-06-21
+  date_accessed: 2023-07-02
   is_public: true
   description: |
     The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from about 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.
@@ -21,6 +21,6 @@ meta:
     Harmonized into a common framework, LIS datasets contain household- and person-level data on labor income, capital income, pensions, public social benefits (excl. pensions) and private transfers, as well as taxes and contributions, demography, employment, and expenditures.
 wdir: ../../../data/snapshots/lis/2023-01-18
 outs:
-- md5: 841bb72f917a7e0e252d5659e967f0d4
-  size: 990378
+- md5: b7051d38a508c049a264b7017127e3d9
+  size: 960426
   path: lis_keyvars.csv

--- a/snapshots/lis/2023-01-18/lissy_ineq_pov.do
+++ b/snapshots/lis/2023-01-18/lissy_ineq_pov.do
@@ -60,6 +60,9 @@ global dataset = "all"
 *Select the variables to extract
 global inc_cons_vars dhi dhci mi hcexp
 
+*Select components of market income
+global market_income hifactor hiprivate hi33
+
 *Select if relative poverty lines should be obtained from the DHI median (1) or from each welfare variable (0)
 global relative_poverty_dhi = 0
 
@@ -82,7 +85,19 @@ program define make_variables
 	quietly drop if miss_comp==1
 
 	*Create market income variable
-	gen mi = hifactor + hiprivate + hi33
+	*Obtain maximum value of component variables
+	foreach var in $market_income {
+		quietly sum `var'
+		local max_`var' = r(max)
+	}
+	
+	if `max_hifactor' > 0 & `max_hiprivate' > 0 & `max_hi33' > 0 {
+		gen mi = hifactor + hiprivate + hi33
+	}
+	
+	else {
+		gen mi = .
+	}
 
 	*Get the grossnet variable from the dataset
 	quietly levelsof grossnet, local(uniq_gross) clean


### PR DESCRIPTION
[Joe realized](https://github.com/owid/owid-issues/issues/377#issuecomment-1615902423) there were differences in market income estimations between the dataset I obtained with my code and the one appearing on [LIS' DART](https://dart.lisdatacenter.org/). The problem is that the code didn't address when one of the components of market income was an entire column of zeros.

To solve this I have introduced a check that is similar to my estimation of total consumption.