### PR TITLE
:sparkles: allow commit sha in chart-sync

### DIFF
--- a/apps/staging_sync/cli.py
+++ b/apps/staging_sync/cli.py
@@ -27,8 +27,8 @@ log = structlog.get_logger()
 
 
 @click.command(name="chart-sync", cls=RichCommand, help=__doc__)
-@click.argument("source", type=Path)
-@click.argument("target", type=Path)
+@click.argument("source")
+@click.argument("target")
 @click.option(
     "--chart-id",
     type=int,
@@ -73,8 +73,8 @@ log = structlog.get_logger()
     help="Do not write to target database.",
 )
 def cli(
-    source: Path,
-    target: Path,
+    source: str,
+    target: str,
     chart_id: Optional[int],
     approve_revisions: bool,
     staging_created_at: Optional[dt.datetime],
@@ -87,7 +87,8 @@ def cli(
 
     It syncs the charts and revisions from `SOURCE` to `TARGET`. This is especially useful for syncing work from staging servers to production.
 
-    `SOURCE` and `TARGET` can be either name of staging servers (e.g. "staging-site-mybranch") or paths to .env files. Use ".env.prod.write" as TARGET to sync to live.
+    `SOURCE` and `TARGET` can be either name of staging servers (e.g. "staging-site-mybranch") or paths to .env files or repo/commit hash if you
+    want to get the branch name from merged pull request. Use ".env.prod.write" as TARGET to sync to live.
 
     - **Note 1:** The dataset (with the new chart's underlying indicators) from `SOURCE` must exist in `TARGET`. This means that you have to merge your work to master and wait for the ETL to finish running all steps.
 
@@ -133,6 +134,10 @@ def cli(
     etl chart-sync staging-site-my-branch .env.prod.write --approve-revisions
     ```
     """
+    if _is_commit_sha(source):
+        source = _get_git_branch_from_commit_sha(source)
+        log.info("staging_sync.use_branch", branch=source)
+
     _validate_env(source)
     _validate_env(target)
 
@@ -356,6 +361,25 @@ def cli(
         print("[green]1.[/green] Chart updates were added as chart revisions, you still have to manually approve them")
 
 
+def _is_commit_sha(source: str) -> bool:
+    return re.match(r"[0-9a-f]{40}", source) is not None
+
+
+def _get_git_branch_from_commit_sha(commit_sha: str) -> str:
+    """Get the branch name from a merged pull request commit sha. This is useful for Buildkite jobs where we only have the commit sha."""
+    # get all pull requests for the commit
+    pull_requests = requests.get(f"https://api.github.com/repos/owid/etl/commits/{commit_sha}/pulls").json()
+
+    # filter the closed ones
+    closed_pull_requests = [pr for pr in pull_requests if pr["state"] == "closed"]
+
+    # get the branch of the most recent one
+    if closed_pull_requests:
+        return closed_pull_requests[0]["head"]["ref"]
+    else:
+        raise ValueError(f"No closed pull requests found for commit {commit_sha}")
+
+
 def _load_revisions(
     source_session: Session, chart_id: int, diff: ChartDiffModified
 ) -> List[gm.SuggestedChartRevisions]:
@@ -445,8 +469,8 @@ def _get_staging_created_at(source: Path, staging_created_at: Optional[str]) -> 
         return pd.to_datetime(staging_created_at)
 
 
-def _is_env(env: Path) -> bool:
-    return env.exists()
+def _is_env(env: Union[str, Path]) -> bool:
+    return Path(env).exists()
 
 
 def _normalise_branch(branch_name):
@@ -465,9 +489,9 @@ def _get_container_name(branch_name):
     return container_name.rstrip("-")
 
 
-def _validate_env(env: Path) -> None:
+def _validate_env(env: Union[str, Path]) -> None:
     # if `env` is a path, it must exist (otherwise we'd confuse it with a staging server name)s
-    if str(env).startswith(".") and "env" in str(env) and not env.exists():
+    if str(env).startswith(".") and "env" in str(env) and not Path(env).exists():
         raise click.BadParameter(f"File {env} does not exist")
 
 

--- a/apps/wizard/pages/chart_diff/app.py
+++ b/apps/wizard/pages/chart_diff/app.py
@@ -196,14 +196,11 @@ def compare_charts(
 
 @st.cache_resource
 def get_engines() -> tuple[Engine, Engine]:
-    s = Path(SOURCE_ENV)
-    t = Path(TARGET_ENV)
+    _validate_env(SOURCE_ENV)
+    _validate_env(TARGET_ENV)
 
-    _validate_env(s)
-    _validate_env(t)
-
-    source_engine = _get_engine_for_env(s)
-    target_engine = _get_engine_for_env(t)
+    source_engine = _get_engine_for_env(SOURCE_ENV)
+    target_engine = _get_engine_for_env(TARGET_ENV)
 
     return source_engine, target_engine
 


### PR DESCRIPTION
This is useful for automation of the new `chart-diff`.