### PR TITLE
📊  undp: default view on data page

### DIFF
--- a/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
+++ b/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
@@ -4,7 +4,10 @@ definitions:
     presentation:
       topic_tags:
         - Human Development Index (HDI)
-
+      grapher_config:
+        tab: map
+        selectedEntityNames:
+          - World
 
 # Learn more about the available fields:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/


### PR DESCRIPTION
Set default chart view for all indicators, so it looks OK in data pages.