### PR TITLE
✨ VersionTracker.steps_df: ~30% reduction in execution time

### DIFF
--- a/etl/version_tracker.py
+++ b/etl/version_tracker.py
@@ -796,12 +796,10 @@ class VersionTracker:
         steps_df["all_active_usages"] = [
             self.get_all_step_usages(step=step, only_active=True) for step in self.all_steps
         ]
-        # TODO
         steps_df["all_usages"] = [self.get_all_step_usages(step=step) for step in self.all_steps]
         steps_df["state"] = ["active" if step in self.all_active_steps else "archive" for step in self.all_steps]
         steps_df["role"] = ["usage" if step in self.dag_all else "dependency" for step in self.all_steps]
         steps_df["dag_file_name"] = [self.get_dag_file_for_step(step=step) for step in self.all_steps]
-        # TODO
         steps_df["path_to_script"] = [self.get_path_to_script(step=step, omit_base_dir=True) for step in self.all_steps]
 
         # Add column for the total number of all dependencies and usges.

--- a/etl/version_tracker.py
+++ b/etl/version_tracker.py
@@ -148,33 +148,6 @@ def get_all_step_usages(dag_reverse: Dict[str, Any], step: str) -> List[str]:
     return dependencies
 
 
-def get_all_step_usages_ndim(steps) -> List[str]:
-    """Get all dependencies for a given step in a dag.
-
-    This function returns all datasets for which a given step is a dependency, as well as those datasets for which they
-    are also dependencies, and so on. In the end, the result contains all datasets that use, directly or indirectly, the
-    given step.
-
-    Parameters
-    ----------
-    dag_reverse : Dict[str, Any]
-        Dag reversed (a dictionary where each item is step: set of usages).
-    step : str
-        Step (as it appears in the dag).
-
-    Returns
-    -------
-    dependencies : List[str]
-        All usages of a given step in a dag.
-
-    """
-    # A simple solution is to simply reverse the graph, and apply the already existing function that finds all
-    # dependencies.
-    dependencies = get_all_step_dependencies(dag=dag_reverse, step=step)
-
-    return dependencies
-
-
 def _recursive_get_all_archivable_steps(steps_df: pd.DataFrame, unused_steps: Set[str] = set()) -> Set[str]:
     # Find active meadow/garden steps for which there is a newer version.
     new_unused_steps = set(

--- a/etl/version_tracker.py
+++ b/etl/version_tracker.py
@@ -510,31 +510,52 @@ class VersionTracker:
         steps_df = steps_df.copy()
         # Create a dataframe with one row per unique step.
         df = steps_df.drop_duplicates(subset="step")[["step", "identifier", "version"]].reset_index(drop=True)
+
+        # Only run for steps that have more than one version.
+        more_than_one_version = df["identifier"].value_counts() > 1
+        ids_more_than_one_version = list(more_than_one_version[more_than_one_version].index)
+        df_n = df[df["identifier"].isin(ids_more_than_one_version)].copy()
+
         # For each step, find all alternative versions.
         # New columns will contain forward versions, backward versions, all versions, and latest version.
         other_versions_forward = []
         other_versions_backward = []
         other_versions_all = []
         latest_version = []
-        for _, row in df.iterrows():
+        for _, row in df_n.iterrows():
             # Create a mask that selects all steps with the same identifier.
-            select_same_identifier = df["identifier"] == row["identifier"]
+            select_same_identifier = df_n["identifier"] == row["identifier"]
             # Find all forward versions of the current step.
-            versions_forward = sorted(set(df[select_same_identifier & (df["version"] > row["version"])]["step"]))
+            versions_forward = sorted(set(
+                df_n[select_same_identifier & (df_n["version"] > row["version"])]["step"]
+            ))
             other_versions_forward.append(versions_forward)
             # Find all backward versions of the current step.
             other_versions_backward.append(
-                sorted(set(df[select_same_identifier & (df["version"] < row["version"])]["step"]))
+                sorted(set(df_n[select_same_identifier & (df_n["version"] < row["version"])]["step"]))
             )
             # Find all versions of the current step.
-            other_versions_all.append(sorted(set(df[select_same_identifier]["step"])))
+            other_versions_all.append(sorted(set(df_n[select_same_identifier]["step"])))
             # Find latest version of the current step.
             latest_version.append(versions_forward[-1] if len(versions_forward) > 0 else row["step"])
         # Add columns to the dataframe.
-        df["same_steps_forward"] = other_versions_forward
-        df["same_steps_backward"] = other_versions_backward
-        df["same_steps_all"] = other_versions_all
-        df["same_steps_latest"] = latest_version
+        df_n["same_steps_forward"] = other_versions_forward
+        df_n["same_steps_backward"] = other_versions_backward
+        df_n["same_steps_all"] = other_versions_all
+        df_n["same_steps_latest"] = latest_version
+
+        # Only one version
+        ids_one_version = list(more_than_one_version[~more_than_one_version].index)
+        df_1 = df[df["identifier"].isin(ids_one_version)].copy()
+        empty_lists = [[] for n in range(len(df_1))]
+        df_1["same_steps_forward"] = empty_lists
+        df_1["same_steps_backward"] = empty_lists
+        df_1["same_steps_all"] = df_1["step"].str.split()
+        df_1["same_steps_latest"] = df_1["step"]
+
+        # Concatenate the two dataframes.
+        df = pd.concat([df_n, df_1], ignore_index=True)
+
         # Add new columns to the original steps dataframe.
         steps_df = pd.merge(steps_df, df.drop(columns=["identifier", "version"]), on="step", how="left")
 
@@ -652,6 +673,83 @@ class VersionTracker:
         steps_df = steps_df.drop(
             steps_df[(steps_df["db_archived"]) & (steps_df["n_charts"] == 0) & (steps_df["kind"].isnull())].index
         ).reset_index(drop=True)
+
+        return steps_df
+
+    def _create_steps_df_2(self) -> pd.DataFrame:
+        # Create a dataframe where each row correspond to one step.
+        steps_df = pd.DataFrame({"step": self.all_steps.copy()})
+        # Add relevant information about each step.
+
+        steps_df["step"].apply(self.get_direct_step_dependencies)
+
+        steps_df["direct_dependencies"] = [self.get_direct_step_dependencies(step=step) for step in self.all_steps]
+        steps_df["direct_usages"] = [self.get_direct_step_usages(step=step) for step in self.all_steps]
+        steps_df["all_active_dependencies"] = [
+            self.get_all_step_dependencies(step=step, only_active=True) for step in self.all_steps
+        ]
+        steps_df["all_dependencies"] = [self.get_all_step_dependencies(step=step) for step in self.all_steps]
+        steps_df["all_active_usages"] = [
+            self.get_all_step_usages(step=step, only_active=True) for step in self.all_steps
+        ]
+        steps_df["all_usages"] = [self.get_all_step_usages(step=step) for step in self.all_steps]
+        steps_df["state"] = ["active" if step in self.all_active_steps else "archive" for step in self.all_steps]
+        steps_df["role"] = ["usage" if step in self.dag_all else "dependency" for step in self.all_steps]
+        steps_df["dag_file_name"] = [self.get_dag_file_for_step(step=step) for step in self.all_steps]
+        steps_df["path_to_script"] = [self.get_path_to_script(step=step, omit_base_dir=True) for step in self.all_steps]
+
+        # Add column for the total number of all dependencies and usges.
+        steps_df["n_all_dependencies"] = [len(dependencies) for dependencies in steps_df["all_dependencies"]]
+        steps_df["n_all_usages"] = [len(usages) for usages in steps_df["all_usages"]]
+
+        # Add attributes to steps.
+        steps_df = pd.merge(steps_df, self.step_attributes_df, on="step", how="left")
+
+        if self.connect_to_db:
+            # Add info from DB.
+            steps_df = self._add_info_from_db(steps_df=steps_df)
+
+            # Add columns with the date and the number of days until the next update.
+            steps_df = add_days_to_update_columns(steps_df=steps_df)
+        else:
+            # Add empty columns.
+            for column in (
+                [
+                    "chart_ids",
+                    "chart_slugs",
+                    "db_dataset_id",
+                    "db_dataset_name",
+                    "db_private",
+                    "db_archived",
+                    "update_period_days",
+                    "date_of_next_update",
+                    "days_to_update",
+                    "all_chart_ids",
+                    "all_chart_slugs",
+                    "n_charts",
+                ]
+                + [f"chart_{metric}" for metric in self.ANALYTICS_COLUMNS]
+                + [f"n_chart_{metric}" for metric in self.ANALYTICS_COLUMNS]
+            ):
+                steps_df[column] = None
+
+        # Add columns with the list of forward and backwards versions for each step.
+        steps_df = self._add_columns_with_different_step_versions(steps_df=steps_df)
+
+        # For convenience, add full local path to dag files to steps dataframe.
+        steps_df["dag_file_path"] = [
+            (paths.DAG_DIR / dag_file_name).with_suffix(".yml") if dag_file_name else None
+            for dag_file_name in steps_df["dag_file_name"].fillna("")
+        ]
+        # For convenience, add full local path to script files.
+        steps_df["full_path_to_script"] = [
+            paths.BASE_DIR / script_file_name if script_file_name else None
+            for script_file_name in steps_df["path_to_script"].fillna("")
+        ]
+
+        # Add column that is true if the step is the latest version.
+        steps_df["is_latest"] = False
+        steps_df.loc[steps_df["version"] == steps_df["latest_version"], "is_latest"] = True
 
         return steps_df
 


### PR DESCRIPTION
~31% execution time reduction in `VersionTracker().steps_df`. 

**In my machine, it went from 6.6 s ± 56.8 ms → 4.5s ± 75.3 ms.** (mean ± std. dev. of 7 runs, 1 loop each)

## What has been optimised?
### `_add_columns_with_different_step_versions`
This has been achieved by slightly optimising the execution time of `_add_columns_with_different_step_versions`. In this function, there is a loop iterating over all "identifiers" of datasets. We only need to iterate over those identifiers that have more than one dataset associated, since those with only one dataset will have deterministic values for columns `"same_steps_forward"`, `"same_steps_backward`, `"same_steps_all"` and `"same_steps_latest"`. Note that the majority of the identifiers only have >` dataset (~1500 vs ~300 with more than one dataset). Therefore the loop is way faster!

### `_init_steps_df`
At the start of `_create_steps_df` there are various column assignments. I have placed all of these lines inside function`_init_steps_df` (no optimisation this far).

Optimisation has been done in assignments to `steps_df["direct_usages"]` and `steps_df["all_usages"]` which were taking the most chunk of the time in these assignments.

The new assignments are done with `_init_steps_df_ndim`, so that one can still use former implementation `_init_steps_df`.