### PR TITLE
✨ war: minor improvements

### DIFF
--- a/etl/steps/data/garden/war/2023-07-18/cow.py
+++ b/etl/steps/data/garden/war/2023-07-18/cow.py
@@ -201,6 +201,9 @@ def combine_tables(tb_extra: Table, tb_nonstate: Table, tb_inter: Table, tb_intr
     log.info("war.cow: rename regions")
     tb["region"] = tb["region"].map(REGIONS_RENAME | {"World": "World"})
     assert tb["region"].isna().sum() == 0, "Unmapped regions!"
+    # Add suffix with source name
+    msk = tb["region"] != "World"
+    tb.loc[msk, "region"] = tb.loc[msk, "region"] + " (COW)"
 
     # Sanity check on NaNs
     log.info("war.cow: check NaNs in `number_deaths_ongoing_conflicts`")

--- a/etl/steps/data/garden/war/2023-07-18/cow.py
+++ b/etl/steps/data/garden/war/2023-07-18/cow.py
@@ -29,6 +29,13 @@ REGIONS_RENAME = {
 ## We have done this manually, and is summarised in the dictionary below.
 PATH_CUSTOM_REGIONS_INTRASTATE = paths.directory / "cow.intrastate.region_mapping_custom.json"
 
+# Last reported end years for each of the building datasets
+END_YEAR_MAX_EXTRA = 2007
+END_YEAR_MAX_INTRA = 2014
+END_YEAR_MAX_INTER = 2003
+END_YEAR_MAX_NONSTATE = 2005
+END_YEAR_MAX = min([END_YEAR_MAX_EXTRA, END_YEAR_MAX_INTRA, END_YEAR_MAX_INTER, END_YEAR_MAX_NONSTATE])
+
 
 def run(dest_dir: str) -> None:
     #
@@ -264,6 +271,10 @@ def _sanity_checks_extra(tb: Table) -> None:
     assert set(tb.loc[tb[col] < 0, col]) == {-9, -8}, f"Negative values other than -9 or -8 found for {col}"
     col = "year_end"
     assert set(tb.loc[tb[col] < 0, col]) == {-7}, f"Negative values other than -7 found for {col}"
+    # Check max end year is as expected
+    assert (
+        tb["year_end"].max() == END_YEAR_MAX_EXTRA - 1
+    ), f"Extra-state data is expected to have its latest end year by {END_YEAR_MAX_EXTRA - 1}, but that was not the case! Revisit this assertion and 'set NaNs' section in `replace_missing_data_with_zeros` function."
 
 
 def replace_negative_values_extra(tb: Table) -> Table:
@@ -347,6 +358,14 @@ def _sanity_check_nonstate(tb: Table) -> None:
     assert set(tb.loc[tb[col] < 0, col]) == {-9}, f"Negative values other than -9 found for {col}"
     # Check year end
     assert (tb["year_end"] > 1819).all(), "Unexpected value for `year_end`!"
+    # Check latest end year
+    assert (
+        tb["year_end"].max() == END_YEAR_MAX_NONSTATE
+    ), f"Non-state data is expected to have its latest end year by {END_YEAR_MAX_NONSTATE}, but that was not the case! Revisit this assertion and 'set NaNs' section in `replace_missing_data_with_zeros` function."
+    # Check outcome
+    assert (
+        tb["outcome"] != 5
+    ).all(), "Some conflicts are coded as if they were still on going in 2007! That shouldn't be the case! Check if maximum value for `year_end` has changed."
 
 
 ########################################################################
@@ -388,7 +407,15 @@ def _sanity_checks_inter(tb: Table) -> Table:
     col = "number_deaths_ongoing_conflicts"
     assert set(tb.loc[tb[col] < 0, col]) == {-9}, f"Negative values other than -9 found for {col}"
     # Check year end
-    assert not (tb["year_end"].isna().any()), "Unexpected NaN value for `year_end`!"
+    assert not (tb["year_end"].isna().any()), "Unexpected NaN values for `year_end`!"
+    assert not ((tb["year_end"] < 0).any()), "Unexpected negative values for `year_end`!"
+    assert (
+        tb["year_end"].max() == END_YEAR_MAX_INTER
+    ), f"Inter-state data is expected to have its latest end year by {END_YEAR_MAX_INTER}, but that was not the case! Revisit this assertion and 'set NaNs' section in `replace_missing_data_with_zeros` function."
+    # Check outcome
+    assert (
+        tb["outcome"] != 5
+    ).all(), "Some conflicts are coded as if they were still on going in 2007! That shouldn't be the case! Check if maximum value for `year_end` has changed."
 
 
 def aggregate_rows_by_periods_inter(tb: Table) -> Table:
@@ -504,6 +531,9 @@ def _sanity_checks_intra(tb: Table) -> None:
     col = "year_end"
     assert not (tb[col].isna().any()), "Unexpected NaN value for `year_end`!"
     assert set(tb.loc[tb[col] < 0, col]) == {-7}, f"Negative values other than -7 found for {col}"
+    assert (
+        tb["year_end"].max() == END_YEAR_MAX_INTRA
+    ), f"Intra-state data is expected to have its latest end year by {END_YEAR_MAX_INTRA}, but that was not the case! Revisit this assertion and 'set NaNs' section in `replace_missing_data_with_zeros` function."
 
 
 def replace_negative_values_intra(tb: Table) -> Table:
@@ -821,4 +851,21 @@ def replace_missing_data_with_zeros(tb: Table) -> Table:
     ]
     tb.loc[:, columns] = tb.loc[:, columns].fillna(0)
 
+    # Set NaNs
+    tb.loc[(tb["year"] > END_YEAR_MAX) & (tb["conflict_type"] == "all"), columns] = np.nan
+    tb.loc[(tb["year"] > END_YEAR_MAX_EXTRA) & (tb["conflict_type"] == "extra-state"), columns] = np.nan
+    tb.loc[(tb["year"] > END_YEAR_MAX_INTER) & (tb["conflict_type"] == "inter-state"), columns] = np.nan
+    tb.loc[
+        (tb["year"] > END_YEAR_MAX_INTRA)
+        & (
+            tb["conflict_type"].isin(
+                ["intra-state", "intra-state (internationalized)", "intra-state (non-internationalized)"]
+            )
+        ),
+        columns,
+    ] = np.nan
+    tb.loc[(tb["year"] > END_YEAR_MAX_NONSTATE) & (tb["conflict_type"] == "non-state"), columns] = np.nan
+
+    # Drop all-NaN rows
+    tb = tb.dropna(subset=columns, how="all")
     return tb

--- a/etl/steps/data/garden/war/2023-07-20/brecke.py
+++ b/etl/steps/data/garden/war/2023-07-20/brecke.py
@@ -24,21 +24,16 @@ log = get_logger()
 REGIONS_RENAME = {
     1: "America",  # "North America, Central America, and the Caribbean (Brecke)",
     2: "America",  # "South America (Brecke)",
-
     3: "Europe",  # "Western Europe (Brecke)",
     4: "Europe",  # "Eastern Europe (Brecke)",
-
     5: "Middle East (Brecke)",
-
     6: "Africa",  # "North Africa (Brecke)",
     7: "Africa",  # "West & Central Africa (Brecke)",
     8: "Africa",  # "East & South Africa (Brecke)",
-
     9: "Asia",  # "Central Asia (Brecke)",
     10: "Asia",  # "South Asia (Brecke)",
     11: "Asia",  # "Southeast Asia (Brecke)",
     12: "Asia",  # "East Asia (Brecke)",
-
     -9: -9,  # Unknown
 }
 

--- a/etl/steps/data/garden/war/2023-07-20/brecke.py
+++ b/etl/steps/data/garden/war/2023-07-20/brecke.py
@@ -22,19 +22,24 @@ paths = PathFinder(__file__)
 log = get_logger()
 # Region mapping
 REGIONS_RENAME = {
-    1: "North America, Central America, and the Caribbean (Brecke)",
-    2: "South America (Brecke)",
-    3: "Western Europe (Brecke)",
-    4: "Eastern Europe (Brecke)",
+    1: "America",  # "North America, Central America, and the Caribbean (Brecke)",
+    2: "America",  # "South America (Brecke)",
+
+    3: "Europe",  # "Western Europe (Brecke)",
+    4: "Europe",  # "Eastern Europe (Brecke)",
+
     5: "Middle East (Brecke)",
-    6: "North Africa (Brecke)",
-    7: "West & Central Africa (Brecke)",
-    8: "East & South Africa (Brecke)",
-    9: "Central Asia (Brecke)",
-    10: "South Asia (Brecke)",
-    11: "Southeast Asia (Brecke)",
-    12: "East Asia (Brecke)",
-    -9: "Unknown",
+
+    6: "Africa",  # "North Africa (Brecke)",
+    7: "Africa",  # "West & Central Africa (Brecke)",
+    8: "Africa",  # "East & South Africa (Brecke)",
+
+    9: "Asia",  # "Central Asia (Brecke)",
+    10: "Asia",  # "South Asia (Brecke)",
+    11: "Asia",  # "Southeast Asia (Brecke)",
+    12: "Asia",  # "East Asia (Brecke)",
+
+    -9: -9,  # Unknown
 }
 
 
@@ -80,6 +85,11 @@ def run(dest_dir: str) -> None:
     log.info("war.brecke: add lower bound value of deaths")
     tb = add_lower_bound_deaths(tb)
 
+    # Rename regions
+    log.info("war.brecke: rename regions")
+    tb["region"] = tb["region"].map(REGIONS_RENAME)
+    assert tb["region"].isna().sum() == 0, "Unmapped regions!"
+
     # Expand observations
     log.info("war.brecke: expand observations")
     tb = expand_observations(tb)
@@ -96,11 +106,7 @@ def run(dest_dir: str) -> None:
     # Distribute numbers for region -9
     log.info("war.brecke: distributing metrics for region -9")
     tb = distribute_metrics_m9(tb)
-
-    # Rename regions
-    log.info("war.brecke: rename regions")
-    tb["region"] = tb["region"].map(REGIONS_RENAME | {"World": "World"})
-    assert tb["region"].isna().sum() == 0, "Unmapped regions!"
+    assert (tb["region"] != -9).all(), "-9 region still detected!"
 
     # Set index
     log.info("war.brecke: set index")

--- a/etl/steps/data/garden/war/2023-07-20/brecke.py
+++ b/etl/steps/data/garden/war/2023-07-20/brecke.py
@@ -169,10 +169,21 @@ def add_conflict_type(tb: Table) -> Table:
         tb["name"] = tb["name"].str.replace(text, text.replace("-", ""))
 
     # Remove year part
-    name_to_year = tb.name.apply(lambda x: ",".join(x.split(",")[:-1]))
+    name_wo_year = tb["name"].apply(lambda x: ",".join(x.split(",")[:-1]))
 
     # Get mask
-    mask = name_to_year.str.contains("-")
+    ## Wars that are inter-state but don't have a hyphen, hence would be classified as internal
+    wars_interstate = [
+        "First World War, 1914-18",
+        "Thirty Years' War, 1618-48",
+        "Napoleonic Wars, 1803-15",
+        "Wars of the French Revolution, 1791-1802",
+        "Vietnam, 1964-75",
+    ]
+    mask_custom = tb["name"].isin(wars_interstate)
+    assert mask_custom.sum() == len(wars_interstate), "Some corrections can't be made, because some war names specified in `wars_interstate` are not found in the data!"
+    ## Build final mask
+    mask = name_wo_year.str.contains("-") | mask_custom
 
     # Set conflict type
     tb["conflict_type"] = "internal"

--- a/etl/steps/data/garden/war/2023-07-20/brecke.py
+++ b/etl/steps/data/garden/war/2023-07-20/brecke.py
@@ -181,7 +181,9 @@ def add_conflict_type(tb: Table) -> Table:
         "Vietnam, 1964-75",
     ]
     mask_custom = tb["name"].isin(wars_interstate)
-    assert mask_custom.sum() == len(wars_interstate), "Some corrections can't be made, because some war names specified in `wars_interstate` are not found in the data!"
+    assert mask_custom.sum() == len(
+        wars_interstate
+    ), "Some corrections can't be made, because some war names specified in `wars_interstate` are not found in the data!"
     ## Build final mask
     mask = name_wo_year.str.contains("-") | mask_custom
 


### PR DESCRIPTION
- Add suffix `(COW)` to region names in COW dataset.
- In COW data, set values to missing (instead of zero) accordingly. This is because each dataset covers different year periods. (also added several checks).
  - Intra-state conflicts: All NaNs after 2014.
  - Inter-state conflicts: All NaNs after 2003.
  - Extra-state conflicts: All NaNs after 2007.
  - Non-state conflicts: All NaNs after 2005.
- Simplify regions in Brecke:
  - Asia
    - Central Asia
    - East Asia
    - South Asia
    - Southeast Asia
  - Africa
    - East & south Africa
    - North Africa
    - West & Central Africa
  - Americas
    - North America, Central America and Caribbean
    - South America
  - Europe
    - Eastern Europe
    - Western Europe
  - Middle East
    - Middle East
- Correct wrongly classified wars. These were automatically classified as `internal`, using the rules defined by the author. However, these are inter-state wars. These include: 
  - First World War, 1914-18
  - Thirty Years' War, 1618-48
  - Napoleonic Wars, 1803-15
  - Wars of the French Revolution, 1791-1802
  - Vietnam, 1964-75