### PR TITLE
📊 ivs: Add happiness questions to Integrated Values Surveys

### DIFF
--- a/etl/steps/data/garden/ivs/2023-11-27/integrated_values_survey.meta.yml
+++ b/etl/steps/data/garden/ivs/2023-11-27/integrated_values_survey.meta.yml
@@ -3835,3 +3835,70 @@ tables:
         presentation:
           title_public: "A civil war: Average score"
 
+      happy:
+        title: "Happiness: Happy (aggregate)"
+        description_short: '% of respondents replying "very happy" or "quite happy" when asked "Taking all things together, would you say you are very happy, quite happy, not very happy or not at all happy?"'
+        display:
+          name: "Happiness: Happy"
+          <<: *common-display
+        presentation:
+          title_public: "Happiness: Happy"
+      not_happy:
+        title: "Happiness: Not happy (aggregate)"
+        description_short: '% of respondents replying "not very happy" or "not at all happy" when asked "Taking all things together, would you say you are very happy, quite happy, not very happy or not at all happy?"'
+        display:
+          name: "Happiness: Not happy"
+          <<: *common-display
+        presentation:
+          title_public: "Happiness: Not happy"
+      very_happy:
+        title: "Happiness: Very happy"
+        description_short: '% of respondents replying "very happy" when asked "Taking all things together, would you say you are very happy, quite happy, not very happy or not at all happy?"'
+        display:
+          name: "Happiness: Very happy"
+          <<: *common-display
+        presentation:
+          title_public: "Happiness: Very happy"
+      quite_happy:
+        title: "Happiness: Quite happy"
+        description_short: '% of respondents replying "quite happy" when asked "Taking all things together, would you say you are very happy, quite happy, not very happy or not at all happy?"'
+        display:
+          name: "Happiness: Quite happy"
+          <<: *common-display
+        presentation:
+          title_public: "Happiness: Quite happy"
+      not_very_happy:
+        title: "Happiness: Not very happy"
+        description_short: '% of respondents replying "not very happy" when asked "Taking all things together, would you say you are very happy, quite happy, not very happy or not at all happy?"'
+        display:
+          name: "Happiness: Not very happy"
+          <<: *common-display
+        presentation:
+          title_public: "Happiness: Not very happy"
+      not_at_all_happy:
+        title: "Happiness: Not at all happy"
+        description_short: '% of respondents replying "not at all happy" when asked "Taking all things together, would you say you are very happy, quite happy, not very happy or not at all happy?"'
+        display:
+          name: "Happiness: Not at all happy"
+          <<: *common-display
+        presentation:
+          title_public: "Happiness: Not at all happy"
+      dont_know_happy:
+        title: "Happiness: Don't know"
+        description_short: '% of respondents replying "don‘t know" when asked "Taking all things together, would you say you are very happy, quite happy, not very happy or not at all happy?"'
+        display:
+          name: "Happiness: Don't know"
+          <<: *common-display
+        presentation:
+          title_public: "Happiness: Don't know"
+      no_answer_happy:
+        title: "Happiness: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Taking all things together, would you say you are very happy, quite happy, not very happy or not at all happy?"'
+        display:
+          name: "Happiness: No answer"
+          <<: *common-display
+        presentation:
+          title_public: "Happiness: No answer"
+
+
+

--- a/etl/steps/data/garden/ivs/2023-11-27/integrated_values_survey.py
+++ b/etl/steps/data/garden/ivs/2023-11-27/integrated_values_survey.py
@@ -89,6 +89,8 @@ JUSTIFIABLE_QUESTIONS = [
 
 WORRIES_QUESTIONS = ["losing_job", "not_being_able_to_provide_good_education", "war", "terrorist_attack", "civil_war"]
 
+HAPPINESS_QUESTIONS = ["happy"]
+
 
 def run(dest_dir: str) -> None:
     #
@@ -251,6 +253,11 @@ def drop_indicators_and_replace_nans(tb: Table) -> Table:
         answers=["very_much", "a_great_deal", "not_much", "not_at_all"],
     )
 
+    # For happiness questions
+    tb = replace_dont_know_by_null(
+        tb=tb, questions=HAPPINESS_QUESTIONS, answers=["very", "quite", "not_very", "not_at_all"]
+    )
+
     # Drop rows with all null values in columns not country and year
     tb = tb.dropna(how="all", subset=tb.columns.difference(["country", "year"]))
 
@@ -398,6 +405,14 @@ def sanity_checks(tb: Table) -> Table:
         tb=tb,
         questions=WORRIES_QUESTIONS,
         answers=["very_much", "a_great_deal", "not_much", "not_at_all", "dont_know", "no_answer"],
+        margin=MARGIN,
+    )
+
+    # For happiness questions
+    tb = check_sum_100(
+        tb=tb,
+        questions=HAPPINESS_QUESTIONS,
+        answers=["very", "quite", "not_very", "not_at_all", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 

--- a/snapshots/ivs/2023-11-27/integrated_values_survey.csv.dvc
+++ b/snapshots/ivs/2023-11-27/integrated_values_survey.csv.dvc
@@ -26,6 +26,6 @@ meta:
 
 wdir: ../../../data/snapshots/ivs/2023-11-27
 outs:
-  - md5: 0d0bc9e81b69d6d25812395cec6621d2
-    size: 976196
+  - md5: f7fd53a0d4579c300f77210b14afbee0
+    size: 1003487
     path: integrated_values_survey.csv


### PR DESCRIPTION
Issue here: https://github.com/owid/owid-issues/issues/1400

- I have replicated the ["happy" indicator](https://owid.cloud/admin/variables/1704) (very happy + quite happy)
- I have also created new not happy (not very happy, not at all happy), very happy, quite happy, not very happy, not at all happy, don't know and no answer indicators. They are useful for further exploration (in stacked charts, for example).
- I have not created the [happy indicator for the first and last waves](https://owid.cloud/admin/variables/1765), because I thought it's too specific. Would you prefer to modify the text or actually create the variable, @spoonerf?