### PR TITLE
Fix issues with carbon pricing

### DIFF
--- a/snapshots/rff/2023-10-19/emissions_weighted_carbon_price.zip.dvc
+++ b/snapshots/rff/2023-10-19/emissions_weighted_carbon_price.zip.dvc
@@ -13,7 +13,10 @@ meta:
     citation_full: |-
       Dolphin, G., Pollitt, M. and Newbery, D. 2020. The political economy of carbon pricing: a panel analysis. Oxford Economic Papers 72(2): 472-500.
 
+      Dolphin, G., Xiahou, Q. World carbon pricing database: sources and methods. Sci Data 9, 573 (2022). The article is available in Open Access at [https://doi.org/10.1038/s41597-022-01659-x](https://doi.org/10.1038/s41597-022-01659-x).
+
       Supported by Resources for the Future.
+    attribution: Dolphin and Xiahou (2022)
     attribution_short: RFF
 
     # Files

--- a/snapshots/rff/2023-10-19/world_carbon_pricing.zip.dvc
+++ b/snapshots/rff/2023-10-19/world_carbon_pricing.zip.dvc
@@ -16,6 +16,7 @@ meta:
       Dolphin, G., Xiahou, Q. World carbon pricing database: sources and methods. Sci Data 9, 573 (2022). The article is available in Open Access at [https://doi.org/10.1038/s41597-022-01659-x](https://doi.org/10.1038/s41597-022-01659-x).
 
       Supported by Resources for the Future.
+    attribution: Dolphin and Xiahou (2022)
     attribution_short: RFF
 
     # Files


### PR DESCRIPTION
After confirming with the data producer:
* Remove spurious zeros (in Denmark, Iceland and Norway 2021).
* Change attribution to follow the producer's guidelines.
