### PR TITLE
Improve calculation of the share of electricity in primary energy

### DIFF
--- a/etl/steps/data/garden/energy/2023-12-12/electricity_mix.py
+++ b/etl/steps/data/garden/energy/2023-12-12/electricity_mix.py
@@ -24,6 +24,10 @@ TWH_TO_KWH = 1e9
 # Megatonnes to grams.
 MT_TO_G = 1e12
 
+# Constant efficiency factor assumed by the Energy Institute Statistical Review, used to transform electricity
+# generation into input-equivalent primary energy consumption.
+BIOMASS_EFFICIENCY_FACTOR = 0.32
+
 
 def process_statistical_review_data(tb_review: Table) -> Table:
     """Load necessary columns from EI's Statistical Review dataset, and create some new variables (e.g. electricity
@@ -269,7 +273,7 @@ def add_share_variables(combined: Table) -> Table:
                 )
                 / combined["efficiency_factor"]
             )
-            + (combined["bioenergy_generation__twh"].fillna(0) / 0.32)
+            + (combined["bioenergy_generation__twh"].fillna(0) / BIOMASS_EFFICIENCY_FACTOR)
             + (combined["fossil_generation__twh"])
         )
         / combined["primary_energy_consumption__twh"]


### PR DESCRIPTION
We currently calculate the share of electricity in primary energy consumption (shown in [this chart](https://ourworldindata.org/grapher/electricity-as-a-share-of-primary-energy)) as simply dividing the total electricity generation by primary energy consumption.
However, primary energy consumption (from the Statistical Review of World Energy) is defined in "input-equivalents" (what we usually call [the substitution method](https://ourworldindata.org/energy-substitution-method)). This means that non-fossil electricity sources (nuclear, hydro, solar, wind, bioenergy and other renewables) are inflated to mimic the inefficiencies of fossil fuels. To achieve that, the Statistical Review divides the electricity generation of non-fossil sources by an efficiency factor (which is roughly between 0.3 and 0.5).

Therefore, currently, our share of electricity in primary energy is underestimated. We claim in the subtitle that we use the substitution method, but we only do this in the denominator, not in the numerator.

This PR does the calculation of the share of electricity in primary energy properly:
100 * (((electricity generated by non-fossil sources) / efficiency factor) + (electricity generated by fossil fuels) ) / (primary energy consumption)

An alternative would be to estimate the direct primary energy consumption (not using the substitution method), and then simply divide total generation by direct primary energy consumption. This is also possible, but since we use the substitution method in most charts showing primary energy, it makes sense to use it here too.

To clarify, [the affected chart](https://ourworldindata.org/grapher/electricity-as-a-share-of-primary-energy) (also included in [the energy explorer](https://ourworldindata.org/explorers/energy?facet=none&country=USA~GBR~CHN~OWID_WRL~IND~BRA~ZAF&Total+or+Breakdown=Total&Energy+or+Electricity=Electricity+only&Metric=Share+of+total)) will barely be affected for countries that rely mostly on fossil fuels. But for countries that have a big share of renewables and nuclear, the change can be significant. One of the most significant examples is Norway. Here's the comparison of the old (currently in production) and new (this PR) indicator:
![newplot](https://github.com/owid/etl/assets/12246978/0b492bf2-423a-4fb7-8149-c3bd1a130460)
And the missing points in the new curve happen because we don't have electricity generation disaggregated by source for all countries and years (for which we do have total electricity generation and primary energy consumption).