### PR TITLE
:bug: keep title as None if underscoring didn't change anything

### DIFF
--- a/lib/catalog/owid/catalog/utils.py
+++ b/lib/catalog/owid/catalog/utils.py
@@ -210,7 +210,8 @@ def underscore_table(
 
     # put original names as titles into metadata by default
     for c_old, c_new in columns_map.items():
-        if t[c_new].metadata.title is None:
+        # if underscoring didn't change anything, don't add title
+        if t[c_new].metadata.title is None and c_old != c_new:
             t[c_new].metadata.title = c_old
 
     return t

--- a/lib/catalog/tests/test_utils.py
+++ b/lib/catalog/tests/test_utils.py
@@ -94,17 +94,24 @@ def test_underscore():
 
 
 def test_underscore_table():
-    df = pd.DataFrame({"A": [1, 2, 3]})
+    df = pd.DataFrame({"A": [1, 2, 3], "b": [1, 2, 3]})
     df.index.names = ["I"]
 
     t = Table(df)
     t["A"].metadata.description = "column A"
+    t["b"].metadata.description = "column B"
 
     tt = underscore_table(t)
-    assert tt.columns == ["a"]
+    assert list(tt.columns) == ["a", "b"]
     assert tt.index.names == ["i"]
+
+    # original column name is moved to title if we underscored it
     assert tt["a"].metadata.description == "column A"
     assert tt["a"].metadata.title == "A"
+
+    # title is None if underscoring didn't change the name
+    assert tt["b"].metadata.description == "column B"
+    assert tt["b"].metadata.title is None
 
 
 def test_underscore_table_collision():


### PR DESCRIPTION
Underscoring in meadow step assigns titles to variables even if the underscoring doesn't change anything. It's safer to keep it as None.