### PR TITLE
📊 UN WPP population five year age-groups for 0-100, instead of 0-20

### DIFF
--- a/dag/demography.yml
+++ b/dag/demography.yml
@@ -1,5 +1,4 @@
 steps:
-
   ####################################
   # Population #######################
   ####################################
@@ -70,7 +69,6 @@ steps:
     - data://garden/faostat/2023-06-12/faostat_rl
   data://grapher/demography/2023-06-12/population_density:
     - data://garden/demography/2023-06-12/population_density
-
 
   ####################################
   # Life expectancy ##################
@@ -174,3 +172,9 @@ steps:
     - snapshot://ggdc/2024-01-19/maddison_federico_paper.xlsx
   data://garden/ggdc/2024-01-19/maddison_federico_paper:
     - data://meadow/ggdc/2024-01-19/maddison_federico_paper
+
+  # UN WPP experiments
+  data://garden/un/2024-03-14/un_wpp_most:
+    - data://garden/un/2022-07-11/un_wpp
+  data://grapher/un/2024-03-14/un_wpp_most:
+    - data://garden/un/2024-03-14/un_wpp_most

--- a/etl/steps/data/explorers/un/2022/un_wpp.py
+++ b/etl/steps/data/explorers/un/2022/un_wpp.py
@@ -29,7 +29,33 @@ def _keep_relevant_rows(df: pd.DataFrame) -> pd.DataFrame:
     df = df.reset_index()
     df = df.loc[
         df.variant.isin(["estimates", "low", "medium", "high"])
-        & -(df.metric.isin(["net_migration", "net_migration_rate"]) & (df.location == "World"))
+        & -(
+            df.metric.isin(["net_migration", "net_migration_rate"])
+            & (df.location == "World")
+            & -(df.metric == "population")
+            & (
+                df.age.isin(
+                    [
+                        "20-24",
+                        "25-29",
+                        "30-34",
+                        "35-39",
+                        "40-44",
+                        "45-49",
+                        "50-54",
+                        "55-59",
+                        "60-64",
+                        "65-69",
+                        "70-74",
+                        "75-79",
+                        "80-84",
+                        "85-89",
+                        "90-94",
+                        "95-99",
+                    ]
+                )
+            )
+        )
     ].reset_index(drop=True)
     return df
 

--- a/etl/steps/data/explorers/un/2022/un_wpp.py
+++ b/etl/steps/data/explorers/un/2022/un_wpp.py
@@ -29,10 +29,10 @@ def _keep_relevant_rows(df: pd.DataFrame) -> pd.DataFrame:
     df = df.reset_index()
     df = df.loc[
         df.variant.isin(["estimates", "low", "medium", "high"])
-        & -(
+        & ~(
             df.metric.isin(["net_migration", "net_migration_rate"])
             & (df.location == "World")
-            & -(df.metric == "population")
+            & ~(df.metric == "population")
             & (
                 df.age.isin(
                     [

--- a/etl/steps/data/garden/un/2022-07-11/un_wpp/population.py
+++ b/etl/steps/data/garden/un/2022-07-11/un_wpp/population.py
@@ -151,7 +151,6 @@ def _add_metric_population(df: Table) -> Tuple[Table, Table]:
     # Basic age groups
     age_map = {
         **{str(i): f"{i - i%5}-{i + 4 - i%5}" for i in range(0, 100)},
-        **{str(i): f"{i - i%10}-{i + 9 - i%10}" for i in range(20, 100)},
         **{"100+": "100+"},
     }
     df_p_granular = df_p.assign(age=df_p.age.map(age_map).astype("category"))
@@ -180,6 +179,22 @@ def _add_metric_population(df: Table) -> Tuple[Table, Table]:
     df_p_15_plus = _add_age_group(df_p, 15, 200, "15+")
     # 18+
     df_p_18_plus = _add_age_group(df_p, 18, 200, "18+")
+    # 20 - 29
+    df_p_20_29 = _add_age_group(df_p, 20, 29)
+    # 30 - 39
+    df_p_30_39 = _add_age_group(df_p, 30, 39)
+    # 40 - 49
+    df_p_40_49 = _add_age_group(df_p, 40, 49)
+    # 50 - 59
+    df_p_50_59 = _add_age_group(df_p, 50, 59)
+    # 60 - 69
+    df_p_60_69 = _add_age_group(df_p, 60, 69)
+    # 70 - 79
+    df_p_70_79 = _add_age_group(df_p, 70, 79)
+    # 80 - 89
+    df_p_80_89 = _add_age_group(df_p, 80, 89)
+    # 90 - 99
+    df_p_90_99 = _add_age_group(df_p, 90, 99) 
     # all
     df_p_all = (
         df_p.groupby(
@@ -203,6 +218,14 @@ def _add_metric_population(df: Table) -> Tuple[Table, Table]:
             df_p_15_64,
             df_p_15_plus,
             df_p_18_plus,
+            df_p_20_29,
+            df_p_30_39,
+            df_p_40_49,
+            df_p_50_59,
+            df_p_60_69,
+            df_p_70_79,
+            df_p_80_89,
+            df_p_90_99,
             df_p_all,
         ],
         ignore_index=True,

--- a/etl/steps/data/garden/un/2022-07-11/un_wpp/population.py
+++ b/etl/steps/data/garden/un/2022-07-11/un_wpp/population.py
@@ -150,7 +150,7 @@ def _add_metric_population(df: Table) -> Tuple[Table, Table]:
     df_p = df.loc[df.metric == "population"]
     # Basic age groups
     age_map = {
-        **{str(i): f"{i - i%5}-{i + 4 - i%5}" for i in range(0, 20)},
+        **{str(i): f"{i - i%5}-{i + 4 - i%5}" for i in range(0, 100)},
         **{str(i): f"{i - i%10}-{i + 9 - i%10}" for i in range(20, 100)},
         **{"100+": "100+"},
     }

--- a/etl/steps/data/garden/un/2022-07-11/un_wpp/population.py
+++ b/etl/steps/data/garden/un/2022-07-11/un_wpp/population.py
@@ -194,7 +194,7 @@ def _add_metric_population(df: Table) -> Tuple[Table, Table]:
     # 80 - 89
     df_p_80_89 = _add_age_group(df_p, 80, 89)
     # 90 - 99
-    df_p_90_99 = _add_age_group(df_p, 90, 99) 
+    df_p_90_99 = _add_age_group(df_p, 90, 99)
     # all
     df_p_all = (
         df_p.groupby(

--- a/etl/steps/data/garden/un/2024-03-14/un_wpp_most.meta.yml
+++ b/etl/steps/data/garden/un/2024-03-14/un_wpp_most.meta.yml
@@ -5,11 +5,11 @@ tables:
         title: Age-group with the highest population
         unit: ""
         description_short: |-
-          Age of the five-year population age-group with the highest population
+          Five-year age group with the highest population.
       value:
         title: Population of the most populous age group
         unit: "people"
         description_short: |-
-          Population of the most populous five-year age-group
+          Population of the most populous five-year age-group.
         display:
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/un/2024-03-14/un_wpp_most.meta.yml
+++ b/etl/steps/data/garden/un/2024-03-14/un_wpp_most.meta.yml
@@ -1,0 +1,15 @@
+tables:
+  population:
+    variables:
+      age:
+        title: Age-group with the highest population
+        unit: ""
+        description_short: |-
+          Age of the five-year population age-group with the highest population
+      value:
+        title: Population of the most populous age group
+        unit: "people"
+        description_short: |-
+          Population of the most populous five-year age-group
+        display:
+          numDecimalPlaces: 0

--- a/etl/steps/data/garden/un/2024-03-14/un_wpp_most.py
+++ b/etl/steps/data/garden/un/2024-03-14/un_wpp_most.py
@@ -1,0 +1,57 @@
+from typing import List, cast
+
+from owid.catalog import Dataset
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    ds_garden = cast(Dataset, paths.load_dependency("un_wpp"))
+    tb_pop = ds_garden["population"].reset_index()
+
+    # filter data for just sex = all, metrics = population, variant = estimates
+    tb_pop = tb_pop[
+        (tb_pop.sex == "all")
+        & (tb_pop.metric == "population")
+        & (tb_pop.variant == "estimates")
+        & (tb_pop.age.isin(create_age_groups()))
+    ]
+    tb_pop = tb_pop.drop(columns=["metric", "sex", "variant"])
+    assert tb_pop["age"].nunique() == 21
+    # Group by country and year, and apply the custom function
+    tb_pop = tb_pop.groupby(["location", "year"]).apply(get_largest_age_group)
+    # The function above creates NAs for some locations that don't appear to be in the table e.g. Vatican, Melanesia, so dropping here
+    tb_pop = tb_pop.dropna()
+    tb_pop = tb_pop.reset_index(drop=True)
+    tb_pop = tb_pop.set_index(["location", "year"], verify_integrity=True)
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(dest_dir, tables=[tb_pop], default_metadata=ds_garden.metadata)
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()
+
+
+def create_age_groups() -> List[str]:
+    # Initialize an empty list to hold the age bands
+    age_bands = []
+
+    # Loop through a range with a step of 5, stopping before 100
+    for i in range(0, 100, 5):
+        age_bands.append(f"{i}-{i+4}")
+
+    # Add the "100+" group at the end
+    age_bands.append("100+")
+
+    return age_bands
+
+
+# Function to apply to each group to find the age group with the largest population
+def get_largest_age_group(group):
+    return group.loc[group["value"].idxmax()]

--- a/etl/steps/data/grapher/un/2024-03-14/un_wpp_most.py
+++ b/etl/steps/data/grapher/un/2024-03-14/un_wpp_most.py
@@ -1,0 +1,28 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset("un_wpp_most")
+
+    # Read table from garden dataset.
+    tb = ds_garden["population"].reset_index()
+    tb = tb.rename(columns={"location": "country"})
+    tb = tb.set_index(["country", "year"], verify_integrity=True)
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(
+        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
+    )
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()


### PR DESCRIPTION
* Adding 5-year age-groups for population across the whole age range (0-100) - for [this chart](http://staging-site-five-year-pops/admin/charts/7691/edit)
* Removing the new 5-year age-groups from the explorer step, so the explorer is unchanged
* Adding an experimental dataset to show the populous age-group for each country-year - for[ this chart](http://staging-site-five-year-pops/admin/charts/7690/edit)