### PR TITLE
:bug: fix aother_subtype_details column in flunet

### DIFF
--- a/etl/steps/data/meadow/who/latest/flunet.py
+++ b/etl/steps/data/meadow/who/latest/flunet.py
@@ -32,6 +32,12 @@ def run(dest_dir: str) -> None:
     # Create a new table and ensure all columns are snake-case.
     tb = Table(df, short_name=paths.short_name, underscore=True)
     tb = tb.rename(columns={"country_area_territory": "country"})
+
+    # Convert messy columns to string.
+    for col in ("aother_subtype_details",):
+        ix = tb[col].notnull()
+        tb.loc[ix, col] = tb.loc[ix, col].astype("str")
+
     #
     # Save outputs.
     #

--- a/lib/repack/owid/repack/__init__.py
+++ b/lib/repack/owid/repack/__init__.py
@@ -48,7 +48,7 @@ def repack_frame(
 
     for col in df.columns:
         if df[col].dtype == "object":
-            raise ValueError(f"column {col} is still object")
+            raise ValueError(f"Column {col} is still object. Consider converting it to str.")
 
     # set the primary key back again
     if primary_key:


### PR DESCRIPTION
`who/latest/flunet` step was failing because column `aother_subtype_details` contains mix of everything (floats, nans, strings, ...) and repack wasn't able to convert it to category. Converting it to string (while preserving nans) fixes it.

@spoonerf I'm gonna merge this now to fix ETL, but could you still take a look?