### PR TITLE
:sparkles: exclude certain datasets from metadata changes

### DIFF
--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -15,6 +15,16 @@ ADMIN_GRAPHER_USER_ID = 1
 log = get_logger()
 
 
+# Some datasets like COVID or certain AI datasets use {TODAY} in their metadata, making the metadata dependent
+# on the creation date. Merging a day later results in many metadata changes. The current workaround is to
+# exclude these datasets from comparison, similar to what we do for data-diff.
+EXCLUDE_METADATA_CHANGES = [
+    "grapher/covid/latest",
+    "grapher/climate/.*/surface_temperature_annual_average",
+    "grapher/artificial_intelligence/.*/epoch",
+]
+
+
 class ChartDiff:
     # Chart in source environment
     source_chart: gm.Chart
@@ -412,6 +422,12 @@ class ChartDiff:
         # If checksum has not been filled yet, assume unchanged
         checksums_diff[checksums_target.isna()] = False
 
+        # If the chart was updated by indicator upgrader, then variables in both charts will have different
+        # variable ids (and catalog paths). We don't want to label these as data or metadata changes, as they
+        # will be labaled as config change (if the change was done on the staging server). This helps with
+        # false positives when rebasing PRs.
+        checksums_diff[checksums_source.isna()] = False
+
         return checksums_diff
 
 
@@ -571,6 +587,11 @@ def _modified_data_metadata_by_admin(
             "metadataEdited": source_df.metadataChecksum != target_df.metadataChecksum,
         }
     )
+
+    # Exclude metadata changes for certain datasets
+    for ex in EXCLUDE_METADATA_CHANGES:
+        ix = diff.index.get_level_values("catalogPath").str.contains(ex)
+        diff.loc[ix, "metadataEdited"] = False
 
     diff = diff.groupby("chartId").any()
 

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -337,27 +337,27 @@ class Chart(Base):
         q = """
         select
             cd.chartId,
-            v.id as variableId,
+            v.catalogPath,
             v.dataChecksum,
             v.metadataChecksum
         from chart_dimensions as cd
         join variables as v on v.id = cd.variableId
         where cd.chartId in %(chart_id)s
         """
-        return read_sql(q, session, params={"chart_id": chart_ids}).set_index(["chartId", "variableId"])
+        return read_sql(q, session, params={"chart_id": chart_ids}).set_index(["chartId", "catalogPath"])
 
     def load_variable_checksums(self, session: Session) -> pd.DataFrame:
         """Load checksums for all variables from the chart and return them as a list of dicts."""
         q = """
         select
-            v.id as variableId,
+            v.catalogPath,
             v.dataChecksum,
             v.metadataChecksum
         from chart_dimensions as cd
         join variables as v on v.id = cd.variableId
         where cd.chartId = %(chart_id)s
         """
-        return read_sql(q, session, params={"chart_id": self.id}).set_index("variableId")
+        return read_sql(q, session, params={"chart_id": self.id}).set_index("catalogPath")
 
     def migrate_to_db(self, source_session: Session, target_session: Session) -> "Chart":
         """Remap variable ids from source to target session. Variable in source is uniquely identified


### PR DESCRIPTION
Fix for https://github.com/owid/etl/pull/2995

This PR reduces false positives from data & metadata changes (all are described in code in detail)
- Exclude certain datasets like COVID and AI Epoch from `METADATA CHANGE` in chart-diff (fixing the root cause turned out to be too challenging)
- Use `catalogPath` instead of `variableId` when comparing data & metadata checksums
- Remove data & metadata checksums change when variable is updated by indicator upgrader

If you want to test it, you can check that running it against `cset-ai` shows only relevant config changes
```
STAGING=cset-ai streamlit run apps/wizard/app_pages/chart_diff/app.py
```