### PR TITLE
:sparkles: GBD 2021 faster snapshot creation

### DIFF
--- a/snapshots/ihme_gbd/2024-05-20/gbd_cause.csv.dvc
+++ b/snapshots/ihme_gbd/2024-05-20/gbd_cause.csv.dvc
@@ -21,3 +21,7 @@ meta:
     license:
       name: Free-of-Charge Non-commercial User Agreement
       url: https://www.healthdata.org/Data-tools-practices/data-practices/ihme-free-charge-non-commercial-user-agreement
+outs:
+  - md5: 8aeba0d80c0abeda98eea46de5946b98
+    size: 609110834
+    path: gbd_cause.csv

--- a/snapshots/ihme_gbd/2024-05-20/gbd_cause.py
+++ b/snapshots/ihme_gbd/2024-05-20/gbd_cause.py
@@ -19,16 +19,16 @@ The data will then be requested and a download link will be sent to you with a n
 We will download and combine the files in the following script.
 """
 
-import os
-import tempfile
 from pathlib import Path
 
 import click
+import pandas as pd
+from owid.datautils.dataframes import concatenate
+from owid.repack import repack_frame
+from shared import download_data
 from structlog import get_logger
 
 from etl.snapshot import Snapshot
-
-from .shared import compress_files, download_data
 
 log = get_logger()
 
@@ -45,15 +45,18 @@ def main(upload: bool) -> None:
     # Create a new snapshot.
     snap = Snapshot(f"ihme_gbd/{SNAPSHOT_VERSION}/gbd_cause.csv")
     # Download data from source.
-    all_file_paths = []
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        for file_number in range(1, NUMBER_OF_FILES + 1):
-            log.info(f"Downloading file {file_number} of {NUMBER_OF_FILES}")
-            file_path = download_data(file_number, tmpdirname, base_url=BASE_URL)
-            all_file_paths.append(file_path)
-        zip_file_path = os.path.join(tmpdirname, "all_csv_files.zip")
-        compress_files(all_file_paths, zip_file_path)
-        snap.create_snapshot(upload=upload, filename=zip_file_path)
+    dfs: list[pd.DataFrame] = []
+    for file_number in range(1, NUMBER_OF_FILES + 1):
+        log.info(f"Downloading file {file_number} of {NUMBER_OF_FILES}")
+        df = download_data(file_number, base_url=BASE_URL)
+        log.info(f"Download of file {file_number} finished", size=f"{df.memory_usage(deep=True).sum()/1e6:.2f} MB")
+        dfs.append(df)
+
+    # Concatenate the dataframes while keeping categorical columns to reduce memory usage.
+    df = repack_frame(concatenate(dfs))
+
+    log.info("Uploading final file", size=f"{df.memory_usage(deep=True).sum()/1e6:.2f} MB")
+    snap.create_snapshot(upload=upload, data=df)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Running `python snapshots/ihme_gbd/2024-05-20/gbd_cause.py` took quite long and "froze" at the end when creating the snapshot. The "froze" was caused by uploading a pretty large file as snapshot.

This PR tries to save memory wherever possible. It avoids unzipping file to disk and instead loads it directly to memory as dataframe. Then it optimizes it with `repack_frame`.

Finally, we concatenate all dataframes using our `concatenate` function that efficiently handles categorical variables.

(The previous approach might have been ok - it's just that uploading took so long. Zipped file should have similar size as dataframe with optimal types. One advantage of working with dataframes is that we don't have to unzip them in meadow step.)