### PR TITLE
🎉 Create `etl explorer-update` tool to automatically update explorer `.tsv` files

### DIFF
--- a/apps/cli/__init__.py
+++ b/apps/cli/__init__.py
@@ -162,6 +162,7 @@ GROUPS = (
                 "graphviz": "etl.to_graphviz.to_graphviz",
                 "compare": "etl.compare.cli",
                 "update": "apps.step_update.cli.cli",
+                "explorer-update": "apps.explorer_update.cli.cli",
             },
         },
         {
@@ -181,7 +182,7 @@ GROUPS = (
             },
         },
     ]
-    # Add subroups (don't moddify)
+    # Add subgroups (don't modify)
     + subgroups
     # Others (not so relevant, maybe deprecated one day...)
     + [

--- a/apps/explorer_update/cli.py
+++ b/apps/explorer_update/cli.py
@@ -47,8 +47,180 @@ def extract_variable_ids_from_explorer_content(explorer: str) -> List[int]:
     return variable_ids
 
 
+def update_file_based_explorer(explorer: str) -> Optional[str]:
+    # Gather all data catalog URLs from the explorer content.
+    steps = []
+    for line in explorer.split("\n"):
+        if CATALOG_URL in line:
+            urls = [substring for substring in line.split() if CATALOG_URL in substring]
+            steps.extend(["/".join(url.replace(CATALOG_URL, "data://").split("/")[:-1]) for url in urls])
+    steps = sorted(set(steps))
+
+    # Filter out steps with version "latest", as they are not updateable.
+    updateable_steps = [step for step in steps if step.split("/")[-2] != "latest"]
+
+    if len(updateable_steps) == 0:
+        log.info("No URLs to update.")
+        return None
+
+    # Load dataframe of all steps in ETL.
+    steps_df = VersionTracker().steps_df
+
+    # Select steps whose version is not the latest possible.
+    updateable_df = steps_df[
+        steps_df["step"].isin(updateable_steps) & (steps_df["step"] != steps_df["same_steps_latest"])
+    ].reset_index(drop=True)
+
+    if updateable_df.empty:
+        log.info("No URLs to update.")
+        return None
+
+    # Create columns for the old and new urls.
+    updateable_df["url_old"] = [step.replace("data://", CATALOG_URL) for step in updateable_df["step"]]
+    updateable_df["url_new"] = [step.replace("data://", CATALOG_URL) for step in updateable_df["same_steps_latest"]]
+
+    # Dictionary mapping old to new urls.
+    url_mapping = updateable_df[["url_old", "url_new"]].set_index("url_old")["url_new"].to_dict()
+
+    # Replace old urls with new ones in the explorer content.
+    explorer_new = explorer
+    # Create an informative log message.
+    message = "URLs to be replaced in explorer file:\n"
+    for url_old, url_new in url_mapping.items():
+        assert url_new.split("/")[-2] > url_old.split("/")[-2], "New version should be greater than old version."  # type: ignore
+        message += f"{url_old} ->\n{url_new})\n"
+        explorer_new = explorer_new.replace(url_old, url_new)  # type: ignore
+    log.info(message)
+
+    return explorer_new
+
+
+def update_indicator_based_explorer(explorer: str) -> Optional[str]:
+    # Extract all possible variable ids from the explorer file.
+    variable_ids = extract_variable_ids_from_explorer_content(explorer=explorer)
+
+    if len(variable_ids) == 0:
+        log.info("No variable ids found in the explorer file. This may not be an indicator-based explorer.")
+        return None
+
+    # Fetch data for these variables from the database, if possible.
+    variable_data = get_variables_data(filter={"id": variable_ids})
+
+    # Warn about those variable ids that don't have a catalogPath (and therefore may not be created by ETL).
+    variables_wihout_path = set(variable_data[variable_data["catalogPath"].isnull()]["id"])
+    if len(variables_wihout_path) > 0:
+        log.warning(f"Variable ids without catalogPath: {variables_wihout_path}\nThey may need to be updated manually.")
+        variable_data = variable_data[variable_data["catalogPath"].notnull()].reset_index(drop=True)
+
+    if len(variable_data) == 0:
+        log.info("No variable ids can be automatically updated.")
+        return None
+
+    # Select relevant columns.
+    variables_df = variable_data[["id", "catalogPath", "name"]].copy()
+
+    # Create a column with the step name of each variable's grapher dataset.
+    variables_df["step"] = [
+        "data://" + "/".join(etl_path.split("#")[0].split("/")[:-1]) for etl_path in variables_df["catalogPath"]
+    ]
+
+    # Create a column with the table name and variable name.
+    variables_df["table_and_variable_short_name"] = [path.split("/")[4] for path in variables_df["catalogPath"]]
+
+    # Load dataframe of all steps in ETL.
+    steps_df = VersionTracker().steps_df
+
+    # Steps in the variables table are stored as, e.g. "grapher/faostat/2023-06-12/faostat_qcl/...",
+    # so we don't know if they are all "data://..." or they could also be "data-private://...".
+    # For now, assume all steps are public, hence using the prefix "data://".
+    missing_steps = set(variables_df["step"]) - set(steps_df["step"])
+    if len(missing_steps) > 0:
+        private_steps = [
+            step for step in missing_steps if step.replace("data://", "data-private://") in set(steps_df["step"])
+        ]
+        other_missing_steps = missing_steps - set(private_steps)
+        if len(private_steps) > 0:
+            log.warning(
+                f"Unexpected private steps found in explorer: {private_steps}\nUnclear if this should be allowed."
+            )
+        if len(other_missing_steps) > 0:
+            log.warning(f"Steps not found in ETL: {missing_steps}\nThey may have been accidentally archived.")
+        variables_df = variables_df[~variables_df["step"].isin(missing_steps)].reset_index(drop=True)
+
+    # Combine variable data with steps data.
+    variables_df = variables_df.merge(steps_df[["step", "same_steps_latest", "version"]], on="step", how="left")
+
+    # Select variables that can be updated.
+    updateable = variables_df[variables_df["step"] != variables_df["same_steps_latest"]].reset_index(drop=True)[
+        ["id", "name", "version", "step", "table_and_variable_short_name", "same_steps_latest"]
+    ]
+
+    # Create a column for the "catalogPath" of the latest steps.
+    updateable["catalogPath_new"] = [
+        variable["same_steps_latest"].replace("data://", "") + "/" + variable["table_and_variable_short_name"]
+        for _, variable in updateable.iterrows()
+    ]
+
+    # Create a column for the new version of the latest steps.
+    updateable["version_new"] = [variable["catalogPath_new"].split("/")[2] for _, variable in updateable.iterrows()]
+
+    if len(updateable) == 0:
+        log.info("No variables to update.")
+        return None
+
+    # Fetch variable data for the latest steps from the database.
+    variable_data_new = get_variables_data(filter={"catalogPath": updateable["catalogPath_new"].tolist()})
+
+    # Select and rename columns.
+    variable_data_new = variable_data_new.rename(
+        columns={"id": "id_new", "catalogPath": "catalogPath_new", "name": "name_new"}, errors="raise"
+    )[["id_new", "catalogPath_new", "name_new"]]
+
+    # Combine old and new variable data.
+    combined = updateable.merge(variable_data_new, on="catalogPath_new", how="left")
+
+    # Create a dictionary mapping old to new variables.
+    variable_mapping = combined.set_index("id")["id_new"].to_dict()
+
+    # Ensure variable ids are only replaced in the first column of subtables.
+    explorer_new = ""
+    for line in explorer.split("\n"):
+        new_line = line
+        for variable_id_old, variable_id_new in variable_mapping.items():
+            # Replace variable ids only if they are in the first column (i.e. preceded and followed by tabs).
+            if (
+                (str(variable_id_old) in new_line)
+                and new_line.startswith("\t")
+                and ("\t" in new_line.split(str(variable_id_old))[-1])
+            ):
+                new_line = new_line.replace(str(variable_id_old), str(variable_id_new))
+        explorer_new += new_line + "\n"
+
+    # Warn if old variable ids are still found in the new explorer content.
+    variable_ids_in_new_explorer = extract_variable_ids_from_explorer_content(explorer=explorer_new)
+
+    old_variables_remaining = [
+        old_variable_id for old_variable_id in set(variable_mapping) if old_variable_id in variable_ids_in_new_explorer
+    ]
+
+    if len(old_variables_remaining) > 0:
+        log.warning(f"Old variable ids cannot be replaced in the new explorer content: {old_variables_remaining}")
+
+    message = "Variable ids (and their ETL version) to be replaced in explorer file:\n"
+    for _, row in combined.iterrows():
+        assert int(row["id_new"]) > int(row["id"]), "New variable id should be greater than old variable id."
+        assert row["version_new"] > row["version"], "New version should be greater than old version."
+        message += f"{row['id']} ({row['version']}) -> {row['id_new']} ({row['version_new']})\n"
+        if row["name"] != row["name_new"]:
+            message += "  Name change:\n"
+            message += f"  {row['name']} ->\n  {row['name_new']}\n"
+    log.info(message)
+
+    return explorer_new
+
+
 def update_explorer(explorer_file: Path, dry_run: bool = False) -> None:
-    """Update variable ids in a single indicator-based explorer."""
+    """Update a single explorer file."""
 
     if not explorer_file.is_file():
         raise FileNotFoundError(f"Explorer file not found: {explorer_file}")
@@ -57,193 +229,33 @@ def update_explorer(explorer_file: Path, dry_run: bool = False) -> None:
     with open(explorer_file, "r") as f:
         explorer = f.read()
 
+    # Initialize variable for the updated explorer content.
+    explorer_new = None
+
     if ("yVariableIds" not in explorer) and (CATALOG_URL not in explorer):
         log.info("Nothing to update (it may be a grapher-based explorer).")
+
         return None
 
-    if CATALOG_URL in explorer:
+    elif (CATALOG_URL in explorer) and ("yVariableIds" not in explorer):
         log.info(f"Inspecting file-based explorer: {explorer_file.stem}")
 
-        # Gather all data catalog URLs from the explorer content.
-        steps = []
-        for line in explorer.split("\n"):
-            if CATALOG_URL in line:
-                urls = [substring for substring in line.split() if CATALOG_URL in substring]
-                steps.extend(["/".join(url.replace(CATALOG_URL, "data://").split("/")[:-1]) for url in urls])
-        steps = sorted(set(steps))
+        explorer_new = update_file_based_explorer(explorer=explorer)
 
-        # Filter out steps with version "latest", as they are not updateable.
-        updateable_steps = [step for step in steps if step.split("/")[-2] != "latest"]
-
-        if len(updateable_steps) == 0:
-            log.info("No URLs to update.")
-            return None
-
-        # Load dataframe of all steps in ETL.
-        steps_df = VersionTracker().steps_df
-
-        # Select steps whose version is not the latest possible.
-        updateable_df = steps_df[
-            steps_df["step"].isin(updateable_steps) & (steps_df["step"] != steps_df["same_steps_latest"])
-        ].reset_index(drop=True)
-
-        if updateable_df.empty:
-            log.info("No URLs to update.")
-            return None
-
-        # Create columns for the old and new urls.
-        updateable_df["url_old"] = [step.replace("data://", CATALOG_URL) for step in updateable_df["step"]]
-        updateable_df["url_new"] = [step.replace("data://", CATALOG_URL) for step in updateable_df["same_steps_latest"]]
-
-        # Dictionary mapping old to new urls.
-        url_mapping = updateable_df[["url_old", "url_new"]].set_index("url_old")["url_new"].to_dict()
-
-        # Replace old urls with new ones in the explorer content.
-        explorer_new = explorer
-        # Create an informative log message.
-        message = "URLs to be replaced in explorer file:\n"
-        for url_old, url_new in url_mapping.items():
-            assert url_new.split("/")[-2] > url_old.split("/")[-2], "New version should be greater than old version."  # type: ignore
-            message += f"{url_old} ->\n{url_new})\n"
-            explorer_new = explorer_new.replace(url_old, url_new)  # type: ignore
-        log.info(message)
-
-        if not dry_run:
-            # Write to explorer file, to replace old variable ids with new ones.
-            with open(explorer_file, "w") as f:
-                f.write(explorer_new)
-
-    if "yVariableIds" in explorer:
+    elif ("yVariableIds" in explorer) and (CATALOG_URL not in explorer):
         log.info(f"Inspecting indicator-based explorer: {explorer_file.stem}")
 
-        # Extract all possible variable ids from the explorer file.
-        variable_ids = extract_variable_ids_from_explorer_content(explorer=explorer)
+        explorer_new = update_indicator_based_explorer(explorer=explorer)
 
-        if len(variable_ids) == 0:
-            log.info("No variable ids found in the explorer file. This may not be an indicator-based explorer.")
-            return None
+    else:
+        # Explorer file may be both file-based and indicator-based.
+        # If this is possible, the code could easily be adapted to update first urls and then variable ids.
+        log.warning(f"Unexpected content in explorer file: {explorer_file.stem}")
 
-        # Fetch data for these variables from the database, if possible.
-        variable_data = get_variables_data(filter={"id": variable_ids})
-
-        # Warn about those variable ids that don't have a catalogPath (and therefore may not be created by ETL).
-        variables_wihout_path = set(variable_data[variable_data["catalogPath"].isnull()]["id"])
-        if len(variables_wihout_path) > 0:
-            log.warning(
-                f"Variable ids without catalogPath: {variables_wihout_path}\nThey may need to be updated manually."
-            )
-            variable_data = variable_data[variable_data["catalogPath"].notnull()].reset_index(drop=True)
-
-        if len(variable_data) == 0:
-            log.info("No variable ids can be automatically updated.")
-            return None
-
-        # Select relevant columns.
-        variables_df = variable_data[["id", "catalogPath", "name"]].copy()
-
-        # Create a column with the step name of each variable's grapher dataset.
-        variables_df["step"] = [
-            "data://" + "/".join(etl_path.split("#")[0].split("/")[:-1]) for etl_path in variables_df["catalogPath"]
-        ]
-
-        # Create a column with the table name and variable name.
-        variables_df["table_and_variable_short_name"] = [path.split("/")[4] for path in variables_df["catalogPath"]]
-
-        # Load dataframe of all steps in ETL.
-        steps_df = VersionTracker().steps_df
-
-        # Steps in the variables table are stored as, e.g. "grapher/faostat/2023-06-12/faostat_qcl/...",
-        # so we don't know if they are all "data://..." or they could also be "data-private://...".
-        # For now, assume all steps are public, hence using the prefix "data://".
-        missing_steps = set(variables_df["step"]) - set(steps_df["step"])
-        if len(missing_steps) > 0:
-            private_steps = [
-                step for step in missing_steps if step.replace("data://", "data-private://") in set(steps_df["step"])
-            ]
-            other_missing_steps = missing_steps - set(private_steps)
-            if len(private_steps) > 0:
-                log.warning(
-                    f"Unexpected private steps found in explorer: {private_steps}\nUnclear if this should be allowed."
-                )
-            if len(other_missing_steps) > 0:
-                log.warning(f"Steps not found in ETL: {missing_steps}\nThey may have been accidentally archived.")
-            variables_df = variables_df[~variables_df["step"].isin(missing_steps)].reset_index(drop=True)
-
-        # Combine variable data with steps data.
-        variables_df = variables_df.merge(steps_df[["step", "same_steps_latest", "version"]], on="step", how="left")
-
-        # Select variables that can be updated.
-        updateable = variables_df[variables_df["step"] != variables_df["same_steps_latest"]].reset_index(drop=True)[
-            ["id", "name", "version", "step", "table_and_variable_short_name", "same_steps_latest"]
-        ]
-
-        # Create a column for the "catalogPath" of the latest steps.
-        updateable["catalogPath_new"] = [
-            variable["same_steps_latest"].replace("data://", "") + "/" + variable["table_and_variable_short_name"]
-            for _, variable in updateable.iterrows()
-        ]
-
-        # Create a column for the new version of the latest steps.
-        updateable["version_new"] = [variable["catalogPath_new"].split("/")[2] for _, variable in updateable.iterrows()]
-
-        if len(updateable) == 0:
-            log.info("No variables to update.")
-            return None
-
-        # Fetch variable data for the latest steps from the database.
-        variable_data_new = get_variables_data(filter={"catalogPath": updateable["catalogPath_new"].tolist()})
-
-        # Select and rename columns.
-        variable_data_new = variable_data_new.rename(
-            columns={"id": "id_new", "catalogPath": "catalogPath_new", "name": "name_new"}, errors="raise"
-        )[["id_new", "catalogPath_new", "name_new"]]
-
-        # Combine old and new variable data.
-        combined = updateable.merge(variable_data_new, on="catalogPath_new", how="left")
-
-        # Create a dictionary mapping old to new variables.
-        variable_mapping = combined.set_index("id")["id_new"].to_dict()
-
-        # Ensure variable ids are only replaced in the first column of subtables.
-        explorer_new = ""
-        for line in explorer.split("\n"):
-            new_line = line
-            for variable_id_old, variable_id_new in variable_mapping.items():
-                # Replace variable ids only if they are in the first column (i.e. preceded and followed by tabs).
-                if (
-                    (str(variable_id_old) in new_line)
-                    and new_line.startswith("\t")
-                    and ("\t" in new_line.split(str(variable_id_old))[-1])
-                ):
-                    new_line = new_line.replace(str(variable_id_old), str(variable_id_new))
-            explorer_new += new_line + "\n"
-
-        # Warn if old variable ids are still found in the new explorer content.
-        variable_ids_in_new_explorer = extract_variable_ids_from_explorer_content(explorer=explorer_new)
-
-        old_variables_remaining = [
-            old_variable_id
-            for old_variable_id in set(variable_mapping)
-            if old_variable_id in variable_ids_in_new_explorer
-        ]
-
-        if len(old_variables_remaining) > 0:
-            log.warning(f"Old variable ids cannot be replaced in the new explorer content: {old_variables_remaining}")
-
-        message = "Variable ids (and their ETL version) to be replaced in explorer file:\n"
-        for _, row in combined.iterrows():
-            assert int(row["id_new"]) > int(row["id"]), "New variable id should be greater than old variable id."
-            assert row["version_new"] > row["version"], "New version should be greater than old version."
-            message += f"{row['id']} ({row['version']}) -> {row['id_new']} ({row['version_new']})\n"
-            if row["name"] != row["name_new"]:
-                message += "  Name change:\n"
-                message += f"  {row['name']} ->\n  {row['name_new']}\n"
-        log.info(message)
-
-        if not dry_run:
-            # Write to explorer file, to replace old variable ids with new ones.
-            with open(explorer_file, "w") as f:
-                f.write(explorer_new)
+    if (explorer_new is not None) and (not dry_run):
+        # Write to explorer file, to update its content.
+        with open(explorer_file, "w") as f:
+            f.write(explorer_new)
 
 
 @click.command(name="explorer-update", cls=RichCommand, help=__doc__)
@@ -263,7 +275,13 @@ def cli(
     explorers_dir: Union[Path, str] = EXPLORERS_DIR,
     dry_run: bool = False,
 ) -> None:
-    """Update variable ids in one or more indicator-based explorers."""
+    """Update one or more explorer (tsv) files.
+
+    This command will update the content of one or more explorer (tsv) files, with the following logic:
+    - If it is a file-based explorer, ensure URLs to data catalog point to the latest version of the data.
+    - If it is an indicator-based explorer, ensure variable ids correspond to the latest versions of the variables.
+
+    """
 
     if isinstance(explorers_dir, str):
         # Ensure explorer folder is a Path object.

--- a/apps/explorer_update/cli.py
+++ b/apps/explorer_update/cli.py
@@ -233,7 +233,3 @@ def cli(
 
         # Update variable ids in the explorer file.
         update_explorer(explorer_file=explorer_file, dry_run=dry_run)
-
-
-if __name__ == "__main__":
-    cli()

--- a/apps/explorer_update/cli.py
+++ b/apps/explorer_update/cli.py
@@ -1,0 +1,196 @@
+import re
+from pathlib import Path
+from typing import List, Optional, Union
+
+import click
+from rich_click.rich_command import RichCommand
+from structlog import get_logger
+
+from etl.db import get_variables_data
+from etl.paths import BASE_DIR
+from etl.version_tracker import VersionTracker
+
+# Initialize logger.
+log = get_logger()
+
+# Default path to the explorers folder.
+EXPLORERS_DIR = BASE_DIR.parent / "owid-content/explorers"
+
+
+def extract_variable_ids_from_explorer_content(explorer: str) -> List[int]:
+    variable_ids_all = ""
+    for line in explorer.split("\n"):
+        # Select the lines that correspond to subtables.
+        if line.startswith("\t"):
+            # Skip lines of subtable headers (that contain strings "yVariableIds" and "variableId").
+            if "ariableId" in line:
+                continue
+            else:
+                # Assume the first column contains variable ids (one or more), separated by tabs.
+                variable_ids_all += line.split("\t")[1]
+
+    # Extract all substrings of digits that should be variable ids.
+    variable_ids = sorted(set([int(variable_id) for variable_id in re.findall(r"\d{5,6}", variable_ids_all)]))
+
+    return variable_ids
+
+
+@click.command(name="explorer-update", cls=RichCommand, help=__doc__)
+# @click.argument("explorer_name", type=str or List[str], nargs=-1)
+@click.argument("explorer_name", type=str)
+@click.option(
+    "--explorers-dir", type=str, default=EXPLORERS_DIR, help=f"Path to explorer files. Default: {EXPLORERS_DIR}"
+)
+def cli(explorer_name: str, explorers_dir: Optional[Union[Path, str]] = None) -> None:
+    """Update variable ids in indicator-based explorer files."""
+
+    if explorers_dir is None:
+        # If explorer folder is not provided, assume owid-content is in the same folder as ETL.
+        explorers_dir = EXPLORERS_DIR
+    elif isinstance(explorers_dir, str):
+        explorers_dir = Path(explorers_dir)
+
+    # Define path to explorer file.
+    explorer_file = (explorers_dir / explorer_name).with_suffix(".explorer.tsv")
+
+    if not explorer_file.is_file():
+        raise FileNotFoundError(f"Explorer file not found: {explorer_file}")
+
+    # Load explorer file as a string.
+    with open(explorer_file, "r") as f:
+        explorer = f.read()
+
+    if "yVariableIds" not in explorer:
+        log.info("This may not be an indicator-based explorer ('yVariableIds' not found).")
+        return None
+
+    # Extract all possible variable ids from the explorer file.
+    variable_ids = extract_variable_ids_from_explorer_content(explorer=explorer)
+
+    if len(variable_ids) == 0:
+        log.info("No variable ids found in the explorer file. This may not be an indicator-based explorer.")
+        return None
+
+    # Fetch data for these variables from the database, if possible.
+    variable_data = get_variables_data(filter={"id": variable_ids})
+
+    # Warn about those variable ids that don't have a catalogPath (and therefore may not be created by ETL).
+    variables_wihout_path = set(variable_data[variable_data["catalogPath"].isnull()]["id"])
+    if len(variables_wihout_path) > 0:
+        log.warning(f"Variable ids without catalogPath: {variables_wihout_path}\nThey may need to be updated manually.")
+        variable_data = variable_data[variable_data["catalogPath"].isnull()].reset_index(drop=True)
+
+    # Select relevant columns.
+    variables_df = variable_data[["id", "catalogPath", "name"]].copy()
+
+    # Create a column with the step name of each variable's grapher dataset.
+    variables_df["step"] = [
+        "data://" + "/".join(etl_path.split("#")[0].split("/")[:-1]) for etl_path in variables_df["catalogPath"]
+    ]
+
+    # Create a column with the table name and variable name.
+    variables_df["table_and_variable_short_name"] = [path.split("/")[4] for path in variables_df["catalogPath"]]
+
+    # Load dataframe of all steps in ETL.
+    steps_df = VersionTracker().steps_df
+
+    # Steps in the variables table are stored as, e.g. "grapher/faostat/2023-06-12/faostat_qcl/...",
+    # so we don't know if they are all "data://..." or they could also be "data-private://...".
+    # For now, assume all steps are public, hence using the prefix "data://".
+    missing_steps = set(variables_df["step"]) - set(steps_df["step"])
+    if len(missing_steps) > 0:
+        log.warning(
+            f"Steps not found in ETL: {missing_steps}\nTry using prefix 'data-private://' instead of 'data://'."
+        )
+
+    # Combine variable data with steps data.
+    variables_df = variables_df.merge(steps_df[["step", "same_steps_latest", "version"]], on="step", how="left")
+
+    # Select variables that can be updated.
+    updateable = variables_df[variables_df["step"] != variables_df["same_steps_latest"]].reset_index(drop=True)[
+        ["id", "name", "version", "step", "table_and_variable_short_name", "same_steps_latest"]
+    ]
+
+    # Create a column for the "catalogPath" of the latest steps.
+    updateable["catalogPath_new"] = [
+        variable["same_steps_latest"].replace("data://", "") + "/" + variable["table_and_variable_short_name"]
+        for _, variable in updateable.iterrows()
+    ]
+
+    # Create a column for the new version of the latest steps.
+    updateable["version_new"] = [variable["catalogPath_new"].split("/")[2] for _, variable in updateable.iterrows()]
+
+    if len(updateable) == 0:
+        log.info("No variables to update.")
+        return None
+
+    # Fetch variable data for the latest steps from the database.
+    variable_data_new = get_variables_data(filter={"catalogPath": updateable["catalogPath_new"].tolist()})
+
+    # Select and rename columns.
+    variable_data_new = variable_data_new.rename(
+        columns={"id": "id_new", "catalogPath": "catalogPath_new", "name": "name_new"}, errors="raise"
+    )[["id_new", "catalogPath_new", "name_new"]]
+
+    # Combine old and new variable data.
+    combined = updateable.merge(variable_data_new, on="catalogPath_new", how="left")
+
+    # Create a dictionary mapping old to new variables.
+    variable_mapping = combined.set_index("id")["id_new"].to_dict()
+
+    # The following works, but it may replace variable ids in the wrong places.
+    # explorer_new = explorer
+    # for variable_id_old, variable_id_new in variable_mapping.items():
+    #     explorer_new = explorer_new.replace(str(variable_id_old), str(variable_id_new))
+
+    # Ensure variable ids are only replaced in the first column of subtables.
+    explorer_new = ""
+    for line in explorer.split("\n"):
+        new_line = line
+        for variable_id_old, variable_id_new in variable_mapping.items():
+            # Replace variable ids only if they are in the first column (i.e. preceded and followed by tabs).
+            if (
+                (str(variable_id_old) in new_line)
+                and new_line.startswith("\t")
+                and ("\t" in new_line.split(str(variable_id_old))[-1])
+            ):
+                new_line = new_line.replace(str(variable_id_old), str(variable_id_new))
+        explorer_new += new_line + "\n"
+
+    # Warn if old variable ids are still found in the new explorer content.
+    variable_ids_in_new_explorer = extract_variable_ids_from_explorer_content(explorer=explorer_new)
+
+    old_variables_remaining = [
+        old_variable_id for old_variable_id in set(variable_mapping) if old_variable_id in variable_ids_in_new_explorer
+    ]
+
+    if len(old_variables_remaining) > 0:
+        log.warning(f"Old variable ids cannot be replaced in the new explorer content: {old_variables_remaining}")
+
+    message = "Variables to be replaced in explorer file (showing ids, versions and names):\n"
+    for i, row in combined.iterrows():
+        assert int(row["id_new"]) > int(row["id"]), "New variable id should be greater than old variable id."
+        assert row["version_new"] > row["version"], "New version should be greater than old version."
+        message += f"{row['id']} ({row['version']}) -> {row['id_new']} ({row['version_new']})\n"
+        if row["name"] != row["name_new"]:
+            message += "  Name change:\n"
+            message += f"  {row['name']} ->\n  {row['name_new']}\n"
+    log.info(message)
+    input("Press Enter to rewrite the explorer file.")
+
+    # Write to explorer file, to replace old variable ids with new ones.
+    with open(explorer_file, "w") as f:
+        f.write(explorer_new)
+
+
+# # Apply the function to all explorer files.
+# explorers_dir = EXPLORERS_DIR
+
+# for explorer_file in list(explorers_dir.glob("*.tsv")):
+#     explorer_name = explorer_file.stem
+#     print(explorer_name)
+#     cli(explorer_name, explorers_dir=explorers_dir)
+
+
+if __name__ == "__main__":
+    cli()

--- a/apps/explorer_update/cli.py
+++ b/apps/explorer_update/cli.py
@@ -16,6 +16,9 @@ log = get_logger()
 # Default path to the explorers folder.
 EXPLORERS_DIR = BASE_DIR.parent / "owid-content/explorers"
 
+# URL of the data catalog.
+CATALOG_URL = "https://catalog.ourworldindata.org/"
+
 
 def extract_variable_ids_from_explorer_content(explorer: str) -> List[int]:
     variable_ids_all = []
@@ -54,141 +57,193 @@ def update_explorer(explorer_file: Path, dry_run: bool = False) -> None:
     with open(explorer_file, "r") as f:
         explorer = f.read()
 
-    if "yVariableIds" not in explorer:
-        log.info("Nothing to update (not an indicator-based explorer).")
-        return None
-    else:
-        log.info(f"Updating indicator-based explorer: {explorer_file.stem}")
-
-    # Extract all possible variable ids from the explorer file.
-    variable_ids = extract_variable_ids_from_explorer_content(explorer=explorer)
-
-    if len(variable_ids) == 0:
-        log.info("No variable ids found in the explorer file. This may not be an indicator-based explorer.")
+    if ("yVariableIds" not in explorer) and (CATALOG_URL not in explorer):
+        log.info("Nothing to update (it may be a grapher-based explorer).")
         return None
 
-    # Fetch data for these variables from the database, if possible.
-    variable_data = get_variables_data(filter={"id": variable_ids})
+    if CATALOG_URL in explorer:
+        log.info(f"Inspecting file-based explorer: {explorer_file.stem}")
 
-    # Warn about those variable ids that don't have a catalogPath (and therefore may not be created by ETL).
-    variables_wihout_path = set(variable_data[variable_data["catalogPath"].isnull()]["id"])
-    if len(variables_wihout_path) > 0:
-        log.warning(f"Variable ids without catalogPath: {variables_wihout_path}\nThey may need to be updated manually.")
-        variable_data = variable_data[variable_data["catalogPath"].notnull()].reset_index(drop=True)
+        # Gather all data catalog URLs from the explorer content.
+        steps = []
+        for line in explorer.split("\n"):
+            if CATALOG_URL in line:
+                urls = [substring for substring in line.split() if CATALOG_URL in substring]
+                steps.extend(["/".join(url.replace(CATALOG_URL, "data://").split("/")[:-1]) for url in urls])
+        steps = sorted(set(steps))
 
-    if len(variable_data) == 0:
-        log.info("No variable ids can be automatically updated.")
-        return None
+        # Filter out steps with version "latest", as they are not updateable.
+        updateable_steps = [step for step in steps if step.split("/")[-2] != "latest"]
 
-    # Select relevant columns.
-    variables_df = variable_data[["id", "catalogPath", "name"]].copy()
+        if len(updateable_steps) == 0:
+            log.info("No URLs to update.")
+            return None
 
-    # Create a column with the step name of each variable's grapher dataset.
-    variables_df["step"] = [
-        "data://" + "/".join(etl_path.split("#")[0].split("/")[:-1]) for etl_path in variables_df["catalogPath"]
-    ]
+        # Load dataframe of all steps in ETL.
+        steps_df = VersionTracker().steps_df
 
-    # Create a column with the table name and variable name.
-    variables_df["table_and_variable_short_name"] = [path.split("/")[4] for path in variables_df["catalogPath"]]
+        # Select steps whose version is not the latest possible.
+        updateable_df = steps_df[
+            steps_df["step"].isin(updateable_steps) & (steps_df["step"] != steps_df["same_steps_latest"])
+        ].reset_index(drop=True)
 
-    # Load dataframe of all steps in ETL.
-    steps_df = VersionTracker().steps_df
+        if updateable_df.empty:
+            log.info("No URLs to update.")
+            return None
 
-    # Steps in the variables table are stored as, e.g. "grapher/faostat/2023-06-12/faostat_qcl/...",
-    # so we don't know if they are all "data://..." or they could also be "data-private://...".
-    # For now, assume all steps are public, hence using the prefix "data://".
-    missing_steps = set(variables_df["step"]) - set(steps_df["step"])
-    if len(missing_steps) > 0:
-        private_steps = [
-            step for step in missing_steps if step.replace("data://", "data-private://") in set(steps_df["step"])
-        ]
-        other_missing_steps = missing_steps - set(private_steps)
-        if len(private_steps) > 0:
+        # Create columns for the old and new urls.
+        updateable_df["url_old"] = [step.replace("data://", CATALOG_URL) for step in updateable_df["step"]]
+        updateable_df["url_new"] = [step.replace("data://", CATALOG_URL) for step in updateable_df["same_steps_latest"]]
+
+        # Dictionary mapping old to new urls.
+        url_mapping = updateable_df[["url_old", "url_new"]].set_index("url_old")["url_new"].to_dict()
+
+        # Replace old urls with new ones in the explorer content.
+        explorer_new = explorer
+        # Create an informative log message.
+        message = "URLs to be replaced in explorer file:\n"
+        for url_old, url_new in url_mapping.items():
+            assert url_new.split("/")[-2] > url_old.split("/")[-2], "New version should be greater than old version."  # type: ignore
+            message += f"{url_old} ->\n{url_new})\n"
+            explorer_new = explorer_new.replace(url_old, url_new)  # type: ignore
+        log.info(message)
+
+        if not dry_run:
+            # Write to explorer file, to replace old variable ids with new ones.
+            with open(explorer_file, "w") as f:
+                f.write(explorer_new)
+
+    if "yVariableIds" in explorer:
+        log.info(f"Inspecting indicator-based explorer: {explorer_file.stem}")
+
+        # Extract all possible variable ids from the explorer file.
+        variable_ids = extract_variable_ids_from_explorer_content(explorer=explorer)
+
+        if len(variable_ids) == 0:
+            log.info("No variable ids found in the explorer file. This may not be an indicator-based explorer.")
+            return None
+
+        # Fetch data for these variables from the database, if possible.
+        variable_data = get_variables_data(filter={"id": variable_ids})
+
+        # Warn about those variable ids that don't have a catalogPath (and therefore may not be created by ETL).
+        variables_wihout_path = set(variable_data[variable_data["catalogPath"].isnull()]["id"])
+        if len(variables_wihout_path) > 0:
             log.warning(
-                f"Unexpected private steps found in explorer: {private_steps}\nUnclear if this should be allowed."
+                f"Variable ids without catalogPath: {variables_wihout_path}\nThey may need to be updated manually."
             )
-        if len(other_missing_steps) > 0:
-            log.warning(f"Steps not found in ETL: {missing_steps}\nThey may have been accidentally archived.")
-        variables_df = variables_df[~variables_df["step"].isin(missing_steps)].reset_index(drop=True)
+            variable_data = variable_data[variable_data["catalogPath"].notnull()].reset_index(drop=True)
 
-    # Combine variable data with steps data.
-    variables_df = variables_df.merge(steps_df[["step", "same_steps_latest", "version"]], on="step", how="left")
+        if len(variable_data) == 0:
+            log.info("No variable ids can be automatically updated.")
+            return None
 
-    # Select variables that can be updated.
-    updateable = variables_df[variables_df["step"] != variables_df["same_steps_latest"]].reset_index(drop=True)[
-        ["id", "name", "version", "step", "table_and_variable_short_name", "same_steps_latest"]
-    ]
+        # Select relevant columns.
+        variables_df = variable_data[["id", "catalogPath", "name"]].copy()
 
-    # Create a column for the "catalogPath" of the latest steps.
-    updateable["catalogPath_new"] = [
-        variable["same_steps_latest"].replace("data://", "") + "/" + variable["table_and_variable_short_name"]
-        for _, variable in updateable.iterrows()
-    ]
+        # Create a column with the step name of each variable's grapher dataset.
+        variables_df["step"] = [
+            "data://" + "/".join(etl_path.split("#")[0].split("/")[:-1]) for etl_path in variables_df["catalogPath"]
+        ]
 
-    # Create a column for the new version of the latest steps.
-    updateable["version_new"] = [variable["catalogPath_new"].split("/")[2] for _, variable in updateable.iterrows()]
+        # Create a column with the table name and variable name.
+        variables_df["table_and_variable_short_name"] = [path.split("/")[4] for path in variables_df["catalogPath"]]
 
-    if len(updateable) == 0:
-        log.info("No variables to update.")
-        return None
+        # Load dataframe of all steps in ETL.
+        steps_df = VersionTracker().steps_df
 
-    # Fetch variable data for the latest steps from the database.
-    variable_data_new = get_variables_data(filter={"catalogPath": updateable["catalogPath_new"].tolist()})
+        # Steps in the variables table are stored as, e.g. "grapher/faostat/2023-06-12/faostat_qcl/...",
+        # so we don't know if they are all "data://..." or they could also be "data-private://...".
+        # For now, assume all steps are public, hence using the prefix "data://".
+        missing_steps = set(variables_df["step"]) - set(steps_df["step"])
+        if len(missing_steps) > 0:
+            private_steps = [
+                step for step in missing_steps if step.replace("data://", "data-private://") in set(steps_df["step"])
+            ]
+            other_missing_steps = missing_steps - set(private_steps)
+            if len(private_steps) > 0:
+                log.warning(
+                    f"Unexpected private steps found in explorer: {private_steps}\nUnclear if this should be allowed."
+                )
+            if len(other_missing_steps) > 0:
+                log.warning(f"Steps not found in ETL: {missing_steps}\nThey may have been accidentally archived.")
+            variables_df = variables_df[~variables_df["step"].isin(missing_steps)].reset_index(drop=True)
 
-    # Select and rename columns.
-    variable_data_new = variable_data_new.rename(
-        columns={"id": "id_new", "catalogPath": "catalogPath_new", "name": "name_new"}, errors="raise"
-    )[["id_new", "catalogPath_new", "name_new"]]
+        # Combine variable data with steps data.
+        variables_df = variables_df.merge(steps_df[["step", "same_steps_latest", "version"]], on="step", how="left")
 
-    # Combine old and new variable data.
-    combined = updateable.merge(variable_data_new, on="catalogPath_new", how="left")
+        # Select variables that can be updated.
+        updateable = variables_df[variables_df["step"] != variables_df["same_steps_latest"]].reset_index(drop=True)[
+            ["id", "name", "version", "step", "table_and_variable_short_name", "same_steps_latest"]
+        ]
 
-    # Create a dictionary mapping old to new variables.
-    variable_mapping = combined.set_index("id")["id_new"].to_dict()
+        # Create a column for the "catalogPath" of the latest steps.
+        updateable["catalogPath_new"] = [
+            variable["same_steps_latest"].replace("data://", "") + "/" + variable["table_and_variable_short_name"]
+            for _, variable in updateable.iterrows()
+        ]
 
-    # The following works, but it may replace variable ids in the wrong places.
-    # explorer_new = explorer
-    # for variable_id_old, variable_id_new in variable_mapping.items():
-    #     explorer_new = explorer_new.replace(str(variable_id_old), str(variable_id_new))
+        # Create a column for the new version of the latest steps.
+        updateable["version_new"] = [variable["catalogPath_new"].split("/")[2] for _, variable in updateable.iterrows()]
 
-    # Ensure variable ids are only replaced in the first column of subtables.
-    explorer_new = ""
-    for line in explorer.split("\n"):
-        new_line = line
-        for variable_id_old, variable_id_new in variable_mapping.items():
-            # Replace variable ids only if they are in the first column (i.e. preceded and followed by tabs).
-            if (
-                (str(variable_id_old) in new_line)
-                and new_line.startswith("\t")
-                and ("\t" in new_line.split(str(variable_id_old))[-1])
-            ):
-                new_line = new_line.replace(str(variable_id_old), str(variable_id_new))
-        explorer_new += new_line + "\n"
+        if len(updateable) == 0:
+            log.info("No variables to update.")
+            return None
 
-    # Warn if old variable ids are still found in the new explorer content.
-    variable_ids_in_new_explorer = extract_variable_ids_from_explorer_content(explorer=explorer_new)
+        # Fetch variable data for the latest steps from the database.
+        variable_data_new = get_variables_data(filter={"catalogPath": updateable["catalogPath_new"].tolist()})
 
-    old_variables_remaining = [
-        old_variable_id for old_variable_id in set(variable_mapping) if old_variable_id in variable_ids_in_new_explorer
-    ]
+        # Select and rename columns.
+        variable_data_new = variable_data_new.rename(
+            columns={"id": "id_new", "catalogPath": "catalogPath_new", "name": "name_new"}, errors="raise"
+        )[["id_new", "catalogPath_new", "name_new"]]
 
-    if len(old_variables_remaining) > 0:
-        log.warning(f"Old variable ids cannot be replaced in the new explorer content: {old_variables_remaining}")
+        # Combine old and new variable data.
+        combined = updateable.merge(variable_data_new, on="catalogPath_new", how="left")
 
-    message = "Variable ids (and their ETL version) to be replaced in explorer file:\n"
-    for _, row in combined.iterrows():
-        assert int(row["id_new"]) > int(row["id"]), "New variable id should be greater than old variable id."
-        assert row["version_new"] > row["version"], "New version should be greater than old version."
-        message += f"{row['id']} ({row['version']}) -> {row['id_new']} ({row['version_new']})\n"
-        if row["name"] != row["name_new"]:
-            message += "  Name change:\n"
-            message += f"  {row['name']} ->\n  {row['name_new']}\n"
-    log.info(message)
+        # Create a dictionary mapping old to new variables.
+        variable_mapping = combined.set_index("id")["id_new"].to_dict()
 
-    if not dry_run:
-        # Write to explorer file, to replace old variable ids with new ones.
-        with open(explorer_file, "w") as f:
-            f.write(explorer_new)
+        # Ensure variable ids are only replaced in the first column of subtables.
+        explorer_new = ""
+        for line in explorer.split("\n"):
+            new_line = line
+            for variable_id_old, variable_id_new in variable_mapping.items():
+                # Replace variable ids only if they are in the first column (i.e. preceded and followed by tabs).
+                if (
+                    (str(variable_id_old) in new_line)
+                    and new_line.startswith("\t")
+                    and ("\t" in new_line.split(str(variable_id_old))[-1])
+                ):
+                    new_line = new_line.replace(str(variable_id_old), str(variable_id_new))
+            explorer_new += new_line + "\n"
+
+        # Warn if old variable ids are still found in the new explorer content.
+        variable_ids_in_new_explorer = extract_variable_ids_from_explorer_content(explorer=explorer_new)
+
+        old_variables_remaining = [
+            old_variable_id
+            for old_variable_id in set(variable_mapping)
+            if old_variable_id in variable_ids_in_new_explorer
+        ]
+
+        if len(old_variables_remaining) > 0:
+            log.warning(f"Old variable ids cannot be replaced in the new explorer content: {old_variables_remaining}")
+
+        message = "Variable ids (and their ETL version) to be replaced in explorer file:\n"
+        for _, row in combined.iterrows():
+            assert int(row["id_new"]) > int(row["id"]), "New variable id should be greater than old variable id."
+            assert row["version_new"] > row["version"], "New version should be greater than old version."
+            message += f"{row['id']} ({row['version']}) -> {row['id_new']} ({row['version_new']})\n"
+            if row["name"] != row["name_new"]:
+                message += "  Name change:\n"
+                message += f"  {row['name']} ->\n  {row['name_new']}\n"
+        log.info(message)
+
+        if not dry_run:
+            # Write to explorer file, to replace old variable ids with new ones.
+            with open(explorer_file, "w") as f:
+                f.write(explorer_new)
 
 
 @click.command(name="explorer-update", cls=RichCommand, help=__doc__)

--- a/apps/explorer_update/cli.py
+++ b/apps/explorer_update/cli.py
@@ -232,6 +232,13 @@ def update_explorer(explorer_file: Path, dry_run: bool = False) -> None:
     # Initialize variable for the updated explorer content.
     explorer_new = None
 
+    # TODO: Future improvements based on Sophia's inputs:
+    #  * To follow the same order as grapher, first check for indicator-based, then file-based, then other explorers
+    #    (although this will probably make no difference).
+    #  * The correct way to know if an explorer is file-based is to check if there is a `table` keyword in the very
+    #    first column of the explorer config.
+    #  * Explorers don't care about the order of columns, so technically, it's not safe to assume that variable IDs are
+    #    always in the first column.
     if ("yVariableIds" not in explorer) and (CATALOG_URL not in explorer):
         log.info("Nothing to update (it may be a grapher-based explorer).")
 

--- a/etl/db.py
+++ b/etl/db.py
@@ -167,7 +167,9 @@ def get_variables_in_dataset(
 
 
 def _get_variables_data_with_filter(
-    field_name: str, field_values: List[Any], db_conn: Optional[MySQLdb.Connection] = None
+    field_name: Optional[str] = None,
+    field_values: Optional[List[Any]] = None,
+    db_conn: Optional[MySQLdb.Connection] = None,
 ) -> Any:
     if db_conn is None:
         db_conn = get_connection()
@@ -178,7 +180,7 @@ def _get_variables_data_with_filter(
     # Construct the SQL query with a placeholder for each value in the list.
     query = "SELECT * FROM variables"
 
-    if len(field_values) > 0:
+    if (field_name is not None) and (len(field_values) > 0):
         query += f"\nWHERE {field_name} IN ({', '.join(['%s'] * len(field_values))});"
 
     # Execute the query.

--- a/etl/db.py
+++ b/etl/db.py
@@ -2,7 +2,7 @@ import traceback
 import warnings
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
 import MySQLdb
@@ -164,6 +164,82 @@ def get_variables_in_dataset(
         warnings.simplefilter("ignore", UserWarning)
         variables_data = pd.read_sql(query, con=db_conn)
     return variables_data
+
+
+def _get_variables_data_with_filter(
+    field_name: str, field_values: List[Any], db_conn: Optional[MySQLdb.Connection] = None
+) -> Any:
+    if db_conn is None:
+        db_conn = get_connection()
+
+    if field_values is None:
+        field_values = []
+
+    # Construct the SQL query with a placeholder for each value in the list.
+    query = "SELECT * FROM variables"
+
+    if len(field_values) > 0:
+        query += f"\nWHERE {field_name} IN ({', '.join(['%s'] * len(field_values))});"
+
+    # Execute the query.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        variables_data = pd.read_sql(query, con=db_conn, params=field_values)
+
+    assert set(variables_data[field_name]) <= set(field_values), f"Unexpected values for {field_name}."
+
+    # Warn about values that were not found.
+    missing_values = set(field_values) - set(variables_data[field_name])
+    if len(missing_values) > 0:
+        log.warning(f"Values of {field_name} not found in database: {missing_values}")
+
+    return variables_data
+
+
+def get_variables_data(
+    filter: Optional[Dict[str, Any]] = None,
+    condition: Optional[str] = "OR",
+    db_conn: Optional[MySQLdb.Connection] = None,
+) -> pd.DataFrame:
+    """Get data from variables table, given a certain condition.
+
+    Parameters
+    ----------
+    filter : Optional[Dict[str, Any]], optional
+        Filter to apply to the data, which must contain a field name and a list of field values,
+        e.g. {"id": [123456, 234567, 345678]}.
+        In principle, multiple filters can be given.
+    condition : Optional[str], optional
+        In case multiple filters are given, this parameter specifies whether the output filters should be the union
+        ("OR") or the intersection ("AND").
+    db_conn : MySQLdb.Connection
+        Connection to database. Defaults to None, in which case a default connection is created (uses etl.config).
+
+    Returns
+    -------
+    df : pd.DataFrame
+        Variables data.
+
+    """
+    # NOTE: This function should be optimized. Instead of fetching data for each filter, their conditions should be
+    # combined with OR or AND before executing the query.
+
+    # Initialize an empty dataframe.
+    if filter is not None:
+        df = pd.DataFrame({"id": []}).astype({"id": int})
+        for field_name, field_values in filter.items():
+            _df = _get_variables_data_with_filter(field_name=field_name, field_values=field_values, db_conn=db_conn)
+            if condition == "OR":
+                df = pd.concat([df, _df], axis=0)
+            elif condition == "AND":
+                df = pd.merge(df, _df, on="id", how="inner")
+            else:
+                raise ValueError(f"Invalid condition: {condition}")
+    else:
+        # Fetch data for all variables.
+        df = _get_variables_data_with_filter(db_conn=db_conn)
+
+    return df
 
 
 def get_all_datasets(archived: bool = True, db_conn: Optional[MySQLdb.Connection] = None) -> pd.DataFrame:


### PR DESCRIPTION
## Summary

Create a tool to automatically update explorer (tsv) files.

## Technical details

Currently, we have ways to check if grapher charts are outdated (using `VersionTracker`), but we have no way to check if explorers are outdated.

As far as I understand, explorers can be:
* Grapher-based: They directly show the content of grapher charts. These explorers do not need to be updated, as long as their grapher charts are updated (via, e.g. the chart-upgrader tool).
* File-based: They rely on a URL pointing to the data catalog. This URL may have an ETL version that needs to be manually updated if the dataset is updated.
* Indicator-based: They rely on variable ids. All those ids need to be manually updated if their dataset is updated.
* Mixed file-based and grapher-based.

This PR creates a new cli tool that lets you update any kind of explorer. It can be used on a single explorer file, multiple files, or all existing explorer files.

Note that I assumed that:
* File-based explorers are those that contain the string `"https://catalog.ourworldindata.org/"`.
* Indicator-based explorers are those that contain the string `"yVariableIds"`.

I'm not sure if these assumptions are accurate.

## Review

I executed this tool on all explorer steps. It successfully updated the variable ids in `animal-welfare.explorer` and detected some issues with other explorers (the issues are on private explorers, like the [`debug-conflict-data.explorer`](https://github.com/owid/owid-content/blob/master/explorers/debug-conflict-data.explorer.tsv), so we may need to find a way to skip non-public explorers, to avoid spurious warnings).

Feel free to test it yourself by simply running `etl explorer-update --dry-run`. You can also run it without `--dry-run` and then restore the changes in `owid-content` (I'll create a separate PR for those changes).

Since there was no file-based explorer that needed an update, I manually replaced "latest" -> "2023-06-12" in the `global-food.explorer`. Then, running `etl eplorer-update` successfully replaced those versions back to "latest". Feel free to do a similar test.

The code is not well polished or tested, please let me know if you want me to improve it and add tests before merging.

For now, I think this script will be useful and it can't harm (any unwanted changes to local `owid-content` files can easily be git restored). But in the future we can consider alternative approches, e.g.:
* `VersionTracker` could run code similar to this to check for outdated explorers.
* The chart-upgrader tool could raise a warning if any of the updated variables are in explorers.

Please let me know if you have any thoughts, thanks!
