### PR TITLE
📜 Update metadata guidelines, fix typos, and add section about indicator titles

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -18,7 +18,7 @@ The best data on global issues comes from **the hard work of _data providers_**,
 
 As a data republisher, we therefore need a methodology to process, version, and maintain several datasets all the way from the original source's publication wite to our platform. And it needs to be scalable.
 <!--
-We've had [our own journey](our-journey.md) in the search for this methodology for some time, which has now converged into what we know as the ETL. In this section we describe [its design prinicples](design), our [workflow](workflow/index.md).
+We've had [our own journey](our-journey.md) in the search for this methodology for some time, which has now converged into what we know as the ETL. In this section we describe [its design principles](design), our [workflow](workflow/index.md).
 Learn more about our architecture in the following sections: -->
 
 *[ETL]: Extract Transform Load

--- a/docs/architecture/metadata/faqs.md
+++ b/docs/architecture/metadata/faqs.md
@@ -1,0 +1,37 @@
+## I see that there are multiple fields to define the name of an indicator. When should I use what?
+
+We currently have many fields related to an indicator's title, so you might be wondering when you should use one or the other. Find below a summary on their different use cases.
+
+* **`indicator.title`**: This field must always be given.
+
+    - **Small datasets**: it can be the publicly displayed title of the indicator in all places.
+    - **Big datasets**:
+        - These may have dimensions, and their indicators can include text fragments to communicate these breakdowns (e.g.  "Indicator name - Gender: male - Age: 10-19").
+        - In such cases, `indicator.title` is mostly useful for internal searches, and a human-readable `display.name` should be given.
+
+* **`display.name`**
+    - This is our most versatile human-readable title, shown in many public places. It must be used to replace `indicator.title` when the latter has complex breakdowns.
+
+* **`presentation.grapher_config.title`**
+This should be used when a chart requires a specific title, different from the indicator's title (or `display.name`).
+
+* **`presentation.title_public`**
+This is only used for the title of a data page. It must be an excellent, human-readable title.
+
+* **`presentation.title_variant`**
+This is an additional short text that accompanies the title of the data page. It is only necessary when the indicator needs to be distinguished from others, or when we want to emphasize a special feature of the indicator, e.g. "Historical data".
+
+
+In an ideal world, we could define all previous fields for all indicators, but in practice, we need to minimize our workload when creating metadata. For this reason, most of the fields are optional, and publicly displayed titles follow a hierarchy of choices.
+
+!!! info "Title hierarchy"
+
+    In general, the hierarchy is: `presentation.title_public > grapher_config.title > display.name > indicator.title`
+
+    The following places on our (internal/public) website will be populated using this hierarchy:
+
+    - **Admin**: `indicator.title`
+    - **Charts**:
+        - **'Learn more about this data'** and **Table view** (and possibly other public places): `display.name > indicator.title`
+        - **Chart title**: `grapher_config.title > display.name > indicator.title`
+    - **Data page title**: `presentation.title_public > grapher_config.title > display.name > indicator.title`

--- a/docs/architecture/metadata/faqs.md
+++ b/docs/architecture/metadata/faqs.md
@@ -4,8 +4,8 @@ We currently have many fields related to an indicator's title, so you might be w
 
 * **`indicator.title`**: This field must always be given.
 
-    - **Small datasets**: it can be the publicly displayed title of the indicator in all places.
-    - **Big datasets**:
+    - Small datasets: it can be the publicly displayed title of the indicator in all places.
+    - Big datasets:
         - These may have dimensions, and their indicators can include text fragments to communicate these breakdowns (e.g.  "Indicator name - Gender: male - Age: 10-19").
         - In such cases, `indicator.title` is mostly useful for internal searches, and a human-readable `display.name` should be given.
 

--- a/docs/architecture/metadata/index.md
+++ b/docs/architecture/metadata/index.md
@@ -5,6 +5,8 @@
 
     If you have questions about the metadata, you can share these in our [discussion](https://github.com/owid/etl/discussions/categories/metadata). This greatly helps us keep track of the questions and answers, and makes it easier for others to find answers to similar questions.
 
+    :material-chat-question: Additionally, we have added a [FAQs](faqs) section to this entry.
+
 One of the main values of our work is the careful documentation that we provide along with our data and articles. In the context of
  data, we have created a metadata system in ETL that allows us to describe the data that we are working with.
 
@@ -22,8 +24,8 @@ In Snapshot we define metadata attributes for the data source product. We make s
 
 !!! info "Learn more"
 
-    - [Learn about our workflow in Snapshot :octicons-arrow-right-24:](../workflow/snapshot#metadata)
     - [Learn about the fields available in `origin` :octicons-arrow-right-24:](reference/origin)
+    - [Learn about our workflow in Snapshot :octicons-arrow-right-24:](../workflow/snapshot#metadata)
 
 ## Garden
 In Garden we focus on the metadata of the finished product. After all necessary ETL steps, the initial source file (or files) has (or have) been transformed into a curated dataset. This dataset may have multiple tables, each of them with various indicators.
@@ -32,9 +34,10 @@ In this step we add metadata that describes this dataset, these tables and these
 
 !!! info "Learn more"
 
-    - [Learn about our workflow in Garden :octicons-arrow-right-24:](../workflow/garden#metadata)
+    - [Learn about the fields available in `indicator` :octicons-arrow-right-24:](reference/indicator)
+    - [Learn about the fields available in `table` :octicons-arrow-right-24:](reference/tables)
     - [Learn about the fields available in `dataset` :octicons-arrow-right-24:](reference/dataset)
-    - [Learn about the fields available in `tables` :octicons-arrow-right-24:](reference/tables)
+    - [Learn about our workflow in Garden :octicons-arrow-right-24:](../workflow/garden#metadata)
 
 
 ## Propagation of metadata

--- a/docs/architecture/metadata/index.md
+++ b/docs/architecture/metadata/index.md
@@ -9,7 +9,7 @@ One of the main values of our work is the careful documentation that we provide 
  data, we have created a metadata system in ETL that allows us to describe the data that we are working with.
 
 
-In our [data model](../design/common-format.md) there are various data objects (_Snapshots_, _datasets_ that contain _tables_ with _indicators_, etc.), each of them with different types of metadata.
+In our [data model](../design/common-format.md) there are various data objects (_snapshots_, _datasets_ that contain _tables_ with _indicators_, etc.), each of them with different types of metadata.
 
 
 
@@ -38,7 +38,7 @@ In this step we add metadata that describes this dataset, these tables and these
 
 
 ## Propagation of metadata
-We are building a logic into ETL to automatically propagate metadata fields forward (Snapshot → Meadow → Garden → Grapher).
+We have built a logic into ETL to automatically propagate metadata fields forward (Snapshot → Meadow → Garden → Grapher).
 
 [Learn more :octicons-arrow-right-24:](propagation.md)
 
@@ -49,6 +49,24 @@ We automatically create data pages from an indicator using its metadata fields. 
 
 [Try the demo :octicons-arrow-right-24:](../../tutorials/metadata-play.md)
 
+### Indicator titles
+We currently have many fields related to an indicator's title, namely `indicator.title`, `display.name`, `presentation.grapher_config.title`, `presentation.title_public`, and `presentation.title_variant`. Here's a short clarification of how to define them:
+
+- `indicator.title` must always be given.
+  - For 'small datasets', it can be the publicly displayed title of the indicator in all places.
+  - For 'big datasets' with many dimensions, it can include text fragments to communicate breakdowns, like  "- Gender: male - Age: 10-19". In such cases, `indicator.title` is mostly useful for internal searches, and a human-readable `display.name` should be given.
+- `display.name` is our most versatile human-readable title, shown in many public places. It must be used to replace `indicator.title` when the latter has complex breakdowns.
+- `presentation.grapher_config.title` should be used when a chart requires a specific title, different from the indicator's title (or `display.name`).
+- `presentation.title_public` is only used for the title of a data page. It must be an excellent, human-readable title.
+  - `presentation.title_variant` is an additional short text that accompanies the title of the data page. It is only necessary when the indicator needs to be distinguished from others, or when we want to emphasize a special feature of the indicator, e.g. "Historical data".
+
+In an ideal world, we could define all previous fields for all indicators, but in practice, we need to minimize our workload when creating metadata. For this reason, most of the fields are optional, and publicly displayed titles follow a hierarchy of choices. In general, the hierarchy is:
+`presentation.title_public > grapher_config.title > display.name > indicator.title`
+The following places on our (internal/public) website will be populated using this hierarchy:
+- Admin: `indicator.title`
+- Sources and Table tab (and possibly other public places): `display.name > indicator.title`
+- Chart title: `grapher_config.title > display.name > indicator.title`
+- Data page title: `presentation.title_public > grapher_config.title > display.name > indicator.title`
 
 ### Other uses
-Users can consume the metadata programatically using the [`owid-catalog`](https://github.com/owid/etl/tree/master/lib/catalog).
+Users can consume the metadata programmatically using the [`owid-catalog`](https://github.com/owid/etl/tree/master/lib/catalog).

--- a/docs/architecture/metadata/index.md
+++ b/docs/architecture/metadata/index.md
@@ -49,24 +49,5 @@ We automatically create data pages from an indicator using its metadata fields. 
 
 [Try the demo :octicons-arrow-right-24:](../../tutorials/metadata-play.md)
 
-### Indicator titles
-We currently have many fields related to an indicator's title, namely `indicator.title`, `display.name`, `presentation.grapher_config.title`, `presentation.title_public`, and `presentation.title_variant`. Here's a short clarification of how to define them:
-
-- `indicator.title` must always be given.
-  - For 'small datasets', it can be the publicly displayed title of the indicator in all places.
-  - For 'big datasets' with many dimensions, it can include text fragments to communicate breakdowns, like  "- Gender: male - Age: 10-19". In such cases, `indicator.title` is mostly useful for internal searches, and a human-readable `display.name` should be given.
-- `display.name` is our most versatile human-readable title, shown in many public places. It must be used to replace `indicator.title` when the latter has complex breakdowns.
-- `presentation.grapher_config.title` should be used when a chart requires a specific title, different from the indicator's title (or `display.name`).
-- `presentation.title_public` is only used for the title of a data page. It must be an excellent, human-readable title.
-  - `presentation.title_variant` is an additional short text that accompanies the title of the data page. It is only necessary when the indicator needs to be distinguished from others, or when we want to emphasize a special feature of the indicator, e.g. "Historical data".
-
-In an ideal world, we could define all previous fields for all indicators, but in practice, we need to minimize our workload when creating metadata. For this reason, most of the fields are optional, and publicly displayed titles follow a hierarchy of choices. In general, the hierarchy is:
-`presentation.title_public > grapher_config.title > display.name > indicator.title`
-The following places on our (internal/public) website will be populated using this hierarchy:
-- Admin: `indicator.title`
-- Sources and Table tab (and possibly other public places): `display.name > indicator.title`
-- Chart title: `grapher_config.title > display.name > indicator.title`
-- Data page title: `presentation.title_public > grapher_config.title > display.name > indicator.title`
-
 ### Other uses
 Users can consume the metadata programmatically using the [`owid-catalog`](https://github.com/owid/etl/tree/master/lib/catalog).

--- a/docs/architecture/metadata/propagation.md
+++ b/docs/architecture/metadata/propagation.md
@@ -1,6 +1,6 @@
-<!-- !!! warning "This is still being written."
+!!! warning "This is still being written."
 
-    Our metadata formats are still in flux, and are likely to change over the coming weeks. -->
+    Our metadata formats are still in flux, and are likely to change over the coming weeks.
 
 
 We are defining an internal ETL logic so that the metadata is propagation in a smart way from Snapshot to Grapher.

--- a/etl/docs.py
+++ b/etl/docs.py
@@ -6,12 +6,20 @@ def guidelines_to_markdown(guidelines: List[Any], extra_tab: int = 0) -> str:
     tab = "\t" * extra_tab
     text = ""
     for guideline in guidelines:
-        # Main guideline
+        text = _guideline_to_markdown(text, tab, guideline)
+    return text
+
+
+def _guideline_to_markdown(text: str, tab: str, guideline):
+    # Main guideline
+    if isinstance(guideline, str):
+        text += f"\n{tab}- {guideline}"
+    else:
         if isinstance(guideline[0], str):
             # Add main guideline
             text += f"\n{tab}- {guideline[0]}"
         else:
-            raise TypeError("The first element of an element in `guidelines` must be a string!")
+            raise TypeError(f"The first element of an element in `guidelines` must be a string! {guideline}")
 
         # Additions to the guideline (nested bullet points, exceptions, etc.)
         if len(guideline) == 2:
@@ -24,13 +32,17 @@ def guidelines_to_markdown(guidelines: List[Any], extra_tab: int = 0) -> str:
 
                 # Render exceptions
                 if guideline[1]["type"] == "exceptions":
-                    text += " Exceptions:"
-                    for exception in guideline[1]["value"]:
-                        text += f"\n{tab}\t- {exception}"
+                    text += " **Exceptions:**"
+                    for sub_guideline in guideline[1]["value"]:
+                        text = _guideline_to_markdown(text, f"{tab}\t", sub_guideline)
+                    # for exception in guideline[1]["value"]:
+                    #     text += f"\n{tab}\t- {exception}"
                 # Render nested list
                 elif guideline[1]["type"] == "list":
-                    for subitem in guideline[1]["value"]:
-                        text += f"\n{tab}\t- {subitem}"
+                    for sub_guideline in guideline[1]["value"]:
+                        text = _guideline_to_markdown(text, f"{tab}\t", sub_guideline)
+                    # for subitem in guideline[1]["value"]:
+                    #     text += f"\n{tab}\t- {subitem}"
                 # Exception
                 else:
                     raise ValueError(f"Unknown guideline type: {guideline[1]['type']}!")
@@ -39,7 +51,8 @@ def guidelines_to_markdown(guidelines: List[Any], extra_tab: int = 0) -> str:
 
         # Element in guideliens is more than 2 items long
         if len(guideline) > 2:
-            raise ValueError("Each element in `guidelines` must have at most 2 elements!")
+            raise ValueError(f"Each element in `guidelines` must have at most 2 elements! Found {len(guideline)} instead in '{guideline}'!")
+
     return text
 
 

--- a/etl/docs.py
+++ b/etl/docs.py
@@ -51,7 +51,9 @@ def _guideline_to_markdown(text: str, tab: str, guideline):
 
         # Element in guideliens is more than 2 items long
         if len(guideline) > 2:
-            raise ValueError(f"Each element in `guidelines` must have at most 2 elements! Found {len(guideline)} instead in '{guideline}'!")
+            raise ValueError(
+                f"Each element in `guidelines` must have at most 2 elements! Found {len(guideline)} instead in '{guideline}'!"
+            )
 
     return text
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,9 +59,10 @@ nav:
           - Indicator: "architecture/metadata/reference/indicator.md"
           - Table: "architecture/metadata/reference/tables.md"
           - Dataset: "architecture/metadata/reference/dataset.md"
-        - Propagation of metadata: "architecture/metadata/propagation.md"
         - Structuring YAML file: "architecture/metadata/structuring-yaml.md"
         - Data Pages Workflow: "architecture/metadata/data_pages_workflow.md"
+        - FAQs: "architecture/metadata/faqs.md"
+        - Propagation of metadata: "architecture/metadata/propagation.md"
         - Using metadata: "architecture/metadata/using.md"
       - Our journey: "architecture/our-journey.md"
   - API and catalog:

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -423,7 +423,8 @@
                   "description": "Title of the indicator, which is a few words definition of the indicator.",
                   "examples": [
                     "Number of neutron star mergers in the Milky Way",
-                    "Share of neutron star mergers that happen in the Milky Way"
+                    "Share of neutron star mergers that happen in the Milky Way",
+                    "Barley | 00000044 || Area harvested | 005312 || hectares"
                   ],
                   "examples_bad": [
                     [
@@ -431,6 +432,9 @@
                     ],
                     [
                       "Share of neutron star mergers that happen in the Milky Way (2023)"
+                    ],
+                    [
+                      "Barley"
                     ]
                   ],
                   "requirement_level": "required",
@@ -445,10 +449,10 @@
                       "Must be one short sentence (a few words)."
                     ],
                     [
-                      "Should not mention other metadata fields like `producer` or `version`."
+                      "For 'small datasets', this should be the publicly displayed title. For 'big datasets' (like FAOSTAT, with many dimensions), it can be less human-readable, optimized for internal searches (then, use `display.name` for the publicly displayed title)."
                     ],
                     [
-                      "For big datasets where constructing human-readable titles is hard (e.g. FAOSTAT), consider using other metadata fields to improve the public appearance of the title (namely `presentation.title_public` and `grapher_config.title`)."
+                      "Should not mention other metadata fields like `producer` or `version`."
                     ]
                   ],
                   "category": "metadata"

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -334,14 +334,17 @@
         },
         "licenses": {
           "type": "array",
-          "description": "List of all licenses that have been involved in the processing history of the indicators in this dataset. NOTE: Licenses should be propagated automatically from snapshots. Therefore, this field should only be manually filled out if automatic propagation fails. In the near future, this field may not even exist, since `licenses` should only exist inside `origins`.",
+          "description": "List of all licenses that have been involved in the processing history of the indicators in this dataset.",
+          "guidelines": [
+            "**Note:** Licenses should be propagated automatically from snapshots. Therefore, this field should only be manually filled out if automatic propagation fails. In the near future, this field may not even exist, since `licenses` should only exist inside `origins`."
+          ],
           "items": {
             "$ref": "definitions.json#/license"
           }
         },
         "sources": {
           "type": "array",
-          "description": "List of all sources of the indicators in this dataset. NOTE: This is no longer in use, you should use origins.",
+          "description": "(DEPRECATED, no longer in use). List of all sources of the indicators in this dataset.",
           "items": {
             "$ref": "definitions.json#/source"
           }
@@ -738,7 +741,10 @@
                 },
                 "origins": {
                   "type": "array",
-                  "description": "List of all origins of the indicator. Automatically filled. NOTE: Origins should be propagated automatically from snapshots. Therefore, this field should only be manually filled out if automatic propagation fails.",
+                  "description": "List of all origins of the indicator.",
+                  "guidelines": [
+                    "**Note:** Origins should be propagated automatically from snapshots. Therefore, this field should only be manually filled out if automatic propagation fails."
+                  ],
                   "items": {
                     "$ref": "definitions.json#/origin"
                   }

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -341,9 +341,9 @@
             {
               "type": "list",
               "value": [
-                "One author: `Williams`.",
-                "Two authors: `Williams and Jones`.",
-                "Three or more authors: `Williams et al.`."
+                ["One author: `Williams`."],
+                ["Two authors: `Williams and Jones`."],
+                ["Three or more authors: `Williams et al.`."]
               ]
             }
           ],
@@ -584,7 +584,12 @@
               "type": "exceptions",
               "value": [
                 "The name of the origin is well known and includes other metadata fields.",
-                "The producer's data product has a well-known name, and the snapshot is a specific slice of the data product. If so, use the format 'Data product - Specific slice'. NOTE: This means that the title of the snapshot may contain the title of the data product."
+                [
+                  "The producer's data product has a well-known name, and the snapshot is a specific slice of the data product. If so, use the format 'Data product - Specific slice'.",
+                  {
+                    "type": "list",
+                    "value": ["**Note:** This means that the title of the snapshot may contain the title of the data product."]}
+                ]
               ]
             }
           ],

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -744,7 +744,10 @@
       },
       "conversionFactor": {
         "type": "number",
-        "description": "Conversion factor to apply to indicator values. NOTE: We should avoid using this, and instead convert data and units (and possibly other metadata fields where the units are mentioned) consistently in the ETL grapher step."
+        "description": "Conversion factor to apply to indicator values.",
+        "guidelines": [
+          "**Note:** We should avoid using this, and instead convert data and units (and possibly other metadata fields where the units are mentioned) consistently in the ETL grapher step."
+        ]
       },
       "unit": {
         "type": "string",

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -583,7 +583,8 @@
             {
               "type": "exceptions",
               "value": [
-                "The name of the origin is well known and includes other metadata fields."
+                "The name of the origin is well known and includes other metadata fields.",
+                "The producer's data product has a well-known name, and the snapshot is a specific slice of the data product. If so, use the format 'Data product - Specific slice'. NOTE: This means that the title of the snapshot may contain the title of the data product."
               ]
             }
           ],
@@ -595,9 +596,6 @@
           ],
           [
             "Should not include words like `data`, `dataset` or `database`, unless that's part of a well-known name of the origin."
-          ],
-          [
-            "If the producer's data product has a well-known name, and the snapshot is a specific slice of the data product, use a title like 'Data product - Specific slice'. NOTE: The title of the snapshot may contain the title of the data product."
           ],
           [
             "If the producer's data product does not have a well-known name, use a short sentence that describes the snapshot."
@@ -653,7 +651,42 @@
       },
       "name": {
         "type": "string",
-        "description": "Title to display for the indicator, to replace the indicator's `title`. NOTE: Currently, `grapher_config.title` will be used only in charts, whereas `display.name` will be used in other places, like the table tab."
+        "description": "Title to display for the indicator, to replace the indicator's `title`. NOTE: Currently, `grapher_config.title` will be used only in charts, whereas `display.name` will be used in other places, like the table tab.",
+        "examples": [
+          "Number of neutron star mergers in the Milky Way",
+          "Share of neutron star mergers that happen in the Milky Way",
+          "Area harvested of barley"
+        ],
+        "examples_bad": [
+          [
+            "Number of neutron stars (NASA)"
+          ],
+          [
+            "Share of neutron star mergers that happen in the Milky Way (2023)"
+          ],
+          [
+            "Barley | 00000044 || Area harvested | 005312 || hectares"
+          ]
+        ],
+        "requirement_level": "required",
+        "guidelines": [
+          [
+            "Must be suitable to be publicly displayed, even for 'big datasets' with many dimensions."
+          ],
+          [
+            "Must start with a capital letter."
+          ],
+          [
+            "Must not end with a period."
+          ],
+          [
+            "Must be one short sentence (a few words)."
+          ],
+          [
+            "Should not mention other metadata fields like `producer` or `version`."
+          ]
+        ],
+        "category": "metadata"
       },
       "description": {
         "type": "string",


### PR DESCRIPTION
Following our latest discussions and changes:
* Update metadata guidelines.
* Fix some small typos.
* Add section about indicator titles to the metadata documentation.
