### PR TITLE
🐛 Fix explorer-update cli, to avoid it from failing in odd cases

### DIFF
--- a/apps/explorer_update/cli.py
+++ b/apps/explorer_update/cli.py
@@ -171,6 +171,10 @@ def update_indicator_based_explorer(explorer: str) -> Optional[str]:
     # Fetch variable data for the latest steps from the database.
     variable_data_new = get_variables_data(filter={"catalogPath": updateable["catalogPath_new"].tolist()})
 
+    if len(variable_data_new) == 0:
+        log.error("Unexpected error. Manually inspect this explorer.")
+        return None
+
     # Select and rename columns.
     variable_data_new = variable_data_new.rename(
         columns={"id": "id_new", "catalogPath": "catalogPath_new", "name": "name_new"}, errors="raise"

--- a/apps/explorer_update/cli.py
+++ b/apps/explorer_update/cli.py
@@ -292,6 +292,18 @@ def cli(
     - If it is a file-based explorer, ensure URLs to data catalog point to the latest version of the data.
     - If it is an indicator-based explorer, ensure variable ids correspond to the latest versions of the variables.
 
+    By default, this tool reads the database of your local (or staging) grapher.
+    But normally, you want to update explorers with the information (e.g. variable ids) from the production database.
+
+    Hence, after merging code to create a new dataset in production, wait for ETL to create the dataset, and then run:
+    ```
+    ENV_FILE=.env.production etl explorer-update
+    ```
+    (or, instead of `.env.production`, use whatever you call your production environment file).
+
+    Then you can check that your `owid-content` explorer files may have been updated.
+    If so, create a pull request in `owid-content` with those changes.
+
     """
 
     if isinstance(explorers_dir, str):


### PR DESCRIPTION
`etl explorer-update` was failing for one of the explorers. I haven't looked into why that's happening, but in this PR I simply raised a log error when such a case occurs.
