### PR TITLE
Propagate metadata on fillna

### DIFF
--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -895,6 +895,20 @@ class Table(pd.DataFrame):
         tb = tb.set_index(column_idx_new)
         return tb
 
+    def fillna(self, value, **kwargs) -> "Table":
+        """Usual fillna, but, if the object given to fill values with is a table, transfer its metadata to the filled
+        table."""
+        tb = super().fillna(value, **kwargs)
+
+        if type(value) == type(self):
+            for column in tb.columns:
+                if column in value.columns:
+                    tb._fields[column] = variables.combine_variables_metadata(
+                        variables=[tb[column], value[column]], operation="fillna", name=column
+                    )
+
+        return tb
+
 
 def _create_table(df: pd.DataFrame, metadata: TableMeta, fields: Dict[str, VariableMeta]) -> Table:
     """Create a table with metadata."""


### PR DESCRIPTION
When filling with nans using another table, we should combine the metadata of the two tables.
This change will also make `datautils.dataframes.combine_two_overlapping_dataframes` automatically propagate metadata of the two tables.

`fillna` is a very common operation (although it's unusual to fill with entire tables), and `combine_two_overlapping_dataframes` is also fairly commonly used. So it would be very good to check if this PR alters the metadata of existing steps.

One possible issue I can imagine happening is that, when doing tb1.fillna(tb2), one may expect that the title and description of tb1 should be preserved. But, if tb1 and tb2 have different titles and descriptions, the combination will have no title/description (which also makes sense).
