### PR TITLE
Track-created-from-origin

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -324,7 +324,6 @@ def _backporting_steps(private: bool, filter_steps: Optional[Set[str]] = None) -
 
     # load all backported snapshots
     for snap in snapshot_catalog(match):
-
         # skip private backported steps
         if not private and not snap.metadata.is_public:
             continue

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -120,6 +120,13 @@ tb = {_snippet_dataset(ds_b, table_name)}
                     table_a = table_a.set_index(new_index)
                     table_b = table_b.set_index(new_index)
 
+            # indexes differ, reset them to make them somehow comparable
+            if table_a.index.names != table_b.index.names:
+                if table_a.index.names != [None]:
+                    table_a = table_a.reset_index()
+                if table_b.index.names != [None]:
+                    table_b = table_b.reset_index()
+
             # only sort index if different to avoid unnecessary sorting for huge datasets such as ghe
             if len(table_a) != len(table_b) or not _index_equals(table_a, table_b):
                 index_diff = True
@@ -325,7 +332,7 @@ def cli(
             continue
         except Exception as e:
             # soft fail and continue with another dataset
-            log.exception(e)
+            log.error(e)
             any_error = True
             continue
 

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -13,6 +13,7 @@ from owid.catalog.utils import underscore
 
 from etl.db import get_connection, get_engine
 from etl.db_utils import DBUtils
+from etl.steps.data.converters import convert_origin_to_source, convert_source_to_origin
 
 log = structlog.get_logger()
 
@@ -349,6 +350,15 @@ def _adapt_dataset_metadata_for_grapher(
         Adapted dataset metadata, ready to be inserted into grapher.
 
     """
+    # Add origins to sources to stay backward compatible.
+    if metadata.origins:
+        metadata.sources = _add_origins_to_sources(metadata.sources, metadata.origins)
+    else:
+        warnings.warn(
+            "Dataset has sources instead of origins. This is deprecated and will be removed in the future. "
+            "Please use origins instead."
+        )
+
     # Combine metadata sources into one.
     metadata.sources = [combine_metadata_sources(metadata.sources)]
 
@@ -415,11 +425,58 @@ def _adapt_table_for_grapher(
 
     table = table.set_index(["entity_id", "year"] + dim_names)
 
+    # Add dataset origins to variables if they don't have an origin.
+    # TODO: In the future, all variables should have their origins and dataset origins will be union of their origins.
+    table = _add_dataset_origins_to_variables(table)
+
+    # Convert sources to origins to stay backward compatible. Note that this happens before we combine all sources into
+    # one source which is needed by MySQL.
+    assert table.metadata.dataset
+    for col in table.columns:
+        table[col].origins = _add_sources_to_origins(
+            table[col].origins, table.metadata.dataset.sources + table[col].sources
+        )
+
+    # NOTE: We already convert origins to sources in snapshot. This would be needed only if we added
+    # origins in meadow / garden through YAML file.
+    # Convert origins to sources to stay backward compatible.
+    # for col in table.columns:
+    #     table[col].sources = _add_origins_to_sources(
+    #         table[col].sources, table.metadata.dataset.sources + table[col].sources
+    #     )
+
     # Ensure the default source of each column includes the description of the table (since that is the description that
     # will appear in grapher on the SOURCES tab).
     table = _ensure_source_per_variable(table)
 
     return cast(catalog.Table, table)
+
+
+def _add_sources_to_origins(origins: List[catalog.Origin], sources: List[catalog.Source]) -> List[catalog.Origin]:
+    """Add sources to origins. Don't add sources with `name` that already exists as `producer` in origins."""
+    origins = list(origins)
+    for source in sources:
+        if source.name not in [origin.producer for origin in origins]:
+            origins.append(convert_source_to_origin(source))
+    return origins
+
+
+def _add_origins_to_sources(sources: List[catalog.Source], origins: List[catalog.Origin]) -> List[catalog.Source]:
+    """Add origins to sources. Don't add origins with `producer` that already exists as `name` in sources."""
+    sources = list(sources)
+    for origin in origins:
+        if origin.producer not in [source.name for source in sources]:
+            sources.append(convert_origin_to_source(origin))
+    return sources
+
+
+def _add_dataset_origins_to_variables(table: catalog.Table) -> catalog.Table:
+    assert table.metadata.dataset
+    for col in table.columns:
+        variable_meta = table[col].metadata
+        if not variable_meta.origins:
+            variable_meta.origins = table.metadata.dataset.origins
+    return table
 
 
 def _ensure_source_per_variable(table: catalog.Table) -> catalog.Table:

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -429,21 +429,19 @@ def _adapt_table_for_grapher(
     # TODO: In the future, all variables should have their origins and dataset origins will be union of their origins.
     table = _add_dataset_origins_to_variables(table)
 
+    # NOTE: We want to avoid converting sources to origins, ideally we'd convert sources to origins at snapshot level
     # Convert sources to origins to stay backward compatible. Note that this happens before we combine all sources into
     # one source which is needed by MySQL.
+    # assert table.metadata.dataset
+    # for col in table.columns:
+    #     table[col].origins = _add_sources_to_origins(
+    #         table[col].origins, table.metadata.dataset.sources + table[col].sources
+    #     )
+
+    # Convert origins to sources to stay backward compatible.
     assert table.metadata.dataset
     for col in table.columns:
-        table[col].origins = _add_sources_to_origins(
-            table[col].origins, table.metadata.dataset.sources + table[col].sources
-        )
-
-    # NOTE: We already convert origins to sources in snapshot. This would be needed only if we added
-    # origins in meadow / garden through YAML file.
-    # Convert origins to sources to stay backward compatible.
-    # for col in table.columns:
-    #     table[col].sources = _add_origins_to_sources(
-    #         table[col].sources, table.metadata.dataset.sources + table[col].sources
-    #     )
+        table[col].sources = _add_origins_to_sources(table[col].sources, table[col].origins)
 
     # Ensure the default source of each column includes the description of the table (since that is the description that
     # will appear in grapher on the SOURCES tab).

--- a/etl/scripts/faostat/create_new_snapshots.py
+++ b/etl/scripts/faostat/create_new_snapshots.py
@@ -188,6 +188,7 @@ def is_dataset_already_up_to_date(
     """
     dataset_up_to_date = False
     for snapshot in existing_snapshots:
+        assert snapshot.metadata.source
         snapshot_source_data_url = snapshot.metadata.source.source_data_url
         snapshot_date_accessed = parser.parse(str(snapshot.metadata.source.date_accessed)).date()
         if (snapshot_source_data_url == source_data_url) and (snapshot_date_accessed > source_modification_date):

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -253,16 +253,18 @@ class SnapshotMeta:
                         url=meta.pop("license_url", None),
                     )
 
+            # NOTE: we used to keep both origin and source, but it's better
+            # to keep them separated and only convert them before saving to MySQL
             # use both source and origin for backwards compatibility
-            from etl.steps.data.converters import (
-                convert_origin_to_source,
-                convert_source_to_origin,
-            )
+            # from etl.steps.data.converters import (
+            #     convert_origin_to_source,
+            #     convert_source_to_origin,
+            # )
 
-            if meta.get("origin"):
-                meta["source"] = convert_origin_to_source(meta["origin"])
-            elif meta.get("source"):
-                meta["origin"] = convert_source_to_origin(meta["source"])
+            # if meta.get("origin"):
+            #     meta["source"] = convert_origin_to_source(meta["origin"])
+            # elif meta.get("source"):
+            #     meta["origin"] = convert_source_to_origin(meta["source"])
 
             snap_meta = cls.from_dict(dict(**meta, outs=yml.get("outs", [])))
 

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -185,15 +185,6 @@ class SnapshotMeta:
             del d["short_name"]
             del d["file_extension"]
 
-        # remove empty fields, these should be removed by pruned_json decorator, but
-        # it doesn't work for nested fields
-        # it would work if we replaced `pruned_json` by this mixin
-        # https://github.com/lidatong/dataclasses-json/issues/187#issuecomment-919992503
-        if "license" in d:
-            d["license"] = _prune_none(d["license"])
-        if "origin" in d:
-            d["origin"] = _prune_none(d["origin"])
-
         return yaml_dump({"meta": d})  # type: ignore
 
     def save(self) -> None:
@@ -385,7 +376,3 @@ def _parse_snapshot_path(path: Path) -> tuple[str, str, str, str]:
     short_name, ext = path.stem.split(".", 1)
     assert "." not in ext, f"{path.name} cannot contain `.`"
     return namespace, version, short_name, ext
-
-
-def _prune_none(d: dict) -> dict[str, Any]:
-    return {k: v for k, v in d.items() if v is not None}

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -779,6 +779,7 @@ class GrapherStep(Step):
             workers=config.GRAPHER_INSERT_WORKERS,
         )
         gi.cleanup_ghost_sources(dataset_upsert_results.dataset_id, upserted_source_ids)
+        # TODO: cleanup origins that are not used by any variable
 
 
 @dataclass

--- a/etl/steps/data/converters.py
+++ b/etl/steps/data/converters.py
@@ -152,7 +152,7 @@ def convert_origin_to_source(o: Origin) -> Source:
         url=o.dataset_url_main,
         source_data_url=o.dataset_url_download,
         date_accessed=str(o.date_accessed) if o.date_accessed else None,
-        publication_date=str(o.date_published) if o.date_published else None,
+        publication_date=o.date_published,
         published_by=o.citation_producer,
         # excluded fields
         # owid_data_url
@@ -171,10 +171,3 @@ def convert_source_to_origin(s: Source) -> Origin:
         date_published=s.publication_date if s.publication_date else None,  # type: ignore
         citation_producer=s.published_by,
     )
-
-
-def _string_to_date(s: str) -> dt.date:
-    """Convert string to date, or raise ValueError."""
-    if isinstance(s, dt.date):
-        return s
-    return dt.datetime.strptime(s, "%Y-%m-%d").date()

--- a/etl/steps/data/garden/biodiversity/2023-01-11/cherry_blossom.meta.yml
+++ b/etl/steps/data/garden/biodiversity/2023-01-11/cherry_blossom.meta.yml
@@ -1,30 +1,3 @@
-dataset:
-  namespace: biodiversity
-  short_name: cherry_blossom
-  title: Peak Cherry Tree Blossom at Kyoto City (2022)
-  description: ''
-  licenses:
-  - url: http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
-  version: '2023-01-11'
-  sources:
-  - name: Multiple sources compiled by Aono (2021)
-    description: |-
-
-      Multiple sources compiled by Aono (2021):
-
-      - Taguchi,T. (1939) Climatic change in historical time in Japan J. Mar. Meteorol. Soc. 19 217–27
-
-      - Sekiguchi,T. (1969) The historical dates of Japanese cherry festival since the 8th century and her climatic changes Tokyo Geog. Pap. 13 175–90
-
-      - Aono,Y. and Omoto,Y. (1994) Estimation of temperature at Kyoto since 11th century using flowering data of cherry tree in old documents J. Agric. Meteorol. 49 263–72
-
-      - Aono,Y. and Kazui,K. (2008) Phenological data series of cherry tree flowering in Kyoto, Japan, and its application to reconstruction of springtime temperatures since the 9th century Int. J. Climatol. 28 905–14
-
-      - Aono,Y. and Saito,S. (2010) Clarifying springtime temperature reconstructions of the medieval period by gap-filling the cherry blossom phenological data series at Kyoto, Japan Int. J. Biometeorol. 54 211–9
-
-      Data for 812-2021 is available here - http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
-
-      Date for 2022 peak blossom gathered from the Met Office (2022) - https://www.metoffice.gov.uk/about-us/press-office/news/weather-and-climate/2022/kyoto-cherry-blossom-dates-shifted-by-human-influence#:~:text=Last%20year%20was%20the%20earliest,declared%20on%201%20April%202022.
 tables:
   cherry_blossom:
     variables:

--- a/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
+++ b/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
@@ -1,10 +1,3 @@
-dataset:
-  sources:
-    -
-      name: Maddison Project Database 2020 (Bolt and van Zanden, 2020)
-      published_by: Bolt, Jutta and Jan Luiten van Zanden (2020), “Maddison style estimates of the evolution of the world economy. A new 2020 update“.
-
-
 tables:
   maddison_gdp:
     variables:

--- a/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.py
+++ b/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.py
@@ -24,12 +24,6 @@ N = PathFinder(__file__)
 GDP_COLUMN = "gdp"
 # Column name for GDP per capita in output dataset.
 GDP_PER_CAPITA_COLUMN = "gdp_per_capita"
-# Additional description to be prepended to the description given in walden.
-ADDITIONAL_DESCRIPTION = """Notes:
-- Tanzania refers only to Mainland Tanzania.
-- Time series for former countries and territories are calculated forward in time by estimating values based on their last official borders.
-
-"""
 
 
 def load_countries() -> Dict[str, str]:
@@ -213,7 +207,6 @@ def run(dest_dir: str) -> None:
 
     # Create a new dataset.
     ds = create_dataset(dest_dir, tables=[Table(df, short_name="maddison_gdp")], default_metadata=snap.metadata)
-    ds.metadata.description = ADDITIONAL_DESCRIPTION + ds.metadata.description  # type: ignore
 
     # Save dataset to garden.
     ds.save()

--- a/etl/steps/data/grapher/biodiversity/2023-01-11/cherry_blossom.py
+++ b/etl/steps/data/grapher/biodiversity/2023-01-11/cherry_blossom.py
@@ -1,20 +1,39 @@
-from owid import catalog
+"""Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder
+from typing import cast
 
-N = PathFinder(__file__)
+from owid.catalog import Dataset
+
+from etl.helpers import PathFinder, create_dataset, grapher_checks
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
-    dataset = catalog.Dataset.create_empty(dest_dir, N.garden_dataset.metadata)
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = cast(Dataset, paths.load_dependency("cherry_blossom"))
 
-    table = N.garden_dataset["cherry_blossom"]
+    # Read table from garden dataset.
+    tb = ds_garden["cherry_blossom"]
 
-    # optionally set additional dimensions
-    # table = table.set_index(["sex", "income_group"], append=True)
+    #
+    # Process data.
+    #
 
-    # if your data is in long format, you can use `grapher_helpers.long_to_wide_tables`
-    # to get into wide format
-    dataset.add(table)
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
 
-    dataset.save()
+    #
+    # Checks.
+    #
+    grapher_checks(ds_grapher)
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()

--- a/etl/steps/data/meadow/biodiversity/2023-01-11/cherry_blossom.meta.yml
+++ b/etl/steps/data/meadow/biodiversity/2023-01-11/cherry_blossom.meta.yml
@@ -1,30 +1,6 @@
 dataset:
-  namespace: biodiversity
-  short_name: cherry_blossom
   title: Peak Cherry Tree Blossom at Kyoto City (2022)
   description: ''
-  licenses:
-  - url: http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
-  version: '2023-01-11'
-  sources:
-  - name: Multiple sources compiled by Aono (2021)
-    description: |-
-
-      Multiple sources compiled by Aono (2021):
-
-      - Taguchi T 1939 Climatic change in historical time in Japan J. Mar. Meteorol. Soc. 19 217–27
-
-      - Sekiguchi T 1969 The historical dates of Japanese cherry festival since the 8th century and her climatic changes Tokyo Geog. Pap. 13 175–90
-
-      - Aono Y and Omoto Y 1994 Estimation of temperature at Kyoto since 11th century using flowering data of cherry tree in old documents J. Agric. Meteorol. 49 263–72
-
-      - Aono Y and Kazui K 2008 Phenological data series of cherry tree flowering in Kyoto, Japan, and its application to reconstruction of springtime temperatures since the 9th century Int. J. Climatol. 28 905–14
-
-      - Aono Y and Saito S 2010 Clarifying springtime temperature reconstructions of the medieval period by gap-filling the cherry blossom phenological data series at Kyoto, Japan Int. J. Biometeorol. 54 211–9
-
-      Data for 812-2021 is available here - http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
-
-      Date for 2022 peak blossom gathered from the Met Office (2022) - https://www.metoffice.gov.uk/about-us/press-office/news/weather-and-climate/2022/kyoto-cherry-blossom-dates-shifted-by-human-influence#:~:text=Last%20year%20was%20the%20earliest,declared%20on%201%20April%202022.
 tables:
   cherry_blossom:
     variables:

--- a/etl/tempcompare.py
+++ b/etl/tempcompare.py
@@ -103,7 +103,7 @@ def series_equals(
     assert all(s1.index == s2.index), "Indices must be the same"
 
     # Union categories of categorical columns to enable comparison
-    if s1.dtype == "category":
+    if s1.dtype == "category" and s2.dtype == "category":
         s1, s2 = align_categoricals(s1, s2)
 
     # Eq above does not take tolerance into account so compare again with tolerance

--- a/fasttrack/cli.py
+++ b/fasttrack/cli.py
@@ -520,6 +520,7 @@ def _load_existing_sheets_from_snapshots() -> List[Dict[str, str]]:
     # decrypt URLs if private
     for meta in metas:
         if not meta.is_public:
+            assert meta.source
             assert meta.source.source_data_url
             meta.source.source_data_url = _decrypt(meta.source.source_data_url)
 

--- a/fasttrack/cli.py
+++ b/fasttrack/cli.py
@@ -515,7 +515,7 @@ def _load_existing_sheets_from_snapshots() -> List[Dict[str, str]]:
     metas.sort(key=lambda meta: str(meta.source.date_accessed), reverse=True)  # type: ignore
 
     # exclude local CSVs
-    metas = [m for m in metas if m.source.name != "Local CSV"]
+    metas = [m for m in metas if m.source.name != "Local CSV"]  # type: ignore
 
     # decrypt URLs if private
     for meta in metas:

--- a/lib/catalog/owid/catalog/__init__.py
+++ b/lib/catalog/owid/catalog/__init__.py
@@ -3,7 +3,7 @@ __version__ = "0.1.0"
 from . import processing, utils
 from .catalogs import CHANNEL, LocalCatalog, RemoteCatalog, find, find_latest, find_one
 from .datasets import Dataset
-from .meta import DatasetMeta, License, Source, TableMeta, VariableMeta
+from .meta import DatasetMeta, License, Origin, Source, TableMeta, VariableMeta
 from .tables import Table
 from .variables import Variable
 
@@ -20,6 +20,7 @@ __all__ = [
     "TableMeta",
     "VariableMeta",
     "Source",
+    "Origin",
     "License",
     "utils",
     "CHANNEL",

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -150,7 +150,10 @@ class Dataset:
         for format in SUPPORTED_FORMATS:
             path = stem.with_suffix(f".{format}")
             if path.exists():
-                return tables.Table.read(path)
+                t = tables.Table.read(path)
+                # dataset metadata might have been updated, refresh it
+                t.metadata.dataset = self.metadata
+                return t
 
         raise KeyError(f"Table `{name}` not found, available tables: {', '.join(self.table_names)}")
 

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -9,7 +9,7 @@ import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, TypeVar, Union
+from typing import Any, Dict, List, Literal, NewType, Optional, TypeVar, Union
 
 import yaml
 from dataclasses_json import dataclass_json
@@ -29,6 +29,9 @@ def pruned_json(cls: T) -> T:
 
 
 SOURCE_EXISTS_OPTIONS = Literal["fail", "append", "replace"]
+
+
+YearDateLatest = NewType("YearDateLatest", str)
 
 
 # DEPRECATED: use Origin instead
@@ -90,13 +93,13 @@ class Origin:
     # The URL of the dataset on our website
     date_accessed: Optional[str] = None
     # Either date or year of publication
-    date_published: Optional[str] = None
+    date_published: Optional[YearDateLatest] = None
 
     def __post_init__(self):
         if self.date_published:
             # convert date to string
             if isinstance(self.date_published, dt.date):
-                self.date_published = str(self.date_published)
+                self.date_published = YearDateLatest(self.date_published)
 
             if self.date_published != "latest" and not is_year_or_date(self.date_published):
                 raise ValueError("date_published should be either a year or a date or latest")

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -21,8 +21,11 @@ def pruned_json(cls: T) -> T:
     orig = cls.to_dict  # type: ignore
 
     # only keep non-null public variables
+    # make sure to call `to_dict` of nested objects as well
     cls.to_dict = lambda self, **kwargs: {  # type: ignore
-        k: v for k, v in orig(self, **kwargs).items() if not k.startswith("_") and v not in [None, [], {}]
+        k: getattr(self, k).to_dict(**kwargs) if hasattr(getattr(self, k), "to_dict") else v
+        for k, v in orig(self, **kwargs).items()
+        if not k.startswith("_") and v not in [None, [], {}]
     }
 
     return cls

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -4,6 +4,7 @@
 #  Metadata helpers.
 #
 
+import datetime as dt
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -29,6 +30,7 @@ def pruned_json(cls: T) -> T:
 SOURCE_EXISTS_OPTIONS = Literal["fail", "append", "replace"]
 
 
+# DEPRECATED: use Origin instead
 @pruned_json
 @dataclass_json
 @dataclass
@@ -54,6 +56,47 @@ class Source:
     published_by: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
+        ...
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "Source":
+        ...
+
+    def update(self, **kwargs: Dict[str, Any]) -> None:
+        for key, value in kwargs.items():
+            if value is not None:
+                setattr(self, key, value)
+
+
+@pruned_json
+@dataclass_json
+@dataclass
+class Origin:
+    # Original title from the source
+    dataset_title_owid: Optional[str] = None
+    # Our description of the dataset
+    dataset_description_owid: Optional[str] = None
+    # The description for this dataset used by the producer
+    dataset_description_producer: Optional[str] = None
+    # The name of the institution (without a year) or the main authors of the paper
+    producer: Optional[str] = None
+    # The full citation that the producer asks for
+    citation_producer: Optional[str] = None
+    # The authorative URL of the dataset
+    dataset_url_main: Optional[str] = None
+    # Direct URL to download the dataset
+    dataset_url_download: Optional[str] = None
+    # The URL of the dataset on our website
+    date_accessed: Optional[dt.date] = None
+    # TODO: we're not clear yet whether to have both `date_published` and `year_published`
+    # year_published: Optional[str] = None
+    date_published: Optional[dt.date] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        ...
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "Origin":
         ...
 
     def update(self, **kwargs: Dict[str, Any]) -> None:
@@ -102,6 +145,7 @@ class VariableMeta:
     title: Optional[str] = None
     description: Optional[str] = None
     sources: List[Source] = field(default_factory=list)
+    origins: List[Origin] = field(default_factory=list)
     licenses: List[License] = field(default_factory=list)
     unit: Optional[str] = None
     short_unit: Optional[str] = None
@@ -147,6 +191,8 @@ class DatasetMeta:
     short_name: Optional[str] = None
     title: Optional[str] = None
     description: Optional[str] = None
+    origins: List[Origin] = field(default_factory=list)
+    # sources is deprecated, use origins instead
     sources: List[Source] = field(default_factory=list)
     licenses: List[License] = field(default_factory=list)
     is_public: bool = True

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -99,7 +99,7 @@ class Origin:
         if self.date_published:
             # convert date to string
             if isinstance(self.date_published, dt.date):
-                self.date_published = YearDateLatest(self.date_published)
+                self.date_published = YearDateLatest(str(self.date_published))
 
             if self.date_published != "latest" and not is_year_or_date(self.date_published):
                 raise ValueError("date_published should be either a year or a date or latest")

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -62,6 +62,10 @@ class Source:
     # we're keeping both for the time being. We might consolidate them in the future
     published_by: Optional[str] = None
 
+    # This tracks if the source was created from the modern Origin class
+    # This is done to avoid duplicating information
+    is_copy_of_origin: bool = False
+
     def to_dict(self) -> Dict[str, Any]:
         ...
 

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -4,7 +4,6 @@
 #  Metadata helpers.
 #
 
-import datetime as dt
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -87,10 +86,10 @@ class Origin:
     # Direct URL to download the dataset
     dataset_url_download: Optional[str] = None
     # The URL of the dataset on our website
-    date_accessed: Optional[dt.date] = None
+    date_accessed: Optional[str] = None
     # TODO: we're not clear yet whether to have both `date_published` and `year_published`
     # year_published: Optional[str] = None
-    date_published: Optional[dt.date] = None
+    date_published: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         ...

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -5,6 +5,7 @@
 #
 
 import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, TypeVar, Union
@@ -87,9 +88,12 @@ class Origin:
     dataset_url_download: Optional[str] = None
     # The URL of the dataset on our website
     date_accessed: Optional[str] = None
-    # TODO: we're not clear yet whether to have both `date_published` and `year_published`
-    # year_published: Optional[str] = None
+    # Either date or year of publication
     date_published: Optional[str] = None
+
+    def __post_init__(self):
+        if self.date_published and self.date_published != "latest" and not is_year_or_date(self.date_published):
+            raise ValueError("date_published should be either a year or a date or latest")
 
     def to_dict(self) -> Dict[str, Any]:
         ...
@@ -336,3 +340,14 @@ def to_html(record: Any) -> Optional[str]:
 
     else:
         return str(record)
+
+
+def is_year_or_date(s: str) -> bool:
+    """Matches dates in "yyyy-mm-dd" format or years in "yyyy" format."""
+    date_pattern = r"^\d{4}-\d{2}-\d{2}$"
+    year_pattern = r"^\d{4}$"
+
+    if re.match(date_pattern, s) or re.match(year_pattern, s):
+        return True
+    else:
+        return False

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -4,6 +4,7 @@
 #  Metadata helpers.
 #
 
+import datetime as dt
 import json
 import re
 from dataclasses import dataclass, field
@@ -92,8 +93,13 @@ class Origin:
     date_published: Optional[str] = None
 
     def __post_init__(self):
-        if self.date_published and self.date_published != "latest" and not is_year_or_date(self.date_published):
-            raise ValueError("date_published should be either a year or a date or latest")
+        if self.date_published:
+            # convert date to string
+            if isinstance(self.date_published, dt.date):
+                self.date_published = str(self.date_published)
+
+            if self.date_published != "latest" and not is_year_or_date(self.date_published):
+                raise ValueError("date_published should be either a year or a date or latest")
 
     def to_dict(self) -> Dict[str, Any]:
         ...

--- a/lib/catalog/tests/mocking.py
+++ b/lib/catalog/tests/mocking.py
@@ -50,7 +50,7 @@ def mock(_type: type) -> Any:
         return 10 * random.random() / random.random()
 
     elif _type == dt.date:
-        return dt.date.fromordinal(dt.date.today().toordinal() - random.randint(0, 1000))
+        return _random_date()
 
     elif _type == str:
         # some strings in the frictionless standard must be lowercase with no spaces
@@ -72,4 +72,11 @@ def mock(_type: type) -> Any:
     elif _type == Any:
         return mock(random.choice([str, int, float]))
 
+    elif getattr(_type, "__name__", None) == "YearDateLatest":
+        return str(_random_date())
+
     raise ValueError(f"don't know how to mock type: {_type}")
+
+
+def _random_date() -> dt.date:
+    return dt.date.fromordinal(dt.date.today().toordinal() - random.randint(0, 1000))

--- a/lib/catalog/tests/test_datasets.py
+++ b/lib/catalog/tests/test_datasets.py
@@ -226,7 +226,6 @@ def test_dataset_hash_changes_with_data_changes():
 def test_dataset_hash_invariant_to_copying():
     # make a mock dataset
     with mock_dataset() as d1:
-
         # make a copy of it
         with temp_dataset_dir() as dirname:
             d2 = Dataset.create_empty(dirname)

--- a/lib/catalog/tests/test_meta.py
+++ b/lib/catalog/tests/test_meta.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 import pytest
 import yaml
 from dataclasses_json import dataclass_json
+
 from owid.catalog import meta
 
 

--- a/lib/catalog/tests/test_meta.py
+++ b/lib/catalog/tests/test_meta.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 import pytest
 import yaml
 from dataclasses_json import dataclass_json
-
 from owid.catalog import meta
 
 
@@ -77,3 +76,11 @@ def test_load_license_from_dict():
     }
     license = meta.License.from_dict(d)
     assert license.url == d["url"]
+
+
+def test_Origin_date_published():
+    assert meta.Origin(date_published="2020-01-01").date_published == "2020-01-01"  # type: ignore
+    assert meta.Origin(date_published="2020").date_published == "2020"  # type: ignore
+    assert meta.Origin(date_published="latest").date_published == "latest"  # type: ignore
+    with pytest.raises(ValueError):
+        assert meta.Origin(date_published="nope")  # type: ignore

--- a/lib/catalog/tests/test_meta.py
+++ b/lib/catalog/tests/test_meta.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional
 import pytest
 import yaml
 from dataclasses_json import dataclass_json
-
 from owid.catalog import meta
 
 
@@ -25,6 +24,28 @@ def test_dict_mixin():
 
     assert Dog(name="fred").to_dict() == {"name": "fred"}
     assert Dog(age=10).to_dict() == {"age": 10}
+
+
+def test_dict_mixin_nested():
+    @meta.pruned_json
+    @dataclass_json
+    @dataclass
+    class Cat:
+        name: Optional[str] = None
+        age: Optional[int] = None
+
+    @meta.pruned_json
+    @dataclass_json
+    @dataclass
+    class Dog:
+        name: Optional[str] = None
+        age: Optional[int] = None
+        cat: Optional[Cat] = None
+
+        def to_dict(self) -> Dict[str, Any]:
+            ...
+
+    assert Dog(name="fred", cat=Cat(name="cred")).to_dict() == {"name": "fred", "cat": {"name": "cred"}}
 
 
 def test_empty_dataset_metadata():

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -10,6 +10,7 @@ import jsonschema
 import numpy as np
 import pandas as pd
 import pytest
+
 from owid.catalog import tables
 from owid.catalog.datasets import FileFormat
 from owid.catalog.meta import TableMeta, VariableMeta

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -10,7 +10,6 @@ import jsonschema
 import numpy as np
 import pandas as pd
 import pytest
-
 from owid.catalog import tables
 from owid.catalog.datasets import FileFormat
 from owid.catalog.meta import TableMeta, VariableMeta

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -6,19 +6,10 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "namespace": {
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
           "title": {
             "type": "string"
           },
           "description": {
-            "type": "string"
-          },
-          "version": {
             "type": "string"
           },
           "licenses": {

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -25,9 +25,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "url"
-                ]
+                "required": ["url"]
               }
             ]
           },
@@ -68,9 +66,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "name"
-                ]
+                "required": ["name"]
               }
             ]
           }
@@ -149,9 +145,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "name"
-                        ]
+                        "required": ["name"]
                       }
                     ]
                   },
@@ -168,9 +162,7 @@
                             "type": "string"
                           }
                         },
-                        "required": [
-                          "url"
-                        ]
+                        "required": ["url"]
                       }
                     ]
                   },
@@ -210,6 +202,46 @@
                         "type": "boolean"
                       }
                     }
+                  },
+                  "origins": {
+                    "type": "array",
+                    "items": [
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "dataset_title_owid": {
+                            "type": "string"
+                          },
+                          "dataset_description_owid": {
+                            "type": "string"
+                          },
+                          "dataset_description_producer": {
+                            "type": "string"
+                          },
+                          "producer": {
+                            "type": "string"
+                          },
+                          "citation_producer": {
+                            "type": "string"
+                          },
+                          "dataset_url_main": {
+                            "type": "string"
+                          },
+                          "dataset_url_download": {
+                            "type": "string"
+                          },
+                          "date_accessed": {
+                            "type": "string",
+                            "format": "date"
+                          },
+                          "date_published": {
+                            "type": "string",
+                            "format": "date"
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/schemas/snapshot-schema.json
+++ b/schemas/snapshot-schema.json
@@ -7,16 +7,7 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "namespace": {
-            "type": "string"
-          },
-          "short_name": {
-            "type": "string"
-          },
           "name": {
-            "type": "string"
-          },
-          "version": {
             "type": "string"
           },
           "source_name": {
@@ -38,9 +29,6 @@
           "source_published_by": {
             "type": "string"
           },
-          "file_extension": {
-            "type": "string"
-          },
           "license_url": {
             "type": ["string", "null"]
           },
@@ -59,15 +47,56 @@
           },
           "is_public": {
             "type": "boolean"
+          },
+          "origin": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "dataset_title_owid": {
+                "type": "string"
+              },
+              "dataset_description_owid": {
+                "type": "string"
+              },
+              "dataset_description_producer": {
+                "type": "string"
+              },
+              "producer": {
+                "type": "string"
+              },
+              "citation_producer": {
+                "type": "string"
+              },
+              "dataset_url_main": {
+                "type": "string"
+              },
+              "dataset_url_download": {
+                "type": "string"
+              },
+              "date_accessed": {
+                "type": "string",
+                "format": "date"
+              },
+              "date_published": {
+                "type": "string",
+                "format": "date"
+              }
+            }
+          },
+          "license": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
           }
         },
-        "required": [
-          "name",
-          "source_name",
-          "url",
-          "date_accessed",
-          "description"
-        ]
+        "required": []
       },
       "wdir": {
         "type": "string"

--- a/scripts/migrate_sources.py
+++ b/scripts/migrate_sources.py
@@ -1,0 +1,93 @@
+import rich_click as click
+import structlog
+import yaml
+from owid.catalog import License, Origin
+
+from etl.snapshot import SnapshotMeta
+
+log = structlog.get_logger()
+
+
+@click.command(help=__doc__)
+@click.argument(
+    "path",
+    type=click.Path(),
+)
+def cli(
+    path: str,
+) -> None:
+    """
+    Migrate snapshot YAML file from sources to origin.
+
+    Usage:
+        python scripts/migrate_sources.py snapshots/ggdc/2020-10-01/ggdc_maddison.xlsx.dvc
+    """
+    sm = SnapshotMeta.load_from_yaml(path)
+
+    assert not sm.origin, "YAML has been already migrated"
+
+    origin = Origin(
+        producer=sm.source_name,
+        citation_producer=sm.source_published_by,
+        dataset_title_owid=sm.name,
+        dataset_url_main=sm.url,
+        dataset_url_download=sm.source_data_url,
+        dataset_description_owid=sm.description,
+        date_published=sm.publication_date,
+        date_accessed=sm.date_accessed,
+    )
+
+    # replace empty strings by None
+    if getattr(origin, "dataset_description_owid") == "":
+        origin.dataset_description_owid = None
+
+    del sm.source_name
+    del sm.source_published_by
+    del sm.name
+    del sm.url
+    del sm.source_data_url
+    del sm.description
+    del sm.publication_date
+    # we're just dropping this one, shoud be inferred from publication_date
+    del sm.publication_year
+    del sm.date_accessed
+
+    license = License(
+        name=sm.license_name,
+        url=sm.license_url,
+    )
+
+    del sm.license_name
+    del sm.license_url
+
+    sm.origin = origin
+    sm.license = license
+
+    if not license.name and not license.url:
+        del sm.license
+
+    # is_public is true by default
+    if sm.is_public:
+        del sm.is_public
+
+    # save YAML file
+    sm.save()
+
+    # add original `outs` and `wdir` to the snapshot file
+    with open(sm.path, "a") as f:
+        yaml.dump(
+            {
+                "wdir": f"../../../data/snapshots/{sm.namespace}/{sm.version}",
+            },
+            f,
+        )
+        yaml.dump(
+            {
+                "outs": sm.outs,
+            },
+            f,
+        )
+
+
+if __name__ == "__main__":
+    cli()

--- a/snapshots/biodiversity/2023-01-11/cherry_blossom.csv.dvc
+++ b/snapshots/biodiversity/2023-01-11/cherry_blossom.csv.dvc
@@ -1,18 +1,30 @@
 meta:
-  name: Peak Cherry Tree Blossom at Kyoto City (2022)
-  source_name: Multiple datasets compiled by Aono (2021)
-  publication_year: 2021
-  publication_date: 2021-03-26
-  url: http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
-  source_data_url:
-  license_url: http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
-  license_name:
-  date_accessed: 2023-01-11
-  is_public: true
-  description: |
+  origin:
+    producer: Multiple datasets compiled by Aono (2021)
+    dataset_title_owid: Peak Cherry Tree Blossom at Kyoto City (2022)
+    dataset_url_main: http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
+    dataset_description_owid: |-
+      Multiple sources compiled by Aono (2021):
 
+      - Taguchi T 1939 Climatic change in historical time in Japan J. Mar. Meteorol. Soc. 19 217–27
+
+      - Sekiguchi T 1969 The historical dates of Japanese cherry festival since the 8th century and her climatic changes Tokyo Geog. Pap. 13 175–90
+
+      - Aono Y and Omoto Y 1994 Estimation of temperature at Kyoto since 11th century using flowering data of cherry tree in old documents J. Agric. Meteorol. 49 263–72
+
+      - Aono Y and Kazui K 2008 Phenological data series of cherry tree flowering in Kyoto, Japan, and its application to reconstruction of springtime temperatures since the 9th century Int. J. Climatol. 28 905–14
+
+      - Aono Y and Saito S 2010 Clarifying springtime temperature reconstructions of the medieval period by gap-filling the cherry blossom phenological data series at Kyoto, Japan Int. J. Biometeorol. 54 211–9
+
+      Data for 812-2021 is available here - http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
+
+      Date for 2022 peak blossom gathered from the Met Office (2022) - https://www.metoffice.gov.uk/about-us/press-office/news/weather-and-climate/2022/kyoto-cherry-blossom-dates-shifted-by-human-influence#:~:text=Last%20year%20was%20the%20earliest,declared%20on%201%20April%202022.
+    date_published: 2021-03-26
+    date_accessed: 2023-01-11
+  license:
+    url: http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
 wdir: ../../../data/snapshots/biodiversity/2023-01-11
 outs:
 - md5: e966a7746093969705cf9582cd6109a4
-  size: 42758
   path: cherry_blossom.csv
+  size: 42758

--- a/snapshots/biodiversity/2023-01-11/cherry_blossom.csv.dvc
+++ b/snapshots/biodiversity/2023-01-11/cherry_blossom.csv.dvc
@@ -6,15 +6,15 @@ meta:
     dataset_description_owid: |-
       Multiple sources compiled by Aono (2021):
 
-      - Taguchi T 1939 Climatic change in historical time in Japan J. Mar. Meteorol. Soc. 19 217–27
+      - Taguchi,T. (1939) Climatic change in historical time in Japan J. Mar. Meteorol. Soc. 19 217–27
 
-      - Sekiguchi T 1969 The historical dates of Japanese cherry festival since the 8th century and her climatic changes Tokyo Geog. Pap. 13 175–90
+      - Sekiguchi,T. (1969) The historical dates of Japanese cherry festival since the 8th century and her climatic changes Tokyo Geog. Pap. 13 175–90
 
-      - Aono Y and Omoto Y 1994 Estimation of temperature at Kyoto since 11th century using flowering data of cherry tree in old documents J. Agric. Meteorol. 49 263–72
+      - Aono,Y. and Omoto,Y. (1994) Estimation of temperature at Kyoto since 11th century using flowering data of cherry tree in old documents J. Agric. Meteorol. 49 263–72
 
-      - Aono Y and Kazui K 2008 Phenological data series of cherry tree flowering in Kyoto, Japan, and its application to reconstruction of springtime temperatures since the 9th century Int. J. Climatol. 28 905–14
+      - Aono,Y. and Kazui,K. (2008) Phenological data series of cherry tree flowering in Kyoto, Japan, and its application to reconstruction of springtime temperatures since the 9th century Int. J. Climatol. 28 905–14
 
-      - Aono Y and Saito S 2010 Clarifying springtime temperature reconstructions of the medieval period by gap-filling the cherry blossom phenological data series at Kyoto, Japan Int. J. Biometeorol. 54 211–9
+      - Aono,Y. and Saito,S. (2010) Clarifying springtime temperature reconstructions of the medieval period by gap-filling the cherry blossom phenological data series at Kyoto, Japan Int. J. Biometeorol. 54 211–9
 
       Data for 812-2021 is available here - http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
 

--- a/snapshots/emissions/2023-05-02/national_contributions_annual_emissions.csv.dvc
+++ b/snapshots/emissions/2023-05-02/national_contributions_annual_emissions.csv.dvc
@@ -1,40 +1,50 @@
 meta:
-  namespace: emissions
-  short_name: national_contributions_annual_emissions
-  name: National contributions to climate change - Annual emissions (Jones et al.
-    (2023), 2023)
-  version: '2023-05-02'
-  publication_date: '2023-02-13'
-  source_name: Jones et al. (2023)
-  source_published_by: Jones, Matthew W., Peters, Glen P., Gasser, Thomas, Andrew,
-    Robbie M., Schwingshackl, Clemens, Gütschow, Johannes, Houghton, Richard A., Friedlingstein,
-    Pierre, Pongratz, Julia, & Le Quéré, Corinne. (2023). National contributions to
-    climate change due to historical emissions of carbon dioxide, methane and nitrous
-    oxide [Data set]. In Scientific Data (2023.1). Zenodo.
-  url: https://zenodo.org/record/7636699#.ZFCy4exBweZ
-  source_data_url: https://zenodo.org/record/7636699/files/EMISSIONS_ANNUAL_1830-2021.csv
-  file_extension: csv
-  license_url: https://zenodo.org/record/7636699#.ZFCy4exBweZ
-  license_name: Creative Commons Attribution 4.0 International
-  date_accessed: 2023-05-02
-  is_public: true
-  description: |
-    Annual emissions data (1830-2021).
+  origin:
+    dataset_title_owid: National contributions to climate change - Annual emissions (Jones et al. (2023), 2023)
+    dataset_description_owid: >-
+      Annual emissions data (1830-2021).
 
-    Dataset description by Jones et al. (2023):
-    A dataset describing the global warming response to national emissions CO2, CH4 and N2O from fossil and land use sources during 1851-2021.
 
-    National CO2 emissions data are collated from the Global Carbon Project (Andrew and Peters, 2022; Friedlingstein et al., 2022). 
+      Dataset description by Jones et al. (2023):
 
-    National CH4 and N2O emissions data are collated from PRIMAP-hist (HISTTP) (Gütschow et al., 2022).
+      A dataset describing the global warming response to national emissions CO2, CH4 and N2O from fossil and land use sources
+      during 1851-2021.
 
-    We construct a time series of cumulative CO2-equivalent emissions for each country, gas, and emissions source (fossil or land use). Emissions of CH4 and N2O emissions are related to cumulative CO2-equivalent emissions using the Global Warming Potential (GWP*) approach, with best-estimates of the coefficients taken from the IPCC AR6 (Forster et al., 2021).
 
-    Warming in response to cumulative CO2-equivalent emissions is estimated using the transient climate response to cumulative carbon emissions (TCRE) approach, with best-estimate value of TCRE taken from the IPCC AR6 (Forster et al., 2021, Canadell et al., 2021). 'Warming' is specifically the change in global mean surface temperature (GMST).
+      National CO2 emissions data are collated from the Global Carbon Project (Andrew and Peters, 2022; Friedlingstein et
+      al., 2022).
 
-    The data files provide emissions, cumulative emissions and the GMST response by country, gas (CO2, CH4, N2O or 3-GHG total) and source (fossil emissions, land use emissions or the total).
+
+      National CH4 and N2O emissions data are collated from PRIMAP-hist (HISTTP) (Gütschow et al., 2022).
+
+
+      We construct a time series of cumulative CO2-equivalent emissions for each country, gas, and emissions source (fossil
+      or land use). Emissions of CH4 and N2O emissions are related to cumulative CO2-equivalent emissions using the Global
+      Warming Potential (GWP*) approach, with best-estimates of the coefficients taken from the IPCC AR6 (Forster et al.,
+      2021).
+
+
+      Warming in response to cumulative CO2-equivalent emissions is estimated using the transient climate response to cumulative
+      carbon emissions (TCRE) approach, with best-estimate value of TCRE taken from the IPCC AR6 (Forster et al., 2021, Canadell
+      et al., 2021). 'Warming' is specifically the change in global mean surface temperature (GMST).
+
+
+      The data files provide emissions, cumulative emissions and the GMST response by country, gas (CO2, CH4, N2O or 3-GHG
+      total) and source (fossil emissions, land use emissions or the total).
+    producer: Jones et al. (2023)
+    citation_producer: Jones, Matthew W., Peters, Glen P., Gasser, Thomas, Andrew, Robbie M., Schwingshackl, Clemens, Gütschow,
+      Johannes, Houghton, Richard A., Friedlingstein, Pierre, Pongratz, Julia, & Le Quéré, Corinne. (2023). National contributions
+      to climate change due to historical emissions of carbon dioxide, methane and nitrous oxide [Data set]. In Scientific
+      Data (2023.1). Zenodo.
+    dataset_url_main: https://zenodo.org/record/7636699#.ZFCy4exBweZ
+    dataset_url_download: https://zenodo.org/record/7636699/files/EMISSIONS_ANNUAL_1830-2021.csv
+    date_accessed: 2023-05-02
+    date_published: '2023-02-13'
+  license:
+    name: Creative Commons Attribution 4.0 International
+    url: https://zenodo.org/record/7636699#.ZFCy4exBweZ
 wdir: ../../../data/snapshots/emissions/2023-05-02
 outs:
 - md5: dce07a206256931a5a23589ef76bcd3e
-  size: 26320900
   path: national_contributions_annual_emissions.csv
+  size: 26320900

--- a/snapshots/emissions/2023-05-02/national_contributions_cumulative_emissions.csv.dvc
+++ b/snapshots/emissions/2023-05-02/national_contributions_cumulative_emissions.csv.dvc
@@ -1,40 +1,50 @@
 meta:
-  namespace: emissions
-  short_name: national_contributions_cumulative_emissions
-  name: National contributions to climate change - Cumulative emissions (Jones et
-    al. (2023), 2023)
-  version: '2023-05-02'
-  publication_date: '2023-02-13'
-  source_name: Jones et al. (2023)
-  source_published_by: Jones, Matthew W., Peters, Glen P., Gasser, Thomas, Andrew,
-    Robbie M., Schwingshackl, Clemens, Gütschow, Johannes, Houghton, Richard A., Friedlingstein,
-    Pierre, Pongratz, Julia, & Le Quéré, Corinne. (2023). National contributions to
-    climate change due to historical emissions of carbon dioxide, methane and nitrous
-    oxide [Data set]. In Scientific Data (2023.1). Zenodo.
-  url: https://zenodo.org/record/7636699#.ZFCy4exBweZ
-  source_data_url: https://zenodo.org/record/7636699/files/EMISSIONS_CUMULATIVE_CO2e100_1851-2021.csv
-  file_extension: csv
-  license_url: https://zenodo.org/record/7636699#.ZFCy4exBweZ
-  license_name: Creative Commons Attribution 4.0 International
-  date_accessed: 2023-05-02
-  is_public: true
-  description: |
-    Cumulative emissions data (1851-2021).
+  origin:
+    dataset_title_owid: National contributions to climate change - Cumulative emissions (Jones et al. (2023), 2023)
+    dataset_description_owid: >-
+      Cumulative emissions data (1851-2021).
 
-    Dataset description by Jones et al. (2023):
-    A dataset describing the global warming response to national emissions CO2, CH4 and N2O from fossil and land use sources during 1851-2021.
 
-    National CO2 emissions data are collated from the Global Carbon Project (Andrew and Peters, 2022; Friedlingstein et al., 2022). 
+      Dataset description by Jones et al. (2023):
 
-    National CH4 and N2O emissions data are collated from PRIMAP-hist (HISTTP) (Gütschow et al., 2022).
+      A dataset describing the global warming response to national emissions CO2, CH4 and N2O from fossil and land use sources
+      during 1851-2021.
 
-    We construct a time series of cumulative CO2-equivalent emissions for each country, gas, and emissions source (fossil or land use). Emissions of CH4 and N2O emissions are related to cumulative CO2-equivalent emissions using the Global Warming Potential (GWP*) approach, with best-estimates of the coefficients taken from the IPCC AR6 (Forster et al., 2021).
 
-    Warming in response to cumulative CO2-equivalent emissions is estimated using the transient climate response to cumulative carbon emissions (TCRE) approach, with best-estimate value of TCRE taken from the IPCC AR6 (Forster et al., 2021, Canadell et al., 2021). 'Warming' is specifically the change in global mean surface temperature (GMST).
+      National CO2 emissions data are collated from the Global Carbon Project (Andrew and Peters, 2022; Friedlingstein et
+      al., 2022).
 
-    The data files provide emissions, cumulative emissions and the GMST response by country, gas (CO2, CH4, N2O or 3-GHG total) and source (fossil emissions, land use emissions or the total).
+
+      National CH4 and N2O emissions data are collated from PRIMAP-hist (HISTTP) (Gütschow et al., 2022).
+
+
+      We construct a time series of cumulative CO2-equivalent emissions for each country, gas, and emissions source (fossil
+      or land use). Emissions of CH4 and N2O emissions are related to cumulative CO2-equivalent emissions using the Global
+      Warming Potential (GWP*) approach, with best-estimates of the coefficients taken from the IPCC AR6 (Forster et al.,
+      2021).
+
+
+      Warming in response to cumulative CO2-equivalent emissions is estimated using the transient climate response to cumulative
+      carbon emissions (TCRE) approach, with best-estimate value of TCRE taken from the IPCC AR6 (Forster et al., 2021, Canadell
+      et al., 2021). 'Warming' is specifically the change in global mean surface temperature (GMST).
+
+
+      The data files provide emissions, cumulative emissions and the GMST response by country, gas (CO2, CH4, N2O or 3-GHG
+      total) and source (fossil emissions, land use emissions or the total).
+    producer: Jones et al. (2023)
+    citation_producer: Jones, Matthew W., Peters, Glen P., Gasser, Thomas, Andrew, Robbie M., Schwingshackl, Clemens, Gütschow,
+      Johannes, Houghton, Richard A., Friedlingstein, Pierre, Pongratz, Julia, & Le Quéré, Corinne. (2023). National contributions
+      to climate change due to historical emissions of carbon dioxide, methane and nitrous oxide [Data set]. In Scientific
+      Data (2023.1). Zenodo.
+    dataset_url_main: https://zenodo.org/record/7636699#.ZFCy4exBweZ
+    dataset_url_download: https://zenodo.org/record/7636699/files/EMISSIONS_CUMULATIVE_CO2e100_1851-2021.csv
+    date_accessed: 2023-05-02
+    date_published: '2023-02-13'
+  license:
+    name: Creative Commons Attribution 4.0 International
+    url: https://zenodo.org/record/7636699#.ZFCy4exBweZ
 wdir: ../../../data/snapshots/emissions/2023-05-02
 outs:
 - md5: fadd9ba4cd7e9c7e333e45c68bdfb4df
-  size: 33776823
   path: national_contributions_cumulative_emissions.csv
+  size: 33776823

--- a/snapshots/emissions/2023-05-02/national_contributions_temperature_response.csv.dvc
+++ b/snapshots/emissions/2023-05-02/national_contributions_temperature_response.csv.dvc
@@ -1,40 +1,50 @@
 meta:
-  namespace: emissions
-  short_name: national_contributions_temperature_response
-  name: National contributions to climate change - Temperature response (Jones et
-    al. (2023), 2023)
-  version: '2023-05-02'
-  publication_date: '2023-02-13'
-  source_name: Jones et al. (2023)
-  source_published_by: Jones, Matthew W., Peters, Glen P., Gasser, Thomas, Andrew,
-    Robbie M., Schwingshackl, Clemens, Gütschow, Johannes, Houghton, Richard A., Friedlingstein,
-    Pierre, Pongratz, Julia, & Le Quéré, Corinne. (2023). National contributions to
-    climate change due to historical emissions of carbon dioxide, methane and nitrous
-    oxide [Data set]. In Scientific Data (2023.1). Zenodo.
-  url: https://zenodo.org/record/7636699#.ZFCy4exBweZ
-  source_data_url: https://zenodo.org/record/7636699/files/GMST_response_1851-2021.csv
-  file_extension: csv
-  license_url: https://zenodo.org/record/7636699#.ZFCy4exBweZ
-  license_name: Creative Commons Attribution 4.0 International
-  date_accessed: 2023-05-02
-  is_public: true
-  description: |
-    Temperature response data (1851-2021).
+  origin:
+    dataset_title_owid: National contributions to climate change - Temperature response (Jones et al. (2023), 2023)
+    dataset_description_owid: >-
+      Temperature response data (1851-2021).
 
-    Dataset description by Jones et al. (2023):
-    A dataset describing the global warming response to national emissions CO2, CH4 and N2O from fossil and land use sources during 1851-2021.
 
-    National CO2 emissions data are collated from the Global Carbon Project (Andrew and Peters, 2022; Friedlingstein et al., 2022). 
+      Dataset description by Jones et al. (2023):
 
-    National CH4 and N2O emissions data are collated from PRIMAP-hist (HISTTP) (Gütschow et al., 2022).
+      A dataset describing the global warming response to national emissions CO2, CH4 and N2O from fossil and land use sources
+      during 1851-2021.
 
-    We construct a time series of cumulative CO2-equivalent emissions for each country, gas, and emissions source (fossil or land use). Emissions of CH4 and N2O emissions are related to cumulative CO2-equivalent emissions using the Global Warming Potential (GWP*) approach, with best-estimates of the coefficients taken from the IPCC AR6 (Forster et al., 2021).
 
-    Warming in response to cumulative CO2-equivalent emissions is estimated using the transient climate response to cumulative carbon emissions (TCRE) approach, with best-estimate value of TCRE taken from the IPCC AR6 (Forster et al., 2021, Canadell et al., 2021). 'Warming' is specifically the change in global mean surface temperature (GMST).
+      National CO2 emissions data are collated from the Global Carbon Project (Andrew and Peters, 2022; Friedlingstein et
+      al., 2022).
 
-    The data files provide emissions, cumulative emissions and the GMST response by country, gas (CO2, CH4, N2O or 3-GHG total) and source (fossil emissions, land use emissions or the total).
+
+      National CH4 and N2O emissions data are collated from PRIMAP-hist (HISTTP) (Gütschow et al., 2022).
+
+
+      We construct a time series of cumulative CO2-equivalent emissions for each country, gas, and emissions source (fossil
+      or land use). Emissions of CH4 and N2O emissions are related to cumulative CO2-equivalent emissions using the Global
+      Warming Potential (GWP*) approach, with best-estimates of the coefficients taken from the IPCC AR6 (Forster et al.,
+      2021).
+
+
+      Warming in response to cumulative CO2-equivalent emissions is estimated using the transient climate response to cumulative
+      carbon emissions (TCRE) approach, with best-estimate value of TCRE taken from the IPCC AR6 (Forster et al., 2021, Canadell
+      et al., 2021). 'Warming' is specifically the change in global mean surface temperature (GMST).
+
+
+      The data files provide emissions, cumulative emissions and the GMST response by country, gas (CO2, CH4, N2O or 3-GHG
+      total) and source (fossil emissions, land use emissions or the total).
+    producer: Jones et al. (2023)
+    citation_producer: Jones, Matthew W., Peters, Glen P., Gasser, Thomas, Andrew, Robbie M., Schwingshackl, Clemens, Gütschow,
+      Johannes, Houghton, Richard A., Friedlingstein, Pierre, Pongratz, Julia, & Le Quéré, Corinne. (2023). National contributions
+      to climate change due to historical emissions of carbon dioxide, methane and nitrous oxide [Data set]. In Scientific
+      Data (2023.1). Zenodo.
+    dataset_url_main: https://zenodo.org/record/7636699#.ZFCy4exBweZ
+    dataset_url_download: https://zenodo.org/record/7636699/files/GMST_response_1851-2021.csv
+    date_accessed: 2023-05-02
+    date_published: '2023-02-13'
+  license:
+    name: Creative Commons Attribution 4.0 International
+    url: https://zenodo.org/record/7636699#.ZFCy4exBweZ
 wdir: ../../../data/snapshots/emissions/2023-05-02
 outs:
 - md5: 842d9a3f041cc5bd56d908c5a310c08a
-  size: 28946077
   path: national_contributions_temperature_response.csv
+  size: 28946077

--- a/snapshots/excess_mortality/latest/hmd_stmf.py
+++ b/snapshots/excess_mortality/latest/hmd_stmf.py
@@ -40,6 +40,7 @@ def modify_metadata(snap: Snapshot) -> Snapshot:
     snap.metadata.source.date_accessed = date.today()
     # Set publication date
     publication_date = _get_publication_date()
+    assert snap.metadata.source
     snap.metadata.source.publication_date = publication_date
     # Set publication year
     snap.metadata.source.publication_year = publication_date.year

--- a/snapshots/excess_mortality/latest/hmd_stmf.py
+++ b/snapshots/excess_mortality/latest/hmd_stmf.py
@@ -37,11 +37,11 @@ def main(upload: bool) -> None:
 def modify_metadata(snap: Snapshot) -> Snapshot:
     """Modify metadata"""
     # Get access date
-    snap.metadata.source.date_accessed = date.today()
+    snap.metadata.source.date_accessed = date.today()  # type: ignore
     # Set publication date
     publication_date = _get_publication_date()
     assert snap.metadata.source
-    snap.metadata.source.publication_date = publication_date
+    snap.metadata.source.publication_date = publication_date  # type: ignore
     # Set publication year
     snap.metadata.source.publication_year = publication_date.year
     # Save

--- a/snapshots/excess_mortality/latest/wmd.py
+++ b/snapshots/excess_mortality/latest/wmd.py
@@ -23,7 +23,7 @@ def main(upload: bool) -> None:
     snap = Snapshot(f"excess_mortality/{SNAPSHOT_VERSION}/wmd.csv")
 
     # Add date_accessed
-    snap.metadata.source.date_accessed = date.today()
+    snap.metadata.source.date_accessed = date.today()  # type: ignore
     snap.metadata.save()
 
     # Download data from source.

--- a/snapshots/excess_mortality/latest/xm_karlinsky_kobak.py
+++ b/snapshots/excess_mortality/latest/xm_karlinsky_kobak.py
@@ -28,7 +28,7 @@ def add_snapshot(uri: str, upload: bool):
     # Load snapshot
     snap = Snapshot(uri)
     # Add date_accessed
-    snap.metadata.source.date_accessed = date.today()
+    snap.metadata.source.date_accessed = date.today()  # type: ignore
     snap.metadata.save()
     # Download file
     snap.download_from_source()

--- a/snapshots/ggdc/2020-10-01/ggdc_maddison.xlsx.dvc
+++ b/snapshots/ggdc/2020-10-01/ggdc_maddison.xlsx.dvc
@@ -1,242 +1,487 @@
 meta:
-  # Institution name: The Groningen Growth and Development Centre (GGDC), from the Faculty of Economics and
-  # Business of the University of Groningen.
-  name: Maddison Project Database (GGDC, 2020)
-  source_name: Maddison Project Database 2020 (Bolt and van Zanden, 2020)
-  publication_year: 2020
-  # Date of publication of the dataset.
-  # Since we don't know this exact date, we use the first day of the month of the publication of the paper
-  # https://www.rug.nl/ggdc/historicaldevelopment/maddison/publications/wp15.pdf
-  publication_date: 2020-10-01
-  # Url to the main page of the project.
-  url: https://www.rug.nl/ggdc/historicaldevelopment/maddison/releases/maddison-project-database-2020
-  # Url to download the dataset.
-  source_data_url: https://www.rug.nl/ggdc/historicaldevelopment/maddison/data/mpd2020.xlsx
-  # License is defined in the main page of the project.
-  license_url: https://www.rug.nl/ggdc/historicaldevelopment/maddison/releases/maddison-project-database-2020
-  license_name: Creative Commons BY 4.0
-  date_accessed: 2022-04-12
-  description: |
-    Full citation:
-    Maddison Project Database, version 2020. Bolt, Jutta and Jan Luiten van Zanden (2020), “Maddison style estimates of the evolution of the world economy. A new 2020 update”.
+  origin:
+    dataset_title_owid: Maddison Project Database (GGDC, 2020)
+    dataset_description_owid: >-
+      The Maddison Project Database is based on the work of many researchers that have produced estimates of
+      economic growth for individual countries. The full list of sources for this historical data is given for each country below.
 
-    The Maddison Project Database is based on the work of many researchers that have produced estimates of
-    economic growth for individual countries. The full list of sources for this historical data is given for each country below.
 
-    Argentina
-    1800 - 1870 	Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,” Journal of Latin America Studies 41: 279–307 (updated data)
-    1870 - 1900 	Bertola, L and Ocampo, J.A. (2012) The Economic Development of Latin America since Independence. Oxford, Oxford U.P
+      Notes:
+      - Tanzania refers only to Mainland Tanzania.
+      - Time series for former countries and territories are calculated forward in time by estimating values based on their last official borders.
 
-    Belgium
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    1500- 1846 	Buyst, E. (2011), “Towards Estimates of Long Term Growth in the Southern Low Countries, ca.1500-1846”, Results presented at the Conference on Quantifying Long Run Economic Development, Venice, 22-24 March, 2011
 
-    Bulgaria
-    1892-1945 	Ivanov, M. (2006). “Bulgarian National Income between 1892 and 1924,” Bulgarian National Discussion Papers DP/54/2006
+      Argentina
 
-    Bosnia and Herzegovina
-    1952-2008	Milanovic (2011). Estimates provided to the Maddison-Project
+      1800 - 1870   Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,”
+      Journal of Latin America Studies 41: 279–307 (updated data)
 
-    Bolivia (Plurinational State of)
-    1846-1950	Herranz-Loncán, A. and Peres-Cajías (2016). “Bolivian GDP per capita since the mid-nineteenth century” Cliometrica 10: 99-128
+      1870 - 1900   Bertola, L and Ocampo, J.A. (2012) The Economic Development of Latin America since Independence. Oxford,
+      Oxford U.P
 
-    Brazil
-    1800 - 1870 	Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,” Journal of Latin America Studies 41: 279–307 (updated data)
-    1850–1899	Barro, R.J. and J.F. Ursua, (2008). “Macroeconomic Crises since 1870” Brookings Papers on Economic Activity, Economic Studies Program, The Brookings Institution, vol. 39(1 (Spring), pages 255-350
 
-    Switzerland
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    1850-2011	Stohr, Christian (2016), Trading Gains: new estimates of Swiss GDP, 1851-2008. Economic History Working Papers, 245/2016. London School of Economics and Political Science, Economic History Department, London, UK
+      Belgium
 
-    Chile
-    1810–2004	Díaz, J.B. Lüders, R. and Wagner, G. (2007) Economia Chilena 1810 - 2000, Producto total y sectorial una nueva mirada, Pontificia universidad Catolica de Chile, Insituto de Economia, Documeno de Trabajo no. 315
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
 
-    China
-    1000-1661	Broadberry, S.N., Guan, Hanhui and David Daokui Li (2018), “China, Europe and the Great Divergence: a Study in Historical National Accounting, 980-1850”, Journal of Economic History, 78, 4, 955-1000
-    1661–1933	Broadberry, S.N., Guan, Hanhui and David Daokui Li (2018), “China, Europe and the Great Divergence: a Study in Historical National Accounting, 980-1850”, Journal of Economic History, 78, 4, 955-1000
-    1661–1933	Xu, Y. Z. Shi, B. van Leeuwen, Y Ni, Z Zhang, and Y Ma, (2016) 'Chinese National Income, ca. 1661-1933', Australian Economic History Review 57(3), 368–393
-    1952–2008	Wu, Harry X. (2014), “China’s growth and productivity performance debate revisited – Accounting for China’s sources of growth with a new data set” The Conference Board Economics Program Working Paper Series EWP#14-01.
+      1500- 1846   Buyst, E. (2011), “Towards Estimates of Long Term Growth in the Southern Low Countries, ca.1500-1846”,
+      Results presented at the Conference on Quantifying Long Run Economic Development, Venice, 22-24 March, 2011
 
-    Colombia
-    1800 - 1870 	Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,” Journal of Latin America Studies 41: 279–307 (updated data)
-    1870 - 1923 	Bertola, L and Ocampo, J.A. (2012) The Economic Development of Latin America since Independence. Oxford, Oxford U.P.
 
-    Czechoslovakia
-    1993 - 	Based on GDP and population data for their successor states
+      Bulgaria
 
-    Cuba
-    1690–1895	Santamaria Garcia, A. (2005). Las Cuentas nacionales de Cuba, 1960 - 2005', mimeo
-    1902–1958	Ward, M. and Devereux, J. (2012), “The Road Not Taken: Pre-Revolutionary Cuban Living Standards in Comparative Perspective” Journal of Economic History, 72(1): 104–132
+      1892-1945   Ivanov, M. (2006). “Bulgarian National Income between 1892 and 1924,” Bulgarian National Discussion Papers
+      DP/54/2006
 
-    Germany
-    1500-1850	Pfister, U. (2011). “ Economic growth in Germany, 1500–1850”, Paper presented at the Conference on Quantifying Long Run Economic Development, Venice, 22-24 March, 2011
 
-    Ecuador
-    1833-1938	Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,” Journal of Latin America Studies 41: 279–307. (updated data). We use the growth rate between 1933 and 1938 from Prados de la Escosura (2009) and link that to the 1939 level of Maddison’s original estimates.
+      Bosnia and Herzegovina
 
-    Egypt
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    700 – 1500 	Pamuk, Ş. and M. Shatzmiller (2011). “Real Wages and GDP per capita in the Medieval Islamic Middle East in Comparative Perspective, 700-1500”, paper presented at the 9th Conference of the European Historical Economics Society, Dublin, September 2-3, 2011.
-    1820, 1870, 1913, 1950	Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic History, vol 66, no. 3, pp. 809 - 828
+      1952-2008  Milanovic (2011). Estimates provided to the Maddison-Project
 
-    Spain
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    1270-1850	Álvarez-Nogal, C. and L. Prados de la Escosura (2013). "The Rise and Fall of Spain (1270-1850)," Economic History Review, 66, 1, 1-37, using their annual benchmarks
-    1850–2016	Prados de la Escosura, L. (2017), Spanish Economic Growth, 1850-2015 (London: Palgrave Macmillan)
 
-    Finland
-    1600–1860	Eloranta, J., Voutilainen, M. and Nummela, I. (2016).  “Estimating Finnish Economic Growth Before 1860” mimeo.
+      Bolivia (Plurinational State of)
 
-    France
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    1250–1800	Ridolfi, L. (2016) “The French economy in the longue durée. A study on real wages, working days and economic performance from Louis IX to the Revolution (1250-1789)” Dissertation IMT School for Advanced Studies, Lucca, available at http://e-theses.imtlucca.it/211/1/Ridolfi_phdthesis.pdf
+      1846-1950  Herranz-Loncán, A. and Peres-Cajías (2016). “Bolivian GDP per capita since the mid-nineteenth century” Cliometrica
+      10: 99-128
 
-    United Kingdom
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    1252–1700 (England)	Broadberry, S.N., B. Campbell, A. Klein, M. Overton and B. van Leeuwen (2015), British Economic Growth 1270-1870 Cambridge: Cambridge University Press.
-    1700–1870	Broadberry, S.N., B. Campbell, A. Klein, M. Overton and B. van Leeuwen (2015), British Economic Growth 1270-1870 Cambridge: Cambridge University Press.
 
-    Greece
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    1833-1913	Kostelenos G., S. Petmezas, D. Vasiliou,  E. Kounaris and M. Sfakianakis, (2007), "Gross Domestic Product 1830-1939", Sources of Economic History of Modern Greece: Quantitative data and statistical series 1830-1939, Historical Archives of the National Bank of Greece, Athens.
+      Brazil
 
-    Croatia
-    1952-2008	Milanovic (2011). Estimates provided to the Maddison-Project
+      1800 - 1870   Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,”
+      Journal of Latin America Studies 41: 279–307 (updated data)
 
-    Indonesia
-    1815 – 1880 (Java)	Van Zanden (2012). “Economic Growth in Java 1815-1939: The Reconstruction of the Historical National Accounts of a Colonial Economy”, Maddison-Project Working Paper WP-3.
-    1880-2008	Van der Eng, P. (2010). The Sources of Long-Term Economic Growth in Indonesia, 1880-2008”,  Explorations in Economic History, 47: 294-309
+      1850–1899  Barro, R.J. and J.F. Ursua, (2008). “Macroeconomic Crises since 1870” Brookings Papers on Economic Activity,
+      Economic Studies Program, The Brookings Institution, vol. 39(1 (Spring), pages 255-350
 
-    India
-    1600–1870	Broadberry, S.N., Custodis, J. and Gupta, B. (2015), “India and the great divergence: an Anglo-Indian comparison of GDP per capita, 1600–1871” Explorations in Economic History, 55: 58-75.
 
-    Iran (Islamic Republic of)
-    1820, 1870, 1913, 1950	Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic History, vol 66, no. 3, pp. 809 - 828
+      Switzerland
 
-    Iraq
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    700 – 1500 	Pamuk, Ş. and M. Shatzmiller (2011). “Real Wages and GDP per capita in the Medieval Islamic Middle East in Comparative Perspective, 700-1500”, paper presented at the 9th Conference of the European Historical Economics Society, Dublin, September 2-3, 2011.
-    1820, 1870, 1913, 1950	Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic History, vol 66, no. 3, pp. 809 - 828
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
 
-    Israel
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
+      1850-2011  Stohr, Christian (2016), Trading Gains: new estimates of Swiss GDP, 1851-2008. Economic History Working Papers,
+      245/2016. London School of Economics and Political Science, Economic History Department, London, UK
 
-    Italy
-    1310-1871 (North Italy)	Malanima, P. (2010), “The long decline of a leading economy: GDP in central and northern Italy, 1300–1913” European Review of Economic History 15 (2): 169–219.
-    1871-1990	Baffigi, A. (2011).”Italian National Accounts, 1861-2011”, Banca d’Italia Economic History Working Papers 18.
 
-    Jamaica
-    1850 - 1938 	Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,” Journal of Latin America Studies 41: 279–307 (updated data)
+      Chile
 
-    Jordan
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    1820, 1870, 1913, 1950	Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic History, vol 66, no. 3, pp. 809 - 828
+      1810–2004  Díaz, J.B. Lüders, R. and Wagner, G. (2007) Economia Chilena 1810 - 2000, Producto total y sectorial una
+      nueva mirada, Pontificia universidad Catolica de Chile, Insituto de Economia, Documeno de Trabajo no. 315
 
-    Japan
-    724-1874	Bassino, Jean-Pascal & Broadberry, Stephen & Fukao, Kyoji & Gupta, Bishnupriya & Takashima, Masanori, (2018). "Japan and the Great Divergence, 730-1874," CEI Working Paper Series 2018-13, Center for Economic Institutions, Institute of Economic Research, Hitotsubashi University
-    1874-1940	Fukao, K., Bassino, J.-P., Makino, T., Paprzycki, R., Settsu, T., Takashima, M., and Tokui, J. (2015) Regional Inequality and Industrial Structure in Japan: 1874-2008, Tokyo: Maruzen Publishing.
 
-    Republic of Korea
-    1911-1990	Cha, M.S., Kim, N.N., Park, K.-J., Park, Y. (Eds.) (2020), Historical Statistics of Korea. Studies in Economic History, New York: Springer Publishing
+      China
 
-    Lebanon
-    1820, 1870, 1913, 1950	Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic History, vol 66, no. 3, pp. 809 - 828
+      1000-1661  Broadberry, S.N., Guan, Hanhui and David Daokui Li (2018), “China, Europe and the Great Divergence: a Study
+      in Historical National Accounting, 980-1850”, Journal of Economic History, 78, 4, 955-1000
 
-    Mexico
-    1550–1812	Arroyo Abad, L. and J.L. van Zanden (2016), “Growth under Extractive Institutions? Latin American Per Capita GDP in Colonial Times” Journal of Economic History 76(4): 1182–1215.
-    1812–1870	Prados de la Escosura, L., (2009), ‘Lost decades? Economic performance in post-independence Latin America’, Journal of Latin America Studies, 41, pp. 279–307. (updated data)
-    1895–2003	Barro, R.J. and J.F. Ursua, (2008). “Macroeconomic Crises since 1870” Brookings Papers on Economic Activity, Economic Studies Program, The Brookings Institution, vol. 39(1 (Spring), pages 255-350
+      1661–1933  Broadberry, S.N., Guan, Hanhui and David Daokui Li (2018), “China, Europe and the Great Divergence: a Study
+      in Historical National Accounting, 980-1850”, Journal of Economic History, 78, 4, 955-1000
 
-    TFYR of Macedonia
-    1952-2008	Milanovic (2011). Estimates provided to the Maddison-Project
+      1661–1933  Xu, Y. Z. Shi, B. van Leeuwen, Y Ni, Z Zhang, and Y Ma, (2016) 'Chinese National Income, ca. 1661-1933',
+      Australian Economic History Review 57(3), 368–393
 
-    Montenegro
-    1952-2008	Milanovic (2011). Estimates provided to the Maddison-Project
+      1952–2008  Wu, Harry X. (2014), “China’s growth and productivity performance debate revisited – Accounting for China’s
+      sources of growth with a new data set” The Conference Board Economics Program Working Paper Series EWP#14-01.
 
-    Malaysia
-    1900-1939	Nazrin Shah, S. (2017). Charting the Economy: Early 20th Century Malaya and Contemporary Malaysian Contrasts, Oxford University Press
 
-    Netherlands
-    1348–1807 (Holland)	Van Zanden, J. L. and van Leeuwen, B. (2012), ‘Persistent but not consistent: the growth of national income in Holland 1347–1807’, Explorations in Economic History, 49 (2012), pp. 119–30.
-    1807-1913	Smits, J.P., E. Horlings and J.L. van Zanden (2000). The Measurement of Gross National Product and its Components 1800-1913 (Groningen Growth and Development Centre Monograph series no 5).
+      Colombia
 
-    Norway
-    1820–1930	Grytten, O.H. (2015). Norwegian gross domestic product by industry 1830 - 1930, Norges Bank Working paper 19/2015. Population from Maddison (2006)
+      1800 - 1870   Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,”
+      Journal of Latin America Studies 41: 279–307 (updated data)
 
-    Panama
-    1906–1945	De Corso, G. (2013). El crecimiento economico de Venuzuela, Desde la Oligarquia Conservadora Hasta La Revolucion Bolivariana: 1830-2012. Uno Vision cuantitativa *: Venezuelan Economic Growth From The Conservative Oligarchy To The Bolivarian Revolution (1830-2012), Revista De Historia Económica / Journal of Iberian and Latin American Economic History, 31(3), 321-357. doi:10.1017/S0212610913000190
+      1870 - 1923   Bertola, L and Ocampo, J.A. (2012) The Economic Development of Latin America since Independence. Oxford,
+      Oxford U.P.
 
-    Peru
-    1600–1812	Arroyo Abad, L. and J.L. van Zanden (2016), “Growth under Extractive Institutions? Latin American Per Capita GDP in Colonial Times” Journal of Economic History 76(4): 1182–1215.
-    1812–1870	Seminario, B. (2015). El Desarrallo de la Economía Peruana en la Era Moderna, Universidad de Pacifico, Lima
-    1870-1901	Bertola, L and Ocampo, J.A. (2012) The Economic Development of Latin America since Independence. Oxford, Oxford U.P
 
-    Poland
-    1409–1913	Malinowski, M. and Van Zanden (2017), “National income and its distribution in preindustrial Poland in a global perspective” Cliometrica, Volume 11, Issue 3, pp 375–40
+      Czechoslovakia
 
-    D.P.R. of Korea
-    1911-1943	Cha, M.S., Kim, N.N., Park, K.-J., Park, Y. (Eds.) (2020), Historical Statistics of Korea. Studies in Economic History, New York: Springer Publishing.
-    1990-2015	Cha, M.S., Kim, N.N., Park, K.-J., Park, Y. (Eds.) (2020), Historical Statistics of Korea. Studies in Economic History, New York: Springer Publishing.
+      1993 -   Based on GDP and population data for their successor states
 
-    Portugal
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    1530–1850	Palma, N., & Reis, J. (2019). From Convergence to Divergence: Portuguese Economic Growth, 1527–1850. The Journal of Economic History, 79(2), 477-506. doi:10.1017/S0022050719000056
 
-    Romania
-    1862–1995	Axenciuc, V. (2012). Produsul intern brut al Romaniei, Vol. 1, Institutl de Economie Nationala, Bucarest
+      Cuba
 
-    Saudi Arabia
-    1820, 1870, 1913, 1950	Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic History, vol 66, no. 3, pp. 809 - 828
+      1690–1895  Santamaria Garcia, A. (2005). Las Cuentas nacionales de Cuba, 1960 - 2005', mimeo
 
-    Singapore
-    1900–1959	Sugimoto, I. (2011), Economic growth of Singapore in the twentieth century: historical GDP estimates and empirical investigations, Economic Growth Centre Research Monograph ser., 2, http://www.worldscibooks.com/economics/7858.html (accessed on 30 Jan. 2013).
+      1902–1958  Ward, M. and Devereux, J. (2012), “The Road Not Taken: Pre-Revolutionary Cuban Living Standards in Comparative
+      Perspective” Journal of Economic History, 72(1): 104–132
 
-    Serbia
-    1952-2008	Milanovic (2011). Estimates provided to the Maddison-Project
 
-    Former USSR
-    1885-1913 	Gregory, P. R. (1982). Russian National Income, 1885–1913, Cambridge: Cambridge University Press
-    1913-1928 	Markevich, A. and M. Harrison (2011). “Great War, Civil War, and Recovery: Russia's National Income, 1913 to 1928”, The Journal of Economic History, Volume 71 (3): 672 – 703, table 6.
-    1991 -	Based on GDP and population data for their successor states
+      Germany
 
-    Slovenia
-    1952-2008	Milanovic (2011). Estimates provided to the Maddison-Project
+      1500-1850  Pfister, U. (2011). “ Economic growth in Germany, 1500–1850”, Paper presented at the Conference on Quantifying
+      Long Run Economic Development, Venice, 22-24 March, 2011
 
-    Sweden
-    1300–1560	Krantz, O. (2017) “Swedish GDP 1300-1560 A Tentative Estimate” Lund Papers in Economic History: General Issues; No. 152.
-    1560–1950	Schön, L., and O. Krantz (2015) “New Swedish Historical National Accounts since the 16th Century in Constant and Current Prices” Lund Papers in Economic History no. 140
 
-    Syrian Arab Republic
-    1820, 1870, 1913, 1950	Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic History, vol 66, no. 3, pp. 809 - 828
+      Ecuador
 
-    Turkey
-    1	Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal of Roman Studies, 99 (2009), pp. 61–91
-    700 - 1820 	Pamuk, Ş. and M. Shatzmiller (2011). “Real Wages and GDP per capita in the Medieval Islamic Middle East in Comparative Perspective, 700-1500”, paper presented at the 9th Conference of the European Historical Economics Society, Dublin, September 2-3, 2011; Milanovic, B. (2006), “An estimate of average income and inequality in Byzantium around year 1000,” Review of Income and Wealth 52 (3).
-    1500-1820	Pamuk, S. (2009). “Estimating GDP per capita for the Ottoman Empire in a European Comparative Framework, 1500-1820”,  paper presented at the XVth World Economic History Congress, August 2009, Utrecht
+      1833-1938  Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,”
+      Journal of Latin America Studies 41: 279–307. (updated data). We use the growth rate between 1933 and 1938 from Prados
+      de la Escosura (2009) and link that to the 1939 level of Maddison’s original estimates.
 
-    Taiwan, Province of China
-    1820 - 1940 	Fukao, K., D. Ma and T. Yuan (2007). Real GDP in Pre-War East Asia: A 1934-36 Benchmark Purchasing Power Parity Comparison with the U.S. Review of Income and Wealth, 53 (3): 503 - 537. Trend from original Maddison estimates applied to benchmark for 1934/36
 
-    Uruguay
-    1800-1870	Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,” Journal of Latin America Studies 41: 279–307. (updated data)
-    1870–2014	Bèrtola, L. (2016). El PIB per Capita de Uruguay 1870 - 2016: una reconstruccion. PHES working paper No 48
+      Egypt
 
-    United States
-    1650 - 1790 	McCusker, John J., ‘Colonial Statistics’, Historical Statistics of the United States: Earliest Time to the Present, in S. B. Carter, S. S. Gartner, M. R. Haineset al. New York, Cambridge University Press. V-671.
-    1790 - 1870 	Sutch, R. (2006). National Income and Product. Historical Statistics of the United States: Earliest Time to the Present, in S. B. Carter, S. S. Gartner, M. R. Haineset al. New York, Cambridge University Press III-23-25.
-    1800-1830	Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,” Journal of Latin America Studies 41: 279–307. (updated data)
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
 
-    Venezuela (Bolivarian Republic of)
-    1830–2012	De Corso, G. (2013). El crecimiento economico de Venuzuela, Desde la Oligarquia Conservadora Hasta La Revolucion Bolivariana: 1830-2012. Uno Vision cuantitativa *: Venezuelan Economic Growth From The Conservative Oligarchy To The Bolivarian Revolution (1830-2012), Revista De Historia Económica / Journal of Iberian and Latin American Economic History, 31(3), 321-357. doi:10.1017/S0212610913000190
+      700 – 1500   Pamuk, Ş. and M. Shatzmiller (2011). “Real Wages and GDP per capita in the Medieval Islamic Middle East
+      in Comparative Perspective, 700-1500”, paper presented at the 9th Conference of the European Historical Economics Society,
+      Dublin, September 2-3, 2011.
 
-    Former Yugoslavia
-    1952-2008	Milanovic (2011). Estimates provided to the Maddison-Project
-    2008 -	Based on GDP and population data for their successor states
+      1820, 1870, 1913, 1950  Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic
+      History, vol 66, no. 3, pp. 809 - 828
 
-    South Africa
-    1700–1900 (Cape Colony)	Fourie, J. and Van Zanden, J.L. (2013). GDP in the Dutch Cape Colony: the Nationals Accounts of a Slave-Based Society, South African Journal of Economics, vol. 81 (4): 467 - 490
+
+      Spain
+
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
+
+      1270-1850  Álvarez-Nogal, C. and L. Prados de la Escosura (2013). "The Rise and Fall of Spain (1270-1850)," Economic
+      History Review, 66, 1, 1-37, using their annual benchmarks
+
+      1850–2016  Prados de la Escosura, L. (2017), Spanish Economic Growth, 1850-2015 (London: Palgrave Macmillan)
+
+
+      Finland
+
+      1600–1860  Eloranta, J., Voutilainen, M. and Nummela, I. (2016).  “Estimating Finnish Economic Growth Before 1860” mimeo.
+
+
+      France
+
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
+
+      1250–1800  Ridolfi, L. (2016) “The French economy in the longue durée. A study on real wages, working days and economic
+      performance from Louis IX to the Revolution (1250-1789)” Dissertation IMT School for Advanced Studies, Lucca, available
+      at http://e-theses.imtlucca.it/211/1/Ridolfi_phdthesis.pdf
+
+
+      United Kingdom
+
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
+
+      1252–1700 (England)  Broadberry, S.N., B. Campbell, A. Klein, M. Overton and B. van Leeuwen (2015), British Economic
+      Growth 1270-1870 Cambridge: Cambridge University Press.
+
+      1700–1870  Broadberry, S.N., B. Campbell, A. Klein, M. Overton and B. van Leeuwen (2015), British Economic Growth 1270-1870
+      Cambridge: Cambridge University Press.
+
+
+      Greece
+
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
+
+      1833-1913  Kostelenos G., S. Petmezas, D. Vasiliou,  E. Kounaris and M. Sfakianakis, (2007), "Gross Domestic Product
+      1830-1939", Sources of Economic History of Modern Greece: Quantitative data and statistical series 1830-1939, Historical
+      Archives of the National Bank of Greece, Athens.
+
+
+      Croatia
+
+      1952-2008  Milanovic (2011). Estimates provided to the Maddison-Project
+
+
+      Indonesia
+
+      1815 – 1880 (Java)  Van Zanden (2012). “Economic Growth in Java 1815-1939: The Reconstruction of the Historical National
+      Accounts of a Colonial Economy”, Maddison-Project Working Paper WP-3.
+
+      1880-2008  Van der Eng, P. (2010). The Sources of Long-Term Economic Growth in Indonesia, 1880-2008”,  Explorations
+      in Economic History, 47: 294-309
+
+
+      India
+
+      1600–1870  Broadberry, S.N., Custodis, J. and Gupta, B. (2015), “India and the great divergence: an Anglo-Indian comparison
+      of GDP per capita, 1600–1871” Explorations in Economic History, 55: 58-75.
+
+
+      Iran (Islamic Republic of)
+
+      1820, 1870, 1913, 1950  Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic
+      History, vol 66, no. 3, pp. 809 - 828
+
+
+      Iraq
+
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
+
+      700 – 1500   Pamuk, Ş. and M. Shatzmiller (2011). “Real Wages and GDP per capita in the Medieval Islamic Middle East
+      in Comparative Perspective, 700-1500”, paper presented at the 9th Conference of the European Historical Economics Society,
+      Dublin, September 2-3, 2011.
+
+      1820, 1870, 1913, 1950  Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic
+      History, vol 66, no. 3, pp. 809 - 828
+
+
+      Israel
+
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
+
+
+      Italy
+
+      1310-1871 (North Italy)  Malanima, P. (2010), “The long decline of a leading economy: GDP in central and northern Italy,
+      1300–1913” European Review of Economic History 15 (2): 169–219.
+
+      1871-1990  Baffigi, A. (2011).”Italian National Accounts, 1861-2011”, Banca d’Italia Economic History Working Papers
+      18.
+
+
+      Jamaica
+
+      1850 - 1938   Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,”
+      Journal of Latin America Studies 41: 279–307 (updated data)
+
+
+      Jordan
+
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
+
+      1820, 1870, 1913, 1950  Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic
+      History, vol 66, no. 3, pp. 809 - 828
+
+
+      Japan
+
+      724-1874  Bassino, Jean-Pascal & Broadberry, Stephen & Fukao, Kyoji & Gupta, Bishnupriya & Takashima, Masanori, (2018).
+      "Japan and the Great Divergence, 730-1874," CEI Working Paper Series 2018-13, Center for Economic Institutions, Institute
+      of Economic Research, Hitotsubashi University
+
+      1874-1940  Fukao, K., Bassino, J.-P., Makino, T., Paprzycki, R., Settsu, T., Takashima, M., and Tokui, J. (2015) Regional
+      Inequality and Industrial Structure in Japan: 1874-2008, Tokyo: Maruzen Publishing.
+
+
+      Republic of Korea
+
+      1911-1990  Cha, M.S., Kim, N.N., Park, K.-J., Park, Y. (Eds.) (2020), Historical Statistics of Korea. Studies in Economic
+      History, New York: Springer Publishing
+
+
+      Lebanon
+
+      1820, 1870, 1913, 1950  Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic
+      History, vol 66, no. 3, pp. 809 - 828
+
+
+      Mexico
+
+      1550–1812  Arroyo Abad, L. and J.L. van Zanden (2016), “Growth under Extractive Institutions? Latin American Per Capita
+      GDP in Colonial Times” Journal of Economic History 76(4): 1182–1215.
+
+      1812–1870  Prados de la Escosura, L., (2009), ‘Lost decades? Economic performance in post-independence Latin America’,
+      Journal of Latin America Studies, 41, pp. 279–307. (updated data)
+
+      1895–2003  Barro, R.J. and J.F. Ursua, (2008). “Macroeconomic Crises since 1870” Brookings Papers on Economic Activity,
+      Economic Studies Program, The Brookings Institution, vol. 39(1 (Spring), pages 255-350
+
+
+      TFYR of Macedonia
+
+      1952-2008  Milanovic (2011). Estimates provided to the Maddison-Project
+
+
+      Montenegro
+
+      1952-2008  Milanovic (2011). Estimates provided to the Maddison-Project
+
+
+      Malaysia
+
+      1900-1939  Nazrin Shah, S. (2017). Charting the Economy: Early 20th Century Malaya and Contemporary Malaysian Contrasts,
+      Oxford University Press
+
+
+      Netherlands
+
+      1348–1807 (Holland)  Van Zanden, J. L. and van Leeuwen, B. (2012), ‘Persistent but not consistent: the growth of national
+      income in Holland 1347–1807’, Explorations in Economic History, 49 (2012), pp. 119–30.
+
+      1807-1913  Smits, J.P., E. Horlings and J.L. van Zanden (2000). The Measurement of Gross National Product and its Components
+      1800-1913 (Groningen Growth and Development Centre Monograph series no 5).
+
+
+      Norway
+
+      1820–1930  Grytten, O.H. (2015). Norwegian gross domestic product by industry 1830 - 1930, Norges Bank Working paper
+      19/2015. Population from Maddison (2006)
+
+
+      Panama
+
+      1906–1945  De Corso, G. (2013). El crecimiento economico de Venuzuela, Desde la Oligarquia Conservadora Hasta La Revolucion
+      Bolivariana: 1830-2012. Uno Vision cuantitativa *: Venezuelan Economic Growth From The Conservative Oligarchy To The
+      Bolivarian Revolution (1830-2012), Revista De Historia Económica / Journal of Iberian and Latin American Economic History,
+      31(3), 321-357. doi:10.1017/S0212610913000190
+
+
+      Peru
+
+      1600–1812  Arroyo Abad, L. and J.L. van Zanden (2016), “Growth under Extractive Institutions? Latin American Per Capita
+      GDP in Colonial Times” Journal of Economic History 76(4): 1182–1215.
+
+      1812–1870  Seminario, B. (2015). El Desarrallo de la Economía Peruana en la Era Moderna, Universidad de Pacifico, Lima
+
+      1870-1901  Bertola, L and Ocampo, J.A. (2012) The Economic Development of Latin America since Independence. Oxford,
+      Oxford U.P
+
+
+      Poland
+
+      1409–1913  Malinowski, M. and Van Zanden (2017), “National income and its distribution in preindustrial Poland in a
+      global perspective” Cliometrica, Volume 11, Issue 3, pp 375–40
+
+
+      D.P.R. of Korea
+
+      1911-1943  Cha, M.S., Kim, N.N., Park, K.-J., Park, Y. (Eds.) (2020), Historical Statistics of Korea. Studies in Economic
+      History, New York: Springer Publishing.
+
+      1990-2015  Cha, M.S., Kim, N.N., Park, K.-J., Park, Y. (Eds.) (2020), Historical Statistics of Korea. Studies in Economic
+      History, New York: Springer Publishing.
+
+
+      Portugal
+
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
+
+      1530–1850  Palma, N., & Reis, J. (2019). From Convergence to Divergence: Portuguese Economic Growth, 1527–1850. The
+      Journal of Economic History, 79(2), 477-506. doi:10.1017/S0022050719000056
+
+
+      Romania
+
+      1862–1995  Axenciuc, V. (2012). Produsul intern brut al Romaniei, Vol. 1, Institutl de Economie Nationala, Bucarest
+
+
+      Saudi Arabia
+
+      1820, 1870, 1913, 1950  Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic
+      History, vol 66, no. 3, pp. 809 - 828
+
+
+      Singapore
+
+      1900–1959  Sugimoto, I. (2011), Economic growth of Singapore in the twentieth century: historical GDP estimates and
+      empirical investigations, Economic Growth Centre Research Monograph ser., 2, http://www.worldscibooks.com/economics/7858.html
+      (accessed on 30 Jan. 2013).
+
+
+      Serbia
+
+      1952-2008  Milanovic (2011). Estimates provided to the Maddison-Project
+
+
+      Former USSR
+
+      1885-1913   Gregory, P. R. (1982). Russian National Income, 1885–1913, Cambridge: Cambridge University Press
+
+      1913-1928   Markevich, A. and M. Harrison (2011). “Great War, Civil War, and Recovery: Russia's National Income, 1913
+      to 1928”, The Journal of Economic History, Volume 71 (3): 672 – 703, table 6.
+
+      1991 -  Based on GDP and population data for their successor states
+
+
+      Slovenia
+
+      1952-2008  Milanovic (2011). Estimates provided to the Maddison-Project
+
+
+      Sweden
+
+      1300–1560  Krantz, O. (2017) “Swedish GDP 1300-1560 A Tentative Estimate” Lund Papers in Economic History: General Issues;
+      No. 152.
+
+      1560–1950  Schön, L., and O. Krantz (2015) “New Swedish Historical National Accounts since the 16th Century in Constant
+      and Current Prices” Lund Papers in Economic History no. 140
+
+
+      Syrian Arab Republic
+
+      1820, 1870, 1913, 1950  Pamuk, S. (2006), Estimating Economic Growth in the Middle East since 1820, The Journal of Economic
+      History, vol 66, no. 3, pp. 809 - 828
+
+
+      Turkey
+
+      1  Scheidel, W. and Friesen, S. J., ‘The size of the economy and the distribution of income in the Roman Empire’, Journal
+      of Roman Studies, 99 (2009), pp. 61–91
+
+      700 - 1820   Pamuk, Ş. and M. Shatzmiller (2011). “Real Wages and GDP per capita in the Medieval Islamic Middle East
+      in Comparative Perspective, 700-1500”, paper presented at the 9th Conference of the European Historical Economics Society,
+      Dublin, September 2-3, 2011; Milanovic, B. (2006), “An estimate of average income and inequality in Byzantium around
+      year 1000,” Review of Income and Wealth 52 (3).
+
+      1500-1820  Pamuk, S. (2009). “Estimating GDP per capita for the Ottoman Empire in a European Comparative Framework,
+      1500-1820”,  paper presented at the XVth World Economic History Congress, August 2009, Utrecht
+
+
+      Taiwan, Province of China
+
+      1820 - 1940   Fukao, K., D. Ma and T. Yuan (2007). Real GDP in Pre-War East Asia: A 1934-36 Benchmark Purchasing Power
+      Parity Comparison with the U.S. Review of Income and Wealth, 53 (3): 503 - 537. Trend from original Maddison estimates
+      applied to benchmark for 1934/36
+
+
+      Uruguay
+
+      1800-1870  Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,”
+      Journal of Latin America Studies 41: 279–307. (updated data)
+
+      1870–2014  Bèrtola, L. (2016). El PIB per Capita de Uruguay 1870 - 2016: una reconstruccion. PHES working paper No 48
+
+
+      United States
+
+      1650 - 1790   McCusker, John J., ‘Colonial Statistics’, Historical Statistics of the United States: Earliest Time to
+      the Present, in S. B. Carter, S. S. Gartner, M. R. Haineset al. New York, Cambridge University Press. V-671.
+
+      1790 - 1870   Sutch, R. (2006). National Income and Product. Historical Statistics of the United States: Earliest Time
+      to the Present, in S. B. Carter, S. S. Gartner, M. R. Haineset al. New York, Cambridge University Press III-23-25.
+
+      1800-1830  Prados de la Escosura, L. (2009). “Lost Decades? Economic Performance in Post-Independence Latin America,”
+      Journal of Latin America Studies 41: 279–307. (updated data)
+
+
+      Venezuela (Bolivarian Republic of)
+
+      1830–2012  De Corso, G. (2013). El crecimiento economico de Venuzuela, Desde la Oligarquia Conservadora Hasta La Revolucion
+      Bolivariana: 1830-2012. Uno Vision cuantitativa *: Venezuelan Economic Growth From The Conservative Oligarchy To The
+      Bolivarian Revolution (1830-2012), Revista De Historia Económica / Journal of Iberian and Latin American Economic History,
+      31(3), 321-357. doi:10.1017/S0212610913000190
+
+
+      Former Yugoslavia
+
+      1952-2008  Milanovic (2011). Estimates provided to the Maddison-Project
+
+      2008 -  Based on GDP and population data for their successor states
+
+
+      South Africa
+
+      1700–1900 (Cape Colony)  Fourie, J. and Van Zanden, J.L. (2013). GDP in the Dutch Cape Colony: the Nationals Accounts
+      of a Slave-Based Society, South African Journal of Economics, vol. 81 (4): 467 - 490
+    producer: Maddison Project Database 2020 (Bolt and van Zanden, 2020)
+    citation_producer: Bolt, Jutta and Jan Luiten van Zanden (2020), “Maddison style estimates of the evolution of the world economy. A new 2020 update“.
+    dataset_url_main: https://www.rug.nl/ggdc/historicaldevelopment/maddison/releases/maddison-project-database-2020
+    dataset_url_download: https://www.rug.nl/ggdc/historicaldevelopment/maddison/data/mpd2020.xlsx
+    date_accessed: 2022-04-12
+    date_published: 2020-10-01
+  license:
+    name: Creative Commons BY 4.0
+    url: https://www.rug.nl/ggdc/historicaldevelopment/maddison/releases/maddison-project-database-2020
 wdir: ../../../data/snapshots/ggdc/2020-10-01
 outs:
 - md5: 0fadb25212dd37be38cd098899873a35
-  size: 1764793
   path: ggdc_maddison.xlsx
+  size: 1764793

--- a/snapshots/un/2023-01-24/un_sdg.py
+++ b/snapshots/un/2023-01-24/un_sdg.py
@@ -64,6 +64,7 @@ def main(upload: bool) -> None:
         add_snapshot("un/2023-01-24/un_sdg_dimension.json", filename=dim_file, upload=upload)  # type: ignore
 
         # fetch the file locally
+        assert metadata.source
         assert metadata.source.source_data_url is not None
         log.info("Downloading data...")
         all_data = download_data(snap)
@@ -76,6 +77,7 @@ def create_metadata(snap: Snapshot) -> SnapshotMeta:
     meta = snap.metadata
     meta_update = load_external_metadata()
     meta.name = meta_update["name"]
+    assert meta.source
     meta.source.publication_year = meta_update["publication_year"]
     meta.source.publication_date = meta_update["publication_date"]
     meta.source.date_accessed = str(dt.datetime.now().date())
@@ -105,6 +107,7 @@ def load_external_metadata() -> dict:
 def download_data(snap: Snapshot) -> pd.DataFrame:
     # retrieves all goal codes
     print("Retrieving SDG goal codes...")
+    assert snap.metadata.source
     url = f"{snap.metadata.source.source_data_url}/v1/sdg/Goal/List"
     res = requests.get(url)
     assert res.ok
@@ -192,6 +195,7 @@ def attributes_description(snap: Snapshot) -> Dict[Any, Any]:
     """Gathers each of the unit codes and their more descriptive counterparts."""
     goal_codes = get_goal_codes(snap)
     a = []
+    assert snap.metadata.source
     for goal in goal_codes:
         url = f"{snap.metadata.source.source_data_url}/v1/sdg/Goal/{goal}/Attributes"
         res = requests.get(url)
@@ -214,6 +218,7 @@ def dimensions_description(snap: Snapshot) -> dict:
     """Gathers each of the dimension codes and their more descriptive versions. This updates regularly so is important to snapshot"""
     goal_codes = get_goal_codes(snap)
     d = []
+    assert snap.metadata.source
     for goal in goal_codes:
         url = f"{snap.metadata.source.source_data_url}/v1/sdg/Goal/{goal}/Dimensions"
         res = requests.get(url)
@@ -237,6 +242,7 @@ def dimensions_description(snap: Snapshot) -> dict:
 
 def get_goal_codes(snap: Snapshot) -> List[int]:
     # retrieves all goal codes
+    assert snap.metadata.source
     url = f"{snap.metadata.source.source_data_url}/v1/sdg/Goal/List"
     res = requests.get(url)
     assert res.ok

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -24,41 +24,41 @@ def test_variable_metadata():
             "entityCode": [None, None, None, None, None],
         }
     )
-    variable_meta = (
-        pd.Series(
-            {
-                "id": 525715,
-                "name": "Population density",
-                "unit": "people per km²",
-                "description": "Population density by country...",
-                "createdAt": pd.Timestamp("2022-09-20 12:16:46"),  # type: ignore
-                "updatedAt": pd.Timestamp("2023-02-10 11:46:31"),  # type: ignore
-                "code": None,
-                "coverage": "",
-                "timespan": "-10000-2100",
-                "datasetId": 5774,
-                "sourceId": 27065,
-                "shortUnit": None,
-                "display": '{"name": "Population density", "unit": "people per km²", "shortUnit": null, "includeInTable": true, "numDecimalPlaces": 1}',
-                "columnOrder": 0,
-                "originalMetadata": None,
-                "grapherConfig": None,
-                "shortName": "population_density",
-                "catalogPath": "grapher/owid/latest/key_indicators/population_density",
-                "dimensions": None,
-                "dataPath": None,
-                "metadataPath": None,
-                "datasetName": "Key Indicators",
-                "nonRedistributable": 0,
-                "sourceName": "Gapminder (v6); UN (2022); HYDE (v3.2); Food and Agriculture Organization of the United Nations",
-                "sourceDescription": '{"link": "https://www.gapminder.org/data/documentation/gd003/", "retrievedDate": "October 8, 2021", "additionalInfo": "Our World in Data builds...", "dataPublishedBy": "Gapminder (v6); United Nations - Population Division (2022); HYDE (v3.2); World Bank", "dataPublisherSource": null}',
-            }
-        )
-        .to_frame()
-        .T
+    variable_meta = {
+        "id": 525715,
+        "name": "Population density",
+        "unit": "people per km²",
+        "description": "Population density by country...",
+        "createdAt": pd.Timestamp("2022-09-20 12:16:46"),  # type: ignore
+        "updatedAt": pd.Timestamp("2023-02-10 11:46:31"),  # type: ignore
+        "code": None,
+        "coverage": "",
+        "timespan": "-10000-2100",
+        "datasetId": 5774,
+        "sourceId": 27065,
+        "shortUnit": None,
+        "display": '{"name": "Population density", "unit": "people per km²", "shortUnit": null, "includeInTable": true, "numDecimalPlaces": 1}',
+        "columnOrder": 0,
+        "originalMetadata": None,
+        "grapherConfig": None,
+        "shortName": "population_density",
+        "catalogPath": "grapher/owid/latest/key_indicators/population_density",
+        "dimensions": None,
+        "dataPath": None,
+        "metadataPath": None,
+        "datasetName": "Key Indicators",
+        "nonRedistributable": 0,
+        "sourceName": "Gapminder (v6); UN (2022); HYDE (v3.2); Food and Agriculture Organization of the United Nations",
+        "sourceDescription": '{"link": "https://www.gapminder.org/data/documentation/gd003/", "retrievedDate": "October 8, 2021", "additionalInfo": "Our World in Data builds...", "dataPublishedBy": "Gapminder (v6); United Nations - Population Division (2022); HYDE (v3.2); World Bank", "dataPublisherSource": null}',
+    }
+    origins_df = pd.DataFrame(
+        {
+            "datasetDescriptionOwid": ["Origin A", "Origin B"],
+        }
     )
-    with mock.patch("pandas.read_sql", return_value=variable_meta):
-        meta = variable_metadata(engine, 525715, variable_df)
+    with mock.patch("backport.datasync.data_metadata._load_variable", return_value=variable_meta):
+        with mock.patch("backport.datasync.data_metadata._load_origins_df", return_value=origins_df):
+            meta = variable_metadata(engine, 525715, variable_df)
 
     assert meta == {
         "id": 525715,
@@ -76,6 +76,7 @@ def test_variable_metadata():
         "datasetName": "Key Indicators",
         "type": "mixed",
         "nonRedistributable": False,
+        "origins": [{"datasetDescriptionOwid": "Origin A"}, {"datasetDescriptionOwid": "Origin B"}],
         "display": {
             "name": "Population density",
             "unit": "people per km²",

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import numpy as np
 import pandas as pd
-from owid.catalog import DatasetMeta, Source, Table, TableMeta, VariableMeta
+from owid.catalog import DatasetMeta, Origin, Source, Table, TableMeta, VariableMeta
 
 from etl import grapher_helpers as gh
 
@@ -188,3 +188,12 @@ def test_adapt_table_for_grapher_multiindex():
         out_table = gh._adapt_table_for_grapher(table)
         assert out_table.index.names == ["entity_id", "year", "sex"]
         assert out_table.columns.tolist() == ["deaths"]
+
+
+def test_add_dataset_origins_to_variables():
+    table = _sample_table()
+    assert table.deaths.metadata.origins == []
+    origins = [Origin(dataset_title_owid="A")]
+    table.metadata.dataset = DatasetMeta(origins=origins)
+    table = gh._add_dataset_origins_to_variables(table)
+    assert table.deaths.metadata.origins == origins

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
 import pytest
+from owid.catalog import Origin
 
-from etl.snapshot import _parse_snapshot_path
+from etl.snapshot import SnapshotMeta, _parse_snapshot_path
 
 
 def test_parse_snapshot_path():
@@ -18,3 +19,21 @@ def test_parse_snapshot_path():
     with pytest.raises(AssertionError):
         path = Path("etl/snapshots/unep/2023-03-17/consumption_controlled_substances.hydrobromofluorocarbons.xlsx.dvc")
         _parse_snapshot_path(path)
+
+
+def test_snapshot_to_yaml():
+    d = SnapshotMeta(
+        namespace="aviation_safety_network",
+        version="2023-04-18",
+        short_name="aviation_statistics_by_period",
+        file_extension="csv",
+        origin=Origin(dataset_title_owid="Aviation Statistics by Period"),
+    ).to_dict()
+    assert d == {
+        "file_extension": "csv",
+        "is_public": True,
+        "namespace": "aviation_safety_network",
+        "short_name": "aviation_statistics_by_period",
+        "version": "2023-04-18",
+        "origin": {"dataset_title_owid": "Aviation Statistics by Period"},
+    }


### PR DESCRIPTION
Adds tracking of whether a source was created from an origin. This will be useful when we display this information. Code that is only aware of sources will not care and code that is aware of both can then easily ignore sources that are just copies of Origin