### PR TITLE
🐛 generalise fillna table method

### DIFF
--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -899,18 +899,21 @@ class Table(pd.DataFrame):
         tb = tb.set_index(column_idx_new)
         return tb
 
-    def fillna(self, value, **kwargs) -> "Table":
+    def fillna(self, **kwargs) -> "Table":
         """Usual fillna, but, if the object given to fill values with is a table, transfer its metadata to the filled
         table."""
-        tb = super().fillna(value, **kwargs)
+        if "value" in kwargs:
+            value = kwargs.pop("value")
+            tb = super().fillna(value, **kwargs)
 
-        if type(value) == type(self):
-            for column in tb.columns:
-                if column in value.columns:
-                    tb._fields[column] = variables.combine_variables_metadata(
-                        variables=[tb[column], value[column]], operation="fillna", name=column
-                    )
-
+            if type(value) == type(self):
+                for column in tb.columns:
+                    if column in value.columns:
+                        tb._fields[column] = variables.combine_variables_metadata(
+                            variables=[tb[column], value[column]], operation="fillna", name=column
+                        )
+        else:
+            tb = super().fillna(**kwargs)
         return tb
 
 

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -899,11 +899,10 @@ class Table(pd.DataFrame):
         tb = tb.set_index(column_idx_new)
         return tb
 
-    def fillna(self, **kwargs) -> "Table":
+    def fillna(self, value=None, **kwargs) -> "Table":
         """Usual fillna, but, if the object given to fill values with is a table, transfer its metadata to the filled
         table."""
-        if "value" in kwargs:
-            value = kwargs.pop("value")
+        if value is not None:
             tb = super().fillna(value, **kwargs)
 
             if type(value) == type(self):
@@ -914,6 +913,8 @@ class Table(pd.DataFrame):
                         )
         else:
             tb = super().fillna(**kwargs)
+
+        tb = cast(Table, tb)
         return tb
 
 

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -1036,3 +1036,48 @@ def test_fillna_with_another_table(table_1, origins, licenses) -> None:
     # # Now check the table metadata has not changed.
     assert tb.metadata == table_1.metadata
     assert tb2.metadata == table_1.metadata
+
+
+def test_ffill_with_number(table_1) -> None:
+    # Make a copy of table_1 and introduce a nan in it.
+    table = table_1.copy()
+    table.loc[1, "a"] = None
+    # Now fill it up with a number.
+    table["a"] = table["a"].ffill()
+    # The metadata of "a" should be preserved.
+    assert table["a"].metadata == table_1["a"].metadata
+    assert table.loc[1, "a"] == table_1.loc[0, "a"]
+
+    # Make a copy of table_1 and introduce a nan in it.
+    table = table_1.copy()
+    table.loc[1, "a"] = None
+    # Now fill it up with a number.
+    table["a"] = table["a"].fillna(method="ffill")
+    # The metadata of "a" should be preserved.
+    assert table["a"].metadata == table_1["a"].metadata
+    assert table.loc[1, "a"] == table_1.loc[0, "a"]
+
+
+def test_bfill_with_number(table_1) -> None:
+    # Make a copy of table_1 and introduce a nan in it.
+    table = table_1.copy()
+    table.loc[0, "a"] = None
+    # Now fill it up with a number.
+    table["a"] = table["a"].bfill()
+    # The metadata of "a" should be preserved.
+    assert table["a"].metadata == table_1["a"].metadata
+    assert table.loc[0, "a"] == table_1.loc[1, "a"]
+
+    # Make a copy of table_1 and introduce a nan in it.
+    table = table_1.copy()
+    table.loc[0, "a"] = None
+    # Now fill it up with a number.
+    table["a"] = table["a"].fillna(method="bfill")
+    # The metadata of "a" should be preserved.
+    assert table["a"].metadata == table_1["a"].metadata
+    assert table.loc[0, "a"] == table_1.loc[1, "a"]
+
+
+def test_fillna_error(table_1: Table) -> None:
+    with pytest.raises(ValueError):
+        table_1["a"].fillna()


### PR DESCRIPTION
Pandas `fillna` _does not_ impose the usage of argument `value`. Therefore, `Table.fillna` should do the same.

Forcing it, makes calls to `.ffill` or `.fillna(how="ffill")` raise errors.

Example of error:

```python
# Load some table
tb = ...
tb.ffill()
```

leads to 

```
TypeError: Table.fillna() missing 1 required positional argument: 'value'
```