### PR TITLE
:bug: fix case with swapped titles

### DIFF
--- a/apps/wizard/pages/fasttrack/fast_import.py
+++ b/apps/wizard/pages/fasttrack/fast_import.py
@@ -1,6 +1,7 @@
 """Definition of FasttrackImport object (mainly backend)."""
 import datetime as dt
 import difflib
+import html
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -237,7 +238,7 @@ class FasttrackImport:
         else:
             return (
                 True,
-                f'<iframe srcdoc="{html_diff}" width="100%" height="400px" style="border: 1px solid black; background: white"></iframe>',
+                f'<iframe srcdoc="{html.escape(html_diff)}" width="100%" height="400px" style="border: 1px solid black; background: white"></iframe>',
             )
 
     def commit_and_push(self) -> str:


### PR DESCRIPTION
If we swap titles of two indicators, but their `short_name` isn't swapped (e.g. when one makes a mistake in fast-track), we'd get an error from MySQL saying that `dataset-name` must be unique. Ideally, we wouldn't have this constraint, but as a hotfix we can check if such indicator exists and rename it temporarily.