### PR TITLE
:bug: allow nans in ordinal types & add missing fields to `combine_variables_metadata`

### DIFF
--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -129,7 +129,10 @@ def _validate_description_key(description_key: list[str], col: str) -> None:
 
 def _validate_ordinal_variables(tab: Table, col: str) -> None:
     if tab[col].m.sort:
-        extra_values = set(tab[col]) - set(tab[col].m.sort)
+        # Exclude NaN values, these will be dropped before inserting to the database.
+        vals = tab[col].dropna()
+
+        extra_values = set(vals) - set(vals.m.sort)
         assert (
             not extra_values
         ), f"Ordinal variable `{col}` has extra values that are not defined in field `sort`: {extra_values}"

--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -473,6 +473,15 @@ def combine_variables_processing_level(variables: List[Variable]) -> Optional[PR
     return cast(PROCESSING_LEVELS, combined_processing_level)
 
 
+def combine_variables_sort(variables: List[Variable]) -> List[str]:
+    # Return sort if all variables have the same sort, otherwise return empty list.
+    sorts = [variable.metadata.sort for variable in variables if variable.metadata.sort]
+    if not sorts:
+        return []
+    else:
+        return sorts[0] if all(sort == sorts[0] for sort in sorts) else []
+
+
 def combine_variables_metadata(
     variables: List[Any], operation: OPERATION, name: str = UNNAMED_VARIABLE
 ) -> VariableMeta:
@@ -510,6 +519,14 @@ def combine_variables_metadata(
     metadata.display = combine_variables_display(variables=variables_only, operation=operation)
     metadata.presentation = combine_variables_presentation(variables=variables_only, operation=operation)
     metadata.processing_level = combine_variables_processing_level(variables=variables_only)
+
+    metadata.type = _get_metadata_value_from_variables_if_all_identical(
+        variables=variables_only, field="type", operation=operation, warn_if_different=True
+    )
+    metadata.sort = combine_variables_sort(variables=variables_only)
+    metadata.license = _get_metadata_value_from_variables_if_all_identical(
+        variables=variables_only, field="license", operation=operation, warn_if_different=True
+    )
 
     if pl.enabled():
         metadata.processing_log = combine_variables_processing_logs(variables=variables_only)

--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -2,6 +2,8 @@
 #  test_variables
 #
 
+import dataclasses
+
 import pandas as pd
 import pytest
 
@@ -530,3 +532,52 @@ def test_presentation_propagation_on_divisions(variable_1, variable_2) -> None:
     variable_2.metadata.presentation = VariablePresentationMeta("test 2")  # type: ignore
     variable = variable_1 / variable_2
     assert variable.metadata.presentation is None
+
+
+def test_combine_variables_sort(variable_1, variable_2) -> None:
+    variable_1 = variable_1.copy().astype(str) + "a"
+    variable_2 = variable_2.copy().astype(str) + "b"
+
+    variable_1.m.type = "ordinal"
+    variable_1.m.sort = ["1a", "2a", "3a"]
+
+    assert variable_1.m.type == "ordinal"
+    assert variable_1.dropna().m.sort == ["1a", "2a", "3a"]
+
+    variable_2.m.type = "ordinal"
+    variable_2.m.sort = ["1b", "2b", "3b"]
+
+    variable_3 = variable_1 + variable_2
+    assert variable_3.m.type == "ordinal"
+    assert variable_3.m.sort == []
+
+
+def test_combine_variables_metadata_uses_all_fields() -> None:
+    """Make sure we don't forget to process new fields in combine_variables_metadata in case we're adding
+    new fields to the VariableMeta.
+    If you add a new field to VariableMeta, you should add it to combine_variables_metadata as well and
+    this unit test.
+    """
+    assert {f.name for f in dataclasses.fields(VariableMeta)} == {
+        "title",
+        "description",
+        "description_short",
+        "description_from_producer",
+        "description_key",
+        "sources",
+        "origins",
+        "licenses",
+        "unit",
+        "short_unit",
+        "display",
+        "processing_level",
+        "processing_log",
+        "presentation",
+        "license",
+        "type",
+        "sort",
+        # This is only used right before upserting to grapher
+        "additional_info",
+        # TODO: we should implement this, if not identical, append one after another
+        "description_processing",
+    }


### PR DESCRIPTION
Fix for https://github.com/owid/etl/issues/2636

When working on this, I noticed that we don't combine `type` and `sort` (e.g. `dropna()` loses information about ordinal types). I fixed those fields (I haven't fixed all possible edge cases as it is rarely used and typically in a grapher step) and added unit test in case we add more fields to remind us about adding them.