### PR TITLE
:bug: fix catalogPath for cases with multiple tables

### DIFF
--- a/etl/steps/data/grapher/biodiversity/2023-01-11/cherry_blossom.py
+++ b/etl/steps/data/grapher/biodiversity/2023-01-11/cherry_blossom.py
@@ -1,8 +1,5 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from typing import cast
-
-from owid.catalog import Dataset
 
 from etl.helpers import PathFinder, create_dataset, grapher_checks
 
@@ -15,7 +12,7 @@ def run(dest_dir: str) -> None:
     # Load inputs.
     #
     # Load garden dataset.
-    ds_garden = cast(Dataset, paths.load_dependency("cherry_blossom"))
+    ds_garden = paths.load_dataset("cherry_blossom")
 
     # Read table from garden dataset.
     tb = ds_garden["cherry_blossom"]

--- a/etl/steps/data/grapher/ihme_gbd/2019/gbd_cause.py
+++ b/etl/steps/data/grapher/ihme_gbd/2019/gbd_cause.py
@@ -1,5 +1,3 @@
-from owid import catalog
-
 from etl.helpers import PathFinder
 
 from .shared import run_wrapper
@@ -8,6 +6,5 @@ paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
-    garden_dataset = paths.garden_dataset
-    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
-    dataset = run_wrapper(garden_dataset=garden_dataset, dataset=dataset)
+    ds_garden = paths.load_dataset("gbd_cause")
+    run_wrapper(dest_dir, garden_dataset=ds_garden)

--- a/etl/steps/data/grapher/ihme_gbd/2019/gbd_child_mortality.py
+++ b/etl/steps/data/grapher/ihme_gbd/2019/gbd_child_mortality.py
@@ -1,5 +1,3 @@
-from owid import catalog
-
 from etl.helpers import PathFinder
 
 from .shared import run_wrapper
@@ -8,8 +6,5 @@ paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
-    garden_dataset = paths.garden_dataset
-    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
-    # dataset.save()
-
-    run_wrapper(garden_dataset=garden_dataset, dataset=dataset)
+    ds_garden = paths.load_dataset("gbd_child_mortality")
+    run_wrapper(dest_dir, garden_dataset=ds_garden)

--- a/etl/steps/data/grapher/ihme_gbd/2019/gbd_mental_health.py
+++ b/etl/steps/data/grapher/ihme_gbd/2019/gbd_mental_health.py
@@ -1,5 +1,3 @@
-from owid import catalog
-
 from etl.helpers import PathFinder
 
 from .shared import run_wrapper
@@ -8,6 +6,5 @@ paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
-    garden_dataset = paths.garden_dataset
-    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
-    dataset = run_wrapper(garden_dataset=garden_dataset, dataset=dataset)
+    ds_garden = paths.load_dataset("gbd_mental_health")
+    run_wrapper(dest_dir, garden_dataset=ds_garden)

--- a/etl/steps/data/grapher/ihme_gbd/2019/gbd_prevalence.py
+++ b/etl/steps/data/grapher/ihme_gbd/2019/gbd_prevalence.py
@@ -1,5 +1,3 @@
-from owid import catalog
-
 from etl.helpers import PathFinder
 
 from .shared import run_wrapper
@@ -8,6 +6,5 @@ paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
-    garden_dataset = paths.garden_dataset
-    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
-    run_wrapper(garden_dataset=garden_dataset, dataset=dataset)
+    ds_garden = paths.load_dataset("gbd_prevalence")
+    run_wrapper(dest_dir, garden_dataset=ds_garden)

--- a/etl/steps/data/grapher/ihme_gbd/2019/gbd_risk.py
+++ b/etl/steps/data/grapher/ihme_gbd/2019/gbd_risk.py
@@ -1,5 +1,3 @@
-from owid import catalog
-
 from etl.helpers import PathFinder
 
 from .shared import run_wrapper
@@ -8,6 +6,5 @@ paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
-    garden_dataset = paths.garden_dataset
-    dataset = catalog.Dataset.create_empty(dest_dir, garden_dataset.metadata)
-    run_wrapper(garden_dataset=garden_dataset, dataset=dataset)
+    ds_garden = paths.load_dataset("gbd_risk")
+    run_wrapper(dest_dir, garden_dataset=ds_garden)

--- a/etl/steps/data/grapher/ihme_gbd/2019/shared.py
+++ b/etl/steps/data/grapher/ihme_gbd/2019/shared.py
@@ -1,13 +1,22 @@
 from owid.catalog import Dataset
-from structlog import get_logger
 
-log = get_logger()
+from etl.helpers import create_dataset, grapher_checks
 
 
-def run_wrapper(garden_dataset: Dataset, dataset: Dataset) -> Dataset:
-    # add tables to dataset
-    tables = garden_dataset.table_names
-    for table in tables:
-        tab = garden_dataset[table]
-        dataset.add(tab)
-    dataset.save()
+def run_wrapper(dest_dir: str, garden_dataset: Dataset) -> None:
+    # Read tables from garden dataset.
+    tables = [garden_dataset[table_name] for table_name in garden_dataset.table_names]
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(dest_dir, tables=tables, default_metadata=garden_dataset.metadata)
+
+    #
+    # Checks.
+    #
+    grapher_checks(ds_grapher)
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()


### PR DESCRIPTION
We were getting strange table names in `catalogPath` for variables in datasets with multiple tables. One of them is GBD. It's hard to replicate, but I believe it's caused by using `lambda` function in a loop, which can cause some nasty surprises. 