### PR TITLE
:tada: custom warnings module

### DIFF
--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -16,7 +16,7 @@ import jsonref
 import structlog
 import yaml
 from owid import catalog
-from owid.catalog import CHANNEL, DatasetMeta, Table
+from owid.catalog import CHANNEL, DatasetMeta, Table, warnings
 from owid.catalog.datasets import DEFAULT_FORMATS, FileFormat
 from owid.catalog.meta import SOURCE_EXISTS_OPTIONS
 from owid.catalog.tables import (
@@ -110,8 +110,9 @@ def grapher_checks(ds: catalog.Dataset, warn_title_public: bool = True) -> None:
             display_name = (tab[col].m.display or {}).get("name")
             title_public = getattr(tab[col].m.presentation, "title_public", None)
             if warn_title_public and display_name and not title_public:
-                log.warning(
+                warnings.warn(
                     f"Column {col} uses display.name but no presentation.title_public. Ensure the latter is also defined, otherwise display.name will be used as the indicator's title.",
+                    warnings.DisplayNameWarning,
                 )
 
 

--- a/etl/steps/data/grapher/lis/2023-08-30/luxembourg_income_study.py
+++ b/etl/steps/data/grapher/lis/2023-08-30/luxembourg_income_study.py
@@ -1,5 +1,7 @@
 """Load luxembourg_income_Study garden dataset and create the luxembourg_income_study grapher dataset."""
 
+from owid.catalog import warnings
+
 from etl.helpers import PathFinder, create_dataset
 
 # Get paths and naming conventions for current step.
@@ -23,7 +25,9 @@ def run(dest_dir: str) -> None:
     #
     # Save outputs.
     #
-    ds_garden = create_dataset(
-        dest_dir, tables=[tb_garden], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    with warnings.ignore_warnings([warnings.NoOriginsWarning, warnings.DisplayNameWarning]):
+        ds_garden = create_dataset(
+            dest_dir, tables=[tb_garden], check_variables_metadata=True, default_metadata=ds_garden.metadata
+        )
+
     ds_garden.save()

--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -14,6 +14,7 @@ from pandas._typing import Scalar
 from pandas.core.series import Series
 
 from . import processing_log as pl
+from . import warnings
 from .meta import (
     PROCESSING_LEVELS,
     PROCESSING_LEVELS_ORDER,
@@ -231,7 +232,9 @@ class Variable(pd.Series):
         # NOTE: Argument "inplace" will modify the original variable's data, but not its metadata.
         #  But we should not use "inplace" anyway.
         if "inplace" in kwargs and kwargs["inplace"] is True:
-            log.warning("Avoid using fillna(inplace=True), which may not handle metadata as expected.")
+            warnings.warn(
+                "Avoid using fillna(inplace=True), which may not handle metadata as expected.", warnings.MetadataWarning
+            )
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().fillna(value, *args, **kwargs), name=variable_name)
         variable._fields = copy.deepcopy(self._fields)
@@ -244,7 +247,9 @@ class Variable(pd.Series):
         # NOTE: Argument "inplace" will modify the original variable's data, but not its metadata.
         #  But we should not use "inplace" anyway.
         if "inplace" in kwargs and kwargs["inplace"] is True:
-            log.warning("Avoid using dropna(inplace=True), which may not handle metadata as expected.")
+            warnings.warn(
+                "Avoid using dropna(inplace=True), which may not handle metadata as expected.", warnings.MetadataWarning
+            )
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().dropna(*args, **kwargs), name=variable_name)
         variable._fields = copy.deepcopy(self._fields)
@@ -352,7 +357,10 @@ def _get_metadata_value_from_variables_if_all_identical(
             # There is no need to warn if units are different when doing a multiplication or a division.
             # In most cases, units will be different, and that is fine, as long as the resulting variable has no units.
             # Note that the same reasoning can be applied to other operations, so we may need to generalize this logic.
-            log.warning(f"Different values of '{field}' detected among variables: {unique_values}")
+            warnings.warn(
+                f"Different values of '{field}' detected among variables: {unique_values}",
+                warnings.DifferentValuesWarning,
+            )
 
     return combined_value
 

--- a/lib/catalog/owid/catalog/warnings.py
+++ b/lib/catalog/owid/catalog/warnings.py
@@ -1,0 +1,54 @@
+import contextlib
+import warnings
+from typing import Iterable
+from warnings import catch_warnings, simplefilter, warn  # noqa: F401
+
+import structlog
+
+log = structlog.get_logger()
+
+
+def warn_with_structlog(message, category, filename, lineno, file=None, line=None):
+    log.warning(message, category=category.__name__, filename=filename, lineno=lineno)
+
+
+# Replace the default showwarning with structlog warnings
+warnings.showwarning = warn_with_structlog
+
+
+class MetadataWarning(Warning):
+    pass
+
+
+class StepWarning(Warning):
+    pass
+
+
+class DifferentValuesWarning(MetadataWarning):
+    pass
+
+
+class DisplayNameWarning(MetadataWarning):
+    pass
+
+
+class NoOriginsWarning(MetadataWarning):
+    pass
+
+
+class GroupingByCategoricalWarning(StepWarning):
+    pass
+
+
+@contextlib.contextmanager
+def ignore_warnings(ignore_warnings: Iterable[type] = (Warning,)):
+    """Ignore warnings. You can pass a list of specific warnings to ignore like MetadataWarning or StepWarning.
+
+    Usage:
+        with ignore_warnings():
+            ds_garden = create_dataset(...)
+    """
+    with warnings.catch_warnings():
+        for w in ignore_warnings:
+            warnings.filterwarnings("ignore", category=w)
+        yield


### PR DESCRIPTION
This was heavily inspired by https://github.com/owid/etl/pull/2388.

## Motivation

Warnings are sometimes unavoidable, or it's just more convenient to ignore them (especially when you are not the maintainer of the data and need to silence them to have readable logs).

## Solution

Implement our own `warnings.py` module with custom warnings that can be selectively ignored. The module lets us use context manager to ignore warnings which is the cleanest way.

```python
from owid.catalog import warnings

with warnings.ignore_warnings([warnings.NoOriginsWarning, warnings.DisplayNameWarning]):
        ds_garden = create_dataset(
            dest_dir, tables=[tb_garden], check_variables_metadata=True, default_metadata=ds_garden.metadata
        )
```

Warnings module also overwrites the formatting function so that warnings are printed by colourful `structlog.warning` rather than the ugly default.

<img width="1440" alt="image" src="https://github.com/owid/etl/assets/1550888/7a20d663-e14a-4360-94a6-c00e32b56fbb">

I've only updated warnings from tables.py and variables.py, but we can add more warnings on the fly.

This has already been useful in silencing noisy warnings from `data://grapher/lis/2023-08-30/luxembourg_income_study`.