### PR TITLE
Avoid metadata warning on division

### DIFF
--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -348,7 +348,10 @@ def _get_metadata_value_from_variables_if_all_identical(
         combined_value = unique_values.pop()
     else:
         combined_value = None
-        if (len(unique_values) > 1) and warn_if_different:
+        if (len(unique_values) > 1) and (operation != "/") and warn_if_different:
+            # There is no need to warn if units are different when doing a division.
+            # In most cases, units will be different, and that is fine, as long as the resulting variable has no units.
+            # Note that the same reasoning could be applied to multiplication, so we may need to generalize this logic.
             log.warning(f"Different values of '{field}' detected among variables: {unique_values}")
 
     return combined_value


### PR DESCRIPTION
Avoid a warning when dividing two variables with different units (which is very common, e.g. when computing per capita variables).

We may want to make this logic a bit more generic in the future, but for now this will significantly reduce the number of warnings.

