### PR TITLE
Bump owid catalog version

### DIFF
--- a/lib/catalog/README.md
+++ b/lib/catalog/README.md
@@ -215,6 +215,11 @@ t = Table.read_csv('/tmp/my_table.csv')
 ## Changelog
 
 - `dev`
+- `v0.3.7`
+  - Fix bugs.
+  - Improve metadata propagation.
+  - Improve metadata YAML file handling, to have common definitions.
+  - Remove `DatasetMeta.origins`.
 - `v0.3.6`
   - Fixed tons of bugs
   - `processing.py` module with pandas-like functions that propagate metadata

--- a/lib/catalog/pyproject.toml
+++ b/lib/catalog/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "owid-catalog"
-version = "0.3.6"
+version = "0.4.0"
 description = "Core data types used by OWID for managing data."
 authors = ["Our World in Data <tech@ourworldindata.org>"]
 license = "MIT"


### PR DESCRIPTION
Bump owid catalog version and update the changelong.

For context, I'm trying to use `catalog.find` in the `co2-data` repos, and it raises an error, which doesn't happen when using the same command from the current ETL. I haven't looked into it, but I suppose that upgrading `owid-catalog` should fix the issue.
