### PR TITLE
✨ mab bracketer: ux/ui

### DIFF
--- a/apps/wizard/app_pages/map_brackets.py
+++ b/apps/wizard/app_pages/map_brackets.py
@@ -659,7 +659,9 @@ def map_bracketer_interactive(mb: MapBracketer) -> None:
 
     # Select bracket type.
     bracket_type_labels = {
+        # Add optimal choice
         f"Optimal ({mb.brackets_optimal['optimal']})": mb.brackets_optimal["optimal"],
+        # Rest of the options
         **{
             value: value
             for value in list(BRACKET_LABELS["log"].values())
@@ -667,13 +669,11 @@ def map_bracketer_interactive(mb: MapBracketer) -> None:
             + list(BRACKET_LABELS["custom"].values())
         },
     }
-    # Add optimal choice.
-    # bracket_type_labels[f"Optimal ({mb.brackets_optimal['optimal']})"] =
-    # Create a bracket type selector with radio buttons.
-    # NOTE: By default, the last option will be selected, which is expected to be the optimal one (the last element in bracket_type_labels, defined above).
+    # Create a bracket type selector with a select box.
     bracket_type = st.selectbox(
         "Select linear or log-like",
         options=bracket_type_labels,
+        # NOTE: By default, the first option will be selected, which is expected to be the optimal one.
         index=0,
         # horizontal=True,
     )

--- a/apps/wizard/app_pages/map_brackets.py
+++ b/apps/wizard/app_pages/map_brackets.py
@@ -639,10 +639,11 @@ def map_bracketer_interactive(mb: MapBracketer) -> None:
         reload_optimal_brackets=True,
     )
     mb.percentile_min, mb.percentile_max = st.slider(
-        label="Percentile range to be covered by brackets (so far only for linear brackets)",
+        label="Percentile range covered by brackets",
         min_value=0,
         max_value=100,
         value=(MIN_PERCENTILE, MAX_PERCENTILE),
+        help="Currently, this only affects linear brackets",
     )
     mb.run(
         reload_data_values=False,
@@ -915,7 +916,8 @@ elif use_type == USE_TYPE_EXPLORERS:
             mb.chart_config["map"]["colorScale"][key_grapher] = value
 
     # Display the chart.
-    chart_html(mb.chart_config, owid_env=OWID_ENV, height=550)
+    chart_html(chart_config=mb.chart_config, owid_env=OWID_ENV, height=540)
 
-    if edit_brackets and st.button("Save brackets in explorer file", type="primary"):
-        update_explorer_file(mb=mb, explorer=explorer)
+    with st.sidebar:
+        if edit_brackets and st.button("Save brackets in explorer file", type="primary"):
+            update_explorer_file(mb=mb, explorer=explorer)


### PR DESCRIPTION
## UX/UI improvements

The main motivation for these improvements is to have the chart shown more prominently so that the user doesn't have to constantly scroll down.

Actions taken:
- Move description and limitations to a `popover` (labeled as "Learn about it") so that it doesn't take much vertical space.
- Don't show the different 'use cases' radio buttons, since only one is supported. Signal this in the `Learn about it` popover.
- Put dataset and indicator selection in a container with border so it is easily found.
- Sidebar is shown by default. It was set to `collapsed`; I thought there we don't necessarily need to hide it this time since the page doesn't need much width. 
- Move configuration parameters to the side bar.
- Move export config button to the side bar, so that it is always visible.

## Future work
There are some minor things that we could tackle in https://github.com/owid/etl/pull/2790.

I'll leave comments in there once we merge this.

Basically, some improvements I can think of are to add more help messages to streamlit widgets.