### PR TITLE
:bug: use map.columnSlug rather than map.variableId

### DIFF
--- a/etl/chart_revision/v2/schema.py
+++ b/etl/chart_revision/v2/schema.py
@@ -102,13 +102,8 @@ def validate_chart_config_and_set_defaults(
 def fix_errors_in_schema(config: Dict[str, Any]) -> Dict[str, Any]:
     """Fix common errors in schema and tries to catch up with latest schema version."""
     config_new = copy.deepcopy(config)
-    # Remove map.columnSlug. This should be map.variableId instead.
     if "map" in config_new:
-        if "columnSlug" in config_new["map"]:
-            print("DELETE")
-            if "variableId" not in config_new["map"]:
-                config_new["map"]["variableId"] = config_new["map"]["columnSlug"]
-            del config_new["map"]["columnSlug"]
+        assert "variableId" not in config_new["map"], "map.variableId has been deprecated by map.columnSlug"
     if ("timelineMaxTime" in config_new) and (config_new["timelineMaxTime"] is None):
         del config_new["timelineMaxTime"]
     if ("timelineMinTime" in config_new) and (config_new["timelineMinTime"] is None):

--- a/etl/chart_revision/v2/updaters/variable_update.py
+++ b/etl/chart_revision/v2/updaters/variable_update.py
@@ -190,16 +190,15 @@ class ChartVariableUpdater(ChartUpdater):
         # Proceed only if chart uses map
         if config["hasMapTab"]:
             log.info("variable_update: chart uses map")
-            # Get map_variable_id
+            # Get map.columnSlug
             map_var_id = config["map"].get(
-                "variableId", variable_id_default_for_map
+                "columnSlug", variable_id_default_for_map
             )  # chart.config["dimensions"][0]["variableId"]
             # Proceed only if variable ID used for map is in variable_mapping (i.e. needs update)
             if map_var_id in self.variable_mapping:
                 # Get and set new map variable ID in the chart config
                 map_var_id_new = self.variable_mapping[map_var_id]
-                config["map"]["variableId"] = map_var_id_new
-
+                config["map"]["columnSlug"] = str(map_var_id_new)
                 if self.slider_range_check:
                     # Get year ranges from new variables
                     year_range_new_min = self.variable_meta[map_var_id_new]["minYear"]


### PR DESCRIPTION
Chart config field `map.variableId` was recently renamed to `map.columnSlug` and changed the type to string. All entries in MySQL have been migrated, so there's no `map.variableId`.

Update this in `etl-chart-suggester`. This was tested on the [IHME data](https://github.com/owid/etl/issues/1437#issue-1841475289) from the parent issue.