### PR TITLE
 :hammer: Streamlit integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,15 @@ watch: .venv
 	fi
 	touch .sanity-check
 
+unittest: .venv
+	@echo '==> Running unit tests'
+	poetry run pytest -m "not integration" $(SRC)
+
 test: check-formatting check-linting check-typing unittest version-tracker
+
+test-integration: .venv
+	@echo '==> Running integration tests'
+	poetry run pytest -m integration $(SRC)
 
 .venv: .sanity-check pyproject.toml poetry.toml poetry.lock
 	@echo '==> Installing packages'

--- a/lib/catalog/owid/catalog/utils.py
+++ b/lib/catalog/owid/catalog/utils.py
@@ -187,6 +187,10 @@ def dynamic_yaml_load(path: Union[Path, str], params: dict = {}) -> dict:
     yd.update(params)
 
     # additional parameters
+    # NOTE: TODAY is dynamic and can depend on the time of creation. This goes against our
+    #   philosophy of having deterministic outputs from snapshots and its use is therefore
+    #   discouraged. You should use origin.date_accessed instead if possible.
+    #   We only keep it here because of its convenience for COVID and AI automatic updates.
     yd["TODAY"] = dt.datetime.now().astimezone(pytz.timezone("Europe/London")).strftime("%-d %B %Y")
 
     return yd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,3 +151,8 @@ exclude = [
     ".cachedir/",
     ".cache/",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests as integration tests (deselect with '-m \"not integration\"')"
+]

--- a/tests/apps/wizard/app_pages/test_apps.py
+++ b/tests/apps/wizard/app_pages/test_apps.py
@@ -1,0 +1,99 @@
+import os
+from contextlib import contextmanager
+
+import pytest
+from streamlit.testing.v1 import AppTest
+from streamlit.testing.v1.element_tree import Button
+
+from apps.wizard.utils import WIZARD_DIR
+from etl import config
+
+DEFAULT_TIMEOUT = 20
+
+
+@contextmanager
+def temporary_config(env_config):
+    original_config = config.OWID_ENV
+    config.OWID_ENV = env_config
+    try:
+        yield
+    finally:
+        config.OWID_ENV = original_config
+
+
+@pytest.fixture
+def set_config():
+    """Connect to staging MySQL if running in Buildkite. Otherwise, connect to local MySQL.
+
+    In case we want to create a dedicated database, use the following:
+    # download DB
+    # curl -Lo playground/owid_metadata.sql.gz https://files.ourworldindata.org/owid_metadata.sql.gz
+    # create new database
+    # mysql -h 127.0.0.1 -u root --port 3306 -p"owid" -D "" -e "CREATE DATABASE test_owid_123;"
+    # fill it with data
+    # cat playground/owid_metadata.sql.gz | gunzip | mysql -h 127.0.0.1 -u root --port 3306 -p"owid" -D "test_owid_123"
+    """
+    if "BUILDKITE_BRANCH" in os.environ:
+        branch_name = os.environ["BUILDKITE_BRANCH"]
+        env_config = config.OWIDEnv(
+            config.Config(
+                GRAPHER_USER_ID=1,
+                DB_USER="owid",
+                DB_NAME="owid",
+                DB_PASS="",
+                DB_PORT="3306",
+                DB_HOST=config.get_container_name(branch_name),
+            )
+        )
+        with temporary_config(env_config):
+            yield
+    else:
+        # running locally, connect to DB specified in .env
+        yield
+
+
+def _pick_button_by_label(at: AppTest, label: str) -> Button:
+    buttons = [button for button in at.button if button.label == label]
+    if len(buttons) > 1:
+        raise ValueError(f"Multiple buttons with label '{label}' found.")
+    elif len(buttons) == 0:
+        raise ValueError(f"Button with label '{label}' not found.")
+    return buttons[0]
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("set_config")
+def test_app_chart_diff():
+    """Ensure that chart-diff doesn't raise any errors on start."""
+    at = AppTest.from_file(str(WIZARD_DIR / "app_pages/chart_diff/app.py"), default_timeout=DEFAULT_TIMEOUT).run()
+    assert not at.exception
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("set_config")
+def test_app_indicator_upgrade():
+    at = AppTest.from_file(
+        str(WIZARD_DIR / "app_pages/indicator_upgrade/app.py"), default_timeout=DEFAULT_TIMEOUT
+    ).run()
+    assert not at.exception
+
+    # Click on Next (1/3)
+    _pick_button_by_label(at, "Next (1/3)").click().run()
+
+    # Click on Next (2/3)
+    _pick_button_by_label(at, "Next (2/3)").click().run()
+
+    assert not at.exception
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("set_config")
+def test_app_fasttrack():
+    at = AppTest.from_file(str(WIZARD_DIR / "app_pages/fasttrack/app.py"), default_timeout=DEFAULT_TIMEOUT).run()
+    assert not at.exception
+
+    # Try to reimport the latest uploaded sheet
+    at.radio[0].set_value("update_gsheet")
+    _pick_button_by_label(at, "Submit").click().run()
+
+    assert not at.exception


### PR DESCRIPTION
Proof of concept for streamlit integration tests. These tests run streamlit app and connect to the staging MySQL (tests should be therefore read-only).

I've added a new Buildkite step for running integration tests. These are **not run by default** when you run `make test`, but with `make test-integration` (and connect to DB from your `.env`).

There are basic tests for chart-diff, fasttrack and indicator-upgrade. Nothing fancy, just making sure those apps start without errors and that you can click some buttons. We could of course make them more complex, but that would add additional friction to development. The main point of these tests is to prevent basic errors like circular imports.

## How to review
There's an artificial `raise Exception` in chart-diff to test it out. If you click on `Details` of `buildkite/etl-automated-staging-environment` below, you should see a failing integration test. (It's set to soft-fail now, but will show a red once we merge it). You can also try to run `make test-integration` locally.

## TODO before merging
- [x] Remove `raise Exception` from chart-diff
- [ ] Remove `soft-fail` from [Buildkite job](https://buildkite.com/our-world-in-data/etl-automated-staging-environment/settings/steps)