### PR TITLE
:bug: Revert GDP in the long run, using WDI

### DIFF
--- a/dag/main.yml
+++ b/dag/main.yml
@@ -685,20 +685,21 @@ steps:
   data://grapher/ggdc/2024-04-26/maddison_project_database:
     - data://garden/ggdc/2024-04-26/maddison_project_database
 
-  # Global GDP in the long run
+  # Global GDP in the long run (MD + MPD)
   data://grapher/growth/2024-04-29/gdp_historical:
     - data://garden/growth/2024-04-29/gdp_historical
   data://garden/growth/2024-04-29/gdp_historical:
     - data://garden/ggdc/2024-04-26/maddison_project_database
     - data://garden/ggdc/2022-12-23/maddison_database
 
-  # Global GDP in the long run (previous version)
-  data://garden/growth/2024-01-04/gdp_historical:
-    - data://grapher/worldbank_wdi/2023-05-29/wdi
-    - data://grapher/ggdc/2020-10-01/ggdc_maddison
+  # Global GDP in the long run (with WDI)
+  data://garden/growth/2024-05-16/gdp_historical:
+    - data://garden/ggdc/2024-04-26/maddison_project_database
     - data://garden/ggdc/2022-12-23/maddison_database
-  data://grapher/growth/2024-01-04/gdp_historical:
-    - data://garden/growth/2024-01-04/gdp_historical
+    - data://grapher/worldbank_wdi/2023-05-29/wdi
+
+  data://grapher/growth/2024-05-16/gdp_historical:
+    - data://garden/growth/2024-05-16/gdp_historical
 
   ######################################################################################################################
   # Older versions to be archived once they are not used by any other steps.

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -692,6 +692,14 @@ steps:
     - data://garden/ggdc/2024-04-26/maddison_project_database
     - data://garden/ggdc/2022-12-23/maddison_database
 
+  # Global GDP in the long run (previous version)
+  data://garden/growth/2024-01-04/gdp_historical:
+    - data://grapher/worldbank_wdi/2023-05-29/wdi
+    - data://grapher/ggdc/2020-10-01/ggdc_maddison
+    - data://garden/ggdc/2022-12-23/maddison_database
+  data://grapher/growth/2024-01-04/gdp_historical:
+    - data://garden/growth/2024-01-04/gdp_historical
+
   ######################################################################################################################
   # Older versions to be archived once they are not used by any other steps.
 

--- a/etl/steps/data/garden/growth/2024-05-16/gdp_historical.meta.yml
+++ b/etl/steps/data/garden/growth/2024-05-16/gdp_historical.meta.yml
@@ -1,0 +1,103 @@
+# NOTE: To learn more about the fields, hover over their names.
+definitions:
+  common:
+    presentation:
+      topic_tags:
+        - Economic Growth
+      title_variant: Historical data
+      attribution_short: World Bank, Maddison Project Database, Maddison Database
+    processing_level: major
+
+    description_processing: |-
+      The data presented here from 1990 onwards is from the World Bank. Data before 1990 is constructed using the 1990 World Bank observation and applying the growth rates implied by the Maddison Project Database. Similarly, data before 1820 is built using the adjusted 1820 estimate calculated by the previous method and applying the growth rates implied by the Maddison Database. These steps are necessary because World Bank data adjusted for inflation and the cost of living between countries is only available from 1990 onwards and also because the three datasets estimate GDP with different prices.
+
+      The adjusted results before 1990 have been rounded to address uncertainty in the underlying data. GDP data is rounded to the nearest million, and GDP is rounded to the nearest hundred.
+
+  description_adjustment: This data is adjusted for inflation and for differences in the cost of living between countries.
+  description_unit_merge: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices, merging data from the World Bank, backwards extended with growth rates from Maddison Project Database and Maddison Database.
+
+
+# Learn more about the available fields:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/dataset/
+dataset:
+  update_period_days: 365
+  title: Global economic growth in the long run
+
+
+# Learn more about the available fields:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/tables/
+tables:
+  gdp_historical:
+    # Learn more about the available fields:
+    # http://docs.owid.io/projects/etl/architecture/metadata/reference/indicator/
+    variables:
+      gdp:
+        title: GDP
+        unit: international-$ in 2017 prices
+        short_unit: $
+        display:
+          name: GDP
+          numDecimalPlaces: 0
+        description_short: Total output of the world economy. This data is adjusted for inflation and differences in the cost
+          of living between countries.
+        description_key:
+          - This GDP indicator provides information on global economic growth and income levels in the very long run. Estimates are available as far back as 1 CE.
+          - "{definitions.description_adjustment}"
+          - "{definitions.description_unit_merge}"
+        presentation:
+          title_public: Global GDP over the long run
+          faqs:
+            - fragment_id: poverty-international-dollars
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          grapher_config:
+            title: Global GDP over the long run
+            subtitle: Total output of the world economy. This data is adjusted for inflation and differences in the cost of
+              living between countries.
+            originUrl: https://ourworldindata.org/economic-growth
+            yAxis:
+              min: 0
+              canChangeScaleType: true
+            hideAnnotationFieldsInTitle:
+              time: true
+              entity: true
+              changeInPrefix: true
+            hideRelativeToggle: false
+            selectedEntityNames:
+              - World
+            note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices.
+            hideLegend: true
+
+      gdp_per_capita:
+        title: GDP per capita
+        unit: international-$ in 2017 prices
+        short_unit: $
+        display:
+          name: GDP per capita
+          numDecimalPlaces: 0
+        description_short: This data is adjusted for inflation and differences in the cost of living between countries.
+        description_key:
+          - This GDP per capita indicator provides information on global economic growth and income levels in the very long run. Estimates are available as far back as 1 CE.
+          - "{definitions.description_adjustment}"
+          - "{definitions.description_unit_merge}"
+        presentation:
+          title_public: Global average GDP per capita over the long run
+          faqs:
+            - fragment_id: poverty-international-dollars
+              gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
+          grapher_config:
+            title: Global average GDP per capita over the long run
+            subtitle: This data is adjusted for inflation and differences in the cost of living between countries.
+            originUrl: https://ourworldindata.org/economic-growth
+            yAxis:
+              min: 0
+              canChangeScaleType: true
+            hideAnnotationFieldsInTitle:
+              time: true
+              entity: true
+              changeInPrefix: true
+            hideRelativeToggle: false
+            selectedEntityNames:
+              - World
+            note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices.
+            hideLegend: true
+

--- a/etl/steps/data/garden/growth/2024-05-16/gdp_historical.py
+++ b/etl/steps/data/garden/growth/2024-05-16/gdp_historical.py
@@ -1,0 +1,190 @@
+"""
+This code combines the data of three different sources of GDP and GDP per capita:
+    - World Bank (WDI), in 2017 PPPs (coverage from 1990 to the most recent year available)
+    - Maddison Project Database, in 2011 PPPs (coverage from 1820 to the most recent year available)
+    - Maddison Database, in 1990 PPPs (coverage from 1 CE to 2008)
+
+The goal is to have a single dataset with GDP and GDP per capita estimations in the very long run (from 1 CE to the most current data).
+
+The units of the variables are different in each source, so the data is processed by applying the growth of the Maddison Project Database between 1820 and 1990 retroactively to the World Bank data, and the growth of the Maddison Database between 1 to 1820 retroactively to the data already adjusted in the previous step.
+
+The Maddison Database is a different project from Maddison Project Database: the former was produced by Angus Maddison, while the latter is the continuation of his work after his death. Only the Maddison Database includes world estimates from 1 CE to 1820.
+
+"""
+
+import owid.catalog.processing as pr
+from owid.catalog import Table, warnings
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+# Define constants: variables to process and references years where merge is done.
+VAR_LIST = ["gdp", "gdp_per_capita"]
+YEAR_WDI_MPD = 1990
+YEAR_MPD_MD = 1820
+
+# Define accuracy of data (in tens)
+# 6 means that the data is accurate to the 10^6
+ACCURACY_GDP = 6
+ACCURACY_GDP_PER_CAPITA = 2
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load dataset and tables
+
+    # World Bank WDI
+    ds_wdi = paths.load_dataset("wdi")
+    tb_wdi = ds_wdi["wdi"].reset_index()
+
+    # Maddison Project Database
+    ds_mpd = paths.load_dataset("maddison_project_database")
+    tb_mpd = ds_mpd["maddison_project_database"].reset_index()
+
+    # Maddison Database
+    ds_md = paths.load_dataset("maddison_database")
+    tb_md = ds_md["maddison_database"].reset_index()
+
+    #
+    # Process data.
+    tb = process_and_combine_datasets(tb_wdi, tb_mpd, tb_md)
+
+    tb = tb.format()
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(
+        dest_dir,
+        tables=[tb],
+        check_variables_metadata=True,
+    )
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()
+
+
+def process_and_combine_datasets(tb_wdi: Table, tb_mpd: Table, tb_md: Table) -> Table:
+    """
+    Process WDI, Maddison Project Database and Maddison Database to create a single dataset with GDP and GDP per capita estimations in the very long run.
+    """
+
+    # Sort by year to apply growth with the correct order
+    tb_wdi = tb_wdi.sort_values(by=["year"]).reset_index(drop=True)
+    tb_mpd = tb_mpd.sort_values(by=["year"]).reset_index(drop=True)
+    tb_md = tb_md.sort_values(by=["year"]).reset_index(drop=True)
+
+    #############################
+    # FOR WDI
+    # Select GDP and GDP pc in international-$ in 2017 prices
+    tb_wdi = tb_wdi[["country", "year", "ny_gdp_mktp_pp_kd", "ny_gdp_pcap_pp_kd"]]
+    tb_wdi = tb_wdi.rename(columns={"ny_gdp_mktp_pp_kd": "gdp", "ny_gdp_pcap_pp_kd": "gdp_per_capita"})
+
+    # Filter "World" entity
+    tb_wdi = tb_wdi[tb_wdi["country"] == "World"]
+
+    # Drop empty World GDP estimations
+    tb_wdi = tb_wdi.dropna().reset_index(drop=True)
+
+    #############################
+    # FOR MADDISON PROJECT DATABASE
+    # Select only "World" entity
+    tb_mpd = tb_mpd[tb_mpd["country"] == "World"].reset_index(drop=True)
+
+    # Drop population, as it's not needed
+    tb_mpd = tb_mpd.drop(columns=["population"])
+
+    # Filter years until YEAR_WDI_MPD
+    tb_mpd = tb_mpd[tb_mpd["year"] <= YEAR_WDI_MPD].reset_index(drop=True)
+
+    #############################
+    # FOR MADDISON DATABASE
+    # Keep data until YEAR_MPD_MD
+    tb_md = tb_md[tb_md["year"] <= YEAR_MPD_MD].reset_index(drop=True)
+
+    # Drop population, as it's not needed
+    tb_md = tb_md.drop(columns=["population"])
+
+    #############################
+
+    # Merge both MPD and WDI world estimations in different columns and add suffixes. This will be useful for the next step.
+    tb = tb_mpd.merge(tb_wdi, on="year", how="left", suffixes=("_mpd", "_wdi"), short_name="gdp_historical")
+
+    # Apply Maddison Project Database growth retroactively to YEAR_WDI_MPD WDI data
+    tb = create_estimations_from_growth(
+        tb=tb, var_list=VAR_LIST, reference_year=YEAR_WDI_MPD, reference_var_suffix="_mpd", to_adjust_var_suffix="_wdi"
+    )
+
+    # Concatenate this with original WDI data (data after YEAR_WDI_MPD)
+    tb = pr.concat([tb, tb_wdi[tb_wdi["year"] > YEAR_WDI_MPD]], ignore_index=True)
+
+    # Merge datasets to include Maddison Database, which will be used as reference for the next step
+    tb = tb.merge(tb_md, on="year", how="outer", suffixes=("", "_md"), sort=True)
+
+    # Apply Maddison Database growth retroactively to YEAR_MPD_MD estimations
+    tb = create_estimations_from_growth(
+        tb=tb, var_list=VAR_LIST, reference_year=YEAR_MPD_MD, reference_var_suffix="_md", to_adjust_var_suffix=""
+    )
+
+    # Round variables to address uncertainty on old estimations (previous to 1990)
+    tb["gdp"] = tb["gdp"].round(-ACCURACY_GDP).where(tb["year"] < YEAR_WDI_MPD, tb["gdp"])
+    tb["gdp_per_capita"] = (
+        tb["gdp_per_capita"].round(-ACCURACY_GDP_PER_CAPITA).where(tb["year"] < YEAR_WDI_MPD, tb["gdp_per_capita"])
+    )
+
+    return tb
+
+
+def create_estimations_from_growth(
+    tb: Table, var_list: list, reference_year: int, reference_var_suffix: str, to_adjust_var_suffix: str
+) -> Table:
+    """
+    Adjust estimations of variables according to the growth of a reference variable.
+
+    Parameters
+    ----------
+    tb : Table
+        Table that contains both the reference variable (the one the growth is extracted from) and the variable to be adjusted (the one the growth is applied to).
+    var_list : list
+        List of the variable types to be adjusted. In this project, ["gdp", "gdp_per_capita"]
+    reference_year : int
+        Reference year from which the growth will be applied retroactively.
+    reference_var_suffix : str
+        Suffix of the reference variable (the one the growth is extracted from). In this project, "_mpd" or "_md".
+    to_adjust_var_suffix : str
+        Suffix of the variable to be adjusted (the one the growth is applied to). In this project, "_wdi" or "".
+
+    Returns
+    -------
+    tb : Table
+        Table with the adjusted variables.
+    """
+    with warnings.ignore_warnings([warnings.DifferentValuesWarning]):
+        for var in var_list:
+            # Get value from the reference variable in the reference year
+            reference_value = tb.loc[tb["year"] == reference_year, f"{var}{reference_var_suffix}"].iloc[0]
+
+            # The scalar is the previous value divided by the reference variable. This is the growth that will be applied retroactively to the variable to be adjusted.
+            tb[f"{var}_scalar"] = tb[f"{var}{reference_var_suffix}"] / reference_value
+
+            # Get value to be adjusted in the reference year
+            to_adjust_value = tb.loc[tb["year"] == reference_year, f"{var}{to_adjust_var_suffix}"].iloc[0]
+
+            # The estimated values are the division between the reference value and the scalars. This is the variable to be adjusted effectively adjusted by the growth of the reference variable.
+            tb[f"{var}_estimated"] = to_adjust_value * tb[f"{var}_scalar"]
+
+            # Rename the estimated variables without the suffix
+            tb[f"{var}"] = tb[f"{var}{to_adjust_var_suffix}"].fillna(tb[f"{var}_estimated"])
+
+    # Specify "World" entity for each row
+    tb["country"] = "World"
+
+    # Keep only new variables
+    tb = tb[["country", "year"] + var_list]
+
+    return tb

--- a/etl/steps/data/grapher/growth/2024-05-16/gdp_historical.py
+++ b/etl/steps/data/grapher/growth/2024-05-16/gdp_historical.py
@@ -1,0 +1,27 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset("gdp_historical")
+
+    # Read table from garden dataset.
+    tb = ds_garden["gdp_historical"]
+
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(
+        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
+    )
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()


### PR DESCRIPTION
Return to use World Bank's estimates from 1990 onwards instead of Maddison Project Database to recreate a Maddison + Maddison Project + World Bank series in 2017 prices. https://github.com/owid/owid-issues/issues/379