### PR TITLE
Improve function that writes to dag

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -388,6 +388,83 @@ include:
     )
 
 
+def test_write_to_dag_file_keeping_comments_below_updated_steps():
+    old_content = """\
+steps:
+  # Comment of step to be updated.
+  meadow_a:
+    - snapshot_a
+  # Comment of the step following the updated step.
+  meadow_b:
+    - snapshot_b
+"""
+    expected_content = """\
+steps:
+  # Comment of step to be updated.
+  meadow_a:
+    - snapshot_a
+  # Comment of the step following the updated step.
+  meadow_b:
+    - snapshot_b
+"""
+    _assert_write_to_dag_file(old_content, expected_content, dag_part={"meadow_a": ["snapshot_a"]})
+
+
+def test_write_to_dag_file_keeping_comments_below_updated_steps_with_line_breaks():
+    old_content = """\
+steps:
+  # Comment of step to be updated.
+  meadow_a:
+    - snapshot_a
+  # Comment of the step following the updated step.
+
+
+  meadow_b:
+    - snapshot_b
+"""
+    expected_content = """\
+steps:
+  # Comment of step to be updated.
+  meadow_a:
+    - snapshot_a
+
+
+  # Comment of the step following the updated step.
+  meadow_b:
+    - snapshot_b
+"""
+    # NOTE: This is not necessarily desired behavior, but it is the one to be expected.
+    # Comments that come after a step definition are considered belonging to the next step.
+    # Therefore, they will appear right above the next step (and the line breaks will be below the previous step).
+    _assert_write_to_dag_file(old_content, expected_content, dag_part={"meadow_a": ["snapshot_a"]})
+
+
+def test_write_to_dag_file_keeping_comments_on_two_consecutive_updated_steps():
+    old_content = """\
+steps:
+  # Comment of step to be updated.
+  meadow_a:
+    - snapshot_a
+  # Comment of the step following the updated step.
+  meadow_b:
+    - snapshot_b
+"""
+    expected_content = """\
+steps:
+  # Comment of step to be updated.
+  meadow_a:
+    - snapshot_a
+  # Comment of the step following the updated step.
+  meadow_b:
+    - snapshot_b
+    - snapshot_c
+"""
+    # NOTE: This is not necessarily desired behavior, but it is the one to be expected.
+    # Comments that come after a step definition are considered belonging to the next step.
+    # Therefore, they will appear right above the next step (and the line breaks will be below the previous step).
+    _assert_write_to_dag_file(old_content, expected_content, dag_part={"meadow_a": ["snapshot_a"], "meadow_b": ["snapshot_b", "snapshot_c"]})
+
+
 def test_get_comments_above_step_in_dag():
     yaml_content = """\
 steps:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -462,7 +462,9 @@ steps:
     # NOTE: This is not necessarily desired behavior, but it is the one to be expected.
     # Comments that come after a step definition are considered belonging to the next step.
     # Therefore, they will appear right above the next step (and the line breaks will be below the previous step).
-    _assert_write_to_dag_file(old_content, expected_content, dag_part={"meadow_a": ["snapshot_a"], "meadow_b": ["snapshot_b", "snapshot_c"]})
+    _assert_write_to_dag_file(
+        old_content, expected_content, dag_part={"meadow_a": ["snapshot_a"], "meadow_b": ["snapshot_b", "snapshot_c"]}
+    )
 
 
 def test_get_comments_above_step_in_dag():


### PR DESCRIPTION
When function `write_to_dag_file` writes to the dag, it removes the comment of a step that appears right after an updated step (mentioned in: https://github.com/owid/etl/issues/2365). This PR solves that issue.


