### PR TITLE
:hammer: Refactor DVC and snapshots

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -316,10 +316,25 @@ def exec_steps(steps: List[Step], strict: Optional[bool] = None) -> None:
             print()
 
 
+def _steps_sort_key(step: Step) -> int:
+    """Sort steps by channel, so that grapher steps are executed first, then garden, then meadow, then snapshots."""
+    str_step = str(step)
+    if "grapher://" in str_step:
+        return 0
+    elif "garden://" in str_step:
+        return 1
+    elif "meadow://" in str_step:
+        return 2
+    elif "snapshot://" in str_step:
+        return 3
+    else:
+        return 4
+
+
 def exec_steps_parallel(steps: List[Step], workers: int, dag: DAG, strict: Optional[bool] = None) -> None:
     # put grapher steps in front of the queue to process them as soon as possible and lessen
     # the load on MySQL
-    steps = sorted(steps, key=lambda x: "grapher://" not in str(x))
+    steps = sorted(steps, key=_steps_sort_key)
 
     # create execution graph from steps
     exec_graph = {}

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -3,10 +3,11 @@ import json
 import re
 from contextlib import contextmanager
 from dataclasses import dataclass
+from multiprocessing import Lock
 from pathlib import Path
-from threading import Lock
 from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Union
 
+import fasteners
 import owid.catalog.processing as pr
 import pandas as pd
 import yaml
@@ -36,6 +37,7 @@ from etl.files import RuntimeCache, yaml_dump
 # DVC is not thread-safe, so we need to lock it
 dvc_lock = Lock()
 unignore_backports_lock = Lock()
+dvc_pull_lock = fasteners.InterProcessLock(paths.BASE_DIR / ".dvc/tmp/dvc_pull_lock")
 
 DVC_REPO_CACHE = RuntimeCache()
 
@@ -106,11 +108,55 @@ class Snapshot:
         else:
             return Path(f"{paths.SNAPSHOTS_DIR / self.uri}.dvc")
 
+    def _cached_dvc_repo(self) -> Any:
+        """Return DVC repo and cache it. Backported steps do not use cached repository."""
+        if "backport" in str(self.metadata_path):
+            # The repo has to be created again to pick unignored files
+            return get_dvc(use_cache=False)
+        else:
+            return get_dvc(use_cache=True)
+
     def pull(self, force=True) -> None:
         """Pull file from S3."""
-        with _unignore_backports(self.path):
-            dvc = get_dvc()
-            dvc.pull(str(self.path), remote="public-read" if self.metadata.is_public else "private", force=force)
+        if not force and not self.is_dirty():
+            return
+
+        from dvc.exceptions import CheckoutError
+
+        # DVC locking is terrible. It'd fail if we didn't use our own file locks.
+        # This is pretty limiting as it allows us to only pull
+        # one snapshot at a time. One option is to pre-pull all snapshot steps or
+        # we could just download the file directly.
+        # The combination of different kinds of locks is kinda magical and waiting
+        # to be refactored soon.
+        with dvc_pull_lock, _unignore_backports(self.path):
+            try:
+                repo = self._cached_dvc_repo()
+                repo.pull(str(self.path), remote="public-read" if self.metadata.is_public else "private", force=force)
+            except CheckoutError as e:
+                raise Exception(
+                    "File not found in DVC. Have you run the snapshot script? Make sure you're not using `is_public: false`."
+                ) from e
+
+    def is_dirty(self) -> bool:
+        """Return True if snapshot exists and is in DVC."""
+        from dvc.dvcfile import load_file
+
+        if not self.path.exists():
+            return True
+
+        with open(self.metadata_path) as istream:
+            if "outs:\n" not in istream.read():
+                raise Exception(f"File {self.metadata_path} has not been added to DVC. Run snapshot script to add it.")
+
+        # See notes about locking in `pull` method.
+        with dvc_lock, _unignore_backports(self.metadata_path):
+            repo = self._cached_dvc_repo()
+            dvc_file = load_file(repo, self.metadata_path.as_posix())
+            with repo.lock:
+                # DVC returns empty dictionary if file is up to date
+                stage = dvc_file.stage
+                return stage.status() != {}
 
     def delete_local(self) -> None:
         """Delete local file and its metadata."""

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -11,11 +11,12 @@ from glob import glob
 from os import environ
 from os.path import join
 from pathlib import Path
-from typing import Any, Iterator, List, Literal, Optional, Union
+from typing import Iterator, List, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
 import yaml
+from _hashlib import HASH
 
 from . import tables, utils
 from .meta import SOURCE_EXISTS_OPTIONS, DatasetMeta, TableMeta
@@ -307,7 +308,7 @@ for k in DatasetMeta.__dataclass_fields__:
     setattr(Dataset, k, metadata_property(k))
 
 
-def checksum_file(filename: str) -> Any:
+def checksum_file(filename: str) -> HASH:
     "Return the MD5 checksum of a given file."
     chunk_size = 2**20  # 1MB
     checksum = hashlib.md5()

--- a/lib/walden/owid/walden/files.py
+++ b/lib/walden/owid/walden/files.py
@@ -72,7 +72,7 @@ def _stream_to_file(
     return md5.hexdigest()
 
 
-def download(url: str, filename: str, expected_md5: Optional[str] = None, quiet: bool = False) -> None:
+def download(url: str, filename: str, expected_md5: Optional[str] = None, quiet: bool = False, **kwargs) -> None:
     "Download the file at the URL to the given local filename."
     # NOTE: we are not streaming to a NamedTemporaryFile because it was causing weird
     # issues one some systems, it's safer to stream directly to the file and remove it
@@ -81,7 +81,7 @@ def download(url: str, filename: str, expected_md5: Optional[str] = None, quiet:
     with open(tmp_filename, "wb") as f, requests.get(url, stream=True) as r:
         r.raise_for_status()
 
-        md5 = _stream_to_file(r, f)
+        md5 = _stream_to_file(r, f, **kwargs)
 
         if expected_md5 and md5 != expected_md5:
             if os.path.exists(filename):


### PR DESCRIPTION
Refactor DVC in steps and snapshots and simplify it a bit. It uses somehow magical combination of locks to make it work for nightly builds with multiple processes. When I have time I plan to replace `dvc.pull` [with something custom](https://github.com/owid/etl/pull/2058).