### PR TITLE
:sparkles: Speedup add_regions_aggregates

### DIFF
--- a/etl/data_helpers/geo.py
+++ b/etl/data_helpers/geo.py
@@ -320,26 +320,25 @@ def add_region_aggregates(
     variables = list(aggregations)
 
     # Initialise dataframe of added regions, and add variables one by one to it.
-    df_region = pd.DataFrame({country_col: [], year_col: []}).astype(dtype={country_col: "object", year_col: "int"})
+    # df_region = Table({country_col: [], year_col: []}).astype(dtype={country_col: "object", year_col: "int"})
     # Select data for countries in the region.
     df_countries = df[df[country_col].isin(countries_in_region)]
-    for variable in variables:
-        df_added = groupby_agg(
-            df=df_countries,
-            groupby_columns=year_col,
-            aggregations={
-                country_col: lambda x: set(countries_that_must_have_data).issubset(set(list(x))),
-                variable: aggregations[variable],
-            },
-            num_allowed_nans=num_allowed_nans_per_year,
-            frac_allowed_nans=frac_allowed_nans_per_year,
-        ).reset_index()
-        # Make nan all aggregates if the most contributing countries were not present.
-        df_added.loc[~df_added[country_col], variable] = np.nan
-        # Replace the column that was used to check if most contributing countries were present by the region's name.
-        df_added[country_col] = region
-        # Include this variable to the dataframe of added regions.
-        df_region = pd.merge(df_region, df_added, on=[country_col, year_col], how="outer")
+
+    df_region = groupby_agg(
+        df=df_countries,
+        groupby_columns=year_col,
+        aggregations=dict(
+            **aggregations,
+            **{country_col: lambda x: set(countries_that_must_have_data).issubset(set(list(x)))},
+        ),
+        num_allowed_nans=num_allowed_nans_per_year,
+        frac_allowed_nans=frac_allowed_nans_per_year,
+    ).reset_index()
+
+    # Make nan all aggregates if the most contributing countries were not present.
+    df_region.loc[~df_region[country_col], variables] = np.nan
+    # Replace the column that was used to check if most contributing countries were present by the region's name.
+    df_region[country_col] = region
 
     if isinstance(keep_original_region_with_suffix, str):
         # Keep rows in the original dataframe containing rows for region (adding a suffix to the region name), and then
@@ -543,6 +542,10 @@ def add_population_to_dataframe(
 
     # Add population to original dataframe.
     merge = pr.merge if isinstance(df, Table) else pd.merge
+
+    if population.index.names != [None]:
+        # If population has a multiindex, we need to reset it before merging.
+        population = population.reset_index()
 
     df_with_population = merge(df, population, on=[country_col, year_col], how="left")
 

--- a/tests/data_helpers/test_geo.py
+++ b/tests/data_helpers/test_geo.py
@@ -645,6 +645,44 @@ class TestAddRegionAggregates:
         )
         assert dataframes.are_equal(df1=df, df2=df_out)[0]
 
+    def test_replace_region_with_one_mandatory_country_having_nan(self):
+        # Country 2 has NaN value in 2021. It is a mandatory country and is present, so the aggregation will
+        # exist, but will be nan.
+        df_in = self.df_in.copy()
+
+        # Add NaN value for Country 2
+        df_in = df_in.append(
+            {"country": "Country 2", "year": 2021, "var_01": np.nan, "var_02": np.nan}, ignore_index=True
+        )
+
+        df = geo.add_region_aggregates(
+            df=df_in,
+            region="Region 1",
+            countries_in_region=["Country 1", "Country 2"],
+            countries_that_must_have_data=["Country 1", "Country 2"],
+            num_allowed_nans_per_year=0,
+            country_col="country",
+            year_col="year",
+        )
+        df_out = pd.DataFrame(
+            {
+                "country": [
+                    "Country 1",
+                    "Country 1",
+                    "Country 2",
+                    "Country 2",
+                    "Country 3",
+                    "Income group 1",
+                    "Region 1",
+                    "Region 1",
+                ],
+                "year": [2020, 2021, 2020, 2021, 2022, 2022, 2020, 2021],
+                "var_01": [1.0, 2.0, 3.0, np.nan, np.nan, 6.0, 4.0, np.nan],
+                "var_02": [10.0, 20.0, 30.0, np.nan, 40.0, 60.0, 40.0, np.nan],
+            }
+        )
+        assert dataframes.are_equal(df1=df, df2=df_out)[0]
+
     def test_replace_region_with_custom_aggregations(self):
         # Country 2 does not have data for 2021, and, given that it is a mandatory country, the aggregation will be nan.
         df = geo.add_region_aggregates(
@@ -733,3 +771,35 @@ class TestAddRegionAggregates:
             }
         )
         assert dataframes.are_equal(df1=df, df2=df_out)[0]
+
+    def test_add_region_with_Table(self):
+        tb = Table(self.df_in)
+        tb.var_01.m.title = "Var 01"
+        df = geo.add_region_aggregates(
+            df=tb,
+            region="Region 2",
+            countries_in_region=["Country 3"],
+            countries_that_must_have_data=["Country 3"],
+            num_allowed_nans_per_year=None,
+            frac_allowed_nans_per_year=None,
+            country_col="country",
+            year_col="year",
+        )
+        df_out = Table(
+            {
+                "country": [
+                    "Country 1",
+                    "Country 1",
+                    "Country 2",
+                    "Country 3",
+                    "Income group 1",
+                    "Region 1",
+                    "Region 2",
+                ],
+                "year": [2020, 2021, 2020, 2022, 2022, 2022, 2022],
+                "var_01": [1, 2, 3, np.nan, 6, 5, 0.0],
+                "var_02": [10.0, 20.0, 30.0, 40.0, 60.0, 50.0, 40.0],
+            }
+        )
+        assert dataframes.are_equal(df1=df, df2=df_out)[0]
+        assert df.var_01.m.title == "Var 01"


### PR DESCRIPTION
Speed up add_regions_aggregates by avoiding for loop over variables. This is very noticeable for datasets with 100+ variables.

Also add unit test to clarify what happens if mandatory country has NaN values (@pabloarosado  this is not a but, it works in the end)