### PR TITLE
:sparkles: Various core ETL improvements needed for GHO dataset

### DIFF
--- a/etl/config.py
+++ b/etl/config.py
@@ -121,6 +121,11 @@ GRAPHER_INSERT_WORKERS = int(env.get("GRAPHER_WORKERS", max(10, int(40 / RUN_STE
 # of data pages for a single indicator
 GRAPHER_FILTER = env.get("GRAPHER_FILTER", None)
 
+# if set, don't delete indicators from MySQL, only append / update new ones
+# you can use this to only process subset of indicators in your step to
+# speed up development. It's up to you how you define filtering logic in your step
+SUBSET = env.get("SUBSET", None)
+
 # forbid any individual step from consuming more than this much memory
 # (only enforced on Linux)
 MAX_VIRTUAL_MEMORY_LINUX = 32 * 2**30  # 32 GB

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -15,6 +15,7 @@ from owid.catalog.utils import underscore
 
 from etl.db import get_connection, get_engine
 from etl.db_utils import DBUtils
+from etl.files import checksum_str
 
 log = structlog.get_logger()
 
@@ -233,7 +234,7 @@ def _underscore_column_and_dimensions(column: str, dim_dict: Dict[str, Any], tri
 
     if len(short_name) > 255:
         if trim_long_short_name:
-            unique_hash = f"_{abs(hash(short_name))}"
+            unique_hash = f"_{checksum_str(short_name)}"
             short_name = short_name[: (255 - len(unique_hash))] + unique_hash
             log.warning(
                 "short_name_trimmed",

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -360,7 +360,7 @@ def cleanup_ghost_variables(dataset_id: int, upserted_variable_ids: List[int]) -
             """
             SELECT id FROM variables WHERE datasetId=%(dataset_id)s AND id NOT IN %(variable_ids)s
         """,
-            {"dataset_id": dataset_id, "variable_ids": upserted_variable_ids},
+            {"dataset_id": dataset_id, "variable_ids": upserted_variable_ids or [-1]},
         )
         rows = db.cursor.fetchall()
 

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -9,7 +9,7 @@ import tempfile
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Union, cast
+from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional, Union, cast
 from urllib.parse import urljoin
 
 import jsonref
@@ -124,6 +124,7 @@ def create_dataset(
     check_variables_metadata: bool = False,
     run_grapher_checks: bool = True,
     if_origins_exist: SOURCE_EXISTS_OPTIONS = "replace",
+    errors: Literal["ignore", "warn", "raise"] = "raise",
 ) -> catalog.Dataset:
     """Create a dataset and add a list of tables. The dataset metadata is inferred from
     default_metadata and the dest_dir (which is in the form `channel/namespace/version/short_name`).
@@ -204,7 +205,7 @@ def create_dataset(
 
     meta_path = get_metadata_path(str(dest_dir))
     if meta_path.exists():
-        ds.update_metadata(meta_path, if_origins_exist=if_origins_exist)
+        ds.update_metadata(meta_path, if_origins_exist=if_origins_exist, errors=errors)
 
         # check that we are not using metadata inconsistent with path
         for k, v in match.groupdict().items():

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -9,7 +9,6 @@ import re
 import subprocess
 import sys
 import tempfile
-import time
 import warnings
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -499,6 +498,13 @@ class DataStep(Step):
         for f in self._step_files():
             checksums[f] = files.checksum_file(f)
 
+            # if using SUBSET to process just a subset of the data, then add it to its checksum if
+            # the file contains it
+            if config.SUBSET:
+                with open(f) as istream:
+                    if "SUBSET" in istream.read():
+                        checksums[f] += config.SUBSET
+
         in_order = [v for _, v in sorted(checksums.items())]
         return hashlib.md5(",".join(in_order).encode("utf8")).hexdigest()
 
@@ -849,7 +855,7 @@ class GrapherStep(Step):
 
             variable_upsert_results = [future.result() for future in as_completed(futures)]
 
-        if not config.GRAPHER_FILTER:
+        if not config.GRAPHER_FILTER and not config.SUBSET:
             self._cleanup_ghost_resources(dataset_upsert_results, variable_upsert_results)
 
             # set checksum and updatedAt timestamps after all data got inserted

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import time
 import warnings
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -206,7 +206,10 @@ class Dataset:
             - "replace" (default): replace existing origin with new one
             - "append": append new origin to existing ones
             - "fail": raise an exception if origin already exists
-        :param errors: Optionally ignore errors like missing tables that are specified in YAML file
+        :param errors: How to handle errors encountered during metadata update. Possible values:
+            - "ignore" (default): ignore all errors
+            - "warn": issue a warning if there's an indicator in metadata that doesn't exist in the dataset
+            - "raise": same as "warn" but also raise an exception
         """
         self.metadata.update_from_yaml(metadata_path, if_source_exists=if_source_exists)
 

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -704,6 +704,9 @@ class Table(pd.DataFrame):
 
         return cast("Table", tb)
 
+    def drop(self, *args, **kwargs) -> "Table":
+        return cast(Table, super().drop(*args, **kwargs))
+
     def update_log(
         self,
         operation: str,
@@ -1335,7 +1338,7 @@ def read_fwf(
 
 
 def read_feather(
-    filepath: Union[str, Path],
+    filepath: Union[str, Path, IO[AnyStr]],
     metadata: Optional[TableMeta] = None,
     origin: Optional[Origin] = None,
     underscore: bool = False,

--- a/lib/catalog/owid/catalog/utils.py
+++ b/lib/catalog/owid/catalog/utils.py
@@ -94,6 +94,7 @@ def underscore(name: Optional[str], validate: bool = True, camel_to_snake: bool 
         .replace("”", "")
         .replace("#", "")
         .replace("^", "")
+        .replace("ˆ", "")
         .lower()
     )
 

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -58,15 +58,15 @@ def test_yield_wide_table_with_dimensions():
     table = Table(df.set_index(["entity_id", "year", "age"]))
     table.deaths.metadata.unit = "people"
     table.deaths.metadata.title = "Deaths"
-    grapher_tables = list(gh._yield_wide_table(table, dim_titles=["Age group"]))
+    grapher_tables = list(gh._yield_wide_table(table))
 
     t = grapher_tables[0]
     assert t.columns[0] == "deaths__age_10_18"
-    assert t[t.columns[0]].metadata.title == "Deaths - Age group: 10-18"
+    assert t[t.columns[0]].metadata.title == "Deaths - Age: 10-18"
 
     t = grapher_tables[1]
     assert t.columns[0] == "deaths__age_19_25"
-    assert t[t.columns[0]].metadata.title == "Deaths - Age group: 19-25"
+    assert t[t.columns[0]].metadata.title == "Deaths - Age: 19-25"
 
 
 def test_long_to_wide_tables():


### PR DESCRIPTION
I had to do various improvements to core ETL to make Global Health Observatory dataset work in ETL. The plan is to merge this first and then rebase [GHO PR](https://github.com/owid/etl/pull/2172).

## New env variable `SUBSET` for debugging

When working with a huge dataset like GHO or WDI, running a step can take minutes or more. In development, one typically focuses on a single indicator, debugs, fixes it, and pushes to grapher to see the output. To speed up this process, you can now load `SUBSET` from environment and filter your data by it (typically indicator name). With this, I can run GHO steps for indicator `sa_0000001547` in a few seconds
```
SUBSET=sa_0000001547 STAGING=gho etl run who/2024-01-03/gho --grapher
```

If you use `SUBSET`, ghost indicators are not removed from MySQL, hence you only add / edit that indicator without messing up the whole dataset. `SUBSET` is added to the checksum if used.

## Trimming long `short_name`

Sometimes, we run into 255 char limit for `short_name`, typically because of many dimensions with long values. Trimming to 255 chars doesn't help because prefix could be same and manually updating affected variables is a tedious process (and there isn't a good way how to do that).

What I'm doing now is that I take prefix with 245 characters and use the remaining 10 characters for `hash(short_name)`. This guarantees that my **short names are unique**.

## Other improvements
- Refactor dimensions when upserting to MySQL
- Don't exclude NaN values in dimensions
- A few minor fixes specific for GHO dataset

Adding unit tests.... ⌛ 