### PR TITLE
Add missing faostat step to dag

### DIFF
--- a/dag/faostat.yml
+++ b/dag/faostat.yml
@@ -318,3 +318,8 @@ steps:
     - data://garden/faostat/2023-06-12/faostat_fbsc
     - data://garden/faostat/2023-06-12/faostat_ef
     - data://garden/faostat/2023-06-12/faostat_rfn
+  #
+  # FAOSTAT grapher step for additional variables for version 2023-06-12
+  #
+  data://grapher/faostat/2023-06-12/additional_variables:
+    - data://garden/faostat/2023-06-12/additional_variables


### PR DESCRIPTION
After some experiments with the new version tracker, I noticed that the dataset on additional FAOSTAT variables was still using an old version of the data. This PR creates the corresponding new grapher dataset.

