### PR TITLE
🐛  Allowing dataframes without age column to be used in data_helpers.population.add_population()

### DIFF
--- a/etl/data_helpers/population.py
+++ b/etl/data_helpers/population.py
@@ -18,7 +18,6 @@ def add_population(
     age_col: Optional[str] = None,
     age_group_mapping: Optional[Dict[str, Optional[Any]]] = None,
 ) -> pd.DataFrame:
-
     """Add population to dataframe.
 
     Currently uses population from UN WPP 2022, as this dataset contains dissagregated data by age and sex groups.
@@ -122,7 +121,7 @@ def add_population(
             df_pop.append(pop_g)
         df_pop = pd.concat(df_pop, ignore_index=True)
     else:
-        df_pop = pop.groupby(["location", "year", "sex"], as_index=False).sum().drop(columns=["age"])
+        df_pop = pop.groupby(["location", "year", "sex"], as_index=False).sum().drop(columns=["age"], errors="ignore")
 
     # Merge
     columns_input = list(df.columns)


### PR DESCRIPTION
Current behaviour: 

```
import pandas as pd
from etl.data_helpers.population import add_population


data = {'country': ['Chad', 'Chad', 'Canada', 'Canada', 'Germany', 'Germany'],
        'year': [2019, 2020, 2019, 2020, 2019, 2020],
        'value': [10, 15, 5, 8, 12, 18]}

df = pd.DataFrame(data)

add_population(df, country_col = 'country', year_col= 'year' )
```

Throws the following error:

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Untitled-1 in line 8
      3 data = {'country': ['Chad', 'Chad', 'Canada', 'Canada', 'Germany', 'Germany'],
      4         'year': [2019, 2020, 2019, 2020, 2019, 2020],
      5         'value': [10, 15, 5, 8, 12, 18]}
      7 df = pd.DataFrame(data)
----> 8 add_population(df, country_col = 'country', year_col= 'year' )

File ~/Documents/OWID/repos/etl/etl/data_helpers/population.py:124, in add_population(df, country_col, year_col, sex_col, sex_group_all, sex_group_female, sex_group_male, age_col, age_group_mapping)
    122     df_pop = pd.concat(df_pop, ignore_index=True)
    123 else:
--> 124     df_pop = pop.groupby(["location", "year", "sex"], as_index=False).sum().drop(columns=["age"])
    126 # Merge
    127 columns_input = list(df.columns)

File ~/Documents/OWID/repos/etl/.venv/lib/python3.11/site-packages/pandas/util/_decorators.py:331, in deprecate_nonkeyword_arguments..decorate..wrapper(*args, **kwargs)
    325 if len(args) > num_allow_args:
    326     warnings.warn(
    327         msg.format(arguments=_format_argument_list(allow_args)),
    328         FutureWarning,
    329         stacklevel=find_stack_level(),
    330     )
--> 331 return func(*args, **kwargs)
...
-> 6977         raise KeyError(f"{list(labels[mask])} not found in axis")
   6978     indexer = indexer[~mask]
   6979 return self.delete(indexer)

KeyError: "['age'] not found in axis"
```