### PR TITLE
✨ draft-pr: add options

### DIFF
--- a/apps/utils/draft_pull_request.py
+++ b/apps/utils/draft_pull_request.py
@@ -134,23 +134,7 @@ def cli(
     local_branches = [branch.name for branch in repo.branches]
 
     # Create title
-    if title is not None:
-        prefix = ""
-        # Add emoji for PR mode chosen if applicable
-        if category is not None:
-            if category in PR_CATEGORIES:
-                prefix = PR_CATEGORIES[category]["emoji"]
-            else:
-                log.error(f"Invalid PR type '{category}'. Choose one of {list(PR_CATEGORIES.keys())}.")
-                return
-        # Add scope
-        if scope is not None:
-            if prefix != "":
-                prefix += " "
-            prefix += f"{scope}:"
-
-        # Add prefix
-        title = f"{prefix} {title}"
+    title = generate_pr_title(title, category, scope)
 
     # Update the list of remote branches in the local repository.
     origin = repo.remote(name="origin")
@@ -225,3 +209,30 @@ def cli(
         log.info(f"Draft pull request created successfully at {js['html_url']}.")
     else:
         log.error(f"Failed to create draft pull request:\n{response.json()}")
+
+
+def generate_pr_title(title: str | None, category: str | None, scope: str | None) -> None | str:
+    """Generate the PR title.
+
+    title + category + scope -> 'category scope: title'
+    title + category -> 'category title'
+    scope + title -> 'scope: title'
+    """
+    if title is not None:
+        prefix = ""
+        # Add emoji for PR mode chosen if applicable
+        if category is not None:
+            if category in PR_CATEGORIES:
+                prefix = PR_CATEGORIES[category]["emoji"]
+            else:
+                log.error(f"Invalid PR type '{category}'. Choose one of {list(PR_CATEGORIES.keys())}.")
+                return
+        # Add scope
+        if scope is not None:
+            if prefix != "":
+                prefix += " "
+            prefix += f"{scope}:"
+
+        # Add prefix
+        title = f"{prefix} {title}"
+    return title

--- a/apps/utils/draft_pull_request.py
+++ b/apps/utils/draft_pull_request.py
@@ -81,7 +81,7 @@ PR_CATEGORIES = {
     },
 }
 description = "- " + "\n- ".join(
-    f"**{choice}: {choice_params['description']}" for choice, choice_params in PR_CATEGORIES.items()
+    f"**{choice}**: {choice_params['description']}" for choice, choice_params in PR_CATEGORIES.items()
 )
 
 

--- a/apps/utils/draft_pull_request.py
+++ b/apps/utils/draft_pull_request.py
@@ -100,12 +100,12 @@ description = "- " + "\n- ".join(
     "--category",
     "-c",
     type=click.Choice(list(PR_CATEGORIES.keys()), case_sensitive=False),
-    help=f"Category of the PR. Only works if --title is used (it will be added to the PR title). A corresponding emoji will be pre-fixed to the PR title.\n {description}",
+    help=f"Category of the PR (only relevant if --title is given). A corresponding emoji will be prepended to the title.\n {description}",
 )
 @click.option(
     "--scope",
     "-s",
-    help="Scope of the PR. Only works if --title is used (it will be added to the PR title).\n\n\n**Examples**: 'demography' for data work on this field, 'etl.db' if working on specific modules, 'wizard', etc.",
+    help="Scope of the PR (only relevant if --title is given). This text will be preprended to the PR title. \n\n\n**Examples**: 'demography' for data work on this field, 'etl.db' if working on specific modules, 'wizard', etc.",
 )
 def cli(
     new_branch: Optional[str] = None,


### PR DESCRIPTION
## Add prefix options

- `--category` (or `-c`): PR category based on [our etiquette](https://www.notion.so/owid/Git-GitHub-etiquette-68e824bed1a747e1a01f2b771c695bf7). Will be used to add an emoji to the start of the PR title.
- `--scope` (or `-s`): brief summary of the PR scope (e.g. 'wizard')

### Examples

`etl d draft-pr <branch-name> -c data -t "Update VDEM data"` →  **:bar_chart: Update VDEM data**

`etl d draft-pr <branch-name> -c data -s vdem -t "update"` →  **:bar_chart: vdem: update**

`etl d draft-pr <branch-name> "Update VDEM data"` →  **Update VDEM data**

`etl d draft-pr <branch-name> -c enhance -s vdem` →  **🚧 Draft PR for branch <branch-name>** (i.e. no title is given, will ignore prefixes and use default title)



### Notes
- This brings us closer to harmonizing PR titles. It also encourages us to define the scope of our work beforehand. Still, one can still change the PR name later from GitHub, of course.
- I can see how this command could be made shorter in the future if we need to:
  - `etl d draft-pr` → `etl pr`
  - `-c data -s vdem -t "update"` → `-d vdem "update"`, where first is flag with PR category, and then two positional (free-text) arguments: scope, and title.
  - so it'd be `etl d draft-pr -c data -s vdem -t update` → `etl pr -d vdem update`


### Other modifications
In addition, I've added shorter argument names `-t` for `--title` and `-b` for `--base-branch`.