### PR TITLE
🐛 wizard: remove licenses field

### DIFF
--- a/apps/wizard/templating/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}.dvc
+++ b/apps/wizard/templating/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}.dvc
@@ -44,12 +44,6 @@ meta:
       url: {{cookiecutter.license_url}}
       {%- endif %}
 
-  # License (same as origin.license, for backwards compatibility)
-  license:
-    name: {{cookiecutter.license_name}}
-    {%- if cookiecutter.license_url %}
-    url: {{cookiecutter.license_url}}
-    {%- endif %}
   {% if cookiecutter.is_private == "True" %}
   is_public: false
   {%- endif -%}

--- a/apps/wizard/templating/snapshot.py
+++ b/apps/wizard/templating/snapshot.py
@@ -163,7 +163,6 @@ class SnapshotForm(utils.StepForm):
                     "date_accessed": self.date_accessed,
                     "license": license_field,
                 },
-                "license": license_field,
                 "is_public": not self.is_private,
             }
         }


### PR DESCRIPTION
Remove `licenses` from `$.meta`.

This complements https://github.com/owid/etl/pull/1638, and fixes the wizard bug:

```
File "/home/lucas/repos/etl/.venv/lib/python3.10/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 548, in _run_script
    self._session_state.on_script_will_rerun(rerun_data.widget_states)
File "/home/lucas/repos/etl/.venv/lib/python3.10/site-packages/streamlit/runtime/state/safe_session_state.py", line 68, in on_script_will_rerun
    self._state.on_script_will_rerun(latest_widget_states)
File "/home/lucas/repos/etl/.venv/lib/python3.10/site-packages/streamlit/runtime/state/session_state.py", line 486, in on_script_will_rerun
    self._call_callbacks()
File "/home/lucas/repos/etl/.venv/lib/python3.10/site-packages/streamlit/runtime/state/session_state.py", line 499, in _call_callbacks
    self._new_widget_state.call_callback(wid)
File "/home/lucas/repos/etl/.venv/lib/python3.10/site-packages/streamlit/runtime/state/session_state.py", line 251, in call_callback
    callback(*args, **kwargs)
File "/home/lucas/repos/etl/apps/wizard/templating/snapshot.py", line 526, in update_state
    form = SnapshotForm.from_state()
File "/home/lucas/repos/etl/apps/wizard/utils.py", line 391, in from_state
    return cls(**data)
File "/home/lucas/repos/etl/apps/wizard/templating/snapshot.py", line 116, in __init__
    super().__init__(**data)
File "/home/lucas/repos/etl/apps/wizard/utils.py", line 378, in __init__
    self.validate()
File "/home/lucas/repos/etl/apps/wizard/templating/snapshot.py", line 126, in validate
    self.validate_schema(SNAPSHOT_SCHEMA, ["meta"])
File "/home/lucas/repos/etl/apps/wizard/utils.py", line 424, in validate_schema
    raise Exception(f"Unknown error type {error_type} with message '{error.message}'")
```