### PR TITLE
 :bug: Make widget keys unique in chart-diff

### DIFF
--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -203,6 +203,7 @@ class ChartDiffShow:
             st.warning("This is under development! Find below a form with the different fields that present conflicts.")
         with col2:
             st.button(
+                key=f"resolve-conflicts-{self.diff.chart_id}",
                 label="⚠️ Mark as resolved: Accept all changes from staging",
                 help="Click to resolve the conflict by accepting all changes from staging. The changes from production will be ignored. This can be useul if you're happy with the changes in staging as they are.",
                 on_click=_mark_as_resolved,
@@ -223,7 +224,7 @@ class ChartDiffShow:
             st.button(
                 "Resolve conflicts",
                 help="Click to resolve the conflicts and update the chart config.",
-                key="resolve-conflicts-btn",
+                key=f"resolve-conflicts-btn-{self.diff.chart_id}",
                 type="primary",
                 on_click=lambda r=resolver: _resolve_conflicts(r),
             )

--- a/apps/wizard/app_pages/chart_diff/conflict_resolver.py
+++ b/apps/wizard/app_pages/chart_diff/conflict_resolver.py
@@ -109,7 +109,7 @@ class ChartDiffConflictResolver:
             options=[1, 2],
             captions=["Insert production config", "Insert staging config"],
             format_func=lambda x: ENVIRONMENT_IDS[x],
-            key=f"conflict-radio-{field['key']}",
+            key=f"conflict-radio-{field['key']}-{self.diff.chart_id}",
             horizontal=True,
             label_visibility="collapsed",
         )
@@ -125,7 +125,7 @@ class ChartDiffConflictResolver:
             placeholder=f"This field is not present in {ENVIRONMENT_IDS[choice]}!" if is_none else "",
             help="Edit the final config here. When cliking on 'Resolve conflicts', this value will be used to update the chart config.",
             disabled=is_none,
-            key=f"conflict-editor-{field['key']}",
+            key=f"conflict-editor-{field['key']}-{self.diff.chart_id}",
         )
 
     def resolve_conflicts(self, rerun: bool = False):


### PR DESCRIPTION
I saw errors from chart-diff on this [staging server](http://staging-site-yougob/etl/wizard/chart-diff?change_type=new&change_type=config) about `DuplicateWidgetID`. Adding suffix `chart_id` to all those widgets fixed them, but I'm not sure if there could be any side effects.