### PR TITLE
:bar_chart: migrate JSON data page for internet usage

### DIFF
--- a/etl/steps/data/garden/worldbank_wdi/2023-05-29/wdi.meta.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2023-05-29/wdi.meta.yml
@@ -1954,7 +1954,6 @@ tables:
           tolerance: 5
         origins:  # Going forward this will usually come from snapshots in this form but you could also set it here
         - producer: World Bank
-          # UNICEF, World Health Organization and World Bank
           title: World Development Indicators
           description: >-
             The World Development Indicators (WDI) is the primary
@@ -1964,7 +1963,7 @@ tables:
             data available, and includes national, regional and
             global estimates.
 
-            \[Text from [World Bank data catalog](https://datacatalog.worldbank.org/dataset/world-development-indicators)\]
+            [Text from [World Bank data catalog](https://datacatalog.worldbank.org/dataset/world-development-indicators)]
           attribution: International Telecommunication Union (via World Bank) # This is an override that we would want to do for many indicators in the WDI especially
           attribution_short: World Bank
           citation_full: ""
@@ -1985,33 +1984,28 @@ tables:
           title_public: Share of the population using the Internet
           # title_variant: WDI
           title_variant: International Telecommunication Union
-          attribution_short: the World Bank
           # attribution: # defaults to origin[*].producer so does not have to be set here
           topic_tags:
-          - Technological Progress
+          - Technological Change
           - Internet
-          - Loneliness and Social Connections
+          - Loneliness & Social Connections
           faqs: []
           grapher_config:
-            slug: share-of-individuals-using-the-internet
             title: Share of the population using the Internet
             subtitle: 'Share of the population who [used the Internet](#dod:internetuser) in the last three months.'
+            timelineMinTime: 1990
             sourceDesc: International Telecommunication Union (via World Bank)
             originUrl: https://ourworldindata.org/internet
             hideAnnotationFieldsInTitle:
               time: true
               entity: true
               changeInPrefix: true
-            minTime: 1960
-            maxTime: 2020
-            timelineMinTime: 1990
             hasMapTab: true
             yAxis:
               min: 0
               max: 100
             map:
               timeTolerance: 5
-              columnSlug: '735493'
               colorScale:
                   baseColorScheme: Blues
                   colorSchemeInvert: false

--- a/etl/steps/data/garden/worldbank_wdi/2023-05-29/wdi.meta.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2023-05-29/wdi.meta.yml
@@ -1,3 +1,6 @@
+dataset:
+  update_period_days: 365
+
 tables:
   wdi:
     variables:
@@ -1910,9 +1913,8 @@ tables:
         unit: per 1 million people
       it_net_user_zs:
         title: Individuals using the Internet (% of population)
-        description: Share of the population who used the Internet in the last three months.
         description_short: Share of the population who used the Internet in the last three months.
-        description_from_producer: >
+        description_from_producer: >-
           Internet users are individuals who have used the Internet (from any location)
           in the last 3 months. The Internet can be used via a computer, mobile phone,
           personal digital assistant, games machine, digital TV etc.
@@ -1952,14 +1954,17 @@ tables:
           tolerance: 5
         origins:  # Going forward this will usually come from snapshots in this form but you could also set it here
         - producer: World Bank
+          # UNICEF, World Health Organization and World Bank
           title: World Development Indicators
-          description: >
+          description: >-
             The World Development Indicators (WDI) is the primary
             World Bank collection of development indicators, compiled
             from officially-recognized international sources. It
             presents the most current and accurate global development
             data available, and includes national, regional and
             global estimates.
+
+            \[Text from [World Bank data catalog](https://datacatalog.worldbank.org/dataset/world-development-indicators)\]
           attribution: International Telecommunication Union (via World Bank) # This is an override that we would want to do for many indicators in the WDI especially
           attribution_short: World Bank
           citation_full: ""
@@ -1978,17 +1983,27 @@ tables:
         processing_level: minor
         presentation:
           title_public: Share of the population using the Internet
-          title_variant: WDI
+          # title_variant: WDI
+          title_variant: International Telecommunication Union
+          attribution_short: the World Bank
           # attribution: # defaults to origin[*].producer so does not have to be set here
           topic_tags:
           - Technological Progress
           - Internet
+          - Loneliness and Social Connections
           faqs: []
-          # - gdoc_id: 1E1sLXZmwU1SSVDFvMsJNbOAreHaKnRXqmJDqCAUfdDE
-          #   fragment_id: test
           grapher_config:
+            slug: share-of-individuals-using-the-internet
             title: Share of the population using the Internet
             subtitle: 'Share of the population who [used the Internet](#dod:internetuser) in the last three months.'
+            sourceDesc: International Telecommunication Union (via World Bank)
+            originUrl: https://ourworldindata.org/internet
+            hideAnnotationFieldsInTitle:
+              time: true
+              entity: true
+              changeInPrefix: true
+            minTime: 1960
+            maxTime: 2020
             timelineMinTime: 1990
             hasMapTab: true
             yAxis:
@@ -1996,20 +2011,44 @@ tables:
               max: 100
             map:
               timeTolerance: 5
+              columnSlug: '735493'
               colorScale:
                   baseColorScheme: Blues
                   colorSchemeInvert: false
                   binningStrategy: manual
                   customNumericMinValue: 0
+                  customNumericValues:
+                    - 10
+                    - 20
+                    - 30
+                    - 40
+                    - 50
+                    - 60
+                    - 70
+                    - 80
+                    - 90
+                    - 100
+                  customNumericLabels:
+                    - ''
+                    - ''
+                    - ''
+                    - ''
+                    - ''
+                    - ''
+                    - ''
+                    - ''
+                    - ''
+                    - ''
+                  legendDescription: Individuals using the Internet (% of population)
             selectedEntityNames:
-            - South Asia
-            - North America
-            - Sub-Saharan Africa
-            - East Asia and Pacific
-            - Middle East and North Africa
-            - Europe and Central Asia
-            - Latin America and Caribbean
-            - World
+              - South Asia (WB)
+              - North America (WB)
+              - Sub-Saharan Africa (WB)
+              - East Asia and Pacific (WB)
+              - Middle East and North Africa (WB)
+              - Europe and Central Asia (WB)
+              - Latin America and Caribbean (WB)
+              - World
       lp_exp_durs_md:
         title: Lead time to export, median case (days)
         short_unit: days


### PR DESCRIPTION
Migrate [JSON-based Data page](https://ourworldindata.org/grapher/share-of-individuals-using-the-internet) to [ETL-based Data page](http://staging-site-mojmir/admin/datapage-preview/735493) by adding metadata to its grapher step. I tried to match the original Data page as closely as possible, which means some metadata fields might not **adhere to our guidelines**. I moved [FAQs to its GDoc](https://docs.google.com/document/d/1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw/edit) and used official topic tags names.

@danyx23 could you please check the Data Page for any issues? You are also encouraged to update metadata in the YAML file according to guidelines. Commented lines are metadata from the ETL dataset, you should delete them if they're not helpful. **Add commits to this PR** as you wish!

You can test it by running
```
ENV=.env.mojmir GRAPHER_FILTER=it_net_user_zs etl worldbank_wdi/2023-05-29/wdi --grapher
```
and visiting the [data page](http://staging-site-mojmir/admin/datapage-preview/735493).


Parent issue https://github.com/owid/etl/issues/1666