### PR TITLE
:bug: Fix dataclasses-json error

### DIFF
--- a/lib/catalog/README.md
+++ b/lib/catalog/README.md
@@ -215,6 +215,8 @@ t = Table.read_csv('/tmp/my_table.csv')
 ## Changelog
 
 - `dev`
+- `v0.3.8`
+  - Pin dataclasses-json==0.5.8 to fix error with python3.9
 - `v0.3.7`
   - Fix bugs.
   - Improve metadata propagation.

--- a/lib/catalog/poetry.lock
+++ b/lib/catalog/poetry.lock
@@ -355,13 +355,13 @@ toml = ["tomli"]
 
 [[package]]
 name = "dataclasses-json"
-version = "0.5.7"
+version = "0.5.8"
 description = "Easily serialize dataclasses to and from JSON"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "dataclasses-json-0.5.7.tar.gz", hash = "sha256:c2c11bc8214fbf709ffc369d11446ff6945254a7f09128154a7620613d8fda90"},
-    {file = "dataclasses_json-0.5.7-py3-none-any.whl", hash = "sha256:bc285b5f892094c3a53d558858a88553dd6a61a11ab1a8128a0e554385dcc5dd"},
+    {file = "dataclasses-json-0.5.8.tar.gz", hash = "sha256:6572ac08ad9340abcb74fd8c4c8e9752db2a182a402c8e871d0a8aa119e3804e"},
+    {file = "dataclasses_json-0.5.8-py3-none-any.whl", hash = "sha256:65b167c15fdf9bde27569c09ac18dd39bf1cc5b7998525024cb4678d2653946c"},
 ]
 
 [package.dependencies]
@@ -370,7 +370,7 @@ marshmallow-enum = ">=1.5.1,<2.0.0"
 typing-inspect = ">=0.4.0"
 
 [package.extras]
-dev = ["flake8", "hypothesis", "ipython", "mypy (>=0.710)", "portray", "pytest (>=6.2.3)", "simplejson", "types-dataclasses"]
+dev = ["flake8", "hypothesis", "ipython", "mypy (>=0.710)", "portray", "pytest (>=7.2.0)", "simplejson", "types-dataclasses"]
 
 [[package]]
 name = "decorator"
@@ -1543,4 +1543,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1"
-content-hash = "faf0857395efc44c70a1f6e473b16ee337ef67ee64a373add6fb875957fff663"
+content-hash = "d02fda7c502fe8e8529a1cde6cdbf7903a6a875f23330f22aace65e396e32bdd"

--- a/lib/catalog/pyproject.toml
+++ b/lib/catalog/pyproject.toml
@@ -13,7 +13,6 @@ homepage = "https://github.com/owid/owid-grapher-py"
 python = ">=3.8.1"
 pandas = ">=1.3.3,<2.0"
 jsonschema = ">=3.2.0"
-dataclasses-json = ">=0.5.6"
 pyarrow = ">=10.0.1"
 ipdb = ">=0.13.9"
 requests = ">=2.26.0"
@@ -24,6 +23,9 @@ structlog = ">=21.5.0"
 owid-repack = ">=0.1.1"
 dynamic-yaml = "^1.3.4"
 mistune = "^3.0.1"
+# higher version causes error in python 3.9 when running
+# from owid import catalog; catalog.find("global_carbon_budget").sort_values("version", ascending=False).iloc[0].load()
+dataclasses-json = "0.5.8"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=6.2.5"
@@ -36,7 +38,6 @@ isort = ">=5.12.0"
 # unpinning those would introduce tons of type errors
 pyright = "1.1.288"
 pandas-stubs = "1.2.0.62"
-dataclasses-json = "0.5.7"
 
 
 [tool.isort]

--- a/lib/catalog/pyproject.toml
+++ b/lib/catalog/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "owid-catalog"
-version = "0.3.7"
+version = "0.3.8"
 description = "Core data types used by OWID for managing data."
 authors = ["Our World in Data <tech@ourworldindata.org>"]
 license = "MIT"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4577,7 +4577,7 @@ files = [
 
 [[package]]
 name = "owid-catalog"
-version = "0.3.7"
+version = "0.3.8"
 description = "Core data types used by OWID for managing data."
 optional = false
 python-versions = ">=3.8.1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1607,13 +1607,13 @@ files = [
 
 [[package]]
 name = "dataclasses-json"
-version = "0.5.7"
+version = "0.5.8"
 description = "Easily serialize dataclasses to and from JSON"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "dataclasses-json-0.5.7.tar.gz", hash = "sha256:c2c11bc8214fbf709ffc369d11446ff6945254a7f09128154a7620613d8fda90"},
-    {file = "dataclasses_json-0.5.7-py3-none-any.whl", hash = "sha256:bc285b5f892094c3a53d558858a88553dd6a61a11ab1a8128a0e554385dcc5dd"},
+    {file = "dataclasses-json-0.5.8.tar.gz", hash = "sha256:6572ac08ad9340abcb74fd8c4c8e9752db2a182a402c8e871d0a8aa119e3804e"},
+    {file = "dataclasses_json-0.5.8-py3-none-any.whl", hash = "sha256:65b167c15fdf9bde27569c09ac18dd39bf1cc5b7998525024cb4678d2653946c"},
 ]
 
 [package.dependencies]
@@ -1622,7 +1622,7 @@ marshmallow-enum = ">=1.5.1,<2.0.0"
 typing-inspect = ">=0.4.0"
 
 [package.extras]
-dev = ["flake8", "hypothesis", "ipython", "mypy (>=0.710)", "portray", "pytest (>=6.2.3)", "simplejson", "types-dataclasses"]
+dev = ["flake8", "hypothesis", "ipython", "mypy (>=0.710)", "portray", "pytest (>=7.2.0)", "simplejson", "types-dataclasses"]
 
 [[package]]
 name = "debugpy"
@@ -3060,7 +3060,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*"
 files = [
     {file = "jsonpointer-2.4-py2.py3-none-any.whl", hash = "sha256:15d51bba20eea3165644553647711d150376234112651b4f1811022aecad7d7a"},
-    {file = "jsonpointer-2.4.tar.gz", hash = "sha256:585cee82b70211fa9e6043b7bb89db6e1aa49524340dde8ad6b63206ea689d88"},
 ]
 
 [[package]]
@@ -4578,7 +4577,7 @@ files = [
 
 [[package]]
 name = "owid-catalog"
-version = "0.3.6"
+version = "0.3.7"
 description = "Core data types used by OWID for managing data."
 optional = false
 python-versions = ">=3.8.1"
@@ -4587,7 +4586,7 @@ develop = true
 
 [package.dependencies]
 boto3 = ">=1.21.13"
-dataclasses-json = ">=0.5.6"
+dataclasses-json = "0.5.8"
 dynamic-yaml = "^1.3.4"
 ipdb = ">=0.13.9"
 jsonschema = ">=3.2.0"
@@ -4630,7 +4629,7 @@ url = "lib/datautils"
 
 [[package]]
 name = "owid-repack"
-version = "0.1.2"
+version = "0.1.3"
 description = "Pack Pandas data frames into smaller, more memory-efficient data types."
 optional = false
 python-versions = ">=3.8.1"
@@ -8075,4 +8074,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <3.13"
-content-hash = "29c6d5dcdda31ad380646b912e7c75e8356baf9c1c702c69302bf66347eab191"
+content-hash = "18c4742ad544bf4f576e0e4ef27a518b7c142c4775f3fb79a310244cc09eff64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,6 @@ gspread = "^5.10.0"
 # unpinning those would introduce tons of type errors
 pyright = "1.1.288"
 pandas-stubs = "1.2.0.62"
-dataclasses-json = "0.5.7"
 jsonref = "^1.1.0"
 mkdocs-jupyter = "^0.24.2"
 mkdocs-exclude = "^1.0.2"


### PR DESCRIPTION
Fix for https://github.com/owid/etl/issues/1789. The issue happens only in python3.9 and dataclasses-json versions >5.8. Let's pin it to 5.8 for now.