### PR TITLE
Fix wrong behavior of buttons in operations list

### DIFF
--- a/apps/wizard/pages/dashboard.py
+++ b/apps/wizard/pages/dashboard.py
@@ -648,7 +648,7 @@ with st.container(border=True):
     # Create an operations list, that contains the steps (selected from the main steps table) we will operate upon.
     # Note: Selected steps might contain steps other those selected in the main steps table, based on user selections (e.g. dependencies).
     if st.session_state.selected_steps:
-        for step in st.session_state.selected_steps:
+        for index, step in enumerate(st.session_state.selected_steps):
             # Define the layout of the list.
             cols = st.columns([0.5, 3, 1, 1, 1, 1])
 
@@ -684,6 +684,8 @@ with st.container(border=True):
 
             # Display the operations list.
             for (action_name, key_suffix, help_text), col in zip(actions, cols):
+                # Create a unique key for the button (if any button is to be created).
+                unique_key = f"{key_suffix}_{step}_{index}"
                 # Write step URI
                 if key_suffix == "write":
                     if step in st.session_state.selected_steps_table:
@@ -694,7 +696,7 @@ with st.container(border=True):
                 elif key_suffix == "remove":
                     col.button(
                         label=action_name,
-                        key=f"{key_suffix}_{step}",
+                        key=unique_key,
                         on_click=lambda step=step: remove_step(step),
                         help=help_text,
                     )
@@ -702,7 +704,7 @@ with st.container(border=True):
                 else:
                     col.button(
                         label=action_name,
-                        key=f"{key_suffix}_{step}",
+                        key=unique_key,
                         on_click=lambda step=step, key_suffix=key_suffix: include_related_steps(step, key_suffix),
                         help=help_text,
                     )
@@ -712,6 +714,7 @@ with st.container(border=True):
             "Clear _Operations list_",
             help="Remove all steps currently in the _Operations list_.",
             type="secondary",
+            key="clear_operations_list",
             on_click=lambda: st.session_state.selected_steps.clear(),
         )
 
@@ -730,7 +733,8 @@ with st.container(border=True):
             help="Remove steps that cannot be updated (i.e. with `update_period_days=0`), and other auxiliary datasets, namely: "
             + "\n- ".join(sorted(NON_UPDATEABLE_IDENTIFIERS)),
             type="secondary",
-            on_click=remove_non_updateable_steps(),
+            key="remove_non_updateable",
+            on_click=remove_non_updateable_steps,
         )
 
         def upgrade_steps_in_operations_list():
@@ -753,7 +757,8 @@ with st.container(border=True):
             "Replace steps with their latest versions",
             help="Replace steps in the _Operations list_ by their latest version available. You may want to use this button after updating steps, to be able to operate on the newly created steps.",
             type="secondary",
-            on_click=upgrade_steps_in_operations_list(),
+            key="replace_with_latest",
+            on_click=upgrade_steps_in_operations_list,
         )
 
     else:


### PR DESCRIPTION
# Issue

Buttons in the operations list were acting in quite unexpected ways.

## Example 1:

1. Add the latest garden step of long_term_crop_yields to the Operations list.
2. In the Operations list, click on "Add direct dependencies" of long_term_crop_yields.
3. Click on "Add direct dependencies" of long_term_wheat_yields.
4. Click on "Add direct dependencies" of faostat_qcl.

An error appears: DuplicateWidgetID: There are multiple widgets with the same key='remove_data://garden/faostat/2024-03-14/faostat_qcl'. To fix this, please make sure that the key argument is unique for each widget you create.

## Example 2:

1. Add the latest garden step of long_term_crop_yields to the Operations list.
2. In the Operations list, click on "Add direct dependencies" of long_term_crop_yields.
3. Click again on the same button.

You can see that the content of the operations list has suddenly changed. Steps have been replaced by their latest version (as if we had clicked on "Replace steps with their latest versions").

# Solution

The solution to the first problem was easy: buttons needed a unique identifier.

Then I realized that the steps in the operations list were actually being silently replaced by their latest versions, because of the `on_click=upgrade_steps_in_operations_list()`. Here, it should be `on_click=upgrade_steps_in_operations_list` (without actually calling the function).

This PR fixes both problems, and now buttons in the operations list work as expected.
