### PR TITLE
:lipstick: add sections for buildkite logs

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -242,18 +242,18 @@ def run_dag(
         )
 
     if not force:
-        print("Detecting which steps need rebuilding...")
+        print("--- Detecting which steps need rebuilding...")
         start_time = time.time()
         steps = select_dirty_steps(steps, workers)
         click.echo(f"{click.style('OK', fg='blue')} ({time.time() - start_time:.1f}s)")
 
     if not steps:
-        print("All datasets up to date!")
+        print("--- All datasets up to date!")
         return
 
-    print(f"Running {len(steps)} steps:")
+    print(f"--- Running {len(steps)} steps:")
     for i, step in enumerate(steps, 1):
-        print(f"{i}. {step}...")
+        print(f"--- {i}. {step}...")
         if not dry_run:
             strict = _detect_strictness_level(step, strict)
             with strictness_level(strict):

--- a/etl/steps/data/meadow/dummy/2020-01-01/dummy.py
+++ b/etl/steps/data/meadow/dummy/2020-01-01/dummy.py
@@ -2,7 +2,7 @@
 
 from etl.helpers import PathFinder, create_dataset
 
-# Get paths and naming conventions for current step.
+# Get paths and naming conventions for current step
 paths = PathFinder(__file__)
 
 


### PR DESCRIPTION
Buildkite [collapses sections](https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output) prefixed with `---`. This should declutter outputs we get from ETL builds.

Example
<img width="1087" alt="image" src="https://github.com/owid/etl/assets/1550888/d29d32b2-4f98-4707-97bf-350d2fb691c2">
