### PR TITLE
:bug: fix metadata checksum

### DIFF
--- a/apps/backport/datasync/data_metadata.py
+++ b/apps/backport/datasync/data_metadata.py
@@ -203,7 +203,11 @@ def _variable_metadata(
 ) -> Dict[str, Any]:
     row = db_variable_row
 
-    variable = row
+    # Drop checksums, they shouldn't be part of variable metadata, otherwise we get a
+    # feedback loop with changing checksums
+    row.pop("dataChecksum", None)
+    row.pop("metadataChecksum", None)
+
     sourceId = row.pop("sourceId")
     sourceName = row.pop("sourceName")
     sourceDescription = row.pop("sourceDescription")
@@ -238,7 +242,7 @@ def _variable_metadata(
     )
 
     variableMetadata = dict(
-        **_omit_nullable_values(variable),
+        **_omit_nullable_values(row),
         nonRedistributable=bool(nonRedistributable),
         display=display,
         schemaVersion=schemaVersion,

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -76,6 +76,8 @@ def _variable_meta():
         "descriptionProcessing": None,
         "sourceName": "Gapminder (v6); UN (2022); HYDE (v3.2); Food and Agriculture Organization of the United Nations",
         "sourceDescription": '{"link": "https://www.gapminder.org/data/documentation/gd003/", "retrievedDate": "October 8, 2021", "additionalInfo": "Our World in Data builds...", "dataPublishedBy": "Gapminder (v6); United Nations - Population Division (2022); HYDE (v3.2); World Bank", "dataPublisherSource": null}',
+        "dataChecksum": "123",
+        "metadataChecksum": "456",
     }
 
 


### PR DESCRIPTION
Function `variable_metadata` was including `dataChecksum` and `metadataChecksum` in its output. This output was then used to calculate `checksum_metadata` which was creating a feedback loop with ever changing checksums and inconsistencies.

This PR removes `dataChecksum` and `metadataChecksum` from there and doesn't include it in S3 JSON file.