### PR TITLE
:hammer: migrate JSON Data Page - Per capita consumption-based CO₂ emissions

### DIFF
--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -486,7 +486,7 @@ def _adapt_table_for_grapher(
 
     table = table.set_index(["entity_id", "year"] + dim_names)
 
-    # Add dataset origins to variables if they don't have an origin.
+    # Append dataset origins to all variables
     # TODO: In the future, all variables should have their origins and dataset origins will be union of their origins.
     table = _add_dataset_origins_to_variables(table)
 
@@ -499,10 +499,15 @@ def _adapt_table_for_grapher(
 
 def _add_dataset_origins_to_variables(table: catalog.Table) -> catalog.Table:
     assert table.metadata.dataset
+    if not table.metadata.dataset.origins:
+        return table
+
     for col in table.columns:
         variable_meta = table[col].metadata
-        if not variable_meta.origins:
-            variable_meta.origins = table.metadata.dataset.origins
+        for origin in table.metadata.dataset.origins:
+            if origin not in variable_meta.origins:
+                variable_meta.origins.append(origin)
+
     return table
 
 

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -182,6 +182,7 @@ class Tag(SQLModel, table=True):
     isBulkImport: int = Field(sa_column=Column("isBulkImport", TINYINT(1), nullable=False, server_default=text("'0'")))
     parentId: Optional[int] = Field(default=None, sa_column=Column("parentId", Integer))
     specialType: Optional[str] = Field(default=None, sa_column=Column("specialType", String(255, "utf8mb4_0900_as_cs")))
+    isTopic: int = Field(sa_column=Column("isTopic", TINYINT(1), nullable=False, server_default=text("'0'")))
 
     post: List["Posts"] = Relationship(back_populates="tag")
     tags: Optional["Tag"] = Relationship(back_populates="tags_reverse")
@@ -1088,7 +1089,7 @@ class Variable(SQLModel, table=True):
 
         # establish relationships between variables and tags
         # get tags by their name
-        tags = session.exec(select(Tag).where(Tag.name.in_(tag_names))).all()  # type: ignore
+        tags = session.exec(select(Tag).where(Tag.name.in_(tag_names), Tag.isTopic == 1)).all()  # type: ignore
 
         # raise a warning if some tags were not found
         if len(tags) != len(tag_names):

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -19,6 +19,7 @@ import yaml
 from owid import catalog
 from owid.catalog import CHANNEL, DatasetMeta, Table
 from owid.catalog.datasets import DEFAULT_FORMATS, FileFormat
+from owid.catalog.meta import SOURCE_EXISTS_OPTIONS
 from owid.catalog.tables import (
     combine_tables_description,
     combine_tables_title,
@@ -105,6 +106,7 @@ def create_dataset(
     formats: List[FileFormat] = DEFAULT_FORMATS,
     check_variables_metadata: bool = False,
     run_grapher_checks: bool = True,
+    if_origins_exist: SOURCE_EXISTS_OPTIONS = "replace",
 ) -> catalog.Dataset:
     """Create a dataset and add a list of tables. The dataset metadata is inferred from
     default_metadata and the dest_dir (which is in the form `channel/namespace/version/short_name`).
@@ -121,6 +123,7 @@ def create_dataset(
     :param camel_to_snake: Whether to convert camel case to snake case for the table name.
     :param check_variables_metadata: Check that all variables in tables have metadata; raise a warning otherwise.
     :param run_grapher_checks: Run grapher checks on the dataset, only applies to grapher channel.
+    :param if_origins_exist: What to do if origins already exist in the dataset metadata.
 
     Usage:
         ds = create_dataset(dest_dir, [table_a, table_b], default_metadata=snap.metadata)
@@ -187,7 +190,7 @@ def create_dataset(
     else:
         N = PathFinder(str(paths.STEP_DIR / "data" / Path(dest_dir).relative_to(Path(dest_dir).parents[3])))
     if N.metadata_path.exists():
-        ds.update_metadata(N.metadata_path)
+        ds.update_metadata(N.metadata_path, if_origins_exist=if_origins_exist)
 
         # check that we are not using metadata inconsistent with path
         for k, v in match.groupdict().items():

--- a/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.meta.yml
+++ b/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.meta.yml
@@ -1,68 +1,45 @@
 dataset:
   update_period_days: 365
 
-# TODO: we need combined population origin here
 origins: &origins
   - producer: Global Carbon Project
     title: Global Carbon Budget
-    # TODO: newlines are not rendered properly
-    description: |-
-      _The Global Carbon Budget 2022 has over 105 contributors from 80 organisations and 18 countries. It was founded by the Global Carbon Project international science team to track the trends in global carbon emissions and sinks and is a key measure of progress towards the goals of the Paris Agreement. It’s widely recognised as the most comprehensive report of its kind. The 2022 report was published at COP27 in Egypt on Friday 11th November._
-
-
-      Text from [Global Carbon Budget website](https://globalcarbonbudget.org/carbonbudget/)
-
-
-      The dataset is available at [https://globalcarbonbudget.org/archive/](https://globalcarbonbudget.org/archive/).
-
-
-      Documentation of the dataset can be found in P. Friedlingstein et al., Global Carbon Budget 2022, Earth Syst. Sci. Data, 14, 4811-4900, 2022: [https://doi.org/10.5194/essd-14-4811-2022](https://doi.org/10.5194/essd-14-4811-2022).
-    citation_full: 'Friedlingstein, P., O''Sullivan, M., Jones, M. W., Andrew, R. M., Gregor, L., Hauck, J., Le Quéré,
-      C., Luijkx, I. T., Olsen, A., Peters, G. P., Peters, W., Pongratz, J., Schwingshackl, C., Sitch, S., Canadell, J. G.,
-      Ciais, P., Jackson, R. B., Alin, S. R., Alkama, R., Arneth, A., Arora, V. K., Bates, N. R., Becker, M., Bellouin, N.,
-      Bittig, H. C., Bopp, L., Chevallier, F., Chini, L. P., Cronin, M., Evans, W., Falk, S., Feely, R. A., Gasser, T., Gehlen,
-      M., Gkritzalis, T., Gloege, L., Grassi, G., Gruber, N., Gürses, Ö., Harris, I., Hefner, M., Houghton, R. A., Hurtt,
-      G. C., Iida, Y., Ilyina, T., Jain, A. K., Jersild, A., Kadono, K., Kato, E., Kennedy, D., Klein Goldewijk, K., Knauer,
-      J., Korsbakken, J. I., Landschützer, P., Lefèvre, N., Lindsay, K., Liu, J., Liu, Z., Marland, G., Mayot, N., McGrath,
-      M. J., Metzl, N., Monacci, N. M., Munro, D. R., Nakaoka, S.-I., Niwa, Y., O''Brien, K., Ono, T., Palmer, P. I., Pan,
-      N., Pierrot, D., Pocock, K., Poulter, B., Resplandy, L., Robertson, E., Rödenbeck, C., Rodriguez, C., Rosan, T. M.,
-      Schwinger, J., Séférian, R., Shutler, J. D., Skjelvan, I., Steinhoff, T., Sun, Q., Sutton, A. J., Sweeney, C., Takao,
-      S., Tanhua, T., Tans, P. P., Tian, X., Tian, H., Tilbrook, B., Tsujino, H., Tubiello, F., van der Werf, G. R., Walker,
-      A. P., Wanninkhof, R., Whitehead, C., Willstrand Wranne, A., Wright, R., Yuan, W., Yue, C., Yue, X., Zaehle, S., Zeng,
-      J., and Zheng, B.: Global Carbon Budget 2022, Earth Syst. Sci. Data, 14, 4811-4900, https://doi.org/10.5194/essd-14-4811-2022,
-      2022.'
+    description: |
+      The Global Carbon Budget 2022 has over 105 contributors from 80 organizations and 18 countries. It was founded by the Global Carbon Project international science team to track the trends in global carbon emissions and sinks and is a key measure of progress towards the goals of the Paris Agreement. It's widely recognized as the most comprehensive report of its kind. The 2022 report was published at COP27 in Egypt on Friday 11th November.
+    citation_full: |
+      Friedlingstein, P., O'Sullivan, M., Jones, M. W., Andrew, R. M., Gregor, L., Hauck, J., Le Quéré, C., Luijkx, I. T., Olsen, A., Peters, G. P., Peters, W., Pongratz, J., Schwingshackl, C., Sitch, S., Canadell, J. G., Ciais, P., Jackson, R. B., Alin, S. R., Alkama, R., Arneth, A., Arora, V. K., Bates, N. R., Becker, M., Bellouin, N., Bittig, H. C., Bopp, L., Chevallier, F., Chini, L. P., Cronin, M., Evans, W., Falk, S., Feely, R. A., Gasser, T., Gehlen, M., Gkritzalis, T., Gloege, L., Grassi, G., Gruber, N., Gürses, Ö., Harris, I., Hefner, M., Houghton, R. A., Hurtt, G. C., Iida, Y., Ilyina, T., Jain, A. K., Jersild, A., Kadono, K., Kato, E., Kennedy, D., Klein Goldewijk, K., Knauer, J., Korsbakken, J. I., Landschützer, P., Lefèvre, N., Lindsay, K., Liu, J., Liu, Z., Marland, G., Mayot, N., McGrath, M. J., Metzl, N., Monacci, N. M., Munro, D. R., Nakaoka, S.-I., Niwa, Y., O'Brien, K., Ono, T., Palmer, P. I., Pan, N., Pierrot, D., Pocock, K., Poulter, B., Resplandy, L., Robertson, E., Rödenbeck, C., Rodriguez, C., Rosan, T. M.,
+      Schwinger, J., Séférian, R., Shutler, J. D., Skjelvan, I., Steinhoff, T., Sun, Q., Sutton, A. J., Sweeney, C., Takao, S., Tanhua, T., Tans, P. P., Tian, X., Tian, H., Tilbrook, B., Tsujino, H., Tubiello, F., van der Werf, G. R., Walker, A. P., Wanninkhof, R., Whitehead, C., Willstrand Wranne, A., Wright, R., Yuan, W., Yue, C., Yue, X., Zaehle, S., Zeng, J., and Zheng, B.: Global Carbon Budget 2022, Earth Syst. Sci. Data, 14, 4811-4900, https://doi.org/10.5194/essd-14-4811-2022,
+      2022.
     url_main: https://globalcarbonbudget.org/
-    # TODO: should we put actual CSV with data there or https://globalcarbonbudget.org/carbonbudget/?
     url_download: https://zenodo.org/record/7215364/files/GCB2022v27_MtCO2_flat.csv
     date_accessed: '2023-04-28'
     date_published: '2022-11-11'
     license:
       name: CC BY 4.0
       url: https://zenodo.org/record/7215364
-datasets:
-  update_period_days: 90
+
 tables:
   global_carbon_budget:
     variables:
       consumption_emissions_per_capita:
-        unit: tonnes per capita
-        # TODO: shouldn't we rename title to `Per capita consumption-based CO₂ emissions`?
-        title: Annual consumption-based CO₂ emissions (per capita)
-        description_short: Annual consumption-based emissions of carbon dioxide (CO₂), measured in tonnes per person. Consumption-based
-          emissions are national or regional emissions which have been adjusted for trade (i.e. territorial/production emissions
-          minus emissions embedded in exports, plus emissions embedded in imports). If a country's consumption-based emissions
-          are higher than its production emissions it is a net importer of carbon dioxide. Consumption-based CO₂ emissions
-          have been converted by Our World in Data from tonnes of carbon to tonnes of CO₂ using a conversion factor of 3.664.
-        short_unit: t
+        unit: tonnes per person
+        short_unit: t/person
+        title: Per capita consumption-based CO₂ emissions
+        description_short: |
+          Annual consumption-based emissions of carbon dioxide (CO₂), measured in tonnes per person.
+        description_processing: |
+          Consumption-based CO₂ emissions have been converted by Our World in Data from tonnes of carbon to tonnes of CO₂ using a conversion factor of 3.664.
         display:
+          shortUnit: t
           numDecimalPlaces: 0
         description_key:
           - Consumption-based emissions attribute the emissions generated in the production of goods and services according to where they were _consumed_, rather than where they were _produced_.
-          - "The data is calculated by adjusting ‘production-based’ emissions (emissions produced domestically) for trade: Consumption-based emissions equals production-based emissions, _minus_ emissions embedded in exports, _plus_ emissions embedded in imports. If a country's consumption-based emissions are higher than its production emissions it is a net importer of carbon dioxide. If its consumption-based emissions are lower, then it is a net exporter."
-          - Per capita emissions represent the emissions of an average person in a country or region – they are total emissions divided by population.
+          - "The data is calculated by adjusting 'production-based' emissions (emissions produced domestically) for trade: Consumption-based emissions equals production-based emissions, _minus_ emissions embedded in exports, _plus_ emissions embedded in imports."
+          - If a country's consumption-based emissions are higher than its production emissions it is a net importer of carbon dioxide. If its consumption-based emissions are lower, then it is a net exporter.
+          - Per capita emissions represent the emissions of an average person in a country or region - they are total emissions divided by population.
           - Consumption-based emissions are not available for all countries because not all countries have sufficient, high-quality trade data. But those without complete data are a small fraction (3%) of the global total.
           - This data measures Carbon dioxide (CO₂) emissions from fossil fuels and industry and does not include emissions from land use change, deforestation, soils, or vegetation.
-          - Emissions from international aviation and shipping are not included in any country or region’s emissions. They are only included in the global total emissions.
+          - Emissions from international aviation and shipping are not included in any country or region's emissions. They are only included in the global total emissions.
         presentation:
           title_public: Per capita consumption-based CO₂ emissions
           attribution_short: Global Carbon Project
@@ -75,10 +52,7 @@ tables:
             gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
           - fragment_id: missing-consumption-based-emissions
             gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
-          # NOTE: copied from http://staging-site-mojmir/admin/charts/3488/edit
           grapher_config:
-            # TODO: slug does not make sense in grapher_config, right?
-            slug: consumption-co2-per-capita
             title: Per capita consumption-based CO₂ emissions
             subtitle: >-
               [Consumption-based emissions](#dod:consumptionbasedemissions) are national

--- a/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.meta.yml
+++ b/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.meta.yml
@@ -76,6 +76,7 @@ tables:
               colorScale:
                 baseColorScheme: Reds
                 binningStrategy: manual
+                # TODO: these intervals are not well chosen according to our map bracket guidelines
                 customNumericValues:
                   - 1
                   - 2.5

--- a/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.meta.yml
+++ b/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.meta.yml
@@ -1,5 +1,5 @@
 dataset:
-  update_period_days: 90
+  update_period_days: 365
   sources: []
   origins:
   - producer: Global Carbon Project
@@ -52,7 +52,6 @@ tables:
               gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
             - fragment_id: missing-consumption-based-emissions
               gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
-          # NOTE: copied from http://staging-site-mojmir/admin/charts/3488/edit
           grapher_config:
             title: Per capita consumption-based CO₂ emissions
             subtitle: >-

--- a/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.meta.yml
+++ b/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.meta.yml
@@ -1,7 +1,7 @@
 dataset:
-  update_period_days: 365
-
-origins: &origins
+  update_period_days: 90
+  sources: []
+  origins:
   - producer: Global Carbon Project
     title: Global Carbon Budget
     description: |
@@ -48,10 +48,11 @@ tables:
             - Climate Change
             - Energy
           faqs:
-          - fragment_id: emissions-from-aviation-and-shipping
-            gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
-          - fragment_id: missing-consumption-based-emissions
-            gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+            - fragment_id: emissions-from-aviation-and-shipping
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+            - fragment_id: missing-consumption-based-emissions
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          # NOTE: copied from http://staging-site-mojmir/admin/charts/3488/edit
           grapher_config:
             title: Per capita consumption-based CO₂ emissions
             subtitle: >-
@@ -100,6 +101,3 @@ tables:
             relatedQuestions:
               - url: https://ourworldindata.org/grapher/consumption-co2-per-capita#faqs
                 text: FAQs on this data
-
-        sources: []
-        origins: *origins

--- a/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.meta.yml
+++ b/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.meta.yml
@@ -1,0 +1,131 @@
+dataset:
+  update_period_days: 365
+
+# TODO: we need combined population origin here
+origins: &origins
+  - producer: Global Carbon Project
+    title: Global Carbon Budget
+    # TODO: newlines are not rendered properly
+    description: |-
+      _The Global Carbon Budget 2022 has over 105 contributors from 80 organisations and 18 countries. It was founded by the Global Carbon Project international science team to track the trends in global carbon emissions and sinks and is a key measure of progress towards the goals of the Paris Agreement. It’s widely recognised as the most comprehensive report of its kind. The 2022 report was published at COP27 in Egypt on Friday 11th November._
+
+
+      Text from [Global Carbon Budget website](https://globalcarbonbudget.org/carbonbudget/)
+
+
+      The dataset is available at [https://globalcarbonbudget.org/archive/](https://globalcarbonbudget.org/archive/).
+
+
+      Documentation of the dataset can be found in P. Friedlingstein et al., Global Carbon Budget 2022, Earth Syst. Sci. Data, 14, 4811-4900, 2022: [https://doi.org/10.5194/essd-14-4811-2022](https://doi.org/10.5194/essd-14-4811-2022).
+    citation_full: 'Friedlingstein, P., O''Sullivan, M., Jones, M. W., Andrew, R. M., Gregor, L., Hauck, J., Le Quéré,
+      C., Luijkx, I. T., Olsen, A., Peters, G. P., Peters, W., Pongratz, J., Schwingshackl, C., Sitch, S., Canadell, J. G.,
+      Ciais, P., Jackson, R. B., Alin, S. R., Alkama, R., Arneth, A., Arora, V. K., Bates, N. R., Becker, M., Bellouin, N.,
+      Bittig, H. C., Bopp, L., Chevallier, F., Chini, L. P., Cronin, M., Evans, W., Falk, S., Feely, R. A., Gasser, T., Gehlen,
+      M., Gkritzalis, T., Gloege, L., Grassi, G., Gruber, N., Gürses, Ö., Harris, I., Hefner, M., Houghton, R. A., Hurtt,
+      G. C., Iida, Y., Ilyina, T., Jain, A. K., Jersild, A., Kadono, K., Kato, E., Kennedy, D., Klein Goldewijk, K., Knauer,
+      J., Korsbakken, J. I., Landschützer, P., Lefèvre, N., Lindsay, K., Liu, J., Liu, Z., Marland, G., Mayot, N., McGrath,
+      M. J., Metzl, N., Monacci, N. M., Munro, D. R., Nakaoka, S.-I., Niwa, Y., O''Brien, K., Ono, T., Palmer, P. I., Pan,
+      N., Pierrot, D., Pocock, K., Poulter, B., Resplandy, L., Robertson, E., Rödenbeck, C., Rodriguez, C., Rosan, T. M.,
+      Schwinger, J., Séférian, R., Shutler, J. D., Skjelvan, I., Steinhoff, T., Sun, Q., Sutton, A. J., Sweeney, C., Takao,
+      S., Tanhua, T., Tans, P. P., Tian, X., Tian, H., Tilbrook, B., Tsujino, H., Tubiello, F., van der Werf, G. R., Walker,
+      A. P., Wanninkhof, R., Whitehead, C., Willstrand Wranne, A., Wright, R., Yuan, W., Yue, C., Yue, X., Zaehle, S., Zeng,
+      J., and Zheng, B.: Global Carbon Budget 2022, Earth Syst. Sci. Data, 14, 4811-4900, https://doi.org/10.5194/essd-14-4811-2022,
+      2022.'
+    url_main: https://globalcarbonbudget.org/
+    # TODO: should we put actual CSV with data there or https://globalcarbonbudget.org/carbonbudget/?
+    url_download: https://zenodo.org/record/7215364/files/GCB2022v27_MtCO2_flat.csv
+    date_accessed: '2023-04-28'
+    date_published: '2022-11-11'
+    license:
+      name: CC BY 4.0
+      url: https://zenodo.org/record/7215364
+datasets:
+  update_period_days: 90
+tables:
+  global_carbon_budget:
+    variables:
+      consumption_emissions_per_capita:
+        unit: tonnes per capita
+        # TODO: shouldn't we rename title to `Per capita consumption-based CO₂ emissions`?
+        title: Annual consumption-based CO₂ emissions (per capita)
+        description_short: Annual consumption-based emissions of carbon dioxide (CO₂), measured in tonnes per person. Consumption-based
+          emissions are national or regional emissions which have been adjusted for trade (i.e. territorial/production emissions
+          minus emissions embedded in exports, plus emissions embedded in imports). If a country's consumption-based emissions
+          are higher than its production emissions it is a net importer of carbon dioxide. Consumption-based CO₂ emissions
+          have been converted by Our World in Data from tonnes of carbon to tonnes of CO₂ using a conversion factor of 3.664.
+        short_unit: t
+        display:
+          numDecimalPlaces: 0
+        description_key:
+          - Consumption-based emissions attribute the emissions generated in the production of goods and services according to where they were _consumed_, rather than where they were _produced_.
+          - "The data is calculated by adjusting ‘production-based’ emissions (emissions produced domestically) for trade: Consumption-based emissions equals production-based emissions, _minus_ emissions embedded in exports, _plus_ emissions embedded in imports. If a country's consumption-based emissions are higher than its production emissions it is a net importer of carbon dioxide. If its consumption-based emissions are lower, then it is a net exporter."
+          - Per capita emissions represent the emissions of an average person in a country or region – they are total emissions divided by population.
+          - Consumption-based emissions are not available for all countries because not all countries have sufficient, high-quality trade data. But those without complete data are a small fraction (3%) of the global total.
+          - This data measures Carbon dioxide (CO₂) emissions from fossil fuels and industry and does not include emissions from land use change, deforestation, soils, or vegetation.
+          - Emissions from international aviation and shipping are not included in any country or region’s emissions. They are only included in the global total emissions.
+        presentation:
+          title_public: Per capita consumption-based CO₂ emissions
+          attribution_short: Global Carbon Project
+          topic_tags:
+            - CO2 & Greenhouse Gas Emissions
+            - Climate Change
+            - Energy
+          faqs:
+          - fragment_id: emissions-from-aviation-and-shipping
+            gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          - fragment_id: missing-consumption-based-emissions
+            gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          # NOTE: copied from http://staging-site-mojmir/admin/charts/3488/edit
+          grapher_config:
+            # TODO: slug does not make sense in grapher_config, right?
+            slug: consumption-co2-per-capita
+            title: Per capita consumption-based CO₂ emissions
+            subtitle: >-
+              [Consumption-based emissions](#dod:consumptionbasedemissions) are national
+              emissions that have been adjusted for trade. It's production-based emissions
+              minus emissions embedded in exports, plus emissions embedded in imports.
+            hideAnnotationFieldsInTitle:
+              time: true
+              entity: true
+              changeInPrefix: true
+            minTime: 1990
+            hideRelativeToggle: false
+            hasMapTab: true
+            tab: map
+            originUrl: https://ourworldindata.org/co2-and-greenhouse-gas-emissions
+            yAxis:
+              min: 0
+              max: 0
+            colorScale:
+              binningStrategy: equalInterval
+            map:
+              colorScale:
+                baseColorScheme: Reds
+                binningStrategy: manual
+                customNumericValues:
+                  - 1
+                  - 2.5
+                  - 5
+                  - 7.5
+                  - 10
+                  - 15
+                  - 20
+                  - 50
+                customNumericColors:
+                  - null
+                  - null
+            selectedEntityNames:
+              - United States
+              - United Kingdom
+              - European Union (27)
+              - China
+              - India
+              - Australia
+              - Brazil
+              - South Africa
+            relatedQuestions:
+              - url: https://ourworldindata.org/grapher/consumption-co2-per-capita#faqs
+                text: FAQs on this data
+
+        sources: []
+        origins: *origins

--- a/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.py
+++ b/etl/steps/data/grapher/gcp/2023-07-10/global_carbon_budget.py
@@ -32,12 +32,20 @@ def run(dest_dir: str) -> None:
     years = np.arange(tb_garden.reset_index()["year"].min(), tb_garden.reset_index()["year"].max() + 1, dtype=int)
     tb_garden = tb_garden.reindex(pd.MultiIndex.from_product([countries, years], names=["country", "year"]))
 
+    # Remove sources from all indicators
+    for col in tb_garden.columns:
+        tb_garden[col].m.sources = []
+
     #
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = create_dataset(
-        dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata, check_variables_metadata=True
+        dest_dir,
+        tables=[tb_garden],
+        default_metadata=ds_garden.metadata,
+        check_variables_metadata=True,
+        if_origins_exist="append",
     )
 
     # Sanity checks.

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -183,7 +183,12 @@ class Dataset:
             table.metadata.dataset = self.metadata
             table._save_metadata(join(self.path, table.metadata.checked_name + ".meta.json"))
 
-    def update_metadata(self, metadata_path: Path, if_source_exists: SOURCE_EXISTS_OPTIONS = "replace") -> None:
+    def update_metadata(
+        self,
+        metadata_path: Path,
+        if_source_exists: SOURCE_EXISTS_OPTIONS = "replace",
+        if_origins_exist: SOURCE_EXISTS_OPTIONS = "replace",
+    ) -> None:
         """
         Load YAML file with metadata from given path and update metadata of dataset and its tables.
 
@@ -193,14 +198,20 @@ class Dataset:
             - "replace" (default): replace existing source with new one
             - "append": append new source to existing ones
             - "fail": raise an exception if source already exists
+        :param if_origins_exist: What to do if origin already exists in metadata. Possible values:
+            - "replace" (default): replace existing origin with new one
+            - "append": append new origin to existing ones
+            - "fail": raise an exception if origin already exists
         """
-        self.metadata.update_from_yaml(metadata_path, if_source_exists=if_source_exists)
+        self.metadata.update_from_yaml(
+            metadata_path, if_source_exists=if_source_exists, if_origins_exist=if_origins_exist
+        )
 
         with open(metadata_path) as istream:
             metadata = yaml.safe_load(istream)
             for table_name in metadata.get("tables", {}).keys():
                 table = self[table_name]
-                table.update_metadata_from_yaml(metadata_path, table_name)
+                table.update_metadata_from_yaml(metadata_path, table_name, if_origins_exist=if_origins_exist)
                 table._save_metadata(join(self.path, table.metadata.checked_name + ".meta.json"))
 
     def index(self, catalog_path: Path = Path("/")) -> pd.DataFrame:


### PR DESCRIPTION
[JSON Data Page](https://ourworldindata.org/grapher/consumption-co2-per-capita)
[ETL Data Page](http://staging-site-mojmir/admin/datapage-preview/738081)

Command for "live" reloading of Data Page
```
ENV=.env.mojmir GRAPHER_FILTER=consumption_emissions_per_capita etl grapher/gcp/2023-07-10/global_carbon_budget --grapher --watch
```

## Issues
- Topic tags links redirect to non-existing pages and they have different names than those on the data page (I took topic names from [datasette](http://datasette-private/owid?sql=SELECT+tags.%60name%60+from+tags+where+isTopic+%3D+1+ORDER+BY+tags.%60name%60%0D%0A))
- [FAQ GDoc](https://owid.cloud/admin/gdocs/1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw/preview) doesn't work well with staging server, since it only gets saved to live MySQL. I had to replicate it from live to staging-site-mojmir with custom script
- Newlines in origin description are not rendered properly, is that a known bug?
- See other `# TODO` in the YAML file


Parent issue https://github.com/owid/etl/issues/1666