### PR TITLE
Remove new unused population steps

### DIFF
--- a/dag/archive/demography.yml
+++ b/dag/archive/demography.yml
@@ -11,3 +11,30 @@ steps:
     - data://garden/hmd/2023-09-19/hmd
   data://grapher/demography/2023-09-29/gini_le:
     - data://garden/demography/2023-09-29/gini_le
+
+  # Population (new versions, experimental)
+  # Population OMM 2024-01-05: HYDE 3.3 + Gapminder + UN WPP 2022
+  # data://garden/demography/2024-01-05/population:
+  #   - data://garden/hyde/2024-01-02/all_indicators
+  #   - data://garden/gapminder/2023-03-31/population
+  #   - data://garden/un/2022-07-11/un_wpp
+  #   - data://open_numbers/open_numbers/latest/gapminder__systema_globalis
+  #   - data://garden/regions/2023-01-01/regions
+  #   - data://garden/wb/2021-07-01/wb_income
+
+  # # Population OMM 2024-01-25: HYDE 3.3 + Maddison + UN WPP 2022
+  # data://garden/demography/2024-01-25/population:
+  #   # HYDE
+  #   - data://garden/hyde/2024-01-02/all_indicators
+  #   # Maddison
+  #   - data://garden/ggdc/2024-01-19/maddison_federico_paper
+  #   # WPP
+  #   - data://garden/un/2022-07-11/un_wpp
+  #   # Auxiliary files
+  #   - data://garden/regions/2023-01-01/regions
+  #   - data://garden/wb/2021-07-01/wb_income
+
+  # # Combine population in grapher
+  # data://grapher/demography/2024-01-25/population:
+  #   - data://garden/demography/2024-01-25/population
+  #   - data://garden/demography/2024-01-05/population

--- a/dag/demography.yml
+++ b/dag/demography.yml
@@ -23,33 +23,6 @@ steps:
   data://grapher/demography/2023-03-31/population:
     - data://garden/demography/2023-03-31/population
 
-  # Population (new versions, experimental)
-  # Population OMM 2024-01-05: HYDE 3.3 + Gapminder + UN WPP 2022
-  data://garden/demography/2024-01-05/population:
-    - data://garden/hyde/2024-01-02/all_indicators
-    - data://garden/gapminder/2023-03-31/population
-    - data://garden/un/2022-07-11/un_wpp
-    - data://open_numbers/open_numbers/latest/gapminder__systema_globalis
-    - data://garden/regions/2023-01-01/regions
-    - data://garden/wb/2021-07-01/wb_income
-
-  # Population OMM 2024-01-25: HYDE 3.3 + Maddison + UN WPP 2022
-  data://garden/demography/2024-01-25/population:
-    # HYDE
-    - data://garden/hyde/2024-01-02/all_indicators
-    # Maddison
-    - data://garden/ggdc/2024-01-19/maddison_federico_paper
-    # WPP
-    - data://garden/un/2022-07-11/un_wpp
-    # Auxiliary files
-    - data://garden/regions/2023-01-01/regions
-    - data://garden/wb/2021-07-01/wb_income
-
-  # Combine population in grapher
-  data://grapher/demography/2024-01-25/population:
-    - data://garden/demography/2024-01-25/population
-    - data://garden/demography/2024-01-05/population
-
   # Population (Fariss et al.)
   data://meadow/demography/2023-12-20/population_fariss:
     - snapshot://demography/2023-12-20/population_fariss.rds


### PR DESCRIPTION
Move unused new (experimental) population steps to the archive dag, and comment them.

Given that this experimental dataset is currently not used, and we do not advise using for now, this PR moves the steps to the archive (and comments them). This way we avoid population to appear as outdated (hence making all datasets that use population be outdated too) in the ETL dashboard. We also avoid confusion and the risk of using this dataset by mistake.

Once we decide to use this dataset, we can just move the steps from the archive to the active dag (the steps code has not moved).
