### PR TITLE
🎉 Create function to import run from a previous version of a step

### DIFF
--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -873,6 +873,25 @@ def write_to_dag_file(
 
 
 def import_module_from_path(module_path: Union[str, Path], module_name: str = "module_name") -> ModuleType:
+    """Import module from a given path to a .py file.
+
+    This function is particularly useful when attempting to import a function from a step file, whose name contains
+    numbers, and it's hence impossible to do a simple `from ..2024-01-01 import run`.
+
+    Parameters
+    ----------
+    module_path : Union[str, Path]
+        Path to .py file.
+    module_name : str, optional
+        Name to assign to the imported module, by default "module_name". This is only important if this function is used
+        multiple times, in which case the imported modules should be given different names.
+
+    Returns
+    -------
+    module: ModuleType
+        Module imported from the given path.
+
+    """
     # Ensure the given path is a Path object.
     module_path = Path(module_path)
 
@@ -895,6 +914,30 @@ def import_module_from_path(module_path: Union[str, Path], module_name: str = "m
 
 
 def load_run_from_previous_version(path_to_current_file: Union[str, Path], previous_version: str) -> Callable:
+    """Load 'run' function from a previous version of a given step file.
+
+    If you update a data step, say, of version "2024-01-01", and the code of the new step is identical to the previous
+    version, instead of duplicating the code, you can use this function.
+    The resulting data step would have just the following content:
+    ```
+    from etl.helpers import load_run_from_previous_version
+
+    run = load_run_from_previous_version(__file__, "2024-01-01")
+    ```
+
+    Parameters
+    ----------
+    path_to_current_file : Union[str, Path]
+        Path to the file corresponding to new data step (simply use __file__).
+    previous_version : str
+        Version of the previous step file, whose code will also be used in the new step.
+
+    Returns
+    -------
+    run : Callable
+        Function 'run' imported from the previous version of the step file.
+
+    """
     # Ensure the given path is a Path object.
     path_to_current_file = Path(path_to_current_file)
 


### PR DESCRIPTION
## Summary
Create a helper function to import the `run` function from a previous version. This could let us avoid duplicating a lot of code, every time we update a data step with no changes in the code.

## Motivation
The ETL currently relies on having a recipe for each dataset. But this means that we end up having many files with the exact same content.

Having duplicated code is not only bad when refactoring, or upgrading libraries. It is also inconvenient when searching for previous code. It can be quite confusing when many files have the same content.

I think it's very valuable to have easy access to multiple versions of a dataset, and its code. But, because of the need to duplicate code, one may be less keen to keep different versions, and prefer to use "latest" (there are other reasons why "latest" is convenient, but that's out of the scope of this PR).

## Solution
This PR would let us have data steps with the following content:
```
from etl.helpers import load_run_from_previous_version

run = load_run_from_previous_version(__file__, "2024-01-01")
```

This way, we would avoid duplicated code. And it would also make it more evident when different versions of a dataset have exactly the same data processing.

## Possible issues
* Would the new step be loading the correct dependencies? I've checked that, indeed, the new `run` module imports the correct dependencies stated in the dag (and not the old ones).
* I've also checked that, if the old step imports other modules within the same folder (e.g. `shared.py`), the new step still runs well.
* (Unlikely) If one accidentally archived the old file, the new step would fail to run. We could find a way to raise an error when this happens, instead of waiting for ETL to fail. But even if ETL fails, it would not be a big deal (we would easily find the issue).
* If one edits the old file, the new step will be changed. But (1) one has no direct way to be aware of that, and (2) ETL will not consider the new step as "dirty".
* What if I just want to edit the new metadata? I've checked that, using `load_run_from_previous_version` and having a new metadata file inside the new folder works as desired:  The old code runs with the new dependencies and loads the new metadata. This works as long as the metadata is loaded with `create_dataset`, and not imported directly with `paths.metadata_file` (see next point).
* What if I just want to edit the new country harmonization? Unlike with metadata, a new `.countries.json` file in the new folder is ignored. I think that the underlying reason is that the `paths = PathFinder(__file__)` object defined in the old file is still loaded in the new file, and therefore all paths are the old ones. 

Given these caveats, with the current implementation, `load_run_from_previous_version` can safely be used in those cases where the code is exactly duplicated (including metadata and countries). In any other case, if someone wants to edit minor things, it may or may not work, so it's safest to duplicate code and edit it.
