### PR TITLE
:bug: add proper path to pythonpath if step is a module

### DIFF
--- a/etl/run_python_step.py
+++ b/etl/run_python_step.py
@@ -36,7 +36,9 @@ def main(uri: str, dest_dir: str, ipdb: Optional[bool]) -> None:
 
 def _import_and_run(path: str, dest_dir: str) -> None:
     # ensure that the module search path includes the script
-    module_dir = (STEP_DIR / "data" / path).parent
+    step_path = STEP_DIR / "data" / path
+    # path can be either in a module with __init__.py or a single .py file
+    module_dir = step_path if step_path.is_dir() else step_path.parent
     sys.path.append(module_dir.as_posix())
 
     # import the module

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -506,7 +506,8 @@ class DataStep(Step):
         """
         from etl.helpers import isolated_env
 
-        module_dir = self._search_path.parent
+        # path can be either in a module with __init__.py or a single .py file
+        module_dir = self._search_path if self._search_path.is_dir() else self._search_path.parent
 
         with isolated_env(module_dir):
             step_module = import_module(self._search_path.relative_to(paths.BASE_DIR).as_posix().replace("/", "."))


### PR DESCRIPTION
With this, you'll be able to import files without relative imports. Absolute imports let you use VSCode code interpreter.