### PR TITLE
:hammer: remove etl-metadata-export from wizard instructions

### DIFF
--- a/apps/wizard/templating/garden.py
+++ b/apps/wizard/templating/garden.py
@@ -345,25 +345,11 @@ if submitted:
 
         2. (Optional) Generated notebook `{notebook_path.relative_to(BASE_DIR)}` can be used to examine the dataset output interactively.
 
-        3. (Optional) Generate metadata file `{form.short_name}.meta.yml` from your dataset with
+        3. (Optional) You can manually move steps from `dag/walkthrough.yml` to some other `dag/*.yml` if you feel like it belongs there. After you are happy with your code, run `make test` to find any issues.
 
-            ```
-            poetry run etl-metadata-export data/garden/{form.namespace}/{form.version}/{form.short_name} -o etl/steps/data/garden/{form.namespace}/{form.version}/{form.short_name}.meta.yml
-            ```
+        4. Create a pull request in [ETL](https://github.com/owid/etl), get it reviewed and merged.
 
-            then manual edit it and rerun the step again with
-
-            ```
-            poetry run etl data{private_suffix}://garden/{form.namespace}/{form.version}/{form.short_name} {"--private" if form.is_private else ""}
-            ```
-
-            Note that metadata is inherited from previous step (snapshot) and you don't have to repeat it.
-
-        4. (Optional) You can manually move steps from `dag/walkthrough.yml` to some other `dag/*.yml` if you feel like it belongs there. After you are happy with your code, run `make test` to find any issues.
-
-        5. Create a pull request in [ETL](https://github.com/owid/etl), get it reviewed and merged.
-
-        6. (Optional) Once your changes are merged, your steps will be run automatically by our server and published to the OWID catalog. Then it can be loaded by anyone using:
+        5. (Optional) Once your changes are merged, your steps will be run automatically by our server and published to the OWID catalog. Then it can be loaded by anyone using:
 
             ```python
             from owid.catalog import find_one
@@ -372,7 +358,7 @@ if submitted:
             print(tab.head())
             ```
 
-        7. If you are an internal OWID member and want to push data to our Grapher DB, continue to the grapher step or to explorers step.
+        6. If you are an internal OWID member and want to push data to our Grapher DB, continue to the grapher step or to explorers step.
         """
             )
 


### PR DESCRIPTION
Generating YAML metadata with `etl-metadata-export ...` isn't needed anymore now that wizard generates reasonable YAML file and we don't have to repeat metadata in the garden step.

I removed the optional instruction to run `etl-metadata-export` and also fixed the function in case anyone uses it to prune fields like `origins` or `licenses` that aren't useful anymore.