### PR TITLE
:sparkles: don't map onto same variables in wizard charts

### DIFF
--- a/apps/wizard/charts/utils.py
+++ b/apps/wizard/charts/utils.py
@@ -49,6 +49,10 @@ def get_variables_from_datasets(dataset_id_1: int, dataset_id_2: int) -> Tuple[p
         old_variables = get_variables_in_dataset(db_conn=db_conn, dataset_id=dataset_id_1, only_used_in_charts=True)
         # Get all variables from new dataset.
         new_variables = get_variables_in_dataset(db_conn=db_conn, dataset_id=dataset_id_2, only_used_in_charts=False)
+        # Remove new variables that are in the old dataset. This can happen if we're matching a dataset to itself
+        # in case of renaming variables.
+        new_variables = new_variables[~new_variables["id"].isin(old_variables["id"])]
+
     return old_variables, new_variables
 
 

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -712,6 +712,7 @@ class Dimensions(TypedDict):
 
 class PostsGdocs(SQLModel, table=True):
     __tablename__ = "posts_gdocs"  # type: ignore
+    __table_args__ = {"extend_existing": True}
 
     id: Optional[str] = Field(default=None, sa_column=Column("id", VARCHAR(255), primary_key=True))
     slug: str = Field(sa_column=Column("slug", VARCHAR(255), nullable=False))
@@ -730,6 +731,7 @@ class PostsGdocs(SQLModel, table=True):
 
 class OriginsVariablesLink(SQLModel, table=True):
     __tablename__: str = "origins_variables"  # type: ignore
+    __table_args__ = {"extend_existing": True}
 
     originId: int = Field(default=None, foreign_key="origins.id", primary_key=True)
     variableId: int = Field(default=None, foreign_key="variables.id", primary_key=True)
@@ -772,6 +774,7 @@ class PostsGdocsVariablesFaqsLink(SQLModel, table=True):
         ForeignKeyConstraint(["gdocId"], ["posts_gdocs.id"], name="posts_gdocs_variables_faqs_ibfk_1"),
         ForeignKeyConstraint(["variableId"], ["variables.id"], name="posts_gdocs_variables_faqs_ibfk_2"),
         Index("variableId", "variableId"),
+        {"extend_existing": True},
     )
 
     gdocId: Optional[str] = Field(
@@ -821,6 +824,7 @@ class TagsVariablesTopicTagsLink(SQLModel, table=True):
         ForeignKeyConstraint(["tagId"], ["tags.id"], name="tags_variables_topic_tags_ibfk_1"),
         ForeignKeyConstraint(["variableId"], ["variables.id"], name="tags_variables_topic_tags_ibfk_2"),
         Index("variableId", "variableId"),
+        {"extend_existing": True},
     )
 
     tagId: Optional[str] = Field(default=None, sa_column=Column("tagId", Integer, primary_key=True, nullable=False))
@@ -1188,6 +1192,7 @@ class Origin(SQLModel, table=True):
     """
 
     __tablename__: str = "origins"  # type: ignore
+    __table_args__ = {"extend_existing": True}
 
     id: Optional[int] = Field(default=None, primary_key=True)
     producer: Optional[str] = None


### PR DESCRIPTION
Occasionally, we rename variables in a dataset, which disrupts the ETL process because some charts still reference the old variable names and cannot be deleted. The error appears as follows:
```
ValueError: Variables used in charts will not be deleted automatically:
    chartId  variableId
0      3405      812319
1       714      812319
2      2328      812319
3      3446      812319
4      2724      812319
```

To resolve this, we must remap the old variables to the new ones and rerun the ETL process, which will remove those old variables. This can be particularly challenging if the dataset is extensive. In such cases, using `etl-wizard charts` can be very beneficial. However, there is an issue where the wizard maps "old" variables to themselves, causing the process to fail. This PR addresses the issue by excluding "old" variables from the list of new candidates.

(Additionally, it adds several `extend_existing` flags to the ORM to resolve autoreloading issues in Streamlit. Without these flags, Streamlit reports errors.)