### PR TITLE
:sparkles: Reintroduce `etl-metadata-export` and add more options

### DIFF
--- a/apps/wizard/templating/garden.py
+++ b/apps/wizard/templating/garden.py
@@ -39,6 +39,7 @@ with get_session() as session:
     tag_list = gm.Tag.load_tags(session)
 tag_list = ["Uncategorized"] + sorted([tag.name for tag in tag_list])
 
+
 #########################################################
 # FUNCTIONS & CLASSES ###################################
 #########################################################
@@ -387,11 +388,21 @@ if submitted:
 
         2. (Optional) Generated notebook `{notebook_path.relative_to(BASE_DIR)}` can be used to examine the dataset output interactively.
 
-        3. (Optional) You can manually move steps from `dag/walkthrough.yml` to some other `dag/*.yml` if you feel like it belongs there. After you are happy with your code, run `make test` to find any issues.
+        3. (Optional) Generate metadata file `{form.short_name}.meta.yml` from your dataset with
+            ```
+            poetry run etl-metadata-export data/garden/{form.namespace}/{form.version}/{form.short_name}
+            ```
+            then manual edit it and rerun the step again with
+            ```
+            poetry run etl data{private_suffix}://garden/{form.namespace}/{form.version}/{form.short_name} {"--private" if form.is_private else ""}
+            ```
+            Note that origins are inherited from previous step (snapshot) and you don't have to repeat them.
 
-        4. Create a pull request in [ETL](https://github.com/owid/etl), get it reviewed and merged.
+        4. (Optional) You can manually move steps from `dag/walkthrough.yml` to some other `dag/*.yml` if you feel like it belongs there. After you are happy with your code, run `make test` to find any issues.
 
-        5. (Optional) Once your changes are merged, your steps will be run automatically by our server and published to the OWID catalog. Then it can be loaded by anyone using:
+        5. Create a pull request in [ETL](https://github.com/owid/etl), get it reviewed and merged.
+
+        6. (Optional) Once your changes are merged, your steps will be run automatically by our server and published to the OWID catalog. Then it can be loaded by anyone using:
 
             ```python
             from owid.catalog import find_one
@@ -400,7 +411,7 @@ if submitted:
             print(tab.head())
             ```
 
-        6. If you are an internal OWID member and want to push data to our Grapher DB, continue to the grapher step or to explorers step.
+        7. If you are an internal OWID member and want to push data to our Grapher DB, continue to the grapher step or to explorers step.
         """
             )
 

--- a/docs/architecture/metadata/structuring-yaml.md
+++ b/docs/architecture/metadata/structuring-yaml.md
@@ -16,8 +16,10 @@ tables:
 To generate a metadata YAML file with pre-populated variable names for an existing garden dataset, execute:
 
 ```
-poetry run etl-metadata-export data/garden/my_namespace/my_version/my_dataset -o etl/steps/data/garden/my_namespace/my_version/my_dataset.meta.yml
+poetry run etl-metadata-export data/garden/my_namespace/my_version/my_dataset
 ```
+
+Check `poetry run etl-metadata-export --help` for more options.
 
 ## Handling Multi-line Strings and Whitespace
 

--- a/etl/metadata_export.py
+++ b/etl/metadata_export.py
@@ -1,11 +1,14 @@
 import copy
 import os
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Literal, Optional, Tuple, Union
 
 import pandas as pd
 import rich_click as click
 from owid.catalog import Dataset, utils
+from rich.console import Console
+from rich.syntax import Syntax
 
+from etl import paths
 from etl.files import yaml_dump
 
 
@@ -18,31 +21,60 @@ from etl.files import yaml_dump
     "-o",
     "--output",
     type=click.Path(),
-    help="Save output into YAML file",
+    help="Save output into YAML file. If not specified, save to *.meta.yml",
+)
+@click.option(
+    "--show/--no-show",
+    default=False,
+    type=bool,
+    help="Show output instead of saving it into a file.",
+)
+@click.option(
+    "--decimals",
+    default="auto",
+    type=str,
+    help="Add display.numDecimalPlaces to all numeric variables. Use integer or `auto` for autodetection. Disable with `no`.",
 )
 def cli(
     path: str,
     output: str,
+    show: bool,
+    decimals: Optional[str],
 ) -> None:
     """Export dataset & tables & columns metadata in YAML format. This
     is useful for generating *.meta.yml files that can be later manually edited.
 
     Usage:
-        etl-metadata-export data/garden/ggdc/2020-10-01/ggdc_maddison -o etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
+        # save to YAML file etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
+        etl-metadata-export data/garden/ggdc/2020-10-01/ggdc_maddison
+
+        # show output instead of saving the file
+        etl-metadata-export data/garden/ggdc/2020-10-01/ggdc_maddison --show
     """
+    if show:
+        assert not output, "Can't use --show and --output at the same time."
+
     ds = Dataset(path)
-    meta_str = metadata_export(ds, prune=True)
-    if output:
+    meta_dict = metadata_export(ds, prune=True, decimals=int(decimals) if decimals.isnumeric() else decimals)  # type: ignore
+
+    if not output:
+        output = str(paths.STEP_DIR / "data" / f"{ds.metadata.uri}.meta.yml")
+
+    yaml_str = yaml_dump(meta_dict, replace_confusing_ascii=True)
+    assert yaml_str
+
+    if show:
+        Console().print(Syntax(yaml_str, "yaml", line_numbers=True))
+    else:
         os.makedirs(os.path.dirname(output), exist_ok=True)
         with open(output, "w") as f:
-            f.write(yaml_dump(meta_str, replace_confusing_ascii=True))  # type: ignore
-    else:
-        print(meta_str)
+            f.write(yaml_str)  # type: ignore
 
 
 def metadata_export(
     ds: Dataset,
     prune: bool = False,
+    decimals: Optional[Union[int, Literal["auto", "no"]]] = None,
 ) -> dict:
     """
     :param prune: If True, remove origins and licenses that would be propagated from the snapshot.
@@ -111,6 +143,15 @@ def metadata_export(
 
                 if not display:
                     variable.pop("display")
+
+            # add decimals
+            if decimals is not None and decimals != "no" and pd.api.types.is_numeric_dtype(tab[col]):
+                if "display" not in variable:
+                    variable["display"] = {}
+                if decimals == "auto":
+                    variable["display"]["numDecimalPlaces"] = _guess_decimals(tab[col])
+                else:
+                    variable["display"]["numDecimalPlaces"] = decimals
 
             # we can't have duplicate titles
             if "title" in variable:
@@ -198,6 +239,24 @@ def _prune_empty(d: Dict[str, Any]) -> None:
     for k, v in list(d.items()):
         if not v:
             del d[k]
+
+
+def _guess_decimals(s: pd.Series, max_decimals=3) -> int:
+    """Guess the number of decimals in a series."""
+    if pd.api.types.is_integer_dtype(s):
+        return 0
+
+    s = s.dropna()
+    if s.empty:
+        return 0
+
+    assert pd.api.types.is_float_dtype(s)
+
+    for d in range(max_decimals + 1):
+        if (s - s.round(d)).abs().max() < 1e-6:
+            return d
+
+    return max_decimals
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some time ago, I removed `etl-metadata-export` for no good reason. It turned out people are still using it for pre-generating YAML files with indicators.

This PR puts a mention about it back to Wizard and adds some options to the tool like `--decimals` that automatically detect number of decimal places.