### PR TITLE
🔧  Fixing UN IGME metadata

### DIFF
--- a/etl/steps/data/garden/un/2023-08-16/igme.meta.yml
+++ b/etl/steps/data/garden/un/2023-08-16/igme.meta.yml
@@ -1,12 +1,13 @@
 tables:
-  igme_combined:
+  igme_under_fifteen_mortality_rate:
     variables:
       ? observation_value_deaths_per_1_000_live_births_under_fifteen_mortality_rate_both_sexes_all_wealth_quintiles
-      : title: Under fifteen mortality rate, both sexes, all wealth quintiles
-        description_processing: Under-fifteen mortality rate has been calculated by OWID from the under-five mortality rate and the infant mortality rate. Additionally, two vintages of the UN IGME Child Mortality Estimates have been used to ensure a longer time series.
+      : title: Observation value-Deaths per 1,000 live births-Under-fifteen mortality rate-Both sexes-All wealth quintiles
+        description_processing: This indicator is processed by OWID based on the original data source. It is a combination of the under-five mortality rate and the 5-14 mortality rate.
         unit: deaths per 1,000 live births
         display:
           numDecimalPlaces: 1
+        sources:
+          - name: United Nations Inter-agency Group for Child Mortality Estimation (2018; 2023)
         presentation:
-          title_public: Under-fifteen mortality rate
-          attribution: UN IGME (2018; 2023)
+          attribution: United Nations Inter-agency Group for Child Mortality Estimation (2018; 2023)

--- a/etl/steps/data/garden/un/2023-08-16/igme.py
+++ b/etl/steps/data/garden/un/2023-08-16/igme.py
@@ -25,8 +25,9 @@ def run(dest_dir: str) -> None:
     tb = ds_meadow["igme"].reset_index()
     tb_vintage = ds_vintage["igme"].reset_index()
     tb_youth = tb_vintage[tb_vintage["indicator_name"].isin(["Deaths age 5 to 14", "Mortality rate age 5 to 14"])]
-    #
-    # Process data.
+    tb_youth = process_vintage_data(tb_youth)
+
+    # Process current data.
     #
     tb = fix_sub_saharan_africa(tb)
     tb: Table = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
@@ -37,8 +38,74 @@ def run(dest_dir: str) -> None:
         columns={"obs_value": "Observation value", "lower_bound": "Lower bound", "upper_bound": "Upper bound"}
     )
     tb["source"] = "igme (current)"
+    # Separate out the variables needed to calculate the under-fifteen mortality rate.
+    tb_under_fifteen = tb[
+        (
+            tb["indicator"].isin(
+                ["Under-five deaths", "Deaths age 5 to 14", "Under-five mortality rate", "Mortality rate age 5-14"]
+            )
+        )
+        & (
+            tb["unit_of_measure"].isin(
+                ["Number of deaths", "Deaths per 1,000 live births", "Deaths per 1000 children aged 5"]
+            )
+        )
+    ]
 
-    # Process 5-14 mortality data
+    # Combine datasets with a preference for the current data when there is a conflict.
+
+    tb_com = combine_datasets(
+        tb_a=tb_under_fifteen, tb_b=tb_youth, table_name="igme_combined", preferred_source="igme (current)"
+    )
+
+    tb_com = calculate_under_fifteen_deaths(tb_com)
+
+    # Pivot the table so that the variables are in columns.
+    tb = pivot_table_and_format(tb)
+    tb_com = pivot_table_and_format(tb_com)
+
+    tb_com = calculate_under_fifteen_mortality_rates(tb_com)
+    # Add some metadata to the variables. Getting the unit from the column name and inferring the number of decimal places from the unit.
+    # If it contains " per " we know it is a rate and should have 1 d.p., otherwise it should be an integer.
+
+    tb = add_metadata_and_set_index(tb)
+    tb_com = add_metadata_and_set_index(tb_com)
+
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(dest_dir, tables=[tb, tb_com], default_metadata=ds_meadow.metadata)
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()
+
+
+def add_metadata_and_set_index(tb: Table) -> Table:
+    for col in tb.columns[2:]:
+        unit = col.split("-")[1]
+        tb[col].metadata.unit = unit.lower().strip()
+        tb[col].metadata.title = col
+        if " per " in unit:
+            tb[col].metadata.display = {"numDecimalPlaces": 1}
+        else:
+            tb[col].metadata.display = {"numDecimalPlaces": 0}
+    tb = tb.set_index(["country", "year"], verify_integrity=True)
+    return tb
+
+
+def pivot_table_and_format(tb: Table) -> Table:
+    tb = tb.pivot(
+        index=["country", "year"],
+        values=["Observation value", "Lower bound", "Upper bound"],
+        columns=["unit_of_measure", "indicator", "sex", "wealth_quintile"],
+    )
+    tb.columns = ["-".join(col).strip() for col in tb.columns.values]
+    tb = tb.reset_index()
+    return tb
+
+
+def process_vintage_data(tb_youth: Table) -> Table:
+    # Process vintage 5-14 mortality data
     tb_youth = tb_youth.rename(
         columns={
             "indicator_name": "indicator",
@@ -54,38 +121,7 @@ def run(dest_dir: str) -> None:
     tb_youth["source"] = "igme (2018)"
     tb_youth["indicator"] = tb_youth["indicator"].replace({"Mortality rate age 5 to 14": "Mortality rate age 5-14"})
 
-    # Combine datasets with a preference for the current data when there is a conflict.
-
-    tb = combine_datasets(tb_a=tb, tb_b=tb_youth, table_name="igme_combined", preferred_source="igme (current)")
-
-    tb = calculate_under_fifteen_deaths(tb)
-
-    tb = tb.pivot(
-        index=["country", "year"],
-        values=["Observation value", "Lower bound", "Upper bound"],
-        columns=["unit_of_measure", "indicator", "sex", "wealth_quintile"],
-    )
-    tb.columns = ["-".join(col).strip() for col in tb.columns.values]
-    tb = tb.reset_index()
-    tb = calculate_under_fifteen_mortality_rates(tb)
-    # Add some metadata to the variables. Getting the unit from the column name and inferring the number of decimal places from the unit.
-    # If it contains " per " we know it is a rate and should have 1 d.p., otherwise it should be an integer.
-    for col in tb.columns[2:]:
-        unit = col.split("-")[1]
-        tb[col].metadata.unit = unit.lower().strip()
-        tb[col].metadata.title = col
-        if " per " in unit:
-            tb[col].metadata.display = {"numDecimalPlaces": 1}
-        else:
-            tb[col].metadata.display = {"numDecimalPlaces": 0}
-    tb = tb.set_index(["country", "year"], verify_integrity=True)
-    # Save outputs.
-    #
-    # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
-
-    # Save changes in the new garden dataset.
-    ds_garden.save()
+    return tb_youth
 
 
 def calculate_under_fifteen_mortality_rates(tb: Table) -> Table:
@@ -112,7 +148,14 @@ def calculate_under_fifteen_mortality_rates(tb: Table) -> Table:
         tb["Observation value-Deaths per 1,000 live births-Under-five mortality rate-Both sexes-All wealth quintiles"]
         + tb["adjusted_5_14_mortality_rate"]
     )
-    tb = tb.drop(columns="adjusted_5_14_mortality_rate")
+    tb = tb[
+        [
+            "country",
+            "year",
+            "Observation value-Deaths per 1,000 live births-Under-fifteen mortality rate-Both sexes-All wealth quintiles",
+        ]
+    ]
+    tb.metadata.short_name = "igme_under_fifteen_mortality_rate"
     return tb
 
 

--- a/etl/steps/data/garden/un/2023-08-29/long_run_child_mortality.py
+++ b/etl/steps/data/garden/un/2023-08-29/long_run_child_mortality.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     ds_gapminder_v7: Dataset = paths.load_dependency("under_five_mortality", version="2023-09-18")
 
     # Read table from meadow dataset.
-    tb_igme = ds_igme["igme_combined"].reset_index()
+    tb_igme = ds_igme["igme"].reset_index()
 
     # Select out columns of interest.
     columns = {

--- a/etl/steps/data/grapher/un/2023-08-16/igme.py
+++ b/etl/steps/data/grapher/un/2023-08-16/igme.py
@@ -18,7 +18,8 @@ def run(dest_dir: str) -> None:
     ds_garden = cast(Dataset, paths.load_dependency("igme"))
 
     # Read table from garden dataset.
-    tb = ds_garden["igme_combined"]
+    tb = ds_garden["igme"]
+    tb_youth = ds_garden["igme_under_fifteen_mortality_rate"]
 
     #
     # Process data.
@@ -28,7 +29,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = create_dataset(dest_dir, tables=[tb, tb_youth], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/snapshots/un/2023-08-16/igme.zip.dvc
+++ b/snapshots/un/2023-08-16/igme.zip.dvc
@@ -1,15 +1,16 @@
 meta:
   name: United Nations Inter-agency Group for Child Mortality Estimation (2023)
   publication_year: 2023
-  source_name: UN IGME (2023)
-  source_published_by: 'United Nations Inter-agency Group for Child Mortality Estimation
+  source_name: United Nations Inter-agency Group for Child Mortality Estimation (2023)
+  source_published_by:
+    "United Nations Inter-agency Group for Child Mortality Estimation
     (UN IGME), Levels & Trends in Child Mortality: Report 2022, Estimates developed
     by the United Nations Inter-agency Group for Child Mortality Estimation, United
-    Nations Children’s Fund, New York, 2023.'
+    Nations Children’s Fund, New York, 2023."
   url: https://childmortality.org/data
   source_data_url: https://childmortality.org/wp-content/uploads/2021/09/UN-IGME-2022.zip
   license_url: https://www.unicef.org/legal#copyright
-  license_name: ''
+  license_name: ""
   date_accessed: 2023-08-16
   is_public: true
   description: |
@@ -20,6 +21,6 @@ meta:
     UN IGME updates its child mortality estimates annually after reviewing newly available data and assessing data quality. The web portal contains the latest UN IGME estimates of child mortality at the country, regional and global levels, and the data used to derive them.
 wdir: ../../../data/snapshots/un/2023-08-16
 outs:
-- md5: ef59edbab7791b7a16b2551248e835c9
-  size: 17737197
-  path: igme.zip
+  - md5: ef59edbab7791b7a16b2551248e835c9
+    size: 17737197
+    path: igme.zip


### PR DESCRIPTION
Splitting the under fifteen mortality out into a different table, to make it easier to give it slightly amended metadata as it is a combination of two vintages of UN IGME.