### PR TITLE
:bug: get proper container name when using weird branch names

### DIFF
--- a/apps/chart_sync/cli.py
+++ b/apps/chart_sync/cli.py
@@ -17,9 +17,10 @@ from sqlalchemy.orm import Session
 
 from apps.chart_sync.admin_api import AdminAPI
 from apps.wizard.pages.chart_diff.chart_diff import ChartDiffModified
-from apps.wizard.utils.env import OWIDEnv, get_container_name
+from apps.wizard.utils.env import OWIDEnv
 from etl import config
 from etl import grapher_model as gm
+from etl.config import get_container_name
 from etl.datadiff import _dict_diff
 from etl.db import read_sql
 

--- a/apps/owidbot/chart_diff.py
+++ b/apps/owidbot/chart_diff.py
@@ -4,7 +4,8 @@ from structlog import get_logger
 
 from apps.chart_sync.cli import _modified_chart_ids_by_admin
 from apps.wizard.pages.chart_diff.chart_diff import ChartDiffModified
-from apps.wizard.utils.env import OWID_ENV, OWIDEnv, get_container_name
+from apps.wizard.utils.env import OWID_ENV, OWIDEnv
+from etl.config import get_container_name
 
 from . import github_utils as gh_utils
 

--- a/apps/owidbot/cli.py
+++ b/apps/owidbot/cli.py
@@ -9,7 +9,7 @@ from rich import print
 from rich_click.rich_command import RichCommand
 
 from apps.owidbot import chart_diff, data_diff, grapher
-from apps.wizard.utils.env import get_container_name
+from etl.config import get_container_name
 
 from . import github_utils as gh_utils
 

--- a/apps/wizard/utils/env.py
+++ b/apps/wizard/utils/env.py
@@ -1,6 +1,5 @@
 """Tools to handle OWID environment."""
 
-import re
 from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Literal, cast
@@ -9,6 +8,7 @@ from dotenv import dotenv_values
 from typing_extensions import Self
 
 from etl import config
+from etl.config import get_container_name
 from etl.db import Engine, get_engine
 
 OWIDEnvType = Literal["production", "local", "staging", "unknown"]
@@ -173,22 +173,6 @@ class OWIDEnv:
         Into https://ourworldindata.org/grapher/thumbnail/life-expectancy.png
         """
         return f"{self.site}/grapher/thumbnail/{slug}.png"
-
-
-def _normalise_branch(branch_name):
-    return re.sub(r"[\/\._]", "-", branch_name)
-
-
-def get_container_name(branch_name):
-    normalized_branch = _normalise_branch(branch_name)
-
-    # Strip staging-site- prefix to add it back later
-    normalized_branch = normalized_branch.replace("staging-site-", "")
-
-    # Ensure the container name is less than 63 characters
-    container_name = f"staging-site-{normalized_branch[:50]}"
-    # Remove trailing hyphens
-    return container_name.rstrip("-")
 
 
 OWID_ENV = OWIDEnv()

--- a/etl/config.py
+++ b/etl/config.py
@@ -9,6 +9,7 @@ only important for OWID staff.
 
 import os
 import pwd
+import re
 from os import environ as env
 from typing import Optional
 
@@ -34,6 +35,22 @@ def load_env():
         raise ValueError(f"ENV was replaced by ENV_FILE, please use ENV_FILE={env['ENV']} ... instead.")
 
     load_dotenv(ENV_FILE, override=True)
+
+
+def _normalise_branch(branch_name):
+    return re.sub(r"[\/\._]", "-", branch_name)
+
+
+def get_container_name(branch_name):
+    normalized_branch = _normalise_branch(branch_name)
+
+    # Strip staging-site- prefix to add it back later
+    normalized_branch = normalized_branch.replace("staging-site-", "")
+
+    # Ensure the container name is less than 63 characters
+    container_name = f"staging-site-{normalized_branch[:50]}"
+    # Remove trailing hyphens
+    return container_name.rstrip("-")
 
 
 load_env()
@@ -109,8 +126,8 @@ if STAGING is not None:
     DB_NAME = "owid"
     DB_PASS = ""
     DB_PORT = 3306
-    DB_HOST = f"staging-site-{STAGING}"
-    DATA_API_ENV = f"staging-site-{STAGING}"
+    DB_HOST = get_container_name(STAGING)
+    DATA_API_ENV = get_container_name(STAGING)
 
 
 # if running against live, use s3://owid-api, otherwise use s3://owid-api-staging

--- a/tests/apps/wizard/utils/test_env.py
+++ b/tests/apps/wizard/utils/test_env.py
@@ -1,10 +1,4 @@
-from apps.wizard.utils.env import Config, OWIDEnv, get_container_name
-
-
-def test_get_container_name():
-    assert get_container_name("branch") == "staging-site-branch"
-    assert get_container_name("feature/x") == "staging-site-feature-x"
-    assert get_container_name("do_not-do/this") == "staging-site-do-not-do-this"
+from apps.wizard.utils.env import Config, OWIDEnv
 
 
 def test_OWIDEnv_staging():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,7 @@
+from etl.config import get_container_name
+
+
+def test_get_container_name():
+    assert get_container_name("branch") == "staging-site-branch"
+    assert get_container_name("feature/x") == "staging-site-feature-x"
+    assert get_container_name("do_not-do/this") == "staging-site-do-not-do-this"


### PR DESCRIPTION
Fix `STAGING=fix/wizard-3 etlr ...` and `STAGING=1` with branch names containing `/` and other unusual characters.