### PR TITLE
🐛 demography: change countries included

### DIFF
--- a/dag/demography.yml
+++ b/dag/demography.yml
@@ -128,5 +128,6 @@ steps:
   # Broken limits of Life Expectancy
   data://garden/demography/2023-10-20/broken_limits_le:
     - data://garden/demography/2023-10-03/life_tables
+    - data://garden/hmd/2023-09-19/hmd
   data://grapher/demography/2023-10-20/broken_limits_le:
     - data://garden/demography/2023-10-20/broken_limits_le

--- a/etl/steps/data/garden/demography/2023-10-20/broken_limits_le.py
+++ b/etl/steps/data/garden/demography/2023-10-20/broken_limits_le.py
@@ -1,4 +1,9 @@
-"""Load a meadow dataset and create a garden dataset."""
+"""Load a meadow dataset and create a garden dataset.
+
+We only consider data from countries that are present in HMD. And, additionally, we only consider entries for these countries since the year they first appear in the HMD dataset (even if for that period we use UN WPP data, i.e. post-1950)
+"""
+
+from owid.catalog import Table
 
 from etl.helpers import PathFinder, create_dataset
 
@@ -14,9 +19,11 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset.
     ds_meadow = paths.load_dataset("life_tables")
+    ds_hmd = paths.load_dataset("hmd")
 
     # Read table from meadow dataset.
     tb = ds_meadow["life_tables"]
+    tb_hmd = ds_hmd["hmd"].reset_index()
 
     #
     # Process data.
@@ -33,9 +40,12 @@ def run(dest_dir: str) -> None:
     # Rename column
     tb = tb.rename(columns={"location": "country"})
 
+    # Get country-sex and first year of LE reported in HMD
+    tb_hmd = get_first_year_of_country_in_hmd(tb_hmd)
+
     # Only preserve countries coming from HDM
-    countries_hmd = set(tb.loc[tb["year"] < 1950, "country"])
-    tb = tb[tb["country"].isin(countries_hmd)]
+    tb = tb.merge(tb_hmd, on=["country", "sex"], suffixes=("", "_min"))
+    tb = tb[tb["year"] >= tb["year_min"]].drop(columns=["year_min"])
 
     # Get max for each year
     tb = tb.loc[tb.groupby(["year", "sex"], observed=True)["life_expectancy"].idxmax()]
@@ -61,3 +71,12 @@ def run(dest_dir: str) -> None:
 
     # Save changes in the new garden dataset.
     ds_garden.save()
+
+
+def get_first_year_of_country_in_hmd(tb_hmd: Table) -> Table:
+    tb_hmd = tb_hmd[(tb_hmd["format"] == "1x1") & (tb_hmd["type"] == "period") & (tb_hmd["age"] == "0")]
+    tb_hmd = tb_hmd[["country", "year", "sex", "life_expectancy"]]
+    tb_hmd = tb_hmd.dropna()
+    tb_hmd["year"] = tb_hmd["year"].astype(str).astype(int)
+    tb_hmd = tb_hmd.groupby(["country", "sex"], observed=True, as_index=False)["year"].min()
+    return tb_hmd


### PR DESCRIPTION
Previously, we were including only countries present in HMD _**pre-1959**_. With this change, we consider all countries since they first appear in HMD dataset. E.g. if Ukrain starts being reported in HMD since 1959, we consider its values since 1959.

This is done even if we use UN WPP data post-1950.