### PR TITLE
🔨  etl-staging-sync improvements

### DIFF
--- a/apps/staging_sync/cli.py
+++ b/apps/staging_sync/cli.py
@@ -1,9 +1,11 @@
 import datetime as dt
+import subprocess
 from pathlib import Path
-from typing import Optional, Set
+from typing import Any, Dict, Optional, Set
 
 import click
 import pandas as pd
+import pytz
 import structlog
 from dotenv import dotenv_values
 from rich import print
@@ -13,6 +15,7 @@ from sqlmodel import Session
 
 from etl import grapher_model as gm
 from etl.config import GRAPHER_USER_ID
+from etl.datadiff import _dict_diff
 from etl.db import Engine, get_engine
 
 from .admin_api import AdminAPI
@@ -43,6 +46,13 @@ log = structlog.get_logger()
     creates a chart revision if the target chart has been modified.""",
 )
 @click.option(
+    "--staging-created-at",
+    default=None,
+    type=str,
+    help="""Staging server UTC creation date. It is used to warn about charts that have been
+    updated in production. Default is branch creation date.""",
+)
+@click.option(
     "--dry-run/--no-dry-run",
     default=False,
     type=bool,
@@ -54,49 +64,65 @@ def cli(
     chart_id: Optional[int],
     publish: bool,
     approve_revisions: bool,
+    staging_created_at: Optional[dt.datetime],
     dry_run: bool,
 ) -> None:
-    """Syncs grapher charts and revisions modified by Admin user from source_env to target_env (Admin user is used
-    by staging servers). This is especially useful for syncing work from staging servers to production.
+    """Syncs grapher charts and revisions from SOURCE (e.g. staging-site-mybranch or just
+    mybranch) to TARGET (e.g. .env.prod.write).
 
-    Staging servers are destroyed after 7 days of merging to master, so this script should be run before that, but
-    after the dataset has been built by ETL in production.
+    SOURCE and TARGET can be either name of servers like staging-site-mybranch or paths
+    to .env files. You have to use `.env.prod.write` as TARGET to sync to live.
+
+    This is especially useful for syncing work from staging servers to production.
+
+    Staging servers are destroyed after 1 day of merging to master, so this script should be
+    run before that, but after the dataset has been built by ETL in production.
 
     SOURCE and TARGET can be either paths to .env file or name of a staging server.
 
     The dataset from source must exist in target (i.e. you have to merge your work to master and wait for the ETL to finish).
 
     Usage:
-        # run staging-sync in dry-run mode to see what charts will be updated
+        # Run staging-sync in dry-run mode to see what charts will be updated
         etl-staging-sync staging-site-my-branch .env.prod.write --dry-run
 
-        # run it for real
+        # Run it for real
         etl-staging-sync staging-site-my-branch .env.prod.write
 
-        # sync only one chart
+        # Sync only one chart
         etl-staging-sync staging-site-my-branch .env.prod.write --chart-id 123 --dry-run
 
-        # WARNING: skip chart revisions and update charts directly
+        # Update charts directly without creating chart revisions (useful for large datasets
+        # updates like population)
         etl-staging-sync staging-site-my-branch .env.prod.write --approve-revisions
 
     Charts:
-        - New charts are synced as **drafts** in target.
+        - Only **published charts** from staging are synced.
+        - New charts are synced as **drafts** in target (unless `--publish` flag is used).
         - Existing charts (with the same slug) are added as chart revisions in target. (Revisions could be pre-approved with --approve-revisions flag)
-        - You get a warning if the chart has been updated in production.
+        - You get a warning if the chart **has been modified on live** after staging server was created.
         - Deleted charts are **not synced**.
-
-        Only syncs charts that are **published** on staging server. They are **created as drafts** in target and must be published
-        manually, unless the --publish flag is used.
 
     Chart revisions:
         - Approved chart revisions on staging are automatically applied in target, assuming the chart has not been modified.
 
     Tags:
-        - Tags are synced only for **new charts**.
+        - Tags are synced only for **new charts**, any edits to tags in existing charts are ignored.
     """
     source_engine = _get_engine_for_env(source)
     target_engine = _get_engine_for_env(target)
 
+    if staging_created_at is None:
+        if not _is_env(source):
+            staging_created_at = _get_git_branch_creation_date(str(source).replace("staging-site-", ""))
+        else:
+            raise click.BadParameter("staging-created-at is required when source is not a staging server name")
+    else:
+        staging_created_at = pd.to_datetime(staging_created_at)
+        assert staging_created_at
+
+    # go through Admin API as creating / updating chart has side effects like
+    # adding entries to chart_dimensions. We can't directly update it in MySQL
     target_api: AdminAPI = AdminAPI(target_engine) if not dry_run else None  # type: ignore
 
     with Session(source_engine) as source_session:
@@ -112,10 +138,23 @@ def cli(
                 source_chart = gm.Chart.load_chart(source_session, chart_id)
                 target_chart = source_chart.migrate_to_db(source_session, target_session)
 
+                # try getting chart with the same slug
                 try:
                     existing_chart = gm.Chart.load_chart(target_session, slug=source_chart.config["slug"])
                 except NoResultFound:
                     existing_chart = None
+
+                # it's possible that slug is different, but chart id is the same
+                if existing_chart is None:
+                    try:
+                        existing_chart = gm.Chart.load_chart(target_session, chart_id=chart_id)
+
+                        # make sure createdAt matches and double check with createdAt
+                        if existing_chart.createdAt != source_chart.createdAt:
+                            log.warning("staging_sync.different_chart_with_same_id", chart_id=chart_id)
+                            existing_chart = None
+                    except NoResultFound:
+                        existing_chart = None
 
                 if existing_chart:
                     if _charts_configs_are_equal(existing_chart.config, target_chart.config):
@@ -127,15 +166,22 @@ def cli(
                         )
                         continue
 
-                    # if chart has been updated in production after our change, warn about it
-                    if existing_chart.updatedAt > source_chart.updatedAt:
+                    # warn if chart has been updated in production after the staging server got created
+                    if existing_chart.updatedAt > min(staging_created_at, source_chart.updatedAt):
                         log.warning(
                             "staging_sync.chart_modified_in_target",
                             slug=target_chart.config["slug"],
                             target_updatedAt=str(existing_chart.updatedAt),
                             source_updatedAt=str(source_chart.updatedAt),
+                            staging_created_at=str(staging_created_at),
                             chart_id=chart_id,
                         )
+                        print(
+                            f"[bold red]WARNING[/bold red]: [bright_cyan]Chart [bold]{target_chart.config['slug']}[/bold] has been modified in target[/bright_cyan]"
+                        )
+                        print(f"[yellow]\tDifferences from source chart[/yellow]")
+                        print(_chart_config_diff(target_chart.config, existing_chart.config))
+                        print()
 
                     # if the chart has gone through a revision, update it directly
                     revs = gm.SuggestedChartRevisions.load_revisions(source_session, chart_id=chart_id)
@@ -150,8 +196,9 @@ def cli(
                         and min(rev.createdAt, rev.updatedAt) > existing_chart.updatedAt
                     ]
 
-                    # if chart has gone through revision in source and --approve-revisions is set, update it directly
-                    if approve_revisions and revs:
+                    # if chart has gone through revision in source and --approve-revisions is set and
+                    # chart hasn't been updated in production, update it directly
+                    if approve_revisions and revs and staging_created_at > existing_chart.updatedAt:
                         log.info(
                             "staging_sync.update_chart", slug=target_chart.config["slug"], chart_id=existing_chart.id
                         )
@@ -213,9 +260,13 @@ def cli(
     print("[green]2.[/green] Chart updates were added as chart revisions, you still have to manually approve them")
 
 
+def _is_env(env: Path) -> bool:
+    return env.exists()
+
+
 def _get_engine_for_env(env: Path) -> Engine:
     # env exists as a path
-    if env.exists():
+    if _is_env(env):
         config = dotenv_values(str(env))
     # env could be server name
     else:
@@ -235,6 +286,12 @@ def _get_engine_for_env(env: Path) -> Engine:
         }
 
     return get_engine(config)
+
+
+def _chart_config_diff(source_config: Dict[str, Any], target_config: Dict[str, Any]) -> str:
+    source_config = {k: v for k, v in source_config.items() if k not in ("version",)}
+    target_config = {k: v for k, v in target_config.items() if k not in ("version",)}
+    return _dict_diff(source_config, target_config, tabs=1)
 
 
 def _charts_configs_are_equal(config_1, config_2):
@@ -265,6 +322,20 @@ def _modified_chart_ids_by_admin(session: Session) -> Set[int]:
     where updatedBy = 1 and status = 'approved'
     """
     return set(pd.read_sql(q, session.bind).chartId.tolist())
+
+
+def _get_git_branch_creation_date(branch_name, base_branch="master") -> dt.datetime:
+    # Define the git command
+    git_command = f"git log --format=%cI {base_branch}..{branch_name} --reverse | head -1"
+
+    # Execute the git command
+    result = subprocess.run(git_command, shell=True, check=True, stdout=subprocess.PIPE, text=True)
+
+    # Get the output and strip any whitespace
+    creation_date = result.stdout.strip()
+
+    # Parse the timestamp
+    return dt.datetime.fromisoformat(creation_date).astimezone(pytz.utc).replace(tzinfo=None)
 
 
 if __name__ == "__main__":

--- a/docs/architecture/workflow/staging-servers.md
+++ b/docs/architecture/workflow/staging-servers.md
@@ -1,0 +1,48 @@
+TODO - improve docs
+
+## Data Manager Workflow
+
+```mermaid
+sequenceDiagram
+    participant PR as Pull Request (ETL)
+    participant SSB as staging-site-branch
+    participant live as Live
+
+    PR ->>+ SSB: PR Created
+    SSB -->>- SSB: Bake
+    PR ->>+ SSB: New Commit
+    SSB -->>- SSB: Bake & run ETL
+    PR ->> SSB: Merge PR
+    Note right of PR: Schedule Destruction in 1 day
+    SSB ->> live: etl-staging-sync
+    Note left of live: Sync all charts
+    PR ->> SSB: Destroy server
+```
+
+## Staging Sync Workflow
+
+```mermaid
+sequenceDiagram
+    box Staging
+    participant NewChart as New Chart
+    participant UpdatedChart as Updated Chart
+    end
+    box Live
+    participant ChartRevision as Suggested Chart Revisions
+    participant Draft as Draft
+    participant PublishedChart as Published Chart
+    end
+
+    # New charts process
+    NewChart->>Draft: New charts created as drafts
+    Draft->>PublishedChart: Publish chart (manual)
+
+    # Updated charts process
+    UpdatedChart->>ChartRevision: Updates added as revisions
+    Note over UpdatedChart, ChartRevision: Warn if chart has been modified on live
+    ChartRevision->>PublishedChart: Approve revision (manual)
+
+    # Updated charts with revisions, useful for population updates
+    UpdatedChart->>PublishedChart: Updates with approved revision on staging are applied directly (with --approve-revisions flag)
+    Note over UpdatedChart, PublishedChart: Submit revision if chart has been modified on live
+```

--- a/docs/architecture/workflow/staging-servers.md
+++ b/docs/architecture/workflow/staging-servers.md
@@ -1,6 +1,8 @@
-TODO - improve docs
-
 ## Data Manager Workflow
+
+Dedicated staging servers are automatically created from every ETL pull request. That gives data manager the ability to share and test their changes before they are merged into the live site.
+
+Once the PR is ready, data manager should merge it into master, wait for deploy process to run ETL with their updates and then migrate all charts to the live site. This has to be done within 24 hours after the PR is merged, then the staging server will be destroyed.
 
 ```mermaid
 sequenceDiagram
@@ -20,6 +22,8 @@ sequenceDiagram
 ```
 
 ## Staging Sync Workflow
+
+Once the work is merged, data manager should run `etl-staging-sync` to migrate all charts to the live site. This command will sync all charts from staging to live as either draft charts or revisions.
 
 ```mermaid
 sequenceDiagram
@@ -46,3 +50,5 @@ sequenceDiagram
     UpdatedChart->>PublishedChart: Updates with approved revision on staging are applied directly (with --approve-revisions flag)
     Note over UpdatedChart, PublishedChart: Submit revision if chart has been modified on live
 ```
+
+!!! info "Run `etl-staging-sync --help` for more details"

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -374,7 +374,7 @@ def _index_equals(table_a: pd.DataFrame, table_b: pd.DataFrame, sample: int = 10
     return index_a.equals(index_b)
 
 
-def _dict_diff(dict_a: Dict[str, Any], dict_b: Dict[str, Any], tabs) -> str:
+def _dict_diff(dict_a: Dict[str, Any], dict_b: Dict[str, Any], tabs: int = 0) -> str:
     """Convert dictionaries into YAML and compare them using difflib. Return colored diff as a string."""
     meta_a = yaml_dump(dict_a)
     meta_b = yaml_dump(dict_b)

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -374,10 +374,10 @@ def _index_equals(table_a: pd.DataFrame, table_b: pd.DataFrame, sample: int = 10
     return index_a.equals(index_b)
 
 
-def _dict_diff(dict_a: Dict[str, Any], dict_b: Dict[str, Any], tabs: int = 0) -> str:
+def _dict_diff(dict_a: Dict[str, Any], dict_b: Dict[str, Any], tabs: int = 0, **kwargs) -> str:
     """Convert dictionaries into YAML and compare them using difflib. Return colored diff as a string."""
-    meta_a = yaml_dump(dict_a)
-    meta_b = yaml_dump(dict_b)
+    meta_a = yaml_dump(dict_a, **kwargs)
+    meta_b = yaml_dump(dict_b, **kwargs)
 
     lines = difflib.ndiff(meta_a.splitlines(keepends=True), meta_b.splitlines(keepends=True))  # type: ignore
     # do not print lines that are identical

--- a/etl/files.py
+++ b/etl/files.py
@@ -121,7 +121,11 @@ _MyDumper.add_representer(
 
 
 def yaml_dump(
-    d: Dict[str, Any], stream: Optional[TextIO] = None, strip_lines: bool = True, replace_confusing_ascii: bool = False
+    d: Dict[str, Any],
+    stream: Optional[TextIO] = None,
+    strip_lines: bool = True,
+    replace_confusing_ascii: bool = False,
+    width: int = 120,
 ) -> Optional[str]:
     """Alternative to yaml.dump which produces good looking multi-line strings and perserves ordering
     of keys. If strip_lines is True, all lines in the string will be stripped and all tabs will be
@@ -129,7 +133,7 @@ def yaml_dump(
     # strip lines, otherwise YAML won't output strings in literal format
     if strip_lines:
         d = _strip_lines_in_dict(d)
-    s = yaml.dump(d, stream=stream, sort_keys=False, allow_unicode=True, Dumper=_MyDumper, width=120)
+    s = yaml.dump(d, stream=stream, sort_keys=False, allow_unicode=True, Dumper=_MyDumper, width=width)
     if replace_confusing_ascii:
         assert s, "replace_confusing_ascii does not work for streams"
         s = (

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -319,7 +319,10 @@ class Chart(SQLModel, table=True):
         # add columnSlug if present
         column_slug = self.config.get("map", {}).get("columnSlug")
         if column_slug:
-            variables[int(column_slug)] = Variable.load_variable(session, column_slug)
+            try:
+                variables[int(column_slug)] = Variable.load_variable(session, column_slug)
+            except NoResultFound:
+                raise ValueError(f"columnSlug variable {column_slug} for chart {self.id} not found")
 
         return variables
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ nav:
           - ETag: "architecture/workflow/other-steps/etag.md"
           - GitHub: "architecture/workflow/other-steps/github.md"
           - Private steps: "architecture/workflow/other-steps/private.md"
+        - Staging servers: "architecture/workflow/staging-servers.md"
       - Metadata:
         - Metadata: "architecture/metadata/index.md"
         # - Workflow with metadata: "architecture/metadata/workflow.md"


### PR DESCRIPTION
## Changes

* Match existing charts on chart id instead of slug (which can change)
* Don't use `chart.updatedAt` when comparing whether chart has been updated on live, but use staging server creation time
* Show metadata diff if a chart has been updated on live
* Improve CLI help
* Add docs