### PR TITLE
:sparkles: add .copy methods to Variable and VariableMeta

### DIFF
--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -517,14 +517,11 @@ class Table(pd.DataFrame):
             if missing_columns:
                 log.warning(f"Missing columns in table: {missing_columns}")
 
-        # NOTE: copying with `dataclasses.replace` is much faster than `copy.deepcopy`
         new_fields = defaultdict(VariableMeta)
         for k in common_columns:
             # copy if we have metadata in the other table
             if k in table._fields:
-                v = table._fields[k]
-                new_fields[k] = dataclasses.replace(v)
-                new_fields[k].sources = [dataclasses.replace(s) for s in v.sources]
+                new_fields[k] = table._fields[k].copy()
             # otherwise keep current metadata (if it exists)
             elif k in self._fields:
                 new_fields[k] = self._fields[k]
@@ -596,8 +593,7 @@ class Table(pd.DataFrame):
         # copy variables metadata from other table
         if isinstance(other, Table):
             for k, v in other._fields.items():
-                t._fields[k] = dataclasses.replace(v)
-                t._fields[k].sources = [dataclasses.replace(s) for s in v.sources]
+                t._fields[k] = v.copy()
         return t  # type: ignore
 
     def _repr_html_(self):

--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -303,6 +303,9 @@ class Variable(pd.Series):
             inplace=inplace,
         )
 
+    def copy_metadata(self, from_variable: "Variable", inplace: bool = False) -> Optional["Variable"]:
+        return copy_metadata(to_variable=self, from_variable=from_variable, inplace=inplace)
+
     def copy(self, deep: bool = True) -> "Variable":
         new_var = super().copy(deep=deep)
         if deep:

--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -303,8 +303,11 @@ class Variable(pd.Series):
             inplace=inplace,
         )
 
-    def copy_metadata(self, from_variable: "Variable", inplace: bool = False) -> Optional["Variable"]:
-        return copy_metadata(to_variable=self, from_variable=from_variable, inplace=inplace)
+    def copy(self, deep: bool = True) -> "Variable":
+        new_var = super().copy(deep=deep)
+        if deep:
+            new_var._fields = {k: var_meta.copy(deep=deep) for k, var_meta in self._fields.items()}
+        return new_var
 
 
 # dynamically add all metadata properties to the class

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -297,6 +297,10 @@ def test_copy_metadata_from() -> None:
     assert t2.country.metadata.title == "Country"
     assert t2.metadata.title == "GDP table"
 
+    # make sure it doesn't affect the original table
+    t2.gdp.metadata.title = "new GDP"
+    assert t.gdp.metadata.title == "GDP"
+
 
 def test_addition_without_metadata() -> None:
     t: Table = Table({"a": [1, 2], "b": [3, 4]})

--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -7,6 +7,7 @@ import pytest
 
 from owid.catalog.meta import VariableMeta
 from owid.catalog.variables import (
+    License,
     Variable,
     combine_variables_metadata,
     get_unique_licenses_from_variables,
@@ -270,3 +271,19 @@ def test_dropna(table_1) -> None:
     assert tb1.metadata == table_1.metadata
     # Check that the original variable's metadata is not affected.
     assert tb1["b"].metadata == table_1["b"].metadata
+
+
+def test_copy() -> None:
+    v1 = Variable([1, 2, 3], name="dog")
+    v1.metadata.title = "dog"
+    v1.metadata.license = License(name="dog license")
+
+    v2 = v1.copy()
+
+    # change metadata of a new variable
+    v2.metadata.title = "cat"
+    v2.metadata.license.name = "cat license"  # type: ignore
+
+    # make sure it doesn't affect original variable
+    assert v1.metadata.title == "dog"
+    assert v1.metadata.license.name == "dog license"


### PR DESCRIPTION
Add `Variable.copy(deep=True)` method. This fixes https://github.com/owid/etl/issues/1454. The method can be reused for other dataclasses (we could even add it to all by default with a decator, similarly to `@pruned_json`).

@pabloarosado I've noticed you implemented `Table.copy_metadata` method. There's already `Table.copy_metadata_from` that I believe does the same (and doesn't use `copy.deepcopy` which is quite slow). Do you think it'd be possible to unify them?