### PR TITLE
:sparkles: enable Jinja for description_short

### DIFF
--- a/.github/workflows/publish-owid-catalog.yml
+++ b/.github/workflows/publish-owid-catalog.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Publish owid-catalog to PyPI'
+        description: 'Publish owid-catalog to PyPI. Make sure you have bumped the version.'
 
 jobs:
   publish:

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -170,9 +170,16 @@ def _yield_wide_table(
                 tab[short_name].metadata.title = title_with_dims
 
             # expand metadata with Jinja template
-            tab[short_name].metadata.description = _expand_jinja_template(
-                tab[short_name].metadata.description, dim_dict
-            )
+            for k in (
+                "description",
+                "description_short",
+            ):
+                if getattr(tab[short_name].m, k):
+                    setattr(
+                        tab[short_name].m,
+                        k,
+                        _expand_jinja_template(getattr(tab[short_name].m, k), dim_dict),
+                    )
 
             # Keep only entity_id and year in index
             yield tab.reset_index().set_index(["entity_id", "year"])[[short_name]]


### PR DESCRIPTION
Enable Jinja templating for `description_short` in addition to `description` and `title`. @lucasrodes do you have a use case for any other fields? We could do it for any field, but the fewer the better (those nested fields or lists are slightly trickier and I don't have a good test case).