### PR TITLE
:sparkles: Improve repack performance and fix groupby

### DIFF
--- a/etl/steps/data/garden/wvs/2023-06-25/longitudinal_wvs.py
+++ b/etl/steps/data/garden/wvs/2023-06-25/longitudinal_wvs.py
@@ -76,17 +76,14 @@ def calculate_percentage(df, column, valid_responses_dict):
     # Group by country and year
     grouped = df_filtered.groupby(["country", "year"])
 
-    # HOTFIX: rename `count` to `countt` until we fix groupby.transform
     # Count valid responses
-    counts = grouped[column].value_counts().reset_index(name="countt")
+    counts = grouped[column].value_counts().reset_index(name="count")
 
     # Calculate total counts for each country and year
-    total_counts = counts.groupby(["country", "year"])["countt"].transform("sum")
+    total_counts = counts.groupby(["country", "year"])["count"].transform("sum")
 
     # Calculate percentage
-    counts["percentage"] = (counts["countt"] / total_counts) * 100
-
-    counts = counts.rename(columns={"countt": "count"})
+    counts["percentage"] = (counts["count"] / total_counts) * 100
 
     # Map response codes to labels
     counts[column] = counts[column].map(valid_responses_dict)

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -932,7 +932,8 @@ class TableGroupBy:
         if isinstance(key, list):
             return TableGroupBy(self.groupby[key], self.metadata, self._fields)
         else:
-            return self.__getattr__(key)  # type: ignore
+            self.__annotations__[key] = VariableGroupBy
+            return VariableGroupBy(self.groupby[key], key, self._fields[key])
 
     def __iter__(self) -> Iterator[Tuple[Any, "Table"]]:
         for name, group in self.groupby:

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -1007,6 +1007,13 @@ def test_groupby_count(table_1) -> None:
     assert gt.a.m.title == "Title of Table 1 Variable a"
 
 
+def test_groupby_transform(table_1) -> None:
+    # column named `count` should work
+    gt = table_1.rename(columns={"a": "count"}).groupby("country")["count"].transform("sum")
+    assert gt.values.tolist() == [3, 3, 3]
+    assert gt.m.title == "Title of Table 1 Variable a"
+
+
 def test_groupby_size(table_1) -> None:
     gt = table_1.groupby("country").size()
     assert gt.values.tolist() == [1, 2]

--- a/lib/repack/README.md
+++ b/lib/repack/README.md
@@ -64,6 +64,8 @@ The `repack_frame()` method simply does this across every column in your DataFra
 
 ## Releases
 
+- `0.1.3`:
+    - Improve performance on float dtypes
 - `0.1.2`:
     - Shrink columns with all NaNs to Int8
 - `0.1.1`:

--- a/lib/repack/owid/repack/__init__.py
+++ b/lib/repack/owid/repack/__init__.py
@@ -140,16 +140,14 @@ def series_eq(lhs: pd.Series, rhs: pd.Series, cast: Any, rtol: float = 1e-5, ato
     """
     # NOTE: this could be speeded up with numpy methods or smarter comparison,
     # but it's not bottleneck at the moment
-    if len(lhs) != len(rhs) or (lhs.isnull() != rhs.isnull()).any():
+    if len(lhs) != len(rhs):
         return False
 
     # improve performance by calling native astype method
     if cast == float:
         func = lambda s: s.astype(float)  # noqa: E731
     else:
+        # NOTE: this would be extremely slow in practice
         func = lambda s: s.apply(cast)  # noqa: E731
 
-    lhs_values = func(lhs.dropna())  # type: ignore
-    rhs_values = func(lhs.dropna())  # type: ignore
-
-    return np.allclose(lhs_values, rhs_values, rtol=rtol, atol=atol)
+    return np.allclose(func(lhs), func(rhs), rtol=rtol, atol=atol, equal_nan=True)

--- a/lib/repack/pyproject.toml
+++ b/lib/repack/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "owid-repack"
-version = "0.1.2"
+version = "0.1.3"
 description = "Pack Pandas data frames into smaller, more memory-efficient data types."
 authors = ["Our World in Data <tech@ourworldindata.org>"]
 license = "MIT"
@@ -23,6 +23,8 @@ isort = ">=5.11.4"
 
 [tool.isort]
 profile = "black"
+# owid is actually first party library, but we need to stay compatible with ETL
+known_third_party = "owid"
 
 [tool.black]
 line-length = 120

--- a/lib/repack/tests/test_repack.py
+++ b/lib/repack/tests/test_repack.py
@@ -3,9 +3,8 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pytest
-from pandas.testing import assert_frame_equal
-
 from owid import repack
+from pandas.testing import assert_frame_equal
 
 
 def test_repack_non_object_columns():
@@ -216,3 +215,13 @@ def test_repack_float64_all_nans():
     s = pd.Series([np.nan, np.nan, np.nan], dtype="float64")
     v = repack.repack_series(s)
     assert v.dtype.name == "Int8"
+
+
+def test_series_eq():
+    a = pd.Series([1, np.nan], dtype="float64")
+    b = pd.Series([2, np.nan], dtype="float64")
+    assert not repack.series_eq(a, b, cast=float)
+
+    a = pd.Series([1, np.nan], dtype="float64")
+    b = pd.Series([1, np.nan], dtype="float64")
+    assert repack.series_eq(a, b, cast=float)


### PR DESCRIPTION
* Improve repack performance (speeds up `garden/faostat/2023-06-12/faostat_scl` by 10x)
* Fix groupby with `count` column