### PR TITLE
 :sparkles: Add --step-update to draft-pr command

### DIFF
--- a/apps/step_update/cli.py
+++ b/apps/step_update/cli.py
@@ -360,6 +360,11 @@ class StepUpdater:
                     log.error(f"Stopped because of a failure on step {step}.")
                     break
 
+            # Tell user how to automatically create PR
+            short_name = steps[-1].split("/")[-1].split(".")[0]
+            cmd = f'etl d draft-pr update-{short_name} --title ":bar_chart: Update {short_name}" --step-update'
+            log.info(f"Create PR automatically with:\n  {cmd}")
+
     def _archive_step(self, step: str) -> None:
         # Move a certain step from its active dag to its corresponding archive dag.
 

--- a/apps/utils/draft_pull_request.py
+++ b/apps/utils/draft_pull_request.py
@@ -107,12 +107,18 @@ description = "- " + "\n- ".join(
     "-s",
     help="Scope of the PR (only relevant if --title is given). This text will be preprended to the PR title. \n\n\n**Examples**: 'demography' for data work on this field, 'etl.db' if working on specific modules, 'wizard', etc.",
 )
+@click.option(
+    "--step-update",
+    is_flag=True,
+    help="Run after updating a step in ETL Dashboard. In addition to creating PR, this will commit generated files.",
+)
 def cli(
     new_branch: Optional[str] = None,
     base_branch: Optional[str] = None,
     title: Optional[str] = None,
     category: Optional[str] = None,
     scope: Optional[str] = None,
+    step_update: bool = False,
 ) -> None:
     if not GITHUB_TOKEN:
         log.error(
@@ -193,6 +199,11 @@ def cli(
     log.info("Creating an empty commit.")
     repo.git.commit("--allow-empty", "-m", title or f"Start a new staging server for branch '{new_branch}'")
 
+    if step_update:
+        log.info("Committing all files.")
+        repo.git.add(".")
+        repo.git.commit("-m", "Copy steps")
+
     log.info("Pushing the new branch to remote.")
     repo.git.push("origin", new_branch)
 
@@ -211,6 +222,20 @@ def cli(
         log.info(f"Draft pull request created successfully at {js['html_url']}.")
     else:
         log.error(f"Failed to create draft pull request:\n{response.json()}")
+        return
+
+    # modify the PR body to include the diff link
+    if step_update:
+        diff_link = f"{js['html_url']}/files/{repo.head.commit.hexsha}..HEAD"
+
+        # Update body of the pull request
+        requests.patch(
+            js["url"],
+            json={
+                "body": f"[View diff without step copy]({diff_link})",
+            },
+            headers=headers,
+        )
 
 
 def generate_pr_title(title: str | None, category: str | None, scope: str | None) -> None | str:


### PR DESCRIPTION
Automate PR creation after updating step in ETL dashboard (see our docs on [Updating data](https://docs.owid.io/projects/etl/guides/data-work/update-data/)).

## Motivation

We update a step with ETL dashboard, but then have to manually create a PR and potentially reference branch or a link to Github diff that excludes copying steps. This PR automates it a bit, while keeping it flexible enough.

## Solution

After you update your step, StepUpdater CLI will show you a command:
```
Create PR automatically with:
etl d draft-pr update-{short_name} --title ":bar_chart: Update {short_name}" --step-update
```

An extra flag `--step-update` will commit the updated steps and post a link to view diff without copied steps (we used to use reference branch for this). See https://github.com/owid/etl/pull/3044 for example.

If this proves to be useful, we can add a modal window to ETL dashboard that would run the command for you.