### PR TITLE
:hammer: Remove `dos2unix` from checksum calculation

### DIFF
--- a/etl/files.py
+++ b/etl/files.py
@@ -54,10 +54,6 @@ TEXT_CHARS = bytes(range(32, 127)) + b"\n\r\t\f\b"
 DEFAULT_CHUNK_SIZE = 512
 
 
-def dos2unix(data: bytes) -> bytes:
-    return data.replace(b"\r\n", b"\n")
-
-
 def istextblock(block: bytes) -> bool:
     if not block:
         # An empty file is considered a valid text file
@@ -75,7 +71,7 @@ def istextblock(block: bytes) -> bool:
 
 def checksum_str(s: str) -> str:
     "Return the md5 hex digest of the string."
-    return hashlib.md5(dos2unix(s.encode())).hexdigest()
+    return hashlib.md5(s.encode()).hexdigest()
 
 
 def checksum_file_nocache(filename: Union[str, Path]) -> str:
@@ -85,9 +81,6 @@ def checksum_file_nocache(filename: Union[str, Path]) -> str:
     with open(filename, "rb") as istream:
         chunk = istream.read(chunk_size)
         while chunk:
-            if istextblock(chunk[:DEFAULT_CHUNK_SIZE]):
-                chunk = dos2unix(chunk)
-
             _hash.update(chunk)
             chunk = istream.read(chunk_size)
 

--- a/lib/walden/owid/walden/files.py
+++ b/lib/walden/owid/walden/files.py
@@ -42,10 +42,6 @@ def _create_progress_bar() -> Progress:
     )
 
 
-def dos2unix(data: bytes) -> bytes:
-    return data.replace(b"\r\n", b"\n")
-
-
 def istextblock(block: bytes) -> bool:
     if not block:
         # An empty file is considered a valid text file
@@ -84,8 +80,6 @@ def _stream_to_file(
 
     for chunk in streamer:  # 16k
         file.write(chunk)
-        if istextblock(chunk[:DEFAULT_CHUNK_SIZE]):
-            chunk = dos2unix(chunk)
         md5.update(chunk)
         if display_progress:
             progress.update(task_id, advance=len(chunk))  # type: ignore

--- a/lib/walden/owid/walden/index/postnatal_care/2022-09-19/postnatal_care.json
+++ b/lib/walden/owid/walden/index/postnatal_care/2022-09-19/postnatal_care.json
@@ -14,5 +14,5 @@
   "publication_year": 2022,
   "publication_date": "2022-09-19",
   "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/postnatal_care/2022-09-19/postnatal_care.csv",
-  "md5": "8aba1631da32d612218e6faa281cc3e0"
+  "md5": "dbea3cf2b1d0075680f305d532df9c9a"
 }

--- a/lib/walden/owid/walden/index/un/2019/un_igme.json
+++ b/lib/walden/owid/walden/index/un/2019/un_igme.json
@@ -12,5 +12,5 @@
   "version": "2019",
   "publication_date": "2019",
   "owid_data_url": "https://walden.nyc3.digitaloceanspaces.com/un/2019/un_igme.csv",
-  "md5": "30a5e2e4f9679b1867bb534dc5e3fe8b"
+  "md5": "b1157efed0e72c1aa9f3e3e7ad96c2af"
 }

--- a/snapshots/artificial_intelligence/2023-06-14/ai_adoption.csv.dvc
+++ b/snapshots/artificial_intelligence/2023-06-14/ai_adoption.csv.dvc
@@ -6,14 +6,11 @@ meta:
   publication_year: 2023
   publication_date: '2023-03-20'
   source_name: McKinsey & Company Survey (2022) via AI Index (2023)
-  source_published_by: McKinsey & Company Survey (2022) via the AI Index 2023 Annual
-    Report, AI Index Steering Committee, Institute for Human-Centered AI, Stanford
-    University, Stanford, CA, April 2023
+  source_published_by: McKinsey & Company Survey (2022) via the AI Index 2023 Annual Report, AI Index Steering Committee, Institute for Human-Centered AI, Stanford University, Stanford, CA, April 2023
   url: https://drive.google.com/drive/folders/1ma9WZJzKreS8f2It1rMy_KkkbX6XwDOK
   source_data_url: https://drive.google.com/uc?export=download&id=1dqEzwMBXVol7bt_ScuLdMpJ4GhGGuR7e
   file_extension: csv
-  license_url:
-    https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
+  license_url: https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
   license_name: Public domain
   date_accessed: 2023-06-19
   is_public: true
@@ -21,6 +18,6 @@ meta:
     Data from McKinsey & Company Survey via AI Index (2023) on AI adoption by organisations in Developing Markets (incl. India, Latin America, MENA), Greater China (incl. Hong Kong, Taiwan), North America, Europe and Asia-PaciǇc.
 wdir: ../../../data/snapshots/artificial_intelligence/2023-06-14
 outs:
-- md5: 8dd0fee242b8aad6f6ffa75f83aa463a
-  size: 471
-  path: ai_adoption.csv
+  - md5: fae6f16f53244d8778797609fe8065b7
+    size: 471
+    path: ai_adoption.csv

--- a/snapshots/artificial_intelligence/2023-06-14/ai_bills.csv.dvc
+++ b/snapshots/artificial_intelligence/2023-06-14/ai_bills.csv.dvc
@@ -1,19 +1,16 @@
 meta:
   namespace: artificial_intelligence
   short_name: ai_bills
-  name: Number of AI-Related Bills Passed Into Law by Country, 2016–22 (AI Index,
-    2023)
+  name: Number of AI-Related Bills Passed Into Law by Country, 2016–22 (AI Index, 2023)
   version: '2023-06-14'
   publication_year: 2023
   publication_date: '2023-04-01'
   source_name: AI Index (2023)
-  source_published_by: AI Index 2023 Annual Report, AI Index Steering Committee,
-    Institute for Human-Centered AI, Stanford University, Stanford, CA, April 2023
+  source_published_by: AI Index 2023 Annual Report, AI Index Steering Committee, Institute for Human-Centered AI, Stanford University, Stanford, CA, April 2023
   url: https://drive.google.com/drive/folders/1ma9WZJzKreS8f2It1rMy_KkkbX6XwDOK
   source_data_url: https://drive.google.com/uc?export=download&id=1fpjGF3CFRH88_7LR7BB_8vdFWUcRJeEn
   file_extension: csv
-  license_url:
-    https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
+  license_url: https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
   license_name: Public domain
   date_accessed: 2023-06-19
   is_public: true
@@ -22,6 +19,6 @@ meta:
 
 wdir: ../../../data/snapshots/artificial_intelligence/2023-06-14
 outs:
-- md5: 39505639f41faa2deeac7429ba8dd7c3
-  size: 1600
-  path: ai_bills.csv
+  - md5: e83b8b7b9b2bc0f15960b0d51079d499
+    size: 1600
+    path: ai_bills.csv

--- a/snapshots/artificial_intelligence/2023-06-14/ai_corporate_investment.csv.dvc
+++ b/snapshots/artificial_intelligence/2023-06-14/ai_corporate_investment.csv.dvc
@@ -1,20 +1,16 @@
 meta:
   namespace: artificial_intelligence
   short_name: ai_corporate_investment
-  name: Global Corporate Investment in AI by Investment Activity, 2013–22 (AI Index,
-    2023)
+  name: Global Corporate Investment in AI by Investment Activity, 2013–22 (AI Index, 2023)
   version: '2023-06-14'
   publication_year: 2023
   publication_date: '2023-03-20'
   source_name: NetBase Quid (2022) via AI Index (2023)
-  source_published_by: NetBase Quid (2022) via the AI Index 2023 Annual Report, AI
-    Index Steering Committee, Institute for Human-Centered AI, Stanford University,
-    Stanford, CA, April 2023
+  source_published_by: NetBase Quid (2022) via the AI Index 2023 Annual Report, AI Index Steering Committee, Institute for Human-Centered AI, Stanford University, Stanford, CA, April 2023
   url: https://drive.google.com/drive/folders/1ma9WZJzKreS8f2It1rMy_KkkbX6XwDOK
   source_data_url: https://drive.google.com/uc?export=download&id=1Vqc-L9XlaPgghNZGbAGpU23d9Pn5ZuHh
   file_extension: csv
-  license_url:
-    https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
+  license_url: https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
   license_name: Public domain
   date_accessed: 2023-06-19
   is_public: true
@@ -22,6 +18,6 @@ meta:
     Data from NetBase Quid via AI Index (2023) on global corporate investment in AI from 2013 to 2022. Corporate investment includes mergers and acquisitions, minority stakes, private investment, and public offerings.
 wdir: ../../../data/snapshots/artificial_intelligence/2023-06-14
 outs:
-- md5: 92e59f47fe749ff1b20fdc6b6c3347f6
-  size: 1205
-  path: ai_corporate_investment.csv
+  - md5: 1044a26d4ce3e6259e30ac9dde93194d
+    size: 1205
+    path: ai_corporate_investment.csv

--- a/snapshots/artificial_intelligence/2023-06-14/ai_employers.csv.dvc
+++ b/snapshots/artificial_intelligence/2023-06-14/ai_employers.csv.dvc
@@ -6,14 +6,11 @@ meta:
   publication_year: 2023
   publication_date: '2023-03-21'
   source_name: SCRA Taulbee Survey (2022) via AI Index Report
-  source_published_by: SCRA Taulbee Survey (2022) via AI Index 2023 Annual Report,
-    AI Index Steering Committee, Institute for Human-Centered AI, Stanford University,
-    Stanford, CA, April 2023
+  source_published_by: SCRA Taulbee Survey (2022) via AI Index 2023 Annual Report, AI Index Steering Committee, Institute for Human-Centered AI, Stanford University, Stanford, CA, April 2023
   url: https://drive.google.com/drive/folders/1ma9WZJzKreS8f2It1rMy_KkkbX6XwDOK
   source_data_url: https://drive.google.com/uc?export=download&id=15_Gji-pjmATWPG_QsHVmq3uKYU33PPw8
   file_extension: csv
-  license_url: 
-    https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
+  license_url: https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
   license_name: Public domain
   date_accessed: 2023-06-19
   is_public: true
@@ -21,6 +18,6 @@ meta:
     Employment of New AI PhDs (% of Total) in North America by Sector (industry, government, academia), 2010–21.
 wdir: ../../../data/snapshots/artificial_intelligence/2023-06-14
 outs:
-- md5: ca7d2dbb88045f80748cd5a03d9dbd85
-  size: 708
-  path: ai_employers.csv
+  - md5: 6a76f4b745bb586902c6d742c0012a05
+    size: 708
+    path: ai_employers.csv

--- a/snapshots/artificial_intelligence/2023-06-14/ai_large_conferences.csv.dvc
+++ b/snapshots/artificial_intelligence/2023-06-14/ai_large_conferences.csv.dvc
@@ -7,13 +7,11 @@ meta:
 
   publication_date: '2023-03-24'
   source_name: AI Index (2023)
-  source_published_by: The AI Index 2023 Annual Report, AI Index Steering Committee,
-    Institute for Human-Centered AI, Stanford University, Stanford, CA, April 2023.
+  source_published_by: The AI Index 2023 Annual Report, AI Index Steering Committee, Institute for Human-Centered AI, Stanford University, Stanford, CA, April 2023.
   url: https://drive.google.com/drive/folders/1ma9WZJzKreS8f2It1rMy_KkkbX6XwDOK
   source_data_url: https://drive.google.com/uc?export=download&id=1LlEwGnFxr8WDITu4uh6GYoUojvC4mSm-
   file_extension: csv
-  license_url:
-    https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
+  license_url: https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
   license_name: Public domain
   date_accessed: 2023-06-14
   is_public: true
@@ -21,6 +19,6 @@ meta:
     Data from AI Index report on annual attendance of large conferences (split by type). It should be interpreted with caution given that many conferences in the last few years have had virtual or hybrid formats. Conference organisers report that measuring the exact attendance numbers at virtual conferences is difficult, as virtual conferences allow for higher attendance of researchers from around the world.
 wdir: ../../../data/snapshots/artificial_intelligence/2023-06-14
 outs:
-- md5: 7b0ac1d11a5a47f85dcaa039a80d7538
-  size: 1522
-  path: ai_large_conferences.csv
+  - md5: 7187f9f53dc1090f746654206a1ac309
+    size: 1522
+    path: ai_large_conferences.csv

--- a/snapshots/artificial_intelligence/2023-06-14/ai_national_strategy.csv.dvc
+++ b/snapshots/artificial_intelligence/2023-06-14/ai_national_strategy.csv.dvc
@@ -6,13 +6,11 @@ meta:
   publication_year: 2023
   publication_date: '2023-03-20'
   source_name: AI Index (2023)
-  source_published_by: AI Index 2023 Annual Report, AI Index Steering Committee,
-    Institute for Human-Centered AI, Stanford University, Stanford, CA, April 2023
+  source_published_by: AI Index 2023 Annual Report, AI Index Steering Committee, Institute for Human-Centered AI, Stanford University, Stanford, CA, April 2023
   url: https://drive.google.com/drive/folders/1ma9WZJzKreS8f2It1rMy_KkkbX6XwDOK
   source_data_url: https://drive.google.com/uc?export=download&id=11ReYSMwl460b1DXkG5e4hscXlC8XhvXU
   file_extension: csv
-  license_url:
-    https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
+  license_url: https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
   license_name: Public domain
   date_accessed: 2023-06-19
   is_public: true
@@ -28,6 +26,6 @@ meta:
     also maximizing the benefits of AI for society.
 wdir: ../../../data/snapshots/artificial_intelligence/2023-06-14
 outs:
-- md5: c293437993f1bce209bc2b13505c1a01
-  size: 1331
-  path: ai_national_strategy.csv
+  - md5: 8867126e269cbbc6475469df7e533c77
+    size: 1331
+    path: ai_national_strategy.csv

--- a/snapshots/artificial_intelligence/2023-06-14/ai_small_conferences.csv.dvc
+++ b/snapshots/artificial_intelligence/2023-06-14/ai_small_conferences.csv.dvc
@@ -7,13 +7,11 @@ meta:
 
   publication_date: '2023-03-24'
   source_name: AI Index (2023)
-  source_published_by: The AI Index 2023 Annual Report, AI Index Steering Committee, Institute
-    for Human-Centered AI, Stanford University, Stanford, CA, April 2023.
+  source_published_by: The AI Index 2023 Annual Report, AI Index Steering Committee, Institute for Human-Centered AI, Stanford University, Stanford, CA, April 2023.
   url: https://drive.google.com/drive/folders/1ma9WZJzKreS8f2It1rMy_KkkbX6XwDOK
   source_data_url: https://drive.google.com/uc?export=download&id=1_8GtlYbvB4Gp64Fy2_oy_Jk83lsEIYOj
   file_extension: csv
-  license_url:
-    https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
+  license_url: https://aiindex.stanford.edu/wp-content/uploads/2023/04/HAI_AI-Index-Report_2023.pdf
   license_name: Public domain
   date_accessed: 2023-06-14
   is_public: true
@@ -22,6 +20,6 @@ meta:
 
 wdir: ../../../data/snapshots/artificial_intelligence/2023-06-14
 outs:
-- md5: 9227c198a1c100a76ac0d58720795eda
-  size: 957
-  path: ai_small_conferences.csv
+  - md5: 2e73a441a24a07336a4f57bec73027d6
+    size: 957
+    path: ai_small_conferences.csv

--- a/snapshots/artificial_intelligence/2023-06-21/epoch.csv.dvc
+++ b/snapshots/artificial_intelligence/2023-06-21/epoch.csv.dvc
@@ -6,11 +6,9 @@ meta:
   publication_year: 2023
   publication_date:
   source_name: Epoch (2023)
-  source_published_by: 'Epoch, Parameter, Compute and Data Trends in Machine Learning.
-    Published online at epochai.org. Retrieved from: https://epochai.org/mlinputs/visualization'
+  source_published_by: 'Epoch, Parameter, Compute and Data Trends in Machine Learning. Published online at epochai.org. Retrieved from: https://epochai.org/mlinputs/visualization'
   url: https://epochai.org/mlinputs/visualization
-  source_data_url: 
-    https://docs.google.com/spreadsheets/d/1AAIebjNsnJj_uKALHbXNfn3_YsT6sHXtCU0q7OIPuc4/export?gid=0&format=csv
+  source_data_url: https://docs.google.com/spreadsheets/d/1AAIebjNsnJj_uKALHbXNfn3_YsT6sHXtCU0q7OIPuc4/export?gid=0&format=csv
 
   file_extension: csv
   license_url:
@@ -34,6 +32,6 @@ meta:
         The authors note that: "For new models (from 2020 onward) it is harder to assess these criteria, so we fall back to a subjective selection. We refer to models meeting our selection criteria as 'milestone models.'"
 wdir: ../../../data/snapshots/artificial_intelligence/2023-06-21
 outs:
-- md5: 28c4f1e432b7ce3b2b5467ed4991c0f4
-  size: 609893
-  path: epoch.csv
+  - md5: f7e94b8afdccd19e04d71664880cdb18
+    size: 609893
+    path: epoch.csv

--- a/snapshots/artificial_intelligence/2023-07-07/semiconductors_cset.csv.dvc
+++ b/snapshots/artificial_intelligence/2023-07-07/semiconductors_cset.csv.dvc
@@ -6,8 +6,7 @@ meta:
     "Emerging Technology Observatory Advanced Semiconductor Supply Chain Dataset (2022
     release)"
   url: https://chipexplorer.eto.tech/
-  source_data_url: 
-    https://raw.githubusercontent.com/georgetown-cset/eto-supply-chain/main/data/provision.csv
+  source_data_url: https://raw.githubusercontent.com/georgetown-cset/eto-supply-chain/main/data/provision.csv
   license_url: https://eto.tech/tou/
   license_name: Creative Commons BY 4.0
   date_accessed: 2023-07-07
@@ -31,6 +30,6 @@ meta:
 
 wdir: ../../../data/snapshots/artificial_intelligence/2023-07-07
 outs:
-- md5: 6f54d4db643ec96a2da82f5b6daeaf14
-  size: 29312
-  path: semiconductors_cset.csv
+  - md5: 27f7eb2f717e21ded94ec346b21b3689
+    size: 29312
+    path: semiconductors_cset.csv

--- a/snapshots/artificial_intelligence/2023-07-12/epoch_llms.csv.dvc
+++ b/snapshots/artificial_intelligence/2023-07-12/epoch_llms.csv.dvc
@@ -3,11 +3,8 @@ meta:
   publication_year: 1994
   publication_date: '2023-07-12'
   source_name: Epoch (2023)
-  source_published_by: "David Owen (2023), Extrapolating performance in language modeling
-    benchmarks. Published online at epochai.org. Retrieved from: 'https://epochai.org/blog/extrapolating-performance-in-language-modelling-benchmarks'
-    [online resource]"
-  url: 
-    https://docs.google.com/spreadsheets/d/1HSGbUVwGy3XLuChH_H16Keux2jmVfKT9rfDrC3uu-SQ/edit?usp=sharing
+  source_published_by: "David Owen (2023), Extrapolating performance in language modeling benchmarks. Published online at epochai.org. Retrieved from: 'https://epochai.org/blog/extrapolating-performance-in-language-modelling-benchmarks' [online resource]"
+  url: https://docs.google.com/spreadsheets/d/1HSGbUVwGy3XLuChH_H16Keux2jmVfKT9rfDrC3uu-SQ/edit?usp=sharing
   source_data_url:
   license_url:
   license_name: Creative Commons BY 4.0
@@ -17,6 +14,6 @@ meta:
     Epoch dataset on how performance on a MMLU language benchmark scales with computational resources.
 wdir: ../../../data/snapshots/artificial_intelligence/2023-07-12
 outs:
-- md5: 30e9dea32e9a2952e2f021f90290eb54
-  size: 1574
-  path: epoch_llms.csv
+  - md5: cb9b029797e06266a2f4caae52d98b92
+    size: 1574
+    path: epoch_llms.csv

--- a/snapshots/artificial_intelligence/2024-02-05/chess.csv.dvc
+++ b/snapshots/artificial_intelligence/2024-02-05/chess.csv.dvc
@@ -34,6 +34,6 @@ meta:
 
 wdir: ../../../data/snapshots/artificial_intelligence/2024-02-05
 outs:
-- md5: a50b0dfb80d7bdd15ea1fb807d8f7c6f
-  size: 1309
-  path: chess.csv
+  - md5: 2cddb5285d4795b407845cbadca5c049
+    size: 1309
+    path: chess.csv

--- a/snapshots/artificial_intelligence/2024-02-15/epoch_llms.csv.dvc
+++ b/snapshots/artificial_intelligence/2024-02-15/epoch_llms.csv.dvc
@@ -1,21 +1,18 @@
 meta:
   origin:
     title: Large Language Model Performance and Compute
-    description: Epoch dataset on how performance on a MMLU language benchmark scales
-      with computational resources.
+    description: Epoch dataset on how performance on a MMLU language benchmark scales with computational resources.
     producer: Epoch
     citation_full: |-
       Owen, David. (2023). Large Language Model performance and compute, Epoch (2023) [Data set]. In Extrapolating performance in language modeling benchmarks. Published online at epochai.org. Retrieved from: 'https://epochai.org/blog/extrapolating-performance-in-language-modelling-benchmarks' [online resource].
-    url_main:
-      https://epochai.org/blog/extrapolating-performance-in-language-modelling-benchmarks
+    url_main: https://epochai.org/blog/extrapolating-performance-in-language-modelling-benchmarks
     date_accessed: 2024-02-15
     date_published: 2023-07-12
     license:
       name: Creative Commons BY 4.0
-      url:
-        https://epochai.org/blog/extrapolating-performance-in-language-modelling-benchmarks
+      url: https://epochai.org/blog/extrapolating-performance-in-language-modelling-benchmarks
 wdir: ../../../data/snapshots/artificial_intelligence/2024-02-15
 outs:
-- md5: b325a41d52e44c2fd2285cf558f0a3ab
-  size: 1611
-  path: epoch_llms.csv
+  - md5: 134cb73f28be470ee6566d86a19812e4
+    size: 1611
+    path: epoch_llms.csv

--- a/snapshots/backport/latest/dataset_5676_global_health_observatory__world_health_organization__2022_08_values.feather.dvc
+++ b/snapshots/backport/latest/dataset_5676_global_health_observatory__world_health_organization__2022_08_values.feather.dvc
@@ -9,6 +9,6 @@ meta:
   description: This is a dataset imported by the automated fetcher
 wdir: ../../../data/snapshots/backport/latest
 outs:
-  - md5: 04e7de5a67a01d201b31a244c111d205
+  - md5: 6b9e6c6a47fe24b3c8d2a73ed728f077
     size: 31578410
     path: dataset_5676_global_health_observatory__world_health_organization__2022_08_values.feather

--- a/snapshots/biodiversity/2023-01-11/cherry_blossom.csv.dvc
+++ b/snapshots/biodiversity/2023-01-11/cherry_blossom.csv.dvc
@@ -27,6 +27,6 @@ meta:
       url: http://atmenv.envi.osakafu-u.ac.jp/aono/kyophenotemp4/
 wdir: ../../../data/snapshots/biodiversity/2023-01-11
 outs:
-- md5: e966a7746093969705cf9582cd6109a4
-  path: cherry_blossom.csv
-  size: 42758
+  - md5: 86bf238517d1f2711a69057669ad8042
+    path: cherry_blossom.csv
+    size: 42758

--- a/snapshots/climate/2024-01-28/global_sea_level.csv.dvc
+++ b/snapshots/climate/2024-01-28/global_sea_level.csv.dvc
@@ -10,16 +10,14 @@ meta:
       * The early part of the time series comes from the sea level group of CSIRO (Commonwealth Scientific and Industrial Research Organisation), Australia's national science agency. Church, J. A., and White, N. J. (2011). Sea-Level Rise from the Late 19th to the Early 21st Century. Surveys in Geophysics, 32(4-5), 585-602. http://doi.org/10.1007/s10712-011-9119-1
       * The more recent part of the time series is from the University of Hawaii Sea Level Center (UHSLC). It is based on a weighted average of 373 global tide gauge records collected by the U.S. National Ocean Service, UHSLC, and partner agencies worldwide.
     attribution_short: NOAA/Climate.gov
-    url_main: 
-      https://www.climate.gov/news-features/understanding-climate/climate-change-global-sea-level
-    url_download: 
-      https://www.climate.gov/sites/default/files/Climate_dot_gov_dashboard_SeaLevel_Jan2021update.txt
+    url_main: https://www.climate.gov/news-features/understanding-climate/climate-change-global-sea-level
+    url_download: https://www.climate.gov/sites/default/files/Climate_dot_gov_dashboard_SeaLevel_Jan2021update.txt
     date_accessed: 2024-01-28
     license:
       name: CC BY 4.0
 
 wdir: ../../../data/snapshots/climate/2024-01-28
 outs:
-- md5: 58d29b59f9dac796412beddc92bbb163
-  size: 18100
-  path: global_sea_level.csv
+  - md5: 9c00ba285d35437306eaf22459230198
+    size: 18100
+    path: global_sea_level.csv

--- a/snapshots/climate/2024-01-31/hawaii_ocean_time_series.csv.dvc
+++ b/snapshots/climate/2024-01-31/hawaii_ocean_time_series.csv.dvc
@@ -18,8 +18,7 @@ meta:
 
       More details can be found at [the HOT Carbon Dioxide page](https://hahana.soest.hawaii.edu/hot/hotco2/hotco2.html),
       specifically in [this technical document](https://hahana.soest.hawaii.edu/hot/hotco2/HOT_surface_CO2_readme.pdf).
-    attribution: School of Ocean & Earth Science & Technology - Hawaii Ocean Time-series
-      (2023)
+    attribution: School of Ocean & Earth Science & Technology - Hawaii Ocean Time-series (2023)
     attribution_short: SOEST/Hawaii
     url_main: https://hahana.soest.hawaii.edu/hot/
     url_download: https://hahana.soest.hawaii.edu/hot/hotco2/HOT_surface_CO2.txt
@@ -30,6 +29,6 @@ meta:
       url: https://hahana.soest.hawaii.edu/hot/dataaccess.html
 wdir: ../../../data/snapshots/climate/2024-01-31
 outs:
-- md5: 74e636539b06abae72a4cba91df12f51
-  size: 44820
-  path: hawaii_ocean_time_series.csv
+  - md5: fd502d28aa85a6f241e9507d85b8ca8b
+    size: 44820
+    path: hawaii_ocean_time_series.csv

--- a/snapshots/countries/2023-09-22/cow_ssm_majors.csv.dvc
+++ b/snapshots/countries/2023-09-22/cow_ssm_majors.csv.dvc
@@ -35,6 +35,6 @@ meta:
 
 wdir: ../../../data/snapshots/countries/2023-09-22
 outs:
-- md5: eaa0e0d76834b0f583e753dbe2cfdc97
-  size: 539
-  path: cow_ssm_majors.csv
+  - md5: 72d84c81e926d4d6538ec8302ffe8d86
+    size: 539
+    path: cow_ssm_majors.csv

--- a/snapshots/countries/2023-09-22/cow_ssm_states.csv.dvc
+++ b/snapshots/countries/2023-09-22/cow_ssm_states.csv.dvc
@@ -18,8 +18,7 @@ meta:
 
     # Citation
     producer: Correlates of War
-    citation_full: Correlates of War Project. 2017. “State System Membership List,
-      v2016.” Online, http://correlatesofwar.org
+    citation_full: Correlates of War Project. 2017. “State System Membership List, v2016.” Online, http://correlatesofwar.org
     attribution: Correlates of War - State System Membership (2017)
     attribution_short: COW
 
@@ -35,6 +34,6 @@ meta:
 
 wdir: ../../../data/snapshots/countries/2023-09-22
 outs:
-- md5: 66885ad5b0281f620cabdd899a814434
-  size: 10845
-  path: cow_ssm_states.csv
+  - md5: 3f234a00f07689a4297dc80d39cc832b
+    size: 10845
+    path: cow_ssm_states.csv

--- a/snapshots/countries/2023-09-22/cow_ssm_system.csv.dvc
+++ b/snapshots/countries/2023-09-22/cow_ssm_system.csv.dvc
@@ -18,8 +18,7 @@ meta:
 
     # Citation
     producer: Correlates of War
-    citation_full: Correlates of War Project. 2017. “State System Membership List,
-      v2016.” Online, http://correlatesofwar.org
+    citation_full: Correlates of War Project. 2017. “State System Membership List, v2016.” Online, http://correlatesofwar.org
     attribution: Correlates of War - State System Membership (2017)
     attribution_short: COW
 
@@ -35,6 +34,6 @@ meta:
 
 wdir: ../../../data/snapshots/countries/2023-09-22
 outs:
-- md5: dbbb46252c2e3e93e7549b599d054ae4
-  size: 300836
-  path: cow_ssm_system.csv
+  - md5: 2dce9e384f8968292557a6bc1f93fe12
+    size: 300836
+    path: cow_ssm_system.csv

--- a/snapshots/countries/2023-09-22/gleditsch_microstates.dat.dvc
+++ b/snapshots/countries/2023-09-22/gleditsch_microstates.dat.dvc
@@ -27,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/countries/2023-09-22
 outs:
-- md5: b9ef1b421b1afbf2004abfe5050774fe
-  size: 1015
-  path: gleditsch_microstates.dat
+  - md5: e011d4bed704f2e0fdada0549e9098b3
+    size: 1015
+    path: gleditsch_microstates.dat

--- a/snapshots/countries/2023-09-22/gleditsch_states.dat.dvc
+++ b/snapshots/countries/2023-09-22/gleditsch_states.dat.dvc
@@ -27,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/countries/2023-09-22
 outs:
-- md5: a14a4d36ab74faeab281e431c11996aa
-  size: 9093
-  path: gleditsch_states.dat
+  - md5: 304fa68f0809dfb7351241d63b9bc3b4
+    size: 9093
+    path: gleditsch_states.dat

--- a/snapshots/demography/2023-10-10/riley_2005.pdf.dvc
+++ b/snapshots/demography/2023-10-10/riley_2005.pdf.dvc
@@ -17,8 +17,7 @@ meta:
 
     # Files
     url_main: https://doi.org/10.1111/j.1728-4457.2005.00083.x
-    url_download: 
-      https://u.demog.berkeley.edu/~jrw/Biblio/Eprints/%20P-S/riley.2005_estimates.global.e0.pdf
+    url_download: https://u.demog.berkeley.edu/~jrw/Biblio/Eprints/%20P-S/riley.2005_estimates.global.e0.pdf
     date_accessed: 2023-10-10
 
     # License
@@ -28,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/demography/2023-10-10
 outs:
-- md5: f72f60c74142ec25af1c6e069c25c728
-  size: 1107
-  path: riley_2005.pdf
+  - md5: 3f325cfc2cf3ba93bb8d2261c1373220
+    size: 1107
+    path: riley_2005.pdf

--- a/snapshots/education/2023-12-15/wittgenstein_center_data.csv.dvc
+++ b/snapshots/education/2023-12-15/wittgenstein_center_data.csv.dvc
@@ -30,6 +30,6 @@ meta:
 
 wdir: ../../../data/snapshots/education/2023-12-15
 outs:
-  - md5: 56fbd4dc31402e2f226e66a386589ee5
+  - md5: 8b77a93a01ab5ab8fb3f42fda2b7f0e4
     size: 101373997
     path: wittgenstein_center_data.csv

--- a/snapshots/education/2023-12-15/wittgenstein_center_dictionary.csv.dvc
+++ b/snapshots/education/2023-12-15/wittgenstein_center_dictionary.csv.dvc
@@ -10,8 +10,7 @@ meta:
       This dataset includes demographic data up to the year 2012, reflecting changes in the population structure by age, sex, and education since the base year of 2010. These changes are primarily attributed to newer and more accurate data. The dataset captures shifts in mortality rates, especially in countries affected by HIV/AIDS and those with high child mortality rates. It also considers the impact of COVID-19 on demographic trends, noting significant shifts such as the rapid decline of fertility rates in many countries and the unpredictable patterns of international migration. These updates and changes are comprehensively reflected in the dataset, offering a refined and current view of the SSPs.
     date_published: 2023-03-31
     version_producer: 2023-05-10
-    title_snapshot: Wittgenstein Center Population and Human Capital Projections -
-      Educational Attainment - Dictionary
+    title_snapshot: Wittgenstein Center Population and Human Capital Projections - Educational Attainment - Dictionary
     description_snapshot: |-
       The dataset provides annual population projections from 2020 to 2100 based on the SSP2 "Middle of the Road" scenario, detailing demographic changes by age group, educational attainment, and sex for each country. It includes a range of age groups from newborns up to those aged 120+, educational levels from no education to post-secondary, and demographic indicators such as births per 1000 women, mean age in years, proportions, ratios, and population numbers in thousands.
 
@@ -32,6 +31,6 @@ meta:
 
 wdir: ../../../data/snapshots/education/2023-12-15
 outs:
-- md5: 0f83d200498f39f965a186f469fdd582
-  size: 18332
-  path: wittgenstein_center_dictionary.csv
+  - md5: 7601883296246ead95db3608b7031740
+    size: 18332
+    path: wittgenstein_center_dictionary.csv

--- a/snapshots/energy_institute/2023-06-26/statistical_review_of_world_energy.csv.dvc
+++ b/snapshots/energy_institute/2023-06-26/statistical_review_of_world_energy.csv.dvc
@@ -5,10 +5,8 @@ meta:
   source_name: Energy Institute Statistical Review of World Energy (2023)
   source_published_by: Energy Institute Statistical Review of World Energy (2023)
   url: https://www.energyinst.org/statistical-review/
-  source_data_url:
-    https://www.energyinst.org/__data/assets/file/0007/1055761/Consolidated-Dataset-Panel-format-CSV.csv
-  license_url:
-    https://web.archive.org/web/20230626200231/https://www.energyinst.org/__data/assets/pdf_file/0004/1055542/EI_Stat_Review_PDF_single-2.pdf
+  source_data_url: https://www.energyinst.org/__data/assets/file/0007/1055761/Consolidated-Dataset-Panel-format-CSV.csv
+  license_url: https://web.archive.org/web/20230626200231/https://www.energyinst.org/__data/assets/pdf_file/0004/1055542/EI_Stat_Review_PDF_single-2.pdf
   license_name: © Energy Institute 2023
   date_accessed: 2023-06-27
   is_public: true
@@ -17,6 +15,6 @@ meta:
 
 wdir: ../../../data/snapshots/energy_institute/2023-06-26
 outs:
-- md5: fad4d30abdd090c09620038e81fdeb9d
-  size: 3388062
-  path: statistical_review_of_world_energy.csv
+  - md5: 74ca57954dcf12322dd27709f0f59a17
+    size: 3388062
+    path: statistical_review_of_world_energy.csv

--- a/snapshots/energy_institute/2023-12-12/statistical_review_of_world_energy.csv.dvc
+++ b/snapshots/energy_institute/2023-12-12/statistical_review_of_world_energy.csv.dvc
@@ -1,8 +1,7 @@
 meta:
   origin:
     title: Statistical Review of World Energy
-    title_snapshot: Statistical Review of World Energy - Consolidated dataset panel
-      format
+    title_snapshot: Statistical Review of World Energy - Consolidated dataset panel format
     description: |-
       The Energy Institute Statistical Review of World Energy analyses data on world energy markets from the prior year.
     producer: Energy Institute
@@ -13,14 +12,13 @@ meta:
     date_accessed: 2023-12-12
     date_published: 2023-06-26
     url_main: https://www.energyinst.org/statistical-review/
-    url_download:
-      https://www.energyinst.org/__data/assets/file/0007/1055761/Consolidated-Dataset-Panel-format-CSV.csv
+    url_download: https://www.energyinst.org/__data/assets/file/0007/1055761/Consolidated-Dataset-Panel-format-CSV.csv
     license:
       name: © Energy Institute 2023
       url: https://web.archive.org/web/20230626200231/https://www.energyinst.org/__data/assets/pdf_file/0004/1055542/EI_Stat_Review_PDF_single-2.pdf
 
 wdir: ../../../data/snapshots/energy_institute/2023-12-12
 outs:
-- md5: fad4d30abdd090c09620038e81fdeb9d
-  size: 3388062
-  path: statistical_review_of_world_energy.csv
+  - md5: 74ca57954dcf12322dd27709f0f59a17
+    size: 3388062
+    path: statistical_review_of_world_energy.csv

--- a/snapshots/epa/2024-01-29/ch4_concentration.csv.dvc
+++ b/snapshots/epa/2024-01-29/ch4_concentration.csv.dvc
@@ -6,8 +6,7 @@ meta:
       This indicator describes how the levels of major greenhouse gases in the atmosphere have changed over time.
 
       The data contains concentrations of carbon dioxide in the atmosphere from hundreds of thousands of years ago through 2021, measured in parts per million (ppm). The data come from a variety of historical ice core studies and recent air monitoring sites around the world.
-    title_snapshot: 'Climate Change Indicators: Atmospheric Concentrations of Greenhouse
-      Gases - Methane'
+    title_snapshot: 'Climate Change Indicators: Atmospheric Concentrations of Greenhouse Gases - Methane'
     citation_full: |-
       United States Environmental Protection Agency (EPA) - Climate Change Indicators: Atmospheric Concentrations of Greenhouse Gases (2022)
 
@@ -16,10 +15,8 @@ meta:
       More details can be found on [their technical documentation](https://www.epa.gov/sites/default/files/2021-03/documents/ghg-concentrations_td.pdf).
     attribution: EPA based on various sources (2022)
     attribution_short: EPA
-    url_main: 
-      https://www.epa.gov/climate-indicators/climate-change-indicators-atmospheric-concentrations-greenhouse-gases
-    url_download: 
-      https://www.epa.gov/system/files/other-files/2022-07/ghg-concentrations_fig-2.csv
+    url_main: https://www.epa.gov/climate-indicators/climate-change-indicators-atmospheric-concentrations-greenhouse-gases
+    url_download: https://www.epa.gov/system/files/other-files/2022-07/ghg-concentrations_fig-2.csv
     date_accessed: '2024-01-29'
     date_published: '2022-07-01'
     license:
@@ -27,6 +24,6 @@ meta:
       url: https://edg.epa.gov/epa_data_license.html
 wdir: ../../../data/snapshots/epa/2024-01-29
 outs:
-- md5: ccb5c5d3b751b6e81dd9761f3f07d0a7
-  size: 48396
-  path: ch4_concentration.csv
+  - md5: e960453c271261622b4bfe2b2131755e
+    size: 48396
+    path: ch4_concentration.csv

--- a/snapshots/epa/2024-01-29/co2_concentration.csv.dvc
+++ b/snapshots/epa/2024-01-29/co2_concentration.csv.dvc
@@ -6,8 +6,7 @@ meta:
       This indicator describes how the levels of major greenhouse gases in the atmosphere have changed over time.
 
       The data contains concentrations of carbon dioxide in the atmosphere from hundreds of thousands of years ago through 2021, measured in parts per million (ppm). The data come from a variety of historical ice core studies and recent air monitoring sites around the world.
-    title_snapshot: 'Climate Change Indicators: Atmospheric Concentrations of Greenhouse
-      Gases - Carbon Dioxide'
+    title_snapshot: 'Climate Change Indicators: Atmospheric Concentrations of Greenhouse Gases - Carbon Dioxide'
     citation_full: |-
       United States Environmental Protection Agency (EPA) - Climate Change Indicators: Atmospheric Concentrations of Greenhouse Gases (2022)
 
@@ -16,8 +15,7 @@ meta:
       More details can be found on [their technical documentation](https://www.epa.gov/sites/default/files/2021-03/documents/ghg-concentrations_td.pdf).
     attribution: EPA based on various sources (2022)
     attribution_short: EPA
-    url_main: 
-      https://www.epa.gov/climate-indicators/climate-change-indicators-atmospheric-concentrations-greenhouse-gases
+    url_main: https://www.epa.gov/climate-indicators/climate-change-indicators-atmospheric-concentrations-greenhouse-gases
     url_download: https://www.epa.gov/sites/default/files/2021-03/ghg-concentrations_fig-1.csv
     date_accessed: '2024-01-29'
     date_published: '2022-07-01'
@@ -26,6 +24,6 @@ meta:
       url: https://edg.epa.gov/epa_data_license.html
 wdir: ../../../data/snapshots/epa/2024-01-29
 outs:
-- md5: 61d82b2624d8f71da5d7b2ec0f592d03
-  size: 51721
-  path: co2_concentration.csv
+  - md5: b93b2e77561a17255f953e0a26f09119
+    size: 51721
+    path: co2_concentration.csv

--- a/snapshots/epa/2024-01-29/ice_sheet_mass_balance.csv.dvc
+++ b/snapshots/epa/2024-01-29/ice_sheet_mass_balance.csv.dvc
@@ -32,6 +32,6 @@ meta:
       url: https://edg.epa.gov/epa_data_license.html
 wdir: ../../../data/snapshots/epa/2024-01-29
 outs:
-- md5: b5ddce405590e06ce836c09b6b12a985
-  size: 25986
-  path: ice_sheet_mass_balance.csv
+  - md5: 4855164ffa55ddf71df690fadceac94c
+    size: 25986
+    path: ice_sheet_mass_balance.csv

--- a/snapshots/epa/2024-01-29/mass_balance_us_glaciers.csv.dvc
+++ b/snapshots/epa/2024-01-29/mass_balance_us_glaciers.csv.dvc
@@ -23,6 +23,6 @@ meta:
       url: https://edg.epa.gov/epa_data_license.html
 wdir: ../../../data/snapshots/epa/2024-01-29
 outs:
-- md5: fef71d1bebaedcd289d28e374f3e795c
-  size: 2257
-  path: mass_balance_us_glaciers.csv
+  - md5: 98571ba4a0568f2f3ab78bc2aa9c9c3f
+    size: 2257
+    path: mass_balance_us_glaciers.csv

--- a/snapshots/epa/2024-01-29/n2o_concentration.csv.dvc
+++ b/snapshots/epa/2024-01-29/n2o_concentration.csv.dvc
@@ -6,8 +6,7 @@ meta:
       This indicator describes how the levels of major greenhouse gases in the atmosphere have changed over time.
 
       The data contains concentrations of carbon dioxide in the atmosphere from hundreds of thousands of years ago through 2021, measured in parts per million (ppm). The data come from a variety of historical ice core studies and recent air monitoring sites around the world.
-    title_snapshot: 'Climate Change Indicators: Atmospheric Concentrations of Greenhouse
-      Gases - Nitrous Oxide'
+    title_snapshot: 'Climate Change Indicators: Atmospheric Concentrations of Greenhouse Gases - Nitrous Oxide'
     citation_full: |-
       United States Environmental Protection Agency (EPA) - Climate Change Indicators: Atmospheric Concentrations of Greenhouse Gases (2022)
 
@@ -16,10 +15,8 @@ meta:
       More details can be found on [their technical documentation](https://www.epa.gov/sites/default/files/2021-03/documents/ghg-concentrations_td.pdf).
     attribution: EPA based on various sources (2022)
     attribution_short: EPA
-    url_main: 
-      https://www.epa.gov/climate-indicators/climate-change-indicators-atmospheric-concentrations-greenhouse-gases
-    url_download: 
-      https://www.epa.gov/system/files/other-files/2022-07/ghg-concentrations_fig-3.csv
+    url_main: https://www.epa.gov/climate-indicators/climate-change-indicators-atmospheric-concentrations-greenhouse-gases
+    url_download: https://www.epa.gov/system/files/other-files/2022-07/ghg-concentrations_fig-3.csv
     date_accessed: '2024-01-29'
     date_published: '2022-07-01'
     license:
@@ -27,6 +24,6 @@ meta:
       url: https://edg.epa.gov/epa_data_license.html
 wdir: ../../../data/snapshots/epa/2024-01-29
 outs:
-- md5: a36b26bd1b84c25ee27f975282ca764b
-  size: 19470
-  path: n2o_concentration.csv
+  - md5: b2bcc42a26e9d7fb47bb9c107fe60f66
+    size: 19470
+    path: n2o_concentration.csv

--- a/snapshots/epa/2024-01-29/ocean_heat_content_annual_world_2000m.csv.dvc
+++ b/snapshots/epa/2024-01-29/ocean_heat_content_annual_world_2000m.csv.dvc
@@ -27,6 +27,6 @@ meta:
       url: https://edg.epa.gov/epa_data_license.html
 wdir: ../../../data/snapshots/epa/2024-01-29
 outs:
-- md5: da3ed600aee40a3716db2bd3fc5a7613
-  size: 3152
-  path: ocean_heat_content_annual_world_2000m.csv
+  - md5: 56d585ef448f394150031a8f335eb373
+    size: 3152
+    path: ocean_heat_content_annual_world_2000m.csv

--- a/snapshots/epa/2024-01-29/ocean_heat_content_annual_world_700m.csv.dvc
+++ b/snapshots/epa/2024-01-29/ocean_heat_content_annual_world_700m.csv.dvc
@@ -27,6 +27,6 @@ meta:
       url: https://edg.epa.gov/epa_data_license.html
 wdir: ../../../data/snapshots/epa/2024-01-29
 outs:
-- md5: ebbe4344007e753240afc9ea3dcf75cd
-  size: 3919
-  path: ocean_heat_content_annual_world_700m.csv
+  - md5: 909371e229b3a4f40427659b376d5432
+    size: 3919
+    path: ocean_heat_content_annual_world_700m.csv

--- a/snapshots/excess_mortality/2023-01-27/hmd_stmf.csv.dvc
+++ b/snapshots/excess_mortality/2023-01-27/hmd_stmf.csv.dvc
@@ -6,9 +6,7 @@ meta:
   publication_year: 2023
   publication_date: 2023-01-23
   source_name: HMD
-  source_published_by: HMD. Human Mortality Database. Max Planck Institute for Demographic
-    Research (Germany), University of California, Berkeley (USA), and French Institute
-    for Demographic Studies (France). Available at www.mortality.org.
+  source_published_by: HMD. Human Mortality Database. Max Planck Institute for Demographic Research (Germany), University of California, Berkeley (USA), and French Institute for Demographic Studies (France). Available at www.mortality.org.
   url: https://www.mortality.org/Data/STMF
   source_data_url: https://www.mortality.org/File/GetDocument/Public/STMF/Outputs/stmf.csv
   file_extension: csv
@@ -29,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/excess_mortality/2023-01-27
 outs:
-- md5: e5a7bbc119c5cec2c5464ef112dde315
-  size: 19516305
-  path: hmd_stmf.csv
+  - md5: bf4310ebf71e334c6a06f79d43b237a7
+    size: 19516305
+    path: hmd_stmf.csv

--- a/snapshots/excess_mortality/2023-02-17/hmd_stmf.csv.dvc
+++ b/snapshots/excess_mortality/2023-02-17/hmd_stmf.csv.dvc
@@ -6,9 +6,7 @@ meta:
   publication_year: 2023
   publication_date: 2023-02-06
   source_name: HMD
-  source_published_by: HMD. Human Mortality Database. Max Planck Institute for Demographic
-    Research (Germany), University of California, Berkeley (USA), and French Institute
-    for Demographic Studies (France). Available at www.mortality.org.
+  source_published_by: HMD. Human Mortality Database. Max Planck Institute for Demographic Research (Germany), University of California, Berkeley (USA), and French Institute for Demographic Studies (France). Available at www.mortality.org.
   url: https://www.mortality.org/Data/STMF
   source_data_url: https://www.mortality.org/File/GetDocument/Public/STMF/Outputs/stmf.csv
   file_extension: csv
@@ -28,6 +26,6 @@ meta:
     HMD provides an online STMF visualization toolkit (https://mpidr.shinyapps.io/stmortality).
 wdir: ../../../data/snapshots/excess_mortality/2023-02-17
 outs:
-- md5: 282101f217c228ebbeabf526d53dbbee
-  size: 19547690
-  path: hmd_stmf.csv
+  - md5: ef38fe6e5c22b7ccbde7363c6d74d376
+    size: 19547690
+    path: hmd_stmf.csv

--- a/snapshots/excess_mortality/2023-02-28/hmd_stmf.csv.dvc
+++ b/snapshots/excess_mortality/2023-02-28/hmd_stmf.csv.dvc
@@ -6,9 +6,7 @@ meta:
   publication_year: 2023
   publication_date: 2023-02-27
   source_name: HMD
-  source_published_by: HMD. Human Mortality Database. Max Planck Institute for Demographic
-    Research (Germany), University of California, Berkeley (USA), and French Institute
-    for Demographic Studies (France). Available at www.mortality.org.
+  source_published_by: HMD. Human Mortality Database. Max Planck Institute for Demographic Research (Germany), University of California, Berkeley (USA), and French Institute for Demographic Studies (France). Available at www.mortality.org.
   url: https://www.mortality.org/Data/STMF
   source_data_url: https://www.mortality.org/File/GetDocument/Public/STMF/Outputs/stmf.csv
   file_extension: csv
@@ -28,6 +26,6 @@ meta:
     HMD provides an online STMF visualization toolkit (https://mpidr.shinyapps.io/stmortality).
 wdir: ../../../data/snapshots/excess_mortality/2023-02-28
 outs:
-- md5: 8a9aaa380ea3c36885f206ec52489815
-  size: 19604292
-  path: hmd_stmf.csv
+  - md5: 98e231bcfe97c79aa3d3773566490b64
+    size: 19604292
+    path: hmd_stmf.csv

--- a/snapshots/excess_mortality/latest/hmd_stmf.csv.dvc
+++ b/snapshots/excess_mortality/latest/hmd_stmf.csv.dvc
@@ -33,6 +33,6 @@ meta:
     name: Creative Commons BY 4.0
     url: https://www.mortality.org/Data/UserAgreement
 outs:
-  - md5: 77d5aa1745dfc7467302555c54f3ab6a
+  - md5: a7245c9538a7712a6b86ee8b4c1891ab
     size: 20499650
     path: hmd_stmf.csv

--- a/snapshots/gcp/2023-04-28/global_carbon_budget_fossil_co2_emissions.csv.dvc
+++ b/snapshots/gcp/2023-04-28/global_carbon_budget_fossil_co2_emissions.csv.dvc
@@ -5,26 +5,7 @@ meta:
   version: '2023-04-28'
   publication_date: '2022-11-11'
   source_name: Global Carbon Budget (2022)
-  source_published_by: "Friedlingstein, P., O'Sullivan, M., Jones, M. W., Andrew,\
-    \ R. M., Gregor, L., Hauck, J., Le Quéré, C., Luijkx, I. T., Olsen, A., Peters,\
-    \ G. P., Peters, W., Pongratz, J., Schwingshackl, C., Sitch, S., Canadell, J.\
-    \ G., Ciais, P., Jackson, R. B., Alin, S. R., Alkama, R., Arneth, A., Arora, V.\
-    \ K., Bates, N. R., Becker, M., Bellouin, N., Bittig, H. C., Bopp, L., Chevallier,\
-    \ F., Chini, L. P., Cronin, M., Evans, W., Falk, S., Feely, R. A., Gasser, T.,\
-    \ Gehlen, M., Gkritzalis, T., Gloege, L., Grassi, G., Gruber, N., Gürses, Ö.,\
-    \ Harris, I., Hefner, M., Houghton, R. A., Hurtt, G. C., Iida, Y., Ilyina, T.,\
-    \ Jain, A. K., Jersild, A., Kadono, K., Kato, E., Kennedy, D., Klein Goldewijk,\
-    \ K., Knauer, J., Korsbakken, J. I., Landschützer, P., Lefèvre, N., Lindsay, K.,\
-    \ Liu, J., Liu, Z., Marland, G., Mayot, N., McGrath, M. J., Metzl, N., Monacci,\
-    \ N. M., Munro, D. R., Nakaoka, S.-I., Niwa, Y., O'Brien, K., Ono, T., Palmer,\
-    \ P. I., Pan, N., Pierrot, D., Pocock, K., Poulter, B., Resplandy, L., Robertson,\
-    \ E., Rödenbeck, C., Rodriguez, C., Rosan, T. M., Schwinger, J., Séférian, R.,\
-    \ Shutler, J. D., Skjelvan, I., Steinhoff, T., Sun, Q., Sutton, A. J., Sweeney,\
-    \ C., Takao, S., Tanhua, T., Tans, P. P., Tian, X., Tian, H., Tilbrook, B., Tsujino,\
-    \ H., Tubiello, F., van der Werf, G. R., Walker, A. P., Wanninkhof, R., Whitehead,\
-    \ C., Willstrand Wranne, A., Wright, R., Yuan, W., Yue, C., Yue, X., Zaehle, S.,\
-    \ Zeng, J., and Zheng, B.: Global Carbon Budget 2022, Earth Syst. Sci. Data, 14,\
-    \ 4811-4900, https://doi.org/10.5194/essd-14-4811-2022, 2022."
+  source_published_by: "Friedlingstein, P., O'Sullivan, M., Jones, M. W., Andrew, R. M., Gregor, L., Hauck, J., Le Quéré, C., Luijkx, I. T., Olsen, A., Peters, G. P., Peters, W., Pongratz, J., Schwingshackl, C., Sitch, S., Canadell, J. G., Ciais, P., Jackson, R. B., Alin, S. R., Alkama, R., Arneth, A., Arora, V. K., Bates, N. R., Becker, M., Bellouin, N., Bittig, H. C., Bopp, L., Chevallier, F., Chini, L. P., Cronin, M., Evans, W., Falk, S., Feely, R. A., Gasser, T., Gehlen, M., Gkritzalis, T., Gloege, L., Grassi, G., Gruber, N., Gürses, Ö., Harris, I., Hefner, M., Houghton, R. A., Hurtt, G. C., Iida, Y., Ilyina, T., Jain, A. K., Jersild, A., Kadono, K., Kato, E., Kennedy, D., Klein Goldewijk, K., Knauer, J., Korsbakken, J. I., Landschützer, P., Lefèvre, N., Lindsay, K., Liu, J., Liu, Z., Marland, G., Mayot, N., McGrath, M. J., Metzl, N., Monacci, N. M., Munro, D. R., Nakaoka, S.-I., Niwa, Y., O'Brien, K., Ono, T., Palmer, P. I., Pan, N., Pierrot, D., Pocock, K., Poulter, B., Resplandy, L., Robertson, E., Rödenbeck, C., Rodriguez, C., Rosan, T. M., Schwinger, J., Séférian, R., Shutler, J. D., Skjelvan, I., Steinhoff, T., Sun, Q., Sutton, A. J., Sweeney, C., Takao, S., Tanhua, T., Tans, P. P., Tian, X., Tian, H., Tilbrook, B., Tsujino, H., Tubiello, F., van der Werf, G. R., Walker, A. P., Wanninkhof, R., Whitehead, C., Willstrand Wranne, A., Wright, R., Yuan, W., Yue, C., Yue, X., Zaehle, S., Zeng, J., and Zheng, B.: Global Carbon Budget 2022, Earth Syst. Sci. Data, 14, 4811-4900, https://doi.org/10.5194/essd-14-4811-2022, 2022."
   url: https://globalcarbonbudget.org/
   source_data_url: https://zenodo.org/record/7215364/files/GCB2022v27_MtCO2_flat.csv
   file_extension: csv
@@ -35,6 +16,6 @@ meta:
   description: |
 wdir: ../../../data/snapshots/gcp/2023-04-28
 outs:
-- md5: 8a9511bb7d2623ac32d6cf49707c09d0
-  size: 2957261
-  path: global_carbon_budget_fossil_co2_emissions.csv
+  - md5: 251ce1c5f07d5d28128fa84df856b2f9
+    size: 2957261
+    path: global_carbon_budget_fossil_co2_emissions.csv

--- a/snapshots/gcp/2023-09-28/global_carbon_budget_fossil_co2_emissions.csv.dvc
+++ b/snapshots/gcp/2023-09-28/global_carbon_budget_fossil_co2_emissions.csv.dvc
@@ -2,12 +2,7 @@ meta:
   origin:
     producer: Global Carbon Project
     title: Global Carbon Budget
-    description: The Global Carbon Budget 2022 has over 105 contributors from 80 organisations
-      and 18 countries. It was founded by the Global Carbon Project international
-      science team to track the trends in global carbon emissions and sinks and is
-      a key measure of progress towards the goals of the Paris Agreement. It's widely
-      recognised as the most comprehensive report of its kind. The 2022 report was
-      published at COP27 in Egypt on Friday 11th November.
+    description: The Global Carbon Budget 2022 has over 105 contributors from 80 organisations and 18 countries. It was founded by the Global Carbon Project international science team to track the trends in global carbon emissions and sinks and is a key measure of progress towards the goals of the Paris Agreement. It's widely recognised as the most comprehensive report of its kind. The 2022 report was published at COP27 in Egypt on Friday 11th November.
     title_snapshot: Global Carbon Budget - Fossil CO2 emissions
     citation_full: >-
       Andrew, R. M., & Peters, G. P. (2022). The Global Carbon Project's fossil CO2
@@ -56,6 +51,6 @@ meta:
     url: https://zenodo.org/record/7215364
 wdir: ../../../data/snapshots/gcp/2023-09-28
 outs:
-- md5: 8a9511bb7d2623ac32d6cf49707c09d0
-  size: 2957261
-  path: global_carbon_budget_fossil_co2_emissions.csv
+  - md5: 251ce1c5f07d5d28128fa84df856b2f9
+    size: 2957261
+    path: global_carbon_budget_fossil_co2_emissions.csv

--- a/snapshots/gcp/2023-12-05/global_carbon_budget_fossil_co2_emissions.csv.dvc
+++ b/snapshots/gcp/2023-12-05/global_carbon_budget_fossil_co2_emissions.csv.dvc
@@ -67,6 +67,6 @@ meta:
     url: https://zenodo.org/records/10177738
 wdir: ../../../data/snapshots/gcp/2023-12-05
 outs:
-- md5: 33d883a0a14e069eb239cce68b127c62
-  size: 2902409
-  path: global_carbon_budget_fossil_co2_emissions.csv
+  - md5: 5bb46f04063157eff3dcdca66c19c553
+    size: 2902409
+    path: global_carbon_budget_fossil_co2_emissions.csv

--- a/snapshots/gcp/2023-12-12/global_carbon_budget_fossil_co2_emissions.csv.dvc
+++ b/snapshots/gcp/2023-12-12/global_carbon_budget_fossil_co2_emissions.csv.dvc
@@ -68,6 +68,6 @@ meta:
       url: https://zenodo.org/records/10177738
 wdir: ../../../data/snapshots/gcp/2023-12-12
 outs:
-- md5: 33d883a0a14e069eb239cce68b127c62
-  size: 2902409
-  path: global_carbon_budget_fossil_co2_emissions.csv
+  - md5: 5bb46f04063157eff3dcdca66c19c553
+    size: 2902409
+    path: global_carbon_budget_fossil_co2_emissions.csv

--- a/snapshots/harvard/2023-09-18/colonial_dates_dataset.csv.dvc
+++ b/snapshots/harvard/2023-09-18/colonial_dates_dataset.csv.dvc
@@ -1,17 +1,9 @@
 meta:
   origin:
     title: Colonial Dates Dataset (COLDAT)
-    description: The Colonial Dates Dataset (COLDAT) aggregates information on the
-      reach and duration of European colonial empires from renowned secondary sources.
-      By aggregating secondary sources, rather than collecting from primary sources,
-      the new dataset reflects the accumulated knowledge in the discipline and relieves
-      researchers from making hard to justify choices between different historical
-      datasets.
-
-      The dataset only considers the colonial status of countries that are independent today. It also includes overseas colonies only.
+    description: "The Colonial Dates Dataset (COLDAT) aggregates information on the reach and duration of European colonial empires from renowned secondary sources. By aggregating secondary sources, rather than collecting from primary sources, the new dataset reflects the accumulated knowledge in the discipline and relieves researchers from making hard to justify choices between different historical datasets.\nThe dataset only considers the colonial status of countries that are independent today. It also includes overseas colonies only."
     producer: Bastian Becker
-    citation_full: 'Becker, Bastian (2019), Introducing COLDAT: The Colonial Dates
-      Dataset, SOCIUM/SFB1342 Working Paper Series, 02/2019. url: https://www.socium.uni-bremen.de/f/51ebd445c4.pdf'
+    citation_full: 'Becker, Bastian (2019), Introducing COLDAT: The Colonial Dates Dataset, SOCIUM/SFB1342 Working Paper Series, 02/2019. url: https://www.socium.uni-bremen.de/f/51ebd445c4.pdf'
     version_producer: '3.0'
     url_main: https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/T9SDEW
     date_published: '2023-09-21'
@@ -22,6 +14,6 @@ meta:
   is_public: true
 wdir: ../../../data/snapshots/harvard/2023-09-18
 outs:
-- md5: 24b51081f5a86f83901b9d0eeb2ac574
-  size: 58327
-  path: colonial_dates_dataset.csv
+  - md5: 8c152765deee0304157fb271a6a178dc
+    size: 58327
+    path: colonial_dates_dataset.csv

--- a/snapshots/ihme_gbd/2023-10-04/cause_hierarchy.csv.dvc
+++ b/snapshots/ihme_gbd/2023-10-04/cause_hierarchy.csv.dvc
@@ -28,6 +28,6 @@ meta:
 
 wdir: ../../../data/snapshots/ihme_gbd/2023-10-04
 outs:
-  - md5: 4a8b78999255e14d7faf03b76793a97d
+  - md5: 7954d55badd3d2d551d62d2525883fd2
     size: 26745
     path: cause_hierarchy.csv

--- a/snapshots/imf/2023-11-02/world_economic_outlook.xls.dvc
+++ b/snapshots/imf/2023-11-02/world_economic_outlook.xls.dvc
@@ -17,8 +17,7 @@ meta:
 
     # Files
     url_main: https://www.imf.org/en/Publications/WEO/weo-database/2023/October
-    url_download: 
-      https://www.imf.org/-/media/Files/Publications/WEO/WEO-Database/2023/WEOOct2023all.ashx
+    url_download: https://www.imf.org/-/media/Files/Publications/WEO/WEO-Database/2023/WEOOct2023all.ashx
     date_accessed: 2023-11-02
 
     # License
@@ -28,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/imf/2023-11-02
 outs:
-- md5: 2c63c189e84979591623273e64028872
-  size: 9984224
-  path: world_economic_outlook.xls
+  - md5: f81178dcdf1add4d400adf29feaec8d9
+    size: 9984224
+    path: world_economic_outlook.xls

--- a/snapshots/lgbt_rights/2023-04-13/equaldex.csv.dvc
+++ b/snapshots/lgbt_rights/2023-04-13/equaldex.csv.dvc
@@ -17,6 +17,6 @@ meta:
     Equaldex is a collaborative knowledge base for the LGBT (lesbian, gay, bisexual, transgender) movement. The site aims to crowdsource every law related to LGBT rights to provide a comprehensive and global view of the LGBT rights movement.
 wdir: ../../../data/snapshots/lgbt_rights/2023-04-13
 outs:
-- md5: 7b78427e2622821f8f035a4b0868b90e
-  size: 9442348
-  path: equaldex.csv
+  - md5: 587d0a876f4255a52300d242d8a87533
+    size: 9442348
+    path: equaldex.csv

--- a/snapshots/lgbt_rights/2023-04-13/equaldex_current.csv.dvc
+++ b/snapshots/lgbt_rights/2023-04-13/equaldex_current.csv.dvc
@@ -19,6 +19,6 @@ meta:
     This version of the dataset contains only the current situation of each issue.
 wdir: ../../../data/snapshots/lgbt_rights/2023-04-13
 outs:
-- md5: 44aa5dd079016b650bea94c3c510c9f4
-  size: 498404
-  path: equaldex_current.csv
+  - md5: c4c64fc0876e9c8da8e1f967c1a71c84
+    size: 498404
+    path: equaldex_current.csv

--- a/snapshots/oecd/2023-05-01/health_pharma_market.csv.dvc
+++ b/snapshots/oecd/2023-05-01/health_pharma_market.csv.dvc
@@ -20,6 +20,6 @@ meta:
     This dataset is a subset of all the metrics in the database. More details at https://stats.oecd.org/OECDStat_Metadata/ShowMetadata.ashx?Dataset=HEALTH_PHMC&Lang=en
 wdir: ../../../data/snapshots/oecd/2023-05-01
 outs:
-- md5: cf39808319ed8e633f846c39a6cceeea
-  size: 9726240
-  path: health_pharma_market.csv
+  - md5: b5581344c20b17084f278bf4a57e6a4a
+    size: 9726240
+    path: health_pharma_market.csv

--- a/snapshots/oecd/2023-05-18/co2_air_transport.csv.dvc
+++ b/snapshots/oecd/2023-05-18/co2_air_transport.csv.dvc
@@ -6,8 +6,7 @@ meta:
   publication_year: 2023
   publication_date: March 2023
   source_name: OECD
-  source_published_by: OECD (2023), Air Transport CO₂ Emissions , https://stats.oecd.org/Index.aspx?DataSetCode=AIRTRANS_CO2#,
-    accessed on 18 May 2023
+  source_published_by: OECD (2023), Air Transport CO₂ Emissions , https://stats.oecd.org/Index.aspx?DataSetCode=AIRTRANS_CO2#, accessed on 18 May 2023
   url: https://stats.oecd.org/Index.aspx?DataSetCode=AIRTRANS_CO2#
   source_data_url:
   file_extension: csv
@@ -22,6 +21,6 @@ meta:
     These CO2 emissions are estimated by the OECD, based on a consistent methodology across countries.
 wdir: ../../../data/snapshots/oecd/2023-05-18
 outs:
-- md5: 320570f5ee7c11eff8123a78abb2426e
-  size: 84521205
-  path: co2_air_transport.csv
+  - md5: ccc9c118aaf14b1bbd5938b74b700836
+    size: 84521205
+    path: co2_air_transport.csv

--- a/snapshots/oecd/2023-06-06/income_distribution_database.csv.dvc
+++ b/snapshots/oecd/2023-06-06/income_distribution_database.csv.dvc
@@ -21,6 +21,6 @@ meta:
     Small changes in estimates between years should be treated with caution as they may not be statistically significant.
 wdir: ../../../data/snapshots/oecd/2023-06-06
 outs:
-- md5: 475da98f3f67e8a349af4114dcae2125
-  size: 1026173
-  path: income_distribution_database.csv
+  - md5: ec61534a8ad1a438fb3aef3faad181e5
+    size: 1026173
+    path: income_distribution_database.csv

--- a/snapshots/oecd/2023-06-20/ppp_exchange_rates.csv.dvc
+++ b/snapshots/oecd/2023-06-20/ppp_exchange_rates.csv.dvc
@@ -5,8 +5,7 @@ meta:
   version: '2023-06-20'
   publication_year: 2023
   source_name: OECD (2023)
-  source_published_by: 'OECD (2023), Exchange rates and PPP. doi: 10.1787/037ed317-en
-    (Accessed on 20 June 2023)'
+  source_published_by: 'OECD (2023), Exchange rates and PPP. doi: 10.1787/037ed317-en (Accessed on 20 June 2023)'
   url: https://stats.oecd.org/viewhtml.aspx?datasetcode=SNA_TABLE4&lang=en
   source_data_url:
   file_extension: csv
@@ -18,6 +17,6 @@ meta:
     OECD provides data on Purchasing Power Parities (actual individual consumption, private consumption and GDP) and Exchange rates (period-average and end of period data) between 2000-2022. 
 wdir: ../../../data/snapshots/oecd/2023-06-20
 outs:
-- md5: 50ea96e4b29a88a99e8c6aaebaee1f21
-  size: 1179935
-  path: ppp_exchange_rates.csv
+  - md5: 4a71eedfc146928442b826f1d008459f
+    size: 1179935
+    path: ppp_exchange_rates.csv

--- a/snapshots/oecd/2023-08-11/road_accidents.csv.dvc
+++ b/snapshots/oecd/2023-08-11/road_accidents.csv.dvc
@@ -2,11 +2,9 @@ meta:
   name: Road accidents (OECD, 2023)
   publication_year: 2023
   source_name: OECD (2023)
-  source_published_by: 'OECD (2023), Road accidents (indicator). doi: 10.1787/2fe1b899-en
-    (Accessed on 11 August 2023)'
+  source_published_by: 'OECD (2023), Road accidents (indicator). doi: 10.1787/2fe1b899-en (Accessed on 11 August 2023)'
   url: https://data.oecd.org/transport/road-accidents.htm
-  source_data_url: 
-    https://stats.oecd.org/sdmx-json/data/DP_LIVE/.ROADACCID.../OECD?contentType=csv&detail=code&separator=comma&csv-lang=en
+  source_data_url: https://stats.oecd.org/sdmx-json/data/DP_LIVE/.ROADACCID.../OECD?contentType=csv&detail=code&separator=comma&csv-lang=en
   license_url: https://www.oecd.org/termsandconditions/
   license_name: ''
   date_accessed: 2023-08-11
@@ -15,6 +13,6 @@ meta:
     Road accidents are measured in terms of the number of persons injured and deaths due to road accidents, whether immediate or within 30 days of the accident, and excluding suicides involving the use of road motor vehicles. A road motor vehicle is a road vehicle fitted with an engine as the sole means of propulsion and one that is normally used to carry people or goods, or for towing, on the road. This includes buses, coaches, trolleys, tramways (streetcars) and road vehicles used to transport goods and to transport passengers. Road motor vehicles are attributed to the countries where they are registered, while deaths are attributed to the countries in which they occur. This indicator is measured in number of accidents, number of persons, per million inhabitants and million vehicles.
 wdir: ../../../data/snapshots/oecd/2023-08-11
 outs:
-- md5: 4f25544c3e16d9fdb83c1a9d1777af22
-  size: 531673
-  path: road_accidents.csv
+  - md5: 00adfc698c64133ed1332520bc1ffc8d
+    size: 531673
+    path: road_accidents.csv

--- a/snapshots/oecd/2023-09-21/plastic_aquatic_leakage.csv.dvc
+++ b/snapshots/oecd/2023-09-21/plastic_aquatic_leakage.csv.dvc
@@ -29,6 +29,6 @@ meta:
       url: https://www.oecd.org/termsandconditions
 wdir: ../../../data/snapshots/oecd/2023-09-21
 outs:
-- md5: a4673d7ac7dfdf488963b7e6eab6f1ee
-  size: 136268
-  path: plastic_aquatic_leakage.csv
+  - md5: 8f3b627b94f4e1bc0583290b9c257906
+    size: 136268
+    path: plastic_aquatic_leakage.csv

--- a/snapshots/oecd/2023-09-21/plastic_aquatic_leakage_projections.csv.dvc
+++ b/snapshots/oecd/2023-09-21/plastic_aquatic_leakage_projections.csv.dvc
@@ -28,10 +28,9 @@ meta:
     # License
     license:
       name: CC BY 4.0
-      url:
-        https://www.oecd.org/termsandconditions
+      url: https://www.oecd.org/termsandconditions
 wdir: ../../../data/snapshots/oecd/2023-09-21
 outs:
-- md5: a6f73452abc54c9be3bd42d0c0417aaa
-  size: 87887
-  path: plastic_aquatic_leakage_projections.csv
+  - md5: 3988172bf5cb3179008c837e74224309
+    size: 87887
+    path: plastic_aquatic_leakage_projections.csv

--- a/snapshots/oecd/2023-09-21/plastic_emissions.csv.dvc
+++ b/snapshots/oecd/2023-09-21/plastic_emissions.csv.dvc
@@ -13,8 +13,7 @@ meta:
       Greenhouse gas emissions are combined using a measurement called the 100-year Global Warming Potential (GWP), which comes from a 1995 report by the international climate science group, IPCC. Emissions are estimated at different stages, for different types of plastics, and when they are thrown away, based on data from 2015. These estimates are calculated using specific measures that consider the emissions created during the making of primary and secondary plastics, including those from related industries. These measures are taken from a model by the Organisation for Economic Co-operation and Development (OECD), ensuring a detailed and thorough analysis of emissions related to plastic production.
     # Citation
     producer: OECD
-    citation_full: OECD (2022), Global Plastics Outlook , https://stats.oecd.org/viewhtml.aspx?datasetcode=PLASTIC_GHG_2&lang=en#,     accessed
-      on 21 September 2023
+    citation_full: OECD (2022), Global Plastics Outlook , https://stats.oecd.org/viewhtml.aspx?datasetcode=PLASTIC_GHG_2&lang=en#,     accessed on 21 September 2023
 
     # Files
     url_main: https://stats.oecd.org/viewhtml.aspx?datasetcode=PLASTIC_GHG_2&lang=en#
@@ -26,6 +25,6 @@ meta:
       url: https://www.oecd.org/termsandconditions
 wdir: ../../../data/snapshots/oecd/2023-09-21
 outs:
-- md5: b405dcd5163b1df4012a245e264fa8bb
-  size: 4335
-  path: plastic_emissions.csv
+  - md5: 028921975c8c7bb04f37aecfd2937ba7
+    size: 4335
+    path: plastic_emissions.csv

--- a/snapshots/oecd/2023-09-21/plastic_environment_leakage_projections.csv.dvc
+++ b/snapshots/oecd/2023-09-21/plastic_environment_leakage_projections.csv.dvc
@@ -13,8 +13,7 @@ meta:
 
     # Citation
     producer: OECD
-    citation_full: OECD (2022), Global Plastics Outlook ,https://stats.oecd.org/viewhtml.aspx?datasetcode=PLASTIC_LEAKAGE_V2_3&lang=en,      accessed
-      on 21 September 2023
+    citation_full: OECD (2022), Global Plastics Outlook ,https://stats.oecd.org/viewhtml.aspx?datasetcode=PLASTIC_LEAKAGE_V2_3&lang=en,      accessed on 21 September 2023
 
     # Files
     url_main: https://stats.oecd.org/viewhtml.aspx?datasetcode=PLASTIC_LEAKAGE_V2_3&lang=en
@@ -26,6 +25,6 @@ meta:
       url: https://www.oecd.org/termsandconditions
 wdir: ../../../data/snapshots/oecd/2023-09-21
 outs:
-- md5: e86b116ac8c6b7ddaf98ef10338fab13
-  size: 34953
-  path: plastic_environment_leakage_projections.csv
+  - md5: 8d1ec0e160b296da1120593e70a92260
+    size: 34953
+    path: plastic_environment_leakage_projections.csv

--- a/snapshots/oecd/2023-09-21/plastic_fate_regions.csv.dvc
+++ b/snapshots/oecd/2023-09-21/plastic_fate_regions.csv.dvc
@@ -28,6 +28,6 @@ meta:
       url: https://www.oecd.org/termsandconditions
 wdir: ../../../data/snapshots/oecd/2023-09-21
 outs:
-- md5: 7c1ba26d48b9e16acae1bdd93b398920
-  size: 116164
-  path: plastic_fate_regions.csv
+  - md5: 9c3e686776ec21d9ae52d906645aac84
+    size: 116164
+    path: plastic_fate_regions.csv

--- a/snapshots/oecd/2023-09-21/plastic_fate_regions_projections.csv.dvc
+++ b/snapshots/oecd/2023-09-21/plastic_fate_regions_projections.csv.dvc
@@ -3,8 +3,7 @@
 meta:
   origin:
     # Data product / Snapshot
-    title: Global Plastics Outlook - Plastics waste by region and end-of-life fate
-      - projections
+    title: Global Plastics Outlook - Plastics waste by region and end-of-life fate - projections
     description: |-
       This dataset provides estimates of plastics waste for the 15 global regions of the OECD ENV-Linkages model, detailed in the Annex of the OECD Global Plastics Outlook.
 
@@ -29,6 +28,6 @@ meta:
       url: https://www.oecd.org/termsandconditions
 wdir: ../../../data/snapshots/oecd/2023-09-21
 outs:
-- md5: d6339dcf73247ad6def7ab8c3fed3677
-  size: 207117
-  path: plastic_fate_regions_projections.csv
+  - md5: 602cf872c33aa360f40a31f80be2d0c8
+    size: 207117
+    path: plastic_fate_regions_projections.csv

--- a/snapshots/oecd/2023-09-21/plastic_use_application.csv.dvc
+++ b/snapshots/oecd/2023-09-21/plastic_use_application.csv.dvc
@@ -25,6 +25,6 @@ meta:
       url: https://www.oecd.org/termsandconditions
 wdir: ../../../data/snapshots/oecd/2023-09-21
 outs:
-- md5: ff6c4a81d37cb74788d896eeda75d3c6
-  size: 28015
-  path: plastic_use_application.csv
+  - md5: 1ee0300c16fe7d5712eb500ccc84e8e1
+    size: 28015
+    path: plastic_use_application.csv

--- a/snapshots/oecd/2023-09-21/plastic_use_polymer.csv.dvc
+++ b/snapshots/oecd/2023-09-21/plastic_use_polymer.csv.dvc
@@ -25,6 +25,6 @@ meta:
       url: https://www.oecd.org/termsandconditions
 wdir: ../../../data/snapshots/oecd/2023-09-21
 outs:
-- md5: eab53b86d7bc1ff5df01d45a8aa82859
-  size: 20537
-  path: plastic_use_polymer.csv
+  - md5: 866e730990ebc07d17881eed78376b59
+    size: 20537
+    path: plastic_use_polymer.csv

--- a/snapshots/oecd/2023-09-21/plastic_use_projections.csv.dvc
+++ b/snapshots/oecd/2023-09-21/plastic_use_projections.csv.dvc
@@ -26,6 +26,6 @@ meta:
 
 wdir: ../../../data/snapshots/oecd/2023-09-21
 outs:
-- md5: 1a0a6dbc0d30cd997f3de9e908562f31
-  size: 29072
-  path: plastic_use_projections.csv
+  - md5: 579fda8865cdb240cc224ca56207326f
+    size: 29072
+    path: plastic_use_projections.csv

--- a/snapshots/oecd/2023-09-21/plastic_waste_2019.csv.dvc
+++ b/snapshots/oecd/2023-09-21/plastic_waste_2019.csv.dvc
@@ -3,8 +3,7 @@
 meta:
   origin:
     # Data product / Snapshot
-    title: Global Plastics Outlook - Plastics waste in 2019 by region, polymer and
-      application
+    title: Global Plastics Outlook - Plastics waste in 2019 by region, polymer and application
     description: |-
       This dataset provides estimates of plastics waste  per polymer and application for the 15 global regions of the OECD ENV-Linkages model, detailed in the Annex of the OECD Global Plastics Outlook.
 
@@ -25,6 +24,6 @@ meta:
 
 wdir: ../../../data/snapshots/oecd/2023-09-21
 outs:
-- md5: fe9788c98058910e8a1fc6975a343fd8
-  size: 134026
-  path: plastic_waste_2019.csv
+  - md5: fd1808cd6282ee29c86346030cca13ea
+    size: 134026
+    path: plastic_waste_2019.csv

--- a/snapshots/oecd/2023-10-11/life_expectancy_birth.csv.dvc
+++ b/snapshots/oecd/2023-10-11/life_expectancy_birth.csv.dvc
@@ -15,8 +15,7 @@ meta:
 
     # Files
     url_main: https://data.oecd.org/healthstat/life-expectancy-at-birth.htm
-    url_download: 
-      https://stats.oecd.org/sdmx-json/data/DP_LIVE/.LIFEEXP.../OECD?contentType=csv&detail=code&separator=comma&csv-lang=en
+    url_download: https://stats.oecd.org/sdmx-json/data/DP_LIVE/.LIFEEXP.../OECD?contentType=csv&detail=code&separator=comma&csv-lang=en
     date_accessed: 2023-10-11
 
     # License
@@ -26,6 +25,6 @@ meta:
 
 wdir: ../../../data/snapshots/oecd/2023-10-11
 outs:
-- md5: f28e5fbe6538efe3e1d01a8859808808
-  size: 381472
-  path: life_expectancy_birth.csv
+  - md5: c6b660c01904ea745f02eeedb215fb6f
+    size: 381472
+    path: life_expectancy_birth.csv

--- a/snapshots/papers/2023-01-04/farmer_lafond_2016.csv.dvc
+++ b/snapshots/papers/2023-01-04/farmer_lafond_2016.csv.dvc
@@ -15,6 +15,6 @@ meta:
   description: |
 wdir: ../../../data/snapshots/papers/2023-01-04
 outs:
-- md5: b2dd2d2d7bdf788da15bd2e7dba8aaa9
-  size: 18416
-  path: farmer_lafond_2016.csv
+  - md5: e76cc538ad6bf6233b99a075eb0cea10
+    size: 18416
+    path: farmer_lafond_2016.csv

--- a/snapshots/papers/2023-07-10/smil_2017.csv.dvc
+++ b/snapshots/papers/2023-07-10/smil_2017.csv.dvc
@@ -2,13 +2,10 @@ meta:
   name: 'Energy Transitions: Global and National Perspectives - Vaclav Smil (2017)'
   publication_year: 2017
   source_name: Vaclav Smil (2017)
-  source_published_by: 'Energy Transitions: Global and National Perspectives, 2nd
-    edition, Appendix A, Vaclav Smil (2017)'
-  url: 
-    https://vaclavsmil.com/2016/12/14/energy-transitions-global-and-national-perspectives-second-expanded-and-updated-edition/
+  source_published_by: 'Energy Transitions: Global and National Perspectives, 2nd edition, Appendix A, Vaclav Smil (2017)'
+  url: https://vaclavsmil.com/2016/12/14/energy-transitions-global-and-national-perspectives-second-expanded-and-updated-edition/
   source_data_url:
-  license_url: 
-    https://vaclavsmil.com/2016/12/14/energy-transitions-global-and-national-perspectives-second-expanded-and-updated-edition/
+  license_url: https://vaclavsmil.com/2016/12/14/energy-transitions-global-and-national-perspectives-second-expanded-and-updated-edition/
   license_name: CC BY
   date_accessed: 2023-07-10
   is_public: true
@@ -16,6 +13,6 @@ meta:
 
 wdir: ../../../data/snapshots/papers/2023-07-10
 outs:
-- md5: b0b7aff72e3ec643fd7fbd02f26317f5
-  size: 2355
-  path: smil_2017.csv
+  - md5: ebb24fa147511d78f4c11cf63bea0a91
+    size: 2355
+    path: smil_2017.csv

--- a/snapshots/papers/2023-12-12/farmer_lafond_2016.csv.dvc
+++ b/snapshots/papers/2023-12-12/farmer_lafond_2016.csv.dvc
@@ -16,6 +16,6 @@ meta:
 
 wdir: ../../../data/snapshots/papers/2023-12-12
 outs:
-- md5: b2dd2d2d7bdf788da15bd2e7dba8aaa9
-  size: 18416
-  path: farmer_lafond_2016.csv
+  - md5: e76cc538ad6bf6233b99a075eb0cea10
+    size: 18416
+    path: farmer_lafond_2016.csv

--- a/snapshots/papers/2023-12-12/smil_2017.csv.dvc
+++ b/snapshots/papers/2023-12-12/smil_2017.csv.dvc
@@ -7,8 +7,7 @@ meta:
     attribution_short: Smil
     date_published: 2017-01-01
     date_accessed: 2023-12-12
-    url_main:
-      https://vaclavsmil.com/2016/12/14/energy-transitions-global-and-national-perspectives-second-expanded-and-updated-edition/
+    url_main: https://vaclavsmil.com/2016/12/14/energy-transitions-global-and-national-perspectives-second-expanded-and-updated-edition/
     url_download: https://vaclavsmil.com/wp-content/uploads/2017/01/ET2_Appendix_A.pdf
     license:
       name: CC BY 4.0
@@ -16,6 +15,6 @@ meta:
 
 wdir: ../../../data/snapshots/papers/2023-12-12
 outs:
-- md5: b0b7aff72e3ec643fd7fbd02f26317f5
-  size: 2355
-  path: smil_2017.csv
+  - md5: ebb24fa147511d78f4c11cf63bea0a91
+    size: 2355
+    path: smil_2017.csv

--- a/snapshots/plastic_waste/2023-09-26/geyer_2017.pdf.dvc
+++ b/snapshots/plastic_waste/2023-09-26/geyer_2017.pdf.dvc
@@ -7,8 +7,7 @@ meta:
     description: |-
       Plastics have outgrown most man-made materials and have long been under environmental scrutiny. However, robust global information, particularly about their end-of-life fate, is lacking. By identifying and synthesizing dispersed data on production, use, and end-of-life management of polymer resins, synthetic fibers, and additives, we present the first global analysis of all mass-produced plastics ever manufactured. We estimate that 8300 million metric tons (Mt) as of virgin plastics have been produced to date. As of 2015, approximately 6300 Mt of plastic waste had been generated, around 9% of which had been recycled, 12% was incinerated, and 79% was accumulated in landfills or the natural environment. If current production and waste management trends continue, roughly 12,000 Mt of plastic waste will be in landfills or in the natural environment by 2050.
     date_published: 2017-07-19
-    title_snapshot: Production, use, and fate of all plastics ever made (Geyer et
-      al., 2017)
+    title_snapshot: Production, use, and fate of all plastics ever made (Geyer et al., 2017)
     description_snapshot: |-
       Data on annual waste production in million metric tons between 1950 and 2015.
 
@@ -27,6 +26,6 @@ meta:
       url: https://www.science.org/doi/10.1126/sciadv.1700782
 wdir: ../../../data/snapshots/plastic_waste/2023-09-26
 outs:
-- md5: 36c3af508e73baee35d6a14acf6df340
-  size: 880844
-  path: geyer_2017.pdf
+  - md5: 9b5c36519fad5fb6d1c8ab553837c59a
+    size: 880844
+    path: geyer_2017.pdf

--- a/snapshots/research_development/2023-05-24/us_patents.htm.dvc
+++ b/snapshots/research_development/2023-05-24/us_patents.htm.dvc
@@ -5,8 +5,7 @@ meta:
   version: '2023-05-24'
   publication_year: 2020
   source_name: United States Patent and Trademark Office (2020)
-  source_published_by: U.S. Patent and Trademark Office, U.S. Patent Activity Calendar
-    Years 1790 to the Present
+  source_published_by: U.S. Patent and Trademark Office, U.S. Patent Activity Calendar Years 1790 to the Present
   url: https://www.uspto.gov/web/offices/ac/ido/oeip/taf/reports.htm
   source_data_url: https://www.uspto.gov/web/offices/ac/ido/oeip/taf/h_counts.htm
   file_extension: htm
@@ -14,13 +13,9 @@ meta:
   license_name: USPTO Terms and Conditions
   date_accessed: 2023-05-24
   is_public: true
-  description: The U.S. Patent and Trademark Office (USPTO)'s Patent Technology Monitoring
-    Team periodically issues general statistics and reports that profile patenting
-    activity. The data imported by Our World in Data focuses on annual, U.S. patent
-    application and grant activity from 1790 to the present. Annual activity is determined
-    based on the calendar year.
+  description: The U.S. Patent and Trademark Office (USPTO)'s Patent Technology Monitoring Team periodically issues general statistics and reports that profile patenting activity. The data imported by Our World in Data focuses on annual, U.S. patent application and grant activity from 1790 to the present. Annual activity is determined based on the calendar year.
 wdir: ../../../data/snapshots/research_development/2023-05-24
 outs:
-- md5: a7d47bb15446f0fcd347ee743a5893ee
-  size: 48933
-  path: us_patents.htm
+  - md5: f3c6d86e711ed577cbcb34ca83212eef
+    size: 48933
+    path: us_patents.htm

--- a/snapshots/technology/2023-03-16/hcctad.txt.dvc
+++ b/snapshots/technology/2023-03-16/hcctad.txt.dvc
@@ -5,9 +5,7 @@ meta:
   version: 2023-03-16
   publication_date: 2004-01-01
   source_name: Data compiled from multiple sources by Comin & Hobijn (2004)
-  source_published_by: 'Comin, D. and Hohijn B., "Cross-Country Technological Adoption:
-    Making the Theories Face the Facts". Journal of Monetary Economics, January 2004,
-    pp. 39-83.'
+  source_published_by: 'Comin, D. and Hohijn B., "Cross-Country Technological Adoption: Making the Theories Face the Facts". Journal of Monetary Economics, January 2004, pp. 39-83.'
   url: https://www.nber.org/research/data/historical-cross-country-technology-adoption-hccta-dataset
   source_data_url: https://www.nber.org/hccta/hcctad.txt
   file_extension: txt
@@ -19,6 +17,6 @@ meta:
     The Historical Cross Country Technology Adoption Dataset (HCCTAD) is a dataset collected by Diego Comin (NYU) and Bart Hobijn (Federal Reserve Bank of New York), to allow for the analysis of the adoption patterns of some of the major technologies introduced in the past 250 years across the World’s leading industrialized economies.
 wdir: ../../../data/snapshots/technology/2023-03-16
 outs:
-- md5: 464999cc6bc55deaae815b413223cba9
-  size: 1572981
-  path: hcctad.txt
+  - md5: 4c50a1fef4a9174cab0cf548feeccc7f
+    size: 1572981
+    path: hcctad.txt

--- a/snapshots/terrorism/2023-07-20/global_terrorism_database.csv.dvc
+++ b/snapshots/terrorism/2023-07-20/global_terrorism_database.csv.dvc
@@ -13,6 +13,6 @@ meta:
     The GTD is an event-level database containing more than 200,000 records of terrorist attacks that took place around the world since 1970. It is maintained by the National Consortium for the Study of Terrorism and Responses to Terrorism (START) at the University of Maryland.
 wdir: ../../../data/snapshots/terrorism/2023-07-20
 outs:
-  - md5: 6a76caa30fd2266952401d55351e209b
+  - md5: 783d2bf94a2267ba8c30cf5ebb77026c
     size: 193451541
     path: global_terrorism_database.csv

--- a/snapshots/terrorism/2023-07-20/global_terrorism_database_2021.csv.dvc
+++ b/snapshots/terrorism/2023-07-20/global_terrorism_database_2021.csv.dvc
@@ -2,8 +2,7 @@ meta:
   name: Terrorism dataset, Global Terrorism Database (2020-2021)
   publication_year: 2022
   source_name: Global Terrorism Database (2022)
-  source_published_by: START (National Consortium for the Study of Terrorism and Responses
-    to Terrorism). (2022). Global Terrorism Database, 1970 - 2020 [data file]. https://www.start.umd.edu/gtd
+  source_published_by: START (National Consortium for the Study of Terrorism and Responses to Terrorism). (2022). Global Terrorism Database, 1970 - 2020 [data file]. https://www.start.umd.edu/gtd
   url: https://www.start.umd.edu/gtd/
   source_data_url:
   license_url: https://www.start.umd.edu/gtd/terms-of-use/
@@ -15,6 +14,6 @@ meta:
     Seperate file for terrorism data between 2020 and 2021.
 wdir: ../../../data/snapshots/terrorism/2023-07-20
 outs:
-- md5: dfaeaea5b32c7c2ad88cb9afcc93e056
-  size: 5468150
-  path: global_terrorism_database_2021.csv
+  - md5: 6cb1b18acee1f130d807095aa157d8e2
+    size: 5468150
+    path: global_terrorism_database_2021.csv

--- a/snapshots/tuberculosis/2023-11-27/burden_estimates.csv.dvc
+++ b/snapshots/tuberculosis/2023-11-27/burden_estimates.csv.dvc
@@ -26,6 +26,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-11-27
 outs:
-  - md5: e43b1122a8387c2f4e3d7278caada121
+  - md5: 7b25e5471711704535b036f69530f7cb
     size: 1015793
     path: burden_estimates.csv

--- a/snapshots/tuberculosis/2023-11-27/data_dictionary.csv.dvc
+++ b/snapshots/tuberculosis/2023-11-27/data_dictionary.csv.dvc
@@ -26,6 +26,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-11-27
 outs:
-  - md5: 448a7b668c0234746af432350682792b
+  - md5: 437d099e8c0e2ad39af8728fd0476d6e
     size: 97992
     path: data_dictionary.csv

--- a/snapshots/tuberculosis/2023-12-01/budget.csv.dvc
+++ b/snapshots/tuberculosis/2023-12-01/budget.csv.dvc
@@ -26,6 +26,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-12-01
 outs:
-  - md5: f42a50156694212daf7c91847a1d38e2
+  - md5: 71b85c9398abb2837faa921056baec64
     size: 216735
     path: budget.csv

--- a/snapshots/tuberculosis/2023-12-04/burden_disaggregated.csv.dvc
+++ b/snapshots/tuberculosis/2023-12-04/burden_disaggregated.csv.dvc
@@ -26,6 +26,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-12-04
 outs:
-  - md5: c3457c48d0399c65ffbf33c78c1fcc22
+  - md5: b83fcce0fe2a54a64e7ac6098ba3c7d0
     size: 560909
     path: burden_disaggregated.csv

--- a/snapshots/tuberculosis/2023-12-04/drug_resistance_surveillance.csv.dvc
+++ b/snapshots/tuberculosis/2023-12-04/drug_resistance_surveillance.csv.dvc
@@ -27,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-12-04
 outs:
-- md5: 9614a70dc736faad4b255302737876ac
-  size: 170279
-  path: drug_resistance_surveillance.csv
+  - md5: 63549e2ab0f94513c92138e3724ec537
+    size: 170279
+    path: drug_resistance_surveillance.csv

--- a/snapshots/tuberculosis/2023-12-05/expenditure.csv.dvc
+++ b/snapshots/tuberculosis/2023-12-05/expenditure.csv.dvc
@@ -26,6 +26,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-12-05
 outs:
-  - md5: 2e0adea9343faa98b6c77249688453ca
+  - md5: f636f0f57e3f1c2e2f1db8a48b5cc80d
     size: 219422
     path: expenditure.csv

--- a/snapshots/tuberculosis/2023-12-06/laboratories.csv.dvc
+++ b/snapshots/tuberculosis/2023-12-06/laboratories.csv.dvc
@@ -27,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-12-06
 outs:
-- md5: 410569e1522edde83c2f1d2f817f80fa
-  size: 382108
-  path: laboratories.csv
+  - md5: df1b7fe4744cc5362dd7b5dd0d1b3b28
+    size: 382108
+    path: laboratories.csv

--- a/snapshots/tuberculosis/2023-12-06/latent.csv.dvc
+++ b/snapshots/tuberculosis/2023-12-06/latent.csv.dvc
@@ -27,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-12-06
 outs:
-- md5: ec1854d94f1bae8c55550a0e29066564
-  size: 23231
-  path: latent.csv
+  - md5: 17d8d4ed0e40ae3f1817884f5f7ecf87
+    size: 23231
+    path: latent.csv

--- a/snapshots/tuberculosis/2023-12-11/notifications.csv.dvc
+++ b/snapshots/tuberculosis/2023-12-11/notifications.csv.dvc
@@ -27,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-12-11
 outs:
-- md5: a62693a019ab15868ff4e39ec2e2f4dc
-  size: 2768221
-  path: notifications.csv
+  - md5: 0e45c14dce2de6cfc61249fb75ab5a23
+    size: 2768221
+    path: notifications.csv

--- a/snapshots/tuberculosis/2023-12-11/outcomes.csv.dvc
+++ b/snapshots/tuberculosis/2023-12-11/outcomes.csv.dvc
@@ -26,6 +26,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-12-11
 outs:
-- md5: 5e9eca2e7d46bd658810c5440a7b0340
-  size: 891688
-  path: outcomes.csv
+  - md5: c92b81565f57f12d08e52c4341e77654
+    size: 891688
+    path: outcomes.csv

--- a/snapshots/tuberculosis/2023-12-12/outcomes_disagg.csv.dvc
+++ b/snapshots/tuberculosis/2023-12-12/outcomes_disagg.csv.dvc
@@ -7,8 +7,7 @@ meta:
     description: |-
       WHO has published a global tuberculosis (TB) report every year since 1997. The report provides a comprehensive and up-to-date assessment of the TB epidemic, and of progress in prevention, diagnosis and treatment of the disease at global, regional and country levels.
     date_published: 2023-11-07
-    title_snapshot: Global Tuberculosis Report - Treatment outcomes by age group and
-      sex
+    title_snapshot: Global Tuberculosis Report - Treatment outcomes by age group and sex
 
     # Citation
     producer: WHO
@@ -28,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-12-12
 outs:
-- md5: 4fcb4c45a89a7faf2399ce0f2441d045
-  size: 88146
-  path: outcomes_disagg.csv
+  - md5: fbe3128e0ce59fca725026412f012452
+    size: 88146
+    path: outcomes_disagg.csv

--- a/snapshots/tuberculosis/2023-12-12/unhlm_commitments.csv.dvc
+++ b/snapshots/tuberculosis/2023-12-12/unhlm_commitments.csv.dvc
@@ -29,6 +29,6 @@ meta:
 
 wdir: ../../../data/snapshots/tuberculosis/2023-12-12
 outs:
-- md5: ee4a262e14cc4818b8af0b1d395dc746
-  size: 17817
-  path: unhlm_commitments.csv
+  - md5: b4cd70eff8bdff1dd6ce822f96e63e7a
+    size: 17817
+    path: unhlm_commitments.csv

--- a/snapshots/un/2018/igme.csv.dvc
+++ b/snapshots/un/2018/igme.csv.dvc
@@ -24,6 +24,6 @@ meta:
       url: https://www.unicef.org/legal#copyright
 wdir: ../../../data/snapshots/un/2018
 outs:
-  - md5: 16fc4f6a083467848e58093d85636eed
+  - md5: 9517a40cce8b20366543c5791d347054
     size: 62755821
     path: igme.csv

--- a/snapshots/un/2022-11-29/undp_hdr.csv.dvc
+++ b/snapshots/un/2022-11-29/undp_hdr.csv.dvc
@@ -22,6 +22,6 @@ meta:
     This file contains the data.
 wdir: ../../../data/snapshots/un/2022-11-29
 outs:
-- md5: a7f78e9e86ac64657406328aa0c03fd3
-  size: 1781357
-  path: undp_hdr.csv
+  - md5: 6682503b24efe5fbc0e7bd695d677819
+    size: 1781357
+    path: undp_hdr.csv

--- a/snapshots/un/2023-01-24/un_sdg.feather.dvc
+++ b/snapshots/un/2023-01-24/un_sdg.feather.dvc
@@ -18,6 +18,6 @@ meta:
 
 wdir: ../../../data/snapshots/un/2023-01-24
 outs:
-  - md5: eb837bbb87823b7923f919c0c7e93220
+  - md5: 4eec76d904280209ba5a635b21e28b54
     size: 684540210
     path: un_sdg.feather

--- a/snapshots/un/2023-08-02/comtrade_pandemics_1987_1998.csv.dvc
+++ b/snapshots/un/2023-08-02/comtrade_pandemics_1987_1998.csv.dvc
@@ -31,6 +31,6 @@ meta:
 
 wdir: ../../../data/snapshots/un/2023-08-02
 outs:
-- md5: 83194ef1c39834a9857ef98c123ec0bb
-  size: 2426326
-  path: comtrade_pandemics_1987_1998.csv
+  - md5: ba0047837638ab5e2e222c11ccf2d718
+    size: 2426326
+    path: comtrade_pandemics_1987_1998.csv

--- a/snapshots/un/2023-08-02/comtrade_pandemics_1999_2010.csv.dvc
+++ b/snapshots/un/2023-08-02/comtrade_pandemics_1999_2010.csv.dvc
@@ -31,6 +31,6 @@ meta:
 
 wdir: ../../../data/snapshots/un/2023-08-02
 outs:
-- md5: 7e1950d13c4aa46ef0a5f836f336bd04
-  size: 6104688
-  path: comtrade_pandemics_1999_2010.csv
+  - md5: 8705b5e580de5e5aa6e41c43fd9cb114
+    size: 6104688
+    path: comtrade_pandemics_1999_2010.csv

--- a/snapshots/un/2023-08-02/comtrade_pandemics_2011_2022.csv.dvc
+++ b/snapshots/un/2023-08-02/comtrade_pandemics_2011_2022.csv.dvc
@@ -31,6 +31,6 @@ meta:
 
 wdir: ../../../data/snapshots/un/2023-08-02
 outs:
-- md5: 7a26d05d445d2ddf9967c5515e801044
-  size: 6212557
-  path: comtrade_pandemics_2011_2022.csv
+  - md5: 10ab464972a70e8ac1a0395d923c93c1
+    size: 6212557
+    path: comtrade_pandemics_2011_2022.csv

--- a/snapshots/un/2023-08-16/un_sdg.feather.dvc
+++ b/snapshots/un/2023-08-16/un_sdg.feather.dvc
@@ -18,6 +18,6 @@ meta:
 
 wdir: ../../../data/snapshots/un/2023-08-16
 outs:
-  - md5: 7feccfad2b08751074249ee4bd4849fe
+  - md5: d5e6755cbe4650e8434e0ddabeb228ce
     size: 816163802
     path: un_sdg.feather

--- a/snapshots/un/2023-10-09/plastic_waste_1987_1998.csv.dvc
+++ b/snapshots/un/2023-10-09/plastic_waste_1987_1998.csv.dvc
@@ -19,11 +19,11 @@ meta:
     date_published: '2023'
     title_snapshot: 'Comtrade Database: Plastic Waste Trade, 1987-1998'
     description_snapshot: |-
-        Subset of Comtrade database only concerning indicators related to plastic waste.
+      Subset of Comtrade database only concerning indicators related to plastic waste.
 
-        The data is sourced from the commodity category '3915 – Waste, parings and scrap, of plastics' from the UN's Comtrade Database.
+      The data is sourced from the commodity category '3915 – Waste, parings and scrap, of plastics' from the UN's Comtrade Database.
 
-        This snapshot only includes data from 1987 until 1998.
+      This snapshot only includes data from 1987 until 1998.
 
     # Citation
     producer: United Nations Comtrade Database
@@ -42,6 +42,6 @@ meta:
 
 wdir: ../../../data/snapshots/un/2023-10-09
 outs:
-- md5: 133f171f9ea495903b05aeedee023f43
-  size: 5603174
-  path: plastic_waste_1987_1998.csv
+  - md5: 18d39e6d900ce49f32f731d0c1e05811
+    size: 5603174
+    path: plastic_waste_1987_1998.csv

--- a/snapshots/un/2023-10-09/plastic_waste_1999_2010.csv.dvc
+++ b/snapshots/un/2023-10-09/plastic_waste_1999_2010.csv.dvc
@@ -43,6 +43,6 @@ meta:
 
 wdir: ../../../data/snapshots/un/2023-10-09
 outs:
-- md5: a7008b559825916b6022161f66d93647
-  size: 18654144
-  path: plastic_waste_1999_2010.csv
+  - md5: 1d2f2c48365f1db417c9060021a6676a
+    size: 18654144
+    path: plastic_waste_1999_2010.csv

--- a/snapshots/un/2023-10-09/plastic_waste_2011_2022.csv.dvc
+++ b/snapshots/un/2023-10-09/plastic_waste_2011_2022.csv.dvc
@@ -43,6 +43,6 @@ meta:
 
 wdir: ../../../data/snapshots/un/2023-10-09
 outs:
-- md5: a008db2144789b0aeb52791277e66504
-  size: 31960508
-  path: plastic_waste_2011_2022.csv
+  - md5: 6351e43803659a29fefa8b5bbfdb7eb8
+    size: 31960508
+    path: plastic_waste_2011_2022.csv

--- a/snapshots/unep/2023-12-12/global_trends_in_renewable_energy_investment.pdf.dvc
+++ b/snapshots/unep/2023-12-12/global_trends_in_renewable_energy_investment.pdf.dvc
@@ -23,6 +23,6 @@ meta:
 
 wdir: ../../../data/snapshots/unep/2023-12-12
 outs:
-  - md5: 931583f95a4c43162e361cc265312cbf
+  - md5: d0629a9a4218ed60412761be9030049b
     size: 4681700
     path: global_trends_in_renewable_energy_investment.pdf

--- a/snapshots/war/2023-01-09/bouthoul_carrere_1978.csv.dvc
+++ b/snapshots/war/2023-01-09/bouthoul_carrere_1978.csv.dvc
@@ -65,6 +65,6 @@ meta:
       - We excluded conflicts without deaths.
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
-- md5: d0b1416eade865e82e5f935f1c641610
-  size: 46668
-  path: bouthoul_carrere_1978.csv
+  - md5: 4a417e2fb2e8563a715a7bb61104bc7a
+    size: 46668
+    path: bouthoul_carrere_1978.csv

--- a/snapshots/war/2023-01-09/clodfelter_2017.csv.dvc
+++ b/snapshots/war/2023-01-09/clodfelter_2017.csv.dvc
@@ -1,8 +1,7 @@
 meta:
   namespace: war
   short_name: clodfelter_2017
-  name: 'Warfare and Armed Conflicts: A Statistical Encyclopedia of Casualty and Other
-    Figures, 1492-2015, 4th ed.'
+  name: 'Warfare and Armed Conflicts: A Statistical Encyclopedia of Casualty and Other Figures, 1492-2015, 4th ed.'
   source_name: Clodfelter (2017)
   publication_year: 2017
   publication_date: 2017-04-24
@@ -173,6 +172,6 @@ meta:
     row.
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
-- md5: 3d352b60ea0bf89d81061ffdb6db9322
-  size: 41745
-  path: clodfelter_2017.csv
+  - md5: abb021bfa5cd726d64aa03c30a9d7af4
+    size: 41745
+    path: clodfelter_2017.csv

--- a/snapshots/war/2023-01-09/dunnigan_martel_1987.csv.dvc
+++ b/snapshots/war/2023-01-09/dunnigan_martel_1987.csv.dvc
@@ -115,6 +115,6 @@ meta:
     book, starting at page 207.
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
-- md5: 5ab165a63ccfdec62b72d3bddf114497
-  size: 150480
-  path: dunnigan_martel_1987.csv
+  - md5: f197fb1e4ea3807a186e7dfffa93d1ed
+    size: 150480
+    path: dunnigan_martel_1987.csv

--- a/snapshots/war/2023-01-09/eckhardt_1991.csv.dvc
+++ b/snapshots/war/2023-01-09/eckhardt_1991.csv.dvc
@@ -58,6 +58,6 @@ meta:
       this book by Eckhardt may have more details in chapter 9.
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
-- md5: ef6af27bf85a82675f41a9e4423b6120
-  size: 103932
-  path: eckhardt_1991.csv
+  - md5: 8714107efdc4a5d6a7bf1e7ac0531382
+    size: 103932
+    path: eckhardt_1991.csv

--- a/snapshots/war/2023-01-09/kaye_1985.csv.dvc
+++ b/snapshots/war/2023-01-09/kaye_1985.csv.dvc
@@ -5,14 +5,11 @@ meta:
   source_name: Kaye et al. (1985)
   publication_year: 1985
   publication_date: 1985-11-01
-  url: 
-    https://books.google.es/books/about/Major_Armed_Conflict.html?id=Xce_PwAACAAJ&redir_esc=y
-  source_data_url: 
-    https://docs.google.com/spreadsheets/d/1GIB-8ZPNXqTATwHU4ZDavKz0iJoiOg2UROfoRz43kQY/edit#gid=1251805698
+  url: https://books.google.es/books/about/Major_Armed_Conflict.html?id=Xce_PwAACAAJ&redir_esc=y
+  source_data_url: https://docs.google.com/spreadsheets/d/1GIB-8ZPNXqTATwHU4ZDavKz0iJoiOg2UROfoRz43kQY/edit#gid=1251805698
   file_extension: csv
   license_url:
-  license_name: Department of National Defence, Canada, Operational Research and Analysis
-    Establishment, 1985
+  license_name: Department of National Defence, Canada, Operational Research and Analysis Establishment, 1985
   date_accessed: 2023-01-09
   is_public: true
   description: >-
@@ -144,6 +141,6 @@ meta:
       - We excluded conflicts with 0 deaths.
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
-- md5: ebe21d08d52544800ffdfdb2b9ceec62
-  size: 81484
-  path: kaye_1985.csv
+  - md5: 3d199e72dd14724172c093594f1225ec
+    size: 81484
+    path: kaye_1985.csv

--- a/snapshots/war/2023-01-09/sorokin_1937.csv.dvc
+++ b/snapshots/war/2023-01-09/sorokin_1937.csv.dvc
@@ -1,8 +1,7 @@
 meta:
   namespace: war
   short_name: sorokin_1937
-  name: 'Social and cultural dynamics. Volume III: Fluctuation of Social Relationships,
-    War, and Revolution (1937)'
+  name: 'Social and cultural dynamics. Volume III: Fluctuation of Social Relationships, War, and Revolution (1937)'
   source_name: Sorokin (1937)
   publication_year: 1937
   publication_date: 1937-12-01
@@ -85,6 +84,6 @@ meta:
 
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
-- md5: 62db4de77391db49dca0ee88c989f6e9
-  size: 115599
-  path: sorokin_1937.csv
+  - md5: b3f14480bf4936bccc548afa77d237b6
+    size: 115599
+    path: sorokin_1937.csv

--- a/snapshots/war/2023-01-09/sutton_1971.csv.dvc
+++ b/snapshots/war/2023-01-09/sutton_1971.csv.dvc
@@ -55,6 +55,6 @@ meta:
       - We also copied any of his notes that numbers were 'estimated' or 'suspect'
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
-  - md5: 478d9301b194525a227243df1b5b2a28
+  - md5: 8205dd3c7b31f5c94eea6b3fbf75afdd
     size: 125790
     path: sutton_1971.csv

--- a/snapshots/war/2024-01-11/spread_of_nuclear_weapons.pdf.dvc
+++ b/snapshots/war/2024-01-11/spread_of_nuclear_weapons.pdf.dvc
@@ -17,20 +17,17 @@ meta:
     attribution_short: Bleek
 
     # Files
-    url_main: 
-      https://www.belfercenter.org/sites/default/files/files/publication/When%20Did%20%28and%20Didn%27t%29%20States%20Proliferate%3F_1.pdf
-    url_download: 
-      https://www.belfercenter.org/sites/default/files/files/publication/When%20Did%20%28and%20Didn%27t%29%20States%20Proliferate%3F_1.pdf
+    url_main: https://www.belfercenter.org/sites/default/files/files/publication/When%20Did%20%28and%20Didn%27t%29%20States%20Proliferate%3F_1.pdf
+    url_download: https://www.belfercenter.org/sites/default/files/files/publication/When%20Did%20%28and%20Didn%27t%29%20States%20Proliferate%3F_1.pdf
     date_accessed: 2024-01-11
 
     # License
     license:
       name: Copyright 2017, President and Fellows of Harvard College
-      url: 
-        https://www.belfercenter.org/sites/default/files/files/publication/When%20Did%20%28and%20Didn%27t%29%20States%20Proliferate%3F_1.pdf
+      url: https://www.belfercenter.org/sites/default/files/files/publication/When%20Did%20%28and%20Didn%27t%29%20States%20Proliferate%3F_1.pdf
 
 wdir: ../../../data/snapshots/war/2024-01-11
 outs:
-- md5: dfcb04001bf2161d794d9964af627dd4
-  size: 728103
-  path: spread_of_nuclear_weapons.pdf
+  - md5: 46ffcdd3c9b40e718a45411c0e2acab2
+    size: 728103
+    path: spread_of_nuclear_weapons.pdf

--- a/snapshots/wash/2024-02-04/who.csv.dvc
+++ b/snapshots/wash/2024-02-04/who.csv.dvc
@@ -3,8 +3,7 @@
 meta:
   origin:
     # Data product / Snapshot
-    title: WHO/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and  Hygiene
-      (JMP) - Households
+    title: WHO/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and  Hygiene (JMP) - Households
     description: |-
       The WHO/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and Hygiene (JMP) has reported country, regional and global estimates of progress on drinking water, sanitation and hygiene (WASH) since 1990.
     date_published: 2024-02-01
@@ -16,8 +15,7 @@ meta:
       The JMP database includes over 5,000 national data sources with information on WASH in households including nationally representative household surveys, censuses and administrative reports.
 
     # Citation
-    producer: WHO/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and       Hygiene
-      (JMP)
+    producer: WHO/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and       Hygiene (JMP)
     citation_full: |-
       World Health Organization/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and Hygiene (JMP; 2023). Estimates for drinking water, sanitation and hygiene services by country (2000-2022) [dataset]. World Health Organization and UNICEF [original data].
     attribution_short: WHO/UNICEF JMP
@@ -32,6 +30,6 @@ meta:
 
 wdir: ../../../data/snapshots/wash/2024-02-04
 outs:
-- md5: 46d876875bee021c3b8c3e21c1348169
-  size: 5263939
-  path: who.csv
+  - md5: abfb1f9c4595948960b5cbc7ddbe30b2
+    size: 5263939
+    path: who.csv

--- a/snapshots/wash/2024-02-04/who_regions.csv.dvc
+++ b/snapshots/wash/2024-02-04/who_regions.csv.dvc
@@ -3,8 +3,7 @@
 meta:
   origin:
     # Data product / Snapshot
-    title: WHO/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and  Hygiene
-      (JMP) - Households - Regions
+    title: WHO/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and  Hygiene (JMP) - Households - Regions
     description: |-
       The WHO/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and Hygiene (JMP) has reported country, regional and global estimates of progress on drinking water, sanitation and hygiene (WASH) since 1990.
     date_published: 2024-02-01
@@ -16,8 +15,7 @@ meta:
       The JMP database includes over 5,000 national data sources with information on WASH in households including nationally representative household surveys, censuses and administrative reports.
 
     # Citation
-    producer: WHO/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and       Hygiene
-      (JMP)
+    producer: WHO/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and       Hygiene (JMP)
     citation_full: |-
       World Health Organization/UNICEF Joint Monitoring Programme for Water Supply, Sanitation and Hygiene (JMP; 2023). Estimates for drinking water, sanitation and hygiene services by country (2000-2022) [dataset]. World Health Organization and UNICEF [original data].
     attribution_short: WHO/UNICEF JMP
@@ -31,6 +29,6 @@ meta:
 
 wdir: ../../../data/snapshots/wash/2024-02-04
 outs:
-- md5: 2ebc481f5b75a139bf039f2bd455e86d
-  size: 715813
-  path: who_regions.csv
+  - md5: a4af6d9584be938d19ee2db5ddf1e2f7
+    size: 715813
+    path: who_regions.csv

--- a/snapshots/wash/2024-02-15/nutrients_europe.csv.dvc
+++ b/snapshots/wash/2024-02-15/nutrients_europe.csv.dvc
@@ -28,6 +28,6 @@ meta:
 
 wdir: ../../../data/snapshots/wash/2024-02-15
 outs:
-  - md5: 21bd1b2b8e0c1af1987f1fdbdab68135
+  - md5: 76eb5066d70d165436b3bd060b2ac63c
     size: 125618
     path: nutrients_europe.csv

--- a/snapshots/wb/2023-11-21/worldwide_bureaucracy_indicators.csv.dvc
+++ b/snapshots/wb/2023-11-21/worldwide_bureaucracy_indicators.csv.dvc
@@ -27,6 +27,6 @@ meta:
 
 wdir: ../../../data/snapshots/wb/2023-11-21
 outs:
-  - md5: 191d0f3335056c4b3548b9c83c49e2a8
+  - md5: 75a835ea5891938c7f26965c7559e5d7
     size: 13369262
     path: worldwide_bureaucracy_indicators.csv

--- a/snapshots/who/2023-08-14/avian_influenza_ah5n1.csv.dvc
+++ b/snapshots/who/2023-08-14/avian_influenza_ah5n1.csv.dvc
@@ -22,6 +22,6 @@ meta:
     H5N1 bird flu viruses that are currently circulating in wild birds and poultry in much of the world are genetically different from earlier versions of the virus and emerged to become the predominant subtype of HPAI H5 in the fall of 2021. These viruses have caused sporadic poultry infections and poultry outbreaks in many countries, most recently the United States. In contrast to previous H5N1 viruses, which still circulate to a lesser extent in several countries, at this time, fewer than 10 cases with current H5N1 bird flu viruses have been reported globally. However, illness in humans from all bird flu virus infections has ranged in severity from no symptoms or mild illness to severe disease that resulted in death.
 wdir: ../../../data/snapshots/who/2023-08-14
 outs:
-- md5: 16498ed922a90d22c50a4b465e9c5255
-  size: 21641
-  path: avian_influenza_ah5n1.csv
+  - md5: 39cf203df8b39811b7c9f3a01b65f6da
+    size: 21641
+    path: avian_influenza_ah5n1.csv

--- a/snapshots/who/2023-10-13/medical_devices_atlas_ct.csv.dvc
+++ b/snapshots/who/2023-10-13/medical_devices_atlas_ct.csv.dvc
@@ -27,8 +27,7 @@ meta:
       maps reflecting the global status quo
       list of country profiles (177 to date)
     date_published: '2022'
-    title_snapshot: Global atlas of medical devices -  Gamma Camera or Computed Tomography
-      Units (CT)
+    title_snapshot: Global atlas of medical devices -  Gamma Camera or Computed Tomography Units (CT)
     description_snapshot: |-
       The dataset comprises data extracted from The Global Atlas of Medical Devices (GAMD) regarding the total density of Computed Tomography Units (CT) per million population    # Citation
     producer: World Health Organisation
@@ -37,8 +36,7 @@ meta:
     attribution_short: WHO
 
     # Files
-    url_main:
-      https://www.who.int/teams/health-product-policy-and-standards/assistive-and-medical-technology/medical-devices/global-atlas-of-medical-devices
+    url_main: https://www.who.int/teams/health-product-policy-and-standards/assistive-and-medical-technology/medical-devices/global-atlas-of-medical-devices
     date_accessed: 2023-10-13
 
     # License
@@ -48,6 +46,6 @@ meta:
 
 wdir: ../../../data/snapshots/who/2023-10-13
 outs:
-- md5: 258639d08db29d990e795409408acef5
-  size: 63651
-  path: medical_devices_atlas_ct.csv
+  - md5: cd1fcd7d34b1c32b08d2be4135f81ca9
+    size: 63651
+    path: medical_devices_atlas_ct.csv

--- a/snapshots/who/2023-10-13/medical_devices_atlas_gc_nm.csv.dvc
+++ b/snapshots/who/2023-10-13/medical_devices_atlas_gc_nm.csv.dvc
@@ -29,8 +29,7 @@ meta:
     attribution_short: WHO
 
     # Files
-    url_main:
-      https://www.who.int/teams/health-product-policy-and-standards/assistive-and-medical-technology/medical-devices/global-atlas-of-medical-devices
+    url_main: https://www.who.int/teams/health-product-policy-and-standards/assistive-and-medical-technology/medical-devices/global-atlas-of-medical-devices
     date_accessed: 2023-10-13
 
     # License
@@ -40,6 +39,6 @@ meta:
 
 wdir: ../../../data/snapshots/who/2023-10-13
 outs:
-- md5: 66e2217616942a63cd5129504fb71ea0
-  size: 56546
-  path: medical_devices_atlas_gc_nm.csv
+  - md5: fc394631ad1b3d914eebd2d74b96d11c
+    size: 56546
+    path: medical_devices_atlas_gc_nm.csv

--- a/snapshots/who/2023-10-13/medical_devices_atlas_mri.csv.dvc
+++ b/snapshots/who/2023-10-13/medical_devices_atlas_mri.csv.dvc
@@ -19,8 +19,7 @@ meta:
 
       The **WHO Baseline Country Survey on Medical Devices** was developed in 2009. The aim was to determine the health technology areas that required support in countries and regions. It was launched in February 2010. In 2013, it was updated and re-launched as the Global Atlas of Medical Devices. The GAMD was updated in 2017, and the 2022 update is under development.
     date_published: '2022'
-    title_snapshot: Global atlas of medical devices -  Magnetic Resonance Imaging
-      Units (MRI)
+    title_snapshot: Global atlas of medical devices -  Magnetic Resonance Imaging Units (MRI)
     description_snapshot: |-
       The dataset contains information obtained from the Global Atlas of Medical Devices (GAMD) pertaining to the total density of Magnetic Resonance Imaging Units (MRI) per million population.
     # Citation
@@ -30,8 +29,7 @@ meta:
     attribution_short: WHO
 
     # Files
-    url_main:
-      https://www.who.int/teams/health-product-policy-and-standards/assistive-and-medical-technology/medical-devices/global-atlas-of-medical-devices
+    url_main: https://www.who.int/teams/health-product-policy-and-standards/assistive-and-medical-technology/medical-devices/global-atlas-of-medical-devices
     date_accessed: 2023-10-13
 
     # License
@@ -41,6 +39,6 @@ meta:
 
 wdir: ../../../data/snapshots/who/2023-10-13
 outs:
-- md5: 3f9ccbcd55cdbb67fc16f950b814942a
-  size: 62382
-  path: medical_devices_atlas_mri.csv
+  - md5: cb1b7cb7d5be79d84d53b91dccff5a57
+    size: 62382
+    path: medical_devices_atlas_mri.csv

--- a/snapshots/who/2023-10-13/medical_devices_atlas_pet.csv.dvc
+++ b/snapshots/who/2023-10-13/medical_devices_atlas_pet.csv.dvc
@@ -19,8 +19,7 @@ meta:
 
       The **WHO Baseline Country Survey on Medical Devices** was developed in 2009. The aim was to determine the health technology areas that required support in countries and regions. It was launched in February 2010. In 2013, it was updated and re-launched as the Global Atlas of Medical Devices. The GAMD was updated in 2017, and the 2022 update is under development.
     date_published: '2022'
-    title_snapshot: Global atlas of medical devices - Positron Emission Tomography
-      (PET)
+    title_snapshot: Global atlas of medical devices - Positron Emission Tomography (PET)
     description_snapshot: |-
       The dataset comprises information sourced from the Global Atlas of Medical Devices (GAMD) regarding the Positron Emission Tomography (PET) density per million population.
     # Citation
@@ -30,8 +29,7 @@ meta:
     attribution_short: WHO
 
     # Files
-    url_main:
-      https://www.who.int/teams/health-product-policy-and-standards/assistive-and-medical-technology/medical-devices/global-atlas-of-medical-devices
+    url_main: https://www.who.int/teams/health-product-policy-and-standards/assistive-and-medical-technology/medical-devices/global-atlas-of-medical-devices
     date_accessed: 2023-10-13
 
     # License
@@ -41,6 +39,6 @@ meta:
 
 wdir: ../../../data/snapshots/who/2023-10-13
 outs:
-- md5: 53dc9817e8d9f5d8e472b3d97997487e
-  size: 53910
-  path: medical_devices_atlas_pet.csv
+  - md5: 89f1eb5661cb937a709e441188b5e937
+    size: 53910
+    path: medical_devices_atlas_pet.csv

--- a/snapshots/who/2023-11-01/who_statins.csv.dvc
+++ b/snapshots/who/2023-11-01/who_statins.csv.dvc
@@ -15,8 +15,7 @@ meta:
     attribution_short: WHO
 
     # Files
-    url_main:
-      https://www.who.int/data/gho/data/indicators/indicator-details/GHO/general-availability-of-statins-in-the-public-health-sector
+    url_main: https://www.who.int/data/gho/data/indicators/indicator-details/GHO/general-availability-of-statins-in-the-public-health-sector
     date_accessed: 2023-11-01
 
     # License
@@ -25,6 +24,6 @@ meta:
       url: https://www.who.int/about/policies/publishing/copyright
 wdir: ../../../data/snapshots/who/2023-11-01
 outs:
-- md5: 655553642366040b293ccda2ab5ca4d2
-  size: 186313
-  path: who_statins.csv
+  - md5: e7469e5b10fbc1ab47a31586f1d153fe
+    size: 186313
+    path: who_statins.csv

--- a/snapshots/who/latest/fluid.csv.dvc
+++ b/snapshots/who/latest/fluid.csv.dvc
@@ -20,6 +20,6 @@ meta:
     The platform accommodates both qualitative and quantitative data which facilitates the tracking of global trends, spread, intensity, and impact of influenza. These data are made freely available to health policy makers in order to assist them in making informed decisions regarding the management of influenza.
 wdir: ../../../data/snapshots/who/latest
 outs:
-  - md5: 18816822097b8d36c52a1322bcdf5300
+  - md5: f24aee3202d3b63146a4db2751e73997
     size: 148667170
     path: fluid.csv

--- a/snapshots/who/latest/flunet.csv.dvc
+++ b/snapshots/who/latest/flunet.csv.dvc
@@ -20,6 +20,6 @@ meta:
     The data are provided remotely by National Influenza Centres (NICs) of the Global Influenza Surveillance and Response System (GISRS) and other national influenza reference laboratories collaborating actively with GISRS, or are uploaded from WHO regional databases.
 wdir: ../../../data/snapshots/who/latest
 outs:
-  - md5: d7675827134014c50246eb8e5510e2f3
+  - md5: f84bbba86d78f4af9651cc6d3497d7af
     size: 25450854
     path: flunet.csv

--- a/snapshots/wvs/2023-06-25/longitudinal_wvs.csv.dvc
+++ b/snapshots/wvs/2023-06-25/longitudinal_wvs.csv.dvc
@@ -14,6 +14,6 @@ meta:
 
 wdir: ../../../data/snapshots/wvs/2023-06-25
 outs:
-  - md5: 20ddc662945bef22464c8614066e7afe
+  - md5: 7551df3ae753117e33bbbd9ddefc997c
     size: 1394309381
     path: longitudinal_wvs.csv

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -67,16 +67,3 @@ def test_checksum_file_regions(tmp_path):
     checksum2 = files.checksum_file(tmp_path / "regions.yml")
 
     assert checksum1 == checksum2
-
-
-def test_checksum_file_dvc(tmp_path):
-    f = tmp_path / "test.csv"
-    f.write_text("a,b,c\r\n1,2,3")
-
-    # Checksum replaces \r\n with \n
-    assert files.checksum_file(f) == "1a477f6d2f9c9fc827fa46b5ace1a145"
-
-
-def test_checksum_str_dvc():
-    # Checksum replaces \r\n with \n
-    assert files.checksum_str("a,b,c\r\n1,2,3") == files.checksum_str("a,b,c\n1,2,3")


### PR DESCRIPTION
Some time ago, we adapted our MD5 checksum calculation to treat Windows newlines `\r\n` as `\n`, primarily to be compatible with DVC. Now that we don't use DVC anymore, this step seems unnecessary and could be confusing (e.g. linux command `md5sum` would return a different checksum than ours).

This PR unifies MD5 calculation across our codebase and updates all snapshots in R2.

I wrote a script that:
1. Fetch all files from `r2://owid-snapshots`
2. Filter to files that contain `\r\n` (Windows newlines)
3. Calculate new md5 checksum without converting `\r\n` to `\n`
4. Save the file to `r2://owid-snapshots/[new_md5_checksum]`
5. Update `*.dvc` file

Note that we're not deleting any snapshots, so the old ETL versions should keep working.