### PR TITLE
📊  war: change format of COW MID dataset

### DIFF
--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
@@ -10,15 +10,15 @@ dataset:
       Regions: The regions are defined based on Gleditsch and Ward codes (GWno). Find complete mapping at
       https://dornsife.usc.edu/assets/sites/298/docs/country_to_gwno_PUBLIC_6-5-2015.txt
 
-      • Americas: 2-199
+      • Americas: 2-165
 
-      • Europe: 200-399
+      • Europe: 200-395
 
       • Africa: 400-626
 
-      • Middle East: 630-699
+      • Middle East: 630-698
 
-      • Asia: 700-999
+      • Asia: 700-990
 
 
 tables:

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
@@ -46,20 +46,24 @@ tables:
           The sum across all regions can therefore be higher than the total number of ongoing conflicts.
 
 
-          The same conflict can have different "hostility level" for different regions. When this is the case, we classify its global
-          hostility level as the most hostile level based on the following rank (from less to most hostile):
+          The data is disaggregated by region and "fatality". "Fatality" gives lower and upper estimates on the total number of
+          fatalities over the complete span of a dispute. These are the types:
 
+            - No deaths
 
-            1: No militarized action
+            - 1-25 deaths
 
-            2: Threat to use force
+            - 26-100 deaths
 
-            3: Display of force
+            - 101-250 deaths
 
-            4: Use of force
+            - 251-500 deaths
 
-            5: War
+            - 501-999 deaths
 
+            - > 999 deaths
+
+            - Unknown
         processing_level: major
         display:
           numDecimalPlaces: 0
@@ -71,86 +75,3 @@ tables:
               - Asia
               - Europe
               - Middle East
-      number_new_disputes:
-        title: Number of new disputes
-        unit: disputes
-        description_short: The annual number of new disputes
-        description: >-
-          Number of new disputes in a given year.
-
-
-          • New disputes for the 'World': We only count a dispute as new when the dispute overall started that year, not if it restarted
-          or its hostility level changed.
-
-          • New disputes for all regions (except 'World'): We count a dispute as new in a region even if the dispute overall started
-          earlier in another region. The sum across all regions can therefore be higher than the total number of new disputes.
-
-          • New disputes by hostility level: We only count a dispute as new when the dispute overall started that year, not if it changed
-          its hostility level.
-
-
-          The same conflict can have different "hostility level" for different regions. When this is the case, we classify its global
-          hostility level as the most hostile level based on the following rank (from less to most hostile):
-
-
-            1: No militarized action
-
-            2: Threat to use force
-
-            3: Display of force
-
-            4: Use of force
-
-            5: War
-        processing_level: major
-        display:
-          numDecimalPlaces: 0
-        presentation:
-          grapher_config:
-            selectedEntityNames:
-              - Africa
-              - Americas
-              - Asia
-              - Europe
-              - Middle East
-      number_deaths_ongoing_disputes:
-        title: Number of deaths in ongoing disputes
-        unit: deaths
-        description_short: Annual number of deaths in ongoing disputes
-        description: >-
-          The estimated number of fatalities in a year over the course of disputes.
-
-
-          For some conflicts, data on the number of fatalities was missing (source field "FatalPre"). In such cases, we have used the lower bound from the range
-          specified by the source field "Fatality". If this was also missing, we have set the value to zero. Consequently, the number of fatalities in ongoing
-          disputes is likely to be underestimated.
-        description_from_producer: >-
-          The Participant Fatalities section of the dispute coding spreadsheet is used to record the fatalities of each and every
-          participant in the dispute. These values should be derived from the incidents related to the dispute and may require a good
-          deal of work in complex disputes.
-
-          Assessment of each participant's fatalities should be based on the following categories:
-
-          • -9 — No overall assessment of military fatalities for this participant was possible.
-          • 0 — No military fatalities were suffered by this participant.
-          • 1 — Participant fatalities were between 1 and 25.
-          • 2 — Participant fatalities were between 26 and 100.
-          • 3 — Participant fatalities were between 101 and 250.
-          • 4 — Participant fatalities were between 251 and 500.
-          • 5 — Participant fatalities were between 501 and 999.
-          • 6 — Participant fatalities were 1,000 or more.
-
-          If an exact value for total military fatalities can be determined from the related incidents, then that number should
-          be entered in the precise fatality cell of the coding spreadsheet
-        processing_level: major
-        display:
-          numDecimalPlaces: 0
-        presentation:
-          grapher_config:
-            selectedEntityNames:
-              - Africa
-              - Americas
-              - Asia
-              - Europe
-              - Middle East
-

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.py
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.py
@@ -29,22 +29,17 @@ from etl.helpers import PathFinder, create_dataset
 paths = PathFinder(__file__)
 # Log
 log = get_logger()
-# Mapping from hostility level code to name
-HOSTILITY_LEVEL_MAP = {
-    1: "No militarized action",
-    2: "Threat to use force",
-    3: "Display of force",
-    4: "Use of force",
-    5: "War",
+# Mapping from fatality code to name
+FATALITY_LEVEL_MAP = {
+    0: "No deaths",
+    1: "1-25 deaths",
+    2: "26-100 deaths",
+    3: "101-250 deaths",
+    4: "251-500 deaths",
+    5: "501-999 deaths",
+    6: "> 999 deaths",
+    -9: "Unknown",
 }
-
-
-def load_countries_regions() -> Table:
-    """Load countries-regions table from reference dataset (e.g. to map from iso codes to country names)."""
-    ds_reference = cast(Dataset, paths.load_dependency("regions"))
-    tb_countries_regions = ds_reference["regions"]
-
-    return tb_countries_regions
 
 
 def run(dest_dir: str) -> None:
@@ -55,51 +50,30 @@ def run(dest_dir: str) -> None:
     ds_meadow = cast(Dataset, paths.load_dependency("cow_mid"))
 
     # Read table from meadow dataset.
-    tb = ds_meadow["midb"]
+    tb_a = ds_meadow["mida"].reset_index()
+    tb_b = ds_meadow["midb"].reset_index()
 
     #
     # Process data.
     #
-    log.info("war.cow_mid: complete number of deaths with lower bounds")
-    tb = complete_num_deaths(tb)
+    log.info("war.cow_mid: read and process MIDA table")
+    tb_a = process_mida_table(tb_a)
 
-    log.info("war.cow_mid: sanity checks")
-    _sanity_checks(tb)
+    log.info("war.cow_mid: read and process MIDB table")
+    tb_b = process_midb_table(tb_b)
 
-    log.info("war.cow_mid: keep relevant columns")
-    COLUMNS_RELEVANT = [
-        "dispnum",
-        "ccode",
-        "stabb",
-        "hostlev",
-        "styear",
-        "endyear",
-        "fatalpre",
-    ]
-    tb = tb[COLUMNS_RELEVANT]
-
-    log.info("war.cow_mid: add regions")
-    tb = add_regions(tb)
-
-    log.info("war.cow_mid: rename column")
-    tb = tb.rename(columns={"hostlev": "hostility_level"})
-
-    log.info("war.cow_mid: aggregate entries")
-    tb = tb.groupby(["dispnum", "region", "styear", "endyear"], as_index=False).agg(
-        {"fatalpre": "sum", "hostility_level": "max"}
-    )
-
-    log.info("war.cow_mid: expand observations")
-    tb = expand_observations(tb)
+    log.info("war.cow_mid: combine tables")
+    tb = combine_tables(tb_a, tb_b)
 
     # Estimate metrics
     log.info("war.cow_mid: estimate metrics")
     tb = estimate_metrics(tb)
 
-    # Rename hotility levels
-    log.info("war.cow_mid: rename hostility_level")
-    tb["hostility_level"] = tb["hostility_level"].map(HOSTILITY_LEVEL_MAP | {"all": "all"})
-    assert tb["hostility_level"].isna().sum() == 0, "Unmapped regions!"
+    # Map fatality codes to names
+    log.info("war.cow_mid: map fatality codes to names")
+    tb["fatality"] = tb["fatality"].map(FATALITY_LEVEL_MAP)
+    assert tb["fatality"].isna().sum() == 0, "Unmapped fatality codes!"
+
     # Add suffix with source name
     msk = tb["region"] != "World"
     tb.loc[msk, "region"] = tb.loc[msk, "region"] + " (COW)"
@@ -109,7 +83,7 @@ def run(dest_dir: str) -> None:
 
     # Set index
     log.info("war.cow_mid: set index")
-    tb = tb.set_index(["year", "region", "hostility_level"], verify_integrity=True)
+    tb = tb.set_index(["year", "region", "fatality"], verify_integrity=True)
 
     # Add short_name to table
     log.info("war.cow_mid: add shortname to table")
@@ -125,39 +99,103 @@ def run(dest_dir: str) -> None:
     ds_garden.save()
 
 
-def complete_num_deaths(tb: Table) -> Table:
-    """Complement `fatalpre` with information from `fatality`.
+def process_mida_table(tb: Table) -> Table:
+    """Process MIDA table.
 
-    `fatalpre` gives the precise number of deaths. However, this value is sometimes missing. In these cases, we can
-    use the information from `fatality` to get a lower bound for the number of deaths.
-
-    When information is missing in both fields, we set the value to 0.
+    - Sanity checks
+    - Keep relevant columns
+    - Add observation per year
     """
-    # Reduce NaNs in `fatalpre`
-    fatality_lower_bound = {
-        0: 0,
-        1: 1,
-        2: 26,
-        3: 101,
-        4: 251,
-        5: 501,
-        6: 1000,
-        -9: np.nan,
-    }
-    mask = tb["fatalpre"] == -9
-    tb.loc[mask, "fatalpre"] = tb.loc[mask, "fatality"].map(fatality_lower_bound)
+    # Sanity checks
+    assert tb["dispnum"].value_counts().max() == 1, "The same conflict (with same `dispnum`) appears multiple times"
+    assert tb["styear"].notna().all() and (tb["styear"] >= 0).all(), "NA values (or negative) found in `styear`"
+    assert tb["endyear"].notna().all() and (tb["endyear"] >= 0).all(), "NA values (or negative) found in `endyear`"
+    assert not set(tb["fatality"]) - set(FATALITY_LEVEL_MAP), "Unnexpected values for `fatality`!"
 
-    assert tb["fatalpre"].isna().sum() == 599, "Different number of NaNs found. Expected was 599."
-    tb["fatalpre"] = tb["fatalpre"].fillna(0)
+    # Keep relevant columns
+    COLUMNS_RELEVANT = [
+        "dispnum",
+        "styear",
+        "endyear",
+        "fatality",
+    ]
+    tb = tb[COLUMNS_RELEVANT]
+
+    # Add observation for each year
+    tb = expand_observations(tb)
+
+    # Drop columns
+    tb = tb.drop(columns=["styear", "endyear"])
 
     return tb
 
 
-def _sanity_checks(tb: Table) -> Table:
-    # sanity checks
-    assert tb.groupby(["dispnum", "ccode", "styear", "endyear"]).size().max() == 1
-    assert set(tb["hostlev"]) == {1, 2, 3, 4, 5}, "Set of hostlev values should be {1, 2, 3, 4, 5}."
-    assert ((tb["ccode"] > 1) & (tb["ccode"] < 1000)).all(), "ccode should be between 1 and 1000."
+def process_midb_table(tb: Table) -> Table:
+    """Process MIDB table.
+
+    - Sanity checks
+    - Keep relevant columns
+    - Add observation per year
+    - Add regions
+    """
+    # Sanity checks
+    assert (
+        tb.groupby(["dispnum", "ccode", "styear", "endyear"]).size().max() == 1
+    ), "Multiple entries for a conflict-country-start_year-end_year"
+    assert tb["styear"].notna().all() and (tb["styear"] >= 0).all(), "NA values (or negative) found in `styear`"
+    assert tb["endyear"].notna().all() and (tb["endyear"] >= 0).all(), "NA values (or negative) found in `endyear`"
+
+    # Add regions
+    tb = add_regions(tb)
+
+    # Keep relevant columns
+    COLUMNS_RELEVANT = [
+        "dispnum",
+        "styear",
+        "endyear",
+        "region",
+    ]
+    tb = tb[COLUMNS_RELEVANT]
+
+    # Drop duplicates
+    tb = tb.drop_duplicates()
+
+    # Add observation for each year
+    tb = expand_observations(tb)
+
+    # Drop columns
+    tb = tb.drop(columns=["styear", "endyear"])
+
+    return tb
+
+
+def combine_tables(tb_a: Table, tb_b: Table) -> Table:
+    """Combine MIDA and MIDB processed tables.
+
+    Basically, it adds region information (from MIDB) to MIDA.
+    """
+    # Merge
+    tb = tb_a.merge(tb_b, on=["dispnum", "year"], how="left")
+
+    # Fill NaNs
+    ## Sanity check (1)
+    dispnum_nans_expected = {2044, 2328, 4005}
+    dispnum_nans_found = set(tb.loc[tb["region"].isna()])
+    dispnum_nans_unexpected = dispnum_nans_found - dispnum_nans_expected
+    assert dispnum_nans_unexpected, f"Unexpected dispnum with NaN regions: {dispnum_nans_unexpected}"
+    ## Sanity check (2)
+    assert (
+        tb_b[tb_b["dispnum"].isin(dispnum_nans_expected)].groupby("dispnum")["region"].nunique().max() == 1
+    ), f"More than one region for some dispnum in {dispnum_nans_expected}"
+    ## Actually fill NaNs
+    tb.loc[tb["dispnum"] == 2044, "region"] = "Americas"
+    tb.loc[tb["dispnum"] == 2328, "region"] = "Europe"
+    tb.loc[tb["dispnum"] == 4005, "region"] = "Asia"
+
+    # Check there is no NaN!
+    assert (tb.isna().sum() == 0).all(), "NaN in some field!"
+
+    return tb
 
 
 def add_regions(tb: Table) -> Table:
@@ -188,9 +226,6 @@ def expand_observations(tb: Table) -> Table:
     Table
         Here, each dispute has as many rows as years of activity. Its deaths have been uniformly distributed among the years of activity.
     """
-    # For that we scale the number of deaths proportional to the duration of the dispute.
-    tb[["fatalpre"]] = tb[["fatalpre"]].div(tb["endyear"] - tb["styear"] + 1, "index").round()
-
     # Add missing years for each triplet ("warcode", "campcode", "ccode")
     YEAR_MIN = tb["styear"].min()
     YEAR_MAX = tb["endyear"].max()
@@ -222,95 +257,25 @@ def estimate_metrics(tb: Table) -> Table:
     Table
         Table with a row per year, and the corresponding metrics of interest.
     """
-    # Get metrics (ongoing and new)
-    tb_ongoing = _add_ongoing_metrics(tb)
-    tb_new = _add_new_metrics(tb)
+    assert (
+        tb.groupby(["dispnum"]).fatality.nunique().max() == 1
+    ), "The same conflict appears with multiple fatality levels!"
 
-    # Combine
-    columns_idx = ["year", "region", "hostility_level"]
-    tb = tb_ongoing.merge(tb_new, on=columns_idx, how="outer").sort_values(columns_idx)
-
-    return tb
-
-
-def _add_ongoing_metrics(tb: Table) -> Table:
-    ## Aggregate by (dispute, region, year)
-    ## The same dispute may appear more than once in the same region and year with a different hostility_level.
-    ## We want a single hostility_level per dispute, region and year. Therefore, we assign the highest hostility level.
-    tb = tb.groupby(["dispnum", "region", "year"], as_index=False).agg({"hostility_level": "max", "fatalpre": "sum"})
-
-    ops = {"dispnum": "nunique"}
-    ## By region and hostility_level
-    tb_ongoing = tb.groupby(["year", "region", "hostility_level"], as_index=False).agg(ops)
-    ## region='World' and by hostility_level
-    tb_ = tb.groupby(["dispnum", "year"], as_index=False).agg({"hostility_level": max})
-    tb_ongoing_world = tb_.groupby(["year", "hostility_level"], as_index=False).agg(ops)
-    tb_ongoing_world["region"] = "World"
-
-    ops = {"dispnum": "nunique", "fatalpre": sum}
-    ## By region and hostility_level='all'
-    tb_ongoing_alltypes = tb.groupby(["year", "region"], as_index=False).agg(ops)
-    tb_ongoing_alltypes["hostility_level"] = "all"
-    ## region='World' and hostility_level='all'
-    tb_ongoing_world_alltypes = tb.groupby(["year"], as_index=False).agg(ops)
-    tb_ongoing_world_alltypes["region"] = "World"
-    tb_ongoing_world_alltypes["hostility_level"] = "all"
-
-    ## Combine tables
-    tb_ongoing = pr.concat([tb_ongoing, tb_ongoing_world, tb_ongoing_alltypes, tb_ongoing_world_alltypes], ignore_index=True).sort_values(  # type: ignore
-        by=["year", "region", "hostility_level"]
-    )
-
-    ## Rename columns
-    tb_ongoing = tb_ongoing.rename(  # type: ignore
-        columns={
-            "dispnum": "number_ongoing_disputes",
-            "fatalpre": "number_deaths_ongoing_disputes",
-        }
-    )
-
-    return tb_ongoing
-
-
-def _add_new_metrics(tb: Table) -> Table:
-    # Operations
+    # Operations to apply
     ops = {"dispnum": "nunique"}
 
-    # Regions
-    ## Keep one row per (dispnum, region).
-    tb_ = tb.sort_values("styear").drop_duplicates(subset=["dispnum", "region"], keep="first")
-    ## By region and hostility_level
-    tb_new = tb_.groupby(["styear", "region", "hostility_level"], as_index=False).agg(ops)
-    ## By region and hostility_level='all'
-    tb_new_alltypes = tb_.groupby(["styear", "region"], as_index=False).agg(ops)
-    tb_new_alltypes["hostility_level"] = "all"
-
+    # By regions
+    tb_regions = tb.groupby(["year", "fatality", "region"], as_index=False).agg(ops)
     # World
-    ## Keep one row per (dispnum). Otherwise, we might count the same dispute in multiple years!
-    tb_ = tb.groupby(["dispnum", "styear"], as_index=False).agg({"hostility_level": max})
-    # tb_ = tb.sort_values("styear").drop_duplicates(subset=["dispnum"], keep="first")
-    ## region='World' and by hostility_level
-    tb_new_world = tb_.groupby(["styear", "hostility_level"], as_index=False).agg(ops)
-    tb_new_world["region"] = "World"
-    ## World and hostility_level='all'
-    tb_new_world_alltypes = tb_.groupby(["styear"], as_index=False).agg(ops)
-    tb_new_world_alltypes["region"] = "World"
-    tb_new_world_alltypes["hostility_level"] = "all"
+    tb_world = tb.groupby(["year", "fatality"], as_index=False).agg(ops)
+    tb_world["region"] = "World"
 
     # Combine
-    tb_new = pd.concat([tb_new, tb_new_alltypes, tb_new_world, tb_new_world_alltypes], ignore_index=True).sort_values(  # type: ignore
-        by=["styear", "region", "hostility_level"]
-    )
+    tb = pr.concat([tb_regions, tb_world], ignore_index=False)
 
-    # Rename columns
-    tb_new = tb_new.rename(  # type: ignore
-        columns={
-            "styear": "year",
-            "dispnum": "number_new_disputes",
-        }
-    )
-
-    return tb_new
+    # Field name
+    tb = tb.rename(columns={"dispnum": "number_ongoing_disputes"})
+    return tb
 
 
 def replace_missing_data_with_zeros(tb: Table) -> Table:
@@ -320,22 +285,16 @@ def replace_missing_data_with_zeros(tb: Table) -> Table:
     # Add missing (year, region, hostility_type) entries (filled with NaNs)
     years = np.arange(tb["year"].min(), tb["year"].max() + 1)
     regions = set(tb["region"])
-    hostility_types = set(tb["hostility_level"])
-    new_idx = pd.MultiIndex.from_product([years, regions, hostility_types], names=["year", "region", "hostility_level"])
-    tb = tb.set_index(["year", "region", "hostility_level"], verify_integrity=True).reindex(new_idx).reset_index()
+    fatality_types = set(tb["fatality"])
+    new_idx = pd.MultiIndex.from_product([years, regions, fatality_types], names=["year", "region", "fatality"])
+    tb = tb.set_index(["year", "region", "fatality"], verify_integrity=True).reindex(new_idx).reset_index()
 
     # Change NaNs for 0 for specific rows
     ## For columns "number_ongoing_disputes", "number_new_disputes"
     columns = [
         "number_ongoing_disputes",
-        "number_new_disputes",
     ]
     tb.loc[:, columns] = tb.loc[:, columns].fillna(0)
-
-    # We are only reporting number of deaths for hostility_level='all'
-    ## for hostility_level != 'all' we don't mind having NaNs
-    mask = tb["hostility_level"] == "all"
-    tb.loc[mask, "number_deaths_ongoing_disputes"] = tb.loc[mask, "number_deaths_ongoing_disputes"].fillna(0)
 
     # Drop all-NaN rows
     tb = tb.dropna(subset=columns, how="all")

--- a/etl/steps/data/garden/war/2023-08-15/mie.py
+++ b/etl/steps/data/garden/war/2023-08-15/mie.py
@@ -1,4 +1,19 @@
-"""Load a meadow dataset and create a garden dataset."""
+"""Load a meadow dataset and create a garden dataset.
+
+- This dataset only contains inter-state conflicts. We use the hostility level to differentiate different "types" of conflicts.
+
+- The same conflict might be happening in different regions, with different hostility levels. This is important to consider when
+estimating the global number of ongoing (or new) conflicts by broken down by hostility level
+
+    - Such a conflict (occuring in mutliple regions at the same time with different hostility levels) has been coded using the
+    most hostile category at global level.
+
+- Each entry in this dataset describes a conflict (its participants and period). Therefore we need to "explode" it to add observations
+for each year of the conflict.
+
+- The number of deaths is not estimated for each hostile level, but rather only the aggregate is obtained.
+
+"""
 
 from typing import cast
 

--- a/etl/steps/data/grapher/war/2023-08-08/cow_mid.py
+++ b/etl/steps/data/grapher/war/2023-08-08/cow_mid.py
@@ -30,7 +30,7 @@ def run(dest_dir: str) -> None:
     tb["country"] = tb["country"].str.replace(r" \(.+\)", "", regex=True)
 
     # Set an appropriate index and sort conveniently.
-    tb = tb.set_index(["year", "country", "hostility_level"])
+    tb = tb.set_index(["year", "country", "fatality"])
 
     #
     # Save outputs.


### PR DESCRIPTION
Simplify the COW MID dataset.

- Only report one metric: number of ongoing conflicts.
- Report disaggregated by `region` and `fatality`.
  - `fatality` describes a range of fatalities (lower and upper bounds) over the complete lifetime of a dispute globally.
  - We include an "unknown" category for `fatality`.