### PR TITLE
🐛 wizard charts: fix and improve experience with same-dataset-updates

### DIFF
--- a/apps/wizard/charts/search_config.py
+++ b/apps/wizard/charts/search_config.py
@@ -35,7 +35,11 @@ def build_dataset_form(df: pd.DataFrame, similarity_names: Dict[str, Any]) -> "S
     col0, _, _ = st.columns(3)
     with col0:
         with st.expander("Parameters"):
-            map_identical = st.checkbox("Map identically named variables", value=True)
+            map_identical = st.checkbox(
+                "Map identically named variables",
+                value=True,
+                help="Map variables with the same name in the old and new datasets. \n\n**NOTE:** This is option is DISABLED when working with the same dataset (i.e. old dataset and new dataset are the same) and can't be changed via this checkbox.",
+            )
             enable_explore = st.checkbox(
                 "Explore variable mappings (Experimental)",
                 help="Compare the variable mappings with tables and charts. This might take some time initially, as we need to download data values from S3",

--- a/apps/wizard/charts/utils.py
+++ b/apps/wizard/charts/utils.py
@@ -42,17 +42,20 @@ def get_schema() -> Dict[str, Any]:
             return schema
 
 
-def get_variables_from_datasets(dataset_id_1: int, dataset_id_2: int) -> Tuple[pd.DataFrame, pd.DataFrame]:
+def get_variables_from_datasets(
+    dataset_id_1: int, dataset_id_2: int, show_new_not_in_old: int = False
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Get variables from two datasets."""
     with get_connection() as db_conn:
         # Get variables from old dataset that have been used in at least one chart.
         old_variables = get_variables_in_dataset(db_conn=db_conn, dataset_id=dataset_id_1, only_used_in_charts=True)
         # Get all variables from new dataset.
         new_variables = get_variables_in_dataset(db_conn=db_conn, dataset_id=dataset_id_2, only_used_in_charts=False)
-        # Remove new variables that are in the old dataset. This can happen if we're matching a dataset to itself
-        # in case of renaming variables.
-        new_variables = new_variables[~new_variables["id"].isin(old_variables["id"])]
-
+        if show_new_not_in_old:
+            # Unsure why this was done, but it seems to be wrong.
+            # Remove variables in the new dataset that are not in the old dataset.
+            # This can happen if we are matching a dataset to itself in case of renaming variables.
+            new_variables = new_variables[~new_variables["id"].isin(old_variables["id"])]
     return old_variables, new_variables
 
 


### PR DESCRIPTION
There were minor issues when updating indicators from the same dataset (i.e. having `old dataset = new dataset`).

Pablo surfaced this in https://github.com/owid/etl/issues/1563#issuecomment-1903700162.

**Some fixes/improvements include**:

- **Mapping identically named variables**
  - By default, indicators with the same name were mapped automatically (with no edits allowed by the user) if there was a 100% name match. This option can be tweaked by the parameter "Mapped identically named variables". This flexible parameter is useful when old and new datasets differ. However, in this case, we prefer the default behaviour to be that no automatic mapping is done to allow for "variable migrations" (migrating a variable to a new one, which does not necessarily have the same name).
![image](https://github.com/owid/etl/assets/18101289/9b264b06-7721-423e-9dab-3242b0772444)
  - Added a help text to explain this option better to the user.
- Bug: a minor bug would give a variable in the new dataset a higher score than another with the same name as the old variable. For a certain variable, even if there is a variable with the same name in the new dataset, it wouldn't be suggested as the top mapping. This is now fixed.