### PR TITLE
:tada: strict YAML metadata schema validation

### DIFF
--- a/etl/steps/data/garden/covid/latest/variants.meta.yml
+++ b/etl/steps/data/garden/covid/latest/variants.meta.yml
@@ -1,6 +1,7 @@
-default_display: &default_display
-  yearIsDay: true
-  zeroDay: '2020-01-21'
+definitions:
+  default_display: &default_display
+    yearIsDay: true
+    zeroDay: '2020-01-21'
 
 dataset:
   title: COVID-19 - Variants

--- a/etl/steps/data/garden/who/latest/fluid.meta.yml
+++ b/etl/steps/data/garden/who/latest/fluid.meta.yml
@@ -5,8 +5,6 @@ dataset:
     The platform accommodates both qualitative and quantitative data which facilitates the tracking of global trends, spread, intensity, and impact of influenza. These data are made freely available to health policy makers in order to assist them in making informed decisions regarding the management of influenza.
   licenses:
   - {}
-  sources:
-  - {}
 tables:
   fluid:
     variables:

--- a/schemas/snapshot-schema.json
+++ b/schemas/snapshot-schema.json
@@ -65,6 +65,9 @@
         },
         "source": {
           "$ref": "definitions.json#/source"
+        },
+        "license": {
+          "$ref": "definitions.json#/license"
         }
       }
     },

--- a/snapshots/unep/2023-01-03/global_trends_in_renewable_energy_investment.pdf.dvc
+++ b/snapshots/unep/2023-01-03/global_trends_in_renewable_energy_investment.pdf.dvc
@@ -1,13 +1,10 @@
 meta:
-  namespace: unep
-  short_name: global_trends_in_renewable_energy_investment
   name: Global trends in renewable energy investment
   source_name: UNEP
   publication_year: 2019
   publication_date: 2019-09-11
   url: https://www.unep.org/resources/report/global-trends-renewable-energy-investment-2019
   source_data_url: https://wedocs.unep.org/bitstream/handle/20.500.11822/29752/GTR2019.pdf
-  file_extension: pdf
   license_url: https://wedocs.unep.org/bitstream/handle/20.500.11822/29752/GTR2019.pdf
   license_name: Copyright © Frankfurt School of Finance & Management gGmbH 2019
   date_accessed: 2023-01-03

--- a/snapshots/who/latest/fluid.csv.dvc
+++ b/snapshots/who/latest/fluid.csv.dvc
@@ -1,15 +1,11 @@
 meta:
-  namespace: who
-  short_name: fluid
   name: FluID, World Health Oragnization (2023)
-  version: latest
   publication_year: 2023
   publication_date: 2023-02-16
   source_name: FluID, World Health Oragnization (2023)
   source_published_by: FluID, World Health Oragnization (2023)
   url: https://www.who.int/teams/global-influenza-programme/surveillance-and-monitoring/fluid
   source_data_url: https://frontdoor-l4uikgap6gz3m.azurefd.net/FLUMART/VIW_FID?&$format=csv
-  file_extension: csv
   license_url: https://www.who.int/about/policies/publishing/copyright
   license_name: CC BY-NC-SA 3.0 IGO
   date_accessed: 2023-02-16

--- a/snapshots/who/latest/flunet.csv.dvc
+++ b/snapshots/who/latest/flunet.csv.dvc
@@ -1,15 +1,11 @@
 meta:
-  namespace: who
-  short_name: flunet
   name: FluNet, World Health Organization (2023)
-  version: latest
   publication_year: 2023
   publication_date: 2023-02-16
   source_name: FluNet, World Health Organization (2023)
   source_published_by: Global Influenza Surveillance and Response System, World Health Organization
   url: https://www.who.int/tools/flunet
   source_data_url: https://frontdoor-l4uikgap6gz3m.azurefd.net/FLUMART/VIW_FNT?&$format=csv
-  file_extension: csv
   license_url: https://www.who.int/about/policies/publishing/copyright
   license_name: CC BY-NC-SA 3.0 IGO
   date_accessed: 2023-02-16

--- a/tests/test_metadata_schemas.py
+++ b/tests/test_metadata_schemas.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+import yaml
+from jsonschema import (
+    Draft7Validator,
+)
+from jsonschema.exceptions import ValidationError
+from yaml.loader import SafeLoader
+
+from etl.helpers import read_json_schema
+from etl.paths import SCHEMAS_DIR, SNAPSHOTS_DIR, STEPS_DATA_DIR
+
+DATASET_SCHEMA = read_json_schema(path=SCHEMAS_DIR / "dataset-schema.json")
+SNAPSHOT_SCHEMA = read_json_schema(path=SCHEMAS_DIR / "snapshot-schema.json")
+
+
+# only validate versions after this date
+# bump this if we significantly change the schema
+VALIDATE_AFTER = "2024-03-01"
+
+# Excluded invalid metadata files, should be fixed if possible
+EXCLUDE = [
+    "garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml",
+    "meadow/who/latest/fluid.meta.yml",
+]
+
+
+# Override the default YAML loader to treat dates as strings
+def construct_yaml_str(self, node):
+    return self.construct_scalar(node)
+
+
+def load_yaml_as_string(path):
+    SafeLoader.add_constructor("tag:yaml.org,2002:timestamp", construct_yaml_str)
+    with open(path, "r") as file:
+        return yaml.load(file, Loader=SafeLoader)
+
+
+def test_dataset_schemas():
+    validator = Draft7Validator(DATASET_SCHEMA)
+
+    # Walk over all files in STEPS_DATA_DIR with *.meta.yml extension
+    for meta_file_path in Path(STEPS_DATA_DIR).glob("**/*.meta.yml"):
+        # extract version from path
+        version = meta_file_path.relative_to(STEPS_DATA_DIR).parts[2]
+
+        # Only validate versions after VALIDATE_AFTER
+        if version != "latest" and version < VALIDATE_AFTER:
+            continue
+
+        # Exclude known invalid metadata files
+        if any(ex in str(meta_file_path) for ex in EXCLUDE):
+            continue
+
+        # Ignore fasttrack and backport metadata
+        if "fasttrack/" in str(meta_file_path) or "backport/" in str(meta_file_path):
+            continue
+
+        data = load_yaml_as_string(meta_file_path)
+
+        # Ignore invalid `description` field, it's in too many latest datasets
+        for tab in data.get("tables", {}).values():
+            for ind in tab.get("variables", {}).values():
+                if "description" in ind:
+                    del ind["description"]
+
+        # Validate the loaded data against the schema
+        try:
+            validator.validate(data)
+        except ValidationError as e:
+            raise ValidationError(f"Validation error in file: {meta_file_path}") from e
+
+
+def test_snapshot_schemas():
+    validator = Draft7Validator(SNAPSHOT_SCHEMA)
+
+    for meta_file_path in Path(SNAPSHOTS_DIR).glob("**/*.dvc"):
+        # extract version from etl/snapshots/namespace/version/snapshot_name.ext.dvc
+        version = meta_file_path.parent.name
+
+        # Only validate versions after VALIDATE_AFTER
+        if version != "latest" and version < VALIDATE_AFTER:
+            continue
+
+        # Ignore fasttrack and backport metadata
+        if "fasttrack/" in str(meta_file_path) or "backport/" in str(meta_file_path):
+            continue
+
+        data = load_yaml_as_string(meta_file_path)
+
+        # Validate the loaded data against the schema
+        try:
+            validator.validate(data)
+        except ValidationError as e:
+            raise ValidationError(f"Validation error in file: {meta_file_path}") from e


### PR DESCRIPTION
Light implementation of https://github.com/owid/etl/issues/2238.

The original issue suggests to
> Add the $schema parameter and opt-in historical YAML files that are already compliant

In my opinion, adding a property to every YAML file would add too much boilerplate code. I'm not sure if we need such a granular approach. Similarly with versioning metadata schema. I don't think we have to check every metadata file at each point in time. If we always have a green CI, then bump the version in `VALIDATE_AFTER`, update schema and have green again, then it's sufficient. (Especially since we have linting enabled)

I fixed a couple of datasets, but added some to `EXCLUDE` list. I've also disabled checking for `description` as it is present in too many datasets (we still get linting error for it).