### PR TITLE
:sparkles: parallel upserts to grapher on table level

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -245,7 +245,7 @@ def run_dag(
         print("Detecting which steps need rebuilding...")
         start_time = time.time()
         steps = select_dirty_steps(steps, workers)
-        click.echo(f"{click.style('OK', fg='blue')} ({time.time() - start_time:.0f}s)")
+        click.echo(f"{click.style('OK', fg='blue')} ({time.time() - start_time:.1f}s)")
 
     if not steps:
         print("All datasets up to date!")
@@ -258,7 +258,7 @@ def run_dag(
             strict = _detect_strictness_level(step, strict)
             with strictness_level(strict):
                 time_taken = timed_run(lambda: step.run())
-                click.echo(f"{click.style('OK', fg='blue')} ({time_taken:.0f}s)")
+                click.echo(f"{click.style('OK', fg='blue')} ({time_taken:.1f}s)")
                 print()
 
 
@@ -324,7 +324,6 @@ def _backporting_steps(private: bool, filter_steps: Optional[Set[str]] = None) -
 
     # load all backported snapshots
     for snap in snapshot_catalog(match):
-
         # skip private backported steps
         if not private and not snap.metadata.is_public:
             continue

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -131,12 +131,6 @@ def _yield_wide_table(
             else:
                 title_with_dims = None
 
-            log.info(
-                "yield_wide_table.create_variable",
-                short_name=short_name,
-                title=title_with_dims,
-            )
-
             # Keep only entity_id and year in index
             yield tab.reset_index().set_index(["entity_id", "year"])[[short_name]]
 

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -192,8 +192,6 @@ def upsert_table(
     _update_variables_display(table)
 
     with Session(engine) as session:
-        log.info("upsert_table.upsert_variable", variable=table.columns[0])
-
         # For easy retrieveal of the value series we store the name
         column_name = table.columns[0]
 
@@ -263,7 +261,7 @@ def upsert_table(
         session.add(variable)
         session.commit()
 
-        log.info("upsert_table.uploaded_to_s3", size=len(table), variable_id=variable_id)
+        log.info("upsert_table.upserted_variable", size=len(table), id=variable_id, title=variable.name)
 
         return VariableUpsertResult(variable_id, source_id)  # type: ignore
 

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -287,6 +287,7 @@ class Table(pd.DataFrame):
         df.metadata = TableMeta.from_dict(metadata)
         df._set_fields_from_dict(fields)
 
+        # NOTE: setting index is really slow for large datasets
         if primary_key:
             df.set_index(primary_key, inplace=True)
 


### PR DESCRIPTION
Grapher step for `un_sdg` takes almost two hours now. That's because we use thousands of tables and grapher upsert only runs in parallel within table. This PR moves the parallelism up so that multiple tables can be processed in parallel. This makes `un_sdg` run about 10x faster.