### PR TITLE
:sparkles: add amend_log to plog

### DIFF
--- a/lib/catalog/owid/catalog/processing_log.py
+++ b/lib/catalog/owid/catalog/processing_log.py
@@ -145,6 +145,27 @@ class ProcessingLog(List[LogEntry]):
 
         self.append(entry)
 
+    def amend_entry(
+        self,
+        operation: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> None:
+        """Amend last entry in the log."""
+        if not enabled():
+            # Avoid any processing
+            return
+
+        if len(self) == 0:
+            raise ValueError("Cannot amend empty processing log.")
+
+        kwargs = {}
+        if operation:
+            kwargs["operation"] = operation
+        if comment:
+            kwargs["comment"] = comment
+
+        self[-1] = self[-1].clone(**kwargs)
+
     def display(
         self,
         data_dir: Optional[Path] = None,

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -706,7 +706,7 @@ class Table(pd.DataFrame):
         parents: Optional[List[Any]] = None,
         variable_names: Optional[List[str]] = None,
         comment: Optional[str] = None,
-    ) -> None:
+    ) -> "Table":
         # Append a new entry to the processing log of the required variables.
         if variable_names is None:
             # If no variable is specified, assume all (including index columns).
@@ -721,26 +721,26 @@ class Table(pd.DataFrame):
                 operation=operation,
                 comment=comment,
             )
+        return self
 
-    # TODO: make this work with plog
-    # def amend_log(
-    #     self,
-    #     operation: str,
-    #     parents: Optional[List[Any]] = None,
-    #     variable_names: Optional[List[str]] = None,
-    #     comment: Optional[str] = None,
-    #     entry_num: Optional[int] = -1,
-    #     inplace: bool = False,
-    # ) -> Optional["Table"]:
-    #     return amend_log(
-    #         table=self,
-    #         operation=operation,
-    #         parents=parents,
-    #         variable_names=variable_names,
-    #         comment=comment,
-    #         entry_num=entry_num,
-    #         inplace=inplace,
-    #     )
+    def amend_log(
+        self,
+        variable_names: Optional[List[str]] = None,
+        comment: Optional[str] = None,
+        operation: Optional[str] = None,
+    ) -> "Table":
+        """Amend operation or comment of the latest processing log entry."""
+        # Append a new entry to the processing log of the required variables.
+        if variable_names is None:
+            # If no variable is specified, assume all (including index columns).
+            variable_names = list(self.all_columns)
+        for column in variable_names:
+            # Update (in place) the processing log of current variable.
+            self._fields[column].processing_log.amend_entry(
+                operation=operation,
+                comment=comment,
+            )
+        return self
 
     def sort_values(self, by: str, *args, **kwargs) -> "Table":
         tb = super().sort_values(by=by, *args, **kwargs).copy()
@@ -1500,40 +1500,6 @@ def copy_metadata(from_table: Table, to_table: Table, deep=False) -> Table:
 
     tab._fields = new_fields
     return tab
-
-
-# TODO: make this work
-# def amend_log(
-#     table: Table,
-#     operation: str,
-#     parents: Optional[List[Any]] = None,
-#     variable_names: Optional[List[str]] = None,
-#     comment: Optional[str] = None,
-#     entry_num: Optional[int] = -1,
-#     inplace: bool = False,
-# ) -> Optional[Table]:
-#     if not inplace:
-#         table = table.copy()
-
-#     # Append a new entry to the processing log of the required variables.
-#     if variable_names is None:
-#         # If no variable is specified, assume all (including index columns).
-#         variable_names = list(table.all_columns)
-#     for column in variable_names:
-#         # If parents is not defined, assume the parents are simply the current variable.
-#         _parents = parents or [column]
-#         # Update (in place) the processing log of current variable.
-#         table._fields[column].processing_log = variables.amend_entry_in_processing_log(
-#             processing_log=table._fields[column].processing_log,
-#             variable_name=column,
-#             parents=_parents,
-#             operation=operation,
-#             comment=comment,
-#             entry_num=entry_num,
-#         )
-
-#     if not inplace:
-#         return table
 
 
 def get_unique_sources_from_tables(tables: List[Table]) -> List[Source]:

--- a/lib/catalog/tests/test_processing_log.py
+++ b/lib/catalog/tests/test_processing_log.py
@@ -74,6 +74,21 @@ def test_agg() -> None:
 
 
 @enable_pl
+def test_amend_log() -> None:
+    t: Table = Table({"a": [1, 2, 3], "b": ["a", "a", "b"]})
+    tb = t.groupby("b").agg("sum").amend_log(["a"], comment="sum over b", operation="my_sum")
+    assert tb["a"].metadata.processing_log.as_dict() == [
+        {
+            "variable": "a",
+            "operation": "my_sum",
+            "target": "a#7921731533",
+            "parents": ["a", "b"],
+            "comment": "sum over b",
+        }
+    ]
+
+
+@enable_pl
 def test_proper_type_after_copy():
     v1 = Variable([1], name="v", metadata=VariableMeta(processing_log=ProcessingLog([LogEntry("a", "+", "")])))
     assert isinstance(v1.metadata.processing_log, ProcessingLog)


### PR DESCRIPTION
Adding `Table.amend_log` that modifies the latest entry in plog. It's a light version of the original implementation, as I couldn't find a good use case yet. I expect that we'll make it more powerful as we start using plog for real.

@pabloarosado comments from the [previous PR](https://github.com/owid/etl/pull/1574)

Thanks for working on this! I haven't looked deeply into the guts of the code, but I have tried a few things and it makes sense. I think it would be good to merge this as soon as possible to avoid it from stalling (provided that it doesn't affect any other ETL step unless `PROCESSING_LOG=1`). I just have a few comments/questions:
* I see that the `rename` operation is now omitted. I understand why this happens after other operations, but in general, if you explicitly want to rename a variable, that may also be relevant. For example, if you go to the `uk_egg_statistics` garden step and, right before creating a dataset, you do `tb = tb.rename(columns={"number_of_eggs_all": "test"})` (and change the name in the yaml file accordingly), this rename operation doesn't explicitly show up in the diagram. You do see that the `save` entry in the log calls the saved column as `test`. So, I suppose the logic is robust, and maybe we could simply change the mermaid diagram to also show the name of the column stored (`test`).
* I see that `wrap` can be used for complicated processing functions. But is there any way to wrap any line of code, to avoid the processing log from creating many small irrelevant entries? E.g.
```
with squash_log(operation="custom", comment="Blah blah explanation of some complicated processing"):
    tb = tb.something_huge()
    tb = something_else(tb)
```
But if that's not implemented, it doesn't really matter, I was just wondering if this was already a thing.
* Similar to the above: Something we have mentioned in the past is that we could document all relevant operations directly in the log, instead of having comments in the code (of course, by looking at the code, one would also see these explanations). With the previous implementation this was possible by doing `...update_log(comment="...")` or using `amend_log`. But how would that happen now? Ideally, it would be something like:
```
with plog("Explanation of operation"):
    tb = tb.something()
```
Is there anything like this? Again, if not, it doesn't matter, it's just nice to have.
* I cloned a new `etl` repos called `etl-plog` as you suggested. But would that also be necessary in the future, every time you want to check the log, or was that just a suggestion for testing this PR?

The main use case for `amend_log` was to have an easy way to add a comment to a complicated operation, e.g.

```
tb["something"] = tb.groupby(...).horrible_operation("why_doing_this").amend_log("Explanation of what was done to this indicator here.")
```
By default, this would edit the very last entry in the log. But you could also use it multiple times to edit more entries (changing `entry_num`).

But I agree that a decorator on top of the complicated operations would be a better option. It could also avoid adding many entries to the log, to have just one with a reasonable custom message (meanwhile `amend_log` only amends one entry at a time).