### PR TITLE
Improve format of war shared file

### DIFF
--- a/etl/steps/data/garden/war/2023-09-21/shared.py
+++ b/etl/steps/data/garden/war/2023-09-21/shared.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional, Type, cast
+from typing import List, Literal, Optional, Type
 
 import numpy as np
 import owid.catalog.processing as pr


### PR DESCRIPTION
Hey @Marigold this file has been showing up every time I do `make test` (because it had an unused import). And `make check` doesn't notice it. I just created this PR in case this is a potential issue of `make check` (maybe it ignores `shared.py` files).
