### PR TITLE
Add documentation about tags limitation of the chart sync tool

### DIFF
--- a/apps/staging_sync/app.py
+++ b/apps/staging_sync/app.py
@@ -25,7 +25,14 @@ def main():
     directly to live. This tool allows you to first create charts on the staging server and then synchronize
     them to the live environment after merging.
 
-    ⚠️ Tags are synced only for **new charts** in the source server, any edits to tags in existing charts are ignored.
+    """
+    )
+
+    st.info(
+        """
+    Note that tags are synced only for **new charts** in the source server, any edits to tags in existing charts are
+    ignored.
+
     """
     )
 

--- a/apps/staging_sync/app.py
+++ b/apps/staging_sync/app.py
@@ -24,6 +24,8 @@ def main():
     before creating charts in the live environment. In some cases, it was even necessary to push your dataset
     directly to live. This tool allows you to first create charts on the staging server and then synchronize
     them to the live environment after merging.
+
+    ⚠️ Tags are synced only for **new charts** in the source server, any edits to tags in existing charts are ignored.
     """
     )
 

--- a/docs/guides/indicator-upgrade.md
+++ b/docs/guides/indicator-upgrade.md
@@ -96,6 +96,9 @@ For the chart approval process, feel free to involve other stakeholders (data ma
 
 Optionally, once the charts are approved, you can further fine-tune them in their respective edit pages.
 
+!!! note "Notes"
+    - There is a technical limitation related to chart tags: If you create a new chart and add tags to it, the `Chart Sync` tool (see below) will be able to transfer those tags from your current environment to production. However, if you edit the tags of an existing chart, those changes will not be synced.
+
 ## Merge your changes
 After approving all the new charts in your PR staging, and your PR code has been approved, you can merge your changes to the master branch.
 

--- a/docs/guides/indicator-upgrade.md
+++ b/docs/guides/indicator-upgrade.md
@@ -96,8 +96,8 @@ For the chart approval process, feel free to involve other stakeholders (data ma
 
 Optionally, once the charts are approved, you can further fine-tune them in their respective edit pages.
 
-!!! note "Notes"
-    - There is a technical limitation related to chart tags: If you create a new chart and add tags to it, the `Chart Sync` tool (see below) will be able to transfer those tags from your current environment to production. However, if you edit the tags of an existing chart, those changes will not be synced.
+!!! warning "Adding tags to existing charts"
+    There is a technical limitation related to chart tags: If you create a new chart and add tags to it, the `Chart Sync` tool (see below) will be able to transfer those tags from your current environment to production. However, if you edit the tags of an existing chart, those changes will not be synced.
 
 ## Merge your changes
 After approving all the new charts in your PR staging, and your PR code has been approved, you can merge your changes to the master branch.


### PR DESCRIPTION
As discussed [here](https://owid.slack.com/archives/C0193RW5E2J/p1711101052248769). Note that Mojmir had already added a comment in the instructions of the chart sync (but it was a bit hidden, so now that info is more evident).
