### PR TITLE
:tada: periodic runs of chart-diff against all open PRs

### DIFF
--- a/apps/cli/__init__.py
+++ b/apps/cli/__init__.py
@@ -72,6 +72,7 @@ SUBGROUPS = {
             "reindex": "etl.reindex.reindex_cli",
             "run-python-step": "etl.run_python_step.main",
             "map-datasets": "apps.utils.map_datasets.cli",
+            "scan-chart-diff": "apps.utils.scan_chart_diff.cli",
         },
     },
     "b": {

--- a/apps/owidbot/cli.py
+++ b/apps/owidbot/cli.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import re
 import time
 from typing import Any, Dict, List, Literal, Optional, get_args
 
@@ -82,8 +83,22 @@ def cli(
     else:
         if not comment:
             pr.create_issue_comment(body=body)
+        elif strip_appendix(comment.body) == strip_appendix(body):
+            log.info("No changes detected, skipping.", repo=repo, branch=branch, services=services)
         else:
+            log.info("Updating comment.", repo=repo, branch=branch, services=services)
             comment.edit(body=body)
+
+
+def strip_appendix(body: str) -> str:
+    """Strip variable parts of the body so that we can compare two different comments."""
+    # replace line with _Edited: 2024-05-06 11:21:29 UTC_
+    body = re.sub(r"_Edited:.*UTC_", "", body)
+
+    # replace line with _Execution time: 1.78 seconds_
+    body = re.sub(r"_Execution time:.*seconds_", "", body)
+
+    return body
 
 
 def services_from_comment(comment: Any) -> Dict[str, str]:

--- a/apps/utils/scan_chart_diff.py
+++ b/apps/utils/scan_chart_diff.py
@@ -1,0 +1,81 @@
+import click
+import requests
+from rich_click.rich_command import RichCommand
+from sqlalchemy.exc import OperationalError, ProgrammingError
+from structlog import get_logger
+
+from apps.owidbot.cli import cli as owidbot_cli
+from etl import config
+
+config.enable_bugsnag()
+
+log = get_logger()
+
+
+@click.command(name="scan-chart-diff", cls=RichCommand, help=__doc__)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    type=bool,
+    help="Print to console, do not post to Github.",
+)
+def cli(dry_run: bool) -> None:
+    """Scan all open PRs in the etl repository and run
+    `etl owidbot etl/branch --services chart-diff` against them.
+    """
+    active_prs = get_prs_from_repo("etl")
+
+    log.info("scan-chart-diff.init", active_prs=active_prs)
+
+    # active_prs = [pr for pr in active_prs if "update-electricity-mix-data" in pr]
+
+    for pr in active_prs:
+        log.info("scan-chart-diff.start", pr=pr)
+        args = [f"etl/{pr}", "--services", "chart-diff"]
+        if dry_run:
+            args.append("--dry-run")
+
+        try:
+            owidbot_cli(args, standalone_mode=False)
+        except ProgrammingError as e:
+            # old staging servers without the table
+            if "Table 'owid.chart_diff_approvals' doesn't exist" in str(e):
+                log.warning("scan-chart-diff.missing-table", pr=pr)
+                continue
+            else:
+                raise e
+        except OperationalError as e:
+            # PRs without a staging server
+            if "Unknown MySQL server host" in str(e):
+                log.warning("scan-chart-diff.unknown-host", pr=pr)
+                continue
+            else:
+                raise e
+
+
+def get_prs_from_repo(repo):
+    active_prs = []
+    # Start with the first page
+    url = f"https://api.github.com/repos/owid/{repo}/pulls?per_page=100"
+
+    while url:
+        response = requests.get(url)
+        response.raise_for_status()  # To handle HTTP errors
+        js = response.json()
+
+        # Collect PR head refs from the current page
+        for d in js:
+            # only owid PRs
+            if d["head"]["label"].startswith("owid:"):
+                active_prs.append(d["head"]["ref"])
+
+        # Check for the 'next' page link in the headers
+        if "next" in response.links:
+            url = response.links["next"]["url"]
+        else:
+            url = None  # No more pages
+
+    # exclude dependabot PRs
+    active_prs = [pr for pr in active_prs if "dependabot" not in pr]
+
+    return active_prs

--- a/apps/wizard/pages/chart_diff/app.py
+++ b/apps/wizard/pages/chart_diff/app.py
@@ -3,8 +3,10 @@ from pathlib import Path
 
 import streamlit as st
 from sqlalchemy.engine.base import Engine
+from sqlalchemy.exc import OperationalError
 from sqlmodel import Session, SQLModel
 from st_pages import add_indentation
+from structlog import get_logger
 
 from apps.staging_sync.cli import _get_engine_for_env, _modified_chart_ids_by_admin, _validate_env
 from apps.wizard.pages.chart_diff.chart_diff import ChartDiffModified
@@ -13,6 +15,9 @@ from apps.wizard.utils import chart_html, set_states
 from apps.wizard.utils.env import OWID_ENV
 from etl import grapher_model as gm
 from etl.config import DB_HOST
+from etl.paths import ENV_FILE_PROD
+
+log = get_logger()
 
 # from apps.wizard import utils as wizard_utils
 
@@ -22,8 +27,12 @@ CURRENT_DIR = Path(__file__).resolve().parent
 # TODO: simplify this
 SOURCE_ENV = DB_HOST  # "staging-site-streamlit-chart-approval"
 SOURCE_API = f"https://api-staging.owid.io/{SOURCE_ENV}/v1/indicators/"
-# TODO: switch to production once we are ready
-TARGET_ENV = "staging-site-master"
+
+if ENV_FILE_PROD.exists():
+    TARGET_ENV = ENV_FILE_PROD
+else:
+    log.warning(f"Production env file {ENV_FILE_PROD} not found, comparing against staging-site-master")
+    TARGET_ENV = "staging-site-master"
 TARGET_API = "https://api.ourworldindata.org/v1/indicators/"
 
 st.session_state.chart_diffs = st.session_state.get("chart_diffs", {})
@@ -254,7 +263,13 @@ def main():
         )
     # TODO: this should be created via migration in owid-grapher!!!!!
     # Create chart_diff_approvals table if it doesn't exist
-    SQLModel.metadata.create_all(source_engine, [gm.ChartDiffApprovals.__table__])  # type: ignore
+    try:
+        SQLModel.metadata.create_all(source_engine, [gm.ChartDiffApprovals.__table__])  # type: ignore
+    except OperationalError as e:
+        if "Table 'chart_diff_approvals' already exists" in str(e):
+            pass
+        else:
+            raise e
 
     # Get actual charts
     if st.session_state.chart_diffs == {}:

--- a/etl/paths.py
+++ b/etl/paths.py
@@ -65,3 +65,6 @@ DEFAULT_DAG_FILE = DAG_FILE
 
 # Hidden ETL file that will keep the time it took to execute each step.
 EXECUTION_TIME_FILE = BASE_DIR / ".execution_time.json"
+
+# Special ENV file for production
+ENV_FILE_PROD = Path(os.environ.get("ENV_FILE_PROD", BASE_DIR / ".env.prod"))


### PR DESCRIPTION
Script that iterates over all open PRs by OWID members and runs `owidbot --services chart-diff` against them. Can be invoked with
```
etl d scan-chart-diff --dry-run
```

This script will be run from `etl-prod-2` as a CRON job every 10 minutes (could be lower if needed). I was considering running a Buildkite scheduled job, but that'd be probably too heavy.

In addition to the script, there are a couple of improvements:
- `owidbot` doesn't update `Last edited` timestamp when body hasn't changed
- If `.env.prod` exists, we use it to connect to prod (otherwise we keep using `staging-site-master`). By the way, this is getting a bit messy, maybe we could wrap staging & prod info in an object similar to `OWIDEnv`?