### PR TITLE
:hammer: unify access to R2

### DIFF
--- a/apps/backport/datasync/datasync.py
+++ b/apps/backport/datasync/datasync.py
@@ -11,7 +11,6 @@ from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_exponential
 
 from etl import config
-from etl.publish import connect_s3_cached
 
 log = structlog.get_logger()
 
@@ -24,7 +23,7 @@ def upload_gzip_dict(d: Dict[str, Any], s3_path: str, private: bool = False) -> 
 
     bucket, key = s3_utils.s3_bucket_key(s3_path)
 
-    client = connect_s3_cached()
+    client = s3_utils.connect_r2_cached()
 
     assert not private, "r2 does not support private files yet"
     extra_args = {}

--- a/etl/config.py
+++ b/etl/config.py
@@ -7,11 +7,9 @@ The environment variables and settings here are for publishing options, they're
 only important for OWID staff.
 """
 
-import configparser
 import os
 import pwd
 from os import environ as env
-from typing import Dict
 
 import bugsnag
 import pandas as pd
@@ -47,31 +45,6 @@ ENV_IS_REMOTE = ENV in ("production", "staging")
 
 # publishing to OWID's public data catalog in R2
 R2_BUCKET = "owid-catalog"
-R2_REGION_NAME = "auto"
-R2_ENDPOINT_URL = env.get("R2_ENDPOINT_URL", "https://078fcdfed9955087315dd86792e71a7e.r2.cloudflarestorage.com")
-R2_ACCESS_KEY = env.get("R2_ACCESS_KEY")
-R2_SECRET_KEY = env.get("R2_SECRET_KEY")
-
-
-# if R2_ACCESS_KEY and R2_SECRET_KEY are null, try using credentials from rclone config
-def _read_owid_rclone_config() -> Dict[str, str]:
-    # Create a ConfigParser object
-    config = configparser.ConfigParser()
-
-    # Read the configuration file
-    config.read(os.path.expanduser("~/.config/rclone/rclone.conf"))
-
-    return dict(config["owid-r2"].items())
-
-
-if not R2_ACCESS_KEY or not R2_SECRET_KEY:
-    try:
-        rclone_config = _read_owid_rclone_config()
-        R2_ACCESS_KEY = R2_ACCESS_KEY or rclone_config.get("access_key_id")
-        R2_SECRET_KEY = R2_SECRET_KEY or rclone_config.get("secret_access_key")
-    except KeyError:
-        pass
-
 R2_SNAPSHOTS_PUBLIC = "owid-snapshots"
 R2_SNAPSHOTS_PRIVATE = "owid-snapshots-private"
 R2_SNAPSHOTS_PUBLIC_READ = "https://snapshots.owid.io"

--- a/scripts/audit_s3.py
+++ b/scripts/audit_s3.py
@@ -6,10 +6,10 @@ from io import BytesIO
 import pandas as pd
 import rich_click as click
 import structlog
+from owid.catalog.s3_utils import connect_r2
 
 from apps.backport.datasync.datasync import upload_gzip_dict
 from etl.db import get_engine
-from etl.publish import connect_s3
 
 log = structlog.get_logger()
 
@@ -124,7 +124,7 @@ def cli(
     """
     assert dry_run, "Only --dry-run is supported at the moment, we don't want to modify files on S3"
 
-    s3 = connect_s3()
+    s3 = connect_r2()
 
     variable_ids = load_variable_ids(limit)
 

--- a/snapshots/wb/2024-01-17/pip_api.py
+++ b/snapshots/wb/2024-01-17/pip_api.py
@@ -41,6 +41,7 @@ import pandas as pd
 import requests
 from botocore.exceptions import ClientError
 from joblib import Memory
+from owid.catalog import connect_r2_cached
 from structlog import get_logger
 from tenacity import retry
 from tenacity.stop import stop_after_attempt
@@ -48,7 +49,6 @@ from tenacity.wait import wait_random_exponential
 
 from etl.files import checksum_str
 from etl.paths import CACHE_DIR
-from etl.publish import connect_s3_cached
 
 # Initialize logger.
 log = get_logger()
@@ -239,7 +239,7 @@ def _get_request(url: str) -> requests.Response:
 
 @memory.cache
 def _fetch_csv(url: str) -> pd.DataFrame:
-    r2 = connect_s3_cached()
+    r2 = connect_r2_cached()
     r2_bucket = "owid-private"
     r2_key = "cache/pip_api/" + checksum_str(url)
 

--- a/snapshots/wb/2024-03-27/pip_api.py
+++ b/snapshots/wb/2024-03-27/pip_api.py
@@ -48,6 +48,7 @@ import pandas as pd
 import requests
 from botocore.exceptions import ClientError
 from joblib import Memory
+from owid.catalog import connect_r2_cached
 from structlog import get_logger
 from tenacity import retry
 from tenacity.stop import stop_after_attempt
@@ -55,7 +56,6 @@ from tenacity.wait import wait_random_exponential
 
 from etl.files import checksum_str
 from etl.paths import CACHE_DIR
-from etl.publish import connect_s3_cached
 
 # Initialize logger.
 log = get_logger()
@@ -250,7 +250,7 @@ def _get_request(url: str) -> requests.Response:
 
 @memory.cache
 def _fetch_csv(url: str) -> pd.DataFrame:
-    r2 = connect_s3_cached()
+    r2 = connect_r2_cached()
     r2_bucket = "owid-private"
     r2_key = "cache/pip_api/" + checksum_str(url)
 


### PR DESCRIPTION
Connecting to R2 now happens exclusively in `owid.catalog.s3_utils`. Credentials are taken either from `.env` file or from rclone config file.

Previously we were using different function for running snapshot and in ETL which caused problems and confusion.