### PR TITLE
Update nuclear weapons tests dataset

### DIFF
--- a/dag/archive/war.yml
+++ b/dag/archive/war.yml
@@ -74,3 +74,11 @@ steps:
     - data://meadow/war/2023-09-25/peace_diehl
   data://grapher/war/2023-09-26/peace_diehl:
     - data://garden/war/2023-09-25/peace_diehl
+
+  # Arms Control Association - Nuclear Weapons Tests.
+  data://meadow/war/2024-01-15/nuclear_weapons_tests:
+    - snapshot://war/2024-01-15/nuclear_weapons_tests.csv
+  data://garden/war/2024-01-15/nuclear_weapons_tests:
+    - data://meadow/war/2024-01-15/nuclear_weapons_tests
+  data://grapher/war/2024-01-15/nuclear_weapons_tests:
+    - data://garden/war/2024-01-15/nuclear_weapons_tests

--- a/dag/war.yml
+++ b/dag/war.yml
@@ -175,12 +175,12 @@ steps:
     - data://garden/war/2024-01-11/nuclear_weapons_proliferation
 
   # Arms Control Association - Nuclear Weapons Tests.
-  data://meadow/war/2024-01-15/nuclear_weapons_tests:
-    - snapshot://war/2024-01-15/nuclear_weapons_tests.csv
-  data://garden/war/2024-01-15/nuclear_weapons_tests:
-    - data://meadow/war/2024-01-15/nuclear_weapons_tests
-  data://grapher/war/2024-01-15/nuclear_weapons_tests:
-    - data://garden/war/2024-01-15/nuclear_weapons_tests
+  data://meadow/war/2024-01-25/nuclear_weapons_tests:
+    - snapshot://war/2024-01-25/nuclear_weapons_tests.csv
+  data://garden/war/2024-01-25/nuclear_weapons_tests:
+    - data://meadow/war/2024-01-25/nuclear_weapons_tests
+  data://grapher/war/2024-01-25/nuclear_weapons_tests:
+    - data://garden/war/2024-01-25/nuclear_weapons_tests
 
   # UNODA - Treaties Database.
   data://meadow/war/2024-01-23/nuclear_weapons_treaties:
@@ -195,3 +195,18 @@ steps:
     - data://garden/war/2024-01-23/nuclear_weapons_treaties
   data://grapher/war/2024-01-23/nuclear_weapons_treaties_country_counts:
     - data://garden/war/2024-01-23/nuclear_weapons_treaties
+
+  ######################################################################################################################
+  # Older versions to be archived once they are not used by any other steps.
+  # Arms Control Association - Nuclear Weapons Tests.
+  data://meadow/war/2024-01-15/nuclear_weapons_tests:
+    - snapshot://war/2024-01-15/nuclear_weapons_tests.csv
+  data://garden/war/2024-01-15/nuclear_weapons_tests:
+    - data://meadow/war/2024-01-15/nuclear_weapons_tests
+  data://grapher/war/2024-01-15/nuclear_weapons_tests:
+    - data://garden/war/2024-01-15/nuclear_weapons_tests
+
+  ######################################################################################################################
+
+
+

--- a/etl/steps/data/garden/war/2024-01-25/nuclear_weapons_tests.countries.json
+++ b/etl/steps/data/garden/war/2024-01-25/nuclear_weapons_tests.countries.json
@@ -1,0 +1,10 @@
+{
+    "China": "China",
+    "France": "France",
+    "India": "India",
+    "North Korea": "North Korea",
+    "Pakistan": "Pakistan",
+    "United Kingdom": "United Kingdom",
+    "United States": "United States",
+    "Ussr Russia": "Russia"
+}

--- a/etl/steps/data/garden/war/2024-01-25/nuclear_weapons_tests.meta.yml
+++ b/etl/steps/data/garden/war/2024-01-25/nuclear_weapons_tests.meta.yml
@@ -1,0 +1,23 @@
+dataset:
+  update_period_days: 365
+
+tables:
+  nuclear_weapons_tests:
+    title: "Nuclear Weapons Tests"
+    variables:
+      nuclear_weapons_tests:
+        title: Number of nuclear weapons tests
+        unit: tests
+        short_unit: ""
+        description_key:
+          - The number of nuclear tests for the United States does not include the bombings of Hiroshima and Nagasaki.
+          - This data only includes nuclear tests announced or reported by governments and/or intergovernmental organizations.
+          - This data does not include the "Vela Incident" of 1979 because it has not yet officially been declared a nuclear test explosion by any government or intergovernmental organization, although there is strong evidence that suggests it was.
+          - India's three simultaneous nuclear test explosions on May 11 are counted as only one, as are the two explosions on May 13. Likewise, Pakistan's five simultaneous explosions on May 28 are counted as a single test.
+        processing_level: minor
+        presentation:
+          topic_tags:
+            - Nuclear Weapons
+            - War & Peace
+        display:
+          numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2024-01-25/nuclear_weapons_tests.py
+++ b/etl/steps/data/garden/war/2024-01-25/nuclear_weapons_tests.py
@@ -1,0 +1,86 @@
+"""Load a meadow dataset and create a garden dataset."""
+
+from etl.data_helpers import geo
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def extract_year_ranges(years_ranges, year_last):
+    # Extract years from a string that contains a list of years and year ranges.
+    # Examples: "1964-66,72-75,80-", "1980-", "1953-62,82-87", "1970-2003", "1975-90", "2002-07".
+    years = []
+    for years_range in years_ranges.split(","):
+        if "-" in years_range:
+            start, end = years_range.split("-")
+            if end.lower() == "present":
+                end = year_last
+            years.extend(list(range(int(start), int(end) + 1)))
+        else:
+            years.append(int(years_range))
+
+    return years
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load meadow dataset and read its main table.
+    ds_meadow = paths.load_dataset("nuclear_weapons_tests")
+    tb = ds_meadow["nuclear_weapons_tests"].reset_index()
+
+    #
+    # Process data.
+    #
+    # By looking at the original table, it seems clear that empty cells mean zero.
+    tb = tb.fillna(0)
+
+    # Temporarily convert all columns to string (to avoid issues with categorical variables).
+    tb = tb.astype(str)
+
+    # Remove thousands separator, e.g. 1,000 -> 1000.
+    tb = tb.replace(",", "", regex=True)
+
+    # Remove row that contains the total number of tests (and keep it for a later sanity check).
+    tb_total = tb[tb["year"] == "Total"].copy()
+    tb = tb[tb["year"] != "Total"].reset_index(drop=True)
+
+    # Find out the last informed year in the data. This should be the last full year before the last publication date.
+    year_last = int(tb["year"].metadata.origins[0].date_published.split("-")[0]) - 1
+
+    # Adapt years column, so that they are integers, and not ranges, e.g. 2018-2019.
+    tb["year"] = tb["year"].astype(str).apply(extract_year_ranges, year_last=year_last)
+    tb = tb.explode("year").reset_index(drop=True)
+
+    # All columns should be integers.
+    tb = tb.astype(str).astype(int)
+
+    # Sanity check.
+    error = "The yearly total number of tests should be equal to the value in the 'total' column."
+    assert tb[tb.drop(columns=["year", "total"]).columns].sum(axis=1).equals(tb["total"]), error
+    error = "The last row (called 'total') should be equal to the sum of all other rows."
+    assert (
+        tb_total.drop(columns=["year", "total"]).astype(int).iloc[0] == tb.drop(columns=["year", "total"]).sum(axis=0)
+    ).all(), error
+
+    # Remove 'total' column.
+    tb = tb.drop(columns=["total"])
+
+    # Transpose table to have a country column.
+    tb = tb.melt(id_vars=["year"], var_name="country", value_name="nuclear_weapons_tests")
+
+    # Harmonize country names.
+    tb["country"] = tb["country"].str.replace("__", "_").str.replace("_", " ").str.title()
+    tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
+
+    # Set an appropriate index and sort conveniently.
+    tb = tb.set_index(["country", "year"], verify_integrity=True).sort_index()
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset.
+    ds_garden = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_garden.save()

--- a/etl/steps/data/grapher/war/2024-01-25/nuclear_weapons_tests.py
+++ b/etl/steps/data/grapher/war/2024-01-25/nuclear_weapons_tests.py
@@ -1,0 +1,22 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset and read its main table.
+    ds_garden = paths.load_dataset("nuclear_weapons_tests")
+    tb = ds_garden["nuclear_weapons_tests"]
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/war/2024-01-25/nuclear_weapons_tests.py
+++ b/etl/steps/data/meadow/war/2024-01-25/nuclear_weapons_tests.py
@@ -1,0 +1,36 @@
+"""Load a snapshot and create a meadow dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Retrieve snapshot and read its data.
+    snap = paths.load_snapshot("nuclear_weapons_tests.csv")
+    # Load data as string to be able to fix annotations issue (see below).
+    tb = snap.read(dtype=str)
+
+    #
+    # Process data.
+    #
+    # Manually remove spurious numbers which are annotations.
+    # Currently there is only one for North Korea in 2010.
+    error = "Expected annotation for North Korea in 2010. It may have changed, so remove this part of the code."
+    assert tb[(tb["Year"] == "2010")]["North Korea"].item() == "03", error
+    # Remove the annotation.
+    tb.loc[(tb["Year"] == "2010"), "North Korea"] = "0"
+
+    # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
+    tb = tb.underscore().set_index(["year"], verify_integrity=True).sort_index()
+
+    #
+    # Save outputs.
+    #
+    # Create a new meadow dataset.
+    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_meadow.save()

--- a/snapshots/war/2024-01-25/nuclear_weapons_tests.csv.dvc
+++ b/snapshots/war/2024-01-25/nuclear_weapons_tests.csv.dvc
@@ -1,0 +1,31 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/origin/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: The Nuclear Testing Tally
+    description: |-
+      This dataset provides the yearly number of nuclear weapons tests by country.
+    date_published: 2023-08-01
+
+    # Citation
+    producer: Arms Control Association
+    citation_full: |-
+      Arms Control Association - The Nuclear Testing Tally (2023).
+
+      Daryl Kimball, Executive Director.
+    attribution_short: ACA
+
+    # Files
+    url_main: https://www.armscontrol.org/factsheets/nucleartesttally
+    date_accessed: 2024-01-25
+
+    # License
+    license:
+      name: CC BY 4.0
+
+wdir: ../../../data/snapshots/war/2024-01-25
+outs:
+- md5: 32d32735f7f68d05bfa4bc9a11b78b07
+  size: 1623
+  path: nuclear_weapons_tests.csv

--- a/snapshots/war/2024-01-25/nuclear_weapons_tests.py
+++ b/snapshots/war/2024-01-25/nuclear_weapons_tests.py
@@ -1,0 +1,63 @@
+"""Script to create a snapshot of dataset.
+
+The data is directly extracted from the website.
+
+"""
+
+from pathlib import Path
+
+import click
+import pandas as pd
+import requests
+from bs4 import BeautifulSoup
+
+from etl.snapshot import Snapshot
+
+# Version for current snapshot dataset.
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+
+@click.command()
+@click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
+def main(upload: bool) -> None:
+    # Create a new snapshot.
+    snap = Snapshot(f"war/{SNAPSHOT_VERSION}/nuclear_weapons_tests.csv")
+
+    # Request HTML content from website.
+    response = requests.get(snap.metadata.origin.url_main)  # type: ignore
+
+    # Parse HTML content.
+    soup = BeautifulSoup(response.text, "html.parser")
+
+    # Extract the title of the table.
+    tables = soup.find_all("table")
+
+    # The table we are interested in is the second one, containing the number of tests for each country-year.
+    table = tables[1]
+
+    # Initialize a list to hold all rows of data.
+    table_data = []
+    # Iterate over all rows in the table and gather data.
+    for row in table.find_all("tr"):  # type: ignore
+        row_data = [cell.get_text(strip=True) for cell in row.find_all("td")]
+        # Add the row data to the table data list
+        table_data.append(row_data)
+
+    # The zeroth element fetched is the left column text, which we don't need.
+    # The first element is the name of the columns.
+    # The last element are the notes, which we will rephrase in the metadata.
+    columns = table_data[1]
+    table_data = table_data[2:-1]
+
+    # Create a dataframe with the extracted data.
+    df = pd.DataFrame(table_data, columns=columns)
+
+    # Remove empty rows.
+    df = df.dropna().reset_index(drop=True)
+
+    # Copy data to snapshots data folder, add file to DVC and upload to S3.
+    snap.create_snapshot(data=df, upload=upload)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Following our suggestion, the Arms Control Association updated the values in their table on the Nuclear Testing Tally (so that, instead of saying "2018-2019" now it says "2018-Present"). The only change in the data is that instead of 2019, the last informed year now is 2022.
* Update nuclear weapons tests dataset.
* Move steps of the previous version to archive dag.
