### PR TITLE
Fix owid-catalog version

### DIFF
--- a/lib/catalog/pyproject.toml
+++ b/lib/catalog/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "owid-catalog"
-version = "0.4.0"
+version = "0.3.7"
 description = "Core data types used by OWID for managing data."
 authors = ["Our World in Data <tech@ourworldindata.org>"]
 license = "MIT"


### PR DESCRIPTION
Instead of 0.4.0, use 0.3.7 (this avoid incompatibility issues with datautils).
