### PR TITLE
:bug: fix index column left in percentile file

### DIFF
--- a/snapshots/wb/2024-03-27/pip_api.py
+++ b/snapshots/wb/2024-03-27/pip_api.py
@@ -294,7 +294,13 @@ def _fetch_percentiles(version: int) -> pd.DataFrame:
         url = "https://datacatalogfiles.worldbank.org/ddh-published/0063646/DR0090251/world_100bin.csv"
     else:
         raise ValueError(f"Version {version} is not supported")
-    return pd.read_csv(url)
+
+    _df_percentiles = pd.read_csv(url)
+
+    # Drop  Unnamed: 0 column (it sometimes appears in the files)
+    _df_percentiles = _df_percentiles.drop(columns=["Unnamed: 0"])
+
+    return _df_percentiles
 
 
 ############################################################################################################

--- a/snapshots/wb/2024-03-27/world_bank_pip_percentiles.csv.dvc
+++ b/snapshots/wb/2024-03-27/world_bank_pip_percentiles.csv.dvc
@@ -28,6 +28,6 @@ meta:
 
 wdir: ../../../data/snapshots/wb/2024-01-17
 outs:
-  - md5: e4bb2cf5f15aa0cf75ee79dfa4489103
-    size: 54755658
+  - md5: 0d95165f10bcfdc49a832c25e270c412
+    size: 50329221
     path: world_bank_pip_percentiles.csv


### PR DESCRIPTION
The file provided from the World Bank now includes an empty column that propagated through all percentile steps. I corrected the extraction code to drop that column and updated the snapshot.