### PR TITLE
:left_arrow: backport share of agriculture in GDP

### DIFF
--- a/dag/migrated.yml
+++ b/dag/migrated.yml
@@ -16,3 +16,7 @@ steps:
   - data://garden/education/2017-09-30/public_expenditure
   data://garden/education/2017-09-30/public_expenditure:
   - snapshot://education/2017-09-30/public_expenditure.feather
+  data://grapher/agriculture/2023-10-04/share_of_agriculture_in_gdp:
+  - data://garden/agriculture/2023-10-04/share_of_agriculture_in_gdp
+  data://garden/agriculture/2023-10-04/share_of_agriculture_in_gdp:
+  - snapshot://agriculture/2023-10-04/share_of_agriculture_in_gdp.feather

--- a/etl/steps/data/garden/agriculture/2023-10-04/share_of_agriculture_in_gdp.meta.yml
+++ b/etl/steps/data/garden/agriculture/2023-10-04/share_of_agriculture_in_gdp.meta.yml
@@ -1,0 +1,38 @@
+dataset:
+  title: Share of agriculture in GDP at current prices (Herrendorf et al. and GGDC-10 data) (split)
+tables:
+  share_of_agriculture_in_gdp:
+    variables:
+      share_of_agriculture_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data:
+        title: Share of agriculture in GDP at current prices (Herrendorf et al. and GGDC-10 data)
+        description: Historical estimates of value added by economic sector, at current prices (expressed as share of total
+          value added at current prices)
+        unit: '% GDP'
+        short_unit: '%'
+      share_of_employment_in_agriculture__herrendorf_et_al__and_ggdc_10_data:
+        title: Share of employment in agriculture (Herrendorf et al. and GGDC-10 data)
+        description: Historical estimates of employment shares by economic sector.
+        unit: '%'
+        short_unit: '%'
+      share_of_employment_in_industry__herrendorf_et_al__and_ggdc_10_data:
+        title: Share of employment in industry (Herrendorf et al. and GGDC-10 data)
+        description: Historical estimates of employment shares by economic sector.
+        unit: '%'
+        short_unit: '%'
+      share_of_employment_in_services__herrendorf_et_al__and_ggdc_10_data:
+        title: Share of employment in services (Herrendorf et al. and GGDC-10 data)
+        description: Historical estimates of employment shares by economic sector.
+        unit: '%'
+        short_unit: '%'
+      share_of_industry_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data:
+        title: Share of industry in GDP at current prices (Herrendorf et al. and GGDC-10 data)
+        description: Historical estimates of value added by economic sector, at current prices (expressed as share of total
+          value added at current prices)
+        unit: '% GDP'
+        short_unit: '%'
+      share_of_services_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data:
+        title: Share of services in GDP at current prices (Herrendorf et al. and GGDC-10 data)
+        description: Historical estimates of value added by economic sector, at current prices (expressed as share of total
+          value added at current prices)
+        unit: '% GDP'
+        short_unit: '%'

--- a/etl/steps/data/garden/agriculture/2023-10-04/share_of_agriculture_in_gdp.py
+++ b/etl/steps/data/garden/agriculture/2023-10-04/share_of_agriculture_in_gdp.py
@@ -1,0 +1,23 @@
+"""Load snapshot and create a garden dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load data from snapshot.
+    #
+    snap = paths.load_snapshot()
+    tb = snap.read().set_index(["country", "year"])
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the snapshot.
+    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()

--- a/etl/steps/data/grapher/agriculture/2023-10-04/share_of_agriculture_in_gdp.py
+++ b/etl/steps/data/grapher/agriculture/2023-10-04/share_of_agriculture_in_gdp.py
@@ -1,0 +1,26 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset()
+
+    # Read table from garden dataset.
+    tb = ds_garden["share_of_agriculture_in_gdp"]
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()

--- a/snapshots/agriculture/2023-10-04/share_of_agriculture_in_gdp.feather.dvc
+++ b/snapshots/agriculture/2023-10-04/share_of_agriculture_in_gdp.feather.dvc
@@ -1,0 +1,39 @@
+meta:
+  source:
+    name: Our World In Data based on Herrendorf et al. (2014) and GGDC-10 (2015)
+    description: >-
+      For Belgium, Spain, France, Japan, South Korea, the Netherlands, Sweden, the
+      UK, and the USA, observations in this dataset
+      correspond to the data published by Herrendorf, Rogerson, and Valentinyi (2014),
+      except in some cases where we have
+      updated observation using new releases of the same underlying data sources.
+      The most important update corresponds to
+      the 2015 release of the Groningen Growth and Development Centre’s (GGDC) 10-sector
+      database. However, some other country-specific
+      updates were also considered (e.g. US data published by the Bureau of Economic
+      Analysis). In [the attached documentation](https://drive.google.com/file/d/1JMXH6IYOtR_Cs0gASRVT1VQRxBIZn-11/view?usp=sharing)
+      we describe sources and updates, country by country.
+
+
+      For the rest of the countries, data comes directly from the 2015 release of
+      the GGDC 10-sector database. The only change
+      we applied to the GGDC 10-sector database was dropping observations for GDP
+      shares in Peru 1950-1985 (these are reported
+      as negative in the original).
+    url: Data from Herrendorf et al. (2014) is available from https://drive.google.com/file/d/1Oq02EqNF5AqJDw5FmDRLg5yUHQ5basKR/view
+      . The GGDC 10-Sector Database is available from http://www.rug.nl/ggdc/productivity/10-sector/
+      Links to other data used to update the Herrendorf et al. (2014) series is available
+      in our attached documentation
+    date_accessed: 2017-03-08
+    published_by: 'Our World in Data (Nicolas Lippolis) based on: (i) Berthold Herrendorf,
+      Richard Rogerson and Akos Valentinyi (2014) – “Growth and Structural Transformation”
+      Handbook of Economic Growth Vol. 2B, (ii) 2015 release of the Groningen Growth
+      and Development Centre’s (GGDC) 10-sector database'
+  name: Share of agriculture in GDP at current prices (Herrendorf et al. and GGDC-10
+    data) (split)
+  description: ''
+wdir: ../../../data/snapshots/agriculture/2023-10-04
+outs:
+- md5: 3ce82b23325e8851d45df17a4727792b
+  size: 74522
+  path: share_of_agriculture_in_gdp.feather

--- a/snapshots/agriculture/2023-10-04/share_of_agriculture_in_gdp.py
+++ b/snapshots/agriculture/2023-10-04/share_of_agriculture_in_gdp.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import click
+import pandas as pd
+
+from etl.backport_helpers import long_to_wide
+from etl.snapshot import Snapshot, SnapshotMeta
+
+SNAPSHOT_NAMESPACE = Path(__file__).parent.parent.name
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+
+@click.command()
+@click.option(
+    "--upload/--skip-upload",
+    default=True,
+    type=bool,
+    help="Upload dataset to Snapshot",
+)
+def main(upload: bool) -> None:
+    # Load backported snapshot.
+    snap_values = Snapshot(
+        "backport/latest/dataset_3009_share_of_agriculture_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data__split_values.feather"
+    )
+    snap_values.pull()
+    snap_config = Snapshot(
+        "backport/latest/dataset_3009_share_of_agriculture_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data__split_config.json"
+    )
+    snap_config.pull()
+
+    # Create snapshot metadata for the new file
+    meta = SnapshotMeta(**snap_values.metadata.to_dict())
+    meta.namespace = SNAPSHOT_NAMESPACE
+    meta.version = SNAPSHOT_VERSION
+    meta.short_name = "share_of_agriculture_in_gdp"
+    meta.is_public = True
+    meta.fill_from_backport_snapshot(snap_config.path)
+    meta.save()
+
+    # Create a new snapshot.
+    snap = Snapshot(meta.uri)
+
+    # Convert from long to wide format.
+    df = long_to_wide(pd.read_feather(snap_values.path))
+
+    # Copy file to the new snapshot.
+    snap.path.parent.mkdir(parents=True, exist_ok=True)
+    df.reset_index().to_feather(snap.path)
+
+    # Add file to DVC and upload to S3.
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/backport/latest/dataset_3009_share_of_agriculture_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data__split_config.json.dvc
+++ b/snapshots/backport/latest/dataset_3009_share_of_agriculture_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data__split_config.json.dvc
@@ -2,7 +2,7 @@ meta:
   source:
     name: Our World in Data catalog backport
     url: https://owid.cloud/admin/datasets/3009
-    date_accessed: 2023-08-10 09:22:08.962632
+    date_accessed: 2023-10-04 08:05:24.629426
     publication_date: latest
     published_by: Our World in Data catalog backport
   name: Grapher metadata for 
@@ -11,7 +11,7 @@ meta:
   is_public: false
 wdir: ../../../data/snapshots/backport/latest
 outs:
-- md5: 964b49331c2991263158ddc2c0beb0c0
-  size: 8009
+- md5: d786fa82233a8d574c15cd4cbd000f15
+  size: 8038
   path: 
     dataset_3009_share_of_agriculture_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data__split_config.json

--- a/snapshots/backport/latest/dataset_3009_share_of_agriculture_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data__split_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_3009_share_of_agriculture_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data__split_values.feather.dvc
@@ -2,7 +2,7 @@ meta:
   source:
     name: Our World in Data catalog backport
     url: https://owid.cloud/admin/datasets/3009
-    date_accessed: 2023-08-10 09:22:45.352956
+    date_accessed: 2023-10-04 08:05:31.149527
     publication_date: latest
     published_by: Our World in Data catalog backport
   name: Share of agriculture in GDP at current prices (Herrendorf et al. and GGDC-10
@@ -11,7 +11,7 @@ meta:
   is_public: false
 wdir: ../../../data/snapshots/backport/latest
 outs:
-- md5: 1dd1232a79c3f3cc3fbe6a729f596e41
-  size: 65930
+- md5: 39cab1ad43cf42b386700dec72268191
+  size: 131322
   path: 
     dataset_3009_share_of_agriculture_in_gdp_at_current_prices__herrendorf_et_al__and_ggdc_10_data__split_values.feather


### PR DESCRIPTION
Backported with

```
ENV=.env.prod backport-migrate --dataset-id 3009 --namespace agriculture --version 2017-03-08 --short-name share_of_agriculture_in_gdp
```

