### PR TITLE
Minor improvement in metadata documentation

### DIFF
--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -379,6 +379,9 @@
             "Must end with a period."
           ],
           [
+            "Must include (wherever is appropriate) the year of publication, i.e. the year given in `date_published`."
+          ],
+          [
             "If the producer specified how to cite them, this field should be identical to the producer's text, except for some formatting changes, typo corrections, or other appropriate minor edits.",
             {
               "type": "list",


### PR DESCRIPTION
Ensure that we include the year in the full citation of an origin (as [suggested by Lars](https://owid.slack.com/archives/C064666EG8K/p1699357652810009)).
