### PR TITLE
🐛  Kingdom of the Netherlands -> Netherlands

### DIFF
--- a/etl/steps/data/garden/un/2023-08-16/un_sdg.countries.json
+++ b/etl/steps/data/garden/un/2023-08-16/un_sdg.countries.json
@@ -276,7 +276,7 @@
     "Residual/unallocated ODA: Northern America and Europe": "Residual/unallocated ODA: Northern America and Europe",
     "Residual/unallocated ODA: Central Asia and Southern Asia": "Residual/unallocated ODA: Central Asia and Southern Asia",
     "Middle East and North Africa (ILO)": "Middle East and North Africa (ILO)",
-    "Netherlands (Kingdom of the)": "Kingdom of the Netherlands",
+    "Netherlands (Kingdom of the)": "Netherlands",
     "Middle East (ILO)": "Middle East (ILO)",
     "Bouvet Island": "Bouvet Island",
     "Central and Eastern Europe (ILO)": "Central and Eastern Europe (ILO)",


### PR DESCRIPTION
The UN renamed [the Netherlands to the Kingdom of the Netherlands](https://unterm.un.org/unterm2/en/view/08960271-ea69-4614-8f58-7952a92c6e94). I originally kept this as a separate entity but I think now it is okay to move back to using the Netherlands. 