### PR TITLE
✨ match-variables: check validity of output_file

### DIFF
--- a/etl/match_variables.py
+++ b/etl/match_variables.py
@@ -117,6 +117,8 @@ def main(
     similarity_name: str = SIMILARITY_NAME,
     max_suggestions: int = N_MAX_SUGGESTIONS,
 ) -> None:
+    if os.path.isdir(output_file):
+        raise ValueError(f"`output_file` ({output_file}) should point to a JSON file ('*.json') and not a directory!")
     if Path(output_file).suffix != ".json":
         raise ValueError(f"`output_file` ({output_file}) should point to a JSON file ('*.json')!")
 

--- a/etl/match_variables.py
+++ b/etl/match_variables.py
@@ -10,6 +10,7 @@ manually. This script is a CLI tool that may help in either scenario.
 
 import json
 import os
+from pathlib import Path
 from typing import Any, Dict, List, Tuple, Union, cast
 
 import click
@@ -41,7 +42,7 @@ SIMILARITY_NAMES = {
     "-f",
     "--output-file",
     type=str,
-    help="Path to output json file.",
+    help="Path to output JSON file.",
     required=True,
 )
 @click.option(
@@ -116,6 +117,9 @@ def main(
     similarity_name: str = SIMILARITY_NAME,
     max_suggestions: int = N_MAX_SUGGESTIONS,
 ) -> None:
+    if Path(output_file).suffix != '.json':
+        raise ValueError(f"`output_file` ({output_file}) should point to a JSON file ('*.json')!")
+
     with db.get_connection() as db_conn:
         # Get old and new dataset ids.
         old_dataset_id = db.get_dataset_id(db_conn=db_conn, dataset_name=old_dataset_name)

--- a/etl/match_variables.py
+++ b/etl/match_variables.py
@@ -117,7 +117,7 @@ def main(
     similarity_name: str = SIMILARITY_NAME,
     max_suggestions: int = N_MAX_SUGGESTIONS,
 ) -> None:
-    if Path(output_file).suffix != '.json':
+    if Path(output_file).suffix != ".json":
         raise ValueError(f"`output_file` ({output_file}) should point to a JSON file ('*.json')!")
 
     with db.get_connection() as db_conn:


### PR DESCRIPTION
Command line tool `etl-match-variables` has a required input argument `output-file`, which points to the file where the variable mapping will be saved. If this file is not `JSON`, the export will fail.

This is currently not being checked, hence if the user of the tool was to insert an invalid value for `output-file` they will only realise at the very end (after investing time in building the variable mapping).

Hence, this PR sanity checks the value of `output-file` at first.


First raised in #1403 