### PR TITLE
:tada: Add a new charts-based data API

### DIFF
--- a/lib/catalog/Makefile
+++ b/lib/catalog/Makefile
@@ -10,6 +10,11 @@ SRC = owid tests
 # watch:
 # 	poetry run watchmedo shell-command -c 'clear; make unittest' --recursive --drop .
 
+.venv: poetry.toml pyproject.toml poetry.lock
+	@echo '==> Installing packages'
+	poetry install
+	touch .venv
+
 check-typing: .venv
 	@echo '==> Checking types'
 	poetry run pyright $(SRC)

--- a/lib/catalog/README.md
+++ b/lib/catalog/README.md
@@ -26,7 +26,27 @@ We would love feedback on how we can make this library and overall data catalog 
 
 ## Quickstart
 
-Install with `pip install owid-catalog`. Then you can begin exploring the experimental data catalog:
+Install with `pip install owid-catalog`. Then you can get data in two different ways.
+
+### Charts catalog
+
+This API attempts to give you exactly the data you in a chart on our site.
+
+```python
+from owid.catalog import charts
+
+# list all available charts
+slugs = charts.list_charts()
+
+# get the data for one chart by its slug
+df = charts.get_data('life-expectancy')
+```
+
+### Data science API
+
+We also curate much more data than is available on our site. To access that in efficient binary (Feather) format, use our data science API.
+
+This API works very well in a Jupyter notebook.
 
 ```python
 from owid import catalog
@@ -54,167 +74,10 @@ make test
 make watch
 ```
 
-## Data types
-
-### Catalog
-
-A catalog is an arbitrarily deep folder structure containing datasets inside. It can be local on disk, or remote.
-
-#### Load the remote catalog
-
-```python
-# find the default OWID catalog and fetch the catalog index over HTTPS
-cat = RemoteCatalog()
-
-# get a list of matching tables in different datasets
-matches = cat.find('population')
-
-# fetch a data frame for a specific match over HTTPS
-t = cat.find_one('population', namespace='gapminder')
-
-# load other channels than `garden`
-cat = RemoteCatalog(channels=('garden', 'meadow', 'open_numbers'))
-```
-
-### Datasets
-
-A dataset is a folder of tables containing metadata about the overall collection.
-
-- Metadata about the dataset lives in `index.json`
-- All tables in the folder must share a common format (CSV or Feather)
-
-#### Create a new dataset
-
-```python
-# make a folder and an empty index.json file
-ds = Dataset.create('/tmp/my_data')
-```
-
-```python
-# choose CSV instead of feather for files
-ds = Dataset.create('/tmp/my_data', format='csv')
-```
-
-#### Add a table to a dataset
-
-```python
-# serialize a table using the table's name and the dataset's default format (feather)
-# (e.g. /tmp/my_data/my_table.feather)
-ds.add(table)
-```
-
-#### Remove a table from a dataset
-
-```python
-ds.remove('table_name')
-```
-
-#### Access a table
-
-```python
-# load a table including metadata into memory
-t = ds['my_table']
-```
-
-#### List tables
-
-```python
-# the length is the number of datasets discovered on disk
-assert len(ds) > 0
-```
-
-```python
-# iterate over the tables discovered on disk
-for table in ds:
-    do_something(table)
-```
-
-#### Add metadata
-
-```python
-# you need to manually save your changes
-ds.title = "Very Important Dataset"
-ds.description = "This dataset is a composite of blah blah blah..."
-ds.save()
-```
-
-#### Copy a dataset
-
-```python
-# copying a dataset copies all its files to a new location
-ds_new = ds.copy('/tmp/new_data_path')
-
-# copying a dataset is identical to copying its folder, so this works too
-shutil.copytree('/tmp/old_data', '/tmp/new_data_path')
-ds_new = Dataset('/tmp/new_data_path')
-```
-
-### Tables
-
-Tables are essentially pandas DataFrames but with metadata. All operations on them occur in-memory, except for loading from and saving to disk. On disk, they are represented by tabular file (feather or CSV) and a JSON metadata file.
-
-Columns of `Table` have attribute `VariableMeta`, including their type, description, and unit. Be carful when manipulating them, not all operations are currently supported. Supported are: adding a column, renaming columns. Not supported: direct assignment to `t.columns = ...` or to index names `t.columns.index = ...`.
-
-#### Make a new table
-
-```python
-# same API as DataFrames
-t = Table({
-    'gdp': [1, 2, 3],
-    'country': ['AU', 'SE', 'CH']
-}).set_index('country')
-```
-
-#### Add metadata about the whole table
-
-```python
-t.title = 'Very important data'
-```
-
-#### Add metadata about a field
-
-```python
-t.gdp.description = 'GDP measured in 2011 international $'
-t.sources = [
-    Source(title='World Bank', url='https://www.worldbank.org/en/home')
-]
-```
-
-#### Add metadata about all fields at once
-
-```python
-# sources and licenses are actually stored a the field level
-t.sources = [
-    Source(title='World Bank', url='https://www.worldbank.org/en/home')
-]
-t.licenses = [
-    License('CC-BY-SA-4.0', url='https://creativecommons.org/licenses/by-nc/4.0/')
-]
-```
-
-#### Save a table to disk
-
-```python
-# save to /tmp/my_table.feather + /tmp/my_table.meta.json
-t.to_feather('/tmp/my_table.feather')
-
-# save to /tmp/my_table.csv + /tmp/my_table.meta.json
-t.to_csv('/tmp/my_table.csv')
-```
-
-#### Load a table from disk
-
-These work like normal pandas DataFrames, but if there is also a `my_table.meta.json` file, then metadata will also get read. Otherwise it will be assumed that the data has no metadata:
-
-```python
-t = Table.read_feather('/tmp/my_table.feather')
-
-t = Table.read_csv('/tmp/my_table.csv')
-```
-
 ## Changelog
 
 - `dev`
+  - Add experimental chart data API in `owid.catalog.charts`
 - `v0.3.8`
   - Switch from isort & black & fake8 to ruff
 - `v0.3.8`

--- a/lib/catalog/README.md
+++ b/lib/catalog/README.md
@@ -35,18 +35,33 @@ This API attempts to give you exactly the data you in a chart on our site.
 ```python
 from owid.catalog import charts
 
-# list all available charts
-slugs = charts.list_charts()
+# get the data for one chart by URL
+df = charts.get_data('https://ourworldindata.org/grapher/life-expectancy')
+```
 
-# get the data for one chart by its slug
+Notice that the last part of the URL is the chart's slug, its identifier, in this case `life-expectancy`. Using the slug alone also works.
+
+```python
 df = charts.get_data('life-expectancy')
+```
+
+To see what charts are available, you can list them all.
+
+```python
+>>> slugs = charts.list_charts()
+>>> slugs[:5]
+['above-ground-biomass-in-forest-per-hectare',
+ 'above-or-below-extreme-poverty-line-world-bank',
+ 'abs-change-energy-consumption',
+ 'absolute-change-co2',
+ 'absolute-gains-in-mean-female-height']
 ```
 
 ### Data science API
 
 We also curate much more data than is available on our site. To access that in efficient binary (Feather) format, use our data science API.
 
-This API works very well in a Jupyter notebook.
+This API is designed for use in Jupyter notebooks.
 
 ```python
 from owid import catalog
@@ -56,10 +71,17 @@ catalog.find('covid')
 
 # load Covid-19 data from the Our World in Data namespace as a data frame
 df = catalog.find('covid', namespace='owid').load()
+```
 
-# load data from other than the default `garden` channel
-lung_cancer_tables = catalog.find('lung_cancer_deaths_per_100000_men', channels=['open_numbers'])
-df = lung_cancer_tables.iloc[0].load()
+There many be multiple versions of the same dataset in a catalog, each will have a unique path. To easily load the same dataset again, you should record its path and load it this way:
+
+```python
+from owid import catalog
+
+path = 'garden/ihme_gbd/2023-05-15/gbd_mental_health_prevalence_rate/gbd_mental_health_prevalence_rate'
+
+rc = catalog.RemoteCatalog()
+df = rc[path]
 ```
 
 ## Development

--- a/lib/catalog/owid/catalog/charts.py
+++ b/lib/catalog/owid/catalog/charts.py
@@ -1,0 +1,67 @@
+#
+#  owid.catalog.charts
+#
+#
+#  Access to data in OWID charts.
+#
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+import pandas as pd
+
+from .internal import (
+    ChartNotFoundError,  # noqa
+    LicenseError,  # noqa
+    _fetch_bundle,
+    _GrapherBundle,
+    _list_charts,
+)
+
+
+@dataclass
+class Chart:
+    """
+    A chart published on Our World in Data, for example:
+
+    https://ourworldindata.org/grapher/life-expectancy
+    """
+
+    slug: str
+
+    _bundle: Optional[_GrapherBundle] = None
+
+    @property
+    def bundle(self) -> _GrapherBundle:
+        # LARS: give a nice error if the chart does not exist
+        if self._bundle is None:
+            self._bundle = _fetch_bundle(self.slug)
+
+        return self._bundle
+
+    @property
+    def config(self) -> dict:
+        return self.bundle.config  # type: ignore
+
+    def get_data(self) -> pd.DataFrame:
+        return self.bundle.to_frame()
+
+    def __lt__(self, other):
+        return self.slug < other.slug
+
+    def __eq__(self, value: object) -> bool:
+        return isinstance(value, Chart) and value.slug == self.slug
+
+
+def list_charts() -> List[str]:
+    """
+    List all available charts published on Our World in Data.
+    """
+    return sorted(_list_charts())
+
+
+def get_data(slug: str) -> pd.DataFrame:
+    """
+    Fetch the data for a chart by its slug.
+    """
+    return Chart(slug).get_data()

--- a/lib/catalog/owid/catalog/charts.py
+++ b/lib/catalog/owid/catalog/charts.py
@@ -55,13 +55,25 @@ class Chart:
 
 def list_charts() -> List[str]:
     """
-    List all available charts published on Our World in Data.
+    List all available charts published on Our World in Data, representing each via
+    a short slug that you can use with `get_data()`.
     """
     return sorted(_list_charts())
 
 
-def get_data(slug: str) -> pd.DataFrame:
+def get_data(slug_or_url: str) -> pd.DataFrame:
     """
-    Fetch the data for a chart by its slug.
+    Fetch the data for a chart by its slug or by the URL of the chart.
+
+    Additional metadata about the chart is available in the DataFrame's `attrs` attribute.
     """
+    if slug_or_url.startswith("https://ourworldindata.org/grapher/"):
+        slug = slug_or_url.split("/")[-1]
+
+    elif slug_or_url.startswith("https://"):
+        raise ValueError("URL must be a Grapher URL, e.g. https://ourworldindata.org/grapher/life-expectancy")
+
+    else:
+        slug = slug_or_url
+
     return Chart(slug).get_data()

--- a/lib/catalog/owid/catalog/internal.py
+++ b/lib/catalog/owid/catalog/internal.py
@@ -139,7 +139,7 @@ class _GrapherBundle:
 def _fetch_grapher_config(slug):
     resp = requests.get(f"https://ourworldindata.org/grapher/{slug}")
     if resp.status_code == 404:
-        raise ChartNotFoundError(slug)
+        raise ChartNotFoundError(f"No such chart found at https://ourworldindata.org/grapher/{slug}")
 
     resp.raise_for_status()
     return json.loads(resp.content.decode("utf-8").split("//EMBEDDED_JSON")[1])

--- a/lib/catalog/owid/catalog/internal.py
+++ b/lib/catalog/owid/catalog/internal.py
@@ -1,0 +1,171 @@
+#
+#  internal.py
+#
+#  Internal APIs subject to change at any time.
+#
+
+import datetime as dt
+import json
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Literal
+
+import pandas as pd
+import requests
+from dateutil.parser import parse as date_parse
+
+
+class LicenseError(Exception):
+    pass
+
+
+class ChartNotFoundError(Exception):
+    pass
+
+
+@dataclass
+class _Indicator:
+    data: dict
+    metadata: dict
+
+    def to_dict(self):
+        return {"data": self.data, "metadata": self.metadata}
+
+    def to_frame(self):
+        if self.metadata.get("nonRedistributable"):
+            raise LicenseError(
+                "API download is disallowed for this indicator due to license restrictions from the data provider"
+            )
+
+        # getting a data frame is easy
+        df = pd.DataFrame.from_dict(self.data)
+
+        # turning entity ids into entity names
+        entities = pd.DataFrame.from_records(self.metadata["dimensions"]["entities"]["values"])
+        id_to_name = entities.set_index("id").name.to_dict()
+        df["entities"] = df.entities.apply(id_to_name.__getitem__)
+
+        # make the "values" column more interestingly named
+        short_name = self.metadata.get("shortName", f'_{self.metadata["id"]}')
+        df = df.rename(columns={"values": short_name})
+
+        time_col = self._detect_time_col_type()
+        if time_col == "dates":
+            df["years"] = self._convert_years_to_dates(df["years"])
+
+        # order the columns better
+        cols = ["entities", "years"] + sorted(df.columns.difference(["entities", "years"]))
+        df = df[cols]
+
+        return df
+
+    def _detect_time_col_type(self) -> Literal["dates", "years"]:
+        if self.metadata.get("display", {}).get("yearIsDay"):
+            return "dates"
+
+        return "years"
+
+    def _convert_years_to_dates(self, years):
+        base_date = date_parse(self.metadata["display"]["zeroDay"])
+        return years.apply(lambda y: base_date + dt.timedelta(days=y))
+
+
+@dataclass
+class _GrapherBundle:
+    config: dict
+    dimensions: Dict[int, _Indicator]
+    origins: List[dict]
+
+    def to_json(self):
+        return json.dumps(
+            {
+                "config": self.config,
+                "dimensions": {k: i.to_dict() for k, i in self.dimensions.items()},
+                "origins": self.origins,
+            }
+        )
+
+    def size(self):
+        return len(self.to_json())
+
+    @property
+    def indicators(self) -> List[_Indicator]:
+        return list(self.dimensions.values())
+
+    def to_frame(self):
+        # combine all the indicators into a single data frame and one metadata dict
+        metadata = {}
+        df = None
+        for i in self.indicators:
+            to_merge = i.to_frame()
+            (value_col,) = to_merge.columns.difference(["entities", "years"])
+            metadata[value_col] = i.metadata.copy()
+
+            if df is None:
+                df = to_merge
+            else:
+                df = pd.merge(df, to_merge, how="outer", on=["entities", "years"])
+
+        assert df is not None
+
+        # save some useful metadata onto the frame
+        assert self.config
+        slug = self.config["slug"]
+        df.attrs["slug"] = slug
+        df.attrs["url"] = f"https://ourworldindata.org/grapher/{slug}"
+        df.attrs["metadata"] = metadata
+
+        # if there is only one indicator, we can use the slug as the column name
+        if len(df.columns) == 3:
+            assert self.config
+            (value_col,) = df.columns.difference(["entities", "years"])
+            short_name = slug.replace("-", "_")
+            df = df.rename(columns={value_col: short_name})
+            df.attrs["metadata"][short_name] = df.attrs["metadata"].pop(value_col)
+
+            df.attrs["value_col"] = short_name
+
+        # we kept using "years" until now to keep the code paths the same, but they could
+        # be dates
+        if df["years"].astype(str).str.match(r"^\d{4}-\d{2}-\d{2}$").all():
+            df = df.rename(columns={"years": "dates"})
+
+        return df
+
+    def __repr__(self):
+        return f"GrapherBundle(config={self.config}, dimensions=..., origins=...)"
+
+
+def _fetch_grapher_config(slug):
+    resp = requests.get(f"https://ourworldindata.org/grapher/{slug}")
+    if resp.status_code == 404:
+        raise ChartNotFoundError(slug)
+
+    resp.raise_for_status()
+    return json.loads(resp.content.decode("utf-8").split("//EMBEDDED_JSON")[1])
+
+
+def _fetch_dimension(id: int) -> _Indicator:
+    data = requests.get(f"https://api.ourworldindata.org/v1/indicators/{id}.data.json").json()
+    metadata = requests.get(f"https://api.ourworldindata.org/v1/indicators/{id}.metadata.json").json()
+    return _Indicator(data, metadata)
+
+
+def _fetch_bundle(slug: str) -> _GrapherBundle:
+    config = _fetch_grapher_config(slug)
+    indicator_ids = [d["variableId"] for d in config["dimensions"]]
+
+    dimensions = {indicator_id: _fetch_dimension(indicator_id) for indicator_id in indicator_ids}
+
+    origins = []
+    for d in dimensions.values():
+        if d.metadata.get("origins"):
+            origins.append(d.metadata.pop("origins"))
+    return _GrapherBundle(config, dimensions, origins)
+
+
+def _list_charts() -> List[str]:
+    content = requests.get("https://ourworldindata.org/charts").content.decode("utf-8")
+    links = re.findall('"(/grapher/[^"]+)"', content)
+    slugs = [link.strip('"').split("/")[-1] for link in links]
+    return sorted(set(slugs))

--- a/lib/catalog/tests/test_charts.py
+++ b/lib/catalog/tests/test_charts.py
@@ -1,0 +1,57 @@
+import pytest
+
+from owid.catalog import charts
+from owid.catalog.internal import LicenseError
+
+# NOTE: the tests below make multiple network requests per check, we could consider
+#       mocking them out if they cause problems
+
+
+def test_fetch_chart_data_with_slug_as_column():
+    chart = charts.Chart("life-expectancy")
+    df = chart.get_data()
+    assert df is not None
+    assert len(df) > 0
+    assert "entities" in df.columns
+    assert "years" in df.columns
+    assert "life_expectancy" in df.columns
+
+    assert "metadata" in df.attrs
+    assert "life_expectancy" in df.attrs["metadata"]
+
+
+def test_fetch_chart_data_with_multiple_indicators():
+    df = charts.Chart("eat-lancet-diet-comparison").get_data()
+    value_cols = df.columns.difference(["entities", "years"])
+    assert len(value_cols) > 1
+
+    assert "metadata" in df.attrs
+    assert all(c in df.attrs["metadata"] for c in value_cols)
+
+
+def test_fetch_non_redistributable_chart():
+    # a chart where nonRedistributable is true in the indicator's metadata; see also
+    # the dataset at https://admin.owid.io/admin/datasets/6457
+    chart = charts.Chart("test-scores-ai-capabilities-relative-human-performance")
+    with pytest.raises(LicenseError):
+        chart.get_data()
+
+
+def test_list_charts():
+    slugs = charts.list_charts()
+    assert len(slugs) > 0
+    assert "life-expectancy" in slugs
+
+    # all unique
+    assert len(slugs) == len(set(slugs))
+
+
+def test_fetch_missing_chart():
+    with pytest.raises(charts.ChartNotFoundError):
+        charts.Chart("this-chart-does-not-exist").bundle
+
+
+def test_fetch_chart_with_dates():
+    df = charts.Chart("sea-level").get_data()
+    assert "dates" in df.columns
+    assert "years" not in df.columns

--- a/lib/catalog/tests/test_charts.py
+++ b/lib/catalog/tests/test_charts.py
@@ -52,6 +52,23 @@ def test_fetch_missing_chart():
 
 
 def test_fetch_chart_with_dates():
-    df = charts.Chart("sea-level").get_data()
+    df = charts.get_data("sea-level")
     assert "dates" in df.columns
     assert "years" not in df.columns
+    assert len(df) > 0
+
+
+def test_fetch_chart_by_url():
+    df = charts.get_data("https://ourworldindata.org/grapher/life-expectancy")
+    assert set(df.columns) == set(["entities", "years", "life_expectancy"])
+    assert len(df) > 0
+
+
+def test_fetch_chart_by_non_grapher_url():
+    with pytest.raises(ValueError):
+        charts.get_data("https://ourworldindata.org/this-is-not-a-grapher-url")
+
+
+def test_fetch_chart_by_missing_grapher_url():
+    with pytest.raises(charts.ChartNotFoundError):
+        charts.get_data("https://ourworldindata.org/grapher/this-chart-does-not-exist")


### PR DESCRIPTION
_Add a new draft charts-based API for data fetching._

## Motivation

We would like to offer simple code snippets that give you the data powering a chart, but we want to prototype what that could look like before committing to baking data in a special way or making a special worker.

The most likely outcome, if we like this code, is that we will later migrate it to a CloudFlare worker and serve the API from there.

## A Python charts-based API

```python
from owid.catalog import charts

# get all available charts
slugs = charts.list_charts()

# get a nice data frame, with extra metadata in `df.attrs['metadata']`
df = charts.get_data('life-expectancy')
```

## Technical approach

- For `list_charts()`
  - Scrape the [Charts and explorers](https://ourworldindata.org/charts) page for chart links: 
- For `get_data()`
  - Scrape the JSON config from the chart page
  - Fetch data and metadata for every indicator from the indicator-based data API
  - Throw a `LicenseError` if the data is not redistributable
  - Make a merged data frame
  - Resolve `yearIsDay`
  - Stuff indicator metadata into `df.attrs['metadata']`
  - For single-indicator charts, use chart slug as value column name
- Call a bunch of stuff we want to replace `internal`, and prefix it all with underscore (e.g. `_Indicator`) to demonstrate that people shouldn't rely on it

## Before merge

- [x] Wait for:
  - [x] https://github.com/owid/etl/issues/2631
- [x] Get first round of feedback
- [x] Update docs
- [x] Update changelog

## Post merge

- [ ] Cut a new `owid-catalog` release

