### PR TITLE
📊 war: fill with zeroes

### DIFF
--- a/dag/war.yml
+++ b/dag/war.yml
@@ -113,8 +113,9 @@ steps:
     - data://garden/war/2023-09-27/peace_diehl
 
   # UCDP/PRIO
-  data://garden/war/2023-10-24/ucdp_prio:
+  data://garden/war/2023-09-21/ucdp_prio:
     - data://garden/war/2023-09-21/ucdp
     - data://garden/war/2023-09-21/prio_v31
-  data://grapher/war/2023-10-24/ucdp_prio:
-    - data://garden/war/2023-10-24/ucdp_prio
+    - data://garden/countries/2023-09-29/cow_ssm
+  data://grapher/war/2023-09-21/ucdp_prio:
+    - data://garden/war/2023-09-21/ucdp_prio

--- a/dag/war.yml
+++ b/dag/war.yml
@@ -116,6 +116,6 @@ steps:
   data://garden/war/2023-09-21/ucdp_prio:
     - data://garden/war/2023-09-21/ucdp
     - data://garden/war/2023-09-21/prio_v31
-    - data://garden/countries/2023-09-29/cow_ssm
-  data://grapher/war/2023-09-21/ucdp_prio:
+    - data://garden/countries/2023-09-25/gleditsch
+  data://grapher/war/2023-10-24/ucdp_prio:
     - data://garden/war/2023-09-21/ucdp_prio

--- a/etl/steps/data/garden/war/2023-09-21/ucdp.py
+++ b/etl/steps/data/garden/war/2023-09-21/ucdp.py
@@ -546,10 +546,21 @@ def fix_extrasystemic_entries(tb: Table) -> Table:
     tb_extra = tb_extra.set_index(["year", "region"]).reindex(new_idx).reset_index()
     tb_extra["conflict_type"] = "extrasystemic"
 
-    # Replace nulls with zeroes
-    tb_extra[["number_ongoing_conflicts", "number_new_conflicts"]] = tb_extra[
-        ["number_ongoing_conflicts", "number_new_conflicts"]
-    ].fillna(0)
+    # Replace nulls with zeroes (all time series)
+    columns = [
+        "number_ongoing_conflicts",
+        "number_new_conflicts",
+    ]
+    tb_extra[columns] = tb_extra[columns].fillna(0)
+
+    # Replace nulls with zeroes (only post 1989 time series)
+    columns = [
+        "number_deaths_ongoing_conflicts",
+        "number_deaths_ongoing_conflicts_high",
+        "number_deaths_ongoing_conflicts_low",
+    ]
+    mask_1989 = tb_extra["year"] >= 1989
+    tb_extra.loc[mask_1989, columns] = tb_extra.loc[mask_1989, columns].fillna(0)
 
     # Add to main table
     tb = pr.concat([tb[-mask], tb_extra])

--- a/etl/steps/data/garden/war/2023-09-21/ucdp_prio.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/ucdp_prio.meta.yml
@@ -95,3 +95,29 @@ tables:
         display:
           numDecimalPlaces: 0
 
+      number_deaths_ongoing_conflicts_per_capita:
+        title: Number of deaths in ongoing conflicts (best estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "best" %>
+          {definitions.number_deaths.description_short}
+        display:
+          numDecimalPlaces: 1
+
+      number_deaths_ongoing_conflicts_high_per_capita:
+        title: Number of deaths in ongoing conflicts (high estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "high" %>
+          {definitions.number_deaths.description_short}
+        display:
+          numDecimalPlaces: 1
+
+      number_deaths_ongoing_conflicts_low_per_capita:
+        title: Number of deaths in ongoing conflicts (low estimate, per capita)
+        unit: deaths per 100,000 people
+        description_short: |-
+          <% set estimate = "low" %>
+          {definitions.number_deaths.description_short}
+        display:
+          numDecimalPlaces: 1

--- a/etl/steps/data/garden/war/2023-09-21/ucdp_prio.meta.yml
+++ b/etl/steps/data/garden/war/2023-09-21/ucdp_prio.meta.yml
@@ -100,7 +100,7 @@ tables:
         unit: deaths per 100,000 people
         description_short: |-
           <% set estimate = "best" %>
-          {definitions.number_deaths.description_short}
+          {definitions.others.description_short}
         display:
           numDecimalPlaces: 1
 
@@ -109,7 +109,7 @@ tables:
         unit: deaths per 100,000 people
         description_short: |-
           <% set estimate = "high" %>
-          {definitions.number_deaths.description_short}
+          {definitions.others.description_short}
         display:
           numDecimalPlaces: 1
 
@@ -118,6 +118,6 @@ tables:
         unit: deaths per 100,000 people
         description_short: |-
           <% set estimate = "low" %>
-          {definitions.number_deaths.description_short}
+          {definitions.others.description_short}
         display:
           numDecimalPlaces: 1


### PR DESCRIPTION
There is no data on the number of deaths from extrasystemic conflicts after 1989. We fill these with zeroes so charts on Grapher look nicer.