### PR TITLE
:honeybee: complete the merkle tree with checksums

### DIFF
--- a/etl/config.py
+++ b/etl/config.py
@@ -118,7 +118,7 @@ GRAPHER_FILTER = env.get("GRAPHER_FILTER", None)
 MAX_VIRTUAL_MEMORY_LINUX = 32 * 2**30  # 32 GB
 
 # increment this to force a full rebuild of all datasets
-ETL_EPOCH = 3
+ETL_EPOCH = 4
 
 # any garden or grapher dataset after this date will have strict mode enabled
 STRICT_AFTER = "2023-06-25"

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -41,6 +41,7 @@ DAG = Dict[str, Any]
 
 
 ipynb_lock = fasteners.InterProcessLock(paths.BASE_DIR / ".dvc/tmp/ipynb_lock")
+merkel_lock = fasteners.InterProcessLock(paths.BASE_DIR / ".dvc/tmp/merkel_lock")
 
 
 def compile_steps(
@@ -416,7 +417,9 @@ class DataStep(Step):
         # modify the dataset to remember what inputs were used to build it
         dataset = self._output_dataset
         dataset.metadata.source_checksum = self.checksum_input()
-        dataset.save()
+
+        with merkel_lock:
+            dataset.save()
 
         self.after_run()
 

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -315,6 +315,9 @@ class Dataset:
 
     @staticmethod
     def _update_folder_checksum(folder: Path, checksum: Optional[str] = None) -> None:
+        if (folder / ".git").exists():
+            raise Exception("Merkel tree update has visited too many parents")
+
         if not checksum:
             # if we don't have a checksum, try to compute it from the .md5 files of child folders
             checksums = []

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -305,6 +305,8 @@ class Dataset:
     def _propagate_checksums(self) -> None:
         "Maintain a Merkel tree of the whole catalog."
         folder = Path(self.path)
+        assert folder.is_dir()
+        assert folder.parent.parent.parent.parent.name == "data"
         checksum = self.checksum()
         self._update_folder_checksum(folder, checksum)
 


### PR DESCRIPTION
Calculate checksums all the way up the folder structure and all the way to the catalog level.

## How it works

Each time you save a dataset, you store its checksum in a `.md5` file at the root of its folder. 

You likewise walk upwards `dataset < version < namespace < channel < catalog` and calculate the checksum of all the higher level folders, based on their constituents. Since now you are only combining checksums, these steps are cheap.

The net result is that you have a folder tree of checksums, including one top-level checksum that represents the state of the whole catalog.

## Why we care

- It allows quick comparison between two catalogs by comparing checkums along their trees
  - This can be done in fewer network calls, meaning faster diff between local and object storage
- It serialises the dataset checksums to disk
  - This means other codebases can use them without having to know the rules for computing them
