### PR TITLE
:bug: dynamic is_public from selected sheet

### DIFF
--- a/apps/wizard/pages/fasttrack/utils.py
+++ b/apps/wizard/pages/fasttrack/utils.py
@@ -14,27 +14,30 @@ UPDATE_GSHEET = "update_gsheet"
 LOCAL_CSV = "local_csv"
 
 
-def _encrypt(s: str) -> str:
-    fernet = _get_secret_key()
-    return fernet.encrypt(s.encode()).decode() if fernet else s
-
-
-def _decrypt(s: str) -> str:
-    fernet = _get_secret_key()
-    # content is not encrypted, this is to keep it backward compatible with old datasets
-    # that weren't using encryption
-    if "docs.google.com" in s:
-        return s
-    else:
-        return fernet.decrypt(s.encode()).decode() if fernet else s
-
-
 def _get_secret_key() -> Optional[Fernet]:
     secret_key = os.environ.get("FASTTRACK_SECRET_KEY")
     if not secret_key:
         log.warning("FASTTRACK_SECRET_KEY not found in environment variables. Not using encryption.")
         return None
     return Fernet(secret_key)
+
+
+FERNET_KEY = _get_secret_key()
+
+
+def _encrypt(s: str) -> str:
+    fernet = FERNET_KEY
+    return fernet.encrypt(s.encode()).decode() if fernet else s
+
+
+def _decrypt(s: str) -> str:
+    fernet = FERNET_KEY
+    # content is not encrypted, this is to keep it backward compatible with old datasets
+    # that weren't using encryption
+    if "docs.google.com" in s:
+        return s
+    else:
+        return fernet.decrypt(s.encode()).decode() if fernet else s
 
 
 def set_states(states_values: Dict[str, Any]):


### PR DESCRIPTION
The old fast-track is setting the `Make dataset private` field dynamically if the user selects the existing sheet. This is especially important for updating existing private datasets. Without this, we'd have to tick "private" every time when doing an update.

Unfortunately, streamlit doesn't support `on_change` in forms, so I had to put it outside the form [using this hack](https://discuss.streamlit.io/t/updating-radio-inside-a-form/49076/4). It's not very nice.

Alternative solutions:
- select box with `Auto`, `Public` and `Private` (`Auto` would use existing sheet's visibility with public as default)
- disable setting private / public for existing sheets (we might face the same issue with dynamic forms here)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved form handling and user input processes in the application, including new placeholders for selections and settings adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->