### PR TITLE
:bar_chart: Add combined variables for Velasco LGBT+ data

### DIFF
--- a/dag/main.yml
+++ b/dag/main.yml
@@ -274,8 +274,8 @@ steps:
     - snapshot://lgbt_rights/2023-04-27/lgbti_policy_index.xlsx
   data://garden/lgbt_rights/2023-04-27/lgbti_policy_index:
     - data://meadow/lgbt_rights/2023-04-27/lgbti_policy_index
+    - data://garden/regions/2023-01-01/regions
     - data://garden/demography/2023-03-31/population
-    - data://garden/wb/2021-07-01/wb_income
   data://grapher/lgbt_rights/2023-04-27/lgbti_policy_index:
     - data://garden/lgbt_rights/2023-04-27/lgbti_policy_index
 

--- a/etl/steps/data/garden/lgbt_rights/2023-04-27/lgbti_policy_index.meta.yml
+++ b/etl/steps/data/garden/lgbt_rights/2023-04-27/lgbti_policy_index.meta.yml
@@ -1,357 +1,400 @@
-descriptions:
-  policy_robustness: |-
-    This policy is not measured in a binary (adopted/not-adopted) scheme; the author follows Frank and colleagues (2010, 2017) in considering that similar policies can meaningfully vary in scope, benefits, punishment, etc. So, he determines the robustness of each policy by reviewing five indicators (between parentheses are the scoring schemes):
+# NOTE: To learn more about the fields, hover over their names.
+definitions:
+  common:
+    processing_level: major
+    description_processing: |-
+      We estimated regional aggregations by using [Our World in Data definitions of regions](https://ourworldindata.org/world-region-map-definitions) and our [consolidated population data](https://ourworldindata.org/population-sources).
+    presentation:
+      topic_tags:
+        - LGBT+ Rights
+        - Human Rights
 
-      1. Proportion of Population Living Under Law: To acknowledge subnational variations (0-1)
-      2. Scope of Genders Subject to Law: As they can be typically differentiated by gender (0: no law, 0.5: just men or women, 1: both)
-      3. Maximum Level of Punishment: For regressive policies (0: no law, 0.2: less than 3 years, 0.4: over 3 years and less than 15 years, 0.6: over 15 years and less than life in prison, 0.8: life in prison, 1: death penality)
-      4. Ease of Access: To benefits the law outlines (0: no law, 0.25: significant barriers, 0.5: moderate barriers, 0.75: little to few barriers, 1: no barriers)
-      5. Evidence of Enforcement: Has been least one case the previous year where this was implemented? (0: no evidence, 1: evidence)
+  policy_robustness_1: |-
+    This policy is not measured in a binary (adopted/not-adopted) scheme; the author follows Frank and colleagues ([2010](https://www.jstor.org/stable/25782170), [2017](https://www.jstor.org/stable/26166859)) in considering that similar policies can meaningfully vary in scope, benefits, punishment, etc. So, he determines the robustness of each policy by reviewing five indicators.
 
+  policy_robustness_2: |-
+    These indicators are (between parentheses are the scoring schemes): *Proportion of Population Living Under Law*, to acknowledge subnational variations (0-1), *Scope of Genders Subject to Law*, as they can be typically differentiated by gender (0: no law, 0.5: just men or women, 1: both), *Maximum Level of Punishment*, for regressive policies (0: no law, 0.2: less than 3 years, 0.4: over 3 years and less than 15 years, 0.6: over 15 years and less than life in prison, 0.8: life in prison, 1: death penality), *Ease of Access*, to benefits the law outlines (0: no law, 0.25: significant barriers, 0.5: moderate barriers, 0.75: little to few barriers, 1: no barriers, and *Evidence of Enforcement* that considers whether at least one case has happenedthe previous year where this was implemented (0: no evidence, 1: evidence).
+
+  policy_robustness_3: |-
     At least three different indicators are used to estimate the policy score, with the result that each policy score ranges from 0 to 1. Therefore, a score of 1 corresponds to that policy's most robust scope and implementation. This also means that changes in any indicator will influence each policy’s overall score.
-  lgbt_index: |-
-    The LGBT+ Policy Index measures a country’s LGBT+ policy landscape by capturing the implementation of 18 different LGBT+ policies. Policies included in the index are limited to those adopted across at least three countries or are explicitly advocated for by transnational activists.
 
-    These policies are subdivided between:
+  lgbt_index_1: |-
+    These policies that define the index are subdivided between progressive policies and regressive policies. Among the progressive policies are: Same-sex sexual acts Legal, Equal Age of Consent, Employment Discrimination, Hate Crime Protections, Incitement to Hatred, Civil Unions, Marriage Equality, *oint Adoptions, Gender Marker Change, LGB Military, Transgender Military, Ban on Conversion Therapies, and Ban on Gender Assignment Surgeries on Children.
 
-      Progressive policies:
-        1. Same-Sex Sexual Acts Legal
-        2. Equal Age of Consent
-        3. Employment Discrimination
-        4. Hate Crime Protections
-        5. Incitement to Hatred
-        6. Civil Unions
-        7. Marriage Equality
-        8. Joint Adoptions
-        9. Gender Marker Change
-        10. LGB Military
-        11. Transgender Military
-        12. Ban on Conversion Therapies
-        13. Ban on Gender Assignment Surgeries on Children
+  lgbt_index_2: |-
+    On the other hand, the regressive policies are: Death Penalty for Same-Sex Sexual Acts, Propaganda Laws, Same-Sex Sexual Acts Illegal, Unequal Age of Consent, and Ban on Marriage Equality.
 
-      Regressive policies
-        1. Death Penalty for Same-Sex Sexual Acts
-        2. Propaganda Laws
-        3. Same-Sex Sexual Acts Illegal
-        4. Unequal Age of Consent
-        5. Ban on Marriage Equality
+  lgbt_index_3: |-
+    To create the index, the scores for each policy are summed together annually, with progressive policies receiving a positive score and regressive policies receiving a negative score. This results in an index ranging from -5 to +13. No country reaches these extremes, demonstrating that countries can get better and worse in their policy environments.
 
-    These policies are not measured in a binary (adopted/not-adopted) scheme; the author follows Frank and colleagues (2010, 2017) in considering that similar policies can meaningfully vary in scope, benefits, punishment, etc. So, he determines the robustness of each policy by reviewing five indicators (between parentheses are the scoring schemes):
-
-      1. Proportion of Population Living Under Law: To acknowledge subnational variations (0-1)
-      2. Scope of Genders Subject to Law: As they can be typically differentiated by gender (0: no law, 0.5: just men or women, 1: both)
-      3. Maximum Level of Punishment: For regressive policies (0: no law, 0.2: less than 3 years, 0.4: over 3 years and less than 15 years, 0.6: over 15 years and less than life in prison, 0.8: life in prison, 1: death penality)
-      4. Ease of Access: To benefits the law outlines (0: no law, 0.25: significant barriers, 0.5: moderate barriers, 0.75: little to few barriers, 1: no barriers)
-      5. Evidence of Enforcement: Has been least one case the previous year where this was implemented? (0: no evidence, 1: evidence)
-
-    While all five indicators may not be relevant to each policy, each policy in question uses at least three different indicators and with them, each policy score ranges from 0 to 1. Therefore, a score of 1 corresponds to that policy's most robust scope and implementation. This also means that changes in any indicators will influence each policy’s overall score. For example, a country having national marriage equality (indicator 1), few (if any) formal restrictions to obtaining a marriage license (indicator 4), and full implementation (indicator 5) will receive a score of 1.
-
-    To create the index, the scores for each policy are summed together annually, with progressive policies receiving a positive score and regressive policies receiving a negative. This results in an index ranging from -5 to +13. No country reaches these extremes, demonstrating that countries can get better and worse in their policy environments.
-
-    The LGBT+ policy index represents a robust and nuanced measure of LGBT+ policy adoption and implementation and is a novel contribution to the literature. By incorporating progressive and regressive LGBT+ policies and variation in implementation beyond a binary coding scheme, this measure captures even fine-grained changes to the LGBT+ policy landscape.
   count_yes: |-
     This is the number of countries per region with full implementation of the policy.
+
   count_no: |-
     This is the number of countries per region with partial or no implementation of the policy.
+
   pop_yes: |-
     This is the population per region with full implementation of the policy.
+
   pop_no: |-
     This is the population per region with partial or no implementation of the policy.
-dataset:
-  title: LGBT+ policies (Velasco, 2020)
-  description: |-
-    This dataset, from the work of Kristopher Velasco (2020), provides a country’s LGBT+ policy landscape by capturing the implementation of 18 different LGBT+ policies. Policies included in the index are limited to those adopted across at least three countries or are explicitly advocated for by transnational activists.
 
-    These policies are subdivided between:
+  equal_age: Measures the presence of a law defining the same age of consent between same-sex and different-sex partners.
+  unequal_age: Measures the presence of a law outlawing different ages of consent between same-sex and different-sex partners, which serves as a tool to inhibit same-sex acts between consenting adults.
+  constitution: National constitutions are classified as protective against discrimination based on sexual orientation or gender identity if there is explicit language or if judicial cases have set legal precedent for such protections.  This variable is not used to calculate the LGBTI index.
+  conversion_therapies: Measures if bans on conversion therapies are adopted. Conversion therapies are those attempting to change a person’s sexual orientation or gender identity. They can entail counseling, drugging, electric shocks, castrations, or brain surgery.
+  death_penalty: Measures the adoption of policies that allow for individuals caught engaging in same-sex acts to be punished by death.
+  employment_discrim: Measures the presence of legislation banning employers from discriminating on the basis of sexual orientation or gender identity.
+  gender_surgery: Measures if bans on gender assignment surgeries on children are adopted.
+  hate_crimes: Measures the adoption of hate crime laws, which designate a crime against someone based based on sexual orientation or gender identity as an aggravating circumstance.
+  incite_hate: Measures the adoption of incitement to hatred protections, which is any act that could provoke a targeted crime illegal.
+  joint_adoption: Measures if joint adoption policy is adopted. This policy allows for same-sex partners to legally adopt a child, with both parents being recognized as such.
+  lgb_military: Measures if lesbian, gay, and bisexual people are allowed to serve in the military.
+  lgb_military_ban: Measures if lesbian, gay, and bisexual people are banned from the military. This variable is not used to calculate the LGBTI index.
+  marriage_equality: Measures if there is no legal distinction between same-sex and different-sex marriages.
+  marriage_ban: Measures if same-sex marriages are banned.
+  samesex_legal: Measures the presence of a law declaring that same-sex actions are not criminalized between consenting adults.
+  third_gender: Measures if a third gender is recognized in the legislation. This variable is not used to calculate the LGBTI index.
+  trans_military: Measures if transgender people are allowed to serve in the military.
+  samesex_illegal: Measures the presence of a law declaring that same-sex actions are criminalized between consenting adults.
+  civil_unions: Measures if civil unions for same-sex partners are adopted. Domestic and registered partnerships are included.
+  gendermarker: Measures if the gender marker can be legally changed.
+  propaganda: Measures the adoption of policies banning “propaganda for non-traditional sexual relations”. Vaguely written, these laws are utilized to discriminate against LGBT individuals in the name of protecting “public morality, particularly pertaining to children”.
 
-      Progressive policies:
-        1. Same-Sex Sexual Acts Legal
-        2. Equal Age of Consent
-        3. Employment Discrimination
-        4. Hate Crime Protections
-        5. Incitement to Hatred
-        6. Civil Unions
-        7. Marriage Equality
-        8. Joint Adoptions
-        9. Gender Marker Change
-        10. LGB Military
-        11. Transgender Military
-        12. Ban on Conversion Therapies
-        13. Ban on Gender Assignment Surgeries on Children
-
-      Regressive policies
-        1. Death Penalty for Same-Sex Sexual Acts
-        2. Propaganda Laws
-        3. Same-Sex Sexual Acts Illegal
-        4. Unequal Age of Consent
-        5. Ban on Marriage Equality
-
-    Each of these policies score in a range between 0 and 1, according to their level of implementation. Together, they form the LGBT+ Policy Index.
-
-    Additional policies are included in the dataset, as constitutional protections against discrimination, LGB military ban and third gender recognition.
-
-    Multiple sources were consulted to find the necessary data to construct this index. The primary data source was the State Sponsored Homophobia Reports produced by ILGA. These reports, produced almost annually, outline the adoption of various policies and provide some information on implementation. For information on trans- and intersex-specific policies and military information, other sources were used, including the Trans Legal Mapping Report, also produced by ILGA, reports and documentation provided by Transgender Europe, Movement Advancement Project, The Hague Center for Strategic Studies LGBT+ Military Index, and academic studies such as Reynolds (2013). Furthermore, multiple sources were used to obtain data on the evidence of enforcement – particularly arrests – including an extensive newspaper search across each country using LexisNexis and Factiva and other external reports by Amnesty International, Human Rights Watch, and the U.S. State Department.
-
-  sources:
-  - name: Kristopher Velasco (2020)
-    url: https://osf.io/preprints/socarxiv/3rtje/
-    date_accessed: "2023-06-15"
-    publication_date: '2020-07-24'
-    published_by:
-      'Velasco, K. (2020). Transnational Backlash and the Deinstitutionalization of Liberal Norms: LGBT+ Rights in a Contested World. https://doi.org/10.31235/osf.io/3rtje'
 tables:
   lgbti_policy_index:
     variables:
       equal_age:
         title: Equal age of consent
-        description: |
-          Measures the presence of a law defining the same age of consent between same-sex and different-sex partners.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.equal_age}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Equal age of consent
           numDecimalPlaces: 2
+        presentation:
+          title_public: Age of consent for same-sex and different-sex partners equal
       unequal_age:
         title: Unequal age of consent
-        description: |
-          Measures the presence of a law outlawing different ages of consent between same-sex and different-sex partners, which serves as a tool to inhibit same-sex acts between consenting adults.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.unequal_age}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ""
         unit: ''
         display:
           name: Unequal age of consent
           numDecimalPlaces: 2
+        presentation:
+          title_public: Age of consent for same-sex and different-sex partners unequal
       constitution:
         title: Constitutional protections against discrimination
-        description: |
-          National constitutions are classified as protective against discrimination based on sexual orientation or gender identity if there is explicit language or if judicial cases have set legal precedent for such protections.
-
-          Variable not among the 18 policies of the index.
+        description_short: |
+          {definitions.constitution}
         short_unit: ''
         unit: ''
         display:
           name: Constitutional protections against discrimination
           numDecimalPlaces: 0
+        presentation:
+          title_public: Constitutional protections against discrimination based on sexual orientation or gender identity
       conversion_therapies:
         title: Ban on conversion therapies
-        description: |
-          Measures if bans on conversion therapies are adopted. Conversion therapies are those attempting to change a person’s sexual orientation or gender identity. They can entail counseling, drugging, electric shocks, castrations, or brain surgery.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.conversion_therapies}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Ban on conversion therapies
           numDecimalPlaces: 2
+        presentation:
+          title_public: Conversion therapies banned
       death_penalty:
         title: Death penalty for same-sex sexual acts
-        description: |
-          Measures the adoption of policies that allow for individuals caught engaging in same-sex acts to be punished by death.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.death_penalty}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Death penalty for same-sex sexual acts
           numDecimalPlaces: 2
+        presentation:
+          title_public: Same-sex sexual acts punished by death
       employment_discrim:
         title: Employment discrimination bans
-        description: |
-          Measures the presence of legislation banning employers from discriminating on the basis of sexual orientation or gender identity.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.employment_discrim}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Employment discrimination laws
           numDecimalPlaces: 2
+        presentation:
+          title_public: Employment discrimination based on sexual orientation or gender identity prohibited
       gender_surgery:
         title: Ban on gender assignment surgeries on children
-        description: |
-          Measures if bans on gender assignment surgeries on children are adopted.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.gender_surgery}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Ban on gender assignment surgeries on children
           numDecimalPlaces: 0
+        presentation:
+          title_public: Gender assignment surgeries on children banned
       hate_crimes:
         title: Hate crime protections
-        description: |
-          Measures the adoption of hate crime laws, which designate a crime against someone based based on sexual orientation or gender identity as an aggravating circumstance.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.hate_crimes}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Hate crime protections
           numDecimalPlaces: 2
+        presentation:
+          title_public: Hate crimes based on sexual orientation or gender identity are an aggravating circumstance
       incite_hate:
         title: Incitement to hatred
-        description: |
-          Measures the adoption of incitement to hatred protections, which is any act that could provoke a targeted crime illegal
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.incite_hate}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Incitement to hatred
           numDecimalPlaces: 2
+        presentation:
+          title_public: Inciting crimes based on sexual orientation or gender identity is illegal
       joint_adoption:
         title: Joint adoptions
-        description: |
-          Measures if joint adoption policy is adopted. This policy allows for same-sex partners to legally adopt a child, with both parents being recognized as such.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.joint_adoption}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Joint adoptions
           numDecimalPlaces: 2
+        presentation:
+          title_public: Joint adoptions by same-sex partners
       lgb_military:
         title: LGB military
-        description: |
-          Measures if lesbian, gay, and bisexual people are allowed to serve in the military.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.lgb_military}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: LGB military
           numDecimalPlaces: 0
+        presentation:
+          title_public: Lesbian, gay, and bisexual people allowed to openly serve in the military
       lgb_military_ban:
         title: LGB military ban
-        description: |
-          Measures if lesbian, gay, and bisexual people are banned from the military.
-
-          Variable not among the 18 policies of the index.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.lgb_military_ban}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: LGB military ban
           numDecimalPlaces: 0
+        presentation:
+          title_public: Lesbian, gay, and bisexual people banned from the military
       marriage_equality:
         title: Marriage equality
-        description: |
-          Measures if there is no legal distinction between same-sex and different-sex marriages.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.marriage_equality}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Marriage equality
           numDecimalPlaces: 2
+        presentation:
+          title_public: Marriage for same-sex partners
       marriage_ban:
         title: Ban on marriage equality
-        description: |
-          Measures if same-sex marriages are banned.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.marriage_ban}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Ban on marriage equality
           numDecimalPlaces: 2
+        presentation:
+          title_public: Marriage for same-sex partners banned
       samesex_legal:
         title: Same-sex sexual acts legal
-        description: |
-          Measures the presence of a law declaring that same-sex actions are not criminalized between consenting adults.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.samesex_legal}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Same-sex sexual acts legal
           numDecimalPlaces: 2
+        presentation:
+          title_public: Same-sex sexual acts legal
       third_gender:
         title: Third gender recognition
-        description: |
-          Measures if a third gender is recognized in the legislation.
-
-          Variable not among the 18 policies of the index.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.third_gender}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Third gender recognition
           numDecimalPlaces: 0
+        presentation:
+          title_public: Third gender legally recognized
       trans_military:
         title: Trasgender military
-        description: |
-          Measures if transgender people are allowed to serve in the military.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.trans_military}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Trasgender military
           numDecimalPlaces: 0
+        presentation:
+          title_public: Transgender people are allowed to openly serve in the military
       samesex_illegal:
         title: Same-sex sexual acts illegal
-        description: |
-          Measures the presence of a law declaring that same-sex actions are criminalized between consenting adults.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.samesex_illegal}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Same-sex sexual acts illegal
           numDecimalPlaces: 2
+        presentation:
+          title_public: Same-sex sexual acts illegal
       civil_unions:
         title: Civil unions
-        description: |
-          Measures if civil unions for same-sex partners are adopted. Domestic and registered partnerships are included.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.civil_unions}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Civil unions
           numDecimalPlaces: 2
+        presentation:
+          title_public: Civil union for same-sex partners
       gendermarker:
         title: Gender marker change
-        description: |
-          Measures if the gender marker can be legally changed.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.gendermarker}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Gender marker change
           numDecimalPlaces: 2
+        presentation:
+          title_public: Gender marker can be legally changed
       propaganda:
         title: Anti-propaganda laws
-        description: |
-          Measures the adoption of policies banning “propaganda for non-traditional sexual relations”. Vaguely written, these laws are utilized to discriminate against LGBT individuals in the name of protecting “public morality, particularly pertaining to children”.
-
-          {descriptions.policy_robustness}
+        description_short: |
+          {definitions.propaganda}
+        description_key:
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.policy_robustness_3}"
         short_unit: ''
         unit: ''
         display:
           name: Propaganda laws
           numDecimalPlaces: 2
+        presentation:
+          title_public: Public morality laws on non-traditional sexual relations
       policy_index:
         title: LGBT+ Policy Index
-        description: |
-          {descriptions.lgbt_index}
+        description_short: The LGBT+ Policy Index measures a country’s LGBT+ policy landscape by capturing the implementation of 18 different LGBT+ policies. Policies included in the index are limited to those adopted across at least three countries or are explicitly advocated for by transnational activists.
+        description_key:
+          - "{definitions.lgbt_index_1}"
+          - "{definitions.lgbt_index_2}"
+          - "{definitions.policy_robustness_1}"
+          - "{definitions.policy_robustness_2}"
+          - "{definitions.lgbt_index_3}"
         short_unit: ''
         unit: ''
         display:
           name: LGBT+ Policy Index
           numDecimalPlaces: 2
+        presentation:
+          title_public: LGBT+ rights index
       equal_age_yes:
         title: Equal age of consent ("yes", number of countries)
-        description: |
-          Measures the presence of a law defining the same age of consent between same-sex and different-sex partners.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.equal_age} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -359,10 +402,8 @@ tables:
           numDecimalPlaces: 0
       unequal_age_yes:
         title: Unequal age of consent ("yes"/"partially", number of countries)
-        description: |
-          Measures the presence of a law outlawing different ages of consent between same-sex and different-sex partners, which serves as a tool to inhibit same-sex acts between consenting adults.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.unequal_age} {definitions.count_yes}
         short_unit: ""
         unit: ''
         display:
@@ -370,10 +411,8 @@ tables:
           numDecimalPlaces: 0
       constitution_yes:
         title: Constitutional protections against discrimination ("yes", number of countries)
-        description: |
-          National constitutions are classified as protective against discrimination based on sexual orientation or gender identity if there is explicit language or if judicial cases have set legal precedent for such protections.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.constitution} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -381,10 +420,8 @@ tables:
           numDecimalPlaces: 0
       conversion_therapies_yes:
         title: Ban on conversion therapies ("yes", number of countries)
-        description: |
-          Measures if bans on conversion therapies are adopted. Conversion therapies are those attempting to change a person’s sexual orientation or gender identity. They can entail counseling, drugging, electric shocks, castrations, or brain surgery.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.conversion_therapies} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -392,10 +429,8 @@ tables:
           numDecimalPlaces: 0
       death_penalty_yes:
         title: Death penalty for same-sex sexual acts ("yes"/"partially", number of countries)
-        description: |
-          Measures the adoption of policies that allow for individuals caught engaging in same-sex acts to be punished by death.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.death_penalty} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -403,10 +438,8 @@ tables:
           numDecimalPlaces: 0
       employment_discrim_yes:
         title: Employment discrimination bans ("yes", number of countries)
-        description: |
-          Measures the presence of legislation banning employers from discriminating on the basis of sexual orientation or gender identity.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.employment_discrim} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -414,10 +447,8 @@ tables:
           numDecimalPlaces: 0
       gender_surgery_yes:
         title: Ban on gender assignment surgeries on children ("yes", number of countries)
-        description: |
-          Measures if bans on gender assignment surgeries on children are adopted.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.gender_surgery} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -425,10 +456,8 @@ tables:
           numDecimalPlaces: 0
       hate_crimes_yes:
         title: Hate crime protections ("yes", number of countries)
-        description: |
-          Measures the adoption of hate crime laws, which designate a crime against someone based based on sexual orientation or gender identity as an aggravating circumstance.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.hate_crimes} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -436,10 +465,8 @@ tables:
           numDecimalPlaces: 0
       incite_hate_yes:
         title: Incitement to hatred protections ("yes", number of countries)
-        description: |
-          Measures the adoption of incitement to hatred protections, which is any act that could provoke a targeted crime illegal
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.incite_hate} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -447,10 +474,8 @@ tables:
           numDecimalPlaces: 0
       joint_adoption_yes:
         title: Joint adoptions ("yes", number of countries)
-        description: |
-          Measures if joint adoption policy is adopted. This policy allows for same-sex partners to legally adopt a child, with both parents being recognized as such.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.joint_adoption} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -458,10 +483,8 @@ tables:
           numDecimalPlaces: 0
       lgb_military_yes:
         title: LGB military ("yes", number of countries)
-        description: |
-          Measures if lesbian, gay, and bisexual people are allowed to serve in the military.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.lgb_military} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -469,10 +492,8 @@ tables:
           numDecimalPlaces: 0
       lgb_military_ban_yes:
         title: LGB military ban ("yes", number of countries)
-        description: |
-          Measures if lesbian, gay, and bisexual people are banned from the military.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.lgb_military_ban} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -480,10 +501,8 @@ tables:
           numDecimalPlaces: 0
       marriage_equality_yes:
         title: Marriage equality ("yes", number of countries)
-        description: |
-          Measures if there is no legal distinction between same-sex and different-sex marriages.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.marriage_equality} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -491,10 +510,8 @@ tables:
           numDecimalPlaces: 0
       marriage_ban_yes:
         title: Ban on marriage equality ("yes", number of countries)
-        description: |
-          Measures if same-sex marriages are banned.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.marriage_ban} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -502,10 +519,8 @@ tables:
           numDecimalPlaces: 0
       samesex_legal_yes:
         title: Same-sex sexual acts legal ("yes", number of countries)
-        description: |
-          Measures the presence of a law declaring that same-sex actions are not criminalized between consenting adults.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.samesex_legal} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -513,10 +528,8 @@ tables:
           numDecimalPlaces: 0
       third_gender_yes:
         title: Third gender recognition ("yes", number of countries)
-        description: |
-          Measures if a third gender is recognized in the legislation.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.third_gender} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -524,10 +537,8 @@ tables:
           numDecimalPlaces: 0
       trans_military_yes:
         title: Trasgender military ("yes", number of countries)
-        description: |
-          Measures if transgender people are allowed to serve in the military.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.trans_military} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -535,10 +546,8 @@ tables:
           numDecimalPlaces: 0
       civil_unions_yes:
         title: Civil unions ("yes", number of countries)
-        description: |
-          Measures if civil unions for same-sex partners are adopted. Domestic and registered partnerships are included.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.civil_unions} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -546,10 +555,8 @@ tables:
           numDecimalPlaces: 0
       gendermarker_yes:
         title: Gender marker change ("yes", number of countries)
-        description: |
-          Measures if the gender marker can be legally changed.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.gendermarker} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -557,10 +564,8 @@ tables:
           numDecimalPlaces: 0
       propaganda_yes:
         title: Anti-propaganda laws ("yes"/"partially", number of countries)
-        description: |
-          Measures the adoption of policies banning “propaganda for non-traditional sexual relations”. Vaguely written, these laws are utilized to discriminate against LGBT individuals in the name of protecting “public morality, particularly pertaining to children”.
-
-          {descriptions.count_yes}
+        description_short: |
+          {definitions.propaganda} {definitions.count_yes}
         short_unit: ''
         unit: ''
         display:
@@ -568,10 +573,8 @@ tables:
           numDecimalPlaces: 0
       equal_age_no:
         title: Equal age of consent ("no"/"partially", number of countries)
-        description: |
-          Measures the presence of a law defining the same age of consent between same-sex and different-sex partners.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.equal_age} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -579,10 +582,8 @@ tables:
           numDecimalPlaces: 0
       unequal_age_no:
         title: Unequal age of consent ("no", number of countries)
-        description: |
-          Measures the presence of a law outlawing different ages of consent between same-sex and different-sex partners, which serves as a tool to inhibit same-sex acts between consenting adults.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.unequal_age} {definitions.count_no}
         short_unit: ""
         unit: ''
         display:
@@ -590,10 +591,8 @@ tables:
           numDecimalPlaces: 0
       constitution_no:
         title: Constitutional protections against discrimination ("no"/"partially", number of countries)
-        description: |
-          National constitutions are classified as protective against discrimination based on sexual orientation or gender identity if there is explicit language or if judicial cases have set legal precedent for such protections.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.constitution} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -601,10 +600,8 @@ tables:
           numDecimalPlaces: 0
       conversion_therapies_no:
         title: Ban on conversion therapies ("no"/"partially", number of countries)
-        description: |
-          Measures if bans on conversion therapies are adopted. Conversion therapies are those attempting to change a person’s sexual orientation or gender identity. They can entail counseling, drugging, electric shocks, castrations, or brain surgery.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.conversion_therapies} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -612,10 +609,8 @@ tables:
           numDecimalPlaces: 0
       death_penalty_no:
         title: Death penalty for same-sex sexual acts ("no", number of countries)
-        description: |
-          Measures the adoption of policies that allow for individuals caught engaging in same-sex acts to be punished by death.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.death_penalty} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -623,10 +618,8 @@ tables:
           numDecimalPlaces: 0
       employment_discrim_no:
         title: Employment discrimination bans ("no"/"partially", number of countries)
-        description: |
-          Measures the presence of legislation banning employers from discriminating on the basis of sexual orientation or gender identity.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.employment_discrim} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -634,10 +627,8 @@ tables:
           numDecimalPlaces: 0
       gender_surgery_no:
         title: Ban on gender assignment surgeries on children ("no"/"partially", number of countries)
-        description: |
-          Measures if bans on gender assignment surgeries on children are adopted.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.gender_surgery} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -645,10 +636,8 @@ tables:
           numDecimalPlaces: 0
       hate_crimes_no:
         title: Hate crime protections ("no"/"partially", number of countries)
-        description: |
-          Measures the adoption of hate crime laws, which designate a crime against someone based based on sexual orientation or gender identity as an aggravating circumstance.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.hate_crimes} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -656,10 +645,8 @@ tables:
           numDecimalPlaces: 0
       incite_hate_no:
         title: Incitement to hatred ("no"/"partially", number of countries)
-        description: |
-          Measures the adoption of incitement to hatred protections, which is any act that could provoke a targeted crime illegal
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.incite_hate} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -667,10 +654,8 @@ tables:
           numDecimalPlaces: 0
       joint_adoption_no:
         title: Joint adoptions ("no"/"partially", number of countries)
-        description: |
-          Measures if joint adoption policy is adopted. This policy allows for same-sex partners to legally adopt a child, with both parents being recognized as such.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.joint_adoption} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -678,10 +663,8 @@ tables:
           numDecimalPlaces: 0
       lgb_military_no:
         title: LGB military ("no"/"partially", number of countries)
-        description: |
-          Measures if lesbian, gay, and bisexual people are allowed to serve in the military.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.lgb_military} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -689,10 +672,8 @@ tables:
           numDecimalPlaces: 0
       lgb_military_ban_no:
         title: LGB military ban ("no"/"partially", number of countries)
-        description: |
-          Measures if lesbian, gay, and bisexual people are banned from the military.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.lgb_military_ban} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -700,10 +681,8 @@ tables:
           numDecimalPlaces: 0
       marriage_equality_no:
         title: Marriage equality ("no"/"partially", number of countries)
-        description: |
-          Measures if there is no legal distinction between same-sex and different-sex marriages.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.marriage_equality} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -711,10 +690,8 @@ tables:
           numDecimalPlaces: 0
       marriage_ban_no:
         title: Ban on marriage equality ("no"/"partially", number of countries)
-        description: |
-          Measures if same-sex marriages are banned.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.marriage_ban} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -722,10 +699,8 @@ tables:
           numDecimalPlaces: 0
       samesex_legal_no:
         title: Same-sex sexual acts legal ("no"/"partially", number of countries)
-        description: |
-          Measures the presence of a law declaring that same-sex actions are not criminalized between consenting adults.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.samesex_legal} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -733,10 +708,8 @@ tables:
           numDecimalPlaces: 0
       third_gender_no:
         title: Third gender recognition ("no"/"partially", number of countries)
-        description: |
-          Measures if a third gender is recognized in the legislation.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.third_gender} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -744,10 +717,8 @@ tables:
           numDecimalPlaces: 0
       trans_military_no:
         title: Trasgender military ("no"/"partially", number of countries)
-        description: |
-          Measures if transgender people are allowed to serve in the military.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.trans_military} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -755,10 +726,8 @@ tables:
           numDecimalPlaces: 0
       civil_unions_no:
         title: Civil unions ("no"/"partially", number of countries)
-        description: |
-          Measures if civil unions for same-sex partners are adopted. Domestic and registered partnerships are included.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.civil_unions} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -766,10 +735,8 @@ tables:
           numDecimalPlaces: 0
       gendermarker_no:
         title: Gender marker change ("no"/"partially", number of countries)
-        description: |
-          Measures if the gender marker can be legally changed.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.gendermarker} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -777,10 +744,8 @@ tables:
           numDecimalPlaces: 0
       propaganda_no:
         title: Anti-propaganda laws ("no", number of countries)
-        description: |
-          Measures the adoption of policies banning “propaganda for non-traditional sexual relations”. Vaguely written, these laws are utilized to discriminate against LGBT individuals in the name of protecting “public morality, particularly pertaining to children”.
-
-          {descriptions.count_no}
+        description_short: |
+          {definitions.propaganda} {definitions.count_no}
         short_unit: ''
         unit: ''
         display:
@@ -788,10 +753,8 @@ tables:
           numDecimalPlaces: 0
       equal_age_yes_pop:
         title: Equal age of consent ("yes", total population)
-        description: |
-          Measures the presence of a law defining the same age of consent between same-sex and different-sex partners.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.equal_age} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -799,10 +762,8 @@ tables:
           numDecimalPlaces: 0
       unequal_age_yes_pop:
         title: Unequal age of consent ("yes"/"partially", total population)
-        description: |
-          Measures the presence of a law outlawing different ages of consent between same-sex and different-sex partners, which serves as a tool to inhibit same-sex acts between consenting adults.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.unequal_age} {definitions.pop_yes}
         short_unit: ""
         unit: ''
         display:
@@ -810,9 +771,8 @@ tables:
           numDecimalPlaces: 0
       constitution_yes_pop:
         title: Constitutional protections against discrimination ("yes", total population)
-        description: |
-          - National constitutions are classified as protective against discrimination based on sexual orientation or gender identity if there is explicit language or if judicial cases have set legal precedent for such protections.
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.constitution} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -820,10 +780,8 @@ tables:
           numDecimalPlaces: 0
       conversion_therapies_yes_pop:
         title: Ban on conversion therapies ("yes", total population)
-        description: |
-          Measures if bans on conversion therapies are adopted. Conversion therapies are those attempting to change a person’s sexual orientation or gender identity. They can entail counseling, drugging, electric shocks, castrations, or brain surgery.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.conversion_therapies} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -831,10 +789,8 @@ tables:
           numDecimalPlaces: 0
       death_penalty_yes_pop:
         title: Death penalty for same-sex sexual acts ("yes"/"partially", total population)
-        description: |
-          Measures the adoption of policies that allow for individuals caught engaging in same-sex acts to be punished by death.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.death_penalty} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -842,10 +798,8 @@ tables:
           numDecimalPlaces: 0
       employment_discrim_yes_pop:
         title: Employment discrimination bans ("yes", total population)
-        description: |
-          Measures the presence of legislation banning employers from discriminating on the basis of sexual orientation or gender identity.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.employment_discrim} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -853,10 +807,8 @@ tables:
           numDecimalPlaces: 0
       gender_surgery_yes_pop:
         title: Ban on gender assignment surgeries on children ("yes", total population)
-        description: |
-          Measures if bans on gender assignment surgeries on children are adopted.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.gender_surgery} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -864,10 +816,8 @@ tables:
           numDecimalPlaces: 0
       hate_crimes_yes_pop:
         title: Hate crime protections ("yes", total population)
-        description: |
-          Measures the adoption of hate crime laws, which designate a crime against someone based based on sexual orientation or gender identity as an aggravating circumstance.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.hate_crimes} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -875,10 +825,8 @@ tables:
           numDecimalPlaces: 0
       incite_hate_yes_pop:
         title: Incitement to hatred ("yes", total population)
-        description: |
-          Measures the adoption of incitement to hatred protections, which is any act that could provoke a targeted crime illegal
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.incite_hate} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -886,10 +834,8 @@ tables:
           numDecimalPlaces: 0
       joint_adoption_yes_pop:
         title: Joint adoptions ("yes", total population)
-        description: |
-          Measures if joint adoption policy is adopted. This policy allows for same-sex partners to legally adopt a child, with both parents being recognized as such.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.joint_adoption} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -897,10 +843,8 @@ tables:
           numDecimalPlaces: 0
       lgb_military_yes_pop:
         title: LGB military ("yes", total population)
-        description: |
-          Measures if lesbian, gay, and bisexual people are allowed to serve in the military.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.lgb_military} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -908,10 +852,8 @@ tables:
           numDecimalPlaces: 0
       lgb_military_ban_yes_pop:
         title: LGB military ban ("yes", total population)
-        description: |
-          Measures if lesbian, gay, and bisexual people are banned from the military.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.lgb_military_ban} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -919,10 +861,8 @@ tables:
           numDecimalPlaces: 0
       marriage_equality_yes_pop:
         title: Marriage equality ("yes", total population)
-        description: |
-          Measures if there is no legal distinction between same-sex and different-sex marriages.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.marriage_equality} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -930,10 +870,8 @@ tables:
           numDecimalPlaces: 0
       marriage_ban_yes_pop:
         title: Ban on marriage equality ("yes", total population)
-        description: |
-          Measures if same-sex marriages are banned.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.marriage_ban} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -941,10 +879,8 @@ tables:
           numDecimalPlaces: 0
       samesex_legal_yes_pop:
         title: Same-sex sexual acts legal ("yes", total population)
-        description: |
-          Measures the presence of a law declaring that same-sex actions are not criminalized between consenting adults.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.samesex_legal} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -952,10 +888,8 @@ tables:
           numDecimalPlaces: 0
       third_gender_yes_pop:
         title: Third gender recognition ("yes", total population)
-        description: |
-          Measures if a third gender is recognized in the legislation.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.third_gender} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -963,10 +897,8 @@ tables:
           numDecimalPlaces: 0
       trans_military_yes_pop:
         title: Trasgender military ("yes", total population)
-        description: |
-          Measures if transgender people are allowed to serve in the military.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.trans_military} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -974,10 +906,8 @@ tables:
           numDecimalPlaces: 0
       civil_unions_yes_pop:
         title: Civil unions ("yes", total population)
-        description: |
-          Measures if civil unions for same-sex partners are adopted. Domestic and registered partnerships are included.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.civil_unions} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -985,10 +915,8 @@ tables:
           numDecimalPlaces: 0
       gendermarker_yes_pop:
         title: Gender marker change ("yes", total population)
-        description: |
-          Measures if the gender marker can be legally changed.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.gendermarker} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -996,10 +924,8 @@ tables:
           numDecimalPlaces: 0
       propaganda_yes_pop:
         title: Anti-propaganda laws ("yes"/"partially", total population)
-        description: |
-          Measures the adoption of policies banning “propaganda for non-traditional sexual relations”. Vaguely written, these laws are utilized to discriminate against LGBT individuals in the name of protecting “public morality, particularly pertaining to children”.
-
-          {descriptions.pop_yes}
+        description_short: |
+          {definitions.propaganda} {definitions.pop_yes}
         short_unit: ''
         unit: ''
         display:
@@ -1007,10 +933,8 @@ tables:
           numDecimalPlaces: 0
       equal_age_no_pop:
         title: Equal age of consent ("no"/"partially", total population)
-        description: |
-          Measures the presence of a law defining the same age of consent between same-sex and different-sex partners.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.equal_age} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1018,10 +942,8 @@ tables:
           numDecimalPlaces: 0
       unequal_age_no_pop:
         title: Unequal age of consent ("no", total population)
-        description: |
-          Measures the presence of a law outlawing different ages of consent between same-sex and different-sex partners, which serves as a tool to inhibit same-sex acts between consenting adults.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.unequal_age} {definitions.pop_no}
         short_unit: ""
         unit: ''
         display:
@@ -1029,10 +951,8 @@ tables:
           numDecimalPlaces: 0
       constitution_no_pop:
         title: Constitutional protections against discrimination ("no"/"partially", total population)
-        description: |
-          National constitutions are classified as protective against discrimination based on sexual orientation or gender identity if there is explicit language or if judicial cases have set legal precedent for such protections.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.constitution} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1040,10 +960,8 @@ tables:
           numDecimalPlaces: 0
       conversion_therapies_no_pop:
         title: Ban on conversion therapies ("no"/"partially", total population)
-        description: |
-          Measures if bans on conversion therapies are adopted. Conversion therapies are those attempting to change a person’s sexual orientation or gender identity. They can entail counseling, drugging, electric shocks, castrations, or brain surgery.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.conversion_therapies} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1051,10 +969,8 @@ tables:
           numDecimalPlaces: 0
       death_penalty_no_pop:
         title: Death penalty for same-sex sexual acts ("no", total population)
-        description: |
-          Measures the adoption of policies that allow for individuals caught engaging in same-sex acts to be punished by death.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.death_penalty} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1062,10 +978,8 @@ tables:
           numDecimalPlaces: 0
       employment_discrim_no_pop:
         title: Employment discrimination bans ("no"/"partially", total population)
-        description: |
-          Measures the presence of legislation banning employers from discriminating on the basis of sexual orientation or gender identity.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.employment_discrim} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1073,10 +987,8 @@ tables:
           numDecimalPlaces: 0
       gender_surgery_no_pop:
         title: Ban on gender assignment surgeries on children ("no"/"partially", total population)
-        description: |
-          Measures if bans on gender assignment surgeries on children are adopted.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.gender_surgery} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1084,10 +996,8 @@ tables:
           numDecimalPlaces: 0
       hate_crimes_no_pop:
         title: Hate crime protections ("no"/"partially", total population)
-        description: |
-          Measures the adoption of hate crime laws, which designate a crime against someone based based on sexual orientation or gender identity as an aggravating circumstance.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.hate_crimes} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1095,10 +1005,8 @@ tables:
           numDecimalPlaces: 0
       incite_hate_no_pop:
         title: Incitement to hatred ("no"/"partially", total population)
-        description: |
-          Measures the adoption of incitement to hatred protections, which is any act that could provoke a targeted crime illegal
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.incite_hate} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1106,10 +1014,8 @@ tables:
           numDecimalPlaces: 0
       joint_adoption_no_pop:
         title: Joint adoptions ("no"/"partially", total population)
-        description: |
-          Measures if joint adoption policy is adopted. This policy allows for same-sex partners to legally adopt a child, with both parents being recognized as such.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.joint_adoption} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1117,10 +1023,8 @@ tables:
           numDecimalPlaces: 0
       lgb_military_no_pop:
         title: LGB military ("no"/"partially", total population)
-        description: |
-          Measures if lesbian, gay, and bisexual people are allowed to serve in the military.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.lgb_military} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1128,10 +1032,8 @@ tables:
           numDecimalPlaces: 0
       lgb_military_ban_no_pop:
         title: LGB military ban ("no"/"partially", total population)
-        description: |
-          Measures if lesbian, gay, and bisexual people are banned from the military.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.lgb_military_ban} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1139,10 +1041,8 @@ tables:
           numDecimalPlaces: 0
       marriage_equality_no_pop:
         title: Marriage equality ("no"/"partially", total population)
-        description: |
-          Measures if there is no legal distinction between same-sex and different-sex marriages.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.marriage_equality} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1150,10 +1050,8 @@ tables:
           numDecimalPlaces: 0
       marriage_ban_no_pop:
         title: Ban on marriage equality ("no"/"partially", total population)
-        description: |
-          Measures if same-sex marriages are banned.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.marriage_ban} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1161,10 +1059,8 @@ tables:
           numDecimalPlaces: 0
       samesex_legal_no_pop:
         title: Same-sex sexual acts legal ("no"/"partially", total population)
-        description: |
-          Measures the presence of a law declaring that same-sex actions are not criminalized between consenting adults.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.samesex_legal} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1172,10 +1068,8 @@ tables:
           numDecimalPlaces: 0
       third_gender_no_pop:
         title: Third gender recognition ("no"/"partially", total population)
-        description: |
-          Measures if a third gender is recognized in the legislation.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.third_gender} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1183,10 +1077,8 @@ tables:
           numDecimalPlaces: 0
       trans_military_no_pop:
         title: Trasgender military ("no"/"partially", total population)
-        description: |
-          Measures if transgender people are allowed to serve in the military.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.trans_military} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1194,10 +1086,8 @@ tables:
           numDecimalPlaces: 0
       civil_unions_no_pop:
         title: Civil unions ("no"/"partially", total population)
-        description: |
-          Measures if civil unions for same-sex partners are adopted. Domestic and registered partnerships are included.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.civil_unions} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1205,10 +1095,8 @@ tables:
           numDecimalPlaces: 0
       gendermarker_no_pop:
         title: Gender marker change ("no"/"partially", total population)
-        description: |
-          Measures if the gender marker can be legally changed.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.gendermarker} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
@@ -1216,12 +1104,380 @@ tables:
           numDecimalPlaces: 0
       propaganda_no_pop:
         title: Anti-propaganda laws ("no", total population)
-        description: |
-          Measures the adoption of policies banning “propaganda for non-traditional sexual relations”. Vaguely written, these laws are utilized to discriminate against LGBT individuals in the name of protecting “public morality, particularly pertaining to children”.
-
-          {descriptions.pop_no}
+        description_short: |
+          {definitions.propaganda} {definitions.pop_no}
         short_unit: ''
         unit: ''
         display:
           name: "No"
           numDecimalPlaces: 0
+
+      age_of_consent:
+        title: Age of consent (combined)
+        description_short: |
+          Combines the equal and unequal age of consent.
+        short_unit: ''
+        unit: ''
+        display:
+          name: Age of consent
+          numDecimalPlaces: 0
+        type: ordinal
+        sort:
+          - Equal
+          - Partial implementation
+          - No legal provisions
+          - Unequal
+
+      marriage:
+        title: Marriage equality (combined)
+        description_short: |
+          Combines marriage equality, marriage ban and civil unions.
+        short_unit: ''
+        unit: ''
+        display:
+          name: Marriage equality
+          numDecimalPlaces: 0
+        type: ordinal
+        sort:
+          - Legal
+          - Partial
+          - No legal provisions
+          - Marriage and ban both partial
+          - Partial ban
+          - Banned
+
+      lgb_military_join:
+        title: LGB military (combined)
+        description_short: |
+          Combines LGB military and LGB military ban.
+        short_unit: ''
+        unit: ''
+        display:
+          name: LGB military
+          numDecimalPlaces: 0
+        type: ordinal
+        sort:
+          - Allowed
+          - No policy
+          - Banned
+
+      age_of_consent_no_legal_provisions_count:
+        title: Age of consent (no legal provisions, number of countries)
+        description_short: |
+          This is the number of countries that do not have legal provisions for the age of consent.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "No legal provisions"
+          numDecimalPlaces: 0
+
+      age_of_consent_equal_count:
+        title: Age of consent (equal, number of countries)
+        description_short: |
+          This is the number of countries that have equal age of consent for same-sex and different-sex partners.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Equal"
+          numDecimalPlaces: 0
+
+      age_of_consent_partial_implementation_count:
+        title: Age of consent (partial implementation, number of countries)
+        description_short: |
+          This is the number of countries that have partial implementation of the age of consent legislation.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Partial implementation"
+          numDecimalPlaces: 0
+
+      age_of_consent_unequal_count:
+        title: Age of consent (unequal, number of countries)
+        description_short: |
+          This is the number of countries that have unequal age of consent for same-sex and different-sex partners.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Unequal"
+          numDecimalPlaces: 0
+
+      age_of_consent_missing_count:
+        title: Age of consent (missing, number of countries)
+        description_short: |
+          This is the number of countries that have missing data on the age of consent.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Missing"
+          numDecimalPlaces: 0
+
+      marriage_no_legal_provisions_count:
+        title: Marriage equality (no legal provisions, number of countries)
+        description_short: |
+          This is the number of countries that do not have legal provisions for marriage equality.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "No legal provisions"
+          numDecimalPlaces: 0
+
+      marriage_partial_count:
+        title: Marriage equality (partial, number of countries)
+        description_short: |
+          This is the number of countries that have partial implementation of marriage equality.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Partial"
+          numDecimalPlaces: 0
+
+      marriage_legal_count:
+        title: Marriage equality (legal, number of countries)
+        description_short: |
+          This is the number of countries that have legal marriage equality.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Legal"
+          numDecimalPlaces: 0
+
+      marriage_banned_count:
+        title: Marriage equality (banned, number of countries)
+        description_short: |
+          This is the number of countries that have banned marriage equality.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Banned"
+          numDecimalPlaces: 0
+
+      marriage_partial_ban_count:
+        title: Marriage equality (partial ban, number of countries)
+        description_short: |
+          This is the number of countries that have partial implementation of a ban on marriage equality.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Partial ban"
+          numDecimalPlaces: 0
+
+      marriage_marriage_and_ban_both_partial_count:
+        title: Marriage equality (marriage and ban both partial, number of countries)
+        description_short: |
+          This is the number of countries that have partial implementation of both marriage equality and a ban on marriage equality.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Marriage and ban both partial"
+          numDecimalPlaces: 0
+
+      marriage_missing_count:
+        title: Marriage equality (missing, number of countries)
+        description_short: |
+          This is the number of countries that have missing data on marriage equality.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Missing"
+          numDecimalPlaces: 0
+
+      lgb_military_join_no_policy_count:
+        title: LGB military (no policy, number of countries)
+        description_short: |
+          This is the number of countries that do not have a policy on LGB military service.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "No policy"
+          numDecimalPlaces: 0
+
+      lgb_military_join_allowed_count:
+        title: LGB military (allowed, number of countries)
+        description_short: |
+          This is the number of countries that allow LGB military service.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Allowed"
+          numDecimalPlaces: 0
+
+      lgb_military_join_banned_count:
+        title: LGB military (banned, number of countries)
+        description_short: |
+          This is the number of countries that ban LGB military service.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Banned"
+          numDecimalPlaces: 0
+
+      lgb_military_join_missing_count:
+        title: LGB military (missing, number of countries)
+        description_short: |
+          This is the number of countries that have missing data on LGB military service.
+        short_unit: ''
+        unit: 'countries'
+        display:
+          name: "Missing"
+          numDecimalPlaces: 0
+
+      age_of_consent_no_legal_provisions_pop:
+        title: Age of consent (no legal provisions, total population)
+        description_short: |
+          This is the total population of countries that do not have legal provisions for the age of consent.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "No legal provisions"
+          numDecimalPlaces: 0
+
+      age_of_consent_equal_pop:
+        title: Age of consent (equal, total population)
+        description_short: |
+          This is the total population of countries that have equal age of consent between same-sex and different-sex partners.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Equal"
+          numDecimalPlaces: 0
+
+      age_of_consent_partial_implementation_pop:
+        title: Age of consent (partial implementation, total population)
+        description_short: |
+          This is the total population of countries that have partial implementation of the age of consent legislation.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Partial implementation"
+          numDecimalPlaces: 0
+
+      age_of_consent_unequal_pop:
+        title: Age of consent (unequal, total population)
+        description_short: |
+          This is the total population of countries that have unequal age of consent between same-sex and different-sex partners.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Unequal"
+          numDecimalPlaces: 0
+
+      age_of_consent_missing_pop:
+        title: Age of consent (missing, total population)
+        description_short: |
+          This is the total population of countries that have missing data on the age of consent.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Missing"
+          numDecimalPlaces: 0
+
+      marriage_no_legal_provisions_pop:
+        title: Marriage equality (no legal provisions, total population)
+        description_short: |
+          This is the total population of countries that do not have legal provisions for marriage equality.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "No legal provisions"
+          numDecimalPlaces: 0
+
+      marriage_partial_pop:
+        title: Marriage equality (partial, total population)
+        description_short: |
+          This is the total population of countries that have partial implementation of marriage equality.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Partial"
+          numDecimalPlaces: 0
+
+      marriage_legal_pop:
+        title: Marriage equality (legal, total population)
+        description_short: |
+          This is the total population of countries that have legal marriage equality.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Legal"
+          numDecimalPlaces: 0
+
+      marriage_banned_pop:
+        title: Marriage equality (banned, total population)
+        description_short: |
+          This is the total population of countries that have banned marriage equality.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Banned"
+          numDecimalPlaces: 0
+
+      marriage_partial_ban_pop:
+        title: Marriage equality (partial ban, total population)
+        description_short: |
+          This is the total population of countries that have partial implementation of a ban on marriage equality.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Partial ban"
+          numDecimalPlaces: 0
+
+      marriage_marriage_and_ban_both_partial_pop:
+        title: Marriage equality (marriage and ban both partial, total population)
+        description_short: |
+          This is the total population of countries that have partial implementation of both marriage equality and a ban on marriage equality.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Marriage and ban both partial"
+          numDecimalPlaces: 0
+
+      marriage_missing_pop:
+        title: Marriage equality (missing, total population)
+        description_short: |
+          This is the total population of countries that have missing data on marriage equality.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Missing"
+          numDecimalPlaces: 0
+
+      lgb_military_join_no_policy_pop:
+        title: LGB military (no policy, total population)
+        description_short: |
+          This is the total population of countries that do not have a policy on LGB military service.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "No policy"
+          numDecimalPlaces: 0
+
+      lgb_military_join_allowed_pop:
+        title: LGB military (allowed, total population)
+        description_short: |
+          This is the total population of countries that allow LGB military service.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Allowed"
+          numDecimalPlaces: 0
+
+      lgb_military_join_banned_pop:
+        title: LGB military (banned, total population)
+        description_short: |
+          This is the total population of countries that ban LGB military service.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Banned"
+          numDecimalPlaces: 0
+
+      lgb_military_join_missing_pop:
+        title: LGB military (missing, total population)
+        description_short: |
+          This is the total population of countries that have missing data on LGB military service.
+        short_unit: ''
+        unit: ''
+        display:
+          name: "Missing"
+          numDecimalPlaces: 0
+

--- a/etl/steps/data/garden/lgbt_rights/2023-04-27/lgbti_policy_index.py
+++ b/etl/steps/data/garden/lgbt_rights/2023-04-27/lgbti_policy_index.py
@@ -1,34 +1,104 @@
 """Load a meadow dataset and create a garden dataset."""
 
-import pandas as pd
+from typing import List
+
+import owid.catalog.processing as pr
 from owid.catalog import Dataset, Table
-from structlog import get_logger
+from owid.datautils.dataframes import map_series
 
 from etl.data_helpers import geo
 from etl.helpers import PathFinder, create_dataset
 
-log = get_logger()
-
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
+# Define regions to aggregate
+REGIONS = ["Europe", "Asia", "North America", "South America", "Africa", "Oceania", "World"]
 
-def load_population() -> Table:
-    """Load population table from population OMM dataset."""
-    ds_indicators: Dataset = paths.load_dependency(channel="garden", namespace="demography", short_name="population")
-    tb_population = ds_indicators["population"].reset_index(drop=False)
+# Define fraction of allowed NaNs per year
+FRAC_ALLOWED_NANS_PER_YEAR = 0.2
 
-    return tb_population
+# Define categories for merged columns and their new names
+CATEGORIES_RENAMING = {
+    "age_of_consent": {
+        "equal: 1 unequal: 0": "Equal",
+        "equal: 0.5 unequal: 0.5": "Partial implementation",
+        "equal: 0 unequal: 0.5": "Partial implementation",
+        "equal: 0 unequal: 0": "No legal provisions",
+        "equal: 0 unequal: 1": "Unequal",
+    },
+    "marriage": {
+        "equality: 1 ban: 0 civil_unions: 0": "Legal",
+        "equality: 1 ban: 0 civil_unions: 1": "Legal",
+        "equality: 1 ban: 0 civil_unions: 0.5": "Legal",
+        "equality: 0.5 ban: 0 civil_unions: 0.5": "Partial",
+        "equality: 0 ban: 0 civil_unions: 1": "Partial",
+        "equality: 0 ban: 0 civil_unions: 0.5": "Partial",
+        "equality: 0 ban: 0 civil_unions: 0": "No legal provisions",
+        "equality: 0 ban: 0.5 civil_unions: 0.5": "Marriage and ban both partial",
+        "equality: 0.5 ban: 0.5 civil_unions: 0.5": "Marriage and ban both partial",
+        "equality: 0.5 ban: 1 civil_unions: 0.5": "Partial ban",
+        "equality: 0 ban: 0.5 civil_unions: 0": "Partial ban",
+        "equality: 0 ban: 1 civil_unions: 1": "Partial ban",
+        "equality: 0 ban: 1 civil_unions: 0.5": "Partial ban",
+        "equality: 0 ban: 1 civil_unions: 0": "Banned",
+    },
+}
 
 
-def add_regional_aggregations(df: pd.DataFrame) -> pd.DataFrame:
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load meadow, regions and population datasets.
+    ds_meadow = paths.load_dataset("lgbti_policy_index")
+    ds_regions = paths.load_dataset("regions")
+    ds_population = paths.load_dataset("population")
+
+    # Read table from meadow dataset.
+    tb = ds_meadow["lgbti_policy_index"].reset_index()
+
+    #
+    # Process data.
+    # Drop region column
+    tb = tb.drop(columns=["region"])
+
+    # Harmonize country names.
+    tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
+
+    # Add regional aggregations
+    tb = add_regional_aggregations(tb, ds_regions=ds_regions, ds_population=ds_population, regions=REGIONS)
+
+    tb = create_combined_columns(tb)
+
+    tb = add_country_counts_and_population_by_status(
+        tb=tb,
+        columns=["age_of_consent", "marriage", "lgb_military_join"],
+        ds_regions=ds_regions,
+        ds_population=ds_population,
+        regions=REGIONS,
+        missing_data_on_columns=True,
+    )
+
+    # Verify index and sort
+    tb = tb.format(["country", "year"])
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(
+        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata
+    )
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()
+
+
+def add_regional_aggregations(tb: Table, ds_regions: Dataset, ds_population: Dataset, regions: List) -> Table:
     """Add regional aggregations using population and country-region mapping."""
 
-    # Load population data
-    tb_population = load_population()
-
-    # Merge df with tb_population to get population
-    df = pd.merge(df, tb_population[["country", "year", "population"]], how="left", on=["country", "year"])
+    tb = geo.add_population_to_table(tb=tb, ds_population=ds_population, warn_on_missing_countries=False)
 
     # Define a list of variable to make them binary
     binary_vars = [
@@ -65,11 +135,11 @@ def add_regional_aggregations(df: pd.DataFrame) -> pd.DataFrame:
         binary_vars_yes_pop.append(f"{var}_yes_pop")
         binary_vars_no_pop.append(f"{var}_no_pop")
 
-        df[f"{var}_yes"] = df[f"{var}"].apply(lambda x: 1 if x == 1 else 0)
-        df[f"{var}_no"] = df[f"{var}"].apply(lambda x: 1 if x < 1 else 0)
+        tb[f"{var}_yes"] = tb[f"{var}"].apply(lambda x: 1 if x == 1 else 0)
+        tb[f"{var}_no"] = tb[f"{var}"].apply(lambda x: 1 if x < 1 else 0)
 
-        df[f"{var}_yes_pop"] = df[f"{var}_yes"] * df["population"]
-        df[f"{var}_no_pop"] = df[f"{var}_no"] * df["population"]
+        tb[f"{var}_yes_pop"] = tb[f"{var}_yes"] * tb["population"]
+        tb[f"{var}_no_pop"] = tb[f"{var}_no"] * tb["population"]
 
     # Run a similar code for regressive policy variables (yes and partially should be together)
     regressive_vars_yes = []
@@ -82,11 +152,11 @@ def add_regional_aggregations(df: pd.DataFrame) -> pd.DataFrame:
         regressive_vars_yes_pop.append(f"{var}_yes_pop")
         regressive_vars_no_pop.append(f"{var}_no_pop")
 
-        df[f"{var}_yes"] = df[f"{var}"].apply(lambda x: 1 if x > 0 else 0)
-        df[f"{var}_no"] = df[f"{var}"].apply(lambda x: 1 if x == 0 else 0)
+        tb[f"{var}_yes"] = tb[f"{var}"].apply(lambda x: 1 if x > 0 else 0)
+        tb[f"{var}_no"] = tb[f"{var}"].apply(lambda x: 1 if x == 0 else 0)
 
-        df[f"{var}_yes_pop"] = df[f"{var}_yes"] * df["population"]
-        df[f"{var}_no_pop"] = df[f"{var}_no"] * df["population"]
+        tb[f"{var}_yes_pop"] = tb[f"{var}_yes"] * tb["population"]
+        tb[f"{var}_no_pop"] = tb[f"{var}_no"] * tb["population"]
 
     # Define variables which their aggregation is weighted by population
     pop_vars = ["policy_index", "samesex_illegal"]
@@ -95,23 +165,7 @@ def add_regional_aggregations(df: pd.DataFrame) -> pd.DataFrame:
     pop_vars_weighted = []
     for var in pop_vars:
         pop_vars_weighted.append(f"{var}_weighted")
-        df[f"{var}_weighted"] = df[var] * df["population"]
-
-    # Define regions to aggregate
-    regions = [
-        "Europe",
-        "Asia",
-        "North America",
-        "South America",
-        "Africa",
-        "Oceania",
-        "High-income countries",
-        "Low-income countries",
-        "Lower-middle-income countries",
-        "Upper-middle-income countries",
-        "European Union (27)",
-        "World",
-    ]
+        tb[f"{var}_weighted"] = tb[var] * tb["population"]
 
     # Define the variables and aggregation method to be used in the following function loop
     aggregations = dict.fromkeys(
@@ -129,23 +183,20 @@ def add_regional_aggregations(df: pd.DataFrame) -> pd.DataFrame:
     )
 
     # Add regional aggregates, by summing up the variables in `aggregations`
-    for region in regions:
-        df = geo.add_region_aggregates(
-            df,
-            region=region,
-            aggregations=aggregations,
-            countries_that_must_have_data=[],
-            population=df,
-            num_allowed_nans_per_year=None,
-            frac_allowed_nans_per_year=0.2,
-        )
+    tb = geo.add_regions_to_table(
+        tb=tb,
+        ds_regions=ds_regions,
+        regions=regions,
+        aggregations=aggregations,
+        frac_allowed_nans_per_year=FRAC_ALLOWED_NANS_PER_YEAR,
+    )
 
-    # Filter dataset by regions to make additional calculations and drop regions in df
-    df_regions = df[df["country"].isin(regions)].reset_index(drop=True)
-    df = df[~df["country"].isin(regions)].reset_index(drop=True)
+    # Filter dataset by regions to make additional calculations and drop regions in tb
+    tb_regions = tb[tb["country"].isin(regions)].reset_index(drop=True)
+    tb = tb[~tb["country"].isin(regions)].reset_index(drop=True)
 
-    # Also drop binary vars in df (they are only useful for regions)
-    df = df.drop(
+    # Also drop binary vars in tb (they are only useful for regions)
+    tb = tb.drop(
         columns=binary_vars_yes
         + binary_vars_no
         + binary_vars_yes_pop
@@ -158,57 +209,174 @@ def add_regional_aggregations(df: pd.DataFrame) -> pd.DataFrame:
 
     # Calculate average variables for regions
     for var in pop_vars:
-        df_regions[var] = df_regions[f"{var}_weighted"] / df_regions["population"]
+        tb_regions[var] = tb_regions[f"{var}_weighted"] / tb_regions["population"]
 
-    # Concatenate df with df_regions
-    df = pd.concat([df, df_regions], ignore_index=True)
+    # Concatenate tb with tb_regions
+    tb = pr.concat([tb, tb_regions], ignore_index=True)
 
     # Drop weighted and population columns
-    df = df.drop(columns=["population"] + pop_vars_weighted)
+    tb = tb.drop(columns=["population"] + pop_vars_weighted)
 
-    # # Verify index and sort
-    df = df.set_index(["country", "year"], verify_integrity=True).sort_index()
-
-    return df
+    return tb
 
 
-def run(dest_dir: str) -> None:
-    log.info("lgbti_policy_index.start")
+def create_combined_columns(tb: Table) -> Table:
+    """Create combined columns for some variables covering the same issue"""
 
-    #
-    # Load inputs.
-    #
-    # Load meadow dataset.
-    ds_meadow: Dataset = paths.load_dependency("lgbti_policy_index")
+    # AGE OF CONSENT
+    # Create categories to classify equal_age and unequal_age numbers
+    tb = create_temporary_category_cols(tb, ["equal_age", "unequal_age"])
+    tb["age_of_consent"] = "equal: " + tb["equal_age_category"] + " unequal: " + tb["unequal_age_category"]
 
-    # Read table from meadow dataset.
-    tb_meadow = ds_meadow["lgbti_policy_index"]
+    # MARRIAGE
+    # Create categories to classify marriage_equality, marriage_ban and civil_unions numbers
+    tb = create_temporary_category_cols(tb, ["marriage_equality", "marriage_ban", "civil_unions"])
+    tb["marriage"] = (
+        "equality: "
+        + tb["marriage_equality_category"]
+        + " ban: "
+        + tb["marriage_ban_category"]
+        + " civil_unions: "
+        + tb["civil_unions_category"]
+    )
 
-    # Create a dataframe with data from the table.
-    df = pd.DataFrame(tb_meadow).reset_index(drop=False)
+    # LGBT MILITARY
+    tb.loc[(tb["lgb_military"] == 1) & (tb["lgb_military_ban"] == 0), "lgb_military_join"] = "Allowed"
+    tb.loc[(tb["lgb_military"] == 0) & (tb["lgb_military_ban"] == 1), "lgb_military_join"] = "Banned"
+    tb.loc[(tb["lgb_military"] == 0) & (tb["lgb_military_ban"] == 0), "lgb_military_join"] = "No policy"
 
-    #
-    # Process data.
-    # Drop region column
-    df = df.drop(columns=["region"])
+    # Copy metadata to lgbt_military_join
+    tb["lgb_military_join"] = tb["lgb_military_join"].copy_metadata(tb["country"])
 
-    # Harmonize country names.
-    log.info("lgbti_policy_index.harmonize_countries")
-    df = geo.harmonize_countries(df=df, countries_file=paths.country_mapping_path)
+    # Remove temporary columns
+    tb = tb.drop(
+        columns=[
+            "equal_age_category",
+            "unequal_age_category",
+            "marriage_equality_category",
+            "marriage_ban_category",
+            "civil_unions_category",
+        ]
+    )
 
-    # Add regional aggregations
-    df = add_regional_aggregations(df)
+    # Remap categories
+    # Define columns
+    column_list = list(CATEGORIES_RENAMING.keys())
 
-    # Create a new table with the processed data.
-    tb_garden = Table(df, short_name="lgbti_policy_index")
+    # Rename categories
+    for col in column_list:
+        tb[col] = tb[col].astype("string")
+        tb[col] = map_series(
+            series=tb[col],
+            mapping=CATEGORIES_RENAMING[col],
+            warn_on_missing_mappings=False,
+            warn_on_unused_mappings=False,
+            show_full_warning=False,
+        )
+        tb[col] = tb[col].copy_metadata(tb["country"])
 
-    #
-    # Save outputs.
-    #
-    # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb_garden])
+    return tb
 
-    # Save changes in the new garden dataset.
-    ds_garden.save()
 
-    log.info("lgbti_policy_index.end")
+def create_temporary_category_cols(tb: Table, columns: List) -> Table:
+    """
+    Create categories for numerical values and avoid code repetition
+    """
+
+    for col in columns:
+        tb.loc[tb[col] == 1, f"{col}_category"] = "1"
+        tb.loc[(tb[col] > 0) & (tb[col] < 1), f"{col}_category"] = "0.5"
+        tb.loc[tb[col] == 0, f"{col}_category"] = "0"
+
+    return tb
+
+
+def add_country_counts_and_population_by_status(
+    tb: Table,
+    columns: List[str],
+    ds_regions: Dataset,
+    ds_population: Dataset,
+    regions: List[str],
+    missing_data_on_columns: bool = False,
+) -> Table:
+    """
+    Add country counts and population by status for the columns in the list
+    """
+
+    tb_regions = tb.copy()
+
+    tb_regions = geo.add_population_to_table(
+        tb=tb_regions, ds_population=ds_population, warn_on_missing_countries=False
+    )
+
+    # Define empty dictionaries for each of the columns
+    columns_count_dict = {columns[i]: [] for i in range(len(columns))}
+    columns_pop_dict = {columns[i]: [] for i in range(len(columns))}
+    for col in columns:
+        if missing_data_on_columns:
+            # Fill nan values with "missing"
+            tb_regions[col] = tb_regions[col].fillna("missing")
+        # Get the unique values in the column
+        status_list = list(tb_regions[col].unique())
+        for status in status_list:
+            # Calculate count and population for each status in the column
+            tb_regions[f"{col}_{status}_count"] = tb_regions[col].apply(lambda x: 1 if x == status else 0)
+            tb_regions[f"{col}_{status}_pop"] = tb_regions[f"{col}_{status}_count"] * tb_regions["population"]
+
+            # Add the new columns to the list
+            columns_count_dict[col].append(f"{col}_{status}_count")
+            columns_pop_dict[col].append(f"{col}_{status}_pop")
+
+    # Create a new list with all the count columns and population columns
+    columns_count = [item for sublist in columns_count_dict.values() for item in sublist]
+    columns_pop = [item for sublist in columns_pop_dict.values() for item in sublist]
+
+    aggregations = dict.fromkeys(
+        columns_count + columns_pop + ["population"],
+        "sum",
+    )
+
+    tb_regions = geo.add_regions_to_table(
+        tb=tb_regions,
+        ds_regions=ds_regions,
+        regions=regions,
+        aggregations=aggregations,
+        frac_allowed_nans_per_year=FRAC_ALLOWED_NANS_PER_YEAR,
+    )
+
+    # Remove population column
+    tb_regions = tb_regions.drop(columns=["population"])
+
+    # Add population again
+    tb_regions = geo.add_population_to_table(
+        tb=tb_regions, ds_population=ds_population, warn_on_missing_countries=False
+    )
+
+    # Calculate the missing population for each region
+    for col in columns:
+        # Calculate the missing population for each column, by subtracting the population of the countries with data from the total population
+        tb_regions[f"{col}_missing_pop_other_countries"] = tb_regions["population"] - tb_regions[
+            columns_pop_dict[col]
+        ].sum(axis=1)
+        if missing_data_on_columns:
+            tb_regions[f"{col}_missing_pop"] = (
+                tb_regions[f"{col}_missing_pop"] + tb_regions[f"{col}_missing_pop_other_countries"]
+            )
+
+        else:
+            # Rename column
+            tb_regions = tb_regions.rename(columns={f"{col}_missing_pop_other_countries": f"{col}_missing_pop"})
+
+            # Append this missing population column to the list of population columns
+            columns_pop.append(f"{col}_missing_pop")
+
+    # Keep only the regions in the country column
+    tb_regions = tb_regions[tb_regions["country"].isin(REGIONS)].copy().reset_index(drop=True)
+
+    # Keep only the columns I need
+    tb_regions = tb_regions[["country", "year"] + columns_count + columns_pop]
+
+    # Merge the two tables
+    tb = pr.merge(tb, tb_regions, on=["country", "year"], how="outer")
+
+    return tb

--- a/etl/steps/data/garden/lgbt_rights/2024-06-03/equaldex.py
+++ b/etl/steps/data/garden/lgbt_rights/2024-06-03/equaldex.py
@@ -155,7 +155,7 @@ def run(dest_dir: str) -> None:
     # Load inputs.
     #
     # Load meadow and regions and population datasets.
-    ds_meadow: Dataset = paths.load_dependency("equaldex")
+    ds_meadow = paths.load_dataset("equaldex")
     ds_regions = paths.load_dataset("regions")
     ds_population = paths.load_dataset("population")
 
@@ -245,7 +245,13 @@ def make_table_wide_and_map_categories(tb: Table) -> Table:
 
         # Assign an order to the categories, by modifying the metadata of the column
         tb[issue].m.type = "ordinal"
-        tb[issue].m.sort = list(dict.fromkeys(CATEGORIES_RENAMING[issue].values()))
+        # Create a list of unique categories and remove duplicates
+        categories_from_dict = list(dict.fromkeys(CATEGORIES_RENAMING[issue].values()))
+        categories_from_column = list(tb[issue].dropna().unique().copy())
+
+        # Remove values in categories_from_dict that are not in categories_from_column
+        categories_list = [x for x in categories_from_dict if x in categories_from_column]
+        tb[issue].m.sort = categories_list
 
     # Assert if the issues available are EXPECTED_COLUMNS
     assert set(issue_list + ["country", "year"]) == set(tb.columns), paths.log.error(

--- a/etl/steps/data/grapher/lgbt_rights/2023-04-27/lgbti_policy_index.py
+++ b/etl/steps/data/grapher/lgbt_rights/2023-04-27/lgbti_policy_index.py
@@ -19,14 +19,12 @@ def run(dest_dir: str) -> None:
     tb_garden = ds_garden["lgbti_policy_index"]
 
     #
-    # Process data.
-    #
-
-    #
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
+    ds_grapher = create_dataset(
+        dest_dir, tables=[tb_garden], check_variables_metadata=True, default_metadata=ds_garden.metadata
+    )
 
     #
     # Checks.

--- a/etl/steps/data/grapher/lgbt_rights/2024-06-03/equaldex.py
+++ b/etl/steps/data/grapher/lgbt_rights/2024-06-03/equaldex.py
@@ -22,7 +22,9 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
+    ds_grapher = create_dataset(
+        dest_dir, tables=[tb_garden], check_variables_metadata=True, default_metadata=ds_garden.metadata
+    )
 
     #
     # Checks.

--- a/etl/steps/data/meadow/lgbt_rights/2023-04-27/lgbti_policy_index.py
+++ b/etl/steps/data/meadow/lgbt_rights/2023-04-27/lgbti_policy_index.py
@@ -1,55 +1,40 @@
 """Load a snapshot and create a meadow dataset."""
 
-import pandas as pd
-from owid.catalog import Table
-from structlog import get_logger
-
 from etl.helpers import PathFinder, create_dataset
-from etl.snapshot import Snapshot
-
-# Initialize logger.
-log = get_logger()
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
-    log.info("lgbti_policy_index.start")
-
     #
     # Load inputs.
     #
     # Retrieve snapshot.
-    snap: Snapshot = paths.load_dependency("lgbti_policy_index.xlsx")
+    snap = paths.load_snapshot("lgbti_policy_index.xlsx")
 
     # Load data from snapshot.
-    df = pd.read_excel(snap.path, sheet_name="Sheet1")
+    tb = snap.read(sheet_name="Sheet1")
 
     #
     # Process data.
 
     # Remove duplicated values for Australia in region = Europe (the author's original dataset has a duplicated value for Australia, one for Oceania and one for Europe).
-    mask = (df["country"] == "Australia") & (df["region"] == "Europe")
+    mask = (tb["country"] == "Australia") & (tb["region"] == "Europe")
 
     if mask.sum() > 0:
-        log.info("There are duplicated values for Australia in the Europe region. They will be removed.")
-        df = df[~mask]
+        paths.log.info("There are duplicated values for Australia in the Europe region. They will be removed.")
+        tb = tb[~mask]
 
     #
     # Verify index and sort
-    df = df.set_index(["country", "year"], verify_integrity=True).sort_index()
-
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(df, short_name=paths.short_name, underscore=True)
+    tb = tb.format(["country", "year"])
 
     #
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
+    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new garden dataset.
     ds_meadow.save()
-
-    log.info("lgbti_policy_index.end")

--- a/snapshots/lgbt_rights/2023-04-27/lgbti_policy_index.xlsx.dvc
+++ b/snapshots/lgbt_rights/2023-04-27/lgbti_policy_index.xlsx.dvc
@@ -1,61 +1,66 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/origin/
 meta:
-  namespace: lgbt_rights
-  short_name: lgbti_policy_index
-  name: LGBT+ policies (Velasco, 2020)
-  version: '2023-04-27'
-  publication_date: '2020-07-24'
-  source_name: Kristopher Velasco (2020)
-  source_published_by: 'Velasco, K. (2020). Transnational Backlash and the Deinstitutionalization
-    of Liberal Norms: LGBT+ Rights in a Contested World. https://doi.org/10.31235/osf.io/3rtje'
-  url: https://osf.io/preprints/socarxiv/3rtje/
-  source_data_url:
-  file_extension: xlsx
-  license_url:
-  license_name: ''
-  date_accessed: 2023-06-15
-  is_public: true
-  description: |
-    Velasco measures a country’s LGBT+ policy landscape with an original LGBT+ policy index that he created; the LGBT+ Policy Index captures the implementation of 18 different LGBT+ policies. Policies included in the index are limited to those adopted across at least three countries or are explicitly advocated for by transnational activists.
+  origin:
+    # Data product / Snapshot
+    title: LGBT+ policies (Kristopher Velasco)
+    description: |-
+      Velasco measures a country’s LGBT+ policy landscape with an original LGBT+ policy index that he created; the LGBT+ Policy Index captures the implementation of 18 different LGBT+ policies. Policies included in the index are limited to those adopted across at least three countries or are explicitly advocated for by transnational activists.
 
-    These policies are subdivided between:
+      These policies are subdivided between:
 
-      Progressive policies:
-        1.	Same-Sex Sexual Acts Legal
-        2.	Equal Age of Consent
-        3.	Employment Discrimination
-        4.	Hate Crime Protections
-        5.	Incitement to Hatred
-        6.	Civil Unions
-        7.	Marriage Equality
-        8.	Joint Adoptions
-        9.	Gender Marker Change
-        10.	LGB Military
-        11.	Transgender Military
-        12.	Ban on Conversion Therapies
-        13.	Ban on Gender Assignment Surgeries on Children
+        Progressive policies:
+          1.	Same-Sex Sexual Acts Legal
+          2.	Equal Age of Consent
+          3.	Employment Discrimination
+          4.	Hate Crime Protections
+          5.	Incitement to Hatred
+          6.	Civil Unions
+          7.	Marriage Equality
+          8.	Joint Adoptions
+          9.	Gender Marker Change
+          10.	LGB Military
+          11.	Transgender Military
+          12.	Ban on Conversion Therapies
+          13.	Ban on Gender Assignment Surgeries on Children
 
-      Regressive policies
-        1.	Death Penalty for Same-Sex Sexual Acts
-        2.	Propaganda Laws
-        3.	Same-Sex Sexual Acts Ilegal
-        4.	Unequal Age of Consent
-        5.	Ban on Marriage Equality
+        Regressive policies
+          1.	Death Penalty for Same-Sex Sexual Acts
+          2.	Propaganda Laws
+          3.	Same-Sex Sexual Acts Ilegal
+          4.	Unequal Age of Consent
+          5.	Ban on Marriage Equality
 
-    These policies are not measured in a binary (adopted/not-adopted) scheme; the author follows Frank and colleagues (2010, 2017) in considering that similar policies can meaningfully vary in scope, benefits, punishment, etc. So, he determines the robustness of each policy by reviewing five indicators (between parentheses are the scoring schemes):
-      1.	Proportion of Population Living Under Law: To acknowledge subnational variations (0-1)
-      2.	Scope of Genders Subject to Law: As they can be typically differentiated by gender (0: no law, 0.5: just men or women, 1: both)
-      3.	Maximum Level of Punishment: For regressive policies (0: no law, 0.2: <3 years, 0.4: >3 years and <15 years, 0.6: >15 years and < life, 0.8: live in prison, 1: death penality)
-      4.	Ease of Access: To benefits the law outlines (0: no law, 0.25: significant barriers, 0.5: moderate barriers, 0.75: little to few barriers, 1: no barriers)
-      5.	Evidence of Enforcement: Has been least one case the previous year where this was implemented? (0: no evidence, 1: evidence)
+      These policies are not measured in a binary (adopted/not-adopted) scheme; the author follows Frank and colleagues (2010, 2017) in considering that similar policies can meaningfully vary in scope, benefits, punishment, etc. So, he determines the robustness of each policy by reviewing five indicators (between parentheses are the scoring schemes):
+        1.	Proportion of Population Living Under Law: To acknowledge subnational variations (0-1)
+        2.	Scope of Genders Subject to Law: As they can be typically differentiated by gender (0: no law, 0.5: just men or women, 1: both)
+        3.	Maximum Level of Punishment: For regressive policies (0: no law, 0.2: <3 years, 0.4: >3 years and <15 years, 0.6: >15 years and < life, 0.8: live in prison, 1: death penality)
+        4.	Ease of Access: To benefits the law outlines (0: no law, 0.25: significant barriers, 0.5: moderate barriers, 0.75: little to few barriers, 1: no barriers)
+        5.	Evidence of Enforcement: Has been least one case the previous year where this was implemented? (0: no evidence, 1: evidence)
 
-    While all five indicators may not be relevant to each policy, each policy in question uses at least three different indicators and with them, each policy score ranges from 0 to 1. Therefore, a score of 1 corresponds to that policy's most robust scope and implementation. This also means that changes in any indicators will influence each policy’s overall score. For example, a country having national marriage equality (indicator 1), few (if any) formal restrictions to obtaining a marriage license (indicator 4), and full implementation (indicator 5) will receive a score of 1.
+      While all five indicators may not be relevant to each policy, each policy in question uses at least three different indicators and with them, each policy score ranges from 0 to 1. Therefore, a score of 1 corresponds to that policy's most robust scope and implementation. This also means that changes in any indicators will influence each policy’s overall score. For example, a country having national marriage equality (indicator 1), few (if any) formal restrictions to obtaining a marriage license (indicator 4), and full implementation (indicator 5) will receive a score of 1.
 
-    To create the index, the scores for each policy are summed together annually, with progressive policies receiving a positive score and regressive policies receiving a negative. This results in an index ranging from -5 to +13. No country reaches these extremes, demonstrating that countries can get better and worse in their policy environments.
+      To create the index, the scores for each policy are summed together annually, with progressive policies receiving a positive score and regressive policies receiving a negative. This results in an index ranging from -5 to +13. No country reaches these extremes, demonstrating that countries can get better and worse in their policy environments.
 
-    The LGBT+ policy index represents the most robust and nuanced measure of LGBT+ policy adoption and implementation to date and is a novel contribution to the literature. By incorporating progressive and regressive LGBT+ policies and variation in implementation beyond a binary coding scheme, this measure captures even fine-grained changes to the LGBT+ policy landscape. It better assesses the extent to which countries are or are not influenced by transnational processes.
+      The LGBT+ policy index represents the most robust and nuanced measure of LGBT+ policy adoption and implementation to date and is a novel contribution to the literature. By incorporating progressive and regressive LGBT+ policies and variation in implementation beyond a binary coding scheme, this measure captures even fine-grained changes to the LGBT+ policy landscape. It better assesses the extent to which countries are or are not influenced by transnational processes.
 
-    Multiple sources were consulted to find the necessary data to construct this index. The primary data source was the State Sponsored Homophobia Reports produced by ILGA. These reports, produced almost annually, outline the adoption of various policies and provide some information on implementation. For information on trans- and intersex-specific policies and military information, other sources were used, including the Trans Legal Mapping Report, also produced by ILGA, reports and documentation provided by Transgender Europe, Movement Advancement Project, The Hague Center for Strategic Studies LGBT+ Military Index, and academic studies such as Reynolds (2013). Furthermore, multiple sources were used to obtain data on the evidence of enforcement – particularly arrests – including an extensive newspaper search across each country using LexisNexis and Factiva and other external reports by Amnesty International, Human Rights Watch, and the U.S. State Department.
-wdir: ../../../data/snapshots/lgbt_rights/2023-04-27
+      Multiple sources were consulted to find the necessary data to construct this index. The primary data source was the State Sponsored Homophobia Reports produced by ILGA. These reports, produced almost annually, outline the adoption of various policies and provide some information on implementation. For information on trans- and intersex-specific policies and military information, other sources were used, including the Trans Legal Mapping Report, also produced by ILGA, reports and documentation provided by Transgender Europe, Movement Advancement Project, The Hague Center for Strategic Studies LGBT+ Military Index, and academic studies such as Reynolds (2013). Furthermore, multiple sources were used to obtain data on the evidence of enforcement – particularly arrests – including an extensive newspaper search across each country using LexisNexis and Factiva and other external reports by Amnesty International, Human Rights Watch, and the U.S. State Department.
+    date_published: '2020-07-24'
+
+    # Citation
+    producer: Velasco
+    citation_full: |-
+      Velasco, K. (2020). Transnational Backlash and the Deinstitutionalization of Liberal Norms: LGBT+ Rights in a Contested World. https://doi.org/10.31235/osf.io/3rtje
+
+    # Files
+    url_main: https://osf.io/preprints/socarxiv/3rtje/
+    date_accessed: 2023-06-15
+
+    # License
+    license:
+      name: Center for Open Science Terms and Conditions of Use
+      url: https://github.com/CenterForOpenScience/cos.io/blob/master/TERMS_OF_USE.md
+
 outs:
 - md5: e82a8f0caecf5b3187afb24e70591ec4
   size: 380622


### PR DESCRIPTION
Add combined indicators for same-sex marriage, LGB in the military and age of consent. Also add aggregations for each of the status of these columns.
The rest of the code is the same, though it has been updated to reflect the latest metadata changes.
Main issue https://github.com/owid/owid-issues/issues/1556