### PR TITLE
:hammer: shortUnit should never be null in display

### DIFF
--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -140,7 +140,8 @@ def _update_variables_display(table: catalog.Table) -> None:
     for col in table.columns:
         meta = table[col].metadata
         meta.display = meta.display or {}
-        meta.display.setdefault("shortUnit", meta.short_unit)
+        if meta.short_unit:
+            meta.display.setdefault("shortUnit", meta.short_unit)
         if meta.unit:
             meta.display.setdefault("unit", meta.unit)
 


### PR DESCRIPTION
The grapher config schema specifies that the unit and shortUnit of the display section should not be null. This was checked in the ETL for unit but the same check was missing for shortUnit. This PR fixes this.