### PR TITLE
Improve etl dashboard

### DIFF
--- a/apps/wizard/config/config.yml
+++ b/apps/wizard/config/config.yml
@@ -76,12 +76,12 @@ sections:
 
   - title: "Dashboard"
     description: |-
-      Control panel for ETL updates.
+      Control panel for ETL steps.
     apps:
       - title: "ETL Dashboard"
         alias: dashboard
         entrypoint: pages/dashboard.py
-        description: Control panel for ETL updates.
+        description: Control panel for ETL steps.
         maintainer: "@pablo"
         emoji: "📋"
         image_url: "https://cdn.pixabay.com/photo/2018/09/04/17/02/indicator-3654257_960_720.jpg"

--- a/apps/wizard/pages/dashboard.py
+++ b/apps/wizard/pages/dashboard.py
@@ -613,17 +613,13 @@ with st.container(border=True):
                         help=help_text,
                     )
 
-        # Add columns for general buttons (applying to all rows in the operations list).
-        col_button1, col_button2, col_button3, _ = st.columns([2, 3, 3, 3])
-
-        with col_button1:
-            # Add button to clear the operations list.
-            st.button(
-                "Clear _Operations list_",
-                help="Remove all steps currently in the _Operations list_.",
-                type="secondary",
-                on_click=lambda: st.session_state.selected_steps.clear(),
-            )
+        # Add button to clear the operations list.
+        st.button(
+            "Clear _Operations list_",
+            help="Remove all steps currently in the _Operations list_.",
+            type="secondary",
+            on_click=lambda: st.session_state.selected_steps.clear(),
+        )
 
         def remove_non_updateable_steps():
             # Remove steps that cannot be updated (because update_period_days is set to 0).
@@ -635,13 +631,12 @@ with st.container(border=True):
                 step for step in st.session_state.selected_steps if step not in non_updateable_steps
             ]
 
-        with col_button2:
-            st.button(
-                "Remove non-updateable (e.g. population)",
-                help="Remove common steps (like population) and other steps that cannot be updated (for example, those with `update_period_days=0`).",
-                type="secondary",
-                on_click=remove_non_updateable_steps(),
-            )
+        st.button(
+            "Remove non-updateable (e.g. population)",
+            help="Remove common steps (like population) and other steps that cannot be updated (for example, those with `update_period_days=0`).",
+            type="secondary",
+            on_click=remove_non_updateable_steps(),
+        )
 
         def upgrade_steps_in_operations_list():
             new_list = []
@@ -659,13 +654,12 @@ with st.container(border=True):
 
             st.session_state.selected_steps = new_list
 
-        with col_button3:
-            st.button(
-                "Replace steps with their latest versions",
-                help="Replace steps in the _Operations list_ by their latest version available. You may want to use this button after updating steps, to be able to operate on the newly created steps.",
-                type="secondary",
-                on_click=upgrade_steps_in_operations_list(),
-            )
+        st.button(
+            "Replace steps with their latest versions",
+            help="Replace steps in the _Operations list_ by their latest version available. You may want to use this button after updating steps, to be able to operate on the newly created steps.",
+            type="secondary",
+            on_click=upgrade_steps_in_operations_list(),
+        )
 
     else:
         st.markdown(":grey[_No rows selected for operation..._]")

--- a/apps/wizard/pages/dashboard.py
+++ b/apps/wizard/pages/dashboard.py
@@ -565,22 +565,22 @@ with st.container(border=True):
                 (
                     "Add direct dependencies",
                     "direct_dependencies",
-                    "Add direct dependencies of this step to the _Operations list_.",
+                    "Add direct dependencies of this step to the _Operations list_. Direct dependencies are steps that are loaded directly by the current step.",
                 ),
                 (
                     "Add all dependencies",
                     "all_active_dependencies",
-                    "Add all dependencies of this step to the _Operations list_.",
+                    "Add all dependencies (including indirect dependencies) of this step to the _Operations list_. Indirect dependencies are steps that are needed, but not directly loaded, by the current step. In other words: dependencies of dependencies.",
                 ),
                 (
                     "Add direct usages",
                     "direct_usages",
-                    "Add direct usages of this step to the _Operations list_.",
+                    "Add direct usages of this step to the _Operations list_. Direct usages are those steps that load the current step directly.",
                 ),
                 (
                     "Add all usages",
                     "all_active_usages",
-                    "Add all usages of this step to the _Operations list_.",
+                    "Add all usages (including indirect usages) of this step to the _Operations list_. Indirect usages are those steps that need, but do not directly load, the current step. In other words: usages of usages.",
                 ),
             ]
 
@@ -619,7 +619,7 @@ with st.container(border=True):
         with col_button1:
             # Add button to clear the operations list.
             st.button(
-                "Clear Operations list",
+                "Clear _Operations list_",
                 help="Remove all steps currently in the _Operations list_.",
                 type="secondary",
                 on_click=lambda: st.session_state.selected_steps.clear(),
@@ -638,7 +638,7 @@ with st.container(border=True):
         with col_button2:
             st.button(
                 "Remove non-updateable (e.g. population)",
-                help="Remove common steps (like population) and other steps that cannot be updated (for now, these steps are listed in `NON_UPDATEABLE_STEPS`, in `apps/wizard/pages/dashboard.py`).",
+                help="Remove common steps (like population) and other steps that cannot be updated (for example, those with `update_period_days=0`).",
                 type="secondary",
                 on_click=remove_non_updateable_steps(),
             )
@@ -661,8 +661,8 @@ with st.container(border=True):
 
         with col_button3:
             st.button(
-                f"Replace {len(st.session_state.selected_steps)} steps by their latest versions",
-                help="Replace steps in the _Operations list_ by their latest version (consider using after updating).",
+                "Replace steps with their latest versions",
+                help="Replace steps in the _Operations list_ by their latest version available. You may want to use this button after updating steps, to be able to operate on the newly created steps.",
                 type="secondary",
                 on_click=upgrade_steps_in_operations_list(),
             )
@@ -691,7 +691,7 @@ if st.session_state.selected_steps:
 
             btn_submit = st.button(
                 f"Update {len(st.session_state.selected_steps)} steps",
-                help="Update steps in the _Operations list_.",
+                help="Update all steps in the _Operations list_.",
                 type="primary",
                 use_container_width=True,
             )
@@ -773,8 +773,8 @@ if st.session_state.selected_steps:
                 return command
 
             btn_etl_run = st.button(
-                f"Run {len(st.session_state.selected_steps)} snapshots and ETL steps",
-                help="Run ETL on steps in the _Operations list_.",
+                f"Run {len(st.session_state.selected_steps)} all ETL steps (including snapshots)",
+                help="Execute all snapshots currently in the _Operations list_, and run ETL on all data steps.",
                 type="primary",
                 use_container_width=True,
             )

--- a/apps/wizard/pages/dashboard.py
+++ b/apps/wizard/pages/dashboard.py
@@ -190,7 +190,7 @@ def load_steps_df_to_display(show_all_channels: bool) -> pd.DataFrame:
 
     # If toggle is not shown, pre-filter the DataFrame to show only rows where "channel" equals "grapher"
     if not show_all_channels:
-        df = df[((df["channel"] == "grapher") & (df["n_charts"] > 0)) | (df["channel"] == "explorers")]
+        df = df[df["channel"].isin(["grapher", "explorers"])]
 
     # Sort displayed data conveniently.
     df = df.sort_values(
@@ -249,7 +249,7 @@ def load_steps_df_to_display(show_all_channels: bool) -> pd.DataFrame:
 
 
 # Streamlit UI to let users toggle the filter
-show_all_channels = not st.toggle("Select only grapher steps with charts, and explorer steps", True)
+show_all_channels = not st.toggle("Select only grapher and explorer steps", True)
 
 # Load the steps dataframe.
 steps_df = load_steps_df()

--- a/apps/wizard/pages/dashboard.py
+++ b/apps/wizard/pages/dashboard.py
@@ -37,7 +37,7 @@ if not GRAPHER_DATASET_BASE_URL.startswith(("http://", "https://")):
 
 # List of identifiers of steps that should be considered as non-updateable.
 # NOTE: The identifier is the step name without the version (and without the "data://").
-NON_UPDATEAIBLE_IDENTIFIERS = [
+NON_UPDATEABLE_IDENTIFIERS = [
     # All population-related datasets.
     "garden/demography/population",
     "garden/gapminder/population",
@@ -48,7 +48,7 @@ NON_UPDATEAIBLE_IDENTIFIERS = [
     "meadow/hyde/general_files",
     "meadow/un/un_wpp",
     "open_numbers/open_numbers/gapminder__systema_globalis",
-    "open-numbers/open-numbers/ddf--gapminder--systema_globalis",
+    "open-numbers/ddf--gapminder--systema_globalis",
     "snapshot/hyde/general_files.zip",
     "snapshot/hyde/baseline.zip",
     "snapshot/gapminder/population.xlsx",
@@ -630,7 +630,7 @@ with st.container(border=True):
             # Remove steps that cannot be updated (because update_period_days is set to 0).
             # For convenience, also remove steps that a user most likely doesn't want to update.
             non_updateable_steps = steps_df[
-                (steps_df["update_period_days"] == 0) | (steps_df["identifier"].isin(NON_UPDATEAIBLE_IDENTIFIERS))
+                (steps_df["update_period_days"] == 0) | (steps_df["identifier"].isin(NON_UPDATEABLE_IDENTIFIERS))
             ]["step"].tolist()
             st.session_state.selected_steps = [
                 step for step in st.session_state.selected_steps if step not in non_updateable_steps
@@ -640,7 +640,7 @@ with st.container(border=True):
         with col_button2:
             st.button(
                 "Remove non-updateable (e.g. population)",
-                help="Remove common steps (like population) and other steps that cannot be updated.",
+                help="Remove common steps (like population) and other steps that cannot be updated (for now, these steps are listed in `NON_UPDATEABLE_STEPS`, in `apps/wizard/pages/dashboard.py`).",
                 type="secondary",
                 on_click=remove_non_updateable_steps(),
             )

--- a/apps/wizard/pages/dashboard.py
+++ b/apps/wizard/pages/dashboard.py
@@ -66,8 +66,7 @@ NON_UPDATEABLE_IDENTIFIERS = [
 ]
 
 # List of dependencies to ignore when calculating the update state.
-# This is done to avoid a certain common dependency (e.g. population) to make all steps appear as needing major update.
-# TODO: Consider removing this once the new unused population is removed or renamed.
+# This is done to avoid a certain common dependency (e.g. hyde) to make all steps appear as needing a major update.
 DEPENDENCIES_TO_IGNORE = [
     "snapshot://hyde/2017/general_files.zip",
 ]

--- a/apps/wizard/pages/owidle.py
+++ b/apps/wizard/pages/owidle.py
@@ -3,7 +3,7 @@ import datetime as dt
 import math
 from itertools import product
 from pathlib import Path
-from typing import List, Tuple, cast
+from typing import List, Tuple
 
 import geopandas as gpd
 import pandas as pd


### PR DESCRIPTION
This PR improves the ETL dashboard in the following ways:
* Instead of showing by default grapher steps with charts, show all grapher steps by default (plus explorer steps).
* Operations list now has a button to remove steps that we most likely don't want to update (e.g. regions or population).
* Operations list now has a button to replace steps in the list by their corresponding updated versions (useful for after updating).
* There is a button to run snapshots and ETL steps.

Feel free to play around with [the resulting new dashboard on staging](http://staging-site-improve-etl-dashboard/etl/wizard/ETL%20Dashboard).
