### PR TITLE
✨ Add switch to stop Table warnings about metadata issues

### DIFF
--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -71,6 +71,9 @@ class Table(pd.DataFrame):
     # Set to True to help debugging metadata issues.
     DEBUG = False
 
+    # Set to True to enable warnings about metadata issues.
+    WARN = True
+
     # slicing and copying creates tables
     @property
     def _constructor(self) -> type:
@@ -609,9 +612,12 @@ class Table(pd.DataFrame):
         var_name: str = "variable",
         value_name: str = "value",
         short_name: Optional[str] = None,
+        warn: Optional[bool] = None,
         *args,
         **kwargs,
     ) -> "Table":
+        if warn is None:
+            warn = self.WARN
         return melt(
             frame=self,
             id_vars=id_vars,
@@ -619,6 +625,7 @@ class Table(pd.DataFrame):
             var_name=var_name,
             value_name=value_name,
             short_name=short_name,
+            warn=warn,
             *args,
             **kwargs,
         )
@@ -1161,6 +1168,7 @@ def melt(
     var_name: str = "variable",
     value_name: str = "value",
     short_name: Optional[str] = None,
+    warn: bool = True,
     *args,
     **kwargs,
 ) -> Table:
@@ -1196,18 +1204,18 @@ def melt(
 
     # Combine metadata of value variables and assign the combination to the new "value" column.
     table[value_name].metadata = variables.combine_variables_metadata(
-        variables=[frame[var] for var in value_vars_list], operation="melt", name=value_name
+        variables=[frame[var] for var in value_vars_list], operation="melt", name=value_name, warn=warn
     )
 
     # Assign that combined metadata also to the new "variable" column.
     table[var_name].metadata = variables.combine_variables_metadata(
-        variables=[frame[var] for var in value_vars_list], operation="melt", name=var_name
+        variables=[frame[var] for var in value_vars_list], operation="melt", name=var_name, warn=warn
     )
 
     for variable in id_vars_list:
         # Combine metadata of id variables and assign the combination to the new "id" variable.
         table[variable].metadata = variables.combine_variables_metadata(
-            variables=[frame[variable]], operation="melt", name=variable
+            variables=[frame[variable]], operation="melt", name=variable, warn=warn
         )
 
     # Update table metadata.

--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -71,6 +71,9 @@ class Variable(pd.Series):
     _name: Optional[str] = None
     _fields: Dict[str, VariableMeta]
 
+    # Set to True to enable warnings about metadata issues.
+    WARN = True
+
     def __init__(
         self,
         data: Any = None,
@@ -167,7 +170,9 @@ class Variable(pd.Series):
     def __add__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().__add__(other), name=variable_name)
-        variable.metadata = combine_variables_metadata(variables=[self, other], operation="+", name=variable_name)
+        variable.metadata = combine_variables_metadata(
+            variables=[self, other], operation="+", name=variable_name, warn=self.WARN
+        )
         return variable
 
     def __iadd__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
@@ -176,7 +181,9 @@ class Variable(pd.Series):
     def __sub__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().__sub__(other), name=variable_name)
-        variable.metadata = combine_variables_metadata(variables=[self, other], operation="-", name=variable_name)
+        variable.metadata = combine_variables_metadata(
+            variables=[self, other], operation="-", name=variable_name, warn=self.WARN
+        )
         return variable
 
     def __isub__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
@@ -185,7 +192,9 @@ class Variable(pd.Series):
     def __mul__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().__mul__(other), name=variable_name)
-        variable.metadata = combine_variables_metadata(variables=[self, other], operation="*", name=variable_name)
+        variable.metadata = combine_variables_metadata(
+            variables=[self, other], operation="*", name=variable_name, warn=self.WARN
+        )
         return variable
 
     def __imul__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
@@ -194,7 +203,9 @@ class Variable(pd.Series):
     def __truediv__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().__truediv__(other), name=variable_name)
-        variable.metadata = combine_variables_metadata(variables=[self, other], operation="/", name=variable_name)
+        variable.metadata = combine_variables_metadata(
+            variables=[self, other], operation="/", name=variable_name, warn=self.WARN
+        )
         return variable
 
     def __itruediv__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
@@ -203,7 +214,9 @@ class Variable(pd.Series):
     def __floordiv__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().__floordiv__(other), name=variable_name)
-        variable.metadata = combine_variables_metadata(variables=[self, other], operation="//", name=variable_name)
+        variable.metadata = combine_variables_metadata(
+            variables=[self, other], operation="//", name=variable_name, warn=self.WARN
+        )
         return variable
 
     def __ifloordiv__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
@@ -212,7 +225,9 @@ class Variable(pd.Series):
     def __mod__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().__mod__(other), name=variable_name)
-        variable.metadata = combine_variables_metadata(variables=[self, other], operation="%", name=variable_name)
+        variable.metadata = combine_variables_metadata(
+            variables=[self, other], operation="%", name=variable_name, warn=self.WARN
+        )
         return variable
 
     def __imod__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
@@ -221,7 +236,9 @@ class Variable(pd.Series):
     def __pow__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().__pow__(other), name=variable_name)
-        variable.metadata = combine_variables_metadata(variables=[self, other], operation="**", name=variable_name)
+        variable.metadata = combine_variables_metadata(
+            variables=[self, other], operation="**", name=variable_name, warn=self.WARN
+        )
         return variable
 
     def __ipow__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":
@@ -236,7 +253,7 @@ class Variable(pd.Series):
         variable = Variable(super().fillna(value, *args, **kwargs), name=variable_name)
         variable._fields = copy.deepcopy(self._fields)
         variable._fields[variable_name] = combine_variables_metadata(
-            variables=[self, value], operation="fillna", name=variable_name
+            variables=[self, value], operation="fillna", name=variable_name, warn=self.WARN
         )
         return variable
 
@@ -249,7 +266,7 @@ class Variable(pd.Series):
         variable = Variable(super().dropna(*args, **kwargs), name=variable_name)
         variable._fields = copy.deepcopy(self._fields)
         variable._fields[variable_name] = combine_variables_metadata(
-            variables=[self], operation="dropna", name=variable_name
+            variables=[self], operation="dropna", name=variable_name, warn=self.WARN
         )
         return variable
 
@@ -280,7 +297,7 @@ class Variable(pd.Series):
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().pct_change(*args, **kwargs), name=variable_name)
         variable._fields[variable_name] = combine_variables_metadata(
-            variables=[self], operation="pct_change", name=variable_name
+            variables=[self], operation="pct_change", name=variable_name, warn=self.WARN
         )
         return variable
 

--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -462,7 +462,7 @@ def combine_variables_processing_level(variables: List[Variable]) -> Optional[PR
 
 
 def combine_variables_metadata(
-    variables: List[Any], operation: OPERATION, name: str = UNNAMED_VARIABLE
+    variables: List[Any], operation: OPERATION, name: str = UNNAMED_VARIABLE, warn: bool = True
 ) -> VariableMeta:
     # Initialise an empty metadata.
     metadata = VariableMeta()
@@ -487,10 +487,10 @@ def combine_variables_metadata(
         variables=variables_only, field="description_from_producer", operation=operation
     )
     metadata.unit = _get_metadata_value_from_variables_if_all_identical(
-        variables=variables_only, field="unit", operation=operation, warn_if_different=True
+        variables=variables_only, field="unit", operation=operation, warn_if_different=warn
     )
     metadata.short_unit = _get_metadata_value_from_variables_if_all_identical(
-        variables=variables_only, field="short_unit", operation=operation, warn_if_different=True
+        variables=variables_only, field="short_unit", operation=operation, warn_if_different=warn
     )
     metadata.sources = get_unique_sources_from_variables(variables=variables_only)
     metadata.origins = get_unique_origins_from_variables(variables=variables_only)


### PR DESCRIPTION
When combining variables with different units (and short units) it is useful to have a warning. For example:
```
tb = Table({"index": [1, 2, 3], "a": [4, 5, 6], "b": [7, 8, 9]})
tb["a"].metadata.unit = "terawatt-hours"
tb["b"].metadata.unit = "megawatt-hours"
tb["c"] = tb["a"] + tb["b"]
```
will raise a warning because "a" and "b" have different units.

When doing a melt operation,
```
tb.melt(id_vars="index", value_vars=["a", "b"])
```
you also get a warning if you are melting together variables with different units. In this case, it would also be useful. But if you are consciously melting together variables with different units, you may want to hide the warning (which is what started [this conversation](https://owid.slack.com/archives/C6C0MCXU0/p1709829759694139)).

For that reason, this PR lets you do that in two ways:
(A) Having a general switch `Table.WARN = False` that turns off all warnings.
(B) Having a function argument `melt(..., warn=False)`.

Similarly, I created a class-level WARN attribute to Variable, in case we want to turn off warnings for other operations (e.g. `tb["a"] + tb["b"]`).

@Marigold what do you think about this approach? Please let me know if you think there are better solutions.
