### PR TITLE
Improve metadata propagation

### DIFF
--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -721,6 +721,24 @@ class Table(pd.DataFrame):
 
         return cast("Table", tb)
 
+    def sum(self, *args, **kwargs) -> variables.Variable:
+        variable_name = variables.UNNAMED_VARIABLE
+        variable = variables.Variable(super().sum(*args, **kwargs), name=variable_name)
+        variable.metadata = variables.combine_variables_metadata(
+            variables=[self[column] for column in self.columns], operation="+", name=variable_name
+        )
+
+        return variable
+
+    def prod(self, *args, **kwargs) -> variables.Variable:
+        variable_name = variables.UNNAMED_VARIABLE
+        variable = variables.Variable(super().prod(*args, **kwargs), name=variable_name)
+        variable.metadata = variables.combine_variables_metadata(
+            variables=[self[column] for column in self.columns], operation="*", name=variable_name
+        )
+
+        return variable
+
 
 def merge(
     left,

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -27,6 +27,8 @@ import pyarrow
 import pyarrow.parquet as pq
 import structlog
 from owid.repack import repack_frame
+from pandas._typing import Scalar
+from pandas.core.series import Series
 from pandas.util._decorators import rewrite_axis_style_signature
 
 from . import variables
@@ -738,6 +740,86 @@ class Table(pd.DataFrame):
         )
 
         return variable
+
+    def __add__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        tb = cast(Table, Table(super().__add__(other=other)).copy_metadata(self))
+        # The following would have a parents only the scalar, not the scalar and the corresponding variable.
+        # tb = update_log(table=tb, operation="+", parents=[other], variable_names=tb.columns)
+        # Instead, update the processing log of each variable in the table.
+        for column in tb.columns:
+            tb[column] = variables.update_log(
+                variable=tb[column], parents=[column, other], operation="+", variable_name=column
+            )
+        return tb
+
+    def __iadd__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        return self.__add__(other)
+
+    def __sub__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        tb = cast(Table, Table(super().__sub__(other=other)).copy_metadata(self))
+        for column in tb.columns:
+            tb[column] = variables.update_log(
+                variable=tb[column], parents=[column, other], operation="-", variable_name=column
+            )
+        return tb
+
+    def __isub__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        return self.__sub__(other)
+
+    def __mul__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        tb = cast(Table, Table(super().__mul__(other=other)).copy_metadata(self))
+        for column in tb.columns:
+            tb[column] = variables.update_log(
+                variable=tb[column], parents=[column, other], operation="*", variable_name=column
+            )
+        return tb
+
+    def __imul__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        return self.__mul__(other)
+
+    def __truediv__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        tb = cast(Table, Table(super().__truediv__(other=other)).copy_metadata(self))
+        for column in tb.columns:
+            tb[column] = variables.update_log(
+                variable=tb[column], parents=[column, other], operation="/", variable_name=column
+            )
+        return tb
+
+    def __itruediv__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        return self.__truediv__(other)
+
+    def __floordiv__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        tb = cast(Table, Table(super().__floordiv__(other=other)).copy_metadata(self))
+        for column in tb.columns:
+            tb[column] = variables.update_log(
+                variable=tb[column], parents=[column, other], operation="//", variable_name=column
+            )
+        return tb
+
+    def __ifloordiv__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        return self.__floordiv__(other)
+
+    def __mod__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        tb = cast(Table, Table(super().__mod__(other=other)).copy_metadata(self))
+        for column in tb.columns:
+            tb[column] = variables.update_log(
+                variable=tb[column], parents=[column, other], operation="%", variable_name=column
+            )
+        return tb
+
+    def __imod__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        return self.__mod__(other)
+
+    def __pow__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        tb = cast(Table, Table(super().__pow__(other=other)).copy_metadata(self))
+        for column in tb.columns:
+            tb[column] = variables.update_log(
+                variable=tb[column], parents=[column, other], operation="**", variable_name=column
+            )
+        return tb
+
+    def __ipow__(self, other: Union[Scalar, Series, variables.Variable]) -> "Table":
+        return self.__pow__(other)
 
 
 def merge(

--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -410,6 +410,9 @@ def add_entry_to_processing_log(
     # Consider using a deepcopy if any of the operations in this function alter mutable objects in processing_log.
     processing_log_updated = copy.deepcopy(processing_log)
 
+    # TODO: Parents currently can be anything. Here we should ensure that they are strings. For example, we could
+    # extract the name of the parent if it is a variable.
+
     # Define new log entry.
     log_new_entry = {"variable": variable_name, "parents": parents, "operation": operation}
     if comment is not None:

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -783,3 +783,29 @@ def test_get_unique_sources_from_tables(table_1, sources):
         sources[1],
         sources[3],
     ]
+
+
+def test_sum_columns(table_1, sources, licenses):
+    # Create a new column that is the element-wise sum of the other two existing columns.
+    table_1["c"] = table_1[["a", "b"]].sum(axis=1)
+    assert table_1["c"].metadata.sources == [sources[2], sources[1], sources[3]]
+    assert table_1["c"].metadata.licenses == [licenses[1], licenses[2], licenses[3]]
+
+    # Create a new variable (it cannot be added as a new column since it has different dimensions) that is the sum of
+    # each of the other two existing columns.
+    variable_c = table_1[["a", "b"]].sum(axis=0)
+    assert variable_c.metadata.sources == [sources[2], sources[1], sources[3]]
+    assert variable_c.metadata.licenses == [licenses[1], licenses[2], licenses[3]]
+
+
+def test_multiply_columns(table_1, sources, licenses):
+    # Create a new column that is the element-wise product of the other two existing columns.
+    table_1["c"] = table_1[["a", "b"]].prod(axis=1)
+    assert table_1["c"].metadata.sources == [sources[2], sources[1], sources[3]]
+    assert table_1["c"].metadata.licenses == [licenses[1], licenses[2], licenses[3]]
+
+    # Create a new variable (it cannot be added as a new column since it has different dimensions) that is the product
+    # of each of the other two existing columns.
+    variable_c = table_1[["a", "b"]].prod(axis=0)
+    assert variable_c.metadata.sources == [sources[2], sources[1], sources[3]]
+    assert variable_c.metadata.licenses == [licenses[1], licenses[2], licenses[3]]

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -798,6 +798,28 @@ def test_sum_columns(table_1, sources, licenses):
     assert variable_c.metadata.licenses == [licenses[1], licenses[2], licenses[3]]
 
 
+def test_operations_of_table_and_scalar(table_1, sources, licenses):
+    table_1[["a", "b"]] = table_1[["a", "b"]] + 1
+    table_1[["a", "b"]] += 1
+    table_1[["a", "b"]] = table_1[["a", "b"]] - 1
+    table_1[["a", "b"]] -= 1
+    table_1[["a", "b"]] = table_1[["a", "b"]] * 1
+    table_1[["a", "b"]] *= 1
+    table_1[["a", "b"]] = table_1[["a", "b"]] / 1
+    table_1[["a", "b"]] /= 1
+    table_1[["a", "b"]] = table_1[["a", "b"]] // 1
+    table_1[["a", "b"]] //= 1
+    table_1[["a", "b"]] = table_1[["a", "b"]] % 1
+    table_1[["a", "b"]] %= 1
+    table_1[["a", "b"]] = table_1[["a", "b"]] ** 1
+    table_1[["a", "b"]] **= 1
+
+    assert table_1["a"].metadata.sources == [sources[2], sources[1]]
+    assert table_1["a"].metadata.licenses == [licenses[1]]
+    assert table_1["b"].metadata.sources == [sources[2], sources[3]]
+    assert table_1["b"].metadata.licenses == [licenses[2], licenses[3]]
+
+
 def test_multiply_columns(table_1, sources, licenses):
     # Create a new column that is the element-wise product of the other two existing columns.
     table_1["c"] = table_1[["a", "b"]].prod(axis=1)

--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -103,6 +103,34 @@ def test_replace_a_variables_own_value(table_1) -> None:
     assert tb1._fields["a"] == table_1._fields["a"]
     assert tb1._fields["b"] == table_1._fields["b"]
 
+    # Idem using +=.
+    tb1 = table_1.copy()
+    tb1["a"] += 1
+    assert (tb1["a"] == pd.Series([2, 3, 4])).all()
+    # Metadata for "a" and "b" should be identical.
+    assert tb1._fields["a"] == table_1._fields["a"]
+    assert tb1._fields["b"] == table_1._fields["b"]
+
+
+def test_operations_of_variable_and_scalar(table_1, sources, licenses):
+    table_1["a"] = table_1["a"] + 1
+    table_1["a"] += 1
+    table_1["a"] = table_1["a"] - 1
+    table_1["a"] -= 1
+    table_1["a"] = table_1["a"] * 1
+    table_1["a"] *= 1
+    table_1["a"] = table_1["a"] / 1
+    table_1["a"] /= 1
+    table_1["a"] = table_1["a"] // 1
+    table_1["a"] //= 1
+    table_1["a"] = table_1["a"] % 1
+    table_1["a"] %= 1
+    table_1["a"] = table_1["a"] ** 1
+    table_1["a"] **= 1
+
+    assert table_1["a"].metadata.sources == [sources[2], sources[1]]
+    assert table_1["a"].metadata.licenses == [licenses[1]]
+
 
 def test_create_new_variable_as_product_of_other_two(table_1, sources, licenses) -> None:
     tb1 = table_1.copy()


### PR DESCRIPTION
Various improvements on metadata propagation:
* Propagate metadata when doing operations like `tb[["a", "b"]].sum(axis=1)` (idem for `prod`).
* Idem for operations like `tb[["a", "b"]] *= 2` and other similar operations.
* Add tests.
