### PR TITLE
:bug: fix MD5 yet again

### DIFF
--- a/snapshots/climate/2023-12-20/surface_temperature.gz.dvc
+++ b/snapshots/climate/2023-12-20/surface_temperature.gz.dvc
@@ -20,6 +20,6 @@ meta:
       url: https://cds.climate.copernicus.eu/api/v2/terms/static/licence-to-use-copernicus-products.pdf
 wdir: ../../../data/snapshots/climate/2023-12-20
 outs:
-  - md5: 2c28d91e6af3e1119d66620eabb99a78
-    size: 1495360206
+  - md5: 82d19416c569459ecb164ae66c18d528
+    size: 1495360207
     path: surface_temperature.gz

--- a/snapshots/education/2023-12-15/wittgenstein_center_data.csv.dvc
+++ b/snapshots/education/2023-12-15/wittgenstein_center_data.csv.dvc
@@ -30,6 +30,6 @@ meta:
 
 wdir: ../../../data/snapshots/education/2023-12-15
 outs:
-  - md5: a4a21fb6806012919b14d9a8a9515331
-    size: 100313261
+  - md5: 56fbd4dc31402e2f226e66a386589ee5
+    size: 101373997
     path: wittgenstein_center_data.csv

--- a/snapshots/excess_mortality/latest/hmd_stmf.csv.dvc
+++ b/snapshots/excess_mortality/latest/hmd_stmf.csv.dvc
@@ -34,5 +34,5 @@ meta:
     url: https://www.mortality.org/Data/UserAgreement
 outs:
   - md5: 77d5aa1745dfc7467302555c54f3ab6a
-    size: 20377337
+    size: 20377339
     path: hmd_stmf.csv

--- a/snapshots/oecd/2023-05-18/co2_air_transport.csv.dvc
+++ b/snapshots/oecd/2023-05-18/co2_air_transport.csv.dvc
@@ -23,5 +23,5 @@ meta:
 wdir: ../../../data/snapshots/oecd/2023-05-18
 outs:
 - md5: 320570f5ee7c11eff8123a78abb2426e
-  size: 84203878
+  size: 84521205
   path: co2_air_transport.csv

--- a/snapshots/terrorism/2023-07-20/global_terrorism_database.csv.dvc
+++ b/snapshots/terrorism/2023-07-20/global_terrorism_database.csv.dvc
@@ -14,5 +14,5 @@ meta:
 wdir: ../../../data/snapshots/terrorism/2023-07-20
 outs:
   - md5: 6a76caa30fd2266952401d55351e209b
-    size: 193241848
+    size: 193451541
     path: global_terrorism_database.csv

--- a/snapshots/un/2018/igme.csv.dvc
+++ b/snapshots/un/2018/igme.csv.dvc
@@ -25,5 +25,5 @@ meta:
 wdir: ../../../data/snapshots/un/2018
 outs:
   - md5: 16fc4f6a083467848e58093d85636eed
-    size: 62516710
+    size: 62755821
     path: igme.csv

--- a/snapshots/wb/2023-11-21/worldwide_bureaucracy_indicators.csv.dvc
+++ b/snapshots/wb/2023-11-21/worldwide_bureaucracy_indicators.csv.dvc
@@ -28,5 +28,5 @@ meta:
 wdir: ../../../data/snapshots/wb/2023-11-21
 outs:
   - md5: 191d0f3335056c4b3548b9c83c49e2a8
-    size: 13308262
+    size: 13369262
     path: worldwide_bureaucracy_indicators.csv

--- a/snapshots/who/latest/fluid.csv.dvc
+++ b/snapshots/who/latest/fluid.csv.dvc
@@ -21,5 +21,5 @@ meta:
 wdir: ../../../data/snapshots/who/latest
 outs:
   - md5: 6968b584dd96d00a26c5c7e4bc29486b
-    size: 125009397
+    size: 125829120
     path: fluid.csv

--- a/snapshots/who/latest/flunet.csv.dvc
+++ b/snapshots/who/latest/flunet.csv.dvc
@@ -21,5 +21,5 @@ meta:
 wdir: ../../../data/snapshots/who/latest
 outs:
   - md5: 6c5b4622f93692b7776cc02206fa5f64
-    size: 25275851
+    size: 25432110
     path: flunet.csv

--- a/snapshots/wvs/2023-06-25/longitudinal_wvs.csv.dvc
+++ b/snapshots/wvs/2023-06-25/longitudinal_wvs.csv.dvc
@@ -15,5 +15,5 @@ meta:
 wdir: ../../../data/snapshots/wvs/2023-06-25
 outs:
   - md5: 20ddc662945bef22464c8614066e7afe
-    size: 1394309380
+    size: 1394309381
     path: longitudinal_wvs.csv


### PR DESCRIPTION
The previous fuckup was caused by working with cached Cloudflare files from R2. These checksums and file sizes are taken directly from R2, not from custom domain that caches it.