### PR TITLE
🐛 le: markdown rendering

### DIFF
--- a/snapshots/demography/2023-10-10/zijdeman_et_al_2015.xlsx.dvc
+++ b/snapshots/demography/2023-10-10/zijdeman_et_al_2015.xlsx.dvc
@@ -16,7 +16,7 @@ meta:
         - [Gapminder](http://www.gapminder.org).
         - [OECD](http://stats.oecd.org).
         - [Montevideo-Oxford Latin America Economic History Database](http://www.lac.ox.ac.uk/moxlad-database).
-        - [ONX](http://www.ons.gov.uk/ons/datasets-and-tables/index.html).
+        - [ONS](http://www.ons.gov.uk/ons/datasets-and-tables/index.html).
         - [Australian Bureau of Statistics](http://www.abs.gov.au/ausstats/abs@.nsf/web+pages/statistics?opendocument#from-banner=LN).
         - Kannisto, V., Nieminen, M. & Turpeinen, O. (1999). Finnish Life Tables since 1751, Demographic Research, 1(1), DOI: 10.4054/DemRes.1999.1.1
 

--- a/snapshots/demography/2023-10-10/zijdeman_et_al_2015.xlsx.dvc
+++ b/snapshots/demography/2023-10-10/zijdeman_et_al_2015.xlsx.dvc
@@ -12,12 +12,12 @@ meta:
         The sources used are:
 
         - [UN World Population Project](http://esa.un.org/wpp/).
-        - [http://www.mortality.org](Human Mortality Database).
-        - [http://www.gapminder.org](Gapminder).
-        - [http://stats.oecd.org](OECD).
+        - [Human Mortality Database](http://www.mortality.org).
+        - [Gapminder](http://www.gapminder.org).
+        - [OECD](http://stats.oecd.org).
         - [Montevideo-Oxford Latin America Economic History Database](http://www.lac.ox.ac.uk/moxlad-database).
-        - [http://www.ons.gov.uk/ons/datasets-and-tables/index.html](ONS).
-        - [http://www.abs.gov.au/ausstats/abs@.nsf/web+pages/statistics?opendocument#from-banner=LN](Australian Bureau of Statistics).
+        - [ONX](http://www.ons.gov.uk/ons/datasets-and-tables/index.html).
+        - [Australian Bureau of Statistics](http://www.abs.gov.au/ausstats/abs@.nsf/web+pages/statistics?opendocument#from-banner=LN).
         - Kannisto, V., Nieminen, M. & Turpeinen, O. (1999). Finnish Life Tables since 1751, Demographic Research, 1(1), DOI: 10.4054/DemRes.1999.1.1
 
         For specifics concerning (selections of) the sources, see the R code available in the working paper [here](https://clio-infra.eu/Indicators/LifeExpectancyatBirthTotal.html).
@@ -41,6 +41,6 @@ meta:
 
 wdir: ../../../data/snapshots/demography/2023-10-10
 outs:
-- md5: 2f07837592cb3be6da56647b63b9a831
-  size: 557461
-  path: zijdeman_et_al_2015.xlsx
+  - md5: 2f07837592cb3be6da56647b63b9a831
+    size: 557461
+    path: zijdeman_et_al_2015.xlsx


### PR DESCRIPTION
## Problem
Description for Zijdeman snapshot was wrong, leading to wrong markdown rendering.

See https://ourworldindata.org/grapher/life-expectancy
![image](https://github.com/user-attachments/assets/cc9a709a-c063-4e1d-a2c6-b64156d0355d)

## Solution
- Fix links in snapshot file.
- Re-run snapshot step: `python snapshots/demography/2023-10-10/zijdeman_et_al_2015.py`

---
Fixes https://owid.slack.com/archives/C03NV9Z3YSV/p1721221808426329, raised by @rakyi 
