### PR TITLE
Use description key as description short in population indicators

### DIFF
--- a/etl/steps/data/garden/demography/2023-03-31/population/population.meta.yml
+++ b/etl/steps/data/garden/demography/2023-03-31/population/population.meta.yml
@@ -33,18 +33,17 @@ tables:
     variables:
       population:
         title: Population
-        description_key:
-          - &population-description "Population by country, available from 10,000 BCE to 2100, based on data and estimates from different sources."
+        description_short: &population-description "Population by country, available from 10,000 BCE to 2100, based on data and estimates from different sources."
         description_processing: &description-processing |-
           The population time series is constructed by combining data from multiple sources:
 
-          • 10,000 BCE - 1799: Historical estimates by HYDE (v3.2). Includes some data from Gapminder (Systema Globalis).
+          - 10,000 BCE - 1799: Historical estimates by HYDE (v3.2). Includes some data from Gapminder (Systema Globalis).
 
-          • 1800-1949: Historical estimates by Gapminder. Includes some data from HYDE (v3.2) and Gapminder (Systema Globalis).
+          - 1800-1949: Historical estimates by Gapminder. Includes some data from HYDE (v3.2) and Gapminder (Systema Globalis).
 
-          • 1950-2021: Population records by the UN World Population Prospects (2022 revision). Includes some data from HYDE (v3.2), Gapminder (Systema Globalis) and Gapminder (v7).
+          - 1950-2021: Population records by the UN World Population Prospects (2022 revision). Includes some data from HYDE (v3.2), Gapminder (Systema Globalis) and Gapminder (v7).
 
-          • 2022-2100: Projections based on Medium variant by the UN World Population Prospects (2022 revision).
+          - 2022-2100: Projections based on Medium variant by the UN World Population Prospects (2022 revision).
         unit: persons
         display:
           numDecimalPlaces: 0
@@ -53,8 +52,7 @@ tables:
 
       world_pop_share:
         title: Share of world population
-        description_key:
-          - &population-share-description "Share of the world's population by country, available from 10,000 BCE to 2100, based on data and estimates from different sources."
+        description_short: &population-share-description "Share of the world's population by country, available from 10,000 BCE to 2100, based on data and estimates from different sources."
         description_processing: *description-processing
         unit: "%"
         short_unit: "%"
@@ -63,8 +61,7 @@ tables:
 
       source:
         title: Source
-        description_key:
-          - &population-source-description "Name of the source for a specific data point. The name includes a short name for the source and a link."
+        description_short: &population-source-description "Name of the source for a specific data point. The name includes a short name for the source and a link."
         description_processing: *description-processing
         unit: ""
         origins: *origins-combined
@@ -76,8 +73,7 @@ tables:
     variables:
       population:
         title: Population
-        description_key:
-          - *population-description
+        description_short: *population-description
         description_processing: *description-processing
         unit: persons
         display:
@@ -85,16 +81,14 @@ tables:
         processing_level: major
       world_pop_share:
         title: Share of world population
-        description_key:
-          - *population-share-description
+        description_short: *population-share-description
         description_processing: *description-processing
         unit: "%"
         short_unit: "%"
         processing_level: major
       source:
         title: Source
-        description_key:
-          - *population-source-description
+        description_short: *population-source-description
         description_processing: *description-processing
         unit: ""
         processing_level: major

--- a/etl/steps/data/garden/demography/2023-03-31/population/population.meta.yml
+++ b/etl/steps/data/garden/demography/2023-03-31/population/population.meta.yml
@@ -3,6 +3,16 @@ definitions:
     presentation:
       topic_tags:
         - Population Growth
+    description_processing: |-
+      The population time series is constructed by combining data from multiple sources:
+
+      - 10,000 BCE - 1799: Historical estimates by HYDE (v3.2). Includes some data from Gapminder (Systema Globalis).
+
+      - 1800-1949: Historical estimates by Gapminder. Includes some data from HYDE (v3.2) and Gapminder (Systema Globalis).
+
+      - 1950-2021: Population records by the UN World Population Prospects (2022 revision). Includes some data from HYDE (v3.2), Gapminder (Systema Globalis) and Gapminder (v7).
+
+      - 2022-2100: Projections based on Medium variant by the UN World Population Prospects (2022 revision).
 
 dataset:
   title: Population (various sources, 2023.1)
@@ -34,16 +44,6 @@ tables:
       population:
         title: Population
         description_short: &population-description "Population by country, available from 10,000 BCE to 2100, based on data and estimates from different sources."
-        description_processing: &description-processing |-
-          The population time series is constructed by combining data from multiple sources:
-
-          - 10,000 BCE - 1799: Historical estimates by HYDE (v3.2). Includes some data from Gapminder (Systema Globalis).
-
-          - 1800-1949: Historical estimates by Gapminder. Includes some data from HYDE (v3.2) and Gapminder (Systema Globalis).
-
-          - 1950-2021: Population records by the UN World Population Prospects (2022 revision). Includes some data from HYDE (v3.2), Gapminder (Systema Globalis) and Gapminder (v7).
-
-          - 2022-2100: Projections based on Medium variant by the UN World Population Prospects (2022 revision).
         unit: persons
         display:
           numDecimalPlaces: 0
@@ -53,7 +53,6 @@ tables:
       world_pop_share:
         title: Share of world population
         description_short: &population-share-description "Share of the world's population by country, available from 10,000 BCE to 2100, based on data and estimates from different sources."
-        description_processing: *description-processing
         unit: "%"
         short_unit: "%"
         origins: *origins-combined
@@ -62,7 +61,6 @@ tables:
       source:
         title: Source
         description_short: &population-source-description "Name of the source for a specific data point. The name includes a short name for the source and a link."
-        description_processing: *description-processing
         unit: ""
         origins: *origins-combined
         processing_level: major
@@ -74,7 +72,6 @@ tables:
       population:
         title: Population
         description_short: *population-description
-        description_processing: *description-processing
         unit: persons
         display:
           numDecimalPlaces: 0
@@ -82,13 +79,11 @@ tables:
       world_pop_share:
         title: Share of world population
         description_short: *population-share-description
-        description_processing: *description-processing
         unit: "%"
         short_unit: "%"
         processing_level: major
       source:
         title: Source
         description_short: *population-source-description
-        description_processing: *description-processing
         unit: ""
         processing_level: major


### PR DESCRIPTION
* I changed `description_key` -> `description_short` in all indicators in the population dataset.
* I also changed `·` with `-` in a list of bullet points (which should render properly as a list).

@lucasrodes @Marigold do you see any unintentional risks on these changes? And do you remember if there was any particular reason why we were using `description_key` for those short descriptions? Thanks.

**NOTE**: This PR should be merged at the end of the day, since it will trigger a big ETL run.