### PR TITLE
Add relative poverty in WID

### DIFF
--- a/etl/steps/data/garden/wid/2023-08-24/world_inequality_database.py
+++ b/etl/steps/data/garden/wid/2023-08-24/world_inequality_database.py
@@ -1,6 +1,7 @@
 """Load World Inequality Database meadow dataset and create a garden dataset."""
 
 
+import owid.catalog.processing as pr
 from owid.catalog import Dataset, Table
 from shared import add_metadata_vars, add_metadata_vars_distribution
 from structlog import get_logger
@@ -11,6 +12,10 @@ log = get_logger()
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
+
+# Define combinations of variables to calculate relative poverty
+extrapolated_dict = {"no": "", "yes": "_extrapolated"}
+welfare_vars = ["pretax", "posttax_nat", "posttax_dis", "wealth"]
 
 
 # Data processing function (cleaning and small transformations)
@@ -30,6 +35,69 @@ def data_processing(tb: Table) -> Table:
     return tb
 
 
+def add_relative_poverty(tb: Table, tb_percentiles: Table, extrapolated_dict: dict, welfare_vars: list) -> Table:
+    """
+    Add relative poverty values by estimating the median and checking that value against the percentile distribution
+    """
+    log.info("add_relative_poverty.start")
+
+    # Make tb_percentiles wide, by creating a column for each welfare
+    tb_percentiles = tb_percentiles.pivot(
+        index=["country", "year", "p", "percentile"], columns="welfare", values=["thr", "thr_extrapolated"]
+    )
+
+    # Flatten column names
+    tb_percentiles.columns = ["_".join(col).strip() for col in tb_percentiles.columns.values]
+    tb_percentiles = tb_percentiles.reset_index()
+
+    # Calculate 40, 50, and 60 percent of the median for each country and year
+    for var in welfare_vars:
+        for yn, extrapolated in extrapolated_dict.items():
+            for pct in [40, 50, 60]:
+                tb[f"median{pct}pct_{var}{extrapolated}"] = tb[f"median_{var}{extrapolated}"] * pct / 100
+
+    # Merge the two tables
+    tb_percentiles = pr.merge(tb_percentiles, tb, on=["country", "year"], how="left")
+
+    # Calculate absolute difference between thresholds and percentage of median
+    for var in welfare_vars:
+        for yn, extrapolated in extrapolated_dict.items():
+            for pct in [40, 50, 60]:
+                tb_percentiles[f"abs_diff{pct}pct_{var}{extrapolated}"] = abs(
+                    tb_percentiles[f"thr{extrapolated}_{var}"] - tb_percentiles[f"median{pct}pct_{var}{extrapolated}"]
+                )
+
+    # For each country and year, find the percentile with the minimum absolute difference for each welafre, extrapolation and pct
+    tb_relative_poverty = Table()
+    for var in welfare_vars:
+        for yn, extrapolated in extrapolated_dict.items():
+            for pct in [40, 50, 60]:
+                tb_percentiles[f"min{pct}pct_{var}{extrapolated}"] = tb_percentiles.groupby(["country", "year"])[
+                    f"abs_diff{pct}pct_{var}{extrapolated}"
+                ].transform("min")
+
+                # Create a table with the minimum absolute difference for each country and year
+                tb_min = tb_percentiles[
+                    tb_percentiles[f"abs_diff{pct}pct_{var}{extrapolated}"]
+                    == tb_percentiles[f"min{pct}pct_{var}{extrapolated}"]
+                ]
+                tb_min = tb_min[["country", "year", "p"]]
+                # Multiply by 100 to get the headcount ratio in percentage
+                tb_min["p"] *= 100
+                tb_min = tb_min.rename(columns={"p": f"headcount_ratio_{pct}_median_{var}{extrapolated}"})
+
+                # Merge this table with tb_relative_poverty
+                if tb_relative_poverty.empty:
+                    tb_relative_poverty = tb_min
+                else:
+                    tb_relative_poverty = pr.merge(tb_relative_poverty, tb_min, on=["country", "year"], how="outer")
+
+    # Export to csv
+    tb_relative_poverty.to_csv("wid_relative_poverty.csv", index=False)
+
+    return tb_relative_poverty
+
+
 def run(dest_dir: str) -> None:
     log.info("world_inequality_database.start")
 
@@ -40,30 +108,38 @@ def run(dest_dir: str) -> None:
     ds_meadow: Dataset = paths.load_dependency("world_inequality_database")
 
     # Read table from meadow dataset.
-    tb = ds_meadow["world_inequality_database"]
+    tb = ds_meadow["world_inequality_database"].reset_index()
 
     #
     # Process data.
     # Change units and drop unnecessary columns
     tb = data_processing(tb)
 
-    # Add metadata by code
-    tb = add_metadata_vars(tb)
-
     ########################################
     # Percentile data
     ########################################
 
     # Read table from meadow dataset.
-    tb_percentiles = ds_meadow["world_inequality_database_distribution"]
+    tb_percentiles = ds_meadow["world_inequality_database_distribution"].reset_index()
 
     #
     # Process data.
     # Multiple share and share_extrapolated columns by 100
     tb_percentiles[["share", "share_extrapolated"]] *= 100
 
+    # Add relative poverty values
+    tb_relative_poverty = add_relative_poverty(tb, tb_percentiles, extrapolated_dict, welfare_vars)
+    tb = pr.merge(tb, tb_relative_poverty, on=["country", "year"], how="left")
+
+    # Add metadata by code
+    tb = add_metadata_vars(tb)
+
     # Add metadata by code
     tb_percentiles = add_metadata_vars_distribution(tb_percentiles)
+
+    # Add index and sort
+    tb = tb.set_index(["country", "year"]).sort_index()
+    tb_percentiles = tb_percentiles.set_index(["country", "year", "welfare", "p", "percentile"]).sort_index()
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/wid/2023-08-24/world_inequality_database.py
+++ b/etl/steps/data/garden/wid/2023-08-24/world_inequality_database.py
@@ -41,6 +41,10 @@ def add_relative_poverty(tb: Table, tb_percentiles: Table, extrapolated_dict: di
     """
     log.info("add_relative_poverty.start")
 
+    # Make copies of the tables
+    tb = tb.copy()
+    tb_percentiles = tb_percentiles.copy()
+
     # Make tb_percentiles wide, by creating a column for each welfare
     tb_percentiles = tb_percentiles.pivot(
         index=["country", "year", "p", "percentile"], columns="welfare", values=["thr", "thr_extrapolated"]
@@ -130,6 +134,8 @@ def run(dest_dir: str) -> None:
 
     # Add relative poverty values
     tb_relative_poverty = add_relative_poverty(tb, tb_percentiles, extrapolated_dict, welfare_vars)
+
+    # Merge tables
     tb = pr.merge(tb, tb_relative_poverty, on=["country", "year"], how="left")
 
     # Add metadata by code

--- a/etl/steps/data/garden/wid/2023-08-24/world_inequality_database.py
+++ b/etl/steps/data/garden/wid/2023-08-24/world_inequality_database.py
@@ -93,7 +93,7 @@ def add_relative_poverty(tb: Table, tb_percentiles: Table, extrapolated_dict: di
                     tb_relative_poverty = pr.merge(tb_relative_poverty, tb_min, on=["country", "year"], how="outer")
 
     # Export to csv
-    tb_relative_poverty.to_csv("wid_relative_poverty.csv", index=False)
+    tb_relative_poverty.to_csv("wid_relative_poverty.csv")
 
     return tb_relative_poverty
 

--- a/snapshots/wid/2023-08-24/wid_indices.do
+++ b/snapshots/wid/2023-08-24/wid_indices.do
@@ -67,6 +67,8 @@ qui wid, indicators(xlcusp) clear
 qui sum year
 global max_year = r(max)
 
+dis "Year of PPP data: $max_year"
+
 *Get ppp data to convert to USD
 wid, indicators(xlcusp) year($max_year) clear
 rename value ppp
@@ -78,7 +80,7 @@ foreach option in $options {
 	* Define different indicators and percentiles depending on the dataset
 	if `option' == 1 {
 		global indicators_gini_share sptinc gptinc sdiinc gdiinc scainc gcainc shweal ghweal
-		global percentiles p0p10 p10p20 p20p30 p30p40 p40p50 p50p60 p60p70 p70p80 p80p90 p90p100 p0p100 p99p100 p99.9p100 p99.99p100 p99.999p100
+		global percentiles p0p10 p10p20 p20p30 p30p40 p40p50 p50p60 p60p70 p70p80 p80p90 p90p100 p0p100 p0p50 p99p100 p99.9p100 p99.99p100 p99.999p100
 	}
 
 	else if `option' == 2 {
@@ -164,8 +166,11 @@ foreach option in $options {
 			rename *thweal* *thr_wealth
 
 			*Drop shares and thresholds for the entire distribution, as they do not have relevance for analysis (or they repeat other numbers from the dataset)
+			*Same for some p0p50 indicators
 			drop p0p100_share*
 			drop p0p100_thr*
+			drop p0p50_avg*
+			drop p0p50_thr*
 
 			*Define each income/wealth variable
 			local var_names pretax posttax_nat posttax_dis wealth
@@ -173,8 +178,6 @@ foreach option in $options {
 			*Calculate ratios for each variable + create a duplicate variable for median
 			* Also, generate a variable for the share between p90 and p99 and recalculate p50p90_share, because their components are more available.
 			foreach var in `var_names' {
-
-				gen p0p50_share_`var' = p0p10_share_`var' + p10p20_share_`var' + p20p30_share_`var' + p30p40_share_`var' + p40p50_share_`var'
 
 				gen palma_ratio_`var' = p90p100_share_`var' / (p0p50_share_`var' - p40p50_share_`var')
 				gen s90_s10_ratio_`var' = p90p100_share_`var' / p0p10_share_`var'


### PR DESCRIPTION
Add relative poverty measures (headcount ratio, 40, 50 and 60% of the median) by estimating 40, 50 and 60% of the median and checking that value against the closest thresholds in the newly created percentile file.