### PR TITLE
📊 grapher/regions/latest: Add income group information

### DIFF
--- a/dag/main.yml
+++ b/dag/main.yml
@@ -229,6 +229,7 @@ steps:
   data://garden/regions/2023-01-01/regions:
   data://grapher/regions/latest/regions:
     - data://garden/regions/2023-01-01/regions
+    - data://garden/wb/2024-03-11/income_groups
 
   # Democracy and Human rights - V-Dem index
   data://meadow/democracy/2023-03-02/vdem:
@@ -666,7 +667,6 @@ steps:
     - data://garden/demography/2023-03-31/population
   data://grapher/missing_data/2024-03-26/who_md_suicides:
     - data://garden/missing_data/2024-03-26/who_md_suicides
-
 
   ######################################################################################################################
   # Older versions to be archived once they are not used by any other steps.


### PR DESCRIPTION
This is working towards https://github.com/owid/owid-grapher/issues/3517.

This is adding the 4 WB income groups as rows to the `regions.csv` file _which is only consumed by owid-grapher_.
These rows get the new entity type `income_group`, which we will then handle in grapher. We mostly care about the members of these income groups; and for these to be up to date, we will want to update this step to use the latest `wb/.../income_groups` classification once a new one becomes available.

This also assigns new entity codes to these four regions: `OWID_WB_LIC, OWID_WB_LMC, OWID_WB_UMC, OWID_WB_HIC`. The last part of these are the official 3-letter codes that the WB uses for these entities.

**Changing these entity codes in the future is going to be a major pain, so please let me know if you would want to use different ones instead.**