### PR TITLE
fix(energy_institute): Fix missing regions in Statistical Review

### DIFF
--- a/etl/steps/data/garden/energy_institute/2023-06-26/statistical_review_of_world_energy.py
+++ b/etl/steps/data/garden/energy_institute/2023-06-26/statistical_review_of_world_energy.py
@@ -273,7 +273,7 @@ def add_region_aggregates(tb: Table, ds_regions: Dataset, ds_income_groups: Data
     # Copy metadata of original table.
     tb_regions.copy_metadata(from_table=tb)
 
-    return tb
+    return tb_regions
 
 
 def create_additional_variables(tb: Table) -> Table:


### PR DESCRIPTION
Fixed a small bug that prevented aggregate regions to be added to the main garden table.
