### PR TITLE
:bug: load .env by default instead of loading local

### DIFF
--- a/etl/config.py
+++ b/etl/config.py
@@ -480,4 +480,4 @@ class OWIDEnv:
         return f"{self.indicators_url}/{variable_id}.data.json"
 
 
-OWID_ENV = OWIDEnv.from_local()
+OWID_ENV = OWIDEnv.from_env_file(str(ENV_FILE))

--- a/etl/config.py
+++ b/etl/config.py
@@ -25,7 +25,7 @@ from etl.paths import BASE_DIR
 
 log = structlog.get_logger()
 
-ENV_FILE = env.get("ENV_FILE", BASE_DIR / ".env")
+ENV_FILE = Path(env.get("ENV_FILE", BASE_DIR / ".env"))
 
 
 def get_username():
@@ -480,4 +480,7 @@ class OWIDEnv:
         return f"{self.indicators_url}/{variable_id}.data.json"
 
 
-OWID_ENV = OWIDEnv.from_env_file(str(ENV_FILE))
+if ENV_FILE.exists():
+    OWID_ENV = OWIDEnv.from_env_file(str(ENV_FILE))
+else:
+    OWID_ENV = OWIDEnv.from_local()


### PR DESCRIPTION
`OWID_ENV` was set to local by default during this [refactoring](https://github.com/owid/etl/commit/2c6b6938bcdc1a4674a7ba1411bda851c51cc4f0#diff-65c3044b26e69b8a41f84a5c6dd8fe22ceb6f6c91b7b1815186968c2177dc5c5R479). Wizard then uses it as a default env in function [get_staging_creation_time](https://github.com/owid/etl/blob/5be4b4dbf1bc403d26a6ce6398e5c9420e9b1928/apps/wizard/utils/__init__.py#L711). Since local MySQL doesn't exist in production, wizard fails when trying to connect to it with
```
Access denied for user 'owid'@'etl-prod-2.owid.org.github.beta.tailscale.net
```

This PR doesn't load local by default, but from env by default.