### PR TITLE
Avoid raising a warning when a table has a non-unique index

### DIFF
--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -107,12 +107,6 @@ class Dataset:
         for col in list(table.columns) + list(table.index.names):
             utils.validate_underscore(col, "Variable's name")
 
-        # non-unique index might be causing problems down the line and is typically a mistake
-        if not table.index.is_unique:
-            warnings.warn(
-                f"Table `{table.metadata.short_name}` from dataset `{self.metadata.short_name}` has non-unique index"
-            )
-
         if not table.primary_key:
             if "OWID_STRICT" in environ:
                 raise PrimaryKeyMissing(


### PR DESCRIPTION
Often, meadow datasets contain tables that have non-unique indexes (e.g. because a row is repeated). This is to be expected, and we don't need ETL to raise a warning every time we run such steps (e.g. `data://meadow/emdat/2023-09-20/natural_disasters`). When there is a non-unique index in garden (where it actually matters), an error is raised.

This PR removes the warning.

In genral, we should always have a `set_index(..., verify_integrity=True)` for each table before creating the dataset. And, if the index is non-unique, we should turn `verify_integrity=False`. But we don't need a warning because there's nothing to do about this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic in dataset handling to ensure smoother operations without unnecessary warnings for non-unique indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->