### PR TITLE
:bug: bump expected year in XM checks

### DIFF
--- a/etl/steps/data/garden/excess_mortality/latest/wmd.py
+++ b/etl/steps/data/garden/excess_mortality/latest/wmd.py
@@ -15,7 +15,7 @@ log = get_logger()
 paths = PathFinder(__file__)
 # Minimum and maximum years expected in data
 YEAR_MIN_EXPECTED = 2015
-YEAR_MAX_EXPECTED = 2023
+YEAR_MAX_EXPECTED = 2024
 
 
 def run(dest_dir: str) -> None:


### PR DESCRIPTION
We have hardcoded the year 2023 in excess mortality datasets. Change it to the current year.