### PR TITLE
 :sparkles: Add decorator keep_metadata

### DIFF
--- a/lib/catalog/owid/catalog/processing.py
+++ b/lib/catalog/owid/catalog/processing.py
@@ -4,6 +4,7 @@
 from .tables import (
     ExcelFile,
     concat,
+    keep_metadata,
     melt,
     merge,
     multi_merge,
@@ -19,6 +20,7 @@ from .tables import (
     read_rda,
     read_rds,
     read_stata,
+    to_numeric,
 )
 
 __all__ = [
@@ -39,4 +41,6 @@ __all__ = [
     "read_stata",
     "read_rda",
     "read_rds",
+    "to_numeric",
+    "keep_metadata",
 ]

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -1893,3 +1893,42 @@ def _extract_variables(t: Table, cols: Optional[Union[List[str], str]]) -> List[
     if isinstance(cols, str):
         cols = [cols]
     return [t[col] for col in cols]  # type: ignore
+
+
+def keep_metadata(func: Callable[..., Union[pd.DataFrame, pd.Series]]) -> Callable[..., Union[Table, Variable]]:
+    """Decorator that turns a function that works on DataFrame or Series into a function that works
+    on Table or Variable and preserves metadata.  If the decorated function renames columns, their
+    metadata won't be copied.
+
+    Usage:
+
+    import owid.catalog.processing as pr
+
+    @pr.keep_metadata
+    def my_df_func(df: pd.DataFrame) -> pd.DataFrame:
+        return df + 1
+
+    tb = my_df_func(tb)
+
+
+    @pr.keep_metadata
+    def my_series_func(s: pd.Series) -> pd.Series:
+        return s + 1
+
+    tb.a = my_series_func(tb.a)
+    """
+
+    def wrapper(*args: Any, **kwargs: Any) -> Union[Table, Variable]:
+        tb = args[0]
+        df = func(*args, **kwargs)
+        if isinstance(df, pd.Series):
+            return Variable(df, name=tb.name, metadata=tb.metadata)
+        elif isinstance(df, pd.DataFrame):
+            return Table(df).copy_metadata(tb)
+        else:
+            raise ValueError(f"Unexpected return type: {type(df)}")
+
+    return wrapper
+
+
+to_numeric = keep_metadata(pd.to_numeric)

--- a/lib/catalog/tests/test_tables.py
+++ b/lib/catalog/tests/test_tables.py
@@ -20,6 +20,7 @@ from owid.catalog.tables import (
     Table,
     get_unique_licenses_from_tables,
     get_unique_sources_from_tables,
+    keep_metadata,
 )
 from owid.catalog.variables import Variable
 
@@ -1175,3 +1176,22 @@ def test_bfill_with_number(table_1) -> None:
 def test_fillna_error(table_1: Table) -> None:
     with pytest.raises(ValueError):
         table_1["a"].fillna()
+
+
+def test_keep_metadata_dataframe(table_1: Table) -> None:
+    @keep_metadata
+    def rolling_sum(df: pd.DataFrame) -> pd.DataFrame:
+        return df.rolling(window=2, min_periods=1).sum()
+
+    tb = rolling_sum(table_1[["a", "b"]])
+    assert list(tb.a) == [1.0, 3.0, 5.0]
+    assert tb.a.m.title == "Title of Table 1 Variable a"
+
+
+def test_keep_metadata_series(table_1: Table) -> None:
+    @keep_metadata
+    def to_numeric(s: pd.Series) -> pd.Series:
+        return pd.to_numeric(s)
+
+    table_1.a = to_numeric(table_1.a)
+    assert table_1.a.m.title == "Title of Table 1 Variable a"


### PR DESCRIPTION
Trivial implementation of `keep_metadata` decorator from https://github.com/owid/etl/issues/3009. It is used for `pr.to_numeric` function.