### PR TITLE
:bug: Replace DVC pull with direct fetch

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,14 +1,14 @@
 [core]
     remote = public
     autostage = true
-['remote "public"']
+[remote "public"]
     url = s3://owid-snapshots
     endpointurl = https://078fcdfed9955087315dd86792e71a7e.r2.cloudflarestorage.com
     acl = public-read
     # Increase this if you are seeing requests timing out
     connect_timeout = 600
-['remote "public-read"']
+[remote "public-read"]
     url = https://snapshots.owid.io
-['remote "private"']
+[remote "private"]
     url = s3://owid-snapshots-private
     endpointurl = https://078fcdfed9955087315dd86792e71a7e.r2.cloudflarestorage.com

--- a/etl/files.py
+++ b/etl/files.py
@@ -11,7 +11,7 @@ import time
 from collections import OrderedDict
 from pathlib import Path
 from threading import Lock
-from typing import Any, Dict, Generator, List, Literal, Optional, Set, TextIO, Union
+from typing import Any, Dict, Generator, List, Optional, Set, TextIO, Union
 
 import ruamel.yaml
 import yaml
@@ -50,8 +50,6 @@ class RuntimeCache:
 
 CACHE_CHECKSUM_FILE = RuntimeCache()
 
-HASH_TYPES = Literal["md5sum", "dvc"]
-
 TEXT_CHARS = bytes(range(32, 127)) + b"\n\r\t\f\b"
 DEFAULT_CHUNK_SIZE = 512
 
@@ -75,24 +73,20 @@ def istextblock(block: bytes) -> bool:
     return float(len(nontext)) / len(block) <= 0.30
 
 
-def checksum_str(s: str, typ: HASH_TYPES = "md5sum") -> str:
+def checksum_str(s: str) -> str:
     "Return the md5 hex digest of the string."
-    buf = s.encode()
-    if typ == "dvc":
-        buf = dos2unix(buf)
-    return hashlib.md5(buf).hexdigest()
+    return hashlib.md5(dos2unix(s.encode())).hexdigest()
 
 
-def checksum_file_nocache(filename: Union[str, Path], typ: HASH_TYPES = "md5sum") -> str:
+def checksum_file_nocache(filename: Union[str, Path]) -> str:
     "Return the md5 hex digest of the file without using cache."
     chunk_size = 2**20
     _hash = hashlib.md5()
     with open(filename, "rb") as istream:
         chunk = istream.read(chunk_size)
         while chunk:
-            if typ == "dvc":
-                if istextblock(chunk[:DEFAULT_CHUNK_SIZE]):
-                    chunk = dos2unix(chunk)
+            if istextblock(chunk[:DEFAULT_CHUNK_SIZE]):
+                chunk = dos2unix(chunk)
 
             _hash.update(chunk)
             chunk = istream.read(chunk_size)
@@ -100,13 +94,13 @@ def checksum_file_nocache(filename: Union[str, Path], typ: HASH_TYPES = "md5sum"
     return _hash.hexdigest()
 
 
-def checksum_file(filename: Union[str, Path], typ: HASH_TYPES = "md5sum") -> str:
+def checksum_file(filename: Union[str, Path]) -> str:
     "Return the md5 hex digest of the file contents."
     if isinstance(filename, Path):
         filename = filename.as_posix()
 
     mtime = os.path.getmtime(filename)
-    key = f"{filename}-{mtime}-{typ}"
+    key = f"{filename}-{mtime}"
 
     if filename not in CACHE_CHECKSUM_FILE:
         # Special case for regions.yml, we want to ignore the 'aliases' key
@@ -118,9 +112,9 @@ def checksum_file(filename: Union[str, Path], typ: HASH_TYPES = "md5sum") -> str
             regex_pattern = r"  aliases:\n(\s+-[^\n]*\n?)*"
             s = re.sub(regex_pattern, "", s)
 
-            checksum = checksum_str(s.strip(), typ=typ)
+            checksum = checksum_str(s.strip())
         else:
-            checksum = checksum_file_nocache(filename, typ=typ)
+            checksum = checksum_file_nocache(filename)
         CACHE_CHECKSUM_FILE.add(key, checksum)
 
     return CACHE_CHECKSUM_FILE[key]

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -1,3 +1,4 @@
+import configparser
 import datetime as dt
 import json
 import re
@@ -8,7 +9,6 @@ from multiprocessing import Lock
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union
 
-import fasteners
 import owid.catalog.processing as pr
 import pandas as pd
 import yaml
@@ -33,14 +33,16 @@ if TYPE_CHECKING:
     from dvc.repo import Repo
 
 from etl import config, paths
-from etl.files import RuntimeCache, yaml_dump
+from etl.files import RuntimeCache, checksum_file, ruamel_dump, ruamel_load, yaml_dump
 
 # DVC is not thread-safe, so we need to lock it
 dvc_lock = Lock()
 unignore_backports_lock = Lock()
-dvc_pull_lock = fasteners.InterProcessLock(paths.BASE_DIR / ".dvc/tmp/dvc_pull_lock")
 
 DVC_REPO_CACHE = RuntimeCache()
+
+DVC_CONFIG = configparser.ConfigParser()
+DVC_CONFIG.read(paths.BASE_DIR / ".dvc/config")
 
 
 def get_dvc(use_cache: bool = True) -> "Repo":
@@ -117,55 +119,56 @@ class Snapshot:
         else:
             return get_dvc(use_cache=True)
 
+    def _download_dvc_file(self, md5: str) -> None:
+        """Download file from DVC remote to self.path."""
+        self.path.parent.mkdir(exist_ok=True, parents=True)
+        if self.metadata.is_public:
+            https_url = DVC_CONFIG['remote "public-read"']["url"]
+            download_url = f"{https_url}/{md5[:2]}/{md5[2:]}"
+            files.download(download_url, str(self.path), progress_bar_min_bytes=2**100)
+        else:
+            s3_url = DVC_CONFIG['remote "private"']["url"]
+            download_url = f"{s3_url}/{md5[:2]}/{md5[2:]}"
+            s3_utils.download(download_url, str(self.path))
+
     def pull(self, force=True) -> None:
         """Pull file from S3."""
         if not force and not self.is_dirty():
             return
 
-        from dvc.exceptions import CheckoutError
+        assert len(self.metadata.outs) == 1
+        md5 = self.metadata.outs[0]["md5"]
 
-        # DVC locking is terrible. It'd fail if we didn't use our own file locks.
-        # This is pretty limiting as it allows us to only pull
-        # one snapshot at a time. One option is to pre-pull all snapshot steps or
-        # we could just download the file directly.
-        # The combination of different kinds of locks is kinda magical and waiting
-        # to be refactored soon.
-        with dvc_pull_lock, _unignore_backports(self.path):
-            try:
-                repo = self._cached_dvc_repo()
-                repo.pull(str(self.path), remote="public-read" if self.metadata.is_public else "private", force=force)
-            except CheckoutError as e:
-                raise Exception(
-                    "File not found in DVC. Have you run the snapshot script? Make sure you're not using `is_public: false`."
-                ) from e
+        self._download_dvc_file(md5)
+
+        # update metadata
+        with open(self.metadata_path, "r") as f:
+            m = ruamel_load(f)
+
+        m["outs"][0]["md5"] = checksum_file(self.path)
+        m["outs"][0]["size"] = self.path.stat().st_size
+        m["outs"][0]["path"] = self.path.name
+
+        with open(self.metadata_path, "w") as f:
+            f.write(ruamel_dump(m))
 
     def is_dirty(self) -> bool:
         """Return True if snapshot exists and is in DVC."""
-        from dvc.dvcfile import load_file
-        from dvc.rwlock import RWLockFileCorruptedError
-
         if not self.path.exists():
             return True
 
-        with open(self.metadata_path) as istream:
-            if "outs:\n" not in istream.read():
-                raise Exception(f"File {self.metadata_path} has not been added to DVC. Run snapshot script to add it.")
+        if self.metadata.outs is None:
+            raise Exception(f"File {self.metadata_path} has not been added to DVC. Run snapshot script to add it.")
 
-        # See notes about locking in `pull` method.
-        with dvc_lock, _unignore_backports(self.metadata_path):
-            repo = self._cached_dvc_repo()
-            dvc_file = load_file(repo, self.metadata_path.as_posix())
-            with repo.lock:
-                # DVC returns empty dictionary if file is up to date
-                stage = dvc_file.stage
-                try:
-                    return stage.status() != {}
-                except RWLockFileCorruptedError:
-                    rwlock_path = paths.BASE_DIR / ".dvc/tmp/rwlock"
-                    # If the lock file is corrupted, we need to delete it and try again
-                    if rwlock_path.exists():
-                        rwlock_path.unlink()
-                    return stage.status() != {}
+        assert len(self.metadata.outs) == 1
+        file_size = self.path.stat().st_size
+        # Compare file size if it's larger than 10MB, otherwise compare md5
+        # This should be pretty safe and speeds up the process significantly
+        if file_size >= 10 * 2**20:  # 10MB
+            return file_size != self.m.outs[0]["size"]
+        else:
+            # NOTE: DVC uses different md5 checksum than md5sum
+            return checksum_file(self.path.as_posix(), typ="dvc") != self.m.outs[0]["md5"]
 
     def delete_local(self) -> None:
         """Delete local file and its metadata."""

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -60,3 +60,20 @@ def test_checksum_file_regions(tmp_path):
     checksum2 = files.checksum_file(tmp_path / "regions.yml")
 
     assert checksum1 == checksum2
+
+
+def test_checksum_file_dvc(tmp_path):
+    f = tmp_path / "test.csv"
+    f.write_text("a,b,c\r\n1,2,3")
+
+    # DVC replaces \r\n with \n, while md5sum does not
+    assert files.checksum_file(f, typ="dvc") == "1a477f6d2f9c9fc827fa46b5ace1a145"
+    assert files.checksum_file(f, typ="md5sum") == "71687777aed243ae2f42756ca886c9d6"
+
+
+def test_checksum_str_dvc():
+    s = "a,b,c\r\n1,2,3"
+
+    # DVC replaces \r\n with \n, while md5sum does not
+    assert files.checksum_str(s, typ="dvc") == "1a477f6d2f9c9fc827fa46b5ace1a145"
+    assert files.checksum_str(s, typ="md5sum") == "71687777aed243ae2f42756ca886c9d6"

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -66,14 +66,10 @@ def test_checksum_file_dvc(tmp_path):
     f = tmp_path / "test.csv"
     f.write_text("a,b,c\r\n1,2,3")
 
-    # DVC replaces \r\n with \n, while md5sum does not
-    assert files.checksum_file(f, typ="dvc") == "1a477f6d2f9c9fc827fa46b5ace1a145"
-    assert files.checksum_file(f, typ="md5sum") == "71687777aed243ae2f42756ca886c9d6"
+    # Checksum replaces \r\n with \n
+    assert files.checksum_file(f) == "1a477f6d2f9c9fc827fa46b5ace1a145"
 
 
 def test_checksum_str_dvc():
-    s = "a,b,c\r\n1,2,3"
-
-    # DVC replaces \r\n with \n, while md5sum does not
-    assert files.checksum_str(s, typ="dvc") == "1a477f6d2f9c9fc827fa46b5ace1a145"
-    assert files.checksum_str(s, typ="md5sum") == "71687777aed243ae2f42756ca886c9d6"
+    # Checksum replaces \r\n with \n
+    assert files.checksum_str("a,b,c\r\n1,2,3") == files.checksum_str("a,b,c\n1,2,3")


### PR DESCRIPTION
UPDATED 2024-01-02

## Problem

DVC has become a bit annoying in some aspects:

1. DVC doesn't interact well with multiprocessing (we got around this by using various hacks, and we can only pull a single snapshot at a time).
2. DVC is slow with the large number of DVC files we have (the current workaround is to dynamically use `.dvcignore` for backported datasets... it works, but is prone to errors).
3. DVC is spamming our logs because of these workarounds.
4. The new major version of DVC doesn't support our file model (which involves having DVC YAML files next to data files).
5. We can't add comments to `*.dvc` files.

We only use a small fraction of DVC's capabilities (just storing files on remote S3 storage), so it's worth considering whether dealing with these issues is justifiable. Initially, we thought we might leverage DVC more extensively, but that hasn't materialized.

## Solution

While we could consider replacing DVC, most of the problems mentioned above are solved by reimplementing `dvc pull` from `Snapshot.pull` and the MD5 checksum comparison in `Snapshot.is_dirty`. The only annoying thing is that **DVC uses its own MD5 function**.

Checksum comparison is only done for files < 10MB. Larger snapshots are compared based on size only. (This significantly speeds up ETL)

We could similarly implement `dvc add`, but that isn't critical and would only slightly improve performance.