### PR TITLE
:bug: use proper Tailscale address for AdminAPI

### DIFF
--- a/apps/backport/backport.py
+++ b/apps/backport/backport.py
@@ -306,7 +306,7 @@ def _snapshot_values_metadata(ds: gm.Dataset, short_name: str, public: bool) -> 
         source=Source(
             name="Our World in Data catalog backport",
             published_by="Our World in Data catalog backport",
-            url=f"https://owid.cloud/admin/datasets/{ds.id}",
+            url=f"https://admin.owid.io/admin/datasets/{ds.id}",
             publication_date="latest",
             date_accessed=dt.datetime.utcnow(),  # type: ignore
         ),

--- a/apps/staging_sync/admin_api.py
+++ b/apps/staging_sync/admin_api.py
@@ -9,7 +9,7 @@ import requests
 from sqlmodel import Session
 
 from etl import grapher_model as gm
-from etl.config import GRAPHER_USER_ID
+from etl.config import GRAPHER_USER_ID, TAILSCALE_ADMIN_HOST
 from etl.db import Engine
 
 
@@ -25,7 +25,7 @@ class AdminAPI(object):
             session.commit()
 
         if engine.url.database == "live_grapher" and "prod-db" in str(engine.url.host):
-            self.base_url = "http://owid-admin-prod"
+            self.base_url = TAILSCALE_ADMIN_HOST
         else:
             self.base_url = f"http://{engine.url.host}"
 
@@ -42,8 +42,8 @@ class AdminAPI(object):
             f"{self.base_url}/admin/api/charts/{chart_id}.config.json",
             cookies={"sessionid": self.session_id},
         )
-        resp.raise_for_status()
-        return resp.json()
+        js = self._json_from_response(resp)
+        return js
 
     def create_chart(self, chart_config: dict) -> dict:
         resp = requests.post(

--- a/apps/wizard/utils/env.py
+++ b/apps/wizard/utils/env.py
@@ -68,7 +68,7 @@ class OWIDEnv:
     def base_site(self) -> str | None:
         """Get site."""
         if self.env_type_id == "live":
-            return "https://owid.cloud"
+            return "https://admin.owid.io"
         elif self.env_type_id == "staging":
             return "https://staging.owid.cloud"
         elif self.env_type_id in ["local", "remote-staging"]:

--- a/docs/architecture/workflow/index.md
+++ b/docs/architecture/workflow/index.md
@@ -279,7 +279,7 @@ To use the tool, you upload a CSV file containing a column called `Country`, and
 
 ??? Tip "For staff"
 
-    The interactive harmonization tool for staff is available at [https://owid.cloud/admin/standardize](https://owid.cloud/admin/standardize).
+    The interactive harmonization tool for staff is available at [https://admin.owid.io/admin/standardize](https://admin.owid.io/admin/standardize).
 
 
 ### Metadata

--- a/etl/config.py
+++ b/etl/config.py
@@ -148,6 +148,10 @@ FASTTRACK_COMMIT = env.get("FASTTRACK_COMMIT") in ("True", "true", "1")
 
 ADMIN_HOST = env.get("ADMIN_HOST", f"http://staging-site-{STAGING}" if STAGING else "http://localhost:3030")
 
+# Tailscale address of Admin, this cannot be just `http://owid-admin-prod`
+# because that would resolve to LXC container instead of the actual server
+TAILSCALE_ADMIN_HOST = "http://owid-admin-prod.tail6e23.ts.net"
+
 BUGSNAG_API_KEY = env.get("BUGSNAG_API_KEY")
 
 OPENAI_API_KEY = env.get("OPENAI_API_KEY", None)


### PR DESCRIPTION
Use Tailscale address http://owid-admin-prod.tail6e23.ts.net for AdminAPI instead of http://owid-admin-prod. The problem is that `owid-admin-prod` resolves to an address of the actual LXC container instead of going through the Tailscale. Using alias `owid-admin-prod.tail6e23.ts.net` fixes the problem.