### PR TITLE
:tada: automatic wildfires update

### DIFF
--- a/etl/steps/data/garden/climate/latest/weekly_wildfires.meta.yml
+++ b/etl/steps/data/garden/climate/latest/weekly_wildfires.meta.yml
@@ -10,7 +10,7 @@ definitions:
   desc_wildfires: &desc_wildfires
     - Wildfires are detected through the use of satellite imagery obtained from MODIS (Moderate Resolution Imaging Spectroradiometer) and VIIRS (Visible Infrared Imaging Radiometer Suite). These satellite systems are capable of identifying thermal anomalies and alterations in landscape patterns, which are indicative of burning.
     - The data provider is presently engaged in a global accuracy assessment and acknowledged that they might be underestimating the genuine impact of wildfires, primarily due to constraints imposed by the spatial resolution of the sensors they employ.
-  desc_update: The 2024 data is incomplete and was last updated on the 19th of March.
+  desc_update: The 2024 data is incomplete and was last updated {TODAY}.
 # Learn more about the available fields:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/dataset/
 dataset:

--- a/snapshots/climate/latest/weekly_wildfires.csv.dvc
+++ b/snapshots/climate/latest/weekly_wildfires.csv.dvc
@@ -1,33 +1,20 @@
-# Learn more at:
-# http://docs.owid.io/projects/etl/architecture/metadata/reference/origin/
 meta:
   origin:
-    # Data product / Snapshot
+    producer: Global Wildfire Information System
     title: Seasonal wildfire trends
     description: |-
       The dataset provides a weekly comprehensive overview of fire activity and its environmental impact, incorporating data from the Global Wildfire Information System (GWIS) and satellite imagery from MODIS and VIIRS. It includes metrics such as the area of land burnt, cumulative burnt areas, carbon dioxide emissions from fires, cumulative carbon emissions, the number of fires, and cumulative fire counts.
-
-    date_published: 2024-03-19
     title_snapshot: Seasonal wildfire trends (2024 and later)
-    description_snapshot: |-
-      This dataset focuses specifically on older data. A separate snapshot will be created to add more recent data.
-
-    # Citation
-    producer: Global Wildfire Information System
-    citation_full: |-
-      Global Wildfire Information System
+    description_snapshot: This dataset focuses specifically on older data. A separate snapshot will be created to add more recent data.
+    citation_full: Global Wildfire Information System
     attribution_short: GWIS
-
-    # Files
     url_main: https://gwis.jrc.ec.europa.eu/apps/gwis.statistics/seasonaltrend
-    date_accessed: 2024-03-19
-
-    # License
+    date_accessed: 2024-03-27
+    date_published: 2024-03-27
     license:
       name: CC BY 4.0
       url: https://gwis.jrc.ec.europa.eu/about-gwis/data-license
-
 outs:
-  - md5: 36e0812627f66e264ec389400deb0d1e
-    size: 9923169
+  - md5: db8e068e2a57c5dbcecb2b58348f8f04
+    size: 11556873
     path: weekly_wildfires.csv

--- a/snapshots/climate/latest/weekly_wildfires.py
+++ b/snapshots/climate/latest/weekly_wildfires.py
@@ -1,6 +1,7 @@
 """Script to create a snapshot of dataset. Loads data from the EFFIS API and creates a snapshot of the dataset with weekly wildire numbers, area burnt and emissions.
 This script generates data from 2003-2023. The data for the year 2024 and above will be processed separately to avoid long processing times."""
 
+import datetime as dt
 from pathlib import Path
 
 import click
@@ -48,6 +49,9 @@ COUNTRIES = {
 def main(upload: bool) -> None:
     # Initialize a new snapshot object for storing data, using a predefined file path structure.
     snap = Snapshot(f"climate/{SNAPSHOT_VERSION}/weekly_wildfires.csv")
+
+    # Add date_accessed
+    snap = modify_metadata(snap)
 
     # Initialize an empty list to hold DataFrames for wildfire data.
     dfs_fires = []
@@ -167,6 +171,13 @@ def main(upload: bool) -> None:
 
     # Add the file to DVC and optionally upload it to S3, based on the `upload` parameter.
     snap.dvc_add(upload=upload)
+
+
+def modify_metadata(snap: Snapshot) -> Snapshot:
+    snap.metadata.origin.date_published = dt.date.today()  # type: ignore
+    snap.metadata.origin.date_accessed = dt.date.today()  # type: ignore
+    snap.metadata.save()
+    return snap
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adjustments needed to update wildfires automatically. The script will run `python snapshots/climate/latest/weekly_wildfires.py` and then run ETL to update wildfires dataset.

There are couple of minor differences to the current process:
- Data will be updated daily (nothing happens if there are no changes)
- Description short slightly changes its date format to `The 2024 data is incomplete and was last updated 2024-03-27.`

Is it safe to run it daily or does it have to be run once a week?

## TODO after merging

- [x] Enable wildfires in [Buildkite](https://buildkite.com/our-world-in-data/etl-automatic-dataset-updates-master/settings/steps)