### PR TITLE
Include different sources by variable in Multidimensional Poverty Index

### DIFF
--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -531,6 +531,9 @@ class Source(SQLModel, table=True):
         if self.description.get("additionalInfo"):
             conds.append(cls.description["additionalInfo"] == self.description["additionalInfo"])  # type: ignore
 
+        if self.description.get("dataPublishedBy"):
+            conds.append(cls.description["dataPublishedBy"] == self.description["dataPublishedBy"])  # type: ignore
+
         return select(cls).where(*conds)  # type: ignore
 
     def upsert(self, session: Session) -> "Source":

--- a/etl/steps/data/garden/ophi/2023-07-05/multidimensional_poverty_index.meta.yml
+++ b/etl/steps/data/garden/ophi/2023-07-05/multidimensional_poverty_index.meta.yml
@@ -11,30 +11,24 @@ all_sources:
       published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'The global Multidimensional Poverty Index (MPI) 2023. Country Results and Methodological Note', OPHI MPI Methodological Note 55, Oxford Poverty and Human Development Initiative, University of Oxford.
       url: |
         {source_common.url}
-      date_accessed: |
-        {source_common.date_accessed}
-      publication_date: |
-        {source_common.publication_date}
+      date_accessed: "{source_common.date_accessed}"
+      publication_date: "{source_common.publication_date}"
   - hot: &source-hot
       name: |
         {source_common.name}
       published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'A methodological note on the global Multidimensional Poverty Index (MPI) 2023 changes over time results for 84 countries', OPHI MPI Methodological Note 57, Oxford Poverty and Human Development Initiative, University of Oxford.
       url: |
         {source_common.url}
-      date_accessed: |
-        {source_common.date_accessed}
-      publication_date: |
-        {source_common.publication_date}
+      date_accessed: "{source_common.date_accessed}"
+      publication_date: "{source_common.publication_date}"
   - dissagregated: &source-dissagregated
       name: |
         {source_common.name}
       published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'The global Multidimensional Poverty Index (MPI) 2023. Dissagregation Results and Methodological Note', OPHI MPI Methodological Note 56, Oxford Poverty and Human Development Initiative, University of Oxford.
       url: |
         {source_common.url}
-      date_accessed: |
-        {source_common.date_accessed}
-      publication_date: |
-        {source_common.publication_date}
+      date_accessed: "{source_common.date_accessed}"
+      publication_date: "{source_common.publication_date}"
 
 definitions:
   core: |-

--- a/etl/steps/data/garden/ophi/2023-07-05/multidimensional_poverty_index.meta.yml
+++ b/etl/steps/data/garden/ophi/2023-07-05/multidimensional_poverty_index.meta.yml
@@ -141,6 +141,8 @@ tables:
         display:
            name: MPI (camp)
            numDecimalPlaces: 3
+        sources:
+          - *source-dissagregated
       cme_share_national:
         title: Share of population multidimensionally poor (national) - Current margin estimate
         unit: "%"
@@ -154,6 +156,8 @@ tables:
         display:
            name: Share of population multidimensionally poor
            numDecimalPlaces: 1
+        sources:
+          - *source-cme
       cme_share_urban:
         title: Share of population multidimensionally poor (urban) - Current margin estimate
         unit: "%"
@@ -167,6 +171,8 @@ tables:
         display:
            name: Share of population multidimensionally poor (urban)
            numDecimalPlaces: 1
+        sources:
+          - *source-dissagregated
       cme_share_rural:
         title: Share of population multidimensionally poor (rural) - Current margin estimate
         unit: "%"
@@ -180,6 +186,8 @@ tables:
         display:
            name: Share of population multidimensionally poor (rural)
            numDecimalPlaces: 1
+        sources:
+          - *source-dissagregated
       cme_share_camp:
         title: Share of population multidimensionally poor (camp) - Current margin estimate
         unit: "%"
@@ -193,6 +201,8 @@ tables:
         display:
            name: Share of population multidimensionally poor (camp)
            numDecimalPlaces: 1
+        sources:
+          - *source-dissagregated
       cme_intensity_national:
         title: Intensity of multidimensional poverty (national) - Current margin estimate
         unit: "%"
@@ -208,6 +218,8 @@ tables:
         display:
            name: Intensity of multidimensional poverty
            numDecimalPlaces: 1
+        sources:
+          - *source-cme
       cme_intensity_urban:
         title: Intensity of multidimensional poverty (urban) - Current margin estimate
         unit: "%"
@@ -223,6 +235,8 @@ tables:
         display:
            name: Intensity of multidimensional poverty (urban)
            numDecimalPlaces: 1
+        sources:
+          - *source-dissagregated
       cme_intensity_rural:
         title: Intensity of multidimensional poverty (rural) - Current margin estimate
         unit: "%"
@@ -238,6 +252,8 @@ tables:
         display:
            name: Intensity of multidimensional poverty (rural)
            numDecimalPlaces: 1
+        sources:
+          - *source-dissagregated
       cme_intensity_camp:
         title: Intensity of multidimensional poverty (camp) - Current margin estimate
         unit: "%"
@@ -253,6 +269,8 @@ tables:
         display:
            name: Intensity of multidimensional poverty (camp)
            numDecimalPlaces: 1
+        sources:
+          - *source-dissagregated
       hot_mpi_national:
         title: MPI (national) - Harmonized over time
         unit: ""
@@ -272,6 +290,8 @@ tables:
         display:
            name: MPI
            numDecimalPlaces: 3
+        sources:
+          - *source-hot
       hot_mpi_urban:
         title: MPI (urban) - Harmonized over time
         unit: ""
@@ -291,6 +311,9 @@ tables:
         display:
            name: MPI (urban)
            numDecimalPlaces: 3
+        sources:
+          - *source-hot
+          - *source-dissagregated
       hot_mpi_rural:
         title: MPI (rural) - Harmonized over time
         unit: ""
@@ -310,6 +333,9 @@ tables:
         display:
            name: MPI (rural)
            numDecimalPlaces: 3
+        sources:
+          - *source-hot
+          - *source-dissagregated
       hot_mpi_camp:
         title: MPI (camp) - Harmonized over time
         unit: ""
@@ -329,6 +355,9 @@ tables:
         display:
            name: MPI (camp)
            numDecimalPlaces: 3
+        sources:
+          - *source-hot
+          - *source-dissagregated
       hot_share_national:
         title: Share of population multidimensionally poor (national) - Harmonized over time
         unit: "%"
@@ -342,6 +371,8 @@ tables:
         display:
            name: Share of population multidimensionally poor
            numDecimalPlaces: 1
+        sources:
+          - *source-hot
       hot_share_urban:
         title: Share of population multidimensionally poor (urban) - Harmonized over time
         unit: "%"
@@ -355,6 +386,9 @@ tables:
         display:
            name: Share of population multidimensionally poor (urban)
            numDecimalPlaces: 1
+        sources:
+          - *source-hot
+          - *source-dissagregated
       hot_share_rural:
         title: Share of population multidimensionally poor (rural) - Harmonized over time
         unit: "%"
@@ -368,6 +402,9 @@ tables:
         display:
            name: Share of population multidimensionally poor (rural)
            numDecimalPlaces: 1
+        sources:
+          - *source-hot
+          - *source-dissagregated
       hot_share_camp:
         title: Share of population multidimensionally poor (camp) - Harmonized over time
         unit: "%"
@@ -381,6 +418,9 @@ tables:
         display:
            name: Share of population multidimensionally poor (camp)
            numDecimalPlaces: 1
+        sources:
+          - *source-hot
+          - *source-dissagregated
       hot_intensity_national:
         title: Intensity of multidimensional poverty (national) - Harmonized over time
         unit: "%"
@@ -396,6 +436,8 @@ tables:
         display:
            name: Intensity of multidimensional poverty
            numDecimalPlaces: 1
+        sources:
+          - *source-hot
       hot_intensity_urban:
         title: Intensity of multidimensional poverty (urban) - Harmonized over time
         unit: "%"
@@ -411,6 +453,9 @@ tables:
         display:
            name: Intensity of multidimensional poverty (urban)
            numDecimalPlaces: 1
+        sources:
+          - *source-hot
+          - *source-dissagregated
       hot_intensity_rural:
         title: Intensity of multidimensional poverty (rural) - Harmonized over time
         unit: "%"
@@ -426,6 +471,9 @@ tables:
         display:
            name: Intensity of multidimensional poverty (rural)
            numDecimalPlaces: 1
+        sources:
+          - *source-hot
+          - *source-dissagregated
       hot_intensity_camp:
         title: Intensity of multidimensional poverty (camp) - Harmonized over time
         unit: "%"
@@ -441,3 +489,6 @@ tables:
         display:
            name: Intensity of multidimensional poverty (camp)
            numDecimalPlaces: 1
+        sources:
+          - *source-hot
+          - *source-dissagregated

--- a/etl/steps/data/garden/ophi/2023-07-05/multidimensional_poverty_index.meta.yml
+++ b/etl/steps/data/garden/ophi/2023-07-05/multidimensional_poverty_index.meta.yml
@@ -6,21 +6,21 @@ source_common:
 
 all_sources:
   - cme: &source-cme
-      name: source_common.name
+      name: {source_common.name}
       published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'The global Multidimensional Poverty Index (MPI) 2023. Country Results and Methodological Note', OPHI MPI Methodological Note 55, Oxford Poverty and Human Development Initiative, University of Oxford.
-      url: source_common.url
+      url: {source_common.url}
       date_accessed: {source_common.date_accessed}
       publication_date: {source_common.publication_date}
   - hot: &source-hot
-      name: source_common.name
+      name: {source_common.name}
       published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'A methodological note on the global Multidimensional Poverty Index (MPI) 2023 changes over time results for 84 countries', OPHI MPI Methodological Note 57, Oxford Poverty and Human Development Initiative, University of Oxford.
-      url: source_common.url
-      date_accessed: source_common.date_accessed
-      publication_date: source_common.publication_date
+      url: {source_common.url}
+      date_accessed: {source_common.date_accessed}
+      publication_date: {source_common.publication_date}
   - dissagregated: &source-dissagregated
-      name: source_common.name
+      name: {source_common.name}
       published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'The global Multidimensional Poverty Index (MPI) 2023. Dissagregation Results and Methodological Note', OPHI MPI Methodological Note 56, Oxford Poverty and Human Development Initiative, University of Oxford.
-      url: source_common.url
+      url: {source_common.url}
       date_accessed: {source_common.date_accessed}
       publication_date: {source_common.publication_date}
 

--- a/etl/steps/data/garden/ophi/2023-07-05/multidimensional_poverty_index.meta.yml
+++ b/etl/steps/data/garden/ophi/2023-07-05/multidimensional_poverty_index.meta.yml
@@ -1,28 +1,40 @@
 source_common:
-  name: Multidimensional Poverty Index (MPI) (OPHI, 2023)
-  url: https://ophi.org.uk/multidimensional-poverty-index/
+  name: "Multidimensional Poverty Index (MPI) (OPHI, 2023)"
+  url: "https://ophi.org.uk/multidimensional-poverty-index/"
   date_accessed: 2023-07-11
   publication_date: 2023-07-11
 
 all_sources:
   - cme: &source-cme
-      name: {source_common.name}
+      name: |
+        {source_common.name}
       published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'The global Multidimensional Poverty Index (MPI) 2023. Country Results and Methodological Note', OPHI MPI Methodological Note 55, Oxford Poverty and Human Development Initiative, University of Oxford.
-      url: {source_common.url}
-      date_accessed: {source_common.date_accessed}
-      publication_date: {source_common.publication_date}
+      url: |
+        {source_common.url}
+      date_accessed: |
+        {source_common.date_accessed}
+      publication_date: |
+        {source_common.publication_date}
   - hot: &source-hot
-      name: {source_common.name}
+      name: |
+        {source_common.name}
       published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'A methodological note on the global Multidimensional Poverty Index (MPI) 2023 changes over time results for 84 countries', OPHI MPI Methodological Note 57, Oxford Poverty and Human Development Initiative, University of Oxford.
-      url: {source_common.url}
-      date_accessed: {source_common.date_accessed}
-      publication_date: {source_common.publication_date}
+      url: |
+        {source_common.url}
+      date_accessed: |
+        {source_common.date_accessed}
+      publication_date: |
+        {source_common.publication_date}
   - dissagregated: &source-dissagregated
-      name: {source_common.name}
+      name: |
+        {source_common.name}
       published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'The global Multidimensional Poverty Index (MPI) 2023. Dissagregation Results and Methodological Note', OPHI MPI Methodological Note 56, Oxford Poverty and Human Development Initiative, University of Oxford.
-      url: {source_common.url}
-      date_accessed: {source_common.date_accessed}
-      publication_date: {source_common.publication_date}
+      url: |
+        {source_common.url}
+      date_accessed: |
+        {source_common.date_accessed}
+      publication_date: |
+        {source_common.publication_date}
 
 definitions:
   core: |-

--- a/etl/steps/data/garden/ophi/2023-07-05/multidimensional_poverty_index.meta.yml
+++ b/etl/steps/data/garden/ophi/2023-07-05/multidimensional_poverty_index.meta.yml
@@ -1,3 +1,29 @@
+source_common:
+  name: Multidimensional Poverty Index (MPI) (OPHI, 2023)
+  url: https://ophi.org.uk/multidimensional-poverty-index/
+  date_accessed: 2023-07-11
+  publication_date: 2023-07-11
+
+all_sources:
+  - cme: &source-cme
+      name: source_common.name
+      published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'The global Multidimensional Poverty Index (MPI) 2023. Country Results and Methodological Note', OPHI MPI Methodological Note 55, Oxford Poverty and Human Development Initiative, University of Oxford.
+      url: source_common.url
+      date_accessed: {source_common.date_accessed}
+      publication_date: {source_common.publication_date}
+  - hot: &source-hot
+      name: source_common.name
+      published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'A methodological note on the global Multidimensional Poverty Index (MPI) 2023 changes over time results for 84 countries', OPHI MPI Methodological Note 57, Oxford Poverty and Human Development Initiative, University of Oxford.
+      url: source_common.url
+      date_accessed: source_common.date_accessed
+      publication_date: source_common.publication_date
+  - dissagregated: &source-dissagregated
+      name: source_common.name
+      published_by: Alkire, S., Kanagaratnam, U., and Suppa, N. (2023), 'The global Multidimensional Poverty Index (MPI) 2023. Dissagregation Results and Methodological Note', OPHI MPI Methodological Note 56, Oxford Poverty and Human Development Initiative, University of Oxford.
+      url: source_common.url
+      date_accessed: {source_common.date_accessed}
+      publication_date: {source_common.publication_date}
+
 definitions:
   core: |-
     <h4>How is multidimensional poverty defined?</h4>
@@ -46,6 +72,8 @@ tables:
         display:
            name: MPI
            numDecimalPlaces: 3
+        sources:
+          - *source-cme
       cme_mpi_urban:
         title: MPI (urban) - Current margin estimate
         unit: ""
@@ -65,6 +93,8 @@ tables:
         display:
            name: MPI (urban)
            numDecimalPlaces: 3
+        sources:
+          - *source-dissagregated
       cme_mpi_rural:
         title: MPI (rural) - Current margin estimate
         unit: ""
@@ -84,6 +114,8 @@ tables:
         display:
            name: MPI (rural)
            numDecimalPlaces: 3
+        sources:
+          - *source-dissagregated
       cme_mpi_camp:
         title: MPI (camp) - Current margin estimate
         unit: ""

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -60,8 +60,16 @@
                     "type": "string"
                   },
                   "date_accessed": {
-                    "type": "string",
-                    "format": "date"
+                    "anyOf": [
+                      {
+                          "type": "string",
+                          "format": "date"
+                      },
+                      {
+                          "type": "string",
+                          "pattern": "^\\{.*\\}$"
+                      }
+                    ]
                   },
                   "description": {
                     "type": "string"
@@ -70,8 +78,16 @@
                     "type": "integer"
                   },
                   "publication_date": {
-                    "type": "string",
-                    "format": "date"
+                    "anyOf": [
+                      {
+                          "type": "string",
+                          "format": "date"
+                      },
+                      {
+                          "type": "string",
+                          "pattern": "^\\{.*\\}$"
+                      }
+                    ]
                   },
                   "published_by": {
                     "type": "string"
@@ -141,8 +157,16 @@
                             "type": "string"
                           },
                           "date_accessed": {
-                            "type": "string",
-                            "format": "date"
+                            "anyOf": [
+                              {
+                                  "type": "string",
+                                  "format": "date"
+                              },
+                              {
+                                  "type": "string",
+                                  "pattern": "^\\{.*\\}$"
+                              }
+                            ]
                           },
                           "description": {
                             "type": "string"
@@ -151,8 +175,16 @@
                             "type": "integer"
                           },
                           "publication_date": {
-                            "type": "string",
-                            "format": "date"
+                            "anyOf": [
+                              {
+                                  "type": "string",
+                                  "format": "date"
+                              },
+                              {
+                                  "type": "string",
+                                  "pattern": "^\\{.*\\}$"
+                              }
+                            ]
                           },
                           "published_by": {
                             "type": "string"

--- a/snapshots/ophi/2023-07-05/multidimensional_poverty_index.csv.dvc
+++ b/snapshots/ophi/2023-07-05/multidimensional_poverty_index.csv.dvc
@@ -19,8 +19,7 @@ meta:
     <ul>
         <li><strong>Health</strong> – using two indicators: nutrition, child mortality
         <li><strong>Education</strong> – using two indicators: years of schooling, school attendance
-        <li><strong>Living standards</strong> – using five indicators: cooking fuel, sanitation, drinking water, electricity, housing, assets.</li>
-    </ul>
+        <li><strong>Living standards</strong> – using five indicators: cooking fuel, sanitation, drinking water, electricity, housing, assets.</li></ul>
     Households are assessed as being deprived in a given indicator if they do not meet a certain threshold for that indicator. For instance, a household is deprived in the <em>Years of schooling</em> indicator if no household member has completed six years of schooling. A person is considered deprived in the <em>Cooking fuel</em> indicator if they cook using solid fuel, such as dung, agricultural crops, wood, charcoal, or coal. The thresholds for each indicator are published by OPHI in their <a href="https://www.ophi.org.uk/wp-content/uploads/OPHI_MPI_MN55_2023.pdf">methodological notes</a>.
 
     The individual indicators are not ‘weighted’ equally: When adding up the number of indicators in which a person is deprived, some count for more than others. Health and education indicators are given a weight of 1/6, while the indicators within the living standards dimension are given a weight of 1/18. This means that the three dimensions – health, education and living standards – have an equal weight in the total of one-third each.


### PR DESCRIPTION
@Marigold I am experimenting with two things:

1. Call values to fill three different source definitions that share parameters (in `source_common`)
2. Call the `sources` structure for each indicator (like in `cme_mpi_national` or `cme_mpi_urban`)

Is it possible to make placeholders work for (1) and (2)?

For (1) I thought I was doing right, but I have YAML warnings (strangely not for `hot` (?)):
<img width="536" alt="image" src="https://github.com/owid/etl/assets/63430031/33a92e5c-32c6-4639-8d26-d012693fee5f">

I tried to use placeholders for (2), but I couldn't. For now, I was trying to use anchors, as in [here](https://github.com/owid/etl/blob/master/etl/steps/data/garden/eth/2023-03-15/ethnic_power_relations.meta.yml), but we are trying to avoid that.