### PR TITLE
:tada: streamlit app for etl-staging-sync

### DIFF
--- a/apps/staging_sync/app.py
+++ b/apps/staging_sync/app.py
@@ -1,0 +1,132 @@
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import streamlit as st
+import streamlit.components.v1 as components
+from git.exc import GitCommandError
+from git.repo import Repo
+from rich.ansi import AnsiDecoder
+from rich.console import Console
+from rich.terminal_theme import MONOKAI
+
+from etl.paths import BASE_DIR
+
+CURRENT_DIR = Path(__file__).resolve().parent
+
+
+def main():
+    st.title("etl-staging-sync")
+    st.markdown(
+        """
+    Sync charts and revisions from staging server to production.
+    """
+    )
+
+    # SIDEBAR
+    with st.sidebar:
+        with open(CURRENT_DIR / "instructions.md", "r") as f:
+            st.markdown(f.read())
+
+    st.markdown("### Config")
+    source = st.text_input(
+        "Source",
+        placeholder="my-branch",
+        help="Name of the branch to sync from (with existing `staging-site-mybranch` server).",
+    )
+    target = st.text_input("Target", value="live", help="Using `live` uses DB from local `.env` file as target.")
+    publish = st.checkbox(
+        "Automatically publish new charts", value=False, help="Otherwise you'd have to publish new charts manually."
+    )
+    approve_revisions = st.checkbox(
+        "Automatically approve chart revisions for edited charts",
+        value=False,
+        help=" This still creates a chart revision if the target chart has been modified.",
+    )
+    dry_run = st.checkbox("Dry run", value=True)
+
+    # Live uses `.env` file which points to the live database in production
+    if target == "live":
+        target = ".env"
+
+    # Button to show text
+    if st.button("Sync charts", help="This can take a while."):
+        if not _is_valid_config(source, target):
+            return
+
+        # Open the local repository
+        repo = Repo(BASE_DIR)
+
+        # Fetch the specific branch from the remote
+        try:
+            repo.git.fetch("origin", source)
+        except GitCommandError:
+            st.error(f"Branch {source} not found in owid/etl repository.")
+            sys.exit(1)
+
+        cmd = ["poetry", "run", "etl-staging-sync", source, "master"]
+        if dry_run:
+            cmd.append("--dry-run")
+        if publish:
+            cmd.append("--publish")
+        if approve_revisions:
+            cmd.append("--approve-revisions")
+
+        _run_command(cmd)
+
+
+def _is_valid_config(source: str, target: str) -> bool:
+    if source.strip() == "":
+        st.warning("Please enter a valid source.")
+        return False
+    if target.strip() == "":
+        st.warning("Please enter a valid target.")
+        return False
+    return True
+
+
+def _run_command(cmd: list[str]):
+    console = Console(record=True)
+
+    # Run bash command
+    my_env = os.environ.copy()
+    my_env["FORCE_COLOR"] = "1"
+    result = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=my_env)
+    stdout, stderr = result.communicate()
+
+    stdout = stdout.decode()
+    stderr = stderr.decode()
+
+    if stderr:
+        st.markdown("### Error")
+        st.error(stderr)
+
+    stdout = _strip_log_timestamps(stdout)
+
+    decoder = AnsiDecoder()
+
+    n_lines = 0
+    for line in decoder.decode(stdout):
+        n_lines += 1
+        console.print(line, soft_wrap=True)
+
+    html = console.export_html(inline_styles=True, theme=MONOKAI)
+
+    st.markdown("### Output")
+    # st.markdown(f"`{' '.join(cmd)}`")
+    components.html(html, scrolling=True, height=n_lines * 21)
+
+
+def _strip_log_timestamps(stdout: str) -> str:
+    pattern = r"\x1b\[\dm\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\x1b\[0m "
+    return re.sub(pattern, "", stdout)
+
+
+def cli():
+    subprocess.run(["streamlit", "run", f"{CURRENT_DIR}/app.py"])
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/staging_sync/instructions.md
+++ b/apps/staging_sync/instructions.md
@@ -1,0 +1,28 @@
+# Instructions
+
+1. Merge your ETL branch to master and wait for the ETL to rebuild your dataset.
+2. Fill `Config` section and tick `Dry run` first to see what charts will be updated and hit `Sync charts`.
+3. Check the output, look for warnings that might indicate unexpected changes to charts in production.
+4. Untick `Dry run` and hit `Sync charts` again to apply changes to production.
+5. New charts were created as drafts, make sure to **publish them in production**.
+6. Chart updates were added as chart revisions, you still have to manually approve them.
+
+
+# Notes
+
+Staging servers are **destroyed 3 days after merging to master**, so this app should be
+run before that, but after the dataset has been built by ETL in production.
+
+
+## Charts:
+- Only **published charts** from staging are synced.
+- New charts are synced as **drafts** in target (unless you set the checkbox).
+- Existing charts (with the same slug) are added as chart revisions in target (unless you set the checkbox).
+- You get a warning if the chart **has been modified on live** after staging server was created.
+- Deleted charts are **not synced**.
+
+## Chart revisions:
+- Approved chart revisions on staging are automatically applied in target, assuming the chart has not been modified.
+
+## Tags:
+- Tags are synced only for **new charts**, any edits to tags in existing charts are ignored.

--- a/apps/staging_sync/instructions.md
+++ b/apps/staging_sync/instructions.md
@@ -2,27 +2,27 @@
 
 1. Merge your ETL branch to master and wait for the ETL to rebuild your dataset.
 2. Fill `Config` section and tick `Dry run` first to see what charts will be updated and hit `Sync charts`.
-3. Check the output, look for warnings that might indicate unexpected changes to charts in production.
-4. Untick `Dry run` and hit `Sync charts` again to apply changes to production.
-5. New charts were created as drafts, make sure to **publish them in production**.
+3. Check the output, look for warnings that might indicate unexpected changes to charts in target server.
+4. Untick `Dry run` and hit `Sync charts` again to apply changes to target.
+5. New charts were created as drafts, make sure to **publish them in target**.
 6. Chart updates were added as chart revisions, you still have to manually approve them.
 
 
 # Notes
 
 Staging servers are **destroyed 3 days after merging to master**, so this app should be
-run before that, but after the dataset has been built by ETL in production.
+run before that, but after the dataset has been built by ETL.
 
 
 ## Charts:
-- Only **published charts** from staging are synced.
+- Only **published charts** from source are synced.
 - New charts are synced as **drafts** in target (unless you set the checkbox).
 - Existing charts (with the same slug) are added as chart revisions in target (unless you set the checkbox).
-- You get a warning if the chart **has been modified on live** after staging server was created.
+- You get a warning if the chart **has been modified in target** after source server was created.
 - Deleted charts are **not synced**.
 
 ## Chart revisions:
-- Approved chart revisions on staging are automatically applied in target, assuming the chart has not been modified.
+- Approved chart revisions in source are automatically applied in target, assuming the chart has not been modified.
 
 ## Tags:
-- Tags are synced only for **new charts**, any edits to tags in existing charts are ignored.
+- Tags are synced only for **new charts** in the source server, any edits to tags in existing charts are ignored.

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -1,0 +1,46 @@
+import os
+import re
+import subprocess
+
+import streamlit as st
+import streamlit.components.v1 as components
+from rich.ansi import AnsiDecoder
+from rich.console import Console
+from rich.terminal_theme import MONOKAI
+
+
+def run_command(cmd: list[str]):
+    """Run a bash command with `subprocess.Popen` and show the output in a streamlit component."""
+    console = Console(record=True)
+
+    # Run bash command
+    my_env = os.environ.copy()
+    my_env["FORCE_COLOR"] = "1"
+    result = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=my_env)
+    stdout, stderr = result.communicate()
+
+    stdout = stdout.decode()
+    stderr = stderr.decode()
+
+    if stderr:
+        st.markdown("### Error")
+        st.error(stderr)
+
+    stdout = _strip_log_timestamps(stdout)
+
+    decoder = AnsiDecoder()
+
+    n_lines = 0
+    for line in decoder.decode(stdout):
+        n_lines += 1
+        console.print(line, soft_wrap=True)
+
+    html = console.export_html(inline_styles=True, theme=MONOKAI)
+
+    st.markdown("### Output")
+    components.html(html, scrolling=True, height=n_lines * 21)
+
+
+def _strip_log_timestamps(stdout: str) -> str:
+    pattern = r"\x1b\[\dm\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\x1b\[0m "
+    return re.sub(pattern, "", stdout)

--- a/apps/wizard/app.py
+++ b/apps/wizard/app.py
@@ -28,6 +28,7 @@ show_pages(
         Page(str(CURRENT_DIR / "charts/__main__.py"), "Charts", icon="📊"),
         Page(str(CURRENT_DIR / "metagpt.py"), "MetaGPT", icon="🤖"),
         Page(str(CURRENT_DIR / "dataset_explorer.py"), "Dataset Explorer", icon="🕵️"),
+        Page(str(CURRENT_DIR / "../staging_sync/app.py"), "Staging sync", icon="🔄"),
     ]
 )
 

--- a/apps/wizard/home.py
+++ b/apps/wizard/home.py
@@ -92,6 +92,11 @@ pages = [
         "image": "https://cdn.pixabay.com/photo/2017/08/30/01/05/milky-way-2695569_1280.jpg",
         "key": "D",
     },
+    {
+        "title": "Staging Sync",
+        "image": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Font_Awesome_5_solid_sync-alt.svg/640px-Font_Awesome_5_solid_sync-alt.svg.png",
+        "key": "S",
+    },
 ]
 columns = st.columns(len(pages))
 # keys = "qwertasdfgzxcvb".upper()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ etl-chartgpt = 'etl.chart_revision.v2.chartgpt:cli'
 etl-metaplay = 'apps.metadata_playground.cli:cli'
 etl-wizard = 'apps.wizard.cli:cli'
 etl-staging-sync = 'apps.staging_sync.cli:cli'
+etl-staging-sync-app = 'apps.staging_sync.app:cli'
 etl-metagpt = 'apps.metagpt.cli:main'
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
UI for command `etl-staging-sync` for migrating charts from staging servers to production. 

It will be run on `owid@etl-prod-2` together with fast-track (on a different port), and there'll be a link to it from admin.

The current version needs **active staging server** to sync charts from there, and the branch **must be merged in ETL**. I've increased the time for killing staging servers from 1 day to **3 days after merging**.

Last time, we talked about snapshotting the staging server somewhere so that we can kill the server right away and reconstruct updated charts from the snapshot. I gave it a try, and it turned out to be unnecessarily complicated. Moreover, having an active staging server when syncing charts could be useful (e.g. if you realise you still have to make some chart edits there or if you find that the chart has been updated on live and you want to make the same changes on your staging before syncing the chart).

The streamlit app is very basic, though one think that's pretty cool is `_run_command` that runs a CLI command and shows its output (with colours!) as HTML in the app.

I haven't used streamlit for a while, so any tips are welcome!

## How to test it

1. `poetry install`
2. `etl-staging-sync-app`
3. Use source `gho` and target `etl-staging-sync-app` (I've updated two charts)
4. Follow instructions (feel free to do anything to both staging servers)