### PR TITLE
Fix attribution in World GDP dataset

### DIFF
--- a/snapshots/wb/2017-04-16/world_gdp.feather.dvc
+++ b/snapshots/wb/2017-04-16/world_gdp.feather.dvc
@@ -16,7 +16,7 @@ meta:
 
       Data before 1990: World Bank observation from 1990 expanded with
       "Maddison Project Database, version 2013. Bolt, J. and J. L. van Zanden (2014). The Maddison Project: collaborative research on historical national accounts. The Economic History Review, 67 (3): 627–651, working paper"
-
+    attribution: World Bank and Maddison (2017)
 
     # Files
     url_main: http://data.worldbank.org/indicator/NY.GDP.MKTP.PP.KD


### PR DESCRIPTION
I have changed the attribution of the World GDP dataset, since [Max pointed out](https://owid.slack.com/archives/C03NV9Z3YSV/p1703764800168289) that it was wrong. But I'm not sure if this is the correct attribution (I haven't worked on this dataset), @lucasrodes feel free to change it if this is not correct.
