### PR TITLE
:sparkles: compute checksums from ingredients only

### DIFF
--- a/apps/owidbot/etldiff.py
+++ b/apps/owidbot/etldiff.py
@@ -55,6 +55,10 @@ def cli(
 
     nbranch = _normalise_branch(branch) if branch else "dry-run"
 
+    # TODO: only include site-screenshots if the PR is from owid-grapher. Similarly, don't
+    # run etl diff if the PR is from etl repo.
+    # - **Site-screenshots**: https://github.com/owid/site-screenshots/compare/{nbranch}
+
     body = f"""
 <details>
 
@@ -63,7 +67,6 @@ def cli(
 - **Admin**: http://staging-site-{nbranch}/admin/login
 - **Site**: http://staging-site-{nbranch}/
 - **Login**: `ssh owid@staging-site-{nbranch}`
-- **Site-screenshots**: https://github.com/owid/site-screenshots/compare/{nbranch}
 </details>
 
 <details>

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -518,7 +518,8 @@ class DataStep(Step):
         return catalog.Dataset(self._dest_dir.as_posix())
 
     def checksum_output(self) -> str:
-        return self._output_dataset.checksum()
+        # output checksum is checksum of all ingredients
+        return self.checksum_input()
 
     def _step_files(self) -> List[str]:
         "Return a list of code files defining this step."
@@ -714,12 +715,7 @@ class SnapshotStep(Step):
         return True
 
     def checksum_output(self) -> str:
-        # NOTE: we could use the checksum from `_dvc_path` to
-        # speed this up. Test the performance on
-        # time poetry run etl run garden --dry-run
-        # Make sure that the checksum below is the same as DVC checksum! It
-        # looks like it might be different for some reason
-        return files.checksum_file(self._dvc_path)
+        return Snapshot(self.path).m.outs[0]["md5"]
 
     @property
     def _dvc_path(self) -> str:

--- a/etl/steps/data/garden/nasa/2023-03-06/ozone_hole_area.meta.yml
+++ b/etl/steps/data/garden/nasa/2023-03-06/ozone_hole_area.meta.yml
@@ -16,9 +16,6 @@ dataset:
     Minimum and mean Southern Hemisphere daily ozone concentrations, measured in Dobson Units (DU).
 
     This dataset should be next updated by the source every year. We will update it on Our World in Data soon after the new version is published. At the link above you can directly access the source page and see the latest available data.
-  licenses:
-    - name: # TO BE FILLED. Example: Testing License Name
-      url: # TO BE FILLED. Example: https://url_of_testing_source.com/license
   sources:
     - *source-testing
 

--- a/etl/steps/data/garden/war/2023-01-18/dunnigan_martel_1987.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/dunnigan_martel_1987.meta.yml
@@ -17,7 +17,6 @@ dataset:
     This dataset provides information on military and civilian deaths from wars, drawn from the book by Dunnigan and Martel (1987).
   licenses:
     - name: Doubleday (1987)
-      url: # TO BE FILLED. Example: https://url_of_testing_source.com/license
   sources:
     - *source-testing
 

--- a/etl/steps/data/garden/war/2023-01-18/eckhardt_1991.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/eckhardt_1991.meta.yml
@@ -17,7 +17,6 @@ dataset:
     This dataset provides information on military and civilian deaths from wars, drawn from the chapter by Eckhardt (1991).
   licenses:
     - name: World Priorities
-      url: # TO BE FILLED. Example: https://url_of_testing_source.com/license
   sources:
     - *source-testing
 

--- a/etl/steps/data/garden/war/2023-01-18/kaye_1985.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/kaye_1985.meta.yml
@@ -17,7 +17,6 @@ dataset:
     This dataset provides information on direct and indirect military and civilian deaths from major armed conflicts, drawn from the report by Kaye et al. (1985).
   licenses:
     - name: Department of National Defence, Canada, Operational Research and Analysis Establishment, 1985
-      url: # TO BE FILLED. Example: https://url_of_testing_source.com/license
   sources:
     - *source-testing
 

--- a/etl/steps/data/garden/war/2023-01-18/sutton_1971.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/sutton_1971.meta.yml
@@ -4,7 +4,6 @@ all_sources:
       published_by: Sutton, Antony. 1972. Wars and Revolutions in the Nineteenth Century. Hoover Institution Archives.
       url: https://searchworks.stanford.edu/view/3023823
       date_accessed: 2023-01-09
-      publication_date: # TO BE FILLED. Example: 2023-01-01
       publication_year: 1971
       # description: Source description.
 
@@ -15,9 +14,6 @@ dataset:
   version: 2023-01-18
   description: |
     This dataset provides information on deaths from wars and revolutions, using data from Sutton (1972).
-  licenses:
-    - name: Unknown
-      url: # TO BE FILLED. Example: https://url_of_testing_source.com/license
   sources:
     - *source-testing
 


### PR DESCRIPTION
Implements https://github.com/owid/etl/issues/2497

The big drawback is that this will rebuild the entire ETL again.

## TODO:

- [x] Does it speed up `etl run --dry-run`?
  - Only a bit (we still calculate checksums of snapshots on disk to make sure they match checksum in their `*.dvc` file)
- [x] Does it help with datadiff checksum comparison?
  - Yes! This is a major blocker for datadiff right now. It'd speed it up by a lot.