### PR TITLE
:bug: fix chart revisions for edge cases

### DIFF
--- a/apps/wizard/charts/submission.py
+++ b/apps/wizard/charts/submission.py
@@ -62,7 +62,8 @@ def create_submission(variable_config: VariableConfig, schema_chart_config: Dict
 
     # If we managed to get the charts and updaters, show results.
     if submission.is_valid:
-        log.info(f"chart_revision: Submission is valid: {submission}")
+        # NOTE: turned off because it's too noisy
+        # log.info(f"chart_revision: Submission is valid: {submission}")
         # Display details
         num_charts = len(charts)  # type: ignore
         with st.container():

--- a/etl/chart_revision/v2/core.py
+++ b/etl/chart_revision/v2/core.py
@@ -217,6 +217,10 @@ def create_chart_comparison(config_1: Dict[str, Any], config_2: Dict[str, Any]) 
     if config_1["id"] != config_2["id"]:
         raise ValueError("Configurations must be from the same chart.")
     chart_id = config_1["id"]
+
+    assert "version" in config_1, f"version of chart {chart_id} is missing from config!"
+    assert "version" in config_2, f"version of chart {chart_id} is missing from new config!"
+
     return gm.SuggestedChartRevisions(
         chartId=chart_id,
         createdBy=int(GRAPHER_USER_ID),  # type: ignore

--- a/etl/chart_revision/v2/schema.py
+++ b/etl/chart_revision/v2/schema.py
@@ -135,8 +135,9 @@ def validate_chart_config_and_remove_defaults(
 
         def _set_defaults(validator, properties, instance, schema):  # type: ignore
             for property, subschema in properties.items():
+                is_required = property in (schema or {}).get("required", [])
                 if "default" in subschema:
-                    if subschema["default"] == instance[property]:
+                    if not is_required and subschema["default"] == instance[property]:
                         del instance[property]
 
             for error in validate_properties(

--- a/etl/chart_revision/v2/updaters/variable_update.py
+++ b/etl/chart_revision/v2/updaters/variable_update.py
@@ -450,7 +450,18 @@ def find_charts_from_variable_ids(variable_ids: Set[int]) -> List[gm.Chart]:
             .all()
         )
         # Retrieve charts from a given list of chart IDs
-        return session.exec(select(gm.Chart).where(gm.Chart.id.in_(chart_ids))).all()  # type: ignore
+        charts = session.exec(select(gm.Chart).where(gm.Chart.id.in_(chart_ids))).all()  # type: ignore
+
+    # some charts don't have ID in config, fix that here (should be ideally fixed in the database)
+    for chart in charts:
+        if "id" not in chart.config:
+            log.warning(f"Chart {chart.id} does not have an ID in config.")
+            chart.config["id"] = chart.id
+        if "version" not in chart.config:
+            log.warning(f"Chart {chart.id} does not have a version in config.")
+            chart.config["version"] = 1
+
+    return charts
 
 
 def _get_time_ranges(


### PR DESCRIPTION
There were two issues with chart revisions:
1. Some charts don't have `config["id"]` - Hotfixed by creating it when loading the chart, but the plan is to fix all charts like that in MySQL
2. Some suggested revisions don't have `version` - this was caused by function that was deleting properties with default values (where `version = 1`) even though the property is required

I've tested it locally. If you run into an error that says chart revisions don't have a unique `chartId`, you'll have to delete that revision manually from DB (this happens because of previous failed attempts).