### PR TITLE
 :bar_chart: Reduce memory footprint of surface temperature

### DIFF
--- a/etl/steps/data/meadow/climate/2023-12-20/surface_temperature.py
+++ b/etl/steps/data/meadow/climate/2023-12-20/surface_temperature.py
@@ -28,10 +28,16 @@ def _load_data_array(snap: Snapshot) -> xr.DataArray:
     with gzip.open(snap.path, "r") as _file:
         ds = xr.open_dataset(_file)
 
+    # Use smaller types
+    ds["t2m"] = ds["t2m"].astype("float32")
+
     # The latest 3 months in this dataset are made available through ERA5T, which is slightly different to ERA5. In the downloaded file, an extra dimenions ‘expver’ indicates which data is ERA5 (expver = 1) and which is ERA5T (expver = 5).
     # If a value is missing in the first dataset, it is filled with the value from the second dataset.
     # Select the 't2m' variable from the combined dataset.
-    da = ds.sel(expver=1).combine_first(ds.sel(expver=5))["t2m"]
+    ds1 = ds.sel(expver=1)
+    ds5 = ds.sel(expver=5)
+    da = ds1.combine_first(ds5)["t2m"]
+    del ds1, ds5
 
     # Convert temperature from Kelvin to Celsius.
     da = da - 273.15


### PR DESCRIPTION
Use smaller type float32 to reduce memory footprint. Check out data-diff below for differences (it's on the sixth decimal place). If this doesn't work, I guess we can just move the entire `_load_data_array` to snapshot.