### PR TITLE
🐛 war: region names

### DIFF
--- a/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2023-06-22/ucdp.meta.yml
@@ -23,7 +23,7 @@ dataset:
 
       • Middle East: 630-699
 
-      • Asia: 700-999
+      • Asia and Oceania: 700-999
 
 
 
@@ -50,7 +50,7 @@ tables:
             selectedEntityNames:
               - Africa
               - Americas
-              - Asia
+              - Asia and Oceania
               - Europe
               - Middle East
       number_deaths_ongoing_conflicts_high:
@@ -69,7 +69,7 @@ tables:
             selectedEntityNames:
               - Africa
               - Americas
-              - Asia
+              - Asia and Oceania
               - Europe
               - Middle East
       number_deaths_ongoing_conflicts_low:
@@ -93,7 +93,7 @@ tables:
             selectedEntityNames:
               - Africa
               - Americas
-              - Asia
+              - Asia and Oceania
               - Europe
               - Middle East
 
@@ -114,7 +114,7 @@ tables:
             selectedEntityNames:
               - Africa
               - Americas
-              - Asia
+              - Asia and Oceania
               - Europe
               - Middle East
       number_new_conflicts:
@@ -141,6 +141,6 @@ tables:
             selectedEntityNames:
               - Africa
               - Americas
-              - Asia
+              - Asia and Oceania
               - Europe
               - Middle East

--- a/etl/steps/data/garden/war/2023-06-22/ucdp.py
+++ b/etl/steps/data/garden/war/2023-06-22/ucdp.py
@@ -1,4 +1,12 @@
-"""Load a meadow dataset and create a garden dataset."""
+"""Data from UCDP.
+
+
+Notes:
+    - conflict types for state-based violence is sourced from UCDP/PRIO dataset. non-state and one-sided violence is sourced from GED dataset.
+    - incompatibilities in oceania are encoded in "Asia". We therefore use region "Asia and Oceania".
+    - there can be some missmatches with latest official reported data (UCDP's live dashboard). This is because UCDP uses latest data for their
+    dashboard, which might not be available yet as bulk download.
+"""
 
 from typing import cast
 
@@ -30,7 +38,7 @@ TYPE_OF_CONFLICT_MAPPING = {
 REGIONS_MAPPING = {
     1: "Europe",
     2: "Middle East",
-    3: "Asia",
+    3: "Asia and Oceania",
     4: "Africa",
     5: "Americas",
 }

--- a/etl/steps/data/garden/war/2023-06-22/ucdp.py
+++ b/etl/steps/data/garden/war/2023-06-22/ucdp.py
@@ -69,6 +69,9 @@ def run(dest_dir: str) -> None:
     log.info("war.ucdp: keep active conflicts")
     tb_geo = tb_geo[tb_geo["active_year"] == 1]
 
+    # Change region named "Asia" with "Asia and Oceania"
+    tb_geo["region"] = tb_geo["region"].replace(to_replace={"Asia": "Asia and Oceania"})
+
     # Create `conflict_type` column
     log.info("war.ucdp: add field `conflict_type`")
     tb = add_conflict_type(tb_geo, tb_conflict)

--- a/etl/steps/data/garden/war/2023-07-20/brecke.py
+++ b/etl/steps/data/garden/war/2023-07-20/brecke.py
@@ -22,8 +22,8 @@ paths = PathFinder(__file__)
 log = get_logger()
 # Region mapping
 REGIONS_RENAME = {
-    1: "America",  # "North America, Central America, and the Caribbean (Brecke)",
-    2: "America",  # "South America (Brecke)",
+    1: "Americas",  # "North America, Central America, and the Caribbean (Brecke)",
+    2: "Americas",  # "South America (Brecke)",
     3: "Europe",  # "Western Europe (Brecke)",
     4: "Europe",  # "Eastern Europe (Brecke)",
     5: "Middle East (Brecke)",

--- a/etl/steps/data/garden/war/2023-07-21/prio_v31.meta.yml
+++ b/etl/steps/data/garden/war/2023-07-21/prio_v31.meta.yml
@@ -7,7 +7,18 @@ dataset:
     It has been constructed using the Battledeaths PRIO v3.1 dataset.
 
 
-    Regions equivalent to COW War dataset.
+    Regions: The regions are defined based on Gleditsch and Ward codes (GWno). Find complete mapping at
+    https://dornsife.usc.edu/assets/sites/298/docs/country_to_gwno_PUBLIC_6-5-2015.txt
+
+      • Americas: 2-199
+
+      • Europe: 200-399
+
+      • Africa: 400-626
+
+      • Middle East: 630-699
+
+      • Asia and Oceania: 700-999
 
 tables:
   prio_v31:
@@ -25,7 +36,7 @@ tables:
             selectedEntityNames:
               - Africa
               - Americas
-              - Asia
+              - Asia and Oceania
               - Europe
               - Middle East
       number_deaths_ongoing_conflicts_battle_low:
@@ -40,7 +51,7 @@ tables:
             selectedEntityNames:
               - Africa
               - Americas
-              - Asia
+              - Asia and Oceania
               - Europe
               - Middle East
       number_deaths_ongoing_conflicts_battle:
@@ -58,7 +69,7 @@ tables:
             selectedEntityNames:
               - Africa
               - Americas
-              - Asia
+              - Asia and Oceania
               - Europe
               - Middle East
 
@@ -78,7 +89,7 @@ tables:
             selectedEntityNames:
               - Africa
               - Americas
-              - Asia
+              - Asia and Oceania
               - Europe
               - Middle East
       number_new_conflicts:
@@ -101,6 +112,6 @@ tables:
             selectedEntityNames:
               - Africa
               - Americas
-              - Asia
+              - Asia and Oceania
               - Europe
               - Middle East

--- a/etl/steps/data/garden/war/2023-07-21/prio_v31.py
+++ b/etl/steps/data/garden/war/2023-07-21/prio_v31.py
@@ -11,6 +11,8 @@ Also, a conflict (i.e. one specific `id`) can have multiple campaigns. Take `id=
     - Second campaign: 1952 (Bolivia and MNR)
     - Third campaign: 1967 (Bolivia and ELN)
 
+
+Data for incompatibilities in Oceania are included in region Asia (source decision)
 """
 from typing import cast
 
@@ -29,7 +31,7 @@ log = get_logger()
 REGIONS_RENAME = {
     1: "Europe (PRIO)",
     2: "Middle East (PRIO)",
-    3: "Asia (PRIO)",
+    3: "Asia and Oceania (PRIO)",
     4: "Africa (PRIO)",
     5: "Americas (PRIO)",
 }


### PR DESCRIPTION
- Brecke dataset: Fixed region "America" → "Americas"
- UCDP and PRIO v3.1 datasets: Changed region "Asia" → "Asia and Oceania"