### PR TITLE
📊 population: update historical dataset

### DIFF
--- a/dag/demography.yml
+++ b/dag/demography.yml
@@ -44,6 +44,16 @@ steps:
   data://grapher/un/2024-07-12/un_wpp_full:
     - data://garden/un/2024-07-12/un_wpp
 
+  # WPP Historical comparison
+  data://garden/demography/2024-07-12/un_wpp_historical:
+    - snapshot://fasttrack/latest/un_wpp_historical.csv
+    - data://garden/un/2024-07-12/un_wpp
+    - data://garden/un/2022-07-11/un_wpp
+  data://grapher/demography/2024-07-12/un_wpp_historical:
+    - data://garden/demography/2024-07-12/un_wpp_historical
+
+
+
   # WPP (2024) [under embargo]
   data-private://meadow/un/2024-07-11/un_wpp:
     ## Population

--- a/etl/steps/data/garden/demography/2024-07-12/un_wpp_historical.meta.yml
+++ b/etl/steps/data/garden/demography/2024-07-12/un_wpp_historical.meta.yml
@@ -1,0 +1,26 @@
+# NOTE: To learn more about the fields, hover over their names.
+definitions:
+  common:
+    presentation:
+      topic_tags:
+        - Population Growth
+
+
+# Learn more about the available fields:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+dataset:
+  update_period_days: 740
+  title: Historical World Population Prospects
+
+
+tables:
+  un_wpp_historical:
+    variables:
+      population:
+        title: Population, UN <<revision>> Revision
+        description_short: |-
+          De facto population in a country, area or region as of July 1 of the year indicated and UN WPP <<revision>> revision.
+        unit: people
+        presentation:
+          title_public: Population, UN <<revision>> revision.
+          attribution: UN, World Population Prospects (1968 - 2024)

--- a/etl/steps/data/garden/demography/2024-07-12/un_wpp_historical.py
+++ b/etl/steps/data/garden/demography/2024-07-12/un_wpp_historical.py
@@ -1,0 +1,61 @@
+"""Load a meadow dataset and create a garden dataset."""
+
+from owid.catalog.tables import concat
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load fasttrack data (1968-2019)
+    tb_historic = paths.read_snap_table("un_wpp_historical")
+    ds_wpp_22 = paths.load_dataset("un_wpp", version="2022-07-11")
+    ds_wpp_24 = paths.load_dataset("un_wpp", version="2024-07-12")
+
+    #
+    # Process data.
+    #
+
+    # Reshape historic (1968-2019) data.
+    tb_historic = tb_historic.melt(
+        id_vars=["country", "year"],
+        var_name="revision",
+        value_name="population",
+    ).dropna(subset="population")
+    tb_historic["revision"] = tb_historic["revision"].str.replace("revision_", "")
+
+    # 2022 data
+    tb_22 = ds_wpp_22["population"].loc["World", list(range(2025, 2060, 5)), "population", "all", "all", "medium"]
+    tb_22 = tb_22.reset_index()
+    tb_22 = (
+        tb_22[["location", "year", "value"]]
+        .assign(revision=2022)
+        .rename(columns={"location": "country", "value": "population"})
+    )
+
+    # 2024 data
+    tb_24 = ds_wpp_24["population"].loc[("World", list(range(2025, 2060, 5)), "all", "all", "medium"), ["population"]]
+    tb_24 = tb_24.reset_index()
+    tb_24 = tb_24[["country", "year", "population"]].assign(revision=2024)
+
+    # Combine
+    tb = concat([tb_historic, tb_22, tb_24])
+
+    # Format
+    tb = tb.format(["country", "year", "revision"])
+
+    #
+    # Save outputs.
+    #
+    # Create a new garden dataset with the same metadata as the meadow dataset.
+    ds_garden = create_dataset(
+        dest_dir, tables=[tb], check_variables_metadata=True,
+    )
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()

--- a/etl/steps/data/garden/demography/2024-07-12/un_wpp_historical.py
+++ b/etl/steps/data/garden/demography/2024-07-12/un_wpp_historical.py
@@ -54,7 +54,9 @@ def run(dest_dir: str) -> None:
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
     ds_garden = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True,
+        dest_dir,
+        tables=[tb],
+        check_variables_metadata=True,
     )
 
     # Save changes in the new garden dataset.

--- a/etl/steps/data/grapher/demography/2024-07-12/un_wpp_historical.py
+++ b/etl/steps/data/grapher/demography/2024-07-12/un_wpp_historical.py
@@ -1,0 +1,32 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder, create_dataset
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run(dest_dir: str) -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset("un_wpp_historical")
+
+    # Read table from garden dataset.
+    tb = ds_garden["un_wpp_historical"]
+
+    #
+    # Process data.
+    #
+
+    #
+    # Save outputs.
+    #
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = create_dataset(
+        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
+    )
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()

--- a/snapshots/fasttrack/latest/un_wpp_historical.csv.dvc
+++ b/snapshots/fasttrack/latest/un_wpp_historical.csv.dvc
@@ -1,0 +1,25 @@
+meta:
+  origin:
+    producer: United Nations
+    title: Historical World Population Prospects
+    description: |-
+      Population values from various World Population Prospects revisions. The estimates are based on all available sources of data on population size and levels of fertility, mortality and international migration for 237 countries or areas.
+    citation_full: |-
+      United Nations, Department of Economic and Social Affairs, Population Division (1968-2019). World Population Prospects 1968-2019, archive
+    attribution: UN, World Population Prospects (1968-2019)
+    attribution_short: UN WPP
+    url_main: https://population.un.org/wpp/Download/Archive/Standard/
+    url_download: |-
+      https://docs.google.com/spreadsheets/d/e/2PACX-1vTrmu10dRJqFyl6fP95CLFfhJbm4yut09HXIin1Eg66WFVHoq1eNEdsmRL626V8TZONCtjt7Z4vC0RJ/pub?output=csv
+    date_accessed: '2024-07-12'
+    date_published: 2019-07-11
+    license:
+      name: CC BY 3.0 IGO
+      url: http://creativecommons.org/licenses/by/3.0/igo/
+  name: Historical World Population Prospects
+  description: ''
+  license: {}
+outs:
+  - md5: 7b70e0c391304ec50b0c2f6a578f5820
+    size: 2536
+    path: un_wpp_historical.csv


### PR DESCRIPTION
[Tracking issue](https://github.com/owid/owid-issues/issues/1561)

- Migrate Grapher dataset to ETL
  - Import historical WPP data via Fast-Track, using the data we had manually transcribed in the past.
    - I've added more data from revisions we hadn't transcribed. These are available from WPP's site: https://population.un.org/wpp/Download/Archive/Standard/. We now have data for all revisions since 1990.
  - Add data from recent reviews 2022 and 2024 via ETL (from Garden datasets)
- Update the chart with a gradient color scheme, and add two samples for 2002 and 2012 (to avoid large time gaps).