### PR TITLE
🐛 set first year to baseline of –1 for all benchmarks

### DIFF
--- a/etl/steps/data/garden/artificial_intelligence/2024-04-02/dynabench.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2024-04-02/dynabench.meta.yml
@@ -27,6 +27,7 @@ definitions:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/
 dataset:
   update_period_days: 365
+  non_redistributable: true
 
 tables:
   dynabench:

--- a/etl/steps/data/garden/artificial_intelligence/2024-04-02/dynabench.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-04-02/dynabench.py
@@ -24,6 +24,12 @@ def run(dest_dir: str) -> None:
     # Selecting the best performance for each benchmark per year
     tb = tb.groupby(["benchmark", "year"])["performance"].max().reset_index().copy_metadata(from_table=tb)
 
+    # Set the first year's performance to the baseline of –1 for each benchmark.
+    # This is to preserve a baseline for –1 for all benchmarks,
+    # even when a second, better performance is recorded in a later year.
+    tb = tb.sort_values(by=["benchmark", "year"])
+    tb.loc[tb.groupby("benchmark").head(1).index, "performance"] = -1
+
     mapping = {
         "MNIST": "Handwriting recognition",
         "Switchboard": "Speech recognition",


### PR DESCRIPTION
Set the first year's performance to the baseline of –1 for each benchmark. This is to preserve a baseline for –1 for all benchmarks, even when a second, better performance is recorded in a later year.