### PR TITLE
:sparkles: improve backport performance by undvcignoring single file

### DIFF
--- a/.dvcignore
+++ b/.dvcignore
@@ -9,6 +9,6 @@ vendor/
 .cachedir/
 .venv/
 !data/snapshots/
-# this folder contains thousands of .dvc files which slows it down, we dynamically comment it when working with
-# backported snapshots (see _unignore_backports)
-# snapshots/backport/
+# this folder contains thousands of .dvc files which slows it down, when we work with backported snapshots, we
+# dynamically exclude it (see _unignore_backports)
+snapshots/backport/latest/*

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -377,7 +377,13 @@ def _unignore_backports(path: Path):
                 s = f.read()
             try:
                 with open(dvc_ignore_path, "w") as f:
-                    f.write(s.replace("snapshots/backport/", "# snapshots/backport/"))
+                    dataset_id = path.name.split("_")[1]
+                    f.write(
+                        s.replace(
+                            "snapshots/backport/latest/*",
+                            f"snapshots/backport/latest/*\n!snapshots/backport/latest/dataset_{dataset_id}*",
+                        )
+                    )
                 yield
             finally:
                 with open(dvc_ignore_path, "w") as f:


### PR DESCRIPTION
Backports currently took around minute due to huge number of DVC files. Better targeting of exclude in .dvcignore cuts this into several seconds.