### PR TITLE
:bug: fix duplicate origins

### DIFF
--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -165,6 +165,7 @@ def _add_or_update_source(
 
 def _add_or_update_origins(session: Session, origins: list[catalog.Origin]) -> list[gm.Origin]:
     out = []
+    assert len(origins) == len(set(origins)), "origins must be unique"
     for origin in origins:
         out.append(gm.Origin.from_origin(origin).upsert(session))
     return out


### PR DESCRIPTION
We rarely end up with duplicate origins in the `origins` table. The current script assumes uniqueness, but that's tricky to do because having unique constraint on all columns is impossible and ensuring no race conditions is tricky too (honestly, I don't know how can we end up with duplicate origins. There are locks when upserting to `origins`). Anyway, having multiple origins is not such a big deal (especially since we might clean them up later).

This PR makes it robust to duplicate origins.