### PR TITLE
:bug: fix metadata checksum

### DIFF
--- a/apps/backport/datasync/data_metadata.py
+++ b/apps/backport/datasync/data_metadata.py
@@ -15,7 +15,7 @@ from tenacity.retry import retry_if_exception_type
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
 
-from etl import config
+from etl import config, files
 from etl.db import read_sql
 
 log = get_logger()
@@ -203,11 +203,6 @@ def _variable_metadata(
 ) -> Dict[str, Any]:
     row = db_variable_row
 
-    # Drop checksums, they shouldn't be part of variable metadata, otherwise we get a
-    # feedback loop with changing checksums
-    row.pop("dataChecksum", None)
-    row.pop("metadataChecksum", None)
-
     sourceId = row.pop("sourceId")
     sourceName = row.pop("sourceName")
     sourceDescription = row.pop("sourceDescription")
@@ -361,3 +356,30 @@ def _convert_strings_to_numeric(lst: List[str]) -> List[Union[int, float, str]]:
 
 def _omit_nullable_values(d: dict) -> dict:
     return {k: v for k, v in d.items() if v is not None and (isinstance(v, list) and len(v) or not pd.isna(v))}
+
+
+def checksum_data_str(var_data_str: str) -> str:
+    return files.checksum_str(var_data_str)
+
+
+def checksum_metadata(meta: Dict[str, Any]) -> str:
+    """Calculate checksum for metadata. It modifies the metadata dict!"""
+    # Drop checksums, they shouldn't be part of variable metadata, otherwise we get a
+    # feedback loop with changing checksums
+    meta.pop("dataChecksum", None)
+    meta.pop("metadataChecksum", None)
+
+    # Drop all IDs. If we create the same dataset on the staging server, it might have different
+    # IDs, but the metadata should be the same.
+    meta.pop("id", None)
+    meta.pop("datasetId", None)
+    for origin in meta.get("origins", []):
+        origin.pop("id", None)
+
+    # Drop dimensions to make it faster. It is captured in `dataChecksum` anyway
+    meta.pop("dimensions", None)
+
+    # Ignore updatedAt timestamps
+    meta.pop("updatedAt", None)
+
+    return files.checksum_str(json.dumps(meta, default=str))

--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -12,7 +12,6 @@ Usage:
 import datetime
 import json
 import os
-import re
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from threading import Lock
@@ -26,16 +25,11 @@ from sqlalchemy import select, text, update
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.orm import Session
 
-from apps.backport.datasync.data_metadata import (
-    add_entity_code_and_name,
-    variable_data,
-    variable_metadata,
-)
+from apps.backport.datasync import data_metadata as dm
 from apps.backport.datasync.datasync import upload_gzip_string
 from etl import config
 from etl.db import get_engine
 
-from . import files
 from . import grapher_helpers as gh
 from . import grapher_model as gm
 
@@ -298,7 +292,7 @@ def upsert_table(
 
         # NOTE: we could prefetch all entities in advance, but it's not a bottleneck as it takes
         # less than 10ms per variable
-        df = add_entity_code_and_name(session, df)
+        df = dm.add_entity_code_and_name(session, df)
 
         # update links, we need to do it after we commit deleted relationships above
         db_variable.update_links(
@@ -314,14 +308,15 @@ def upsert_table(
         session.commit()
 
         # process data and metadata
-        var_data = variable_data(df)
-        var_metadata = variable_metadata(session, db_variable_id, df)
+        var_data = dm.variable_data(df)
+        var_metadata = dm.variable_metadata(session, db_variable_id, df)
 
         var_data_str = json.dumps(var_data, default=str)
         var_metadata_str = json.dumps(var_metadata, default=str)
 
-        checksum_data = _checksum_data(var_data_str)
-        checksum_metadata = _checksum_metadata(var_metadata_str)
+        checksum_data = dm.checksum_data_str(var_data_str)
+        # NOTE: _checksum_metadata modifies `var_metadata` object, but we have it as a string already
+        checksum_metadata = dm.checksum_metadata(var_metadata)
 
         # upload them to R2
         with ThreadPoolExecutor() as executor:
@@ -518,14 +513,3 @@ def _get_entity_name(session: Session, entity_id: int) -> str:
     q = select(gm.Entity).where(gm.Entity.id == entity_id)
     entity = session.scalars(q).one_or_none()
     return entity.name if entity else ""
-
-
-def _checksum_data(var_data_str: str) -> str:
-    return files.checksum_str(var_data_str)
-
-
-def _checksum_metadata(var_metadata_str: str) -> str:
-    # ignore updatedAt and checksums
-    return files.checksum_str(
-        re.sub(r'("updatedAt"|"dataChecksum"|"metadataChecksum"): "[^"]*"', r'\1: ""', var_metadata_str)
-    )


### PR DESCRIPTION
Metadata checksum should be as consistent as possible. There are problematic fields like `updatedAt` that can change even though it has no effect on metadata and should be excluded from checksum calculation.

This PR adds a couple more fields that cause problems
 - `dataChecksum`, `metadataChecksum` - including these would lead to a feedback loop of ever-changing checksums
 - `dimensions` - these are not causing problems, but are already captured in `dataChecksum`
 - `IDs` - staging server and production can build ETL separately and end up with different ids (but same metadata)

## TODO after merging:
- [ ] delete values in `variables.metadataChecksum` in production DB (we're not going to backfill them all, this will be done in the future when incrementing ETL epoch)