### PR TITLE
Use literal style when dumping yaml files

### DIFF
--- a/etl/files.py
+++ b/etl/files.py
@@ -140,12 +140,11 @@ class _MyDumper(Dumper):
 
 def _str_presenter(dumper: Any, data: Any) -> Any:
     lines = data.splitlines()
-    if len(lines) > 1:  # check for multiline string
-        max_line_length = max([len(line) for line in lines])
-        if max_line_length > 120:
-            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=">")
-        else:
-            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    # If there are multiple lines, or there is a line that is longer than 120 characters, use the literal style.
+    # NOTE: Here the 120 is a bit arbitrary. This is the default length of our lines in the code, but once written
+    # to YAML, the lines will be longer because of the indentation. So, we could use a smaller number here.
+    if (len(lines) > 1) or (max([len(line) for line in lines]) > 120):
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
     else:
         return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 


### PR DESCRIPTION
By default, when writing snapshot yaml files, we use the folded style (">") for multiline texts. I find this annoying, because metadata often needs to be manually edited, and the folded style introduces arbitrary line breaks. It's much easier to use the literal style ("|") and let the text editor wrap the code conveniently.

This PR imposes that, when writing text to a yaml file that either has line breaks, or contains long lines of text, the literal style will be used.

@Marigold this will affect all places where `yaml_dump` is used. Let me know if you think this can be dangerous or lead to unwanted changes. Also, I'll ask the data people if anyone is against the literal style. Thanks!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic for determining YAML string style in the ETL process, enhancing readability and simplification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->