### PR TITLE
✨ catalog: add ds.tables to get list with all tables

### DIFF
--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -22,6 +22,7 @@ from . import tables, utils
 from .meta import SOURCE_EXISTS_OPTIONS, DatasetMeta, TableMeta
 from .processing_log import disable_processing_log
 from .properties import metadata_property
+from .tables import Table
 
 FileFormat = Literal["csv", "feather", "parquet"]
 
@@ -185,6 +186,18 @@ class Dataset:
                 table = self[table_name]
             table.metadata.dataset = self.metadata
             table._save_metadata(join(self.path, table.metadata.checked_name + ".meta.json"))
+
+    @property
+    def tables(self) -> list[Table]:
+        """Get all dataset tables.
+
+        TODO: should probably store as class attribute. I'm just afraid that tables could be huge?
+        """
+        tables = []
+        for table_name in self.table_names:
+            with disable_processing_log():
+                tables.append(self[table_name])
+        return tables
 
     def update_metadata(
         self,


### PR DESCRIPTION
When working with a dataset with multiple tables, we sometimes need to load all of them. This is specially true for Grapher steps when we just want to push propagate _all_ tables coming from garden to Grapher.

The idea would be that, instead of doing:

```py
# Load dataset
ds_garden = paths.load_dataset("leading_causes_deaths")

# Read all tables
all_tb = [ds_garden[tb_name for tb_name in ds_garden.table_names]

# Create a new grapher dataset with the same metadata as the garden dataset.
ds_grapher = create_dataset(
    dest_dir,
    tables=all_tb,
    check_variables_metadata=True,
    default_metadata=ds_garden.metadata,
)
```

one can simply write

```py
# Load dataset
ds_garden = paths.load_dataset("leading_causes_deaths")

# Create a new grapher dataset with the same metadata as the garden dataset.
ds_grapher = create_dataset(
    dest_dir,
    tables=ds_garden.tables,
    check_variables_metadata=True,
    default_metadata=ds_garden.metadata,
)
```