### PR TITLE
Remove fasttrack steps that do not exist anymore

### DIFF
--- a/dag/fasttrack.yml
+++ b/dag/fasttrack.yml
@@ -94,10 +94,6 @@ steps:
     - snapshot://fasttrack/2023-08-21/survey_livestock_oklahoma.csv
   data://grapher/fasttrack/latest/sentience_institute:
     - snapshot://fasttrack/latest/sentience_institute.csv
-  data://grapher/fasttrack/latest/nuclear_warhead_stockpiles:
-    - snapshot://fasttrack/latest/nuclear_warhead_stockpiles.csv
-  data://grapher/fasttrack/latest/nuclear_warhead_inventories:
-    - snapshot://fasttrack/latest/nuclear_warhead_inventories.csv
   data://grapher/fasttrack/latest/smallpox_cases:
     - snapshot://fasttrack/latest/smallpox_cases.csv
   data://grapher/fasttrack/latest/transport_co2_emissions_modes:


### PR DESCRIPTION
Remove from the dag fasttrack steps whose code was already removed (on nuclear weapons data). They should have been removed from the dag when the steps were removed.
