### PR TITLE
:sparkles: add column owid_continent to grapher regions

### DIFF
--- a/etl/steps/data/grapher/regions/latest/regions.py
+++ b/etl/steps/data/grapher/regions/latest/regions.py
@@ -6,6 +6,7 @@ This dataset is not meant to be imported to MySQL and is excluded from automatic
 
 import ast
 import re
+from typing import Any, cast
 
 import pandas as pd
 from owid.catalog import Dataset, Table
@@ -299,6 +300,15 @@ def run(dest_dir: str) -> None:
     regions["members"] = (
         members["members"].astype(object).apply(lambda x: ";".join(ast.literal_eval(x)) if pd.notna(x) else "")
     )
+
+    # Add owid_continent for convenience.
+    regions["owid_continent"] = None
+    continents = regions[regions["region_type"] == "continent"]
+    for continent in continents.itertuples():
+        continent = cast(Any, continent)
+        continent_members = continent.members.split(";")
+        assert regions.loc[continent_members, "owid_continent"].isnull().all(), "Some regions already have a continent"
+        regions.loc[continent_members, "owid_continent"] = continent.name
 
     #
     # Save outputs.


### PR DESCRIPTION
Add column `owid_continent` with a name of the continent to `grapher/regions` for convenience (Bastian would find it useful, and I'd say it could be useful in the future, too). This won't rebuild ETL, just a few datasets that depend on `grapher/regions`.