### PR TITLE
:bug: don't modify downloaded file when updating MD5 with Windows newlines

### DIFF
--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -71,12 +71,8 @@ class Snapshot:
         if self.metadata.is_public:
             # TODO: temporarily download files from R2 instead of public link to prevent
             # issues with cached snapshots. Remove this when convenient
-            if config.R2_ACCESS_KEY:
-                download_url = f"s3://{config.R2_SNAPSHOTS_PUBLIC}/{md5[:2]}/{md5[2:]}"
-                s3_utils.download(download_url, str(self.path))
-            else:
-                download_url = f"{config.R2_SNAPSHOTS_PUBLIC_READ}/{md5[:2]}/{md5[2:]}"
-                files.download(download_url, str(self.path), progress_bar_min_bytes=2**100)
+            download_url = f"{config.R2_SNAPSHOTS_PUBLIC_READ}/{md5[:2]}/{md5[2:]}"
+            files.download(download_url, str(self.path), progress_bar_min_bytes=2**100)
         else:
             download_url = f"s3://{config.R2_SNAPSHOTS_PRIVATE}/{md5[:2]}/{md5[2:]}"
             s3_utils.download(download_url, str(self.path))

--- a/lib/walden/owid/walden/files.py
+++ b/lib/walden/owid/walden/files.py
@@ -83,9 +83,9 @@ def _stream_to_file(
         task_id = progress.add_task("Downloading", total=total_length)
 
     for chunk in streamer:  # 16k
+        file.write(chunk)
         if istextblock(chunk[:DEFAULT_CHUNK_SIZE]):
             chunk = dos2unix(chunk)
-        file.write(chunk)
         md5.update(chunk)
         if display_progress:
             progress.update(task_id, advance=len(chunk))  # type: ignore

--- a/lib/walden/pyproject.toml
+++ b/lib/walden/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "walden"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 authors = ["Our World in Data <tech@ourworldindata.org>"]
 packages = [{ include = "owid" }]

--- a/poetry.lock
+++ b/poetry.lock
@@ -7002,7 +7002,7 @@ tooling-extras = ["pyaml (>=23.7.0)", "pypandoc-binary (>=1.11)", "pytest (>=7.4
 
 [[package]]
 name = "walden"
-version = "0.1.0"
+version = "0.1.1"
 description = ""
 optional = false
 python-versions = "^3.8.1"


### PR DESCRIPTION
I was unintentionally stripping Windows newlines from downloaded files, which then led to size mismatch errors. This PR doesn't update the downloaded file and also switches back to downloading from custom domain instead of R2 directly.