### PR TITLE
Fix metadata of welfare broiler chickens data

### DIFF
--- a/etl/steps/data/grapher/fasttrack/latest/welfare_broiler_chickens.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/welfare_broiler_chickens.meta.yml
@@ -6,31 +6,31 @@ dataset:
   sources:
   - name: Welfare Footprint
     url: https://welfarefootprint.org/broilers/
-    publication_year: '2022'
+    publication_year: 2022
     published_by: Welfare Footprint
 tables:
   welfare_broiler_chickens:
     variables:
       excrutiating_pain_seconds:
         title: excrutiating_pain_seconds
-        description: The number of seconds the average broiler chicken spends in excrutiating pain over its lifespan.
+        description_short: The number of seconds the average broiler chicken spends in excruciating pain over its lifespan.
         unit: seconds
         short_unit: seconds
       disabling_pain_days:
         title: disabling_pain_days
-        description: The number of waking days that the average broiler chicken spends in disabling pain over its lifespan.
-          A 'waking day' is 16 hours long.
+        description_short: The number of waking days that the average broiler chicken spends in disabling pain over its lifespan.
+          A 'waking day' is 17 hours long.
         unit: days
         short_unit: days
       hurtful_pain_days:
         title: hurtful_pain_days
-        description: The number of waking days that the average broiler chicken spends in hurtful pain over its lifespan.
-          A 'waking day' is 16 hours long.
+        description_short: The number of waking days that the average broiler chicken spends in hurtful pain over its lifespan.
+          A 'waking day' is 17 hours long.
         unit: days
         short_unit: days
       annoying_pain_days:
         title: annoying_pain_days
-        description: The number of waking days that the average broiler chicken spends in annoying pain over its lifespan.
-          A 'waking day' is 16 hours long.
+        description_short: The number of waking days that the average broiler chicken spends in annoying pain over its lifespan.
+          A 'waking day' is 17 hours long.
         unit: days
         short_unit: days


### PR DESCRIPTION
As pointed out by [a user](https://app.frontapp.com/open/msg_k8dvjb6?key=3ZBso5H5nsIqTTScyyZbVGDoiPbr6ClE), the number of waking hours of broiler chickens was said to be 17 hours in some places (including our main article), but 16 hours in the metadata of the chart. I've fixed the latter.
