### PR TITLE
Make draft grapher step private

### DIFF
--- a/dag/fasttrack.yml
+++ b/dag/fasttrack.yml
@@ -132,5 +132,5 @@ steps:
     - snapshot://fasttrack/2023-05-03/qubits.csv
   data://grapher/fasttrack/latest/completeness_disaster_emdat:
     - snapshot://fasttrack/latest/completeness_disaster_emdat.csv
-  data://grapher/fasttrack/latest/vdem_women_executives:
+  data-private://grapher/fasttrack/latest/vdem_women_executives:
     - snapshot://fasttrack/latest/vdem_women_executives.csv


### PR DESCRIPTION
Grapher dataset [DRAFT vdem_women_executives](https://owid.cloud/admin/datasets/6397) was created to have draft grapher charts, to be able to create static charts. Therefore, none of the charts nor the dataset itself are public. So, since the grapher dataset is private, the corresponding ETL grapher step should also be private. This PR makes that step private.
