### PR TITLE
:bug: fix origins in leading causes of death

### DIFF
--- a/dag/health.yml
+++ b/dag/health.yml
@@ -117,8 +117,8 @@ steps:
   data-private://garden/ihme_gbd/2024-06-10/leading_causes_deaths:
     - data-private://garden/ihme_gbd/2024-05-20/gbd_cause
     - data://meadow/ihme_gbd/2024-06-10/cause_hierarchy
-  #data-private://grapher/ihme_gbd/2024-06-10/leading_causes_deaths:
-  #  - data-private://garden/ihme_gbd/2024-06-10/leading_causes_deaths
+  data-private://grapher/ihme_gbd/2024-06-10/leading_causes_deaths:
+   - data-private://garden/ihme_gbd/2024-06-10/leading_causes_deaths
 
   # Postnatal care coverage - World Bank (2022)
   data://meadow/postnatal_care/2022-09-19/postnatal_care:

--- a/etl/steps/data/garden/ihme_gbd/2024-05-20/shared.py
+++ b/etl/steps/data/garden/ihme_gbd/2024-05-20/shared.py
@@ -64,10 +64,15 @@ def add_regional_aggregates(
 
     # TODO: maybe we could update pr.concat to work with categoricals if pandas can't handle them and converts
     # them to objects
-    tb_rate = Table(dataframes.concatenate([tb_rate, tb_rate_regions], ignore_index=True)).copy_metadata(tb_rate)
+    # NOTE: we need to copy the object from `copy_metadata` because it is lost during the concatenation
+    #  we should implement a better pr.concat function
+    tb_rate_copy = tb_rate.copy(deep=False)
+    tb_rate = Table(dataframes.concatenate([tb_rate, tb_rate_regions], ignore_index=True)).copy_metadata(tb_rate_copy)
+    tb_number_percent_copy = tb_number_percent.copy(deep=False)
     tb_out = Table(dataframes.concatenate([tb_number_percent, tb_rate], ignore_index=True)).copy_metadata(
-        tb_number_percent
+        tb_number_percent_copy
     )
+    assert tb_out.age.m.origins
     tb_out = tb_out.drop(columns="population")
     return tb_out
 


### PR DESCRIPTION
**Should be merged outside of working hours**

Hotfix missing origins in GBD. A proper fix would involve adding `pr.concat` function that works with categoricals (tracking it in this issue https://github.com/owid/etl/issues/2796)