### PR TITLE
:hammer: speed up ETL in DEBUG mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 
 include default.mk
 
-SRC = etl snapshots backport walkthrough fasttrack tests
+SRC = etl snapshots backport walkthrough fasttrack apps tests
 PYTHON_PLATFORM = $(shell python -c "import sys; print(sys.platform)")
 LIBS = lib/*
 

--- a/apps/metadata_playground/app.py
+++ b/apps/metadata_playground/app.py
@@ -18,7 +18,7 @@ from etl.command import main as etl_main
 # Set page config
 st.set_page_config(page_title="Metadata v2 preview", layout="wide", page_icon="🎨")
 st.title("Metadata v2 preview")
-DUMMY = st.selectbox("Choose ETL step to play with", ["dummy_full", "dummy"], index=0)
+DUMMY = str(st.selectbox("Choose ETL step to play with", ["dummy_full", "dummy"], index=0))
 
 # Current directory
 CURRENT_DIR = Path(__file__).parent.absolute()
@@ -165,7 +165,7 @@ try:
 
             reset_metadata_files()
 except Exception as e:
-    st.toast(f"[There was an error](#error).", icon="❌")
+    st.toast("[There was an error](#error).", icon="❌")
     reset_metadata_files()
     st.markdown("### Error")
     raise e

--- a/apps/metadata_playground/cli.py
+++ b/apps/metadata_playground/cli.py
@@ -8,12 +8,14 @@ import sys
 
 from streamlit.web import cli as stcli
 
-from etl.paths import APPS_DIR
 from etl.config import METAPLAY_PORT
+from etl.paths import APPS_DIR
 
 SCRIPT_PATH = APPS_DIR / "metadata_playground" / "app.py"
 
 print(SCRIPT_PATH)
+
+
 def cli():
     """Run app."""
     sys.argv = ["streamlit", "run", str(SCRIPT_PATH), "--server.port", str(METAPLAY_PORT)]

--- a/etl/config.py
+++ b/etl/config.py
@@ -20,7 +20,9 @@ ENV_FILE = env.get("ENV", BASE_DIR / ".env")
 
 load_dotenv(ENV_FILE)
 
-DEBUG = env.get("DEBUG") == "True"
+# When DEBUG is on
+# - run steps in the same process (speeding up ETL)
+DEBUG = env.get("DEBUG") in ("True", "true", "1")
 
 # publishing to OWID's public data catalog
 S3_BUCKET = "owid-catalog"

--- a/etl/files.py
+++ b/etl/files.py
@@ -3,6 +3,7 @@
 #
 
 import hashlib
+import os
 from collections import OrderedDict
 from pathlib import Path
 from threading import Lock
@@ -64,10 +65,13 @@ def checksum_file(filename: Union[str, Path]) -> str:
     if isinstance(filename, Path):
         filename = filename.as_posix()
 
-    if filename not in CACHE_CHECKSUM_FILE:
-        CACHE_CHECKSUM_FILE.add(filename, checksum_file_nocache(filename))
+    mtime = os.path.getmtime(filename)
+    key = f'{filename}-{mtime}'
 
-    return CACHE_CHECKSUM_FILE[filename]
+    if filename not in CACHE_CHECKSUM_FILE:
+        CACHE_CHECKSUM_FILE.add(key, checksum_file_nocache(filename))
+
+    return CACHE_CHECKSUM_FILE[key]
 
 
 def checksum_str(s: str) -> str:

--- a/etl/files.py
+++ b/etl/files.py
@@ -66,7 +66,7 @@ def checksum_file(filename: Union[str, Path]) -> str:
         filename = filename.as_posix()
 
     mtime = os.path.getmtime(filename)
-    key = f'{filename}-{mtime}'
+    key = f"{filename}-{mtime}"
 
     if filename not in CACHE_CHECKSUM_FILE:
         CACHE_CHECKSUM_FILE.add(key, checksum_file_nocache(filename))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,11 +1,13 @@
+import sys
 import unittest
 from unittest.mock import patch
 
+import pytest
 from owid import catalog
 
 import etl.helpers
 from etl import paths
-from etl.helpers import PathFinder, VersionTracker, create_dataset
+from etl.helpers import PathFinder, VersionTracker, create_dataset, isolated_env
 
 # Dag of active steps.
 mock_dag = {
@@ -222,3 +224,20 @@ def test_PathFinder_with_private_steps():
     }
     assert pf.step == "data-private://garden/namespace/2023/name"
     assert pf.get_dependency_step_name("name") == "snapshot-private://namespace/2023/name"
+
+
+def test_isolated_env(tmp_path):
+    (tmp_path / "shared.py").write_text("A = 1; import test_abc")
+    (tmp_path / "test_abc.py").write_text("B = 1")
+
+    with isolated_env(tmp_path):
+        import shared
+
+        assert shared.A == 1
+        assert shared.test_abc.B == 1
+        assert "test_abc" in sys.modules.keys()
+
+    with pytest.raises(ModuleNotFoundError):
+        import shared
+
+    assert "test_abc" not in sys.modules.keys()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -231,13 +231,13 @@ def test_isolated_env(tmp_path):
     (tmp_path / "test_abc.py").write_text("B = 1")
 
     with isolated_env(tmp_path):
-        import shared
+        import shared  # type: ignore
 
         assert shared.A == 1
         assert shared.test_abc.B == 1
         assert "test_abc" in sys.modules.keys()
 
     with pytest.raises(ModuleNotFoundError):
-        import shared
+        import shared  # type: ignore
 
     assert "test_abc" not in sys.modules.keys()


### PR DESCRIPTION
* When running `DEBUG=1 etl ...` don't fork new processes, but keep it all in the same env. That subtracts about 2s from each ETL step
* Run `etl-metaplay` in DEBUG mode (rendering goes down from ~30s to ~5s)
* Check `apps` for linting errors