### PR TITLE
Fix calculation of the share of electricity in primary energy

### DIFF
--- a/etl/steps/data/garden/energy/2023-12-12/electricity_mix.meta.yml
+++ b/etl/steps/data/garden/energy/2023-12-12/electricity_mix.meta.yml
@@ -12,10 +12,6 @@ definitions:
     Measured as a percentage of total electricity.
   description_short_per_capita: &description_short_per_capita |-
     Measured in kilowatt-hours per person.
-  description_short_primary_energy: &description_short_primary_energy |-
-    Measured in terawatt-hours, using the substitution method.
-  description_short_direct_primary_energy: &description_short_direct_primary_energy |-
-    Measured in terawatt-hours.
   description_processing_direct_primary_energy: |-
     - The Statistical Review of World Energy only provides data on input-equivalent primary energy consumption, not on direct primary energy consumption. We estimate the direct primary energy consumption as the sum of the primary energy consumption from coal, oil, gas, and biofuels, together with the electricity generation from low-carbon sources (nuclear, hydro, wind, solar, bioenergy and other renewables). Finally, the share of electricity in direct primary energy consumption is calculated as the ratio of total electricity generation to direct primary energy consumption (multiplied by 100).
 
@@ -384,7 +380,7 @@ tables:
         title: Primary energy consumption - TWh
         short_unit: TWh
         unit: terawatt-hours
-        description_short: *description_short_primary_energy
+        description_short: Measured in terawatt-hours, using the substitution method.
         display:
           name: Primary energy consumption
         presentation:
@@ -393,7 +389,7 @@ tables:
         title: Direct primary energy consumption - TWh
         short_unit: TWh
         unit: terawatt-hours
-        description_short: *description_short_direct_primary_energy
+        description_short: Measured in terawatt-hours.
         description_processing: |-
           {definitions.common.description_processing}
           {definitions.description_processing_direct_primary_energy}

--- a/etl/steps/data/garden/energy/2023-12-12/electricity_mix.meta.yml
+++ b/etl/steps/data/garden/energy/2023-12-12/electricity_mix.meta.yml
@@ -5,13 +5,19 @@ definitions:
       topic_tags:
         - "Energy"
     description_processing: |-
-      We rely on Ember as the primary source of electricity consumption data. While the Energy Institute (EI) provides primary energy (not just electricity) consumption data and it provides a longer time-series (dating back to 1965) than Ember (which only dates back to 1990), EI does not provide data for all countries or for all sources of electricity (for example, only Ember provides data on electricity from bioenergy). So, where data from Ember is available for a given country and year, we rely on it as the primary source. We then supplement this with data from EI where data from Ember is not available.
+      - We rely on Ember as the primary source of electricity consumption data. While the Energy Institute (EI) provides primary energy (not just electricity) consumption data and it provides a longer time-series (dating back to 1965) than Ember (which only dates back to 1990), EI does not provide data for all countries or for all sources of electricity (for example, only Ember provides data on electricity from bioenergy). So, where data from Ember is available for a given country and year, we rely on it as the primary source. We then supplement this with data from EI where data from Ember is not available.
   description_short_twh: &description_short_twh |-
     Measured in terawatt-hours.
   description_short_pct: &description_short_pct |-
     Measured as a percentage of total electricity.
   description_short_per_capita: &description_short_per_capita |-
     Measured in kilowatt-hours per person.
+  description_short_primary_energy: &description_short_primary_energy |-
+    Measured in terawatt-hours, using the substitution method.
+  description_short_direct_primary_energy: &description_short_direct_primary_energy |-
+    Measured in terawatt-hours.
+  description_processing_direct_primary_energy: |-
+    - The Statistical Review of World Energy only provides data on input-equivalent primary energy consumption, not on direct primary energy consumption. We estimate the direct primary energy consumption as the sum of the primary energy consumption from coal, oil, gas, and biofuels, together with the electricity generation from low-carbon sources (nuclear, hydro, wind, solar, bioenergy and other renewables). Finally, the share of electricity in direct primary energy consumption is calculated as the ratio of total electricity generation to direct primary energy consumption (multiplied by 100).
 
 dataset:
   update_period_days: 365
@@ -375,14 +381,26 @@ tables:
         presentation:
           title_public: Population
       primary_energy_consumption__twh:
-        title: Electricity from primary energy consumption - TWh
+        title: Primary energy consumption - TWh
         short_unit: TWh
         unit: terawatt-hours
-        description_short: *description_short_twh
+        description_short: *description_short_primary_energy
         display:
           name: Primary energy consumption
         presentation:
           title_public: Primary energy consumption
+      direct_primary_energy_consumption__twh:
+        title: Direct primary energy consumption - TWh
+        short_unit: TWh
+        unit: terawatt-hours
+        description_short: *description_short_direct_primary_energy
+        description_processing: |-
+          {definitions.common.description_processing}
+          {definitions.description_processing_direct_primary_energy}
+        display:
+          name: Direct primary energy consumption
+        presentation:
+          title_public: Direct primary energy consumption
       renewable_generation__twh:
         title: Electricity from renewables - TWh
         short_unit: TWh
@@ -448,14 +466,17 @@ tables:
         presentation:
           title_public: Electricity demand
       total_electricity_share_of_primary_energy__pct:
-        title: Electricity as share of primary energy - %
+        title: Electricity as share of direct primary energy consumption - %
         short_unit: '%'
         unit: '%'
-        description_short: Measured as a percentage of total primary energy consumption.
+        # description_short: Measured as a percentage of total direct primary energy consumption.
+        description_processing: |-
+          {definitions.common.description_processing}
+          {definitions.description_processing_direct_primary_energy}
         display:
           name: Electricity
         presentation:
-          title_public: Total electricity as share of primary energy
+          title_public: Total electricity generation as share of direct primary energy consumption
       total_emissions__mtco2:
         title: Emissions - MtCO2
         short_unit: Mt

--- a/etl/steps/data/garden/energy/2023-12-12/electricity_mix.meta.yml
+++ b/etl/steps/data/garden/energy/2023-12-12/electricity_mix.meta.yml
@@ -465,14 +465,14 @@ tables:
         title: Electricity as share of direct primary energy consumption - %
         short_unit: '%'
         unit: '%'
-        # description_short: Measured as a percentage of total direct primary energy consumption.
+        description_short: Measured as a percentage of total, direct primary energy consumption.
         description_processing: |-
           {definitions.common.description_processing}
           {definitions.description_processing_direct_primary_energy}
         display:
           name: Electricity
         presentation:
-          title_public: Total electricity generation as share of direct primary energy consumption
+          title_public: Total electricity generation as share of primary energy
       total_emissions__mtco2:
         title: Emissions - MtCO2
         short_unit: Mt

--- a/etl/steps/data/garden/energy/2023-12-12/electricity_mix.meta.yml
+++ b/etl/steps/data/garden/energy/2023-12-12/electricity_mix.meta.yml
@@ -13,7 +13,7 @@ definitions:
   description_short_per_capita: &description_short_per_capita |-
     Measured in kilowatt-hours per person.
   description_processing_direct_primary_energy: |-
-    - The Statistical Review of World Energy only provides data on input-equivalent primary energy consumption, not on direct primary energy consumption. We estimate the direct primary energy consumption as the sum of the primary energy consumption from coal, oil, gas, and biofuels, together with the electricity generation from low-carbon sources (nuclear, hydro, wind, solar, bioenergy and other renewables). Finally, the share of electricity in direct primary energy consumption is calculated as the ratio of total electricity generation to direct primary energy consumption (multiplied by 100).
+    - The Statistical Review of World Energy only provides data on input-equivalent primary energy consumption, not on direct primary energy consumption. We estimate the direct primary energy consumption as the sum of the primary energy consumption from coal, oil, gas, and biofuels, plus the electricity generation from low-carbon sources (nuclear, hydro, wind, solar, bioenergy and other renewables). Finally, the share of electricity in direct primary energy consumption is calculated as the ratio of total electricity generation to direct primary energy consumption (multiplied by 100).
 
 dataset:
   update_period_days: 365

--- a/etl/steps/data/garden/energy/2023-12-12/electricity_mix.py
+++ b/etl/steps/data/garden/energy/2023-12-12/electricity_mix.py
@@ -54,6 +54,8 @@ def process_statistical_review_data(tb_review: Table) -> Table:
         "gas_electricity_generation_twh": "gas_generation__twh",
         # Load primary energy consumption from fossil fuels and biofuels, to be able to calculate direct primary energy.
         # Direct primary energy consumption is needed to calculate the share of electricity in primary energy.
+        # Once direct primary energy consumption and the share of electricity in primary energy are calculated, these
+        # columns will be dropped.
         "oil_consumption_twh": "oil_consumption__twh",
         "coal_consumption_twh": "coal_consumption__twh",
         "gas_consumption_twh": "gas_consumption__twh",


### PR DESCRIPTION
In [my previous PR](https://github.com/owid/etl/pull/2196) I attempted to fix the calculation of the share of electricity in primary energy consumption (used in [this chart](https://ourworldindata.org/grapher/electricity-as-a-share-of-primary-energy)). However, I then realized that the calculation was still problematic, so I reverted it.

# Short explanation (TLDR)

We should calculate the share of electricity in terms of direct primary energy consumption, instead of input-equivalent primary energy. This is not ideal, since we use the substitution method in most of our charts, but it's the best trade-off given the data we have.

Once this PR is merged, I'll change the subtitle of the chart, to mention that we use direct primary energy consumption, and not primary energy using the substitution method.

Comparison:
* [Old chart](https://owid.cloud/admin/charts/6287/edit) (in production).
* [New chart](http://staging-site-corrected-improvement-of-electricity-share/admin/charts/6287/edit) (in temporary PR server). Note that the numbers haven't changed that abruptly (compared to the other PR). The change is more noticeable in the north of Europe. And also note that I have changed the map brackets.

# Detailed explanation

I can think of at least the following different ways to calculate the share of electricity in primary energy:
1. (total electricity generation) / (direct primary energy consumption).
This is what this PR calculates. Since we don't have direct primary energy consumption (the Statistical Review only provides input-equivalent primary energy consumption), we estimate it as the primary energy consumption of fossil and biofuels, plus the electricity generated by nuclear and renewables.

2. (total electricity generation) / (input-equivalent primary energy consumption).
This is what we currently have in production. It has the problem that the denominator includes the "thermal losses" of non-fossil sources (that were introduced to mimic the inefficiencies of fossil fuels). But, since these losses are not in the numerator, the result underestimates the share of electricity.

3. (total electricity generation, where non-fossil electricity sources are inflated to mimic the inefficiencies of fossil fuels) / (input-equivalent primary energy consumption).
This was the solution I proposed in my previous PR. But then I realized that it is arbitrary to include in the numerator the "thermal losses" of nuclear and renewables, but not the actual thermal losses of fossil fuels.

4. (total electricity generation, where all electricity sources are inflated assuming the same inefficiencies as fossil fuels) / (input-equivalent primary energy consumption).
This would be a more accurate version of what I proposed in my previous PR. Here, all electricity sources in the numerator are converted into their input-equivalents. I think this would be a more accurate way to describe the "share of electricity in primary energy consumption, using the substitution method". But this calculation applies the same efficiency factors to all electricity sources (including all fossil sources), which feels like too rough an approximation.

5. (total electricity generation) / (physical energy content primary energy consumption).
I think that the physical energy content method is a more meaningful way to calculate primary energy than the substitution method (and it seems to be [the default method by the IEA](https://www.iea.org/statistics-questionnaires-faq)). We could estimate the physical energy content primary energy by deflating the primary energy consumption from renewable sources, and inflating only the nuclear electricity generation (to account for the thermal losses, in a similar way that they are accounted for in fossil generation). However, since we do not use this method elsewhere on our site, it would be a drastic change. We may consider using this method once the IEA releases its data publicly.

So, in conclusion, there is no perfect choice, but option 1 seems to be a good trade-off. That's why I adopted it in this PR.