### PR TITLE
:sparkles: make all metadata classes hashable

### DIFF
--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -1247,25 +1247,15 @@ def get_unique_sources_from_tables(tables: List[Table]) -> List[Source]:
     sources = sum([table._fields[column].sources for table in tables for column in list(table.all_columns)], [])
 
     # Get unique array of tuples of source fields (respecting the order).
-    unique_sources_array = pd.unique([tuple(source.to_dict().items()) for source in sources])
-
-    # Make a list of unique sources.
-    unique_sources = [Source.from_dict(dict(source)) for source in unique_sources_array]  # type: ignore
-
-    return unique_sources
+    return pd.unique(sources).tolist()
 
 
 def get_unique_licenses_from_tables(tables: List[Table]) -> List[License]:
     # Make a list of all licenses of all variables in all tables.
     licenses = sum([table._fields[column].licenses for table in tables for column in list(table.all_columns)], [])
 
-    # Get unique array of tuples of license fields (respecting the order).
-    unique_licenses_array = pd.unique([tuple(license.to_dict().items()) for license in licenses])
-
-    # Make a list of unique licenses.
-    unique_licenses = [License.from_dict(dict(license)) for license in unique_licenses_array]  # type: ignore
-
-    return unique_licenses
+    # Get unique array of tuples of source fields (respecting the order).
+    return pd.unique(licenses).tolist()
 
 
 def _combine_tables_titles_and_descriptions(tables: List[Table], title_or_description: str) -> Optional[str]:

--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -378,13 +378,7 @@ def get_unique_sources_from_variables(variables: List[Variable]) -> List[Source]
     # Make a list of all sources of all variables.
     sources = sum([variable.metadata.sources for variable in variables], [])
 
-    # Get unique array of tuples of source fields (respecting the order).
-    unique_sources_array = pd.unique([tuple(source.to_dict().items()) for source in sources])
-
-    # Make a list of sources.
-    unique_sources = [Source.from_dict(dict(source)) for source in unique_sources_array]  # type: ignore
-
-    return unique_sources
+    return pd.unique(sources).tolist()
 
 
 def get_unique_origins_from_variables(variables: List[Variable]) -> List[Origin]:
@@ -392,25 +386,14 @@ def get_unique_origins_from_variables(variables: List[Variable]) -> List[Origin]
     origins = sum([variable.metadata.origins for variable in variables], [])
 
     # Get unique array of tuples of origin fields (respecting the order).
-    unique_origins_array = pd.unique([tuple(origin.to_dict().items()) for origin in origins])
-
-    # Make a list of origins.
-    unique_origins = [Origin.from_dict(dict(origin)) for origin in unique_origins_array]  # type: ignore
-
-    return unique_origins
+    return pd.unique(origins).tolist()
 
 
 def get_unique_licenses_from_variables(variables: List[Variable]) -> List[License]:
     # Make a list of all licenses of all variables.
     licenses = sum([variable.metadata.licenses for variable in variables], [])
 
-    # Get unique array of tuples of license fields (respecting the order).
-    unique_licenses_array = pd.unique([tuple(license.to_dict().items()) for license in licenses])
-
-    # Make a list of licenses.
-    unique_licenses = [License.from_dict(dict(license)) for license in unique_licenses_array]
-
-    return unique_licenses
+    return pd.unique(licenses).tolist()
 
 
 def add_entry_to_processing_log(

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -13,7 +13,7 @@ import pytest
 
 from owid.catalog import tables
 from owid.catalog.datasets import FileFormat
-from owid.catalog.meta import Source, TableMeta, VariableMeta
+from owid.catalog.meta import TableMeta, VariableMeta
 from owid.catalog.tables import SCHEMA, Table, get_unique_sources_from_tables
 from owid.catalog.variables import PROCESSING_LOG, Variable
 

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -13,8 +13,8 @@ import pytest
 
 from owid.catalog import tables
 from owid.catalog.datasets import FileFormat
-from owid.catalog.meta import TableMeta, VariableMeta
-from owid.catalog.tables import SCHEMA, Table
+from owid.catalog.meta import Source, TableMeta, VariableMeta
+from owid.catalog.tables import SCHEMA, Table, get_unique_sources_from_tables
 from owid.catalog.variables import PROCESSING_LOG, Variable
 
 from .mocking import mock
@@ -770,3 +770,12 @@ def test_pivot(table_1, sources) -> None:
     assert tb["country"].metadata == table_1["country"].metadata
     # Now check that table metadata is identical.
     assert tb.metadata == table_1.metadata
+
+
+def test_get_unique_sources_from_tables(table_1, sources):
+    unique_sources = get_unique_sources_from_tables([table_1, table_1])
+    assert unique_sources == [
+        sources[2],
+        sources[1],
+        sources[3],
+    ]


### PR DESCRIPTION
Make all metadata classes hashable (i.e. enable `hash(obj)`) to allow usage of `set` or `unique` on those objects.