### PR TITLE
✨ war: fixes

### DIFF
--- a/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
@@ -1,10 +1,25 @@
 dataset:
   title: History of war (UCDP, 2023)
   description: >-
-    This dataset contains information on armed conflicts, both internal and external, in the period of 1989 and 2022.
+    This dataset contains information on armed conflicts - state, non-state and one-sided conflicts, in the period of 1989 and 2022.
 
 
     It has been constructed using the Georeferenced Event Dataset version 23.1 by the UCDP.
+
+
+    Regions: The regions are defined based on Gleditsch and Ward codes (GWno). Find complete mapping at
+    https://dornsife.usc.edu/assets/sites/298/docs/country_to_gwno_PUBLIC_6-5-2015.txt
+
+      • Americas: 2-199
+
+      • Europe: 200-399
+
+      • Africa: 400-626
+
+      • Middle East: 630-699
+
+      • Asia: 700-999
+
 
 
     More details about Georeferenced Event Dataset version 23.1 by the UCDP:

--- a/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
@@ -7,6 +7,11 @@ dataset:
     It has been constructed using the Georeferenced Event Dataset version 23.1 by the UCDP.
 
 
+    Note that the Geo-referenced Event Dataset has been extracted from the UCDP systems at a certaian point in time.
+    However, the UCDP team works with the data all year round, including revisions and updates. Therefore, their dashboard
+    might show slightly more up-to-date data, which sometimes result in minor discrepancies in the data.
+
+
     Regions: The regions are defined based on Gleditsch and Ward codes (GWno). Find complete mapping at
     https://dornsife.usc.edu/assets/sites/298/docs/country_to_gwno_PUBLIC_6-5-2015.txt
 

--- a/etl/steps/data/garden/war/2023-07-07/mars.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-07/mars.meta.yml
@@ -1,7 +1,7 @@
 dataset:
   title: History of war (Project Mars, 2020)
   description: >-
-    This dataset contains information on armed conflicts, both internal and external, in the period of 1800 and 2011.
+    This dataset contains information on armed conflicts, both civil and non-civil, in the period of 1800 and 2011.
 
 
     It has been constructed using the Project Mars dataset by Lyall, Jason.

--- a/etl/steps/data/garden/war/2023-07-07/mars.py
+++ b/etl/steps/data/garden/war/2023-07-07/mars.py
@@ -238,6 +238,7 @@ def estimate_metrics(tb: Table) -> Table:
 
     This function also renames columns to fit expected names.
     """
+    # Add metrcs
     tb_ongoing = _create_ongoing_metrics(tb)
     tb_new = _create_metrics_new(tb)
 
@@ -259,6 +260,9 @@ def estimate_metrics(tb: Table) -> Table:
 
 
 def _create_ongoing_metrics(tb: Table) -> Table:
+    # Check that for a given year and conflict, it only has one conflict type
+    tb.groupby(["year", "warcode"])["conflict_type"].nunique().max()
+
     # Estimate number of ongoing conflicts
     agg_ops = {"warcode": "nunique", "kialow": "sum", "kiahigh": "sum"}
     ## Regions

--- a/etl/steps/data/garden/war/2023-07-18/cow.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-18/cow.meta.yml
@@ -1,7 +1,7 @@
 dataset:
   title: History of war (COW, 2020)
   description: >-
-    This dataset contains information on armed conflicts, both internal and external, in the period of 1816 and 2007.
+    This dataset contains information on armed conflicts (inter-, intra-, extra- and non-state) in the period of 1816 and 2007.
 
 
     It has been constructed using the Correlates of War - War data dataset.

--- a/etl/steps/data/garden/war/2023-07-18/cow.py
+++ b/etl/steps/data/garden/war/2023-07-18/cow.py
@@ -1,4 +1,13 @@
-"""Load a meadow dataset and create a garden dataset."""
+"""COW War data dataset.
+
+- This dataset is built from four different files. Each of them come from the COW site, but have minor differences in
+the fields they contain, etc.
+
+- Each of the source files concerns a specific conflict type (i.e. one file only contains data on "inter-state" conflicts).
+    - Therefore, a conflict (or at least how it is identified in this dataset) never changes its type.
+    - There are fields explaining if a conflict transformed to another conflict (i.e. it stops being in the "inter-state" table with id X, and
+    starts being in the "intra-state" table with id Y).
+"""
 
 import json
 from typing import List, Set, Tuple, cast

--- a/etl/steps/data/garden/war/2023-07-20/brecke.py
+++ b/etl/steps/data/garden/war/2023-07-20/brecke.py
@@ -279,7 +279,7 @@ def _add_ongoing_metrics(tb: Table) -> Table:
     ## By region and conflict_type
     tb_ongoing = tb.groupby(["year", "region", "conflict_type"], as_index=False).agg(ops)
 
-    ## All conflicts
+    ## All conflict types
     tb_ongoing_all_conf = tb.groupby(["year", "region"], as_index=False).agg(ops)
     tb_ongoing_all_conf["conflict_type"] = "all"
 

--- a/etl/steps/data/garden/war/2023-07-21/prio_v31.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-21/prio_v31.meta.yml
@@ -32,6 +32,9 @@ tables:
         unit: deaths
         description: >-
           The number of battle fatalities in a year over the course of wars.
+
+          For some conflicts, data on the number of battle deaths is missing. In such cases, we have used the lower estimate as
+          a lower bound.
         display:
           numDecimalPlaces: 0
 

--- a/etl/steps/data/garden/war/2023-07-21/prio_v31.py
+++ b/etl/steps/data/garden/war/2023-07-21/prio_v31.py
@@ -62,6 +62,9 @@ def run(dest_dir: str) -> None:
     log.info("war.prio_v31: sanity checks")
     _sanity_checks(tb)
 
+    log.info("war.prio_v31: replace NA in best estimate with lower bound")
+    tb["bdeadbes"] = tb["bdeadbes"].fillna(tb["bdeadlow"])
+
     log.info("war.prio_v31: estimate metrics")
     tb = estimate_metrics(tb)
 
@@ -125,10 +128,10 @@ def _sanity_checks(tb: Table) -> None:
 
     # Check regions
     assert (
-        tb.groupby("id").region.nunique() == 1
+        tb.groupby("id")["region"].nunique() == 1
     ).all(), "Some conflicts occurs in multiple regions! That was not expected."
     assert (
-        tb.groupby(["id", "year"]).type.nunique() == 1
+        tb.groupby(["id", "year"])["type"].nunique() == 1
     ).all(), "Some conflicts has different values for `type` in the same year! That was not expected."
 
 

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
@@ -1,7 +1,7 @@
 dataset:
   title: History of war (COW MID, 2020)
   description: >-
-      This dataset contains information on armed conflicts, both internal and external, in the period of 1816 and 2014.
+      This dataset contains information on interstate conflicts in the period of 1816 and 2014.
 
 
       It has been constructed using the Correlates of War - Militarised Interstate Disputes v5.0 dataset.

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
@@ -6,6 +6,7 @@ dataset:
 
       It has been constructed using the Correlates of War - Militarised Interstate Disputes v5.0 dataset.
 
+
       Regions: The regions are defined based on Gleditsch and Ward codes (GWno). Find complete mapping at
       https://dornsife.usc.edu/assets/sites/298/docs/country_to_gwno_PUBLIC_6-5-2015.txt
 
@@ -43,6 +44,22 @@ tables:
 
           We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions.
           The sum across all regions can therefore be higher than the total number of ongoing conflicts.
+
+
+          The same conflict can have different "hostility level" for different regions. When this is the case, we classify its global
+          hostility level as the most hostile level based on the following rank (from less to most hostile):
+
+
+            1: No militarized action
+
+            2: Threat to use force
+
+            3: Display of force
+
+            4: Use of force
+
+            5: War
+
         processing_level: major
         display:
           numDecimalPlaces: 0
@@ -70,6 +87,21 @@ tables:
 
           • New disputes by hostility level: We only count a dispute as new when the dispute overall started that year, not if it changed
           its hostility level.
+
+
+          The same conflict can have different "hostility level" for different regions. When this is the case, we classify its global
+          hostility level as the most hostile level based on the following rank (from less to most hostile):
+
+
+            1: No militarized action
+
+            2: Threat to use force
+
+            3: Display of force
+
+            4: Use of force
+
+            5: War
         processing_level: major
         display:
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.py
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.py
@@ -11,6 +11,8 @@ estimating the global number of ongoing (or new) conflicts by broken down by hos
 
 - Each entry in this dataset describes a conflict (its participants and period). Therefore we need to "explode" it to add observations
 for each year of the conflict.
+
+- The number of deaths is not estimated for each hostile level, but rather only the aggregate is obtained.
 """
 
 from typing import cast

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.py
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.py
@@ -1,4 +1,17 @@
-"""Load a meadow dataset and create a garden dataset."""
+"""COW Militarised Inter-state Dispute dataset.
+
+
+- This dataset only contains inter-state conflicts. We use the hostility level to differentiate different "types" of conflicts.
+
+- The same conflict might be happening in different regions, with different hostility levels. This is important to consider when
+estimating the global number of ongoing (or new) conflicts by broken down by hostility level
+
+    - Such a conflict (occuring in mutliple regions at the same time with different hostility levels) has been coded using the
+    most hostile category at global level.
+
+- Each entry in this dataset describes a conflict (its participants and period). Therefore we need to "explode" it to add observations
+for each year of the conflict.
+"""
 
 from typing import cast
 

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.py
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.py
@@ -228,11 +228,12 @@ def _add_ongoing_metrics(tb: Table) -> Table:
     ## By region and hostility_level
     tb_ongoing = tb.groupby(["year", "region", "hostility_level"], as_index=False).agg(ops)
     ## region='World' and by hostility_level
-    tb_ongoing_world = tb.groupby(["year", "hostility_level"], as_index=False).agg(ops)
+    tb_ = tb.groupby(["dispnum", "year"], as_index=False).agg({"hostility_level": max})
+    tb_ongoing_world = tb_.groupby(["year", "hostility_level"], as_index=False).agg(ops)
     tb_ongoing_world["region"] = "World"
 
     ops = {"dispnum": "nunique", "fatalpre": sum}
-    ## By region and hostility_level='all
+    ## By region and hostility_level='all'
     tb_ongoing_alltypes = tb.groupby(["year", "region"], as_index=False).agg(ops)
     tb_ongoing_alltypes["hostility_level"] = "all"
     ## region='World' and hostility_level='all'
@@ -271,12 +272,13 @@ def _add_new_metrics(tb: Table) -> Table:
 
     # World
     ## Keep one row per (dispnum). Otherwise, we might count the same dispute in multiple years!
-    tb_ = tb.sort_values("styear").drop_duplicates(subset=["dispnum"], keep="first")
+    tb_ = tb.groupby(["dispnum", "styear"], as_index=False).agg({"hostility_level": max})
+    # tb_ = tb.sort_values("styear").drop_duplicates(subset=["dispnum"], keep="first")
     ## region='World' and by hostility_level
-    tb_new_world = tb.groupby(["styear", "hostility_level"], as_index=False).agg(ops)
+    tb_new_world = tb_.groupby(["styear", "hostility_level"], as_index=False).agg(ops)
     tb_new_world["region"] = "World"
     ## World and hostility_level='all'
-    tb_new_world_alltypes = tb.groupby(["styear"], as_index=False).agg(ops)
+    tb_new_world_alltypes = tb_.groupby(["styear"], as_index=False).agg(ops)
     tb_new_world_alltypes["region"] = "World"
     tb_new_world_alltypes["hostility_level"] = "all"
 


### PR DESCRIPTION
- Fixes in dataset descriptions (metadata)
- Fix metrics in COW - MID: `number_ongoing_conflicts` and`number_new_conflicts`:
  -  for `region="World"`, and disaggregated by `hostility_type`. Some conflicts were double-counted (in multiple regions, with different hostility levels).
- Fix metrics in PRIO v3.1
  - The estimate on battle deaths is often missing. In such cases, replace the `NAs` with the value given by the low estimate on battle deaths (low and high estimates are never missing).