### PR TITLE
fix: Add missing index files that are still used in the active dag

### DIFF
--- a/lib/walden/owid/walden/index/ggdc/2021-06-18/penn_world_table.json
+++ b/lib/walden/owid/walden/index/ggdc/2021-06-18/penn_world_table.json
@@ -1,0 +1,20 @@
+{
+  "namespace": "ggdc",
+  "short_name": "penn_world_table",
+  "name": "Penn World Table 10.0",
+  "description": "PWT version 10.0 is a database with information on GDP and its composition, employment, productivity and trade, covering 183 countries between 1950 and 2019.\n",
+  "source_name": "Feenstra et al. (2015), Penn World Table 10.0",
+  "url": "https://www.rug.nl/ggdc/productivity/pwt",
+  "file_extension": "xlsx",
+  "date_accessed": "2022-11-28",
+  "source_data_url": "https://www.rug.nl/ggdc/docs/pwt100.xlsx",
+  "license_url": "https://www.rug.nl/ggdc/productivity/pwt",
+  "license_name": "Creative Commons BY 4.0",
+  "is_public": true,
+  "version": "2021-06-18",
+  "publication_year": 2021,
+  "publication_date": "2021-06-18",
+  "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/ggdc/2021-06-18/penn_world_table.xlsx",
+  "md5": "befabc2fdc1be2f728615c8744b99ead"
+}
+

--- a/lib/walden/owid/walden/index/ggdc/2021-06-18/penn_world_table_national_accounts.json
+++ b/lib/walden/owid/walden/index/ggdc/2021-06-18/penn_world_table_national_accounts.json
@@ -1,0 +1,20 @@
+{
+  "namespace": "ggdc",
+  "short_name": "penn_world_table_national_accounts",
+  "name": "Penn World Table 10.0 - National Accounts",
+  "description": "National Accounts data in current and constant national prices and exchange rate and population data for Penn World Table.\n",
+  "source_name": "Feenstra et al. (2015), Penn World Table 10.0",
+  "url": "https://www.rug.nl/ggdc/productivity/pwt",
+  "file_extension": "xlsx",
+  "date_accessed": "2022-11-28",
+  "source_data_url": "https://www.rug.nl/ggdc/docs/pwt100-na-data.xlsx",
+  "license_url": "https://www.rug.nl/ggdc/productivity/pwt",
+  "license_name": "Creative Commons BY 4.0",
+  "is_public": true,
+  "version": "2021-06-18",
+  "publication_year": 2021,
+  "publication_date": "2021-06-18",
+  "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/ggdc/2021-06-18/penn_world_table_national_accounts.xlsx",
+  "md5": "4a5b758413ce255d97a87acbffed2df6"
+}
+


### PR DESCRIPTION
[ETL is failing to build](https://buildkite.com/our-world-in-data/etl-deploy-master/builds/1813#01896439-46dd-4207-aa0f-e74d6bd8b91e) and I think it's because these walden index files should have not been deleted (in my previous PR, https://github.com/owid/etl/pull/1343).
