### PR TITLE
:hammer: add read_table method to read table without setting primary_key

### DIFF
--- a/etl/data_helpers/geo.py
+++ b/etl/data_helpers/geo.py
@@ -600,7 +600,7 @@ def add_population_to_dataframe(
 
     # Load population data.
     if ds_population is not None:
-        population = ds_population["population"].reset_index()
+        population = ds_population.read_table("population", primary_key=[])
     else:
         population = _load_population()
     population = population.rename(

--- a/etl/data_helpers/geo.py
+++ b/etl/data_helpers/geo.py
@@ -600,7 +600,7 @@ def add_population_to_dataframe(
 
     # Load population data.
     if ds_population is not None:
-        population = ds_population.read_table("population", primary_key=[])
+        population = ds_population.read_table("population")
     else:
         population = _load_population()
     population = population.rename(

--- a/etl/data_helpers/population.py
+++ b/etl/data_helpers/population.py
@@ -71,7 +71,7 @@ def add_population(
         log.warning(f"Dataset {ds_un_wpp_path} is silently being loaded.")
         # Load granular population dataset
         ds_un_wpp = Dataset(ds_un_wpp_path)
-    pop = ds_un_wpp.read_table("population_granular", primary_key=[])  # type: ignore
+    pop = ds_un_wpp.read_table("population_granular")  # type: ignore
     # Keep only variant='medium'
     pop = pop[pop["variant"] == "medium"].drop(columns=["variant"])
     # Keep only metric='population'

--- a/etl/data_helpers/population.py
+++ b/etl/data_helpers/population.py
@@ -71,7 +71,7 @@ def add_population(
         log.warning(f"Dataset {ds_un_wpp_path} is silently being loaded.")
         # Load granular population dataset
         ds_un_wpp = Dataset(ds_un_wpp_path)
-    pop = ds_un_wpp["population_granular"].reset_index()  # type: ignore
+    pop = ds_un_wpp.read_table("population_granular", primary_key=[])  # type: ignore
     # Keep only variant='medium'
     pop = pop[pop["variant"] == "medium"].drop(columns=["variant"])
     # Keep only metric='population'

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -144,20 +144,19 @@ class Dataset:
             table_filename = join(self.path, table.metadata.checked_name + f".{format}")
             table.to(table_filename, repack=repack)
 
-    def read_table(self, name: str, primary_key: Optional[list[str]] = None) -> tables.Table:
+    def read_table(self, name: str, reset_index: bool = True) -> tables.Table:
         """Read dataset's table from disk. Alternative to ds[table_name], but
         with more options to optimize the reading.
 
-        :param primary_key: Set primary keys of the table. If not set, it will be read from the metadata.
-            Setting primary keys can be very slow for large datasets, so make sure to set it to primary_key=[]
-            instead of using ds[table].reset_index()
+        :param reset_index: If true, don't set primary keys of the table. This can make loading
+            large datasets with multi-indexes much faster.
         """
         stem = self.path / Path(name)
 
         for format in SUPPORTED_FORMATS:
             path = stem.with_suffix(f".{format}")
             if path.exists():
-                t = tables.Table.read(path, primary_key=primary_key)
+                t = tables.Table.read(path, primary_key=[] if reset_index else None)
                 # dataset metadata might have been updated, refresh it
                 t.metadata.dataset = self.metadata
                 return t
@@ -165,7 +164,7 @@ class Dataset:
         raise KeyError(f"Table `{name}` not found, available tables: {', '.join(self.table_names)}")
 
     def __getitem__(self, name: str) -> tables.Table:
-        return self.read_table(name)
+        return self.read_table(name, reset_index=False)
 
     def __contains__(self, name: str) -> bool:
         return any((Path(self.path) / name).with_suffix(f".{format}").exists() for format in SUPPORTED_FORMATS)


### PR DESCRIPTION
Reading tables from disk is fast (<1s). What is slow is setting a primary key with `set_index` (>6s). Some steps using population through helper functions could be speeded up by avoiding setting & resetting the index.

This PR adds `read_table` method as an alternative to `ds[table_name]` that lets you optimize the reading.