### PR TITLE
:tada: ETL --watch mode

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -3,6 +3,7 @@
 #  etl.py
 #
 
+import itertools
 import re
 import resource
 import sys
@@ -15,9 +16,17 @@ from typing import Any, Callable, Iterator, List, Optional, Set
 import click
 from ipdb import launch_ipdb_on_exception
 
-from etl import config, paths
+from etl import config, files, paths
 from etl.snapshot import snapshot_catalog
-from etl.steps import DAG, DataStep, Step, compile_steps, load_dag, select_dirty_steps
+from etl.steps import (
+    DAG,
+    DataStep,
+    GrapherStep,
+    Step,
+    compile_steps,
+    load_dag,
+    select_dirty_steps,
+)
 
 config.enable_bugsnag()
 
@@ -77,6 +86,11 @@ LIMIT_NOFILE = 4096
     help="Force strict or lax validation on DAG steps, e.g. checks for primary keys in data steps.",
     default=None,
 )
+@click.option(
+    "--watch",
+    is_flag=True,
+    help="Run ETL infinitely and update changed files.",
+)
 @click.argument("steps", nargs=-1)
 def main_cli(
     steps: List[str],
@@ -93,6 +107,7 @@ def main_cli(
     dag_path: Path = paths.DEFAULT_DAG_FILE,
     workers: int = 5,
     strict: Optional[bool] = None,
+    watch: bool = False,
 ) -> None:
     _update_open_file_limit()
 
@@ -119,14 +134,20 @@ def main_cli(
     if workers == 1:
         config.GRAPHER_INSERT_WORKERS = 1
 
-    if ipdb:
-        config.IPDB_ENABLED = True
-        config.GRAPHER_INSERT_WORKERS = 1
-        kwargs["workers"] = 1
-        with launch_ipdb_on_exception():
-            main(**kwargs)  # type: ignore
+    if watch:
+        runs = itertools.chain([None], files.watch_folder(paths.STEP_DIR))
     else:
-        main(**kwargs)  # type: ignore
+        runs = [None]
+
+    for _ in runs:
+        if ipdb:
+            config.IPDB_ENABLED = True
+            config.GRAPHER_INSERT_WORKERS = 1
+            kwargs["workers"] = 1
+            with launch_ipdb_on_exception():
+                main(**kwargs)  # type: ignore
+        else:
+            main(**kwargs)  # type: ignore
 
 
 def main(
@@ -240,6 +261,11 @@ def run_dag(
         raise ValueError(
             f"No steps matched the given input `{' '.join(includes or [])}`. Check spelling or consult `etl --help` for more options"
         )
+
+    # do not run dependencies if `only` is set by setting them to non-dirty
+    if only:
+        for step in steps:
+            _set_dependencies_to_nondirty(step)
 
     if not force:
         print("--- Detecting which steps need rebuilding...")
@@ -362,6 +388,16 @@ def _update_open_file_limit() -> None:
     soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_NOFILE)
     if soft_limit < LIMIT_NOFILE:
         resource.setrlimit(resource.RLIMIT_NOFILE, (min(LIMIT_NOFILE, hard_limit), hard_limit))
+
+
+def _set_dependencies_to_nondirty(step: Step) -> None:
+    """Set all dependencies of a step to non-dirty."""
+    if isinstance(step, DataStep):
+        for step_dep in step.dependencies:
+            step_dep.is_dirty = lambda: False
+    if isinstance(step, GrapherStep):
+        for step_dep in step.data_step.dependencies:
+            step.data_step.is_dirty = lambda: False
 
 
 if __name__ == "__main__":

--- a/etl/config.py
+++ b/etl/config.py
@@ -90,6 +90,10 @@ IPDB_ENABLED = False
 # number of workers for grapher inserts
 GRAPHER_INSERT_WORKERS = int(env.get("GRAPHER_WORKERS", 40))
 
+# only upsert indicators matching this filter, this is useful for fast development
+# of data pages for a single indicator
+GRAPHER_FILTER = env.get("GRAPHER_FILTER", None)
+
 # forbid any individual step from consuming more than this much memory
 # (only enforced on Linux)
 MAX_VIRTUAL_MEMORY_LINUX = 32 * 2**30  # 32 GB

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -11,6 +11,7 @@ Usage:
 
 import datetime
 import os
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from threading import Lock
 from typing import Dict, List, Optional, cast
@@ -291,13 +292,14 @@ def upsert_table(
         # have to if we used ORM instead
         session.commit()
 
-        # process and upload data to S3
+        # process data and metadata
         var_data = variable_data(df)
-        upload_gzip_dict(var_data, db_variable.s3_data_path(), r2=True)
-
-        # process and upload metadata to S3
         var_metadata = variable_metadata(session, db_variable_id, df)
-        upload_gzip_dict(var_metadata, db_variable.s3_metadata_path(), r2=True)
+
+        # upload them to R2
+        with ThreadPoolExecutor() as executor:
+            executor.submit(upload_gzip_dict, var_data, db_variable.s3_data_path(), r2=True)
+            executor.submit(upload_gzip_dict, var_metadata, db_variable.s3_metadata_path(), r2=True)
 
         log.info("upsert_table.uploaded_to_s3", size=len(table), variable_id=db_variable_id)
 

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -971,7 +971,8 @@ def print_tables_metadata_template(tables: List[Table]):
 
 @contextmanager
 def isolated_env(
-    working_dir: Path, keep_modules: str = r"openpyxl|pyarrow|lxml|PIL|pydantic|sqlalchemy|sqlmodel|pandas"
+    working_dir: Path,
+    keep_modules: str = r"openpyxl|pyarrow|lxml|PIL|pydantic|sqlalchemy|sqlmodel|pandas|frictionless|numpy",
 ) -> Generator[None, None, None]:
     """Add given directory to pythonpath, run code in context, and
     then remove from pythonpath and unimport modules imported in context.

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -197,6 +197,7 @@ def parse_step(step_name: str, dag: Dict[str, Any]) -> "Step":
     parts = urlparse(step_name)
     step_type = parts.scheme
     path = parts.netloc + parts.path
+    # dependencies are new objects
     dependencies = [parse_step(s, dag) for s in dag.get(step_name, [])]
 
     step: Step
@@ -764,6 +765,10 @@ class GrapherStep(Step):
             # is fetching the whole dataset from data-api as they would receive all tables merged in a single
             # table. This won't be a problem after we introduce the concept of "tables"
             for table in dataset:
+                # if GRAPHER_FILTER is set, only upsert matching columns
+                if config.GRAPHER_FILTER:
+                    table = table.loc[:, table.filter(regex=config.GRAPHER_FILTER).columns]
+
                 catalog_path = f"{self.path}/{table.metadata.short_name}"
 
                 table = gh._adapt_table_for_grapher(table)
@@ -782,7 +787,8 @@ class GrapherStep(Step):
 
             variable_upsert_results = [future.result() for future in concurrent.futures.as_completed(futures)]
 
-        self._cleanup_ghost_resources(dataset_upsert_results, variable_upsert_results)
+        if not config.GRAPHER_FILTER:
+            self._cleanup_ghost_resources(dataset_upsert_results, variable_upsert_results)
 
         # set checksum and updatedAt timestamps after all data got inserted
         gi.set_dataset_checksum_and_editedAt(dataset_upsert_results.dataset_id, self.data_step.checksum_input())

--- a/schemas/snapshot-schema.json
+++ b/schemas/snapshot-schema.json
@@ -65,6 +65,9 @@
         },
         "license": {
           "$ref": "definitions.json#/license"
+        },
+        "source": {
+          "$ref": "definitions.json#/source"
         }
       }
     },

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -31,6 +31,6 @@ b: One-liner
 c:
   nested:
     d:
-    - line
+      - line
 """
     )


### PR DESCRIPTION
* Add `etl --watch` that constantly scans for changes to files and rebuilds datasets
* Add `GRAPHER_FILTER` for filtering which indicators to upsert (useful when working on a single indicator from large dataset)
* Fix behaviour of `--only` flag to run ONLY the steps matching pattern and not their dependencies
* Improve performance of grapher upserts
* Fix indentation of saved YAML files

Let's say that you work on metadata for variable `ahdi` from dataset `ahdi/2023-09-08/augmented_hdi`. You open the data page on your staging server and run
```
GRAPHER_FILTER=ahdi ENV=.env.mojmir etl ahdi/2023-09-08/augmented_hdi --grapher --watch
```
which constantly watches changes you make and updates the data page in about 6s (you have to refresh it manually).