### PR TITLE
🐛 wizard: minor fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,21 +1,19 @@
 {
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
             "name": "Python: bulk_packport",
             "type": "python",
             "request": "launch",
-            "program": "debug.sh",
+            "program": "/home/daniel/.local/bin/poetry",
+            "args": ["run", "bulk_backport", "--dry-run"],
             "console": "integratedTerminal",
             "justMyCode": true,
-            "python": "/home/lucas/repos/etl/.venv/bin/python"
-        },
-        {
-            "name": "Python: File",
-            "type": "python",
-            "request": "launch",
-            "program": "${file}",
-            "justMyCode": true
+            "python": "/usr/bin/python",
+
         }
     ]
 }

--- a/apps/wizard/templating/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}.dvc
+++ b/apps/wizard/templating/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}.dvc
@@ -23,7 +23,7 @@ meta:
     # Citation
     producer: {{cookiecutter.producer}}
     citation_full: |-
-      {{cookiecutter.citation_full}}
+      {{cookiecutter.citation_full.replace("\n", "\n      ")}}
     {%- if cookiecutter.attribution %}
     attribution: {{cookiecutter.attribution}}
     {%- endif %}

--- a/apps/wizard/templating/snapshot.py
+++ b/apps/wizard/templating/snapshot.py
@@ -806,4 +806,6 @@ if st.session_state["run_step"]:
     # Run step
     with st.spinner(f"Running snapshot step... {command_str}"):
         subprocess.call(args=commands)
-    st.write("Snapshot uploaded!")
+    st.write(
+        "Snapshot should be uploaded! However, please check in the terminal in case there was an error message raised there."
+    )

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -239,8 +239,7 @@
         "description": "Exact day (or year, if exact day is unknown) when the producer's data (in its current version) was published.",
         "examples": [
           "2023-09-07",
-          "2023",
-          "latest"
+          "2023"
         ],
         "examples_bad": [],
         "requirement_level": "required",
@@ -252,7 +251,7 @@
             "Must be the date when the current version of the dataset was published (not when the dataset was first released)."
           ]
         ],
-        "pattern": "(^\\d\\d\\d\\d\\-\\d\\d\\-\\d\\d$)|(^\\d{4}$)|(^latest$)",
+        "pattern": "(^\\d\\d\\d\\d\\-\\d\\d\\-\\d\\d$)|(^\\d{4}$)",
         "errorMessage": "`date_published` must have format YYYY-MM-DD, YYYY or 'latest'",
         "category": "dataset"
       },


### PR DESCRIPTION
- Fixes indentation in `origin.citation_full` (see #1752).
- Improves uploading message in snapshot step (see #1753).
- Update docs and schema to stop encouraging the usage of `date_published: latest`.