### PR TITLE
 :bug: Helper function `geo.add_population_to_dataframe` uses old version of population dataset

### DIFF
--- a/dag/education.yml
+++ b/dag/education.yml
@@ -20,6 +20,7 @@ steps:
     - data://meadow/education/2023-07-17/education_barro_lee_projections
     - data://garden/regions/2023-01-01/regions
     - data://garden/education/2023-07-17/education_lee_lee
+    - data://garden/demography/2022-12-08/population
   data://grapher/education/2023-07-17/education_barro_lee_projections:
     - data://garden/education/2023-07-17/education_barro_lee_projections
 
@@ -32,7 +33,7 @@ steps:
     - data://meadow/education/2023-07-17/education_lee_lee
     - data://garden/regions/2023-01-01/regions
     - data://garden/worldbank_wdi/2024-05-20/wdi
-    - data://garden/owid/latest/key_indicators
+    - data://garden/demography/2022-12-08/population
   data://grapher/education/2023-07-17/education_lee_lee:
     - data://garden/education/2023-07-17/education_lee_lee
 

--- a/dag/excess_mortality.yml
+++ b/dag/excess_mortality.yml
@@ -19,7 +19,7 @@ steps:
     - data://garden/excess_mortality/latest/xm_karlinsky_kobak
     - data://garden/excess_mortality/latest/wmd
     - data://garden/excess_mortality/latest/hmd_stmf
-    - data://garden/owid/latest/key_indicators
+    - data://garden/demography/2022-12-08/population
   # Grapher
   data://grapher/excess_mortality/latest/excess_mortality:
     - data://garden/excess_mortality/latest/excess_mortality

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -300,9 +300,9 @@ steps:
     - snapshot://tourism/2023-05-04/unwto.xlsx
   data://garden/tourism/2023-05-05/unwto:
     - data://meadow/tourism/2023-05-05/unwto
-    - data://garden/owid/latest/key_indicators
     - data://garden/worldbank_wdi/2022-05-26/wdi
     - data://garden/oecd/2023-06-20/ppp_exchange_rates
+    - data://garden/demography/2022-12-08/population
   data://grapher/tourism/2023-05-11/unwto:
     - data://garden/tourism/2023-05-05/unwto
   # Environment Tables Implementations
@@ -327,6 +327,7 @@ steps:
   data://garden/oecd/2023-05-19/co2_air_transport:
     - data://garden/tourism/2023-05-05/unwto
     - data://meadow/oecd/2023-05-18/co2_air_transport
+    - data://garden/demography/2022-12-08/population
   data://grapher/oecd/2023-05-19/co2_air_transport:
     - data://garden/oecd/2023-05-19/co2_air_transport
 

--- a/etl/data_helpers/geo.py
+++ b/etl/data_helpers/geo.py
@@ -547,7 +547,7 @@ def harmonize_countries(
     return df_harmonized  # type: ignore
 
 
-def add_population_to_dataframe(
+def _add_population_to_dataframe(
     df: TableOrDataFrame,
     ds_population: Optional[Dataset] = None,
     country_col: str = "country",
@@ -733,7 +733,7 @@ def add_population_to_table(
 
     """
     # Create a dataframe with an additional population column.
-    df_with_population = add_population_to_dataframe(
+    df_with_population = _add_population_to_dataframe(
         df=tb,
         ds_population=ds_population,
         country_col=country_col,

--- a/etl/steps/data/garden/demography/2023-02-03/life_expectancy.py
+++ b/etl/steps/data/garden/demography/2023-02-03/life_expectancy.py
@@ -454,7 +454,7 @@ def add_region_aggregates(frame: pd.DataFrame) -> pd.DataFrame:
     ]
     frame = frame.loc[-frame["country"].isin(regions_ignore)]
     # add population
-    df = geo.add_population_to_dataframe(frame.copy())
+    df = geo.add_population_to_table(frame.copy(), N.load_dataset("population"))
 
     # estimate values for regions
     # y(country) = weight(country) * metric(country)

--- a/etl/steps/data/garden/education/2023-07-17/education_barro_lee_projections.py
+++ b/etl/steps/data/garden/education/2023-07-17/education_barro_lee_projections.py
@@ -39,6 +39,7 @@ def add_data_for_regions(tb: Table, ds_regions: Dataset) -> Table:
             num_allowed_nans_per_year=None,
             frac_allowed_nans_per_year=0.2,
             aggregations=aggregations,
+            ds_population=paths.load_dataset("population"),
         )
 
     return tb_with_regions

--- a/etl/steps/data/garden/education/2023-07-17/education_lee_lee.py
+++ b/etl/steps/data/garden/education/2023-07-17/education_lee_lee.py
@@ -38,6 +38,7 @@ def add_data_for_regions(tb: Table, ds_regions: Dataset) -> Table:
             num_allowed_nans_per_year=None,
             frac_allowed_nans_per_year=0.2,
             aggregations=aggregations,
+            ds_population=paths.load_dependency("population"),
         )
     return tb_with_regions
 

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/process.py
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/process.py
@@ -3,11 +3,17 @@ from datetime import datetime, timedelta
 
 import numpy as np
 import pandas as pd
+from owid.catalog import Table
 from structlog import get_logger
 
 from etl.data_helpers import geo
+from etl.helpers import PathFinder
 
 log = get_logger()
+
+# naming conventions
+paths = PathFinder(__file__)
+
 # Maximum year
 YEAR_MAX = 2024
 
@@ -283,7 +289,7 @@ def add_cum_metrics(df: pd.DataFrame) -> pd.DataFrame:
 def add_population(df: pd.DataFrame) -> pd.DataFrame:
     # Load population data
     df["year"] = df["date"].dt.year
-    df = geo.add_population_to_dataframe(df, country_col="entity", year_col="year")
+    df = geo.add_population_to_table(Table(df), paths.load_dataset("population"), country_col="entity", year_col="year")
     df = df.drop(columns=["year"])
     # Get per million metrics
     df["excess_per_million_proj_all_ages"] = df["excess_proj_all_ages"] / (df["population"] / 1e6)

--- a/etl/steps/data/garden/faostat/2022-05-17/shared.py
+++ b/etl/steps/data/garden/faostat/2022-05-17/shared.py
@@ -1590,7 +1590,7 @@ def clean_data(
     # because for one item we may have more European countries informed than for the other.
     data = add_population(df=data, population_col="population_with_data", warn_on_missing_countries=False)
 
-    # Convert back to categorical columns (maybe this should be handled automatically in `add_population_to_dataframe`)
+    # Convert back to categorical columns (maybe this should be handled automatically in `add_population_to_table`)
     data = data.astype({"country": "category"})
 
     return data

--- a/etl/steps/data/garden/faostat/2023-02-22/shared.py
+++ b/etl/steps/data/garden/faostat/2023-02-22/shared.py
@@ -1540,7 +1540,7 @@ def clean_data(
     # because for one item we may have more European countries informed than for the other.
     data = add_population(df=data, population_col="population_with_data", warn_on_missing_countries=False)
 
-    # Convert back to categorical columns (maybe this should be handled automatically in `add_population_to_dataframe`)
+    # Convert back to categorical columns (maybe this should be handled automatically in `add_population_to_table`)
     data = data.astype({"country": "category"})
 
     return data

--- a/etl/steps/data/garden/faostat/2023-06-12/shared.py
+++ b/etl/steps/data/garden/faostat/2023-06-12/shared.py
@@ -1550,7 +1550,7 @@ def clean_data(
     # because for one item we may have more European countries informed than for the other.
     data = add_population(df=data, population_col="population_with_data", warn_on_missing_countries=False)
 
-    # Convert back to categorical columns (maybe this should be handled automatically in `add_population_to_dataframe`)
+    # Convert back to categorical columns (maybe this should be handled automatically in `add_population_to_table`)
     data = data.astype({"country": "category"})
 
     return data

--- a/etl/steps/data/garden/faostat/2024-03-14/shared.py
+++ b/etl/steps/data/garden/faostat/2024-03-14/shared.py
@@ -1541,7 +1541,7 @@ def clean_data(
         tb=tb, ds_population=ds_population, population_col="population_with_data", warn_on_missing_countries=False
     )
 
-    # Convert back to categorical columns (maybe this should be handled automatically in `add_population_to_dataframe`)
+    # Convert back to categorical columns (maybe this should be handled automatically in `add_population_to_table`)
     tb = tb.astype({"country": "category"})
 
     return tb

--- a/etl/steps/data/garden/health/2023-08-16/deaths_karlinsky.py
+++ b/etl/steps/data/garden/health/2023-08-16/deaths_karlinsky.py
@@ -1,8 +1,7 @@
 """Load a meadow dataset and create a garden dataset."""
 
-from typing import cast
 
-from owid.catalog import Dataset, Table
+from owid.catalog import Table
 
 from etl.data_helpers import geo
 from etl.helpers import PathFinder, create_dataset
@@ -16,7 +15,7 @@ def run(dest_dir: str) -> None:
     # Load inputs.
     #
     # Load meadow dataset.
-    ds_meadow = cast(Dataset, paths.load_dependency("deaths_karlinsky"))
+    ds_meadow = paths.load_dataset("deaths_karlinsky")
 
     # Read table from meadow dataset.
     tb = ds_meadow["deaths_karlinsky"].reset_index()
@@ -71,7 +70,7 @@ def _sanity_checks(tb: Table) -> None:
     # ensure absolute values make sense (positive, lower than population)
     columns_absolute = [col for col in tb.columns if col not in columns_perc]
     tb_ = tb.reset_index()
-    tb_ = geo.add_population_to_dataframe(tb_)
+    tb_ = geo.add_population_to_table(tb_, paths.load_dataset("population"))
     for col in columns_absolute:
         x = tb_.dropna(subset=[col])
         assert all(

--- a/etl/steps/data/garden/oecd/2023-05-19/co2_air_transport.py
+++ b/etl/steps/data/garden/oecd/2023-05-19/co2_air_transport.py
@@ -60,8 +60,12 @@ def run(dest_dir: str) -> None:
     pivot_table_ye = process_annual_data(df)
 
     # Add population data to the DataFrame
-    pivot_table_ye = geo.add_population_to_dataframe(
-        pivot_table_ye, country_col="country", year_col="year", population_col="population"
+    pivot_table_ye = geo.add_population_to_table(
+        Table(pivot_table_ye),
+        paths.load_dataset("population"),
+        country_col="country",
+        year_col="year",
+        population_col="population",
     )
 
     emissions_columns = [col for col in pivot_table_ye.columns if col not in ("country", "year", "population")]

--- a/etl/steps/data/garden/tourism/2023-05-05/unwto.py
+++ b/etl/steps/data/garden/tourism/2023-05-05/unwto.py
@@ -86,8 +86,12 @@ def run(dest_dir: str) -> None:
     # assert len(merged_df_concat_transf.index.levels) == 2 and merged_df_concat_transf.index.is_unique, "Index is not well constructed"
 
     # Add population data to the DataFrame
-    merged_df_concat_transf = geo.add_population_to_dataframe(
-        merged_df_concat, country_col="country", year_col="year", population_col="population"
+    merged_df_concat_transf = geo.add_population_to_table(
+        Table(merged_df_concat),
+        paths.load_dataset("population"),
+        country_col="country",
+        year_col="year",
+        population_col="population",
     )
     merged_df_concat_transf.set_index(["country", "year"], inplace=True)
 

--- a/etl/steps/data/garden/un/2023-08-02/comtrade_pandemics.py
+++ b/etl/steps/data/garden/un/2023-08-02/comtrade_pandemics.py
@@ -252,7 +252,7 @@ def add_per_capita_variables(tb: Table, ds_population: Dataset) -> Table:
 
     # Estimate per-capita variables.
     ## Add population variable
-    tb = geo.add_population_to_dataframe(tb, ds_population, expected_countries_without_population=[])
+    tb = geo.add_population_to_table(tb, ds_population, expected_countries_without_population=[])
     ## Estimate ratio
     for col in tb.columns:
         if col not in ["population", "year", "country"]:

--- a/etl/steps/data/garden/un/2023-10-09/plastic_waste.py
+++ b/etl/steps/data/garden/un/2023-10-09/plastic_waste.py
@@ -188,7 +188,7 @@ def add_per_capita_variables(tb: Table) -> Table:
     ds_population = paths.load_dataset("population")
     # Estimate per-capita variables.
     ## Add population variable
-    tb_with_per_capita = geo.add_population_to_dataframe(
+    tb_with_per_capita = geo.add_population_to_table(
         tb_with_per_capita,
         ds_population,
         expected_countries_without_population=[],

--- a/tests/data_helpers/test_geo.py
+++ b/tests/data_helpers/test_geo.py
@@ -80,7 +80,7 @@ class TestAddPopulationToDataframe:
                 "population": [30, 20],
             }
         )
-        assert geo.add_population_to_dataframe(df=df_in).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in).equals(df_out)
 
     def test_countries_and_years_in_population_just_one(self):
         df_in = pd.DataFrame({"country": ["Country 2", "Country 2"], "year": [2020, 2019]})
@@ -91,7 +91,7 @@ class TestAddPopulationToDataframe:
                 "population": [40, 30],
             }
         )
-        assert geo.add_population_to_dataframe(df=df_in).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in).equals(df_out)
 
     def test_one_country_in_and_another_not_in_population(self):
         df_in = pd.DataFrame({"country": ["Country 1", "Country 3"], "year": [2020, 2021]})
@@ -102,7 +102,7 @@ class TestAddPopulationToDataframe:
                 "population": [10, np.nan],
             }
         )
-        assert geo.add_population_to_dataframe(df=df_in).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in).equals(df_out)
 
     def test_no_countries_in_population(self):
         df_in = pd.DataFrame({"country": ["Country_04", "Country_04"], "year": [2000, 2000]})
@@ -113,7 +113,7 @@ class TestAddPopulationToDataframe:
                 "population": [np.nan, np.nan],
             }
         )
-        assert geo.add_population_to_dataframe(df=df_in, warn_on_missing_countries=False).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in, warn_on_missing_countries=False).equals(df_out)
 
     def test_countries_in_population_but_not_for_given_years(self):
         df_in = pd.DataFrame({"country": ["Country 2", "Country 1"], "year": [2000, 2000]})
@@ -124,7 +124,7 @@ class TestAddPopulationToDataframe:
                 "population": [np.nan, np.nan],
             }
         )
-        assert geo.add_population_to_dataframe(df=df_in).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in).equals(df_out)
 
     def test_countries_in_population_but_a_year_in_and_another_not_in_population(self):
         df_in = pd.DataFrame({"country": ["Country 2", "Country 1"], "year": [2019, 2000]})
@@ -135,7 +135,7 @@ class TestAddPopulationToDataframe:
                 "population": [30, np.nan],
             }
         )
-        assert geo.add_population_to_dataframe(df=df_in).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in).equals(df_out)
 
     def test_change_country_and_year_column_names(self):
         df_in = pd.DataFrame({"Country": ["Country 2", "Country 1"], "Year": [2019, 2021]})
@@ -146,7 +146,7 @@ class TestAddPopulationToDataframe:
                 "population": [30, 20],
             }
         )
-        assert geo.add_population_to_dataframe(df=df_in, country_col="Country", year_col="Year").equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in, country_col="Country", year_col="Year").equals(df_out)
 
     def test_warn_if_countries_missing(self):
         df_in = pd.DataFrame({"country": ["Country_04", "Country_04"], "year": [2000, 2000]})
@@ -158,7 +158,7 @@ class TestAddPopulationToDataframe:
             }
         )
         with warns(UserWarning):
-            geo.add_population_to_dataframe(df=df_in, warn_on_missing_countries=True).equals(df_out)
+            geo._add_population_to_dataframe(df=df_in, warn_on_missing_countries=True).equals(df_out)
 
 
 @patch("builtins.open", new=mock_opens)


### PR DESCRIPTION
We had an error in nightly build about `garden/health/2023-08-16/deaths_karlinsky` not having `garden/owid/latest/key_indicators` as dependency, despite having `data://garden/demography/2023-03-31/population` as dependency.

It turned out that it even though we were expecting version `2023-03-31/population` in dependencies, function `geo.add_population_to_dataframe` for adding population is using `key_indicators` by default (instead of population dataset) and **key_indicators use outdated `2022-12-08/population`**.

There are a couple of options how to fix it:
- Replace deprecated `geo.add_population_to_dataframe` function by `geo.add_population_to_table` everywhere
- Make `key_indicators` use the latest `2023-03-31/population` population dataset

Perhaps we could do both?

This PR fixes only a single case so far, but I can add more once we agree what the fix should be.