### PR TITLE
📊 Migrate grapher charts to Data Pages (Lucas)

### DIFF
--- a/etl/steps/data/grapher/gapminder/2019-05-25/fertility_rate.meta.yml
+++ b/etl/steps/data/grapher/gapminder/2019-05-25/fertility_rate.meta.yml
@@ -1,0 +1,120 @@
+definitions:
+  common:
+    processing_level: TBD - major or minor
+    presentation:
+      topic_tags:
+        - TBD - Indicator's topic tags
+    sources: []
+    origins:
+      - producer: Fertility Rate (Selected Gapminder, v12) (2017)
+        title: Fertility Rate (Selected Gapminder, v12) (2017)
+        description: >-
+          Data is that of version 12 of Gapminder, the latest version as of 2019. This is the full fertility rate dataset
+          published by Gapminder.
+
+
+          Gapminder's sources and methodology if well-documented in its dataset at: https://www.gapminder.org/data/
+
+
+          It notes its data sources during three key periods of time:
+
+
+          - 1800 to 1950 (and in some cases also years after 1950): Gapminder v6 which were compiled and documented by Mattias
+          Lindgren.
+
+
+          - 1950 to 2014: In most cases we use the latest UN estimates from World Population Prospects 2017 published in the
+          file with Annually interpolated demographic indicators, called WPP2017_INT_F01_ANNUAL_DEMOGRAPHIC_INDICATORS.xlsx
+          , accessed on September 2, 2017.
+
+
+          - 2015 - 2099: We use the UN forecast of future fertility rate in all countries, called median fertility variant.
+
+
+          Version 12 of the dataset extends back to the year 1800. Version 6 of Gapminder's fertility series includes data
+          for a few countries further than 1800. We have included more historic data from Version 6 for Finland, the United
+          Kingdom and Sweden. All data from 1800 onwards is from Version 12; data from pre-1800 is from Version 6.
+
+
+          There are significant uncertainties in data for many countries pre-1950. To develop full series back to 1800 for
+          all countries, Gapminder combines published estimates within the academic literature and national statistics, with
+          their own guesstimates and extrapolations for countries without published estimates. This series presents the selective
+          Gapminder dataset: we have removed data points which were estimated by Gapminder with high uncertainty and instead
+          only include those from published sources or the United Nations dataset.
+
+
+          We also publish the full dataset from Gapminder for users looking for a complete series. However, we should highlight
+          that some of these estimates have a high degree of uncertainty. This dataset can be accessed here: https://ourworldindata.org/grapher/fertility-rate-complete-gapminder
+        citation_full: Gapminder
+        url_main: https://drive.google.com/drive/folders/1i30LyIcvbLa800Q1ZFrPGlNHIw9ymYGm
+        date_accessed: '2019-05-25'
+        date_published: '2019-05-25'
+dataset:
+  update_period_days: TBD - Number of days between OWID updates
+  sources: []
+tables:
+  fertility_rate:
+    variables:
+      fertility_rate__select_gapminder__v12__2017:
+        title: Fertility rate (Select Gapminder, v12) (2017)
+        unit: children per woman
+        display:
+          name: Fertility rate
+        description_short: TBD - Indicator's short description
+        description_key:
+          - TBD - List of key pieces of information about the indicator.
+        description_from_producer: TBD - Indicator's description given by the producer
+        description_processing: TBD - Indicator's processing description
+        description: Total fertility rate represents the number of children that would be born to a woman if she were to live
+          to the end of her childbearing years and bear children in accordance with age-specific fertility rates of the specified
+          year.
+        presentation:
+          title_public: TBD - Indicator title to be shown in data pages, that overrides the indicator's title.
+          title_variant: TBD - Indicator's title variant
+          attribution_short: TBD - Indicator's attribution (shorter version)
+          faqs:
+            - fragment_id: TBD - Question identifier from FAQ GDoc
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          grapher_config:
+            title: 'Fertility rate: children per woman'
+            variantName: Gapminder
+            sourceDesc: Gapminder (2017)
+            originUrl: https://ourworldindata.org/fertility-rate
+            hasMapTab: true
+            tab: map
+            yAxis:
+              max: 0
+              min: 0
+            timelineMaxTime: 2022
+            map:
+              colorScale:
+                baseColorScheme: OrRd
+                binningStrategy: manual
+                legendDescription: Children per woman
+                customNumericColors:
+                  - null
+                  - null
+                  - null
+                  - null
+                  - null
+                  - null
+                  - null
+                  - null
+                customNumericValues:
+                  - 1
+                  - 2
+                  - 3
+                  - 4
+                  - 5
+                  - 6
+                  - 7
+                  - 8
+                customNumericMinValue: 0
+              timeTolerance: 5
+            selectedEntityNames:
+              - Norway
+              - Luxembourg
+              - United Kingdom
+              - Sweden
+            note: The total fertility rate is the number of children that would be born to a woman if she were to live to
+              the end of her child-bearing years and give birth to children at the current age-specific fertility rates.

--- a/etl/steps/data/grapher/gapminder/2019-05-25/fertility_rate.meta.yml
+++ b/etl/steps/data/grapher/gapminder/2019-05-25/fertility_rate.meta.yml
@@ -1,84 +1,30 @@
 definitions:
   common:
-    processing_level: TBD - major or minor
+    processing_level: minor
     presentation:
       topic_tags:
-        - TBD - Indicator's topic tags
-    sources: []
-    origins:
-      - producer: Fertility Rate (Selected Gapminder, v12) (2017)
-        title: Fertility Rate (Selected Gapminder, v12) (2017)
-        description: >-
-          Data is that of version 12 of Gapminder, the latest version as of 2019. This is the full fertility rate dataset
-          published by Gapminder.
+        - Fertility Rate
 
-
-          Gapminder's sources and methodology if well-documented in its dataset at: https://www.gapminder.org/data/
-
-
-          It notes its data sources during three key periods of time:
-
-
-          - 1800 to 1950 (and in some cases also years after 1950): Gapminder v6 which were compiled and documented by Mattias
-          Lindgren.
-
-
-          - 1950 to 2014: In most cases we use the latest UN estimates from World Population Prospects 2017 published in the
-          file with Annually interpolated demographic indicators, called WPP2017_INT_F01_ANNUAL_DEMOGRAPHIC_INDICATORS.xlsx
-          , accessed on September 2, 2017.
-
-
-          - 2015 - 2099: We use the UN forecast of future fertility rate in all countries, called median fertility variant.
-
-
-          Version 12 of the dataset extends back to the year 1800. Version 6 of Gapminder's fertility series includes data
-          for a few countries further than 1800. We have included more historic data from Version 6 for Finland, the United
-          Kingdom and Sweden. All data from 1800 onwards is from Version 12; data from pre-1800 is from Version 6.
-
-
-          There are significant uncertainties in data for many countries pre-1950. To develop full series back to 1800 for
-          all countries, Gapminder combines published estimates within the academic literature and national statistics, with
-          their own guesstimates and extrapolations for countries without published estimates. This series presents the selective
-          Gapminder dataset: we have removed data points which were estimated by Gapminder with high uncertainty and instead
-          only include those from published sources or the United Nations dataset.
-
-
-          We also publish the full dataset from Gapminder for users looking for a complete series. However, we should highlight
-          that some of these estimates have a high degree of uncertainty. This dataset can be accessed here: https://ourworldindata.org/grapher/fertility-rate-complete-gapminder
-        citation_full: Gapminder
-        url_main: https://drive.google.com/drive/folders/1i30LyIcvbLa800Q1ZFrPGlNHIw9ymYGm
-        date_accessed: '2019-05-25'
-        date_published: '2019-05-25'
 dataset:
-  update_period_days: TBD - Number of days between OWID updates
+  update_period_days: 0
   sources: []
+
 tables:
   fertility_rate:
     variables:
       fertility_rate__select_gapminder__v12__2017:
-        title: Fertility rate (Select Gapminder, v12) (2017)
+        title: Fertility rate (Gapminder, v12, 2017)
         unit: children per woman
         display:
           name: Fertility rate
-        description_short: TBD - Indicator's short description
-        description_key:
-          - TBD - List of key pieces of information about the indicator.
-        description_from_producer: TBD - Indicator's description given by the producer
-        description_processing: TBD - Indicator's processing description
-        description: Total fertility rate represents the number of children that would be born to a woman if she were to live
-          to the end of her childbearing years and bear children in accordance with age-specific fertility rates of the specified
-          year.
+        description_short: |-
+          The number of children that would be born to a woman if she were to live to the end of her child-bearing years and give birth to children at the current age-specific fertility rates.
         presentation:
-          title_public: TBD - Indicator title to be shown in data pages, that overrides the indicator's title.
-          title_variant: TBD - Indicator's title variant
-          attribution_short: TBD - Indicator's attribution (shorter version)
-          faqs:
-            - fragment_id: TBD - Question identifier from FAQ GDoc
-              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          title_public: "Fertility rate: children per woman"
+          attribution_short: Gapminder
           grapher_config:
             title: 'Fertility rate: children per woman'
-            variantName: Gapminder
-            sourceDesc: Gapminder (2017)
+            subtitle: ''
             originUrl: https://ourworldindata.org/fertility-rate
             hasMapTab: true
             tab: map
@@ -116,5 +62,5 @@ tables:
               - Luxembourg
               - United Kingdom
               - Sweden
-            note: The total fertility rate is the number of children that would be born to a woman if she were to live to
-              the end of her child-bearing years and give birth to children at the current age-specific fertility rates.
+            note: |-
+              The total fertility rate is the number of children that would be born to a woman if she were to live to the end of her child-bearing years and give birth to children at the current age-specific fertility rates.

--- a/etl/steps/data/grapher/wb/2017-04-16/world_gdp.meta.yml
+++ b/etl/steps/data/grapher/wb/2017-04-16/world_gdp.meta.yml
@@ -1,46 +1,40 @@
 definitions:
   common:
-    processing_level: TBD - major or minor
+    processing_level: major
     presentation:
       topic_tags:
-        - TBD - Indicator's topic tags
-    sources: []
-    origins:
-      - producer: Our World In Data based on World Bank & Maddison (2017)
-        title: World GDP in 2011 int $ - OWID based on World Bank + Maddison (2017)
-        description: 'The data presented here from 1990 onwards is from the World Bank. It is total global GDP in 2011 international-$
-          as published here: http://data.worldbank.org/indicator/NY.GDP.MKTP.PP.KD (accessed on April 16, 2017). Data earlier
-          than 1990 is backwards extended from the World Bank observation for 1990 based on the growth rates implied by Maddison
-          data. The Maddison data is published here: http://www.ggdc.net/maddison/oriindex.htm'
-        citation_full: New Maddison Project Database and World Bank
-        url_main: Please see additional information for links
-        date_accessed: '2017-04-16'
-        date_published: '2017-04-16'
+        - Economic Growth
+
+
 dataset:
-  update_period_days: TBD - Number of days between OWID updates
+  update_period_days: 0
   sources: []
+  title: World GDP (World Bank & Maddison, 2017)
+
 tables:
   world_gdp:
     variables:
       world_gdp_in_2011_int_dollar__owid_based_on_world_bank__and__maddison__2017:
-        title: World GDP in 2011 Int.$ (OWID based on World Bank & Maddison (2017))
-        unit: int.-$
+        title: World GDP (World Bank & Maddison, 2017)
+        unit: international-$ in 2011 prices
         short_unit: $
         display:
           numDecimalPlaces: 0
           unit: international-$ in 2011 prices
         description_short: Total output of the world economy. This data is adjusted for inflation and differences in the cost
           of living between countries.
-        description_key:
-          - TBD - List of key pieces of information about the indicator.
-        description_from_producer: TBD - Indicator's description given by the producer
-        description_processing: TBD - Indicator's processing description
+        description_from_producer: |-
+          PPP GDP is gross domestic product converted to international dollars using purchasing power parity rates. An international dollar has the same purchasing power over GDP as the U.S. dollar has in the United States. GDP is the sum of gross value added by all resident producers in the country plus any product taxes and minus any subsidies not included in the value of the products. It is calculated without making deductions for depreciation of fabricated assets or for depletion and degradation of natural resources. Data are in constant 2017 international dollars.
+
+        description_processing: |-
+          The data presented here from 1990 onwards is from the World Bank.
+
+          It is total global GDP in 2011 international-$ as published here: http://data.worldbank.org/indicator/NY.GDP.MKTP.PP.KD (accessed on April 16, 2017). Data earlier than 1990 is backwards extended from the World Bank observation for 1990 based on the growth rates implied by Maddison data. The Maddison data is published here: http://www.ggdc.net/maddison/oriindex.htm.
         presentation:
-          title_public: TBD - Indicator title to be shown in data pages, that overrides the indicator's title.
-          title_variant: TBD - Indicator's title variant
-          attribution_short: TBD - Indicator's attribution (shorter version)
+          title_public: World GDP
+          attribution_short: World Bank & Maddison
           faqs:
-            - fragment_id: TBD - Question identifier from FAQ GDoc
+            - fragment_id: What are international-$ and why are they used to measure incomes?
               gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
           grapher_config:
             title: World GDP over the last two millennia

--- a/etl/steps/data/grapher/wb/2017-04-16/world_gdp.meta.yml
+++ b/etl/steps/data/grapher/wb/2017-04-16/world_gdp.meta.yml
@@ -1,0 +1,69 @@
+definitions:
+  common:
+    processing_level: TBD - major or minor
+    presentation:
+      topic_tags:
+        - TBD - Indicator's topic tags
+    sources: []
+    origins:
+      - producer: Our World In Data based on World Bank & Maddison (2017)
+        title: World GDP in 2011 int $ - OWID based on World Bank + Maddison (2017)
+        description: 'The data presented here from 1990 onwards is from the World Bank. It is total global GDP in 2011 international-$
+          as published here: http://data.worldbank.org/indicator/NY.GDP.MKTP.PP.KD (accessed on April 16, 2017). Data earlier
+          than 1990 is backwards extended from the World Bank observation for 1990 based on the growth rates implied by Maddison
+          data. The Maddison data is published here: http://www.ggdc.net/maddison/oriindex.htm'
+        citation_full: New Maddison Project Database and World Bank
+        url_main: Please see additional information for links
+        date_accessed: '2017-04-16'
+        date_published: '2017-04-16'
+dataset:
+  update_period_days: TBD - Number of days between OWID updates
+  sources: []
+tables:
+  world_gdp:
+    variables:
+      world_gdp_in_2011_int_dollar__owid_based_on_world_bank__and__maddison__2017:
+        title: World GDP in 2011 Int.$ (OWID based on World Bank & Maddison (2017))
+        unit: int.-$
+        short_unit: $
+        display:
+          numDecimalPlaces: 0
+          unit: international-$ in 2011 prices
+        description_short: Total output of the world economy. This data is adjusted for inflation and differences in the cost
+          of living between countries.
+        description_key:
+          - TBD - List of key pieces of information about the indicator.
+        description_from_producer: TBD - Indicator's description given by the producer
+        description_processing: TBD - Indicator's processing description
+        presentation:
+          title_public: TBD - Indicator title to be shown in data pages, that overrides the indicator's title.
+          title_variant: TBD - Indicator's title variant
+          attribution_short: TBD - Indicator's attribution (shorter version)
+          faqs:
+            - fragment_id: TBD - Question identifier from FAQ GDoc
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          grapher_config:
+            title: World GDP over the last two millennia
+            subtitle: Total output of the world economy. This data is adjusted for inflation and differences in the cost of
+              living between countries.
+            variantName: ''
+            originUrl: https://ourworldindata.org/economic-growth
+            yAxis:
+              min: 0
+              canChangeScaleType: true
+            hideAnnotationFieldsInTitle:
+              time: true
+              entity: true
+              changeInPrefix: true
+            hideRelativeToggle: false
+            map:
+              time: 1980
+              colorScale:
+                baseColorScheme: BuGn
+                binningStrategy: equalInterval
+                legendDescription: ''
+              timeTolerance: 1
+            selectedEntityNames:
+              - World
+            note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2011 prices.
+            hideLegend: true

--- a/etl/steps/data/grapher/wb/2017-04-16/world_gdp.meta.yml
+++ b/etl/steps/data/grapher/wb/2017-04-16/world_gdp.meta.yml
@@ -34,7 +34,7 @@ tables:
           title_public: World GDP
           attribution_short: World Bank & Maddison
           faqs:
-            - fragment_id: What are international-$ and why are they used to measure incomes?
+            - fragment_id: poverty-international-dollars
               gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
           grapher_config:
             title: World GDP over the last two millennia

--- a/snapshots/gapminder/2019-05-25/fertility_rate.feather.dvc
+++ b/snapshots/gapminder/2019-05-25/fertility_rate.feather.dvc
@@ -1,62 +1,39 @@
 meta:
-  source:
-    name: Fertility Rate (Selected Gapminder, v12) (2017)
-    description: >-
-      Data is that of version 12 of Gapminder, the latest version as of 2019. This
-      is the full fertility rate dataset published
-      by Gapminder.
-
+  origin:
+    # Data product / Snapshot
+    title: Fertility Rate
+    description: |-
+      Data is that of version 12 of Gapminder, the latest version as of 2019. This is the full fertility rate dataset published by Gapminder.
 
       Gapminder's sources and methodology if well-documented in its dataset at: https://www.gapminder.org/data/
 
-
       It notes its data sources during three key periods of time:
 
+      * 1800 to 1950 (and in some cases also years after 1950): Gapminder v6 which were compiled and documented by Mattias Lindgren.
+      * 1950 to 2014: In most cases we use the latest UN estimates from World Population Prospects 2017 published in the file with Annually interpolated demographic indicators, called WPP2017_INT_F01_ANNUAL_DEMOGRAPHIC_INDICATORS.xlsx, accessed on September 2, 2017.
+      * 2015 – 2099: We use the UN forecast of future fertility rate in all countries, called median fertility variant.
 
-      — 1800 to 1950 (and in some cases also years after 1950): Gapminder v6 which
-      were compiled and documented by Mattias
-      Lindgren.
+      Version 12 of the dataset extends back to the year 1800. Version 6 of Gapminder's fertility series includes data for a few countries further than 1800. We have included more historic data from Version 6 for Finland, the United Kingdom and Sweden. All data from 1800 onwards is from Version 12; data from pre-1800 is from Version 6.
 
+      There are significant uncertainties in data for many countries pre-1950. To develop full series back to 1800 for all countries, Gapminder combines published estimates within the academic literature and national statistics, with their own guesstimates and extrapolations for countries without published estimates. This series presents the selective Gapminder dataset: we have removed data points which were estimated by Gapminder with high uncertainty and instead only include those from published sources or the United Nations dataset.
 
-      — 1950 to 2014: In most cases we use the latest UN estimates from World Population
-      Prospects 2017 published in the file
-      with Annually interpolated demographic indicators, called WPP2017_INT_F01_ANNUAL_DEMOGRAPHIC_INDICATORS.xlsx
-      , accessed
-      on September 2, 2017.
+      We also publish the full dataset from Gapminder for users looking for a complete series. However, we should highlight that some of these estimates have a high degree of uncertainty. This dataset can be accessed here: https://ourworldindata.org/grapher/fertility-rate-complete-gapminder
+    date_published: 2017-12-12
 
+    # Citation
+    producer: Gapminder
+    citation_full: |-
+      Free data from www.gapminder.org
 
-      — 2015 – 2099: We use the UN forecast of future fertility rate in all countries,
-      called median fertility variant.
-
-
-      Version 12 of the dataset extends back to the year 1800. Version 6 of Gapminder's
-      fertility series includes data for
-      a few countries further than 1800. We have included more historic data from
-      Version 6 for Finland, the United Kingdom
-      and Sweden. All data from 1800 onwards is from Version 12; data from pre-1800
-      is from Version 6.
-
-
-      There are significant uncertainties in data for many countries pre-1950. To
-      develop full series back to 1800 for all
-      countries, Gapminder combines published estimates within the academic literature
-      and national statistics, with their
-      own guesstimates and extrapolations for countries without published estimates.
-      This series presents the selective Gapminder
-      dataset: we have removed data points which were estimated by Gapminder with
-      high uncertainty and instead only include
-      those from published sources or the United Nations dataset.
-
-
-      We also publish the full dataset from Gapminder for users looking for a complete
-      series. However, we should highlight
-      that some of these estimates have a high degree of uncertainty. This dataset
-      can be accessed here: https://ourworldindata.org/grapher/fertility-rate-complete-gapminder
-    url: https://drive.google.com/drive/folders/1i30LyIcvbLa800Q1ZFrPGlNHIw9ymYGm
+    # Files
+    url_main: https://drive.google.com/drive/folders/1i30LyIcvbLa800Q1ZFrPGlNHIw9ymYGm
     date_accessed: 2019-05-25
-    published_by: Gapminder
-  name: Fertility Rate (Selected Gapminder, v12) (2017)
-  description: ''
+
+    # License
+    license:
+      name: CC BY 4.0
+      url: www.gapm.io/data_license
+
 wdir: ../../../data/snapshots/gapminder/2019-05-25
 outs:
 - md5: 07302fc652ae3018457e339e7fde539a

--- a/snapshots/wb/2017-04-16/world_gdp.feather.dvc
+++ b/snapshots/wb/2017-04-16/world_gdp.feather.dvc
@@ -1,16 +1,32 @@
 meta:
-  source:
-    name: Our World In Data based on World Bank & Maddison (2017)
-    description: 'The data presented here from 1990 onwards is from the World Bank.
-      It is total global GDP in 2011 international-$ as published here: http://data.worldbank.org/indicator/NY.GDP.MKTP.PP.KD
-      (accessed on April 16, 2017). Data earlier than 1990 is backwards extended from
-      the World Bank observation for 1990 based on the growth rates implied by Maddison
-      data. The Maddison data is published here: http://www.ggdc.net/maddison/oriindex.htm'
-    url: Please see additional information for links
+  origin:
+  # Data product / Snapshot
+    title: World GDP
+    description: |-
+      The data presented here from 1990 onwards is from the World Bank.
+
+      It is total global GDP in 2011 international-$ as published here: http://data.worldbank.org/indicator/NY.GDP.MKTP.PP.KD (accessed on April 16, 2017). Data earlier than 1990 is backwards extended from the World Bank observation for 1990 based on the growth rates implied by Maddison data. The Maddison data is published here: http://www.ggdc.net/maddison/oriindex.htm
+    date_published: 2017-04-16
+
+    # Citation
+    producer: World Bank
+    citation_full: |-
+      Data since 1990:
+      "International Comparison Program, World Bank | World Development Indicators database, World Bank | Eurostat-OECD PPP Programme."
+
+      Data before 1990: World Bank observation from 1990 expanded with
+      "Maddison Project Database, version 2013. Bolt, J. and J. L. van Zanden (2014). The Maddison Project: collaborative research on historical national accounts. The Economic History Review, 67 (3): 627–651, working paper"
+
+
+    # Files
+    url_main: http://data.worldbank.org/indicator/NY.GDP.MKTP.PP.KD
     date_accessed: 2017-04-16
-    published_by: New Maddison Project Database and World Bank
-  name: World GDP in 2011 int $ – OWID based on World Bank + Maddison (2017)
-  description: ''
+
+    # License
+    license:
+      name: CC BY 4.0
+      url: https://datacatalog.worldbank.org/public-licenses#cc-by
+
 wdir: ../../../data/snapshots/wb/2017-04-16
 outs:
 - md5: 8987b0657951b975b5bfc9d71306078d


### PR DESCRIPTION
I've taken all Lucas' grapher charts from our [data pages candidate list](https://docs.google.com/spreadsheets/d/1SyyRR_iaokoc-tkDVQ24F4gW7cf47mLRdEyr8ZSBYo0/edit#gid=0) and ran `etl-metadata-migrate` to pre-generate YAML files. This should hopefully ease the migration. Generated YAML files contain all metadata information we have about indicator (including everything from garden step). This means we might end up with duplicate information in garden & grapher YAML files. It's up to you whether you decide to refactor it and move everything to `garden` channel. I don't think it's necessary now (maybe with next update).

## Instructions

Work on this branch and commit back to it. For all data pages from the list:

1. Look up their YAML file from this PR
2. Fill in all TBD fields (update or remove), remove `description` field
3. Push new commit which will trigger **ETL rebuild of staging server**
4. Wait until ETL is rebuilt
5. Look up relevant indicator for a chart on [staging](http://staging-site-data-pages-lucas/admin/variables) and open its data page

Alternatively, you can run it locally with
```
STAGING=data-pages-lucas etl ... --grapher
```

## Additional notes