### PR TITLE
Improve the way we combine units when propagating metadata

### DIFF
--- a/etl/config.py
+++ b/etl/config.py
@@ -68,7 +68,7 @@ GRAPHER_INSERT_WORKERS = int(env.get("GRAPHER_WORKERS", 40))
 MAX_VIRTUAL_MEMORY_LINUX = 32 * 2**30  # 32 GB
 
 # increment this to force a full rebuild of all datasets
-ETL_EPOCH = 2
+ETL_EPOCH = 3
 
 # any garden or grapher dataset after this date will have strict mode enabled
 STRICT_AFTER = "2023-06-25"


### PR DESCRIPTION
Improve way we combine units when propagating metadata, to avoid spurious warnings.

This change affects for example the step `data://meadow/energy_institute/2023-06-26/statistical_review_of_world_energy`. Before this PR, it would raise many warnings on a melt operation, and with this PR it doesn't.

 NOTE: I increased ETL_EPOCH to see if datadiff shows any relevant difference with this change.