### PR TITLE
🐛 indicator upgrader: session state not correctly set due to cache

### DIFF
--- a/apps/wizard/app_pages/indicator_upgrade/indicator_mapping.py
+++ b/apps/wizard/app_pages/indicator_upgrade/indicator_mapping.py
@@ -154,9 +154,6 @@ def _get_params_cached(
     else:
         df_data = None
 
-    # Set states
-    st.session_state.indicator_upgrades_ignore = {i.key: False for i in iu}
-
     return iu, indicator_id_to_display, df_data
 
 
@@ -172,6 +169,9 @@ def get_params(search_form):
         search_form.similarity_function_name,
         search_form.enable_bulk_explore,
     )
+
+    # Set states
+    st.session_state.indicator_upgrades_ignore = {i.key: False for i in iu}
 
     return iu, indicator_id_to_display, df_data
 


### PR DESCRIPTION
A properties in `st.session_state` was being set within a function with decorator `@st.cache_data`.

This was preventing this set operation to be executed correctly on staging. That's because the code on staging had been ran in the past already, and values had been cached, which means that the function (and ultimately the set operation) were not being executed.

This error was not detected earlier because it was not a problem when working locally (but accessing remote resources).