### PR TITLE
:tada: tables.<table_name>.common section

### DIFF
--- a/docs/architecture/metadata/structuring-yaml.md
+++ b/docs/architecture/metadata/structuring-yaml.md
@@ -149,6 +149,19 @@ tables:
           <<: *common-display
 ```
 
+You can also specify `common` for individual tables that would overwrite the `common` section under `definitions`.
+
+```yaml
+tables:
+  my_table:
+    common:
+      display:
+        numDecimalPlaces: 1
+
+    variables:
+      ...
+```
+
 
 ## Dynamic YAML
 

--- a/lib/catalog/owid/catalog/yaml_metadata.py
+++ b/lib/catalog/owid/catalog/yaml_metadata.py
@@ -17,14 +17,14 @@ def update_metadata_from_yaml(
 ) -> None:
     """Update metadata of table and variables from a YAML file.
 
-    The logic is as follows:
+    Metadata in `common` overwrites each other as follows:
 
-    - Whatever you write in the definitions.common section of the yaml file always replaces
+    - Metadata from `definitions.common` always overwrites
       the metadata that was on the table already.
-    - Whatever you write in the tables section of the yaml file always replaces what was
-      written in the definitions.common section of the yaml file.
-
-    See more details [here](https://github.com/owid/etl/pull/1737#issuecomment-1750245399)
+    - Metadata from `tables.<table_name>.common` always overwrites the metadata
+      on the table and the metadata from `definitions.common`.
+    - Metadata from `tables.<table_name>.variables.<variable_name>` always overwrites
+      any metadata that was on the variable already.
 
     :param path: Path to YAML file.
     :param table_name: Name of table, also updates this in the metadata.
@@ -44,6 +44,7 @@ def update_metadata_from_yaml(
         _validate_variables(t_annot, tb)
 
     common_dict = annot.get("definitions", {}).get("common", {})
+    table_common_dict = t_annot.get("common", {})
 
     # update variables
     for v_short_name in tb.columns:
@@ -51,6 +52,11 @@ def update_metadata_from_yaml(
 
         # first overwrite table metadata with definitions.common
         meta_dict = _merge_variable_metadata(meta_dict, common_dict, if_origins_exist=if_origins_exist, overwrite=True)
+
+        # then overwrite with table specific common
+        meta_dict = _merge_variable_metadata(
+            meta_dict, table_common_dict, if_origins_exist=if_origins_exist, overwrite=True
+        )
 
         # then overwrite with table specific metadata
         variable_dict = t_annot.get("variables", {}).get(v_short_name, {})

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -361,6 +361,10 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
+          "common": {
+            "description": "Metadata that will be merged with all indicators. Does not overwrite existing metadata.",
+            "$ref": "#/properties/tables/additionalProperties/properties/variables/additionalProperties"
+          },
           "title": {
             "type": "string",
             "title": "Title of the ETL table",


### PR DESCRIPTION
Enable writing table-specific common metadata like this
```
tables:
  my_table:
    common:
      display:
        numDecimalPlaces: 1
```