### PR TITLE
:hammer: repurpose ENV for environment and rename ENV to ENV_FILE

### DIFF
--- a/apps/wizard/config/__init__.py
+++ b/apps/wizard/config/__init__.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import yaml
 
-from etl.config import ENV
+from apps.wizard.utils.env import ENV_IS_REMOTE
 from etl.paths import APPS_DIR
 
 _config_path = APPS_DIR / "wizard" / "config" / "config.yml"
@@ -28,7 +28,7 @@ def load_wizard_config():  # -> Any:
         enable = props.get("enable", True)
 
         # If `disable_on_remote` is set, then disable if we are on remote (i.e. staging or production)
-        if ENV in ("production", "staging"):
+        if ENV_IS_REMOTE:
             enable = (not disable_on_remote) and enable
 
         return enable

--- a/apps/wizard/config/__init__.py
+++ b/apps/wizard/config/__init__.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import yaml
 
-from etl.config import WIZARD_IS_REMOTE
+from etl.config import ENV
 from etl.paths import APPS_DIR
 
 _config_path = APPS_DIR / "wizard" / "config" / "config.yml"
@@ -27,8 +27,8 @@ def load_wizard_config():  # -> Any:
         # Default for `enable` is True
         enable = props.get("enable", True)
 
-        # If `disable_on_remote` is set, then disable if we are on remote (i.e. WIZARD_IS_REMOTE is set to True)
-        if WIZARD_IS_REMOTE:
+        # If `disable_on_remote` is set, then disable if we are on remote (i.e. staging or production)
+        if ENV in ("production", "staging"):
             enable = (not disable_on_remote) and enable
 
         return enable

--- a/apps/wizard/config/__init__.py
+++ b/apps/wizard/config/__init__.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import yaml
 
-from apps.wizard.utils.env import ENV_IS_REMOTE
+from etl.config import ENV_IS_REMOTE
 from etl.paths import APPS_DIR
 
 _config_path = APPS_DIR / "wizard" / "config" / "config.yml"

--- a/apps/wizard/config/config.yml
+++ b/apps/wizard/config/config.yml
@@ -17,7 +17,7 @@
 # - emoji (str): Emoji to show in the sidebar menu.
 # - enabled (bool): Whether the app is enabled or not. If it's not enabled, it won't be shown at all. Default is True.
 # - image_url (str): Link to the image you want to show on the card in the home page of Wizard.
-# - disable_on_remote (bool): Whether the app is disabled in remote settings. To detect if the app is running in a remote setting, it checks the value of the environment variable `WIZARD_IS_REMOTE`. If it's set to `True`, the app will be disabled and overwrites the value of `enabled`. Set to "False" by default.
+# - disable_on_remote (bool): Whether the app is disabled in remote settings. To detect if the app is running in a remote setting, it checks the value of the environment variable `ENV`. If it's not `staging` or `production`, the app will be disabled and overwrites the value of `enabled`.
 
 etl:
   title: ETL steps

--- a/apps/wizard/pages/dataset_explorer.py
+++ b/apps/wizard/pages/dataset_explorer.py
@@ -13,7 +13,7 @@ from st_pages import add_indentation
 from streamlit_agraph import Config, ConfigBuilder, Edge, Node, agraph
 
 from apps.wizard.utils import metadata_export_basic, set_states
-from etl.config import ENV
+from apps.wizard.utils.env import ENV_IS_REMOTE
 from etl.paths import DATA_DIR
 from etl.steps import extract_step_attributes, filter_to_subgraph, load_dag
 
@@ -303,7 +303,7 @@ if st.session_state.get("show"):
                     st.button(label="Export", on_click=lambda: set_states({"export_metadata": True}))
                     if st.session_state.export_metadata:
                         ## Remote setting
-                        if ENV in ("production", "staging"):
+                        if ENV_IS_REMOTE:
                             try:
                                 with tempfile.TemporaryFile() as f:
                                     output_path = metadata_export_basic(dataset=dataset, output=str(f.name))

--- a/apps/wizard/pages/dataset_explorer.py
+++ b/apps/wizard/pages/dataset_explorer.py
@@ -13,7 +13,7 @@ from st_pages import add_indentation
 from streamlit_agraph import Config, ConfigBuilder, Edge, Node, agraph
 
 from apps.wizard.utils import metadata_export_basic, set_states
-from apps.wizard.utils.env import ENV_IS_REMOTE
+from etl.config import ENV_IS_REMOTE
 from etl.paths import DATA_DIR
 from etl.steps import extract_step_attributes, filter_to_subgraph, load_dag
 

--- a/apps/wizard/pages/dataset_explorer.py
+++ b/apps/wizard/pages/dataset_explorer.py
@@ -13,7 +13,7 @@ from st_pages import add_indentation
 from streamlit_agraph import Config, ConfigBuilder, Edge, Node, agraph
 
 from apps.wizard.utils import metadata_export_basic, set_states
-from etl.config import WIZARD_IS_REMOTE
+from etl.config import ENV
 from etl.paths import DATA_DIR
 from etl.steps import extract_step_attributes, filter_to_subgraph, load_dag
 
@@ -303,7 +303,7 @@ if st.session_state.get("show"):
                     st.button(label="Export", on_click=lambda: set_states({"export_metadata": True}))
                     if st.session_state.export_metadata:
                         ## Remote setting
-                        if WIZARD_IS_REMOTE:
+                        if ENV in ("production", "staging"):
                             try:
                                 with tempfile.TemporaryFile() as f:
                                     output_path = metadata_export_basic(dataset=dataset, output=str(f.name))

--- a/apps/wizard/pages/harmonizer.py
+++ b/apps/wizard/pages/harmonizer.py
@@ -9,7 +9,7 @@ from owid.catalog import Dataset
 from st_pages import add_indentation
 
 from apps.wizard.utils import get_datasets_in_etl, set_states
-from apps.wizard.utils.env import ENV_IS_REMOTE
+from etl.config import ENV_IS_REMOTE
 from etl.harmonize import CountryRegionMapper, harmonize_simple
 from etl.paths import STEP_DIR
 from etl.steps import load_from_uri

--- a/apps/wizard/pages/harmonizer.py
+++ b/apps/wizard/pages/harmonizer.py
@@ -9,7 +9,7 @@ from owid.catalog import Dataset
 from st_pages import add_indentation
 
 from apps.wizard.utils import get_datasets_in_etl, set_states
-from etl.config import WIZARD_IS_REMOTE
+from etl.config import ENV
 from etl.harmonize import CountryRegionMapper, harmonize_simple
 from etl.paths import STEP_DIR
 from etl.steps import load_from_uri
@@ -229,7 +229,7 @@ if option:
                 # 3/ PATH to export & export button
                 directory = f"{STEP_DIR}/data/garden/{dataset.m.namespace}/{dataset.m.version}"
                 path_export = f"{directory}/{dataset.m.short_name}.countries.json"
-                if WIZARD_IS_REMOTE:
+                if ENV in ("production", "staging"):
                     # Submit button
                     export_btn = st.form_submit_button(
                         label="Generate mapping",
@@ -251,7 +251,7 @@ if option:
             # EXPORT
             ####################################################################################################
             if export_btn:
-                if WIZARD_IS_REMOTE:
+                if ENV in ("production", "staging"):
                     path_export = Path(path_export).name
                     json_string = json.dumps(st.session_state.entity_mapping)
                     st.download_button(

--- a/apps/wizard/pages/harmonizer.py
+++ b/apps/wizard/pages/harmonizer.py
@@ -9,7 +9,7 @@ from owid.catalog import Dataset
 from st_pages import add_indentation
 
 from apps.wizard.utils import get_datasets_in_etl, set_states
-from etl.config import ENV
+from apps.wizard.utils.env import ENV_IS_REMOTE
 from etl.harmonize import CountryRegionMapper, harmonize_simple
 from etl.paths import STEP_DIR
 from etl.steps import load_from_uri
@@ -229,7 +229,7 @@ if option:
                 # 3/ PATH to export & export button
                 directory = f"{STEP_DIR}/data/garden/{dataset.m.namespace}/{dataset.m.version}"
                 path_export = f"{directory}/{dataset.m.short_name}.countries.json"
-                if ENV in ("production", "staging"):
+                if ENV_IS_REMOTE:
                     # Submit button
                     export_btn = st.form_submit_button(
                         label="Generate mapping",
@@ -251,7 +251,7 @@ if option:
             # EXPORT
             ####################################################################################################
             if export_btn:
-                if ENV in ("production", "staging"):
+                if ENV_IS_REMOTE:
                     path_export = Path(path_export).name
                     json_string = json.dumps(st.session_state.entity_mapping)
                     st.download_button(

--- a/apps/wizard/utils/env.py
+++ b/apps/wizard/utils/env.py
@@ -8,9 +8,6 @@ from etl import config
 OWIDEnvType = Literal["live", "staging", "local", "remote-staging", "unknown"]
 
 
-ENV_IS_REMOTE = config.ENV in ("production", "staging")
-
-
 class OWIDEnv:
     """OWID environment."""
 

--- a/apps/wizard/utils/env.py
+++ b/apps/wizard/utils/env.py
@@ -8,6 +8,9 @@ from etl import config
 OWIDEnvType = Literal["live", "staging", "local", "remote-staging", "unknown"]
 
 
+ENV_IS_REMOTE = config.ENV in ("production", "staging")
+
+
 class OWIDEnv:
     """OWID environment."""
 

--- a/etl/config.py
+++ b/etl/config.py
@@ -36,6 +36,7 @@ DEBUG = env.get("DEBUG") in ("True", "true", "1")
 
 # Environment, e.g. production, staging, dev
 ENV = env.get("ENV", "dev")
+ENV_IS_REMOTE = ENV in ("production", "staging")
 
 # publishing to OWID's public data catalog in R2
 R2_BUCKET = "owid-catalog"

--- a/etl/config.py
+++ b/etl/config.py
@@ -22,7 +22,10 @@ def get_username():
 
 
 def load_env():
-    ENV_FILE = env.get("ENV", BASE_DIR / ".env")
+    if env.get("ENV", "").startswith("."):
+        raise ValueError(f"ENV was replaced by ENV_FILE, please use ENV_FILE={env['ENV']} ... instead.")
+
+    ENV_FILE = env.get("ENV_FILE", BASE_DIR / ".env")
     load_dotenv(ENV_FILE, override=True)
 
 
@@ -30,6 +33,9 @@ load_env()
 # When DEBUG is on
 # - run steps in the same process (speeding up ETL)
 DEBUG = env.get("DEBUG") in ("True", "true", "1")
+
+# Environment, e.g. production, staging, dev
+ENV = env.get("ENV", "dev")
 
 # publishing to OWID's public data catalog in R2
 R2_BUCKET = "owid-catalog"
@@ -144,9 +150,3 @@ def enable_bugsnag() -> None:
         bugsnag.configure(
             api_key=BUGSNAG_API_KEY,
         )  # type: ignore
-
-
-# For Wizard to know if it is running on remote
-## This could eventuallyb be just a generic flag for other apps/processes too.
-## Why is this important for Wizard? Refer to field `disable_on_remote` in apps/wizard/config/config.yml`
-WIZARD_IS_REMOTE = env.get("WIZARD_IS_REMOTE") in ("True", "true", "1")


### PR DESCRIPTION
## TODO after merging
- [x] announce the change
- [x] merge https://github.com/owid/ops/pull/152 and redeploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated feature toggling to use environment settings (`ENV`) for better flexibility.
- **Chores**
	- Improved environment variable management by introducing `ENV_FILE` and removing obsolete `WIZARD_IS_REMOTE`.
- **Chores**
	- Enhanced environment configuration checks for improved logic and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->