### PR TITLE
:bar_chart: switch WDI from sources to origins

### DIFF
--- a/apps/wizard/pages/owidle.py
+++ b/apps/wizard/pages/owidle.py
@@ -228,7 +228,7 @@ def load_data(placeholder: str) -> Tuple[pd.DataFrame, gpd.GeoDataFrame]:
 
     # Load GDP indicator(s)
     ## WDI
-    ds = Dataset(DATA_DIR / "garden/worldbank_wdi/2023-05-29/wdi")
+    ds = Dataset(DATA_DIR / "garden/worldbank_wdi/2024-05-20/wdi")
     tb_gdp_wdi = ds["wdi"].reset_index()[["year", "country", "ny_gdp_pcap_pp_kd"]]
     tb_gdp_wdi = tb_gdp_wdi.rename(
         columns={

--- a/dag/education.yml
+++ b/dag/education.yml
@@ -31,7 +31,7 @@ steps:
   data://garden/education/2023-07-17/education_lee_lee:
     - data://meadow/education/2023-07-17/education_lee_lee
     - data://garden/regions/2023-01-01/regions
-    - data://garden/worldbank_wdi/2023-05-29/wdi
+    - data://garden/worldbank_wdi/2024-05-20/wdi
     - data://garden/owid/latest/key_indicators
   data://grapher/education/2023-07-17/education_lee_lee:
     - data://garden/education/2023-07-17/education_lee_lee

--- a/dag/emissions.yml
+++ b/dag/emissions.yml
@@ -98,7 +98,7 @@ steps:
   # https://drive.google.com/file/d/1PflfQpr4mceVWRSGEqMP6Gbo1tFQZzOp/view?usp=sharing
   data://garden/emissions/2024-02-26/gdp_and_co2_decoupling:
     - data://garden/gcp/2023-12-12/global_carbon_budget
-    - data://garden/worldbank_wdi/2023-05-29/wdi
+    - data://garden/worldbank_wdi/2024-05-20/wdi
   #
   # Jones et al. - National contributions to climate change.
   #

--- a/dag/health.yml
+++ b/dag/health.yml
@@ -551,7 +551,7 @@ steps:
     - snapshot://health/2024-04-22/gpei_funding.xlsx
   data://garden/health/2024-04-22/gpei_funding:
     - data://meadow/health/2024-04-22/gpei_funding
-    - data://garden/worldbank_wdi/2023-05-29/wdi
+    - data://garden/worldbank_wdi/2024-05-20/wdi
   data://grapher/health/2024-04-22/gpei_funding:
     - data://garden/health/2024-04-22/gpei_funding
 

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -401,7 +401,7 @@ steps:
 
   # Patents & journal articles (World Bank, United Nations)
   data://garden/research_development/2024-05-20/patents_articles:
-    - data://garden/worldbank_wdi/2023-05-29/wdi
+    - data://garden/worldbank_wdi/2024-05-20/wdi
     - data://garden/demography/2023-03-31/population
   data://grapher/research_development/2024-05-20/patents_articles:
     - data://garden/research_development/2024-05-20/patents_articles
@@ -698,7 +698,7 @@ steps:
   data://garden/growth/2024-05-16/gdp_historical:
     - data://garden/ggdc/2024-04-26/maddison_project_database
     - data://garden/ggdc/2022-12-23/maddison_database
-    - data://grapher/worldbank_wdi/2023-05-29/wdi
+    - data://grapher/worldbank_wdi/2024-05-20/wdi
 
   data://grapher/growth/2024-05-16/gdp_historical:
     - data://garden/growth/2024-05-16/gdp_historical

--- a/dag/natural_disasters.yml
+++ b/dag/natural_disasters.yml
@@ -10,7 +10,7 @@ steps:
     - data://garden/demography/2023-03-31/population
     - data://garden/wb/2024-03-11/income_groups
     - data://garden/regions/2023-01-01/regions
-    - data://garden/worldbank_wdi/2023-05-29/wdi
+    - data://garden/worldbank_wdi/2024-05-20/wdi
   # The following dataset has all (yearly and decadal) variables together.
   data://grapher/emdat/2024-04-11/natural_disasters:
     - data://garden/emdat/2024-04-11/natural_disasters

--- a/dag/poverty_inequality.yml
+++ b/dag/poverty_inequality.yml
@@ -11,7 +11,7 @@ steps:
     - data://garden/wid/2024-05-24/world_inequality_database
     - data://garden/lis/2023-08-30/luxembourg_income_study
     - data://garden/wb/2024-01-22/thousand_bins_distribution
-    - data://garden/worldbank_wdi/2023-05-29/wdi
+    - data://garden/worldbank_wdi/2024-05-20/wdi
 
   # World Bank Poverty and Inequality Platform
   data://meadow/wb/2024-03-27/world_bank_pip:

--- a/etl/data_helpers/misc.py
+++ b/etl/data_helpers/misc.py
@@ -10,6 +10,7 @@ should probably be moved to owid-datautils. However this can be time consuming a
 - Prior to moving them to owid-datautils, we can test and discuss them.
 
 """
+
 from typing import Any, List, Set, Union
 
 import pandas as pd
@@ -47,41 +48,6 @@ def check_values_in_column(df: pd.DataFrame, column_name: str, values_expected: 
         raise ValueError(
             f"Values {values_missing} in column `{column_name}` missing, check if they were removed from source!"
         )
-
-
-########################################################################################################################
-# TODO: Remote this temporary function once WDI has origins.
-def add_origins_to_wdi(tb_wdi: Table) -> Table:
-    tb_wdi = tb_wdi.copy()
-
-    # List all non-index columns in the WDI table.
-    data_columns = [column for column in tb_wdi.columns if column not in ["country", "year"]]
-
-    # For each indicator, add an origin (using information from the old source) and then remove the source.
-    for column in data_columns:
-        assert len(tb_wdi[column].metadata.sources) == 1, f"Expected only one source in column {column}"
-        source = tb_wdi[column].metadata.sources[0]
-        error = "Remove temporary solution where origins where manually created."
-        assert tb_wdi[column].metadata.origins == [], error
-        tb_wdi[column].metadata.origins = [
-            Origin(
-                title="World Development Indicators",
-                producer=source.name,
-                attribution="Multiple sources compiled by World Bank (2023)",
-                url_main="https://datacatalog.worldbank.org/search/dataset/0037712/World-Development-Indicators",
-                url_download="http://databank.worldbank.org/data/download/WDI_csv.zip",
-                date_accessed="2023-05-29",
-                date_published="2023-05-11",
-                citation_full="World Bank's World Development Indicators (WDI).",
-                description="The World Development Indicators (WDI) is the primary World Bank collection of development indicators, compiled from officially-recognized international sources. It presents the most current and accurate global development data available, and includes national, regional and global estimates.",
-                license=License(name="CC BY 4.0"),
-            )
-        ]
-
-        # Remove sources from indicator.
-        tb_wdi[column].metadata.sources = []
-
-    return tb_wdi
 
 
 ########################################################################################################################

--- a/etl/steps/data/garden/education/2023-07-17/education_lee_lee.py
+++ b/etl/steps/data/garden/education/2023-07-17/education_lee_lee.py
@@ -59,10 +59,6 @@ def run(dest_dir: str) -> None:
 
     # Extract enrollment rates from the World Bank Education Dataset starting from 2010
     enrolment_wb = extract_related_world_bank_data(tb_wdi)
-    # Add origins metadata to the WDI table (remove when the WDI dataset is updated with new metadata)
-    from etl.data_helpers.misc import add_origins_to_wdi
-
-    enrolment_wb = add_origins_to_wdi(enrolment_wb)
 
     # Get the list of columns from the World Bank dataset
     world_bank_indicators = enrolment_wb.columns

--- a/etl/steps/data/garden/emdat/2023-09-20/natural_disasters.py
+++ b/etl/steps/data/garden/emdat/2023-09-20/natural_disasters.py
@@ -521,13 +521,6 @@ def run(dest_dir: str) -> None:
     ds_wdi = paths.load_dataset("wdi")
     tb_gdp = ds_wdi["wdi"][["ny_gdp_mktp_cd"]].reset_index()
 
-    ####################################################################################################################
-    # TODO: Remote this temporary solution once WDI has origins.
-    from etl.data_helpers.misc import add_origins_to_wdi
-
-    tb_gdp = add_origins_to_wdi(tb_wdi=tb_gdp)
-    ####################################################################################################################
-
     # Load regions dataset.
     ds_regions = paths.load_dataset("regions")
 

--- a/etl/steps/data/garden/emdat/2024-04-11/natural_disasters.py
+++ b/etl/steps/data/garden/emdat/2024-04-11/natural_disasters.py
@@ -1,6 +1,4 @@
-"""Process and harmonize EM-DAT natural disasters dataset.
-
-"""
+"""Process and harmonize EM-DAT natural disasters dataset."""
 
 import datetime
 from typing import Any, Dict, List, Tuple
@@ -913,13 +911,6 @@ def run(dest_dir: str) -> None:
     # Load WDI dataset, read its main table and select variable corresponding to GDP (in current US$).
     ds_wdi = paths.load_dataset("wdi")
     tb_gdp = ds_wdi["wdi"][["ny_gdp_mktp_cd"]].reset_index()
-
-    ####################################################################################################################
-    # TODO: Remote this temporary solution once WDI has origins.
-    from etl.data_helpers.misc import add_origins_to_wdi
-
-    tb_gdp = add_origins_to_wdi(tb_wdi=tb_gdp)
-    ####################################################################################################################
 
     # Load regions dataset.
     ds_regions = paths.load_dataset("regions")

--- a/etl/steps/data/garden/emissions/2023-10-06/gdp_and_co2_decoupling.py
+++ b/etl/steps/data/garden/emissions/2023-10-06/gdp_and_co2_decoupling.py
@@ -9,6 +9,7 @@ The data in the current step is not used by any grapher step, but will be used b
 https://drive.google.com/file/d/1PflfQpr4mceVWRSGEqMP6Gbo1tFQZzOp/view?usp=sharing
 
 """
+
 from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
@@ -65,13 +66,6 @@ def run(dest_dir: str) -> None:
 
     # Select and rename the required variables from WDI.
     tb_wdi = tb_wdi[list(COLUMNS_WDI)].rename(columns=COLUMNS_WDI, errors="raise")
-
-    ####################################################################################################################
-    # TODO: Remote this temporary solution once WDI has origins.
-    from etl.data_helpers.misc import add_origins_to_wdi
-
-    tb_wdi = add_origins_to_wdi(tb_wdi=tb_wdi)
-    ####################################################################################################################
 
     # Combine both tables.
     tb = tb_gcb.merge(tb_wdi, on=["country", "year"], how="outer", short_name=paths.short_name)

--- a/etl/steps/data/garden/emissions/2024-02-26/gdp_and_co2_decoupling.py
+++ b/etl/steps/data/garden/emissions/2024-02-26/gdp_and_co2_decoupling.py
@@ -67,13 +67,6 @@ def run(dest_dir: str) -> None:
     # Select and rename the required variables from WDI.
     tb_wdi = tb_wdi[list(COLUMNS_WDI)].rename(columns=COLUMNS_WDI, errors="raise")
 
-    ####################################################################################################################
-    # TODO: Remote this temporary solution once WDI has origins.
-    from etl.data_helpers.misc import add_origins_to_wdi
-
-    tb_wdi = add_origins_to_wdi(tb_wdi=tb_wdi)
-    ####################################################################################################################
-
     # Combine both tables.
     tb = tb_gcb.merge(tb_wdi, on=["country", "year"], how="outer", short_name=paths.short_name)
 

--- a/etl/steps/data/meadow/worldbank_wdi/2024-05-20/wdi.py
+++ b/etl/steps/data/meadow/worldbank_wdi/2024-05-20/wdi.py
@@ -44,10 +44,10 @@ def run(dest_dir: str) -> None:
 
     # variable code <-> variable name should be a 1:1 mapping
     assert (
-        df.groupby("indicator_code")["indicator_name"].apply(lambda gp: gp.nunique()) == 1
+        df.groupby("indicator_code", observed=True)["indicator_name"].apply(lambda gp: gp.nunique()) == 1
     ).all(), "A variable code in `WDIData.csv` has multiple variable names."
     assert (
-        df.groupby("indicator_name")["indicator_code"].apply(lambda gp: gp.nunique()) == 1
+        df.groupby("indicator_name", observed=True)["indicator_code"].apply(lambda gp: gp.nunique()) == 1
     ).all(), "A variable name in `WDIData.csv` has multiple variable codes."
 
     # reshapes data from `country indicator 1960 1961 ...` format to long format `country indicator_code year value`
@@ -73,6 +73,10 @@ def run(dest_dir: str) -> None:
     #
     # Create a new table and ensure all columns are snake-case.
     tb = Table(df_wide, short_name=paths.short_name, underscore=True)
+
+    # Add origin to all indicators
+    for col in tb.columns:
+        tb[col].m.origins = [snap.m.origin]
 
     #
     # Save outputs.

--- a/snapshots/worldbank_wdi/2024-05-20/wdi.zip.dvc
+++ b/snapshots/worldbank_wdi/2024-05-20/wdi.zip.dvc
@@ -1,17 +1,16 @@
 meta:
-  source:
-    name: World Bank
-    description: |-
-      The World Development Indicators (WDI) is the primary World Bank collection of development indicators, compiled from officially-recognized international sources. It presents the most current and accurate global development data available, and includes national, regional and global estimates.
-    url: https://datacatalog.worldbank.org/search/dataset/0037712/World-Development-Indicators
-    source_data_url: http://databank.worldbank.org/data/download/WDI_csv.zip
+  origin:
+    title: World Development Indicators
+    producer: World Bank
+    attribution: Multiple sources compiled by World Bank (2024)
+    url_main: https://datacatalog.worldbank.org/search/dataset/0037712/World-Development-Indicators
+    url_download: http://databank.worldbank.org/data/download/WDI_csv.zip
     date_accessed: 2024-05-20
-    publication_date: '2024-05-20'
-  name: World Development Indicators - World Bank (2024.03.28)
-  description: |-
-    The World Development Indicators (WDI) is the primary World Bank collection of development indicators, compiled from officially-recognized international sources. It presents the most current and accurate global development data available, and includes national, regional and global estimates.
-  license:
-    name: Creative Commons Attribution 4.0
+    date_published: 2024-05-20
+    citation_full: World Bank's World Development Indicators (WDI).
+    description: The World Development Indicators (WDI) is the primary World Bank collection of development indicators, compiled from officially-recognized international sources. It presents the most current and accurate global development data available, and includes national, regional and global estimates.
+    license:
+      name: Creative Commons Attribution 4.0
 outs:
   - md5: a0009c12c3a09460f373fd7ca1ceed8a
     size: 73436470


### PR DESCRIPTION
Remove misc function `add_origins_to_wdi` and update dependency `garden/worldbank_wdi/2023-05-29/wdi` to `garden/worldbank_wdi/2024-05-20/wdi` in all steps. I used ChatGPT-generated `wdi.sources.json` to get a producer (previously `source.name`) for a source from WDI metadata. Initially, I wanted to avoid ChatGPT and just dump the full source name as producer, but it was too messy and longer than 255 characters. If we wanted to polish it even further, we could use ChatGPT to create a full origin from given source name (not sure if it's worth it though).

Here is an example of an [old chart](https://admin.owid.io/admin/charts/317/edit) and a [new chart](http://staging-site-wdi-sources-to-origins/admin/charts/317/edit). It's almost identical except for indicator's description, which has been moved to `description_from_producer`.