### PR TITLE
:bug: allow both sources and origins

### DIFF
--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -228,14 +228,12 @@ class SnapshotMeta:
             if "file_extension" not in meta:
                 meta["file_extension"] = _parse_snapshot_path(Path(filename))[3]
 
-            # we can have either source or origin in YAML
-            if "origin" in meta and "source" in meta:
-                raise ValueError("Cannot have both `origin` and `source` in metadata")
-            elif "origin" in meta:
+            if "origin" in meta:
                 meta["origin"] = Origin.from_dict(meta["origin"])
-            elif "source" in meta:
+
+            if "source" in meta:
                 meta["source"] = Source.from_dict(meta["source"])
-            else:
+            elif "source_name" in meta:
                 # convert legacy fields to source
                 publication_date = meta.pop("publication_date", None)
                 meta["source"] = Source(

--- a/etl/steps/data/converters.py
+++ b/etl/steps/data/converters.py
@@ -40,30 +40,34 @@ def convert_snapshot_metadata(snap: SnapshotMeta) -> DatasetMeta:
     Copy metadata for a dataset directly from what we have in Snapshot.
     """
     if snap.origin:
-        assert not snap.source, "Snapshot cannot have both origin and source"
-        return DatasetMeta(
+        ds_meta = DatasetMeta(
             short_name=snap.short_name,
             namespace=snap.namespace,
             version=snap.version,
             # dataset title and description are filled from origin
             title=snap.origin.dataset_title_owid,
             description=snap.origin.dataset_description_owid,
-            origins=[snap.origin],
             licenses=[snap.license] if snap.license else [],
         )
     elif snap.source:
-        assert not snap.origin, "Snapshot cannot have both origin and source"
-        return DatasetMeta(
+        ds_meta = DatasetMeta(
             short_name=snap.short_name,
             namespace=snap.namespace,
             title=snap.name,
             version=snap.version,
             description=snap.description,
-            sources=[snap.source],
             licenses=[snap.license] if snap.license else [],
         )
     else:
         raise ValueError("Snapshot must have either origin or source")
+
+    # we allow both origin and source for backward compatiblity
+    if snap.origin:
+        ds_meta.origins = [snap.origin]
+    if snap.source:
+        ds_meta.sources = [snap.source]
+
+    return ds_meta
 
 
 def convert_grapher_source(s: gm.Source) -> Source:


### PR DESCRIPTION
Propagate both sources and origins from snapshot. This makes incremental migration from sources to origins easier.