### PR TITLE
Load Strategic Nuclear Forces data from URL

### DIFF
--- a/dag/archive/war.yml
+++ b/dag/archive/war.yml
@@ -82,3 +82,12 @@ steps:
     - data://meadow/war/2024-01-15/nuclear_weapons_tests
   data://grapher/war/2024-01-15/nuclear_weapons_tests:
     - data://garden/war/2024-01-15/nuclear_weapons_tests
+
+  # The Strategic Nuclear Forces Dataset (Suh).
+  data://meadow/war/2024-01-08/strategic_nuclear_forces:
+    - snapshot://war/2024-01-08/strategic_nuclear_forces.xlsx
+    - snapshot://war/2024-01-08/strategic_nuclear_forces_monadic.xlsx
+  data://garden/war/2024-01-08/strategic_nuclear_forces:
+    - data://meadow/war/2024-01-08/strategic_nuclear_forces
+  data://grapher/war/2024-01-08/strategic_nuclear_forces:
+    - data://garden/war/2024-01-08/strategic_nuclear_forces

--- a/dag/war.yml
+++ b/dag/war.yml
@@ -130,13 +130,13 @@ steps:
     - data://meadow/war/2023-11-29/chupilkin_koczan
 
   # The Strategic Nuclear Forces Dataset (Suh).
-  data://meadow/war/2024-01-08/strategic_nuclear_forces:
-    - snapshot://war/2024-01-08/strategic_nuclear_forces.xlsx
-    - snapshot://war/2024-01-08/strategic_nuclear_forces_monadic.xlsx
-  data://garden/war/2024-01-08/strategic_nuclear_forces:
-    - data://meadow/war/2024-01-08/strategic_nuclear_forces
-  data://grapher/war/2024-01-08/strategic_nuclear_forces:
-    - data://garden/war/2024-01-08/strategic_nuclear_forces
+  data://meadow/war/2024-01-30/strategic_nuclear_forces:
+    - snapshot://war/2024-01-30/strategic_nuclear_forces.xlsx
+    - snapshot://war/2024-01-30/strategic_nuclear_forces_monadic.xlsx
+  data://garden/war/2024-01-30/strategic_nuclear_forces:
+    - data://meadow/war/2024-01-30/strategic_nuclear_forces
+  data://grapher/war/2024-01-30/strategic_nuclear_forces:
+    - data://garden/war/2024-01-30/strategic_nuclear_forces
 
   # Federation of American Scientists - Estimated Global Nuclear Warhead Inventories.
   data://meadow/war/2024-01-09/nuclear_weapons_inventories:

--- a/snapshots/war/2024-01-30/strategic_nuclear_forces.py
+++ b/snapshots/war/2024-01-30/strategic_nuclear_forces.py
@@ -12,17 +12,16 @@ SNAPSHOT_VERSION = Path(__file__).parent.name
 
 @click.command()
 @click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
-@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
-def main(path_to_file: str, upload: bool) -> None:
+def main(upload: bool) -> None:
     # Create a new snapshot for the dyadic dataset.
     snap = Snapshot(f"war/{SNAPSHOT_VERSION}/strategic_nuclear_forces.xlsx")
     # Download data from source, add file to DVC and upload to S3.
     snap.create_snapshot(upload=upload)
 
-    # Create a new snapshot for the monadic dataset (sent to us in a private communication).
+    # Create a new snapshot for the monadic dataset.
     snap = Snapshot(f"war/{SNAPSHOT_VERSION}/strategic_nuclear_forces_monadic.xlsx")
     # Add local file to DVC and upload to S3.
-    snap.create_snapshot(upload=upload, filename=path_to_file)
+    snap.create_snapshot(upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/war/2024-01-30/strategic_nuclear_forces.xlsx.dvc
+++ b/snapshots/war/2024-01-30/strategic_nuclear_forces.xlsx.dvc
@@ -4,6 +4,13 @@ meta:
     title: The Strategic Nuclear Forces Dataset
     description: |-
       This dataset describes times-series-cross-sectional information on all nuclear-armed states' strategic nuclear forces, and provides three indicators: the deliverable strategic warhead count, the equivalent megatonnage (EMT) index, and the counter military potential (CMP) index.
+    title_snapshot: The Strategic Nuclear Forces Dataset - Dyadic data
+    description_snapshot: |-
+      The original data exists in two different formats:
+      1. In the dyadic format, each row in the data corresponds to a pair of states, and the nuclear capabilities of a state depends on the distance to the other state. For example, a country may have a certain number of warheads, but not all of them could be delivered to a very distant country.
+      2. In the monadic format, each row corresponds to just one country. This data shows the nuclear capabilities of a state, regardless of what country they could be used against.
+
+      The current dataset is presented in dyadic format.
     date_published: 2023-09-15
     version_producer: v2.0
 
@@ -19,14 +26,13 @@ meta:
     # Files
     url_main: https://kyungwonsuh.weebly.com/datasets.html
     url_download: https://kyungwonsuh.weebly.com/uploads/1/4/6/1/146191116/snforce2_ndy.xlsx
-    date_accessed: 2024-01-08
+    date_accessed: 2024-01-30
 
     # License
     license:
       name: CC BY 4.0
 
-wdir: ../../../data/snapshots/war/2024-01-08
-
+wdir: ../../../data/snapshots/war/2024-01-30
 outs:
 - md5: ea6b9a96e6068a98ae315a42a57073f6
   size: 156328

--- a/snapshots/war/2024-01-30/strategic_nuclear_forces_monadic.xlsx.dvc
+++ b/snapshots/war/2024-01-30/strategic_nuclear_forces_monadic.xlsx.dvc
@@ -6,11 +6,11 @@ meta:
       This dataset describes times-series-cross-sectional information on all nuclear-armed states' strategic nuclear forces, and provides three indicators: the deliverable strategic warhead count, the equivalent megatonnage (EMT) index, and the counter military potential (CMP) index.
     title_snapshot: The Strategic Nuclear Forces Dataset - Monadic data
     description_snapshot: |-
-      This dataset (sent to Our World in Data by K. Suh in a private communication) is in monadic format.
+      The original data exists in two different formats:
+      1. In the dyadic format, each row in the data corresponds to a pair of states, and the nuclear capabilities of a state depends on the distance to the other state. For example, a country may have a certain number of warheads, but not all of them could be delivered to a very distant country.
+      2. In the monadic format, each row corresponds to just one country. This data shows the nuclear capabilities of a state, regardless of what country they could be used against.
 
-      The original dataset is in dyadic format. This means that each row in the data corresponds to a pair of states, and the nuclear capabilities of a state depends on the distance to the other state. For example, a country may have a certain number of warheads, but not all of them could be delivered to a very distant country.
-
-      On the other hand, each row in the monadic data corresponds to just one country. This data shows the nuclear capabilities of a state, regardless of what country they could be used against.
+      The current dataset is presented in monadic format.
     date_published: 2023-09-15
     version_producer: v2.0
 
@@ -19,22 +19,21 @@ meta:
     citation_full: |-
       Kyungwon Suh - The Strategic Nuclear Forces Dataset, monadic data (2023).
 
-      This monadic dataset was sent to Our World in Data by K. Suh in a private communication. The underlying data is based on the following publication (where data is presented in a dyadic format):
-
       Suh, Kyungwon. 2022. “Nuclear Balance and the Initiation of Nuclear Crises: Does Superiority Matter?” Journal of Peace Research, Vol. 60, No. 2 (March): 337-351. Doi:10.1177/00223433211067899.
     attribution: Suh - The Strategic Nuclear Forces Dataset v2.0 (2023)
     attribution_short: Suh
 
     # Files
     url_main: https://kyungwonsuh.weebly.com/datasets.html
-    date_accessed: 2024-01-08
+    url_download: https://kyungwonsuh.weebly.com/uploads/1/4/6/1/146191116/snforce2_monad.xlsx
+    date_accessed: 2024-01-30
 
     # License
     license:
       name: CC BY 4.0
 
-wdir: ../../../data/snapshots/war/2024-01-08
+wdir: ../../../data/snapshots/war/2024-01-30
 outs:
-- md5: 5628b7187e98995cb455a0db9a12ccf6
-  size: 22082
+- md5: 545881108e83cdafda366038370d4ef5
+  size: 22516
   path: strategic_nuclear_forces_monadic.xlsx


### PR DESCRIPTION
Load strategic nuclear forces monadic data by Suh from a URL (now that the public link exists) instead of a local file, and update documentation.
