### PR TITLE
:sparkles: discourage use of variable.licenses

### DIFF
--- a/apps/walkthrough/garden.py
+++ b/apps/walkthrough/garden.py
@@ -242,7 +242,6 @@ def _fill_dummy_metadata_yaml(metadata_path: Path) -> None:
         variable_meta = {
             "title": "Dummy",
             "description": "This is a dummy indicator with full metadata.",
-            "licenses": [],
             "unit": "Dummy unit",
             "short_unit": "Du",
             "display": {

--- a/apps/wizard/templating/garden.py
+++ b/apps/wizard/templating/garden.py
@@ -33,6 +33,7 @@ dummy_values = {
     "meadow_version": utils.DATE_TODAY,
 }
 
+
 #########################################################
 # FUNCTIONS & CLASSES ###################################
 #########################################################
@@ -116,7 +117,6 @@ def _fill_dummy_metadata_yaml(metadata_path: Path) -> None:
     variable_meta = {
         "title": "Dummy",
         "description": "This is a dummy indicator with full metadata.",
-        "licenses": [],
         "unit": "Dummy unit",
         "short_unit": "Du",
         "display": {

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -834,7 +834,9 @@ class Variable(SQLModel, table=True):
     descriptionFromProducer: Optional[str] = Field(default=None, sa_column=Column("descriptionFromProducer", LONGTEXT))
     descriptionKey: Optional[List[str]] = Field(default=None, sa_column=Column("descriptionKey", JSON))
     descriptionProcessing: Optional[str] = Field(default=None, sa_column=Column("descriptionProcessing", LONGTEXT))
+    # NOTE: Use of `licenses` is discouraged, they should be captured in origins.
     licenses: Optional[List[dict]] = Field(default=None, sa_column=Column("licenses", JSON))
+    # NOTE: License should be the resulting license, given all licenses of the indicator’s origins and given the indicator’s processing level.
     license: Optional[dict] = Field(default=None, sa_column=Column("license", JSON))
 
     datasets: Optional["Dataset"] = Relationship(back_populates="variables")

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -247,6 +247,7 @@ class VariableMeta:
     # List of bullet points for the description key (can use markdown formatting)
     description_key: List[str] = field(default_factory=list)
     origins: List[Origin] = field(default_factory=list)  # Origins is the new replacement for sources
+    # Use of `licenses` is discouraged, they should be captured in origins.
     licenses: List[License] = field(default_factory=list)
     unit: Optional[str] = None
     short_unit: Optional[str] = None

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -1420,7 +1420,7 @@ def combine_tables_metadata(tables: List[Table], short_name: Optional[str] = Non
 
 def check_all_variables_have_metadata(tables: List[Table], fields: Optional[List[str]] = None) -> None:
     if fields is None:
-        fields = ["origins", "licenses"]
+        fields = ["origins"]
 
     for table in tables:
         table_name = table.metadata.short_name

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -717,13 +717,6 @@
                     "$ref": "definitions.json#/origin"
                   }
                 },
-                "licenses": {
-                  "type": "array",
-                  "description": "List of all licenses that have been involved in the processing history of the indicator. Automatically filled.",
-                  "items": {
-                    "$ref": "definitions.json#/license"
-                  }
-                },
                 "display": {
                   "$ref": "definitions.json#/display"
                 },

--- a/schemas/snapshot-schema.json
+++ b/schemas/snapshot-schema.json
@@ -63,9 +63,6 @@
         "origin": {
           "$ref": "definitions.json#/origin"
         },
-        "license": {
-          "$ref": "definitions.json#/license"
-        },
         "source": {
           "$ref": "definitions.json#/source"
         }


### PR DESCRIPTION
Don't raise a warning when `variable.licenses` is missing. Using `origin.license` is preferred. Also show linter error in YAML files when the field is present.