### PR TITLE
:tada: update github check in owidbot's chart-diff

### DIFF
--- a/apps/owidbot/chart_diff.py
+++ b/apps/owidbot/chart_diff.py
@@ -6,13 +6,46 @@ from apps.staging_sync.cli import _get_container_name, _get_engine_for_env, _mod
 from apps.wizard.pages.chart_diff.chart_diff import ChartDiffModified
 from etl import config
 
+from . import github_utils as gh_utils
+
 log = get_logger()
 
 
-def run(branch: str) -> str:
+def create_check_run(repo_name: str, branch: str, charts_df: pd.DataFrame) -> None:
+    access_token = gh_utils.github_app_access_token()
+    repo = gh_utils.get_repo(repo_name, access_token=access_token)
+    pr = gh_utils.get_pr(repo, branch)
+
+    # Get the latest commit of the pull request
+    latest_commit = pr.get_commits().reversed[0]
+
+    if charts_df.empty:
+        conclusion = "neutral"
+        title = "No new or modified charts"
+    elif charts_df.approved.all():
+        conclusion = "success"
+        title = "All charts are approved"
+    else:
+        conclusion = "failure"
+        title = "Some charts are not approved"
+
+    # Create the check run and complete it in a single command
+    repo.create_check_run(
+        name="owidbot/chart-diff",
+        head_sha=latest_commit.sha,
+        status="completed",
+        conclusion=conclusion,
+        output={
+            "title": title,
+            "summary": format_chart_diff(charts_df),
+        },
+    )
+
+
+def run(branch: str, charts_df: pd.DataFrame) -> str:
     container_name = _get_container_name(branch) if branch else "dry-run"
 
-    chart_diff = format_chart_diff(call_chart_diff(branch))
+    chart_diff = format_chart_diff(charts_df)
 
     body = f"""
 <details open>

--- a/apps/owidbot/cli.py
+++ b/apps/owidbot/cli.py
@@ -1,17 +1,17 @@
 import datetime as dt
 import re
 import time
-from typing import Any, Dict, List, Literal, Optional, get_args
+from typing import Any, Dict, List, Literal, get_args
 
 import click
 import structlog
-from github import Auth, Github
 from rich import print
 from rich_click.rich_command import RichCommand
 
 from apps.owidbot import chart_diff, data_diff, grapher
 from apps.staging_sync.cli import _get_container_name
-from etl import config
+
+from . import github_utils as gh_utils
 
 log = structlog.get_logger()
 
@@ -51,13 +51,15 @@ def cli(
     """
     start_time = time.time()
 
-    repo, branch = repo_branch.split("/", 1)
+    repo_name, branch = repo_branch.split("/", 1)
 
-    if repo not in get_args(REPOS):
+    if repo_name not in get_args(REPOS):
         raise AssertionError("Invalid repo")
 
-    pr = get_pr(repo, branch)
-    comment = get_comment_from_pr(pr)
+    repo = gh_utils.get_repo(repo_name)
+    pr = gh_utils.get_pr(repo, branch)
+
+    comment = gh_utils.get_comment_from_pr(pr)
 
     # prefill services from existing PR comment
     if comment:
@@ -69,8 +71,14 @@ def cli(
     for service in services:
         if service == "data-diff":
             services_body["data_diff"] = data_diff.run(include)
+
         elif service == "chart-diff":
-            services_body["chart_diff"] = chart_diff.run(branch)
+            charts_df = chart_diff.call_chart_diff(branch)
+            services_body["chart_diff"] = chart_diff.run(branch, charts_df)
+
+            # update github check run
+            chart_diff.create_check_run(repo_name, branch, charts_df)
+
         elif service == "grapher":
             services_body["grapher"] = grapher.run(branch)
         else:
@@ -138,35 +146,3 @@ _Execution time: {time.time() - start_time:.2f} seconds_
     """.strip()
 
     return body
-
-
-def get_pr(repo_name: str, branch_name: str) -> Any:
-    assert config.OWIDBOT_ACCESS_TOKEN
-    auth = Auth.Token(config.OWIDBOT_ACCESS_TOKEN)
-    g = Github(auth=auth)
-
-    repo = g.get_repo(f"owid/{repo_name}")
-
-    # Find pull requests for the branch (assuming you're looking for open PRs)
-    pulls = repo.get_pulls(state="open", sort="created", head=f"{repo.owner.login}:{branch_name}")
-    pulls = list(pulls)
-
-    if len(pulls) == 0:
-        raise AssertionError(f"No open PR found for branch {branch_name}")
-    elif len(pulls) > 1:
-        raise AssertionError(f"More than one open PR found for branch {branch_name}")
-
-    return pulls[0]
-
-
-def get_comment_from_pr(pr: Any) -> Optional[Any]:
-    comments = pr.get_issue_comments()
-
-    owidbot_comments = [comment for comment in comments if comment.user.login == "owidbot"]
-
-    if len(owidbot_comments) == 0:
-        return None
-    elif len(owidbot_comments) == 1:
-        return owidbot_comments[0]
-    else:
-        raise AssertionError("More than one owidbot comment found.")

--- a/apps/owidbot/cli.py
+++ b/apps/owidbot/cli.py
@@ -77,7 +77,7 @@ def cli(
             services_body["chart_diff"] = chart_diff.run(branch, charts_df)
 
             # update github check run
-            chart_diff.create_check_run(repo_name, branch, charts_df)
+            chart_diff.create_check_run(repo_name, branch, charts_df, dry_run)
 
         elif service == "grapher":
             services_body["grapher"] = grapher.run(branch)

--- a/apps/owidbot/github_utils.py
+++ b/apps/owidbot/github_utils.py
@@ -1,0 +1,79 @@
+import time
+from typing import Any, Optional
+
+import github
+import github.PullRequest
+import github.Repository
+import jwt
+import requests
+from github import Auth, Github
+
+from etl import config
+
+
+def get_repo(repo_name: str, access_token: Optional[str] = None) -> github.Repository.Repository:
+    if not access_token:
+        assert config.OWIDBOT_ACCESS_TOKEN, "OWIDBOT_ACCESS_TOKEN is not set"
+        access_token = config.OWIDBOT_ACCESS_TOKEN
+    auth = Auth.Token(access_token)
+    g = Github(auth=auth)
+    return g.get_repo(f"owid/{repo_name}")
+
+
+def get_pr(repo: github.Repository.Repository, branch_name: str) -> github.PullRequest.PullRequest:
+    # Find pull requests for the branch (assuming you're looking for open PRs)
+    pulls = repo.get_pulls(state="open", sort="created", head=f"{repo.owner.login}:{branch_name}")
+    pulls = list(pulls)
+
+    if len(pulls) == 0:
+        raise AssertionError(f"No open PR found for branch {branch_name}")
+    elif len(pulls) > 1:
+        raise AssertionError(f"More than one open PR found for branch {branch_name}")
+
+    return pulls[0]
+
+
+def get_comment_from_pr(pr: Any) -> Optional[Any]:
+    comments = pr.get_issue_comments()
+
+    owidbot_comments = [comment for comment in comments if comment.user.login == "owidbot"]
+
+    if len(owidbot_comments) == 0:
+        return None
+    elif len(owidbot_comments) == 1:
+        return owidbot_comments[0]
+    else:
+        raise AssertionError("More than one owidbot comment found.")
+
+
+def generate_jwt(client_id: str, private_key_path: str) -> str:
+    now = int(time.time())
+    payload = {
+        "iat": now,
+        "exp": now + (10 * 60),  # JWT expiration time (10 minutes)
+        "iss": client_id,
+    }
+    with open(private_key_path, "r") as key_file:
+        private_key = key_file.read()
+    token = jwt.encode(payload, private_key, algorithm="RS256")
+    return token
+
+
+def github_app_access_token():
+    assert config.OWIDBOT_APP_CLIENT_ID, "OWIDBOT_CLIENT_ID is not set"
+    assert config.OWIDBOT_APP_PRIVATE_KEY_PATH, "OWIDBOT_PRIVATE_KEY_PATH is not set"
+    assert config.OWIDBOT_APP_INSTALLATION_ID, "OWIDBOT_APP_INSTALLATION_ID is not set"
+
+    jwt_token = generate_jwt(config.OWIDBOT_APP_CLIENT_ID, config.OWIDBOT_APP_PRIVATE_KEY_PATH)
+
+    # Use the JWT to get an installation access token
+    headers = {"Authorization": f"Bearer {jwt_token}", "Accept": "application/vnd.github.v3+json"}
+
+    installation_access_token_url = (
+        f"https://api.github.com/app/installations/{config.OWIDBOT_APP_INSTALLATION_ID}/access_tokens"
+    )
+    response = requests.post(installation_access_token_url, headers=headers)
+    response.raise_for_status()
+    access_token = response.json()["token"]
+
+    return access_token

--- a/etl/config.py
+++ b/etl/config.py
@@ -158,6 +158,13 @@ OPENAI_API_KEY = env.get("OPENAI_API_KEY", None)
 
 OWIDBOT_ACCESS_TOKEN = env.get("OWIDBOT_ACCESS_TOKEN", None)
 
+# OWIDBOT app
+OWIDBOT_APP_PRIVATE_KEY_PATH = env.get("OWIDBOT_APP_PRIVATE_KEY_PATH", None)
+# get it from https://github.com/settings/apps/owidbot-app
+OWIDBOT_APP_CLIENT_ID = env.get("OWIDBOT_APP_CLIENT_ID", None)
+# get it from https://github.com/settings/installations
+OWIDBOT_APP_INSTALLATION_ID = env.get("OWIDBOT_APP_INSTALLATION_ID", None)
+
 
 def enable_bugsnag() -> None:
     if BUGSNAG_API_KEY:


### PR DESCRIPTION
Update the GitHub check in owidbot's chart diff in addition to posting it as the owidbot user (owidbot's updates are run every 5 minutes). The check is updated through the GitHub App. This also refactors existing GitHub utility functions.

The check itself is pretty bare-bones since the information about unapproved charts is already shown in owidbot's comment. We can improve the title/summary later.

Example of a check:
<img width="393" alt="image" src="https://github.com/owid/etl/assets/1550888/be075e4d-9e29-453a-b8ba-44250e7263b0">


Example of owidbot comment:
<img width="238" alt="image" src="https://github.com/owid/etl/assets/1550888/ba8195ad-19ea-450f-8567-552a7bcaba3c">