### PR TITLE
:bug: remove isTopic from tags

### DIFF
--- a/apps/metadata_migrate/cli.py
+++ b/apps/metadata_migrate/cli.py
@@ -262,7 +262,7 @@ def cli(
 
         print("\n[bold yellow]Follow-up instructions:[/bold yellow]")
         print(
-            "[green]1.[/green] Pick topic tags [link=http://datasette-private/owid?sql=SELECT+tags.%60name%60+from+tags+where+isTopic+%3D+1+ORDER+BY+tags.%60name%60%0D%0A]from the list[/link].",
+            "[green]1.[/green] Pick topic tags [link=http://datasette-private/owid?sql=SELECT+tags.%60name%60+from+tags+ORDER+BY+tags.%60name%60%0D%0A]from the list[/link].",
         )
         print(
             "[green]2.[/green] Check [link=https://docs.google.com/document/d/1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw/edit]FAQs GDoc document[/link].",

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -183,7 +183,6 @@ class Tag(SQLModel, table=True):
     isBulkImport: int = Field(sa_column=Column("isBulkImport", TINYINT(1), nullable=False, server_default=text("'0'")))
     parentId: Optional[int] = Field(default=None, sa_column=Column("parentId", Integer))
     specialType: Optional[str] = Field(default=None, sa_column=Column("specialType", String(255, "utf8mb4_0900_as_cs")))
-    isTopic: int = Field(sa_column=Column("isTopic", TINYINT(1), nullable=False, server_default=text("'0'")))
 
     post: List["Posts"] = Relationship(back_populates="tag")
     tags: Optional["Tag"] = Relationship(back_populates="tags_reverse")
@@ -192,13 +191,13 @@ class Tag(SQLModel, table=True):
     chart_tags: List["ChartTags"] = Relationship(back_populates="tags")
 
     @classmethod
-    def load_tags(cls, session: Session, is_topic: bool = True) -> List["Tag"]:  # type: ignore
-        return session.exec(select(cls).where(cls.isTopic == is_topic)).all()  # type: ignore
+    def load_tags(cls, session: Session) -> List["Tag"]:  # type: ignore
+        return session.exec(select(cls)).all()  # type: ignore
 
     @classmethod
     def load_tags_by_names(cls, session: Session, tag_names: List[str]) -> List["Tag"]:
         """Load topic tags by their names in the order given in `tag_names`."""
-        tags = session.exec(select(Tag).where(Tag.name.in_(tag_names), Tag.isTopic == 1)).all()  # type: ignore
+        tags = session.exec(select(Tag).where(Tag.name.in_(tag_names))).all()  # type: ignore
 
         if len(tags) != len(tag_names):
             found_tags = [tag.name for tag in tags]

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -907,7 +907,7 @@
                       "requirement_level": "recommended (for curated indicators)",
                       "guidelines": [
                         [
-                          "Must be an existing topic tag, and be spelled correctly (see the list of topic tags in [datasette](http://datasette-private/owid?sql=SELECT+tags.%60name%60+from+tags+where+isTopic+%3D+1+ORDER+BY+tags.%60name%60%0D%0A) (requires Tailscale)."
+                          "Must be an existing topic tag, and be spelled correctly (see the list of topic tags in [datasette](http://datasette-private/owid?sql=SELECT+tags.%60name%60+from+tags+ORDER+BY+tags.%60name%60%0D%0A) (requires Tailscale)."
                         ],
                         [
                           "The first tag must correspond to the most relevant topic page (since that topic page will be used in citations of this indicator)."


### PR DESCRIPTION
Column `tags.isTopic` was removed from MySQL. Reflect that in ETL.

@ikesau I'm not very familiar with how tags work on our site. Is there a way now to tell whether a tag is a topic tag? Topic tags had unique names, which was necessary to get their IDs in ETL. I don't they are unique any more. Any ideas how to filter them?