### PR TITLE
🎉 Ensure steps affecting `external` channel are not archivable

### DIFF
--- a/apps/step_update/cli.py
+++ b/apps/step_update/cli.py
@@ -1,7 +1,6 @@
 import difflib
 import sys
 from datetime import datetime
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -19,90 +18,12 @@ from etl.helpers import (
 from etl.paths import BASE_DIR, DAG_ARCHIVE_FILE, DAG_DIR, DAG_TEMP_FILE, SNAPSHOTS_DIR, STEP_DIR
 from etl.snapshot import SnapshotMeta
 from etl.steps import to_dependency_order
-from etl.version_tracker import DAG_TEMP_STEP, VersionTracker
+from etl.version_tracker import DAG_TEMP_STEP, UpdateState, VersionTracker
 
 log = structlog.get_logger()
 
 # If a new version is not specified, assume current date.
 STEP_VERSION_NEW = datetime.now().strftime("%Y-%m-%d")
-
-
-# Define labels for update states.
-class UpdateState(Enum):
-    UNKNOWN = "Unknown"
-    UP_TO_DATE = "No updates known"
-    OUTDATED = "Outdated"
-    MINOR_UPDATE = "Minor update possible"
-    MAJOR_UPDATE = "Major update possible"
-    ARCHIVABLE = "Archivable"
-
-
-# List of identifiers of steps that should be considered as non-updateable.
-# NOTE: The identifier is the step name without the version (and without the "data://").
-NON_UPDATEABLE_IDENTIFIERS = [
-    # All population-related datasets.
-    "garden/demography/population",
-    "garden/gapminder/population",
-    "garden/hyde/baseline",
-    "garden/un/un_wpp",
-    "meadow/gapminder/population",
-    "meadow/hyde/baseline",
-    "meadow/hyde/general_files",
-    "meadow/un/un_wpp",
-    "open_numbers/open_numbers/gapminder__systema_globalis",
-    "open-numbers/ddf--gapminder--systema_globalis",
-    "snapshot/hyde/general_files.zip",
-    "snapshot/hyde/baseline.zip",
-    "snapshot/gapminder/population.xlsx",
-    "snapshot/un/un_wpp.zip",
-    # Regions dataset.
-    "garden/regions/regions",
-    # Old WB income groups.
-    "garden/wb/wb_income",
-    "meadow/wb/wb_income",
-    "walden/wb/wb_income",
-    # New WB income groups.
-    "garden/wb/income_groups",
-    "meadow/wb/income_groups",
-    "snapshot/wb/income_groups.xlsx",
-    # World Bank country shapes.
-    "snapshot/countries/world_bank.zip",
-    # World Bank WDI.
-    "snapshot/worldbank_wdi/wdi.zip",
-    "meadow/worldbank_wdi/wdi",
-    "garden/worldbank_wdi/wdi",
-    # Other steps we don't want to update (because the underlying data does not get updated).
-    # TODO: We need a better way to achieve this, for example adding update_period_days to all steps and snapshots.
-    #  A simpler alternative would be to move these steps to a separate file in a meaningful place.
-    #  Another option is to have "playlists", e.g. "climate_change_explorer" with the identifiers of steps to update.
-    "meadow/epa/ocean_heat_content",
-    "snapshot/epa/ocean_heat_content_annual_world_700m.csv",
-    "snapshot/epa/ocean_heat_content_annual_world_2000m.csv",
-    "garden/epa/ocean_heat_content",
-    "meadow/epa/ocean_heat_content",
-    "meadow/epa/ice_sheet_mass_balance",
-    "snapshot/epa/ice_sheet_mass_balance.csv",
-    "garden/epa/ice_sheet_mass_balance",
-    "meadow/epa/ice_sheet_mass_balance",
-    "meadow/epa/ghg_concentration",
-    "snapshot/epa/co2_concentration.csv",
-    "snapshot/epa/ch4_concentration.csv",
-    "snapshot/epa/n2o_concentration.csv",
-    "garden/epa/ghg_concentration",
-    "meadow/epa/ghg_concentration",
-    "meadow/epa/mass_balance_us_glaciers",
-    "snapshot/epa/mass_balance_us_glaciers.csv",
-    "garden/epa/mass_balance_us_glaciers",
-    "meadow/epa/mass_balance_us_glaciers",
-    "meadow/climate/antarctic_ice_core_co2_concentration",
-    "snapshot/climate/antarctic_ice_core_co2_concentration.xls",
-    "garden/climate/antarctic_ice_core_co2_concentration",
-    "meadow/climate/antarctic_ice_core_co2_concentration",
-    "meadow/climate/global_sea_level",
-    "snapshot/climate/global_sea_level.csv",
-    "garden/climate/global_sea_level",
-    "meadow/climate/global_sea_level",
-]
 
 
 class StepUpdater:

--- a/apps/wizard/app_pages/dashboard.py
+++ b/apps/wizard/app_pages/dashboard.py
@@ -405,6 +405,8 @@ function(params){{
         return {{'color': 'black', 'backgroundColor': 'orange'}}
     }} else if (params.value === "{UpdateState.ARCHIVABLE.value}") {{
         return {{'color': 'black', 'backgroundColor': 'blue'}}
+    }} else if (params.value === "{UpdateState.UNUSED.value}") {{
+        return {{'color': 'black', 'backgroundColor': 'lightblue'}}
     }} else {{
         return {{'color': 'black', 'backgroundColor': 'yellow'}}
     }}

--- a/apps/wizard/app_pages/dashboard.py
+++ b/apps/wizard/app_pages/dashboard.py
@@ -10,7 +10,7 @@ from st_aggrid import AgGrid, GridUpdateMode, JsCode
 from st_aggrid.grid_options_builder import GridOptionsBuilder
 from structlog import get_logger
 
-from apps.step_update.cli import NON_UPDATEABLE_IDENTIFIERS, StepUpdater, UpdateState
+from apps.step_update.cli import StepUpdater, UpdateState
 from etl.config import ADMIN_HOST, ENV
 from etl.db import can_connect
 
@@ -30,6 +30,73 @@ st.set_page_config(
 # Current date.
 # This is used as the default version of new steps to be created.
 TODAY = datetime.now().strftime("%Y-%m-%d")
+
+# List of identifiers of steps that should be considered as non-updateable.
+# NOTE: The identifier is the step name without the version (and without the "data://").
+NON_UPDATEABLE_IDENTIFIERS = [
+    # All population-related datasets.
+    "garden/demography/population",
+    "garden/gapminder/population",
+    "garden/hyde/baseline",
+    "garden/un/un_wpp",
+    "meadow/gapminder/population",
+    "meadow/hyde/baseline",
+    "meadow/hyde/general_files",
+    "meadow/un/un_wpp",
+    "open_numbers/open_numbers/gapminder__systema_globalis",
+    "open-numbers/ddf--gapminder--systema_globalis",
+    "snapshot/hyde/general_files.zip",
+    "snapshot/hyde/baseline.zip",
+    "snapshot/gapminder/population.xlsx",
+    "snapshot/un/un_wpp.zip",
+    # Regions dataset.
+    "garden/regions/regions",
+    # Old WB income groups.
+    "garden/wb/wb_income",
+    "meadow/wb/wb_income",
+    "walden/wb/wb_income",
+    # New WB income groups.
+    "garden/wb/income_groups",
+    "meadow/wb/income_groups",
+    "snapshot/wb/income_groups.xlsx",
+    # World Bank country shapes.
+    "snapshot/countries/world_bank.zip",
+    # World Bank WDI.
+    "snapshot/worldbank_wdi/wdi.zip",
+    "meadow/worldbank_wdi/wdi",
+    "garden/worldbank_wdi/wdi",
+    # Other steps we don't want to update (because the underlying data does not get updated).
+    # TODO: We need a better way to achieve this, for example adding update_period_days to all steps and snapshots.
+    #  A simpler alternative would be to move these steps to a separate file in a meaningful place.
+    #  Another option is to have "playlists", e.g. "climate_change_explorer" with the identifiers of steps to update.
+    "meadow/epa/ocean_heat_content",
+    "snapshot/epa/ocean_heat_content_annual_world_700m.csv",
+    "snapshot/epa/ocean_heat_content_annual_world_2000m.csv",
+    "garden/epa/ocean_heat_content",
+    "meadow/epa/ocean_heat_content",
+    "meadow/epa/ice_sheet_mass_balance",
+    "snapshot/epa/ice_sheet_mass_balance.csv",
+    "garden/epa/ice_sheet_mass_balance",
+    "meadow/epa/ice_sheet_mass_balance",
+    "meadow/epa/ghg_concentration",
+    "snapshot/epa/co2_concentration.csv",
+    "snapshot/epa/ch4_concentration.csv",
+    "snapshot/epa/n2o_concentration.csv",
+    "garden/epa/ghg_concentration",
+    "meadow/epa/ghg_concentration",
+    "meadow/epa/mass_balance_us_glaciers",
+    "snapshot/epa/mass_balance_us_glaciers.csv",
+    "garden/epa/mass_balance_us_glaciers",
+    "meadow/epa/mass_balance_us_glaciers",
+    "meadow/climate/antarctic_ice_core_co2_concentration",
+    "snapshot/climate/antarctic_ice_core_co2_concentration.xls",
+    "garden/climate/antarctic_ice_core_co2_concentration",
+    "meadow/climate/antarctic_ice_core_co2_concentration",
+    "meadow/climate/global_sea_level",
+    "snapshot/climate/global_sea_level.csv",
+    "garden/climate/global_sea_level",
+    "meadow/climate/global_sea_level",
+]
 
 # Define the base URL for the grapher datasets (which will be different depending on the environment).
 GRAPHER_DATASET_BASE_URL = f"{ADMIN_HOST}/admin/datasets/"

--- a/tests/test_version_tracker.py
+++ b/tests/test_version_tracker.py
@@ -107,42 +107,6 @@ def test_version_tracker_raise_error_if_active_step_depends_on_missing_step(mock
     assert "Missing" in mock_log.error.call_args[0][0]
 
 
-@patch("etl.version_tracker.log")
-def test_version_tracker_raise_warning_if_active_steps_can_safely_be_archived(mock_log):
-    mock_dag = {
-        "steps": {
-            # The following step is an old version of a that depends on old versions of b and c.
-            "data://garden/institution_1/2024-01-01/dataset_a": set(
-                ["data://garden/institution_1/2024-01-01/dataset_b", "data://garden/institution_1/2024-01-01/dataset_c"]
-            ),
-            # The following step is the latest version of a that depends on the latest version of b but an old version of c.
-            "data://garden/institution_1/2024-01-02/dataset_a": set(
-                ["data://garden/institution_1/2024-01-02/dataset_b", "data://garden/institution_1/2024-01-01/dataset_c"]
-            ),
-            # Old version of b.
-            "data://garden/institution_1/2024-01-01/dataset_b": set(),
-            # Latest version of b.
-            "data://garden/institution_1/2024-01-02/dataset_b": set(),
-            # Old version of c.
-            "data://garden/institution_1/2024-01-01/dataset_c": set(),
-            # Latest version of c.
-            "data://garden/institution_1/2024-01-02/dataset_c": set(),
-        },
-        "archive": {},
-    }
-    versions = create_mock_version_tracker(dag=mock_dag, step_prefix="")
-    versions.check_that_all_active_steps_are_necessary()
-    mock_log.warning.assert_called()
-    # Check that archivable steps appear in the warning.
-    assert "data://garden/institution_1/2024-01-01/dataset_a" in mock_log.warning.call_args[0][0]
-    assert "data://garden/institution_1/2024-01-01/dataset_b" in mock_log.warning.call_args[0][0]
-    # Check that non-archivable steps do not appear in the warning.
-    assert "data://garden/institution_1/2024-01-02/dataset_a" not in mock_log.warning.call_args[0][0]
-    assert "data://garden/institution_1/2024-01-02/dataset_b" not in mock_log.warning.call_args[0][0]
-    assert "data://garden/institution_1/2024-01-01/dataset_c" not in mock_log.warning.call_args[0][0]
-    assert "data://garden/institution_1/2024-01-02/dataset_c" not in mock_log.warning.call_args[0][0]
-
-
 def test_version_tracker_get_all_step_versions():
     mock_dag = {
         "steps": {


### PR DESCRIPTION
* Ensure that steps that affect any step in the `external` channel are not archivable.
* Move the logic of the update status of steps from StepUpdater to VersionTracker, and ensure the archiving logic of StepUpdater and VersionTracker are aligned.
* Include the update statuses "Archived" (for steps that have already been archived) and "Not yet used" (for steps that may be in their latest version, but not used in any charts or by any external channel).
* Move a few things around for consistency, and fix broken test.

NOTE: This will make VersionTracker a bit slower, but hopefully not too much. If so, we can figure out ways to speed some things up.
