### PR TITLE
:sparkles: speed up PathFinder

### DIFF
--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -390,11 +390,8 @@ class PathFinder:
     def __init__(self, __file__: str, is_private: Optional[bool] = None):
         self.f = Path(__file__)
 
-        # Load dag.
-        if "/archive/" in __file__:
-            self.dag = load_dag(paths.DAG_ARCHIVE_FILE)
-        else:
-            self.dag = load_dag()
+        # Lazy load dag when needed.
+        self._dag = None
 
         # Current file should be a data step.
         if not self.f.as_posix().startswith(paths.STEP_DIR.as_posix()):
@@ -411,6 +408,16 @@ class PathFinder:
 
         # Default logger
         self.log = structlog.get_logger(step=f"{self.namespace}/{self.channel}/{self.version}/{self.short_name}")
+
+    @property
+    def dag(self):
+        """Lazy loading of DAG."""
+        if self._dag is None:
+            if "/archive/" in str(self.f):
+                self._dag = load_dag(paths.DAG_ARCHIVE_FILE)
+            else:
+                self._dag = load_dag()
+        return self._dag
 
     @property
     def channel(self) -> str:

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -829,7 +829,7 @@ class GrapherStep(Step):
                     cols += [c for c in table.columns if c in {"year", "country"} and c not in cols]
                     table = table.loc[:, cols]
 
-                table = gh._adapt_table_for_grapher(table)
+                table = gh._adapt_table_for_grapher(table, engine)
 
                 for t in gh._yield_wide_table(table, na_action="drop"):
                     i += 1

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -14,6 +14,7 @@ import warnings
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
+from functools import cache
 from glob import glob
 from importlib import import_module
 from pathlib import Path
@@ -130,6 +131,7 @@ def traverse(graph: Graph, nodes: Set[str]) -> Graph:
     return dict(reachable)
 
 
+@cache
 def load_dag(filename: Union[str, Path] = paths.DEFAULT_DAG_FILE) -> Dict[str, Any]:
     return _load_dag(filename, {})
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -73,7 +73,7 @@ tables: {}""".strip()
 def test_PathFinder_with_private_steps():
     pf = PathFinder(str(paths.STEP_DIR / "data/garden/namespace/2023/name/__init__.py"))
 
-    pf.dag = {
+    pf._dag = {
         "data://garden/namespace/2023/name": {
             "snapshot://namespace/2023/snapshot_a",
             "snapshot-private://namespace/2023/snapshot_b",
@@ -88,7 +88,7 @@ def test_PathFinder_with_private_steps():
     # assume it's public, unless explicitly stated otherwise.
     assert pf.get_dependency_step_name("snapshot_a", is_private=True) == "snapshot-private://namespace/2023/snapshot_a"
 
-    pf.dag = {
+    pf._dag = {
         "data-private://garden/namespace/2023/name": {
             "snapshot-private://namespace/2023/name",
         }


### PR DESCRIPTION
`load_dag()` is relatively performance heavy. Cache it in memory and also lazy load it in PathFinder.

Reuse engine to avoid too many connections.