### PR TITLE
:sparkles: support for archived backported datasets

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -329,8 +329,12 @@ def _backporting_steps(private: bool, filter_steps: Optional[Set[str]] = None) -
             continue
 
         # two files are generated for each dataset, skip one
-        if snap.metadata.short_name.endswith("_values"):
-            short_name = snap.metadata.short_name.removesuffix("_values")
+        if snap.metadata.short_name.endswith("_config"):
+            # skip archived backported datasets
+            if "(archived)" in snap.metadata.name:  # type: ignore
+                continue
+
+            short_name = snap.metadata.short_name.removesuffix("_config")
 
             private_suffix = "" if snap.metadata.is_public else "-private"
 

--- a/etl/scripts/faostat/create_new_snapshots.py
+++ b/etl/scripts/faostat/create_new_snapshots.py
@@ -273,7 +273,7 @@ class FAOAdditionalMetadata:
 
 def main(read_only: bool = False) -> None:
     # Load list of existing snapshots related to current NAMESPACE.
-    existing_snapshots = snapshot_catalog(match=NAMESPACE)
+    existing_snapshots = list(snapshot_catalog(match=NAMESPACE))
 
     # Initialise a flag that will become true if any dataset needs to be updated.
     any_dataset_was_updated = False

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterator, Optional, Union
 
 import pandas as pd
 import yaml
@@ -347,17 +347,15 @@ def add_snapshot(
     snap.dvc_add(upload=upload)
 
 
-def snapshot_catalog(match: str = r".*") -> List[Snapshot]:
+def snapshot_catalog(match: str = r".*") -> Iterator[Snapshot]:
     """Return a catalog of all snapshots. It can take more than 10s to load the entire catalog,
     so it's recommended to use `match` to filter the snapshots.
     :param match: pattern to match uri
     """
-    catalog = []
     for path in paths.SNAPSHOTS_DIR.glob("**/*.dvc"):
         uri = str(path.relative_to(paths.SNAPSHOTS_DIR)).replace(".dvc", "")
         if re.search(match, uri):
-            catalog.append(Snapshot(uri))
-    return catalog
+            yield Snapshot(uri)
 
 
 @contextmanager

--- a/snapshots/backport/latest/dataset_5592_covid_testing_time_series_data__vietnam_exemplar_config.json.dvc
+++ b/snapshots/backport/latest/dataset_5592_covid_testing_time_series_data__vietnam_exemplar_config.json.dvc
@@ -2,7 +2,7 @@ meta:
   source:
     name: Our World in Data catalog backport
     url: https://owid.cloud/admin/datasets/5592
-    date_accessed: 2023-08-10 08:09:01.757310
+    date_accessed: 2023-08-10 12:14:17.578038
     publication_date: latest
     published_by: Our World in Data catalog backport
   name: Grapher metadata for dataset_5592_covid_testing_time_series_data__vietnam_exemplar
@@ -10,6 +10,6 @@ meta:
   is_public: false
 wdir: ../../../data/snapshots/backport/latest
 outs:
-- md5: 45de4f41f8eda84fd146431a10b8f016
-  size: 2926
+- md5: 7e2d226ed7fbdbed4efa3215930e9ad9
+  size: 2221
   path: dataset_5592_covid_testing_time_series_data__vietnam_exemplar_config.json

--- a/snapshots/backport/latest/dataset_5592_covid_testing_time_series_data__vietnam_exemplar_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5592_covid_testing_time_series_data__vietnam_exemplar_values.feather.dvc
@@ -2,7 +2,7 @@ meta:
   source:
     name: Our World in Data catalog backport
     url: https://owid.cloud/admin/datasets/5592
-    date_accessed: 2023-08-10 08:09:32.694252
+    date_accessed: 2023-08-10 12:14:23.432290
     publication_date: latest
     published_by: Our World in Data catalog backport
   name: COVID testing time series data (Vietnam exemplar)
@@ -10,6 +10,6 @@ meta:
   is_public: false
 wdir: ../../../data/snapshots/backport/latest
 outs:
-- md5: 55107bdda9163bc19ee16aa01c4f912d
+- md5: e3dc496359dcd4737ff743ce70aa989d
   size: 70714
   path: dataset_5592_covid_testing_time_series_data__vietnam_exemplar_values.feather


### PR DESCRIPTION
Allow backporting archived datasets. This is not meant to be used by ETL, but we need to store the data as snapshots to get rid of `data_values`. Running `etl --backport` doesn't run archived datasets.