### PR TITLE
:tada: save checksums for indicators in MySQL

### DIFF
--- a/apps/backport/datasync/data_metadata.py
+++ b/apps/backport/datasync/data_metadata.py
@@ -98,7 +98,7 @@ def add_entity_code_and_name(session: Session, df: pd.DataFrame) -> pd.DataFrame
         missing_entities = set(unique_entities) - set(entities.entityId)
         raise ValueError(f"Missing entities in the database: {missing_entities}")
 
-    return pd.merge(df, entities, on="entityId")
+    return pd.merge(df, entities.astype({"entityName": "category", "entityCode": "category"}), on="entityId")
 
 
 def variable_data(data_df: pd.DataFrame) -> Dict[str, Any]:

--- a/apps/backport/datasync/datasync.py
+++ b/apps/backport/datasync/datasync.py
@@ -18,8 +18,12 @@ config.enable_bugsnag()
 
 
 def upload_gzip_dict(d: Dict[str, Any], s3_path: str, private: bool = False) -> None:
+    return upload_gzip_string(json.dumps(d, default=str), s3_path=s3_path, private=private)
+
+
+def upload_gzip_string(s: str, s3_path: str, private: bool = False) -> None:
     """Upload compressed dictionary to S3 and return its URL."""
-    body_gzip = gzip.compress(json.dumps(d, default=str).encode())  # type: ignore
+    body_gzip = gzip.compress(s.encode())
 
     bucket, key = s3_utils.s3_bucket_key(s3_path)
 

--- a/etl/files.py
+++ b/etl/files.py
@@ -121,12 +121,13 @@ def checksum_file(filename: Union[str, Path]) -> str:
     return CACHE_CHECKSUM_FILE[key]
 
 
-def checksum_df(df: pd.DataFrame, index=True, method: Literal["md5", "pandas"] = "md5") -> str:
+def checksum_df(df: pd.DataFrame, index=True, method: Literal["md5", "pandas"] = "pandas") -> str:
     """Return the md5 hex digest of dataframe.
     :param method: 'md5' uses hashlib.md5, 'pandas' uses pandas hash_pandas_object. md5 is faster
         for most of our use cases. pandas might be faster for dataframes with >1M rows.
     """
     # NOTE: I tried joblib.hash, but it was much slower than pandas hash
+    # TODO: remove this method, it's not consistent
     if method == "md5":
         _hash = hashlib.md5()
         for col in df.columns:

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -317,22 +317,45 @@ def upsert_table(
         # process data and metadata
         var_data = variable_data(df)
         var_metadata = variable_metadata(session, db_variable_id, df)
+
+        var_data_str = json.dumps(var_data, default=str)
         var_metadata_str = json.dumps(var_metadata, default=str)
 
+        # t = time.time()
+        # files.checksum_dict(var_data)
+        # t_dict = time.time() - t
+
+        # t = time.time()
+        # _checksum_data(df)
+        # t_df = time.time() - t
+
+        # print(f"t_dict: {t_dict:.4f}, t_df: {t_df:.4f}")
+
         # get hashes for data and metadata
-        checksum_data = _checksum_data(df)
+        # checksum_data = _checksum_data(df)
+        checksum_data = _checksum_data(var_data_str)
         checksum_metadata = _checksum_metadata(var_metadata_str)
 
         # upload them to R2
         with ThreadPoolExecutor() as executor:
             futures = []
+
+            # if db_variable_id == 902183:
+            # log.info("checksums", db=db_variable.dataChecksum, computed=checksum_data)
+
             if db_variable.dataChecksum != checksum_data:
                 db_variable.dataChecksum = checksum_data
-                futures.append(executor.submit(upload_gzip_dict, var_data, db_variable.s3_data_path()))
+                futures.append(executor.submit(upload_gzip_string, var_data_str, db_variable.s3_data_path()))
+                log.info("upsert_table.uploaded_data", variable_id=db_variable_id)
+            else:
+                log.info("upsert_table.match_checksum_data")
 
             if db_variable.metadataChecksum != checksum_metadata:
                 db_variable.metadataChecksum = checksum_metadata
                 futures.append(executor.submit(upload_gzip_string, var_metadata_str, db_variable.s3_metadata_path()))
+                log.info("upsert_table.uploaded_metadata", variable_id=db_variable_id)
+            else:
+                log.info("upsert_table.match_checksum_metadata")
 
             # commit new checksums
             if futures:
@@ -342,6 +365,7 @@ def upsert_table(
                 # Wait for futures to complete in case exceptions are raised
                 [f.result() for f in futures]
 
+        verbose = True
         if verbose:
             if futures:
                 log.info("upsert_table.uploaded_to_s3", size=len(table), variable_id=db_variable_id)
@@ -516,10 +540,17 @@ def _get_entity_name(session: Session, entity_id: int) -> str:
     return entity.name if entity else ""
 
 
-def _checksum_data(df: pd.DataFrame) -> str:
+# def _checksum_data(df: pd.DataFrame) -> str:
+#     t = time.time()
+#     checksum_data = files.checksum_df(df[["year", "entityId", "value"]], index=False)
+#     log.info("upsert_table.checksum_data", time=round(time.time() - t, 4), n=len(df))
+#     return checksum_data
+
+
+def _checksum_data(var_data_str: str) -> str:
     t = time.time()
-    checksum_data = files.checksum_df(df[["year", "entityId", "value"]], index=False)
-    log.info("upsert_table.checksum_data", time=round(time.time() - t, 4), n=len(df))
+    checksum_data = files.checksum_str(var_data_str)
+    log.info("upsert_table.checksum_data", time=round(time.time() - t, 4))
     return checksum_data
 
 

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -10,7 +10,10 @@ Usage:
 """
 
 import datetime
+import json
 import os
+import re
+import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from threading import Lock
@@ -29,10 +32,11 @@ from apps.backport.datasync.data_metadata import (
     variable_data,
     variable_metadata,
 )
-from apps.backport.datasync.datasync import upload_gzip_dict
+from apps.backport.datasync.datasync import upload_gzip_dict, upload_gzip_string
 from etl import config
 from etl.db import get_engine
 
+from . import files
 from . import grapher_helpers as gh
 from . import grapher_model as gm
 
@@ -260,6 +264,9 @@ def upsert_table(
                 max_year = max(years)
                 timespan = f"{min_year}-{max_year}"
 
+        # sort table to get deterministic checksum later on
+        table = table.sort_index()
+
         table.reset_index(inplace=True)
 
         source_id = _add_or_update_source(session, variable_meta, column_name, dataset_upsert_result)
@@ -310,18 +317,36 @@ def upsert_table(
         # process data and metadata
         var_data = variable_data(df)
         var_metadata = variable_metadata(session, db_variable_id, df)
+        var_metadata_str = json.dumps(var_metadata, default=str)
+
+        # get hashes for data and metadata
+        checksum_data = _checksum_data(df)
+        checksum_metadata = _checksum_metadata(var_metadata_str)
 
         # upload them to R2
         with ThreadPoolExecutor() as executor:
-            futures = [
-                executor.submit(upload_gzip_dict, var_data, db_variable.s3_data_path()),
-                executor.submit(upload_gzip_dict, var_metadata, db_variable.s3_metadata_path()),
-            ]
-            # Wait for futures to complete in case exceptions are raised
-            [f.result() for f in futures]
+            futures = []
+            if db_variable.dataChecksum != checksum_data:
+                db_variable.dataChecksum = checksum_data
+                futures.append(executor.submit(upload_gzip_dict, var_data, db_variable.s3_data_path()))
+
+            if db_variable.metadataChecksum != checksum_metadata:
+                db_variable.metadataChecksum = checksum_metadata
+                futures.append(executor.submit(upload_gzip_string, var_metadata_str, db_variable.s3_metadata_path()))
+
+            # commit new checksums
+            if futures:
+                session.add(db_variable)
+                session.commit()
+
+                # Wait for futures to complete in case exceptions are raised
+                [f.result() for f in futures]
 
         if verbose:
-            log.info("upsert_table.uploaded_to_s3", size=len(table), variable_id=db_variable_id)
+            if futures:
+                log.info("upsert_table.uploaded_to_s3", size=len(table), variable_id=db_variable_id)
+            else:
+                log.info("upsert_table.skipped_upload_to_s3", size=len(table), variable_id=db_variable_id)
 
         return VariableUpsertResult(db_variable_id, source_id)  # type: ignore
 
@@ -489,3 +514,20 @@ def _get_entity_name(session: Session, entity_id: int) -> str:
     q = select(gm.Entity).where(gm.Entity.id == entity_id)
     entity = session.scalars(q).one_or_none()
     return entity.name if entity else ""
+
+
+def _checksum_data(df: pd.DataFrame) -> str:
+    t = time.time()
+    checksum_data = files.checksum_df(df[["year", "entityId", "value"]], index=False)
+    log.info("upsert_table.checksum_data", time=round(time.time() - t, 4), n=len(df))
+    return checksum_data
+
+
+def _checksum_metadata(var_metadata_str: str) -> str:
+    t = time.time()
+    # ignore updatedAt and checksums
+    checksum_metadata = files.checksum_str(
+        re.sub(r'("updatedAt"|"dataChecksum"|"metadataChecksum"): "[^"]*"', r'\1: ""', var_metadata_str)
+    )
+    log.info("upsert_table.checksum_metadata", time=round(time.time() - t, 4))
+    return checksum_metadata

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -939,6 +939,8 @@ class Variable(Base):
         Index("variables_datasetId_50a98bfd_fk_datasets_id", "datasetId"),
         Index("variables_name_fk_dst_id_f7453c33_uniq", "name", "datasetId", unique=True),
         Index("variables_sourceId_31fce80a_fk_sources_id", "sourceId"),
+        Index("idx_dataChecksum", "dataChecksum", unique=True),
+        Index("idx_metadataChecksum", "metadataChecksum", unique=True),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
@@ -978,6 +980,8 @@ class Variable(Base):
     grapherConfigETL: Mapped[Optional[dict]] = mapped_column(JSON, default=None)
     type: Mapped[Optional[VARIABLE_TYPE]] = mapped_column(ENUM(*get_args(VARIABLE_TYPE)), default=None)
     sort: Mapped[Optional[list[str]]] = mapped_column(JSON, default=None)
+    dataChecksum: Mapped[Optional[str]] = mapped_column(VARCHAR(64), default=None)
+    metadataChecksum: Mapped[Optional[str]] = mapped_column(VARCHAR(64), default=None)
 
     def upsert(self, session: Session) -> "Variable":
         assert self.shortName

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -939,8 +939,6 @@ class Variable(Base):
         Index("variables_datasetId_50a98bfd_fk_datasets_id", "datasetId"),
         Index("variables_name_fk_dst_id_f7453c33_uniq", "name", "datasetId", unique=True),
         Index("variables_sourceId_31fce80a_fk_sources_id", "sourceId"),
-        Index("idx_dataChecksum", "dataChecksum", unique=True),
-        Index("idx_metadataChecksum", "metadataChecksum", unique=True),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,3 +1,5 @@
+import pandas as pd
+
 from etl import files
 
 
@@ -67,3 +69,10 @@ def test_checksum_file_regions(tmp_path):
     checksum2 = files.checksum_file(tmp_path / "regions.yml")
 
     assert checksum1 == checksum2
+
+
+# def test_checksum_df():
+#     # df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "x", "y"]})
+#     df = pd.DataFrame({"b": ["x", "x", "y"]})
+#     print(df["b"].values)
+#     assert files.checksum_df(df) == "c4c885df809ecb46f4fa73d8b58a7b48"

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 
 from etl import files
@@ -71,8 +72,15 @@ def test_checksum_file_regions(tmp_path):
     assert checksum1 == checksum2
 
 
-# def test_checksum_df():
-#     # df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "x", "y"]})
-#     df = pd.DataFrame({"b": ["x", "x", "y"]})
-#     print(df["b"].values)
-#     assert files.checksum_df(df) == "c4c885df809ecb46f4fa73d8b58a7b48"
+def test_checksum_dict():
+    d = {
+        "a": 1,
+        "b": "x",
+        "c": [1, 2, 3, np.nan],
+    }
+    assert files.checksum_dict(d) == "f5ec37a48fc5bdbe085608c8689b696f"
+
+
+def test_checksum_df():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "x", "y"]})
+    assert files.checksum_df(df) == "34c7a3a435e4a0703b37904f09f967f1"


### PR DESCRIPTION
PR with MySQL migration https://github.com/owid/owid-grapher/pull/3690

Right before uploading data & metadata to R2 as JSON files, calculate checksums for data and metadata. If checksums are matching ones in MySQL, it means that the data is identical and there's no need to upload the same files.

Checksums will be added as we refresh datasets. We could also bump `ETL_EPOCH` and populate all datasets, but perhaps only after making sure this concept works.

For metadata, we exclude fields `updatedAt`, `dataChecksum`, `metadataChecksum` (otherwise we'd always get a different checksum).

## Performance

Tested on two staging servers with command
```
time poetry run etlr grapher://grapher/ihme_gbd/2024-05-20/impairments --force --private --grapher --only
```

Calculating checksums doesn't take much time (I ran a few benchmarks and it turned out that computing checksum from JSON we're about to upload to R2 is the fastest. Still, it's a fraction of the entire process). If checksums match and we don't reupload files, it can speed up grapher:// step by ~50% (this could be even more pronounced if you have poor internet connection).

## Links
My previous attempt for improving grapher upsert performance could be relevant. https://github.com/owid/etl/pull/1564