### PR TITLE
Fix etl-staging-sync ignoring target input

### DIFF
--- a/apps/staging_sync/app.py
+++ b/apps/staging_sync/app.py
@@ -53,7 +53,7 @@ def main():
         if not _is_valid_config(source, target):
             return
 
-        cmd = ["poetry", "run", "etl-staging-sync", source, "master"]
+        cmd = ["poetry", "run", "etl-staging-sync", source, target]
         if dry_run:
             cmd.append("--dry-run")
         if publish:


### PR DESCRIPTION
The CLI was working well, but when using the app with the same inputs, I was getting an error.

I think the issue is that the input `target` argument was being ignored by the app. This PR seems to fix it for me, but I haven't looked deeply into the code, so I'm not sure if it's something else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `etl-staging-sync` command to support synchronization with dynamic target branches, improving flexibility in operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->