### PR TITLE
✨ indicator upgrader: explore mode

### DIFF
--- a/apps/wizard/app_pages/indicator_upgrade/explore_mode.py
+++ b/apps/wizard/app_pages/indicator_upgrade/explore_mode.py
@@ -61,6 +61,10 @@ def st_explore_indicator(df, indicator_old, indicator_new, var_id_to_display) ->
 
     # Show indicator names
     # st_show_indicator_names(name_old, name_new)
+    # st.markdown(f":blue-background[Mapping: {indicator_old} → {indicator_new}]")
+    with st.container(border=False):
+        st.markdown(f":red-background[- {name_old}]")
+        st.markdown(f":green-background[+ {name_new}]")
 
     # Check if there is any change
     num_changes = (df_indicators[indicator_old] != df_indicators[indicator_new]).sum()

--- a/apps/wizard/app_pages/indicator_upgrade/explore_mode.py
+++ b/apps/wizard/app_pages/indicator_upgrade/explore_mode.py
@@ -59,8 +59,8 @@ def st_explore_indicator(df, indicator_old, indicator_new, var_id_to_display) ->
     name_old = var_id_to_display[indicator_old]
     name_new = var_id_to_display[indicator_new]
 
-    st.markdown(f"Old: `{name_old}`")
-    st.markdown(f"New: `{name_new}`")
+    # Show indicator names
+    # st_show_indicator_names(name_old, name_new)
 
     # Check if there is any change
     num_changes = (df_indicators[indicator_old] != df_indicators[indicator_new]).sum()
@@ -76,7 +76,7 @@ def st_explore_indicator(df, indicator_old, indicator_new, var_id_to_display) ->
         else:
             tab_names = ["Summary"]
             if is_numeric:
-                tab_names.append("Error distribution")
+                tab_names.extend(["Error distribution", "Country overview"])
             if ((summary.num_categories_old < 10) & (summary.num_categories_new < 10)) | (not is_numeric):
                 tab_names.append("Confusion Matrix")
 
@@ -96,12 +96,28 @@ def st_explore_indicator(df, indicator_old, indicator_new, var_id_to_display) ->
                         )
                     elif tab_name == "Error distribution":
                         st_show_plot(df_indicators, col_old=name_old, col_new=name_new, is_numeric=is_numeric)
+                    elif tab_name == "Country overview":
+                        st_show_country_overview(df_indicators, indicator_old, indicator_new)
                     elif tab_name == "Confusion Matrix":
                         df_ = df_indicators.copy()
                         df_[indicator_old] = df_[indicator_old].fillna("None")
                         df_[indicator_new] = df_[indicator_new].fillna("None")
                         confusion_matrix = pd.crosstab(df_[indicator_old], df_[indicator_new], dropna=False)
                         st.dataframe(confusion_matrix)
+
+
+def st_show_indicator_names(name_old: str, name_new: str):
+    df_names = (
+        pd.DataFrame(
+            {
+                "": ["Old", "New"],
+                "variableName": [name_old, name_new],
+            }
+        )
+        .set_index("")
+        .rename(columns={"variableName": "Indicator name"})
+    )
+    st.dataframe(df_names)
 
 
 def st_show_tab_main(
@@ -477,3 +493,50 @@ def st_show_plot(df: pd.DataFrame, col_old: str, col_new: str, is_numeric: bool)
         if COLUMN_LOG_ERROR in df.columns:
             fig = px.histogram(df, x=COLUMN_LOG_ERROR, nbins=100, title="Distribution of relative log error")
             st.plotly_chart(fig, use_container_width=True)
+
+
+def st_show_country_overview(df_indicators: pd.DataFrame, indicator_old: str, indicator_new: str):
+    """Show timeseries.
+
+    This is experimental.
+    """
+    try:
+        dfg = df_indicators.groupby("entityName")
+        # Build row per country
+        df_countries = []
+        for name, df_ in dfg:
+            df_ = df_.sort_values("year").rename(
+                columns={
+                    indicator_old: "Old",
+                    indicator_new: "New",
+                }
+            )
+            error = df_[COLUMN_RELATIVE_ERROR].dropna()
+            error_max = error.replace([np.inf, -np.inf], np.nan).abs().max()
+            error = error.replace([np.inf], error_max)
+            error = error.replace([-np.inf], -error_max)
+
+            df_countries.append(
+                {
+                    "Country": name,
+                    "error": list(error),
+                    "old": list(df_["Old"].dropna()),
+                    "new": list(df_["New"].dropna()),
+                    "Average error": df_[COLUMN_ABS_RELATIVE_ERROR].mean(),
+                }
+            )
+        df_countries = pd.DataFrame(df_countries).sort_values("Average error", ascending=False)
+    except Exception as e:
+        st.warning("Couldn't show country overview. This is experimental. Please report the following error.")
+        st.exception(e)
+    else:
+        st.dataframe(
+            data=df_countries[["Country", "Average error", "error", "new", "old"]],
+            column_config={
+                "error": st.column_config.LineChartColumn(
+                    "Error(year)", help="Difference between old and new indicator values."
+                ),
+                "old": st.column_config.LineChartColumn("Old"),
+                "new": st.column_config.LineChartColumn("New"),
+            },
+        )


### PR DESCRIPTION
Add dataframe with overview of country data.

Quick comparison of the timeseries of the old and new indicators for each country. Uses `st.column_config` to show line charts in a dataframe ([see docs](https://docs.streamlit.io/develop/api-reference/data/st.column_config/st.column_config.linechartcolumn)).

<img width="585" alt="image" src="https://github.com/owid/etl/assets/18101289/5496948d-e192-4ff5-beba-4f0a7e230c92">
