### PR TITLE
:sparkles: add --errors and --include/--exclude to chart-sync

### DIFF
--- a/apps/staging_sync/cli.py
+++ b/apps/staging_sync/cli.py
@@ -54,6 +54,18 @@ log = structlog.get_logger()
     updated in production. Default is branch creation date.""",
 )
 @click.option(
+    "--include",
+    default=None,
+    type=str,
+    help="""Include only variables which catalogPath includes the provided string.""",
+)
+@click.option(
+    "--exclude",
+    default=None,
+    type=str,
+    help="""Exclude variables which catalogPath includes the provided string.""",
+)
+@click.option(
     "--dry-run/--no-dry-run",
     default=False,
     type=bool,
@@ -66,6 +78,8 @@ def cli(
     publish: bool,
     approve_revisions: bool,
     staging_created_at: Optional[dt.datetime],
+    include: Optional[str],
+    exclude: Optional[str],
     dry_run: bool,
 ) -> None:
     """Sync Grapher charts and revisions from an environment to the main environment.

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -5,6 +5,7 @@ sqlacodegen --generator sqlmodels mysql://root@localhost:3306/owid
 It has been slightly modified since then.
 """
 import json
+import re
 from datetime import date, datetime
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Literal, Optional, TypedDict, Union, get_args
@@ -329,7 +330,9 @@ class Chart(SQLModel, table=True):
 
         return variables
 
-    def migrate_to_db(self, source_session: Session, target_session: Session) -> "Chart":
+    def migrate_to_db(
+        self, source_session: Session, target_session: Session, exclude: Optional[str] = None
+    ) -> Optional["Chart"]:
         """Remap variable ids from source to target session. Variable in source is uniquely identified
         by its catalogPath if available, or by name and datasetId otherwise. It is looked up
         by this identifier in the target session to get the new variable id.
@@ -342,6 +345,10 @@ class Chart(SQLModel, table=True):
 
         remap_ids = {}
         for source_var_id, source_var in source_variables.items():
+            # if chart contains a variable that is excluded, skip the whole chart
+            if exclude and source_var.catalogPath and re.search(exclude, source_var.catalogPath):
+                return None
+
             if source_var.catalogPath:
                 try:
                     target_var = Variable.load_from_catalog_path(target_session, source_var.catalogPath)


### PR DESCRIPTION
Fix for https://github.com/owid/etl/issues/2533#issuecomment-2061210834

You can either exclude charts that have variables matching `--include`, e.g.
```
etl chart-sync .env update-natural-disasters-data --include natural --dry-run
```
or `--exclude`
```
etl chart-sync .env update-natural-disasters-data --exclude foo --dry-run
```
or simply ignore charts causing errors
```
etl chart-sync .env update-natural-disasters-data --errors warn --dry-run
```

@pabloarosado could you try merging this into your PR and testing it out? I've only tested it on a few simple cases.