### PR TITLE
🐛 Remove double counting of one-year olds in age-standardized variables of global health estimates

### DIFF
--- a/etl/steps/data/garden/who/2022-09-30/ghe.py
+++ b/etl/steps/data/garden/who/2022-09-30/ghe.py
@@ -19,7 +19,7 @@ log = get_logger()
 paths = PathFinder(__file__)
 AGE_GROUPS_RANGES = {
     "ALLAges": [0, None],
-    "YEARS0-1": [0, 1],
+    "YEARS0-1": [0, 0],
     "YEARS1-4": [1, 4],
     "YEARS5-9": [5, 9],
     "YEARS10-14": [10, 14],


### PR DESCRIPTION
One-year olds were incorrectly being double-counted in the add_population() function, used to calculate age-standardised variables. 

This will fix that but I expect it will impact a lot of variables (although not many of those are used), so should probably be merged in the evening or overnight. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the age range for the "YEARS0-1" group to ensure accurate data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->