### PR TITLE
:sparkles: Post grapherConfigETL update to Admin API

### DIFF
--- a/apps/backport/datasync/data_metadata.py
+++ b/apps/backport/datasync/data_metadata.py
@@ -253,23 +253,17 @@ def _variable_metadata(
 
     schemaVersion = row.pop("schemaVersion")
     processingLevel = row.pop("processingLevel")
-    grapherConfigETLJson = row.pop("grapherConfigETL")
-    grapherConfigAdminJson = row.pop("grapherConfigAdmin")
     licenseJson = row.pop("license")
     descriptionKeyJson = row.pop("descriptionKey")
     sortJson = row.pop("sort")
 
     display = json.loads(displayJson)
-    grapherConfigETL = json.loads(grapherConfigETLJson) if grapherConfigETLJson else None
-    grapherConfigAdmin = json.loads(grapherConfigAdminJson) if grapherConfigAdminJson else None
     license = json.loads(licenseJson) if licenseJson else None
     descriptionKey = json.loads(descriptionKeyJson) if descriptionKeyJson else None
     sort = json.loads(sortJson) if sortJson else None
 
     # group fields from flat structure into presentation field
     presentation = dict(
-        grapherConfigETL=grapherConfigETL,
-        grapherConfigAdmin=grapherConfigAdmin,
         titlePublic=row.pop("titlePublic"),
         titleVariant=row.pop("titleVariant"),
         attributionShort=row.pop("attributionShort"),

--- a/apps/chart_sync/admin_api.py
+++ b/apps/chart_sync/admin_api.py
@@ -81,6 +81,25 @@ class AdminAPI(object):
         assert js["success"]
         return js
 
+    def put_grapher_config(self, variable_id: int, grapher_config: Dict[str, Any]) -> dict:
+        resp = requests.put(
+            self.base_url + f"/admin/api/variables/{variable_id}/grapherConfigETL",
+            cookies={"sessionid": self.session_id},
+            json=grapher_config,
+        )
+        js = self._json_from_response(resp)
+        assert js["success"]
+        return js
+
+    def delete_grapher_config(self, variable_id: int) -> dict:
+        resp = requests.delete(
+            self.base_url + f"/admin/api/variables/{variable_id}/grapherConfigETL",
+            cookies={"sessionid": self.session_id},
+        )
+        js = self._json_from_response(resp)
+        assert js["success"]
+        return js
+
 
 def _generate_random_string(length=32) -> str:
     letters_and_digits = string.ascii_letters + string.digits

--- a/apps/wizard/app_pages/expert/prompts.py
+++ b/apps/wizard/app_pages/expert/prompts.py
@@ -607,7 +607,6 @@ The schema is provided in yaml below. The top level array represents the tables,
       - name: display
       - name: columnOrder
       - name: originalMetadata
-      - name: grapherConfigAdmin
       - name: shortName
       - name: catalogPath
       - name: dimensions

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -991,7 +991,7 @@ class Variable(Base):
     license: Mapped[Optional[dict]] = mapped_column(JSON, default=None)
     type: Mapped[Optional[VARIABLE_TYPE]] = mapped_column(ENUM(*get_args(VARIABLE_TYPE)), default=None)
     sort: Mapped[Optional[list[str]]] = mapped_column(JSON, default=None)
-    grapherConfigIdAdmin: Mapped[Optional[bytes]] = mapped_column(BINARY(16), default=None)
+    grapherConfigIdAdmin: Mapped[Optional[str]] = mapped_column(VARCHAR(32), default=None)
     grapherConfigIdETL: Mapped[Optional[bytes]] = mapped_column(BINARY(16), default=None)
     dataChecksum: Mapped[Optional[str]] = mapped_column(VARCHAR(64), default=None)
     metadataChecksum: Mapped[Optional[str]] = mapped_column(VARCHAR(64), default=None)

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -929,7 +929,6 @@ class Variable(Base):
         'display': '{}',
         'columnOrder': 0,
         'originalMetadata': '{}',
-        'grapherConfigAdmin': None
     }
     """
 
@@ -973,7 +972,6 @@ class Variable(Base):
     sourceId: Mapped[Optional[int]] = mapped_column(Integer, default=None)
     shortUnit: Mapped[Optional[str]] = mapped_column(VARCHAR(255), default=None)
     originalMetadata: Mapped[Optional[dict]] = mapped_column(JSON, default=None)
-    grapherConfigAdmin: Mapped[Optional[dict]] = mapped_column(JSON, default=None)
     shortName: Mapped[Optional[str]] = mapped_column(VARCHAR(255), default=None)
     catalogPath: Mapped[Optional[str]] = mapped_column(VARCHAR(767), default=None)
     dimensions: Mapped[Optional[Dimensions]] = mapped_column(JSON, default=None)
@@ -991,9 +989,10 @@ class Variable(Base):
     licenses: Mapped[Optional[list[dict]]] = mapped_column(JSON, default=None)
     # NOTE: License should be the resulting license, given all licenses of the indicator’s origins and given the indicator’s processing level.
     license: Mapped[Optional[dict]] = mapped_column(JSON, default=None)
-    grapherConfigETL: Mapped[Optional[dict]] = mapped_column(JSON, default=None)
     type: Mapped[Optional[VARIABLE_TYPE]] = mapped_column(ENUM(*get_args(VARIABLE_TYPE)), default=None)
     sort: Mapped[Optional[list[str]]] = mapped_column(JSON, default=None)
+    grapherConfigIdAdmin: Mapped[Optional[bytes]] = mapped_column(BINARY(16), default=None)
+    grapherConfigIdETL: Mapped[Optional[bytes]] = mapped_column(BINARY(16), default=None)
     dataChecksum: Mapped[Optional[str]] = mapped_column(VARCHAR(64), default=None)
     metadataChecksum: Mapped[Optional[str]] = mapped_column(VARCHAR(64), default=None)
 
@@ -1077,11 +1076,8 @@ class Variable(Base):
                 ds.code = self.code
             if self.originalMetadata is not None:
                 ds.originalMetadata = self.originalMetadata
-            if self.grapherConfigETL is not None:
-                ds.grapherConfigETL = self.grapherConfigETL
             if self.sort is not None:
                 ds.sort = self.sort
-            assert self.grapherConfigAdmin is None, "grapherConfigETL should be used instead of grapherConfigAdmin"
 
         session.add(ds)
 
@@ -1121,10 +1117,6 @@ class Variable(Base):
 
         if metadata.description_key:
             assert isinstance(metadata.description_key, list), "descriptionKey should be a list of bullet points"
-
-        # rename grapherConfig to grapherConfigETL
-        if "grapherConfig" in presentation_dict:
-            presentation_dict["grapherConfigETL"] = presentation_dict.pop("grapherConfig")
 
         return cls(
             shortName=short_name,

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -31,6 +31,7 @@ from owid.walden import Catalog as WaldenCatalog
 from owid.walden import Dataset as WaldenDataset
 from sqlalchemy.engine import Engine
 
+from apps.chart_sync.admin_api import AdminAPI
 from etl import config, files, git_helpers, paths
 from etl import grapher_helpers as gh
 from etl.db import get_engine
@@ -798,6 +799,7 @@ class GrapherStep(Step):
         dataset.metadata = gh._adapt_dataset_metadata_for_grapher(dataset.metadata)
 
         engine = get_engine()
+        admin_api = AdminAPI(engine)
 
         assert dataset.metadata.namespace
         dataset_upsert_results = gi.upsert_dataset(
@@ -847,6 +849,7 @@ class GrapherStep(Step):
                         thread_pool.submit(
                             gi.upsert_table,
                             engine,
+                            admin_api,
                             t,
                             dataset_upsert_results,
                             catalog_path=catalog_path,

--- a/tests/backport/datasync/test_data_metadata.py
+++ b/tests/backport/datasync/test_data_metadata.py
@@ -60,7 +60,6 @@ def _variable_meta():
         "sort": None,
         "columnOrder": 0,
         "originalMetadata": None,
-        "grapherConfigAdmin": None,
         "shortName": "population_density",
         "catalogPath": "grapher/owid/latest/key_indicators/population_density#population_density",
         "dimensions": None,
@@ -68,7 +67,6 @@ def _variable_meta():
         "nonRedistributable": 0,
         "schemaVersion": 2,
         "processingLevel": "minor",
-        "grapherConfigETL": '{"title": "Population density"}',
         "license": '{"name": "License"}',
         "descriptionKey": '["Population density"]',
         "titlePublic": "Population density title",
@@ -133,7 +131,6 @@ def test_variable_metadata():
         "origins": [{"descriptionSnapshot": "Origin A"}, {"descriptionSnapshot": "Origin B"}],
         "presentation": {
             "faqs": [{"fragmentId": "test", "gdocId": "1"}],
-            "grapherConfigETL": {"title": "Population density"},
             "attributionShort": "Gapminder",
             "titlePublic": "Population density title",
             "titleVariant": "Population density variant",
@@ -243,11 +240,11 @@ def test_convert_strings_to_numeric():
 
 def test_checksum_metadata():
     meta = _variable_meta()
-    assert checksum_metadata(meta) == "3123b1b4a25809c199e19e8203507a77"
+    assert checksum_metadata(meta) == "367a0d273b3ba021f811259e0ef80b99"
 
     # change id, checksums or updatedAt shouldn't change it
     meta = _variable_meta()
     meta["id"] = 999
     meta["dataChecksum"] = 999
     meta["updatedAt"] = dt.datetime.now()
-    assert checksum_metadata(meta) == "3123b1b4a25809c199e19e8203507a77"
+    assert checksum_metadata(meta) == "367a0d273b3ba021f811259e0ef80b99"


### PR DESCRIPTION
ETL part of https://github.com/owid/owid-grapher/pull/3793.

`grapherConfig` can't be directly saved to MySQL, because there are side effects to it (it updates all relevant chart configs). Instead of duplicating the side effect logic in ETL, we'll rather call Admin endpoints that handle all that:
```
PUT /variables/:variableId/grapherConfigETL
DELETE /variables/:variableId/grapherConfigETL
```

It works fairly well. I haven't optimized it much, since only a handful of indicators use `grapher_config`.

## Changes
- `grapherConfigETL` is no longer in `*.metadata.json`, is that ok?
- This will change checksum of a lot of indicators, we might have to trigger a full ETL rebuild with new epoch