### PR TITLE
Fix detect region overlap

### DIFF
--- a/etl/data_helpers/geo.py
+++ b/etl/data_helpers/geo.py
@@ -950,7 +950,7 @@ def detect_overlapping_regions(
     """
     # Sum over all columns to get the total sum of each column for each country-year.
     tb_total = (
-        df.groupby([country_col, year_col])
+        df.groupby([country_col, year_col], observed=True)
         .agg({column: "sum" for column in df.columns if column not in index_columns})
         .reset_index()
     )

--- a/etl/steps/data/garden/artificial_intelligence/2024-03-22/papers_with_code_math.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-03-22/papers_with_code_math.py
@@ -1,4 +1,3 @@
-import owid.catalog.processing as pr
 from shared import load_and_process_dataset
 
 from etl.helpers import PathFinder

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -446,5 +446,5 @@ def test__validate_description_key():
     col = "column3"
     try:
         _validate_description_key(description_key, col)
-    except AssertionError as e:
+    except AssertionError:
         assert False, f"AssertionError raised for valid description_key: {description_key}"


### PR DESCRIPTION
This PR fixes https://github.com/owid/etl/issues/2474

(The changes in the other two files were created by `make test`, they are just formatting problems).

I checked that in the example you gave in the issue:

```python
import pandas as pd
from etl.data_helpers.geo import add_regions_to_table
from etl.paths import DATA_DIR
from owid.catalog import Dataset

# Create table
df = pd.DataFrame({
    "country": ["Germany", "East Germany", "East Germany"],
    "year": [1950, 1950, 1951],
    "indicator": [1, 2, 3]
})
# Set country as category type
df["country"] = df["country"].astype("category")

# Load ds_regions
ds_regions = Dataset(DATA_DIR / "garden" / "regions" / "2023-01-01" / "regions")

# Detect overlapping countries
add_regions_to_table(df, ds_regions)

```

now I see the expected warning:

```
2024-03-29 15:14:14 [warning  ] Either the list of accepted overlaps is not found in the data or there are unknown overlaps. Accepted overlaps: [].
Found overlaps: [{1950: {'East Germany', 'Germany'}}].
```