### PR TITLE
🐛 indicator-upgrader: team feedback

### DIFF
--- a/apps/wizard/app_pages/indicator_upgrade/app.py
+++ b/apps/wizard/app_pages/indicator_upgrade/app.py
@@ -122,31 +122,42 @@ if st.session_state.submitted_datasets:
     indicator_mapping = render_indicator_mapping(search_form)
     # log.info(f"INDICATORS CONFIG (2): {indicator_config}")
 
-##########################################################################################
-# 3 GET CHARTS
-#
-# Once the indicator mapping is done, we retrieve the affected charts (those that rely on
-# the indicators in the mapping. create the revisions. We store these under what we
-# call the "submission_config". This is a dataclass that holds the charts and updaters.
-#
-##########################################################################################
-if st.session_state.submitted_datasets and st.session_state.submitted_indicators:
-    # log.info(f"INDICATOR CONFIG (3): {indicator_config}")
-    # st.write(reset_indicator_form)
-    if indicator_mapping is not None:
-        if indicator_mapping == {}:
-            msg_error = "No indicators selected! Please select at least one indicator."
-            st.error(msg_error)
-        else:
-            charts = get_affected_charts_and_preview(
-                indicator_mapping,
-            )
+    ##########################################################################################
+    # 3 GET CHARTS
+    #
+    # Once the indicator mapping is done, we retrieve the affected charts (those that rely on
+    # the indicators in the mapping. create the revisions. We store these under what we
+    # call the "submission_config". This is a dataclass that holds the charts and updaters.
+    #
+    ##########################################################################################
+    if st.session_state.submitted_indicators:
+        # log.info(f"INDICATOR CONFIG (3): {indicator_config}")
+        # st.write(reset_indicator_form)
+        if indicator_mapping is not None:
+            if indicator_mapping == {}:
+                msg_error = "No indicators selected! Please select at least one indicator."
+                st.error(msg_error)
+            else:
+                charts = get_affected_charts_and_preview(
+                    indicator_mapping,
+                )
+
+        ##########################################################################################
+        # 4 UPDATE CHARTS
+        #
+        # TODO: add description
+        ##########################################################################################
+        if st.session_state.submitted_charts:
+            if isinstance(charts, list) and len(charts) > 0:
+                st.toast("Updating charts...")
+                push_new_charts(charts, SCHEMA_CHART_CONFIG)
+
 ##########################################################################################
 # 4 UPDATE CHARTS
 #
 # TODO: add description
 ##########################################################################################
-if st.session_state.submitted_datasets and st.session_state.submitted_charts and st.session_state.submitted_indicators:
-    if isinstance(charts, list) and len(charts) > 0:
-        st.toast("Updating charts...")
-        push_new_charts(charts, SCHEMA_CHART_CONFIG)
+# if st.session_state.submitted_datasets and st.session_state.submitted_charts and st.session_state.submitted_indicators:
+#     if isinstance(charts, list) and len(charts) > 0:
+#         st.toast("Updating charts...")
+#         push_new_charts(charts, SCHEMA_CHART_CONFIG)


### PR DESCRIPTION
Errors found

- [x] `ValueError`: caused by not finding a key in `st.session_state.indicator_upgrades_ignore`. (first image). It worked fine after refresh. Refreshing is fine for a small dataset, but not great if user has done substantial work already. After selecting some indicators from dropdowns, the user went to select another one and this error was raised.
- [ ] A user reported weird charts appearing in chart-diff. After looking into them, they seem to originate from updating the referenced indicator IDs in the chart config via the indicator upgrader. Unclear if it was due to a human mistake or some logic in indicator-upgrader failed.  **UNCLEAR FOR NOW ー TO EXPLORE IF IT IS REPORTED AGAIN**

![image](https://github.com/owid/etl/assets/18101289/23f2c478-e25b-4be8-b126-b95c73a90204)
