### PR TITLE
🐛 Fix wrong url to production admin in chart-sync

### DIFF
--- a/apps/staging_sync/admin_api.py
+++ b/apps/staging_sync/admin_api.py
@@ -25,7 +25,7 @@ class AdminAPI(object):
             session.commit()
 
         if engine.url.database == "live_grapher" and "prod-db" in str(engine.url.host):
-            self.base_url = "https://owid.cloud"
+            self.base_url = "http://owid-admin-prod"
         else:
             self.base_url = f"http://{engine.url.host}"
 

--- a/apps/staging_sync/cli.py
+++ b/apps/staging_sync/cli.py
@@ -16,13 +16,12 @@ from slack_sdk import WebClient
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
+from apps.staging_sync.admin_api import AdminAPI
 from apps.wizard.pages.chart_diff.chart_diff import ChartDiffModified
 from etl import config
 from etl import grapher_model as gm
 from etl.datadiff import _dict_diff
 from etl.db import Engine, get_engine, read_sql
-
-from .admin_api import AdminAPI
 
 log = structlog.get_logger()
 


### PR DESCRIPTION
Chart-sync was failing in production (see [this thread](https://owid.slack.com/archives/C46U9LXRR/p1714663753633919)). After some trial and error (thanks to [Daniel](https://owid.slack.com/archives/C46U9LXRR/p1715593275334989)) I figured that there was a wrong url for the production charts api.
