### PR TITLE
:bug: fix overriding table's short name

### DIFF
--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -158,9 +158,13 @@ def create_dataset(
     ds = catalog.Dataset.create_empty(dest_dir, metadata=default_metadata)
 
     # add tables to dataset
+    used_short_names = set()
     for table in tables:
         if underscore_table:
             table = catalog.utils.underscore_table(table, camel_to_snake=camel_to_snake)
+        if table.metadata.short_name in used_short_names:
+            raise ValueError(f"Table short name `{table.metadata.short_name}` is already in use.")
+        used_short_names.add(table.metadata.short_name)
         ds.add(table, formats=formats)
 
     # set metadata from dest_dir

--- a/etl/steps/data/meadow/rff/2023-10-19/emissions_weighted_carbon_price.py
+++ b/etl/steps/data/meadow/rff/2023-10-19/emissions_weighted_carbon_price.py
@@ -59,7 +59,7 @@ def run(dest_dir: str) -> None:
     #
     # Save outputs.
     #
-    # Create new dataset with metadata from walden.
+    # Create new dataset with metadata from snapshot.
     ds_meadow = create_dataset(
         dest_dir=dest_dir,
         tables=[tb_economy, tb_coverage],

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -1275,7 +1275,7 @@ def _add_table_and_variables_metadata_to_table(
     table: Table, metadata: Optional[TableMeta], origin: Optional[Origin]
 ) -> Table:
     if metadata is not None:
-        table.metadata = metadata
+        table.metadata = metadata.copy()
         for column in list(table.all_columns):
             if origin:
                 table._fields[column].origins = [origin]


### PR DESCRIPTION
The problem is in [these lines](https://github.com/owid/etl/blob/master/etl/steps/data/meadow/rff/2023-10-19/emissions_weighted_carbon_price.py#L40-L45)
```
# Read economy data.
tb_economy = pr.read_csv(z.open(DATA_PATH_ECONOMY), metadata=metadata, origin=origin)
tb_economy.metadata.short_name = "emissions_weighted_carbon_price_economy"

# Read coverage data.
tb_coverage = pr.read_csv(z.open(DATA_PATH_COVERAGE), metadata=metadata, origin=origin)
tb_coverage.metadata.short_name = "emissions_weighted_carbon_price_coverage"
```
`metadata` refers to the same object and the second `tb_coverage.metadata.short_name` updates the short name of the first table, too. Function `create_dataset`, which accepts two tables, then overwrites the tables.

I've added a uniqueness check for table short names and also fixed this by copying `metadata` object inside `pd.read_csv` function.

(Found this bug in our [full rebuild](https://buildkite.com/our-world-in-data/etl-full-private-rebuild-every-2nd-night/builds/379#018c0e13-c5de-4775-b67c-c104f1478958).)