### PR TITLE
📊 Create IPCC CO2 emission factors dataset

### DIFF
--- a/dag/emissions.yml
+++ b/dag/emissions.yml
@@ -102,6 +102,15 @@ steps:
   data://garden/emissions/2023-10-06/gdp_and_co2_decoupling:
     - data://garden/gcp/2023-09-28/global_carbon_budget
     - data://garden/worldbank_wdi/2022-05-26/wdi
+  #
+  # IPCC - Emission Factor Database (2023-10-24).
+  #
+  data://meadow/emissions/2023-10-24/emission_factors:
+    - snapshot://emissions/2023-10-24/emission_factors.xlsx
+  data://garden/emissions/2023-10-24/emission_factors:
+    - data://meadow/emissions/2023-10-24/emission_factors
+  data://grapher/emissions/2023-10-24/emission_factors:
+    - data://garden/emissions/2023-10-24/emission_factors
   ######################################################################################################################
   # Older versions to be archived once they are not used by any other steps.
   ######################################################################################################################
@@ -111,3 +120,4 @@ steps:
     - data://meadow/emissions/2023-10-10/net_zero_tracker
   data://grapher/emissions/2023-10-10/net_zero_tracker:
     - data://garden/emissions/2023-10-10/net_zero_tracker
+  ######################################################################################################################

--- a/etl/steps/data/garden/emissions/2023-10-24/emission_factors.meta.yml
+++ b/etl/steps/data/garden/emissions/2023-10-24/emission_factors.meta.yml
@@ -1,0 +1,14 @@
+dataset:
+  update_period_days: 365
+
+tables:
+  emission_factors:
+    variables:
+      emission_factor:
+        title: CO₂ emission factor
+        description_short: Amount of carbon dioxide emissions produced per unit of a specific energy source.
+        unit: kilograms per megawatt-hour
+        short_unit: kg/MWh
+        processing_level: minor
+        description_processing: |-
+          - Data has been converted from kilograms per terajoule (kg/TJ) to kilograms per megawatt-hour (kg/MWh) using a conversion factor of 0.0036.

--- a/etl/steps/data/garden/emissions/2023-10-24/emission_factors.py
+++ b/etl/steps/data/garden/emissions/2023-10-24/emission_factors.py
@@ -1,0 +1,76 @@
+"""Load a meadow dataset and create a garden dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+# Rows to select from the "description" column.
+SELECTED_DESCRIPTION = "CO2 Emission Factor for Stationary Combustion (kg/TJ on a net calorific basis)"
+
+# Unit conversion factors.
+KILOGRAMS_PER_TERAJOULE_TO_KILOGRAMS_PER_MEGAWATT_HOUR = 3600 / 1e6
+
+# Columns to select and how to rename them.
+COLUMNS = {
+    "gas": "gas",
+    "fuel_2006": "fuel",
+    "unit": "unit",
+    "value": "emission_factor",
+    "source_of_data": "source_of_data",
+    "description": "description",
+}
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load meadow dataset and read its main table.
+    ds_meadow = paths.load_dataset("emission_factors")
+    tb = ds_meadow["emission_factors"].reset_index()
+
+    #
+    # Process data.
+    #
+    # Select and rename columns.
+    tb = tb[list(COLUMNS)].rename(columns=COLUMNS, errors="raise")
+
+    # Select rows.
+    tb = tb[tb["description"] == SELECTED_DESCRIPTION].reset_index(drop=True)
+
+    # Sanity checks.
+    error = "Unexpected sources, units, or gas in selected rows."
+    assert (
+        tb["source_of_data"].str.startswith("2006 IPCC Guidelines for National Greenhouse Gas Inventories").all()
+    ), error
+    assert tb["gas"].str.startswith("CARBON DIOXIDE").all(), error
+    assert (tb["unit"] == "kg/TJ").all(), error
+
+    # Converted units from kilograms per terajoule to kilograms per MWh (kg/MWh).
+    tb["emission_factor"] = (
+        tb["emission_factor"].astype(str).astype(float) * KILOGRAMS_PER_TERAJOULE_TO_KILOGRAMS_PER_MEGAWATT_HOUR
+    )
+
+    # Drop unnecessary columns.
+    tb = tb.drop(columns=["source_of_data", "description", "unit", "gas"], errors="raise")
+
+    # Drop repeated rows.
+    tb = tb.drop_duplicates().reset_index(drop=True)
+
+    # Clean spurious symbols in the fuel names.
+    tb["fuel"] = tb["fuel"].str.replace("\n", " ").str.replace("&", "and").str.strip()
+
+    # Set an appropriate index and sort conveniently.
+    tb = tb.set_index(["fuel"], verify_integrity=True).sort_index()
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(
+        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata
+    )
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()

--- a/etl/steps/data/grapher/emissions/2023-10-24/emission_factors.py
+++ b/etl/steps/data/grapher/emissions/2023-10-24/emission_factors.py
@@ -1,0 +1,38 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset("emission_factors")
+
+    # Read table from garden dataset.
+    tb = ds_garden["emission_factors"].reset_index()
+
+    #
+    # Process data.
+    #
+    # For compatibility with grapher, add a country and year column.
+    tb = tb.rename(columns={"fuel": "country"}, errors="raise")
+    tb["year"] = paths.version.split("-")[0]
+
+    # Set an appropriate index and sort conveniently.
+    tb = tb.set_index(["country", "year"], verify_integrity=True).sort_index()
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(
+        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
+    )
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()

--- a/etl/steps/data/meadow/emissions/2023-10-24/emission_factors.py
+++ b/etl/steps/data/meadow/emissions/2023-10-24/emission_factors.py
@@ -1,0 +1,32 @@
+"""Load a snapshot and create a meadow dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Retrieve snapshot.
+    snap = paths.load_snapshot("emission_factors.xls")
+
+    # Load data from snapshot.
+    tb = snap.read()
+
+    #
+    # Process data.
+    #
+    # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
+    tb = tb.underscore().set_index(["ef_id"], verify_integrity=True).sort_index()
+
+    #
+    # Save outputs.
+    #
+    # Create a new meadow dataset with the same metadata as the snapshot.
+    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+
+    # Save changes in the new meadow dataset.
+    ds_meadow.save()

--- a/snapshots/emissions/2023-10-24/emission_factors.py
+++ b/snapshots/emissions/2023-10-24/emission_factors.py
@@ -1,8 +1,8 @@
 """Script to create a snapshot of dataset.
 
 To create a snapshot of the dataset, follow these steps:
-* Go to https://www.ipcc-nggip.iges.or.jp/EFDB/
-* Click on the button "Export to XLS".
+* Go to https://www.ipcc-nggip.iges.or.jp/EFDB/find_ef.php
+* Search for "Export to XLS" in the page, and click on that button.
 * Run this snapshot using the flag "--path-to-file" followed by the path to the downloaded file.
 
 """

--- a/snapshots/emissions/2023-10-24/emission_factors.py
+++ b/snapshots/emissions/2023-10-24/emission_factors.py
@@ -1,0 +1,32 @@
+"""Script to create a snapshot of dataset.
+
+To create a snapshot of the dataset, follow these steps:
+* Go to https://www.ipcc-nggip.iges.or.jp/EFDB/
+* Click on the button "Export to XLS".
+* Run this snapshot using the flag "--path-to-file" followed by the path to the downloaded file.
+
+"""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+# Version for current snapshot dataset.
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+
+@click.command()
+@click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
+@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+def main(path_to_file: str, upload: bool) -> None:
+    # Create a new snapshot.
+    snap = Snapshot(f"emissions/{SNAPSHOT_VERSION}/emission_factors.xlsx")
+
+    # Copy local data file to snapshots data folder, add file to DVC and upload to S3.
+    snap.create_snapshot(filename=path_to_file, upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/emissions/2023-10-24/emission_factors.xlsx.dvc
+++ b/snapshots/emissions/2023-10-24/emission_factors.xlsx.dvc
@@ -5,16 +5,13 @@ meta:
     # Data product / Snapshot
     title: Emission Factor Database
     description: |-
-      The Intergovernmental Panel on Climate Change (IPCC) Emission Factor Database (EFDB) is a library of emission factors and
-      parameters that can be used for estimation of national greenhouse gas
-      emissions/removals. For more details, see [the User Manual](https://www.ipccnggip.iges.or.jp/EFDB/documents/EFDB_User_Manual.pdf).
+      The Intergovernmental Panel on Climate Change (IPCC) Emission Factor Database (EFDB) is a library of emission factors and parameters that can be used for estimation of national greenhouse gas emissions/removals. For more details, see [the User Manual](https://www.ipccnggip.iges.or.jp/EFDB/documents/EFDB_User_Manual.pdf).
     date_published: 2023-10-24
 
     # Citation
     producer: Intergovernmental Panel on Climate Change
     citation_full: |-
-      The Intergovernmental Panel on Climate Change (IPCC) Emission Factor Database (EFDB) contains default data from IPCC Guidelines and data
-      from other sources (e.g., peer-reviewed papers) with background information.
+      The Intergovernmental Panel on Climate Change (IPCC) Emission Factor Database (EFDB) contains default data from IPCC Guidelines and data from other sources (e.g., peer-reviewed papers) with background information.
 
       The data extracted from the IPCC EFDB comes from the 2006 IPCC Guidelines for National Greenhouse Gas Inventories, 1A, Sheet 1 of 4 (page A1.6) in Annex 1 of Volume 2.
     attribution: IPCC - Emission Factor Database (2023)

--- a/snapshots/emissions/2023-10-24/emission_factors.xlsx.dvc
+++ b/snapshots/emissions/2023-10-24/emission_factors.xlsx.dvc
@@ -1,0 +1,36 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/origin/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Emission Factor Database
+    description: |-
+      The Intergovernmental Panel on Climate Change (IPCC) Emission Factor Database (EFDB) is a library of emission factors and
+      parameters that can be used for estimation of national greenhouse gas
+      emissions/removals. For more details, see [the User Manual](https://www.ipccnggip.iges.or.jp/EFDB/documents/EFDB_User_Manual.pdf).
+    date_published: 2023-10-24
+
+    # Citation
+    producer: Intergovernmental Panel on Climate Change
+    citation_full: |-
+      The Intergovernmental Panel on Climate Change (IPCC) Emission Factor Database (EFDB) contains default data from IPCC Guidelines and data
+      from other sources (e.g., peer-reviewed papers) with background information.
+
+      The data extracted from the IPCC EFDB comes from the 2006 IPCC Guidelines for National Greenhouse Gas Inventories, 1A, Sheet 1 of 4 (page A1.6) in Annex 1 of Volume 2.
+    attribution: IPCC - Emission Factor Database (2023)
+    attribution_short: IPCC
+
+    # Files
+    url_main: https://www.ipcc-nggip.iges.or.jp/EFDB/
+    date_accessed: 2023-10-24
+
+    # License
+    license:
+      name: ©IPCC 2023
+      url: https://www.ipcc.ch/copyright/
+
+wdir: ../../../data/snapshots/emissions/2023-10-24
+outs:
+- md5: 4efb88d3ee7a0926dd8310044f0c8464
+  size: 2232494
+  path: emission_factors.xlsx


### PR DESCRIPTION
Add snapshots, meadow, garden and grapher steps for CO2 emission factors.
This is a very small dataset that we used to have [here](https://owid.cloud/admin/datasets/970). I thought we would find more updated emission factors, but the best data I've found from [the official source](https://www.ipcc-nggip.iges.or.jp/EFDB/) comes from the same document, from 2006. However, I think those factors are still used as reference values.
