### PR TITLE
Create dummy full dataset

### DIFF
--- a/apps/metadata_playground/app.py
+++ b/apps/metadata_playground/app.py
@@ -17,28 +17,28 @@ from etl import config
 # Initial configuration ###########################
 ###################################################
 # Set page config
-# st.title("Metadata v2 preview")
 st.set_page_config(page_title="Metadata v2 preview", layout="wide", page_icon="🎨")
 st.title("Metadata v2 preview")
+DUMMY = st.selectbox('Choose ETL step to play with', ["dummy_full", "dummy"], index=0)
 
 # Current directory
 CURRENT_DIR = Path(__file__).parent.absolute()
 
 # Load metadata from Snapshot
-PATH_METADATA_SNAPSHOT = paths.SNAPSHOTS_DIR / "dummy" / "2020-01-01" / "dummy.csv.dvc"
+PATH_METADATA_SNAPSHOT = paths.SNAPSHOTS_DIR / "dummy" / "2020-01-01" / f"{DUMMY}.csv.dvc"
 with open(PATH_METADATA_SNAPSHOT, 'r') as f:
     METADATA_SNAPSHOT_BASE = f.read()
 SNAPSHOT_META_TOKEN_SPLIT = "outs:"
 METADATA_SNAPSHOT_DISPLAY = METADATA_SNAPSHOT_BASE.split(SNAPSHOT_META_TOKEN_SPLIT)[0]
 METADATA_SNAPSHOT_EXTRA = METADATA_SNAPSHOT_BASE.split(SNAPSHOT_META_TOKEN_SPLIT)[1]
 # Load metadata from Garden
-PATH_METADATA_GARDEN = paths.STEP_DIR / "data" / "garden" / "dummy" / "2020-01-01" / "dummy.meta.yml"
+PATH_METADATA_GARDEN = paths.STEP_DIR / "data" / "garden" / "dummy" / "2020-01-01" / f"{DUMMY}.meta.yml"
 with open(PATH_METADATA_GARDEN, 'r') as f:
     METADATA_GARDEN_BASE = f.read()
 METADATA_GARDEN_DISPLAY = METADATA_GARDEN_BASE
 
 # Catalog path
-CATALOG_PATH = "grapher/dummy/2020-01-01/dummy/dummy"
+CATALOG_PATH = f"grapher/dummy/2020-01-01/{DUMMY}/{DUMMY}"
 
 
 # Functions
@@ -49,7 +49,7 @@ def run_steps() -> None:
     """
     # env_path = paths.BASE_DIR / ".env.X"
     # subprocess.run(f"export $(cat {env_path} | xargs)", shell=True)
-    subprocess.run(["poetry", "run", "etl", "dummy", "--grapher"])
+    subprocess.run(["poetry", "run", "etl", DUMMY, "--grapher"])
 
 
 def get_data_page_url() -> str:

--- a/dag/walkthrough.yml
+++ b/dag/walkthrough.yml
@@ -8,3 +8,11 @@ steps:
   - data://garden/dummy/2020-01-01/dummy
   data://explorers/dummy/2020-01-01/dummy:
   - data://garden/dummy/2020-01-01/dummy
+  data://meadow/dummy/2020-01-01/dummy_full:
+  - snapshot://dummy/2020-01-01/dummy_full.csv
+  data://garden/dummy/2020-01-01/dummy_full:
+  - data://meadow/dummy/2020-01-01/dummy_full
+  data://grapher/dummy/2020-01-01/dummy_full:
+  - data://garden/dummy/2020-01-01/dummy_full
+  # data://explorers/dummy/2020-01-01/dummy_full:
+  # - data://garden/dummy/2020-01-01/dummy_full

--- a/etl/steps/data/garden/dummy/2020-01-01/dummy_full.meta.yml
+++ b/etl/steps/data/garden/dummy/2020-01-01/dummy_full.meta.yml
@@ -13,6 +13,7 @@ tables:
           name: "[indicator.license.name]"
           url: "[indicator.license.url]"
         display:
+          name: "[display.name > indicator.title]"
           isProjection: true
           conversionFactor: 9999
           numDecimalPlaces: 9
@@ -23,7 +24,7 @@ tables:
           includeInTable: true
         presentation:
           grapher_config:
-            title: "[grapher-config.title > indicator.title]"
+            title: "[grapher-config.title > display.name > indicator.title]"
             subtitle: "[grapher-config.subtitle > indicator.description-short]"
             hasMapTab: true
             selectedEntityNames:

--- a/etl/steps/data/garden/dummy/2020-01-01/dummy_full.meta.yml
+++ b/etl/steps/data/garden/dummy/2020-01-01/dummy_full.meta.yml
@@ -34,9 +34,9 @@ tables:
           title_public: "[presentation.title-public > indicator.title]"
           title_variant: "[presentation.title-variant]"
           producer_short: "[presentation.producer-short]"
-          attribution: "[presentation.attribution > indicator.attribution]"
+          attribution: "[presentation.attribution > origin.attribution > origin.producer (year)]"
           topic_tags_links:
-          - "[presentation.topic-tags-links example 1]"
+          - "Internet"
           - "[presentation.topic-tags-links example 2]"
           key_info_text:
           - "[presentation.key-info-text example 1]"

--- a/etl/steps/data/garden/dummy/2020-01-01/dummy_full.meta.yml
+++ b/etl/steps/data/garden/dummy/2020-01-01/dummy_full.meta.yml
@@ -1,0 +1,45 @@
+tables:
+  dummy_full:
+    variables:
+      dummy_variable:
+        title: "[indicator.title]"
+        unit: "[indicator.unit]"
+        short_unit: "[indicator.short-unit]"
+        description: "[indicator.description]"
+        description_short: "[indicator.description-short]"
+        description_from_producer: "[indicator.description-from-producer]"
+        processing_level: "[indicator.processing-level]"
+        license:
+          name: "[indicator.license.name]"
+          url: "[indicator.license.url]"
+        display:
+          isProjection: true
+          conversionFactor: 9999
+          numDecimalPlaces: 9
+          tolerance: 9
+          yearIsDay: false
+          zeroDay: '1900-01-01'
+          entityAnnotationsMap: 'France: [display.entityAnnotationsMap example France]'
+          includeInTable: true
+        presentation:
+          grapher_config:
+            title: "[grapher-config.title > indicator.title]"
+            subtitle: "[grapher-config.subtitle > indicator.description-short]"
+            hasMapTab: true
+            selectedEntityNames:
+            - Germany
+            - Italy
+            - France
+          title_public: "[presentation.title-public > indicator.title]"
+          title_variant: "[presentation.title-variant]"
+          producer_short: "[presentation.producer-short]"
+          attribution: "[presentation.attribution > indicator.attribution]"
+          topic_tags_links:
+          - "[presentation.topic-tags-links example 1]"
+          - "[presentation.topic-tags-links example 2]"
+          key_info_text:
+          - "[presentation.key-info-text example 1]"
+          - "[presentation.key-info-text example 2]"
+          faqs:
+          - fragment_id: cherries
+            gdoc_id: 16uGVylqtS-Ipc3OCxqapJ3BEVGjWf648wvZpzio1QFE

--- a/etl/steps/data/garden/dummy/2020-01-01/dummy_full.py
+++ b/etl/steps/data/garden/dummy/2020-01-01/dummy_full.py
@@ -1,0 +1,31 @@
+"""Load a meadow dataset and create a garden dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load meadow dataset.
+    ds_meadow = paths.load_dataset("dummy_full")
+
+    # Read table from meadow dataset.
+    tb = ds_meadow["dummy_full"].reset_index()
+
+    #
+    # Process data.
+    #
+    tb = tb.set_index(["country", "year"], verify_integrity=True)
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()

--- a/etl/steps/data/grapher/dummy/2020-01-01/dummy_full.py
+++ b/etl/steps/data/grapher/dummy/2020-01-01/dummy_full.py
@@ -1,0 +1,30 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset("dummy_full")
+
+    # Read table from garden dataset.
+    tb = ds_garden["dummy_full"]
+
+    #
+    # Process data.
+    #
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()

--- a/etl/steps/data/meadow/dummy/2020-01-01/dummy_full.py
+++ b/etl/steps/data/meadow/dummy/2020-01-01/dummy_full.py
@@ -1,0 +1,32 @@
+"""Load a snapshot and create a meadow dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Retrieve snapshot.
+    snap = paths.load_snapshot("dummy_full.csv")
+
+    # Load data from snapshot.
+    tb = snap.read()
+
+    #
+    # Process data.
+    #
+    # Create a new table and ensure all columns are snake-case.
+    tb = tb.underscore().set_index(["country", "year"], verify_integrity=True)
+
+    #
+    # Save outputs.
+    #
+    # Create a new meadow dataset with the same metadata as the snapshot.
+    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+
+    # Save changes in the new garden dataset.
+    ds_meadow.save()

--- a/snapshots/dummy/2020-01-01/dummy_full.csv.dvc
+++ b/snapshots/dummy/2020-01-01/dummy_full.csv.dvc
@@ -1,0 +1,23 @@
+meta:
+  origin:
+    dataset_title_owid: '[origin.dataset-title-owid]'
+    dataset_title_producer: '[origin.dataset-title-producer]'
+    dataset_description_owid: '[origin.dataset-description-owid]'
+    dataset_description_producer: '[origin.dataset-description-producer]'
+    producer: '[origin.producer]'
+    citation_producer: '[origin.citation-producer]'
+    attribution: '[origin.attribution > origin.producer (year)]'
+    attribution_short: '[origin.attribution-short]'
+    version: '[origin.version]'
+    dataset_url_main: '[origin.dataset-url-main]'
+    dataset_url_download: https://raw.githubusercontent.com/owid/etl/master/walkthrough/dummy_data.csv
+    date_published: 2000-01-01
+    date_accessed: 2020-01-01
+  license:
+    name: '[license.name]'
+    url: '[license.url]'
+wdir: ../../../data/snapshots/dummy/2020-01-01
+outs:
+- md5: becb9bc64792f7372580683b384e5411
+  size: 96
+  path: dummy_full.csv

--- a/snapshots/dummy/2020-01-01/dummy_full.py
+++ b/snapshots/dummy/2020-01-01/dummy_full.py
@@ -1,0 +1,32 @@
+"""Script to create a snapshot of dataset."""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+# Version for current snapshot dataset.
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+
+@click.command()
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(upload: bool) -> None:
+    # Create a new snapshot.
+    snap = Snapshot(f"dummy/{SNAPSHOT_VERSION}/dummy_full.csv")
+
+    # Download data from source.
+    snap.download_from_source()
+
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I let metaplay now use either `dummy` or `dummy_full`. The latter is a new dataset that includes (almost) all metadata fields with their names (when possible). I've also tried to express the fallback options, e.g.
```yaml
title: "[grapher-config.title > indicator.title]"
```
I'm not sure if all of them are true (in fact I know that `subtitle: "[grapher-config.subtitle > indicator.description-short]"` is not true, but I think it should be), but precisely for this reason I created this dataset, to be able to play around with the metadata fields and see how the resulting grapher chart/data page changes.