### PR TITLE
✨ 

### DIFF
--- a/apps/wizard/templating/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}.dvc
+++ b/apps/wizard/templating/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}.dvc
@@ -1,0 +1,55 @@
+meta:
+  origin:
+    # Data product / Snapshot
+    title: {{cookiecutter.title}}
+    {%- if cookiecutter.description %}
+    description: |-
+      {{cookiecutter.description.replace("\n", "\n      ")}}
+    {%- endif %}
+    date_published: {{cookiecutter.date_published}}
+    {%- if cookiecutter.origin_version %}
+    version_producer: {{cookiecutter.origin_version}}
+    {%- endif %}
+    title_snapshot: {{cookiecutter.title_snapshot}}
+    {%- if cookiecutter.description_snapshot %}
+    description_snapshot: |-
+      {{cookiecutter.description_snapshot.replace("\n", "\n      ")}}
+    {%- endif %}
+
+    # Citation
+    producer: {{cookiecutter.producer}}
+    citation_full: {{cookiecutter.citation_full}}
+    {%- if cookiecutter.attribution %}
+    attribution: {{cookiecutter.attribution}}
+    {%- endif %}
+    {%- if cookiecutter.attribution_short %}
+    attribution_short: {{cookiecutter.attribution_short}}
+    {%- endif %}
+
+    # Files
+    url_main: {{cookiecutter.url_main}}
+    {%- if cookiecutter.url_download %}
+    url_download: {{cookiecutter.url_download}}
+    {%- endif %}
+    date_accessed: {{cookiecutter.date_accessed}}
+
+    # License
+    license:
+      {%- if cookiecutter.license_url %}
+      url: {{cookiecutter.license_url}}
+      {%- endif -%}
+      {%- if cookiecutter.license_name %}
+      name: {{cookiecutter.license_name}}
+      {%- endif -%}
+
+  # License (same as origin.license, for backwards compatibility)
+  license:
+    {%- if cookiecutter.license_url %}
+    url: {{cookiecutter.license_url}}
+    {%- endif -%}
+    {%- if cookiecutter.license_name %}
+    name: {{cookiecutter.license_name}}
+    {%- endif -%}
+  {% if cookiecutter.is_private == "True" %}
+  is_public: false
+  {%- endif -%}

--- a/apps/wizard/templating/snapshot.py
+++ b/apps/wizard/templating/snapshot.py
@@ -572,7 +572,7 @@ if submitted:
         meta_path = (
             SNAPSHOTS_DIR / form.namespace / form.snapshot_version / f"{form.short_name}.{form.file_extension}.dvc"
         )
-        form.to_yaml(meta_path)
+        # form.to_yaml(meta_path)
 
         # Display next steps
         if form.dataset_manual_import:

--- a/apps/wizard/templating/snapshot.py
+++ b/apps/wizard/templating/snapshot.py
@@ -136,7 +136,7 @@ class SnapshotForm(utils.StepForm):
                     "citation_full": self.citation_full,
                     "attribution": self.attribution,
                     "attribution_short": self.attribution_short,
-                    "version": self.origin_version,
+                    "version_producer": self.origin_version,
                     "url_main": self.url_main,
                     "url_download": self.url_download,
                     "date_published": self.date_published,

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -151,8 +151,8 @@
     "required": [
       "title",
       "date_published",
-      "citation_full",
       "producer",
+      "citation_full",
       "url_main",
       "date_accessed"
     ],
@@ -359,6 +359,13 @@
               ]
             }
           ]
+        ],
+        "faqs": [
+          {
+            "question": "What should be the value if there are multiple producers?",
+            "answer": "We don't have a clear guideline for this at the moment, and depending on the case you might want to specify all the producers. However, a good option is to use 'Various sources'.",
+            "link": "https://github.com/owid/etl/discussions/1608"
+          }
         ],
         "category": "citation"
       },


### PR DESCRIPTION
- Improve error messages
  - There was a bug in the error message for missing required fields.
  - With this bug, the error message for a missing required field was always referencing a particular field name, even if the missing field was another one.
- Added FAQs section for `origin.producer`, based on https://github.com/owid/etl/discussions/1608.
- Create metadata in snapshot using cookie-cutter instead of exporting form as YAML in python. This way, we can add comments, and make sure that string fields look nicer (e.g. use `|>`).