### PR TITLE
Add nuclear warhead inventories data

### DIFF
--- a/dag/war.yml
+++ b/dag/war.yml
@@ -136,3 +136,11 @@ steps:
     - data://meadow/war/2024-01-09/nuclear_weapons_inventories
   data://grapher/war/2024-01-09/nuclear_weapons_inventories:
     - data://garden/war/2024-01-09/nuclear_weapons_inventories
+
+  # Federation of American Scientists - Status of World Nuclear Forces.
+  data://meadow/war/2024-01-09/status_of_world_nuclear_forces:
+    - snapshot://war/2024-01-09/status_of_world_nuclear_forces.csv
+  data://garden/war/2024-01-09/status_of_world_nuclear_forces:
+    - data://meadow/war/2024-01-09/status_of_world_nuclear_forces
+  data://grapher/war/2024-01-09/status_of_world_nuclear_forces:
+    - data://garden/war/2024-01-09/status_of_world_nuclear_forces

--- a/dag/war.yml
+++ b/dag/war.yml
@@ -128,3 +128,11 @@ steps:
     - snapshot://war/2023-11-29/chupilkin_koczan.dta
   data://garden/war/2023-11-29/chupilkin_koczan:
     - data://meadow/war/2023-11-29/chupilkin_koczan
+
+  # Federation of American Scientists - Estimated Global Nuclear Warhead Inventories.
+  data://meadow/war/2024-01-09/nuclear_weapons_inventories:
+    - snapshot://war/2024-01-09/nuclear_weapons_inventories.csv
+  data://garden/war/2024-01-09/nuclear_weapons_inventories:
+    - data://meadow/war/2024-01-09/nuclear_weapons_inventories
+  data://grapher/war/2024-01-09/nuclear_weapons_inventories:
+    - data://garden/war/2024-01-09/nuclear_weapons_inventories

--- a/etl/steps/data/garden/war/2024-01-09/nuclear_weapons_inventories.countries.json
+++ b/etl/steps/data/garden/war/2024-01-09/nuclear_weapons_inventories.countries.json
@@ -1,0 +1,13 @@
+{
+    "China": "China",
+    "France": "France",
+    "India": "India",
+    "Israel": "Israel",
+    "North  Korea": "North Korea",
+    "Pakistan": "Pakistan",
+    "Russia": "Russia",
+    "South Africa": "South Africa",
+    "Total  Inventories": "World",
+    "UK": "United Kingdom",
+    "US": "United States"
+}

--- a/etl/steps/data/garden/war/2024-01-09/nuclear_weapons_inventories.meta.yml
+++ b/etl/steps/data/garden/war/2024-01-09/nuclear_weapons_inventories.meta.yml
@@ -1,0 +1,27 @@
+definitions:
+  common:
+    presentation:
+      topic_tags:
+        - Nuclear Weapons
+        - War & Peace
+
+dataset:
+  update_period_days: 365
+
+tables:
+  nuclear_weapons_inventories:
+    variables:
+      number_of_warheads:
+        title: Number of nuclear warheads
+        unit: warheads
+        short_unit: ""
+        description_short: |-
+          Estimated number of nuclear warheads in the stockpiles of nuclear powers.
+        description_key:
+          - Stockpiles include warheads assigned to military forces, but exclude retired warheads queued for dismantlement.
+          - Retired warheads are only included in the global total.
+          - The exact number of countries' warheads is secret, and the estimates are based on publicly available information, historical records, and occasional leaks.
+          - Warheads vary substantially in their destructing power.
+        processing_level: minor
+        display:
+          numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2024-01-09/nuclear_weapons_inventories.py
+++ b/etl/steps/data/garden/war/2024-01-09/nuclear_weapons_inventories.py
@@ -28,6 +28,9 @@ def run(dest_dir: str) -> None:
     # Rename columns.
     tb = tb.rename(columns=COLUMNS, errors="raise")
 
+    # Looking at the original dashboards, it seems that missing values are shown as zeros.
+    tb = tb.fillna(0)
+
     # Harmonize country names.
     tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
 

--- a/etl/steps/data/garden/war/2024-01-09/nuclear_weapons_inventories.py
+++ b/etl/steps/data/garden/war/2024-01-09/nuclear_weapons_inventories.py
@@ -1,0 +1,42 @@
+"""Load a meadow dataset and create a garden dataset."""
+
+from etl.data_helpers import geo
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+# Columns to use from the data, and how to rename them.
+COLUMNS = {
+    "year": "year",
+    "measure_names": "country",
+    "measure_values": "number_of_warheads",
+}
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load meadow dataset and read its main table.
+    ds_meadow = paths.load_dataset("nuclear_weapons_inventories")
+    tb = ds_meadow["nuclear_weapons_inventories"].reset_index()
+
+    #
+    # Process data.
+    #
+    # Rename columns.
+    tb = tb.rename(columns=COLUMNS, errors="raise")
+
+    # Harmonize country names.
+    tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
+
+    # Set an appropriate index and sort conveniently.
+    tb = tb.set_index(["country", "year"], verify_integrity=True)
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset.
+    ds_garden = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_garden.save()

--- a/etl/steps/data/garden/war/2024-01-09/status_of_world_nuclear_forces.countries.json
+++ b/etl/steps/data/garden/war/2024-01-09/status_of_world_nuclear_forces.countries.json
@@ -1,0 +1,11 @@
+{
+    "China": "China",
+    "France": "France",
+    "India": "India",
+    "Israel": "Israel",
+    "North Korea": "North Korea",
+    "Pakistan": "Pakistan",
+    "Russia": "Russia",
+    "United Kingdom": "United Kingdom",
+    "United States": "United States"
+}

--- a/etl/steps/data/garden/war/2024-01-09/status_of_world_nuclear_forces.meta.yml
+++ b/etl/steps/data/garden/war/2024-01-09/status_of_world_nuclear_forces.meta.yml
@@ -1,0 +1,45 @@
+definitions:
+  common:
+    presentation:
+      topic_tags:
+        - Nuclear Weapons
+        - War & Peace
+    description_key:
+      - The exact number of countries' warheads is secret, and the estimates are based on publicly available information, historical records, and occasional leaks.
+      - Warheads vary substantially in their destructing power.
+    unit: warheads
+    short_unit: ""
+    processing_level: minor
+    display:
+      numDecimalPlaces: 0
+
+dataset:
+  update_period_days: 365
+
+tables:
+  status_of_world_nuclear_forces:
+    variables:
+      deployed_nonstrategic:
+        title: Number of deployed nonstrategic nuclear warheads
+        description_short: |-
+          Deployed warheads are those on ballistic missiles or bomber bases. Nonstrategic or tactical warheads are those for use on the battlefield.
+      deployed_strategic:
+        title: Number of deployed strategic nuclear warheads
+        description_short: |-
+          Deployed warheads are those on ballistic missiles or bomber bases. Strategic warheads are those for use away from the battlefield, such as against military bases, arms industries, or infrastructure.
+      reserve_nondeployed:
+        title: Number of nondeployed nuclear warheads in reserve
+        description_short: |-
+          Nondeployed or reserve warheads are those not on ballistic missiles or bomber bases.
+      stockpile:
+        title: Number of nuclear warheads in stockpile
+        description_short: |-
+          Estimated number of nuclear warheads except for those that are queued for dismantlement.
+      retired:
+        title: Number of retired nuclear warheads
+        description_short: |-
+          Estimated number of retired nuclear warheads queued for dismantlement.
+      inventory:
+        title: Total number of nuclear warheads
+        description_short: |-
+          Estimated number of all nuclear warheads, be they deployed strategic, deployed nonstrategic, nondeployed, or retired.

--- a/etl/steps/data/garden/war/2024-01-09/status_of_world_nuclear_forces.py
+++ b/etl/steps/data/garden/war/2024-01-09/status_of_world_nuclear_forces.py
@@ -1,0 +1,63 @@
+"""Load a meadow dataset and create a garden dataset."""
+
+from etl.data_helpers import geo
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+# Columns to read from the data, and how to rename them.
+COLUMNS = {
+    "country": "country",
+    "year": "year",
+    "deployed_strategic": "deployed_strategic",
+    "deployed_nonstrategic": "deployed_nonstrategic",
+    "reserve_nondeployed": "reserve_nondeployed",
+    "military_stockpile__a": "stockpile",
+    "total_inv": "inventory",
+}
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load meadow dataset and read its main table.
+    ds_meadow = paths.load_dataset("status_of_world_nuclear_forces")
+    tb = ds_meadow["status_of_world_nuclear_forces"].reset_index()
+
+    #
+    # Process data.
+    #
+    # Rename columns.
+    tb = tb[list(COLUMNS)].rename(columns=COLUMNS, errors="raise")
+
+    # Remove annotations and thousand separators from data values, and set an appropriate type.
+    for column in tb.drop(columns=["country", "year"]).columns:
+        tb[column] = tb[column].str.replace(r"\D", "", regex=True).astype(float)
+
+    # Looking at the original dashboard, it seems that missing values are shown as zeros.
+    # https://public.tableau.com/app/profile/kate.kohn/viz/EstimatedGlobalNuclearWarheadInventories2021/Dashboard1
+    tb = tb.fillna(0)
+
+    # Harmonize country names.
+    tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
+
+    # Sanity check.
+    error = "Column 'stockpile' should be the sum of deployed and reserve nuclear weapons."
+    assert (
+        tb["stockpile"] == tb[["deployed_strategic", "deployed_nonstrategic", "reserve_nondeployed"]].sum(axis=1)
+    ).any(), error
+
+    # Add column for retired nuclear weapons, which is the total inventory minus the stockpile.
+    tb["retired"] = tb["inventory"] - tb["stockpile"]
+
+    # Set an appropriate index and sort conveniently.
+    tb = tb.set_index(["country", "year"], verify_integrity=True).sort_index().sort_index(axis=1)
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset.
+    ds_garden = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_garden.save()

--- a/etl/steps/data/grapher/war/2024-01-09/nuclear_weapons_inventories.py
+++ b/etl/steps/data/grapher/war/2024-01-09/nuclear_weapons_inventories.py
@@ -1,0 +1,22 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset and read its main table.
+    ds_garden = paths.load_dataset("nuclear_weapons_inventories")
+    tb = ds_garden["nuclear_weapons_inventories"]
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset.
+    ds_grapher = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_grapher.save()

--- a/etl/steps/data/grapher/war/2024-01-09/status_of_world_nuclear_forces.py
+++ b/etl/steps/data/grapher/war/2024-01-09/status_of_world_nuclear_forces.py
@@ -1,0 +1,22 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset and read its main table.
+    ds_garden = paths.load_dataset("status_of_world_nuclear_forces")
+    tb = ds_garden["status_of_world_nuclear_forces"]
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset.
+    ds_grapher = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/war/2024-01-09/nuclear_weapons_inventories.py
+++ b/etl/steps/data/meadow/war/2024-01-09/nuclear_weapons_inventories.py
@@ -1,0 +1,33 @@
+"""Load a snapshot and create a meadow dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Retrieve snapshot.
+    snap = paths.load_snapshot("nuclear_weapons_inventories.csv")
+
+    # Load data from snapshot.
+    tb = snap.read(sep="\t", encoding="utf-16")
+
+    #
+    # Process data.
+    #
+    # Remove empty rows.
+    tb = tb.dropna().reset_index(drop=True)
+
+    # Ensure all columns are snake-case, set an appropriate index and sort conveniently.
+    tb = tb.underscore().set_index(["measure_names", "year"], verify_integrity=True).sort_index()
+
+    #
+    # Save outputs.
+    #
+    # Create a new meadow dataset with the same metadata as the snapshot.
+    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_meadow.save()

--- a/etl/steps/data/meadow/war/2024-01-09/nuclear_weapons_inventories.py
+++ b/etl/steps/data/meadow/war/2024-01-09/nuclear_weapons_inventories.py
@@ -19,9 +19,6 @@ def run(dest_dir: str) -> None:
     #
     # Process data.
     #
-    # Remove empty rows.
-    tb = tb.dropna().reset_index(drop=True)
-
     # Ensure all columns are snake-case, set an appropriate index and sort conveniently.
     tb = tb.underscore().set_index(["measure_names", "year"], verify_integrity=True).sort_index()
 

--- a/etl/steps/data/meadow/war/2024-01-09/status_of_world_nuclear_forces.py
+++ b/etl/steps/data/meadow/war/2024-01-09/status_of_world_nuclear_forces.py
@@ -1,0 +1,30 @@
+"""Load a snapshot and create a meadow dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Retrieve snapshot.
+    snap = paths.load_snapshot("status_of_world_nuclear_forces.csv")
+
+    # Load data from snapshot.
+    tb = snap.read(na_values="n.a.")
+
+    #
+    # Process data.
+    #
+    # Ensure all columns are snake-case, set an appropriate index and sort conveniently.
+    tb = tb.underscore().set_index(["country", "year"], verify_integrity=True).sort_index()
+
+    #
+    # Save outputs.
+    #
+    # Create a new meadow dataset with the same metadata as the snapshot.
+    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_meadow.save()

--- a/snapshots/war/2024-01-09/nuclear_weapons_inventories.csv.dvc
+++ b/snapshots/war/2024-01-09/nuclear_weapons_inventories.csv.dvc
@@ -1,0 +1,29 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/origin/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Estimated Global Nuclear Warhead Inventories
+    description: |-
+      This dataset provides information on the number of stockpiled nuclear warheads by the nuclear powers.
+    date_published: 2023-03-28
+
+    # Citation
+    producer: Federation of American Scientists
+    citation_full: |-
+      Hans M. Kristensen, Matt Korda, Robert S. Norris, and Eliana Reynolds, Federation of American Scientists - Estimated Global Nuclear Warhead Inventories (2023).
+    attribution_short: FAS
+
+    # Files
+    url_main: https://fas.org/initiative/status-world-nuclear-forces/
+    date_accessed: 2024-01-09
+
+    # License
+    license:
+      name: CC BY 4.0
+
+wdir: ../../../data/snapshots/war/2024-01-09
+outs:
+- md5: e923102a89e7bebaf65056df3f6f8521
+  size: 28942
+  path: nuclear_weapons_inventories.csv

--- a/snapshots/war/2024-01-09/nuclear_weapons_inventories.py
+++ b/snapshots/war/2024-01-09/nuclear_weapons_inventories.py
@@ -1,0 +1,35 @@
+"""Script to create a snapshot of dataset.
+
+The data needs to be manually downloaded from a Tableau dashboard:
+1. Open an incognito window (to avoid Tableau from changing the default language of the data columns).
+2. Go to: https://public.tableau.com/app/profile/kate.kohn/viz/EstimatedGlobalNuclearWarheadInventories1945-2021/Dashboard1
+3. Click on the "Download" button on the upper right corner of the dashboard.
+4. Select "Data" on the small pop-up window.
+5. A new window will open. Click on the "Download" button on the upper right corner of the window.
+6. Run this script using the --path-to-file argument followed by the path to the downloaded file.
+
+"""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+# Version for current snapshot dataset.
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+
+@click.command()
+@click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
+@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+def main(path_to_file: str, upload: bool) -> None:
+    # Create a new snapshot.
+    snap = Snapshot(f"war/{SNAPSHOT_VERSION}/nuclear_weapons_inventories.csv")
+
+    # Copy local data file to snapshots data folder, add file to DVC and upload to S3.
+    snap.create_snapshot(filename=path_to_file, upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/war/2024-01-09/status_of_world_nuclear_forces.csv.dvc
+++ b/snapshots/war/2024-01-09/status_of_world_nuclear_forces.csv.dvc
@@ -1,0 +1,29 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/origin/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Status Of World Nuclear Forces
+    description: |-
+      This dataset provides information on the number of nuclear warheads owned by the nuclear powers, as well as their status (e.g. retired, non-deployed, etc.).
+    date_published: 2023-03-28
+
+    # Citation
+    producer: Federation of American Scientists
+    citation_full: |-
+      Hans M. Kristensen, Matt Korda, and Eliana Reynolds, Federation of American Scientists - Estimated Global Nuclear Warhead Inventories (2023).
+    attribution_short: FAS
+
+    # Files
+    url_main: https://fas.org/initiative/status-world-nuclear-forces/
+    date_accessed: 2024-01-09
+
+    # License
+    license:
+      name: CC BY 4.0
+
+wdir: ../../../data/snapshots/war/2024-01-09
+outs:
+- md5: 4aa98b8ff827d069f01e57b074aaf92d
+  size: 486
+  path: status_of_world_nuclear_forces.csv

--- a/snapshots/war/2024-01-09/status_of_world_nuclear_forces.csv.dvc
+++ b/snapshots/war/2024-01-09/status_of_world_nuclear_forces.csv.dvc
@@ -5,7 +5,7 @@ meta:
     # Data product / Snapshot
     title: Status Of World Nuclear Forces
     description: |-
-      This dataset provides information on the number of nuclear warheads owned by the nuclear powers, as well as their status (e.g. retired, non-deployed, etc.).
+      This dataset provides information on the number of nuclear warheads owned by the nuclear powers, as well as their status (e.g. whether or not they are deployed, nondeployed, or retired).
     date_published: 2023-03-28
 
     # Citation

--- a/snapshots/war/2024-01-09/status_of_world_nuclear_forces.py
+++ b/snapshots/war/2024-01-09/status_of_world_nuclear_forces.py
@@ -1,0 +1,74 @@
+"""Script to create a snapshot of dataset.
+
+The data needs to be manually extracted from the website.
+
+"""
+
+import re
+from pathlib import Path
+
+import click
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+from etl.snapshot import Snapshot
+
+# Version for current snapshot dataset.
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+
+@click.command()
+@click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
+def main(upload: bool) -> None:
+    # Create a new snapshot.
+    snap = Snapshot(f"war/{SNAPSHOT_VERSION}/status_of_world_nuclear_forces.csv")
+
+    # Request HTML content from website.
+    response = requests.get(snap.metadata.origin.url_main)  # type: ignore
+
+    # Parse HTML content.
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    # Extract the title of the table.
+    title = soup.find("div", class_="data-embed__title").get_text(strip=True)  # type: ignore
+
+    # Extract the year from the title.
+    year = int(re.findall("\d{4}", title)[0])  # type: ignore
+
+    # Find the relevant table by its class.
+    table = soup.find("div", class_="data-embed__embed data-embed__embed--scroll")
+
+    # Initialize a list to hold all rows of data.
+    table_data = []
+    # Iterate over all rows in the table and gather data.
+    for row in table.find_all("tr"):  # type: ignore
+        row_data = [cell.get_text(strip=True) for cell in row.find_all("td")]
+        # Add the row data to the table data list
+        table_data.append(row_data)
+
+    # Create a dataframe with the extracted data.
+    df = pd.DataFrame(
+        table_data,
+        columns=[
+            "COUNTRY",
+            "DEPLOYED STRATEGIC",
+            "DEPLOYED NONSTRATEGIC",
+            "RESERVE/NONDEPLOYED",
+            "MILITARY STOCKPILE(A)",
+            "TOTAL INV",
+        ],
+    )
+
+    # Remove empty rows.
+    df = df.dropna().reset_index(drop=True)
+
+    # Add year to table.
+    df["year"] = year
+
+    # Copy data to snapshots data folder, add file to DVC and upload to S3.
+    snap.create_snapshot(data=df, upload=upload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add data from [the Federation of American Scientists](https://fas.org/initiative/status-world-nuclear-forces/), on stockpiles of nuclear weapons over time, and on 2023 inventories.
- [Old dataset](https://owid.cloud/admin/datasets/6203) -> [New dataset](http://staging-site-add-nuclear-warhead-inventories-data/admin/datasets/6347) (2 charts).
- [Old dataset](https://owid.cloud/admin/datasets/6204) -> [New dataset](http://staging-site-add-nuclear-warhead-inventories-data/admin/datasets/6346) (1 chart). Here, the old dataset used to have data for 2022 and 2023, whereas the new one only has data for 2023. This is because the 2022 data has been removed from their page. We will consider fetching it from somewhere else, if there is time (in a separate PR).
