### PR TITLE
:bug: add kwargs to Table.groupby.agg

### DIFF
--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -978,18 +978,15 @@ class TableGroupBy:
         for name, group in self.groupby:
             yield name, _create_table(group, self.metadata, self._fields)
 
-    def _groupby_operation(self, op, *args, **kwargs):
-        df = getattr(self.groupby, op)(*args, **kwargs)
-        return _create_table(df, self.metadata, self._fields)
-
-    def agg(self, func: Any, *args, **kwargs) -> "Table":
+    def agg(self, func: Optional[Any] = None, *args, **kwargs) -> "Table":
         df = self.groupby.agg(func, *args, **kwargs)
+        tb = _create_table(df, self.metadata, self._fields)
 
-        # agg returning multiindex is not yet supported
-        if isinstance(df.columns, pd.MultiIndex):
-            return _create_table(df, self.metadata, self._fields)
-        else:
-            return _create_table(df, self.metadata, self._fields)
+        # kwargs rename fields
+        for new_col, (col, _) in kwargs.items():
+            tb._fields[new_col] = self._fields[col]
+
+        return tb
 
 
 class VariableGroupBy:

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -972,6 +972,12 @@ def test_groupby_agg(table_1) -> None:
     assert gt.values.tolist() == [[False, 3, 6], [False, 3, 9]]
     assert isinstance(gt.a, Table)
 
+    gt = table_1.groupby("country").agg(
+        min_a=("a", "min"),
+    )
+    assert gt.min_a.values.tolist() == [3, 1]
+    assert gt.min_a.m.title == "Title of Table 1 Variable a"
+
 
 def test_groupby_count(table_1) -> None:
     gt = table_1.groupby("country").count()


### PR DESCRIPTION
Fix for https://github.com/owid/etl/issues/1698. Thanks @lucasrodes, I didn't know `agg` accepts kwargs.