### PR TITLE
:tada: show chart diffs with changed checksums

### DIFF
--- a/apps/chart_sync/cli.py
+++ b/apps/chart_sync/cli.py
@@ -153,7 +153,7 @@ def cli(
             if chart_id:
                 chart_ids = {chart_id}
             else:
-                chart_ids = _modified_chart_ids_by_admin(source_session)
+                chart_ids = modified_chart_ids(source_session, target_session)
 
             log.info("chart_sync.start", n=len(chart_ids), chart_ids=chart_ids)
 
@@ -488,30 +488,59 @@ def _chart_config_diff(
     )
 
 
-def _modified_chart_ids_by_admin(session: Session) -> Set[int]:
-    """Get charts created by Admin user with ID = 1 on a staging server. These charts have been
-    modified on the staging server and are candidates for syncing back to production."""
-    q = """
-    -- modified charts
+def modified_chart_ids(source_session: Session, target_session: Session) -> Set[int]:
+    """Get charts that have been modified in staging. It includes chart with different
+    config, data or metadata checksums. It assumes that all changes on staging server are
+    done by Admin user with ID = 1."""
+    # TODO: we could aggregate it by charts and get a combined checksum, for now we want
+    #   a view with variable granularity
+    # get modified charts and charts from modified datasets
+    base_q = """
     select
-        id as chartId
-    from charts
-    where (publishedByUserId = 1 or lastEditedByUserId = 1)
-
-    union
-
-    -- charts revisions that were approved on staging, such charts would have publishedByUserId
-    -- of the user that ran etlwiz locally, but would be updated by Admin
-    -- the chart must be published
-    select
-        chartId
-    from suggested_chart_revisions
-    where updatedBy = 1 and status = 'approved' and chartId in (
-        select id from charts
-    )
+        v.id as variableId,
+        cd.chartId,
+        v.dataChecksum,
+        v.metadataChecksum,
+        MD5(c.config) as chartChecksum
+    from chart_dimensions as cd
+    join charts as c on cd.chartId = c.id
+    join variables as v on cd.variableId = v.id
+    join datasets as d on v.datasetId = d.id
+    where
     """
+    # NOTE: We assume that all changes on staging server are done by Admin user with ID = 1. This is
+    #   set automatically if you use STAGING env variable.
+    where = """
+        -- only compare datasets or charts that have been updated on staging server
+        -- by Admin user
+        (c.lastEditedByUserId = 1 or c.publishedByUserId = 1)
+        or
+        -- include all charts from datasets that have been updated
+        (d.dataEditedByUserId = 1 or d.metadataEditedByUserId = 1)
+    """
+    source_df = read_sql(base_q + where, source_session)
 
-    return set(read_sql(q, session.bind).chartId.tolist())  # type: ignore
+    # read those charts from target
+    where = """
+        c.id in %(chart_ids)s
+    """
+    target_df = read_sql(base_q + where, target_session, params={"chart_ids": tuple(source_df.chartId.unique())})
+
+    source_df = source_df.set_index(["chartId", "variableId"])
+    target_df = target_df.set_index(["chartId", "variableId"])
+
+    # align dataframes with left join (so that source has non-null values)
+    # NOTE: new charts will be already in source
+    source_df, target_df = source_df.align(target_df, join="left")
+
+    # get charts / variables with differing checksums
+    cols = ["dataChecksum", "metadataChecksum", "chartChecksum"]
+    ix = (source_df[cols] != target_df[cols]).any(axis=1)
+
+    source_df = source_df[ix]
+    target_df = target_df[ix]
+
+    return set(source_df.index.get_level_values("chartId").unique())
 
 
 def _get_git_branch_creation_date(branch_name: str) -> dt.datetime:

--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 # from st_copy_to_clipboard import st_copy_to_clipboard
 from structlog import get_logger
 
-from apps.chart_sync.cli import _modified_chart_ids_by_admin
+from apps.chart_sync.cli import modified_chart_ids
 from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiff
 from apps.wizard.app_pages.chart_diff.show import st_show
 from apps.wizard.app_pages.chart_diff.utils import WARN_MSG, get_engines
@@ -81,7 +81,8 @@ def get_chart_diffs_from_grapher(max_workers: int = 10) -> dict[int, ChartDiff]:
     """
     # Get IDs from modified charts
     with Session(SOURCE_ENGINE) as source_session:
-        chart_ids = _modified_chart_ids_by_admin(source_session)
+        with Session(TARGET_ENGINE) as target_session:
+            chart_ids = modified_chart_ids(source_session, target_session)
 
     # Get all chart diffs in parallel
     with ThreadPoolExecutor(max_workers=max_workers) as executor:

--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -15,6 +15,7 @@ from apps.wizard.app_pages.chart_diff.show import st_show
 from apps.wizard.app_pages.chart_diff.utils import WARN_MSG, get_engines
 from apps.wizard.utils import Pagination, set_states
 from apps.wizard.utils.env import OWID_ENV
+from etl import config
 
 log = get_logger()
 
@@ -47,8 +48,16 @@ st.session_state.arrange_charts_vertically = st.session_state.get("arrange_chart
 # LOAD VARIABLES
 ########################################
 CHART_PER_PAGE = 10
-WARN_MSG += ["This tool is being developed! Please report any issues you encounter in `#proj-new-data-workflow`"]
-# st.warning("- " + "\n\n- ".join(warn_msg))
+# WARN_MSG += ["This tool is being developed! Please report any issues you encounter in `#proj-new-data-workflow`"]
+
+if str(config.GRAPHER_USER_ID) != "1":
+    WARN_MSG.append(
+        "`GRAPHER_USER_ID` from your .env is not set to 1 (Admin user). Please modify your .env or use STAGING=1 flag to set it automatically. "
+        "All changes on staging servers must be done with Admin user."
+    )
+
+if WARN_MSG:
+    st.warning("- " + "\n\n- ".join(WARN_MSG))
 
 
 ########################################

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -1,6 +1,7 @@
 import datetime as dt
-from typing import List, Optional, cast
+from typing import List, Optional
 
+import pandas as pd
 import streamlit as st
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session
@@ -15,9 +16,16 @@ class ChartDiff:
     target_chart: Optional[gm.Chart]
     # Three state: 'approved', 'pending', 'rejected'
     approval_status: gm.CHART_DIFF_STATUS | str
+    # DataFrame for all variables with columns dataChecksum and metadataChecksum
+    # If True, then the checksum has changed
+    modified_checksum: Optional[pd.DataFrame]
 
     def __init__(
-        self, source_chart: gm.Chart, target_chart: Optional[gm.Chart], approval_status: gm.CHART_DIFF_STATUS | str
+        self,
+        source_chart: gm.Chart,
+        target_chart: Optional[gm.Chart],
+        approval_status: gm.CHART_DIFF_STATUS | str,
+        modified_checksum: Optional[pd.DataFrame] = None,
     ):
         self.source_chart = source_chart
         self.target_chart = target_chart
@@ -26,6 +34,7 @@ class ChartDiff:
             assert source_chart.id == target_chart.id, "Missmatch in chart ids between Target and Source!"
         self.chart_id = source_chart.id
         self._in_conflict = None
+        self.modified_checksum = modified_checksum
 
     @property
     def is_reviewed(self) -> bool:
@@ -78,7 +87,7 @@ class ChartDiff:
         """
         if self.target_chart:
             assert self.source_chart.config["slug"] == self.target_chart.config["slug"], "Slug mismatch!"
-        return cast(str, self.source_chart.config["slug"])
+        return self.source_chart.config.get("slug", "no-slug")
 
     @property
     def in_conflict(self) -> bool:
@@ -124,12 +133,36 @@ class ChartDiff:
             source_chart.updatedAt,
             target_chart.updatedAt if target_chart else None,
         )
-        print("called DB for state, got:", approval_status)
+
+        # Load checksums for underlying indicators
+        # TODO: is this fast enough for large datasets? maybe we should avoid dataframes at all
+        if target_chart and target_session is not None:
+            source_df = source_chart.load_variables_checksums(source_session)
+            target_df = target_chart.load_variables_checksums(target_session)
+            source_df, target_df = source_df.align(target_df)
+            modified_checksum = source_df != target_df
+        else:
+            modified_checksum = None
 
         # Build object
-        chart_diff = cls(source_chart, target_chart, approval_status)
+        chart_diff = cls(source_chart, target_chart, approval_status, modified_checksum)
 
         return chart_diff
+
+    def checksum_changes(self) -> list[str]:
+        """Return list of chart changes."""
+        if self.is_new:
+            return []
+
+        changes = []
+        if self.modified_checksum is not None:
+            if self.modified_checksum["dataChecksum"].any():
+                changes.append("DATA CHANGE")
+            if self.modified_checksum["metadataChecksum"].any():
+                changes.append("METADATA CHANGE")
+        if self.target_chart and not self.configs_are_equal():
+            changes.append("CONFIG CHANGE")
+        return changes
 
     def get_all_approvals(self, session: Session) -> List[gm.ChartDiffApprovals]:
         """Get history of chart diff."""

--- a/apps/wizard/app_pages/chart_diff/show.py
+++ b/apps/wizard/app_pages/chart_diff/show.py
@@ -71,6 +71,8 @@ class ChartDiffShow:
             tags.append(" :blue-background[**NEW**]")
         if self.diff.is_draft:
             tags.append(" :gray-background[**DRAFT**]")
+        for change in self.diff.checksum_changes():
+            tags.append(f":red-background[**{change}**]")
         label += f":break[{' '.join(tags)}]"
         return label
 

--- a/apps/wizard/utils/__init__.py
+++ b/apps/wizard/utils/__init__.py
@@ -683,20 +683,22 @@ class Pagination:
 
         with st.container(border=True):
             with col1:
+                key = f"previous-{self.pagination_key}"
                 if self.page > 1:
-                    if st.button("⏮️ Previous"):
+                    if st.button("⏮️ Previous", key=key):
                         self.page -= 1
                         st.rerun()
                 else:
-                    st.button("⏮️ Previous", disabled=True)
+                    st.button("⏮️ Previous", disabled=True, key=key)
 
             with col3:
+                key = f"next-{self.pagination_key}"
                 if self.page < self.total_pages:
-                    if st.button("Next ⏭️"):
+                    if st.button("Next ⏭️", key=key):
                         self.page += 1
                         st.rerun()
                 else:
-                    st.button("Next ⏭️", disabled=True)
+                    st.button("Next ⏭️", disabled=True, key=key)
 
             with col2:
                 st.text(f"Page {self.page} of {self.total_pages}")

--- a/etl/config.py
+++ b/etl/config.py
@@ -122,6 +122,7 @@ STAGING = load_STAGING()
 
 # if STAGING is used, override ENV values
 if STAGING is not None:
+    GRAPHER_USER_ID = 1  # use Admin user when working with staging
     DB_USER = "owid"
     DB_NAME = "owid"
     DB_PASS = ""

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -301,6 +301,19 @@ class Chart(Base):
 
         return variables
 
+    def load_variables_checksums(self, session: Session) -> pd.DataFrame:
+        """Load checksums for all variables from the chart and return them as a list of dicts."""
+        q = """
+        select
+            v.id as variableId,
+            v.dataChecksum,
+            v.metadataChecksum
+        from chart_dimensions as cd
+        join variables as v on v.id = cd.variableId
+        where cd.chartId = %(chart_id)s
+        """
+        return read_sql(q, session, params={"chart_id": self.id}).set_index("variableId")
+
     def migrate_to_db(self, source_session: Session, target_session: Session) -> "Chart":
         """Remap variable ids from source to target session. Variable in source is uniquely identified
         by its catalogPath if available, or by name and datasetId otherwise. It is looked up

--- a/etl/steps/data/garden/biodiversity/2024-01-25/cherry_blossom.meta.yml
+++ b/etl/steps/data/garden/biodiversity/2024-01-25/cherry_blossom.meta.yml
@@ -1,5 +1,5 @@
 dataset:
-  update_period_days: 365
+  update_period_days: 368
 tables:
   cherry_blossom:
     variables:

--- a/etl/steps/data/garden/biodiversity/2024-01-25/cherry_blossom.meta.yml
+++ b/etl/steps/data/garden/biodiversity/2024-01-25/cherry_blossom.meta.yml
@@ -1,5 +1,5 @@
 dataset:
-  update_period_days: 368
+  update_period_days: 365
 tables:
   cherry_blossom:
     variables:

--- a/etl/steps/data/grapher/biodiversity/2024-01-25/cherry_blossom.py
+++ b/etl/steps/data/grapher/biodiversity/2024-01-25/cherry_blossom.py
@@ -16,7 +16,6 @@ def run(dest_dir: str) -> None:
 
     # Read table from garden dataset.
     tb = ds_garden["cherry_blossom"]
-
     #
     # Save outputs.
     #

--- a/etl/steps/data/grapher/biodiversity/2024-01-25/cherry_blossom.py
+++ b/etl/steps/data/grapher/biodiversity/2024-01-25/cherry_blossom.py
@@ -16,6 +16,10 @@ def run(dest_dir: str) -> None:
 
     # Read table from garden dataset.
     tb = ds_garden["cherry_blossom"]
+
+    # TODO: remove me
+    tb["average_20_years"] += 5
+
     #
     # Save outputs.
     #


### PR DESCRIPTION
## Motivation

Chart-diff currently only shows charts with changed config (due to updating variable ids by indicator upgrader). We'd like to have an option to show all charts with changes - either coming from change to the underlying data or metadata.

## Summary

Use data and metadata checksums to optionally show chart differences, in addition to just changed chart configurations. This information is displayed as tags next to a chart slug. Currently, only charts with changed configurations are shown by default, and approving them is enough for owidbot to give you a ✅. However, if desired, you can enable the option to show data and metadata changes in the filters.

The new function `modified_charts_by_admin` assumes that all charts or datasets were created by an Admin user with ID=1. This is a temporary solution until we determine how to display the real name of the creator.

I think we should carefully test this before making it the default. I am concerned that updating datasets, such as regions or population, would trigger a review for almost all charts.

<img width="339" alt="image" src="https://github.com/owid/etl/assets/1550888/bb464189-3e8e-4430-9e7a-8e4acf83776a">

<img width="385" alt="image" src="https://github.com/owid/etl/assets/1550888/52d677ce-2670-4987-b9df-ba478063f366">

## How to test it

Go to chart-diff on the staging server and select "metadata" in filters. You should see a cherry blossom chart with updated metadata.

@lucasrodes I noticed that warnings have been turned off. Is that expected? I want to show a warning if `GRAPHER_USER_ID` isn't Admin.

## TODO before merging:
- [x] undo modifications to cherry blossom