### PR TITLE
Let VersionTracker optionally ignore archive steps

### DIFF
--- a/apps/step_update/cli.py
+++ b/apps/step_update/cli.py
@@ -36,7 +36,7 @@ class StepUpdater:
         # It can be used when initializing StepUpdater, but also to reload steps_df after making changes to the dag.
 
         # Initialize version tracker.
-        self.tracker = VersionTracker()
+        self.tracker = VersionTracker(ignore_archive=True)
 
         # Update the temporary dag.
         _update_temporary_dag(dag_active=self.tracker.dag_active, dag_all_reverse=self.tracker.dag_all_reverse)

--- a/etl/version_tracker.py
+++ b/etl/version_tracker.py
@@ -264,13 +264,17 @@ class VersionTracker:
         "snapshot://dummy/2020-01-01/dummy_full.csv",
     ]
 
-    def __init__(self, connect_to_db: bool = True, warn_on_archivable: bool = True):
-        # Load dag of active and archive steps (a dictionary where each item is step: set of dependencies).
-        self.dag_all = load_dag(paths.DAG_ARCHIVE_FILE)
+    def __init__(self, connect_to_db: bool = True, warn_on_archivable: bool = True, ignore_archive: bool = False):
+        # Load dag of active steps (a dictionary step: set of dependencies).
+        self.dag_active = load_dag(paths.DAG_FILE)
+        if ignore_archive:
+            # Fully ignore the archive dag (so that all steps are only active steps, and there are no archive steps).
+            self.dag_all = self.dag_active.copy()
+        else:
+            # Load dag of active and archive steps.
+            self.dag_all = load_dag(paths.DAG_ARCHIVE_FILE)
         # Create a reverse dag (a dictionary where each item is step: set of usages).
         self.dag_all_reverse = reverse_graph(graph=self.dag_all)
-        # Load dag of active steps.
-        self.dag_active = load_dag(paths.DAG_FILE)
         # Create a reverse dag (a dictionary where each item is step: set of usages) of active steps.
         self.dag_active_reverse = reverse_graph(graph=self.dag_active)
         # Generate the dag of only archive steps.


### PR DESCRIPTION
In `StepUpdater`, the property `steps_df` should only contain active steps (since they are the only ones to be considered for update, and the only ones relevant for the ETL dashboard). Indeed, column `step` of `steps_df` (which is the main index) only contains active seps. However, other columns (e.g. `direct_usages`) do contain archive steps. This issue was mentioned in https://github.com/owid/etl/issues/2365

This raises an `IndexError` in the ETL dashboard, if, in the Operations list, you click on "Add direct usages" for steps that are used by archive steps.

This PR fixes that. Now `VersionTracker` (which is loaded by `StepUpdater`) can be initialized with the argument `ignore_archive=True`.
