### PR TITLE
 :bug: Use latest approval for chart-diff

### DIFF
--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -1439,7 +1439,7 @@ class ChartDiffApprovals(Base):
         # Get matches from DB
         criteria = list(zip(chart_ids, source_updated_ats, target_updated_ats))
 
-        results = session.scalars(
+        raw_results = session.scalars(
             select(cls)
             .where(
                 or_(
@@ -1455,7 +1455,13 @@ class ChartDiffApprovals(Base):
             )
             .order_by(cls.updatedAt.desc())
         ).all()
-        results = {res.chartId: res for res in results}
+
+        # Take the latest approval for each chart - note that it's sorted by updatedAt, so we take just the
+        # first element
+        results = {}
+        for r in raw_results:
+            if r.chartId not in results:
+                results[r.chartId] = r
 
         # List with statuses corresponding to charts specified by IDs in chart_ids
         statuses = []


### PR DESCRIPTION
> chart-sync ran on my latest merged [PR here](https://github.com/owid/etl/pull/2834). In it, I rejected all the chart-diffs, yet one of them was migrated to PROD. You can see I rejected all of them here: http://staging-site-news/etl/wizard/chart-diff.

@lucasrodes this is the fix. I noticed that in MySQL that chart was first rejected and then approved
```
mysql> select * from chart_diff_approvals;
+----+---------+---------------------+-----------------+---------------------+----------+
| id | chartId | sourceUpdatedAt     | targetUpdatedAt | updatedAt           | status   |
+----+---------+---------------------+-----------------+---------------------+----------+
|  1 |    7906 | 2024-06-18 20:34:20 | NULL            | 2024-06-19 12:47:50 | rejected |
|  2 |    7906 | 2024-06-18 20:34:20 | NULL            | 2024-06-19 12:47:56 | approved |
|  3 |    7904 | 2024-06-18 20:26:58 | NULL            | 2024-06-19 12:48:13 | rejected |
|  4 |    7903 | 2024-06-18 17:14:15 | NULL            | 2024-06-19 12:48:15 | rejected |
|  5 |    7905 | 2024-06-18 20:31:41 | NULL            | 2024-06-19 12:48:17 | rejected |
+----+---------+---------------------+-----------------+---------------------+----------+
```
chart-diff was using the first one and chart-sync the second (correctly). So it thought it's approved and synced it.