### PR TITLE
Skip metagpt on etl cli, to avoid error

### DIFF
--- a/apps/cli/__init__.py
+++ b/apps/cli/__init__.py
@@ -174,7 +174,7 @@ GROUPS = (
             "commands": {
                 "metadata-export": "etl.metadata_export.cli",
                 "metadata-migrate": "apps.metadata_migrate.cli.cli",
-                "metadata-upgrade": "apps.metagpt.cli.main",
+                # "metadata-upgrade": "apps.metagpt.cli.main",
             },
         },
         {


### PR DESCRIPTION
This PR doesn't fix https://github.com/owid/etl/issues/2735
but for now it simply skips the load of metagpt, to be able to keep using `etl --help`.