### PR TITLE
:sparkles: Refactor repack_series function to handle string dtype

### DIFF
--- a/lib/repack/owid/repack/__init__.py
+++ b/lib/repack/owid/repack/__init__.py
@@ -62,7 +62,7 @@ def repack_series(s: pd.Series) -> pd.Series:
     if s.dtype.name in ("Int64", "int64", "UInt64", "uint64"):
         return shrink_integer(s)
 
-    if s.dtype.name in ("object", "float64", "Float64"):
+    if s.dtype.name in ("object", "string", "float64", "Float64"):
         for strategy in [to_int, to_float, to_category]:
             try:
                 return strategy(s)

--- a/lib/repack/tests/test_repack.py
+++ b/lib/repack/tests/test_repack.py
@@ -245,3 +245,11 @@ def test_repack_with_datetime():
     s = pd.Series([dt.datetime.today(), dt.date.today()], dtype=object)
     v = repack.repack_series(s)
     assert v.dtype.name == "category"
+
+
+def test_repack_string_type():
+    s = pd.Series(["a", "b", "c"]).astype("string")
+    assert s.dtype == "string"
+
+    v = repack.repack_series(s)
+    assert v.dtype == "category"


### PR DESCRIPTION
Fix https://github.com/owid/etl/pull/2974#discussion_r1691003507

`"string"` type should be handled in the same way as `object` (`str`) by `repack`.