### PR TITLE
:hammer: set override=False when loading env

### DIFF
--- a/apps/utils/scan_chart_diff.py
+++ b/apps/utils/scan_chart_diff.py
@@ -27,8 +27,6 @@ def cli(dry_run: bool) -> None:
 
     log.info("scan-chart-diff.init", active_prs=active_prs)
 
-    # active_prs = [pr for pr in active_prs if "update-electricity-mix-data" in pr]
-
     for pr in active_prs:
         log.info("scan-chart-diff.start", pr=pr)
         args = [f"etl/{pr}", "--services", "chart-diff"]

--- a/etl/config.py
+++ b/etl/config.py
@@ -33,7 +33,7 @@ def load_env():
     if env.get("ENV", "").startswith("."):
         raise ValueError(f"ENV was replaced by ENV_FILE, please use ENV_FILE={env['ENV']} ... instead.")
 
-    load_dotenv(ENV_FILE, override=True)
+    load_dotenv(ENV_FILE)
 
 
 load_env()


### PR DESCRIPTION
Don't override system environment variables by those from `.env` file. We've [enabled it](https://github.com/owid/etl/pull/2272) some time ago for reasons no one remembers. It's unintuitive behaviour. Imagine I use `STAGING=mojmir` in my `.env` file and I run `STAGING=other etlr ...`. I'm expecting that the env variable in front of the command has higher priority, but it gets overwritten.

(I want to have `STAGING=1` in my `.env` and optionally set `STAGING=mojmir` to override it.)