### PR TITLE
📜 fix hierarchy error in indicator name

### DIFF
--- a/docs/architecture/metadata/faqs.md
+++ b/docs/architecture/metadata/faqs.md
@@ -26,12 +26,12 @@ In an ideal world, we could define all previous fields for all indicators, but i
 
 !!! info "Title hierarchy"
 
-    In general, the hierarchy is: `presentation.title_public > grapher_config.title > display.name > indicator.title`
+    In general, the hierarchy is: `presentation.title_public > presentation.grapher_config.title > display.name > indicator.title`
 
     The following places on our (internal/public) website will be populated using this hierarchy:
 
     - **Admin**: `indicator.title`
     - **Charts**:
         - **'Learn more about this data'** and **Table view** (and possibly other public places): `display.name > indicator.title`
-        - **Chart title**: `grapher_config.title > display.name > indicator.title`
-    - **Data page title**: `presentation.title_public > grapher_config.title > display.name > indicator.title`
+        - **Chart title**: `presentation.grapher_config.title > display.name > indicator.title`
+    - **Data page title**: `presentation.title_public > presentation.grapher_config.title > indicator.title`


### PR DESCRIPTION
- Change `grapher_config.title` to `presentation.grapher_config.title`
- The hierarchy for the title of the data page was wrong
  - wrong: `presentation.title_public > grapher_config.title > display.name > indicator.title`
  - correct: `presentation.title_public > presentation.grapher_config.title > indicator.title`