### PR TITLE
Avoid propagating metadata on division

### DIFF
--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -361,3 +361,57 @@ def test_copy() -> None:
     # make sure it doesn't affect original variable
     assert v1.metadata.title == "dog"
     assert v1.metadata.license.name == "dog license"
+
+
+def test_divide_variables_where_only_numerator_has_metadata(variable_1, variable_2, sources, origins, licenses) -> None:
+    variable_1 = variable_1.copy()
+    variable_2 = variable_2.copy()
+    # We remove metadata values from the denominator.
+    variable_2.metadata.title = None
+    variable_2.metadata.description = None
+    variable_2.metadata.unit = None
+    variable_2.metadata.short_unit = None
+
+    # The new variable should have all metadata values from the numerator (for those fields).
+    variable = variable_1 / variable_2
+    assert variable.metadata.title == variable_1.metadata.title
+    assert variable.metadata.description == variable_1.metadata.description
+    assert variable.metadata.unit == variable_1.metadata.unit
+    assert variable.metadata.short_unit == variable_1.metadata.short_unit
+    # Sources, origins and licenses should be propagated as normally.
+    assert variable.metadata.sources == [sources[2], sources[1], sources[3]]
+    assert variable.metadata.origins == [origins[2], origins[1], origins[3]]
+    assert variable.metadata.licenses == [licenses[1], licenses[2], licenses[3]]
+    # variable_2 has a major processing level, so the combined variable should have a major processing level.
+    assert variable.metadata.processing_level == "major"
+    # Both variables have different values in presentation, so the combination should have no presentation.
+    assert variable.metadata.presentation is None
+    # Since both variables have identical display, the combination should have the same display.
+    assert variable.metadata.display == variable_1.metadata.display
+
+
+def test_divide_variables_where_only_denominator_has_metadata(variable_1, variable_2, sources, origins, licenses) -> None:
+    variable_1 = variable_1.copy()
+    variable_2 = variable_2.copy()
+    # We remove metadata values from the numerator.
+    variable_1.metadata.title = None
+    variable_1.metadata.description = None
+    variable_1.metadata.unit = None
+    variable_1.metadata.short_unit = None
+
+    # The new variable should have no metadata values (for those fields).
+    variable = variable_1 / variable_2
+    assert variable.metadata.title is None
+    assert variable.metadata.description is None
+    assert variable.metadata.unit is None
+    assert variable.metadata.short_unit is None
+    # Sources, origins and licenses should be propagated as normally.
+    assert variable.metadata.sources == [sources[2], sources[1], sources[3]]
+    assert variable.metadata.origins == [origins[2], origins[1], origins[3]]
+    assert variable.metadata.licenses == [licenses[1], licenses[2], licenses[3]]
+    # variable_2 has a major processing level, so the combined variable should have a major processing level.
+    assert variable.metadata.processing_level == "major"
+    # Both variables have different values in presentation, so the combination should have no presentation.
+    assert variable.metadata.presentation is None
+    # Since both variables have identical display, the combination should have the same display.
+    assert variable.metadata.display == variable_1.metadata.display

--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -390,7 +390,9 @@ def test_divide_variables_where_only_numerator_has_metadata(variable_1, variable
     assert variable.metadata.display == variable_1.metadata.display
 
 
-def test_divide_variables_where_only_denominator_has_metadata(variable_1, variable_2, sources, origins, licenses) -> None:
+def test_divide_variables_where_only_denominator_has_metadata(
+    variable_1, variable_2, sources, origins, licenses
+) -> None:
     variable_1 = variable_1.copy()
     variable_2 = variable_2.copy()
     # We remove metadata values from the numerator.


### PR DESCRIPTION
Avoid propagating metadata fields (titles, units and descriptions) of the denominator, when dividing two variables.

When dividing a variable by another, it only makes sense to keep the metadata values of the first variable. For example, if we have energy (without description) and population (with a description), when calculating energy per capita, the result shouldn't have the description of population. It should have no description.

This PR would fix for example [this chart](https://owid.cloud/admin/charts/4451/edit) of electricity per capita. The sources tab shows the description of population.

In a separate PR we can add similar logic to display and presentation.