### PR TITLE
📜 add additional troubleshooting info to first steps documentation

### DIFF
--- a/docs/getting-started/building-datasets.md
+++ b/docs/getting-started/building-datasets.md
@@ -30,6 +30,33 @@ OK (0.0s)
 3. data://garden/biodiversity/2024-01-25/cherry_blossom
 ```
 
+??? note "Activate your virtual environment"
+
+    If you are not already, make sure to use these tools within your **virtual environment**.
+
+    Details can be found in the [Poetry docs](https://python-poetry.org/docs/basic-usage/#using-your-virtual-environment), but if you have never used the tool before here is a basic usage that will get you started (this assumes you have been [here](https://docs.owid.io/projects/etl/getting-started/working-environment/#install-dependencies) and installed Poetry):
+
+    ```bash
+    # Install the dependencies defined in pyproject.toml and poetry.lock
+    poetry install
+    ```
+
+    Next you can use one of the following two methods:
+
+    ```bash
+    # Activate virtual environment. Once activated, you can use the tools here as normal.
+    poetry shell
+    etl run --dry-run data://garden/biodiversity/2024-01-25/cherry_blossom
+    ```
+
+    Or
+
+    ```bash
+    # Run a specific command in virtual environment. This will not leave you in the virtual environment.
+    poetry run etl run --dry-run data://garden/biodiversity/2024-01-25/cherry_blossom
+    ```
+
+
 The first step is a `snapshot://` steps, which when executed will download upstream snapshot of the dataset to the `data/snapshots/` folder. The remaining steps are `data://` steps, which will generate local datasets in the `data/` folder.
 
 !!! note "`meadow` and `garden` channels"

--- a/docs/getting-started/building-datasets.md
+++ b/docs/getting-started/building-datasets.md
@@ -30,11 +30,11 @@ OK (0.0s)
 3. data://garden/biodiversity/2024-01-25/cherry_blossom
 ```
 
-??? note "Activate your virtual environment"
+!!! note "Activate your virtual environment"
 
     If you are not already, make sure to use these tools within your **virtual environment**.
 
-    Details can be found in the [Poetry docs](https://python-poetry.org/docs/basic-usage/#using-your-virtual-environment), but if you have never used the tool before here is a basic usage that will get you started (this assumes you have been [here](https://docs.owid.io/projects/etl/getting-started/working-environment/#install-dependencies) and installed Poetry):
+    Details can be found in the [Poetry docs](https://python-poetry.org/docs/basic-usage/#using-your-virtual-environment), but if you have never used the tool before here is a basic usage that will get you started (this assumes you have been [here](../working-environment/#install-dependencies) and installed Poetry):
 
     ```bash
     # Install the dependencies defined in pyproject.toml and poetry.lock


### PR DESCRIPTION
This PR adds a small toggle note to the "First Steps" documentation. It explains how to activate the Poetry environment in order to use the CLI tool. If this isn't useful, feel free to give it a thumbs down and I can close/delete it, but I thought it might benefit some public users who aren't familiar with Poetry. Thank you!