### PR TITLE
🐛 Fix issue with metadata after pivot operations

### DIFF
--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -431,8 +431,8 @@ def _get_dict_from_list_if_all_identical(list_of_objects: List[Optional[Dict[str
     # Take the first dictionary as a reference.
     reference_dict = defined_dicts[0]
 
-    # Return the first dictionary if all dictionaries are identical, otherwise return None.
-    return reference_dict if all(d == reference_dict for d in defined_dicts) else None
+    # Return a copy of the first dictionary if all dictionaries are identical, otherwise return None.
+    return reference_dict.copy() if all(d == reference_dict for d in defined_dicts) else None
 
 
 def combine_variables_display(


### PR DESCRIPTION
I was finding very strange metadata issues, and it took me a while to find the culprit.

When pivoting a table, we are copying metadata from one variable to another. But this copy is shallow, so, when modifying the metadata of one variable, it affects others.

For example: 

```
from owid.catalog import Table, VariablePresentationMeta
import pandas as pd
tb = Table(pd.DataFrame({"year": [2020, 2021, 2022], "group": ["g1", "g1", "g1"], "subgroup": ["s1", "s1", "s2"], "value": [1, 2, 3]}))
tb["value"].m.presentation = VariablePresentationMeta(title_public="Value")
tb_p = tb.pivot(index="year", columns=["group", "subgroup"], values="value", join_column_levels_with="_")
tb_p["g1_s1"].m.presentation.title_public = "Group 1, Subgroup 1"
print(tb_p["g1_s2"].m.presentation.title_public)  # This returns "Group 1, Subgroup 1"
```

Once I found this, my first attempt to fix it was to add a `.copy()` inside `pivot`, where a column's metadata is copied:
```
        column_metadata = variables.combine_variables_metadata(
            variables=variables_to_combine, operation="pivot", name=column
        ).copy()
```

This fixed the issue. But then I noticed that the problem was happening with `presentation` metadata (not other fields). So I think a less invasive solution is what I propose in this PR: When propagating `display` and `presentation` metadata, instead of returning the original dictionary, return a copy.