### PR TITLE
:tada: special ordinal type for indicators

### DIFF
--- a/apps/backport/datasync/data_metadata.py
+++ b/apps/backport/datasync/data_metadata.py
@@ -233,7 +233,6 @@ def _variable_metadata(
         presentation=_omit_nullable_values(presentation),
         license=license,
         descriptionKey=descriptionKey,
-        sort=sort,
     )
 
     assert variableMetadata["type"], "type must be set"

--- a/apps/backport/datasync/data_metadata.py
+++ b/apps/backport/datasync/data_metadata.py
@@ -203,12 +203,14 @@ def _variable_metadata(
     grapherConfigAdminJson = row.pop("grapherConfigAdmin")
     licenseJson = row.pop("license")
     descriptionKeyJson = row.pop("descriptionKey")
+    sortJson = row.pop("sort")
 
     display = json.loads(displayJson)
     grapherConfigETL = json.loads(grapherConfigETLJson) if grapherConfigETLJson else None
     grapherConfigAdmin = json.loads(grapherConfigAdminJson) if grapherConfigAdminJson else None
     license = json.loads(licenseJson) if licenseJson else None
     descriptionKey = json.loads(descriptionKeyJson) if descriptionKeyJson else None
+    sort = json.loads(sortJson) if sortJson else None
 
     # group fields from flat structure into presentation field
     presentation = dict(
@@ -231,6 +233,7 @@ def _variable_metadata(
         presentation=_omit_nullable_values(presentation),
         license=license,
         descriptionKey=descriptionKey,
+        sort=sort,
     )
 
     assert variableMetadata["type"], "type must be set"
@@ -275,9 +278,9 @@ def _variable_metadata(
         "entities": {"values": entityArray},
     }
     # Add values for ordinal variables
-    if db_variable_row.get("sort"):
+    if sort:
         dim_values = variableMetadata["dimensions"].get("values", {})
-        dim_values["values"] = [{"id": i, "name": v} for i, v in enumerate(json.loads(db_variable_row["sort"]))]
+        dim_values["values"] = [{"id": i, "name": v} for i, v in enumerate(sort)]
         variableMetadata["dimensions"]["values"] = dim_values
 
     # convert timestamp to string

--- a/apps/backport/datasync/data_metadata.py
+++ b/apps/backport/datasync/data_metadata.py
@@ -269,10 +269,16 @@ def _variable_metadata(
         .to_dict(orient="records")
     )
 
+    # Create dimensions
     variableMetadata["dimensions"] = {
         "years": {"values": yearArray},
         "entities": {"values": entityArray},
     }
+    # Add values for ordinal variables
+    if db_variable_row.get("sort"):
+        dim_values = variableMetadata["dimensions"].get("values", {})
+        dim_values["values"] = [{"id": i, "name": v} for i, v in enumerate(json.loads(db_variable_row["sort"]))]
+        variableMetadata["dimensions"]["values"] = dim_values
 
     # convert timestamp to string
     time_format = "%Y-%m-%dT%H:%M:%S.000Z"

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -280,10 +280,11 @@ def upsert_table(
 
         df = table.rename(columns={column_name: "value", "entity_id": "entityId"})
 
-        db_variable.infer_type(df["value"])
-
         # following functions assume that `value` is string
+        # NOTE: we could make the code more efficient if we didn't convert `value` to string
         df["value"] = df["value"].astype(str)
+
+        db_variable.type = db_variable.infer_type(df["value"])
 
         # NOTE: we could prefetch all entities in advance, but it's not a bottleneck as it takes
         # less than 10ms per variable

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -280,6 +280,8 @@ def upsert_table(
 
         df = table.rename(columns={column_name: "value", "entity_id": "entityId"})
 
+        db_variable.infer_type(df["value"])
+
         # following functions assume that `value` is string
         df["value"] = df["value"].astype(str)
 

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -284,7 +284,8 @@ def upsert_table(
         # NOTE: we could make the code more efficient if we didn't convert `value` to string
         df["value"] = df["value"].astype(str)
 
-        db_variable.type = db_variable.infer_type(df["value"])
+        if not db_variable.type:
+            db_variable.type = db_variable.infer_type(df["value"])
 
         # NOTE: we could prefetch all entities in advance, but it's not a bottleneck as it takes
         # less than 10ms per variable

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -1273,7 +1273,9 @@ class Variable(SQLModel, table=True):
 
     def s3_metadata_path(self, typ: S3_PATH_TYP = "s3") -> str:
         """Path to S3 with metadata in JSON format for Grapher. Typically
-        s3://owid-api/v1/indicators/123.metadata.json."""
+        s3://owid-api/v1/indicators/123.metadata.json or
+        s3://owid-api-staging/name/v1/indicators/123.metadata.json
+        ."""
         if typ == "s3":
             return f"{config.BAKED_VARIABLES_PATH}/{self.id}.metadata.json"
         elif typ == "http":

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -103,6 +103,7 @@ def grapher_checks(ds: catalog.Dataset, warn_title_public: bool = True) -> None:
 
             # Validate ordinal variables
             if tab[col].m.sort:
+                assert tab[col].m.type == "ordinal", f"Column `{col}` has a sort but is not of type ordinal"
                 extra_values = set(tab[col]) - set(tab[col].m.sort)
                 assert (
                     not extra_values

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -99,6 +99,14 @@ def grapher_checks(ds: catalog.Dataset, warn_title_public: bool = True) -> None:
             ), f"Column `{col}` must have either sources or origins"
 
             _validate_description_key(tab[col].m.description_key, col)
+            _validate_ordinal_variables(tab, col)
+
+            # Validate ordinal variables
+            if tab[col].m.sort:
+                extra_values = set(tab[col]) - set(tab[col].m.sort)
+                assert (
+                    not extra_values
+                ), f"Ordinal variable `{col}` has extra values that are not defined in field `sort`: {extra_values}"
 
             # Data Page title uses the following fallback
             # [title_public > grapher_config.title > display.name > title] - [attribution_short] - [title_variant]
@@ -123,6 +131,14 @@ def _validate_description_key(description_key: list[str], col: str) -> None:
         assert not all(
             len(x) == 1 for x in description_key
         ), f"Column `{col}` uses string {description_key} as description_key, should be list of strings."
+
+
+def _validate_ordinal_variables(tab: Table, col: str) -> None:
+    if tab[col].m.sort:
+        extra_values = set(tab[col]) - set(tab[col].m.sort)
+        assert (
+            not extra_values
+        ), f"Ordinal variable `{col}` has extra values that are not defined in field `sort`: {extra_values}"
 
 
 def create_dataset(

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -101,14 +101,6 @@ def grapher_checks(ds: catalog.Dataset, warn_title_public: bool = True) -> None:
             _validate_description_key(tab[col].m.description_key, col)
             _validate_ordinal_variables(tab, col)
 
-            # Validate ordinal variables
-            if tab[col].m.sort:
-                assert tab[col].m.type == "ordinal", f"Column `{col}` has a sort but is not of type ordinal"
-                extra_values = set(tab[col]) - set(tab[col].m.sort)
-                assert (
-                    not extra_values
-                ), f"Ordinal variable `{col}` has extra values that are not defined in field `sort`: {extra_values}"
-
             # Data Page title uses the following fallback
             # [title_public > grapher_config.title > display.name > title] - [attribution_short] - [title_variant]
             # the Table tab

--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -82,7 +82,9 @@ class Snapshot:
         if downloaded_md5 != md5:
             # remove the downloaded file
             self.path.unlink()
-            raise ValueError(f"Checksum mismatch for {self.path}: expected {md5}, got {downloaded_md5}")
+            raise ValueError(
+                f"Checksum mismatch for {self.path}: expected {md5}, got {downloaded_md5}. It is possible that download got interrupted."
+            )
 
     def pull(self, force=True) -> None:
         """Pull file from S3."""

--- a/etl/steps/data/garden/wb/2024-03-11/income_groups.meta.yml
+++ b/etl/steps/data/garden/wb/2024-03-11/income_groups.meta.yml
@@ -37,6 +37,7 @@ tables:
         title: World Bank's income classification
         unit: ""
         description_short: Income classification based on the country's income each year.
+        type: ordinal
         sort: *classification_sort
 
   income_groups_latest:
@@ -46,6 +47,7 @@ tables:
         title: World Bank's latest income classification
         unit: ""
         description_short: Income classification based on the country's income for the latest year informed.
+        type: ordinal
         sort: *classification_sort
 
 

--- a/etl/steps/data/garden/wb/2024-03-11/income_groups.meta.yml
+++ b/etl/steps/data/garden/wb/2024-03-11/income_groups.meta.yml
@@ -19,6 +19,12 @@ definitions:
       - Upper-middle-income countries are those with a GNI per capita between $4,466 and $13,845 in 2022.
       - High-income countries are those with a GNI per capita of $13,846 or more in 2022.
 
+  classification_sort: &classification_sort
+    - Low-income countries
+    - Lower-middle-income countries
+    - Upper-middle-income countries
+    - High-income countries
+
 dataset:
   title: World Bank's income classification
   update_period_days: 365
@@ -31,6 +37,8 @@ tables:
         title: World Bank's income classification
         unit: ""
         description_short: Income classification based on the country's income each year.
+        sort: *classification_sort
+
   income_groups_latest:
     title: World Bank's latest income classification
     variables:
@@ -38,3 +46,6 @@ tables:
         title: World Bank's latest income classification
         unit: ""
         description_short: Income classification based on the country's income for the latest year informed.
+        sort: *classification_sort
+
+

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -21,6 +21,7 @@ from .utils import pruned_json
 
 SOURCE_EXISTS_OPTIONS = Literal["fail", "append", "replace"]
 
+VARIABLE_TYPE = Literal["float", "int", "mixed", "string", "ordinal", "categorical"]
 
 YearDateLatest = NewType("YearDateLatest", str)
 
@@ -259,6 +260,9 @@ class VariableMeta:
 
     # This is the old sources that we keep for compatibility. Use is strongly discouraged going forward
     sources: List[Source] = field(default_factory=list)
+
+    # The type of the variable, automatically inferred from the data if empty
+    type: Optional[VARIABLE_TYPE] = None
 
     # List of categories for ordinal type indicators
     sort: List[str] = field(default_factory=list)

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -260,6 +260,9 @@ class VariableMeta:
     # This is the old sources that we keep for compatibility. Use is strongly discouraged going forward
     sources: List[Source] = field(default_factory=list)
 
+    # List of categories for ordinal type indicators
+    sort: List[str] = field(default_factory=list)
+
     def __hash__(self):
         """Hash that uniquely identifies VariableMeta."""
         return _hash_dataclass(self)

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -1664,6 +1664,19 @@
                       "additionalProperties": false
                     }
                   }
+                },
+                "sort": {
+                  "title": "Ordered categorical values of the indicator (ordinal)",
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "requirement_level": "recommended (for curated indicators)",
+                  "category": "metadata"
                 }
               }
             }

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -1666,17 +1666,17 @@
                   }
                 },
                 "sort": {
-                  "title": "Ordered categorical values of the indicator (ordinal)",
-                  "oneOf": [
-                    {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    }
-                  ],
-                  "requirement_level": "recommended (for curated indicators)",
-                  "category": "metadata"
+                  "title": "Ordered categorical values for ordinal type",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "type": {
+                  "title": "Indicator type",
+                  "description": "Indicator type is usually automatically inferred from the data, but must be manually set for ordinal and categorical types.",
+                  "type": "string",
+                  "enum": ["float", "int", "mixed", "string", "ordinal", "categorical"]
                 }
               }
             }

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -55,6 +55,7 @@ def _variable_meta():
         "shortUnit": None,
         "display": '{"name": "Population density", "unit": "people per km²", "shortUnit": null, "includeInTable": true, "numDecimalPlaces": 1}',
         "type": "mixed",
+        "sort": None,
         "columnOrder": 0,
         "originalMetadata": None,
         "grapherConfigAdmin": None,
@@ -189,7 +190,7 @@ def test_variable_metadata_ordinal():
     meta = _call_variable_metadata(525715, variable_df, variable_meta)
     assert meta["type"] == "ordinal"
     # TODO: keep only one - either `sort` or `dimensions.values.values`
-    assert meta["sort"] == json.dumps(["Low", "Middle", "High"])
+    assert meta["sort"] == ["Low", "Middle", "High"]
     assert meta["dimensions"]["values"] == {
         "values": [{"id": 0, "name": "Low"}, {"id": 1, "name": "Middle"}, {"id": 2, "name": "High"}]
     }

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -189,8 +189,6 @@ def test_variable_metadata_ordinal():
 
     meta = _call_variable_metadata(525715, variable_df, variable_meta)
     assert meta["type"] == "ordinal"
-    # TODO: keep only one - either `sort` or `dimensions.values.values`
-    assert meta["sort"] == ["Low", "Middle", "High"]
     assert meta["dimensions"]["values"] == {
         "values": [{"id": 0, "name": "Low"}, {"id": 1, "name": "Middle"}, {"id": 2, "name": "High"}]
     }

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import pandas as pd
@@ -183,11 +184,15 @@ def test_variable_metadata_ordinal():
     )
     variable_meta = _variable_meta()
     variable_meta["type"] = "ordinal"
-    variable_meta["sort"] = ["Low", "Middle", "High"]
+    variable_meta["sort"] = json.dumps(["Low", "Middle", "High"])
 
     meta = _call_variable_metadata(525715, variable_df, variable_meta)
     assert meta["type"] == "ordinal"
-    assert meta["sort"] == ["Low", "Middle", "High"]
+    # TODO: keep only one - either `sort` or `dimensions.values.values`
+    assert meta["sort"] == json.dumps(["Low", "Middle", "High"])
+    assert meta["dimensions"]["values"] == {
+        "values": [{"id": 0, "name": "Low"}, {"id": 1, "name": "Middle"}, {"id": 2, "name": "High"}]
+    }
 
 
 def test_variable_data_df_from_s3():


### PR DESCRIPTION
Implementation of this [Notion proposal](https://www.notion.so/owid/2023-03-10-Add-type-information-to-variables-dd15d4b5fdb74292b9420923981b2a1c). Relevant issue https://github.com/owid/owid-grapher/issues/1690.

We currently recognise these types "float", "int", "mixed", "string" and save them as `type` field in JSON metadata. We'd like to add two new types - `categorical` and `ordinal` (which is especially useful for ordering and coloring charts). Furthermore, we'd like to start saving the `type` field to MySQL (that field currently only exists in JSON) and also the `sort` containing a list of categories for ordinal type.

## Links

- JSON on the staging server https://api-staging.owid.io/staging-site-ordinal-types/v1/indicators/830988.metadata.json
- Migration in owid-grapher repository https://github.com/owid/owid-grapher/pull/3362
- WB Income Classification on the [staging server](http://staging-site-ordinal-types/admin/datasets/6406)

## Scope

- Only adds support for `ordinal` type. There aren't any indicators with `categorical` type yet (we don't distinguish between `string` and `categorical` in ETL, so it's hard to define it at this point. It might need more thought)

## Questions

- Ordinal categories are saved in both `sort` field and `dimensions.values.values`. I couldn't decide which one is better, it'd be better to wait for the grapher part to see what is more ergonomic


@sophiamersmann the PR is not ready for merging yet (missing unit tests, etc.), but we have a staging server with an ordinal type indicator you could use to try how it fits into grapher. It might be better to wait for your feedback first and then polish this PR. Feel free to push to the [grapher branch with the migration](https://github.com/owid/owid-grapher/pull/3362), which rebuilds the staging server. We can be very flexible on the ETL side, and I'm not great at naming things, so if you have any feedback, I'll be glad to add it to ETL.