### PR TITLE
:bug: Fix years assigned to EVS data in Integrated Values Survey

### DIFF
--- a/snapshots/ivs/2023-11-27/integrated_values_survey.csv.dvc
+++ b/snapshots/ivs/2023-11-27/integrated_values_survey.csv.dvc
@@ -26,6 +26,6 @@ meta:
 
 wdir: ../../../data/snapshots/ivs/2023-11-27
 outs:
-- md5: 5c0462f203384a48946c9281dd1c2fae
-  size: 409554
+- md5: 29625a89effe8ae733754007baee67dc
+  size: 397673
   path: integrated_values_survey.csv

--- a/snapshots/ivs/2023-11-27/ivs_create_file.do
+++ b/snapshots/ivs/2023-11-27/ivs_create_file.do
@@ -57,12 +57,12 @@ replace S002VS=2010 if S002VS==5
 replace S002VS=2014 if S002VS==6
 replace S002VS=2022 if S002VS==7
 
-* There are several S002VS missing (only in EVS), so they are replaced according to the year of survey of EVS
+* There are several S002VS missing (only in EVS), so they are replaced according to the WVS-EVS waves
 replace S002VS = 1984 if S002VS==. & S002EVS==1
 replace S002VS = 1993 if S002VS==. & S002EVS==2
-replace S002VS = 2001 if S002VS==. & S002EVS==3
+replace S002VS = 2004 if S002VS==. & S002EVS==3
 replace S002VS = 2010 if S002VS==. & S002EVS==4
-replace S002VS = 2021 if S002VS==. & S002EVS==5
+replace S002VS = 2022 if S002VS==. & S002EVS==5
 
 rename S002VS year
 rename S003 country


### PR DESCRIPTION
In the Integrated Values Survey dataset, each observation has variables associated to the WVS/EVS wave (S002VS):

- 1981-1984 (EVS/WVS1)
- 1989-1993 (EVS/WVS2)
- 1994-1998 (WVS3)
- 1999-2004 (EVS3, WVS4)
- 2005-2010 (EVS4, WVS5)
- 2010-2014 (WVS6)
- 2017-2022 (EVS5, WVS7)

Strangely, there were many observations with this variable set as missing. All of them have a defined S002EVS value (EVS wave), so I initially assigned last year of these EVS waves as the year of these observations.

I communicated with WVS/EVS people to ask if I should assign EVS/WVS waves instead (or none) and they told me

> We published an erratum on this issue only on Tuesday. The problem relies on a mistaken spelling of S002VS in the EVS Trend File (s002vs instead of S002VS), resulting in missing values after merging the EVS and WVS Trend Files. The EVS variable needs to be renamed before combining the data files. However, your approach is correct. 

So I assign the missing values to the corresponding EVS WVS waves.

Related issue: https://github.com/owid/owid-issues/issues/1374