### PR TITLE
🎉  Create CLI to print affected grapher datasets

### DIFF
--- a/apps/cli/__init__.py
+++ b/apps/cli/__init__.py
@@ -71,6 +71,7 @@ SUBGROUPS = {
             "publish": "etl.publish.publish_cli",
             "reindex": "etl.reindex.reindex_cli",
             "run-python-step": "etl.run_python_step.main",
+            "map-datasets": "apps.utils.map_datasets.cli",
         },
     },
     "b": {


### PR DESCRIPTION
This is a simple CLI that prints the old and new grapher dataset that should manually be passed to the chart upgrader tool, based on the changes you have commited to your current ETL branch.

To test it, go to any branch and run `etl d map-datasets`.

Note: This is a temporary solution before this logic is implemented in the indicator upgrader (or possibly also in chart diff).
