### PR TITLE
✨ Improve faostat metadata

### DIFF
--- a/docs/data/faostat.md
+++ b/docs/data/faostat.md
@@ -264,6 +264,13 @@ If no dataset requires an update, the workflow stops here.
     python etl/scripts/faostat/create_new_steps.py -c garden
     ```
 
+    !!! note
+
+        We used to handle custom definitions via custom_* files.
+        They let us handle individual definitions of items, elements and units (used by the food explorer).
+        However, for more common changes in an indicator's metadata, it is now better to directly modify the `faostat_*.meta.yml` files of the garden steps.
+        TODO: In the next data update, we will need to edit these scripts to be able to update not only the `custom_*` files, but also the `faostat_*.meta.yml` files, in case FAOSTAT definitions change.
+
 6. Run the new etl garden steps, to generate the garden datasets.
 
     ```bash

--- a/etl/scripts/faostat/archive/migrate_to_new_metadata.py
+++ b/etl/scripts/faostat/archive/migrate_to_new_metadata.py
@@ -1,0 +1,92 @@
+"""Generate a faostat_*.meta.yml file for each faostat garden step, with metadata fetched from grapher.
+
+NOTE: This script should only be used once, to generate the files for the first time.
+
+In future updates we will need to adapt the scripts or etl steps to be able to easily update metadata.
+
+"""
+import argparse
+import json
+
+from owid import catalog
+from structlog import get_logger
+
+from etl import db
+from etl.files import yaml_dump
+from etl.paths import DATA_DIR, STEP_DIR
+
+# Initialize logger.
+log = get_logger()
+
+# Latest faostat version.
+VERSION = "2024-03-14"
+
+
+def main():
+    # List all faostat garden steps whose metadata may need to be improved.
+    domains = [
+        step.stem
+        for step in list((STEP_DIR / f"data/garden/faostat/{VERSION}/").glob("faostat_*.py"))
+        if step.stem not in ["faostat_metadata", "faostat_food_explorer"]
+    ]
+
+    # Initialize a dictionary that will contain, for each step, all variables metadata from grapher.
+    metadata_dict = {}
+
+    # Fetch all data from grapher database.
+    for domain in domains:
+        try:
+            dataset_name = catalog.Dataset(DATA_DIR / f"garden/faostat/{VERSION}/{domain}").metadata.title
+        except FileNotFoundError:
+            log.error(
+                f"ETL grapher step for {domain} could not be loaded. "
+                f"Run `etl run {domain} --grapher` and try again."
+            )
+            continue
+        try:
+            dataset_id = db.get_dataset_id(dataset_name=dataset_name, version=VERSION)
+        except AssertionError:
+            log.error(
+                f"Grapher dataset for {domain} could not be found in the database. "
+                f"Run `etl run {domain} --grapher` and try again."
+            )
+            continue
+        variables = db.get_variables_in_dataset(dataset_id=dataset_id, only_used_in_charts=True)
+        if len(variables) > 0:
+            # variables_in_charts[domain] = variables.set_index("shortName").T.to_dict()
+            variables_dict = {}
+            for variable in variables.to_dict(orient="records"):
+                display = json.loads(variable["display"])
+                variables_dict[variable["shortName"]] = {
+                    "title": variable["name"],
+                    "unit": variable["unit"],
+                    "short_unit": variable["shortUnit"],
+                    "description_from_producer": variable["description"],
+                    "processing_level": "major",
+                    "display": {"name": display["name"], "shortUnit": variable["shortUnit"], "numDecimalPlaces": 2},
+                    "presentation": {
+                        "title_public": variable["titlePublic"],
+                    },
+                }
+            metadata_dict[domain] = {
+                "dataset": {"title": dataset_name, "update_period_days": 365},
+                "definitions": {
+                    "common": {
+                        "processing_level": "major",
+                        "presentation": {"topic_tags": ["Agricultural Production"], "attribution_short": "FAO"},
+                    }
+                },
+                "tables": {f"{domain}_flat": {"title": dataset_name, "variables": variables_dict}},
+            }
+
+    # For each domain, create a yml metadata file.
+    for domain, metadata in metadata_dict.items():
+        metadata_file = STEP_DIR / f"data/garden/faostat/{VERSION}/{domain}.meta.yml"
+        yaml_text = yaml_dump(metadata)
+        metadata_file.write_text(yaml_text)  # type: ignore
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    args = parser.parse_args()
+    main()

--- a/etl/scripts/faostat/archive/migrate_to_new_metadata.py
+++ b/etl/scripts/faostat/archive/migrate_to_new_metadata.py
@@ -61,7 +61,7 @@ def main():
                     "title": variable["name"],
                     "unit": variable["unit"],
                     "short_unit": variable["shortUnit"],
-                    "description_from_producer": variable["description"],
+                    # "description_from_producer": variable["description"],
                     "processing_level": "major",
                     "display": {"name": display["name"], "shortUnit": variable["shortUnit"], "numDecimalPlaces": 2},
                     "presentation": {

--- a/etl/steps/data/garden/faostat/2024-03-14/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/additional_variables.meta.yml
@@ -3,6 +3,14 @@ dataset:
   description: |
     Additional variables created using data from different FAOSTAT datasets.
 
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
 tables:
   arable_land_per_crop_output:
     variables:
@@ -34,8 +42,9 @@ tables:
         title: "Area used for production"
         unit: "hectares"
         short_unit: "ha"
-        # Description will be fetched from the original FAOSTAT item and element descriptions.
-        # description: |
+        description_short: |-
+          Total surface area used for production of a given crop.
+        # description_from_producer will be fetched from the original FAOSTAT item and element descriptions.
   share_of_sustainable_and_overexploited_fish:
     variables:
       sustainable_fish:

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_fbsc.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_fbsc.meta.yml
@@ -42,22 +42,22 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from egg products
+          name: Daily supply of protein from egg products
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from egg products
+          title_public: Daily supply of protein from egg products
       animal_products__00002941__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Animal Products | 00002941 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from animal products
+          name: Daily supply of protein from animal products
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from animal products
+          title_public: Daily supply of protein from animal products
       animal_fats_group__00002946__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Animal fats group | 00002946 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
@@ -108,7 +108,7 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Production if cephalopods
+          name: Production of cephalopods
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
@@ -295,11 +295,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from fish and seafood
+          name: Daily supply of protein from fish and seafood
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from fish and seafood
+          title_public: Daily supply of protein from fish and seafood
       fish_and_seafood__00002960__production__005511__tonnes:
         title: Fish and seafood | 00002960 || Production | 005511 || tonnes
         unit: tonnes
@@ -368,15 +368,17 @@ tables:
           title_public: Per capita consumption of grapefruit
       grapes_and_products__excl_wine__00002620__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Grapes and products (excl wine) | 00002620 || Food available for consumption | 0645pc || kilograms per year per capita
+        description_short: |-
+          Grapes, raisins, and grape juice are included, but not wine.
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Per capita consumption of grapes and products, excluding wine
+          name: Per capita consumption of grape products, excluding wine
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Per capita consumption of grapes and products, excluding wine
+          title_public: Per capita consumption of grape products, excluding wine
       lemons_and_limes__00002612__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Lemons and limes | 00002612 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -438,11 +440,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from other meat
+          name: Daily supply of protein from other meat
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from other meat
+          title_public: Daily supply of protein from other meat
       meat__beef__00002731__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, beef | 00002731 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -471,11 +473,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from beef
+          name: Daily supply of protein from beef
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from beef
+          title_public: Daily supply of protein from beef
       meat__pig__00002733__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, pig | 00002733 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -504,11 +506,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from pig meat
+          name: Daily supply of protein from pig meat
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from pig meat
+          title_public: Daily supply of protein from pig meat
       meat__poultry__00002734__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, poultry | 00002734 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -537,11 +539,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from poultry meat
+          name: Daily supply of protein from poultry meat
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from poultry meat
+          title_public: Daily supply of protein from poultry meat
       meat__sheep_and_goat__00002732__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, sheep and goat | 00002732 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -570,11 +572,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from sheep and goat meat
+          name: Daily supply of protein from sheep and goat meat
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from sheep and goat meat
+          title_public: Daily supply of protein from sheep and goat meat
       meat__total__00002943__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, total | 00002943 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -603,11 +605,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from meat
+          name: Daily supply of protein from meat
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from meat
+          title_public: Daily supply of protein from meat
       milk__excluding_butter__00002848__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Milk - Excluding Butter | 00002848 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -636,11 +638,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from milk, excluding butter
+          name: Daily supply of protein from milk, excluding butter
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from milk, excluding butter
+          title_public: Daily supply of protein from milk, excluding butter
       milk__00002948__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Milk | 00002948 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
@@ -658,11 +660,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from milk
+          name: Daily supply of protein from milk
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from milk
+          title_public: Daily supply of protein from milk
       miscellaneous_group__00002928__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Miscellaneous group | 00002928 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
@@ -764,8 +766,8 @@ tables:
           title_public: Per capita consumption of plantains
       population__00002501__total_population__both_sexes__000511__thousand_number:
         title: Population | 00002501 || Total Population - Both sexes | 000511 || thousand Number
-        unit: thousand Number
-        short_unit: 1000 No
+        unit: thousands
+        short_unit: thousands
         processing_level: major
         display:
           name: Population
@@ -889,11 +891,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Total daily supply of proteins
+          name: Total daily supply of protein
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Total daily supply of proteins
+          title_public: Total daily supply of protein
       total__00002901__food_available_for_consumption__0684pc__grams_of_fat_per_day_per_capita:
         title: Total | 00002901 || Food available for consumption | 0684pc || grams of fat per day per capita
         unit: grams of fat per day per capita
@@ -955,11 +957,11 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Daily supply of proteins from vegetal products
+          name: Daily supply of protein from vegetal products
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Daily supply of proteins from vegetal products
+          title_public: Daily supply of protein from vegetal products
       wheat__00002511__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Wheat | 00002511 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_fbsc.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_fbsc.meta.yml
@@ -20,88 +20,88 @@ tables:
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Alcoholic Beverages - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from alcoholic beverages
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Alcoholic Beverages - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from alcoholic beverages
       all_egg_products__00002744__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: All egg products | 00002744 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: All egg products - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from all egg products
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: All egg products - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from all egg products
       all_egg_products__00002744__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: All egg products | 00002744 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: All egg products - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from egg products
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: All egg products - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from egg products
       animal_products__00002941__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Animal Products | 00002941 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Animal Products - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from animal products
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Animal Products - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from animal products
       animal_fats_group__00002946__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Animal fats group | 00002946 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Animal fats group - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from animal fats
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Animal fats group - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from animal fats
       apples__00002617__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Apples | 00002617 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Apples - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of apples
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Apples - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of apples
       bananas__00002615__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Bananas | 00002615 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Bananas - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of bananas
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Bananas - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of bananas
       barley__00002513__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Barley | 00002513 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Barley - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from barley
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Barley - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from barley
       cephalopods__00002766__production__005511__tonnes:
         title: Cephalopods | 00002766 || Production | 005511 || tonnes
         unit: tonnes
@@ -185,33 +185,33 @@ tables:
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Cereals, Other - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from other cereals
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Cereals, Other - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from other cereals
       citrus__other__00002614__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Citrus, Other | 00002614 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Citrus, Other - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of other citrus
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Citrus, Other - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of other citrus
       cocoa_beans__00002633__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Cocoa beans | 00002633 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Cocoa beans - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of cocoa beans
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Cocoa beans - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of cocoa beans
       crustaceans__00002765__production__005511__tonnes:
         title: Crustaceans | 00002765 || Production | 005511 || tonnes
         unit: tonnes
@@ -229,11 +229,11 @@ tables:
         short_unit: kg
         processing_level: major
         display:
-          name: Dates - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of dates
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Dates - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of dates
       demersal_fish__00002762__production__005511__tonnes:
         title: Demersal Fish | 00002762 || Production | 005511 || tonnes
         unit: tonnes
@@ -251,55 +251,55 @@ tables:
         short_unit: kg
         processing_level: major
         display:
-          name: Eggs - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of eggs
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Eggs - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of eggs
       eggs__00002949__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Eggs | 00002949 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Eggs - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from eggs
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Eggs - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from eggs
       fish_and_seafood__00002960__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Fish and seafood | 00002960 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Fish and seafood - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of fish and seafood
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Fish and seafood - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of fish and seafood
       fish_and_seafood__00002960__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Fish and seafood | 00002960 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Fish and seafood - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from fish and seafood
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Fish and seafood - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from fish and seafood
       fish_and_seafood__00002960__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Fish and seafood | 00002960 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Fish and seafood - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from fish and seafood
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Fish and seafood - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from fish and seafood
       fish_and_seafood__00002960__production__005511__tonnes:
         title: Fish and seafood | 00002960 || Production | 005511 || tonnes
         unit: tonnes
@@ -328,44 +328,44 @@ tables:
         short_unit: kg
         processing_level: major
         display:
-          name: Fruit - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of fruit
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Fruit - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of fruit
       fruit__00002919__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Fruit | 00002919 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Fruit - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from fruit
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Fruit - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from fruit
       fruits__other__00002625__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Fruits, other | 00002625 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Fruits, other - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of other fruits
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Fruits, other - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of other fruits
       grapefruit__00002613__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Grapefruit | 00002613 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Grapefruit - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of grapefruit
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Grapefruit - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of grapefruit
       grapes_and_products__excl_wine__00002620__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Grapes and products (excl wine) | 00002620 || Food available for consumption | 0645pc || kilograms per year
           per capita
@@ -373,33 +373,33 @@ tables:
         short_unit: kg
         processing_level: major
         display:
-          name: Grapes and products (excl wine) - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of grapes and products, excluding wine
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Grapes and products (excl wine) - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of grapes and products, excluding wine
       lemons_and_limes__00002612__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Lemons and limes | 00002612 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Lemons and limes - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of lemons and limes
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Lemons and limes - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of lemons and limes
       maize__00002514__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Maize | 00002514 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Maize - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from maize
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Maize - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from maize
       marine_fish__other__00002764__production__005511__tonnes:
         title: Marine Fish, Other | 00002764 || Production | 005511 || tonnes
         unit: tonnes
@@ -417,154 +417,154 @@ tables:
         short_unit: kg
         processing_level: major
         display:
-          name: Meat, Other - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of other meat
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, Other - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of other meat
       meat__other__00002735__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Meat, Other | 00002735 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Meat, Other - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from other meat
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, Other - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from other meat
       meat__other__00002735__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Meat, Other | 00002735 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Meat, Other - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from other meat
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, Other - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from other meat
       meat__beef__00002731__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, beef | 00002731 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Meat, beef - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of beef
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, beef - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of beef
       meat__beef__00002731__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Meat, beef | 00002731 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Meat, beef - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from beef
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, beef - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from beef
       meat__beef__00002731__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Meat, beef | 00002731 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Meat, beef - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from beef
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, beef - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from beef
       meat__pig__00002733__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, pig | 00002733 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Meat, pig - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of pig meat
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, pig - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of pig meat
       meat__pig__00002733__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Meat, pig | 00002733 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Meat, pig - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from pig meat
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, pig - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from pig meat
       meat__pig__00002733__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Meat, pig | 00002733 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Meat, pig - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from pig meat
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, pig - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from pig meat
       meat__poultry__00002734__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, poultry | 00002734 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Meat, poultry - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of poultry meat
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, poultry - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of poultry meat
       meat__poultry__00002734__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Meat, poultry | 00002734 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Meat, poultry - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from poultry meat
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, poultry - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from poultry meat
       meat__poultry__00002734__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Meat, poultry | 00002734 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Meat, poultry - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from poultry meat
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, poultry - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from poultry meat
       meat__sheep_and_goat__00002732__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, sheep and goat | 00002732 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Meat, sheep and goat - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of sheep and goat meat
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, sheep and goat - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of sheep and goat meat
       meat__sheep_and_goat__00002732__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Meat, sheep and goat | 00002732 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Meat, sheep and goat - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from sheep and goat meat
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, sheep and goat - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from sheep and goat meat
       meat__sheep_and_goat__00002732__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Meat, sheep and goat | 00002732 || Food available for consumption | 0674pc || grams of protein per day per
           capita
@@ -572,66 +572,66 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Meat, sheep and goat - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from sheep and goat meat
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, sheep and goat - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from sheep and goat meat
       meat__total__00002943__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, total | 00002943 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Meat, total - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of meat
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, total - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of meat
       meat__total__00002943__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Meat, total | 00002943 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Meat, total - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from meat
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, total - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from meat
       meat__total__00002943__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Meat, total | 00002943 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Meat, total - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from meat
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, total - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from meat
       milk__excluding_butter__00002848__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Milk - Excluding Butter | 00002848 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Milk - Excluding Butter - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of milk, excluding butter
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Milk - Excluding Butter - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of milk, excluding butter
       milk__excluding_butter__00002848__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Milk - Excluding Butter | 00002848 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Milk - Excluding Butter - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from milk, excluding butter
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Milk - Excluding Butter - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from milk, excluding butter
       milk__excluding_butter__00002848__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Milk - Excluding Butter | 00002848 || Food available for consumption | 0674pc || grams of protein per day per
           capita
@@ -639,44 +639,44 @@ tables:
         short_unit: g/day
         processing_level: major
         display:
-          name: Milk - Excluding Butter - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from milk, excluding butter
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Milk - Excluding Butter - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from milk, excluding butter
       milk__00002948__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Milk | 00002948 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Milk - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from milk
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Milk - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from milk
       milk__00002948__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Milk | 00002948 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Milk - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from milk
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Milk - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from milk
       miscellaneous_group__00002928__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Miscellaneous group | 00002928 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Miscellaneous group - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from other food commodities
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Miscellaneous group - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from other food commodities
       molluscs__other__00002767__production__005511__tonnes:
         title: Molluscs, Other | 00002767 || Production | 005511 || tonnes
         unit: tonnes
@@ -694,33 +694,33 @@ tables:
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Nuts - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from nuts
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Nuts - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from nuts
       oilcrops__00002913__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Oilcrops | 00002913 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Oilcrops - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from oilcrops
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Oilcrops - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from oilcrops
       oranges__00002611__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Oranges | 00002611 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Oranges - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of oranges
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Oranges - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of oranges
       palm_oil__00002577__imports__005611__tonnes:
         title: Palm Oil | 00002577 || Imports | 005611 || tonnes
         unit: tonnes
@@ -749,22 +749,22 @@ tables:
         short_unit: kg
         processing_level: major
         display:
-          name: Pineapples - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of pineapples
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Pineapples - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of pineapples
       plantains__00002616__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Plantains | 00002616 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Plantains - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of plantains
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Plantains - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of plantains
       population__00002501__total_population__both_sexes__000511__thousand_number:
         title: Population | 00002501 || Total Population - Both sexes | 000511 || thousand Number
         unit: thousand Number
@@ -782,22 +782,22 @@ tables:
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Pulses - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from pulses
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Pulses - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from pulses
       rice__00002807__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Rice | 00002807 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Rice - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from rice
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Rice - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from rice
       soybeans__00002555__feed__005521__tonnes:
         title: Soybeans | 00002555 || Feed | 005521 || tonnes
         unit: tonnes
@@ -837,33 +837,33 @@ tables:
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Starchy Roots - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from starchy roots
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Starchy Roots - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from starchy roots
       sugar__and__sweeteners__00002909__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Sugar & Sweeteners | 00002909 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Sugar & Sweeteners - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from sugar and sweeteners
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Sugar & Sweeteners - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from sugar and sweeteners
       sugar_crops__00002908__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Sugar crops | 00002908 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Sugar crops - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from sugar crops
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Sugar crops - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from sugar crops
       total__00002901__food_available_for_consumption__000664__kilocalories_per_day:
         title: Total | 00002901 || Food available for consumption | 000664 || kilocalories per day
         unit: kilocalories per day
@@ -881,96 +881,96 @@ tables:
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Total - Food available for consumption (kilocalories per day per capita)
+          name: Total daily supply of calories
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Total - Food available for consumption (kilocalories per day per capita)
+          title_public: Total daily supply of calories
       total__00002901__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Total | 00002901 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Total - Food available for consumption (grams of protein per day per capita)
+          name: Total daily supply of proteins
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Total - Food available for consumption (grams of protein per day per capita)
+          title_public: Total daily supply of proteins
       total__00002901__food_available_for_consumption__0684pc__grams_of_fat_per_day_per_capita:
         title: Total | 00002901 || Food available for consumption | 0684pc || grams of fat per day per capita
         unit: grams of fat per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Total - Food available for consumption (grams of fat per day per capita)
+          name: Daily fat supply
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Total - Food available for consumption (grams of fat per day per capita)
+          title_public: Daily fat supply
       vegetable_oils__00002914__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Vegetable Oils | 00002914 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Vegetable Oils - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from vegetable oils
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Vegetable Oils - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from vegetable oils
       vegetables__00002918__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Vegetables | 00002918 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
         display:
-          name: Vegetables - Food available for consumption (kilograms per year per capita)
+          name: Per capita consumption of vegetables
           shortUnit: kg
           numDecimalPlaces: 2
         presentation:
-          title_public: Vegetables - Food available for consumption (kilograms per year per capita)
+          title_public: Per capita consumption of vegetables
       vegetables__00002918__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Vegetables | 00002918 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Vegetables - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from vegetables
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Vegetables - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from vegetables
       vegetal_products__00002903__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Vegetal Products | 00002903 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Vegetal Products - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from vegetal products
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Vegetal Products - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from vegetal products
       vegetal_products__00002903__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
         title: Vegetal Products | 00002903 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
         display:
-          name: Vegetal Products - Food available for consumption (grams of protein per day per capita)
+          name: Daily supply of proteins from vegetal products
           shortUnit: g/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Vegetal Products - Food available for consumption (grams of protein per day per capita)
+          title_public: Daily supply of proteins from vegetal products
       wheat__00002511__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Wheat | 00002511 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Wheat - Food available for consumption (kilocalories per day per capita)
+          name: Daily supply of calories from wheat
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Wheat - Food available for consumption (kilocalories per day per capita)
+          title_public: Daily supply of calories from wheat

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_fbsc.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_fbsc.meta.yml
@@ -1,0 +1,976 @@
+dataset:
+  title: Food Balances (old methodology before 2010, and new from 2010 onwards)
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
+tables:
+  faostat_fbsc_flat:
+    title: Food Balances (old methodology before 2010, and new from 2010 onwards)
+    variables:
+      alcoholic_beverages__00002924__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Alcoholic Beverages | 00002924 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Alcoholic Beverages - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Alcoholic Beverages - Food available for consumption (kilocalories per day per capita)
+      all_egg_products__00002744__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: All egg products | 00002744 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: All egg products - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: All egg products - Food available for consumption (kilocalories per day per capita)
+      all_egg_products__00002744__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: All egg products | 00002744 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: All egg products - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: All egg products - Food available for consumption (grams of protein per day per capita)
+      animal_products__00002941__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Animal Products | 00002941 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Animal Products - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Animal Products - Food available for consumption (grams of protein per day per capita)
+      animal_fats_group__00002946__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Animal fats group | 00002946 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Animal fats group - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Animal fats group - Food available for consumption (kilocalories per day per capita)
+      apples__00002617__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Apples | 00002617 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Apples - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Apples - Food available for consumption (kilograms per year per capita)
+      bananas__00002615__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Bananas | 00002615 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Bananas - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Bananas - Food available for consumption (kilograms per year per capita)
+      barley__00002513__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Barley | 00002513 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Barley - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Barley - Food available for consumption (kilocalories per day per capita)
+      cephalopods__00002766__production__005511__tonnes:
+        title: Cephalopods | 00002766 || Production | 005511 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cephalopods - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cephalopods - Production (tonnes)
+      cereals__excluding_beer__00002905__exports__005911__tonnes:
+        title: Cereals - Excluding Beer | 00002905 || Exports | 005911 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cereals - Excluding Beer - Exports (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cereals - Excluding Beer - Exports (tonnes)
+      cereals__excluding_beer__00002905__feed__005521__tonnes:
+        title: Cereals - Excluding Beer | 00002905 || Feed | 005521 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cereals - Excluding Beer - Feed (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cereals - Excluding Beer - Feed (tonnes)
+      cereals__excluding_beer__00002905__food__005142__tonnes:
+        title: Cereals - Excluding Beer | 00002905 || Food | 005142 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cereals - Excluding Beer - Food (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cereals - Excluding Beer - Food (tonnes)
+      cereals__excluding_beer__00002905__imports__005611__tonnes:
+        title: Cereals - Excluding Beer | 00002905 || Imports | 005611 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cereals - Excluding Beer - Imports (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cereals - Excluding Beer - Imports (tonnes)
+      cereals__excluding_beer__00002905__other_uses__005154__tonnes:
+        title: Cereals - Excluding Beer | 00002905 || Other uses | 005154 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cereals - Excluding Beer - Other uses (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cereals - Excluding Beer - Other uses (tonnes)
+      cereals__excluding_beer__00002905__processing__005131__tonnes:
+        title: Cereals - Excluding Beer | 00002905 || Processing | 005131 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cereals - Excluding Beer - Processing (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cereals - Excluding Beer - Processing (tonnes)
+      cereals__other__00002520__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Cereals, Other | 00002520 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Cereals, Other - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cereals, Other - Food available for consumption (kilocalories per day per capita)
+      citrus__other__00002614__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Citrus, Other | 00002614 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Citrus, Other - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Citrus, Other - Food available for consumption (kilograms per year per capita)
+      cocoa_beans__00002633__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Cocoa beans | 00002633 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Cocoa beans - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cocoa beans - Food available for consumption (kilograms per year per capita)
+      crustaceans__00002765__production__005511__tonnes:
+        title: Crustaceans | 00002765 || Production | 005511 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Crustaceans - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Crustaceans - Production (tonnes)
+      dates__00002619__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Dates | 00002619 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Dates - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Dates - Food available for consumption (kilograms per year per capita)
+      demersal_fish__00002762__production__005511__tonnes:
+        title: Demersal Fish | 00002762 || Production | 005511 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Demersal Fish - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Demersal Fish - Production (tonnes)
+      eggs__00002949__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Eggs | 00002949 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Eggs - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Eggs - Food available for consumption (kilograms per year per capita)
+      eggs__00002949__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Eggs | 00002949 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Eggs - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Eggs - Food available for consumption (kilocalories per day per capita)
+      fish_and_seafood__00002960__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Fish and seafood | 00002960 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Fish and seafood - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Fish and seafood - Food available for consumption (kilograms per year per capita)
+      fish_and_seafood__00002960__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Fish and seafood | 00002960 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Fish and seafood - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Fish and seafood - Food available for consumption (kilocalories per day per capita)
+      fish_and_seafood__00002960__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Fish and seafood | 00002960 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Fish and seafood - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Fish and seafood - Food available for consumption (grams of protein per day per capita)
+      fish_and_seafood__00002960__production__005511__tonnes:
+        title: Fish and seafood | 00002960 || Production | 005511 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Fish and seafood - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Fish and seafood - Production (tonnes)
+      freshwater_fish__00002761__production__005511__tonnes:
+        title: Freshwater Fish | 00002761 || Production | 005511 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Freshwater Fish - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Freshwater Fish - Production (tonnes)
+      fruit__00002919__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Fruit | 00002919 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Fruit - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Fruit - Food available for consumption (kilograms per year per capita)
+      fruit__00002919__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Fruit | 00002919 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Fruit - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Fruit - Food available for consumption (kilocalories per day per capita)
+      fruits__other__00002625__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Fruits, other | 00002625 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Fruits, other - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Fruits, other - Food available for consumption (kilograms per year per capita)
+      grapefruit__00002613__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Grapefruit | 00002613 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Grapefruit - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Grapefruit - Food available for consumption (kilograms per year per capita)
+      grapes_and_products__excl_wine__00002620__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Grapes and products (excl wine) | 00002620 || Food available for consumption | 0645pc || kilograms per year
+          per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Grapes and products (excl wine) - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Grapes and products (excl wine) - Food available for consumption (kilograms per year per capita)
+      lemons_and_limes__00002612__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Lemons and limes | 00002612 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Lemons and limes - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Lemons and limes - Food available for consumption (kilograms per year per capita)
+      maize__00002514__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Maize | 00002514 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Maize - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Maize - Food available for consumption (kilocalories per day per capita)
+      marine_fish__other__00002764__production__005511__tonnes:
+        title: Marine Fish, Other | 00002764 || Production | 005511 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Marine Fish, Other - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Marine Fish, Other - Production (tonnes)
+      meat__other__00002735__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Meat, Other | 00002735 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Meat, Other - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, Other - Food available for consumption (kilograms per year per capita)
+      meat__other__00002735__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Meat, Other | 00002735 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Meat, Other - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, Other - Food available for consumption (kilocalories per day per capita)
+      meat__other__00002735__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Meat, Other | 00002735 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Meat, Other - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, Other - Food available for consumption (grams of protein per day per capita)
+      meat__beef__00002731__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Meat, beef | 00002731 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Meat, beef - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, beef - Food available for consumption (kilograms per year per capita)
+      meat__beef__00002731__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Meat, beef | 00002731 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Meat, beef - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, beef - Food available for consumption (kilocalories per day per capita)
+      meat__beef__00002731__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Meat, beef | 00002731 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Meat, beef - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, beef - Food available for consumption (grams of protein per day per capita)
+      meat__pig__00002733__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Meat, pig | 00002733 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Meat, pig - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, pig - Food available for consumption (kilograms per year per capita)
+      meat__pig__00002733__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Meat, pig | 00002733 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Meat, pig - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, pig - Food available for consumption (kilocalories per day per capita)
+      meat__pig__00002733__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Meat, pig | 00002733 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Meat, pig - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, pig - Food available for consumption (grams of protein per day per capita)
+      meat__poultry__00002734__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Meat, poultry | 00002734 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Meat, poultry - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, poultry - Food available for consumption (kilograms per year per capita)
+      meat__poultry__00002734__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Meat, poultry | 00002734 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Meat, poultry - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, poultry - Food available for consumption (kilocalories per day per capita)
+      meat__poultry__00002734__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Meat, poultry | 00002734 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Meat, poultry - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, poultry - Food available for consumption (grams of protein per day per capita)
+      meat__sheep_and_goat__00002732__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Meat, sheep and goat | 00002732 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Meat, sheep and goat - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, sheep and goat - Food available for consumption (kilograms per year per capita)
+      meat__sheep_and_goat__00002732__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Meat, sheep and goat | 00002732 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Meat, sheep and goat - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, sheep and goat - Food available for consumption (kilocalories per day per capita)
+      meat__sheep_and_goat__00002732__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Meat, sheep and goat | 00002732 || Food available for consumption | 0674pc || grams of protein per day per
+          capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Meat, sheep and goat - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, sheep and goat - Food available for consumption (grams of protein per day per capita)
+      meat__total__00002943__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Meat, total | 00002943 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Meat, total - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, total - Food available for consumption (kilograms per year per capita)
+      meat__total__00002943__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Meat, total | 00002943 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Meat, total - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, total - Food available for consumption (kilocalories per day per capita)
+      meat__total__00002943__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Meat, total | 00002943 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Meat, total - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, total - Food available for consumption (grams of protein per day per capita)
+      milk__excluding_butter__00002848__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Milk - Excluding Butter | 00002848 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Milk - Excluding Butter - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Milk - Excluding Butter - Food available for consumption (kilograms per year per capita)
+      milk__excluding_butter__00002848__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Milk - Excluding Butter | 00002848 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Milk - Excluding Butter - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Milk - Excluding Butter - Food available for consumption (kilocalories per day per capita)
+      milk__excluding_butter__00002848__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Milk - Excluding Butter | 00002848 || Food available for consumption | 0674pc || grams of protein per day per
+          capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Milk - Excluding Butter - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Milk - Excluding Butter - Food available for consumption (grams of protein per day per capita)
+      milk__00002948__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Milk | 00002948 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Milk - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Milk - Food available for consumption (kilocalories per day per capita)
+      milk__00002948__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Milk | 00002948 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Milk - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Milk - Food available for consumption (grams of protein per day per capita)
+      miscellaneous_group__00002928__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Miscellaneous group | 00002928 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Miscellaneous group - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Miscellaneous group - Food available for consumption (kilocalories per day per capita)
+      molluscs__other__00002767__production__005511__tonnes:
+        title: Molluscs, Other | 00002767 || Production | 005511 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Molluscs, Other - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Molluscs, Other - Production (tonnes)
+      nuts__00002551__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Nuts | 00002551 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Nuts - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Nuts - Food available for consumption (kilocalories per day per capita)
+      oilcrops__00002913__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Oilcrops | 00002913 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Oilcrops - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Oilcrops - Food available for consumption (kilocalories per day per capita)
+      oranges__00002611__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Oranges | 00002611 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Oranges - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Oranges - Food available for consumption (kilograms per year per capita)
+      palm_oil__00002577__imports__005611__tonnes:
+        title: Palm Oil | 00002577 || Imports | 005611 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Palm Oil - Imports (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Palm Oil - Imports (tonnes)
+      pelagic_fish__00002763__production__005511__tonnes:
+        title: Pelagic Fish | 00002763 || Production | 005511 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Pelagic Fish - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Pelagic Fish - Production (tonnes)
+      pineapples__00002618__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Pineapples | 00002618 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Pineapples - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Pineapples - Food available for consumption (kilograms per year per capita)
+      plantains__00002616__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Plantains | 00002616 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Plantains - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Plantains - Food available for consumption (kilograms per year per capita)
+      population__00002501__total_population__both_sexes__000511__thousand_number:
+        title: Population | 00002501 || Total Population - Both sexes | 000511 || thousand Number
+        unit: thousand Number
+        short_unit: 1000 No
+        processing_level: major
+        display:
+          name: Population - Total Population - Both sexes (thousand Number)
+          shortUnit: 1000 No
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Population - Total Population - Both sexes (thousand Number)
+      pulses__00002911__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Pulses | 00002911 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Pulses - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Pulses - Food available for consumption (kilocalories per day per capita)
+      rice__00002807__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Rice | 00002807 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Rice - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rice - Food available for consumption (kilocalories per day per capita)
+      soybeans__00002555__feed__005521__tonnes:
+        title: Soybeans | 00002555 || Feed | 005521 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Soybeans - Feed (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Soybeans - Feed (tonnes)
+      soybeans__00002555__food__005142__tonnes:
+        title: Soybeans | 00002555 || Food | 005142 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Soybeans - Food (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Soybeans - Food (tonnes)
+      soybeans__00002555__processing__005131__tonnes:
+        title: Soybeans | 00002555 || Processing | 005131 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Soybeans - Processing (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Soybeans - Processing (tonnes)
+      starchy_roots__00002907__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Starchy Roots | 00002907 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Starchy Roots - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Starchy Roots - Food available for consumption (kilocalories per day per capita)
+      sugar__and__sweeteners__00002909__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Sugar & Sweeteners | 00002909 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Sugar & Sweeteners - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sugar & Sweeteners - Food available for consumption (kilocalories per day per capita)
+      sugar_crops__00002908__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Sugar crops | 00002908 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Sugar crops - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sugar crops - Food available for consumption (kilocalories per day per capita)
+      total__00002901__food_available_for_consumption__000664__kilocalories_per_day:
+        title: Total | 00002901 || Food available for consumption | 000664 || kilocalories per day
+        unit: kilocalories per day
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Total - Food available for consumption (kilocalories per day)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Total - Food available for consumption (kilocalories per day)
+      total__00002901__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Total | 00002901 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Total - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Total - Food available for consumption (kilocalories per day per capita)
+      total__00002901__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Total | 00002901 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Total - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Total - Food available for consumption (grams of protein per day per capita)
+      total__00002901__food_available_for_consumption__0684pc__grams_of_fat_per_day_per_capita:
+        title: Total | 00002901 || Food available for consumption | 0684pc || grams of fat per day per capita
+        unit: grams of fat per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Total - Food available for consumption (grams of fat per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Total - Food available for consumption (grams of fat per day per capita)
+      vegetable_oils__00002914__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Vegetable Oils | 00002914 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Vegetable Oils - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Vegetable Oils - Food available for consumption (kilocalories per day per capita)
+      vegetables__00002918__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
+        title: Vegetables | 00002918 || Food available for consumption | 0645pc || kilograms per year per capita
+        unit: kilograms per year per capita
+        short_unit: kg
+        processing_level: major
+        display:
+          name: Vegetables - Food available for consumption (kilograms per year per capita)
+          shortUnit: kg
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Vegetables - Food available for consumption (kilograms per year per capita)
+      vegetables__00002918__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Vegetables | 00002918 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Vegetables - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Vegetables - Food available for consumption (kilocalories per day per capita)
+      vegetal_products__00002903__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Vegetal Products | 00002903 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Vegetal Products - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Vegetal Products - Food available for consumption (kilocalories per day per capita)
+      vegetal_products__00002903__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
+        title: Vegetal Products | 00002903 || Food available for consumption | 0674pc || grams of protein per day per capita
+        unit: grams of protein per day per capita
+        short_unit: g/day
+        processing_level: major
+        display:
+          name: Vegetal Products - Food available for consumption (grams of protein per day per capita)
+          shortUnit: g/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Vegetal Products - Food available for consumption (grams of protein per day per capita)
+      wheat__00002511__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
+        title: Wheat | 00002511 || Food available for consumption | 0664pc || kilocalories per day per capita
+        unit: kilocalories per day per capita
+        short_unit: kcal/day
+        processing_level: major
+        display:
+          name: Wheat - Food available for consumption (kilocalories per day per capita)
+          shortUnit: kcal/day
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Wheat - Food available for consumption (kilocalories per day per capita)

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_fbsc.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_fbsc.meta.yml
@@ -108,77 +108,77 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Cephalopods - Production (tonnes)
+          name: Production if cephalopods
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cephalopods - Production (tonnes)
+          title_public: Production of cephalopods
       cereals__excluding_beer__00002905__exports__005911__tonnes:
         title: Cereals - Excluding Beer | 00002905 || Exports | 005911 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Cereals - Excluding Beer - Exports (tonnes)
+          name: Cereal exports
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cereals - Excluding Beer - Exports (tonnes)
+          title_public: Cereal exports
       cereals__excluding_beer__00002905__feed__005521__tonnes:
         title: Cereals - Excluding Beer | 00002905 || Feed | 005521 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Cereals - Excluding Beer - Feed (tonnes)
+          name: Cereals allocated to animal feed
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cereals - Excluding Beer - Feed (tonnes)
+          title_public: Cereals allocated to animal feed
       cereals__excluding_beer__00002905__food__005142__tonnes:
         title: Cereals - Excluding Beer | 00002905 || Food | 005142 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Cereals - Excluding Beer - Food (tonnes)
+          name: Cereals allocated to food
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cereals - Excluding Beer - Food (tonnes)
+          title_public: Cereals allocated to food
       cereals__excluding_beer__00002905__imports__005611__tonnes:
         title: Cereals - Excluding Beer | 00002905 || Imports | 005611 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Cereals - Excluding Beer - Imports (tonnes)
+          name: Cereal imports
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cereals - Excluding Beer - Imports (tonnes)
+          title_public: Cereal imports
       cereals__excluding_beer__00002905__other_uses__005154__tonnes:
         title: Cereals - Excluding Beer | 00002905 || Other uses | 005154 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Cereals - Excluding Beer - Other uses (tonnes)
+          name: Other uses of cereals
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cereals - Excluding Beer - Other uses (tonnes)
+          title_public: Other uses of cereals
       cereals__excluding_beer__00002905__processing__005131__tonnes:
         title: Cereals - Excluding Beer | 00002905 || Processing | 005131 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Cereals - Excluding Beer - Processing (tonnes)
+          name: Processing of cereals
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cereals - Excluding Beer - Processing (tonnes)
+          title_public: Processing of cereals
       cereals__other__00002520__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Cereals, Other | 00002520 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
@@ -218,11 +218,11 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Crustaceans - Production (tonnes)
+          name: Production of crustaceans
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Crustaceans - Production (tonnes)
+          title_public: Production of crustaceans
       dates__00002619__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Dates | 00002619 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -240,11 +240,11 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Demersal Fish - Production (tonnes)
+          name: Production of demersal fish
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Demersal Fish - Production (tonnes)
+          title_public: Production of demersal fish
       eggs__00002949__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Eggs | 00002949 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -306,22 +306,22 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Fish and seafood - Production (tonnes)
+          name: Production of fish and seafood
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Fish and seafood - Production (tonnes)
+          title_public: Production of fish and seafood
       freshwater_fish__00002761__production__005511__tonnes:
         title: Freshwater Fish | 00002761 || Production | 005511 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Freshwater Fish - Production (tonnes)
+          name: Production of freshwater fish
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Freshwater Fish - Production (tonnes)
+          title_public: Production of freshwater fish
       fruit__00002919__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Fruit | 00002919 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -367,8 +367,7 @@ tables:
         presentation:
           title_public: Per capita consumption of grapefruit
       grapes_and_products__excl_wine__00002620__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
-        title: Grapes and products (excl wine) | 00002620 || Food available for consumption | 0645pc || kilograms per year
-          per capita
+        title: Grapes and products (excl wine) | 00002620 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
         short_unit: kg
         processing_level: major
@@ -406,11 +405,11 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Marine Fish, Other - Production (tonnes)
+          name: Production of other marine fish
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Marine Fish, Other - Production (tonnes)
+          title_public: Production of other marine fish
       meat__other__00002735__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Meat, Other | 00002735 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -566,8 +565,7 @@ tables:
         presentation:
           title_public: Daily supply of calories from sheep and goat meat
       meat__sheep_and_goat__00002732__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
-        title: Meat, sheep and goat | 00002732 || Food available for consumption | 0674pc || grams of protein per day per
-          capita
+        title: Meat, sheep and goat | 00002732 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
@@ -633,8 +631,7 @@ tables:
         presentation:
           title_public: Daily supply of calories from milk, excluding butter
       milk__excluding_butter__00002848__food_available_for_consumption__0674pc__grams_of_protein_per_day_per_capita:
-        title: Milk - Excluding Butter | 00002848 || Food available for consumption | 0674pc || grams of protein per day per
-          capita
+        title: Milk - Excluding Butter | 00002848 || Food available for consumption | 0674pc || grams of protein per day per capita
         unit: grams of protein per day per capita
         short_unit: g/day
         processing_level: major
@@ -683,11 +680,11 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Molluscs, Other - Production (tonnes)
+          name: Production of other molluscs
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Molluscs, Other - Production (tonnes)
+          title_public: Production of other molluscs
       nuts__00002551__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Nuts | 00002551 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
@@ -727,22 +724,22 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Palm Oil - Imports (tonnes)
+          name: Palm oil imports
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Palm Oil - Imports (tonnes)
+          title_public: Palm oil imports
       pelagic_fish__00002763__production__005511__tonnes:
         title: Pelagic Fish | 00002763 || Production | 005511 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Pelagic Fish - Production (tonnes)
+          name: Production of pelagic fish
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Pelagic Fish - Production (tonnes)
+          title_public: Production of pelagic fish
       pineapples__00002618__food_available_for_consumption__0645pc__kilograms_per_year_per_capita:
         title: Pineapples | 00002618 || Food available for consumption | 0645pc || kilograms per year per capita
         unit: kilograms per year per capita
@@ -771,11 +768,11 @@ tables:
         short_unit: 1000 No
         processing_level: major
         display:
-          name: Population - Total Population - Both sexes (thousand Number)
+          name: Population
           shortUnit: 1000 No
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Population - Total Population - Both sexes (thousand Number)
+          title_public: Population
       pulses__00002911__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Pulses | 00002911 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
@@ -804,33 +801,33 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Soybeans - Feed (tonnes)
+          name: Soybeans allocated to animal feed
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Soybeans - Feed (tonnes)
+          title_public: Soybeans allocated to animal feed
       soybeans__00002555__food__005142__tonnes:
         title: Soybeans | 00002555 || Food | 005142 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Soybeans - Food (tonnes)
+          name: Soybeans allocated to food
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Soybeans - Food (tonnes)
+          title_public: Soybeans allocated to food
       soybeans__00002555__processing__005131__tonnes:
         title: Soybeans | 00002555 || Processing | 005131 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Soybeans - Processing (tonnes)
+          name: Processing of soybeans
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Soybeans - Processing (tonnes)
+          title_public: Processing of soybeans
       starchy_roots__00002907__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Starchy Roots | 00002907 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita
@@ -870,11 +867,11 @@ tables:
         short_unit: kcal/day
         processing_level: major
         display:
-          name: Total - Food available for consumption (kilocalories per day)
+          name: Food available for consumption
           shortUnit: kcal/day
           numDecimalPlaces: 2
         presentation:
-          title_public: Total - Food available for consumption (kilocalories per day)
+          title_public: Food available for consumption
       total__00002901__food_available_for_consumption__0664pc__kilocalories_per_day_per_capita:
         title: Total | 00002901 || Food available for consumption | 0664pc || kilocalories per day per capita
         unit: kilocalories per day per capita

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_fbsc.py
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_fbsc.py
@@ -242,8 +242,6 @@ def run(dest_dir: str) -> None:
     assert DATASET_TITLE == dataset_metadata["owid_dataset_title"], error
 
     # Update dataset metadata.
-    ds_garden.metadata.update_period_days = 365
-    ds_garden.metadata.title = dataset_metadata["owid_dataset_title"]
     # The following description is not publicly shown in charts; it is only visible when accessing the catalog.
     ds_garden.metadata.description = dataset_metadata["owid_dataset_description"] + anomaly_descriptions
 

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_fs.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_fs.meta.yml
@@ -15,114 +15,107 @@ tables:
     title: 'Food Security: Suite of Food Security Indicators'
     variables:
       minimum_dietary_energy_requirement__kcal_cap_day__00021056__value__006128__kilocalories_per_capita_per_day:
-        title: Minimum dietary energy requirement  (kcal/cap/day) | 00021056 || Value | 006128 || Kilocalories per capita
-          per day
+        title: Minimum dietary energy requirement  (kcal/cap/day) | 00021056 || Value | 006128 || Kilocalories per capita per day
         unit: Kilocalories per capita per day
         short_unit: kcal/cap/d
         processing_level: major
         display:
-          name: Minimum dietary energy requirement  (kcal/cap/day) - Value (Kilocalories per capita per day)
+          name: Minimum dietary energy requirement
           shortUnit: kcal/cap/d
           numDecimalPlaces: 2
         presentation:
-          title_public: Minimum dietary energy requirement  (kcal/cap/day) - Value (Kilocalories per capita per day)
+          title_public: Minimum dietary energy requirement
       number_of_moderately_or_severely_food_insecure_people__million__3_year_average__00210081__value__006132__million_number:
-        title: |-
-          Number of moderately or severely food insecure people (million) (3-year average) | 00210081 || Value | 006132 || million Number
+        title: Number of moderately or severely food insecure people (million) (3-year average) | 00210081 || Value | 006132 || million Number
         unit: million Number
         short_unit: million No
         processing_level: major
         display:
-          name: Number of moderately or severely food insecure people (million) (3-year average) - Value (million Number)
+          name: Number of moderately or severely food insecure people
           shortUnit: million No
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Number of moderately or severely food insecure people (million) (3-year average) - Value (million
-            Number)
+          title_public: Number of moderately or severely food insecure people
+          title_variant: 3-year average
       number_of_severely_food_insecure_people__million__3_year_average__00210071__value__006132__million_number:
-        title: Number of severely food insecure people (million) (3-year average) | 00210071 || Value | 006132 || million
-          Number
+        title: Number of severely food insecure people (million) (3-year average) | 00210071 || Value | 006132 || million Number
         unit: million Number
         short_unit: million No
         processing_level: major
         display:
-          name: Number of severely food insecure people (million) (3-year average) - Value (million Number)
+          name: Number of severely food insecure people
           shortUnit: million No
           numDecimalPlaces: 2
         presentation:
-          title_public: Number of severely food insecure people (million) (3-year average) - Value (million Number)
+          title_public: Number of severely food insecure people
+          title_variant: 3-year average
       number_of_severely_food_insecure_people__million__annual_value__00210070__value__006132__million_number:
         title: Number of severely food insecure people (million) (annual value) | 00210070 || Value | 006132 || million Number
         unit: million Number
         short_unit: million No
         processing_level: major
         display:
-          name: Number of severely food insecure people (million) (annual value) - Value (million Number)
+          name: Number of severely food insecure people
           shortUnit: million No
           numDecimalPlaces: 2
         presentation:
-          title_public: Number of severely food insecure people (million) (annual value) - Value (million Number)
-      "percentage_of_children_under_5_years_of_age_who_are_stunted__modelled_estimates__percent__00021025__value__006121__percent":
-        title: |-
-          Percentage of children under 5 years of age who are stunted (modelled estimates) (percent) | 00021025 || Value | 006121 || Percent
+          title_public: Number of severely food insecure people
+          title_variant: annual value
+      percentage_of_children_under_5_years_of_age_who_are_stunted__modelled_estimates__percent__00021025__value__006121__percent:
+        title: Percentage of children under 5 years of age who are stunted (modelled estimates) (percent) | 00021025 || Value | 006121 || Percent
         unit: Percent
         short_unit: '%'
         processing_level: major
         display:
-          name: Percentage of children under 5 years of age who are stunted (modelled estimates) (percent) - Value (Percent)
+          name: Percentage of children under 5 years of age who are stunted
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: Percentage of children under 5 years of age who are stunted (modelled estimates) (percent) - Value
-            (Percent)
+          title_public: Percentage of children under 5 years of age who are stunted (Percent)
       prevalence_of_moderate_or_severe_food_insecurity_in_the_total_population__percent__3_year_average__00210091__value__006121__percent:
-        title: |-
-          Prevalence of moderate or severe food insecurity in the total population (percent) (3-year average) | 00210091 || Value | 006121 || Percent
+        title: Prevalence of moderate or severe food insecurity in the total population (percent) (3-year average) | 00210091 || Value | 006121 || Percent
         unit: Percent
         short_unit: '%'
         processing_level: major
         display:
-          name: Prevalence of moderate or severe food insecurity in the total population (percent) (3-year average) - Value
-            (Percent)
+          name: Prevalence of moderate or severe food insecurity in the total population
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: Prevalence of moderate or severe food insecurity in the total population (percent) (3-year average)
-            - Value (Percent)
+          title_public: Prevalence of moderate or severe food insecurity in the total population
+          title_variant: 3-year average
       prevalence_of_severe_food_insecurity_in_the_total_population__percent__3_year_average__00210401__value__006121__percent:
-        title: |-
-          Prevalence of severe food insecurity in the total population (percent) (3-year average) | 00210401 || Value | 006121 || Percent
+        title: Prevalence of severe food insecurity in the total population (percent) (3-year average) | 00210401 || Value | 006121 || Percent
         unit: Percent
         short_unit: '%'
         processing_level: major
         display:
-          name: Prevalence of severe food insecurity in the total population (percent) (3-year average) - Value (Percent)
+          name: Prevalence of severe food insecurity in the total population
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: Prevalence of severe food insecurity in the total population (percent) (3-year average) - Value (Percent)
+          title_public: Prevalence of severe food insecurity in the total population
+          title_variant: 3-year average
       prevalence_of_undernourishment__percent__annual_value__00210040__value__006121__percent:
         title: Prevalence of undernourishment (percent) (annual value) | 00210040 || Value | 006121 || Percent
         unit: Percent
         short_unit: '%'
         processing_level: major
         display:
-          name: Prevalence of undernourishment (percent) (annual value) - Value (Percent)
+          name: Prevalence of undernourishment
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: Prevalence of undernourishment (percent) (annual value) - Value (Percent)
+          title_public: Prevalence of undernourishment
+          title_variant: annual value
       share_of_dietary_energy_supply_derived_from_cereals__roots_and_tubers__kcal_cap_day__3_year_average__00021012__value__006121__percent:
-        title: |-
-          Share of dietary energy supply derived from cereals, roots and tubers (kcal/cap/day) (3-year average) | 00021012 || Value | 006121 || Percent
+        title: Share of dietary energy supply derived from cereals, roots and tubers (kcal/cap/day) (3-year average) | 00021012 || Value | 006121 || Percent
         unit: Percent
         short_unit: '%'
         processing_level: major
         display:
-          name: Share of dietary energy supply derived from cereals, roots and tubers (kcal/cap/day) (3-year average) - Value
-            (Percent)
+          name: Share of dietary energy supply derived from cereals, roots and tubers
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: Share of dietary energy supply derived from cereals, roots and tubers (kcal/cap/day) (3-year average)
-            - Value (Percent)
+          title_public: Share of dietary energy supply derived from cereals, roots and tubers

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_fs.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_fs.meta.yml
@@ -16,7 +16,7 @@ tables:
     variables:
       minimum_dietary_energy_requirement__kcal_cap_day__00021056__value__006128__kilocalories_per_capita_per_day:
         title: Minimum dietary energy requirement  (kcal/cap/day) | 00021056 || Value | 006128 || Kilocalories per capita per day
-        unit: Kilocalories per capita per day
+        unit: kilocalories per capita per day
         short_unit: kcal/cap/d
         processing_level: major
         display:
@@ -63,7 +63,7 @@ tables:
           title_variant: annual value
       percentage_of_children_under_5_years_of_age_who_are_stunted__modelled_estimates__percent__00021025__value__006121__percent:
         title: Percentage of children under 5 years of age who are stunted (modelled estimates) (percent) | 00021025 || Value | 006121 || Percent
-        unit: Percent
+        unit: percent
         short_unit: '%'
         processing_level: major
         display:
@@ -74,7 +74,7 @@ tables:
           title_public: Percentage of children under 5 years of age who are stunted (Percent)
       prevalence_of_moderate_or_severe_food_insecurity_in_the_total_population__percent__3_year_average__00210091__value__006121__percent:
         title: Prevalence of moderate or severe food insecurity in the total population (percent) (3-year average) | 00210091 || Value | 006121 || Percent
-        unit: Percent
+        unit: percent
         short_unit: '%'
         processing_level: major
         display:
@@ -86,7 +86,7 @@ tables:
           title_variant: 3-year average
       prevalence_of_severe_food_insecurity_in_the_total_population__percent__3_year_average__00210401__value__006121__percent:
         title: Prevalence of severe food insecurity in the total population (percent) (3-year average) | 00210401 || Value | 006121 || Percent
-        unit: Percent
+        unit: percent
         short_unit: '%'
         processing_level: major
         display:
@@ -98,7 +98,7 @@ tables:
           title_variant: 3-year average
       prevalence_of_undernourishment__percent__annual_value__00210040__value__006121__percent:
         title: Prevalence of undernourishment (percent) (annual value) | 00210040 || Value | 006121 || Percent
-        unit: Percent
+        unit: percent
         short_unit: '%'
         processing_level: major
         display:
@@ -110,7 +110,7 @@ tables:
           title_variant: annual value
       share_of_dietary_energy_supply_derived_from_cereals__roots_and_tubers__kcal_cap_day__3_year_average__00021012__value__006121__percent:
         title: Share of dietary energy supply derived from cereals, roots and tubers (kcal/cap/day) (3-year average) | 00021012 || Value | 006121 || Percent
-        unit: Percent
+        unit: percent
         short_unit: '%'
         processing_level: major
         display:

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_fs.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_fs.meta.yml
@@ -1,0 +1,130 @@
+dataset:
+  title: 'Food Security: Suite of Food Security Indicators'
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
+tables:
+  faostat_fs_flat:
+    title: 'Food Security: Suite of Food Security Indicators'
+    variables:
+      minimum_dietary_energy_requirement__kcal_cap_day__00021056__value__006128__kilocalories_per_capita_per_day:
+        title: Minimum dietary energy requirement  (kcal/cap/day) | 00021056 || Value | 006128 || Kilocalories per capita
+          per day
+        unit: Kilocalories per capita per day
+        short_unit: kcal/cap/d
+        processing_level: major
+        display:
+          name: Minimum dietary energy requirement  (kcal/cap/day) - Value (Kilocalories per capita per day)
+          shortUnit: kcal/cap/d
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Minimum dietary energy requirement  (kcal/cap/day) - Value (Kilocalories per capita per day)
+      number_of_moderately_or_severely_food_insecure_people__million__3_year_average__00210081__value__006132__million_number:
+        title: |-
+          Number of moderately or severely food insecure people (million) (3-year average) | 00210081 || Value | 006132 || million Number
+        unit: million Number
+        short_unit: million No
+        processing_level: major
+        display:
+          name: Number of moderately or severely food insecure people (million) (3-year average) - Value (million Number)
+          shortUnit: million No
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Number of moderately or severely food insecure people (million) (3-year average) - Value (million
+            Number)
+      number_of_severely_food_insecure_people__million__3_year_average__00210071__value__006132__million_number:
+        title: Number of severely food insecure people (million) (3-year average) | 00210071 || Value | 006132 || million
+          Number
+        unit: million Number
+        short_unit: million No
+        processing_level: major
+        display:
+          name: Number of severely food insecure people (million) (3-year average) - Value (million Number)
+          shortUnit: million No
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Number of severely food insecure people (million) (3-year average) - Value (million Number)
+      number_of_severely_food_insecure_people__million__annual_value__00210070__value__006132__million_number:
+        title: Number of severely food insecure people (million) (annual value) | 00210070 || Value | 006132 || million Number
+        unit: million Number
+        short_unit: million No
+        processing_level: major
+        display:
+          name: Number of severely food insecure people (million) (annual value) - Value (million Number)
+          shortUnit: million No
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Number of severely food insecure people (million) (annual value) - Value (million Number)
+      "percentage_of_children_under_5_years_of_age_who_are_stunted__modelled_estimates__percent__00021025__value__006121__percent":
+        title: |-
+          Percentage of children under 5 years of age who are stunted (modelled estimates) (percent) | 00021025 || Value | 006121 || Percent
+        unit: Percent
+        short_unit: '%'
+        processing_level: major
+        display:
+          name: Percentage of children under 5 years of age who are stunted (modelled estimates) (percent) - Value (Percent)
+          shortUnit: '%'
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Percentage of children under 5 years of age who are stunted (modelled estimates) (percent) - Value
+            (Percent)
+      ? |-
+        prevalence_of_moderate_or_severe_food_insecurity_in_the_total_population__percent__3_year_average__00210091__value__006121__percent
+      : title: |-
+          Prevalence of moderate or severe food insecurity in the total population (percent) (3-year average) | 00210091 || Value | 006121 || Percent
+        unit: Percent
+        short_unit: '%'
+        processing_level: major
+        display:
+          name: Prevalence of moderate or severe food insecurity in the total population (percent) (3-year average) - Value
+            (Percent)
+          shortUnit: '%'
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Prevalence of moderate or severe food insecurity in the total population (percent) (3-year average)
+            - Value (Percent)
+      prevalence_of_severe_food_insecurity_in_the_total_population__percent__3_year_average__00210401__value__006121__percent:
+        title: |-
+          Prevalence of severe food insecurity in the total population (percent) (3-year average) | 00210401 || Value | 006121 || Percent
+        unit: Percent
+        short_unit: '%'
+        processing_level: major
+        display:
+          name: Prevalence of severe food insecurity in the total population (percent) (3-year average) - Value (Percent)
+          shortUnit: '%'
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Prevalence of severe food insecurity in the total population (percent) (3-year average) - Value (Percent)
+      prevalence_of_undernourishment__percent__annual_value__00210040__value__006121__percent:
+        title: Prevalence of undernourishment (percent) (annual value) | 00210040 || Value | 006121 || Percent
+        unit: Percent
+        short_unit: '%'
+        processing_level: major
+        display:
+          name: Prevalence of undernourishment (percent) (annual value) - Value (Percent)
+          shortUnit: '%'
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Prevalence of undernourishment (percent) (annual value) - Value (Percent)
+      ? |-
+        share_of_dietary_energy_supply_derived_from_cereals__roots_and_tubers__kcal_cap_day__3_year_average__00021012__value__006121__percent
+      : title: |-
+          Share of dietary energy supply derived from cereals, roots and tubers (kcal/cap/day) (3-year average) | 00021012 || Value | 006121 || Percent
+        unit: Percent
+        short_unit: '%'
+        processing_level: major
+        display:
+          name: Share of dietary energy supply derived from cereals, roots and tubers (kcal/cap/day) (3-year average) - Value
+            (Percent)
+          shortUnit: '%'
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Share of dietary energy supply derived from cereals, roots and tubers (kcal/cap/day) (3-year average)
+            - Value (Percent)

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_fs.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_fs.meta.yml
@@ -75,9 +75,8 @@ tables:
         presentation:
           title_public: Percentage of children under 5 years of age who are stunted (modelled estimates) (percent) - Value
             (Percent)
-      ? |-
-        prevalence_of_moderate_or_severe_food_insecurity_in_the_total_population__percent__3_year_average__00210091__value__006121__percent
-      : title: |-
+      prevalence_of_moderate_or_severe_food_insecurity_in_the_total_population__percent__3_year_average__00210091__value__006121__percent:
+        title: |-
           Prevalence of moderate or severe food insecurity in the total population (percent) (3-year average) | 00210091 || Value | 006121 || Percent
         unit: Percent
         short_unit: '%'
@@ -113,9 +112,8 @@ tables:
           numDecimalPlaces: 2
         presentation:
           title_public: Prevalence of undernourishment (percent) (annual value) - Value (Percent)
-      ? |-
-        share_of_dietary_energy_supply_derived_from_cereals__roots_and_tubers__kcal_cap_day__3_year_average__00021012__value__006121__percent
-      : title: |-
+      share_of_dietary_energy_supply_derived_from_cereals__roots_and_tubers__kcal_cap_day__3_year_average__00021012__value__006121__percent:
+        title: |-
           Share of dietary energy supply derived from cereals, roots and tubers (kcal/cap/day) (3-year average) | 00021012 || Value | 006121 || Percent
         unit: Percent
         short_unit: '%'

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_fs.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_fs.meta.yml
@@ -27,20 +27,20 @@ tables:
           title_public: Minimum dietary energy requirement
       number_of_moderately_or_severely_food_insecure_people__million__3_year_average__00210081__value__006132__million_number:
         title: Number of moderately or severely food insecure people (million) (3-year average) | 00210081 || Value | 006132 || million Number
-        unit: million Number
-        short_unit: million No
+        unit: millions
+        short_unit: millions
         processing_level: major
         display:
           name: Number of moderately or severely food insecure people
-          shortUnit: million No
+          shortUnit: millions
           numDecimalPlaces: 0
         presentation:
           title_public: Number of moderately or severely food insecure people
           title_variant: 3-year average
       number_of_severely_food_insecure_people__million__3_year_average__00210071__value__006132__million_number:
         title: Number of severely food insecure people (million) (3-year average) | 00210071 || Value | 006132 || million Number
-        unit: million Number
-        short_unit: million No
+        unit: millions
+        short_unit: millions
         processing_level: major
         display:
           name: Number of severely food insecure people
@@ -51,8 +51,8 @@ tables:
           title_variant: 3-year average
       number_of_severely_food_insecure_people__million__annual_value__00210070__value__006132__million_number:
         title: Number of severely food insecure people (million) (annual value) | 00210070 || Value | 006132 || million Number
-        unit: million Number
-        short_unit: million No
+        unit: millions
+        short_unit: millions
         processing_level: major
         display:
           name: Number of severely food insecure people
@@ -67,11 +67,11 @@ tables:
         short_unit: '%'
         processing_level: major
         display:
-          name: Percentage of children under 5 years of age who are stunted
+          name: Percentage of children under five years of age who are stunted
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: Percentage of children under 5 years of age who are stunted (Percent)
+          title_public: Percentage of children under five years of age who are stunted (Percent)
       prevalence_of_moderate_or_severe_food_insecurity_in_the_total_population__percent__3_year_average__00210091__value__006121__percent:
         title: Prevalence of moderate or severe food insecurity in the total population (percent) (3-year average) | 00210091 || Value | 006121 || Percent
         unit: percent

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_ic.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_ic.meta.yml
@@ -1,0 +1,27 @@
+dataset:
+  title: 'Investment: Credit to Agriculture'
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
+tables:
+  faostat_ic_flat:
+    title: 'Investment: Credit to Agriculture'
+    variables:
+      credit_to_agriculture__forestry_and_fishing__00023068__agriculture_orientation_index_usd__006159:
+        title: Credit to Agriculture, Forestry and Fishing | 00023068 || Agriculture orientation index US$ | 006159 ||
+        unit: ''
+        short_unit: ''
+        processing_level: major
+        display:
+          name: Credit to Agriculture, Forestry and Fishing - Agriculture orientation index US$ ()
+          shortUnit: ''
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Credit to Agriculture, Forestry and Fishing - Agriculture orientation index US$ ()

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_ic.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_ic.meta.yml
@@ -16,12 +16,14 @@ tables:
     variables:
       credit_to_agriculture__forestry_and_fishing__00023068__agriculture_orientation_index_usd__006159:
         title: Credit to Agriculture, Forestry and Fishing | 00023068 || Agriculture orientation index US$ | 006159 ||
+        description_short: |-
+          A value greater than 1 means the agriculture sector receives a higher share of government spending relative to its economic value. A value less than 1 reflects a lower orientation to agriculture.
         unit: ''
         short_unit: ''
         processing_level: major
         display:
-          name: Credit to Agriculture, Forestry and Fishing - Agriculture orientation index US$ ()
+          name: "Agriculture orientation index: Credit to agriculture, forestry and fishing"
           shortUnit: ''
           numDecimalPlaces: 2
         presentation:
-          title_public: Credit to Agriculture, Forestry and Fishing - Agriculture orientation index US$ ()
+          title_public: "Agriculture orientation index: Credit to agriculture, forestry and fishing"

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_lc.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_lc.meta.yml
@@ -18,7 +18,7 @@ tables:
         title: Artificial surfaces (including urban and associated areas) | 00006970 || Area from CGLS | 005006 || thousand Hectares
         description_key:
           - Land cover information is based on maps from the European Copernicus Global Land Service (CGLS), with a spatial resolution of 100m.
-        unit: thousand Hectares
+        unit: thousand hectares
         short_unit: 1000 ha
         processing_level: major
         display:
@@ -31,7 +31,7 @@ tables:
         title: Inland water bodies | 00006981 || Area from CGLS | 005006 || thousand Hectares
         description_key:
           - Land cover information is based on maps from the European Copernicus Global Land Service (CGLS), with a spatial resolution of 100m.
-        unit: thousand Hectares
+        unit: thousand hectares
         short_unit: 1000 ha
         processing_level: major
         display:
@@ -44,7 +44,7 @@ tables:
         title: Shrub-covered areas | 00006976 || Area from CCI_LC | 005008 || thousand Hectares
         description_key:
           - Land cover information is based on maps from the European Spatial Agency (ESA) Climate Change Initiative (CCI) produced by the Université catholique de Louvain (UCL)-Geomatics and now under the European Copernicus Program.
-        unit: thousand Hectares
+        unit: thousand hectares
         short_unit: 1000 ha
         processing_level: major
         display:

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_lc.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_lc.meta.yml
@@ -1,0 +1,50 @@
+dataset:
+  title: 'Agri-Environmental Indicators: Land Cover'
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
+tables:
+  faostat_lc_flat:
+    title: 'Agri-Environmental Indicators: Land Cover'
+    variables:
+      artificial_surfaces__including_urban_and_associated_areas__00006970__area_from_cgls__005006__thousand_hectares:
+        title: Artificial surfaces (including urban and associated areas) | 00006970 || Area from CGLS | 005006 || thousand
+          Hectares
+        unit: thousand Hectares
+        short_unit: 1000 ha
+        processing_level: major
+        display:
+          name: Artificial surfaces (including urban and associated areas) - Area from CGLS (thousand Hectares)
+          shortUnit: 1000 ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Artificial surfaces (including urban and associated areas) - Area from CGLS (thousand Hectares)
+      inland_water_bodies__00006981__area_from_cgls__005006__thousand_hectares:
+        title: Inland water bodies | 00006981 || Area from CGLS | 005006 || thousand Hectares
+        unit: thousand Hectares
+        short_unit: 1000 ha
+        processing_level: major
+        display:
+          name: Inland water bodies - Area from CGLS (thousand Hectares)
+          shortUnit: 1000 ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Inland water bodies - Area from CGLS (thousand Hectares)
+      shrub_covered_areas__00006976__area_from_cci_lc__005008__thousand_hectares:
+        title: Shrub-covered areas | 00006976 || Area from CCI_LC | 005008 || thousand Hectares
+        unit: thousand Hectares
+        short_unit: 1000 ha
+        processing_level: major
+        display:
+          name: Shrub-covered areas - Area from CCI_LC (thousand Hectares)
+          shortUnit: 1000 ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Shrub-covered areas - Area from CCI_LC (thousand Hectares)

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_lc.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_lc.meta.yml
@@ -15,36 +15,41 @@ tables:
     title: 'Agri-Environmental Indicators: Land Cover'
     variables:
       artificial_surfaces__including_urban_and_associated_areas__00006970__area_from_cgls__005006__thousand_hectares:
-        title: Artificial surfaces (including urban and associated areas) | 00006970 || Area from CGLS | 005006 || thousand
-          Hectares
+        title: Artificial surfaces (including urban and associated areas) | 00006970 || Area from CGLS | 005006 || thousand Hectares
+        description_key:
+          - Land cover information is based on maps from the European Copernicus Global Land Service (CGLS), with a spatial resolution of 100m.
         unit: thousand Hectares
         short_unit: 1000 ha
         processing_level: major
         display:
-          name: Artificial surfaces (including urban and associated areas) - Area from CGLS (thousand Hectares)
+          name: Area of artificial surfaces, including urban and associated areas
           shortUnit: 1000 ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Artificial surfaces (including urban and associated areas) - Area from CGLS (thousand Hectares)
+          title_public: Area from artificial surfaces, including urban and associated areas
       inland_water_bodies__00006981__area_from_cgls__005006__thousand_hectares:
         title: Inland water bodies | 00006981 || Area from CGLS | 005006 || thousand Hectares
+        description_key:
+          - Land cover information is based on maps from the European Copernicus Global Land Service (CGLS), with a spatial resolution of 100m.
         unit: thousand Hectares
         short_unit: 1000 ha
         processing_level: major
         display:
-          name: Inland water bodies - Area from CGLS (thousand Hectares)
+          name: Area of inland water bodies
           shortUnit: 1000 ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Inland water bodies - Area from CGLS (thousand Hectares)
+          title_public: Area from inland water bodies
       shrub_covered_areas__00006976__area_from_cci_lc__005008__thousand_hectares:
         title: Shrub-covered areas | 00006976 || Area from CCI_LC | 005008 || thousand Hectares
+        description_key:
+          - Land cover information is based on maps from the European Spatial Agency (ESA) Climate Change Initiative (CCI) produced by the Université catholique de Louvain (UCL)-Geomatics and now under the European Copernicus Program.
         unit: thousand Hectares
         short_unit: 1000 ha
         processing_level: major
         display:
-          name: Shrub-covered areas - Area from CCI_LC (thousand Hectares)
+          name: Area of shrub-covered land
           shortUnit: 1000 ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Shrub-covered areas - Area from CCI_LC (thousand Hectares)
+          title_public: Area from shrub-covered land

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_qcl.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_qcl.meta.yml
@@ -21,21 +21,11 @@ tables:
         description_short: Measured in tonnes per hectare.
         description_key:
           - Cereals include wheat, rice, maize, barley, oats, rye, millet, sorghum, buckwheat, and mixed grains.
-        description_from_producer: |
-          Cereals are generally of the gramineous family and, in the FAO concept, refer to crops harvested for dry grain only. Crops harvested green for forage, silage or grazingare classified as fodder crops. Also excluded are industrial crops, e.g. broom sorghum (Crude organic materials nes) and sweet sorghum when grown for syrup (Sugar crops nes). For international trade classifications, fresh cereals (other than sweet corn), whether or not suitable for use as fresh vegetables, are classified as cereals.
-
-          Cereals are identified according to their genus. However, when two or more genera are sown and harvested as a mixture they should be classified and reported as "mixed grains". Production data are reported in terms of clean, dry weight of grains (12-14 percent moisture) in the form usually marketed. Rice, however, is reported in terms of paddy. Apart from moisture content and inedible substances such as cellulose, cereal grains contain, along with traces of minerals and vitamins, carbohydrates - mainly starches - (comprising 65-75 percent of their total weight), as well as proteins (6-12 percent) and fat (1-5 percent).
-
-          The FAO definitions cover 17 primary cereals, of which one - white maize - is a component of maize. Each definition is listed along with its code, botanical name or names, and a short description. Cereal products derive either from the processing of grain through one or more mechanical or chemical operations, or from the processing of flour, meal or starch. Each cereal product is listed after the cereal from which it is derived.
-
-          Yield: Harvested production per unit of harvested area for crop products. In most of the cases yield data are not recorded but obtained by dividing the production data by the data on area harvested. Data on yields of permanent crops are not as reliable as those for temporary crops either because most of the area information may correspond to planted area, as for grapes, or because of the scarcity and unreliability of the area figures reported by the countries, as for example for cocoa and coffee. Source: FAO Statistics Division.
-        processing_level: major
         presentation:
-          attribution_short: FAO
+          title_public: Cereal yields
           topic_tags:
             - Agricultural Production
             - Crop Yields
-          title_public: Cereal yields
           grapher_config:
             title: Cereal yields
             subtitle: |-
@@ -64,11 +54,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Almonds - Yield (tonnes per hectare)
+          name: Almond yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Almonds - Yield (tonnes per hectare)
+          title_public: Almond yields
       apples__00000515__area_harvested__005312__hectares:
         title: Apples | 00000515 || Area harvested | 005312 || hectares
         unit: hectares
@@ -130,11 +120,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Bananas - Yield (tonnes per hectare)
+          name: Banana yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Bananas - Yield (tonnes per hectare)
+          title_public: Banana yields
       barley__00000044__area_harvested__005312__hectares:
         title: Barley | 00000044 || Area harvested | 005312 || hectares
         unit: hectares
@@ -163,11 +153,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Barley - Yield (tonnes per hectare)
+          name: Barley yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Barley - Yield (tonnes per hectare)
+          title_public: Barley yields
       beans__dry__00000176__area_harvested__005312__hectares:
         title: Beans, dry | 00000176 || Area harvested | 005312 || hectares
         unit: hectares
@@ -196,11 +186,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Beans, dry - Yield (tonnes per hectare)
+          name: Bean yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Beans, dry - Yield (tonnes per hectare)
+          title_public: Bean yields
       cashew_nuts__00000217__production__005510__tonnes:
         title: Cashew nuts | 00000217 || Production | 005510 || tonnes
         unit: tonnes
@@ -218,11 +208,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Cashew nuts - Yield (tonnes per hectare)
+          name: Cashew nut yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Cashew nuts - Yield (tonnes per hectare)
+          title_public: Cashew nut yields
       cassava__00000125__area_harvested__005312__hectares:
         title: Cassava | 00000125 || Area harvested | 005312 || hectares
         unit: hectares
@@ -251,11 +241,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Cassava - Yield (tonnes per hectare)
+          name: Cassava yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Cassava - Yield (tonnes per hectare)
+          title_public: Cassava yields
       castor_oil_seed__00000265__area_harvested__005312__hectares:
         title: Castor oil seed | 00000265 || Area harvested | 005312 || hectares
         unit: hectares
@@ -300,17 +290,6 @@ tables:
           numDecimalPlaces: 2
         presentation:
           title_public: Cereals - Production (tonnes)
-      cereals__00001717__yield__005419__tonnes_per_hectare:
-        title: Cereals | 00001717 || Yield | 005419 || tonnes per hectare
-        unit: tonnes per hectare
-        short_unit: t/ha
-        processing_level: major
-        display:
-          name: Cereals - Yield (tonnes per hectare)
-          shortUnit: t/ha
-          numDecimalPlaces: 2
-        presentation:
-          title_public: Cereal yields
       cocoa_beans__00000661__area_harvested__005312__hectares:
         title: Cocoa beans | 00000661 || Area harvested | 005312 || hectares
         unit: hectares
@@ -339,11 +318,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Cocoa beans - Yield (tonnes per hectare)
+          name: Cocoa bean yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Cocoa beans - Yield (tonnes per hectare)
+          title_public: Cocoa bean yields
       coconut_oil__00000252__production__005510__tonnes:
         title: Coconut oil | 00000252 || Production | 005510 || tonnes
         unit: tonnes
@@ -383,11 +362,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Coffee, green - Yield (tonnes per hectare)
+          name: Coffee bean yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Coffee, green - Yield (tonnes per hectare)
+          title_public: Coffee bean yields
       cottonseed_oil__00000331__production__005510__tonnes:
         title: Cottonseed oil | 00000331 || Production | 005510 || tonnes
         unit: tonnes
@@ -416,11 +395,11 @@ tables:
         short_unit: kg/animal
         processing_level: major
         display:
-          name: Eggs - Yield (kilograms per animal)
+          name: Eggs per bird
           shortUnit: kg/animal
           numDecimalPlaces: 2
         presentation:
-          title_public: Eggs - Yield (kilograms per animal)
+          title_public: Eggs per bird
       grapes__00000560__production__005510__tonnes:
         title: Grapes | 00000560 || Production | 005510 || tonnes
         unit: tonnes
@@ -460,11 +439,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Groundnuts - Yield (tonnes per hectare)
+          name: Groundnut yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Groundnuts - Yield (tonnes per hectare)
+          title_public: Groundnut yields
       karite_nuts__00000263__area_harvested__005312__hectares:
         title: Karite nuts | 00000263 || Area harvested | 005312 || hectares
         unit: hectares
@@ -482,11 +461,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Lettuce - Yield (tonnes per hectare)
+          name: Lettuce yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Lettuce - Yield (tonnes per hectare)
+          title_public: Lettuce yields
       linseed_oil__00000334__production__005510__tonnes:
         title: Linseed oil | 00000334 || Production | 005510 || tonnes
         unit: tonnes
@@ -548,11 +527,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Maize - Yield (tonnes per hectare)
+          name: Maize yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Maize - Yield (tonnes per hectare)
+          title_public: Maize yields
       meat_of_cattle_with_the_bone__fresh_or_chilled__00000867__producing_or_slaughtered_animals__005320__animals:
         title: Meat of cattle with the bone, fresh or chilled | 00000867 || Producing or slaughtered animals | 005320 || animals
         unit: animals
@@ -570,11 +549,11 @@ tables:
         short_unit: kg/animal
         processing_level: major
         display:
-          name: Meat of cattle with the bone, fresh or chilled - Yield (kilograms per animal)
+          name: Cattle meat yield per animal
           shortUnit: kg/animal
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat of cattle with the bone, fresh or chilled - Yield (kilograms per animal)
+          title_public: Cattle meat yield per animal
       meat__beef_and_buffalo__00001806__production__005510__tonnes:
         title: Meat, beef and buffalo | 00001806 || Production | 005510 || tonnes
         unit: tonnes
@@ -625,11 +604,11 @@ tables:
         short_unit: kg/animal
         processing_level: major
         display:
-          name: Meat, chicken - Yield (kilograms per animal)
+          name: Chicken meat yield per animal
           shortUnit: kg/animal
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, chicken - Yield (kilograms per animal)
+          title_public: Chicken meat yield per animal
       meat__duck__00001069__producing_or_slaughtered_animals__005321__animals:
         title: Meat, duck | 00001069 || Producing or slaughtered animals | 005321 || animals
         unit: animals
@@ -713,11 +692,11 @@ tables:
         short_unit: kg/animal
         processing_level: major
         display:
-          name: Meat, pig - Yield (kilograms per animal)
+          name: Pig meat yield per animal
           shortUnit: kg/animal
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, pig - Yield (kilograms per animal)
+          title_public: Pig meat yield per animal
       meat__poultry__00001808__production__005510__tonnes:
         title: Meat, poultry | 00001808 || Production | 005510 || tonnes
         unit: tonnes
@@ -735,11 +714,11 @@ tables:
         short_unit: kg/animal
         processing_level: major
         display:
-          name: Meat, poultry - Yield (kilograms per animal)
+          name: Poultry meat yield per animal
           shortUnit: kg/animal
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, poultry - Yield (kilograms per animal)
+          title_public: Poultry meat yield per animal
       meat__sheep_and_goat__00001807__production__005510__tonnes:
         title: Meat, sheep and goat | 00001807 || Production | 005510 || tonnes
         unit: tonnes
@@ -790,22 +769,22 @@ tables:
         short_unit: kg/animal
         processing_level: major
         display:
-          name: Milk - Yield (kilograms per animal)
+          name: Milk yield per animal
           shortUnit: kg/animal
           numDecimalPlaces: 2
         presentation:
-          title_public: Milk - Yield (kilograms per animal)
+          title_public: Milk yield per animal
       millet__00000079__yield__005419__tonnes_per_hectare:
         title: Millet | 00000079 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
         short_unit: t/ha
         processing_level: major
         display:
-          name: Millet - Yield (tonnes per hectare)
+          name: Millet yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Millet - Yield (tonnes per hectare)
+          title_public: Millet yields
       olive_oil__00000261__production__005510__tonnes:
         title: Olive oil | 00000261 || Production | 005510 || tonnes
         unit: tonnes
@@ -856,11 +835,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Oranges - Yield (tonnes per hectare)
+          name: Orange yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Oranges - Yield (tonnes per hectare)
+          title_public: Orange yields
       palm_fruit_oil__00000254__area_harvested__005312__hectares:
         title: Palm fruit oil | 00000254 || Area harvested | 005312 || hectares
         unit: hectares
@@ -889,11 +868,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Palm fruit oil - Yield (tonnes per hectare)
+          name: Palm fruit oil yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Palm fruit oil - Yield (tonnes per hectare)
+          title_public: Palm fruit oil yields
       palm_kernel_oil__00000258__production__005510__tonnes:
         title: Palm kernel oil | 00000258 || Production | 005510 || tonnes
         unit: tonnes
@@ -944,11 +923,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Peas, dry - Yield (tonnes per hectare)
+          name: Pea yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Peas, dry - Yield (tonnes per hectare)
+          title_public: Pea yields
       potatoes__00000116__area_harvested__005312__hectares:
         title: Potatoes | 00000116 || Area harvested | 005312 || hectares
         unit: hectares
@@ -977,11 +956,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Potatoes - Yield (tonnes per hectare)
+          name: Potato yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Potatoes - Yield (tonnes per hectare)
+          title_public: Potato yields
       poultry__00002029__stocks__005112__animals:
         title: Poultry | 00002029 || Stocks | 005112 || animals
         unit: animals
@@ -1021,11 +1000,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Rapeseed - Yield (tonnes per hectare)
+          name: Rapeseed yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Rapeseed - Yield (tonnes per hectare)
+          title_public: Rapeseed yields
       rice__00000027__area_harvested__005312__hectares:
         title: Rice | 00000027 || Area harvested | 005312 || hectares
         unit: hectares
@@ -1054,11 +1033,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Rice - Yield (tonnes per hectare)
+          name: Rice yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Rice - Yield (tonnes per hectare)
+          title_public: Rice yields
       rye__00000071__area_harvested__005312__hectares:
         title: Rye | 00000071 || Area harvested | 005312 || hectares
         unit: hectares
@@ -1109,11 +1088,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Seed cotton - Yield (tonnes per hectare)
+          name: Seed cotton yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Seed cotton - Yield (tonnes per hectare)
+          title_public: Seed cotton yields
       sesame_seed__00000289__area_harvested__005312__hectares:
         title: Sesame seed | 00000289 || Area harvested | 005312 || hectares
         unit: hectares
@@ -1142,11 +1121,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Sorghum - Yield (tonnes per hectare)
+          name: Sorghum yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Sorghum - Yield (tonnes per hectare)
+          title_public: Sorghum yields
       soybeans__00000236__area_harvested__005312__hectares:
         title: Soybeans | 00000236 || Area harvested | 005312 || hectares
         unit: hectares
@@ -1175,11 +1154,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Soybeans - Yield (tonnes per hectare)
+          name: Soybean yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Soybeans - Yield (tonnes per hectare)
+          title_public: Soybean yields
       sugar_beet__00000157__area_harvested__005312__hectares:
         title: Sugar beet | 00000157 || Area harvested | 005312 || hectares
         unit: hectares
@@ -1230,11 +1209,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Sugar cane - Yield (tonnes per hectare)
+          name: Sugar cane yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Sugar cane - Yield (tonnes per hectare)
+          title_public: Sugar cane yields
       sunflower_seed__00000267__area_harvested__005312__hectares:
         title: Sunflower seed | 00000267 || Area harvested | 005312 || hectares
         unit: hectares
@@ -1263,11 +1242,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Sunflower seed - Yield (tonnes per hectare)
+          name: Sunflower seed yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Sunflower seed - Yield (tonnes per hectare)
+          title_public: Sunflower seed yields
       sweet_potatoes__00000122__production__005510__tonnes:
         title: Sweet potatoes | 00000122 || Production | 005510 || tonnes
         unit: tonnes
@@ -1340,11 +1319,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Tomatoes - Yield (tonnes per hectare)
+          name: Tomato yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Tomatoes - Yield (tonnes per hectare)
+          title_public: Tomato yields
       tung_nuts__00000275__area_harvested__005312__hectares:
         title: Tung nuts | 00000275 || Area harvested | 005312 || hectares
         unit: hectares
@@ -1384,11 +1363,11 @@ tables:
         short_unit: t/ha
         processing_level: major
         display:
-          name: Wheat - Yield (tonnes per hectare)
+          name: Wheat yields
           shortUnit: t/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Wheat - Yield (tonnes per hectare)
+          title_public: Wheat yields
       wine__00000564__production__005510__tonnes:
         title: Wine | 00000564 || Production | 005510 || tonnes
         unit: tonnes

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_qcl.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_qcl.meta.yml
@@ -65,55 +65,55 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Apples - Area harvested (hectares)
+          name: Land used for apple production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Apples - Area harvested (hectares)
+          title_public: Land used for apple production
       apples__00000515__production__005510__tonnes:
         title: Apples | 00000515 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Apples - Production (tonnes)
+          name: Apple production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Apples - Production (tonnes)
+          title_public: Apple production
       avocados__00000572__production__005510__tonnes:
         title: Avocados | 00000572 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Avocados - Production (tonnes)
+          name: Avocado production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Avocados - Production (tonnes)
+          title_public: Avocado production
       bananas__00000486__area_harvested__005312__hectares:
         title: Bananas | 00000486 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Bananas - Area harvested (hectares)
+          name: Land used for banana production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Bananas - Area harvested (hectares)
+          title_public: Land used for banana production
       bananas__00000486__production__005510__tonnes:
         title: Bananas | 00000486 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Bananas - Production (tonnes)
+          name: Banana production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Bananas - Production (tonnes)
+          title_public: Banana production
       bananas__00000486__yield__005419__tonnes_per_hectare:
         title: Bananas | 00000486 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -131,22 +131,22 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Barley - Area harvested (hectares)
+          name: Land used for barley production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Barley - Area harvested (hectares)
+          title_public: Land used for barley production
       barley__00000044__production__005510__tonnes:
         title: Barley | 00000044 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Barley - Production (tonnes)
+          name: Barley production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Barley - Production (tonnes)
+          title_public: Barley production
       barley__00000044__yield__005419__tonnes_per_hectare:
         title: Barley | 00000044 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -164,22 +164,22 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Beans, dry - Area harvested (hectares)
+          name: Land used for bean production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Beans, dry - Area harvested (hectares)
+          title_public: Land used for bean production
       beans__dry__00000176__production__005510__tonnes:
         title: Beans, dry | 00000176 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Beans, dry - Production (tonnes)
+          name: Bean production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Beans, dry - Production (tonnes)
+          title_public: Bean production
       beans__dry__00000176__yield__005419__tonnes_per_hectare:
         title: Beans, dry | 00000176 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -197,11 +197,11 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Cashew nuts - Production (tonnes)
+          name: Cashew nut production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cashew nuts - Production (tonnes)
+          title_public: Cashew nut production
       cashew_nuts__00000217__yield__005419__tonnes_per_hectare:
         title: Cashew nuts | 00000217 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -219,22 +219,22 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Cassava - Area harvested (hectares)
+          name: Land used for cassava production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Cassava - Area harvested (hectares)
+          title_public: Land used for cassava production
       cassava__00000125__production__005510__tonnes:
         title: Cassava | 00000125 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Cassava - Production (tonnes)
+          name: Cassava production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cassava - Production (tonnes)
+          title_public: Cassava production
       cassava__00000125__yield__005419__tonnes_per_hectare:
         title: Cassava | 00000125 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -252,66 +252,66 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Castor oil seed - Area harvested (hectares)
+          name: Land used for castor oil seed production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Castor oil seed - Area harvested (hectares)
+          title_public: Land used for castor oil seed production
       cattle__00000866__stocks__005111__animals:
         title: Cattle | 00000866 || Stocks | 005111 || animals
         unit: animals
         short_unit: animals
         processing_level: major
         display:
-          name: Cattle - Stocks (animals)
+          name: Number of cattle
           shortUnit: animals
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Cattle - Stocks (animals)
+          title_public: Number of cattle
       cereals__00001717__area_harvested__005312__hectares:
         title: Cereals | 00001717 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Cereals - Area harvested (hectares)
+          name: Land used for cereal production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Cereals - Area harvested (hectares)
+          title_public: Land used for cereal production
       cereals__00001717__production__005510__tonnes:
         title: Cereals | 00001717 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Cereals - Production (tonnes)
+          name: Cereal production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cereals - Production (tonnes)
+          title_public: Cereal production
       cocoa_beans__00000661__area_harvested__005312__hectares:
         title: Cocoa beans | 00000661 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Cocoa beans - Area harvested (hectares)
+          name: Land used for cocoa bean production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Cocoa beans - Area harvested (hectares)
+          title_public: Land used for cocoa bean production
       cocoa_beans__00000661__production__005510__tonnes:
         title: Cocoa beans | 00000661 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Cocoa beans - Production (tonnes)
+          name: Cocoa bean production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cocoa beans - Production (tonnes)
+          title_public: Cocoa bean production
       cocoa_beans__00000661__yield__005419__tonnes_per_hectare:
         title: Cocoa beans | 00000661 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -329,33 +329,33 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Coconut oil - Production (tonnes)
+          name: Coconut oil production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Coconut oil - Production (tonnes)
+          title_public: Coconut oil production
       coconuts__00000249__area_harvested__005312__hectares:
         title: Coconuts | 00000249 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Coconuts - Area harvested (hectares)
+          name: Land used for coconut production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Coconuts - Area harvested (hectares)
+          title_public: Land used for coconut production
       coffee__green__00000656__production__005510__tonnes:
         title: Coffee, green | 00000656 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Coffee, green - Production (tonnes)
+          name: Coffee bean production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Coffee, green - Production (tonnes)
+          title_public: Coffee bean production
       coffee__green__00000656__yield__005419__tonnes_per_hectare:
         title: Coffee, green | 00000656 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -373,22 +373,22 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Cottonseed oil - Production (tonnes)
+          name: Cottonseed oil production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Cottonseed oil - Production (tonnes)
+          title_public: Cottonseed oil production
       eggs__00001783__production__005510__tonnes:
         title: Eggs | 00001783 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Eggs - Production (tonnes)
+          name: Egg production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Eggs - Production (tonnes)
+          title_public: Egg production
       eggs__00001783__yield__005410__kilograms_per_animal:
         title: Eggs | 00001783 || Yield | 005410 || kilograms per animal
         unit: kilograms per animal
@@ -406,33 +406,33 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Grapes - Production (tonnes)
+          name: Grape production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Grapes - Production (tonnes)
+          title_public: Grape production
       groundnut_oil__00000244__production__005510__tonnes:
         title: Groundnut oil | 00000244 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Groundnut oil - Production (tonnes)
+          name: Groundnut oil production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Groundnut oil - Production (tonnes)
+          title_public: Groundnut oil production
       groundnuts__00000242__area_harvested__005312__hectares:
         title: Groundnuts | 00000242 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Groundnuts - Area harvested (hectares)
+          name: Land used for groundnut production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Groundnuts - Area harvested (hectares)
+          title_public: Land used for groundnut production
       groundnuts__00000242__yield__005419__tonnes_per_hectare:
         title: Groundnuts | 00000242 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -450,11 +450,11 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Karite nuts - Area harvested (hectares)
+          name: Land used for karite nut production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Karite nuts - Area harvested (hectares)
+          title_public: Land used for karite nut production
       lettuce__00000372__yield__005419__tonnes_per_hectare:
         title: Lettuce | 00000372 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -472,55 +472,55 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Linseed oil - Production (tonnes)
+          name: Linseed oil production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Linseed oil - Production (tonnes)
+          title_public: Linseed oil production
       linseed__00000333__area_harvested__005312__hectares:
         title: Linseed | 00000333 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Linseed - Area harvested (hectares)
+          name: Land used for linseed production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Linseed - Area harvested (hectares)
+          title_public: Land used for linseed production
       maize_oil__00000060__production__005510__tonnes:
         title: Maize oil | 00000060 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Maize oil - Production (tonnes)
+          name: Maize oil production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Maize oil - Production (tonnes)
+          title_public: Maize oil production
       maize__00000056__area_harvested__005312__hectares:
         title: Maize | 00000056 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Maize - Area harvested (hectares)
+          name: Land used for corn production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Maize - Area harvested (hectares)
+          title_public: Land used for corn production
       maize__00000056__production__005510__tonnes:
         title: Maize | 00000056 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Maize - Production (tonnes)
+          name: Maize production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Maize - Production (tonnes)
+          title_public: Maize production
       maize__00000056__yield__005419__tonnes_per_hectare:
         title: Maize | 00000056 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -538,11 +538,11 @@ tables:
         short_unit: animals
         processing_level: major
         display:
-          name: Meat of cattle with the bone, fresh or chilled - Producing or slaughtered animals (animals)
+          name: Number of cattle slaughtered for meat
           shortUnit: animals
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Meat of cattle with the bone, fresh or chilled - Producing or slaughtered animals (animals)
+          title_public: Number of cattle slaughtered for meat
       meat_of_cattle_with_the_bone__fresh_or_chilled__00000867__yield__005417__kilograms_per_animal:
         title: Meat of cattle with the bone, fresh or chilled | 00000867 || Yield | 005417 || kilograms per animal
         unit: kilograms per animal
@@ -560,44 +560,44 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Meat, beef and buffalo - Production (tonnes)
+          name: Beef and buffalo meat production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, beef and buffalo - Production (tonnes)
+          title_public: Beef and buffalo meat production
       meat__camel__00001127__production__005510__tonnes:
         title: Meat, camel | 00001127 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Meat, camel - Production (tonnes)
+          name: Camel meat production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, camel - Production (tonnes)
+          title_public: Camel meat production
       meat__chicken__00001058__producing_or_slaughtered_animals__005321__animals:
         title: Meat, chicken | 00001058 || Producing or slaughtered animals | 005321 || animals
         unit: animals
         short_unit: animals
         processing_level: major
         display:
-          name: Meat, chicken - Producing or slaughtered animals (animals)
+          name: Number of chickens slaughtered for meat
           shortUnit: animals
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Meat, chicken - Producing or slaughtered animals (animals)
+          title_public: Number of chickens slaughtered for meat
       meat__chicken__00001058__production__005510__tonnes:
         title: Meat, chicken | 00001058 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Meat, chicken - Production (tonnes)
+          name: Chicken meat production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, chicken - Production (tonnes)
+          title_public: Chicken meat production
       meat__chicken__00001058__yield__005424__kilograms_per_animal:
         title: Meat, chicken | 00001058 || Yield | 005424 || kilograms per animal
         unit: kilograms per animal
@@ -615,77 +615,77 @@ tables:
         short_unit: animals
         processing_level: major
         display:
-          name: Meat, duck - Producing or slaughtered animals (animals)
+          name: Number of ducks slaughtered for meat
           shortUnit: animals
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Meat, duck - Producing or slaughtered animals (animals)
+          title_public: Number of ducks slaughtered for meat
       meat__game__00001163__production__005510__tonnes:
         title: Meat, game | 00001163 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Meat, game - Production (tonnes)
+          name: Game meat production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, game - Production (tonnes)
+          title_public: Game meat production
       meat__goat__00001017__producing_or_slaughtered_animals__005320__animals:
         title: Meat, goat | 00001017 || Producing or slaughtered animals | 005320 || animals
         unit: animals
         short_unit: animals
         processing_level: major
         display:
-          name: Meat, goat - Producing or slaughtered animals (animals)
+          name: Number of goats slaughtered for meat
           shortUnit: animals
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Meat, goat - Producing or slaughtered animals (animals)
+          title_public: Number of goats slaughtered for meat
       meat__horse__00001097__production__005510__tonnes:
         title: Meat, horse | 00001097 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Meat, horse - Production (tonnes)
+          name: Horse meat production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, horse - Production (tonnes)
+          title_public: Horse meat production
       meat__lamb_and_mutton__00000977__producing_or_slaughtered_animals__005320__animals:
         title: Meat, lamb and mutton | 00000977 || Producing or slaughtered animals | 005320 || animals
         unit: animals
         short_unit: animals
         processing_level: major
         display:
-          name: Meat, lamb and mutton - Producing or slaughtered animals (animals)
+          name: Number of sheep slaughtered for meat
           shortUnit: animals
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Meat, lamb and mutton - Producing or slaughtered animals (animals)
+          title_public: Number of sheep slaughtered for meat
       meat__pig__00001035__producing_or_slaughtered_animals__005320__animals:
         title: Meat, pig | 00001035 || Producing or slaughtered animals | 005320 || animals
         unit: animals
         short_unit: animals
         processing_level: major
         display:
-          name: Meat, pig - Producing or slaughtered animals (animals)
+          name: Number of pigs slaughtered for meat
           shortUnit: animals
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Meat, pig - Producing or slaughtered animals (animals)
+          title_public: Number of pigs slaughtered for meat
       meat__pig__00001035__production__005510__tonnes:
         title: Meat, pig | 00001035 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Meat, pig - Production (tonnes)
+          name: Pig meat production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, pig - Production (tonnes)
+          title_public: Pig meat production
       meat__pig__00001035__yield__005417__kilograms_per_animal:
         title: Meat, pig | 00001035 || Yield | 005417 || kilograms per animal
         unit: kilograms per animal
@@ -703,11 +703,11 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Meat, poultry - Production (tonnes)
+          name: Poutry meat production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, poultry - Production (tonnes)
+          title_public: Poutry meat production
       meat__poultry__00001808__yield__005424__kilograms_per_animal:
         title: Meat, poultry | 00001808 || Yield | 005424 || kilograms per animal
         unit: kilograms per animal
@@ -725,44 +725,44 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Meat, sheep and goat - Production (tonnes)
+          name: Sheep and goat meat production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, sheep and goat - Production (tonnes)
+          title_public: Sheep and goat meat production
       meat__total__00001765__production__005510__tonnes:
         title: Meat, total | 00001765 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Meat, total - Production (tonnes)
+          name: Total meat production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Meat, total - Production (tonnes)
+          title_public: Total meat production
       meat__turkey__00001080__producing_or_slaughtered_animals__005321__animals:
         title: Meat, turkey | 00001080 || Producing or slaughtered animals | 005321 || animals
         unit: animals
         short_unit: animals
         processing_level: major
         display:
-          name: Meat, turkey - Producing or slaughtered animals (animals)
+          name: Number of turkeys slaughtered for meat
           shortUnit: animals
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Meat, turkey - Producing or slaughtered animals (animals)
+          title_public: Number of turkeys slaughtered for meat
       milk__00001780__production__005510__tonnes:
         title: Milk | 00001780 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Milk - Production (tonnes)
+          name: Milk production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Milk - Production (tonnes)
+          title_public: Milk production
       milk__00001780__yield__005420__kilograms_per_animal:
         title: Milk | 00001780 || Yield | 005420 || kilograms per animal
         unit: kilograms per animal
@@ -791,44 +791,44 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Olive oil - Production (tonnes)
+          name: Olive oil production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Olive oil - Production (tonnes)
+          title_public: Olive oil production
       olives__00000260__area_harvested__005312__hectares:
         title: Olives | 00000260 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Olives - Area harvested (hectares)
+          name: Land used for olive production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Olives - Area harvested (hectares)
+          title_public: Land used for olive production
       oranges__00000490__area_harvested__005312__hectares:
         title: Oranges | 00000490 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Oranges - Area harvested (hectares)
+          name: Land used for orange production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Oranges - Area harvested (hectares)
+          title_public: Land used for orange production
       oranges__00000490__production__005510__tonnes:
         title: Oranges | 00000490 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Oranges - Production (tonnes)
+          name: Orange production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Oranges - Production (tonnes)
+          title_public: Orange production
       oranges__00000490__yield__005419__tonnes_per_hectare:
         title: Oranges | 00000490 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -846,22 +846,22 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Palm fruit oil - Area harvested (hectares)
+          name: Land used for palm fruit oil production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Palm fruit oil - Area harvested (hectares)
+          title_public: Land used for palm fruit oil production
       palm_fruit_oil__00000254__production__005510__tonnes:
         title: Palm fruit oil | 00000254 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Palm fruit oil - Production (tonnes)
+          name: Palm fruit oil production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Palm fruit oil - Production (tonnes)
+          title_public: Palm fruit oil production
       palm_fruit_oil__00000254__yield__005419__tonnes_per_hectare:
         title: Palm fruit oil | 00000254 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -879,44 +879,44 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Palm kernel oil - Production (tonnes)
+          name: Palm kernel oil production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Palm kernel oil - Production (tonnes)
+          title_public: Palm kernel oil production
       palm_oil__00000257__production__005510__tonnes:
         title: Palm oil | 00000257 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Palm oil - Production (tonnes)
+          name: Palm oil production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Palm oil - Production (tonnes)
+          title_public: Palm oil production
       peas__dry__00000187__area_harvested__005312__hectares:
         title: Peas, dry | 00000187 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Peas, dry - Area harvested (hectares)
+          name: Land used for pea production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Peas, dry - Area harvested (hectares)
+          title_public: Land used for pea production
       peas__dry__00000187__production__005510__tonnes:
         title: Peas, dry | 00000187 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Peas, dry - Production (tonnes)
+          name: Pea production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Peas, dry - Production (tonnes)
+          title_public: Pea production
       peas__dry__00000187__yield__005419__tonnes_per_hectare:
         title: Peas, dry | 00000187 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -934,22 +934,22 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Potatoes - Area harvested (hectares)
+          name: Land used for potato production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Potatoes - Area harvested (hectares)
+          title_public: Land used for potato production
       potatoes__00000116__production__005510__tonnes:
         title: Potatoes | 00000116 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Potatoes - Production (tonnes)
+          name: Potato production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Potatoes - Production (tonnes)
+          title_public: Potato production
       potatoes__00000116__yield__005419__tonnes_per_hectare:
         title: Potatoes | 00000116 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -967,33 +967,33 @@ tables:
         short_unit: animals
         processing_level: major
         display:
-          name: Poultry - Stocks (animals)
+          name: Number of poultry birds
           shortUnit: animals
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Poultry - Stocks (animals)
+          title_public: Number of poultry birds
       rapeseed__00000270__area_harvested__005312__hectares:
         title: Rapeseed | 00000270 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Rapeseed - Area harvested (hectares)
+          name: Land used for rapeseed production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Rapeseed - Area harvested (hectares)
+          title_public: Land used for rapeseed production
       rapeseed__00000270__production__005510__tonnes:
         title: Rapeseed | 00000270 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Rapeseed - Production (tonnes)
+          name: Rapeseed production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Rapeseed - Production (tonnes)
+          title_public: Rapeseed production
       rapeseed__00000270__yield__005419__tonnes_per_hectare:
         title: Rapeseed | 00000270 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -1011,22 +1011,22 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Rice - Area harvested (hectares)
+          name: Land used for rice production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Rice - Area harvested (hectares)
+          title_public: Land used for rice production
       rice__00000027__production__005510__tonnes:
         title: Rice | 00000027 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Rice - Production (tonnes)
+          name: Rice production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Rice - Production (tonnes)
+          title_public: Rice production
       rice__00000027__yield__005419__tonnes_per_hectare:
         title: Rice | 00000027 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -1044,44 +1044,44 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Rye - Area harvested (hectares)
+          name: Land used for rye production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Rye - Area harvested (hectares)
+          title_public: Land used for rye production
       rye__00000071__production__005510__tonnes:
         title: Rye | 00000071 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Rye - Production (tonnes)
+          name: Rye production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Rye - Production (tonnes)
+          title_public: Rye production
       safflower_seed__00000280__area_harvested__005312__hectares:
         title: Safflower seed | 00000280 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Safflower seed - Area harvested (hectares)
+          name: Land used for safflower seed production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Safflower seed - Area harvested (hectares)
+          title_public: Land used for safflower seed production
       seed_cotton__00000328__area_harvested__005312__hectares:
         title: Seed cotton | 00000328 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Seed cotton - Area harvested (hectares)
+          name: Land used for seed cotton production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Seed cotton - Area harvested (hectares)
+          title_public: Land used for seed cotton production
       seed_cotton__00000328__yield__005419__tonnes_per_hectare:
         title: Seed cotton | 00000328 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -1099,22 +1099,22 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Sesame seed - Area harvested (hectares)
+          name: Land used for sesame seed production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Sesame seed - Area harvested (hectares)
+          title_public: Land used for sesame seed production
       sesame_seed__00000289__production__005510__tonnes:
         title: Sesame seed | 00000289 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Sesame seed - Production (tonnes)
+          name: Sesame seed production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Sesame seed - Production (tonnes)
+          title_public: Sesame seed production
       sorghum__00000083__yield__005419__tonnes_per_hectare:
         title: Sorghum | 00000083 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -1132,22 +1132,22 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Soybeans - Area harvested (hectares)
+          name: Land used for soybean production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Soybeans - Area harvested (hectares)
+          title_public: Land used for soybean production
       soybeans__00000236__production__005510__tonnes:
         title: Soybeans | 00000236 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Soybeans - Production (tonnes)
+          name: Soybean production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Soybeans - Production (tonnes)
+          title_public: Soybean production
       soybeans__00000236__yield__005419__tonnes_per_hectare:
         title: Soybeans | 00000236 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -1165,44 +1165,44 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Sugar beet - Area harvested (hectares)
+          name: Land used for sugar beet production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Sugar beet - Area harvested (hectares)
+          title_public: Land used for sugar beet production
       sugar_beet__00000157__production__005510__tonnes:
         title: Sugar beet | 00000157 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Sugar beet - Production (tonnes)
+          name: Sugar beet production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Sugar beet - Production (tonnes)
+          title_public: Sugar beet production
       sugar_cane__00000156__area_harvested__005312__hectares:
         title: Sugar cane | 00000156 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Sugar cane - Area harvested (hectares)
+          name: Land used for sugar cane production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Sugar cane - Area harvested (hectares)
+          title_public: Land used for sugar cane production
       sugar_cane__00000156__production__005510__tonnes:
         title: Sugar cane | 00000156 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Sugar cane - Production (tonnes)
+          name: Sugar cane production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Sugar cane - Production (tonnes)
+          title_public: Sugar cane production
       sugar_cane__00000156__yield__005419__tonnes_per_hectare:
         title: Sugar cane | 00000156 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -1220,22 +1220,22 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Sunflower seed - Area harvested (hectares)
+          name: Land used for sunflower seed production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Sunflower seed - Area harvested (hectares)
+          title_public: Land used for sunflower seed production
       sunflower_seed__00000267__production__005510__tonnes:
         title: Sunflower seed | 00000267 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Sunflower seed - Production (tonnes)
+          name: Sunflower seed production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Sunflower seed - Production (tonnes)
+          title_public: Sunflower seed production
       sunflower_seed__00000267__yield__005419__tonnes_per_hectare:
         title: Sunflower seed | 00000267 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -1253,66 +1253,66 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Sweet potatoes - Production (tonnes)
+          name: Sweet potato production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Sweet potatoes - Production (tonnes)
+          title_public: Sweet potato production
       swine__pigs__00001034__stocks__005111__animals:
         title: Swine / pigs | 00001034 || Stocks | 005111 || animals
         unit: animals
         short_unit: animals
         processing_level: major
         display:
-          name: Swine / pigs - Stocks (animals)
+          name: Number of pigs
           shortUnit: animals
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
-          title_public: Swine / pigs - Stocks (animals)
+          title_public: Number of pigs
       tea__00000667__production__005510__tonnes:
         title: Tea | 00000667 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Tea - Production (tonnes)
+          name: Tea production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Tea - Production (tonnes)
+          title_public: Tea production
       tobacco__00000826__production__005510__tonnes:
         title: Tobacco | 00000826 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Tobacco - Production (tonnes)
+          name: Tobacco production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Tobacco - Production (tonnes)
+          title_public: Tobacco production
       tomatoes__00000388__area_harvested__005312__hectares:
         title: Tomatoes | 00000388 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Tomatoes - Area harvested (hectares)
+          name: Land used for tomato production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Tomatoes - Area harvested (hectares)
+          title_public: Land used for tomato production
       tomatoes__00000388__production__005510__tonnes:
         title: Tomatoes | 00000388 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Tomatoes - Production (tonnes)
+          name: Tomato production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Tomatoes - Production (tonnes)
+          title_public: Tomato production
       tomatoes__00000388__yield__005419__tonnes_per_hectare:
         title: Tomatoes | 00000388 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -1330,33 +1330,33 @@ tables:
         short_unit: ha
         processing_level: major
         display:
-          name: Tung nuts - Area harvested (hectares)
+          name: Land used for tung nut production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Tung nuts - Area harvested (hectares)
+          title_public: Land used for tung nut production
       wheat__00000015__area_harvested__005312__hectares:
         title: Wheat | 00000015 || Area harvested | 005312 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Wheat - Area harvested (hectares)
+          name: Land used for wheat production
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Wheat - Area harvested (hectares)
+          title_public: Land used for wheat production
       wheat__00000015__production__005510__tonnes:
         title: Wheat | 00000015 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Wheat - Production (tonnes)
+          name: Wheat production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Wheat - Production (tonnes)
+          title_public: Wheat production
       wheat__00000015__yield__005419__tonnes_per_hectare:
         title: Wheat | 00000015 || Yield | 005419 || tonnes per hectare
         unit: tonnes per hectare
@@ -1374,19 +1374,19 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Wine - Production (tonnes)
+          name: Wine production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Wine - Production (tonnes)
+          title_public: Wine production
       yams__00000137__production__005510__tonnes:
         title: Yams | 00000137 || Production | 005510 || tonnes
         unit: tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Yams - Production (tonnes)
+          name: Yam production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Yams - Production (tonnes)
+          title_public: Yam production

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_qcl.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_qcl.meta.yml
@@ -260,7 +260,7 @@ tables:
       cattle__00000866__stocks__005111__animals:
         title: Cattle | 00000866 || Stocks | 005111 || animals
         unit: animals
-        short_unit: animals
+        short_unit: ''
         processing_level: major
         display:
           name: Number of cattle
@@ -392,7 +392,7 @@ tables:
       eggs__00001783__yield__005410__kilograms_per_animal:
         title: Eggs | 00001783 || Yield | 005410 || kilograms per animal
         unit: kilograms per animal
-        short_unit: kg/animal
+        short_unit: kg
         processing_level: major
         display:
           name: Eggs per bird
@@ -535,7 +535,7 @@ tables:
       meat_of_cattle_with_the_bone__fresh_or_chilled__00000867__producing_or_slaughtered_animals__005320__animals:
         title: Meat of cattle with the bone, fresh or chilled | 00000867 || Producing or slaughtered animals | 005320 || animals
         unit: animals
-        short_unit: animals
+        short_unit: ''
         processing_level: major
         display:
           name: Number of cattle slaughtered for meat
@@ -546,7 +546,7 @@ tables:
       meat_of_cattle_with_the_bone__fresh_or_chilled__00000867__yield__005417__kilograms_per_animal:
         title: Meat of cattle with the bone, fresh or chilled | 00000867 || Yield | 005417 || kilograms per animal
         unit: kilograms per animal
-        short_unit: kg/animal
+        short_unit: kg
         processing_level: major
         display:
           name: Cattle meat yield per animal
@@ -579,7 +579,7 @@ tables:
       meat__chicken__00001058__producing_or_slaughtered_animals__005321__animals:
         title: Meat, chicken | 00001058 || Producing or slaughtered animals | 005321 || animals
         unit: animals
-        short_unit: animals
+        short_unit: ''
         processing_level: major
         display:
           name: Number of chickens slaughtered for meat
@@ -601,7 +601,7 @@ tables:
       meat__chicken__00001058__yield__005424__kilograms_per_animal:
         title: Meat, chicken | 00001058 || Yield | 005424 || kilograms per animal
         unit: kilograms per animal
-        short_unit: kg/animal
+        short_unit: kg
         processing_level: major
         display:
           name: Chicken meat yield per animal
@@ -612,7 +612,7 @@ tables:
       meat__duck__00001069__producing_or_slaughtered_animals__005321__animals:
         title: Meat, duck | 00001069 || Producing or slaughtered animals | 005321 || animals
         unit: animals
-        short_unit: animals
+        short_unit: ''
         processing_level: major
         display:
           name: Number of ducks slaughtered for meat
@@ -634,7 +634,7 @@ tables:
       meat__goat__00001017__producing_or_slaughtered_animals__005320__animals:
         title: Meat, goat | 00001017 || Producing or slaughtered animals | 005320 || animals
         unit: animals
-        short_unit: animals
+        short_unit: ''
         processing_level: major
         display:
           name: Number of goats slaughtered for meat
@@ -656,7 +656,7 @@ tables:
       meat__lamb_and_mutton__00000977__producing_or_slaughtered_animals__005320__animals:
         title: Meat, lamb and mutton | 00000977 || Producing or slaughtered animals | 005320 || animals
         unit: animals
-        short_unit: animals
+        short_unit: ''
         processing_level: major
         display:
           name: Number of sheep slaughtered for meat
@@ -667,7 +667,7 @@ tables:
       meat__pig__00001035__producing_or_slaughtered_animals__005320__animals:
         title: Meat, pig | 00001035 || Producing or slaughtered animals | 005320 || animals
         unit: animals
-        short_unit: animals
+        short_unit: ''
         processing_level: major
         display:
           name: Number of pigs slaughtered for meat
@@ -689,7 +689,7 @@ tables:
       meat__pig__00001035__yield__005417__kilograms_per_animal:
         title: Meat, pig | 00001035 || Yield | 005417 || kilograms per animal
         unit: kilograms per animal
-        short_unit: kg/animal
+        short_unit: kg
         processing_level: major
         display:
           name: Pig meat yield per animal
@@ -711,7 +711,7 @@ tables:
       meat__poultry__00001808__yield__005424__kilograms_per_animal:
         title: Meat, poultry | 00001808 || Yield | 005424 || kilograms per animal
         unit: kilograms per animal
-        short_unit: kg/animal
+        short_unit: kg
         processing_level: major
         display:
           name: Poultry meat yield per animal
@@ -744,7 +744,7 @@ tables:
       meat__turkey__00001080__producing_or_slaughtered_animals__005321__animals:
         title: Meat, turkey | 00001080 || Producing or slaughtered animals | 005321 || animals
         unit: animals
-        short_unit: animals
+        short_unit: ''
         processing_level: major
         display:
           name: Number of turkeys slaughtered for meat
@@ -766,7 +766,7 @@ tables:
       milk__00001780__yield__005420__kilograms_per_animal:
         title: Milk | 00001780 || Yield | 005420 || kilograms per animal
         unit: kilograms per animal
-        short_unit: kg/animal
+        short_unit: kg
         processing_level: major
         display:
           name: Milk yield per animal
@@ -964,7 +964,7 @@ tables:
       poultry__00002029__stocks__005112__animals:
         title: Poultry | 00002029 || Stocks | 005112 || animals
         unit: animals
-        short_unit: animals
+        short_unit: ''
         processing_level: major
         display:
           name: Number of poultry birds
@@ -1261,7 +1261,7 @@ tables:
       swine__pigs__00001034__stocks__005111__animals:
         title: Swine / pigs | 00001034 || Stocks | 005111 || animals
         unit: animals
-        short_unit: animals
+        short_unit: ''
         processing_level: major
         display:
           name: Number of pigs

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_qcl.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_qcl.meta.yml
@@ -1,5 +1,18 @@
+dataset:
+  title: 'Production: Crops and livestock products'
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
 tables:
   faostat_qcl_flat:
+    title: 'Production: Crops and livestock products'
     variables:
       cereals__00001717__yield__005419__tonnes_per_hectare:
         title: Cereals | 00001717 || Yield | 005419 || tonnes per hectare
@@ -45,3 +58,1356 @@ tables:
               - Northern America
               - Europe
               - South America
+      almonds__00000221__yield__005419__tonnes_per_hectare:
+        title: Almonds | 00000221 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Almonds - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Almonds - Yield (tonnes per hectare)
+      apples__00000515__area_harvested__005312__hectares:
+        title: Apples | 00000515 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Apples - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Apples - Area harvested (hectares)
+      apples__00000515__production__005510__tonnes:
+        title: Apples | 00000515 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Apples - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Apples - Production (tonnes)
+      avocados__00000572__production__005510__tonnes:
+        title: Avocados | 00000572 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Avocados - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Avocados - Production (tonnes)
+      bananas__00000486__area_harvested__005312__hectares:
+        title: Bananas | 00000486 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Bananas - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Bananas - Area harvested (hectares)
+      bananas__00000486__production__005510__tonnes:
+        title: Bananas | 00000486 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Bananas - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Bananas - Production (tonnes)
+      bananas__00000486__yield__005419__tonnes_per_hectare:
+        title: Bananas | 00000486 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Bananas - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Bananas - Yield (tonnes per hectare)
+      barley__00000044__area_harvested__005312__hectares:
+        title: Barley | 00000044 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Barley - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Barley - Area harvested (hectares)
+      barley__00000044__production__005510__tonnes:
+        title: Barley | 00000044 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Barley - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Barley - Production (tonnes)
+      barley__00000044__yield__005419__tonnes_per_hectare:
+        title: Barley | 00000044 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Barley - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Barley - Yield (tonnes per hectare)
+      beans__dry__00000176__area_harvested__005312__hectares:
+        title: Beans, dry | 00000176 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Beans, dry - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Beans, dry - Area harvested (hectares)
+      beans__dry__00000176__production__005510__tonnes:
+        title: Beans, dry | 00000176 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Beans, dry - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Beans, dry - Production (tonnes)
+      beans__dry__00000176__yield__005419__tonnes_per_hectare:
+        title: Beans, dry | 00000176 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Beans, dry - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Beans, dry - Yield (tonnes per hectare)
+      cashew_nuts__00000217__production__005510__tonnes:
+        title: Cashew nuts | 00000217 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cashew nuts - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cashew nuts - Production (tonnes)
+      cashew_nuts__00000217__yield__005419__tonnes_per_hectare:
+        title: Cashew nuts | 00000217 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Cashew nuts - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cashew nuts - Yield (tonnes per hectare)
+      cassava__00000125__area_harvested__005312__hectares:
+        title: Cassava | 00000125 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Cassava - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cassava - Area harvested (hectares)
+      cassava__00000125__production__005510__tonnes:
+        title: Cassava | 00000125 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cassava - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cassava - Production (tonnes)
+      cassava__00000125__yield__005419__tonnes_per_hectare:
+        title: Cassava | 00000125 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Cassava - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cassava - Yield (tonnes per hectare)
+      castor_oil_seed__00000265__area_harvested__005312__hectares:
+        title: Castor oil seed | 00000265 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Castor oil seed - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Castor oil seed - Area harvested (hectares)
+      cattle__00000866__stocks__005111__animals:
+        title: Cattle | 00000866 || Stocks | 005111 || animals
+        unit: animals
+        short_unit: animals
+        processing_level: major
+        display:
+          name: Cattle - Stocks (animals)
+          shortUnit: animals
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cattle - Stocks (animals)
+      cereals__00001717__area_harvested__005312__hectares:
+        title: Cereals | 00001717 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Cereals - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cereals - Area harvested (hectares)
+      cereals__00001717__production__005510__tonnes:
+        title: Cereals | 00001717 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cereals - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cereals - Production (tonnes)
+      cereals__00001717__yield__005419__tonnes_per_hectare:
+        title: Cereals | 00001717 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Cereals - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cereal yields
+      cocoa_beans__00000661__area_harvested__005312__hectares:
+        title: Cocoa beans | 00000661 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Cocoa beans - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cocoa beans - Area harvested (hectares)
+      cocoa_beans__00000661__production__005510__tonnes:
+        title: Cocoa beans | 00000661 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cocoa beans - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cocoa beans - Production (tonnes)
+      cocoa_beans__00000661__yield__005419__tonnes_per_hectare:
+        title: Cocoa beans | 00000661 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Cocoa beans - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cocoa beans - Yield (tonnes per hectare)
+      coconut_oil__00000252__production__005510__tonnes:
+        title: Coconut oil | 00000252 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Coconut oil - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Coconut oil - Production (tonnes)
+      coconuts__00000249__area_harvested__005312__hectares:
+        title: Coconuts | 00000249 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Coconuts - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Coconuts - Area harvested (hectares)
+      coffee__green__00000656__production__005510__tonnes:
+        title: Coffee, green | 00000656 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Coffee, green - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Coffee, green - Production (tonnes)
+      coffee__green__00000656__yield__005419__tonnes_per_hectare:
+        title: Coffee, green | 00000656 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Coffee, green - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Coffee, green - Yield (tonnes per hectare)
+      cottonseed_oil__00000331__production__005510__tonnes:
+        title: Cottonseed oil | 00000331 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Cottonseed oil - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cottonseed oil - Production (tonnes)
+      eggs__00001783__production__005510__tonnes:
+        title: Eggs | 00001783 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Eggs - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Eggs - Production (tonnes)
+      eggs__00001783__yield__005410__kilograms_per_animal:
+        title: Eggs | 00001783 || Yield | 005410 || kilograms per animal
+        unit: kilograms per animal
+        short_unit: kg/animal
+        processing_level: major
+        display:
+          name: Eggs - Yield (kilograms per animal)
+          shortUnit: kg/animal
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Eggs - Yield (kilograms per animal)
+      grapes__00000560__production__005510__tonnes:
+        title: Grapes | 00000560 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Grapes - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Grapes - Production (tonnes)
+      groundnut_oil__00000244__production__005510__tonnes:
+        title: Groundnut oil | 00000244 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Groundnut oil - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Groundnut oil - Production (tonnes)
+      groundnuts__00000242__area_harvested__005312__hectares:
+        title: Groundnuts | 00000242 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Groundnuts - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Groundnuts - Area harvested (hectares)
+      groundnuts__00000242__yield__005419__tonnes_per_hectare:
+        title: Groundnuts | 00000242 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Groundnuts - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Groundnuts - Yield (tonnes per hectare)
+      karite_nuts__00000263__area_harvested__005312__hectares:
+        title: Karite nuts | 00000263 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Karite nuts - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Karite nuts - Area harvested (hectares)
+      lettuce__00000372__yield__005419__tonnes_per_hectare:
+        title: Lettuce | 00000372 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Lettuce - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Lettuce - Yield (tonnes per hectare)
+      linseed_oil__00000334__production__005510__tonnes:
+        title: Linseed oil | 00000334 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Linseed oil - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Linseed oil - Production (tonnes)
+      linseed__00000333__area_harvested__005312__hectares:
+        title: Linseed | 00000333 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Linseed - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Linseed - Area harvested (hectares)
+      maize_oil__00000060__production__005510__tonnes:
+        title: Maize oil | 00000060 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Maize oil - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Maize oil - Production (tonnes)
+      maize__00000056__area_harvested__005312__hectares:
+        title: Maize | 00000056 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Maize - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Maize - Area harvested (hectares)
+      maize__00000056__production__005510__tonnes:
+        title: Maize | 00000056 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Maize - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Maize - Production (tonnes)
+      maize__00000056__yield__005419__tonnes_per_hectare:
+        title: Maize | 00000056 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Maize - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Maize - Yield (tonnes per hectare)
+      meat_of_cattle_with_the_bone__fresh_or_chilled__00000867__producing_or_slaughtered_animals__005320__animals:
+        title: Meat of cattle with the bone, fresh or chilled | 00000867 || Producing or slaughtered animals | 005320 || animals
+        unit: animals
+        short_unit: animals
+        processing_level: major
+        display:
+          name: Meat of cattle with the bone, fresh or chilled - Producing or slaughtered animals (animals)
+          shortUnit: animals
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat of cattle with the bone, fresh or chilled - Producing or slaughtered animals (animals)
+      meat_of_cattle_with_the_bone__fresh_or_chilled__00000867__yield__005417__kilograms_per_animal:
+        title: Meat of cattle with the bone, fresh or chilled | 00000867 || Yield | 005417 || kilograms per animal
+        unit: kilograms per animal
+        short_unit: kg/animal
+        processing_level: major
+        display:
+          name: Meat of cattle with the bone, fresh or chilled - Yield (kilograms per animal)
+          shortUnit: kg/animal
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat of cattle with the bone, fresh or chilled - Yield (kilograms per animal)
+      meat__beef_and_buffalo__00001806__production__005510__tonnes:
+        title: Meat, beef and buffalo | 00001806 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Meat, beef and buffalo - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, beef and buffalo - Production (tonnes)
+      meat__camel__00001127__production__005510__tonnes:
+        title: Meat, camel | 00001127 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Meat, camel - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, camel - Production (tonnes)
+      meat__chicken__00001058__producing_or_slaughtered_animals__005321__animals:
+        title: Meat, chicken | 00001058 || Producing or slaughtered animals | 005321 || animals
+        unit: animals
+        short_unit: animals
+        processing_level: major
+        display:
+          name: Meat, chicken - Producing or slaughtered animals (animals)
+          shortUnit: animals
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, chicken - Producing or slaughtered animals (animals)
+      meat__chicken__00001058__production__005510__tonnes:
+        title: Meat, chicken | 00001058 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Meat, chicken - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, chicken - Production (tonnes)
+      meat__chicken__00001058__yield__005424__kilograms_per_animal:
+        title: Meat, chicken | 00001058 || Yield | 005424 || kilograms per animal
+        unit: kilograms per animal
+        short_unit: kg/animal
+        processing_level: major
+        display:
+          name: Meat, chicken - Yield (kilograms per animal)
+          shortUnit: kg/animal
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, chicken - Yield (kilograms per animal)
+      meat__duck__00001069__producing_or_slaughtered_animals__005321__animals:
+        title: Meat, duck | 00001069 || Producing or slaughtered animals | 005321 || animals
+        unit: animals
+        short_unit: animals
+        processing_level: major
+        display:
+          name: Meat, duck - Producing or slaughtered animals (animals)
+          shortUnit: animals
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, duck - Producing or slaughtered animals (animals)
+      meat__game__00001163__production__005510__tonnes:
+        title: Meat, game | 00001163 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Meat, game - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, game - Production (tonnes)
+      meat__goat__00001017__producing_or_slaughtered_animals__005320__animals:
+        title: Meat, goat | 00001017 || Producing or slaughtered animals | 005320 || animals
+        unit: animals
+        short_unit: animals
+        processing_level: major
+        display:
+          name: Meat, goat - Producing or slaughtered animals (animals)
+          shortUnit: animals
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, goat - Producing or slaughtered animals (animals)
+      meat__horse__00001097__production__005510__tonnes:
+        title: Meat, horse | 00001097 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Meat, horse - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, horse - Production (tonnes)
+      meat__lamb_and_mutton__00000977__producing_or_slaughtered_animals__005320__animals:
+        title: Meat, lamb and mutton | 00000977 || Producing or slaughtered animals | 005320 || animals
+        unit: animals
+        short_unit: animals
+        processing_level: major
+        display:
+          name: Meat, lamb and mutton - Producing or slaughtered animals (animals)
+          shortUnit: animals
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, lamb and mutton - Producing or slaughtered animals (animals)
+      meat__pig__00001035__producing_or_slaughtered_animals__005320__animals:
+        title: Meat, pig | 00001035 || Producing or slaughtered animals | 005320 || animals
+        unit: animals
+        short_unit: animals
+        processing_level: major
+        display:
+          name: Meat, pig - Producing or slaughtered animals (animals)
+          shortUnit: animals
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, pig - Producing or slaughtered animals (animals)
+      meat__pig__00001035__production__005510__tonnes:
+        title: Meat, pig | 00001035 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Meat, pig - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, pig - Production (tonnes)
+      meat__pig__00001035__yield__005417__kilograms_per_animal:
+        title: Meat, pig | 00001035 || Yield | 005417 || kilograms per animal
+        unit: kilograms per animal
+        short_unit: kg/animal
+        processing_level: major
+        display:
+          name: Meat, pig - Yield (kilograms per animal)
+          shortUnit: kg/animal
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, pig - Yield (kilograms per animal)
+      meat__poultry__00001808__production__005510__tonnes:
+        title: Meat, poultry | 00001808 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Meat, poultry - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, poultry - Production (tonnes)
+      meat__poultry__00001808__yield__005424__kilograms_per_animal:
+        title: Meat, poultry | 00001808 || Yield | 005424 || kilograms per animal
+        unit: kilograms per animal
+        short_unit: kg/animal
+        processing_level: major
+        display:
+          name: Meat, poultry - Yield (kilograms per animal)
+          shortUnit: kg/animal
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, poultry - Yield (kilograms per animal)
+      meat__sheep_and_goat__00001807__production__005510__tonnes:
+        title: Meat, sheep and goat | 00001807 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Meat, sheep and goat - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, sheep and goat - Production (tonnes)
+      meat__total__00001765__production__005510__tonnes:
+        title: Meat, total | 00001765 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Meat, total - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, total - Production (tonnes)
+      meat__turkey__00001080__producing_or_slaughtered_animals__005321__animals:
+        title: Meat, turkey | 00001080 || Producing or slaughtered animals | 005321 || animals
+        unit: animals
+        short_unit: animals
+        processing_level: major
+        display:
+          name: Meat, turkey - Producing or slaughtered animals (animals)
+          shortUnit: animals
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Meat, turkey - Producing or slaughtered animals (animals)
+      milk__00001780__production__005510__tonnes:
+        title: Milk | 00001780 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Milk - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Milk - Production (tonnes)
+      milk__00001780__yield__005420__kilograms_per_animal:
+        title: Milk | 00001780 || Yield | 005420 || kilograms per animal
+        unit: kilograms per animal
+        short_unit: kg/animal
+        processing_level: major
+        display:
+          name: Milk - Yield (kilograms per animal)
+          shortUnit: kg/animal
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Milk - Yield (kilograms per animal)
+      millet__00000079__yield__005419__tonnes_per_hectare:
+        title: Millet | 00000079 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Millet - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Millet - Yield (tonnes per hectare)
+      olive_oil__00000261__production__005510__tonnes:
+        title: Olive oil | 00000261 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Olive oil - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Olive oil - Production (tonnes)
+      olives__00000260__area_harvested__005312__hectares:
+        title: Olives | 00000260 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Olives - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Olives - Area harvested (hectares)
+      oranges__00000490__area_harvested__005312__hectares:
+        title: Oranges | 00000490 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Oranges - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Oranges - Area harvested (hectares)
+      oranges__00000490__production__005510__tonnes:
+        title: Oranges | 00000490 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Oranges - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Oranges - Production (tonnes)
+      oranges__00000490__yield__005419__tonnes_per_hectare:
+        title: Oranges | 00000490 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Oranges - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Oranges - Yield (tonnes per hectare)
+      palm_fruit_oil__00000254__area_harvested__005312__hectares:
+        title: Palm fruit oil | 00000254 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Palm fruit oil - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Palm fruit oil - Area harvested (hectares)
+      palm_fruit_oil__00000254__production__005510__tonnes:
+        title: Palm fruit oil | 00000254 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Palm fruit oil - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Palm fruit oil - Production (tonnes)
+      palm_fruit_oil__00000254__yield__005419__tonnes_per_hectare:
+        title: Palm fruit oil | 00000254 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Palm fruit oil - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Palm fruit oil - Yield (tonnes per hectare)
+      palm_kernel_oil__00000258__production__005510__tonnes:
+        title: Palm kernel oil | 00000258 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Palm kernel oil - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Palm kernel oil - Production (tonnes)
+      palm_oil__00000257__production__005510__tonnes:
+        title: Palm oil | 00000257 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Palm oil - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Palm oil - Production (tonnes)
+      peas__dry__00000187__area_harvested__005312__hectares:
+        title: Peas, dry | 00000187 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Peas, dry - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Peas, dry - Area harvested (hectares)
+      peas__dry__00000187__production__005510__tonnes:
+        title: Peas, dry | 00000187 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Peas, dry - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Peas, dry - Production (tonnes)
+      peas__dry__00000187__yield__005419__tonnes_per_hectare:
+        title: Peas, dry | 00000187 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Peas, dry - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Peas, dry - Yield (tonnes per hectare)
+      potatoes__00000116__area_harvested__005312__hectares:
+        title: Potatoes | 00000116 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Potatoes - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Potatoes - Area harvested (hectares)
+      potatoes__00000116__production__005510__tonnes:
+        title: Potatoes | 00000116 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Potatoes - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Potatoes - Production (tonnes)
+      potatoes__00000116__yield__005419__tonnes_per_hectare:
+        title: Potatoes | 00000116 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Potatoes - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Potatoes - Yield (tonnes per hectare)
+      poultry__00002029__stocks__005112__animals:
+        title: Poultry | 00002029 || Stocks | 005112 || animals
+        unit: animals
+        short_unit: animals
+        processing_level: major
+        display:
+          name: Poultry - Stocks (animals)
+          shortUnit: animals
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Poultry - Stocks (animals)
+      rapeseed__00000270__area_harvested__005312__hectares:
+        title: Rapeseed | 00000270 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Rapeseed - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rapeseed - Area harvested (hectares)
+      rapeseed__00000270__production__005510__tonnes:
+        title: Rapeseed | 00000270 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Rapeseed - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rapeseed - Production (tonnes)
+      rapeseed__00000270__yield__005419__tonnes_per_hectare:
+        title: Rapeseed | 00000270 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Rapeseed - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rapeseed - Yield (tonnes per hectare)
+      rice__00000027__area_harvested__005312__hectares:
+        title: Rice | 00000027 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Rice - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rice - Area harvested (hectares)
+      rice__00000027__production__005510__tonnes:
+        title: Rice | 00000027 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Rice - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rice - Production (tonnes)
+      rice__00000027__yield__005419__tonnes_per_hectare:
+        title: Rice | 00000027 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Rice - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rice - Yield (tonnes per hectare)
+      rye__00000071__area_harvested__005312__hectares:
+        title: Rye | 00000071 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Rye - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rye - Area harvested (hectares)
+      rye__00000071__production__005510__tonnes:
+        title: Rye | 00000071 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Rye - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rye - Production (tonnes)
+      safflower_seed__00000280__area_harvested__005312__hectares:
+        title: Safflower seed | 00000280 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Safflower seed - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Safflower seed - Area harvested (hectares)
+      seed_cotton__00000328__area_harvested__005312__hectares:
+        title: Seed cotton | 00000328 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Seed cotton - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Seed cotton - Area harvested (hectares)
+      seed_cotton__00000328__yield__005419__tonnes_per_hectare:
+        title: Seed cotton | 00000328 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Seed cotton - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Seed cotton - Yield (tonnes per hectare)
+      sesame_seed__00000289__area_harvested__005312__hectares:
+        title: Sesame seed | 00000289 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Sesame seed - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sesame seed - Area harvested (hectares)
+      sesame_seed__00000289__production__005510__tonnes:
+        title: Sesame seed | 00000289 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Sesame seed - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sesame seed - Production (tonnes)
+      sorghum__00000083__yield__005419__tonnes_per_hectare:
+        title: Sorghum | 00000083 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Sorghum - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sorghum - Yield (tonnes per hectare)
+      soybeans__00000236__area_harvested__005312__hectares:
+        title: Soybeans | 00000236 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Soybeans - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Soybeans - Area harvested (hectares)
+      soybeans__00000236__production__005510__tonnes:
+        title: Soybeans | 00000236 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Soybeans - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Soybeans - Production (tonnes)
+      soybeans__00000236__yield__005419__tonnes_per_hectare:
+        title: Soybeans | 00000236 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Soybeans - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Soybeans - Yield (tonnes per hectare)
+      sugar_beet__00000157__area_harvested__005312__hectares:
+        title: Sugar beet | 00000157 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Sugar beet - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sugar beet - Area harvested (hectares)
+      sugar_beet__00000157__production__005510__tonnes:
+        title: Sugar beet | 00000157 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Sugar beet - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sugar beet - Production (tonnes)
+      sugar_cane__00000156__area_harvested__005312__hectares:
+        title: Sugar cane | 00000156 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Sugar cane - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sugar cane - Area harvested (hectares)
+      sugar_cane__00000156__production__005510__tonnes:
+        title: Sugar cane | 00000156 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Sugar cane - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sugar cane - Production (tonnes)
+      sugar_cane__00000156__yield__005419__tonnes_per_hectare:
+        title: Sugar cane | 00000156 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Sugar cane - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sugar cane - Yield (tonnes per hectare)
+      sunflower_seed__00000267__area_harvested__005312__hectares:
+        title: Sunflower seed | 00000267 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Sunflower seed - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sunflower seed - Area harvested (hectares)
+      sunflower_seed__00000267__production__005510__tonnes:
+        title: Sunflower seed | 00000267 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Sunflower seed - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sunflower seed - Production (tonnes)
+      sunflower_seed__00000267__yield__005419__tonnes_per_hectare:
+        title: Sunflower seed | 00000267 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Sunflower seed - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sunflower seed - Yield (tonnes per hectare)
+      sweet_potatoes__00000122__production__005510__tonnes:
+        title: Sweet potatoes | 00000122 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Sweet potatoes - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sweet potatoes - Production (tonnes)
+      swine__pigs__00001034__stocks__005111__animals:
+        title: Swine / pigs | 00001034 || Stocks | 005111 || animals
+        unit: animals
+        short_unit: animals
+        processing_level: major
+        display:
+          name: Swine / pigs - Stocks (animals)
+          shortUnit: animals
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Swine / pigs - Stocks (animals)
+      tea__00000667__production__005510__tonnes:
+        title: Tea | 00000667 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Tea - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Tea - Production (tonnes)
+      tobacco__00000826__production__005510__tonnes:
+        title: Tobacco | 00000826 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Tobacco - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Tobacco - Production (tonnes)
+      tomatoes__00000388__area_harvested__005312__hectares:
+        title: Tomatoes | 00000388 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Tomatoes - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Tomatoes - Area harvested (hectares)
+      tomatoes__00000388__production__005510__tonnes:
+        title: Tomatoes | 00000388 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Tomatoes - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Tomatoes - Production (tonnes)
+      tomatoes__00000388__yield__005419__tonnes_per_hectare:
+        title: Tomatoes | 00000388 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Tomatoes - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Tomatoes - Yield (tonnes per hectare)
+      tung_nuts__00000275__area_harvested__005312__hectares:
+        title: Tung nuts | 00000275 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Tung nuts - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Tung nuts - Area harvested (hectares)
+      wheat__00000015__area_harvested__005312__hectares:
+        title: Wheat | 00000015 || Area harvested | 005312 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Wheat - Area harvested (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Wheat - Area harvested (hectares)
+      wheat__00000015__production__005510__tonnes:
+        title: Wheat | 00000015 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Wheat - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Wheat - Production (tonnes)
+      wheat__00000015__yield__005419__tonnes_per_hectare:
+        title: Wheat | 00000015 || Yield | 005419 || tonnes per hectare
+        unit: tonnes per hectare
+        short_unit: t/ha
+        processing_level: major
+        display:
+          name: Wheat - Yield (tonnes per hectare)
+          shortUnit: t/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Wheat - Yield (tonnes per hectare)
+      wine__00000564__production__005510__tonnes:
+        title: Wine | 00000564 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Wine - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Wine - Production (tonnes)
+      yams__00000137__production__005510__tonnes:
+        title: Yams | 00000137 || Production | 005510 || tonnes
+        unit: tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Yams - Production (tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Yams - Production (tonnes)

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_qcl.py
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_qcl.py
@@ -543,8 +543,6 @@ def run(dest_dir: str) -> None:
     )
 
     # Update dataset metadata.
-    ds_garden.metadata.update_period_days = 365
-    ds_garden.metadata.title = dataset_metadata["owid_dataset_title"]
     # The following description is not publicly shown in charts; it is only visible when accessing the catalog.
     ds_garden.metadata.description = (
         dataset_metadata["owid_dataset_description"] + anomaly_descriptions + SLAUGHTERED_ANIMALS_ADDITIONAL_DESCRIPTION

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_qv.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_qv.meta.yml
@@ -20,8 +20,8 @@ tables:
         short_unit: ''
         processing_level: major
         display:
-          name: Agriculture - Gross Production Value (current thousand US$) (1000 USD)
+          name: Gross production value of the agricultural sector
           shortUnit: ''
           numDecimalPlaces: 2
         presentation:
-          title_public: Agriculture - Gross Production Value (current thousand US$) (1000 USD)
+          title_public: Gross production value of the agricultural sector

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_qv.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_qv.meta.yml
@@ -1,0 +1,27 @@
+dataset:
+  title: 'Production: Value of Agricultural Production'
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
+tables:
+  faostat_qv_flat:
+    title: 'Production: Value of Agricultural Production'
+    variables:
+      agriculture__00002051__gross_production_value__current_thousand_usd__000057__1000_usd:
+        title: Agriculture | 00002051 || Gross Production Value (current thousand US$) | 000057 || 1000 USD
+        unit: 1000 USD
+        short_unit: ''
+        processing_level: major
+        display:
+          name: Agriculture - Gross Production Value (current thousand US$) (1000 USD)
+          shortUnit: ''
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Agriculture - Gross Production Value (current thousand US$) (1000 USD)

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_qv.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_qv.meta.yml
@@ -16,8 +16,8 @@ tables:
     variables:
       agriculture__00002051__gross_production_value__current_thousand_usd__000057__1000_usd:
         title: Agriculture | 00002051 || Gross Production Value (current thousand US$) | 000057 || 1000 USD
-        unit: 1000 USD
-        short_unit: ''
+        unit: current thousand US$
+        short_unit: '$'
         processing_level: major
         display:
           name: Gross production value of the agricultural sector

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_rfn.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_rfn.meta.yml
@@ -1,0 +1,115 @@
+dataset:
+  title: 'Inputs: Fertilizers by Nutrient'
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
+tables:
+  faostat_rfn_flat:
+    title: 'Inputs: Fertilizers by Nutrient'
+    variables:
+      nutrient_nitrogen_n__total__00003102__agricultural_use__005157__tonnes:
+        title: Nutrient nitrogen N (total) | 00003102 || Agricultural Use | 005157 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Nutrient nitrogen N (total) - Agricultural Use (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Nutrient nitrogen N (total) - Agricultural Use (Tonnes)
+      nutrient_nitrogen_n__total__00003102__production__005510__tonnes:
+        title: Nutrient nitrogen N (total) | 00003102 || Production | 005510 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Nutrient nitrogen N (total) - Production (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Nutrient nitrogen N (total) - Production (Tonnes)
+      nutrient_nitrogen_n__total__00003102__use_per_area_of_cropland__005159__kilograms_per_hectare:
+        title: Nutrient nitrogen N (total) | 00003102 || Use per area of cropland | 005159 || Kilograms per hectare
+        unit: Kilograms per hectare
+        short_unit: kg/ha
+        processing_level: major
+        display:
+          name: Nutrient nitrogen N (total) - Use per area of cropland (Kilograms per hectare)
+          shortUnit: kg/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Nutrient nitrogen N (total) - Use per area of cropland (Kilograms per hectare)
+      nutrient_phosphate_p2o5__total__00003103__agricultural_use__005157__tonnes:
+        title: Nutrient phosphate P2O5 (total) | 00003103 || Agricultural Use | 005157 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Nutrient phosphate P2O5 (total) - Agricultural Use (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Nutrient phosphate P2O5 (total) - Agricultural Use (Tonnes)
+      nutrient_phosphate_p2o5__total__00003103__production__005510__tonnes:
+        title: Nutrient phosphate P2O5 (total) | 00003103 || Production | 005510 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Nutrient phosphate P2O5 (total) - Production (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Nutrient phosphate P2O5 (total) - Production (Tonnes)
+      nutrient_phosphate_p2o5__total__00003103__use_per_area_of_cropland__005159__kilograms_per_hectare:
+        title: Nutrient phosphate P2O5 (total) | 00003103 || Use per area of cropland | 005159 || Kilograms per hectare
+        unit: Kilograms per hectare
+        short_unit: kg/ha
+        processing_level: major
+        display:
+          name: Nutrient phosphate P2O5 (total) - Use per area of cropland (Kilograms per hectare)
+          shortUnit: kg/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Nutrient phosphate P2O5 (total) - Use per area of cropland (Kilograms per hectare)
+      nutrient_potash_k2o__total__00003104__agricultural_use__005157__tonnes:
+        title: Nutrient potash K2O (total) | 00003104 || Agricultural Use | 005157 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Nutrient potash K2O (total) - Agricultural Use (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Nutrient potash K2O (total) - Agricultural Use (Tonnes)
+      nutrient_potash_k2o__total__00003104__production__005510__tonnes:
+        title: Nutrient potash K2O (total) | 00003104 || Production | 005510 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Nutrient potash K2O (total) - Production (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Nutrient potash K2O (total) - Production (Tonnes)
+      nutrient_potash_k2o__total__00003104__use_per_area_of_cropland__005159__kilograms_per_hectare:
+        title: Nutrient potash K2O (total) | 00003104 || Use per area of cropland | 005159 || Kilograms per hectare
+        unit: Kilograms per hectare
+        short_unit: kg/ha
+        processing_level: major
+        display:
+          name: Nutrient potash K2O (total) - Use per area of cropland (Kilograms per hectare)
+          shortUnit: kg/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Nutrient potash K2O (total) - Use per area of cropland (Kilograms per hectare)

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_rfn.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_rfn.meta.yml
@@ -16,7 +16,7 @@ tables:
     variables:
       nutrient_nitrogen_n__total__00003102__agricultural_use__005157__tonnes:
         title: Nutrient nitrogen N (total) | 00003102 || Agricultural Use | 005157 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -27,7 +27,7 @@ tables:
           title_public: Nitrogen fertilizer user
       nutrient_nitrogen_n__total__00003102__production__005510__tonnes:
         title: Nutrient nitrogen N (total) | 00003102 || Production | 005510 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -38,7 +38,7 @@ tables:
           title_public: Nitrogen fertilizer production
       nutrient_nitrogen_n__total__00003102__use_per_area_of_cropland__005159__kilograms_per_hectare:
         title: Nutrient nitrogen N (total) | 00003102 || Use per area of cropland | 005159 || Kilograms per hectare
-        unit: Kilograms per hectare
+        unit: kilograms per hectare
         short_unit: kg/ha
         processing_level: major
         display:
@@ -49,7 +49,7 @@ tables:
           title_public: Nitrogen fertilizer use per area of cropland
       nutrient_phosphate_p2o5__total__00003103__agricultural_use__005157__tonnes:
         title: Nutrient phosphate P2O5 (total) | 00003103 || Agricultural Use | 005157 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -60,7 +60,7 @@ tables:
           title_public: Phosphate fertilizer use
       nutrient_phosphate_p2o5__total__00003103__production__005510__tonnes:
         title: Nutrient phosphate P2O5 (total) | 00003103 || Production | 005510 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -71,7 +71,7 @@ tables:
           title_public: Phosphate fertilizer production
       nutrient_phosphate_p2o5__total__00003103__use_per_area_of_cropland__005159__kilograms_per_hectare:
         title: Nutrient phosphate P2O5 (total) | 00003103 || Use per area of cropland | 005159 || Kilograms per hectare
-        unit: Kilograms per hectare
+        unit: kilograms per hectare
         short_unit: kg/ha
         processing_level: major
         display:
@@ -82,7 +82,7 @@ tables:
           title_public: Phosphate fertilizer use per area of cropland
       nutrient_potash_k2o__total__00003104__agricultural_use__005157__tonnes:
         title: Nutrient potash K2O (total) | 00003104 || Agricultural Use | 005157 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -93,7 +93,7 @@ tables:
           title_public: Potash fertilizer use
       nutrient_potash_k2o__total__00003104__production__005510__tonnes:
         title: Nutrient potash K2O (total) | 00003104 || Production | 005510 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -104,7 +104,7 @@ tables:
           title_public: Potash fertilizer production
       nutrient_potash_k2o__total__00003104__use_per_area_of_cropland__005159__kilograms_per_hectare:
         title: Nutrient potash K2O (total) | 00003104 || Use per area of cropland | 005159 || Kilograms per hectare
-        unit: Kilograms per hectare
+        unit: kilograms per hectare
         short_unit: kg/ha
         processing_level: major
         display:

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_rfn.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_rfn.meta.yml
@@ -20,96 +20,96 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Nutrient nitrogen N (total) - Agricultural Use (Tonnes)
+          name: Nitrogen fertilizer user
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Nutrient nitrogen N (total) - Agricultural Use (Tonnes)
+          title_public: Nitrogen fertilizer user
       nutrient_nitrogen_n__total__00003102__production__005510__tonnes:
         title: Nutrient nitrogen N (total) | 00003102 || Production | 005510 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Nutrient nitrogen N (total) - Production (Tonnes)
+          name: Nitrogen fertilizer production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Nutrient nitrogen N (total) - Production (Tonnes)
+          title_public: Nitrogen fertilizer production
       nutrient_nitrogen_n__total__00003102__use_per_area_of_cropland__005159__kilograms_per_hectare:
         title: Nutrient nitrogen N (total) | 00003102 || Use per area of cropland | 005159 || Kilograms per hectare
         unit: Kilograms per hectare
         short_unit: kg/ha
         processing_level: major
         display:
-          name: Nutrient nitrogen N (total) - Use per area of cropland (Kilograms per hectare)
+          name: Nitrogen fertilizer use per area of cropland
           shortUnit: kg/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Nutrient nitrogen N (total) - Use per area of cropland (Kilograms per hectare)
+          title_public: Nitrogen fertilizer use per area of cropland
       nutrient_phosphate_p2o5__total__00003103__agricultural_use__005157__tonnes:
         title: Nutrient phosphate P2O5 (total) | 00003103 || Agricultural Use | 005157 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Nutrient phosphate P2O5 (total) - Agricultural Use (Tonnes)
+          name: Phosphate fertilizer use
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Nutrient phosphate P2O5 (total) - Agricultural Use (Tonnes)
+          title_public: Phosphate fertilizer use
       nutrient_phosphate_p2o5__total__00003103__production__005510__tonnes:
         title: Nutrient phosphate P2O5 (total) | 00003103 || Production | 005510 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Nutrient phosphate P2O5 (total) - Production (Tonnes)
+          name: Phosphate fertilizer production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Nutrient phosphate P2O5 (total) - Production (Tonnes)
+          title_public: Phosphate fertilizer production
       nutrient_phosphate_p2o5__total__00003103__use_per_area_of_cropland__005159__kilograms_per_hectare:
         title: Nutrient phosphate P2O5 (total) | 00003103 || Use per area of cropland | 005159 || Kilograms per hectare
         unit: Kilograms per hectare
         short_unit: kg/ha
         processing_level: major
         display:
-          name: Nutrient phosphate P2O5 (total) - Use per area of cropland (Kilograms per hectare)
+          name: Phosphate fertilizer use per area of cropland
           shortUnit: kg/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Nutrient phosphate P2O5 (total) - Use per area of cropland (Kilograms per hectare)
+          title_public: Phosphate fertilizer use per area of cropland
       nutrient_potash_k2o__total__00003104__agricultural_use__005157__tonnes:
         title: Nutrient potash K2O (total) | 00003104 || Agricultural Use | 005157 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Nutrient potash K2O (total) - Agricultural Use (Tonnes)
+          name: Potash fertilizer use
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Nutrient potash K2O (total) - Agricultural Use (Tonnes)
+          title_public: Potash fertilizer use
       nutrient_potash_k2o__total__00003104__production__005510__tonnes:
         title: Nutrient potash K2O (total) | 00003104 || Production | 005510 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Nutrient potash K2O (total) - Production (Tonnes)
+          name: Potash fertilizer production
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Nutrient potash K2O (total) - Production (Tonnes)
+          title_public: Potash fertilizer production
       nutrient_potash_k2o__total__00003104__use_per_area_of_cropland__005159__kilograms_per_hectare:
         title: Nutrient potash K2O (total) | 00003104 || Use per area of cropland | 005159 || Kilograms per hectare
         unit: Kilograms per hectare
         short_unit: kg/ha
         processing_level: major
         display:
-          name: Nutrient potash K2O (total) - Use per area of cropland (Kilograms per hectare)
+          name: Potash fertilizer use per area of cropland
           shortUnit: kg/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Nutrient potash K2O (total) - Use per area of cropland (Kilograms per hectare)
+          title_public: Potash fertilizer use per area of cropland

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_rl.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_rl.meta.yml
@@ -16,133 +16,141 @@ tables:
     variables:
       agricultural_land__00006610__area__005110__hectares:
         title: Agricultural land | 00006610 || Area | 005110 || hectares
+        description_short: |-
+          Land used for cultivation of crops and animal husbandry. The total of areas under cropland and permanent meadows and pastures.
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Agricultural land - Area (hectares)
+          name: Agricultural land use
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Agricultural land - Area (hectares)
+          title_public: Agricultural land use
       agricultural_land__00006610__area__5110pc__hectares_per_capita:
         title: Agricultural land | 00006610 || Area | 5110pc || hectares per capita
         unit: hectares per capita
         short_unit: ha
         processing_level: major
         display:
-          name: Agricultural land - Area (hectares per capita)
+          name: Agricultural land use per capita
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Agricultural land - Area (hectares per capita)
+          title_public: Agricultural land use per capita
       agriculture_area_certified_organic__00006672__area__005110__hectares:
         title: Agriculture area certified organic | 00006672 || Area | 005110 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Agriculture area certified organic - Area (hectares)
+          name: Agricultural area certified organic
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Agriculture area certified organic - Area (hectares)
+          title_public: Agricultural area certified organic
       agriculture_area_under_organic_agric__00006671__share_in_agricultural_land__007208__percent:
         title: Agriculture area under organic agric. | 00006671 || Share in Agricultural land | 007208 || Percent
+        description_short: |-
+          Organic arable land area is the sum of the area certified as organic by official standards, and land area in the conversion process to organic (which is assumed by the UN FAO as a two-year period prior to certification). Arable land is that used for crops (which does not include grazing land).
         unit: Percent
         short_unit: '%'
         processing_level: major
         display:
-          name: Agriculture area under organic agric. - Share in Agricultural land (Percent)
+          name: Share of arable land that is organic
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: Agriculture area under organic agric. - Share in Agricultural land (Percent)
+          title_public: Share of arable land that is organic
       agriculture__00006602__area__005110__hectares:
         title: Agriculture | 00006602 || Area | 005110 || hectares
+        description_short: |-
+          Land used for agricultural purposes, including for cultivation of crops and animal husbandry, farm buildings, etc.
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Agriculture - Area (hectares)
+          name: Area used for agricultural purposes
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Agriculture - Area (hectares)
+          title_public: Area used for agricultural purposes
       arable_land__00006621__area__005110__hectares:
         title: Arable land | 00006621 || Area | 005110 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Arable land - Area (hectares)
+          name: Area of arable land
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Arable land - Area (hectares)
+          title_public: Area of arable land
       cropland__00006620__area__005110__hectares:
         title: Cropland | 00006620 || Area | 005110 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Cropland - Area (hectares)
+          name: Cropland area
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Cropland - Area (hectares)
+          title_public: Cropland area
       forest_land__00006646__area__005110__hectares:
         title: Forest land | 00006646 || Area | 005110 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Forest land - Area (hectares)
+          name: Area of forest
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Forest land - Area (hectares)
+          title_public: Area of forest
       naturally_regenerating_forest__00006717__area__005110__hectares:
         title: Naturally regenerating forest | 00006717 || Area | 005110 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Naturally regenerating forest - Area (hectares)
+          name: Area of naturally regenerating forest
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Naturally regenerating forest - Area (hectares)
+          title_public: Area of naturally regenerating forest
       permanent_meadows_and_pastures__00006655__area__005110__hectares:
         title: Permanent meadows and pastures | 00006655 || Area | 005110 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Permanent meadows and pastures - Area (hectares)
+          name: Area of permanent meadows and pastures
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Permanent meadows and pastures - Area (hectares)
+          title_public: Area of permanent meadows and pastures
       permanent_meadows_and_pastures__00006655__share_in_land_area__007209__percent:
         title: Permanent meadows and pastures | 00006655 || Share in Land area | 007209 || Percent
+        description_short: |-
+          Permanent meadows and pastures are areas used permanently (five years or more) for herbaceous forage crops, either cultivated or growing wild (wild prairie or grazing land).
         unit: Percent
         short_unit: '%'
         processing_level: major
         display:
-          name: Permanent meadows and pastures - Share in Land area (Percent)
+          name: Share of land used for permanent meadows and pastures
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: Permanent meadows and pastures - Share in Land area (Percent)
+          title_public: Share of land used for permanent meadows and pastures
       planted_forest__00006716__area__005110__hectares:
         title: Planted Forest | 00006716 || Area | 005110 || hectares
         unit: hectares
         short_unit: ha
         processing_level: major
         display:
-          name: Planted Forest - Area (hectares)
+          name: Area of planted forest
           shortUnit: ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Planted Forest - Area (hectares)
+          title_public: Area of planted forest

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_rl.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_rl.meta.yml
@@ -53,7 +53,7 @@ tables:
         title: Agriculture area under organic agric. | 00006671 || Share in Agricultural land | 007208 || Percent
         description_short: |-
           Organic arable land area is the sum of the area certified as organic by official standards, and land area in the conversion process to organic (which is assumed by the UN FAO as a two-year period prior to certification). Arable land is that used for crops (which does not include grazing land).
-        unit: Percent
+        unit: percent
         short_unit: '%'
         processing_level: major
         display:
@@ -134,7 +134,7 @@ tables:
         title: Permanent meadows and pastures | 00006655 || Share in Land area | 007209 || Percent
         description_short: |-
           Permanent meadows and pastures are areas used permanently (five years or more) for herbaceous forage crops, either cultivated or growing wild (wild prairie or grazing land).
-        unit: Percent
+        unit: percent
         short_unit: '%'
         processing_level: major
         display:

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_rl.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_rl.meta.yml
@@ -1,0 +1,148 @@
+dataset:
+  title: 'Inputs: Land Use'
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
+tables:
+  faostat_rl_flat:
+    title: 'Inputs: Land Use'
+    variables:
+      agricultural_land__00006610__area__005110__hectares:
+        title: Agricultural land | 00006610 || Area | 005110 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Agricultural land - Area (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Agricultural land - Area (hectares)
+      agricultural_land__00006610__area__5110pc__hectares_per_capita:
+        title: Agricultural land | 00006610 || Area | 5110pc || hectares per capita
+        unit: hectares per capita
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Agricultural land - Area (hectares per capita)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Agricultural land - Area (hectares per capita)
+      agriculture_area_certified_organic__00006672__area__005110__hectares:
+        title: Agriculture area certified organic | 00006672 || Area | 005110 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Agriculture area certified organic - Area (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Agriculture area certified organic - Area (hectares)
+      agriculture_area_under_organic_agric__00006671__share_in_agricultural_land__007208__percent:
+        title: Agriculture area under organic agric. | 00006671 || Share in Agricultural land | 007208 || Percent
+        unit: Percent
+        short_unit: '%'
+        processing_level: major
+        display:
+          name: Agriculture area under organic agric. - Share in Agricultural land (Percent)
+          shortUnit: '%'
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Agriculture area under organic agric. - Share in Agricultural land (Percent)
+      agriculture__00006602__area__005110__hectares:
+        title: Agriculture | 00006602 || Area | 005110 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Agriculture - Area (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Agriculture - Area (hectares)
+      arable_land__00006621__area__005110__hectares:
+        title: Arable land | 00006621 || Area | 005110 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Arable land - Area (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Arable land - Area (hectares)
+      cropland__00006620__area__005110__hectares:
+        title: Cropland | 00006620 || Area | 005110 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Cropland - Area (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Cropland - Area (hectares)
+      forest_land__00006646__area__005110__hectares:
+        title: Forest land | 00006646 || Area | 005110 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Forest land - Area (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Forest land - Area (hectares)
+      naturally_regenerating_forest__00006717__area__005110__hectares:
+        title: Naturally regenerating forest | 00006717 || Area | 005110 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Naturally regenerating forest - Area (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Naturally regenerating forest - Area (hectares)
+      permanent_meadows_and_pastures__00006655__area__005110__hectares:
+        title: Permanent meadows and pastures | 00006655 || Area | 005110 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Permanent meadows and pastures - Area (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Permanent meadows and pastures - Area (hectares)
+      permanent_meadows_and_pastures__00006655__share_in_land_area__007209__percent:
+        title: Permanent meadows and pastures | 00006655 || Share in Land area | 007209 || Percent
+        unit: Percent
+        short_unit: '%'
+        processing_level: major
+        display:
+          name: Permanent meadows and pastures - Share in Land area (Percent)
+          shortUnit: '%'
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Permanent meadows and pastures - Share in Land area (Percent)
+      planted_forest__00006716__area__005110__hectares:
+        title: Planted Forest | 00006716 || Area | 005110 || hectares
+        unit: hectares
+        short_unit: ha
+        processing_level: major
+        display:
+          name: Planted Forest - Area (hectares)
+          shortUnit: ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Planted Forest - Area (hectares)

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_rp.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_rp.meta.yml
@@ -1,0 +1,104 @@
+dataset:
+  title: 'Inputs: Pesticides Use'
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
+tables:
+  faostat_rp_flat:
+    title: 'Inputs: Pesticides Use'
+    variables:
+      fungicides_and_bactericides__00001331__agricultural_use__005157__tonnes:
+        title: Fungicides and Bactericides | 00001331 || Agricultural Use | 005157 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Fungicides and Bactericides - Agricultural Use (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Fungicides and Bactericides - Agricultural Use (Tonnes)
+      herbicides__00001320__agricultural_use__005157__tonnes:
+        title: Herbicides | 00001320 || Agricultural Use | 005157 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Herbicides - Agricultural Use (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Herbicides - Agricultural Use (Tonnes)
+      insecticides__00001309__agricultural_use__005157__tonnes:
+        title: Insecticides | 00001309 || Agricultural Use | 005157 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Insecticides - Agricultural Use (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Insecticides - Agricultural Use (Tonnes)
+      other_pesticides_nes__00001355__agricultural_use__005157__tonnes:
+        title: Other Pesticides nes | 00001355 || Agricultural Use | 005157 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Other Pesticides nes - Agricultural Use (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Other Pesticides nes - Agricultural Use (Tonnes)
+      pesticides__total__00001357__agricultural_use__005157__tonnes:
+        title: Pesticides (total) | 00001357 || Agricultural Use | 005157 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Pesticides (total) - Agricultural Use (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Pesticides (total) - Agricultural Use (Tonnes)
+      pesticides__total__00001357__use_per_area_of_cropland__005159__kilograms_per_hectare:
+        title: Pesticides (total) | 00001357 || Use per area of cropland | 005159 || Kilograms per hectare
+        unit: Kilograms per hectare
+        short_unit: kg/ha
+        processing_level: major
+        display:
+          name: Pesticides (total) - Use per area of cropland (Kilograms per hectare)
+          shortUnit: kg/ha
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Pesticides (total) - Use per area of cropland (Kilograms per hectare)
+      plant_growth_regulators__00001341__agricultural_use__005157__tonnes:
+        title: Plant Growth Regulators | 00001341 || Agricultural Use | 005157 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Plant Growth Regulators - Agricultural Use (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Plant Growth Regulators - Agricultural Use (Tonnes)
+      rodenticides__00001345__agricultural_use__005157__tonnes:
+        title: Rodenticides | 00001345 || Agricultural Use | 005157 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Rodenticides - Agricultural Use (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rodenticides - Agricultural Use (Tonnes)

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_rp.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_rp.meta.yml
@@ -16,7 +16,7 @@ tables:
     variables:
       fungicides_and_bactericides__00001331__agricultural_use__005157__tonnes:
         title: Fungicides and Bactericides | 00001331 || Agricultural Use | 005157 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -27,7 +27,7 @@ tables:
           title_public: Fungicide and bactericide use
       herbicides__00001320__agricultural_use__005157__tonnes:
         title: Herbicides | 00001320 || Agricultural Use | 005157 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -38,7 +38,7 @@ tables:
           title_public: Herbicide use
       insecticides__00001309__agricultural_use__005157__tonnes:
         title: Insecticides | 00001309 || Agricultural Use | 005157 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -49,7 +49,7 @@ tables:
           title_public: Insecticide use
       other_pesticides_nes__00001355__agricultural_use__005157__tonnes:
         title: Other Pesticides nes | 00001355 || Agricultural Use | 005157 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -60,7 +60,7 @@ tables:
           title_public: Other pesticide use
       pesticides__total__00001357__agricultural_use__005157__tonnes:
         title: Pesticides (total) | 00001357 || Agricultural Use | 005157 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -71,7 +71,7 @@ tables:
           title_public: Total pesticide use
       pesticides__total__00001357__use_per_area_of_cropland__005159__kilograms_per_hectare:
         title: Pesticides (total) | 00001357 || Use per area of cropland | 005159 || Kilograms per hectare
-        unit: Kilograms per hectare
+        unit: kilograms per hectare
         short_unit: kg/ha
         processing_level: major
         display:
@@ -82,7 +82,7 @@ tables:
           title_public: Total pesticide use per area of cropland
       plant_growth_regulators__00001341__agricultural_use__005157__tonnes:
         title: Plant Growth Regulators | 00001341 || Agricultural Use | 005157 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -93,7 +93,7 @@ tables:
           title_public: Plant growth regulator use
       rodenticides__00001345__agricultural_use__005157__tonnes:
         title: Rodenticides | 00001345 || Agricultural Use | 005157 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_rp.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_rp.meta.yml
@@ -20,85 +20,85 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Fungicides and Bactericides - Agricultural Use (Tonnes)
+          name: Fungicide and bactericide use
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Fungicides and Bactericides - Agricultural Use (Tonnes)
+          title_public: Fungicide and bactericide use
       herbicides__00001320__agricultural_use__005157__tonnes:
         title: Herbicides | 00001320 || Agricultural Use | 005157 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Herbicides - Agricultural Use (Tonnes)
+          name: Herbicide use
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Herbicides - Agricultural Use (Tonnes)
+          title_public: Herbicide use
       insecticides__00001309__agricultural_use__005157__tonnes:
         title: Insecticides | 00001309 || Agricultural Use | 005157 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Insecticides - Agricultural Use (Tonnes)
+          name: Insecticide use
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Insecticides - Agricultural Use (Tonnes)
+          title_public: Insecticide use
       other_pesticides_nes__00001355__agricultural_use__005157__tonnes:
         title: Other Pesticides nes | 00001355 || Agricultural Use | 005157 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Other Pesticides nes - Agricultural Use (Tonnes)
+          name: Other pesticide use
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Other Pesticides nes - Agricultural Use (Tonnes)
+          title_public: Other pesticide use
       pesticides__total__00001357__agricultural_use__005157__tonnes:
         title: Pesticides (total) | 00001357 || Agricultural Use | 005157 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Pesticides (total) - Agricultural Use (Tonnes)
+          name: Total pesticide use
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Pesticides (total) - Agricultural Use (Tonnes)
+          title_public: Total pesticide use
       pesticides__total__00001357__use_per_area_of_cropland__005159__kilograms_per_hectare:
         title: Pesticides (total) | 00001357 || Use per area of cropland | 005159 || Kilograms per hectare
         unit: Kilograms per hectare
         short_unit: kg/ha
         processing_level: major
         display:
-          name: Pesticides (total) - Use per area of cropland (Kilograms per hectare)
+          name: Total pesticide use per area of cropland
           shortUnit: kg/ha
           numDecimalPlaces: 2
         presentation:
-          title_public: Pesticides (total) - Use per area of cropland (Kilograms per hectare)
+          title_public: Total pesticide use per area of cropland
       plant_growth_regulators__00001341__agricultural_use__005157__tonnes:
         title: Plant Growth Regulators | 00001341 || Agricultural Use | 005157 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Plant Growth Regulators - Agricultural Use (Tonnes)
+          name: Plant growth regulator use
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Plant Growth Regulators - Agricultural Use (Tonnes)
+          title_public: Plant growth regulator use
       rodenticides__00001345__agricultural_use__005157__tonnes:
         title: Rodenticides | 00001345 || Agricultural Use | 005157 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Rodenticides - Agricultural Use (Tonnes)
+          name: Rodenticide use
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Rodenticides - Agricultural Use (Tonnes)
+          title_public: Rodenticide use

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_scl.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_scl.meta.yml
@@ -16,7 +16,7 @@ tables:
     variables:
       oil_of_sesame_seed__00000290__production__005510__tonnes:
         title: Oil of sesame seed | 00000290 || Production | 005510 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -27,7 +27,7 @@ tables:
           title_public: Production of sesame seed oil
       rapeseed_or_canola_oil__crude__00000271__production__005510__tonnes:
         title: Rapeseed or canola oil, crude | 00000271 || Production | 005510 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -38,7 +38,7 @@ tables:
           title_public: Production of rapeseed or canola oil
       safflower_seed_oil__crude__00000281__production__005510__tonnes:
         title: Safflower-seed oil, crude | 00000281 || Production | 005510 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -49,7 +49,7 @@ tables:
           title_public: Production of safflower-seed oil
       soya_bean_oil__00000237__production__005510__tonnes:
         title: Soya bean oil | 00000237 || Production | 005510 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:
@@ -60,7 +60,7 @@ tables:
           title_public: Production of soya bean oil
       sunflower_seed_oil__crude__00000268__production__005510__tonnes:
         title: Sunflower-seed oil, crude | 00000268 || Production | 005510 || Tonnes
-        unit: Tonnes
+        unit: tonnes
         short_unit: t
         processing_level: major
         display:

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_scl.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_scl.meta.yml
@@ -1,0 +1,71 @@
+dataset:
+  title: 'Food Balances: Supply Utilization Accounts'
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
+tables:
+  faostat_scl_flat:
+    title: 'Food Balances: Supply Utilization Accounts'
+    variables:
+      oil_of_sesame_seed__00000290__production__005510__tonnes:
+        title: Oil of sesame seed | 00000290 || Production | 005510 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Oil of sesame seed - Production (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Oil of sesame seed - Production (Tonnes)
+      rapeseed_or_canola_oil__crude__00000271__production__005510__tonnes:
+        title: Rapeseed or canola oil, crude | 00000271 || Production | 005510 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Rapeseed or canola oil, crude - Production (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Rapeseed or canola oil, crude - Production (Tonnes)
+      safflower_seed_oil__crude__00000281__production__005510__tonnes:
+        title: Safflower-seed oil, crude | 00000281 || Production | 005510 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Safflower-seed oil, crude - Production (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Safflower-seed oil, crude - Production (Tonnes)
+      soya_bean_oil__00000237__production__005510__tonnes:
+        title: Soya bean oil | 00000237 || Production | 005510 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Soya bean oil - Production (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Soya bean oil - Production (Tonnes)
+      sunflower_seed_oil__crude__00000268__production__005510__tonnes:
+        title: Sunflower-seed oil, crude | 00000268 || Production | 005510 || Tonnes
+        unit: Tonnes
+        short_unit: t
+        processing_level: major
+        display:
+          name: Sunflower-seed oil, crude - Production (Tonnes)
+          shortUnit: t
+          numDecimalPlaces: 2
+        presentation:
+          title_public: Sunflower-seed oil, crude - Production (Tonnes)

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_scl.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_scl.meta.yml
@@ -20,52 +20,52 @@ tables:
         short_unit: t
         processing_level: major
         display:
-          name: Oil of sesame seed - Production (Tonnes)
+          name: Production of sesame seed oil
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Oil of sesame seed - Production (Tonnes)
+          title_public: Production of sesame seed oil
       rapeseed_or_canola_oil__crude__00000271__production__005510__tonnes:
         title: Rapeseed or canola oil, crude | 00000271 || Production | 005510 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Rapeseed or canola oil, crude - Production (Tonnes)
+          name: Production of rapeseed or canola oil
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Rapeseed or canola oil, crude - Production (Tonnes)
+          title_public: Production of rapeseed or canola oil
       safflower_seed_oil__crude__00000281__production__005510__tonnes:
         title: Safflower-seed oil, crude | 00000281 || Production | 005510 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Safflower-seed oil, crude - Production (Tonnes)
+          name: Production of safflower-seed oil
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Safflower-seed oil, crude - Production (Tonnes)
+          title_public: Production of safflower-seed oil
       soya_bean_oil__00000237__production__005510__tonnes:
         title: Soya bean oil | 00000237 || Production | 005510 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Soya bean oil - Production (Tonnes)
+          name: Production of soya bean oil
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Soya bean oil - Production (Tonnes)
+          title_public: Production of soya bean oil
       sunflower_seed_oil__crude__00000268__production__005510__tonnes:
         title: Sunflower-seed oil, crude | 00000268 || Production | 005510 || Tonnes
         unit: Tonnes
         short_unit: t
         processing_level: major
         display:
-          name: Sunflower-seed oil, crude - Production (Tonnes)
+          name: Production of sunflower-seed oil
           shortUnit: t
           numDecimalPlaces: 2
         presentation:
-          title_public: Sunflower-seed oil, crude - Production (Tonnes)
+          title_public: Production of sunflower-seed oil

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_sdgb.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_sdgb.meta.yml
@@ -20,45 +20,43 @@ tables:
         short_unit: '%'
         processing_level: major
         display:
-          name: 12.3.1a Food loss percentage - Value (Percent)
+          name: Share of food lost in post-harvest processes
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: 12.3.1a Food loss percentage - Value (Percent)
+          title_public: Share of food lost in post-harvest processes
       _2_1_1_number_of_undernourished_people__000000000024001__value__006132__million_number:
         title: 2.1.1 Number of undernourished people | 000000000024001 || Value | 006132 || million Number
         unit: million Number
         short_unit: million No
         processing_level: major
         display:
-          name: 2.1.1 Number of undernourished people - Value (million Number)
+          name: Number of people that are undernourished
           shortUnit: million No
           numDecimalPlaces: 2
         presentation:
-          title_public: 2.1.1 Number of undernourished people - Value (million Number)
+          title_public: Number of people that are undernourished
       _2_1_1_prevalence_of_undernourishment__000000000024000__value__006121__percent:
         title: 2.1.1 Prevalence of undernourishment | 000000000024000 || Value | 006121 || Percent
         unit: Percent
         short_unit: '%'
         processing_level: major
         display:
-          name: 2.1.1 Prevalence of undernourishment - Value (Percent)
+          name: Share of people that are undernourished
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: 2.1.1 Prevalence of undernourishment - Value (Percent)
-      ? |-
-        _2_1_2_prevalence_of_severe_food_insecurity__both_sexes_or_no_breakdown_by_sex__all_age_ranges_or_no_breakdown_by_age__no_breakdown_by_urbanisation__00000024003_ttt__value__006121__percent
-      : title: |-
+          title_public: Share of people that are undernourished
+      _2_1_2_prevalence_of_severe_food_insecurity__both_sexes_or_no_breakdown_by_sex__all_age_ranges_or_no_breakdown_by_age__no_breakdown_by_urbanisation__00000024003_ttt__value__006121__percent:
+        title: |-
           2.1.2 Prevalence of severe food insecurity (both sexes or no breakdown by sex) (all age ranges or no breakdown by age) (no breakdown by urbanisation) | 00000024003-TTT || Value | 006121 || Percent
         unit: Percent
         short_unit: '%'
         processing_level: major
         display:
-          name: |-
-            2.1.2 Prevalence of severe food insecurity (both sexes or no breakdown by sex) (all age ranges or no breakdown by age) (no breakdown by urbanisation) - Value (Percent)
+          name: Severe food insecurity
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
           title_public: |-
-            2.1.2 Prevalence of severe food insecurity (both sexes or no breakdown by sex) (all age ranges or no breakdown by age) (no breakdown by urbanisation) - Value (Percent)
+            Share of the population defined as severely food insecure

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_sdgb.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_sdgb.meta.yml
@@ -1,0 +1,64 @@
+dataset:
+  title: 'SDG Indicators: SDG Indicators'
+  update_period_days: 365
+
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Agricultural Production
+      attribution_short: FAO
+
+tables:
+  faostat_sdgb_flat:
+    title: 'SDG Indicators: SDG Indicators'
+    variables:
+      _12_3_1a_food_loss_percentage__000000000024044__value__006121__percent:
+        title: 12.3.1a Food loss percentage | 000000000024044 || Value | 006121 || Percent
+        unit: Percent
+        short_unit: '%'
+        processing_level: major
+        display:
+          name: 12.3.1a Food loss percentage - Value (Percent)
+          shortUnit: '%'
+          numDecimalPlaces: 2
+        presentation:
+          title_public: 12.3.1a Food loss percentage - Value (Percent)
+      _2_1_1_number_of_undernourished_people__000000000024001__value__006132__million_number:
+        title: 2.1.1 Number of undernourished people | 000000000024001 || Value | 006132 || million Number
+        unit: million Number
+        short_unit: million No
+        processing_level: major
+        display:
+          name: 2.1.1 Number of undernourished people - Value (million Number)
+          shortUnit: million No
+          numDecimalPlaces: 2
+        presentation:
+          title_public: 2.1.1 Number of undernourished people - Value (million Number)
+      _2_1_1_prevalence_of_undernourishment__000000000024000__value__006121__percent:
+        title: 2.1.1 Prevalence of undernourishment | 000000000024000 || Value | 006121 || Percent
+        unit: Percent
+        short_unit: '%'
+        processing_level: major
+        display:
+          name: 2.1.1 Prevalence of undernourishment - Value (Percent)
+          shortUnit: '%'
+          numDecimalPlaces: 2
+        presentation:
+          title_public: 2.1.1 Prevalence of undernourishment - Value (Percent)
+      ? |-
+        _2_1_2_prevalence_of_severe_food_insecurity__both_sexes_or_no_breakdown_by_sex__all_age_ranges_or_no_breakdown_by_age__no_breakdown_by_urbanisation__00000024003_ttt__value__006121__percent
+      : title: |-
+          2.1.2 Prevalence of severe food insecurity (both sexes or no breakdown by sex) (all age ranges or no breakdown by age) (no breakdown by urbanisation) | 00000024003-TTT || Value | 006121 || Percent
+        unit: Percent
+        short_unit: '%'
+        processing_level: major
+        display:
+          name: |-
+            2.1.2 Prevalence of severe food insecurity (both sexes or no breakdown by sex) (all age ranges or no breakdown by age) (no breakdown by urbanisation) - Value (Percent)
+          shortUnit: '%'
+          numDecimalPlaces: 2
+        presentation:
+          title_public: |-
+            2.1.2 Prevalence of severe food insecurity (both sexes or no breakdown by sex) (all age ranges or no breakdown by age) (no breakdown by urbanisation) - Value (Percent)

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_sdgb.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_sdgb.meta.yml
@@ -27,12 +27,12 @@ tables:
           title_public: Share of food lost in post-harvest processes
       _2_1_1_number_of_undernourished_people__000000000024001__value__006132__million_number:
         title: 2.1.1 Number of undernourished people | 000000000024001 || Value | 006132 || million Number
-        unit: million Number
-        short_unit: million No
+        unit: millions
+        short_unit: millions
         processing_level: major
         display:
           name: Number of people that are undernourished
-          shortUnit: million No
+          shortUnit: millions
           numDecimalPlaces: 0
         presentation:
           title_public: Number of people that are undernourished

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_sdgb.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_sdgb.meta.yml
@@ -33,7 +33,7 @@ tables:
         display:
           name: Number of people that are undernourished
           shortUnit: million No
-          numDecimalPlaces: 2
+          numDecimalPlaces: 0
         presentation:
           title_public: Number of people that are undernourished
       _2_1_1_prevalence_of_undernourishment__000000000024000__value__006121__percent:
@@ -48,8 +48,7 @@ tables:
         presentation:
           title_public: Share of people that are undernourished
       _2_1_2_prevalence_of_severe_food_insecurity__both_sexes_or_no_breakdown_by_sex__all_age_ranges_or_no_breakdown_by_age__no_breakdown_by_urbanisation__00000024003_ttt__value__006121__percent:
-        title: |-
-          2.1.2 Prevalence of severe food insecurity (both sexes or no breakdown by sex) (all age ranges or no breakdown by age) (no breakdown by urbanisation) | 00000024003-TTT || Value | 006121 || Percent
+        title: 2.1.2 Prevalence of severe food insecurity (both sexes or no breakdown by sex) (all age ranges or no breakdown by age) (no breakdown by urbanisation) | 00000024003-TTT || Value | 006121 || Percent
         unit: Percent
         short_unit: '%'
         processing_level: major
@@ -58,5 +57,4 @@ tables:
           shortUnit: '%'
           numDecimalPlaces: 2
         presentation:
-          title_public: |-
-            Share of the population defined as severely food insecure
+          title_public: Share of the population defined as severely food insecure

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_sdgb.meta.yml
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_sdgb.meta.yml
@@ -16,7 +16,7 @@ tables:
     variables:
       _12_3_1a_food_loss_percentage__000000000024044__value__006121__percent:
         title: 12.3.1a Food loss percentage | 000000000024044 || Value | 006121 || Percent
-        unit: Percent
+        unit: percent
         short_unit: '%'
         processing_level: major
         display:
@@ -38,7 +38,7 @@ tables:
           title_public: Number of people that are undernourished
       _2_1_1_prevalence_of_undernourishment__000000000024000__value__006121__percent:
         title: 2.1.1 Prevalence of undernourishment | 000000000024000 || Value | 006121 || Percent
-        unit: Percent
+        unit: percent
         short_unit: '%'
         processing_level: major
         display:
@@ -49,7 +49,7 @@ tables:
           title_public: Share of people that are undernourished
       _2_1_2_prevalence_of_severe_food_insecurity__both_sexes_or_no_breakdown_by_sex__all_age_ranges_or_no_breakdown_by_age__no_breakdown_by_urbanisation__00000024003_ttt__value__006121__percent:
         title: 2.1.2 Prevalence of severe food insecurity (both sexes or no breakdown by sex) (all age ranges or no breakdown by age) (no breakdown by urbanisation) | 00000024003-TTT || Value | 006121 || Percent
-        unit: Percent
+        unit: percent
         short_unit: '%'
         processing_level: major
         display:

--- a/etl/steps/data/garden/faostat/2024-03-14/shared.py
+++ b/etl/steps/data/garden/faostat/2024-03-14/shared.py
@@ -1743,18 +1743,13 @@ def prepare_wide_table(tb: Table) -> Table:
     # Add variable description.
     variable_name_mapping = _variable_name_map(tb, "variable_description")
     for column in tb_wide.columns:
-        tb_wide[column].metadata.description = variable_name_mapping[column]
+        tb_wide[column].metadata.description_from_producer = variable_name_mapping[column]
 
     # Add display and presentation parameters (for grapher).
-    for column in tb_wide.columns:
-        tb_wide[column].metadata.display = {}
-        tb_wide[column].metadata.presentation = VariablePresentationMeta()
-
-    # Display name.
     variable_name_mapping = _variable_name_map(tb, "variable_display_name")
     for column in tb_wide.columns:
-        tb_wide[column].metadata.display["name"] = variable_name_mapping[column]
-        tb_wide[column].metadata.presentation.title_public = variable_name_mapping[column]
+        tb_wide[column].metadata.display = {"name": variable_name_mapping[column]}
+        tb_wide[column].metadata.presentation = VariablePresentationMeta(title_public=variable_name_mapping[column])
 
     # Ensure columns have the optimal dtypes, but codes are categories.
     log.info("prepare_wide_table.optimize_table_dtypes", shape=tb_wide.shape)

--- a/etl/steps/data/garden/faostat/2024-03-14/shared.py
+++ b/etl/steps/data/garden/faostat/2024-03-14/shared.py
@@ -1904,8 +1904,6 @@ def run(dest_dir: str) -> None:
         check_variables_metadata=False,
     )
     # Update dataset metadata.
-    ds_garden.metadata.update_period_days = 365
-    ds_garden.metadata.title = dataset_metadata["owid_dataset_title"]
     # The following description is not publicly shown in charts; it is only visible when accessing the catalog.
     ds_garden.metadata.description = dataset_metadata["owid_dataset_description"] + anomaly_descriptions
 

--- a/snapshots/faostat/2024-03-14/faostat_cahd.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_cahd.zip.dvc
@@ -10,7 +10,7 @@ meta:
       These indicators support efforts within the framework of the Sustainable Development Goals (SDGs) to end hunger, achieve food security and improved nutrition, and promote sustainable agriculture by 2030 (SDG 2). They also support the monitoring of progress towards the objective of transforming agrifood systems by promoting “nutrition-sensitive agriculture”. For definitions of these indicators, see Definitions and standards.
     citation_full: |-
       Food and Agriculture Organization of the United Nations - Cost and Affordability of a Healthy Diet: Cost and Affordability of a Healthy Diet (CoAHD) (2023).
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/CAHD
     url_download: |-
       https://fenixservices.fao.org/faostat/static/bulkdownloads/Cost_Affordability_Healthy_Diet_(CoAHD)_E_All_Data_(Normalized).zip

--- a/snapshots/faostat/2024-03-14/faostat_ei.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_ei.zip.dvc
@@ -8,7 +8,7 @@ meta:
       This indicator is defined as greenhouse gas emissions per kg of product. Data are available for a set of agricultural commodities (e.g. rice and other cereals, meat, milk, eggs), by country, with global coverage and relative to the period 1961-2020.
     citation_full: |-
       Food and Agriculture Organization of the United Nations - Climate Change: Agrifood systems emissions: Emissions intensities (2023).
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/EI
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Environment_Emissions_intensities_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_ek.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_ek.zip.dvc
@@ -9,7 +9,7 @@ meta:
 
       FAOSTAT agri-environmental indicators on livestock patterns closely follow the structure of the indicators in EUROSTAT.
     citation_full: 'Food and Agriculture Organization of the United Nations - Land, Inputs and Sustainability: Livestock Patterns (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/EK
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Environment_LivestockPatterns_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_emn.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_emn.zip.dvc
@@ -9,7 +9,7 @@ meta:
 
       The following elements are disseminated: 1) Stocks; 2) Amount excreted in manure (N content);  3) Manure left on pasture (N content); 4) Manure left on pasture that volatilizes (N content); 5) Manure left on pasture that leaches (N content); 6) Manure treated (N content); 7) Losses from manure treated (N content); 8) Manure applied to soils (N content); 9) Manure applied to soils that volatilizes (N content); 10) Manure applied to soils that leaches (N content).
     citation_full: 'Food and Agriculture Organization of the United Nations - Land, Inputs and Sustainability: Livestock Manure (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/EMN
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Environment_LivestockManure_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_esb.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_esb.zip.dvc
@@ -10,7 +10,7 @@ meta:
       Data are available by country, with global coverage relative to the period 1961-2020, with annual updates.
     citation_full: |-
       Food and Agriculture Organization of the United Nations - Land, Inputs and Sustainability: Cropland Nutrient Balance (2023).
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/ESB
     url_download: |-
       https://fenixservices.fao.org/faostat/static/bulkdownloads/Environment_Cropland_nutrient_budget_E_All_Data_(Normalized).zip

--- a/snapshots/faostat/2024-03-14/faostat_fa.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_fa.zip.dvc
@@ -5,7 +5,7 @@ meta:
     description: ''
     citation_full: |-
       Food and Agriculture Organization of the United Nations - Discontinued archives and data series: Food Aid Shipments (WFP) (2016).
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/FA
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Food_Aid_Shipments_WFP_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_fbs.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_fbs.zip.dvc
@@ -9,7 +9,7 @@ meta:
 
       On the utilization side a distinction is made between the quantities exported, fed to livestock, used for seed, put to manufacture for food use and non-food uses, losses during storage and transportation, and food supplies available for human consumption. The per caput supply of each such food item available for human consumption is then obtained by dividing the respective quantity by the related data on the population actually partaking of it. Data on per caput food supplies are expressed in terms of quantity and - by applying appropriate food composition factors for all primary and processed products - also in terms of caloric value and protein and fat content.
     citation_full: 'Food and Agriculture Organization of the United Nations - Food Balances: Food Balances (2010-) (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/FBS
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/FoodBalanceSheets_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_fbsh.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_fbsh.zip.dvc
@@ -10,7 +10,7 @@ meta:
       On the utilization side a distinction is made between the quantities exported, fed to livestock, used for seed, put to manufacture for food use and non-food uses, losses during storage and transportation, and food supplies available for human consumption. The per caput supply of each such food item available for human consumption is then obtained by dividing the respective quantity by the related data on the population actually partaking of it. Data on per caput food supplies are expressed in terms of quantity and - by applying appropriate food composition factors for all primary and processed products - also in terms of caloric value and protein and fat content.
     citation_full: |-
       Food and Agriculture Organization of the United Nations - Food Balances: Food Balances (-2013, old methodology and population) (2023).
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/FBSH
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/FoodBalanceSheetsHistoric_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_fo.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_fo.zip.dvc
@@ -9,7 +9,7 @@ meta:
 
       The database contains details of the following topics: - Roundwood removals (production) by coniferous and non-coniferous wood and assortments, - production and trade in industrial roundwood, sawnwood, wood-based panels, wood charcoal, pulp, paper and paperboard, and other products. More detailed information on wood products, including definitions, can be found at: https://www.fao.org/forestry/statistics/80572/en
     citation_full: 'Food and Agriculture Organization of the United Nations - Forestry: Forestry Production and Trade (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/FO
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Forestry_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_fs.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_fs.zip.dvc
@@ -12,7 +12,7 @@ meta:
       Indicators are classified along the four dimensions of food security -- availability, access, utilization and stability.
     citation_full: |-
       Food and Agriculture Organization of the United Nations - Food Security and Nutrition: Suite of Food Security Indicators (2023).
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/FS
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Food_Security_Data_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_ic.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_ic.zip.dvc
@@ -9,7 +9,7 @@ meta:
 
       The dataset also provides statistics on the total credit to all industries, indicators on the share of credit to agricultural producers, and an agriculture orientation index (AOI) for credit that normalizes the share of credit to agriculture over total credit by dividing it by the share of agriculture in gross domestic product (GDP). As such, it can provide a more accurate indication of the relative importance that banking sectors place on financing the sector. An AOI lower than 1 indicates that the agriculture sector receives a credit share lower than its contribution to the economy, while an AOI greater than 1 indicates a credit share to the agriculture sector greater than its economic contribution.
     citation_full: 'Food and Agriculture Organization of the United Nations - Investment: Credit to Agriculture (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/IC
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Investment_CreditAgriculture_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_lc.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_lc.zip.dvc
@@ -7,7 +7,7 @@ meta:
 
       The land cover information is compiled from publicly available Global Land Cover (GLC) maps: a) MODIS land cover types based on the Land Cover Classification System, LCCS (2001-2021); b) The European Spatial Agency (ESA) Climate Change Initiative (CCI) annual land cover maps (1992-2020) produced by the Université catholique de Louvain (UCL)-Geomatics and now under the European Copernicus Program; c) The annual land cover maps which were produced under the European Copernicus Global Land Service (CGLS) (CGLS land cover, containing discrete land cover categorization for the period 2015-2019), with spatial resolution 100m; and d) 4) The WorldCover maps of the European Space Agency —available for the years 2020  and 2021, produced at 10m resolution.
     citation_full: 'Food and Agriculture Organization of the United Nations - Land, Inputs and Sustainability: Land Cover (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/LC
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Environment_LandCover_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_metadata.json.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_metadata.json.dvc
@@ -4,7 +4,7 @@ meta:
     title: Metadata and identifiers
     description: Metadata and identifiers used in FAOSTAT datasets.
     citation_full: Food and Agriculture Organization of the United Nations (2024).
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data
     date_accessed: '2024-03-14'
     date_published: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_qcl.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_qcl.zip.dvc
@@ -15,7 +15,7 @@ meta:
 
       5) Livestock processed: Butter (of milk from sheep, goat, buffalo, cow); Cheese (of milk from goat, buffalo, sheep, cow milk); Cheese of skimmed cow milk; Cream fresh; Ghee (cow and buffalo milk); Lard; Milk (dry buttermilk,  skimmed condensed, skimmed cow, skimmed dried, skimmed evaporated, whole condensed, whole dried, whole evaporated); Silk raw; Tallow; Whey (condensed and dry); Yoghurt.
     citation_full: 'Food and Agriculture Organization of the United Nations - Production: Crops and livestock products (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/QCL
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Production_Crops_Livestock_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_qi.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_qi.zip.dvc
@@ -7,7 +7,7 @@ meta:
 
       Indices for meat production are computed based on data for production from indigenous animals.
     citation_full: 'Food and Agriculture Organization of the United Nations - Production: Production Indices (2024).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/QI
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Production_Indices_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_qv.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_qv.zip.dvc
@@ -7,7 +7,7 @@ meta:
 
       The livestock value of production is measured in terms of indigenous meat.
     citation_full: 'Food and Agriculture Organization of the United Nations - Production: Value of Agricultural Production (2024).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/QV
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Value_of_Production_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_rfb.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_rfb.zip.dvc
@@ -8,7 +8,7 @@ meta:
       The fertilizer statistics data are for a set of 23 product categories. Both straight and compound fertilizers are included. There is information available about methodology at: https://fenixservices.fao.org/faostat/static/documents/RFB/RFB_EN_README.pdf
     citation_full: |-
       Food and Agriculture Organization of the United Nations - Land, Inputs and Sustainability: Fertilizers by Product (2023).
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/RFB
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Inputs_FertilizersProduct_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_rfn.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_rfn.zip.dvc
@@ -8,7 +8,7 @@ meta:
       The data are provided for the three primary plant nutrients: nitrogen (N), phosphorus (expressed as P2O5) and potassium (expressed as K2O). Both straight and compound fertilizers are included. There is information on the methodology available at: https://fenixservices.fao.org/faostat/static/documents/RFN/RFN_EN_README.pdf
     citation_full: |-
       Food and Agriculture Organization of the United Nations - Land, Inputs and Sustainability: Fertilizers by Nutrient (2023).
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/RFN
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Inputs_FertilizersNutrient_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_rl.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_rl.zip.dvc
@@ -7,7 +7,7 @@ meta:
 
       Data are available by country and year, with global coverage and annual updates.
     citation_full: 'Food and Agriculture Organization of the United Nations - Land, Inputs and Sustainability: Land Use (2024).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/RL
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Inputs_LandUse_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_rp.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_rp.zip.dvc
@@ -7,7 +7,7 @@ meta:
 
       Data report the quantities (in tonnes of active ingredients).
     citation_full: 'Food and Agriculture Organization of the United Nations - Land, Inputs and Sustainability: Pesticides Use (2024).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/RP
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Inputs_Pesticides_Use_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_rt.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_rt.zip.dvc
@@ -11,7 +11,7 @@ meta:
 
       The correspondence with the HS Nomenclature is shown in the table  at the Related Documents section. For these pesticides, this domain contains trade data (imports and exports) in both value (current 1000 US dollars) and quantity (net weight in tonnes), and the time series extends from 2007 onwards.
     citation_full: 'Food and Agriculture Organization of the United Nations - Land, Inputs and Sustainability: Pesticides Trade (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/RT
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Inputs_Pesticides_Trade_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_scl.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_scl.zip.dvc
@@ -11,7 +11,7 @@ meta:
 
       The per caput supply of each such food item available for human consumption is then obtained by dividing the respective quantity by the related data on the population actually partaking of it. Data on per caput food supplies are expressed in terms of quantity and - by applying appropriate food composition factors for all primary and processed products - also in terms of caloric value and protein and fat content.
     citation_full: 'Food and Agriculture Organization of the United Nations - Food Balances: Supply Utilization Accounts (2010-) (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/SCL
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/SUA_Crops_Livestock_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_sdgb.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_sdgb.zip.dvc
@@ -7,7 +7,7 @@ meta:
 
       This FAOSTAT domain complements the global SDG database administered by the United Nations Statistical Division, as well as FAO's SDG indicators portal, by providing access to the available data for each of these indicators.
     citation_full: 'Food and Agriculture Organization of the United Nations - SDG Indicators: SDG Indicators (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/SDGB
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/SDG_BulkDownloads_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_tcl.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_tcl.zip.dvc
@@ -9,7 +9,7 @@ meta:
 
       The trade database includes the following variables: export quantity, export value, import quantity, and import value. The trade database includes all food and agricultural products imported/exported annually by all the countries in the world.
     citation_full: 'Food and Agriculture Organization of the United Nations - Trade: Crops and livestock products (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/TCL
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Trade_CropsLivestock_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'

--- a/snapshots/faostat/2024-03-14/faostat_ti.zip.dvc
+++ b/snapshots/faostat/2024-03-14/faostat_ti.zip.dvc
@@ -9,7 +9,7 @@ meta:
 
       The trade database includes the following variables: export quantity, export value, import quantity, and import value. The trade database includes all food and agricultural products imported/exported annually by all the countries in the world.
     citation_full: 'Food and Agriculture Organization of the United Nations - Trade: Trade Indices (2023).'
-    attribution_short: FAOSTAT
+    attribution_short: FAO
     url_main: http://www.fao.org/faostat/en/#data/TI
     url_download: https://fenixservices.fao.org/faostat/static/bulkdownloads/Trade_Indices_E_All_Data_(Normalized).zip
     date_accessed: '2024-03-14'


### PR DESCRIPTION
So far we were not able to edit FAOSTAT metadata, and we were showing it (in the sources tab and data pages) raw, as it came from the data provider. It often produced very long, poorly formatted paragraphs, hard do understand, our sources tab and data pages.

Additionally, it wasn't possible (at least not easily) to edit those fields manually, because those texts were produced programmatically in the middle of a complicated processing pipeline.

This PR allows us to quickly fix, add or remove specific fields in the metadata. All FAOSTAT metadata is moved to either the snapshot description, or the `description_from_producer`.

This PR would also fix data pages like [this one](https://ourworldindata.org/grapher/prevalence-of-undernourishment) with very bad titles that were constructed from FAOSTAT names.

I have also gone through all indicators that are used in at least one chart, and added basic metadata to them. I haven't spent much time adding `description_short` and `description_key`, but at least now we have a way to easily add those, if needed.

There is no need to review the code. A thorough review of all the metadata is also unnecessary. But I think it would be good to scroll through the `.meta.yml` files to inspect for some odd titles or descriptions quickly.
