### PR TITLE
:hammer: merge functions copy_metadata and copy_metadata_from

### DIFF
--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -466,6 +466,13 @@ class TableMeta:
             short_name, to_html(record)
         )
 
+    def copy(self, deep=True) -> "TableMeta":
+        """Return a copy of the TableMeta object."""
+        if not deep:
+            return dataclasses.replace(self)
+        else:
+            return _deepcopy_dataclass(self)
+
 
 def to_html(record: Any) -> Optional[str]:
     if isinstance(record, dict):

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -3,7 +3,6 @@
 #
 
 import copy
-import dataclasses
 import json
 from collections import defaultdict
 from os.path import dirname, join, splitext
@@ -491,37 +490,11 @@ class Table(pd.DataFrame):
     def copy(self, deep: bool = True) -> "Table":
         """Copy table together with all its metadata."""
         tab = super().copy(deep=deep)
-        tab.copy_metadata_from(self)
-        return tab
+        return tab.copy_metadata(self)
 
-    def copy_metadata_from(self, table: "Table", errors: Literal["raise", "ignore", "warn"] = "raise") -> None:
+    def copy_metadata(self, from_table: "Table", deep: bool = False) -> "Table":
         """Copy metadata from a different table to self."""
-        self.metadata = dataclasses.replace(table.metadata)
-
-        extra_columns = set(table.columns) - set(self.columns)
-        missing_columns = set(self.columns) - set(table.columns)
-        common_columns = set(self.columns) & set(table.columns)
-
-        if errors == "raise":
-            if extra_columns:
-                raise ValueError(f"Extra columns in table: {extra_columns}")
-            if missing_columns:
-                raise ValueError(f"Missing columns in table: {missing_columns}")
-        elif errors == "warn":
-            if extra_columns:
-                log.warning(f"Extra columns in table: {extra_columns}")
-            if missing_columns:
-                log.warning(f"Missing columns in table: {missing_columns}")
-
-        new_fields = defaultdict(VariableMeta)
-        for k in common_columns:
-            # copy if we have metadata in the other table
-            if k in table._fields:
-                new_fields[k] = table._fields[k].copy()
-            # otherwise keep current metadata (if it exists)
-            elif k in self._fields:
-                new_fields[k] = self._fields[k]
-        self._fields = new_fields
+        return copy_metadata(to_table=self, from_table=from_table, deep=deep)
 
     @overload
     def set_index(
@@ -662,13 +635,6 @@ class Table(pd.DataFrame):
             )
 
         return cast("Table", tb)
-
-    def copy_metadata(
-        self, from_table: "Table", include_missing_variables: bool = False, inplace: bool = False
-    ) -> Optional["Table"]:
-        return copy_metadata(
-            to_table=self, from_table=from_table, include_missing_variables=include_missing_variables, inplace=inplace
-        )
 
     def update_log(
         self,
@@ -1254,42 +1220,23 @@ def assign_dataset_sources_origins_and_licenses_to_each_variable(table: Table) -
     return table
 
 
-@overload
-def copy_metadata(
-    from_table: Table, to_table: Table, include_missing_variables: bool = False, inplace: bool = False
-) -> Table:
-    ...
+def copy_metadata(from_table: Table, to_table: Table, deep=False) -> Table:
+    """Copy metadata from a different table to self."""
+    tab = Table(pd.DataFrame.copy(to_table, deep=deep), metadata=from_table.metadata.copy())
 
+    common_columns = set(to_table.all_columns) & set(from_table.all_columns)
 
-@overload
-def copy_metadata(
-    from_table: Table, to_table: Table, include_missing_variables: bool = False, inplace: bool = True
-) -> None:
-    ...
+    new_fields = defaultdict(VariableMeta)
+    for k in common_columns:
+        # copy if we have metadata in the other table
+        if k in from_table._fields:
+            new_fields[k] = from_table._fields[k].copy()
+        # otherwise keep current metadata (if it exists)
+        elif k in to_table._fields:
+            new_fields[k] = to_table._fields[k]
 
-
-def copy_metadata(
-    from_table: Table, to_table: Table, include_missing_variables: bool = False, inplace: bool = False
-) -> Optional[Table]:
-    if not inplace:
-        to_table = to_table.copy()
-
-    # Copy the table metadata.
-    to_table.metadata = copy.deepcopy(from_table.metadata)
-
-    if include_missing_variables:
-        # Copy metadata from all variables (in case you may need them later).
-        to_table._fields = copy.deepcopy(from_table._fields)
-    else:
-        # Find variables in the destination table that had metadata in the reference table.
-        existing_variables = set(to_table.all_columns) & set(from_table._fields.keys())
-        # Copy the metadata of those variables from the reference table to the destination table.
-        to_table._fields = copy.deepcopy(
-            defaultdict(VariableMeta, {variable: from_table._fields[variable] for variable in existing_variables})
-        )
-
-    if not inplace:
-        return to_table
+    tab._fields = new_fields
+    return tab
 
 
 @overload

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -289,7 +289,7 @@ def test_copy() -> None:
     assert t2.primary_key == []
 
 
-def test_copy_metadata_from() -> None:
+def test_copy_metadata() -> None:
     t: Table = Table({"gdp": [100, 102, 104], "country": ["AU", "SE", "CH"]})
     t.metadata.title = "GDP table"
     t.gdp.metadata.title = "GDP"
@@ -297,7 +297,7 @@ def test_copy_metadata_from() -> None:
     t2: Table = Table(pd.DataFrame(t))
     t2.country.metadata.title = "Country"
 
-    t2.copy_metadata_from(t)
+    t2 = t2.copy_metadata(t)
 
     assert t2.gdp.metadata.title == "GDP"
     assert t2.country.metadata.title == "Country"


### PR DESCRIPTION
* merge both functions into `copy_metadata`
* remove unused arguments from `copy_metadata` to keep it simple
* make shallow copy by default for performance reasons (shouldn't affect any existing use)