### PR TITLE
✨ chart-diff: performance, ux/ui

### DIFF
--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -372,7 +372,7 @@ def show_chart_diffs(chart_diffs, pagination_key, source_session: Session, targe
         )
         ## Show controls only if needed
         if len(chart_diffs) > st.session_state["charts-per-page"]:
-            pagination.show_controls()
+            pagination.show_controls(mode="bar")
 
     # Show charts
     with Session(TARGET_ENGINE) as target_session:

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -475,6 +475,7 @@ class ChartDiffShow:
             with tab2:
                 self._show_approval_history()
 
+    @st.experimental_fragment
     def show(self):
         """Show chart diff."""
         # Show in expander or not

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -94,8 +94,7 @@ class ChartDiffShow:
 
         This contains the state of the approval (by means of an emoji), the slug of the chart, and any tags (like "NEW" or "DRAFT").
         """
-        emoji = DISPLAY_STATE_OPTIONS[self.diff.approval_status]["icon"]  # type: ignore
-        label = f"{emoji} {self.diff.slug}"
+        label = self.diff.slug
         tags = []
         if self.diff.is_new:
             tags.append(" :blue-background[**NEW**]")
@@ -480,7 +479,11 @@ class ChartDiffShow:
         """Show chart diff."""
         # Show in expander or not
         if self.expander:
-            with st.expander(self.box_label, not self.diff.is_reviewed):
+            with st.expander(
+                label=self.box_label,
+                icon=DISPLAY_STATE_OPTIONS[cast(str, self.diff.approval_status)]["icon"],
+                expanded=not self.diff.is_reviewed,
+            ):
                 self._show()
         else:
             self._show()

--- a/apps/wizard/utils/__init__.py
+++ b/apps/wizard/utils/__init__.py
@@ -673,38 +673,53 @@ def enable_bugsnag_for_streamlit():
     error_util.handle_uncaught_app_exception = bugsnag_handler  # type: ignore
 
 
-def chart_html(chart_config: Dict[str, Any], owid_env: OWIDEnv, height=500, **kwargs):
+def chart_html(chart_config: Dict[str, Any], owid_env: OWIDEnv, height=600, **kwargs):
     chart_config_tmp = deepcopy(chart_config)
 
     chart_config_tmp["bakedGrapherURL"] = f"{owid_env.base_site}/grapher"
     chart_config_tmp["adminBaseUrl"] = owid_env.base_site
     chart_config_tmp["dataApiUrl"] = f"{owid_env.indicators_url}/"
 
+    # HTML = f"""
+    # <!DOCTYPE html>
+    # <html>
+    #     <head>
+    #         <meta name="viewport" content="width=device-width, initial-scale=1" />
+    #         <link
+    #         href="https://fonts.googleapis.com/css?family=Lato:300,400,400i,700,700i|Playfair+Display:400,700&amp;display=swap"
+    #         rel="stylesheet"
+    #         />
+    #         <link rel="stylesheet" href="https://ourworldindata.org/assets/owid.css" />
+    #     </head>
+    #     <body class="StandaloneGrapherOrExplorerPage">
+    #         <main>
+    #             <figure data-grapher-src></figure>
+    #         </main>
+    #         <div class="site-tools"></div>
+    #         <script>
+    #             document.cookie = "isAdmin=true;max-age=31536000"
+    #         </script>
+    #         <script type="module" src="https://ourworldindata.org/assets/owid.mjs"></script>
+    #         <script type="module">
+    #             var jsonConfig = {json.dumps(chart_config_tmp)}; window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig);
+    #         </script>
+    #     </body>
+    # </html>
+    # """
+
     HTML = f"""
-    <!DOCTYPE html>
-    <html>
-        <head>
-            <meta name="viewport" content="width=device-width, initial-scale=1" />
-            <link
-            href="https://fonts.googleapis.com/css?family=Lato:300,400,400i,700,700i|Playfair+Display:400,700&amp;display=swap"
-            rel="stylesheet"
-            />
-            <link rel="stylesheet" href="https://ourworldindata.org/assets/owid.css" />
-        </head>
-        <body class="StandaloneGrapherOrExplorerPage">
-            <main>
-                <figure data-grapher-src></figure>
-            </main>
-            <div class="site-tools"></div>
-            <script>
-                document.cookie = "isAdmin=true;max-age=31536000"
-            </script>
-            <script type="module" src="https://ourworldindata.org/assets/owid.mjs"></script>
-            <script type="module">
-                var jsonConfig = {json.dumps(chart_config_tmp)}; window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig);
-            </script>
-        </body>
-    </html>
+    <link href="https://fonts.googleapis.com/css?family=Lato:300,400,400i,700,700i|Playfair+Display:400,700&amp;display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://ourworldindata.org/assets/owid.css" />
+    <div class="StandaloneGrapherOrExplorerPage">
+        <main>
+            <figure data-grapher-src></figure>
+        </main>
+        <script> document.cookie = "isAdmin=true;max-age=31536000" </script>
+        <script type="module" src="https://ourworldindata.org/assets/owid.mjs"></script>
+        <script type="module">
+            var jsonConfig = {json.dumps(chart_config_tmp)}; window.Grapher.renderSingleGrapherOnGrapherPage(jsonConfig);
+        </script>
+    </div>
     """
 
     components.html(HTML, height=height, **kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = ["Our World in Data <tech@ourworldindata.org>"]
 
 [tool.poetry.scripts]
 etl = 'apps.cli:cli'
-etlcli = 'apps.cli:cli'
 etlwiz = 'apps.wizard.cli:cli'
 etlr = 'etl.command:main_cli'
 etl-wizard = 'apps.wizard.cli:cli'


### PR DESCRIPTION
- Increase iframe height: footer buttons were hidden in some display settings. Changed from 500px to 600px.
- Changed pagination mode. Before arrows were used to change page; now a number input.
- remove `etlci` command alias, since it is not used. Instead, we use `etl` which is equivalent.
- improve presentation of icon in expander from chart-diff
- `chart_html`: Reduce the HTML code for the chart. Try to keep just the bare minimum to render the chart.
- use `st.experimental_fragment` for the chartdiff blocks, so that if the user interacts with one box, only code within the box is re-executed. I.e. avoids long re-runs of complete page.