### PR TITLE
:bar_chart: backport literacy rates and public expenditure on education to ETL

### DIFF
--- a/apps/backport/migrate/migrate.py
+++ b/apps/backport/migrate/migrate.py
@@ -5,6 +5,7 @@ from typing import Optional, cast
 import click
 import structlog
 from owid.catalog.utils import underscore
+from rich import print
 from sqlalchemy.engine import Engine
 
 from apps.backport.backport import PotentialBackport
@@ -124,9 +125,14 @@ def migrate(
     # add steps to DAG
     _add_to_migrated_dag(namespace, version, short_name)
 
-    print(f"Execute snapshot with `python snapshots/{namespace}/{version}/{short_name}.py`")
-    print(f"Import dataset with `etl {namespace}/{version}/{short_name} --grapher`")
-    print("Run chart revisions with `ENV=.env.prod.write walkthrough charts`")
+    # Print instructions
+    print("\n[bold yellow]Follow-up instructions:[/bold yellow]")
+    print(
+        f"[green]1.[/green] Execute snapshot with [bold]`python snapshots/{namespace}/{version}/{short_name}.py`[/bold]"
+    )
+    print(f"[green]2.[/green] Import dataset with [bold]`etl {namespace}/{version}/{short_name} --grapher`[/bold]")
+    print("[green]3.[/green] Run chart revisions with [bold]`ENV=.env.prod.write walkthrough charts`[/bold]")
+    print("[green]4.[/green] [bold]Delete[/bold] or archive the old dataset")
 
 
 def _add_to_migrated_dag(namespace: str, version: str, short_name: str):

--- a/dag/education.yml
+++ b/dag/education.yml
@@ -8,6 +8,9 @@ steps:
   - data://garden/regions/2023-01-01/regions
   - data://garden/wb/2023-04-30/income_groups
   - data://garden/owid/latest/key_indicators
+  - data://garden/education/2017-09-30/public_expenditure
+  - data://garden/education/2018-04-18/literacy_rates
+
   data://grapher/wb/2023-07-10/education:
   - data://garden/wb/2023-07-10/education
 

--- a/dag/migrated.yml
+++ b/dag/migrated.yml
@@ -12,3 +12,7 @@ steps:
   - data://garden/education/2018-04-18/literacy_rates
   data://garden/education/2018-04-18/literacy_rates:
   - snapshot://education/2018-04-18/literacy_rates.feather
+  data://grapher/education/2017-09-30/public_expenditure:
+  - data://garden/education/2017-09-30/public_expenditure
+  data://garden/education/2017-09-30/public_expenditure:
+  - snapshot://education/2017-09-30/public_expenditure.feather

--- a/dag/migrated.yml
+++ b/dag/migrated.yml
@@ -8,3 +8,7 @@ steps:
   - data://garden/biodiversity/2022/living_planet_index
   data://garden/biodiversity/2022/living_planet_index:
   - snapshot://biodiversity/2022/living_planet_index.feather
+  data://grapher/education/2018-04-18/literacy_rates:
+  - data://garden/education/2018-04-18/literacy_rates
+  data://garden/education/2018-04-18/literacy_rates:
+  - snapshot://education/2018-04-18/literacy_rates.feather

--- a/etl/metadata_export.py
+++ b/etl/metadata_export.py
@@ -137,7 +137,7 @@ def metadata_export(
             # fix sources
             for source in variable.get("sources", []):
                 if "date_accessed" in source:
-                    source["date_accessed"] = pd.to_datetime(source["date_accessed"]).date()
+                    source["date_accessed"] = pd.to_datetime(source["date_accessed"], dayfirst=True).date()
 
             t["variables"][col] = variable
 

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -334,7 +334,9 @@ class SnapshotMeta:
             description=s["description"].get("additionalInfo"),
             url=s["description"].get("link"),
             published_by=s["description"].get("dataPublishedBy"),
-            date_accessed=pd.to_datetime(s["description"].get("retrievedDate") or dt.date.today()).date(),
+            date_accessed=pd.to_datetime(
+                s["description"].get("retrievedDate") or dt.date.today(), dayfirst=True
+            ).date(),
         )
 
     def to_table_metadata(self):

--- a/etl/steps/data/garden/education/2017-09-30/public_expenditure.meta.yml
+++ b/etl/steps/data/garden/education/2017-09-30/public_expenditure.meta.yml
@@ -1,0 +1,10 @@
+dataset:
+  title: Public Expenditure on Education OECD - Tanzi & Schuknecht (2000)
+tables:
+  public_expenditure:
+    variables:
+      public_expenditure_on_education__tanzi__and__schuktnecht__2000:
+        title: Public Expenditure on Education (Tanzi & Schuktnecht (2000))
+        description: Public Expenditure on Education (% GDP)
+        unit: percent of GDP
+        short_unit: '%'

--- a/etl/steps/data/garden/education/2017-09-30/public_expenditure.py
+++ b/etl/steps/data/garden/education/2017-09-30/public_expenditure.py
@@ -1,0 +1,23 @@
+"""Load snapshot and create a garden dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load data from snapshot.
+    #
+    snap = paths.load_snapshot()
+    tb = snap.read().set_index(["country", "year"])
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the snapshot.
+    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()

--- a/etl/steps/data/garden/education/2018-04-18/literacy_rates.meta.yml
+++ b/etl/steps/data/garden/education/2018-04-18/literacy_rates.meta.yml
@@ -1,0 +1,13 @@
+dataset:
+  title: Cross-country literacy rates - World Bank, CIA World Factbook, and other sources
+tables:
+  literacy_rates:
+    variables:
+      literacy_rates__world_bank__cia_world_factbook__and_other_sources:
+        title: Literacy rates (World Bank, CIA World Factbook, and other sources)
+        description: Percentage of the population (aged 15 and above) who can read and write.
+        unit: '%'
+        display:
+          numDecimalPlaces: 1
+          unit: '%'
+        short_unit: '%'

--- a/etl/steps/data/garden/education/2018-04-18/literacy_rates.py
+++ b/etl/steps/data/garden/education/2018-04-18/literacy_rates.py
@@ -1,0 +1,23 @@
+"""Load snapshot and create a garden dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load data from snapshot.
+    #
+    snap = paths.load_snapshot()
+    tb = snap.read().set_index(["country", "year"])
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the snapshot.
+    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()

--- a/etl/steps/data/garden/wb/2023-07-10/education.py
+++ b/etl/steps/data/garden/wb/2023-07-10/education.py
@@ -250,14 +250,10 @@ def add_metadata(
             tb.rename(columns={column: new_column_name}, inplace=True)
             description_string = " ".join(
                 [
-                    description + "." "World Bank variable id: " + indicator_to_find + ".",
+                    description + "\n\n" "World Bank variable id: " + indicator_to_find + "",
                     source,
                 ]
             )
-
-            # Replace any occurrences of '..' with '.'
-            description_string = description_string.replace("..", ".")
-            description_string = description_string.replace(".W", ". W")
 
             tb[new_column_name].metadata.description = description_string
             tb[new_column_name].metadata.title = name
@@ -343,14 +339,30 @@ def add_metadata(
             tb[column].metadata.short_unit = ""
         elif column == "combined_literacy":
             tb[column].metadata.title = "Historical and more recent literacy estimates"
-            tb[column].metadata.description = "Historical literacy data:\n\n" + combined_literacy_description
+            tb[column].metadata.description = (
+                "**Historical literacy data:**\n\n"
+                + combined_literacy_description
+                + "\n\n"
+                + "**Recent estimates:**\n\n"
+                + "Percentage of the population between age 25 and age 64 who can, with understanding, read and write a short, simple statement on their everyday life. Generally, ‘literacy’ also encompasses ‘numeracy’, the ability to make simple arithmetic calculations. This indicator is calculated by dividing the number of literates aged 25-64 years by the corresponding age group population and multiplying the result by 100."
+                + "\n\n"
+                + "World Bank variable id: UIS.LR.AG25T64. UNESCO Institute for Statistics"
+            )
             tb[column].metadata.display = {}
             tb[column].metadata.display["numDecimalPlaces"] = 2
             tb[column].metadata.unit = "%"
             tb[column].metadata.short_unit = "%"
         elif column == "combined_expenditure":
             tb[column].metadata.title = "Historical and more recent expenditure estimates"
-            tb[column].metadata.description = "Historical expenditure data:\n\n" + combined_expenditure_description
+            tb[column].metadata.description = (
+                "**Historical expenditure data:**\n\n"
+                + combined_expenditure_description
+                + "\n\n"
+                + "**Recent estimates:**\n\n"
+                + "General government expenditure on education (current, capital, and transfers) is expressed as a percentage of GDP. It includes expenditure funded by transfers from international sources to government. General government usually refers to local, regional and central governments."
+                + "\n\n"
+                + "World Bank variable id: SE.XPD.TOTL.GD.ZS. UNESCO Institute for Statistics (UIS). UIS.Stat Bulk Data Download Service. Accessed October 24, 2022."
+            )
             tb[column].metadata.display = {}
             tb[column].metadata.display["numDecimalPlaces"] = 2
             tb[column].metadata.unit = "%"

--- a/etl/steps/data/grapher/education/2017-09-30/public_expenditure.py
+++ b/etl/steps/data/grapher/education/2017-09-30/public_expenditure.py
@@ -1,0 +1,26 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset()
+
+    # Read table from garden dataset.
+    tb = ds_garden["public_expenditure"]
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()

--- a/etl/steps/data/grapher/education/2018-04-18/literacy_rates.py
+++ b/etl/steps/data/grapher/education/2018-04-18/literacy_rates.py
@@ -1,0 +1,26 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset()
+
+    # Read table from garden dataset.
+    tb = ds_garden["literacy_rates"]
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()

--- a/snapshots/backport/latest/dataset_242_public_expenditure_on_education_oecd__tanzi__and__schuknecht__2000_config.json.dvc
+++ b/snapshots/backport/latest/dataset_242_public_expenditure_on_education_oecd__tanzi__and__schuknecht__2000_config.json.dvc
@@ -2,14 +2,14 @@ meta:
   source:
     name: Our World in Data catalog backport
     url: https://owid.cloud/admin/datasets/242
-    date_accessed: 2023-08-10 09:20:13.101737
+    date_accessed: 2023-09-27 06:57:19.235380
     publication_date: latest
     published_by: Our World in Data catalog backport
   name: Grapher metadata for dataset_242_public_expenditure_on_education_oecd__tanzi__and__schuknecht__2000
   description: ''
 wdir: ../../../data/snapshots/backport/latest
 outs:
-- md5: 36dcbbdd1d0d8ac0fd1f752bd4b32f0f
-  size: 2527
+- md5: e853482c2a60ce875e7c12ed9813a0fa
+  size: 2540
   path: 
     dataset_242_public_expenditure_on_education_oecd__tanzi__and__schuknecht__2000_config.json

--- a/snapshots/backport/latest/dataset_242_public_expenditure_on_education_oecd__tanzi__and__schuknecht__2000_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_242_public_expenditure_on_education_oecd__tanzi__and__schuknecht__2000_values.feather.dvc
@@ -2,14 +2,14 @@ meta:
   source:
     name: Our World in Data catalog backport
     url: https://owid.cloud/admin/datasets/242
-    date_accessed: 2023-08-10 09:20:50.311114
+    date_accessed: 2023-09-27 06:57:25.915053
     publication_date: latest
     published_by: Our World in Data catalog backport
   name: Public Expenditure on Education OECD - Tanzi & Schuknecht (2000)
   description: ''
 wdir: ../../../data/snapshots/backport/latest
 outs:
-- md5: d31d35ce1f8e2c131a9f5d6feed1fdf7
-  size: 7186
+- md5: ad263f4a8f71fd6e1d245497fb9e30d2
+  size: 7794
   path: 
     dataset_242_public_expenditure_on_education_oecd__tanzi__and__schuknecht__2000_values.feather

--- a/snapshots/backport/latest/dataset_2762_cross_country_literacy_rates__world_bank__cia_world_factbook__and_other_sources_config.json.dvc
+++ b/snapshots/backport/latest/dataset_2762_cross_country_literacy_rates__world_bank__cia_world_factbook__and_other_sources_config.json.dvc
@@ -2,7 +2,7 @@ meta:
   source:
     name: Our World in Data catalog backport
     url: https://owid.cloud/admin/datasets/2762
-    date_accessed: 2023-08-10 09:08:12.891552
+    date_accessed: 2023-09-27 06:30:23.706995
     publication_date: latest
     published_by: Our World in Data catalog backport
   name: Grapher metadata for 
@@ -10,7 +10,7 @@ meta:
   description: ''
 wdir: ../../../data/snapshots/backport/latest
 outs:
-- md5: 3c4857ad58bdc155a68697064514ec91
-  size: 4937
+- md5: d5cc91d953e1443e03bb5b2bb854dec4
+  size: 4950
   path: 
     dataset_2762_cross_country_literacy_rates__world_bank__cia_world_factbook__and_other_sources_config.json

--- a/snapshots/backport/latest/dataset_2762_cross_country_literacy_rates__world_bank__cia_world_factbook__and_other_sources_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_2762_cross_country_literacy_rates__world_bank__cia_world_factbook__and_other_sources_values.feather.dvc
@@ -2,14 +2,14 @@ meta:
   source:
     name: Our World in Data catalog backport
     url: https://owid.cloud/admin/datasets/2762
-    date_accessed: 2023-08-10 09:08:47.743199
+    date_accessed: 2023-09-27 06:30:31.518935
     publication_date: latest
     published_by: Our World in Data catalog backport
   name: Cross-country literacy rates - World Bank, CIA World Factbook, and other sources
   description: ''
 wdir: ../../../data/snapshots/backport/latest
 outs:
-- md5: 251182c48c885464c85860b237c3823a
-  size: 26106
+- md5: f7127eb7fa156116408e550b70212a0f
+  size: 31722
   path: 
     dataset_2762_cross_country_literacy_rates__world_bank__cia_world_factbook__and_other_sources_values.feather

--- a/snapshots/education/2017-09-30/public_expenditure.feather.dvc
+++ b/snapshots/education/2017-09-30/public_expenditure.feather.dvc
@@ -1,0 +1,23 @@
+meta:
+  source:
+    name: Tanzi & Schuknecht (2000)
+    description: 'The underlying sources for Tanzi & Schuknecht (2000) include: League
+      of Nations Statistical Yearbook (various years), Mitchell (1962), OECD Education
+      at a Glance (1996), UNESCO World Education Report (1993), UNDP Human Development
+      Report (1996), UN World Economics Survey (various years). To the extent that
+      the authors do not specify which sources were prioritised for each year/country,
+      it is not possible for us to reliably extend the time series with newer data.
+      For instance, the OECD Education at a Glance report (1998), which presents estimates
+      for the years 1990 and 1995, suggests discrepancies with the values reported
+      by Tanzi & Schuknecht (2000) for 1993.'
+    url: https://link.springer.com/article/10.1023%2FA%3A1017578302202?LI=true
+    date_accessed: 2017-09-30
+    published_by: Vito and Schuknecht (2000) Public Spending in the 20th Century A
+      Global Perspective
+  name: Public Expenditure on Education OECD - Tanzi & Schuknecht (2000)
+  description: ''
+wdir: ../../../data/snapshots/education/2017-09-30
+outs:
+- md5: 70215292759c49a6bdb664321f757c15
+  size: 3666
+  path: public_expenditure.feather

--- a/snapshots/education/2017-09-30/public_expenditure.feather.dvc
+++ b/snapshots/education/2017-09-30/public_expenditure.feather.dvc
@@ -15,7 +15,6 @@ meta:
     published_by: Vito and Schuknecht (2000) Public Spending in the 20th Century A
       Global Perspective
   name: Public Expenditure on Education OECD - Tanzi & Schuknecht (2000)
-  description: ''
 wdir: ../../../data/snapshots/education/2017-09-30
 outs:
 - md5: 5ecb8cb6411e3a4f47d5f32a79ef9bdf

--- a/snapshots/education/2017-09-30/public_expenditure.feather.dvc
+++ b/snapshots/education/2017-09-30/public_expenditure.feather.dvc
@@ -18,6 +18,6 @@ meta:
   description: ''
 wdir: ../../../data/snapshots/education/2017-09-30
 outs:
-- md5: 70215292759c49a6bdb664321f757c15
+- md5: 5ecb8cb6411e3a4f47d5f32a79ef9bdf
   size: 3666
   path: public_expenditure.feather

--- a/snapshots/education/2017-09-30/public_expenditure.py
+++ b/snapshots/education/2017-09-30/public_expenditure.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import click
+import pandas as pd
+
+from etl.backport_helpers import long_to_wide
+from etl.snapshot import Snapshot, SnapshotMeta
+
+SNAPSHOT_NAMESPACE = Path(__file__).parent.parent.name
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+
+@click.command()
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(upload: bool) -> None:
+    # Load backported snapshot.
+    snap_values = Snapshot(
+        "backport/latest/dataset_242_public_expenditure_on_education_oecd__tanzi__and__schuknecht__2000_values.feather"
+    )
+    snap_values.pull()
+    snap_config = Snapshot(
+        "backport/latest/dataset_242_public_expenditure_on_education_oecd__tanzi__and__schuknecht__2000_config.json"
+    )
+    snap_config.pull()
+
+    # Create snapshot metadata for the new file
+    meta = SnapshotMeta(**snap_values.metadata.to_dict())
+    meta.namespace = SNAPSHOT_NAMESPACE
+    meta.version = SNAPSHOT_VERSION
+    meta.short_name = "public_expenditure"
+    meta.fill_from_backport_snapshot(snap_config.path)
+    meta.save()
+
+    # Create a new snapshot.
+    snap = Snapshot(meta.uri)
+
+    # Convert from long to wide format.
+    df = long_to_wide(pd.read_feather(snap_values.path))
+
+    # Copy file to the new snapshot.
+    snap.path.parent.mkdir(parents=True, exist_ok=True)
+    df.reset_index().to_feather(snap.path)
+
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/education/2018-04-18/literacy_rates.feather.dvc
+++ b/snapshots/education/2018-04-18/literacy_rates.feather.dvc
@@ -4,7 +4,6 @@ meta:
     description: >-
       Additional Information
 
-      </br>
 
       This long run cross-country dataset combines data from a number of sources.
       We took the estimates from the World Bank’s
@@ -12,43 +11,43 @@ meta:
       the CIA Factbook, as well as several other
       long-run series, as follows:
 
-      <ul>
 
-      <li>Data before 1800: Buringh, E., & Van Zanden, J. L. (2009). Charting the
-      “Rise of the West”: Manuscripts and Printed
+
+      - Data before 1800: Buringh, E., & Van Zanden, J. L. (2009). Charting the “Rise
+      of the West”: Manuscripts and Printed
       Books in Europe, A long-term perspective from the sixth through eighteenth centuries.
       The Journal of Economic History.
-      Online <a href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.553.9220&rep=rep1&type=pdf">here</a>.
-      Observations
-      before 1800 are plotted at the midpoint of the given time range (1475 refers
-      to 1451–1500, 1550 refers to 1501-1600
-      etc.)</li>
+      Online [here](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.553.9220&rep=rep1&type=pdf).
+      Observations before
+      1800 are plotted at the midpoint of the given time range (1475 refers to 1451–1500,
+      1550 refers to 1501-1600 etc.)
 
-      <li>Data for 1820 and 1870 (except for the US): Broadberry  and O'Rourke (2010)
-      – The Cambridge Economic History of
-      Modern Europe: Volume 1, 1700-1870 </li>
 
-      <li>Data for the US: National Center for Education Statistics, online <a href="nces.ed.gov/naal/lit_history.asp">here</a>.
-      </li>
+      - Data for 1820 and 1870 (except for the US): Broadberry  and O'Rourke (2010)
+      – The Cambridge Economic History of Modern
+      Europe: Volume 1, 1700-1870
 
-      <li>Global estimates for 1820-2000: van Zanden, J.L., et al. (eds.) (2014),
-      How Was Life?: Global Well-being since 1820,
-      OECD Publishing. Online <a href="http://www.oecd.org/statistics/how-was-life-9789264214262-en.htm">here</a>.
-      </li>
 
-      <li>Historical estimates for Latin America: OxLAD – Oxford Latin American Economic
-      History Data Base, online <a href="http://moxlad-staging.herokuapp.com/home/en">here</a>.
-      </li>
+      - Data for the US: National Center for Education Statistics, online [here](nces.ed.gov/naal/lit_history.asp).
 
-      <li>Most recent estimates for high-income countries, as well as any available
-      estimates for 2016: <a href="https://www.cia.gov/library/publications/the-world-factbook/">CIA
-      World Factbook</a>. </li>
 
-      </ul>
+      - Global estimates for 1820-2000: van Zanden, J.L., et al. (eds.) (2014), How
+      Was Life?: Global Well-being since 1820,
+      OECD Publishing. Online [here](http://www.oecd.org/statistics/how-was-life-9789264214262-en.htm).
+
+
+      - Historical estimates for Latin America: OxLAD – Oxford Latin American Economic
+      History Data Base, online [here](http://moxlad-staging.herokuapp.com/home/en).
+
+
+      - Most recent estimates for high-income countries, as well as any available
+      estimates for 2016: [CIA World Factbook](https://www.cia.gov/library/publications/the-world-factbook/).
+
+
+
 
       Further notes:
 
-      </br>
 
       - All sources rely on the same conceptual definition, but in many cases sources
       do not agree with one another. Because
@@ -56,23 +55,19 @@ meta:
       more about literacy measurement here:
       https://ourworldindata.org/how-is-literacy-measured
 
-      </br>
 
       - The World Bank's WDI estimates correspond to UNESCO Institute for Statistics.
       OxLAD estimates come from several underlying
       sources (see original documentation for more details).
 
-      </br>
 
       - For Paraguay in 1982, the OxLAD data source was favoured over the World Bank
       (WDI) as the latter estimates literacy
       rates at 78.46%, a much lower estimate compared to neighbouring years for which
       there was data available.
 
-      </br>
 
-      - Sources for each country-year observation can be found in <a href="http://ourworldindata.org/wp-content/uploads/2018/06/cross-country-literacy-sources-final.csv"
-      rel="noopener" target="_blank">this table.</a>
+      - Sources for each country-year observation can be found in [this table.](http://ourworldindata.org/wp-content/uploads/2018/06/cross-country-literacy-sources-final.csv)
     url: '- World Bank: https://data.worldbank.org/indicator/SE.ADT.LITR.ZS </br>
       - CIA Factbook: https://www.cia.gov/library/publications/the-world-factbook/
       </br> - Links to other sources below'

--- a/snapshots/education/2018-04-18/literacy_rates.feather.dvc
+++ b/snapshots/education/2018-04-18/literacy_rates.feather.dvc
@@ -1,0 +1,35 @@
+meta:
+  source:
+    name: Literacy rates (World Bank, CIA World Factbook, and other sources)
+    description: |-
+      Additional Information
+
+      This long run cross-country dataset combines data from a number of sources. We took the estimates from the World Bank’s WDI as our base, and then extended coverage by adding literacy estimates from the CIA Factbook, as well as several other long-run series, as follows:
+
+      - Data before 1800: Buringh, E., & Van Zanden, J. L. (2009). Charting the “Rise of the West”: Manuscripts and Printed Books in Europe, A long-term perspective from the sixth through eighteenth centuries. The Journal of Economic History. Online [here](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.553.9220&rep=rep1&type=pdf). Observations before 1800 are plotted at the midpoint of the given time range (1475 refers to 1451–1500, 1550 refers to 1501-1600 etc.)
+      - Data for 1820 and 1870 (except for the US): Broadberry and O'Rourke (2010) – The Cambridge Economic History of Modern Europe: Volume 1, 1700-1870
+      - Data for the US: National Center for Education Statistics, online [here](nces.ed.gov/naal/lit_history.asp).
+      - Global estimates for 1820-2000: van Zanden, J.L., et al. (eds.) (2014), How Was Life?: Global Well-being since 1820, OECD Publishing. Online [here](http://www.oecd.org/statistics/how-was-life-9789264214262-en.htm).
+      - Historical estimates for Latin America: OxLAD – Oxford Latin American Economic History Data Base, online [here](http://moxlad-staging.herokuapp.com/home/en).
+      - Most recent estimates for high-income countries, as well as any available estimates for 2016: [CIA World Factbook](https://www.cia.gov/library/publications/the-world-factbook/).
+
+      Further notes:
+
+      - All sources rely on the same conceptual definition, but in many cases sources do not agree with one another. Because of this, year to year changes should be interpreted with caution. You can read more about literacy measurement here: https://ourworldindata.org/how-is-literacy-measured
+      - The World Bank's WDI estimates correspond to UNESCO Institute for Statistics. OxLAD estimates come from several underlying sources (see original documentation for more details).
+      - For Paraguay in 1982, the OxLAD data source was favoured over the World Bank (WDI) as the latter estimates literacy rates at 78.46%, a much lower estimate compared to neighbouring years for which there was data available.
+
+
+      Sources for each country-year observation can be found in [this table.](http://ourworldindata.org/wp-content/uploads/2018/06/cross-country-literacy-sources-final.csv)
+    url: '- World Bank: https://data.worldbank.org/indicator/SE.ADT.LITR.ZS </br>
+      - CIA Factbook: https://www.cia.gov/library/publications/the-world-factbook/
+      </br> - Links to other sources below'
+    date_accessed: 2018-04-18
+    published_by: Our World in Data
+  name: Cross-country literacy rates - World Bank, CIA World Factbook, and other sources
+  description: ''
+wdir: ../../../data/snapshots/education/2018-04-18
+outs:
+- md5: 1fccefc6026cd4c0161aa08b2bf7551e
+  size: 17602
+  path: literacy_rates.feather

--- a/snapshots/education/2018-04-18/literacy_rates.feather.dvc
+++ b/snapshots/education/2018-04-18/literacy_rates.feather.dvc
@@ -1,26 +1,78 @@
 meta:
   source:
     name: Literacy rates (World Bank, CIA World Factbook, and other sources)
-    description: |-
+    description: >-
       Additional Information
 
-      This long run cross-country dataset combines data from a number of sources. We took the estimates from the World Bank’s WDI as our base, and then extended coverage by adding literacy estimates from the CIA Factbook, as well as several other long-run series, as follows:
+      </br>
 
-      - Data before 1800: Buringh, E., & Van Zanden, J. L. (2009). Charting the “Rise of the West”: Manuscripts and Printed Books in Europe, A long-term perspective from the sixth through eighteenth centuries. The Journal of Economic History. Online [here](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.553.9220&rep=rep1&type=pdf). Observations before 1800 are plotted at the midpoint of the given time range (1475 refers to 1451–1500, 1550 refers to 1501-1600 etc.)
-      - Data for 1820 and 1870 (except for the US): Broadberry and O'Rourke (2010) – The Cambridge Economic History of Modern Europe: Volume 1, 1700-1870
-      - Data for the US: National Center for Education Statistics, online [here](nces.ed.gov/naal/lit_history.asp).
-      - Global estimates for 1820-2000: van Zanden, J.L., et al. (eds.) (2014), How Was Life?: Global Well-being since 1820, OECD Publishing. Online [here](http://www.oecd.org/statistics/how-was-life-9789264214262-en.htm).
-      - Historical estimates for Latin America: OxLAD – Oxford Latin American Economic History Data Base, online [here](http://moxlad-staging.herokuapp.com/home/en).
-      - Most recent estimates for high-income countries, as well as any available estimates for 2016: [CIA World Factbook](https://www.cia.gov/library/publications/the-world-factbook/).
+      This long run cross-country dataset combines data from a number of sources.
+      We took the estimates from the World Bank’s
+      WDI as our base, and then extended coverage by adding literacy estimates from
+      the CIA Factbook, as well as several other
+      long-run series, as follows:
+
+      <ul>
+
+      <li>Data before 1800: Buringh, E., & Van Zanden, J. L. (2009). Charting the
+      “Rise of the West”: Manuscripts and Printed
+      Books in Europe, A long-term perspective from the sixth through eighteenth centuries.
+      The Journal of Economic History.
+      Online <a href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.553.9220&rep=rep1&type=pdf">here</a>.
+      Observations
+      before 1800 are plotted at the midpoint of the given time range (1475 refers
+      to 1451–1500, 1550 refers to 1501-1600
+      etc.)</li>
+
+      <li>Data for 1820 and 1870 (except for the US): Broadberry  and O'Rourke (2010)
+      – The Cambridge Economic History of
+      Modern Europe: Volume 1, 1700-1870 </li>
+
+      <li>Data for the US: National Center for Education Statistics, online <a href="nces.ed.gov/naal/lit_history.asp">here</a>.
+      </li>
+
+      <li>Global estimates for 1820-2000: van Zanden, J.L., et al. (eds.) (2014),
+      How Was Life?: Global Well-being since 1820,
+      OECD Publishing. Online <a href="http://www.oecd.org/statistics/how-was-life-9789264214262-en.htm">here</a>.
+      </li>
+
+      <li>Historical estimates for Latin America: OxLAD – Oxford Latin American Economic
+      History Data Base, online <a href="http://moxlad-staging.herokuapp.com/home/en">here</a>.
+      </li>
+
+      <li>Most recent estimates for high-income countries, as well as any available
+      estimates for 2016: <a href="https://www.cia.gov/library/publications/the-world-factbook/">CIA
+      World Factbook</a>. </li>
+
+      </ul>
 
       Further notes:
 
-      - All sources rely on the same conceptual definition, but in many cases sources do not agree with one another. Because of this, year to year changes should be interpreted with caution. You can read more about literacy measurement here: https://ourworldindata.org/how-is-literacy-measured
-      - The World Bank's WDI estimates correspond to UNESCO Institute for Statistics. OxLAD estimates come from several underlying sources (see original documentation for more details).
-      - For Paraguay in 1982, the OxLAD data source was favoured over the World Bank (WDI) as the latter estimates literacy rates at 78.46%, a much lower estimate compared to neighbouring years for which there was data available.
+      </br>
 
+      - All sources rely on the same conceptual definition, but in many cases sources
+      do not agree with one another. Because
+      of this, year to year changes should be interpreted with caution. You can read
+      more about literacy measurement here:
+      https://ourworldindata.org/how-is-literacy-measured
 
-      Sources for each country-year observation can be found in [this table.](http://ourworldindata.org/wp-content/uploads/2018/06/cross-country-literacy-sources-final.csv)
+      </br>
+
+      - The World Bank's WDI estimates correspond to UNESCO Institute for Statistics.
+      OxLAD estimates come from several underlying
+      sources (see original documentation for more details).
+
+      </br>
+
+      - For Paraguay in 1982, the OxLAD data source was favoured over the World Bank
+      (WDI) as the latter estimates literacy
+      rates at 78.46%, a much lower estimate compared to neighbouring years for which
+      there was data available.
+
+      </br>
+
+      - Sources for each country-year observation can be found in <a href="http://ourworldindata.org/wp-content/uploads/2018/06/cross-country-literacy-sources-final.csv"
+      rel="noopener" target="_blank">this table.</a>
     url: '- World Bank: https://data.worldbank.org/indicator/SE.ADT.LITR.ZS </br>
       - CIA Factbook: https://www.cia.gov/library/publications/the-world-factbook/
       </br> - Links to other sources below'
@@ -30,6 +82,6 @@ meta:
   description: ''
 wdir: ../../../data/snapshots/education/2018-04-18
 outs:
-- md5: 1fccefc6026cd4c0161aa08b2bf7551e
+- md5: ac7d7e08ff61171f09a027dcc15b939e
   size: 17602
   path: literacy_rates.feather

--- a/snapshots/education/2018-04-18/literacy_rates.py
+++ b/snapshots/education/2018-04-18/literacy_rates.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+import click
+import pandas as pd
+
+from etl.backport_helpers import long_to_wide
+from etl.snapshot import Snapshot, SnapshotMeta
+
+SNAPSHOT_NAMESPACE = Path(__file__).parent.parent.name
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+
+@click.command()
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(upload: bool) -> None:
+    # Load backported snapshot.
+    snap_values = Snapshot(
+        "backport/latest/dataset_2762_cross_country_literacy_rates__world_bank__cia_world_factbook__and_other_sources_values.feather"
+    )
+    snap_values.pull()
+    snap_config = Snapshot(
+        "backport/latest/dataset_2762_cross_country_literacy_rates__world_bank__cia_world_factbook__and_other_sources_config.json"
+    )
+    snap_config.pull()
+
+    # Create snapshot metadata for the new file
+    meta = SnapshotMeta(**snap_values.metadata.to_dict())
+    meta.namespace = SNAPSHOT_NAMESPACE
+    meta.version = SNAPSHOT_VERSION
+    meta.short_name = "literacy_rates"
+    meta.fill_from_backport_snapshot(snap_config.path)
+    meta.save()
+
+    # Create a new snapshot.
+    snap = Snapshot(meta.uri)
+
+    # Convert from long to wide format.
+    df = long_to_wide(pd.read_feather(snap_values.path))
+
+    # Copy file to the new snapshot.
+    snap.path.parent.mkdir(parents=True, exist_ok=True)
+    df.reset_index().to_feather(snap.path)
+
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/education/2018-04-18/literacy_rates.py
+++ b/snapshots/education/2018-04-18/literacy_rates.py
@@ -36,8 +36,8 @@ def main(upload: bool) -> None:
     meta.short_name = "literacy_rates"
     meta.fill_from_backport_snapshot(snap_config.path)
     parser = HTMLToMarkdown()
-    parser.feed(meta.source.description)
-    meta.source.description = parser.get_markdown()
+    parser.feed(meta.source.description)  # type: ignore
+    meta.source.description = parser.get_markdown()  # type: ignore
 
     meta.save()
 
@@ -59,7 +59,7 @@ class HTMLToMarkdown(HTMLParser):
     def __init__(self):
         super().__init__()
         self.md = []
-        self.lasttag = None
+        self.lasttag = None  # type: ignore
 
     def handle_starttag(self, tag, attrs):
         if tag == "br":
@@ -72,14 +72,14 @@ class HTMLToMarkdown(HTMLParser):
             for attr in attrs:
                 if attr[0] == "href":
                     self.md.append("[")
-                    self.lasttag = ("a", attr[1])
+                    self.lasttag = ("a", attr[1])  # type: ignore
         elif tag == "strong" or tag == "b":
             self.md.append("**")
 
     def handle_endtag(self, tag):
         if tag == "a" and self.lasttag and self.lasttag[0] == "a":
             self.md.append("](" + self.lasttag[1] + ")")
-            self.lasttag = None
+            self.lasttag = None  # type: ignore
         elif tag == "ul":
             self.md.append("\n")
         elif tag == "li":


### PR DESCRIPTION
Backport [literacy rates](https://owid.cloud/admin/datasets/2762) with
```
ENV=.env.prod backport-migrate --dataset-id 2762 --namespace education --version 2018-04-18 --short-name literacy_rates
```

Backport [public expenditure on education](https://owid.cloud/admin/datasets/242) with
```
ENV=.env.prod backport-migrate --dataset-id 242 --namespace education --version 2017-09-30 --short-name public_expenditure
```

Once these datasets are merged, we should run `ENV=.env.prod.write walkthrough charts` to migrate their charts and delete old datasets.

## Issues
1. Markdown in `snapshots/education/2018-04-18/literacy_rates.feather.dvc` doesn't show list properly, not sure what am I doing wrong?
2. Source fields `Variable geographic coverage` and `Data publisher's source` are not available in ETL (intentionally), we might want to move them to description

<img width="1275" alt="image" src="https://github.com/owid/etl/assets/1550888/174ffe1f-28ec-46dc-b58a-f4d541b908c7">
