### PR TITLE
Let temporary step create a dataset to avoid issues

### DIFF
--- a/etl/steps/data/meadow/temp/latest/step.py
+++ b/etl/steps/data/meadow/temp/latest/step.py
@@ -1,1 +1,8 @@
-# Dummy file created for consistency.
+"""Dummy file created for consistency."""
+from etl.helpers import create_dataset
+
+
+def run(dest_dir: str):
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(dest_dir, tables=[], check_variables_metadata=True)
+    ds_garden.save()


### PR DESCRIPTION
The temporary step was added to the dag to keep track of snapshots that are created but not yet used by any active step.

Initially, this temporary step was only in the dag. But VersionTracker was raising an error because an active step in the dag didn't have code.
Therefore, I created a dummy file for this step.
But now, in production, etl attempts to run it and fails because it doesn't have a `run` function.
This PR adds a dummy run function that creates an empty dataset.
If this solution causes problem, there may be better alternatives (like blacklisting the temporary step so that VersionTracker ignores it).
