### PR TITLE
🐛 (owidbot) fix link rendering on GitHub

### DIFF
--- a/apps/owidbot/grapher.py
+++ b/apps/owidbot/grapher.py
@@ -32,9 +32,10 @@ def run(branch: str) -> str:
 
 <details open>
 <summary><b>SVG tester</b>: </summary>
-Number of differences (default views): {default_views} {default_views_commit}
 
+Number of differences (default views): {default_views} {default_views_commit}
 Number of differences (all views): {all_views} {all_views_commit}
+
 </details>
     """.strip()
 


### PR DESCRIPTION
For some reason, GitHub doesn't properly render the "default views" commit link. Using new lines around the two lines fixes it 🤷🏻‍♀️ 