### PR TITLE
:hammer: stop using display.name to prevent warnings spam

### DIFF
--- a/etl/steps/data/garden/ihme_gbd/2019/shared.py
+++ b/etl/steps/data/garden/ihme_gbd/2019/shared.py
@@ -261,7 +261,6 @@ def create_variable_metadata(variable: Variable, cause: str, age: str, sex: str,
         short_unit=var_name_dict[variable.name]["short_unit"],
     )
     new_variable.metadata.display = {
-        "name": var_name_dict[variable.name]["title"],
         "numDecimalPlaces": var_name_dict[variable.name]["num_decimal_places"],
     }
 


### PR DESCRIPTION
We get huge number of warnings from `ihme_gbd` like this
```
2024-01-02 11:09:53 [warning  ] Column share_of_total_dalys_that_are_from_varicella_and_herpes_zoster__in_females_aged_7_27_days uses display.name but no presentation.title_public. Ensure the latter is also defined, otherwise display.name will be used as the indicator's title.
```

The `display.name` is the same as the indicator's title, so there's no point in keeping both.