### PR TITLE
✨ (owidbot) add svg tester commit links

### DIFF
--- a/apps/owidbot/grapher.py
+++ b/apps/owidbot/grapher.py
@@ -12,16 +12,36 @@ def run(branch: str) -> str:
         default_views = "error"
         all_views = "error"
 
+    try:
+        with open(BASE_DIR.parent / "owid-grapher-svgs/commit_default-views.log") as f:
+            commit_id = f.readline().strip()
+            default_views_commit = f"({make_commit_link(commit_id=commit_id)})" if commit_id else ""
+    except FileNotFoundError:
+        default_views_commit = ""
+
+    try:
+        with open(BASE_DIR.parent / "owid-grapher-svgs/commit_all-views.log") as f:
+            commit_id = f.readline().strip()
+            all_views_commit = f"({make_commit_link(commit_id=commit_id)})" if commit_id else ""
+    except FileNotFoundError:
+        all_views_commit = ""
+
     body = f"""
 - **Site-screenshots**: https://github.com/owid/site-screenshots/compare/{branch}
 - **SVG tester**: https://github.com/owid/owid-grapher-svgs/compare/{branch}
 
 <details open>
 <summary><b>SVG tester</b>: </summary>
-Number of differences (default views): {default_views}
+Number of differences (default views): {default_views} {default_views_commit}
 
-Number of differences (all views): {all_views}
+Number of differences (all views): {all_views} {all_views_commit}
 </details>
     """.strip()
 
     return body
+
+
+def make_commit_link(commit_id: str) -> str:
+    commit_hash = commit_id[:6]
+    commit_url = f"https://github.com/owid/owid-grapher-svgs/commit/{commit_id}"
+    return f"[{commit_hash}]({commit_url})"


### PR DESCRIPTION
Adds commit links to the SVG tester summary. It's useful to have a direct link to the individual commit when there are many changes and GitHub freezes when opening the branch summary, which includes changes of all commits (it happens).

The script reads log files (`commit_{default,all}-views.log`) that contain commit IDs that have been added by the SVG tester Buildkite job.