### PR TITLE
:bug: ivs: Fix high incidence of missing values in Integrated Values Surveys

### DIFF
--- a/etl/steps/data/garden/ivs/2023-11-27/integrated_values_survey.meta.yml
+++ b/etl/steps/data/garden/ivs/2023-11-27/integrated_values_survey.meta.yml
@@ -436,14 +436,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important in life: Family"
-      missing_important_in_life_family:
-        title: "Missing: Important in life: Family"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Family".'
+      no_answer_important_in_life_family:
+        title: "No answer: Important in life: Family"
+        description_short: '% of answers classified as "No answer" for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Family".'
         display:
-          name: "Missing: Important in life: Family"
+          name: "No answer: Important in life: Family"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important in life: Family"
+          title_public: "No answer: Important in life: Family"
 
       important_in_life_friends:
         title: "Important in life: Friends"
@@ -501,14 +501,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important in life: Friends"
-      missing_important_in_life_friends:
-        title: "Missing: Important in life: Friends"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Friends".'
+      no_answer_important_in_life_friends:
+        title: "No answer: Important in life: Friends"
+        description_short: '% of answers classified as "No answer" for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Friends".'
         display:
-          name: "Missing: Important in life: Friends"
+          name: "No answer: Important in life: Friends"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important in life: Friends"
+          title_public: "No answer: Important in life: Friends"
 
       important_in_life_leisure_time:
         title: "Important in life: Leisure time"
@@ -566,14 +566,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important in life: Leisure time"
-      missing_important_in_life_leisure_time:
-        title: "Missing: Important in life: Leisure time"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Leisure time".'
+      no_answer_important_in_life_leisure_time:
+        title: "No answer: Important in life: Leisure time"
+        description_short: '% of answers classified as "No answer" for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Leisure time".'
         display:
-          name: "Missing: Important in life: Leisure time"
+          name: "No answer: Important in life: Leisure time"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important in life: Leisure time"
+          title_public: "No answer: Important in life: Leisure time"
 
       important_in_life_politics:
         title: "Important in life: Politics"
@@ -631,14 +631,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important in life: Politics"
-      missing_important_in_life_politics:
-        title: "Missing: Important in life: Politics"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Politics".'
+      no_answer_important_in_life_politics:
+        title: "No answer: Important in life: Politics"
+        description_short: '% of answers classified as "No answer" for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Politics".'
         display:
-          name: "Missing: Important in life: Politics"
+          name: "No answer: Important in life: Politics"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important in life: Politics"
+          title_public: "No answer: Important in life: Politics"
 
       important_in_life_work:
         title: "Important in life: Work"
@@ -696,14 +696,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important in life: Work"
-      missing_important_in_life_work:
-        title: "Missing: Important in life: Work"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Work".'
+      no_answer_important_in_life_work:
+        title: "No answer: Important in life: Work"
+        description_short: '% of answers classified as "No answer" for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Work".'
         display:
-          name: "Missing: Important in life: Work"
+          name: "No answer: Important in life: Work"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important in life: Work"
+          title_public: "No answer: Important in life: Work"
 
       important_in_life_religion:
         title: "Important in life: Religion"
@@ -761,14 +761,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important in life: Religion"
-      missing_important_in_life_religion:
-        title: "Missing: Important in life: Religion"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Religion".'
+      no_answer_important_in_life_religion:
+        title: "No answer: Important in life: Religion"
+        description_short: '% of answers classified as "No answer" for the question "For each of the following aspects, indicate how important it is in your life. Would you say it is very important, rather important, not very important or not important at all?" in the item "Religion".'
         display:
-          name: "Missing: Important in life: Religion"
+          name: "No answer: Important in life: Religion"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important in life: Religion"
+          title_public: "No answer: Important in life: Religion"
 
       interested_politics:
         title: "Interest in politics"
@@ -826,14 +826,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Interest in politics"
-      missing_interested_politics:
-        title: "Missing: Interest in politics"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "How interested would you say you are in politics?"'
+      no_answer_interested_politics:
+        title: "No answer: Interest in politics"
+        description_short: '% of answers classified as "No answer" for the question "How interested would you say you are in politics?"'
         display:
-          name: "Missing: Interest in politics"
+          name: "No answer: Interest in politics"
           <<: *common-display
         presentation:
-          title_public: "Missing: Interest in politics"
+          title_public: "No answer: Interest in politics"
 
       have_done_political_action_signing_a_petition:
         title: "Political action: Have signed a petition"
@@ -867,14 +867,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Signing a petition (Don't know)"
-      missing_political_action_signing_a_petition:
-        title: "Political action: Signing a petition (Missing)"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I would like you to look at this card. I am going to read out some different forms of political action that people can take, and I would like you to tell me, for each one, whether you have actually done any of these things, whether you might do it or would never, under any circumstances, do it." in the item "Signed a petition".'
+      no_answer_political_action_signing_a_petition:
+        title: "Political action: Signing a petition (No answer)"
+        description_short: '% of answers classified as "No answer" for the question "Now I would like you to look at this card. I am going to read out some different forms of political action that people can take, and I would like you to tell me, for each one, whether you have actually done any of these things, whether you might do it or would never, under any circumstances, do it." in the item "Signed a petition".'
         display:
-          name: "Signing a petition (Missing)"
+          name: "Signing a petition (No answer)"
           <<: *common-display
         presentation:
-          title_public: "Signing a petition (Missing)"
+          title_public: "Signing a petition (No answer)"
 
       have_done_political_action_joining_in_boycotts:
         title: "Political action: Have joined in boycotts"
@@ -908,14 +908,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Joining in boycotts (Don't know)"
-      missing_political_action_joining_in_boycotts:
-        title: "Political action: Joining in boycotts (Missing)"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I would like you to look at this card. I am going to read out some different forms of political action that people can take, and I would like you to tell me, for each one, whether you have actually done any of these things, whether you might do it or would never, under any circumstances, do it." in the item "Joining in boycotts".'
+      no_answer_political_action_joining_in_boycotts:
+        title: "Political action: Joining in boycotts (No answer)"
+        description_short: '% of answers classified as "No answer" for the question "Now I would like you to look at this card. I am going to read out some different forms of political action that people can take, and I would like you to tell me, for each one, whether you have actually done any of these things, whether you might do it or would never, under any circumstances, do it." in the item "Joining in boycotts".'
         display:
-          name: "Joining in boycotts (Missing)"
+          name: "Joining in boycotts (No answer)"
           <<: *common-display
         presentation:
-          title_public: "Joining in boycotts (Missing)"
+          title_public: "Joining in boycotts (No answer)"
 
       have_done_political_action_attending_peaceful_demonstrations:
         title: "Political action: Have attended peaceful demonstrations"
@@ -949,14 +949,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Attending peaceful demonstrations (Don't know)"
-      missing_political_action_attending_peaceful_demonstrations:
-        title: "Political action: Attending peaceful demonstrations (Missing)"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I would like you to look at this card. I am going to read out some different forms of political action that people can take, and I would like you to tell me, for each one, whether you have actually done any of these things, whether you might do it or would never, under any circumstances, do it." in the item "Attending peaceful demonstrations".'
+      no_answer_political_action_attending_peaceful_demonstrations:
+        title: "Political action: Attending peaceful demonstrations (No answer)"
+        description_short: '% of answers classified as "No answer" for the question "Now I would like you to look at this card. I am going to read out some different forms of political action that people can take, and I would like you to tell me, for each one, whether you have actually done any of these things, whether you might do it or would never, under any circumstances, do it." in the item "Attending peaceful demonstrations".'
         display:
-          name: "Attending peaceful demonstrations (Missing)"
+          name: "Attending peaceful demonstrations (No answer)"
           <<: *common-display
         presentation:
-          title_public: "Attending peaceful demonstrations (Missing)"
+          title_public: "Attending peaceful demonstrations (No answer)"
 
       have_done_political_action_joining_unofficial_strikes:
         title: "Political action: Have joined unofficial strikes"
@@ -990,14 +990,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Joining unofficial strikes (Don't know)"
-      missing_political_action_joining_unofficial_strikes:
-        title: "Political action: Joining unofficial strikes (Missing)"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I would like you to look at this card. I am going to read out some different forms of political action that people can take, and I would like you to tell me, for each one, whether you have actually done any of these things, whether you might do it or would never, under any circumstances, do it." in the item "Joining unofficial strikes".'
+      no_answer_political_action_joining_unofficial_strikes:
+        title: "Political action: Joining unofficial strikes (No answer)"
+        description_short: '% of answers classified as "No answer" for the question "Now I would like you to look at this card. I am going to read out some different forms of political action that people can take, and I would like you to tell me, for each one, whether you have actually done any of these things, whether you might do it or would never, under any circumstances, do it." in the item "Joining unofficial strikes".'
         display:
-          name: "Joining unofficial strikes (Missing)"
+          name: "Joining unofficial strikes (No answer)"
           <<: *common-display
         presentation:
-          title_public: "Joining unofficial strikes (Missing)"
+          title_public: "Joining unofficial strikes (No answer)"
 
       environment_env_ec:
         title: "Environment vs economic growth: Environment"
@@ -1031,14 +1031,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Environment vs economic growth: Don't know"
-      missing_env_ec:
-        title: "Environment vs economic growth: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Here are two statements people sometimes make when discussing the environment and economic growth. Which of them comes closer to your own point of view? A. Protecting the environment should be given priority, even if it causes slower economic growth and some loss of jobs B. Economic growth and creating jobs should be the top priority, even if the environment suffers to some extent"'
+      no_answer_env_ec:
+        title: "Environment vs economic growth: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Here are two statements people sometimes make when discussing the environment and economic growth. Which of them comes closer to your own point of view? A. Protecting the environment should be given priority, even if it causes slower economic growth and some loss of jobs B. Economic growth and creating jobs should be the top priority, even if the environment suffers to some extent"'
         display:
-          name: "Environment vs economic growth: Missing"
+          name: "Environment vs economic growth: No answer"
           <<: *common-display
         presentation:
-          title_public: "Environment vs economic growth: Missing"
+          title_public: "Environment vs economic growth: No answer"
 
       equality_eq_ineq:
         title: "Income equality: Incomes should be made more equal"
@@ -1072,14 +1072,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Income equality: Don't know"
-      missing_eq_ineq:
-        title: "Income equality: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I would like you to tell me your views on various issues. How would you place your views on this scale? 1 means you agree completely with the statement on the left; 10 means you agree completely with the statement on the right; and if your views fall somewhere in between, you can choose any number in between." in the statement "Incomes should be made more equal vs There should be greater incentives for individual effort".'
+      no_answer_eq_ineq:
+        title: "Income equality: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I would like you to tell me your views on various issues. How would you place your views on this scale? 1 means you agree completely with the statement on the left; 10 means you agree completely with the statement on the right; and if your views fall somewhere in between, you can choose any number in between." in the statement "Incomes should be made more equal vs There should be greater incentives for individual effort".'
         display:
-          name: "Missing"
+          name: "No answer"
           <<: *common-display
         presentation:
-          title_public: "Income equality: Missing"
+          title_public: "Income equality: No answer"
       avg_score_eq_ineq:
         title: "Income equality: Average score"
         description_short: 'Average score of respondents when asked "Now I would like you to tell me your views on various issues. How would you place your views on this scale? 1 means you agree completely with the statement on the left; 10 means you agree completely with the statement on the right; and if your views fall somewhere in between, you can choose any number in between." in the statement "Incomes should be made more equal vs There should be greater incentives for individual effort".'
@@ -1163,14 +1163,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important to think up new ideas"
-      missing_new_ideas:
-        title: "It is important to this person to think up new ideas and be creative: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person to think up new ideas and be creative".'
+      no_answer_new_ideas:
+        title: "It is important to this person to think up new ideas and be creative: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person to think up new ideas and be creative".'
         display:
-          name: "Missing: Important to think up new ideas"
+          name: "No answer: Important to think up new ideas"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important to think up new ideas"
+          title_public: "No answer: Important to think up new ideas"
 
       like_me_agg_rich:
         title: "It is important to this person to be rich: Like me (aggregate)"
@@ -1244,14 +1244,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important to be rich"
-      missing_rich:
-        title: "It is important to this person to be rich: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person to be rich".'
+      no_answer_rich:
+        title: "It is important to this person to be rich: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person to be rich".'
         display:
-          name: "Missing: Important to be rich"
+          name: "No answer: Important to be rich"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important to be rich"
+          title_public: "No answer: Important to be rich"
 
       like_me_agg_secure:
         title: "It is important to this person living in secure surroundings: Like me (aggregate)"
@@ -1325,14 +1325,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important living in secure surroundings"
-      missing_secure:
-        title: "It is important to this person living in secure surroundings: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person living in secure surroundings".'
+      no_answer_secure:
+        title: "It is important to this person living in secure surroundings: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person living in secure surroundings".'
         display:
-          name: "Missing: Important living in secure surroundings"
+          name: "No answer: Important living in secure surroundings"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important living in secure surroundings"
+          title_public: "No answer: Important living in secure surroundings"
 
       like_me_agg_good_time:
         title: "It is important to this person to have a good time: Like me (aggregate)"
@@ -1406,14 +1406,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important to have a good time"
-      missing_good_time:
-        title: "It is important to this person to have a good time: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person to have a good time".'
+      no_answer_good_time:
+        title: "It is important to this person to have a good time: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person to have a good time".'
         display:
-          name: "Missing: Important to have a good time"
+          name: "No answer: Important to have a good time"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important to have a good time"
+          title_public: "No answer: Important to have a good time"
 
       like_me_agg_help_others:
         title: "It is important to this person to help the people nearby: Like me (aggregate)"
@@ -1487,14 +1487,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important to help the people nearby"
-      missing_help_others:
-        title: "It is important to this person to help the people nearby: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person to help the people nearby".'
+      no_answer_help_others:
+        title: "It is important to this person to help the people nearby: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person to help the people nearby".'
         display:
-          name: "Missing: Important to help the people nearby"
+          name: "No answer: Important to help the people nearby"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important to help the people nearby"
+          title_public: "No answer: Important to help the people nearby"
 
       like_me_agg_success:
         title: "It is important to this person being very successful: Like me (aggregate)"
@@ -1568,14 +1568,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important being very successful"
-      missing_success:
-        title: "It is important to this person being very successful: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person being very successful".'
+      no_answer_success:
+        title: "It is important to this person being very successful: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person being very successful".'
         display:
-          name: "Missing: Important being very successful"
+          name: "No answer: Important being very successful"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important being very successful"
+          title_public: "No answer: Important being very successful"
 
       like_me_agg_risks:
         title: "It is important to this person adventure and taking risks: Like me (aggregate)"
@@ -1649,14 +1649,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important taking risks"
-      missing_risks:
-        title: "It is important to this person adventure and taking risks: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person adventure and taking risks".'
+      no_answer_risks:
+        title: "It is important to this person adventure and taking risks: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person adventure and taking risks".'
         display:
-          name: "Missing: Important taking risks"
+          name: "No answer: Important taking risks"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important taking risks"
+          title_public: "No answer: Important taking risks"
 
       like_me_agg_behave:
         title: "It is important to this person to always behave properly: Like me (aggregate)"
@@ -1730,14 +1730,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important to always behave properly"
-      missing_behave:
-        title: "It is important to this person to always behave properly: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person to always behave properly".'
+      no_answer_behave:
+        title: "It is important to this person to always behave properly: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person to always behave properly".'
         display:
-          name: "Missing: Important to always behave properly"
+          name: "No answer: Important to always behave properly"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important to always behave properly"
+          title_public: "No answer: Important to always behave properly"
 
       like_me_agg_respect_environment:
         title: "It is important to this person looking after the environment: Like me (aggregate)"
@@ -1811,14 +1811,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important looking after the environment"
-      missing_respect_environment:
-        title: "It is important to this person looking after the environment: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person looking after the environment".'
+      no_answer_respect_environment:
+        title: "It is important to this person looking after the environment: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person looking after the environment".'
         display:
-          name: "Missing: Important looking after the environment"
+          name: "No answer: Important looking after the environment"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important looking after the environment"
+          title_public: "No answer: Important looking after the environment"
 
       like_me_agg_tradition:
         title: "It is important to this person tradition: Like me (aggregate)"
@@ -1892,14 +1892,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Don't know: Important tradition"
-      missing_tradition:
-        title: "It is important to this person tradition: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person tradition".'
+      no_answer_tradition:
+        title: "It is important to this person tradition: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Now I will briefly describe some people. Using this card, would you please indicate for each description whether that person is very much like you, like you, somewhat like you, not like you, or not at all like you?" in the description "It is important to this person tradition".'
         display:
-          name: "Missing: Important tradition"
+          name: "No answer: Important tradition"
           <<: *common-display
         presentation:
-          title_public: "Missing: Important tradition"
+          title_public: "No answer: Important tradition"
 
       leisure_lei_vs_wk:
         title: "Leisure vs work: Leisure (aggregate)"
@@ -1965,14 +1965,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Leisure vs work: Don't know"
-      missing_lei_vs_wk:
-        title: "Leisure vs work: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Which point on this scale most clearly describes how much weight you place on work (including housework and schoolwork), as compared with leisure or recreation? A It´s leisure that makes life worth living, not work B Work is what makes life worth living, not leisure", where 1 is description A and 5 is description B.'
+      no_answer_lei_vs_wk:
+        title: "Leisure vs work: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Which point on this scale most clearly describes how much weight you place on work (including housework and schoolwork), as compared with leisure or recreation? A It´s leisure that makes life worth living, not work B Work is what makes life worth living, not leisure", where 1 is description A and 5 is description B.'
         display:
-          name: "Leisure vs work: Missing"
+          name: "Leisure vs work: No answer"
           <<: *common-display
         presentation:
-          title_public: "Leisure vs work: Missing"
+          title_public: "Leisure vs work: No answer"
       avg_score_lei_vs_wk:
         title: "Leisure vs work: Average score"
         description_short: 'Average score in a scale from 1 to 5 when asked "Which point on this scale most clearly describes how much weight you place on work (including housework and schoolwork), as compared with leisure or recreation? A It´s leisure that makes life worth living, not work B Work is what makes life worth living, not leisure", where 1 is description A and 5 is description B.'
@@ -2048,14 +2048,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Work is a duty towards society: Don't know"
-      missing_work_is_a_duty:
-        title: "Work is a duty towards society: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Do you agree or disagree with the following statements? Work is a duty towards society".'
+      no_answer_work_is_a_duty:
+        title: "Work is a duty towards society: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Do you agree or disagree with the following statements? Work is a duty towards society".'
         display:
-          name: "Work is a duty towards society: Missing"
+          name: "Work is a duty towards society: No answer"
           <<: *common-display
         presentation:
-          title_public: "Work is a duty towards society: Missing"
+          title_public: "Work is a duty towards society: No answer"
 
       agree_agg_work_should_come_first:
         title: "Work should come first: Agree (aggregate)"
@@ -2121,14 +2121,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Work should come first: Don't know"
-      missing_work_should_come_first:
-        title: "Work should come first: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Do you agree or disagree with the following statements? Work should always come first, even if it means less spare time".'
+      no_answer_work_should_come_first:
+        title: "Work should come first: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Do you agree or disagree with the following statements? Work should always come first, even if it means less spare time".'
         display:
-          name: "Work should come first: Missing"
+          name: "Work should come first: No answer"
           <<: *common-display
         presentation:
-          title_public: "Work should come first: Missing"
+          title_public: "Work should come first: No answer"
 
       poverty_most_serious:
         title: "Most serious problem: Poverty"
@@ -2178,14 +2178,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Most serious problem: Don't know"
-      missing_most_serious:
-        title: "Most serious problem: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "I’m going to read out some problems. Please indicate which of the following problems you consider the most serious one for the world as a whole?" The problems listed were: "People living in poverty and need", "Discrimination against girls and women", "Poor sanitation and infectious diseases", "Inadequate education", and "Environmental pollution"'
+      no_answer_most_serious:
+        title: "Most serious problem: No answer"
+        description_short: '% of answers classified as "No answer" for the question "I’m going to read out some problems. Please indicate which of the following problems you consider the most serious one for the world as a whole?" The problems listed were: "People living in poverty and need", "Discrimination against girls and women", "Poor sanitation and infectious diseases", "Inadequate education", and "Environmental pollution"'
         display:
-          name: "Most serious problem: Missing"
+          name: "Most serious problem: No answer"
           <<: *common-display
         presentation:
-          title_public: "Most serious problem: Missing"
+          title_public: "Most serious problem: No answer"
 
       never_just_agg_claiming_benefits:
         title: "Claiming government benefits to which you are not entitled: Never justifiable (aggregate)"
@@ -2235,14 +2235,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Claiming benefits: Don't know"
-      missing_claiming_benefits:
-        title: "Claiming government benefits to which you are not entitled: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Claiming government benefits to which you are not entitled". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_claiming_benefits:
+        title: "Claiming government benefits to which you are not entitled: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Claiming government benefits to which you are not entitled". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Claiming benefits: Missing"
+          name: "Claiming benefits: No answer"
           <<: *common-display
         presentation:
-          title_public: "Claiming benefits: Missing"
+          title_public: "Claiming benefits: No answer"
       avg_score_claiming_benefits:
         title: "Claiming government benefits to which you are not entitled: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Claiming government benefits to which you are not entitled". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2302,14 +2302,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Stealing property: Don't know"
-      missing_stealing_property:
-        title: "Stealing property: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Stealing property". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_stealing_property:
+        title: "Stealing property: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Stealing property". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Stealing property: Missing"
+          name: "Stealing property: No answer"
           <<: *common-display
         presentation:
-          title_public: "Stealing property: Missing"
+          title_public: "Stealing property: No answer"
       avg_score_stealing_property:
         title: "Stealing property: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Stealing property". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2369,14 +2369,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Parents beating children: Don't know"
-      missing_parents_beating_children:
-        title: "Parents beating children: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Parents beating their children". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_parents_beating_children:
+        title: "Parents beating children: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Parents beating their children". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Parents beating children: Missing"
+          name: "Parents beating children: No answer"
           <<: *common-display
         presentation:
-          title_public: "Parents beating children: Missing"
+          title_public: "Parents beating children: No answer"
       avg_score_parents_beating_children:
         title: "Parents beating children: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Parents beating their children". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2436,14 +2436,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Violence against other people: Don't know"
-      missing_violence_against_other_people:
-        title: "Violence against other people: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Violence against other people". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_violence_against_other_people:
+        title: "Violence against other people: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Violence against other people". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Violence against other people: Missing"
+          name: "Violence against other people: No answer"
           <<: *common-display
         presentation:
-          title_public: "Violence against other people: Missing"
+          title_public: "Violence against other people: No answer"
       avg_score_violence_against_other_people:
         title: "Violence against other people: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Violence against other people". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2503,14 +2503,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Avoiding a fare on public transport: Don't know"
-      missing_avoiding_fare_on_public_transport:
-        title: "Avoiding a fare on public transport: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Avoiding a fare on public transport". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_avoiding_fare_on_public_transport:
+        title: "Avoiding a fare on public transport: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Avoiding a fare on public transport". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Avoiding a fare on public transport: Missing"
+          name: "Avoiding a fare on public transport: No answer"
           <<: *common-display
         presentation:
-          title_public: "Avoiding a fare on public transport: Missing"
+          title_public: "Avoiding a fare on public transport: No answer"
       avg_score_avoiding_fare_on_public_transport:
         title: "Avoiding a fare on public transport: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Avoiding a fare on public transport". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2570,14 +2570,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Cheating on taxes: Don't know"
-      missing_cheating_on_taxes:
-        title: "Cheating on taxes: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Cheating on taxes". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_cheating_on_taxes:
+        title: "Cheating on taxes: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Cheating on taxes". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Cheating on taxes: Missing"
+          name: "Cheating on taxes: No answer"
           <<: *common-display
         presentation:
-          title_public: "Cheating on taxes: Missing"
+          title_public: "Cheating on taxes: No answer"
       avg_score_cheating_on_taxes:
         title: "Cheating on taxes: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Cheating on taxes". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2637,14 +2637,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Accepting a bribe: Don't know"
-      missing_accepting_a_bribe:
-        title: "Accepting a bribe in the course of their duties: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Accepting a bribe in the course of their duties". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_accepting_a_bribe:
+        title: "Accepting a bribe in the course of their duties: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Accepting a bribe in the course of their duties". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Accepting a bribe: Missing"
+          name: "Accepting a bribe: No answer"
           <<: *common-display
         presentation:
-          title_public: "Accepting a bribe: Missing"
+          title_public: "Accepting a bribe: No answer"
       avg_score_accepting_a_bribe:
         title: "Accepting a bribe in the course of their duties: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Accepting a bribe in the course of their duties". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2704,14 +2704,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Homosexuality: Don't know"
-      missing_homosexuality:
-        title: "Homosexuality: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Homosexuality". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_homosexuality:
+        title: "Homosexuality: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Homosexuality". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Homosexuality: Missing"
+          name: "Homosexuality: No answer"
           <<: *common-display
         presentation:
-          title_public: "Homosexuality: Missing"
+          title_public: "Homosexuality: No answer"
       avg_score_homosexuality:
         title: "Homosexuality: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Homosexuality". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2771,14 +2771,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Prostitution: Don't know"
-      missing_prostitution:
-        title: "Prostitution: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Prostitution". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_prostitution:
+        title: "Prostitution: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Prostitution". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Prostitution: Missing"
+          name: "Prostitution: No answer"
           <<: *common-display
         presentation:
-          title_public: "Prostitution: Missing"
+          title_public: "Prostitution: No answer"
       avg_score_prostitution:
         title: "Prostitution: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Prostitution". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2838,14 +2838,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Abortion: Don't know"
-      missing_abortion:
-        title: "Abortion: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Abortion". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_abortion:
+        title: "Abortion: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Abortion". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Abortion: Missing"
+          name: "Abortion: No answer"
           <<: *common-display
         presentation:
-          title_public: "Abortion: Missing"
+          title_public: "Abortion: No answer"
       avg_score_abortion:
         title: "Abortion: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Abortion". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2905,14 +2905,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Divorce: Don't know"
-      missing_divorce:
-        title: "Divorce: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Divorce". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_divorce:
+        title: "Divorce: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Divorce". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Divorce: Missing"
+          name: "Divorce: No answer"
           <<: *common-display
         presentation:
-          title_public: "Divorce: Missing"
+          title_public: "Divorce: No answer"
       avg_score_divorce:
         title: "Divorce: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Divorce". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -2972,14 +2972,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Euthanasia: Don't know"
-      missing_euthanasia:
-        title: "Euthanasia: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Euthanasia". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_euthanasia:
+        title: "Euthanasia: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Euthanasia". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Euthanasia: Missing"
+          name: "Euthanasia: No answer"
           <<: *common-display
         presentation:
-          title_public: "Euthanasia: Missing"
+          title_public: "Euthanasia: No answer"
       avg_score_euthanasia:
         title: "Euthanasia: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Euthanasia". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -3039,14 +3039,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Suicide: Don't know"
-      missing_suicide:
-        title: "Suicide: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Suicide". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_suicide:
+        title: "Suicide: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Suicide". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Suicide: Missing"
+          name: "Suicide: No answer"
           <<: *common-display
         presentation:
-          title_public: "Suicide: Missing"
+          title_public: "Suicide: No answer"
       avg_score_suicide:
         title: "Suicide: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Suicide". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -3106,14 +3106,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Having casual sex: Don't know"
-      missing_having_casual_sex:
-        title: "Having casual sex: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Having casual sex". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_having_casual_sex:
+        title: "Having casual sex: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Having casual sex". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Having casual sex: Missing"
+          name: "Having casual sex: No answer"
           <<: *common-display
         presentation:
-          title_public: "Having casual sex: Missing"
+          title_public: "Having casual sex: No answer"
       avg_score_having_casual_sex:
         title: "Having casual sex: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Having casual sex". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -3173,14 +3173,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Sex before marriage: Don't know"
-      missing_sex_before_marriage:
-        title: "Sex before marriage: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Sex before marriage". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_sex_before_marriage:
+        title: "Sex before marriage: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Sex before marriage". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Sex before marriage: Missing"
+          name: "Sex before marriage: No answer"
           <<: *common-display
         presentation:
-          title_public: "Sex before marriage: Missing"
+          title_public: "Sex before marriage: No answer"
       avg_score_sex_before_marriage:
         title: "Sex before marriage: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Sex before marriage". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -3240,14 +3240,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Invitro fertilization: Don't know"
-      missing_invitro_fertilization:
-        title: "Invitro fertilization: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Invitro fertilization". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_invitro_fertilization:
+        title: "Invitro fertilization: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Invitro fertilization". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Invitro fertilization: Missing"
+          name: "Invitro fertilization: No answer"
           <<: *common-display
         presentation:
-          title_public: "Invitro fertilization: Missing"
+          title_public: "Invitro fertilization: No answer"
       avg_score_invitro_fertilization:
         title: "Invitro fertilization: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Invitro fertilization". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -3307,14 +3307,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Death penalty: Don't know"
-      missing_death_penalty:
-        title: "Death penalty: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Death penalty". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_death_penalty:
+        title: "Death penalty: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Death penalty". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Death penalty: Missing"
+          name: "Death penalty: No answer"
           <<: *common-display
         presentation:
-          title_public: "Death penalty: Missing"
+          title_public: "Death penalty: No answer"
       avg_score_death_penalty:
         title: "Death penalty: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Death penalty". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -3374,14 +3374,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Man beating wife: Don't know"
-      missing_man_beating_wife:
-        title: "Man beating wife: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Man beating wife". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_man_beating_wife:
+        title: "Man beating wife: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Man beating wife". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Man beating wife: Missing"
+          name: "Man beating wife: No answer"
           <<: *common-display
         presentation:
-          title_public: "Man beating wife: Missing"
+          title_public: "Man beating wife: No answer"
       avg_score_man_beating_wife:
         title: "Man beating wife: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Man beating wife". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -3441,14 +3441,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Political violence: Don't know"
-      missing_political_violence:
-        title: "Political violence: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Political violence". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
+      no_answer_political_violence:
+        title: "Political violence: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Political violence". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
         display:
-          name: "Political violence: Missing"
+          name: "Political violence: No answer"
           <<: *common-display
         presentation:
-          title_public: "Political violence: Missing"
+          title_public: "Political violence: No answer"
       avg_score_political_violence:
         title: "Political violence: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "Please tell me for each of the following statements whether you think it can always be justified, never be justified, or something in between, using this card", when the statement was "Political violence". In the scale, 1 means "never justifiable" and 10 means "always justifiable".'
@@ -3516,14 +3516,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Losing my job or not finding a job: Don't know"
-      missing_losing_job:
-        title: "Losing my job or not finding a job: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "To what degree are you worried about the following situations?", when the situation was "Losing my job or not finding a job".'
+      no_answer_losing_job:
+        title: "Losing my job or not finding a job: No answer"
+        description_short: '% of answers classified as "No answer" for the question "To what degree are you worried about the following situations?", when the situation was "Losing my job or not finding a job".'
         display:
-          name: "Losing my job or not finding a job: Missing"
+          name: "Losing my job or not finding a job: No answer"
           <<: *common-display
         presentation:
-          title_public: "Losing my job or not finding a job: Missing"
+          title_public: "Losing my job or not finding a job: No answer"
       avg_score_losing_job:
         title: "Losing my job or not finding a job: Average score"
         description_short: 'Average score in a scale from 1 to 4 when asked "To what degree are you worried about the following situations?", when the situation was "Losing my job or not finding a job". In the scale, 1 means "very much" and 4 means "not at all".'
@@ -3591,14 +3591,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "Not being able to give one's children a good education: Don't know"
-      missing_not_being_able_to_provide_good_education:
-        title: "Not being able to give one's children a good education: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "To what degree are you worried about the following situations?", when the situation was "Not being able to give one''s children a good education".'
+      no_answer_not_being_able_to_provide_good_education:
+        title: "Not being able to give one's children a good education: No answer"
+        description_short: '% of answers classified as "No answer" for the question "To what degree are you worried about the following situations?", when the situation was "Not being able to give one''s children a good education".'
         display:
-          name: "Not being able to give one's children a good education: Missing"
+          name: "Not being able to give one's children a good education: No answer"
           <<: *common-display
         presentation:
-          title_public: "Not being able to give one's children a good education: Missing"
+          title_public: "Not being able to give one's children a good education: No answer"
       avg_score_not_being_able_to_provide_good_education:
         title: "Not being able to give one's children a good education: Average score"
         description_short: 'Average score in a scale from 1 to 10 when asked "To what degree are you worried about the following situations?", when the situation was "Not being able to give one''s children a good education". In the scale, 1 means "very much" and 4 means "not at all".'
@@ -3666,14 +3666,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "A war involving my country: Don't know"
-      missing_war:
-        title: "A war involving my country: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "To what degree are you worried about the following situations?", when the situation was "A war involving my country".'
+      no_answer_war:
+        title: "A war involving my country: No answer"
+        description_short: '% of answers classified as "No answer" for the question "To what degree are you worried about the following situations?", when the situation was "A war involving my country".'
         display:
-          name: "A war involving my country: Missing"
+          name: "A war involving my country: No answer"
           <<: *common-display
         presentation:
-          title_public: "A war involving my country: Missing"
+          title_public: "A war involving my country: No answer"
       avg_score_war:
         title: "A war involving my country: Average score"
         description_short: 'Average score in a scale from 1 to 4 when asked "To what degree are you worried about the following situations?", when the situation was "A war involving my country". In the scale, 1 means "very much" and 4 means "not at all".'
@@ -3741,14 +3741,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "A terrorist attack: Don't know"
-      missing_terrorist_attack:
-        title: "A terrorist attack: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "To what degree are you worried about the following situations?", when the situation was "A terrorist attack".'
+      no_answer_terrorist_attack:
+        title: "A terrorist attack: No answer"
+        description_short: '% of answers classified as "No answer" for the question "To what degree are you worried about the following situations?", when the situation was "A terrorist attack".'
         display:
-          name: "A terrorist attack: Missing"
+          name: "A terrorist attack: No answer"
           <<: *common-display
         presentation:
-          title_public: "A terrorist attack: Missing"
+          title_public: "A terrorist attack: No answer"
       avg_score_terrorist_attack:
         title: "A terrorist attack: Average score"
         description_short: 'Average score in a scale from 1 to 4 when asked "To what degree are you worried about the following situations?", when the situation was "A terrorist attack". In the scale, 1 means "very much" and 4 means "not at all".'
@@ -3816,14 +3816,14 @@ tables:
           <<: *common-display
         presentation:
           title_public: "A civil war: Don't know"
-      missing_civil_war:
-        title: "A civil war: Missing"
-        description_short: '% of answers classified as No answer, not applicable, not asked in survey o missing: other for the question "To what degree are you worried about the following situations?", when the situation was "A civil war".'
+      no_answer_civil_war:
+        title: "A civil war: No answer"
+        description_short: '% of answers classified as "No answer" for the question "To what degree are you worried about the following situations?", when the situation was "A civil war".'
         display:
-          name: "A civil war: Missing"
+          name: "A civil war: No answer"
           <<: *common-display
         presentation:
-          title_public: "A civil war: Missing"
+          title_public: "A civil war: No answer"
       avg_score_civil_war:
         title: "A civil war: Average score"
         description_short: 'Average score in a scale from 1 to 4 when asked "To what degree are you worried about the following situations?", when the situation was "A civil war". In the scale, 1 means "very much" and 4 means "not at all".'

--- a/etl/steps/data/garden/ivs/2023-11-27/integrated_values_survey.py
+++ b/etl/steps/data/garden/ivs/2023-11-27/integrated_values_survey.py
@@ -146,16 +146,13 @@ def drop_indicators_and_replace_nans(tb: Table) -> Table:
     ]
     tb = tb.drop(columns=vars_to_drop)
 
-    # Define columns containing "missing" and "dont_know"
-    missing_cols = [cols for cols in tb.columns if "missing" in cols]
+    # Define columns containing "no_answer" and "dont_know"
+    no_answer_cols = [cols for cols in tb.columns if "no_answer" in cols]
     dont_know_cols = [cols for cols in tb.columns if "dont_know" in cols]
 
-    # Replace zero values with nulls, except for columns containing "missing" and "dont_know"
-    subset_cols = tb.columns.difference(missing_cols + dont_know_cols)
+    # Replace zero values with nulls, except for columns containing "no_answer" and "dont_know"
+    subset_cols = tb.columns.difference(no_answer_cols + dont_know_cols)
     tb[subset_cols] = tb[subset_cols].replace(0, float("nan"))
-
-    # Replace 100 by null in columns containing "missing"
-    tb[missing_cols] = tb[missing_cols].replace(100, float("nan"))
 
     # Replace nulls in Schwartz questions by 0 when the main answer is not null
     tb = solve_nulls_values_in_schwartz_questions(
@@ -171,7 +168,7 @@ def drop_indicators_and_replace_nans(tb: Table) -> Table:
             "not_like_me",
             "not_at_all_like_me",
             "dont_know",
-            "missing",
+            "no_answer",
         ],
     )
 
@@ -311,7 +308,7 @@ def sanity_checks(tb: Table) -> Table:
     tb = check_sum_100(
         tb=tb,
         questions=IMPORTANT_IN_LIFE_QUESTIONS,
-        answers=["very", "rather", "not_very", "notatall", "dont_know", "missing"],
+        answers=["very", "rather", "not_very", "notatall", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 
@@ -319,7 +316,7 @@ def sanity_checks(tb: Table) -> Table:
     tb = check_sum_100(
         tb=tb,
         questions=INTERESTED_IN_POLITICS_QUESTIONS,
-        answers=["very", "somewhat", "not_very", "not_at_all", "dont_know", "missing"],
+        answers=["very", "somewhat", "not_very", "not_at_all", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 
@@ -327,7 +324,7 @@ def sanity_checks(tb: Table) -> Table:
     tb = check_sum_100(
         tb=tb,
         questions=POLITICAL_ACTION_QUESTIONS,
-        answers=["have_done", "might_do", "never", "dont_know", "missing"],
+        answers=["have_done", "might_do", "never", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 
@@ -335,7 +332,7 @@ def sanity_checks(tb: Table) -> Table:
     tb = check_sum_100(
         tb=tb,
         questions=ENVIRONMENT_VS_ECONOMY_QUESTIONS,
-        answers=["environment", "economy", "other_answer", "dont_know", "missing"],
+        answers=["environment", "economy", "other_answer", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 
@@ -343,7 +340,7 @@ def sanity_checks(tb: Table) -> Table:
     tb = check_sum_100(
         tb=tb,
         questions=INCOME_EQUALITY_QUESTIONS,
-        answers=["equality", "neutral", "inequality", "dont_know", "missing"],
+        answers=["equality", "neutral", "inequality", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 
@@ -359,7 +356,7 @@ def sanity_checks(tb: Table) -> Table:
             "not_like_me",
             "not_at_all_like_me",
             "dont_know",
-            "missing",
+            "no_answer",
         ],
         margin=MARGIN,
     )
@@ -368,7 +365,7 @@ def sanity_checks(tb: Table) -> Table:
     tb = check_sum_100(
         tb=tb,
         questions=WORK_VS_LEISURE_QUESTIONS,
-        answers=["work", "leisure", "neutral", "dont_know", "missing"],
+        answers=["work", "leisure", "neutral", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 
@@ -376,7 +373,7 @@ def sanity_checks(tb: Table) -> Table:
     tb = check_sum_100(
         tb=tb,
         questions=WORK_QUESTIONS,
-        answers=["strongly_agree", "agree", "neither", "disagree", "strongly_disagree", "dont_know", "missing"],
+        answers=["strongly_agree", "agree", "neither", "disagree", "strongly_disagree", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 
@@ -384,7 +381,7 @@ def sanity_checks(tb: Table) -> Table:
     tb = check_sum_100(
         tb=tb,
         questions=MOST_SERIOUS_PROBLEM_QUESTIONS,
-        answers=["poverty", "women_discr", "sanitation", "education", "pollution", "dont_know", "missing"],
+        answers=["poverty", "women_discr", "sanitation", "education", "pollution", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 
@@ -392,7 +389,7 @@ def sanity_checks(tb: Table) -> Table:
     tb = check_sum_100(
         tb=tb,
         questions=JUSTIFIABLE_QUESTIONS,
-        answers=["never_just_agg", "always_just_agg", "neutral", "dont_know", "missing"],
+        answers=["never_just_agg", "always_just_agg", "neutral", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 
@@ -400,7 +397,7 @@ def sanity_checks(tb: Table) -> Table:
     tb = check_sum_100(
         tb=tb,
         questions=WORRIES_QUESTIONS,
-        answers=["very_much", "a_great_deal", "not_much", "not_at_all", "dont_know", "missing"],
+        answers=["very_much", "a_great_deal", "not_much", "not_at_all", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 

--- a/snapshots/ivs/2023-11-27/integrated_values_survey.csv.dvc
+++ b/snapshots/ivs/2023-11-27/integrated_values_survey.csv.dvc
@@ -26,6 +26,6 @@ meta:
 
 wdir: ../../../data/snapshots/ivs/2023-11-27
 outs:
-  - md5: a757c33cffd275259332c6b4ca2d850d
-    size: 1084170
+  - md5: 0d0bc9e81b69d6d25812395cec6621d2
+    size: 976196
     path: integrated_values_survey.csv

--- a/snapshots/ivs/2023-11-27/ivs_create_file.do
+++ b/snapshots/ivs/2023-11-27/ivs_create_file.do
@@ -96,7 +96,10 @@ A165 is the question "most people can be trusted"
 */
 
 * Keep only "most people can be trusted" (1), "Need to be very careful" (2), "Don't know" (-1)
-keep if A165 >= -1
+keep if A165 >= 1
+keep if A165 != .c
+keep if A165 != .d
+keep if A165 != .e
 
 *Generate trust variable, with 1 if it's option 1
 gen trust = 0
@@ -114,7 +117,7 @@ preserve
 G007_34 is the question about trusting people you meet fot the first time
 */
 
-keep if G007_34 >= -1
+keep if G007_34 >= 1
 
 gen trust_first = 0
 replace trust_first = 1 if G007_34 == 1 | G007_34 == 2
@@ -136,7 +139,7 @@ preserve
 G007_33 is the question about trusting people you know personally
 */
 
-keep if G007_33 >= -1
+keep if G007_33 >= 1
 
 gen trust_personally = 0
 replace trust_personally = 1 if G007_33 == 1 | G007_33 == 2
@@ -158,7 +161,10 @@ preserve
 A168 is the question "do you think most people try to take advantage of you"
 */
 
-keep if A168 >= -1
+keep if A168 >= 1
+keep if A168 != .c
+keep if A168 != .d
+keep if A168 != .e
 
 gen take_advantage = 0
 replace take_advantage = 1 if A168 == 1
@@ -175,7 +181,10 @@ Processing of multiple additional trust and confidence questions
 */
 
 foreach var in $additional_questions {
-	keep if `var' >= -1
+	keep if `var' >= 1
+	keep if `var' != .c
+	keep if `var' != .d
+	keep if `var' != .e
 
 	gen confidence_`var' = 0
 	replace confidence_`var' = 1 if `var' == 1 | `var' == 2
@@ -204,6 +213,9 @@ foreach var in $additional_questions {
 
 foreach var in $important_in_life_questions {
 	keep if `var' >= 1
+	keep if `var' != .c
+	keep if `var' != .d
+	keep if `var' != .e
 
 	gen important_in_life_`var' = 0
 	replace important_in_life_`var' = 1 if `var' == 1 | `var' == 2
@@ -226,10 +238,10 @@ foreach var in $important_in_life_questions {
 	gen dont_know_important_in_life_`var' = 0
 	replace dont_know_important_in_life_`var' = 1 if `var' == .a
 	
-	gen missing_important_in_life_`var' = 0
-	replace missing_important_in_life_`var' = 1 if `var' == .b | `var' == .c | `var' == .d | `var' == .e
+	gen no_answer_important_in_life_`var' = 0
+	replace no_answer_important_in_life_`var' = 1 if `var' == .b
 
-	collapse (mean) important_in_life_`var' not_important_in_life_`var' very_important_in_life_`var' rather_important_in_life_`var' not_very_important_in_life_`var' notatall_important_in_life_`var' dont_know_important_in_life_`var' missing_important_in_life_`var' [w=S017], by (year country)
+	collapse (mean) important_in_life_`var' not_important_in_life_`var' very_important_in_life_`var' rather_important_in_life_`var' not_very_important_in_life_`var' notatall_important_in_life_`var' dont_know_important_in_life_`var' no_answer_important_in_life_`var' [w=S017], by (year country)
 	tempfile important_in_life_`var'_file
 	save "`important_in_life_`var'_file'"
 
@@ -253,6 +265,9 @@ foreach var in $important_in_life_questions {
 
 */
 keep if E023 >= 1
+keep if E023 != .c
+keep if E023 != .d
+keep if E023 != .e
 
 gen interested_politics = 0
 replace interested_politics = 1 if E023 == 1 | E023 == 2
@@ -275,10 +290,10 @@ replace not_at_all_interested_politics = 1 if E023 == 4
 gen dont_know_interested_politics = 0
 replace dont_know_interested_politics = 1 if E023 == .a
 
-gen missing_interested_politics = 0
-replace missing_interested_politics = 1 if E023 == .b | E023 == .c | E023 == .d | E023 == .e
+gen no_answer_interested_politics = 0
+replace no_answer_interested_politics = 1 if E023 == .b
 
-collapse (mean) interested_politics not_interested_politics very_interested_politics somewhat_interested_politics not_very_interested_politics not_at_all_interested_politics dont_know_interested_politics missing_interested_politics [w=S017], by (year country)
+collapse (mean) interested_politics not_interested_politics very_interested_politics somewhat_interested_politics not_very_interested_politics not_at_all_interested_politics dont_know_interested_politics no_answer_interested_politics [w=S017], by (year country)
 tempfile interest_politics_file
 save "`interest_politics_file'"
 
@@ -304,6 +319,9 @@ global rest_politics_questions : list global(politics_questions) - global(intere
 foreach var of varlist $rest_politics_questions {
 	
 	keep if `var' >= 1
+	keep if `var' != .c
+	keep if `var' != .d
+	keep if `var' != .e
 
 	gen have_done_political_action_`var' = 0
 	replace have_done_political_action_`var' = 1 if `var' == 1
@@ -317,10 +335,10 @@ foreach var of varlist $rest_politics_questions {
 	gen dont_know_political_action_`var' = 0
 	replace dont_know_political_action_`var' = 1 if `var' == .a
 	
-	gen missing_political_action_`var' = 0
-	replace missing_political_action_`var' = 1 if `var' == .b | `var' == .c | `var' == .d | `var' == .e
+	gen no_answer_political_action_`var' = 0
+	replace no_answer_political_action_`var' = 1 if `var' == .b
 
-	collapse (mean) have_done_political_action_`var' might_do_political_action_`var' never_political_action_`var' dont_know_political_action_`var' missing_political_action_`var' [w=S017], by (year country)
+	collapse (mean) have_done_political_action_`var' might_do_political_action_`var' never_political_action_`var' dont_know_political_action_`var' no_answer_political_action_`var' [w=S017], by (year country)
 	tempfile politics_`var'_file
 	save "`politics_`var'_file'"
 	
@@ -343,6 +361,9 @@ foreach var of varlist $rest_politics_questions {
 
 * Keep only answers
 keep if B008 >= 1
+keep if B008 != .c
+keep if B008 != .d
+keep if B008 != .e
 
 *Generate variables
 gen environment_env_ec = 0
@@ -357,11 +378,11 @@ replace other_answer_env_ec = 1 if B008 == 3
 gen dont_know_env_ec = 0
 replace dont_know_env_ec = 1 if B008 == .a
 
-gen missing_env_ec = 0
-replace missing_env_ec = 1 if B008 == .b | B008 == .c | B008 == .d | B008 == .e
+gen no_answer_env_ec = 0
+replace no_answer_env_ec = 1 if B008 == .b
 
 * Make dataset of the mean trust (which ends up being the % of people saying "most people can be trusted") by wave and country (CHECK WEIGHTS)
-collapse (mean) environment_env_ec economy_env_ec other_answer_env_ec dont_know_env_ec missing_env_ec [w=S017], by (year country)
+collapse (mean) environment_env_ec economy_env_ec other_answer_env_ec dont_know_env_ec no_answer_env_ec [w=S017], by (year country)
 tempfile environment_vs_econ_file
 save "`environment_vs_econ_file'"
 
@@ -390,6 +411,9 @@ preserve
 
 * Keep only answers
 keep if E035 >= 1
+keep if E035 != .c
+keep if E035 != .d
+keep if E035 != .e
 
 *Generate variables
 gen equality_eq_ineq = 0
@@ -404,13 +428,13 @@ replace inequality_eq_ineq = 1 if E035 >= 6 & E035 <=10
 gen dont_know_eq_ineq = 0
 replace dont_know_eq_ineq = 1 if E035 == .a
 
-gen missing_eq_ineq = 0
-replace missing_eq_ineq = 1 if E035 == .b | E035 == .c | E035 == .d | E035 == .e
+gen no_answer_eq_ineq = 0
+replace no_answer_eq_ineq = 1 if E035 == .b
 
 gen avg_score_eq_ineq = E035
 
 * Make dataset of the mean trust (which ends up being the % of people saying "most people can be trusted") by wave and country (CHECK WEIGHTS)
-collapse (mean) equality_eq_ineq neutral_eq_ineq inequality_eq_ineq dont_know_eq_ineq missing_eq_ineq avg_score_eq_ineq [w=S017], by (year country)
+collapse (mean) equality_eq_ineq neutral_eq_ineq inequality_eq_ineq dont_know_eq_ineq no_answer_eq_ineq avg_score_eq_ineq [w=S017], by (year country)
 tempfile income_equality_file
 save "`income_equality_file'"
 
@@ -436,6 +460,9 @@ preserve
 
 foreach var in $schwartz_questions {
 	keep if `var' >= 1
+	keep if `var' != .c
+	keep if `var' != .d
+	keep if `var' != .e
 
 	gen like_me_agg_`var' = 0
 	replace like_me_agg_`var' = 1 if `var' == 4 | `var' == 5 | `var' == 6
@@ -464,10 +491,10 @@ foreach var in $schwartz_questions {
 	gen dont_know_`var' = 0
 	replace dont_know_`var' = 1 if `var' == .a
 	
-	gen missing_`var' = 0
-	replace missing_`var' = 1 if `var' == .b | `var' == .c | `var' == .d | `var' == .e
+	gen no_answer_`var' = 0
+	replace no_answer_`var' = 1 if `var' == .b
 
-	collapse (mean) like_me_agg_`var' not_like_me_agg_`var' very_much_like_me_`var' like_me_`var' somewhat_like_me_`var' a_little_like_me_`var' not_like_me_`var' not_at_all_like_me_`var' dont_know_`var' missing_`var' [w=S017], by (year country)
+	collapse (mean) like_me_agg_`var' not_like_me_agg_`var' very_much_like_me_`var' like_me_`var' somewhat_like_me_`var' a_little_like_me_`var' not_like_me_`var' not_at_all_like_me_`var' dont_know_`var' no_answer_`var' [w=S017], by (year country)
 	tempfile schwartz_`var'_file
 	save "`schwartz_`var'_file'"
 
@@ -491,6 +518,9 @@ foreach var in $schwartz_questions {
 
 * Keep only answers
 keep if C008 >= 1
+keep if C008 != .c
+keep if C008 != .d
+keep if C008 != .e
 
 *Generate variables
 gen leisure_lei_vs_wk = 0
@@ -517,13 +547,13 @@ replace lei_vs_wk_5  = 1 if C008 == 5
 gen dont_know_lei_vs_wk = 0
 replace dont_know_lei_vs_wk = 1 if C008 == .a
 
-gen missing_lei_vs_wk = 0
-replace missing_lei_vs_wk = 1 if C008 == .b | C008 == .c | C008 == .d | C008 == .e
+gen no_answer_lei_vs_wk = 0
+replace no_answer_lei_vs_wk = 1 if C008 == .b
 
 gen avg_score_lei_vs_wk = C008
 
 * Make dataset of the mean trust (which ends up being the % of people saying "most people can be trusted") by wave and country (CHECK WEIGHTS)
-collapse (mean) leisure_lei_vs_wk neutral_lei_vs_wk work_lei_vs_wk lei_vs_wk_1 lei_vs_wk_2 lei_vs_wk_4 lei_vs_wk_5 dont_know_lei_vs_wk missing_lei_vs_wk avg_score_lei_vs_wk [w=S017], by (year country)
+collapse (mean) leisure_lei_vs_wk neutral_lei_vs_wk work_lei_vs_wk lei_vs_wk_1 lei_vs_wk_2 lei_vs_wk_4 lei_vs_wk_5 dont_know_lei_vs_wk no_answer_lei_vs_wk avg_score_lei_vs_wk [w=S017], by (year country)
 tempfile leisure_vs_work_file
 save "`leisure_vs_work_file'"
 
@@ -548,6 +578,9 @@ preserve
 
 foreach var in $work_questions {
 	keep if `var' >= 1
+	keep if `var' != .c
+	keep if `var' != .d
+	keep if `var' != .e
 
 	gen agree_agg_`var' = 0
 	replace agree_agg_`var' = 1 if `var' == 1 | `var' == 2
@@ -573,10 +606,10 @@ foreach var in $work_questions {
 	gen dont_know_`var' = 0
 	replace dont_know_`var' = 1 if `var' == .a
 	
-	gen missing_`var' = 0
-	replace missing_`var' = 1 if `var' == .b | `var' == .c | `var' == .d | `var' == .e
+	gen no_answer_`var' = 0
+	replace no_answer_`var' = 1 if `var' == .b
 
-	collapse (mean) agree_agg_`var' disagree_agg_`var' strongly_agree_`var' agree_`var' neither_`var' disagree_`var' strongly_disagree_`var' dont_know_`var' missing_`var' [w=S017], by (year country)
+	collapse (mean) agree_agg_`var' disagree_agg_`var' strongly_agree_`var' agree_`var' neither_`var' disagree_`var' strongly_disagree_`var' dont_know_`var' no_answer_`var' [w=S017], by (year country)
 	tempfile work_`var'_file
 	save "`work_`var'_file'"
 
@@ -601,6 +634,9 @@ foreach var in $work_questions {
 
 * Keep only answers
 keep if E238 >= 1
+keep if E238 != .c
+keep if E238 != .d
+keep if E238 != .e
 
 *Generate variables
 gen poverty_most_serious = 0
@@ -621,11 +657,11 @@ replace pollution_most_serious  = 1 if E238 == 5
 gen dont_know_most_serious = 0
 replace dont_know_most_serious = 1 if E238 == .a
 
-gen missing_most_serious = 0
-replace missing_most_serious = 1 if E238 == .b | E238 == .c | E238 == .d | E238 == .e
+gen no_answer_most_serious = 0
+replace no_answer_most_serious = 1 if E238 == .b
 
 * Make dataset of the mean trust (which ends up being the % of people saying "most people can be trusted") by wave and country (CHECK WEIGHTS)
-collapse (mean) poverty_most_serious women_discr_most_serious sanitation_most_serious education_most_serious pollution_most_serious dont_know_most_serious missing_most_serious [w=S017], by (year country)
+collapse (mean) poverty_most_serious women_discr_most_serious sanitation_most_serious education_most_serious pollution_most_serious dont_know_most_serious no_answer_most_serious [w=S017], by (year country)
 tempfile most_serious_file
 save "`most_serious_file'"
 
@@ -656,6 +692,9 @@ preserve
 
 foreach var in $justifiable_questions {
 	keep if `var' >= 1
+	keep if `var' != .c
+	keep if `var' != .d
+	keep if `var' != .e
 
 	gen never_just_agg_`var' = 0
 	replace never_just_agg_`var' = 1 if `var' <= 4
@@ -675,12 +714,12 @@ foreach var in $justifiable_questions {
 	gen dont_know_`var' = 0
 	replace dont_know_`var' = 1 if `var' == .a
 	
-	gen missing_`var' = 0
-	replace missing_`var' = 1 if `var' == .b | `var' == .c | `var' == .d | `var' == .e
+	gen no_answer_`var' = 0
+	replace no_answer_`var' = 1 if `var' == .b
 	
 	gen avg_score_`var' = `var'
 
-	collapse (mean) never_just_agg_`var' always_just_agg_`var' never_just_`var' always_just_`var' neutral_`var' dont_know_`var' missing_`var' avg_score_`var' [w=S017], by (year country)
+	collapse (mean) never_just_agg_`var' always_just_agg_`var' never_just_`var' always_just_`var' neutral_`var' dont_know_`var' no_answer_`var' avg_score_`var' [w=S017], by (year country)
 	tempfile justifiable_`var'_file
 	save "`justifiable_`var'_file'"
 
@@ -705,6 +744,9 @@ foreach var in $justifiable_questions {
 
 foreach var in $worries_questions {
 	keep if `var' >= 1
+	keep if `var' != .c
+	keep if `var' != .d
+	keep if `var' != .e
 
 	gen worry_`var' = 0
 	replace worry_`var' = 1 if `var' <= 2
@@ -727,12 +769,12 @@ foreach var in $worries_questions {
 	gen dont_know_`var' = 0
 	replace dont_know_`var' = 1 if `var' == .a
 	
-	gen missing_`var' = 0
-	replace missing_`var' = 1 if `var' == .b | `var' == .c | `var' == .d | `var' == .e
+	gen no_answer_`var' = 0
+	replace no_answer_`var' = 1 if `var' == .b
 	
 	gen avg_score_`var' = `var'
 
-	collapse (mean) worry_`var' not_worry_`var' very_much_`var' a_great_deal_`var' not_much_`var' not_at_all_`var' dont_know_`var' missing_`var' avg_score_`var' [w=S017], by (year country)
+	collapse (mean) worry_`var' not_worry_`var' very_much_`var' a_great_deal_`var' not_much_`var' not_at_all_`var' dont_know_`var' no_answer_`var' avg_score_`var' [w=S017], by (year country)
 	tempfile worries_`var'_file
 	save "`worries_`var'_file'"
 


### PR DESCRIPTION
The high incidence of missing values for some questions is due that I was including the categories
```
          .c Not applicable
          .d Not asked in survey
          .e Missing: other
```
Among the missing variables. This PR replaces these variables by a "No answer" category (.b), which together with "Don't know" (.a) are the only classifications beyond the common answers I am keeping.

https://github.com/owid/owid-issues/issues/1374