### PR TITLE
✨ wizard: add tag field in garden, fix license options

### DIFF
--- a/apps/wizard/templating/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
+++ b/apps/wizard/templating/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
@@ -1,7 +1,7 @@
 # NOTE: To learn more about the fields, hover over their names.
 {%- if cookiecutter.topic_tags %}
 definitions:
-  commons:
+  common:
     presentation:
       topic_tags:
 {%- filter indent(width=8) %}

--- a/apps/wizard/templating/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
+++ b/apps/wizard/templating/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
@@ -20,12 +20,15 @@ dataset:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/tables/
 tables:
   {{cookiecutter.short_name}}:
+    # Learn more about the available fields:
+    # http://docs.owid.io/projects/etl/architecture/metadata/reference/indicator/
     variables:
       # testing_variable:
       #   title: Testing variable title
       #   unit: arbitrary units
       #   short_unit: au
       #   description_short: Short description of testing variable.
+      #   description_processing: Description of processing of testing variable.
       #   description_key: List of key points about the indicator.
       #   description_from_producer: Description of testing variable from producer.
       #   processing_level: minor
@@ -35,8 +38,8 @@ tables:
       #     attribution:
       #     attribution_short:
       #     topic_tags:
-      #     faqs
-      #     grapher_config
+      #     faqs:
+      #     grapher_config:
       #   display:
       #     name: Testing variable
       #     description:

--- a/apps/wizard/templating/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
+++ b/apps/wizard/templating/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
@@ -33,23 +33,28 @@ tables:
       #   description_from_producer: Description of testing variable from producer.
       #   processing_level: minor
       #   presentation:
-      #     title_public:
-      #     title_variant:
       #     attribution:
       #     attribution_short:
-      #     topic_tags:
       #     faqs:
       #     grapher_config:
+      #     title_public:
+      #     title_variant:
+      #     topic_tags:
       #   display:
-      #     name: Testing variable
-      #     description:
-      #     isProjection: false
-      #     entityAnnotationsMap: Test annotation
-      #     numDecimalPlaces: 0
-      #     conversionFactor: 1
-      #     tolerance: 0
-      #     yearIsDay: false
       #     color:
+      #     conversionFactor: 1
+      #     description:
+      #     entityAnnotationsMap: Test annotation
       #     includeInTable:
+      #     isProjection: false
+      #     name: Testing variable
+      #     numDecimalPlaces: 0
+      #     shortUnit: au
       #     tableDisplay:
+      #       hideAbsoluteChange:
+      #       hideRelativeChange:
+      #     tolerance: 0
+      #     unit: arbitrary units
+      #     yearIsDay: false
+      #     zeroDay:
 

--- a/apps/wizard/templating/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
+++ b/apps/wizard/templating/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
@@ -1,4 +1,13 @@
 # NOTE: To learn more about the fields, hover over their names.
+{%- if cookiecutter.topic_tags %}
+definitions:
+  commons:
+    presentation:
+      topic_tags:
+{%- filter indent(width=8) %}
+{{cookiecutter.topic_tags}}
+{%- endfilter -%}
+{%- endif %}
 
 
 # Learn more about the available fields:

--- a/apps/wizard/utils.py
+++ b/apps/wizard/utils.py
@@ -302,15 +302,18 @@ class AppState:
         default_value = self.default_value(key, default_last=default_last)
         # Change key name, to be stored it in general st.session_state
         kwargs["key"] = f"{self.step}.{key}"
-        # Default value for selectbox (and other widgets with selectbox-like behavior)
-        if "options" in kwargs:
-            options = cast(List[str], kwargs["options"])
-            index = options.index(default_value) if default_value in options else 0
-            kwargs["index"] = index
-        # Default value for other widgets (if none is given)
-        elif ("value" not in kwargs) or ("value" in kwargs and kwargs.get("value") is None):
-            kwargs["value"] = default_value
-
+        # Special behaviour for multiselect
+        if "multiselect" not in str(st_widget):
+            # Default value for selectbox (and other widgets with selectbox-like behavior)
+            if "options" in kwargs:
+                options = cast(List[str], kwargs["options"])
+                index = options.index(default_value) if default_value in options else 0
+                kwargs["index"] = index
+            # Default value for other widgets (if none is given)
+            elif ("value" not in kwargs) or ("value" in kwargs and kwargs.get("value") is None):
+                kwargs["value"] = default_value
+        elif "default" not in kwargs:
+            kwargs["default"] = default_value
         # Create widget
         widget = st_widget(**kwargs)
         # Show error message

--- a/etl/db.py
+++ b/etl/db.py
@@ -10,6 +10,7 @@ import pandas as pd
 import structlog
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
+from sqlmodel import Session
 
 from etl import config
 from etl.db_utils import DBUtils
@@ -28,6 +29,11 @@ def get_connection() -> MySQLdb.Connection:
         charset="utf8mb4",
         autocommit=True,
     )
+
+
+def get_session() -> Session:
+    """Get session with defaults."""
+    return Session(get_engine())
 
 
 def get_engine() -> Engine:

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -190,6 +190,10 @@ class Tag(SQLModel, table=True):
     datasets: List["Dataset"] = Relationship(back_populates="tags")
     chart_tags: List["ChartTags"] = Relationship(back_populates="tags")
 
+    @classmethod
+    def load_tags(cls, session: Session, is_topic: bool = True) -> List["Tag"]:  # type: ignore
+        return session.exec(select(cls).where(cls.isTopic == is_topic)).all()  # type: ignore
+
 
 class User(SQLModel, table=True):
     __tablename__: str = "users"  # type: ignore

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -11,7 +11,7 @@
       "name": {
         "type": "string",
         "title": "License name",
-        "description": "Name of the license.",
+        "description": "Name of the license. Find more details on licensing at https://creativecommons.org/share-your-work/cclicenses/.",
         "requirement_level": "required",
         "examples": [
           "Public domain",
@@ -22,17 +22,13 @@
           "© GISAID 2023"
         ],
         "options": [
-          "Public domain",
           "CC0",
-          "PDM",
           "CC BY 4.0",
           "CC BY-SA 4.0",
           "CC BY-ND 4.0",
           "CC BY-NC 4.0",
           "CC BY-NC-SA 4.0",
-          "CC BY-NC-ND 4.0",
-          "©producer year",
-          "custom license"
+          "CC BY-NC-ND 4.0"
         ],
         "examples_bad": [],
         "guidelines": [


### PR DESCRIPTION
- [x] Fixes license selectbox (removes invalid options)
- [x] Adds field to add tag to indicators
- [ ] Adds missing fields in dummy template

Test it by using `etl-wizard garden`