### PR TITLE
📊  war: define selected entities by default

### DIFF
--- a/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
@@ -45,6 +45,14 @@ tables:
           Active conflicts are those resulting into at least 25 deaths each year (based on most plausible estimate).
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
       number_deaths_ongoing_conflicts_high:
         title: Number of deaths in ongoing conflicts (high estimate)
         unit: deaths
@@ -56,6 +64,14 @@ tables:
           Active conflicts are those resulting into at least 25 deaths each year (based on most plausible estimate).
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
       number_deaths_ongoing_conflicts_low:
         title: Number of deaths in ongoing conflicts (low estimate)
         unit: deaths
@@ -72,6 +88,14 @@ tables:
           Active conflicts are those resulting into at least 25 deaths each year (based on most plausible estimate).
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
 
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
@@ -85,6 +109,14 @@ tables:
           Active conflicts are those resulting into at least 25 deaths each year (based on most plausible estimate).
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
       number_new_conflicts:
         title: Number of new conflicts
         unit: deaths
@@ -104,3 +136,11 @@ tables:
           Active conflicts are those resulting into at least 25 deaths each year (based on most plausible estimate).
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East

--- a/etl/steps/data/garden/war/2023-07-07/mars.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-07/mars.meta.yml
@@ -22,6 +22,16 @@ tables:
           died from illness and/or disease. This is the high estimate of those who were killed.
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Asia
+              - Eastern Europe
+              - Latin America
+              - North Africa and the Middle East
+              - North America
+              - Sub-Saharan Africa
+              - Western Europe
       number_deaths_ongoing_conflicts_low:
         title: Number of soldier deaths in ongoing conflicts (low estimate)
         unit: deaths
@@ -30,7 +40,16 @@ tables:
           died from illness and/or disease. This is the low estimate of those who were killed.
         display:
           numDecimalPlaces: 0
-
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Asia
+              - Eastern Europe
+              - Latin America
+              - North Africa and the Middle East
+              - North America
+              - Sub-Saharan Africa
+              - Western Europe
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
         unit: conflicts
@@ -42,9 +61,18 @@ tables:
 
 
           For the wars that had campaigns within it that were a civil war and a non-civil war, we coded them as non-civil wars.
-
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Asia
+              - Eastern Europe
+              - Latin America
+              - North Africa and the Middle East
+              - North America
+              - Sub-Saharan Africa
+              - Western Europe
       number_new_conflicts:
         title: Number of new conflicts
         unit: conflicts
@@ -64,3 +92,13 @@ tables:
 
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Asia
+              - Eastern Europe
+              - Latin America
+              - North Africa and the Middle East
+              - North America
+              - Sub-Saharan Africa
+              - Western Europe

--- a/etl/steps/data/garden/war/2023-07-18/cow.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-18/cow.meta.yml
@@ -34,6 +34,15 @@ tables:
           Number of battle-related combatant fatalities suffered by all participants in wars.
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
+              - Oceania
 
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
@@ -43,6 +52,15 @@ tables:
 
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
+              - Oceania
       number_new_conflicts:
         title: Number of new conflicts
         unit: conflicts
@@ -51,3 +69,12 @@ tables:
 
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
+              - Oceania

--- a/etl/steps/data/garden/war/2023-07-20/brecke.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-20/brecke.meta.yml
@@ -86,6 +86,14 @@ tables:
           deaths defined by the source for a violent conflict to be recorded in the dataset.
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
 
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
@@ -97,6 +105,14 @@ tables:
           We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
       number_new_conflicts:
         title: Number of new conflicts
         unit: conflicts
@@ -109,3 +125,11 @@ tables:
           The sum across all regions can therefore be higher than the total number of new conflicts.
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East

--- a/etl/steps/data/garden/war/2023-07-21/prio_v31.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-21/prio_v31.meta.yml
@@ -20,6 +20,14 @@ tables:
           The number of battle fatalities in a year over the course of wars. This is the high estimate of those who were killed.
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
       number_deaths_ongoing_conflicts_battle_low:
         title: Number of battle deaths in ongoing conflicts (low estimate)
         unit: deaths
@@ -27,6 +35,14 @@ tables:
           The number of battle fatalities in a year over the course of wars. This is the low estimate of those who were killed.
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
       number_deaths_ongoing_conflicts_battle:
         title: Number of battle deaths in ongoing conflicts (best estimate)
         unit: deaths
@@ -37,6 +53,14 @@ tables:
           a lower bound.
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
 
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
@@ -49,6 +73,14 @@ tables:
 
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
       number_new_conflicts:
         title: Number of new conflicts
         unit: conflicts
@@ -64,3 +96,11 @@ tables:
 
         display:
           numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
@@ -75,3 +75,4 @@ tables:
               - Asia
               - Europe
               - Middle East
+              - Oceania

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.py
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.py
@@ -210,7 +210,8 @@ def add_regions(tb: Table) -> Table:
     tb.loc[(tb["ccode"] >= 200) & (tb["ccode"] <= 395), "region"] = "Europe"
     tb.loc[(tb["ccode"] >= 400) & (tb["ccode"] <= 626), "region"] = "Africa"
     tb.loc[(tb["ccode"] >= 630) & (tb["ccode"] <= 698), "region"] = "Middle East"
-    tb.loc[(tb["ccode"] >= 700) & (tb["ccode"] <= 990), "region"] = "Asia"
+    tb.loc[(tb["ccode"] >= 700) & (tb["ccode"] <= 899), "region"] = "Asia"
+    tb.loc[(tb["ccode"] >= 900) & (tb["ccode"] <= 999), "region"] = "Oceania"
 
     # Sanity check: No missing regions
     assert tb["region"].notna().all(), f"Missing regions! {tb.loc[tb['region'].isna(), ['dispnum', 'ccode']]}"

--- a/etl/steps/data/garden/war/2023-08-15/mie.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-15/mie.meta.yml
@@ -58,6 +58,7 @@ tables:
               - Asia
               - Europe
               - Middle East
+              - Oceania
       number_new_conflicts:
         title: Number of new conflicts
         unit: conflicts
@@ -104,6 +105,7 @@ tables:
               - Asia
               - Europe
               - Middle East
+              - Oceania
       number_deaths_ongoing_conflicts_low:
         title: Number of deaths in ongoing conflicts (low estimate)
         unit: deaths
@@ -135,6 +137,7 @@ tables:
               - Asia
               - Europe
               - Middle East
+              - Oceania
       number_deaths_ongoing_conflicts_high:
         title: Number of deaths in ongoing conflicts (high estimate)
         unit: deaths
@@ -166,3 +169,4 @@ tables:
               - Asia
               - Europe
               - Middle East
+              - Oceania

--- a/etl/steps/data/garden/war/2023-08-15/mie.py
+++ b/etl/steps/data/garden/war/2023-08-15/mie.py
@@ -143,7 +143,8 @@ def add_regions(tb: Table) -> Table:
     tb.loc[(tb["ccode"] >= 200) & (tb["ccode"] < 400), "region"] = "Europe"
     tb.loc[(tb["ccode"] >= 400) & (tb["ccode"] < 627), "region"] = "Africa"
     tb.loc[(tb["ccode"] >= 630) & (tb["ccode"] < 699), "region"] = "Middle East"
-    tb.loc[(tb["ccode"] >= 700) & (tb["ccode"] < 1000), "region"] = "Asia"
+    tb.loc[(tb["ccode"] >= 700) & (tb["ccode"] <= 899), "region"] = "Asia"
+    tb.loc[(tb["ccode"] >= 900) & (tb["ccode"] <= 999), "region"] = "Oceania"
 
     return tb
 


### PR DESCRIPTION
Different indicators have data for different regions. We use the field `presentation.grapher_config.selectedEntityNames` to define the default entities selected for each indicator.