### PR TITLE
Filter out outlier values in Penn World Table

### DIFF
--- a/etl/steps/data/garden/ggdc/2022-11-28/penn_world_table.meta.yml
+++ b/etl/steps/data/garden/ggdc/2022-11-28/penn_world_table.meta.yml
@@ -14,6 +14,10 @@ dataset:
       date_accessed: 2022-11-28
       url: https://www.rug.nl/ggdc/productivity/pwt/
 
+info:
+  outliers: |-
+    Values considered outliers from the original dataset (`i_outlier = "Outlier"`) have been excluded from the dataset, due to implausible relative prices (PPPs divided by exchange rates).
+
 tables:
   penn_world_table:
     variables:
@@ -24,6 +28,7 @@ tables:
         description: |
           It measures living standards across countries and across years using prices for final goods that are constant across countries and over time.
           This variable uses ICP PPP benchmarks from multiple years to correct for changing prices over time.
+          {info.outliers}
         display:
            name: GDP
            numDecimalPlaces: 0
@@ -34,6 +39,8 @@ tables:
         description: |
           It measures productive capacity across countries and across years using prices for final goods, exports and imports that are constant across countries and over time.
           This variable uses ICP PPP benchmarks from multiple years to correct for changing prices over time.
+          Values for Bermuda have been replaced by estimates on GDP (output, single price benchmark) due to the unusual changes on prices in this country.
+          {info.outliers}
         display:
             name: GDP
             numDecimalPlaces: 0
@@ -44,6 +51,7 @@ tables:
         description: |
           It measures the standards of living across countries in each year by using prices for final goods that are constant across countries.
           This variable only uses the most recent ICP PPP benchmark.
+          {info.outliers}
         display:
            name: GDP
            numDecimalPlaces: 0
@@ -54,6 +62,7 @@ tables:
         description: |
           It measures the productive capacity across countries in each year by using prices for final goods, exports and imports that are constant across countries.
           This variable only uses the most recent ICP PPP benchmark.
+          {info.outliers}
         display:
            name: GDP
            numDecimalPlaces: 0
@@ -61,7 +70,9 @@ tables:
         title: GDP (using national accounts growth rates)
         unit: international-$ in 2017 prices
         short_unit: $
-        description: The difference with the other GDP variables is this is computed based on the growth rate of real GDP from national accounts data for each country. For this reason, this variable is useful for comparing growth of GDP over time in each country.
+        description: |
+          The difference with the other GDP variables is this is computed based on the growth rate of real GDP from national accounts data for each country. For this reason, this variable is useful for comparing growth of GDP over time in each country.
+          {info.outliers}
         display:
            name: GDP
            numDecimalPlaces: 0
@@ -72,6 +83,7 @@ tables:
         description: |
           Estimated as the GDP (expenditure, multiple price benchmarks) divided by the population of each country.
           This variable uses ICP PPP benchmarks from multiple years to correct for changing prices over time.
+          {info.outliers}
         display:
            name: GDP per capita
            numDecimalPlaces: 0
@@ -82,6 +94,8 @@ tables:
         description: |
           Estimated as the GDP (output, multiple price benchmarks) divided by the population of each country.
           This variable uses ICP PPP benchmarks from multiple years to correct for changing prices over time.
+          Values for Bermuda have been replaced by estimates on GDP per capita (output, single price benchmark) due to the unusual changes on prices in this country.
+          {info.outliers}
         display:
            name: GDP per capita
            numDecimalPlaces: 0
@@ -92,6 +106,7 @@ tables:
         description: |
           Estimated as the GDP (expenditure, single price benchmark) divided by the population of each country.
           The GDP estimate in this variable only uses the most recent ICP PPP benchmark.
+          {info.outliers}
         display:
            name: GDP per capita
            numDecimalPlaces: 0
@@ -102,6 +117,7 @@ tables:
         description: |
           Estimated as the GDP (output, single price benchmark) divided by the population of each country.
           The GDP estimate in this variable only uses the most recent ICP PPP benchmark.
+          {info.outliers}
         display:
            name: GDP per capita
            numDecimalPlaces: 0
@@ -112,6 +128,7 @@ tables:
         description: |
           Estimated as the GDP (using national accounts growth rates) divided by the population of each country.
           The GDP is computed based on the growth rate of real GDP from national accounts data for each country. For this reason, this variable is useful for comparing growth of GDP over time in each country.
+          {info.outliers}
         display:
            name: GDP per capita
            numDecimalPlaces: 0
@@ -135,21 +152,27 @@ tables:
         title: Consumption of households and government (single price benchmark)
         unit: international-$ in 2017 prices
         short_unit: $
-        description: It is the sum of real household and government consumption, used to measure and compare living standards across countries.
+        description: |
+          It is the sum of real household and government consumption, used to measure and compare living standards across countries.
+          {info.outliers}
         display:
            name: Consumption of households and government
       cda:
         title: Domestic absorption (consumption plus investment) (single price benchmark)
         unit: international-$ in 2017 prices
         short_unit: $
-        description: It is computed as real consumption plus real investment. The sum of domestic absorption and the real trade balance generates GDP (expenditure, multiple price benchmarks), the expenditure-side real GDP at chained PPPs.
+        description: |
+          It is computed as real consumption plus real investment. The sum of domestic absorption and the real trade balance generates GDP (expenditure, multiple price benchmarks), the expenditure-side real GDP at chained PPPs.
+          {info.outliers}
         display:
            name: Consumption plus investment
       cn:
         title: Capital stock (single price benchmark)
         unit: international-$ in 2017 prices
         short_unit: $
-        description: It is estimated from investment by asset in each country, as structures, transport equipment, machinery and also computers, communication equipment and software on selected countries. Prices for these assets are constant across countries each year.
+        description: |
+          It is estimated from investment by asset in each country, as structures, transport equipment, machinery and also computers, communication equipment and software on selected countries. Prices for these assets are constant across countries each year.
+          {info.outliers}
         display:
            name: Capital stock
       ck:
@@ -167,21 +190,27 @@ tables:
         title: Consumption of households and government (using national accounts)
         unit: international-$ in 2017 prices
         short_unit: $
-        description: Real household and government consumption at constant national prices. It is useful to compare growth of consumption over time in one country.
+        description: |
+          Real household and government consumption at constant national prices. It is useful to compare growth of consumption over time in one country.
+          {info.outliers}
         display:
            name: Consumption of households and government
       rdana:
         title: Domestic absorption (consumption plus investment) (using national accounts)
         unit: international-$ in 2017 prices
         short_unit: $
-        description: Real consumption plus real investment at constant national prices. It is useful for comparing the growth of the absorption over time in each country.
+        description: |
+          Real consumption plus real investment at constant national prices. It is useful for comparing the growth of the absorption over time in each country.
+          {info.outliers}
         display:
            name: Consumption plus investment
       rnna:
         title: Capital stock (using national accounts)
         unit: international-$ in 2017 prices
         short_unit: $
-        description: Capital stock at constant national prices, based on investment and prices of structures and equipment. Useful for comparing growth of this variable over time in each country.
+        description: |
+          Capital stock at constant national prices, based on investment and prices of structures and equipment. Useful for comparing growth of this variable over time in each country.
+          {info.outliers}
         display:
            name: Capital stock
       rkna:
@@ -237,10 +266,6 @@ tables:
         title: Type of estimation for the exchange rate
         unit:
         description: Market-based (0) or estimated (1)
-      i_outlier:
-        title: Is the observation on pl_gdpe or pl_gdpo an outlier?
-        unit:
-        description: Not an outlier (0) or an outlier (1)
       i_irr:
         title: Is the observation for irr an outlier?
         unit:
@@ -306,7 +331,9 @@ tables:
         title: "Productivity: output per hour worked"
         unit: international-$ in 2017 prices per hour
         short_unit: $/h
-        description: It is the GDP (output, multiple price benchmarks) divided by the Annual working hours per worker and the Number of people in work.
+        description: |
+          It is the GDP (output, multiple price benchmarks) divided by the Annual working hours per worker and the Number of people in work.
+          {info.outliers}
         display:
            name: Productivity
            numDecimalPlaces: 1

--- a/etl/steps/data/garden/ggdc/2022-11-28/penn_world_table.py
+++ b/etl/steps/data/garden/ggdc/2022-11-28/penn_world_table.py
@@ -35,6 +35,13 @@ def run(dest_dir: str) -> None:
     # Multiplying by 1 million to get "people" instead of "millions of people"
     df[["pop", "emp"]] *= 1000000
 
+    # Replace rgdpo values of Bermuda with cgdpo values, because of issues with the data
+    # Recommended by Robert Inklaar:
+    # The chaining of reference prices may be causing these problems. Normally, cgdpo and rgdpo are not too different, but with the wild swings and even negative prices for Bermuda, that seems an exception.
+    # Perhaps the most elegant way would be to either using cgdpo for all countries or just for Bermuda.
+
+    df.loc[df["countrycode"] == "BMU", "rgdpo"] = df.loc[df["countrycode"] == "BMU", "cgdpo"]
+
     # %% [markdown]
     # A range of variables are provided as shares (0-1), which we multiply by 100 to express as a percentage.
 
@@ -64,6 +71,15 @@ def run(dest_dir: str) -> None:
     # %%
     # Productivity = (rgdpo) / (avh*emp) – NB, both rgdpo and emp have been multiplied by 1,000,000 above.
     df["productivity"] = df["rgdpo"] / (df["avh"] * df["emp"])
+
+    # Filter dataframe with i_outlier different to "Outlier"
+    # From Robert Inklaar:
+    # Some country/year observations, we label as outliers because indeed the relative price levels become implausible.
+    # See the i_outlier variable for those observations and in our documentation we have discussion in what qualifies as an outlier.
+    df = df[df["i_outlier"] != "Outlier"]
+
+    # Drop i_outlier column
+    df = df.drop(columns=["i_outlier"])
 
     # Harmonize countries from main dataset before merge with national accounts data
     df = harmonize_countries(df)


### PR DESCRIPTION
We have decided to modify Penn World Table to exclude datapoints considered outliers by the source, given that GDP in those cases is very low or very unstable.

See conversation [here](https://github.com/owid/owid-issues/issues/1060). OWID issue [here](https://github.com/owid/owid-issues/issues/1204).

This fix will be also implemented in the [PWT update](https://github.com/owid/owid-issues/issues/931).