### PR TITLE
:hammer: deprecate dataPath and metadataPath in favour of ENV paths

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,5 @@ R2_ENDPOINT_URL=https://078fcdfed9955087315dd86792e71a7e.r2.cloudflarestorage.co
 
 # optional
 # BUGSNAG_API_KEY
+
+DATA_API_ENV=myname

--- a/backport/datasync/data_metadata.py
+++ b/backport/datasync/data_metadata.py
@@ -12,6 +12,8 @@ from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
 
+from etl import config
+
 
 def variable_data_df_from_mysql(engine: Engine, variable_id: int) -> pd.DataFrame:
     q = """
@@ -30,20 +32,8 @@ def variable_data_df_from_mysql(engine: Engine, variable_id: int) -> pd.DataFram
     return pd.read_sql(q, engine, params={"variable_id": variable_id})
 
 
-def _extract_variable_id_from_data_path(data_path: str) -> int:
-    match = re.search(r"/indicators/(\d+)", data_path)
-    if match:
-        return int(match.group(1))
-    else:
-        match = re.search(r"/data/(\d+)", data_path)
-        assert match, f"Could not find variableId in dataPath `{data_path}`"
-        return int(match.group(1))
-
-
-def _fetch_data_df_from_s3(data_path: str):
+def _fetch_data_df_from_s3(variable_id: int) -> pd.DataFrame:  # type: ignore
     try:
-        variable_id = _extract_variable_id_from_data_path(data_path)
-
         # Cloudflare limits us to 600 requests per minute, retry in case we hit the limit
         # NOTE: increase wait time or attempts if we hit the limit too often
         for attempt in Retrying(
@@ -53,7 +43,7 @@ def _fetch_data_df_from_s3(data_path: str):
         ):
             with attempt:
                 return (
-                    pd.read_json(data_path)
+                    pd.read_json(config.variable_data_url(variable_id))
                     .rename(
                         columns={
                             "entities": "entityId",
@@ -63,30 +53,15 @@ def _fetch_data_df_from_s3(data_path: str):
                     )
                     .assign(variableId=variable_id)
                 )
-    # no data on S3 in dataPath
+    # no data on S3
     except HTTPError:
         return pd.DataFrame(columns=["variableId", "entityId", "year", "value"])
 
 
-def variable_data_df_from_s3(
-    engine: Engine, data_paths: List[str] = [], variable_ids: List[int] = [], workers: int = 1
-) -> pd.DataFrame:
-    """Fetch data from S3 and add entity code and name from DB. You can use either data_paths or variable_ids."""
-    if not data_paths:
-        q = """
-        SELECT
-            dataPath
-        FROM variables as v
-        WHERE id in %(variable_ids)s
-        """
-        data_paths = pd.read_sql(
-            q,
-            engine,
-            params={"variable_ids": variable_ids},
-        )["dataPath"].tolist()
-
+def variable_data_df_from_s3(engine: Engine, variable_ids: List[int] = [], workers: int = 1) -> pd.DataFrame:
+    """Fetch data from S3 and add entity code and name from DB."""
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
-        results = list(executor.map(lambda data_path: _fetch_data_df_from_s3(data_path), data_paths))
+        results = list(executor.map(_fetch_data_df_from_s3, variable_ids))
 
     if isinstance(results, list) and all(isinstance(df, pd.DataFrame) for df in results):
         df = pd.concat(cast(List[pd.DataFrame], results))

--- a/backport/datasync/data_metadata.py
+++ b/backport/datasync/data_metadata.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 import json
-import re
 from http.client import RemoteDisconnected
 from typing import Any, Dict, List, Union, cast
 from urllib.error import HTTPError, URLError

--- a/etl/compare.py
+++ b/etl/compare.py
@@ -326,7 +326,7 @@ def read_variables_from_db(env_path: str, namespace: str, version: str, dataset:
     )
 
     # drop uninteresting columns
-    df = df.drop(["updatedAt", "createdAt", "dataPath", "metadataPath", "catalogPath"], axis=1)
+    df = df.drop(["updatedAt", "createdAt", "catalogPath"], axis=1)
 
     return cast(pd.DataFrame, df)
 
@@ -363,7 +363,6 @@ def read_values_from_s3(env_path: str, namespace: str, version: str, dataset: st
     q = """
     SELECT
         v.id as variableId,
-        v.dataPath,
         v.name as variable
     FROM variables as v
     JOIN datasets as d ON v.datasetId = d.id
@@ -376,7 +375,7 @@ def read_values_from_s3(env_path: str, namespace: str, version: str, dataset: st
     )
 
     # read them from S3
-    df = variable_data_df_from_s3(engine, vf.dataPath.tolist(), workers=10)
+    df = variable_data_df_from_s3(engine, variable_ids=vf.variableId.tolist(), workers=10)
 
     # add variable name
     df = df.merge(vf[["variableId", "variable"]], on="variableId")

--- a/etl/config.py
+++ b/etl/config.py
@@ -9,6 +9,7 @@ only important for OWID staff.
 
 import os
 import pwd
+import warnings
 from os import environ as env
 
 import bugsnag
@@ -49,13 +50,36 @@ def get_username():
     return pwd.getpwuid(os.getuid())[0]
 
 
+if "DATA_API_ENV" in env:
+    DATA_API_ENV = env["DATA_API_ENV"]
+else:
+    warnings.warn("DATA_API_ENV not set, using username")
+    DATA_API_ENV = env.get("DATA_API_ENV", get_username())
+
+# Production checks
+if DATA_API_ENV == "production":
+    assert DB_HOST == "live_grapher", "DB_HOST must be set to live_grapher when publishing to production"
+
+if DB_HOST == "live_grapher":
+    assert DATA_API_ENV == "production", "DATA_API_ENV must be set to production when publishing to live_grapher"
+
 # if running against live, use s3://owid-api, otherwise use s3://owid-api-staging
 # Cloudflare workers running on https://api.ourworldindata.org/ and https://api-staging.owid.io/ will use them
-if DB_NAME == "live_grapher":
-    DEFAULT_BAKED_VARIABLES_PATH = "s3://owid-api/v1/indicators"
+if DATA_API_ENV == "production":
+    BAKED_VARIABLES_PATH = "s3://owid-api/v1/indicators"
+    DATA_API_URL = "https://api.ourworldindata.org/v1/indicators"
 else:
-    DEFAULT_BAKED_VARIABLES_PATH = f"s3://owid-api-staging/{get_username()}/v1/indicators"
-BAKED_VARIABLES_PATH = env.get("BAKED_VARIABLES_PATH", DEFAULT_BAKED_VARIABLES_PATH)
+    BAKED_VARIABLES_PATH = f"s3://owid-api-staging/{DATA_API_ENV}/v1/indicators"
+    DATA_API_URL = f"https://api-staging.owid.io/{DATA_API_ENV}/v1/indicators"
+
+
+def variable_data_url(variable_id):
+    return f"{DATA_API_URL}/{variable_id}.data.json"
+
+
+def variable_metadata_url(variable_id):
+    return f"{DATA_API_URL}/{variable_id}.metadata.json"
+
 
 # run ETL steps with debugger on exception
 IPDB_ENABLED = False

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -291,14 +291,12 @@ def upsert_table(
 
         # process and upload data to S3
         var_data = variable_data(df)
-        data_path = upload_gzip_dict(var_data, db_variable.s3_data_path(), r2=True)
+        upload_gzip_dict(var_data, db_variable.s3_data_path(), r2=True)
 
         # process and upload metadata to S3
         var_metadata = variable_metadata(engine, db_variable.id, df)
-        metadata_path = upload_gzip_dict(var_metadata, db_variable.s3_metadata_path(), r2=True)
+        upload_gzip_dict(var_metadata, db_variable.s3_metadata_path(), r2=True)
 
-        db_variable.dataPath = data_path
-        db_variable.metadataPath = metadata_path
         session.add(db_variable)
         session.commit()
 

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -823,8 +823,6 @@ class Variable(SQLModel, table=True):
     grapherConfigAdmin: Optional[Dict[Any, Any]] = Field(default=None, sa_column=Column("grapherConfigAdmin", JSON))
     grapherConfigETL: Optional[Dict[Any, Any]] = Field(default=None, sa_column=Column("grapherConfigETL", JSON))
     catalogPath: Optional[str] = Field(default=None, sa_column=Column("catalogPath", LONGTEXT))
-    dataPath: Optional[str] = Field(default=None, sa_column=Column("dataPath", LONGTEXT))
-    metadataPath: Optional[str] = Field(default=None, sa_column=Column("metadataPath", LONGTEXT))
     dimensions: Optional[Dimensions] = Field(sa_column=Column("dimensions", JSON, nullable=True))
 
     schemaVersion: Optional[int] = Field(default=None, sa_column=Column("schemaVersion", Integer))
@@ -890,8 +888,6 @@ class Variable(SQLModel, table=True):
             ds.coverage = self.coverage
             ds.display = self.display
             ds.catalogPath = self.catalogPath
-            ds.dataPath = self.dataPath
-            ds.metadataPath = self.metadataPath
             ds.dimensions = self.dimensions
             ds.schemaVersion = self.schemaVersion
             ds.processingLevel = self.processingLevel

--- a/etl/steps/data/grapher/animal_welfare/2023-08-01/global_hen_inventory.py
+++ b/etl/steps/data/grapher/animal_welfare/2023-08-01/global_hen_inventory.py
@@ -18,6 +18,11 @@ def run(dest_dir: str) -> None:
     ds_garden = cast(Dataset, paths.load_dependency("global_hen_inventory"))
     tb = ds_garden["global_hen_inventory"]
 
+    for col in tb.columns:
+        orig_unit = tb[col].metadata.unit
+        tb[col] = tb[col] * 10000
+        tb[col].metadata.unit = orig_unit
+
     #
     # Save outputs.
     #

--- a/scripts/data_parity.py
+++ b/scripts/data_parity.py
@@ -129,8 +129,6 @@ def _parse_metadata(js):
 
     # does not have to match
     x.pop("updatedAt")
-    x.pop("dataPath", None)
-    x.pop("metadataPath", None)
 
     return x
 

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -44,8 +44,6 @@ def test_variable_metadata():
         "shortName": "population_density",
         "catalogPath": "grapher/owid/latest/key_indicators/population_density",
         "dimensions": None,
-        "dataPath": None,
-        "metadataPath": None,
         "datasetName": "Key Indicators",
         "nonRedistributable": 0,
         "schemaVersion": 2,
@@ -173,7 +171,7 @@ def test_variable_data_df_from_s3():
 
     with mock.patch("pandas.read_sql", return_value=entities):
         with mock.patch("pandas.read_json", return_value=s3_data):
-            df = variable_data_df_from_s3(engine, ["https://api.ourworldindata.org/v1/indicators/123.data.json"])
+            df = variable_data_df_from_s3(engine, [123])
 
     assert df.to_dict(orient="records") == [
         {"entityId": 1, "value": "a", "year": 2000, "variableId": 123, "entityName": "UK", "entityCode": "GBR"},


### PR DESCRIPTION
Should be merged at the same time as https://github.com/owid/owid-grapher/pull/2507

Original issue https://github.com/owid/owid-grapher/issues/2474#issue-1815448106

Columns `variables.dataPath` and `variables.metadataPath` were useful for transitioning to Data API, but they're just complicating things now that we have cloudflare workers with fallbacks.

This PR replaces it by new env `DATA_API_ENV` that is your laptop username by default (which raises warning) or can be set to `production` or staging server name for instance.

## TODO
* [ ] set `DATA_API_ENV=production` on our prod servers