### PR TITLE
📊 war: add conflict mortality indicators

### DIFF
--- a/dag/main.yml
+++ b/dag/main.yml
@@ -603,6 +603,7 @@ steps:
     - snapshot://countries/2023-09-22/isd.xlsx
   data://garden/countries/2023-09-25/isd:
     - data://meadow/countries/2023-09-25/isd
+    - data://garden/demography/2023-03-31/population
   data://grapher/countries/2023-10-01/isd:
     - data://garden/countries/2023-09-25/isd
   data://meadow/countries/2023-09-25/gleditsch:
@@ -619,6 +620,7 @@ steps:
     - snapshot://countries/2023-09-22/cow_ssm_system.csv
   data://garden/countries/2023-09-29/cow_ssm:
     - data://meadow/countries/2023-09-29/cow_ssm
+    - data://garden/demography/2023-03-31/population
   data://grapher/countries/2023-09-29/cow_ssm:
     - data://garden/countries/2023-09-29/cow_ssm
 

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -610,6 +610,7 @@ steps:
     - snapshot://countries/2023-09-22/gleditsch_microstates.dat
   data://garden/countries/2023-09-25/gleditsch:
     - data://meadow/countries/2023-09-25/gleditsch
+    - data://garden/demography/2023-03-31/population
   data://grapher/countries/2023-10-01/gleditsch:
     - data://garden/countries/2023-09-25/gleditsch
   data://meadow/countries/2023-09-29/cow_ssm:

--- a/etl/steps/data/garden/countries/2023-09-25/gleditsch.countries.json
+++ b/etl/steps/data/garden/countries/2023-09-25/gleditsch.countries.json
@@ -200,7 +200,7 @@
   "Baden": "Baden",
   "Bavaria": "Bavaria",
   "German Democratic Republic": "East Germany",
-  "German Federal Republic": "West German",
+  "German Federal Republic": "West Germany",
   "Germany (Prussia)": "Germany",
   "Great Colombia": "Great Colombia",
   "Hanover": "Hanover",

--- a/etl/steps/data/garden/countries/2023-09-25/gleditsch.meta.yml
+++ b/etl/steps/data/garden/countries/2023-09-25/gleditsch.meta.yml
@@ -29,3 +29,20 @@ tables:
             - Asia and Oceania: 700-999
         display:
           numDecimalPlaces: 0
+
+      population:
+        title: Population in region
+        description_short: |-
+          Population in the region, using borders from 2022.
+        unit: countries
+        processing_level: minor
+        description_processing: |-
+          We use the list of independent states and microstates from Gleditsch and Ward. We assign each country to a region based on the mapping (using GW codes):
+
+            - Americas: 2-199
+            - Europe: 200-399
+            - Africa: 400-626
+            - Middle East: 630-699
+            - Asia and Oceania: 700-999
+        display:
+          numDecimalPlaces: 0

--- a/etl/steps/data/garden/countries/2023-09-25/isd.meta.yml
+++ b/etl/steps/data/garden/countries/2023-09-25/isd.meta.yml
@@ -36,6 +36,29 @@ tables:
 
         display:
           numDecimalPlaces: 0
+
+      population:
+        title: Population in region
+        description_short: |-
+          Population in the region, using borders from 2022.
+        unit: countries
+        processing_level: minor
+        description_processing: |-
+          We assign each sovereign state to a region based on the mapping (using ISD/COW codes):
+
+            - Americas: 2-165
+            - Europe: 200-395, 2558, 3375
+            - Africa: 400-626, 4044-6257
+            - Middle East: 630-698, 6821-6845
+            - Asia and Oceania: 700-990, 7003-9210
+
+          We also provide the following extra regions (note that this overlap with 'Africa' and 'Middle East'). These regions are used in Project Mars dataset.
+
+            - North Africa and the Middle East: 435-436, 483, 600-698, 4352-4354, 4763, 4832, 6251-6845
+            - Sub-Saharan Africa: 402-434, 437-482, 484-591, 4044-4343, 4362-4761, 4765-4831, 4841-5814
+        display:
+          numDecimalPlaces: 0
+
   isd:
     variables:
       cowid:

--- a/etl/steps/data/garden/countries/2023-09-25/isd.py
+++ b/etl/steps/data/garden/countries/2023-09-25/isd.py
@@ -3,7 +3,7 @@
 import owid.catalog.processing as pr
 from owid.catalog import Table
 from shared import (
-    add_latest_years_with_constat_num_countries,
+    add_latest_years_with_constant_num_countries,
     init_table_countries_in_region,
 )
 from structlog import get_logger
@@ -163,7 +163,7 @@ def create_table_countries_in_region(tb: Table) -> Table:
     tb_regions = pr.concat([tb_regions, tb_world], ignore_index=True, short_name="isd_regions")
 
     # Finish by adding missing last years
-    tb_regions = add_latest_years_with_constat_num_countries(
+    tb_regions = add_latest_years_with_constant_num_countries(
         tb_regions,
         column_year="year",
         expected_last_year=EXPECTED_LAST_YEAR,

--- a/etl/steps/data/garden/countries/2023-09-25/isd.py
+++ b/etl/steps/data/garden/countries/2023-09-25/isd.py
@@ -48,14 +48,14 @@ def run(dest_dir: str) -> None:
     tb = fix_data(tb)
 
     # Format table
-    tb = format_table(tb)
+    tb_formatted = format_table(tb)
 
     # Create new table
     log.info("isd: creating table with countries in region")
-    tb_regions = create_table_countries_in_region(tb=tb)
+    tb_regions = create_table_countries_in_region(tb=tb_formatted)
 
     # Population table
-    tb_pop = add_population_to_table(tb, ds_pop)
+    tb_pop = add_population_to_table(tb_formatted, ds_pop, country_col="statename", region_alt=True)
 
     # Combine tables
     tb_regions = tb_regions.merge(tb_pop, how="left", on=["region", "year"])

--- a/etl/steps/data/garden/countries/2023-09-25/shared.py
+++ b/etl/steps/data/garden/countries/2023-09-25/shared.py
@@ -98,7 +98,7 @@ def _get_end_year(date_str: str, date_format: str) -> int:
 def add_population_to_table(
     tb: Table, ds_pop: Dataset, country_col: str = "country", region_alt: bool = False
 ) -> Table:
-    """Bla.
+    """Add population to table.
 
     1. Get list of countries from latest available year. That is, we only have one row per country.
     2. Duplicate these entries for each year from first available to latest available year. As if they existed.

--- a/etl/steps/data/garden/countries/2023-09-25/shared.py
+++ b/etl/steps/data/garden/countries/2023-09-25/shared.py
@@ -43,7 +43,7 @@ def init_table_countries_in_region(
     return tb_regions
 
 
-def add_latest_years_with_constat_num_countries(tb_regions: Table, column_year: str, expected_last_year: int) -> Table:
+def add_latest_years_with_constant_num_countries(tb_regions: Table, column_year: str, expected_last_year: int) -> Table:
     """Extend data until LAST_YEAR with constant number of countries.
 
     Data stops at expected_last_year, extend it until LAST_YEAR with constant number of countries.

--- a/etl/steps/data/garden/countries/2023-09-25/shared.py
+++ b/etl/steps/data/garden/countries/2023-09-25/shared.py
@@ -2,7 +2,9 @@ from datetime import datetime as dt
 
 import owid.catalog.processing as pr
 import pandas as pd
-from owid.catalog import Table
+from owid.catalog import Dataset, Table
+
+from etl.data_helpers import geo
 
 # Only for table tb_regions:
 # Latest year to have had a 31st of December
@@ -91,3 +93,36 @@ def _get_end_year(date_str: str, date_format: str) -> int:
     if (date.month == 12) & (date.day == 31):
         return date.year + 1
     return date.year
+
+
+def add_population_to_table(tb: Table, ds_pop: Dataset) -> Table:
+    """Bla.
+
+    1. Get list of countries from latest available year. That is, we only have one row per country.
+    2. Duplicate these entries for each year from first available to latest available year. As if they existed.
+        This is because the population dataset tracks population back in time with current countries' borders.
+    3. Merge with population dataset
+    """
+    YEAR_MAX = tb["year"].max()
+    YEAR_MIN = tb["year"].min()
+    # Get last year data
+    tb_last = tb[tb["year"] == YEAR_MAX].drop(columns=["year"])
+
+    # Extend to all years
+    tb_all_years = Table(pd.RangeIndex(YEAR_MIN, LAST_YEAR + 1), columns=["year"])
+    tb_pop = tb_last.merge(tb_all_years, how="cross")
+
+    # Add population
+    tb_pop = geo.add_population_to_table(tb_pop, ds_pop)
+
+    # Estimate population by region
+    tb_pop_regions = tb_pop.groupby(["year", "region"], as_index=False)[["population"]].sum()
+
+    # Estimate world population
+    tb_pop_world = tb_pop.groupby(["year"], as_index=False)[["population"]].sum()
+    tb_pop_world["region"] = "World"
+
+    # Combine
+    tb_pop = pr.concat([tb_pop_regions, tb_pop_world], ignore_index=True)
+
+    return tb_pop

--- a/etl/steps/data/garden/countries/2023-09-29/cow_ssm.meta.yml
+++ b/etl/steps/data/garden/countries/2023-09-29/cow_ssm.meta.yml
@@ -30,3 +30,20 @@ tables:
             - Asia and Oceania: 700-999
         display:
           numDecimalPlaces: 0
+
+      population:
+        title: Population in region
+        description_short: |-
+          Population in the region, using borders from 2022.
+        unit: countries
+        processing_level: minor
+        description_processing: |-
+          We use the state system membership from Correlates of War. We assign each country to a region based on the mapping (using COW codes):
+
+            - Americas: 2-165
+            - Europe: 200-399
+            - Africa: 402-626
+            - Middle East: 630-698
+            - Asia and Oceania: 700-999
+        display:
+          numDecimalPlaces: 0

--- a/etl/steps/data/garden/countries/2023-09-29/cow_ssm.py
+++ b/etl/steps/data/garden/countries/2023-09-29/cow_ssm.py
@@ -2,7 +2,7 @@
 
 import owid.catalog.processing as pr
 import pandas as pd
-from owid.catalog import Table
+from owid.catalog import Dataset, Table
 
 from etl.data_helpers import geo
 from etl.helpers import PathFinder, create_dataset
@@ -21,6 +21,8 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset.
     ds_meadow = paths.load_dataset("cow_ssm")
+    # Load population table
+    ds_pop = paths.load_dataset("population")
 
     # Read table from meadow dataset.
     tb_system = ds_meadow["cow_ssm_system"].reset_index()
@@ -51,8 +53,18 @@ def run(dest_dir: str) -> None:
     tb_states = geo.harmonize_countries(df=tb_states, countries_file=paths.country_mapping_path, country_col="statenme")
     tb_majors = geo.harmonize_countries(df=tb_majors, countries_file=paths.country_mapping_path, country_col="statenme")
 
+    # Minor format
+    tb = tb_system.copy()
+    tb["region"] = tb_system["ccode"].apply(code_to_region)
+
     # Create new table
-    tb_regions = create_table_countries_in_region(tb_system)
+    tb_regions = create_table_countries_in_region(tb)
+
+    # Population table
+    tb_pop = add_population_to_table(tb, ds_pop)
+
+    # Combine tables
+    tb_regions = tb_regions.merge(tb_pop, how="left", on=["region", "year"])
 
     # Group tables and format tables
     tables = [
@@ -78,7 +90,6 @@ def create_table_countries_in_region(tb_system: Table):
     """Create table with number of countries per region per year."""
     # Create new table
     tb_regions = tb_system.copy()
-    tb_regions["region"] = tb_regions["ccode"].apply(code_to_region)
 
     # Get number of countries per region per year
     tb_regions = (
@@ -124,3 +135,38 @@ def code_to_region(cow_code: int) -> str:
             return "Asia and Oceania"
         case _:
             raise ValueError(f"Invalid COW code: {cow_code}")
+
+
+def add_population_to_table(tb: Table, ds_pop: Dataset) -> Table:
+    """Add population.
+
+    1. Get list of countries from latest available year. That is, we only have one row per country.
+    2. Duplicate these entries for each year from first available to latest available year. As if they existed.
+        This is because the population dataset tracks population back in time with current countries' borders.
+    3. Merge with population dataset
+
+    NOTE: Duplicated from etl/steps/data/garden/countries/2023-09-25/shared.py
+    """
+    YEAR_MAX = tb["year"].max()
+    YEAR_MIN = tb["year"].min()
+    # Get last year data
+    tb_last = tb[tb["year"] == YEAR_MAX].drop(columns=["year"])
+
+    # Extend to all years
+    tb_all_years = Table(pd.RangeIndex(YEAR_MIN, LAST_YEAR + 1), columns=["year"])
+    tb_pop = tb_last.merge(tb_all_years, how="cross")
+
+    # Add population
+    tb_pop = geo.add_population_to_table(tb_pop, ds_pop)
+
+    # Estimate population by region
+    tb_pop_regions = tb_pop.groupby(["year", "region"], as_index=False)[["population"]].sum()
+
+    # Estimate world population
+    tb_pop_world = tb_pop.groupby(["year"], as_index=False)[["population"]].sum()
+    tb_pop_world["region"] = "World"
+
+    # Combine
+    tb_pop = pr.concat([tb_pop_regions, tb_pop_world], ignore_index=True)
+
+    return tb_pop

--- a/etl/steps/data/garden/countries/2023-09-29/cow_ssm.py
+++ b/etl/steps/data/garden/countries/2023-09-29/cow_ssm.py
@@ -137,7 +137,7 @@ def code_to_region(cow_code: int) -> str:
             raise ValueError(f"Invalid COW code: {cow_code}")
 
 
-def add_population_to_table(tb: Table, ds_pop: Dataset) -> Table:
+def add_population_to_table(tb: Table, ds_pop: Dataset, country_col: str = "country") -> Table:
     """Add population.
 
     1. Get list of countries from latest available year. That is, we only have one row per country.
@@ -157,7 +157,7 @@ def add_population_to_table(tb: Table, ds_pop: Dataset) -> Table:
     tb_pop = tb_last.merge(tb_all_years, how="cross")
 
     # Add population
-    tb_pop = geo.add_population_to_table(tb_pop, ds_pop)
+    tb_pop = geo.add_population_to_table(tb_pop, ds_pop, country_col="statenme")
 
     # Estimate population by region
     tb_pop_regions = tb_pop.groupby(["year", "region"], as_index=False)[["population"]].sum()

--- a/etl/steps/data/garden/war/2023-09-21/brecke.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/brecke.meta.yml
@@ -120,7 +120,7 @@ tables:
           {definitions.number_deaths.description_short}, per capita.
         description_key: *description_key_deaths
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities

--- a/etl/steps/data/garden/war/2023-09-21/brecke.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/brecke.meta.yml
@@ -113,6 +113,18 @@ tables:
           grapher_config:
             selectedEntityNames: *selected_entities
 
+      number_deaths_ongoing_conflicts_per_capita:
+        title: Number of deaths in ongoing conflicts (per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          {definitions.number_deaths.description_short}, per capita.
+        description_key: *description_key_deaths
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
       #####################
       # Ongoing conflicts #
       #####################

--- a/etl/steps/data/garden/war/2023-09-21/brecke.py
+++ b/etl/steps/data/garden/war/2023-09-21/brecke.py
@@ -45,11 +45,10 @@ import numpy as np
 import owid.catalog.processing as pr
 import pandas as pd
 from owid.catalog import Table
+from shared import add_indicators_extra, expand_observations
 from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
-
-from .shared import add_indicators_conflict_rate, expand_observations
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -147,9 +146,14 @@ def run(dest_dir: str) -> None:
     assert (tb["region"] != -9).all(), "-9 region still detected!"
 
     # Add conflict rates
-    log.info("war.cow: map fatality codes to names")
+    paths.log.info("add conflict rate and conflict mortality indicators")
     tb_regions = tb_regions[~tb_regions["region"].isin(["Sub-Saharan Africa", "North Africa and the Middle East"])]
-    tb = add_indicators_conflict_rate(tb, tb_regions, ["number_ongoing_conflicts", "number_new_conflicts"])
+    tb = add_indicators_extra(
+        tb,
+        tb_regions,
+        columns_conflict_rate=["number_ongoing_conflicts", "number_new_conflicts"],
+        columns_conflict_mortality=["number_deaths_ongoing_conflicts"],
+    )
 
     # Add suffix with source name
     msk = tb["region"] != "World"

--- a/etl/steps/data/garden/war/2023-09-21/cow.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/cow.meta.yml
@@ -195,7 +195,7 @@ tables:
           {definitions.number_deaths.description_short}, per capita.
         description_key: *description_key_deaths
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities

--- a/etl/steps/data/garden/war/2023-09-21/cow.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/cow.meta.yml
@@ -188,6 +188,18 @@ tables:
           grapher_config:
             selectedEntityNames: *selected_entities
 
+      number_deaths_ongoing_conflicts_per_capita:
+        title: Number of battle-related deaths in ongoing conflicts (per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          {definitions.number_deaths.description_short}, per capita.
+        description_key: *description_key_deaths
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
       ####################
       # Ongoing disputes #
       ####################

--- a/etl/steps/data/garden/war/2023-09-21/cow.py
+++ b/etl/steps/data/garden/war/2023-09-21/cow.py
@@ -87,7 +87,7 @@ from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
 
-from .shared import add_indicators_conflict_rate, expand_observations
+from .shared import add_indicators_extra, expand_observations
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -309,7 +309,12 @@ def combine_tables(tb_extra: Table, tb_nonstate: Table, tb_inter: Table, tb_intr
     tb = replace_missing_data_with_zeros(tb)
 
     log.info("war.cow: map fatality codes to names")
-    tb = add_indicators_conflict_rate(tb, tb_regions, ["number_ongoing_conflicts", "number_new_conflicts"])
+    tb = add_indicators_extra(
+        tb,
+        tb_regions,
+        columns_conflict_rate=["number_ongoing_conflicts", "number_new_conflicts"],
+        columns_conflict_mortality=["number_deaths_ongoing_conflicts"],
+    )
 
     # Add suffix with source name
     msk = tb["region"] != "World"

--- a/etl/steps/data/garden/war/2023-09-21/cow_mid.py
+++ b/etl/steps/data/garden/war/2023-09-21/cow_mid.py
@@ -45,7 +45,7 @@ from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
 
-from .shared import add_indicators_conflict_rate, expand_observations
+from .shared import add_indicators_extra, expand_observations
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -120,7 +120,7 @@ def run(dest_dir: str) -> None:
 
     # Add normalised indicators
     log.info("war.mie: add normalised indicators")
-    tb = add_indicators_conflict_rate(tb, tb_regions, ["number_ongoing_disputes", "number_new_disputes"])
+    tb = add_indicators_extra(tb, tb_regions, columns_conflict_rate=["number_ongoing_disputes", "number_new_disputes"])
 
     # Add suffix with source name
     msk = tb["region"] != "World"

--- a/etl/steps/data/garden/war/2023-09-21/mars.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/mars.meta.yml
@@ -147,7 +147,7 @@ tables:
           {definitions.number_deaths.description_short}.
         description_key: *description_key_deaths
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities
@@ -160,7 +160,7 @@ tables:
           {definitions.number_deaths.description_short}.
         description_key: *description_key_deaths
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities

--- a/etl/steps/data/garden/war/2023-09-21/mars.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/mars.meta.yml
@@ -139,6 +139,32 @@ tables:
           grapher_config:
             selectedEntityNames: *selected_entities
 
+      number_deaths_ongoing_conflicts_high_per_capita:
+        title: Number of soldier deaths in ongoing conflicts (high estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "high" %>
+          {definitions.number_deaths.description_short}.
+        description_key: *description_key_deaths
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
+      number_deaths_ongoing_conflicts_low_per_capita:
+        title: Number of soldier deaths in ongoing conflicts (low estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "low" %>
+          {definitions.number_deaths.description_short}.
+        description_key: *description_key_deaths
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
       #####################
       # Ongoing conflicts #
       #####################

--- a/etl/steps/data/garden/war/2023-09-21/mars.py
+++ b/etl/steps/data/garden/war/2023-09-21/mars.py
@@ -48,7 +48,7 @@ from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
 
-from .shared import add_indicators_conflict_rate, expand_observations
+from .shared import add_indicators_extra, expand_observations
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -129,7 +129,15 @@ def run(dest_dir: str) -> None:
     # Add conflict rates
     log.info("war.cow: map fatality codes to names")
     tb_regions = tb_regions[~tb_regions["region"].isin(["Africa", "Middle East"])]
-    tb = add_indicators_conflict_rate(tb, tb_regions, ["number_ongoing_conflicts", "number_new_conflicts"])
+    tb = add_indicators_extra(
+        tb,
+        tb_regions,
+        columns_conflict_rate=["number_ongoing_conflicts", "number_new_conflicts"],
+        columns_conflict_mortality=[
+            "number_deaths_ongoing_conflicts_high",
+            "number_deaths_ongoing_conflicts_low",
+        ],
+    )
 
     # Add suffix with source name
     msk = tb["region"] != "World"

--- a/etl/steps/data/garden/war/2023-09-21/mie.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/mie.meta.yml
@@ -189,3 +189,29 @@ tables:
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities
+
+      number_deaths_ongoing_conflicts_low_per_capita:
+        title: Number of deaths in ongoing conflicts (low estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          The low estimate of the number of deaths in all ongoing interstate conflicts in each year.
+        description_key: *description_key_deaths
+        processing_level: major
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
+      number_deaths_ongoing_conflicts_high_per_capita:
+        title: Number of deaths in ongoing conflicts (high estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          The high estimate of the number of deaths in all ongoing interstate conflicts in each year.
+        description_key: *description_key_deaths
+        processing_level: major
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities

--- a/etl/steps/data/garden/war/2023-09-21/mie.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/mie.meta.yml
@@ -198,7 +198,7 @@ tables:
         description_key: *description_key_deaths
         processing_level: major
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities
@@ -211,7 +211,7 @@ tables:
         description_key: *description_key_deaths
         processing_level: major
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities

--- a/etl/steps/data/garden/war/2023-09-21/mie.py
+++ b/etl/steps/data/garden/war/2023-09-21/mie.py
@@ -37,7 +37,7 @@ from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
 
-from .shared import add_indicators_conflict_rate, expand_observations
+from .shared import add_indicators_extra, expand_observations
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -129,7 +129,12 @@ def run(dest_dir: str) -> None:
 
     # Add normalised indicators
     log.info("war.mie: add normalised indicators")
-    tb = add_indicators_conflict_rate(tb, tb_regions, ["number_ongoing_conflicts", "number_new_conflicts"])
+    tb = add_indicators_extra(
+        tb,
+        tb_regions,
+        columns_conflict_rate=["number_ongoing_conflicts", "number_new_conflicts"],
+        columns_conflict_mortality=["number_deaths_ongoing_conflicts_low", "number_deaths_ongoing_conflicts_high"],
+    )
 
     # Add suffix with source name
     msk = tb["region"] != "World"

--- a/etl/steps/data/garden/war/2023-09-21/prio_v31.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/prio_v31.meta.yml
@@ -187,7 +187,7 @@ tables:
           {definitions.number_deaths.description_short}
         description_key: *description_key_deaths
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities
@@ -200,7 +200,7 @@ tables:
           {definitions.number_deaths.description_short}
         description_key: *description_key_deaths
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities

--- a/etl/steps/data/garden/war/2023-09-21/prio_v31.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/prio_v31.meta.yml
@@ -179,6 +179,45 @@ tables:
           grapher_config:
             selectedEntityNames: *selected_entities
 
+      number_deaths_ongoing_conflicts_battle_high_per_capita:
+        title: Number of battle deaths in ongoing conflicts (high estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "high" %>
+          {definitions.number_deaths.description_short}
+        description_key: *description_key_deaths
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
+      number_deaths_ongoing_conflicts_battle_low_per_capita:
+        title: Number of battle deaths in ongoing conflicts (low estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "low" %>
+          {definitions.number_deaths.description_short}
+        description_key: *description_key_deaths
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
+      number_deaths_ongoing_conflicts_battle_per_capita:
+        title: Number of battle deaths in ongoing conflicts (best estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "best" %>
+          {definitions.number_deaths.description_short}
+        description_key: *description_key_deaths
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
       #####################
       # Ongoing conflicts #
       #####################

--- a/etl/steps/data/garden/war/2023-09-21/prio_v31.py
+++ b/etl/steps/data/garden/war/2023-09-21/prio_v31.py
@@ -30,7 +30,7 @@ from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
 
-from .shared import add_indicators_conflict_rate
+from .shared import add_indicators_extra
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -99,7 +99,16 @@ def run(dest_dir: str) -> None:
 
     # Add conflict rates
     paths.log.info("war.cow: map fatality codes to names")
-    tb = add_indicators_conflict_rate(tb, tb_regions, ["number_ongoing_conflicts", "number_new_conflicts"])
+    tb = add_indicators_extra(
+        tb,
+        tb_regions,
+        columns_conflict_rate=["number_ongoing_conflicts", "number_new_conflicts"],
+        columns_conflict_mortality=[
+            "number_deaths_ongoing_conflicts_battle_high",
+            "number_deaths_ongoing_conflicts_battle_low",
+            "number_deaths_ongoing_conflicts_battle",
+        ],
+    )
 
     # Add suffix with source name
     msk = tb["region"] != "World"

--- a/etl/steps/data/garden/war/2023-09-21/shared.py
+++ b/etl/steps/data/garden/war/2023-09-21/shared.py
@@ -57,53 +57,85 @@ def expand_observations(
     return tb
 
 
-def add_indicators_conflict_rate(tb: Table, tb_regions: Table, columns_to_scale: List[str]) -> Table:
-    """Scale columns `columns_to_scale` based on the number of countries (and country-pairs) in each region and year.
+def add_indicators_extra(
+    tb: Table,
+    tb_regions: Table,
+    columns_conflict_rate: Optional[List[str]] = None,
+    columns_conflict_mortality: Optional[List[str]] = None,
+) -> Table:
+    """Scale original columns to obtain new indicators (conflict rate and conflict mortality indicators).
 
-    For each indicator listed in `columns_to_scale`, two new columns are added to the table:
-    - `{indicator}_per_country`: the indicator value divided by the number of countries in the region and year.
-    - `{indicator}_per_country_pair`: the indicator value divided by the number of country-pairs in the region and year.
+    CONFLICT RATE:
+        Scale columns `columns_conflict_rate` based on the number of countries (and country-pairs) in each region and year.
 
-    TODO: add metadata to derived columns? can't do atm bc metadata of the original columns is added after creating the dataset.
+        For each indicator listed in `columns_to_scale`, two new columns are added to the table:
+        - `{indicator}_per_country`: the indicator value divided by the number of countries in the region and year.
+        - `{indicator}_per_country_pair`: the indicator value divided by the number of country-pairs in the region and year.
+
+    CONFLICT MORTALITY:
+        Scale columns `columns_conflict_mortality` based on the population in each region.
+
+        For each indicator listed in `columns_to_scale`, a new column is added to the table:
+        - `{indicator}_per_capita`: the indicator value divided by the number of countries in the region and year.
+
 
     tb: Main table
     tb_regions: Table with three columns: "year", "region", "num_countries". Gives the number of countries per region per year.
     columns_to_scale: List with the names of the columns that need scaling. E.g. number_ongiong_conflicts -> number_ongiong_conflicts_per_country
-
-    NOTE: Only tested for COW-based state lists (MIE).
     """
+    tb_regions_ = tb_regions.copy()
+
     # Sanity check 1: columns as expected in tb_regions
-    assert set(tb_regions.columns) == {
+    assert set(tb_regions_.columns) == {
         "year",
         "region",
         "number_countries",
-    }, f"Invalid columns in tb_regions {tb_regions.columns}"
+        "population",
+    }, f"Invalid columns in tb_regions {tb_regions_.columns}"
     # Sanity check 2: regions equivalent in both tables
     regions_main = set(tb["region"])
-    regions_aux = set(tb_regions["region"])
+    regions_aux = set(tb_regions_["region"])
     assert regions_main == regions_aux, f"Regions in main table and tb_regions differ: {regions_main} vs {regions_aux}"
 
     # Ensure full precision
-    tb_regions["number_countries"] = tb_regions["number_countries"].astype(float)
-
+    tb_regions_["number_countries"] = tb_regions_["number_countries"].astype(float)
+    tb_regions_["population"] = tb_regions_["population"]  # .astype(float)
     # Get number of country-pairs
-    tb_regions["number_country_pairs"] = (
-        tb_regions["number_countries"] * (tb_regions["number_countries"] - 1) / 2
+    tb_regions_["number_country_pairs"] = (
+        tb_regions_["number_countries"] * (tb_regions_["number_countries"] - 1) / 2
     ).astype(int)
-    # Add number of countries and number of country pairs to main table
-    tb = tb.merge(tb_regions, on=["year", "region"], how="left")
 
-    # Add normalised indicators
-    for column_name in columns_to_scale:
-        # Add per country indicator
-        column_name_new = f"{column_name}_per_country"
-        tb[column_name_new] = (tb[column_name] / tb["number_countries"]).replace([np.inf, -np.inf], np.nan)
-        # Add per country-pair indicator
-        column_name_new = f"{column_name}_per_country_pair"
-        tb[column_name_new] = (tb[column_name] / tb["number_country_pairs"]).replace([np.inf, -np.inf], np.nan)
+    # Add number of countries and number of country pairs to main table
+    tb = tb.merge(tb_regions_, on=["year", "region"], how="left")
+
+    if not columns_conflict_rate and not columns_conflict_mortality:
+        raise ValueError(
+            "Call to function is useless. Either provide `columns_conflict_rate` or `columns_conflict_mortality`."
+        )
+
+    # CONFLICT RATES ###########
+    if columns_conflict_rate:
+        # Add normalised indicators
+        for column_name in columns_conflict_rate:
+            # Add per country indicator
+            column_name_new = f"{column_name}_per_country"
+            tb[column_name_new] = (tb[column_name] / tb["number_countries"]).replace([np.inf, -np.inf], np.nan)
+            # Add per country-pair indicator
+            column_name_new = f"{column_name}_per_country_pair"
+            tb[column_name_new] = (tb[column_name] / tb["number_country_pairs"]).replace([np.inf, -np.inf], np.nan)
+
+    # CONFLICT MORTALITY ###########
+    if columns_conflict_mortality:
+        # Add normalised indicators
+        for column_name in columns_conflict_mortality:
+            # Add per country indicator
+            column_name_new = f"{column_name}_per_capita"
+            tb[column_name_new] = (
+                (100000 * tb[column_name] / tb["population"]).replace([np.inf, -np.inf], np.nan).astype(float)
+            )
 
     # Drop intermediate columns
-    tb = tb.drop(columns=["number_countries", "number_country_pairs"])
+    tb = tb.drop(columns=["number_countries", "number_country_pairs", "population"])
 
     return tb
 

--- a/etl/steps/data/garden/war/2023-09-21/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/ucdp.meta.yml
@@ -195,6 +195,45 @@ tables:
           grapher_config:
             selectedEntityNames: *selected_entities
 
+      number_deaths_ongoing_conflicts_per_capita:
+        title: Number of deaths in ongoing conflicts (best estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "best" %>
+          {definitions.number_deaths.description_short}
+        description_key: *description_key_deaths
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
+      number_deaths_ongoing_conflicts_high_per_capita:
+        title: Number of deaths in ongoing conflicts (high estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "high" %>
+          {definitions.number_deaths.description_short}
+        description_key: *description_key_deaths
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
+      number_deaths_ongoing_conflicts_low_per_capita:
+        title: Number of deaths in ongoing conflicts (low estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "low" %>
+          {definitions.number_deaths.description_short}
+        description_key: *description_key_deaths
+        display:
+          numDecimalPlaces: 0
+        presentation:
+          grapher_config:
+            selectedEntityNames: *selected_entities
+
       #####################
       # Ongoing conflicts #
       #####################

--- a/etl/steps/data/garden/war/2023-09-21/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/ucdp.meta.yml
@@ -203,7 +203,7 @@ tables:
           {definitions.number_deaths.description_short}
         description_key: *description_key_deaths
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities
@@ -216,7 +216,7 @@ tables:
           {definitions.number_deaths.description_short}
         description_key: *description_key_deaths
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities
@@ -229,7 +229,7 @@ tables:
           {definitions.number_deaths.description_short}
         description_key: *description_key_deaths
         display:
-          numDecimalPlaces: 0
+          numDecimalPlaces: 1
         presentation:
           grapher_config:
             selectedEntityNames: *selected_entities

--- a/etl/steps/data/garden/war/2023-09-21/ucdp.py
+++ b/etl/steps/data/garden/war/2023-09-21/ucdp.py
@@ -27,7 +27,7 @@ from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
 
-from .shared import add_indicators_conflict_rate
+from .shared import add_indicators_extra
 
 log = get_logger()
 
@@ -129,7 +129,16 @@ def run(dest_dir: str) -> None:
     # tb = tb.astype({"conflict_type": "category", "region": "category"})
 
     # Add conflict rates
-    tb = add_indicators_conflict_rate(tb, tb_regions, ["number_ongoing_conflicts", "number_new_conflicts"])
+    tb = add_indicators_extra(
+        tb,
+        tb_regions,
+        columns_conflict_rate=["number_ongoing_conflicts", "number_new_conflicts"],
+        columns_conflict_mortality=[
+            "number_deaths_ongoing_conflicts",
+            "number_deaths_ongoing_conflicts_high",
+            "number_deaths_ongoing_conflicts_low",
+        ],
+    )
 
     # Adapt region names
     tb = adapt_region_names(tb)


### PR DESCRIPTION
- Add population in each region in the 'states in region' datasets
  - [x] `etl/steps/data/garden/countries/2023-09-25/*`
  - [x] `etl/steps/data/garden/countries/2023-09-27/*`
- Add conflict mortality indicators to all war datasets. This is basically normalising the number of deaths by the region population.
  - [x] `etl/steps/data/garden/war/2023-09-21/*`