### PR TITLE
:tada: enable Jinja2 templating in metadata

### DIFF
--- a/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
@@ -1,68 +1,116 @@
 definitions:
   deaths_included: |-
     Deaths of combatants and civilians due to fighting are included.
-  conflict_type_estimate: |-
-    <% if conflict_type == "all" %>
-    The << estimate >> estimate of the number of deaths in all ongoing armed conflicts in each year. This includes interstate, intrastate, extrasystemic, and non-state conflicts, as well as one-sided violence.
 
+  conflict_type: |-
+    <% if conflict_type == "all" %>
     An ongoing armed conflict is a disagreement between organized groups, or between one organized group and civilians, that causes at least 25 deaths during a year.
     <% elif conflict_type == "interstate" %>
-    The << estimate >> estimate of the number of deaths in ongoing interstate conflicts in each year.
-
     An interstate conflict is a conflict between states that causes at least 25 deaths during a year.
     <% elif conflict_type == "intrastate" %>
-    The << estimate >> estimate of the number of deaths in ongoing intrastate conflicts in each year.
-
     An intrastate conflict is a conflict between a state and a non-state armed group that causes at least 25 deaths during a year.
     <% elif conflict_type == "intrastate (internationalized)" %>
-    The << estimate >> estimate of the number of deaths in ongoing internationalized intrastate conflicts in each year.
-
     An internationalized intrastate conflict is a conflict between a state and a non-state armed group, with involvement of a foreign state, that causes at least 25 deaths during a year.
     <% elif conflict_type == "intrastate (non-internationalized)" %>
-    The << estimate >> estimate of the number of deaths in ongoing non-internationalized intrastate conflicts in each year.
-
     A non-internationalized intrastate conflict is a conflict between a state and a non-state armed group, without involvement of a foreign state, that causes at least 25 deaths during a year.
     <% elif conflict_type == "non-state conflict" %>
-    The << estimate >> estimate of the number of deaths in ongoing non-state conflicts in each year.
-
     A non-state conflict is a conflict between non-state armed groups that causes at least 25 deaths during a year.
     <% elif conflict_type == "one-sided violence" %>
-    The << estimate >> estimate of the number of deaths in conflicts of one-sided violence in each year.
-
     One-sided violence is the use of armed force by a state or non-state armed group against civilians that causes at least 25 deaths during a year.
     <% endif %>
 
+  conflict_type_estimate: |-
+    <% if conflict_type == "all" %>
+    The << estimate >> estimate of the number of deaths in all ongoing armed conflicts in each year. This includes interstate, intrastate, extrasystemic, and non-state conflicts, as well as one-sided violence.
+    <% elif conflict_type == "interstate" %>
+    The << estimate >> estimate of the number of deaths in ongoing interstate conflicts in each year.
+    <% elif conflict_type == "intrastate" %>
+    The << estimate >> estimate of the number of deaths in ongoing intrastate conflicts in each year.
+    <% elif conflict_type == "intrastate (internationalized)" %>
+    The << estimate >> estimate of the number of deaths in ongoing internationalized intrastate conflicts in each year.
+    <% elif conflict_type == "intrastate (non-internationalized)" %>
+    The << estimate >> estimate of the number of deaths in ongoing non-internationalized intrastate conflicts in each year.
+    <% elif conflict_type == "non-state conflict" %>
+    The << estimate >> estimate of the number of deaths in ongoing non-state conflicts in each year.
+    <% elif conflict_type == "one-sided violence" %>
+    The << estimate >> estimate of the number of deaths in conflicts of one-sided violence in each year.
+    <% endif %>
+
+  ongoing_conflicts: |-
+    <% if conflict_type == "all" %>
+    The number of all ongoing armed conflicts in each year. This includes interstate, intrastate, extrasystemic, and non-state conflicts, as well as one-sided violence.
+    <% elif conflict_type == "interstate" %>
+    The number of ongoing interstate conflicts in each year.
+    <% elif conflict_type == "intrastate" %>
+    The number of ongoing intrastate conflicts in each year.
+    <% elif conflict_type == "intrastate (internationalized)" %>
+    The number of ongoing internationalized intrastate conflicts in each year.
+    <% elif conflict_type == "intrastate (non-internationalized)" %>
+    The number of ongoing non-internationalized intrastate conflicts in each year.
+    <% elif conflict_type == "extrasystemic" %>
+    The number of ongoing extrasystemic conflicts in each year.
+    <% elif conflict_type == "non-state conflict" %>
+    The number of non-state conflicts in each year.
+    <% elif conflict_type == "one-sided violence" %>
+    The number of conflicts of one-sided violence in each year.
+    <% endif %>
+
+  new_conflicts: |-
+    <% if conflict_type == "all" %>
+    The number of new armed conflicts in each year. This includes interstate, intrastate, extrasystemic, and non-state conflicts, as well as one-sided violence.
+
+    A new armed conflict is a disagreement between organized groups, or between one organized group and civilians, that causes at least 25 deaths during a year for the first time.
+    <% elif conflict_type == "interstate" %>
+    The number of new interstate conflicts in each year.
+
+    A new interstate conflict is a conflict between states that causes at least 25 deaths during a year for the first time.
+    <% elif conflict_type == "intrastate" %>
+    The number of new intrastate conflicts in each year.
+
+    A new intrastate conflict is a conflict between a state and a non-state armed group that causes at least 25 deaths during a year for the first time.
+    <% elif conflict_type == "intrastate (internationalized)" %>
+    The number of new internationalized intrastate conflicts in each year.
+
+    A new internationalized intrastate conflict is a conflict between a state and a non-state armed group, with involvement of a foreign state, that causes at least 25 deaths during a year for the first time. We also only count an internationalized intrastate conflict as new when the conflict overall started that year, not if it became internationalized.
+    <% elif conflict_type == "intrastate (non-internationalized)" %>
+    The number of new non-internationalized intrastate conflicts in each year.
+
+    A new non-internationalized intrastate conflict is a conflict between a state and a non-state armed group, without involvement of a foreign state, that causes at least 25 deaths during a year for the first time. We also only count a non-internationalized intrastate conflict as new when the conflict overall started that year, not if it stopped being internationalized.
+    <% elif conflict_type == "extrasystemic" %>
+    The number of new extrasystemic conflicts in each year.
+
+    A new extrasystemic conflict is a conflict between a state and a non-state armed group outside its territory that causes at least 25 deaths during a year for the first time.
+    <% elif conflict_type == "non-state conflict" %>
+    The number of new non-state conflicts in each year.
+
+    A new non-state conflict is a conflict between non-state armed groups that causes at least 25 deaths during a year for the first time.
+    <% elif conflict_type == "one-sided violence" %>
+    The number of new conflicts of one-sided violence in each year.
+
+    New one-sided violence is the use of armed force by a state or non-state armed group against civilians that causes at least 25 deaths during a year for the first time.
+    <% endif %>
+
+
 dataset:
   title: History of war (UCDP, 2023)
-  description: >-
+  description: |-
+    This dataset provides information on armed conflicts, using data from the UCDP Georeferenced Event Dataset (version 23.1), the UCDP/PRIO Armed Conflict Dataset (version 23.1), and the UCDP Battle-Related Deaths Dataset (version 23.1).
+
+    We aggregate the UCDP Georeferenced Event Dataset up to the year and world (region) to identify all conflict deaths, non-state conflicts, and one-sided violence.
+
+    We use the UCDP/PRIO Armed Conflict Dataset to identify state-based conflicts: interstate, intrastate (all, internationalized, and non-internationalized), and extrasystemic.
+
+    We use the UCDP Battle-Related Deaths Dataset to link deaths in the Georeferenced Event Dataset to types of state-based conflicts in the UCDP/PRIO Armed Conflict Dataset.
+
+    We combine these datasets to provide information on the number of ongoing and new conflicts, the number of ongoing and new conflict types, as well as the number of deaths in ongoing conflicts and conflict types.
+
+    Deaths of combatants and civilians due to fighting are included.
+
+    We use the world regions as defined by UCDP/PRIO: Africa, Americas, Asia, Europe, and Middle East.
+
+    You can find more information about the data in our article:"
+
     This dataset contains information on armed conflicts - state, non-state and one-sided conflicts, in the period of 1989 and 2022.
-
-
-    It has been constructed using the Georeferenced Event Dataset version 23.1 by the UCDP.
-
-
-    Note that the Geo-referenced Event Dataset has been extracted from the UCDP systems at a certaian point in time.
-    However, the UCDP team works with the data all year round, including revisions and updates. Therefore, their dashboard
-    might show slightly more up-to-date data, which sometimes result in minor discrepancies in the data.
-
-
-    Regions: The regions are defined based on Gleditsch and Ward codes (GWno). Find complete mapping at
-    https://dornsife.usc.edu/assets/sites/298/docs/country_to_gwno_PUBLIC_6-5-2015.txt
-
-      • Americas: 2-199
-
-      • Europe: 200-399
-
-      • Africa: 400-626
-
-      • Middle East: 630-699
-
-      • Asia and Oceania: 700-999
-
-
-
-    More details about Georeferenced Event Dataset version 23.1 by the UCDP:
-
 
 tables:
   ucdp:
@@ -72,7 +120,10 @@ tables:
         unit: deaths
         description: |-
           <% set estimate = "best" %>
+
           {definitions.conflict_type_estimate}
+
+          {definitions.conflict_type}
 
           {definitions.deaths_included}
         display:
@@ -92,6 +143,8 @@ tables:
           <% set estimate = "high" %>
           {definitions.conflict_type_estimate}
 
+          {definitions.conflict_type}
+
           {definitions.deaths_included}
         display:
           numDecimalPlaces: 0
@@ -110,6 +163,8 @@ tables:
           <% set estimate = "low" %>
           {definitions.conflict_type_estimate}
 
+          {definitions.conflict_type}
+
           {definitions.deaths_included}
         display:
           numDecimalPlaces: 0
@@ -126,12 +181,11 @@ tables:
         title: Number of ongoing conflicts
         unit: deaths
         description: |-
-          Number of ongoing (active) conflicts in a given year.
+          {definitions.ongoing_conflicts}
+
+          {definitions.conflict_type}
 
           We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.
-
-
-          Active conflicts are those resulting into at least 25 deaths each year (based on most plausible estimate).
         display:
           numDecimalPlaces: 0
         presentation:
@@ -146,19 +200,11 @@ tables:
         title: Number of new conflicts
         unit: deaths
         description: |-
-          Number of new (active) conflicts in a given year.
+          {definitions.new_conflicts}
 
+          We only count a conflict as new when the conflict overall started that year, not if it became active again.
 
-          • New conflicts for the 'World': We only count a conflict as new when the conflict overall started that year, not if it became active again.
-
-          • New conflicts for all regions: We count a conflict as new in a region even if the conflict overall started earlier in another region.
-          The sum across all regions can therefore be higher than the total number of new conflicts.
-
-          • New conflicts by type: We only count an internationalized intrastate conflict as new when the conflict overall started that year, not if it became internationalized.
-          We only count a non-internationalized intrastate conflict as new when the conflict overall started that year, not if it stopped being internationalized.
-
-
-          Active conflicts are those resulting into at least 25 deaths each year (based on most plausible estimate).
+          We count a conflict as new in a region even if the conflict started earlier or at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
         display:
           numDecimalPlaces: 0
         presentation:

--- a/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
@@ -1,3 +1,37 @@
+definitions:
+  deaths_included: |-
+    Deaths of combatants and civilians due to fighting are included.
+  conflict_type_estimate: |-
+    <% if conflict_type == "all" %>
+    The << estimate >> estimate of the number of deaths in all ongoing armed conflicts in each year. This includes interstate, intrastate, extrasystemic, and non-state conflicts, as well as one-sided violence.
+
+    An ongoing armed conflict is a disagreement between organized groups, or between one organized group and civilians, that causes at least 25 deaths during a year.
+    <% elif conflict_type == "interstate" %>
+    The << estimate >> estimate of the number of deaths in ongoing interstate conflicts in each year.
+
+    An interstate conflict is a conflict between states that causes at least 25 deaths during a year.
+    <% elif conflict_type == "intrastate" %>
+    The << estimate >> estimate of the number of deaths in ongoing intrastate conflicts in each year.
+
+    An intrastate conflict is a conflict between a state and a non-state armed group that causes at least 25 deaths during a year.
+    <% elif conflict_type == "intrastate (internationalized)" %>
+    The << estimate >> estimate of the number of deaths in ongoing internationalized intrastate conflicts in each year.
+
+    An internationalized intrastate conflict is a conflict between a state and a non-state armed group, with involvement of a foreign state, that causes at least 25 deaths during a year.
+    <% elif conflict_type == "intrastate (non-internationalized)" %>
+    The << estimate >> estimate of the number of deaths in ongoing non-internationalized intrastate conflicts in each year.
+
+    A non-internationalized intrastate conflict is a conflict between a state and a non-state armed group, without involvement of a foreign state, that causes at least 25 deaths during a year.
+    <% elif conflict_type == "non-state conflict" %>
+    The << estimate >> estimate of the number of deaths in ongoing non-state conflicts in each year.
+
+    A non-state conflict is a conflict between non-state armed groups that causes at least 25 deaths during a year.
+    <% elif conflict_type == "one-sided violence" %>
+    The << estimate >> estimate of the number of deaths in conflicts of one-sided violence in each year.
+
+    One-sided violence is the use of armed force by a state or non-state armed group against civilians that causes at least 25 deaths during a year.
+    <% endif %>
+
 dataset:
   title: History of war (UCDP, 2023)
   description: >-
@@ -32,17 +66,15 @@ dataset:
 
 tables:
   ucdp:
-    # (Inherited from meadow, remove if not different.)
     variables:
       number_deaths_ongoing_conflicts:
         title: Number of deaths in ongoing conflicts (best estimate)
         unit: deaths
-        description: >-
-          The best (most likely) estimate of total fatalities in ongoing (active) conflicts in a given year.
-          It includes deaths from both sides in the conflict, civilians and from persons of "unknown status".
+        description: |-
+          <% set estimate = "best" %>
+          {definitions.conflict_type_estimate}
 
-
-          Active conflicts are those resulting into at least 25 deaths each year (based on most plausible estimate).
+          {definitions.deaths_included}
         display:
           numDecimalPlaces: 0
         presentation:
@@ -56,12 +88,11 @@ tables:
       number_deaths_ongoing_conflicts_high:
         title: Number of deaths in ongoing conflicts (high estimate)
         unit: deaths
-        description: >-
-          The highest reliable estimate of total fatalities in ongoing (active) conflicts in a given year.
-          It includes deaths from both sides in the conflict, civilians and from persons of "unknown status".
+        description: |-
+          <% set estimate = "high" %>
+          {definitions.conflict_type_estimate}
 
-
-          Active conflicts are those resulting into at least 25 deaths each year (based on most plausible estimate).
+          {definitions.deaths_included}
         display:
           numDecimalPlaces: 0
         presentation:
@@ -75,17 +106,11 @@ tables:
       number_deaths_ongoing_conflicts_low:
         title: Number of deaths in ongoing conflicts (low estimate)
         unit: deaths
-        description: >-
-          The lowest reliable estimate of total fatalities in ongoing (active) conflicts in a given year.
-          It includes deaths from both sides in the conflict, civilians and from persons of "unknown status".
+        description: |-
+          <% set estimate = "low" %>
+          {definitions.conflict_type_estimate}
 
-
-          Note that UCDP attempts to distinguish and not include unreasonable
-          claims in the high estimate of fatalities, and tends to be highly conservative when counting
-          fatalities
-
-
-          Active conflicts are those resulting into at least 25 deaths each year (based on most plausible estimate).
+          {definitions.deaths_included}
         display:
           numDecimalPlaces: 0
         presentation:
@@ -100,7 +125,7 @@ tables:
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
         unit: deaths
-        description: >-
+        description: |-
           Number of ongoing (active) conflicts in a given year.
 
           We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.
@@ -120,7 +145,7 @@ tables:
       number_new_conflicts:
         title: Number of new conflicts
         unit: deaths
-        description: >-
+        description: |-
           Number of new (active) conflicts in a given year.
 
 

--- a/etl/steps/data/garden/war/2023-07-07/mars.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-07/mars.meta.yml
@@ -1,14 +1,52 @@
+definitions:
+  number_deaths_ongoing_conflicts: |-
+    <% if conflict_type == "all" %>
+    The << estimate >> estimate of the number of deaths in all ongoing conventional wars in each year.
+
+    An ongoing conventional war is a conflict between combatants with differentiated militaries and clear frontlines that causes at least 500 deaths over its duration.
+
+    Deaths of combatants due to fighting are included.
+
+    If a war lasted more than one year, we distributed its deaths evenly across years. If a war was ongoing in more than one world region, we distributed its deaths evenly across regions.
+    <% elif conflict_type == "others (non-civil)" %>
+    The << estimate >> estimate of the number of deaths in ongoing conventional interstate wars in each year.
+
+    An ongoing conventional interstate war is a conflict between combatants that are part of different political authorities, that involves differentiated militaries and clear frontlines, and that causes at least 500 deaths over its duration.
+
+    We identify conventional interstate wars as those wars that are not coded civil wars by Project Mars.
+
+    For the two wars that had campaigns within it that were a civil war and an interstate war, we coded them as interstate wars.
+
+    Deaths of combatants due to fighting are included.
+
+    If a war lasted more than one year, we distributed its deaths evenly across years. If a war was ongoing in more than one world region, we distributed its deaths across the regions of the participants.
+    <% elif conflict_type == "civil war" %>
+    The << estimate >> estimate of the number of deaths in ongoing conventional civil wars in each year.
+
+    An ongoing conventional civil war is a conflict between combatants that were previously part of the same political authority, where now at least one seeks control or secession, that involves differentiated militaries and clear frontlines, and that causes at least 500 deaths over its duration.
+
+    For the two wars that had campaigns within it that were a civil war and an interstate war, we coded them as interstate wars.
+
+    Deaths of combatants due to fighting are included.
+
+    If a war lasted more than one year, we distributed its deaths evenly across years.
+    <% endif %>
+
+
 dataset:
   title: History of war (Project Mars, 2020)
-  description: >-
-    This dataset contains information on armed conflicts, both civil and non-civil, in the period of 1800 and 2011.
+  description: |-
+    This dataset provides information on conventional wars, using data from Jason Lyall's Project Mars.
 
+    The project provides information on the number of ongoing and new wars, the number of ongoing and new war types, as well as the number of deaths in ongoing wars and war types.
 
-    It has been constructed using the Project Mars dataset by Lyall, Jason.
+    Deaths of combatants due to fighting are included.
 
+    We use the world regions as defined by Project Mars: Asia, Eastern Europe, Latin America, North Africa and the Middle East, North America, Sub-Saharan Africa, and Western Europe.
+
+    You can find more information about the data in our article:
 
     More details about Project Mars:
-
 
 tables:
   mars:
@@ -17,9 +55,9 @@ tables:
       number_deaths_ongoing_conflicts_high:
         title: Number of soldier deaths in ongoing conflicts (high estimate)
         unit: deaths
-        description: >-
-          The number of soldiers killed in a year over the course of wars. Excluded from this total are missing soldiers as well as those who
-          died from illness and/or disease. This is the high estimate of those who were killed.
+        description: |-
+          <% set estimate = "high" %>
+          {definitions.number_deaths_ongoing_conflicts}
         display:
           numDecimalPlaces: 0
         presentation:
@@ -35,9 +73,9 @@ tables:
       number_deaths_ongoing_conflicts_low:
         title: Number of soldier deaths in ongoing conflicts (low estimate)
         unit: deaths
-        description: >-
-          The number of soldiers killed in a year over the course of wars. Excluded from this total are missing soldiers as well as those who
-          died from illness and/or disease. This is the low estimate of those who were killed.
+        description: |-
+          <% set estimate = "low" %>
+          {definitions.number_deaths_ongoing_conflicts}
         display:
           numDecimalPlaces: 0
         presentation:
@@ -53,14 +91,28 @@ tables:
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
         unit: conflicts
-        description: >-
-          Number of ongoing conflicts in a given year.
+        description: |-
+          <% if conflict_type == "all" %>
+          The number of ongoing conventional wars in each year.
 
-          We count a war as ongoing in a region even if the conflict is also ongoing in other regions.
-          The sum across all regions can therefore be higher than the total number of ongoing wars.
+          An ongoing conventional war is a conflict between combatants with differentiated militaries and clear frontlines that causes at least 500 deaths over its duration.
+          <% elif conflict_type == "others (non-civil)" %>
+          The number of ongoing conventional interstate wars in each year.
 
+          An ongoing conventional interstate war is a conflict between combatants that are part of different political authorities, that involves differentiated militaries and clear frontlines, and that causes at least 500 deaths over its duration.
 
-          For the wars that had campaigns within it that were a civil war and a non-civil war, we coded them as non-civil wars.
+          We identify conventional interstate wars as those wars that are not coded civil wars by Project Mars.
+
+          For the two wars that had campaigns within it that were a civil war and an interstate war, we coded them as interstate wars.
+          <% elif conflict_type == "civil war" %>
+          The number of ongoing conventional civil wars in each year.
+
+          An ongoing conventional civil war is a conflict between combatants that were previously part of the same political authority, where now at least one seeks control or secession, that involves differentiated militaries and clear frontlines, and that causes at least 500 deaths over its duration.
+
+          For the two wars that had campaigns within it that were a civil war and an interstate war, we coded them as interstate wars.
+          <% endif %>
+
+          We count a war as ongoing in a region even if the war is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing wars.
         display:
           numDecimalPlaces: 0
         presentation:
@@ -76,19 +128,30 @@ tables:
       number_new_conflicts:
         title: Number of new conflicts
         unit: conflicts
-        description: >-
-          Number of new conflicts in a given year.
+        description: |-
+          <% if conflict_type == "all" %>
+          The number of new conventional wars in each year.
 
+          A conventional war is a conflict between combatants with differentiated militaries and clear frontlines that causes at least 500 deaths over its duration. We consider it new in its start year.
 
-          • New conflicts for the 'World': We only count a war as new when the war overall started that year, not if it restarted
-          or a new campaign within it begins.
+          We only count a war as new when the war overall started that year, not if it restarted or a new campaign within it begins.
+          <% elif conflict_type == "others (non-civil)" %>
+          The number of new conventional interstate wars in each year.
 
-          • New conflicts for all regions (except 'World'): We count a war as new in a region even if the war overall started
-          earlier in another region. The sum across all regions can therefore be higher than the total number of new wars.
+          A conventional interstate war is a conflict between combatants that are part of different political authorities, that involves differentiated militaries and clear frontlines, and that causes at least 500 deaths over its duration. We consider it new in its start year.
 
-          • New conflicts by type: We only count a civil war as new when the war overall started that year, not if it became a civil war.
-          We only count a non-civil war as new when the war overall started that year, not if a civil war became internationalized.
+          We identify conventional interstate wars as those wars that are not coded civil wars by Project Mars.
 
+          We only count an interstate war as new when the war overall started that year, not if a civil war became internationalized.
+          <% elif conflict_type == "civil war" %>
+          The number of ongoing conventional civil wars in each year.
+
+          A conventional civil war is a conflict between combatants that were previously part of the same political authority, where now at least one seeks control or secession, that involves differentiated militaries and clear frontlines, and that causes at least 500 deaths over its duration. We consider it new in its start year.
+
+          We only count a civil war as new when the war overall started that year, not if it became a civil war.
+          <% endif %>
+
+          We count a war as new in a region even if the war started earlier or at the same time in another region. The sum across all regions can therefore be higher than the total number of new wars.
 
         display:
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-07-07/mars.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-07/mars.meta.yml
@@ -46,8 +46,6 @@ dataset:
 
     You can find more information about the data in our article:
 
-    More details about Project Mars:
-
 tables:
   mars:
     # (Inherited from meadow, remove if not different.)

--- a/etl/steps/data/garden/war/2023-07-18/cow.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-18/cow.meta.yml
@@ -11,8 +11,6 @@ dataset:
 
     You can find more information about the data in our article:
 
-    More details about Project Mars:
-
 tables:
   cow:
     variables:
@@ -52,7 +50,6 @@ tables:
           If a war lasted more than one year, we distributed its deaths evenly across years.
 
           For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
-
           <% elif conflict_type == "intra-state (internationalized)" %>
           The estimated number of deaths in ongoing internationalized intrastate wars in each year.
 
@@ -63,7 +60,6 @@ tables:
           If a war lasted more than one year, we distributed its deaths evenly across years.
 
           For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
-
           <% elif conflict_type == "intra-state (non-internationalized)" %>
           The estimated number of deaths in ongoing non-internationalized intrastate wars in each year.
 
@@ -74,7 +70,6 @@ tables:
           If a war lasted more than one year, we distributed its deaths evenly across years.
 
           For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
-
           <% elif conflict_type == "extra-state" %>
           The estimated number of deaths in ongoing extrastate wars in each year.
 
@@ -85,7 +80,6 @@ tables:
           If a war lasted more than one year, we distributed its deaths evenly across years.
 
           For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
-
           <% elif conflict_type == "non-state" %>
           The estimated number of deaths in ongoing non-state wars in each year.
 

--- a/etl/steps/data/garden/war/2023-07-18/cow.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-18/cow.meta.yml
@@ -1,28 +1,17 @@
 dataset:
   title: History of war (COW, 2020)
-  description: >-
-    This dataset contains information on armed conflicts (inter-, intra-, extra- and non-state) in the period of 1816 and 2007.
+  description: |-
+    This dataset provides information on wars, using data from Correlates of War's Inter-State War Data (version 4.0), Intra-State War Data (version 5.1), Extra-State War Data (version 4.0), and Non-State War Data (version 4.0).
 
+    We combine these datasets to provide information on the number of ongoing and new wars, the number of ongoing and new war types, as well as the number of deaths in ongoing wars and war types.
 
-    It has been constructed using the Correlates of War - War data dataset.
+    Deaths of combatants due to fighting, disease, and starvation are included.
 
+    We align the world regions across the datasets to be Africa, Americas, Asia, Europe, Middle East, and Oceania. This meant we sometimes had to identify the regions manually.
 
-    The regions defined by the source are:
+    You can find more information about the data in our article:
 
-      • W. Hemisphere (we have renamed this to "Americas")
-
-      • Europe
-
-      • Africa
-
-      • Middle East
-
-      • Asia
-
-      • Oceania
-
-
-      The source does not specify the countries within each region.
+    More details about Project Mars:
 
 tables:
   cow:
@@ -30,8 +19,85 @@ tables:
       number_deaths_ongoing_conflicts:
         title: Number of battle-related deaths in ongoing conflicts
         unit: deaths
-        description: >-
-          Number of battle-related combatant fatalities suffered by all participants in wars.
+        description: |-
+          <% if conflict_type == "all" %>
+          The estimated number of deaths in all ongoing wars in each year. This includes interstate, intrastate, extrastate, and non-state wars.
+
+          An ongoing interstate war is a conflict between states that causes at least 1,000 deaths during a year.
+
+          Deaths of combatants due to fighting, disease, and starvation are included.
+
+          If a war lasted more than one year, we distributed its deaths evenly across years. If a war was ongoing in more than one world region, we distributed its deaths across the regions of the participants.
+
+          For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
+          <% elif conflict_type == "inter-state" %>
+          The estimated number of deaths in ongoing interstate wars in each year.
+
+          An ongoing interstate war is a conflict between states that causes at least 1,000 deaths during a year.
+
+          Deaths of combatants due to fighting, disease, and starvation are included.
+
+          If a war lasted more than one year, we distributed its deaths evenly across years. If a war was ongoing in more than one world region, we distributed its deaths across the regions of the participants.
+
+          For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
+
+          We extend the time-series to 2010, by drawing on Correlates of War's Directed Dyadic Interstate War Dataset (version 4.01), which identifies no wars for the years since 2003.
+          <% elif conflict_type == "intra-state" %>
+          The estimated number of deaths in ongoing intrastate wars in each year.
+
+          An ongoing intrastate war is a conflict between a state and a non-state armed group or between non-state armed groups that causes at least 1,000 deaths during a year.
+
+          Deaths of combatants due to fighting, disease, and starvation are included.
+
+          If a war lasted more than one year, we distributed its deaths evenly across years.
+
+          For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
+
+          <% elif conflict_type == "intra-state (internationalized)" %>
+          The estimated number of deaths in ongoing internationalized intrastate wars in each year.
+
+          An ongoing internationalized intrastate war is a conflict between a state and a non-state armed group or between non-state armed groups, with involvement of a foreign state, that causes at least 1,000 deaths during a year.
+
+          Deaths of combatants due to fighting, disease, and starvation are included.
+
+          If a war lasted more than one year, we distributed its deaths evenly across years.
+
+          For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
+
+          <% elif conflict_type == "intra-state (non-internationalized)" %>
+          The estimated number of deaths in ongoing non-internationalized intrastate wars in each year.
+
+          An ongoing non-internationalized intrastate war is a conflict between a state and a non-state armed group or between non-state armed groups, without involvement of a foreign state, that causes at least 1,000 deaths during a year.
+
+          Deaths of combatants due to fighting, disease, and starvation are included.
+
+          If a war lasted more than one year, we distributed its deaths evenly across years.
+
+          For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
+
+          <% elif conflict_type == "extra-state" %>
+          The estimated number of deaths in ongoing extrastate wars in each year.
+
+          An ongoing extrastate war is a conflict between a state and a non-state region it seeks to control, or between a state and a colony that seeks policy change or independence, and that causes at least 1,000 deaths during a year.
+
+          Deaths of combatants due to fighting, disease, and starvation are included.
+
+          If a war lasted more than one year, we distributed its deaths evenly across years.
+
+          For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
+
+          <% elif conflict_type == "non-state" %>
+          The estimated number of deaths in ongoing non-state wars in each year.
+
+          An ongoing non-state war is a conflict between non-state armed groups within a region without a state or across state broders, that causes at least 1,000 deaths during a year.
+
+          Deaths of combatants due to fighting, disease, and starvation are included.
+
+          If a war lasted more than one year, we distributed its deaths evenly across years.
+
+          For wars without any deaths estimate, we conversatively coded Correlates of War's lower bound for including a war, 1,000 deaths each year.
+          <% endif %>
+
         display:
           numDecimalPlaces: 0
         presentation:
@@ -47,8 +113,55 @@ tables:
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
         unit: conflicts
-        description: >-
-          Number of ongoing conflicts in a given year.
+        description: |-
+          <% if conflict_type == "all" %>
+          The number of all ongoing wars in each year. This includes interstate, intrastate, extrastate, and non-state wars.
+
+          An ongoing war is a conflict between organized armed groups that causes at least 1,000 deaths during a year.
+
+          We count a war as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing wars.
+
+          We extend the time-series to 2007, by drawing on Correlates of War's Directed Dyadic Interstate War Dataset (version 4.01), which identifies no interstate wars for the years since 2003.
+
+          <% elif conflict_type == "inter-state" %>
+          The number of ongoing interstate wars in each year.
+
+          An ongoing interstate war is a conflict between states that causes at least 1,000 deaths during a year.
+
+          We count a war as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing wars.
+
+          We extend the time-series to 2010, by drawing on Correlates of War's Directed Dyadic Interstate War Dataset (version 4.01), which identifies no wars for the years since 2003.
+          <% elif conflict_type == "intra-state" %>
+          The number of ongoing intrastate wars in each year.
+
+          An ongoing intrastate war is a conflict between a state and a non-state armed group or between non-state armed groups that causes at least 1,000 deaths during a year.
+
+          We count a war as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing wars.
+          <% elif conflict_type == "intra-state (internationalized)" %>
+          The number of ongoing internationalized intrastate wars in each year.
+
+          An ongoing internationalized intrastate war is a conflict between a state and a non-state armed group or between non-state armed groups, with involvement of a foreign state, that causes at least 1,000 deaths during a year.
+
+          We count a war as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing wars.
+          <% elif conflict_type == "intra-state (non-internationalized)" %>
+          The number of ongoing non-internationalized intrastate wars in each year.
+
+          An ongoing non-internationalized intrastate war is a conflict between a state and a non-state armed group or between non-state armed groups, without involvement of a foreign state, that causes at least 1,000 deaths during a year.
+
+          We count a war as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing wars.
+          <% elif conflict_type == "extra-state" %>
+          The number of ongoing extrastate wars in each year.
+
+          An ongoing extrastate war is a conflict between a state and a non-state region it seeks to control, or between a state and a colony that seeks policy change or independence, and that causes at least 1,000 deaths during a year.
+
+          We count a war as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing wars.
+          <% elif conflict_type == "non-state" %>
+          The number of ongoing non-state wars in each year.
+
+          An ongoing non-state war is a conflict between non-state armed groups within a region without a state or across state broders, that causes at least 1,000 deaths during a year.
+
+          We count a war as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing wars.
+          <% endif %>
 
         display:
           numDecimalPlaces: 0
@@ -64,8 +177,68 @@ tables:
       number_new_conflicts:
         title: Number of new conflicts
         unit: conflicts
-        description: >-
-          Number of new conflicts in a given year.
+        description: |-
+          <% if conflict_type == "all" %>
+          The number of new wars in each year. This includes interstate, intrastate, extrastate, and non-state wars.
+
+          A new war is a conflict between organized armed groups that causes at least 1,000 deaths during a year for the first time.
+
+          We only count a war as new when the war overall started that year, not if it restarted.
+
+          We count a war as new in a region even if the war started at the same time in another region. The sum across all regions can therefore be higher than the total number of new wars.
+
+          We extend the time-series to 2007, by drawing on Correlates of War's Directed Dyadic Interstate War Dataset (version 4.01), which identifies no interstate wars for the years since 2003.
+          <% elif conflict_type == "inter-state" %>
+          The number of new interstate wars in each year.
+
+          A new interstate war is a conflict between states that causes at least 1,000 deaths during a year for the first time.
+
+          We only count a war as new when the war overall started that year, not if it restarted.
+
+          We count a war as new in a region even if the war started at the same time in another region. The sum across all regions can therefore be higher than the total number of new wars.
+
+          We extend the time-series to 2010, by drawing on Correlates of War's Directed Dyadic Interstate War Dataset (version 4.01), which identifies no wars for the years since 2003.
+          <% elif conflict_type == "intra-state" %>
+          The number of new intrastate wars in each year.
+
+          A new intrastate war is a conflict between a state and a non-state armed group or between non-state armed groups that causes at least 1,000 deaths during a year for the first time.
+
+          We only count a war as new when the war overall started that year, not if it restarted.
+
+          We count a war as new in a region even if the war started at the same time in another region. The sum across all regions can therefore be higher than the total number of new wars.
+          <% elif conflict_type == "intra-state (internationalized)" %>
+          The number of new internationalized intrastate wars in each year.
+
+          A new internationalized intrastate war is a conflict between a state and a non-state armed group or between non-state armed groups, with involvement of a foreign state, that causes at least 1,000 deaths during a year for the first time.
+
+          We only count a war as new when the war overall started that year, not if it restarted. We also only count an internationalized intrastate war as new when the war overall started that year, not if it became internationalized.
+
+          We count a war as new in a region even if the war started at the same time in another region. The sum across all regions can therefore be higher than the total number of new wars.
+          <% elif conflict_type == "intra-state (non-internationalized)" %>
+          The number of new non-internationalized intrastate wars in each year.
+
+          A new non-internationalized intrastate war is a conflict between a state and a non-state armed group or between non-state armed groups, without involvement of a foreign state, that causes at least 1,000 deaths during a year for the first time.
+
+          We only count a war as new when the war overall started that year, not if it restarted. We also only count a non-internationalized intrastate war as new when the war overall started that year, not if it stopped being internationalized.
+
+          We count a war as new in a region even if the war started at the same time in another region. The sum across all regions can therefore be higher than the total number of new wars.
+          <% elif conflict_type == "extra-state" %>
+          The number of new extrastate wars in each year.
+
+          A new extrastate war is a conflict between a state and a non-state region it seeks to control, or between a state and a colony that seeks policy change or independence, and that causes at least 1,000 deaths during a year for the first time.
+
+          We only count a war as new when the war overall started that year, not if it restarted.
+
+          We count a war as new in a region even if the war started at the same time in another region. The sum across all regions can therefore be higher than the total number of new wars.
+          <% elif conflict_type == "non-state" %>
+          The number of new non-state wars in each year.
+
+          A new non-state war is a conflict between non-state armed groups within a region without a state or across state broders, that causes at least 1,000 deaths during a year for the first time.
+
+          We only count a war as new when the war overall started that year, not if it restarted.
+
+          We count a war as new in a region even if the war started at the same time in another region. The sum across all regions can therefore be higher than the total number of new wars.
+          <% endif %>
 
         display:
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-07-20/brecke.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-20/brecke.meta.yml
@@ -1,89 +1,53 @@
 dataset:
   title: History of war (Brecke, 1999)
-  description: >-
-    This dataset contains information on armed conflicts, both internal and external, in the period of 1400 and 1999.
+  description: |-
+    This dataset provides information on armed conflicts, using data from Peter Brecke's Conflict Catalog.
 
+    The data includes information on the number of ongoing and new conflicts, the number of ongoing and new conflict types, as well as the number of deaths in ongoing conflicts and conflict types.
 
-    It has been constructed using the Conflict Catalog Data by Dr. Peter Brecke.
+    Deaths of combatants and civilians due to fighting, disease, and starvation are included.
 
+    We change the world regions in the data: Africa (from East & South Africa, North Africa, and West & Central Africa), Americas (from North America, Central America, and the Carribean and South America), Asia (from Central Asia, East Asia, South Asia, and Southeast Asia), Europe (from Eastern Europe and Western Europe),  and Middle East (from Arabian Peninsula and Iran west to Syria).
 
-    This dataset has its own region definitions (taken from https://bpb-us-w2.wpmucdn.com/sites.gatech.edu/dist/1/19/files/2018/09/Brecke-PSS-1999-paper-Violent-Conflicts-1400-AD-to-the-Present.pdf):
-
-      - Europe west of 15 degrees east longitude plus Sweden and Italy
-
-      - Europe east of 15 degrees east longitude (includes Caucusus region)
-
-      - North America, Central America, and the Caribbean
-
-      - South America
-
-      - Middle East (Iran west to Syria and Arabian peninsula)
-
-      - North Africa (Egypt to Morocco and Mauritania east to Sudan)
-
-      - West & Central Africa (Senegal to Congo)
-
-      - East & South Africa (Ethiopia to Zambia to Angola and south)
-
-      - Central Asia (Afghanistan, former Soviet republics, and Siberia)
-
-      - South Asia
-
-      - Southeast Asia (Burma to Australia and Pacific islands)
-
-      - East Asia (China, Korea, Japan)
-
-
-    We have combined these to create the following regions:
-
-      - Europe:
-
-        - Europe west of 15 degrees east longitude plus Sweden and Italy
-
-        - Europe east of 15 degrees east longitude (includes Caucusus region)
-
-      - Middle East:
-
-        - Middle East (Iran west to Syria and Arabian peninsula)
-
-      - Asia:
-
-        - Central Asia (Afghanistan, former Soviet republics, and Siberia)
-
-        - South Asia
-
-        - Southeast Asia (Burma to Australia and Pacific islands)
-
-        - East Asia (China, Korea, Japan)
-
-      - Africa:
-
-        - North Africa (Egypt to Morocco and Mauritania east to Sudan)
-
-        - West & Central Africa (Senegal to Congo)
-
-        - East & South Africa (Ethiopia to Zambia to Angola and south)
-
-      - Americas:
-
-        - North America, Central America, and the Caribbean
-
-        - South America
-
+    You can find more information about the data in our article:
 
 tables:
   brecke:
-    # (Inherited from meadow, remove if not different.)
     variables:
       number_deaths_ongoing_conflicts:
         title: Number of deaths in ongoing conflicts
         unit: deaths
-        description: >-
-          The total fatalities estimates in a year over the course of wars. The total fatalities estimates vary significantly in terms of the degree to which they include disease, starvation, etc.
+        description: |-
+          <% if conflict_type == "all" %>
+          The estimated number of deaths in all ongoing armed conflicts in each year. This includes interstate and internal conflicts.
 
+          An ongoing armed conflict is a disagreement between organized groups, or between an organized group and civilians, that causes at least 32 deaths during a year.
 
-          For some conflicts, data on the number of fatalities was missing. In such cases, we have set the value to 32, which is the lower bound of yearly
-          deaths defined by the source for a violent conflict to be recorded in the dataset.
+          Deaths of combatants and civilians due to fighting, disease, and starvation are included.
+
+          For conflicts without any deaths estimate, we conversatively coded the Conflict Catalog's lower bound for including a conflict, 32 deaths each year.
+          <% elif conflict_type == "interstate" %>
+          The estimated number of deaths in ongoing interstate conflicts in each year.
+
+          An ongoing interstate conflict is a conflict between states that causes at least 32 deaths during a year.
+
+          We identify interstate conflicts in the Conflict Catalog using the approach by Seshat (while correcting any mistakes for the 200 deadliest conflicts): https://seshatdatabank.info/cleaning-history-data-the-conflict-catalogue/
+
+          Deaths of combatants and civilians due to fighting, disease, and starvation are included.
+
+          For conflicts without any deaths estimate, we conversatively coded the Conflict Catalog's lower bound for including a conflict, 32 deaths each year.
+          <% elif conflict_type == "internal" %>
+          The estimated number of deaths in ongoing internal conflicts in each year.
+
+          An ongoing internal conflict is a conflict between a state and a non-state armed groups, between non-state armed groups, or between an armed group and civilians, that causes at least 32 deaths during a year.
+
+          We identify interstate conflicts in the Conflict Catalog using the approach by Seshat (while correcting any mistakes for the 200 deadliest conflicts): https://seshatdatabank.info/cleaning-history-data-the-conflict-catalogue/
+
+          Deaths of combatants and civilians due to fighting, disease, and starvation are included.
+
+          For conflicts without any deaths estimate, we conversatively coded the Conflict Catalog's lower bound for including a conflict, 32 deaths each year.
+          <% endif %>
+
         display:
           numDecimalPlaces: 0
         presentation:
@@ -98,9 +62,24 @@ tables:
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
         unit: conflicts
-        description: >-
-          Number of ongoing conflicts in a given year.
+        description: |-
+          <% if conflict_type == "all" %>
+          The number of all ongoing armed conflicts in each year. This includes interstate and internal conflicts.
 
+          An ongoing armed conflict is a disagreement between organized groups, or between an organized group and civilians, that causes at least 32 deaths during a year.
+          <% elif conflict_type == "interstate" %>
+          The number of ongoing interstate conflicts in each year.
+
+          An ongoing interstate conflict is a conflict between states that causes at least 32 deaths during a year.
+
+          We identify interstate conflicts in the Conflict Catalog using the approach by Seshat (while correcting any mistakes for the 200 deadliest conflicts): https://seshatdatabank.info/cleaning-history-data-the-conflict-catalogue/
+          <% elif conflict_type == "internal" %>
+          The number of ongoing internal conflicts in each year.
+
+          An ongoing internal conflict is a conflict between a state and a non-state armed groups, between non-state armed groups, or between an armed group and civilians, that causes at least 32 deaths during a year.
+
+          We identify interstate conflicts in the Conflict Catalog using the approach by Seshat (while correcting any mistakes for the 200 deadliest conflicts): https://seshatdatabank.info/cleaning-history-data-the-conflict-catalogue/
+          <% endif %>
 
           We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.
         display:
@@ -116,13 +95,30 @@ tables:
       number_new_conflicts:
         title: Number of new conflicts
         unit: conflicts
-        description: >-
-          Number of new conflicts in a given year.
+        description: |-
+          <% if conflict_type == "all" %>
+          The number of all new armed conflicts in each year. This includes interstate and internal conflicts.
 
-          • New conflicts for the 'World': We only count a conflict as new when the conflict overall started that year, not if it became active again.
+          An ongoing armed conflict is a disagreement between organized groups, or between an organized group and civilians, that causes at least 32 deaths during a year for the first time.
 
-          • New conflicts for all regions: We count a conflict as new in a region even if the conflict overall started earlier in another region.
-          The sum across all regions can therefore be higher than the total number of new conflicts.
+          We count a conflict as new in a region even if the conflict also starts in other regions. The sum across all regions can therefore be higher than the total number of new conflicts.
+          <% elif conflict_type == "interstate" %>
+          The number of new interstate conflicts in each year.
+
+          A new interstate conflict is a conflict between states that causes at least 32 deaths during a year for the first time.
+
+          We identify interstate conflicts in the Conflict Catalog using the approach by Seshat (while correcting any mistakes for the 200 deadliest conflicts): https://seshatdatabank.info/cleaning-history-data-the-conflict-catalogue/
+
+          We count a conflict as new in a region even if the conflict started at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
+          <% elif conflict_type == "internal" %>
+          The number of new internal conflicts in each year.
+
+          A new internal conflict is a conflict between a state and a non-state armed groups, between non-state armed groups, or between an armed group and civilians, that causes at least 32 deaths during a year for the first time.
+
+          We identify interstate conflicts in the Conflict Catalog using the approach by Seshat (while correcting any mistakes for the 200 deadliest conflicts): https://seshatdatabank.info/cleaning-history-data-the-conflict-catalogue/
+
+          We count a conflict as new in a region even if the conflict started at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
+          <% endif %>
         display:
           numDecimalPlaces: 0
         presentation:

--- a/etl/steps/data/garden/war/2023-07-21/prio_v31.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-21/prio_v31.meta.yml
@@ -1,34 +1,59 @@
 dataset:
   title: History of war (PRIO v3.1, 2017)
-  description: >-
-    This dataset contains information on conflicts, in the period of 1946 and 2008.
+  description: |-
+    This dataset provides information on armed conflicts, using data from the PRIO Battledeaths Dataset (version 3.1).
 
+    We combine these datasets to provide information on the number of ongoing and new conflicts, the number of ongoing and new conflict types, as well as the number of deaths in ongoing conflicts and conflict types.
 
-    It has been constructed using the Battledeaths PRIO v3.1 dataset.
+    Deaths of combatants and civilians due to fighting are included.
 
+    We use the world regions as defined by PRIO: Africa, Americas, Asia, Europe, and Middle East.
 
-    Regions: The regions are defined based on Gleditsch and Ward codes (GWno). Find complete mapping at
-    https://dornsife.usc.edu/assets/sites/298/docs/country_to_gwno_PUBLIC_6-5-2015.txt
+    You can find more information about the data in our article:
 
-      • Americas: 2-199
+definitions:
+  number_deaths_estimate: |-
+    <% if conflict_type == "all" %>
+    The << estimate >> estimate of the number of deaths in ongoing state-based conflicts in each year. This includes interstate, intrastate, and extrasystemic conflicts.
 
-      • Europe: 200-399
+    A state-based conflict is a conflict between states, or between a state and a non-state armed group, that causes at least 25 deaths during a year.
+    <% elif conflict_type == "interstate" %>
+    The << estimate >> estimate of the number of deaths in ongoing interstate conflicts in each year.
 
-      • Africa: 400-626
+    An interstate conflict is a conflict between states that causes at least 25 deaths during a year.
+    <% elif conflict_type == "intrastate" %>
+    The << estimate >> estimate of the number of deaths in ongoing intrastate conflicts in each year.
 
-      • Middle East: 630-699
+    An intrastate conflict is a conflict between a state and a non-state armed group that causes at least 25 deaths during a year.
+    <% elif conflict_type == "intrastate (internationalized)" %>
+    The << estimate >> estimate of the number of deaths in ongoing internationalized intrastate conflicts in each year.
 
-      • Asia and Oceania: 700-999
+    An internationalized intrastate conflict is a conflict between a state and a non-state armed group, with involvement of a foreign state, that causes at least 25 deaths during a year.
+    <% elif conflict_type == "intrastate (non-internationalized)" %>
+    The << estimate >> estimate of the number of deaths in ongoing non-internationalized intrastate conflicts in each year.
+
+    A non-internationalized intrastate conflict is a conflict between a state and a non-state armed group, without involvement of a foreign state, that causes at least 25 deaths during a year.
+    <% elif conflict_type == "extrasystemic" %>
+    The << estimate >> estimate of the number of deaths in ongoing extraystemic conflicts in each year.
+
+    An extrasystemic conflict is a conflict between a state and a non-state armed group outside its territory that causes at least 25 deaths during a year.
+    <% endif %>
+
+    Deaths of combatants and civilians due to fighting are included.
+    <% if estimate == "best" %>
+
+    For conflict years without a best deaths estimate, we conversatively coded the low estimate.
+    <% endif %>
 
 tables:
   prio_v31:
-    # (Inherited from meadow, remove if not different.)
     variables:
       number_deaths_ongoing_conflicts_battle_high:
         title: Number of battle deaths in ongoing conflicts (high estimate)
         unit: deaths
-        description: >-
-          The number of battle fatalities in a year over the course of wars. This is the high estimate of those who were killed.
+        description: |-
+          <% set estimate = "high" %>
+          {definitions.number_deaths_estimate}
         display:
           numDecimalPlaces: 0
         presentation:
@@ -42,8 +67,9 @@ tables:
       number_deaths_ongoing_conflicts_battle_low:
         title: Number of battle deaths in ongoing conflicts (low estimate)
         unit: deaths
-        description: >-
-          The number of battle fatalities in a year over the course of wars. This is the low estimate of those who were killed.
+        description: |-
+          <% set estimate = "low" %>
+          {definitions.number_deaths_estimate}
         display:
           numDecimalPlaces: 0
         presentation:
@@ -57,11 +83,9 @@ tables:
       number_deaths_ongoing_conflicts_battle:
         title: Number of battle deaths in ongoing conflicts (best estimate)
         unit: deaths
-        description: >-
-          The number of battle fatalities in a year over the course of wars.
-
-          For some conflicts, data on the number of battle deaths is missing. In such cases, we have used the lower estimate as
-          a lower bound.
+        description: |-
+          <% set estimate = "best" %>
+          {definitions.number_deaths_estimate}
         display:
           numDecimalPlaces: 0
         presentation:
@@ -76,11 +100,34 @@ tables:
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
         unit: conflicts
-        description: >-
-          Number of ongoing conflicts in a given year.
+        description: |-
+          <% if conflict_type == "all" %>
+          The number of all ongoing state-based conflicts in each year. This includes interstate, intrastate, and extrasystemic conflicts.
 
-          We count a war as ongoing in a region even if the conflict is also ongoing in other regions.
-          The sum across all regions can therefore be higher than the total number of ongoing wars.
+          An ongoing state-based conflict is a conflict between states, or between a state and a non-state armed group, that causes at least 25 deaths during a year.
+          <% elif conflict_type == "interstate" %>
+          The number of ongoing interstate conflicts in each year.
+
+          An interstate conflict is a conflict between states that causes at least 25 deaths during a year.
+          <% elif conflict_type == "intrastate" %>
+          The number of ongoing intrastate conflicts in each year.
+
+          An intrastate conflict is a conflict between a state and a non-state armed group that causes at least 25 deaths during a year.
+          <% elif conflict_type == "intrastate (internationalized)" %>
+          The number of ongoing internationalized intrastate conflicts in each year.
+
+          An internationalized intrastate conflict is a conflict between a state and a non-state armed group, with involvement of a foreign state, that causes at least 25 deaths during a year.
+          <% elif conflict_type == "intrastate (non-internationalized)" %>
+          The number of ongoing non-internationalized intrastate conflicts in each year.
+
+          A non-internationalized intrastate conflict is a conflict between a state and a non-state armed group, without involvement of a foreign state, that causes at least 25 deaths during a year.
+          <% elif conflict_type == "extrasystemic" %>
+          The number of ongoing extrasystemic conflicts in each year.
+
+          An extrasystemic conflict is a conflict between a state and a non-state armed group outside its territory that causes at least 25 deaths during a year.
+          <% endif %>
+
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.
 
         display:
           numDecimalPlaces: 0
@@ -95,16 +142,46 @@ tables:
       number_new_conflicts:
         title: Number of new conflicts
         unit: conflicts
-        description: >-
-          Number of new conflicts in a given year.
+        description: |-
+          <% if conflict_type == "all" %>
+          The number of new state-based conflicts in each year. This includes interstate, intrastate, and extrasystemic conflicts.
 
+          A new state-based conflict is a conflict between states, or between a state and a non-state armed group, that causes at least 25 deaths during a year for the first time.
 
-          • New conflicts for the 'World': We only count a war as new when the war overall started that year, not if it restarted
-          or a new campaign within it begins.
+          We only count a conflict as new when the conflict overall started that year, not if it became active again.
+          <% elif conflict_type == "interstate" %>
+          The number of new interstate conflicts in each year.
 
-          • New conflicts by type: We only consider the type of a conflict when it first started. Therefore, if a conflict transitions
-          into a different type, we do not add one to the counter of new conflicts of this particular new type.
+          A new interstate conflict is a conflict between states that causes at least 25 deaths during a year for the first time.
 
+          We only count a conflict as new when the conflict overall started that year, not if it became active again.
+          <% elif conflict_type == "intrastate" %>
+          The number of new intrastate conflicts in each year.
+
+          A new intrastate conflict is a conflict between a state and a non-state armed group that causes at least 25 deaths during a year for the first time.
+
+          We only count a conflict as new when the conflict overall started that year, not if it became active again.
+          <% elif conflict_type == "intrastate (internationalized)" %>
+          The number of new internationalized intrastate conflicts in each year.
+
+          A new internationalized intrastate conflict is a conflict between a state and a non-state armed group, with involvement of a foreign state, that causes at least 25 deaths during a year for the first time.
+
+          We only count a conflict as new when the conflict overall started that year, not if it became active again. We also only count an internationalized intrastate conflict as new when the conflict overall started that year, not if it became internationalized.
+          <% elif conflict_type == "intrastate (non-internationalized)" %>
+          The number of new non-internationalized intrastate conflicts in each year.
+
+          A new non-internationalized intrastate conflict is a conflict between a state and a non-state armed group, without involvement of a foreign state, that causes at least 25 deaths during a year for the first time.
+
+          We only count a conflict as new when the conflict overall started that year, not if it became active again. We also only count a non-internationalized intrastate conflict as new when the conflict overall started that year, not if it stopped being internationalized.
+          <% elif conflict_type == "extrasystemic" %>
+          The number of new extrasystemic conflicts in each year.
+
+          A new extrasystemic conflict is a conflict between a state and a non-state armed group outside its territory that causes at least 25 deaths during a year for the first time.
+
+          We only count a conflict as new when the conflict overall started that year, not if it became active again.
+          <% endif %>
+
+          We count a conflict as new in a region even if the conflict started earlier or at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
         display:
           numDecimalPlaces: 0
         presentation:

--- a/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-05/cow_mid.meta.yml
@@ -1,25 +1,36 @@
 dataset:
   title: History of war (COW MID, 2020)
-  description: >-
-      This dataset contains information on interstate disputes in the period of 1816 and 2014.
+  description: |-
+      This dataset provides information on militarized interstate disputes, using Correlates of War's Militarized Interstate Disputes dataset (version 5.0).
+
+      The dataset provides information on the number of ongoing and new interstate conflicts and the number of deaths in ongoing interstate conflicts.
+
+      Deaths of combatants due to fighting are included.
+
+      We use the world regions of the participants to code the conflicts' world region(s).
+
+      You can find more information about the data in our article:
 
 
-      It has been constructed using the Correlates of War - Militarised Interstate Disputes v5.0 dataset.
-
-
-      Regions: The regions are defined based on Gleditsch and Ward codes (GWno). Find complete mapping at
-      https://dornsife.usc.edu/assets/sites/298/docs/country_to_gwno_PUBLIC_6-5-2015.txt
-
-      • Americas: 2-165
-
-      • Europe: 200-395
-
-      • Africa: 400-626
-
-      • Middle East: 630-698
-
-      • Asia: 700-990
-
+definitions:
+  fatalities: |-
+    <% if fatality == "No deaths" %>
+    The number of ongoing interstate conflicts in each year in which ultimately no combatant dies.
+    <% elif fatality == "1-25 deaths" %>
+    The number of ongoing interstate conflicts in each year in which ultimately 1-25 combatants dies.
+    <% elif fatality == "26-100 deaths" %>
+    The number of ongoing interstate conflicts in each year in which ultimately 26-100 combatants dies.
+    <% elif fatality == "101-250 deaths" %>
+    The number of ongoing interstate conflicts in each year in which ultimately 101-250 combatants dies.
+    <% elif fatality == "251-500 deaths" %>
+    The number of ongoing interstate conflicts in each year in which ultimately 251-500 combatants dies.
+    <% elif fatality == "501-999 deaths" %>
+    The number of ongoing interstate conflicts in each year in which ultimately 501-999 combatants dies.
+    <% elif fatality == "> 999 deaths" %>
+    The number of ongoing interstate conflicts in each year in which ultimately at least 1,000 combatants dies.
+    <% elif fatality == "Unknown" %>
+    The number of ongoing interstate conflicts in each year for which there was no ultimate number of deaths given.
+    <% endif %>
 
 tables:
   cow_mid:
@@ -38,46 +49,52 @@ tables:
         title: Number of ongoing disputes
         unit: disputes
         description_short: The annual number of ongoing disputes
-        description: >-
-          Number of ongoing disputes in a given year.
+        description: |-
+          <% if hostility == "all" and fatality == "all" %>
+          The number of all ongoing interstate conflicts in each year.
 
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-          We count a dispute as ongoing in a region even if the dispute is also ongoing in other regions.
-          The sum across all regions can therefore be higher than the total number of ongoing disputes.
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflict.
+          <% elif hostility == "Threat to use force" %>
+          The number of interstate conflicts in each year where at most the use of force is threatened over the conflict's duration.
 
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-          The data is disaggregated by region and "hostility" or "fatality".
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflict.
 
-          "Fatality" gives lower and upper estimates on the total number of fatalities over the complete span of a dispute. These are the types:
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility == "Display of force" %>
+          The number of interstate conflicts in each year where at most force is displayed over the conflict's duration.
 
-            - No deaths
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-            - 1-25 deaths
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflict.
 
-            - 26-100 deaths
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility == "Use of force" %>
+          The number of interstate conflicts in each year where force is used, but causes fewer than 1,000 combatant deaths due to fighting over the conflict's duration.
 
-            - 101-250 deaths
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-            - 251-500 deaths
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflict.
 
-            - 501-999 deaths
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility == "War" %>
+          The number of interstate conflicts in each year where the use of force causes at least 1,000 combatant deaths due to fighting over the conflict's duration.
 
-            - > 999 deaths
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-            - Unknown
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflict.
 
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility == "all" %>
+          {definitions.fatalities}
 
-          "Hostility" provides a short description of the type of hostility. These are the types:
+          An ongoing interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-            - No militarized action
-
-            - Threat to use force
-
-            - Display of force
-
-            - Use of force
-
-            - War
+          Deaths of combatants due to fighting are included.
+          <% endif %>
         processing_level: major
         display:
           numDecimalPlaces: 0
@@ -93,54 +110,57 @@ tables:
         title: Number of new disputes
         unit: disputes
         description_short: The annual number of new disputes
-        description: >-
-          Number of new disputes in a given year.
+        description: |-
+          <% if hostility == "all" %>
+          The number of all new interstate conflicts in each year.
 
+          A new interstate conflict is a disagreement between states where force is threatened, displayed, or used for the first time.
 
-          We count a dispute as new in a region even if the dispute is also ongoing in other regions.
-          The sum across all regions can therefore be higher than the total number of ongoing disputes.
+          We only count a conflict as new when the conflict overall started that year, not if it restarted or changed its hostility level (i.e. escalated or deescalated).
 
+          We count a conflict as new in a region even if the conflict started at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
+          <% elif hostility == "Threat to use force" %>
+          The number of new interstate conflicts in each year where at most the use of force is threatened over the conflict's duration.
 
-          The data is disaggregated by region and "hostility" or "fatality".
+          A new interstate conflict is a disagreement between states where force is threatened, displayed, or used for the first time.
 
+          We only count a conflict as new when the conflict overall started that year, not if it restarted or changed its hostility level (i.e. escalated or deescalated).
 
-          "Fatality" gives lower and upper estimates on the total number of fatalities over the complete span of a dispute. These are the types:
+          We count a conflict as new in a region even if the conflict started at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
 
-            - No deaths
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility == "Display of force" %>
+          The number of new interstate conflicts in each year where at most force is displayed over the conflict's duration.
 
-            - 1-25 deaths
+          A new interstate conflict is a disagreement between states where force is threatened, displayed, or used for the first time.
 
-            - 26-100 deaths
+          We only count a conflict as new when the conflict overall started that year, not if it restarted or changed its hostility level (i.e. escalated or deescalated).
 
-            - 101-250 deaths
+          We count a conflict as new in a region even if the conflict started at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
 
-            - 251-500 deaths
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility == "Use of force" %>
+          The number of new interstate conflicts in each year where force is used, but causes fewer than 1,000 combatant deaths due to fighting over the conflict's duration.
 
-            - 501-999 deaths
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used for the first time.
 
-            - > 999 deaths
+          We only count a conflict as new when the conflict overall started that year, not if it restarted or changed its hostility level (i.e. escalated or deescalated).
 
-            - Unknown
+          We count a conflict as new in a region even if the conflict started at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
 
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility == "War" %>
+          The number of new interstate conflicts in each year where the use of force causes at least 1,000 combatant deaths due to fighting over the conflict's duration.
 
-          "Hostility" provides a short description of the type of hostility. These are the types:
+          A new interstate conflict is a disagreement between states where force is threatened, displayed, or used for the first time.
 
-            - No militarized action
+          We only count a conflict as new when the conflict overall started that year, not if it restarted or changed its hostility level (i.e. escalated or deescalated).
 
-            - Threat to use force
+          We count a conflict as new in a region even if the conflict started at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
 
-            - Display of force
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% endif %>
 
-            - Use of force
-
-            - War
-
-
-          NOTES:
-
-
-          • New disputes for all regions (except 'World'): We count a dispute as new in a region even if the dispute overall started
-          earlier in another region. The sum across all regions can therefore be higher than the total number of new disputes.
         processing_level: major
         display:
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-08-15/mie.meta.yml
+++ b/etl/steps/data/garden/war/2023-08-15/mie.meta.yml
@@ -1,24 +1,15 @@
 dataset:
   title: History of war (Gibler and Miller, 2020)
-  description: >-
-      This dataset contains information on interstate conflicts in the period of 1816 and 2014.
+  description: |-
+      This dataset provides information on militarized interstate confrontations, using Douglas Gibler and Steven Miller's Militarized Interstate Events dataset (version 1.0).
 
+      The dataset provides information on the number of ongoing and new interstate conflicts and the number of deaths in ongoing interstate conflicts.
 
-      It has been constructed using the Militarized Interstate Events (MIE) Dataset (version 1) by D. M. Gibler and S. V. Miller.
+      Deaths of combatants due to fighting are included.
 
-      Regions: The regions are defined based on Gleditsch and Ward codes (GWno). Find complete mapping at
-      https://dornsife.usc.edu/assets/sites/298/docs/country_to_gwno_PUBLIC_6-5-2015.txt
+      We use the world regions of the participants to code the conflicts' world region(s).
 
-      • Americas: 2-199
-
-      • Europe: 200-399
-
-      • Africa: 400-626
-
-      • Middle East: 630-699
-
-      • Asia: 700-999
-
+      You can find more information about the data in our article:
 
 tables:
   mie:
@@ -26,27 +17,46 @@ tables:
       number_ongoing_conflicts:
         title: Number of ongoing conflicts
         unit: conflicts
-        description: >-
-          Number of ongoing disputes in a given year.
+        description: |-
+          <% if hostility_level == "all" %>
+          The number of all ongoing interstate conflicts in each year.
 
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions.
-          The sum across all regions can therefore be higher than the total number of ongoing conflicts.
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.
+          <% elif hostility_level == "Threat to use force" %>
+          The number of interstate conflicts where at most the use of force is threatened in each year.
 
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-          The same conflict can have different "hostility level" for different regions. When this is the case, we classify its global
-          hostility level as the most hostile level based on the following rank (from less to most hostile):
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.
 
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility_level == "Display of force" %>
+          The number of interstate conflicts where at most force is displayed in each year.
 
-            1: No militarized action
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-            2: Threat to use force
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.
 
-            3: Display of force
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility_level == "Use of force" %>
+          The number of interstate conflicts where force is used, but causes fewer than 1,000 combatant deaths due to fighting, in each year.
 
-            4: Use of force
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-            5: War
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.
+
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility_level == "War" %>
+          The number of interstate conflicts where the use of force causes at least 1,000 combatant deaths due to fighting during the year.
+
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used.
+
+          We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.
+
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% endif %>
         processing_level: major
         display:
           numDecimalPlaces: 0
@@ -62,38 +72,57 @@ tables:
       number_new_conflicts:
         title: Number of new conflicts
         unit: conflicts
-        description: >-
-          Number of new disputes in a given year.
+        description: |-
+          <% if hostility_level == "all" %>
+          The number of all new interstate conflicts in each year.
 
+          A new interstate conflict is a disagreement between states where force is threatened, displayed, or used for the first time.
 
-          • New disputes for the 'World': We only count a dispute as new when the dispute overall started that year, not if it restarted
-          or its hostility level changed.
+          We only count a conflict as new when the conflict overall started that year, not if it restarted or changed its hostility level (i.e. escalated or deescalated).
 
-          • New disputes for all regions (except 'World'): We count a dispute as new in a region even if the dispute overall started
-          earlier in another region. The sum across all regions can therefore be higher than the total number of new disputes.
+          We count a conflict as new in a region even if the conflict started earlier or at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
+          <% elif hostility_level == "Threat to use force" %>
+          The number of new interstate conflicts where at most the use of force is threatened in each year.
 
-          • New disputes by hostility level: We only count a dispute as new when the dispute overall started that year, not if it changed
-          its hostility level.
+          A new interstate conflict is a disagreement between states where force is threatened, displayed, or used for the first time.
 
+          We only count a conflict as new when the conflict overall started that year, not if it restarted or changed its hostility level (i.e. escalated or deescalated).
 
-          Consequently, the number of new conflicts globally might be lower than the sum across all regions. This can be due to multiple reasons:
-          (i) the same conflict occurs in multiple regions or (ii) a conflict starting in a region, but it already started earlier globally
-          (in another region).
+          We count a conflict as new in a region even if the conflict started earlier or at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
 
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility_level == "Display of force" %>
+          The number of new interstate conflicts where at most force is displayed in each year.
 
-          The same conflict can have different "hostility level" for different regions. When this is the case, we classify its global
-          hostility level as the most hostile level based on the following rank (from less to most hostile):
+          A new interstate conflict is a disagreement between states where force is threatened, displayed, or used for the first time.
 
+          We only count a conflict as new when the conflict overall started that year, not if it restarted or changed its hostility level (i.e. escalated or deescalated).
 
-            1: No militarized action
+          We count a conflict as new in a region even if the conflict started earlier or at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
 
-            2: Threat to use force
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility_level == "Use of force" %>
+          The number of new interstate conflicts where force is used, but causes fewer at least 1,000 combatant deaths due to fighting, in each year.
 
-            3: Display of force
+          An interstate conflict is a disagreement between states where force is threatened, displayed, or used for the first time.
 
-            4: Use of force
+          We only count a conflict as new when the conflict overall started that year, not if it restarted or changed its hostility level (i.e. escalated or deescalated).
 
-            5: War
+          We count a conflict as new in a region even if the conflict started earlier or at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
+
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% elif hostility_level == "War" %>
+          The number of new interstate conflicts where the use of force causes at least 1,000 combatant deaths due to fighting during the year.
+
+          A new interstate conflict is a disagreement between states where force is threatened, displayed, or used for the first time.
+
+          We only count a conflict as new when the conflict overall started that year, not if it restarted or changed its hostility level (i.e. escalated or deescalated).
+
+          We count a conflict as new in a region even if the conflict started earlier or at the same time in another region. The sum across all regions can therefore be higher than the total number of new conflicts.
+
+          The hostility level for a conflict overall is the highest level across all world regions.
+          <% endif %>
+
         processing_level: major
         display:
           numDecimalPlaces: 0
@@ -109,23 +138,12 @@ tables:
       number_deaths_ongoing_conflicts_low:
         title: Number of deaths in ongoing conflicts (low estimate)
         unit: deaths
-        description: >-
-          Sum of all low-estimates of military battle-deaths in a year.
+        description: |-
+          The low estimate of the number of deaths in all ongoing interstate conflicts in each year.
 
+          An ongoing interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-          The same conflict can have different "hostility level" for different regions. When this is the case, we classify its global
-          hostility level as the most hostile level based on the following rank (from less to most hostile):
-
-
-            1: No militarized action
-
-            2: Threat to use force
-
-            3: Display of force
-
-            4: Use of force
-
-            5: War
+          Deaths of combatants due to fighting are included.
         processing_level: major
         display:
           numDecimalPlaces: 0
@@ -141,23 +159,12 @@ tables:
       number_deaths_ongoing_conflicts_high:
         title: Number of deaths in ongoing conflicts (high estimate)
         unit: deaths
-        description: >-
-          Sum of all high-estimates of military battle-deaths in a year.
+        description: |-
+          The high estimate of the number of deaths in all ongoing interstate conflicts in each year.
 
+          An ongoing interstate conflict is a disagreement between states where force is threatened, displayed, or used.
 
-          The same conflict can have different "hostility level" for different regions. When this is the case, we classify its global
-          hostility level as the most hostile level based on the following rank (from less to most hostile):
-
-
-            1: No militarized action
-
-            2: Threat to use force
-
-            3: Display of force
-
-            4: Use of force
-
-            5: War
+          Deaths of combatants due to fighting are included.
         processing_level: major
         display:
           numDecimalPlaces: 0

--- a/etl/steps/data/grapher/war/2023-06-26/ucdp.py
+++ b/etl/steps/data/grapher/war/2023-06-26/ucdp.py
@@ -36,10 +36,8 @@ def run(dest_dir: str) -> None:
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
 
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    # Remove source description so that it doesn't get appended to the dataset description.
+    ds_grapher.metadata.sources[0].description = ""
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/war/2023-07-14/mars.py
+++ b/etl/steps/data/grapher/war/2023-07-14/mars.py
@@ -36,10 +36,8 @@ def run(dest_dir: str) -> None:
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
 
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    # Remove source description so that it doesn't get appended to the dataset description.
+    ds_grapher.metadata.sources[0].description = ""
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/war/2023-07-20/brecke.py
+++ b/etl/steps/data/grapher/war/2023-07-20/brecke.py
@@ -36,10 +36,8 @@ def run(dest_dir: str) -> None:
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
 
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    # Remove source description so that it doesn't get appended to the dataset description.
+    ds_grapher.metadata.sources[0].description = ""
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/war/2023-07-21/prio_v31.py
+++ b/etl/steps/data/grapher/war/2023-07-21/prio_v31.py
@@ -36,10 +36,8 @@ def run(dest_dir: str) -> None:
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
 
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    # Remove source description so that it doesn't get appended to the dataset description.
+    ds_grapher.metadata.sources[0].description = ""
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/war/2023-07-26/cow.py
+++ b/etl/steps/data/grapher/war/2023-07-26/cow.py
@@ -36,10 +36,8 @@ def run(dest_dir: str) -> None:
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
 
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    # Remove source description so that it doesn't get appended to the dataset description.
+    ds_grapher.metadata.sources[0].description = ""
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/war/2023-08-08/cow_mid.py
+++ b/etl/steps/data/grapher/war/2023-08-08/cow_mid.py
@@ -38,10 +38,8 @@ def run(dest_dir: str) -> None:
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
 
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    # Remove source description so that it doesn't get appended to the dataset description.
+    ds_grapher.metadata.sources[0].description = ""
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/war/2023-08-15/mie.py
+++ b/etl/steps/data/grapher/war/2023-08-15/mie.py
@@ -38,10 +38,8 @@ def run(dest_dir: str) -> None:
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
 
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    # Remove source description so that it doesn't get appended to the dataset description.
+    ds_grapher.metadata.sources[0].description = ""
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()


### PR DESCRIPTION
Fix for https://github.com/owid/etl/issues/1548

This PR adds support for Jinja2 templating (using `<%` tags instead of standard `{{` because it would collide with `dynamic_yaml` that we use for placeholders). This is especially helpful for long tables where we want to construct titles or descriptions on the fly and the combinations grow exponentially (see [these descriptions](https://docs.google.com/spreadsheets/d/1Z3fWwUJhafUBc75YY2KsO0Cj8VW3XpzwA9P8tHqDfPA/edit#gid=0)).

Dimensions with values are passed to the template and we can use ifs & variables from Jinja2 to get what we want without repetition.

It's a bit annoying to get whitespaces right in Jinja. I recommend setting `DEBUG=1` flag to speed up ad-hoc etl builds and then check back and forth with grapher.

@lucasrodes I've implemented it for some variables of one dataset. Do you think it would work as a solution? If yes, I can try it on all war datasets that use descriptions from the spreadsheet.

## TODO
* [x] Enable it for other fields like `title` etc.
* [ ] Add it to docs if this get approved
* [ ] ~Add unit tests~
* [ ] ~Add a helper function for rendering YAML that we can use from a notebook~