### PR TITLE
:sparkles: Fix rolling methods in VariableGroupBy and TableGroupBy

### DIFF
--- a/etl/steps/data/garden/covid/latest/cases_deaths.py
+++ b/etl/steps/data/garden/covid/latest/cases_deaths.py
@@ -257,14 +257,11 @@ def add_regions(tb: Table, ds_regions: Dataset, ds_income: Dataset) -> Table:
 
 
 def add_period_aggregates(tb: Table, prefix: str, periods: int):
-    # Convert Table to DataFrame
-    df = pd.DataFrame(tb)
-
     # Period-aggregate cases and deaths
     cases_colname = f"{prefix}_cases"
     deaths_colname = f"{prefix}_deaths"
-    df[[cases_colname, deaths_colname]] = (
-        df[["country", "new_cases", "new_deaths"]]
+    tb[[cases_colname, deaths_colname]] = (
+        tb[["country", "new_cases", "new_deaths"]]
         .groupby("country")[["new_cases", "new_deaths"]]
         .rolling(window=periods, min_periods=periods - 1, center=False)
         .sum()
@@ -274,8 +271,8 @@ def add_period_aggregates(tb: Table, prefix: str, periods: int):
     # Period-growth of cases and deaths
     cases_growth_colname = f"{prefix}_pct_growth_cases"
     deaths_growth_colname = f"{prefix}_pct_growth_deaths"
-    df[[cases_growth_colname, deaths_growth_colname]] = (
-        df[["country", cases_colname, deaths_colname]]
+    tb[[cases_growth_colname, deaths_growth_colname]] = (
+        tb[["country", cases_colname, deaths_colname]]
         .groupby("country")[[cases_colname, deaths_colname]]
         .pct_change(periods=periods, fill_method=None)
         .round(3)
@@ -284,17 +281,10 @@ def add_period_aggregates(tb: Table, prefix: str, periods: int):
     )
 
     # Set NaNs where the original data was NaN
-    df.loc[df["new_cases"].isnull(), cases_colname] = np.nan
-    df.loc[df["new_deaths"].isnull(), deaths_colname] = np.nan
+    tb.loc[tb["new_cases"].isnull(), cases_colname] = np.nan
+    tb.loc[tb["new_deaths"].isnull(), deaths_colname] = np.nan
 
-    # Convert dataframe to Table
-    tb_new = Table(df).copy_metadata(tb)
-    tb_new[cases_colname] = tb_new[cases_colname].copy_metadata(tb["new_cases"])
-    tb_new[deaths_colname] = tb_new[deaths_colname].copy_metadata(tb["new_deaths"])
-    tb_new[cases_growth_colname] = tb_new[cases_growth_colname].copy_metadata(tb["new_cases"])
-    tb_new[deaths_growth_colname] = tb_new[deaths_growth_colname].copy_metadata(tb["new_deaths"])
-
-    return tb_new
+    return tb
 
 
 def add_doubling_days(tb: Table) -> Table:
@@ -370,14 +360,11 @@ def add_rolling_avg(tb: Table) -> Table:
     ]
     tb = tb.copy().sort_values(by="date")
 
-    # TMP: Table -> DataFrame
-    df = pd.DataFrame(tb)
-
     for indicator in indicators:
         col = f"{indicator}_7_day_avg_right"
-        df[col] = df[indicator].astype("float")
-        df[col] = (
-            df.groupby("country")[col]
+        tb[col] = tb[indicator].astype("float")
+        tb[col] = (
+            tb.groupby("country")[col]
             .rolling(
                 window=7,
                 min_periods=6,
@@ -386,9 +373,6 @@ def add_rolling_avg(tb: Table) -> Table:
             .mean()
             .reset_index(level=0, drop=True)
         )
-
-    # TMP: DataFrame -> Table
-    tb = Table(df).copy_metadata(tb)
 
     for indicator in indicators:
         col = f"{indicator}_7_day_avg_right"

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -1115,6 +1115,11 @@ class TableGroupBy:
 
         return tb
 
+    def rolling(self, *args, **kwargs) -> "TableGroupBy":
+        """Apply rolling window function and return a new TableGroupBy with proper metadata."""
+        rolling_groupby = self.groupby.rolling(*args, **kwargs)
+        return TableGroupBy(rolling_groupby, self.metadata, self._fields)
+
 
 class VariableGroupBy:
     def __init__(
@@ -1149,6 +1154,11 @@ class VariableGroupBy:
                 raise NotImplementedError()
 
         return func  # type: ignore
+
+    def rolling(self, *args, **kwargs) -> "VariableGroupBy":
+        """Apply rolling window function and return a new VariableGroupBy with proper metadata."""
+        rolling_groupby = self.groupby.rolling(*args, **kwargs)
+        return VariableGroupBy(rolling_groupby, self.name, self.metadata, self.table_metadata)
 
 
 def align_categoricals(left: SeriesOrVariable, right: SeriesOrVariable) -> Tuple[SeriesOrVariable, SeriesOrVariable]:

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -980,6 +980,10 @@ class Table(pd.DataFrame):
         """Groupby that preserves metadata."""
         return TableGroupBy(pd.DataFrame.groupby(self.copy(deep=False), *args, **kwargs), self.metadata, self._fields)
 
+    def rolling(self, *args, **kwargs) -> "TableRolling":
+        """Rolling operation that preserves metadata."""
+        return TableRolling(super().rolling(*args, **kwargs), self.metadata, self._fields)
+
     def check_metadata(self, ignore_columns: Optional[List[str]] = None) -> None:
         """Check that all variables in the table have origins."""
         if ignore_columns is None:
@@ -1115,10 +1119,9 @@ class TableGroupBy:
 
         return tb
 
-    def rolling(self, *args, **kwargs) -> "TableGroupBy":
-        """Apply rolling window function and return a new TableGroupBy with proper metadata."""
+    def rolling(self, *args, **kwargs) -> "TableRollingGroupBy":
         rolling_groupby = self.groupby.rolling(*args, **kwargs)
-        return TableGroupBy(rolling_groupby, self.metadata, self._fields)
+        return TableRollingGroupBy(rolling_groupby, self.metadata, self._fields)
 
 
 class VariableGroupBy:
@@ -1159,6 +1162,56 @@ class VariableGroupBy:
         """Apply rolling window function and return a new VariableGroupBy with proper metadata."""
         rolling_groupby = self.groupby.rolling(*args, **kwargs)
         return VariableGroupBy(rolling_groupby, self.name, self.metadata, self.table_metadata)
+
+
+class TableRolling:
+    # fixes type hints
+    __annotations__ = {}
+
+    def __init__(self, rolling: pd.core.window.rolling.Rolling, metadata: TableMeta, fields: Dict[str, Any]):
+        self.rolling = rolling
+        self.metadata = metadata
+        self._fields = fields
+
+    def __getattr__(self, name: str) -> Callable[..., "Table"]:
+        # Calling method on the rolling object
+        if isinstance(getattr(self.rolling, name), types.MethodType):
+
+            def func(*args, **kwargs):
+                """Apply function and return variable with proper metadata."""
+                df = getattr(self.rolling, name)(*args, **kwargs)
+                return _create_table(df, self.metadata, self._fields)
+
+            self.__annotations__[name] = Callable[..., "Table"]
+            return func
+        else:
+            raise NotImplementedError()
+
+
+class TableRollingGroupBy:
+    # fixes type hints
+    __annotations__ = {}
+
+    def __init__(
+        self, rolling_groupby: pd.core.window.rolling.RollingGroupby, metadata: TableMeta, fields: Dict[str, Any]
+    ):
+        self.rolling_groupby = rolling_groupby
+        self.metadata = metadata
+        self._fields = fields
+
+    def __getattr__(self, name: str) -> Callable[..., "Table"]:
+        # Calling method on the rolling object
+        if isinstance(getattr(self.rolling_groupby, name), types.MethodType):
+
+            def func(*args, **kwargs):
+                """Apply function and return variable with proper metadata."""
+                df = getattr(self.rolling_groupby, name)(*args, **kwargs)
+                return _create_table(df, self.metadata, self._fields)
+
+            self.__annotations__[name] = Callable[..., "Table"]
+            return func
+        else:
+            raise NotImplementedError()
 
 
 def align_categoricals(left: SeriesOrVariable, right: SeriesOrVariable) -> Tuple[SeriesOrVariable, SeriesOrVariable]:

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -1197,17 +1197,25 @@ def test_keep_metadata_series(table_1: Table) -> None:
     assert table_1.a.m.title == "Title of Table 1 Variable a"
 
 
-def test_variable_groupby_rolling():
-    tb = Table(pd.DataFrame({"country": [1, 1, 2, 2, 3, 3], "value": [4, 5, 6, 7, 8, 9]}))
-    result = tb.groupby("country")["value"].rolling(2).sum()
-    expected = pd.Series([np.nan, 9, np.nan, 13, np.nan, 17], name="value")
-    pd.testing.assert_series_equal(result, expected)
-    assert result.metadata == tb["value"].metadata
+def test_table_rolling(table_1: Table):
+    tb = table_1[["a", "b"]].copy()
+
+    rolling = tb.rolling(window=1).sum()
+    assert rolling.a.m.title == table_1.a.m.title
+    assert rolling.b.m.title == table_1.b.m.title
+
+    # make sure we are not modifying the original table
+    rolling.a.m.title = "new"
+    assert table_1.a.m.title != "new"
 
 
-def test_table_groupby_rolling():
-    tb = Table(pd.DataFrame({"country": [1, 1, 2, 2, 3, 3], "value": [4, 5, 6, 7, 8, 9]}))
-    result = tb.groupby("country")[["value"]].rolling(2).sum()
-    expected = pd.DataFrame({"value": [np.nan, 9, np.nan, 13, np.nan, 17]})
-    pd.testing.assert_frame_equal(result, expected)
-    assert result["value"].metadata == tb["value"].metadata
+def test_table_groupby_rolling(table_1: Table):
+    tb = table_1.copy()
+
+    rolling = tb.groupby("country").rolling(window=1).sum()
+    assert rolling.a.m.title == table_1.a.m.title
+    assert rolling.b.m.title == table_1.b.m.title
+
+    # make sure we are not modifying the original table
+    rolling.a.m.title = "new"
+    assert table_1.a.m.title != "new"

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -1195,3 +1195,19 @@ def test_keep_metadata_series(table_1: Table) -> None:
 
     table_1.a = to_numeric(table_1.a)
     assert table_1.a.m.title == "Title of Table 1 Variable a"
+
+
+def test_variable_groupby_rolling():
+    tb = Table(pd.DataFrame({"country": [1, 1, 2, 2, 3, 3], "value": [4, 5, 6, 7, 8, 9]}))
+    result = tb.groupby("country")["value"].rolling(2).sum()
+    expected = pd.Series([np.nan, 9, np.nan, 13, np.nan, 17], name="value")
+    pd.testing.assert_series_equal(result, expected)
+    assert result.metadata == tb["value"].metadata
+
+
+def test_table_groupby_rolling():
+    tb = Table(pd.DataFrame({"country": [1, 1, 2, 2, 3, 3], "value": [4, 5, 6, 7, 8, 9]}))
+    result = tb.groupby("country")[["value"]].rolling(2).sum()
+    expected = pd.DataFrame({"value": [np.nan, 9, np.nan, 13, np.nan, 17]})
+    pd.testing.assert_frame_equal(result, expected)
+    assert result["value"].metadata == tb["value"].metadata

--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -588,3 +588,14 @@ def test_set_categories(variable_3) -> None:
     new_var = new_var.set_categories(["a", "b", "c", "d"])
     assert new_var.m.title == "Title of Variable 3"
     assert tuple(new_var.cat.categories) == ("a", "b", "c", "d")
+
+
+def test_variable_rolling(variable_1: Variable):
+    v = variable_1.copy()
+
+    rolling = v.rolling(window=1).sum()
+    assert rolling.m.title == v.m.title
+
+    # make sure we are not modifying the original table
+    rolling.m.title = "new"
+    assert v.m.title != "new"


### PR DESCRIPTION
Related to #3009

Implement the `rolling` method for `VariableGroupBy` and `TableGroupBy` classes to support rolling window functions and preserve metadata.

* **lib/catalog/owid/catalog/tables.py**
  - Implement the `rolling` method in the `VariableGroupBy` class.
  - Implement the `rolling` method in the `TableGroupBy` class.
  - Ensure metadata preservation in the `rolling` method for both `VariableGroupBy` and `TableGroupBy`.

* **lib/catalog/tests/test_tables.py**
  - Add unit tests for the `rolling` method in `VariableGroupBy`.
  - Add unit tests for the `rolling` method in `TableGroupBy`.
  - Verify that the `rolling` method works without errors and preserves metadata in both classes.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/owid/etl/issues/3009?shareId=3c6afcbf-69ae-48eb-a682-ffb2f97cf9e7).