### PR TITLE
✨ wizard: minor enhancements

### DIFF
--- a/apps/wizard/templating/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}.dvc
+++ b/apps/wizard/templating/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}.dvc
@@ -22,7 +22,8 @@ meta:
 
     # Citation
     producer: {{cookiecutter.producer}}
-    citation_full: {{cookiecutter.citation_full}}
+    citation_full: |-
+      {{cookiecutter.citation_full}}
     {%- if cookiecutter.attribution %}
     attribution: {{cookiecutter.attribution}}
     {%- endif %}

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -257,7 +257,7 @@
         "category": "dataset"
       },
       "version_producer": {
-        "type": "string",
+        "type": ["string", "number"],
         "title": "Version of the data product as given by the producer",
         "description": "Producer's version of the data product.",
         "requirement_level": "recommended (if existing)",


### PR DESCRIPTION
- Use `|-` for `citation_full` in `origin` metadata template. This prevents weird errors (e.g. when citation full contains `:`).
- Accept numeric values for `version_producer`. Sometimes the version might just be a number (e.g. `3.2`) or a year (`2016`). Let's accept these and stop showing error messages when this is the case.