### PR TITLE
📊 ons: Create UK earnings dataset

### DIFF
--- a/dag/poverty_inequality.yml
+++ b/dag/poverty_inequality.yml
@@ -102,3 +102,9 @@ steps:
     - data://meadow/cedlas/2024-03-08/sedlac
   data://grapher/cedlas/2024-03-08/sedlac:
     - data://garden/cedlas/2024-03-08/sedlac
+
+  # Annual Survey of Hours and Earnings time series of selected estimates - UK's Office for National Statistics
+  data://meadow/ons/2024-03-20/hours_and_earnings_uk:
+    - snapshot://ons/2024-03-20/hours_and_earnings_uk.xlsx
+  data://garden/ons/2024-03-20/hours_and_earnings_uk:
+    - data://meadow/ons/2024-03-20/hours_and_earnings_uk

--- a/etl/steps/data/garden/ons/2024-03-20/hours_and_earnings_uk.countries.json
+++ b/etl/steps/data/garden/ons/2024-03-20/hours_and_earnings_uk.countries.json
@@ -1,0 +1,3 @@
+{
+  "United Kingdom": "United Kingdom"
+}

--- a/etl/steps/data/garden/ons/2024-03-20/hours_and_earnings_uk.meta.yml
+++ b/etl/steps/data/garden/ons/2024-03-20/hours_and_earnings_uk.meta.yml
@@ -1,0 +1,63 @@
+# NOTE: To learn more about the fields, hover over their names.
+definitions:
+  common:
+    unit: ""
+    short_unit: ""
+    processing_level: major
+    description_processing: We estimated percentile ratios by dividing income in different thresholds and multiplying by 100.
+    description_from_producer: |-
+      Annual Survey of Hours and Earnings (ASHE) information relates to gross pay before tax, National Insurance or other deductions, and excludes payments in kind. With the exception of annual earnings, the results are restricted to earnings relating to the survey pay period and so exclude payments of arrears from another period made during the survey period; any payments due as a result of a pay settlement but not yet paid at the time of the survey will also be excluded.
+
+      ASHE is based on a 1% sample of employee jobs taken from HM Revenue and Customs Pay As You Earn (PAYE) records. Consequently, individuals with more than one job may appear in the sample more than once. Information on earnings and paid hours worked is obtained from employers and treated confidentially. ASHE does not cover the self-employed or employees not paid during the reference period.
+
+      <% if aggregation == "All employees" %>
+      All employees includes employees on adult rates, whose pay for the survey period was unaffected by absence. Estimates for 2020 and 2021 include employees who have been furloughed under the Coronavirus Job Retention Scheme (CJRS).
+      <% elif aggregation == "Full-time" %>
+      Full-time defined as employees working more than 30 paid hours per week (or 25 or more for the teaching professions).
+      <% elif aggregation == "Part-time" %>
+      Part-time defined as employees working 30 paid hours or less per week (or less than 25 for the teaching professions).
+    description_key:
+      - Income is ‘gross’ — measured before tax, National Insurance or other deductions, and exclude payments in kind.
+    display: &common-display
+      numDecimalPlaces: 1
+      tolerance: 5
+    presentation:
+      topic_tags:
+        - Poverty
+        - Economic Inequality
+
+
+# Learn more about the available fields:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+dataset:
+  update_period_days: 365
+
+
+tables:
+  hours_and_earnings_uk:
+    variables:
+      p90_p50_ratio:
+        title: P90/P50 ratio (<<aggregation>>, spell <<spell>>)
+        description_short: The P90/P50 ratio measures the degree of inequality within the richest half of the population. A ratio of 2 means that someone just falling in the richest tenth of the population has twice the median income or consumption.
+        presentation:
+          title_public: P90/P50 ratio
+        display:
+          name: P90/P50 ratio
+          <<: *common-display
+      p90_p10_ratio:
+        title: P90/P10 ratio (<<aggregation>>, spell <<spell>>)
+        description_short: P90 and P10 are the levels of income below which 90% and 10% of the population live, respectively. This variable gives the ratio of the two. It is a measure of inequality that indicates the gap between the richest and poorest tenth of the population.
+        presentation:
+          title_public: P90/P10 ratio
+        display:
+          name: P90/P10 ratio
+          <<: *common-display
+      p50_p10_ratio:
+        title: P50/P10 ratio (<<aggregation>>, spell <<spell>>)
+        description_short: The P50/P10 ratio measures the degree of inequality within the poorest half of the population. A ratio of 2 means that the median income is two times higher than that of someone just falling in the poorest tenth of the population.
+        presentation:
+          title_public: P50/P10 ratio
+        display:
+          name: P50/P10 ratio
+          <<: *common-display
+

--- a/etl/steps/data/garden/ons/2024-03-20/hours_and_earnings_uk.py
+++ b/etl/steps/data/garden/ons/2024-03-20/hours_and_earnings_uk.py
@@ -40,7 +40,7 @@ def run(dest_dir: str) -> None:
         df=tb,
         countries_file=paths.country_mapping_path,
     )
-    tb = tb.set_index(["aggregation", "country", "year", "spell"], verify_integrity=True)
+    tb = tb.format(["aggregation", "country", "year", "spell"])
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/ons/2024-03-20/hours_and_earnings_uk.py
+++ b/etl/steps/data/garden/ons/2024-03-20/hours_and_earnings_uk.py
@@ -1,0 +1,82 @@
+"""Load a meadow dataset and create a garden dataset."""
+
+from typing import Dict
+
+from owid.catalog import Table
+
+from etl.data_helpers import geo
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+INDICATOR_NAMES = {
+    "10% earned less than": "p10",
+    "10% earned more than": "p90",
+    "25% earned less than": "p25",
+    "25% earned more than": "p75",
+    "50% earned less than": "median",
+}
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load meadow dataset.
+    ds_meadow = paths.load_dataset("hours_and_earnings_uk")
+
+    # Read table from meadow dataset.
+    tb = ds_meadow["hours_and_earnings_uk"].reset_index()
+
+    #
+    # Process data.
+    tb = calculate_ratios(tb, INDICATOR_NAMES)
+
+    # Format year to int
+    tb["year"] = tb["year"].str[:4].astype(int)
+    #
+    tb = geo.harmonize_countries(
+        df=tb,
+        countries_file=paths.country_mapping_path,
+    )
+    tb = tb.set_index(["aggregation", "country", "year", "spell"], verify_integrity=True)
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(
+        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata
+    )
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()
+
+
+def calculate_ratios(tb: Table, indicator_names: Dict[str, str]) -> Table:
+    """Calculate ratios between indicators and median."""
+
+    # Rename values in indicator column
+    tb["indicator"] = tb["indicator"].replace(indicator_names)
+
+    # Make table wide with indicator as columns
+    tb_pivot = (
+        tb.pivot_table(index=["country", "year", "spell", "aggregation"], columns="indicator", values="value")
+        .reset_index()
+        .copy()
+    )
+
+    # Copy metadata
+    for col in indicator_names.values():
+        tb_pivot[col] = tb_pivot[col].copy_metadata(tb["indicator"])
+
+    # Calculate ratios
+    tb_pivot["p90_p50_ratio"] = tb_pivot["p90"] / tb_pivot["median"] * 100
+    tb_pivot["p90_p10_ratio"] = tb_pivot["p90"] / tb_pivot["p10"] * 100
+    tb_pivot["p50_p10_ratio"] = tb_pivot["median"] / tb_pivot["p10"] * 100
+
+    # Remove columns named as the indicator_names.values()
+    tb_pivot = tb_pivot.drop(columns=indicator_names.values())
+
+    return tb_pivot

--- a/etl/steps/data/meadow/ons/2024-03-20/hours_and_earnings_uk.py
+++ b/etl/steps/data/meadow/ons/2024-03-20/hours_and_earnings_uk.py
@@ -1,0 +1,110 @@
+"""Load a snapshot and create a meadow dataset."""
+
+from typing import Dict, List
+
+from owid.catalog import Table
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+AGGREGATION_NAMES = {
+    "All employeesa": "All employees",
+    "Full-timea,b": "Full-time",
+    "Part-timea,c": "Part-time",
+}
+
+GROSS_WEEKLY_EARNINGS_CATEGORY_NAME = "Gross weekly earnings (£)"
+
+TEXTS_BELOW_TABLE = [
+    "a Employees on adult rates, whose pay for the survey period was unaffected by absence. Estimates for 2020 and 2021 include employees who have been furloughed under the Coronavirus Job Retention Scheme (CJRS).",
+    "b Full-time defined as employees working more than 30 paid hours per week (or 25 or more for the teaching professions).",
+    "c Part-time defined as employees working 30 paid hours or less per week (or less than 25 for the teaching professions).",
+    "Go to Contents",
+]
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Retrieve snapshot.
+    snap = paths.load_snapshot("hours_and_earnings_uk.xlsx")
+
+    # Load data from snapshot.
+    tb = snap.read(sheet_name="Table 5", header=2)
+
+    #
+    # Process data.
+
+    tb = reformat_table(tb, AGGREGATION_NAMES, GROSS_WEEKLY_EARNINGS_CATEGORY_NAME, TEXTS_BELOW_TABLE)
+
+    # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
+    tb = tb.format(["country", "year", "spell", "indicator", "aggregation"])
+
+    #
+    # Save outputs.
+    #
+    # Create a new meadow dataset with the same metadata as the snapshot.
+    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+
+    # Save changes in the new meadow dataset.
+    ds_meadow.save()
+
+
+def reformat_table(
+    tb: Table, aggregation_names: Dict, gross_weekly_earnings_name: str, text_below_table: List[str]
+) -> Table:
+    """Format table to be able to process it."""
+
+    # Rename first columms, to facilitate the next steps
+    tb = tb.rename(columns={tb.columns[0]: "indicator", tb.columns[1]: "aggregation"})
+
+    # Strip space from the first two columns
+    tb["indicator"] = tb["indicator"].str.strip()
+    tb["aggregation"] = tb["aggregation"].str.strip()
+
+    # Delete all the rows in indicator containing gross_weekly_earnings_name
+    tb = tb[~tb["indicator"].str.contains(gross_weekly_earnings_name, na=False, regex=False)].reset_index(drop=True)
+
+    # Rename aggregation column with aggregation_names dict
+    tb["aggregation"] = tb["aggregation"].replace(aggregation_names)
+
+    # Fill null values in aggregation
+    tb["aggregation"] = tb["aggregation"].fillna(method="ffill")
+
+    # Delete rows with null values in indicator
+    tb = tb.dropna(subset=["indicator"]).reset_index(drop=True)
+
+    # Drop rows with indicator = ""
+    tb = tb[tb["indicator"] != ""].reset_index(drop=True)
+
+    # Remove indicator rows including text_below_table
+    tb = tb[~tb["indicator"].isin(text_below_table)].reset_index(drop=True)
+
+    # Add a new column with the name of the country
+    tb["country"] = "United Kingdom"
+
+    # Make all column names strings
+    tb.columns = tb.columns.astype(str)
+
+    # Make table long
+    tb = tb.melt(id_vars=["indicator", "aggregation", "country"], var_name="year", value_name="value")
+
+    # Create a new column, spell, with the value of year when it's not a number
+    tb["spell"] = tb.loc[~tb.year.str[:4].str.isnumeric(), "year"]
+
+    # Fill null values in spell
+    tb["spell"] = tb["spell"].fillna(method="ffill")
+
+    # Remove rows when year == spell
+    tb = tb[tb["year"] != tb["spell"]]
+
+    # Name the rest of null values in spell as "Spell 1"
+    tb["spell"] = tb["spell"].fillna("Spell 1")
+
+    # Factorize spell column
+    tb["spell"] = tb["spell"].factorize()[0] + 1
+
+    return tb

--- a/snapshots/ons/2024-03-20/hours_and_earnings_uk.py
+++ b/snapshots/ons/2024-03-20/hours_and_earnings_uk.py
@@ -1,0 +1,24 @@
+"""Script to create a snapshot of dataset."""
+
+from pathlib import Path
+
+import click
+
+from etl.snapshot import Snapshot
+
+# Version for current snapshot dataset.
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+
+@click.command()
+@click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
+def main(upload: bool) -> None:
+    # Create a new snapshot.
+    snap = Snapshot(f"ons/{SNAPSHOT_VERSION}/hours_and_earnings_uk.xlsx")
+
+    # Download data from source, add file to DVC and upload to S3.
+    snap.create_snapshot(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/ons/2024-03-20/hours_and_earnings_uk.xlsx.dvc
+++ b/snapshots/ons/2024-03-20/hours_and_earnings_uk.xlsx.dvc
@@ -1,0 +1,30 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Annual Survey of Hours and Earnings time series of selected estimates
+    description: |-
+      Selected annual estimates of earnings and paid hours worked by UK employees using ASHE data from 1997 to 2023.
+    date_published: "2023-11-01"
+
+    # Citation
+    producer: Office for National Statistics (ONS)
+    citation_full: |-
+      Office for National Statistics (ONS), released 1 November 2023, ONS website, dataset, Annual Survey of Hours and Earnings time series of selected estimates, UK. Retrieved 20 March 2024.
+    attribution_short: ONS
+
+    # Files
+    url_main: https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/earningsandworkinghours/datasets/ashe1997to2015selectedestimates
+    url_download: https://www.ons.gov.uk/file?uri=/employmentandlabourmarket/peopleinwork/earningsandworkinghours/datasets/ashe1997to2015selectedestimates/current/selectedestimates19972023.xlsx
+    date_accessed: 2024-03-20
+
+    # License
+    license:
+      name: Open Government Licence v3.0
+      url: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
+
+outs:
+  - md5: ea8210e7d85c6f913a417dcdc856079e
+    size: 278446
+    path: hours_and_earnings_uk.xlsx


### PR DESCRIPTION
Issue here https://github.com/owid/owid-issues/issues/1441

Creates income ratios from weekly gross income for the UK. Data comes from the [UK's Office of National Statistics](https://www.ons.gov.uk/employmentandlabourmarket/peopleinwork/earningsandworkinghours/datasets/ashe1997to2015selectedestimates).

Data is for the Chartbook of Economic Inequality https://github.com/owid/owid-issues/issues/1177

I am not pushing this to Grapher, because this is for archival reasons, for the Chartbook only.