### PR TITLE
:tada: flatten description key

### DIFF
--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -478,6 +478,12 @@ class Table(pd.DataFrame):
                     else:
                         setattr(self[v_short_name].metadata, k, v)
 
+                    # we allow `- *descriptions` which needs to be flattened
+                    if k == "description_key":
+                        self[v_short_name].metadata.description_key = _flatten(
+                            self[v_short_name].metadata.description_key
+                        )
+
         # update table attributes
         for k, v in t_annot.items():
             if k != "variables":
@@ -1419,3 +1425,8 @@ def check_all_variables_have_metadata(tables: List[Table], fields: Optional[List
             for field in fields:
                 if not getattr(table[column].metadata, field):
                     log.warning(f"Table {table_name}, column {column} has no {field}.")
+
+
+def _flatten(lst: List[Any]) -> List[str]:
+    """Flatten list that contains either strings or lists."""
+    return [item for sublist in lst for item in ([sublist] if isinstance(sublist, str) else sublist)]

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -97,6 +97,31 @@ def test_saving_empty_table_fails():
         t.to_feather("/tmp/example.feather")
 
 
+def test_update_metadata_from_yaml(tmp_path):
+    yaml_text = """
+description_key_common: &description_key_common
+- &text_1 Text 1
+- &text_2 Text 2
+
+tables:
+  test:
+    variables:
+      a:
+        description_key:
+          - *description_key_common
+          - *text_2
+          - Text 3
+""".strip()
+
+    path = tmp_path / "test.yaml"
+    with open(path, "w") as f:
+        f.write(yaml_text)
+
+    t = Table({"a": [1, 2, 3]})
+    t.update_metadata_from_yaml(path, "test")
+    assert t.a.metadata.description_key == ["Text 1", "Text 2", "Text 2", "Text 3"]
+
+
 # The parametrize decorator runs this test multiple times with different formats
 @pytest.mark.parametrize("format", ["csv", "feather", "parquet"])
 def test_round_trip_no_metadata(format: FileFormat) -> None:


### PR DESCRIPTION
Make it possible to use
```
description_key_common: &description_key_common
- &text_1 Text 1
- &text_2 Text 2
tables:
  test:
    variables:
      a:
        description_key:
          - *description_key_common
          - *text_2
          - Text 3
```