### PR TITLE
📊 war: improve COW - MID dataset

### DIFF
--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
@@ -1,7 +1,7 @@
 dataset:
   title: History of war (COW MID, 2020)
   description: >-
-      This dataset contains information on interstate conflicts in the period of 1816 and 2014.
+      This dataset contains information on interstate disputes in the period of 1816 and 2014.
 
 
       It has been constructed using the Correlates of War - Militarised Interstate Disputes v5.0 dataset.
@@ -42,8 +42,8 @@ tables:
           Number of ongoing disputes in a given year.
 
 
-          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions.
-          The sum across all regions can therefore be higher than the total number of ongoing conflicts.
+          We count a dispute as ongoing in a region even if the dispute is also ongoing in other regions.
+          The sum across all regions can therefore be higher than the total number of ongoing disputes.
 
 
           The data is disaggregated by region and "hostility" or "fatality".
@@ -97,8 +97,8 @@ tables:
           Number of new disputes in a given year.
 
 
-          We count a conflict as new in a region even if the conflict is also ongoing in other regions.
-          The sum across all regions can therefore be higher than the total number of ongoing conflicts.
+          We count a dispute as new in a region even if the dispute is also ongoing in other regions.
+          The sum across all regions can therefore be higher than the total number of ongoing disputes.
 
 
           The data is disaggregated by region and "hostility" or "fatality".

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
@@ -46,8 +46,9 @@ tables:
           The sum across all regions can therefore be higher than the total number of ongoing conflicts.
 
 
-          The data is disaggregated by region and "fatality". "Fatality" gives lower and upper estimates on the total number of
-          fatalities over the complete span of a dispute. These are the types:
+          The data is disaggregated by region, "fatality" and "hostility".
+
+          "Fatality" gives lower and upper estimates on the total number of fatalities over the complete span of a dispute. These are the types:
 
             - No deaths
 
@@ -64,6 +65,75 @@ tables:
             - > 999 deaths
 
             - Unknown
+
+
+          "Hostility" provides a short description of the type of hostility. These are the types:
+
+            - No militarized action
+
+            - Threat to use force
+
+            - Display of force
+
+            - Use of force
+
+            - War
+        processing_level: major
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames:
+              - Africa
+              - Americas
+              - Asia
+              - Europe
+              - Middle East
+      number_new_disputes:
+        title: Number of new disputes
+        unit: disputes
+        description_short: The annual number of new disputes
+        description: >-
+          Number of new disputes in a given year.
+
+
+          We count a conflict as new in a region even if the conflict is also ongoing in other regions.
+          The sum across all regions can therefore be higher than the total number of ongoing conflicts.
+
+
+          The data is disaggregated by region, "hostility".
+
+
+          "Hostility" provides a short description of the type of hostility. These are the types:
+
+            - No militarized action
+
+            - Threat to use force
+
+            - Display of force
+
+            - Use of force
+
+            - War
+
+
+
+          • New disputes for the 'World': We only count a dispute as new when the dispute overall started that year, not if it restarted
+          or its hostility level changed.
+
+          • New disputes for all regions (except 'World'): We count a dispute as new in a region even if the dispute overall started
+          earlier in another region. The sum across all regions can therefore be higher than the total number of new disputes.
+
+          • New disputes by hostility level: We only count a dispute as new when the dispute overall started that year, not if it changed
+          its hostility level.
+
+          The same conflict can have different "hostility level" for different regions. When this is the case, we classify its global
+          hostility level as the most hostile level based on the following rank (from less to most hostile):
+            1: No militarized action
+            2: Threat to use force
+            3: Display of force
+            4: Use of force
+            5: War
         processing_level: major
         display:
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
@@ -46,7 +46,7 @@ tables:
           The sum across all regions can therefore be higher than the total number of ongoing conflicts.
 
 
-          The data is disaggregated by region, "fatality" and "hostility".
+          The data is disaggregated by region and "hostility" or "fatality".
 
           "Fatality" gives lower and upper estimates on the total number of fatalities over the complete span of a dispute. These are the types:
 
@@ -101,7 +101,26 @@ tables:
           The sum across all regions can therefore be higher than the total number of ongoing conflicts.
 
 
-          The data is disaggregated by region, "hostility".
+          The data is disaggregated by region and "hostility" or "fatality".
+
+
+          "Fatality" gives lower and upper estimates on the total number of fatalities over the complete span of a dispute. These are the types:
+
+            - No deaths
+
+            - 1-25 deaths
+
+            - 26-100 deaths
+
+            - 101-250 deaths
+
+            - 251-500 deaths
+
+            - 501-999 deaths
+
+            - > 999 deaths
+
+            - Unknown
 
 
           "Hostility" provides a short description of the type of hostility. These are the types:
@@ -117,23 +136,11 @@ tables:
             - War
 
 
+          NOTES:
 
-          • New disputes for the 'World': We only count a dispute as new when the dispute overall started that year, not if it restarted
-          or its hostility level changed.
 
           • New disputes for all regions (except 'World'): We count a dispute as new in a region even if the dispute overall started
           earlier in another region. The sum across all regions can therefore be higher than the total number of new disputes.
-
-          • New disputes by hostility level: We only count a dispute as new when the dispute overall started that year, not if it changed
-          its hostility level.
-
-          The same conflict can have different "hostility level" for different regions. When this is the case, we classify its global
-          hostility level as the most hostile level based on the following rank (from less to most hostile):
-            1: No militarized action
-            2: Threat to use force
-            3: Display of force
-            4: Use of force
-            5: War
         processing_level: major
         display:
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.py
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.py
@@ -1,18 +1,23 @@
 """COW Militarised Inter-state Dispute dataset.
 
 
-- This dataset only contains inter-state conflicts.
+- This dataset only contains inter-state disputes.
 
-- We use the "fatality" level to differentiate different "types" of conflicts. The "fatality" level provides a range of fatalities (e.g. 1-25 deaths)
+- We use the "fatality" and "hostility" levels to differentiate different "types" of disputes.
 
-- Each entry in this dataset describes a conflict (its participants and period). Therefore we need to "explode" it to add observations
-for each year of the conflict.
+    - The "fatality" level provides a range of fatalities (e.g. '1-25 deaths')
+
+    - The "hostility" level provides a short summary of the hostility degree of the dispute ('Use of force', 'War', etc.)
+
+- Each entry in the source dataset describes a dispute (its participants and period). Therefore we need to "explode" it to add observations
+for each year of the dispute.
 
 - Due to missing data in the number of deaths, we are not estimating this metric. Instead, we are using the "fatality" level to group by the different conflicts.
 
-- We also do not report "number of new conflicts".
+- The "number of ongoing disputes" for a particular fatality level can be understood as "the number of conflicts ongoing in a particular year that will have between X1-X2 fatalities
+over their complete lifetime globally".
 
-- The "number of ongoing conflicts" for a particular fatality can be understood as "the number of conflicts ongoing in a particular year that will have X fatalities
+- The "number of ongoing disputes" for a particular hostility level can be understood as "the number of conflicts ongoing in a particular year that will reach this hostility level
 over their complete lifetime globally".
 """
 

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.py
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.py
@@ -431,6 +431,9 @@ def replace_missing_data_with_zeros(tb: Table) -> Table:
     new_idx = pd.MultiIndex.from_product(
         [years, regions, fatality_types, hostility_types], names=["year", "region", "fatality", "hostility"]
     )
+    # Only keep rows with "all" in fatality or hostility
+    # That is, either break down indicators by fatality or by hostility
+    new_idx = [i for i in new_idx if (i[2] == "all") or (i[3] == "all")]
     tb = tb.set_index(["year", "region", "fatality", "hostility"], verify_integrity=True).reindex(new_idx).reset_index()
 
     # Change NaNs for 0 for specific rows

--- a/etl/steps/data/grapher/war/2023-08-08/cow_mid.py
+++ b/etl/steps/data/grapher/war/2023-08-08/cow_mid.py
@@ -30,7 +30,7 @@ def run(dest_dir: str) -> None:
     tb["country"] = tb["country"].str.replace(r" \(.+\)", "", regex=True)
 
     # Set an appropriate index and sort conveniently.
-    tb = tb.set_index(["year", "country", "fatality"])
+    tb = tb.set_index(["year", "country", "fatality", "hostility"]).sort_index()
 
     #
     # Save outputs.


### PR DESCRIPTION
Add old metrics, which were wrongly removed in https://github.com/owid/etl/pull/1509.

These include `number of ongoing disputes` and `number of new disputes` broken down by hostility level.