### PR TITLE
:bar_chart: migrate JSON data page for PIP indicators

### DIFF
--- a/etl/steps/data/grapher/wb/2022-10-03/world_bank_pip.meta.yml
+++ b/etl/steps/data/grapher/wb/2022-10-03/world_bank_pip.meta.yml
@@ -45,7 +45,7 @@ tables:
           - "{definitions.income_consumption_pc}"
           - "{definitions.non_market_income}"
         description_processing: |-
-          {common.processing_notes}
+          {definitions.processing_notes}
         presentation:
           title_public: Share of population living in extreme poverty
           topic_tags:
@@ -120,7 +120,7 @@ tables:
         description_processing: |-
           Measures of relative poverty are not directly available in the World Bank PIP data. To calculate this metric we take the median income or consumption for the country and year, calculate a relative poverty line – in this case 60% of the median – and then run a specific query on the PIP API to return the share of population below that line.
 
-          {common.processing_notes}
+          {definitions.processing_notes}
         presentation:
           title_public: Share of population below 60% of median income or consumption
           topic_tags:
@@ -174,7 +174,7 @@ tables:
           - "{definitions.income_consumption_pc}"
           - "{definitions.non_market_income}"
         description_processing: |-
-          {common.processing_notes}
+          {definitions.processing_notes}
         presentation:
           title_public: Gini Coefficient
           topic_tags:

--- a/etl/steps/data/grapher/wb/2022-10-03/world_bank_pip.meta.yml
+++ b/etl/steps/data/grapher/wb/2022-10-03/world_bank_pip.meta.yml
@@ -1,0 +1,275 @@
+dataset:
+  update_period_days: 365
+  sources: []
+
+definitions:
+  common:
+    sources: []
+    origins:
+      - producer: World Bank Poverty and Inequality Platform
+        title: World Bank, Poverty and Inequality Platform
+        description: |-
+          The Poverty and Inequality Platform (PIP) is an interactive computational tool that offers users quick access to the World Bank’s estimates of poverty, inequality, and shared prosperity. PIP provides a comprehensive view of global, regional, and country-level trends for more than 160 economies around the world.
+
+          \[Text from [PIP website](https://pip.worldbank.org/about)\]
+
+          Version 20220909\_2017\_01\_02\_PROD
+        citation_full: World Bank Poverty and Inequality Platform
+        url_main: https://pip.worldbank.org/
+        date_accessed: '2022-10-03'
+        date_published: '2022-10-03'
+      # - producer: World Bank Poverty and Inequality Platform (2022)
+      #   title: World Bank Poverty and Inequality Platform (PIP)
+      #   description: >-
+      #     Version 20220909_2017_01_02_PROD
+
+      #     The Poverty and Inequality Platform (PIP) is an interactive computational tool that offers users quick access to
+      #     the World Bank’s estimates of poverty, inequality, and shared prosperity. PIP provides a comprehensive view of global,
+      #     regional, and country-level trends for more than 150 economies around the world.
+
+
+      #     Version 20220909_2017_01_02_PROD
+
+
+      #     You can read more information about PIP data and methodology in [GitHub](https://github.com/owid/poverty-data).
+      #   citation_full: World Bank Poverty and Inequality Platform
+      #   url_main: https://pip.worldbank.org/
+      #   date_accessed: '2022-10-03'
+      #   date_published: '2022-10-03'
+
+    presentation:
+      title_variant: World Bank, PIP
+      attribution_short: World Bank
+
+tables:
+  world_bank_pip:
+    variables:
+      dollar2_15_a_day__share_of_population_below_poverty_line:
+        title: $2.15 a day - share of population below poverty line
+        unit: '%'
+        short_unit: '%'
+        description_short: The share of population living below the International Poverty Line of $2.15 per day. This data is adjusted for inflation and for differences in the cost of living between countries.
+        # description: '% of population living in households with an income or expenditure per person below $2.15 a day'
+        description_key:
+          - Extreme poverty here is defined as living below the International Poverty Line of $2.15 per day.
+          - The data is measured in international-$ at 2017 prices – this adjusts for inflation and for differences in the cost of living between countries.
+          - Depending on the country and year, the data relates to either disposable income or consumption per capita, depending on the country and year.
+          - Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account.
+        description_processing: |-
+          For a small number of country-year observations, the World Bank PIP data contains two estimates: one based on income data and one based on consumption data. In these cases we keep only the consumption estimate in order to obtain a single series for each country.
+
+          You can find the data with all available income and consumption data points, including these overlapping estimates, in our [complete dataset](https://github.com/owid/poverty-data#a-global-dataset-of-poverty-and-inequality-measures-prepared-by-our-world-in-data-from-the-world-banks-poverty-and-inequality-platform-pip-database) of the World Bank PIP data.
+        presentation:
+          title_public: Share of population living in extreme poverty
+          topic_tags:
+            - Poverty
+            - Economic Growth
+            - Economic Inequality
+          faqs:
+            # NOTE: there's an image, but I'm getting an error
+            # Image error
+            # Image with filename "Five-income-distributions-national-poverty-and-IPL-2.png" not found. This block will not render when the page is baked.
+            #
+            # perhaps this will be rendered correctly in production?
+            - fragment_id: poverty-povery-line
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+            - fragment_id: poverty-international-dollars
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+            - fragment_id: poverty-comparability
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+            - fragment_id: poverty-estimates
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          grapher_config:
+            slug: share-of-population-in-extreme-poverty
+            title: Share of population living in extreme poverty
+            subtitle: >-
+              Extreme poverty is defined as living below the International Poverty Line of
+              $2.15 per day. This data is adjusted for inflation and for differences in the
+              cost of living between countries.
+            note: >-
+              This data is expressed in [international-$](#dod:int_dollar_abbreviation) at
+              2017 prices. Depending on the country and year, it relates to income measured
+              after taxes and benefits, or to consumption, [per capita](#dod:per-capita).
+            hasMapTab: true
+            tab: map
+            variantName: Line chart
+            originUrl: https://ourworldindata.org/poverty
+            yAxis:
+              min: 0
+              max: 0
+            map:
+              columnSlug: '472273'
+              time: 2019
+              timeTolerance: 5
+              colorScale:
+                baseColorScheme: OrRd
+                binningStrategy: manual
+                customNumericValues:
+                  - 3
+                  - 10
+                  - 20
+                  - 30
+                  - 40
+                  - 50
+                  - 60
+                  - 70
+                  - 80
+                  - 90
+                  - 100
+                customNumericColors:
+                  - '#e31a1c'
+                  - null
+                  - null
+                  - null
+                  - '#bd0026'
+                  - null
+                  - null
+            selectedEntityNames:
+              - Bangladesh
+              - Bolivia
+              - Madagascar
+              - India
+              - China
+              - Ethiopia
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+      _60pct_of_median__share_of_population_below_poverty_line:
+        title: 60% of median - share of population below poverty line
+        unit: '%'
+        short_unit: '%'
+        description_short: A measure of relative poverty — the share of the population with an income or consumption below 60% of the median in their country.
+        # description: '% of population living in households with an income or expenditure per person below 60% of the median'
+        description_from_producer: |-
+          How does the Poverty and Inequality Platform (PIP) describe this metric?
+        description_key:
+          - This is a measure of _relative_ poverty – it captures the share of people whose income is low by the standards typical in their own country.
+          - Depending on the country and year, the data relates to either disposable income or consumption per capita, depending on the country and year.
+          - Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account.
+        description_processing: |-
+          Measures of relative poverty are not directly available in the World Bank PIP data. To calculate this metric we take the median income or consumption for the country and year, calculate a relative poverty line – in this case 60% of the median – and then run a specific query on the PIP API to return the share of population below that line.
+
+          For a small number of country-year observations, the PIP data contains two estimates: one based on income data and one based on consumption data. In these cases we keep only the consumption estimate in order to obtain a single series for each country.
+
+          You can find the data with all available income and consumption data points, including these overlapping estimates, in [this dataset](https://github.com/owid/poverty-data#a-global-dataset-of-poverty-and-inequality-measures-prepared-by-our-world-in-data-from-the-world-banks-poverty-and-inequality-platform-pip-database).
+        presentation:
+          title_public: Share of population below 60% of median income or consumption
+          topic_tags:
+            - Poverty
+            - Economic Inequality
+          faqs:
+            - fragment_id: poverty-comparability
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          grapher_config:
+            slug: relative-poverty-share-of-people-below-60-of-the-median
+            title: 'Relative poverty: Share of people below 60% of median income'
+            subtitle: >-
+              Relative poverty is measured in terms of a poverty line that rises and falls
+              over time with average incomes — in this case set at 60% of median income.
+            note: >-
+              Depending on the country and year, the data relates to income measured after
+              taxes and benefits, or to consumption, [per capita](#dod:per-capita).
+            hasMapTab: true
+            tab: map
+            originUrl: https://ourworldindata.org/poverty
+            yAxis:
+              min: 0
+            colorScale:
+              baseColorScheme: YlGn
+            map:
+              columnSlug: '815367'
+              time: 2019
+              colorScale:
+                baseColorScheme: YlOrBr
+                binningStrategy: manual
+                binningStrategyBinCount: 8
+                customNumericValues:
+                  - 5
+                  - 10
+                  - 15
+                  - 20
+                  - 25
+                  - 30
+                  - 35
+            selectedEntityNames:
+              - Luxembourg
+              - Brazil
+              - Zambia
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+      gini_coefficient:
+        title: Gini coefficient
+        description_short: Inequality, as measured by the Gini coefficient — a measure that ranges between 0 and 1, where higher values indicate higher inequality. Depending on the country and year, the data relates to either disposable income or consumption per capita.
+        display:
+          numDecimalPlaces: 2
+        # description: The Gini coefficient measures inequality on a scale between 0 and 1, where higher values indicate greater inequality.
+        description_key:
+          - The Gini coefficient is a measure of inequality that ranges between 0 and 1, where higher values indicate higher inequality.
+          - Depending on the country and year, the data relates to either disposable income or consumption per capita.
+          - Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account
+        description_processing: |-
+          For a small number of country-year observations, the World Bank PIP data contains two estimates: one based on income data and one based on consumption data. In these cases we keep only the consumption estimate in order to obtain a single series for each country.
+
+          You can find the data with all available income and consumption data points, including these overlapping estimates, in [this dataset](https://github.com/owid/poverty-data#a-global-dataset-of-poverty-and-inequality-measures-prepared-by-our-world-in-data-from-the-world-banks-poverty-and-inequality-platform-pip-database).
+        presentation:
+          title_public: Gini Coefficient
+          topic_tags:
+            - Poverty
+            - Economic Inequality
+          faqs:
+            - fragment_id: poverty-comparability
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          grapher_config:
+            slug: economic-inequality-gini-index
+            title: 'Income inequality: Gini coefficient'
+            subtitle: >-
+              The [Gini coefficient](#dod:gini) measures inequality on a scale from 0 to 1.
+              Higher values indicate higher inequality. Depending on the country and year,
+              the data relates to income measured after taxes and benefits, or to
+              consumption, [per capita](#dod:per-capita).
+            note: >-
+              Income and consumption estimates are available separately in this [Data
+              Explorer](https://ourworldindata.org/explorers/pip-inequality-explorer).
+            hasMapTab: true
+            tab: map
+            variantName: World Bank
+            originUrl: https://ourworldindata.org/economic-inequality
+            yAxis:
+              min: 0
+            map:
+              columnSlug: '45097'
+              time: 2019
+              colorScale:
+                baseColorScheme: Oranges
+                binningStrategy: manual
+                customNumericMinValue: 1
+                customNumericValues:
+                  - 0.3
+                  - 0.35
+                  - 0.4
+                  - 0.45
+                  - 0.5
+                  - 0.55
+                  - 0.6
+                customNumericLabels:
+                  - ''
+                  - ''
+                  - ''
+                  - ''
+                  - ''
+                  - ''
+                  - ''
+                customNumericColors:
+                  - null
+                  - null
+                  - null
+                  - null
+                  - null
+                  - null
+                  - null
+                legendDescription: ''
+            selectedEntityNames:
+              - Chile
+              - Brazil
+              - South Africa
+              - United States
+              - France
+              - China
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json

--- a/etl/steps/data/grapher/wb/2022-10-03/world_bank_pip.meta.yml
+++ b/etl/steps/data/grapher/wb/2022-10-03/world_bank_pip.meta.yml
@@ -7,39 +7,29 @@ definitions:
     sources: []
     origins:
       - producer: World Bank Poverty and Inequality Platform
-        title: World Bank, Poverty and Inequality Platform
+        title: World Bank Poverty and Inequality Platform
+        version_producer: '20220909_2017_01_02_PROD'
         description: |-
           The Poverty and Inequality Platform (PIP) is an interactive computational tool that offers users quick access to the World Bank’s estimates of poverty, inequality, and shared prosperity. PIP provides a comprehensive view of global, regional, and country-level trends for more than 160 economies around the world.
-
-          \[Text from [PIP website](https://pip.worldbank.org/about)\]
-
-          Version 20220909\_2017\_01\_02\_PROD
         citation_full: World Bank Poverty and Inequality Platform
         url_main: https://pip.worldbank.org/
         date_accessed: '2022-10-03'
         date_published: '2022-10-03'
-      # - producer: World Bank Poverty and Inequality Platform (2022)
-      #   title: World Bank Poverty and Inequality Platform (PIP)
-      #   description: >-
-      #     Version 20220909_2017_01_02_PROD
-
-      #     The Poverty and Inequality Platform (PIP) is an interactive computational tool that offers users quick access to
-      #     the World Bank’s estimates of poverty, inequality, and shared prosperity. PIP provides a comprehensive view of global,
-      #     regional, and country-level trends for more than 150 economies around the world.
-
-
-      #     Version 20220909_2017_01_02_PROD
-
-
-      #     You can read more information about PIP data and methodology in [GitHub](https://github.com/owid/poverty-data).
-      #   citation_full: World Bank Poverty and Inequality Platform
-      #   url_main: https://pip.worldbank.org/
-      #   date_accessed: '2022-10-03'
-      #   date_published: '2022-10-03'
 
     presentation:
       title_variant: World Bank, PIP
       attribution_short: World Bank
+      grapher_config:
+        originUrl: https://ourworldindata.org/poverty
+
+  income_consumption_pc: Depending on the country and year, the data relates to income measured after taxes and benefits, or to consumption, per capita. 'Per capita' means that the incomes of each household are attributed equally to each member of the household (including children).
+  non_market_income: Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account.
+  processing_notes: |-
+    For a small number of country-year observations, the World Bank PIP data contains two estimates: one based on income data and one based on consumption data. In these cases we keep only the consumption estimate in order to obtain a single series for each country.
+
+    You can find the data with all available income and consumption data points, including these overlapping estimates, in our [complete dataset](https://github.com/owid/poverty-data#a-global-dataset-of-poverty-and-inequality-measures-prepared-by-our-world-in-data-from-the-world-banks-poverty-and-inequality-platform-pip-database) of the World Bank PIP data.
+
+
 
 tables:
   world_bank_pip:
@@ -48,17 +38,14 @@ tables:
         title: $2.15 a day - share of population below poverty line
         unit: '%'
         short_unit: '%'
-        description_short: The share of population living below the International Poverty Line of $2.15 per day. This data is adjusted for inflation and for differences in the cost of living between countries.
-        # description: '% of population living in households with an income or expenditure per person below $2.15 a day'
+        description_short: "% of population living in households with an income or consumption per person below $2.15 a day."
         description_key:
           - Extreme poverty here is defined as living below the International Poverty Line of $2.15 per day.
           - The data is measured in international-$ at 2017 prices – this adjusts for inflation and for differences in the cost of living between countries.
-          - Depending on the country and year, the data relates to either disposable income or consumption per capita, depending on the country and year.
-          - Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account.
+          - "{definitions.income_consumption_pc}"
+          - "{definitions.non_market_income}"
         description_processing: |-
-          For a small number of country-year observations, the World Bank PIP data contains two estimates: one based on income data and one based on consumption data. In these cases we keep only the consumption estimate in order to obtain a single series for each country.
-
-          You can find the data with all available income and consumption data points, including these overlapping estimates, in our [complete dataset](https://github.com/owid/poverty-data#a-global-dataset-of-poverty-and-inequality-measures-prepared-by-our-world-in-data-from-the-world-banks-poverty-and-inequality-platform-pip-database) of the World Bank PIP data.
+          {common.processing_notes}
         presentation:
           title_public: Share of population living in extreme poverty
           topic_tags:
@@ -71,13 +58,13 @@ tables:
             # Image with filename "Five-income-distributions-national-poverty-and-IPL-2.png" not found. This block will not render when the page is baked.
             #
             # perhaps this will be rendered correctly in production?
-            - fragment_id: poverty-povery-line
+            - fragment_id: poverty-international-poverty-line
               gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
             - fragment_id: poverty-international-dollars
               gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
             - fragment_id: poverty-comparability
               gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
-            - fragment_id: poverty-estimates
+            - fragment_id: poverty-regional-estimates
               gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
           grapher_config:
             slug: share-of-population-in-extreme-poverty
@@ -93,12 +80,9 @@ tables:
             hasMapTab: true
             tab: map
             variantName: Line chart
-            originUrl: https://ourworldindata.org/poverty
             yAxis:
               min: 0
-              max: 0
             map:
-              columnSlug: '472273'
               time: 2019
               timeTolerance: 5
               colorScale:
@@ -116,14 +100,6 @@ tables:
                   - 80
                   - 90
                   - 100
-                customNumericColors:
-                  - '#e31a1c'
-                  - null
-                  - null
-                  - null
-                  - '#bd0026'
-                  - null
-                  - null
             selectedEntityNames:
               - Bangladesh
               - Bolivia
@@ -136,20 +112,15 @@ tables:
         title: 60% of median - share of population below poverty line
         unit: '%'
         short_unit: '%'
-        description_short: A measure of relative poverty — the share of the population with an income or consumption below 60% of the median in their country.
-        # description: '% of population living in households with an income or expenditure per person below 60% of the median'
-        description_from_producer: |-
-          How does the Poverty and Inequality Platform (PIP) describe this metric?
+        description_short: "The share of population with income or consumption below 60% of the median."
         description_key:
           - This is a measure of _relative_ poverty – it captures the share of people whose income is low by the standards typical in their own country.
-          - Depending on the country and year, the data relates to either disposable income or consumption per capita, depending on the country and year.
-          - Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account.
+          - "{definitions.income_consumption_pc}"
+          - "{definitions.non_market_income}"
         description_processing: |-
           Measures of relative poverty are not directly available in the World Bank PIP data. To calculate this metric we take the median income or consumption for the country and year, calculate a relative poverty line – in this case 60% of the median – and then run a specific query on the PIP API to return the share of population below that line.
 
-          For a small number of country-year observations, the PIP data contains two estimates: one based on income data and one based on consumption data. In these cases we keep only the consumption estimate in order to obtain a single series for each country.
-
-          You can find the data with all available income and consumption data points, including these overlapping estimates, in [this dataset](https://github.com/owid/poverty-data#a-global-dataset-of-poverty-and-inequality-measures-prepared-by-our-world-in-data-from-the-world-banks-poverty-and-inequality-platform-pip-database).
+          {common.processing_notes}
         presentation:
           title_public: Share of population below 60% of median income or consumption
           topic_tags:
@@ -169,18 +140,15 @@ tables:
               taxes and benefits, or to consumption, [per capita](#dod:per-capita).
             hasMapTab: true
             tab: map
-            originUrl: https://ourworldindata.org/poverty
             yAxis:
               min: 0
             colorScale:
               baseColorScheme: YlGn
             map:
-              columnSlug: '815367'
               time: 2019
               colorScale:
                 baseColorScheme: YlOrBr
                 binningStrategy: manual
-                binningStrategyBinCount: 8
                 customNumericValues:
                   - 5
                   - 10
@@ -190,24 +158,23 @@ tables:
                   - 30
                   - 35
             selectedEntityNames:
-              - Luxembourg
-              - Brazil
-              - Zambia
+              - Bangladesh
+              - Bolivia
+              - Madagascar
+              - India
+              - China
+              - Ethiopia
             $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
       gini_coefficient:
         title: Gini coefficient
-        description_short: Inequality, as measured by the Gini coefficient — a measure that ranges between 0 and 1, where higher values indicate higher inequality. Depending on the country and year, the data relates to either disposable income or consumption per capita.
+        description_short: The Gini coefficient measures inequality on a scale from 0 to 1. Higher values indicate higher inequality.
         display:
           numDecimalPlaces: 2
-        # description: The Gini coefficient measures inequality on a scale between 0 and 1, where higher values indicate greater inequality.
         description_key:
-          - The Gini coefficient is a measure of inequality that ranges between 0 and 1, where higher values indicate higher inequality.
-          - Depending on the country and year, the data relates to either disposable income or consumption per capita.
-          - Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account
+          - "{definitions.income_consumption_pc}"
+          - "{definitions.non_market_income}"
         description_processing: |-
-          For a small number of country-year observations, the World Bank PIP data contains two estimates: one based on income data and one based on consumption data. In these cases we keep only the consumption estimate in order to obtain a single series for each country.
-
-          You can find the data with all available income and consumption data points, including these overlapping estimates, in [this dataset](https://github.com/owid/poverty-data#a-global-dataset-of-poverty-and-inequality-measures-prepared-by-our-world-in-data-from-the-world-banks-poverty-and-inequality-platform-pip-database).
+          {common.processing_notes}
         presentation:
           title_public: Gini Coefficient
           topic_tags:
@@ -234,7 +201,6 @@ tables:
             yAxis:
               min: 0
             map:
-              columnSlug: '45097'
               time: 2019
               colorScale:
                 baseColorScheme: Oranges
@@ -248,23 +214,6 @@ tables:
                   - 0.5
                   - 0.55
                   - 0.6
-                customNumericLabels:
-                  - ''
-                  - ''
-                  - ''
-                  - ''
-                  - ''
-                  - ''
-                  - ''
-                customNumericColors:
-                  - null
-                  - null
-                  - null
-                  - null
-                  - null
-                  - null
-                  - null
-                legendDescription: ''
             selectedEntityNames:
               - Chile
               - Brazil

--- a/etl/steps/data/grapher/wid/2023-08-24/world_inequality_database.meta.yml
+++ b/etl/steps/data/grapher/wid/2023-08-24/world_inequality_database.meta.yml
@@ -75,4 +75,3 @@ tables:
               - China
               - France
             $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
-

--- a/etl/steps/data/grapher/wid/2023-08-24/world_inequality_database.meta.yml
+++ b/etl/steps/data/grapher/wid/2023-08-24/world_inequality_database.meta.yml
@@ -1,0 +1,485 @@
+dataset:
+  update_period_days: 365
+  sources: []
+definitions:
+  common:
+    sources: []
+    origins:
+      - producer: World Inequality Database (WID.world)
+        title: World Inequality Database
+        description: |-
+          The World Inequality Database (WID), previously The World Wealth and Income Database, is an extensive database on the distribution of income and wealth. It is primarily maintained by the World Inequality Lab, located at the Paris School of Economics, who coordinate a collaborative effort involving hundreds of researchers.
+
+          More details are available at the WID website: [https://wid.world/](https://wid.world/).
+        citation_full: World Inequality Database (WID), https://wid.world
+        url_main: https://wid.world/
+        date_accessed: '2023-08-24'
+        date_published: '2023'
+      # - producer: World Inequality Database (WID.world) (2023)
+      #   title: World Inequality Database (WID, 2023)
+      #   description: >-
+      #     The World Inequality Database (WID) is an extensive database on the distribution of income and wealth, both between
+      #     and within countries. It is primarily maintained by the World Inequality Lab (WIL), located at the Paris School
+      #     of Economics (PSE). But it is fundamentally the result of a coordinated, collaborative effort involving hundreds
+      #     of researchers throughout the world over the past twenty years.
+
+
+      #     In recent years, the WIL has been leading efforts in creating “distributional national accounts” (DINA). The goal
+      #     is to provide estimates of the distribution of income and wealth that are harmonized over time and across countries,
+      #     that are consistent with the macroeconomic aggregates produced by national statistical institutes, and that can
+      #     therefore be viewed as a distributional extension of the existing international System of National Accounts (SNA).
+
+
+      #     The WID provides extensive data on the distribution of pretax income, post-tax income and wealth, on top of a detailed
+      #     decomposition of macroeconomic aggregates of income and wealth. This dataset uploaded to Our World in Data contains
+      #     pretax income data only.
+
+
+      #     WID seeks to distribute the entirety of national income among resident households (including all income flowing
+      #     to corporations, the government, and to and from the foreign sector). In this way it accounts for 100% of macroeconomic
+      #     growth coming from GDP statistics. WID also presents results for numerous concepts across granular percentile groups
+      #     reaching small fractiles at the very top of the distribution.
+
+
+      #     WID CONVENTIONS
+
+      #     Unit of observation
+
+
+      #     “Equal-split adults” series, which distribute income to all adult individuals (over 20 years old), while splitting
+      #     income equally within a couple or a household. It is the benchmark series to deal with the lack of homogeneity in
+      #     the unit of observation for tax records. Equal-split series can be split income and wealth within the couple (narrow
+      #     equal-split) or within the household (broad equal-split). For now, DINA series have relied on narrow equal-split
+      #     measures in countries that primarily rely on tax microdata (France, United States), and broad equal-split in countries
+      #     that rely more heavily on surveys (China). This should be kept in mind when making comparisons between countries.
+      #     Moving forward, whenever the data allow, researchers should try to provide both series.
+
+
+      #     Equivalence scales
+
+
+      #     The DINA project does not use equivalence scales for two reasons. The first one is practical. Equivalence scales
+      #     introduces nonlinearities that make it harder to connect aggregate levels of income and wealth with their distribution.
+      #     If equivalized income is attributed to each individual, then the sum of all incomes across all individuals no longer
+      #     sums up to aggregate income. Equivalence scales therefore prevent from cleanly breaking down national income and
+      #     its growth across population groups. In WID’s view, it negatively impacts the readability and ease of use of indicators,
+      #     and somewhat defeats the purpose of connecting micro and macroeconomic estimates in the first place. The second
+      #     reason is conceptual. The primary aim of DINA is to measure income, wealth and their distribution. In contrast,
+      #     equivalence scales are meant to approximate an individual “welfare” concept. While this distribution of “welfare”
+      #     is related to income and wealth, it also incorporates many other dimensions that are outside of the project’s scope.
+      #     Indeed, the DINA project does not explicitly attempt to measure how well the income of individuals suits their needs
+      #     — which depend not only on their household’s size, but also on their location, their tastes, their health status,
+      #     etc., all of which are partly endogenous to distribution of income and wealth themselves.
+
+
+      #     Price index
+
+
+      #     WID uses the GDP deflator as its preferred price index, following Piketty and Zucman (2014), although it resorts
+      #     to the CPI when no other data is available. WID calls it the national income price index, and use it to deflate
+      #     all the monetary series. Over long periods of time, comparing quantities that are independent of the price level
+      #     (wealth/income ratios, share) can be more informative. Comparing income or wealth levels between time periods that
+      #     are centuries apart is fraught with conceptual difficulties, and it could be argued that such comparisons do not
+      #     always make sense. While WID provides some price indexes over very long time periods for convenience, users should
+      #     be aware of these issues.
+
+
+      #     Purchasing power parities
+
+
+      #     Though a large number of indicators provided by the WID (such as the share of income received by various groups)
+      #     are not sensitive to the overall price level, WID provides purchasing power parities (PPPs) to convert the local
+      #     currency units provided by default in averages and thresholds. This dataset uses 2017 PPPs to account for inflation
+      #     and for differences in the cost of living between countries. Regional aggregations provided by WID are by default
+      #     using PPPs and also include market exchange rates conversions, but they are dropped for this dataset.
+
+
+      #     Measures of the distribution
+
+
+      #     In WID’s view, to focus on a single indicator — for example the well-known Gini coefficient — is not sufficient
+      #     to provide an adequate picture of inequality. WID stresses that the problem is not specifically about the Gini,
+      #     or about any other indicator. The problem is that inequality cannot be reduced to a single number. This is why they
+      #     prefer to describe distributions in their entirety, and then let users use whatever level of detail and whatever
+      #     indicator suits their needs. In terms of presenting the results, WID favors showing the income shares of three main
+      #     groups (the bottom 50%, the middle 40% and the top 10%). These three groups map relatively well to the idea of a
+      #     lower, middle and upper class. They summarize changes happening to the overall distribution fairly well. In practice,
+      #     synthetic indicators can be approximated quite precisely by a weighted average of these three shares. WID also emphasizes
+      #     using the very top groups (top 1%, top 0.1%, etc.) since they can represent a macroeconomically significant share
+      #     of income and wealth. Gini coefficients are provided in the database as a convenience but encourage users to look
+      #     further. WID provides distributional data by generating synthetic microfiles (synthetic microdata representative
+      #     of the distribution of income and wealth for the entire population) and summarizing it in generalized percentiles,
+      #     which are series with thresholds, averages and shares for 127 fractiles:
+
+
+      #     •  99 percentiles from p = 0% to p = 99%,
+
+      #     •  9 tenths of a percentile from p = 99% to p = 99.9%,
+
+      #     •  9 hundredths of a percentile from p = 99.9% to p = 99.99%,
+
+      #     •  10 thousandths of a percentile from p = 99.99% to p = 100%.
+
+
+      #     INCOME CONCEPTS
+
+      #     Income series
+
+
+      #     DINA income series distribute the entirety of net national income using concepts that are consistent with the SNA.
+      #     Therefore, they include certain types of income (like the undistributed profits of corporations or indirect taxes)
+      #     that are traditionally overlooked by other sources.
+
+      #     WID defines four broad types of series:
+
+      #     •  Pretax factor corresponds to the distribution of income before any redistribution, be it through social insurance
+      #     systems of social assistance.
+
+      #     •  Pretax post-replacement income (often referred to as “pretax income”) includes redistribution that occurs through
+      #     social insurance schemes (pension and sometimes unemployment benefits), but not social assistance. The main difference
+      #     with pretax factor income and is the treatment of pensions, which are counted on a contribution basis by pretax
+      #     factor income and on a distribution basis by pretax national income. The key reason “pretax national income” series
+      #     is preferred is that it is less sensitive than pretax factor income inequality to the age structure of the population.
+
+      #     •  Post-tax disposable income includes all cash redistribution through the tax and transfer system, but does not
+      #     include in-kind benefits and therefore does not add up to national income.
+
+      #     •  Finally, post-tax national income redistributes all in-kind transfers (i.e., government consumption expenditures)
+      #     to individuals.
+
+
+      #     Undistributed profits
+
+
+      #     The undistributed profits of corporations are distributed to the shareholders of these corporations. Direct taxes
+      #     and benefits are distributed to the people that pay the tax or receive the benefit. The corporate tax is paid by
+      #     the shareholders. Sales taxes and VATs are distributed proportionally to factor income for pretax concepts, and
+      #     are removed proportionally to consumption in post-tax concepts.
+
+
+      #     In-kind transfers
+
+
+      #     For in-kind transfers, three variants are considered: allocation proportional to post-tax disposable income, lump-sum
+      #     allocation, and proportional allocation except for health spending which we distribute lump sum. That last concept
+      #     is used as WID’s benchmark for post-tax national income.
+
+
+      #     INCOME DISTRIBUTION METHODS
+
+      #     When there is exhaustive tax microdata
+
+
+      #     Preferably, to compute income DINA, WID constructs microfiles that combine information from both tax and survey
+      #     data. In countries with sufficiently exhaustive tax microdata, they only start from these files, and use survey
+      #     data to add information about non-filers and certain tax-exempt incomes. To produce a representative dataset, WID
+      #     recommends using population statistics to impute observations along characteristics such as age, marital status,
+      #     gender and possibly region of residence. This is important as certain population groups may not be represented equally
+      #     in income tax statistics (pensioners and young persons: small taxable incomes).
+
+
+      #     When tax data is limited
+
+      #     In countries where the tax data is too limited (because they only provide tax tabulations or because the informal
+      #     sector is too large), WID uses the tax data to correct the surveys at the top using the approach of Blanchet, Flores,
+      #     and Morgan (2019). The motive for doing so is that surveys tend to underrepresent high incomes as compared to what
+      #     appears in register data. This is even more true when the survey has not been matched to administrative records
+      #     (e.g., social security data on wages). The arbitrary brackets used in tax tabulations are interpolated using the
+      #     generalized Pareto interpolation method, known as gpinter, which allows the distribution to have a flexible form.
+
+      #     The method to incorporate tax information into surveys has three stages:
+
+      #     •  The choice of the merging point: the highest income where the ratio of the density functions of both survey and
+      #     tax records coincides with the respective ratio of cumulative density functions.
+
+      #     •  The reweighting of survey observations above and below this point: below are uniformly reweighted (assuming relative
+      #     probability of response constant over this part of the distribution)
+
+      #     •  The expansion of the survey’s support by including the highest incomes from tax data: after the merging point
+      #     the survey distribution is replaced by the tax distribution
+
+
+      #     Finally, income components are rescaled to SNA aggregates. Several levels of aggregation may be used depending on
+      #     the quality and the precision of the data.
+
+
+      #     More information is available at https://wid.world/methodology/
+
+
+      #     The World Inequality Database (WID) is an extensive database on the distribution of income and wealth, both between
+      #     and within countries. It is primarily maintained by the World Inequality Lab (WIL), located at the Paris School
+      #     of Economics (PSE). But it is fundamentally the result of a coordinated, collaborative effort involving hundreds
+      #     of researchers throughout the world over the past twenty years.
+
+
+      #     In recent years, the WIL has been leading efforts in creating “distributional national accounts” (DINA). The goal
+      #     is to provide estimates of the distribution of income and wealth that are harmonized over time and across countries,
+      #     that are consistent with the macroeconomic aggregates produced by national statistical institutes, and that can
+      #     therefore be viewed as a distributional extension of the existing international System of National Accounts (SNA).
+
+
+      #     The WID provides extensive data on the distribution of pretax income, post-tax income and wealth, on top of a detailed
+      #     decomposition of macroeconomic aggregates of income and wealth. This dataset uploaded to Our World in Data contains
+      #     pretax income data only.
+
+
+      #     WID seeks to distribute the entirety of national income among resident households (including all income flowing
+      #     to corporations, the government, and to and from the foreign sector). In this way it accounts for 100% of macroeconomic
+      #     growth coming from GDP statistics. WID also presents results for numerous concepts across granular percentile groups
+      #     reaching small fractiles at the very top of the distribution.
+
+
+      #     WID CONVENTIONS
+
+      #     Unit of observation
+
+
+      #     “Equal-split adults” series, which distribute income to all adult individuals (over 20 years old), while splitting
+      #     income equally within a couple or a household. It is the benchmark series to deal with the lack of homogeneity in
+      #     the unit of observation for tax records. Equal-split series can be split income and wealth within the couple (narrow
+      #     equal-split) or within the household (broad equal-split). For now, DINA series have relied on narrow equal-split
+      #     measures in countries that primarily rely on tax microdata (France, United States), and broad equal-split in countries
+      #     that rely more heavily on surveys (China). This should be kept in mind when making comparisons between countries.
+      #     Moving forward, whenever the data allow, researchers should try to provide both series.
+
+
+      #     Equivalence scales
+
+
+      #     The DINA project does not use equivalence scales for two reasons. The first one is practical. Equivalence scales
+      #     introduces nonlinearities that make it harder to connect aggregate levels of income and wealth with their distribution.
+      #     If equivalized income is attributed to each individual, then the sum of all incomes across all individuals no longer
+      #     sums up to aggregate income. Equivalence scales therefore prevent from cleanly breaking down national income and
+      #     its growth across population groups. In WID’s view, it negatively impacts the readability and ease of use of indicators,
+      #     and somewhat defeats the purpose of connecting micro and macroeconomic estimates in the first place. The second
+      #     reason is conceptual. The primary aim of DINA is to measure income, wealth and their distribution. In contrast,
+      #     equivalence scales are meant to approximate an individual “welfare” concept. While this distribution of “welfare”
+      #     is related to income and wealth, it also incorporates many other dimensions that are outside of the project’s scope.
+      #     Indeed, the DINA project does not explicitly attempt to measure how well the income of individuals suits their needs
+      #     — which depend not only on their household’s size, but also on their location, their tastes, their health status,
+      #     etc., all of which are partly endogenous to distribution of income and wealth themselves.
+
+
+      #     Price index
+
+
+      #     WID uses the GDP deflator as its preferred price index, following Piketty and Zucman (2014), although it resorts
+      #     to the CPI when no other data is available. WID calls it the national income price index, and use it to deflate
+      #     all the monetary series. Over long periods of time, comparing quantities that are independent of the price level
+      #     (wealth/income ratios, share) can be more informative. Comparing income or wealth levels between time periods that
+      #     are centuries apart is fraught with conceptual difficulties, and it could be argued that such comparisons do not
+      #     always make sense. While WID provides some price indexes over very long time periods for convenience, users should
+      #     be aware of these issues.
+
+
+      #     Purchasing power parities
+
+
+      #     Though a large number of indicators provided by the WID (such as the share of income received by various groups)
+      #     are not sensitive to the overall price level, WID provides purchasing power parities (PPPs) to convert the local
+      #     currency units provided by default in averages and thresholds. This dataset uses 2017 PPPs to account for inflation
+      #     and for differences in the cost of living between countries. Regional aggregations provided by WID are by default
+      #     using PPPs and also include market exchange rates conversions, but they are dropped for this dataset.
+
+
+      #     Measures of the distribution
+
+
+      #     In WID’s view, to focus on a single indicator — for example the well-known Gini coefficient — is not sufficient
+      #     to provide an adequate picture of inequality. WID stresses that the problem is not specifically about the Gini,
+      #     or about any other indicator. The problem is that inequality cannot be reduced to a single number. This is why they
+      #     prefer to describe distributions in their entirety, and then let users use whatever level of detail and whatever
+      #     indicator suits their needs. In terms of presenting the results, WID favors showing the income shares of three main
+      #     groups (the bottom 50%, the middle 40% and the top 10%). These three groups map relatively well to the idea of a
+      #     lower, middle and upper class. They summarize changes happening to the overall distribution fairly well. In practice,
+      #     synthetic indicators can be approximated quite precisely by a weighted average of these three shares. WID also emphasizes
+      #     using the very top groups (top 1%, top 0.1%, etc.) since they can represent a macroeconomically significant share
+      #     of income and wealth. Gini coefficients are provided in the database as a convenience but encourage users to look
+      #     further. WID provides distributional data by generating synthetic microfiles (synthetic microdata representative
+      #     of the distribution of income and wealth for the entire population) and summarizing it in generalized percentiles,
+      #     which are series with thresholds, averages and shares for 127 fractiles:
+
+
+      #     •  99 percentiles from p = 0% to p = 99%,
+
+      #     •  9 tenths of a percentile from p = 99% to p = 99.9%,
+
+      #     •  9 hundredths of a percentile from p = 99.9% to p = 99.99%,
+
+      #     •  10 thousandths of a percentile from p = 99.99% to p = 100%.
+
+
+      #     INCOME CONCEPTS
+
+      #     Income series
+
+
+      #     DINA income series distribute the entirety of net national income using concepts that are consistent with the SNA.
+      #     Therefore, they include certain types of income (like the undistributed profits of corporations or indirect taxes)
+      #     that are traditionally overlooked by other sources.
+
+      #     WID defines four broad types of series:
+
+      #     •  Pretax factor corresponds to the distribution of income before any redistribution, be it through social insurance
+      #     systems of social assistance.
+
+      #     •  Pretax post-replacement income (often referred to as “pretax income”) includes redistribution that occurs through
+      #     social insurance schemes (pension and sometimes unemployment benefits), but not social assistance. The main difference
+      #     with pretax factor income and is the treatment of pensions, which are counted on a contribution basis by pretax
+      #     factor income and on a distribution basis by pretax national income. The key reason “pretax national income” series
+      #     is preferred is that it is less sensitive than pretax factor income inequality to the age structure of the population.
+
+      #     •  Post-tax disposable income includes all cash redistribution through the tax and transfer system, but does not
+      #     include in-kind benefits and therefore does not add up to national income.
+
+      #     •  Finally, post-tax national income redistributes all in-kind transfers (i.e., government consumption expenditures)
+      #     to individuals.
+
+
+      #     Undistributed profits
+
+
+      #     The undistributed profits of corporations are distributed to the shareholders of these corporations. Direct taxes
+      #     and benefits are distributed to the people that pay the tax or receive the benefit. The corporate tax is paid by
+      #     the shareholders. Sales taxes and VATs are distributed proportionally to factor income for pretax concepts, and
+      #     are removed proportionally to consumption in post-tax concepts.
+
+
+      #     In-kind transfers
+
+
+      #     For in-kind transfers, three variants are considered: allocation proportional to post-tax disposable income, lump-sum
+      #     allocation, and proportional allocation except for health spending which we distribute lump sum. That last concept
+      #     is used as WID’s benchmark for post-tax national income.
+
+
+      #     INCOME DISTRIBUTION METHODS
+
+      #     When there is exhaustive tax microdata
+
+
+      #     Preferably, to compute income DINA, WID constructs microfiles that combine information from both tax and survey
+      #     data. In countries with sufficiently exhaustive tax microdata, they only start from these files, and use survey
+      #     data to add information about non-filers and certain tax-exempt incomes. To produce a representative dataset, WID
+      #     recommends using population statistics to impute observations along characteristics such as age, marital status,
+      #     gender and possibly region of residence. This is important as certain population groups may not be represented equally
+      #     in income tax statistics (pensioners and young persons: small taxable incomes).
+
+
+      #     When tax data is limited
+
+      #     In countries where the tax data is too limited (because they only provide tax tabulations or because the informal
+      #     sector is too large), WID uses the tax data to correct the surveys at the top using the approach of Blanchet, Flores,
+      #     and Morgan (2019). The motive for doing so is that surveys tend to underrepresent high incomes as compared to what
+      #     appears in register data. This is even more true when the survey has not been matched to administrative records
+      #     (e.g., social security data on wages). The arbitrary brackets used in tax tabulations are interpolated using the
+      #     generalized Pareto interpolation method, known as gpinter, which allows the distribution to have a flexible form.
+
+      #     The method to incorporate tax information into surveys has three stages:
+
+      #     •  The choice of the merging point: the highest income where the ratio of the density functions of both survey and
+      #     tax records coincides with the respective ratio of cumulative density functions.
+
+      #     •  The reweighting of survey observations above and below this point: below are uniformly reweighted (assuming relative
+      #     probability of response constant over this part of the distribution)
+
+      #     •  The expansion of the survey’s support by including the highest incomes from tax data: after the merging point
+      #     the survey distribution is replaced by the tax distribution
+
+
+      #     Finally, income components are rescaled to SNA aggregates. Several levels of aggregation may be used depending on
+      #     the quality and the precision of the data.
+
+
+      #     More information is available at https://wid.world/methodology/
+      #   citation_full: World Inequality Database (WID), https://wid.world
+      #   url_main: https://wid.world/
+      #   date_accessed: '2023-08-24'
+      #   date_published: '2023'
+tables:
+  world_inequality_database:
+    variables:
+      p99p100_share_pretax:
+        title: Top 1% - Share (Pretax) (Estimated)
+        unit: '%'
+        short_unit: '%'
+        description_short: This is the income of the richest 1% as a share of total income. Income here is measured before the payment and receipt of taxes and non-pension benefits but after payment of public and private pensions.
+        display:
+          name: Top 1% - Share (Pretax) (Estimated)
+          tolerance: 5
+          numDecimalPlaces: 1
+        # description: >-
+        #   The share of income received by the richest 1%.
+
+
+        #   Income is ‘pre-tax’ — measured before taxes have been paid and most government benefits have been received. It is,
+        #   however, measured after the operation of pension schemes, both private and public.
+
+
+
+        #   The data is estimated from a combination of household surveys, tax records and national accounts data. This combination
+        #   can provide a more accurate picture of the incomes of the richest, which tend to be captured poorly in household
+        #   survey data alone.
+
+        #   These underlying data sources are not always available. For some countries, observations are extrapolated from data
+        #   relating to other years, or are sometimes modeled based on data observed in other countries.
+        description_key:
+          - This measures the share of income received by the richest 1% of adult individuals.
+          - Income is ‘pre-tax’ — measured before taxes have been paid and most government benefits have been received. It is, however, measured _after_ the operation of pension schemes, both private and public.
+          - The data is estimated from a combination of household surveys, tax records and national accounts data. This combination can provide a more accurate picture of the incomes of the richest, which tend to be captured poorly in household survey data alone.
+          - These underlying data sources are not always available. For some countries, observations are extrapolated from data relating to other years, or are sometimes modeled based on data observed in other countries.
+        description_processing: |-
+          This is a global dataset of inequality measures prepared by Our World in Data from the World Inequality Database (WID.world).
+
+          The World Inequality Database (WID) is an extensive database on the distribution of income and wealth, both between and within countries.These estimates of the distribution of income and wealth are consistent with the macroeconomic aggregates produced by national statistical institutes.
+
+          To prepare this dataset:
+
+          - **We ingest the original data.** We extract and process the data from WID’s [Stata tool](https://github.com/thomasblanchet/wid-stata-tool).
+          - **We standardize names of countries and regions.** Since the names of countries and regions are different in different data sources, we harmonize all names to the _[Our World in Data](https://ourworldindata.org/world-region-map-definitions)_ [standard entity names](https://ourworldindata.org/world-region-map-definitions).
+          - **Monetary values were converted to international-$ in 2021 prices.** To account for inflation and differences in the cost of living between countries, we transform the data using WID’s xlcusp dataset in Stata.
+          - **We calculate additional metrics.** We make transformations of the data to derive some additional metrics that are not available directly from the original World Inequality Database, as percentile and share ratios, derived from income thresholds and shares, respectively.
+        presentation:
+          title_variant: World Inequality Database - Before tax
+          attribution_short: World Inequality Database
+          topic_tags:
+            - Economic Inequality
+          grapher_config:
+            slug: income-share-top-1-before-tax-wid
+            # title: Income share of the richest 1% (before tax)
+            title: Income share of the richest 1%
+            subtitle: >-
+              This is the income of the richest 1% as a share of total income. Income here is measured before the payment and receipt of taxes and non-pension benefits but after payment of public and private pensions.
+            # subtitle: >-
+            #   The share of income received by the richest 1% of the population. Income here is measured before taxes and benefits.
+            note: >-
+              Income is measured before payment of taxes and non-pension benefits, but after
+              the payment of public and private pensions.
+            hasMapTab: true
+            tab: map
+            variantName: WID
+            originUrl: https://ourworldindata.org/economic-inequality
+            yAxis:
+              min: 0
+            map:
+              columnSlug: '541254'
+              time: 2019
+              colorScale:
+                baseColorScheme: OrRd
+                binningStrategy: manual
+                customNumericValues:
+                  - 5
+                  - 10
+                  - 15
+                  - 20
+                  - 25
+                  - 30
+            selectedEntityNames:
+              - Chile
+              - Brazil
+              - United States
+              - South Africa
+              - China
+              - France
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+

--- a/etl/steps/data/grapher/wid/2023-08-24/world_inequality_database.meta.yml
+++ b/etl/steps/data/grapher/wid/2023-08-24/world_inequality_database.meta.yml
@@ -8,394 +8,15 @@ definitions:
       - producer: World Inequality Database (WID.world)
         title: World Inequality Database
         description: |-
-          The World Inequality Database (WID), previously The World Wealth and Income Database, is an extensive database on the distribution of income and wealth. It is primarily maintained by the World Inequality Lab, located at the Paris School of Economics, who coordinate a collaborative effort involving hundreds of researchers.
-
-          More details are available at the WID website: [https://wid.world/](https://wid.world/).
+          The World Inequality Database (WID), previously The World Wealth and Income Database, is an extensive database on the distribution of income and wealth. It is primarily maintained by the World Inequality Lab (WIL), located at the Paris School of Economics, who coordinate a collaborative effort involving hundreds of researchers.
         citation_full: World Inequality Database (WID), https://wid.world
         url_main: https://wid.world/
         date_accessed: '2023-08-24'
         date_published: '2023'
-      # - producer: World Inequality Database (WID.world) (2023)
-      #   title: World Inequality Database (WID, 2023)
-      #   description: >-
-      #     The World Inequality Database (WID) is an extensive database on the distribution of income and wealth, both between
-      #     and within countries. It is primarily maintained by the World Inequality Lab (WIL), located at the Paris School
-      #     of Economics (PSE). But it is fundamentally the result of a coordinated, collaborative effort involving hundreds
-      #     of researchers throughout the world over the past twenty years.
 
-
-      #     In recent years, the WIL has been leading efforts in creating “distributional national accounts” (DINA). The goal
-      #     is to provide estimates of the distribution of income and wealth that are harmonized over time and across countries,
-      #     that are consistent with the macroeconomic aggregates produced by national statistical institutes, and that can
-      #     therefore be viewed as a distributional extension of the existing international System of National Accounts (SNA).
-
-
-      #     The WID provides extensive data on the distribution of pretax income, post-tax income and wealth, on top of a detailed
-      #     decomposition of macroeconomic aggregates of income and wealth. This dataset uploaded to Our World in Data contains
-      #     pretax income data only.
-
-
-      #     WID seeks to distribute the entirety of national income among resident households (including all income flowing
-      #     to corporations, the government, and to and from the foreign sector). In this way it accounts for 100% of macroeconomic
-      #     growth coming from GDP statistics. WID also presents results for numerous concepts across granular percentile groups
-      #     reaching small fractiles at the very top of the distribution.
-
-
-      #     WID CONVENTIONS
-
-      #     Unit of observation
-
-
-      #     “Equal-split adults” series, which distribute income to all adult individuals (over 20 years old), while splitting
-      #     income equally within a couple or a household. It is the benchmark series to deal with the lack of homogeneity in
-      #     the unit of observation for tax records. Equal-split series can be split income and wealth within the couple (narrow
-      #     equal-split) or within the household (broad equal-split). For now, DINA series have relied on narrow equal-split
-      #     measures in countries that primarily rely on tax microdata (France, United States), and broad equal-split in countries
-      #     that rely more heavily on surveys (China). This should be kept in mind when making comparisons between countries.
-      #     Moving forward, whenever the data allow, researchers should try to provide both series.
-
-
-      #     Equivalence scales
-
-
-      #     The DINA project does not use equivalence scales for two reasons. The first one is practical. Equivalence scales
-      #     introduces nonlinearities that make it harder to connect aggregate levels of income and wealth with their distribution.
-      #     If equivalized income is attributed to each individual, then the sum of all incomes across all individuals no longer
-      #     sums up to aggregate income. Equivalence scales therefore prevent from cleanly breaking down national income and
-      #     its growth across population groups. In WID’s view, it negatively impacts the readability and ease of use of indicators,
-      #     and somewhat defeats the purpose of connecting micro and macroeconomic estimates in the first place. The second
-      #     reason is conceptual. The primary aim of DINA is to measure income, wealth and their distribution. In contrast,
-      #     equivalence scales are meant to approximate an individual “welfare” concept. While this distribution of “welfare”
-      #     is related to income and wealth, it also incorporates many other dimensions that are outside of the project’s scope.
-      #     Indeed, the DINA project does not explicitly attempt to measure how well the income of individuals suits their needs
-      #     — which depend not only on their household’s size, but also on their location, their tastes, their health status,
-      #     etc., all of which are partly endogenous to distribution of income and wealth themselves.
-
-
-      #     Price index
-
-
-      #     WID uses the GDP deflator as its preferred price index, following Piketty and Zucman (2014), although it resorts
-      #     to the CPI when no other data is available. WID calls it the national income price index, and use it to deflate
-      #     all the monetary series. Over long periods of time, comparing quantities that are independent of the price level
-      #     (wealth/income ratios, share) can be more informative. Comparing income or wealth levels between time periods that
-      #     are centuries apart is fraught with conceptual difficulties, and it could be argued that such comparisons do not
-      #     always make sense. While WID provides some price indexes over very long time periods for convenience, users should
-      #     be aware of these issues.
-
-
-      #     Purchasing power parities
-
-
-      #     Though a large number of indicators provided by the WID (such as the share of income received by various groups)
-      #     are not sensitive to the overall price level, WID provides purchasing power parities (PPPs) to convert the local
-      #     currency units provided by default in averages and thresholds. This dataset uses 2017 PPPs to account for inflation
-      #     and for differences in the cost of living between countries. Regional aggregations provided by WID are by default
-      #     using PPPs and also include market exchange rates conversions, but they are dropped for this dataset.
-
-
-      #     Measures of the distribution
-
-
-      #     In WID’s view, to focus on a single indicator — for example the well-known Gini coefficient — is not sufficient
-      #     to provide an adequate picture of inequality. WID stresses that the problem is not specifically about the Gini,
-      #     or about any other indicator. The problem is that inequality cannot be reduced to a single number. This is why they
-      #     prefer to describe distributions in their entirety, and then let users use whatever level of detail and whatever
-      #     indicator suits their needs. In terms of presenting the results, WID favors showing the income shares of three main
-      #     groups (the bottom 50%, the middle 40% and the top 10%). These three groups map relatively well to the idea of a
-      #     lower, middle and upper class. They summarize changes happening to the overall distribution fairly well. In practice,
-      #     synthetic indicators can be approximated quite precisely by a weighted average of these three shares. WID also emphasizes
-      #     using the very top groups (top 1%, top 0.1%, etc.) since they can represent a macroeconomically significant share
-      #     of income and wealth. Gini coefficients are provided in the database as a convenience but encourage users to look
-      #     further. WID provides distributional data by generating synthetic microfiles (synthetic microdata representative
-      #     of the distribution of income and wealth for the entire population) and summarizing it in generalized percentiles,
-      #     which are series with thresholds, averages and shares for 127 fractiles:
-
-
-      #     •  99 percentiles from p = 0% to p = 99%,
-
-      #     •  9 tenths of a percentile from p = 99% to p = 99.9%,
-
-      #     •  9 hundredths of a percentile from p = 99.9% to p = 99.99%,
-
-      #     •  10 thousandths of a percentile from p = 99.99% to p = 100%.
-
-
-      #     INCOME CONCEPTS
-
-      #     Income series
-
-
-      #     DINA income series distribute the entirety of net national income using concepts that are consistent with the SNA.
-      #     Therefore, they include certain types of income (like the undistributed profits of corporations or indirect taxes)
-      #     that are traditionally overlooked by other sources.
-
-      #     WID defines four broad types of series:
-
-      #     •  Pretax factor corresponds to the distribution of income before any redistribution, be it through social insurance
-      #     systems of social assistance.
-
-      #     •  Pretax post-replacement income (often referred to as “pretax income”) includes redistribution that occurs through
-      #     social insurance schemes (pension and sometimes unemployment benefits), but not social assistance. The main difference
-      #     with pretax factor income and is the treatment of pensions, which are counted on a contribution basis by pretax
-      #     factor income and on a distribution basis by pretax national income. The key reason “pretax national income” series
-      #     is preferred is that it is less sensitive than pretax factor income inequality to the age structure of the population.
-
-      #     •  Post-tax disposable income includes all cash redistribution through the tax and transfer system, but does not
-      #     include in-kind benefits and therefore does not add up to national income.
-
-      #     •  Finally, post-tax national income redistributes all in-kind transfers (i.e., government consumption expenditures)
-      #     to individuals.
-
-
-      #     Undistributed profits
-
-
-      #     The undistributed profits of corporations are distributed to the shareholders of these corporations. Direct taxes
-      #     and benefits are distributed to the people that pay the tax or receive the benefit. The corporate tax is paid by
-      #     the shareholders. Sales taxes and VATs are distributed proportionally to factor income for pretax concepts, and
-      #     are removed proportionally to consumption in post-tax concepts.
-
-
-      #     In-kind transfers
-
-
-      #     For in-kind transfers, three variants are considered: allocation proportional to post-tax disposable income, lump-sum
-      #     allocation, and proportional allocation except for health spending which we distribute lump sum. That last concept
-      #     is used as WID’s benchmark for post-tax national income.
-
-
-      #     INCOME DISTRIBUTION METHODS
-
-      #     When there is exhaustive tax microdata
-
-
-      #     Preferably, to compute income DINA, WID constructs microfiles that combine information from both tax and survey
-      #     data. In countries with sufficiently exhaustive tax microdata, they only start from these files, and use survey
-      #     data to add information about non-filers and certain tax-exempt incomes. To produce a representative dataset, WID
-      #     recommends using population statistics to impute observations along characteristics such as age, marital status,
-      #     gender and possibly region of residence. This is important as certain population groups may not be represented equally
-      #     in income tax statistics (pensioners and young persons: small taxable incomes).
-
-
-      #     When tax data is limited
-
-      #     In countries where the tax data is too limited (because they only provide tax tabulations or because the informal
-      #     sector is too large), WID uses the tax data to correct the surveys at the top using the approach of Blanchet, Flores,
-      #     and Morgan (2019). The motive for doing so is that surveys tend to underrepresent high incomes as compared to what
-      #     appears in register data. This is even more true when the survey has not been matched to administrative records
-      #     (e.g., social security data on wages). The arbitrary brackets used in tax tabulations are interpolated using the
-      #     generalized Pareto interpolation method, known as gpinter, which allows the distribution to have a flexible form.
-
-      #     The method to incorporate tax information into surveys has three stages:
-
-      #     •  The choice of the merging point: the highest income where the ratio of the density functions of both survey and
-      #     tax records coincides with the respective ratio of cumulative density functions.
-
-      #     •  The reweighting of survey observations above and below this point: below are uniformly reweighted (assuming relative
-      #     probability of response constant over this part of the distribution)
-
-      #     •  The expansion of the survey’s support by including the highest incomes from tax data: after the merging point
-      #     the survey distribution is replaced by the tax distribution
-
-
-      #     Finally, income components are rescaled to SNA aggregates. Several levels of aggregation may be used depending on
-      #     the quality and the precision of the data.
-
-
-      #     More information is available at https://wid.world/methodology/
-
-
-      #     The World Inequality Database (WID) is an extensive database on the distribution of income and wealth, both between
-      #     and within countries. It is primarily maintained by the World Inequality Lab (WIL), located at the Paris School
-      #     of Economics (PSE). But it is fundamentally the result of a coordinated, collaborative effort involving hundreds
-      #     of researchers throughout the world over the past twenty years.
-
-
-      #     In recent years, the WIL has been leading efforts in creating “distributional national accounts” (DINA). The goal
-      #     is to provide estimates of the distribution of income and wealth that are harmonized over time and across countries,
-      #     that are consistent with the macroeconomic aggregates produced by national statistical institutes, and that can
-      #     therefore be viewed as a distributional extension of the existing international System of National Accounts (SNA).
-
-
-      #     The WID provides extensive data on the distribution of pretax income, post-tax income and wealth, on top of a detailed
-      #     decomposition of macroeconomic aggregates of income and wealth. This dataset uploaded to Our World in Data contains
-      #     pretax income data only.
-
-
-      #     WID seeks to distribute the entirety of national income among resident households (including all income flowing
-      #     to corporations, the government, and to and from the foreign sector). In this way it accounts for 100% of macroeconomic
-      #     growth coming from GDP statistics. WID also presents results for numerous concepts across granular percentile groups
-      #     reaching small fractiles at the very top of the distribution.
-
-
-      #     WID CONVENTIONS
-
-      #     Unit of observation
-
-
-      #     “Equal-split adults” series, which distribute income to all adult individuals (over 20 years old), while splitting
-      #     income equally within a couple or a household. It is the benchmark series to deal with the lack of homogeneity in
-      #     the unit of observation for tax records. Equal-split series can be split income and wealth within the couple (narrow
-      #     equal-split) or within the household (broad equal-split). For now, DINA series have relied on narrow equal-split
-      #     measures in countries that primarily rely on tax microdata (France, United States), and broad equal-split in countries
-      #     that rely more heavily on surveys (China). This should be kept in mind when making comparisons between countries.
-      #     Moving forward, whenever the data allow, researchers should try to provide both series.
-
-
-      #     Equivalence scales
-
-
-      #     The DINA project does not use equivalence scales for two reasons. The first one is practical. Equivalence scales
-      #     introduces nonlinearities that make it harder to connect aggregate levels of income and wealth with their distribution.
-      #     If equivalized income is attributed to each individual, then the sum of all incomes across all individuals no longer
-      #     sums up to aggregate income. Equivalence scales therefore prevent from cleanly breaking down national income and
-      #     its growth across population groups. In WID’s view, it negatively impacts the readability and ease of use of indicators,
-      #     and somewhat defeats the purpose of connecting micro and macroeconomic estimates in the first place. The second
-      #     reason is conceptual. The primary aim of DINA is to measure income, wealth and their distribution. In contrast,
-      #     equivalence scales are meant to approximate an individual “welfare” concept. While this distribution of “welfare”
-      #     is related to income and wealth, it also incorporates many other dimensions that are outside of the project’s scope.
-      #     Indeed, the DINA project does not explicitly attempt to measure how well the income of individuals suits their needs
-      #     — which depend not only on their household’s size, but also on their location, their tastes, their health status,
-      #     etc., all of which are partly endogenous to distribution of income and wealth themselves.
-
-
-      #     Price index
-
-
-      #     WID uses the GDP deflator as its preferred price index, following Piketty and Zucman (2014), although it resorts
-      #     to the CPI when no other data is available. WID calls it the national income price index, and use it to deflate
-      #     all the monetary series. Over long periods of time, comparing quantities that are independent of the price level
-      #     (wealth/income ratios, share) can be more informative. Comparing income or wealth levels between time periods that
-      #     are centuries apart is fraught with conceptual difficulties, and it could be argued that such comparisons do not
-      #     always make sense. While WID provides some price indexes over very long time periods for convenience, users should
-      #     be aware of these issues.
-
-
-      #     Purchasing power parities
-
-
-      #     Though a large number of indicators provided by the WID (such as the share of income received by various groups)
-      #     are not sensitive to the overall price level, WID provides purchasing power parities (PPPs) to convert the local
-      #     currency units provided by default in averages and thresholds. This dataset uses 2017 PPPs to account for inflation
-      #     and for differences in the cost of living between countries. Regional aggregations provided by WID are by default
-      #     using PPPs and also include market exchange rates conversions, but they are dropped for this dataset.
-
-
-      #     Measures of the distribution
-
-
-      #     In WID’s view, to focus on a single indicator — for example the well-known Gini coefficient — is not sufficient
-      #     to provide an adequate picture of inequality. WID stresses that the problem is not specifically about the Gini,
-      #     or about any other indicator. The problem is that inequality cannot be reduced to a single number. This is why they
-      #     prefer to describe distributions in their entirety, and then let users use whatever level of detail and whatever
-      #     indicator suits their needs. In terms of presenting the results, WID favors showing the income shares of three main
-      #     groups (the bottom 50%, the middle 40% and the top 10%). These three groups map relatively well to the idea of a
-      #     lower, middle and upper class. They summarize changes happening to the overall distribution fairly well. In practice,
-      #     synthetic indicators can be approximated quite precisely by a weighted average of these three shares. WID also emphasizes
-      #     using the very top groups (top 1%, top 0.1%, etc.) since they can represent a macroeconomically significant share
-      #     of income and wealth. Gini coefficients are provided in the database as a convenience but encourage users to look
-      #     further. WID provides distributional data by generating synthetic microfiles (synthetic microdata representative
-      #     of the distribution of income and wealth for the entire population) and summarizing it in generalized percentiles,
-      #     which are series with thresholds, averages and shares for 127 fractiles:
-
-
-      #     •  99 percentiles from p = 0% to p = 99%,
-
-      #     •  9 tenths of a percentile from p = 99% to p = 99.9%,
-
-      #     •  9 hundredths of a percentile from p = 99.9% to p = 99.99%,
-
-      #     •  10 thousandths of a percentile from p = 99.99% to p = 100%.
-
-
-      #     INCOME CONCEPTS
-
-      #     Income series
-
-
-      #     DINA income series distribute the entirety of net national income using concepts that are consistent with the SNA.
-      #     Therefore, they include certain types of income (like the undistributed profits of corporations or indirect taxes)
-      #     that are traditionally overlooked by other sources.
-
-      #     WID defines four broad types of series:
-
-      #     •  Pretax factor corresponds to the distribution of income before any redistribution, be it through social insurance
-      #     systems of social assistance.
-
-      #     •  Pretax post-replacement income (often referred to as “pretax income”) includes redistribution that occurs through
-      #     social insurance schemes (pension and sometimes unemployment benefits), but not social assistance. The main difference
-      #     with pretax factor income and is the treatment of pensions, which are counted on a contribution basis by pretax
-      #     factor income and on a distribution basis by pretax national income. The key reason “pretax national income” series
-      #     is preferred is that it is less sensitive than pretax factor income inequality to the age structure of the population.
-
-      #     •  Post-tax disposable income includes all cash redistribution through the tax and transfer system, but does not
-      #     include in-kind benefits and therefore does not add up to national income.
-
-      #     •  Finally, post-tax national income redistributes all in-kind transfers (i.e., government consumption expenditures)
-      #     to individuals.
-
-
-      #     Undistributed profits
-
-
-      #     The undistributed profits of corporations are distributed to the shareholders of these corporations. Direct taxes
-      #     and benefits are distributed to the people that pay the tax or receive the benefit. The corporate tax is paid by
-      #     the shareholders. Sales taxes and VATs are distributed proportionally to factor income for pretax concepts, and
-      #     are removed proportionally to consumption in post-tax concepts.
-
-
-      #     In-kind transfers
-
-
-      #     For in-kind transfers, three variants are considered: allocation proportional to post-tax disposable income, lump-sum
-      #     allocation, and proportional allocation except for health spending which we distribute lump sum. That last concept
-      #     is used as WID’s benchmark for post-tax national income.
-
-
-      #     INCOME DISTRIBUTION METHODS
-
-      #     When there is exhaustive tax microdata
-
-
-      #     Preferably, to compute income DINA, WID constructs microfiles that combine information from both tax and survey
-      #     data. In countries with sufficiently exhaustive tax microdata, they only start from these files, and use survey
-      #     data to add information about non-filers and certain tax-exempt incomes. To produce a representative dataset, WID
-      #     recommends using population statistics to impute observations along characteristics such as age, marital status,
-      #     gender and possibly region of residence. This is important as certain population groups may not be represented equally
-      #     in income tax statistics (pensioners and young persons: small taxable incomes).
-
-
-      #     When tax data is limited
-
-      #     In countries where the tax data is too limited (because they only provide tax tabulations or because the informal
-      #     sector is too large), WID uses the tax data to correct the surveys at the top using the approach of Blanchet, Flores,
-      #     and Morgan (2019). The motive for doing so is that surveys tend to underrepresent high incomes as compared to what
-      #     appears in register data. This is even more true when the survey has not been matched to administrative records
-      #     (e.g., social security data on wages). The arbitrary brackets used in tax tabulations are interpolated using the
-      #     generalized Pareto interpolation method, known as gpinter, which allows the distribution to have a flexible form.
-
-      #     The method to incorporate tax information into surveys has three stages:
-
-      #     •  The choice of the merging point: the highest income where the ratio of the density functions of both survey and
-      #     tax records coincides with the respective ratio of cumulative density functions.
-
-      #     •  The reweighting of survey observations above and below this point: below are uniformly reweighted (assuming relative
-      #     probability of response constant over this part of the distribution)
-
-      #     •  The expansion of the survey’s support by including the highest incomes from tax data: after the merging point
-      #     the survey distribution is replaced by the tax distribution
-
-
-      #     Finally, income components are rescaled to SNA aggregates. Several levels of aggregation may be used depending on
-      #     the quality and the precision of the data.
-
-
-      #     More information is available at https://wid.world/methodology/
-      #   citation_full: World Inequality Database (WID), https://wid.world
-      #   url_main: https://wid.world/
-      #   date_accessed: '2023-08-24'
-      #   date_published: '2023'
+    presentation:
+      grapher_config:
+        originUrl: https://ourworldindata.org/economic-inequality
 tables:
   world_inequality_database:
     variables:
@@ -403,41 +24,18 @@ tables:
         title: Top 1% - Share (Pretax) (Estimated)
         unit: '%'
         short_unit: '%'
-        description_short: This is the income of the richest 1% as a share of total income. Income here is measured before the payment and receipt of taxes and non-pension benefits but after payment of public and private pensions.
+        description_short: "The share of income received by the richest 1% of the population."
         display:
           name: Top 1% - Share (Pretax) (Estimated)
           tolerance: 5
           numDecimalPlaces: 1
-        # description: >-
-        #   The share of income received by the richest 1%.
-
-
-        #   Income is ‘pre-tax’ — measured before taxes have been paid and most government benefits have been received. It is,
-        #   however, measured after the operation of pension schemes, both private and public.
-
-
-
-        #   The data is estimated from a combination of household surveys, tax records and national accounts data. This combination
-        #   can provide a more accurate picture of the incomes of the richest, which tend to be captured poorly in household
-        #   survey data alone.
-
-        #   These underlying data sources are not always available. For some countries, observations are extrapolated from data
-        #   relating to other years, or are sometimes modeled based on data observed in other countries.
         description_key:
-          - This measures the share of income received by the richest 1% of adult individuals.
           - Income is ‘pre-tax’ — measured before taxes have been paid and most government benefits have been received. It is, however, measured _after_ the operation of pension schemes, both private and public.
           - The data is estimated from a combination of household surveys, tax records and national accounts data. This combination can provide a more accurate picture of the incomes of the richest, which tend to be captured poorly in household survey data alone.
           - These underlying data sources are not always available. For some countries, observations are extrapolated from data relating to other years, or are sometimes modeled based on data observed in other countries.
         description_processing: |-
-          This is a global dataset of inequality measures prepared by Our World in Data from the World Inequality Database (WID.world).
-
-          The World Inequality Database (WID) is an extensive database on the distribution of income and wealth, both between and within countries.These estimates of the distribution of income and wealth are consistent with the macroeconomic aggregates produced by national statistical institutes.
-
-          To prepare this dataset:
-
           - **We ingest the original data.** We extract and process the data from WID’s [Stata tool](https://github.com/thomasblanchet/wid-stata-tool).
-          - **We standardize names of countries and regions.** Since the names of countries and regions are different in different data sources, we harmonize all names to the _[Our World in Data](https://ourworldindata.org/world-region-map-definitions)_ [standard entity names](https://ourworldindata.org/world-region-map-definitions).
-          - **Monetary values were converted to international-$ in 2021 prices.** To account for inflation and differences in the cost of living between countries, we transform the data using WID’s xlcusp dataset in Stata.
+          - **Monetary values were converted to international-$ in 2022 prices.** To account for inflation and differences in the cost of living between countries, we transform the data using WID’s `xlcusp` dataset in Stata.
           - **We calculate additional metrics.** We make transformations of the data to derive some additional metrics that are not available directly from the original World Inequality Database, as percentile and share ratios, derived from income thresholds and shares, respectively.
         presentation:
           title_variant: World Inequality Database - Before tax
@@ -446,23 +44,18 @@ tables:
             - Economic Inequality
           grapher_config:
             slug: income-share-top-1-before-tax-wid
-            # title: Income share of the richest 1% (before tax)
-            title: Income share of the richest 1%
+            title: Income share of the richest 1% (before tax)
             subtitle: >-
-              This is the income of the richest 1% as a share of total income. Income here is measured before the payment and receipt of taxes and non-pension benefits but after payment of public and private pensions.
-            # subtitle: >-
-            #   The share of income received by the richest 1% of the population. Income here is measured before taxes and benefits.
+              The share of income received by the richest 1% of the population. Income here is measured before taxes and benefits.
             note: >-
               Income is measured before payment of taxes and non-pension benefits, but after
               the payment of public and private pensions.
             hasMapTab: true
             tab: map
             variantName: WID
-            originUrl: https://ourworldindata.org/economic-inequality
             yAxis:
               min: 0
             map:
-              columnSlug: '541254'
               time: 2019
               colorScale:
                 baseColorScheme: OrRd


### PR DESCRIPTION
Migrate JSON-based Data pages to ETL-based Data page by adding metadata to its grapher step. I tried to match the original Data page as closely as possible, which means some metadata fields might not **adhere to our guidelines**. I moved [FAQs to its GDoc](https://docs.google.com/document/d/1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw/edit) and used official topic tags names.

@paarriagadap  could you please check the Data Page for any issues? You are also encouraged to update metadata in the YAML file according to guidelines. Commented lines are metadata from the ETL dataset, you should delete them if they're not helpful. **Add commits to this PR** as you wish!

### Data pages
- [Extreme poverty JSON](https://ourworldindata.org/grapher/share-of-population-in-extreme-poverty) -> [Extreme poverty ETL](http://staging-site-mojmir/admin/datapage-preview/815270)
- [Below poverty line JSON](https://ourworldindata.org/grapher/relative-poverty-share-of-people-below-60-of-the-median) -> [Below poverty line ETL](http://staging-site-mojmir/admin/datapage-preview/815326)
- [Gini index JSON](https://ourworldindata.org/grapher/economic-inequality-gini-index) -> [Gini idex ETL](http://staging-site-mojmir/admin/datapage-preview/815324)

You can test it by running
```
ENV=.env.mojmir etl wb/2022-10-03/world_bank_pip --grapher
```
and opening [data pages from indicators](http://staging-site-mojmir/admin/datasets/6263)

### Known issues
* Two JSON-based data pages don't render as data pages any more. I'm not sure why

Parent issue https://github.com/owid/etl/issues/1666