### PR TITLE
🐛 Fixing the share of deaths variables in IHME GBD

### DIFF
--- a/etl/steps/data/grapher/ihme_gbd/2019/gbd_risk.py
+++ b/etl/steps/data/grapher/ihme_gbd/2019/gbd_risk.py
@@ -1,8 +1,7 @@
 from owid import catalog
+from shared import run_wrapper
 
 from etl.helpers import PathFinder
-
-from .shared import run_wrapper
 
 paths = PathFinder(__file__)
 

--- a/etl/steps/data/grapher/ihme_gbd/2019/gbd_risk.py
+++ b/etl/steps/data/grapher/ihme_gbd/2019/gbd_risk.py
@@ -1,7 +1,8 @@
 from owid import catalog
-from shared import run_wrapper
 
 from etl.helpers import PathFinder
+
+from .shared import run_wrapper
 
 paths = PathFinder(__file__)
 

--- a/etl/steps/data/meadow/ihme_gbd/2019/shared.py
+++ b/etl/steps/data/meadow/ihme_gbd/2019/shared.py
@@ -69,11 +69,14 @@ def read_and_clean_data(local_file: str) -> pd.DataFrame:
 def fix_percent(df: pd.DataFrame) -> pd.DataFrame:
     """
     IHME doesn't seem to be consistent with how it stores percentages.
-    If the percent value for all causes == 1 for a particular dataset we need to multiply it by 100
+    If the maximum percent value for any cause of death is less than or equal 1,
+    it indicates all values are 100x too small and we need to multiply values by 100
     """
-
-    if all(df[(df["cause"] == "All causes") & (df["metric"] == "Percent")] == 1):
-        df["value"][(df["metric"] == "Percent")] = df["value"][(df["metric"] == "Percent")] * 100
+    if "Percent" in df["metric"].unique():
+        if max(df["value"][df["metric"] == "Percent"]) <= 1:
+            subset_percent = df["metric"] == "Percent"
+            df.loc[subset_percent, "value"] *= 100
+            # df["value"][(df["metric"] == "Percent")] = df["value"][(df["metric"] == "Percent")] * 100
     return df
 
 


### PR DESCRIPTION
- In response to the recent issue with GBD prevalence percentages being the % of total cases rather than % of the population, I added a function to convert the percent variables to be 1000x the rate per 100,000 (where the denominator is population). 
- However, this doesn't make sense for the `gbd_child_mortality`, `gbd_risk` or `gbd_cause` datasets, in these cases, the denominator was DALYs and deaths, which is what we want. 
- Fix is just only using the `add_share_population()` on the `gbd_prevalence` and `gbd_mental_health` datasets.