### PR TITLE
:hammer: enable chart-diff to connect to production and clean up envs

### DIFF
--- a/apps/owidbot/chart_diff.py
+++ b/apps/owidbot/chart_diff.py
@@ -2,9 +2,9 @@ import pandas as pd
 from sqlmodel import Session
 from structlog import get_logger
 
-from apps.staging_sync.cli import _get_container_name, _modified_chart_ids_by_admin
+from apps.staging_sync.cli import _modified_chart_ids_by_admin
 from apps.wizard.pages.chart_diff.chart_diff import ChartDiffModified
-from apps.wizard.utils.env import OWID_ENV, OWIDEnv
+from apps.wizard.utils.env import OWID_ENV, OWIDEnv, get_container_name
 
 from . import github_utils as gh_utils
 
@@ -44,7 +44,7 @@ def create_check_run(repo_name: str, branch: str, charts_df: pd.DataFrame, dry_r
 
 
 def run(branch: str, charts_df: pd.DataFrame) -> str:
-    container_name = _get_container_name(branch) if branch else "dry-run"
+    container_name = get_container_name(branch) if branch else "dry-run"
 
     chart_diff = format_chart_diff(charts_df)
 
@@ -55,7 +55,7 @@ def run(branch: str, charts_df: pd.DataFrame) -> str:
 
     body = f"""
 <details open>
-<summary>{status} <a href="http://{container_name}/etl/wizard/Chart%20Diff"><b>chart-diff</b></a>: </summary>
+<summary><a href="http://{container_name}/etl/wizard/Chart%20Diff"><b>chart-diff</b></a>: {status}</summary>
 {chart_diff}
 </details>
     """.strip()

--- a/apps/owidbot/chart_diff.py
+++ b/apps/owidbot/chart_diff.py
@@ -66,7 +66,7 @@ def run(branch: str, charts_df: pd.DataFrame) -> str:
 def call_chart_diff(branch: str) -> pd.DataFrame:
     source_engine = OWIDEnv.from_staging(branch).get_engine()
 
-    if OWID_ENV.env_type_id == "live":
+    if OWID_ENV.env_type_id == "production":
         target_engine = OWID_ENV.get_engine()
     else:
         log.warning("ENV file doesn't connect to production DB, comparing against staging-site-master")

--- a/apps/owidbot/cli.py
+++ b/apps/owidbot/cli.py
@@ -9,7 +9,7 @@ from rich import print
 from rich_click.rich_command import RichCommand
 
 from apps.owidbot import chart_diff, data_diff, grapher
-from apps.staging_sync.cli import _get_container_name
+from apps.wizard.utils.env import get_container_name
 
 from . import github_utils as gh_utils
 
@@ -122,7 +122,7 @@ def services_from_comment(comment: Any) -> Dict[str, str]:
 
 
 def create_comment_body(branch: str, services: Dict[str, str], start_time: float):
-    container_name = _get_container_name(branch) if branch else "dry-run"
+    container_name = get_container_name(branch) if branch else "dry-run"
 
     body = f"""
 <b>Quick links (staging server)</b>:

--- a/apps/staging_sync/app.py
+++ b/apps/staging_sync/app.py
@@ -48,7 +48,9 @@ def main():
         placeholder="my-branch",
         help="Branch name of PR that created the staging server (with existing `staging-site-mybranch` server) or the name of staging server.",
     )
-    target = st.text_input("Target", value="live", help="Using `live` uses DB from local `.env` file as target.")
+    target = st.text_input(
+        "Target", value="production", help="Using `production` uses DB from local `.env` file as target."
+    )
     approve_revisions = st.checkbox(
         "Automatically approve chart revisions for edited charts",
         value=False,
@@ -57,17 +59,17 @@ def main():
     dry_run = st.checkbox("Dry run", value=True)
 
     # Live uses `.env` file which points to the live database in production
-    if target == "live":
+    if target == "production":
         target_env = ".env"
     else:
         target_env = target
 
     # Button to show text
     if st.button("Sync charts", help="This can take a while."):
-        if target == "live":
+        if target == "production":
             assert (
                 config.DB_IS_PRODUCTION
-            ), "If target = live, then chart-sync must be run in production with .env pointing to live DB."
+            ), "If target = production, then chart-sync must be run in production with .env pointing to live DB."
 
         if not _is_valid_config(source, target_env):
             return

--- a/apps/staging_sync/cli.py
+++ b/apps/staging_sync/cli.py
@@ -17,7 +17,7 @@ from sqlmodel import Session
 
 from apps.staging_sync.admin_api import AdminAPI
 from apps.wizard.pages.chart_diff.chart_diff import ChartDiffModified
-from apps.wizard.utils.env import OWIDEnv, _get_container_name
+from apps.wizard.utils.env import OWIDEnv, get_container_name
 from etl import config
 from etl import grapher_model as gm
 from etl.datadiff import _dict_diff
@@ -402,7 +402,7 @@ def _notify_slack_chart_update(chart_id: int, source: str, diff: ChartDiffModifi
 
     message = f"""
 :warning: *ETL chart-sync: Unapproved Chart Update* from `{source}`
-<http://{_get_container_name(source)}/admin/charts/{chart_id}/edit|View Staging Chart> | <https://admin.owid.io/admin/charts/{chart_id}/edit|View Admin Chart>
+<http://{get_container_name(source)}/admin/charts/{chart_id}/edit|View Staging Chart> | <https://admin.owid.io/admin/charts/{chart_id}/edit|View Admin Chart>
 *Staging        Edited*: {str(diff.source_chart.updatedAt)} UTC
 *Production Edited*: {str(diff.target_chart.updatedAt)} UTC
 ```
@@ -421,7 +421,7 @@ def _notify_slack_chart_update(chart_id: int, source: str, diff: ChartDiffModifi
 def _notify_slack_chart_create(source_chart_id: int, target_chart_id: int, source: str, dry_run: bool) -> None:
     message = f"""
 :warning: *ETL chart-sync: Unapproved New Chart* from `{source}`
-<http://{_get_container_name(source)}/admin/charts/{source_chart_id}/edit|View Staging Chart> | <https://admin.owid.io/admin/charts/{target_chart_id}/edit|View Admin Chart>
+<http://{get_container_name(source)}/admin/charts/{source_chart_id}/edit|View Staging Chart> | <https://admin.owid.io/admin/charts/{target_chart_id}/edit|View Admin Chart>
     """.strip()
 
     print(message)

--- a/apps/wizard/pages/chart_diff/app.py
+++ b/apps/wizard/pages/chart_diff/app.py
@@ -7,11 +7,11 @@ from sqlmodel import Session
 from st_pages import add_indentation
 from structlog import get_logger
 
-from apps.staging_sync.cli import _get_engine_for_env, _modified_chart_ids_by_admin, _validate_env
+from apps.staging_sync.cli import _modified_chart_ids_by_admin
 from apps.wizard.pages.chart_diff.chart_diff import ChartDiffModified
 from apps.wizard.pages.chart_diff.config_diff import st_show_diff
 from apps.wizard.utils import chart_html, set_states
-from apps.wizard.utils.env import OWID_ENV
+from apps.wizard.utils.env import OWID_ENV, OWIDEnv
 from etl import config
 
 log = get_logger()
@@ -41,19 +41,17 @@ st.session_state.hide_approved_charts = st.session_state.get("hide_approved_char
 ########################################
 # LOAD ENVS
 ########################################
-# TODO: simplify this
-SOURCE_ENV = config.DB_HOST  # "staging-site-streamlit-chart-approval"
-SOURCE_API = f"https://api-staging.owid.io/{SOURCE_ENV}/v1/indicators/"
+SOURCE = OWID_ENV
+assert OWID_ENV.env_type_id != "live", "Your .env points to production DB, please use a staging environment."
 
-if config.DB_IS_PRODUCTION:
-    TARGET_ENV = config.ENV_FILE
-    TARGET_API = "https://api.ourworldindata.org/v1/indicators/"
+# Try to compare against production DB if possible, otherwise compare against staging-site-master
+if config.ENV_FILE_PROD:
+    TARGET = OWIDEnv.from_env_file(config.ENV_FILE_PROD)
 else:
     warning_msg = "ENV file doesn't connect to production DB, comparing against staging-site-master"
     log.warning(warning_msg)
     st.warning(warning_msg)
-    TARGET_ENV = "staging-site-master"
-    TARGET_API = f"https://api-staging.owid.io/{TARGET_ENV}/v1/indicators/"
+    TARGET = OWIDEnv.from_staging("master")
 
 
 ########################################
@@ -178,7 +176,7 @@ def compare_charts(
     # Only one chart: new chart
     if target_chart is None:
         st.markdown(f"New version ┃ _{pretty_date(source_chart)}_")
-        chart_html(source_chart.config, base_url=SOURCE_ENV, base_api_url=SOURCE_API)
+        chart_html(source_chart.config, base_url=SOURCE.conf.DB_HOST, base_api_url=SOURCE.indicators_url)
     # Two charts, actual diff
     else:
         # Create two columns for the iframes
@@ -188,10 +186,11 @@ def compare_charts(
         if not prod_is_newer:
             with col1:
                 st.markdown(f"Production ┃ _{pretty_date(target_chart)}_")
-                chart_html(target_chart.config, base_url=TARGET_ENV, base_api_url=TARGET_API)
+                # TODO: fix TARGET.conf.DB_HOST
+                chart_html(target_chart.config, base_url=TARGET.conf.DB_HOST, base_api_url=TARGET.indicators_url)
             with col2:
                 st.markdown(f":green[New version ┃ _{pretty_date(source_chart)}_]")
-                chart_html(source_chart.config, base_url=SOURCE_ENV, base_api_url=SOURCE_API)
+                chart_html(source_chart.config, base_url=SOURCE.conf.DB_HOST, base_api_url=SOURCE.indicators_url)
         # Conflict with live
         else:
             with col1:
@@ -199,21 +198,15 @@ def compare_charts(
                     f":red[Production ┃ _{pretty_date(target_chart)}_] ⚠️",
                     help="The chart in production was modified after creating the staging server. Please resolve the conflict by integrating the latest changes from production into staging.",
                 )
-                chart_html(target_chart.config, base_url=TARGET_ENV, base_api_url=TARGET_API)
+                chart_html(target_chart.config, base_url=TARGET.conf.DB_HOST, base_api_url=TARGET.indicators_url)
             with col2:
                 st.markdown(f"New version ┃ _{pretty_date(source_chart)}_")
-                chart_html(source_chart.config, base_url=SOURCE_ENV, base_api_url=SOURCE_API)
+                chart_html(source_chart.config, base_url=SOURCE.conf.DB_HOST, base_api_url=SOURCE.indicators_url)
 
 
 @st.cache_resource
 def get_engines() -> tuple[Engine, Engine]:
-    _validate_env(SOURCE_ENV)
-    _validate_env(TARGET_ENV)
-
-    source_engine = _get_engine_for_env(SOURCE_ENV)
-    target_engine = _get_engine_for_env(TARGET_ENV)
-
-    return source_engine, target_engine
+    return SOURCE.get_engine(), TARGET.get_engine()
 
 
 def show_help_text():

--- a/apps/wizard/pages/chart_diff/app.py
+++ b/apps/wizard/pages/chart_diff/app.py
@@ -176,7 +176,7 @@ def compare_charts(
     # Only one chart: new chart
     if target_chart is None:
         st.markdown(f"New version ┃ _{pretty_date(source_chart)}_")
-        chart_html(source_chart.config, base_url=SOURCE.conf.DB_HOST, base_api_url=SOURCE.indicators_url)
+        chart_html(source_chart.config, owid_env=SOURCE)
     # Two charts, actual diff
     else:
         # Create two columns for the iframes
@@ -186,11 +186,10 @@ def compare_charts(
         if not prod_is_newer:
             with col1:
                 st.markdown(f"Production ┃ _{pretty_date(target_chart)}_")
-                # TODO: fix TARGET.conf.DB_HOST
-                chart_html(target_chart.config, base_url=TARGET.conf.DB_HOST, base_api_url=TARGET.indicators_url)
+                chart_html(target_chart.config, owid_env=TARGET)
             with col2:
                 st.markdown(f":green[New version ┃ _{pretty_date(source_chart)}_]")
-                chart_html(source_chart.config, base_url=SOURCE.conf.DB_HOST, base_api_url=SOURCE.indicators_url)
+                chart_html(source_chart.config, owid_env=SOURCE)
         # Conflict with live
         else:
             with col1:
@@ -198,10 +197,10 @@ def compare_charts(
                     f":red[Production ┃ _{pretty_date(target_chart)}_] ⚠️",
                     help="The chart in production was modified after creating the staging server. Please resolve the conflict by integrating the latest changes from production into staging.",
                 )
-                chart_html(target_chart.config, base_url=TARGET.conf.DB_HOST, base_api_url=TARGET.indicators_url)
+                chart_html(target_chart.config, owid_env=TARGET)
             with col2:
                 st.markdown(f"New version ┃ _{pretty_date(source_chart)}_")
-                chart_html(source_chart.config, base_url=SOURCE.conf.DB_HOST, base_api_url=SOURCE.indicators_url)
+                chart_html(source_chart.config, owid_env=SOURCE)
 
 
 @st.cache_resource

--- a/apps/wizard/pages/chart_diff/app.py
+++ b/apps/wizard/pages/chart_diff/app.py
@@ -42,7 +42,7 @@ st.session_state.hide_approved_charts = st.session_state.get("hide_approved_char
 # LOAD ENVS
 ########################################
 SOURCE = OWID_ENV
-assert OWID_ENV.env_type_id != "live", "Your .env points to production DB, please use a staging environment."
+assert OWID_ENV.env_type_id != "production", "Your .env points to production DB, please use a staging environment."
 
 # Try to compare against production DB if possible, otherwise compare against staging-site-master
 if config.ENV_FILE_PROD:

--- a/apps/wizard/utils/__init__.py
+++ b/apps/wizard/utils/__init__.py
@@ -28,6 +28,7 @@ from typing_extensions import Self
 
 from apps.wizard.config import PAGES_BY_ALIAS
 from apps.wizard.utils.defaults import load_wizard_defaults, update_wizard_defaults_from_form
+from apps.wizard.utils.env import OWIDEnv
 from apps.wizard.utils.step_form import StepForm
 from etl import config
 from etl.db import get_connection
@@ -613,10 +614,10 @@ def enable_bugsnag_for_streamlit():
     error_util.handle_uncaught_app_exception = bugsnag_handler  # type: ignore
 
 
-def chart_html(chart_config: Dict[str, Any], base_url, base_api_url, height=500, **kwargs):
-    chart_config["bakedGrapherURL"] = f"http://{base_url}/grapher"
-    chart_config["adminBaseUrl"] = f"http://{base_url}"
-    chart_config["dataApiUrl"] = base_api_url
+def chart_html(chart_config: Dict[str, Any], owid_env: OWIDEnv, height=500, **kwargs):
+    chart_config["bakedGrapherURL"] = f"{owid_env.base_site}/grapher"
+    chart_config["adminBaseUrl"] = owid_env.base_site
+    chart_config["dataApiUrl"] = owid_env.indicators_url
 
     HTML = f"""
     <!DOCTYPE html>

--- a/apps/wizard/utils/env.py
+++ b/apps/wizard/utils/env.py
@@ -1,9 +1,13 @@
 """Tools to handle OWID environment."""
-from typing import Literal, Optional
+import re
+from pathlib import Path
+from typing import Any, Literal, Optional
 
+from dotenv import dotenv_values
 from typing_extensions import Self
 
 from etl import config
+from etl.db import Engine, dict_to_object, get_engine
 
 OWIDEnvType = Literal["live", "staging", "local", "remote-staging", "unknown"]
 
@@ -12,11 +16,16 @@ class OWIDEnv:
     """OWID environment."""
 
     env_type_id: OWIDEnvType
+    # TODO: use proper type
+    conf: Any
 
     def __init__(
         self: Self,
         env_type_id: Optional[OWIDEnvType] = None,
+        conf: Any = None,
     ) -> None:
+        self.conf = conf or config
+
         if env_type_id is None:
             self.env_type_id = self.detect_env_type()
         else:
@@ -25,18 +34,50 @@ class OWIDEnv:
     def detect_env_type(self: Self) -> OWIDEnvType:
         """Detect environment type."""
         # live
-        if config.DB_NAME == "live_grapher":
+        if self.conf.DB_NAME == "live_grapher":
             return "live"
         # staging
-        elif config.DB_NAME == "staging_grapher" and config.DB_USER == "staging_grapher":
+        elif self.conf.DB_NAME == "staging_grapher" and self.conf.DB_USER == "staging_grapher":
             return "staging"
         # local
-        elif config.DB_NAME == "grapher" and config.DB_USER == "grapher":
+        elif self.conf.DB_NAME == "grapher" and self.conf.DB_USER == "grapher":
             return "local"
         # other
-        elif config.DB_NAME == "owid" and config.DB_USER == "owid":
+        elif self.conf.DB_NAME == "owid" and self.conf.DB_USER == "owid":
             return "remote-staging"
         return "unknown"
+
+    @classmethod
+    def from_staging(cls, branch: str) -> Self:
+        """Create OWIDEnv for staging."""
+        conf = dict_to_object(
+            {
+                "DB_USER": "owid",
+                "DB_NAME": "owid",
+                "DB_PASS": "",
+                "DB_PORT": "3306",
+                "DB_HOST": _get_container_name(branch),
+            }
+        )
+        return cls("remote-staging", conf)
+
+    @classmethod
+    def from_env_file(cls, env_file: str) -> Self:
+        """Create OWIDEnv from env file."""
+        assert Path(env_file).exists(), f"ENV file {env_file} doesn't exist"
+        conf = dict_to_object(dotenv_values(env_file))
+        return cls(conf=conf)
+
+    @classmethod
+    def from_staging_or_env_file(cls, staging_or_env_file: str) -> Self:
+        """Create OWIDEnv from staging or env file."""
+        if Path(staging_or_env_file).exists():
+            return cls.from_env_file(staging_or_env_file)
+        return cls.from_staging(staging_or_env_file)
+
+    def get_engine(self) -> Engine:
+        """Get engine for env."""
+        return get_engine(self.conf.__dict__)
 
     @property
     def site(self) -> str | None:
@@ -48,7 +89,7 @@ class OWIDEnv:
         elif self.env_type_id == "local":
             return "http://localhost:3030"
         elif self.env_type_id == "remote-staging":
-            return f"http://{config.DB_HOST}"
+            return f"http://{self.conf.DB_HOST}"
         return None
 
     @property
@@ -61,7 +102,7 @@ class OWIDEnv:
         elif self.env_type_id == "local":
             return "local"
         elif self.env_type_id == "remote-staging":
-            return f"{config.DB_HOST}"
+            return f"{self.conf.DB_HOST}"
         raise ValueError("Unknown env_type_id")
 
     @property
@@ -84,9 +125,26 @@ class OWIDEnv:
             return f"{self.base_site}/admin"
 
     @property
+    def api_site(self: Self) -> str:
+        """Get api url."""
+        if self.env_type_id == "live":
+            return "https://api.ourworldindata.org"
+        elif self.env_type_id == "remote-staging":
+            return f"https://api-staging.owid.io/{self.conf.DB_HOST}"
+        elif self.env_type_id == "local":
+            return "http://localhost:3030"
+        else:
+            raise NotImplementedError()
+
+    @property
     def chart_approval_tool_url(self: Self) -> str:
         """Get chart approval tool url."""
         return f"{self.admin_site}/suggested-chart-revisions/review"
+
+    @property
+    def indicators_url(self: Self) -> str:
+        """Get indicators url."""
+        return self.api_site + "/v1/indicators/"
 
     def dataset_admin_site(self: Self, dataset_id: str | int) -> str:
         """Get dataset admin url."""
@@ -110,6 +168,22 @@ class OWIDEnv:
         Into https://ourworldindata.org/grapher/thumbnail/life-expectancy.png
         """
         return f"{self.site}/grapher/thumbnail/{slug}.png"
+
+
+def _normalise_branch(branch_name):
+    return re.sub(r"[\/\._]", "-", branch_name)
+
+
+def _get_container_name(branch_name):
+    normalized_branch = _normalise_branch(branch_name)
+
+    # Strip staging-site- prefix to add it back later
+    normalized_branch = normalized_branch.replace("staging-site-", "")
+
+    # Ensure the container name is less than 63 characters
+    container_name = f"staging-site-{normalized_branch[:50]}"
+    # Remove trailing hyphens
+    return container_name.rstrip("-")
 
 
 OWID_ENV = OWIDEnv()

--- a/apps/wizard/utils/env.py
+++ b/apps/wizard/utils/env.py
@@ -2,7 +2,7 @@
 import re
 from dataclasses import dataclass, fields
 from pathlib import Path
-from typing import Literal, Optional, cast
+from typing import Literal, cast
 
 from dotenv import dotenv_values
 from typing_extensions import Self
@@ -10,7 +10,7 @@ from typing_extensions import Self
 from etl import config
 from etl.db import Engine, get_engine
 
-OWIDEnvType = Literal["live", "local", "remote-staging", "unknown"]
+OWIDEnvType = Literal["production", "local", "staging", "unknown"]
 
 
 @dataclass
@@ -49,15 +49,15 @@ class OWIDEnv:
 
     def detect_env_type(self: Self) -> OWIDEnvType:
         """Detect environment type."""
-        # live
+        # production
         if self.conf.DB_NAME == "live_grapher":
-            return "live"
+            return "production"
         # local
         elif self.conf.DB_NAME == "grapher" and self.conf.DB_USER == "grapher":
             return "local"
         # other
         elif self.conf.DB_NAME == "owid" and self.conf.DB_USER == "owid":
-            return "remote-staging"
+            return "staging"
         return "unknown"
 
     @classmethod
@@ -92,31 +92,31 @@ class OWIDEnv:
     @property
     def site(self) -> str | None:
         """Get site."""
-        if self.env_type_id == "live":
+        if self.env_type_id == "production":
             return "https://ourworldindata.org"
         elif self.env_type_id == "local":
             return "http://localhost:3030"
-        elif self.env_type_id == "remote-staging":
+        elif self.env_type_id == "staging":
             return f"http://{self.conf.DB_HOST}"
         return None
 
     @property
     def name(self) -> str:
         """Get site."""
-        if self.env_type_id == "live":
+        if self.env_type_id == "production":
             return "production"
         elif self.env_type_id == "local":
             return "local"
-        elif self.env_type_id == "remote-staging":
+        elif self.env_type_id == "staging":
             return f"{self.conf.DB_HOST}"
         raise ValueError("Unknown env_type_id")
 
     @property
     def base_site(self) -> str | None:
         """Get site."""
-        if self.env_type_id == "live":
+        if self.env_type_id == "production":
             return "https://admin.owid.io"
-        elif self.env_type_id in ["local", "remote-staging"]:
+        elif self.env_type_id in ["local", "staging"]:
             return self.site
         return None
 
@@ -131,9 +131,9 @@ class OWIDEnv:
     @property
     def api_site(self: Self) -> str:
         """Get api url."""
-        if self.env_type_id == "live":
+        if self.env_type_id == "production":
             return "https://api.ourworldindata.org"
-        elif self.env_type_id == "remote-staging":
+        elif self.env_type_id == "staging":
             return f"https://api-staging.owid.io/{self.conf.DB_HOST}"
         elif self.env_type_id == "local":
             return "http://localhost:8000"

--- a/etl/config.py
+++ b/etl/config.py
@@ -60,6 +60,9 @@ DB_PASS = env.get("DB_PASS", "")
 
 DB_IS_PRODUCTION = DB_NAME == "live_grapher"
 
+# Special ENV file with access to production DB (read-only), used by chart-diff
+ENV_FILE_PROD = os.environ.get("ENV_FILE_PROD")
+
 if "DATA_API_ENV" in env:
     DATA_API_ENV = env["DATA_API_ENV"]
 else:

--- a/tests/apps/wizard/utils/test_env.py
+++ b/tests/apps/wizard/utils/test_env.py
@@ -1,0 +1,56 @@
+from apps.wizard.utils.env import Config, OWIDEnv, get_container_name
+
+
+def test_get_container_name():
+    assert get_container_name("branch") == "staging-site-branch"
+    assert get_container_name("feature/x") == "staging-site-feature-x"
+    assert get_container_name("do_not-do/this") == "staging-site-do-not-do-this"
+
+
+def test_OWIDEnv_staging():
+    env = OWIDEnv.from_staging("branch")
+    assert env.env_type_id == "remote-staging"
+    assert env.site == "http://staging-site-branch"
+    assert env.name == "staging-site-branch"
+    assert env.base_site == "http://staging-site-branch"
+    assert env.admin_site == "http://staging-site-branch/admin"
+    assert env.api_site == "https://api-staging.owid.io/staging-site-branch"
+    assert env.indicators_url == "https://api-staging.owid.io/staging-site-branch/v1/indicators/"
+
+
+def test_OWIDEnv_production():
+    env = OWIDEnv(
+        Config(
+            DB_USER="user",
+            DB_NAME="live_grapher",
+            DB_PASS="xxx",
+            DB_PORT="3306",
+            DB_HOST="prod-db.owid.io",
+        )
+    )
+    assert env.env_type_id == "live"
+    assert env.site == "https://ourworldindata.org"
+    assert env.name == "production"
+    assert env.base_site == "https://admin.owid.io"
+    assert env.admin_site == "https://admin.owid.io/admin"
+    assert env.api_site == "https://api.ourworldindata.org"
+    assert env.indicators_url == "https://api.ourworldindata.org/v1/indicators/"
+
+
+def test_OWIDEnv_local():
+    env = OWIDEnv(
+        Config(
+            DB_USER="grapher",
+            DB_NAME="grapher",
+            DB_PASS="xxx",
+            DB_PORT="3306",
+            DB_HOST="127.0.0.1",
+        )
+    )
+    assert env.env_type_id == "local"
+    assert env.site == "http://localhost:3030"
+    assert env.name == "local"
+    assert env.base_site == "http://localhost:3030"
+    assert env.admin_site == "http://localhost:3030/admin"
+    assert env.api_site == "http://localhost:8000"
+    assert env.indicators_url == "http://localhost:8000/v1/indicators/"

--- a/tests/apps/wizard/utils/test_env.py
+++ b/tests/apps/wizard/utils/test_env.py
@@ -9,7 +9,7 @@ def test_get_container_name():
 
 def test_OWIDEnv_staging():
     env = OWIDEnv.from_staging("branch")
-    assert env.env_type_id == "remote-staging"
+    assert env.env_type_id == "staging"
     assert env.site == "http://staging-site-branch"
     assert env.name == "staging-site-branch"
     assert env.base_site == "http://staging-site-branch"
@@ -28,7 +28,7 @@ def test_OWIDEnv_production():
             DB_HOST="prod-db.owid.io",
         )
     )
-    assert env.env_type_id == "live"
+    assert env.env_type_id == "production"
     assert env.site == "https://ourworldindata.org"
     assert env.name == "production"
     assert env.base_site == "https://admin.owid.io"


### PR DESCRIPTION
## Motivation

Managing various envs (live, staging, local, etc.) has become more scattered and everyone is reinventing the wheel with their own helper functions. This PR unifies env management under existing `OWIDEnv` class.

## Implementation

Leverage `OWIDEnv` object for managing settings and engines for various environments. Instead of using default `etl.config`, you can now pass arbitrary config. There are also helper functions for creating `OWIDEnv` for staging servers etc.

I also removed `staging` from `OWIDEnvType` since we no longer use them (@lucasrodes can I remove `remote-staging` to `staging`?). Should I maybe also remove mentions of `live` from everywhere and replace them by `production`?

## Production env

Currently, we compare `chart-diff` against `staging-site-master` on staging servers. That's not optimal as we'd like to compare it against production. Hence, we add `ENV_FILE_PROD` env variable that points to production `.env` file (e.g. `.env.prod.read`). 


## TODO after merging
- [x] Add `ENV_FILE_PROD=.env.prod.read` variable and actual `.env.prod.read` file to all staging servers