### PR TITLE
✨ accept List[str] in Table.sort_values

### DIFF
--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -749,7 +749,7 @@ class Table(pd.DataFrame):
             )
         return self
 
-    def sort_values(self, by: str | List[str], *args, **kwargs) -> "Table":
+    def sort_values(self, by: Union[str, List[str]], *args, **kwargs) -> "Table":
         tb = super().sort_values(by=by, *args, **kwargs).copy()
         for column in list(tb.all_columns):
             if isinstance(by, str):


### PR DESCRIPTION
Typing `Table.sort_values` should also list `List[str]` as a possible type for argument `by`.