### PR TITLE
 :bug: Don't exclude dimensions from metadata checksum calculation

### DIFF
--- a/apps/backport/datasync/data_metadata.py
+++ b/apps/backport/datasync/data_metadata.py
@@ -428,9 +428,6 @@ def filter_out_fields_in_metadata_for_checksum(meta: Dict[str, Any]) -> Dict[str
     for origin in meta_.get("origins", []):
         origin.pop("id", None)
 
-    # Drop dimensions to make it faster. It is captured in `dataChecksum` anyway
-    meta_.pop("dimensions", None)
-
     # Ignore updatedAt timestamps
     meta_.pop("updatedAt", None)
 

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -516,7 +516,7 @@ def _modified_data_metadata_by_admin(
     from chart_dimensions as cd
     join variables as v on cd.variableId = v.id
     join datasets as d on v.datasetId = d.id
-    where v.dataChecksum is not null and
+    where v.dataChecksum is not null and v.metadataChecksum is not null and
     """
     # NOTE: We assume that all changes on staging server are done by Admin user with ID = 1. This is
     #   set automatically if you use STAGING env variable.

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -243,11 +243,11 @@ def test_convert_strings_to_numeric():
 
 def test_checksum_metadata():
     meta = _variable_meta()
-    assert checksum_metadata(meta) == "76dc6be6b7509058c7b3d1a8e75704ec"
+    assert checksum_metadata(meta) == "3123b1b4a25809c199e19e8203507a77"
 
     # change id, checksums or updatedAt shouldn't change it
     meta = _variable_meta()
     meta["id"] = 999
     meta["dataChecksum"] = 999
     meta["updatedAt"] = dt.datetime.now()
-    assert checksum_metadata(meta) == "76dc6be6b7509058c7b3d1a8e75704ec"
+    assert checksum_metadata(meta) == "3123b1b4a25809c199e19e8203507a77"


### PR DESCRIPTION
Field `dimensions` is excluded from metadata checksum calculation. This means that adding new countries won't refresh the metadata file, which is wrong.

This PR will change `metadataChecksum` for new / refreshed indicators, but **won't update checksums** for existing ones (that would require incrementing ETL epoch). We have two options now - either keep `metadataChecksum` as it is and show all metadata as modified, or we set `metadataChecksum` in MySQL to NULL and don't show any metadata modifications (until checksum is refreshed). @lucasrodes what do you think? Or is the metadata config so used that we should go for the full rebuild?