### PR TITLE
Add short attribution to Global Carbon Budget

### DIFF
--- a/etl/steps/data/garden/gcp/2023-12-12/global_carbon_budget.meta.yml
+++ b/etl/steps/data/garden/gcp/2023-12-12/global_carbon_budget.meta.yml
@@ -27,6 +27,7 @@ definitions:
     presentation:
       topic_tags:
       - CO2 & Greenhouse Gas Emissions
+      attribution_short: GCB
     processing_level: major
 
 dataset:

--- a/snapshots/gcp/2023-12-12/global_carbon_budget.py
+++ b/snapshots/gcp/2023-12-12/global_carbon_budget.py
@@ -27,6 +27,7 @@ DATA_FILES = [
 
 # Define common metadata fields (to be written to dvc files).
 ATTRIBUTION = "Global Carbon Budget (2023)"
+ATTRIBUTION_SHORT = "GCB"
 CITATION_FULL = """Andrew, R. M., & Peters, G. P. (2023). The Global Carbon Project's fossil CO2 emissions dataset (2023v36) [Data set]. Zenodo. https://doi.org/10.5281/zenodo.10177738
 
 The data files of the Global Carbon Budget can be found at: https://globalcarbonbudget.org/carbonbudget/
@@ -53,6 +54,7 @@ def main(upload: bool) -> None:
 
         # Replace the full citation and description in the metadata.
         snap.metadata.origin.attribution = ATTRIBUTION  # type: ignore
+        snap.metadata.origin.attribution_short = ATTRIBUTION_SHORT # type: ignore
         snap.metadata.origin.citation_full = CITATION_FULL  # type: ignore
         snap.metadata.origin.description = DESCRIPTION  # type: ignore
 

--- a/snapshots/gcp/2023-12-12/global_carbon_budget.py
+++ b/snapshots/gcp/2023-12-12/global_carbon_budget.py
@@ -54,7 +54,7 @@ def main(upload: bool) -> None:
 
         # Replace the full citation and description in the metadata.
         snap.metadata.origin.attribution = ATTRIBUTION  # type: ignore
-        snap.metadata.origin.attribution_short = ATTRIBUTION_SHORT # type: ignore
+        snap.metadata.origin.attribution_short = ATTRIBUTION_SHORT  # type: ignore
         snap.metadata.origin.citation_full = CITATION_FULL  # type: ignore
         snap.metadata.origin.description = DESCRIPTION  # type: ignore
 

--- a/snapshots/gcp/2023-12-12/global_carbon_budget_fossil_co2_emissions.csv.dvc
+++ b/snapshots/gcp/2023-12-12/global_carbon_budget_fossil_co2_emissions.csv.dvc
@@ -58,6 +58,7 @@ meta:
       2023, Earth Syst. Sci. Data, 15, 5301-5369, https://doi.org/10.5194/essd-15-5301-2023,
       2023.
     attribution: Global Carbon Budget (2023)
+    attribution_short: GCB
     url_main: https://globalcarbonbudget.org/
     url_download: https://zenodo.org/records/10177738/files/GCB2023v36_MtCO2_flat.csv
     date_accessed: '2023-12-12'

--- a/snapshots/gcp/2023-12-12/global_carbon_budget_global_emissions.xlsx.dvc
+++ b/snapshots/gcp/2023-12-12/global_carbon_budget_global_emissions.xlsx.dvc
@@ -58,6 +58,7 @@ meta:
       2023, Earth Syst. Sci. Data, 15, 5301-5369, https://doi.org/10.5194/essd-15-5301-2023,
       2023.
     attribution: Global Carbon Budget (2023)
+    attribution_short: GCB
     url_main: https://globalcarbonbudget.org/
     url_download: 
       https://globalcarbonbudgetdata.org/downloads/latest-data/Global_Carbon_Budget_2023v1.0.xlsx

--- a/snapshots/gcp/2023-12-12/global_carbon_budget_land_use_change_emissions.xlsx.dvc
+++ b/snapshots/gcp/2023-12-12/global_carbon_budget_land_use_change_emissions.xlsx.dvc
@@ -58,6 +58,7 @@ meta:
       2023, Earth Syst. Sci. Data, 15, 5301-5369, https://doi.org/10.5194/essd-15-5301-2023,
       2023.
     attribution: Global Carbon Budget (2023)
+    attribution_short: GCB
     url_main: https://globalcarbonbudget.org/
     url_download: 
       https://globalcarbonbudgetdata.org/downloads/latest-data/National_LandUseChange_Carbon_Emissions_2023v1.0.xlsx

--- a/snapshots/gcp/2023-12-12/global_carbon_budget_national_emissions.xlsx.dvc
+++ b/snapshots/gcp/2023-12-12/global_carbon_budget_national_emissions.xlsx.dvc
@@ -58,6 +58,7 @@ meta:
       2023, Earth Syst. Sci. Data, 15, 5301-5369, https://doi.org/10.5194/essd-15-5301-2023,
       2023.
     attribution: Global Carbon Budget (2023)
+    attribution_short: GCB
     url_main: https://globalcarbonbudget.org/
     url_download: 
       https://globalcarbonbudgetdata.org/downloads/latest-data/National_Fossil_Carbon_Emissions_2023v1.0.xlsx


### PR DESCRIPTION
Add short attribution to Global Carbon Budget (as suggested by @JoeHasell in [this slack conversation](https://owid.slack.com/archives/C0193RW5E2J/p1705406898711349)).
