### PR TITLE
Update World Bank income groups

### DIFF
--- a/etl/steps/data/garden/wb/2024-03-11/income_groups.meta.yml
+++ b/etl/steps/data/garden/wb/2024-03-11/income_groups.meta.yml
@@ -25,12 +25,12 @@ dataset:
 
 tables:
   income_groups:
-    title: World Bank's historical income classification
+    title: World Bank's income classification
     variables:
       classification:
-        title: World Bank's historical income classification
+        title: World Bank's income classification
         unit: ""
-        description_short: Historical income classification based on the country's income each year.
+        description_short: Income classification based on the country's income each year.
   income_groups_latest:
     title: World Bank's latest income classification
     variables:

--- a/etl/steps/data/garden/wb/2024-03-11/income_groups.meta.yml
+++ b/etl/steps/data/garden/wb/2024-03-11/income_groups.meta.yml
@@ -3,16 +3,36 @@ definitions:
     presentation:
       topic_tags:
         - Economic Growth
-    processing_level: minor
+    processing_level: major
+    description_from_producer: |-
+      For the current 2024 fiscal year, low-income economies are defined as those with a GNI per capita, calculated using [the World Bank Atlas method](https://datahelpdesk.worldbank.org/knowledgebase/articles/378832-what-is-the-world-bank-atlas-method), of $1,135 or less in 2022; lower middle-income economies are those with a GNI per capita between $1,136 and $4,465; upper middle-income economies are those with a GNI per capita between $4,466 and $13,845; high-income economies are those with a GNI per capita of $13,846 or more.
+
+      Income classifications are set each year on July 1 for all World Bank member economies, and all other economies with populations of more than 30,000. These official analytical classifications are fixed during the World Bank's fiscal year (ending on June 30), thus economies remain in the categories in which they are classified irrespective of any revisions to their per capita income data. The historical classifications shown are as published on July 1 of
+      each fiscal year.
+
+      Regions in this dataset include economies at all income levels. The term country, used interchangeably with economy, does not imply political independence but refers to any territory for which authorities report separate social or economic statistics. For more information about how the World Bank classifies countries, check [their documentation](https://datahelpdesk.worldbank.org/knowledgebase/articles/378834-how-does-the-world-bank-classify-countries).
+    description_key:
+      - The World Bank creates a yearly classification of countries by income, for all countries with population over 30,000.
+      - This classification stays the same throughout the fiscal year (from July 1 to June 30) even if the income data for a country changes.
+      - Low-income countries are those with a gross national income (GNI) per capita of $1,135 or less in 2022.
+      - Lower-middle-income countries are those with a GNI per capita between $1,136 and $4,465 in 2022.
+      - Upper-middle-income countries are those with a GNI per capita between $4,466 and $13,845 in 2022.
+      - High-income countries are those with a GNI per capita of $13,846 or more in 2022.
+
+dataset:
+  title: World Bank's income classification
+  update_period_days: 0
 
 tables:
   income_groups:
+    title: World Bank's historical income classification
     variables:
       classification:
         title: World Bank's historical income classification
         unit: ""
         description_short: Historical income classification based on the country's income each year.
   income_groups_latest:
+    title: World Bank's latest income classification
     variables:
       classification:
         title: World Bank's latest income classification

--- a/etl/steps/data/garden/wb/2024-03-11/income_groups.meta.yml
+++ b/etl/steps/data/garden/wb/2024-03-11/income_groups.meta.yml
@@ -1,7 +1,20 @@
+definitions:
+  common:
+    presentation:
+      topic_tags:
+        - Economic Growth
+    processing_level: minor
+
 tables:
   income_groups:
     variables:
       classification:
-        title: World Bank income classification
+        title: World Bank's historical income classification
         unit: ""
-        description: Classification by the World Bank based on the country's income.
+        description_short: Historical income classification based on the country's income each year.
+  income_groups_latest:
+    variables:
+      classification:
+        title: World Bank's latest income classification
+        unit: ""
+        description_short: Income classification based on the country's income for the latest year informed.

--- a/etl/steps/data/grapher/wb/2024-03-11/income_groups.py
+++ b/etl/steps/data/grapher/wb/2024-03-11/income_groups.py
@@ -1,8 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from owid.catalog import Dataset
-
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, create_dataset
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -12,26 +10,13 @@ def run(dest_dir: str) -> None:
     #
     # Load inputs.
     #
-    # Load garden dataset.
-    ds_garden: Dataset = paths.load_dependency("income_groups")
-
-    # Read table from garden dataset.
+    # Load garden dataset and read its table on historical income classifications.
+    ds_garden = paths.load_dataset("income_groups")
     tb_garden = ds_garden["income_groups"]
-
-    #
-    # Process data.
-    #
 
     #
     # Save outputs.
     #
-    # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
-
-    # Save changes in the new grapher dataset.
+    # Create a new grapher dataset.
+    ds_grapher = create_dataset(dest_dir, tables=[tb_garden])
     ds_grapher.save()

--- a/etl/steps/data/meadow/wb/2024-03-11/income_groups.py
+++ b/etl/steps/data/meadow/wb/2024-03-11/income_groups.py
@@ -1,93 +1,74 @@
 """Load a snapshot and create a meadow dataset."""
 
-from typing import List
-
 import numpy as np
-import pandas as pd
 from owid.catalog import Table
-from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
-from etl.snapshot import Snapshot
-
-# Initialize logger.
-log = get_logger()
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
+# Expected index of row where years are located.
+ROW_YEARS = 4
+
 
 def run(dest_dir: str) -> None:
-    log.info("income_groups: start")
-
     #
     # Load inputs.
     #
-    # Retrieve snapshot.
-    snap: Snapshot = paths.load_dependency("income_groups.xlsx")
-
-    # Load data from snapshot.
-    dfs = pd.read_excel(snap.path, sheet_name=None)
+    # Load snapshot and read its data.
+    snap = paths.load_snapshot("income_groups.xlsx")
+    tb = snap.read(sheet_name="Country Analytical History")
 
     #
     # Process data.
     #
-    # Load sheet with historical WB classifications
-    df = dfs["Country Analytical History"]
-    # Minor formatting (only keep cells with relevant data)
-    df = extract_data_from_excel(df)
-    # Pivot to have years as rows
-    # We could leave this for Garden, but catalog.Table won't accept columns starting with a number. We could change these
-    # to be 2020 -> _2020, but it feels inefficient
-    df = df.melt(id_vars=["country_code", "country"], var_name="year", value_name="classification")
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(df, short_name=paths.short_name, underscore=True)
+    # Sanity checks on input data.
+    run_sanity_checks_on_inputs(tb=tb)
+
+    # Extract years from one of the first rows.
+    years = list(tb.loc[ROW_YEARS])
+
+    # Rename columns.
+    tb = tb.rename(columns={column: year for column, year in zip(tb.columns, years)}, errors="raise")
+    tb = tb.rename(columns={tb.columns[0]: "country_code", tb.columns[1]: "country"}, errors="raise")
+
+    # Keep only rows with data (which are rows that have a country code).
+    tb = tb.dropna(subset=["country_code"]).reset_index(drop=True)
+
+    # Pivot to have years as rows.
+    # NOTE: Table in a Dataset can't have number columns (they will be converted, e.g. "2020" -> "_2020").
+    tb = tb.melt(id_vars=["country_code", "country"], var_name="year", value_name="classification")
+
+    # Set an appropriate index and sort conveniently.
+    tb = tb.set_index(["country", "year"], verify_integrity=True).sort_index()
 
     #
     # Save outputs.
     #
-    # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
-
-    # Save changes in the new garden dataset.
+    # Create a new meadow dataset.
+    ds_meadow = create_dataset(dest_dir, tables=[tb])
     ds_meadow.save()
 
-    log.info("income_groups: end")
 
-
-def extract_data_from_excel(df: pd.DataFrame) -> pd.DataFrame:
-    # Sanity shape check
-    log.info("income_groups: sanity check on table dimensions")
-    assert (num_rows := df.shape[0]) == (
+def run_sanity_checks_on_inputs(tb: Table) -> None:
+    # Sanity checks on input data.
+    assert (num_rows := tb.shape[0]) == (
         num_rows_expected := 239
     ), f"Invalid number of rows. Expected was {num_rows_expected}, but found {num_rows}"
-    assert (num_cols := df.shape[1]) >= (
-        num_cols_expected := 37
+    assert (num_cols := tb.shape[1]) >= (
+        num_cols_expected := 38
     ), f"Invalid number of columns. Expected was >{num_cols_expected}, but found {num_cols}"
-    # Check data starts in correct row
-    log.info("income_groups: sanity check on data location in excel file")
     assert (
-        df.loc[10, "World Bank Analytical Classifications"] == "Afghanistan"
+        tb.loc[10, "World Bank Analytical Classifications"] == "Afghanistan"
     ), "Row 10, column 'World Bank Analytical Classifications' expected to have value 'Afghanistan'"
-    # Get year values (columns)
-    log.info("income_groups: extract only relevant data from excel sheet")
-    years = _get_years(df)
-    df.columns = ["country_code", "country"] + years
-    # Drop all but data (based on column 'code' having a value)
-    df = df.dropna(subset=["country_code"])
-    return df
 
-
-def _get_years(df: pd.DataFrame) -> List[int]:
-    # Get years
-    row_years = 4
-    years = list(df.loc[row_years])
-    # Format sanity check
-    assert np.isnan(years[0]), f"The first column in row {row_years} is expected to be NaN. Instead found {years[0]}"
+    # Sanity check on years.
+    years = list(tb.loc[ROW_YEARS])
+    assert np.isnan(years[0]), f"The first column in row {ROW_YEARS} is expected to be NaN. Instead found {years[0]}"
     assert (
         years[1] == "Data for calendar year :"
-    ), f"The second column in row {row_years} is expected to be 'Data for calendar year :'. Instead found {years[1]}"
+    ), f"The second column in row {ROW_YEARS} is expected to be 'Data for calendar year :'. Instead found {years[1]}"
     assert all(
         isinstance(year, int) for year in years[2:]
-    ), f"Columns 3 to the end in row {row_years} should be numbers. Check: {years[2:]}"
-    return years[2:]
+    ), f"Columns 3 to the end in row {ROW_YEARS} should be numbers. Check: {years[2:]}"

--- a/snapshots/wb/2024-03-11/income_groups.py
+++ b/snapshots/wb/2024-03-11/income_groups.py
@@ -1,4 +1,4 @@
-"""Script to create a snapshot of dataset 'Income Classifications (World Bank, 2022)'."""
+"""Script to create a snapshot of the World Bank's Income Classification dataset."""
 
 from pathlib import Path
 
@@ -21,11 +21,8 @@ def main(upload: bool) -> None:
     # Create a new snapshot.
     snap = Snapshot(f"wb/{SNAPSHOT_VERSION}/income_groups.xlsx")
 
-    # Download data from source.
-    snap.download_from_source()
-
-    # Add file to DVC and upload to S3.
-    snap.dvc_add(upload=upload)
+    # Download data from source and upload to S3.
+    snap.create_snapshot(upload=upload)
 
 
 if __name__ == "__main__":

--- a/snapshots/wb/2024-03-11/income_groups.xlsx.dvc
+++ b/snapshots/wb/2024-03-11/income_groups.xlsx.dvc
@@ -1,19 +1,6 @@
 meta:
   origin:
-    title: Income classifications
-    # description: |-
-    # TODO: Update description.
-    #   For the current 2023 fiscal year, low-income economies are defined as those with a GNI per capita, calculated using the World Bank Atlas method (https://datahelpdesk.worldbank.org/knowledgebase/articles/378832-what-is-the-world-bank-atlas-method), of $1,085 or less in 2021; lower middle-income economies are those with a GNI per capita between $1,086 and $4,255; upper middle-income economies are those with a GNI per capita between $4,256 and $13,205; high-income economies are those with a GNI per capita of $13,205 or more. For details on past years, please refer to file:
-    #   https://datacatalogfiles.worldbank.org/ddh-published/0037712/DR0090754/OGHIST.xlsx
-
-    #   Note 1: Income classifications are set each year on July 1 for all World Bank member economies, and all other economies with populations of more than 30,000. These official analytical classifications are fixed during the World Bank's fiscal year (ending on June 30), thus economies remain in the categories in which they are classified irrespective of any revisions to their per capita income data. The historical classifications shown are as published on July 1 of
-    #   each fiscal year.
-
-    #   Note 2: Regions in this table include economies at all income levels. The term country, used interchangeably with economy, does not imply political independence but refers to any territory for which authorities report separate social or economic statistics. For more information about how the World Bank classifies countries please read:
-    #   https://datahelpdesk.worldbank.org/knowledgebase/articles/378834-how-does-the-world-bank-classify-countries
-
-    #   Find more details in World Development Indicators website:
-    #   https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html
+    title: Income Classifications
     date_published: 2023-06-30
     producer: World Bank
     citation_full: |-

--- a/snapshots/wb/2024-03-11/income_groups.xlsx.dvc
+++ b/snapshots/wb/2024-03-11/income_groups.xlsx.dvc
@@ -1,56 +1,32 @@
 meta:
-  namespace: wb
-  short_name: income_groups
-  name: Income classifications (World Bank, 2022)
-  version: '2023-04-30'
-  publication_year: 2022
-  publication_date: '2022-07-01'
-  source_name: World Bank (2022)
-  source_published_by: World Bank, Income classifications (2022)
-  url: https://datahelpdesk.worldbank.org/knowledgebase/articles/906519-world-bank-country-and-lending-groups
-  source_data_url: https://datacatalogfiles.worldbank.org/ddh-published/0037712/DR0090754/OGHIST.xlsx
-  file_extension: xlsx
-  license_url: https://www.worldbank.org/en/about/legal/terms-of-use-for-datasets
-  license_name: Creative Commons BY 4.0
-  date_accessed: 2023-04-30
-  is_public: true
-  description: >-
-    For the current 2023 fiscal year, low-income economies are defined as those with
-    a GNI per capita, calculated using the
-    World Bank Atlas method (https://datahelpdesk.worldbank.org/knowledgebase/articles/378832-what-is-the-world-bank-atlas-method),
-    of $1,085 or less in 2021; lower middle-income economies are those with a GNI
-    per capita between
-    $1,086 and $4,255; upper middle-income economies are those with a GNI per capita
-    between $4,256 and $13,205; high-income
-    economies are those with a GNI per capita of $13,205 or more. For details on past
-    years, please refer to file:
-    https://datacatalogfiles.worldbank.org/ddh-published/0037712/DR0090754/OGHIST.xlsx
+  origin:
+    title: Income classifications
+    # description: |-
+    # TODO: Update description.
+    #   For the current 2023 fiscal year, low-income economies are defined as those with a GNI per capita, calculated using the World Bank Atlas method (https://datahelpdesk.worldbank.org/knowledgebase/articles/378832-what-is-the-world-bank-atlas-method), of $1,085 or less in 2021; lower middle-income economies are those with a GNI per capita between $1,086 and $4,255; upper middle-income economies are those with a GNI per capita between $4,256 and $13,205; high-income economies are those with a GNI per capita of $13,205 or more. For details on past years, please refer to file:
+    #   https://datacatalogfiles.worldbank.org/ddh-published/0037712/DR0090754/OGHIST.xlsx
 
+    #   Note 1: Income classifications are set each year on July 1 for all World Bank member economies, and all other economies with populations of more than 30,000. These official analytical classifications are fixed during the World Bank's fiscal year (ending on June 30), thus economies remain in the categories in which they are classified irrespective of any revisions to their per capita income data. The historical classifications shown are as published on July 1 of
+    #   each fiscal year.
 
-    Note 1: Income classifications are set each year on July 1 for all World Bank
-    member economies,
-    and all other economies with populations of more than 30,000. These official analytical
-    classifications are fixed during the World Bank's fiscal year (ending on June
-    30), thus
-    economies remain in the categories in which they are classified irrespective of
-    any revisions to
-    their per capita income data. The historical classifications shown are as published
-    on July 1 of
-    each fiscal year.
+    #   Note 2: Regions in this table include economies at all income levels. The term country, used interchangeably with economy, does not imply political independence but refers to any territory for which authorities report separate social or economic statistics. For more information about how the World Bank classifies countries please read:
+    #   https://datahelpdesk.worldbank.org/knowledgebase/articles/378834-how-does-the-world-bank-classify-countries
 
-
-    Note 2: Regions in this table include economies at all income levels. The
-    term country, used interchangeably with economy,
-    does not imply political independence but refers to any territory for which authorities
-    report separate social or economic statistics.
-    For more information about how the World Bank classifies countries please read
-    https://datahelpdesk.worldbank.org/knowledgebase/articles/378834-how-does-the-world-bank-classify-countries
-
-
-    Find more details in World Development Indicators website
-    (https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html).
-wdir: ../../../data/snapshots/wb/2023-04-30
+    #   Find more details in World Development Indicators website:
+    #   https://datatopics.worldbank.org/world-development-indicators/the-world-by-income-and-region.html
+    date_published: 2023-06-30
+    producer: World Bank
+    citation_full: |-
+      World Bank - Income classifications (2023).
+    url_main: https://datahelpdesk.worldbank.org/knowledgebase/articles/906519-world-bank-country-and-lending-groups
+    # Note that the World Bank uses the same link every year, even if the data changes.
+    url_download: https://datacatalogfiles.worldbank.org/ddh-published/0037712/DR0090754/OGHIST.xlsx
+    date_accessed: 2024-03-11
+    license:
+      name: Creative Commons BY 4.0
+      url: https://www.worldbank.org/en/about/legal/terms-of-use-for-datasets
+wdir: ../../../data/snapshots/wb/2024-03-11
 outs:
-- md5: bfdf219c089ae93abf8d160915b273ab
-  size: 103024
-  path: income_groups.xlsx
+  - md5: 39b24a541ca085424b42795ed747948e
+    size: 115839
+    path: income_groups.xlsx


### PR DESCRIPTION
Update World Bank income groups.

This PR will replace the old datasets:
* [Income Classification - World Bank (2021)](https://owid.cloud/admin/datasets/5741).
* [Income Classification - World Bank (2017)](https://owid.cloud/admin/datasets/944).
* [Income classifications (World Bank, 2022)](https://owid.cloud/admin/datasets/5997).

By the new [World Bank's historical income classification](http://staging-site-update-wb-income-groups/admin/datasets/6406).

For more context: https://github.com/owid/owid-issues/issues/1179
