### PR TITLE
📊 Improve minerals explorer (different way of combining BGS and USGS)

### DIFF
--- a/dag/minerals.yml
+++ b/dag/minerals.yml
@@ -46,7 +46,6 @@ steps:
     - data://garden/bgs/2024-07-09/world_mineral_statistics
     - data://garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities
     - data://garden/usgs/2024-07-15/mineral_commodity_summaries
-    - data://garden/regions/2023-01-01/regions
   #
   # Minerals - Minerals.
   #

--- a/dag/minerals.yml
+++ b/dag/minerals.yml
@@ -46,6 +46,7 @@ steps:
     - data://garden/bgs/2024-07-09/world_mineral_statistics
     - data://garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities
     - data://garden/usgs/2024-07-15/mineral_commodity_summaries
+    - data://garden/regions/2023-01-01/regions
   #
   # Minerals - Minerals.
   #

--- a/etl/steps/data/explorers/minerals/latest/minerals.py
+++ b/etl/steps/data/explorers/minerals/latest/minerals.py
@@ -57,8 +57,7 @@ def run(dest_dir: str) -> None:
                 sub_commodity = f"{sub_commodity.capitalize()}"
 
             # Metric "Unit value" should not have a map tab.
-            # Also, imports and exports tend to have very sparse data. For now, remove their map tabs.
-            if metric in ["Imports", "Exports", "Unit value"]:
+            if metric in ["Unit value"]:
                 has_map_tab = False
             else:
                 has_map_tab = True
@@ -130,7 +129,7 @@ def run(dest_dir: str) -> None:
     # Sort rows conveniently.
     df_graphers["Metric Dropdown"] = pd.Categorical(
         df_graphers["Metric Dropdown"],
-        categories=["Production", "Reserves", "Unit value", "Imports", "Exports"],
+        categories=["Production", "Reserves", "Unit value"],
         ordered=True,
     )
     df_graphers = df_graphers.sort_values(["Mineral Dropdown", "Metric Dropdown", "Type Dropdown"]).reset_index(
@@ -150,7 +149,7 @@ def run(dest_dir: str) -> None:
     # Prepare explorer metadata.
     config = {
         "explorerTitle": "Minerals",
-        "explorerSubtitle": "Explore the amount of minerals that are produced, imported, and exported.",
+        "explorerSubtitle": "Explore the production, reserves and value of minerals.",
         "selection": ["World", "Australia", "Chile", "China", "United States"],
     }
 

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -485,7 +485,8 @@ COMMODITY_MAPPING = {
     # NOTE: Unclear what "Unknown" means, but it's significantly lower than USGS' "Mine".
     ("Salt", "Unknown"): None,
     ("Selenium, refined", "Unknown"): ("Selenium", "Refinery"),
-    ("Sillimanite minerals", "Andalusite"): ("Andalusite", "Mine"),
+    # NOTE: The following could be mapped to ("Andalusite", "Mine") (and so does USGS, which does not include global data).
+    ("Sillimanite minerals", "Andalusite"): None,
     ("Sillimanite minerals", "Andalusite & kyanite"): None,
     # NOTE: The following could possibly be mapped to ("Kyanite", "Mine"), but it has very sparse data (and so does USGS).
     ("Sillimanite minerals", "Kyanite"): None,

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -1021,6 +1021,15 @@ def run(dest_dir: str) -> None:
     # Harmonize units.
     tb = harmonize_units(tb=tb)
 
+    ####################################################################################################################
+    # Fix some known issues in the data.
+    # Molybdenum, mine for the US between 1970 and 1976 is significantly larger than in USGS.
+    # And BGS notes on 1977 say "Break in series". So I will remove those points prior to 1977.
+    tb.loc[(tb["country"] == "United States") & (tb["year"] < 1977) & (tb["category"] == "Production"), "value"] = None
+    # Similarly, there is a big dip in 1977 for Turkey, with a "Break in series" note.
+    tb.loc[(tb["country"] == "Turkey") & (tb["year"] < 1977) & (tb["category"] == "Production"), "value"] = None
+    ####################################################################################################################
+
     # Pivot table to have a column for each category.
     tb = (
         tb.pivot(

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -370,8 +370,10 @@ COMMODITY_MAPPING = {
     #  units are explicitly mentioned, and sometimes the notes mention oil equivalent.
     ("Natural gas", "Unknown"): None,
     ("Nepheline syenite", "Nepheline concentrates"): None,
-    ("Nepheline syenite", "Nepheline-syenite"): ("Nepheline syenite", "Mine"),
-    ("Nepheline syenite", "Unknown"): ("Nepheline syenite", "Mine"),
+    # NOTE: The following could be mapped to ("Nepheline syenite", "Mine"), but it has very sparse and noisy data for just a few countries.
+    ("Nepheline syenite", "Nepheline-syenite"): None,
+    # NOTE: The following could be mapped to ("Nepheline syenite", "Mine"), but it has very sparse and noisy data for just a few countries.
+    ("Nepheline syenite", "Unknown"): None,
     ("Nickel", "Mattes, sinters etc"): None,
     ("Nickel", "Ores & concentrates"): None,
     ("Nickel", "Ores, concentrates & scrap"): None,

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -639,7 +639,8 @@ COMMODITY_MAPPING = {
     ("Vanadium, mine", "Unknown"): ("Vanadium", "Mine"),
     # NOTE: The following could be mapped to ("Vermiculite", "Mine"). However, we decided to discard Vemiculite.
     ("Vermiculite", "Unknown"): None,
-    ("Wollastonite", "Unknown"): ("Wollastonite", "Mine"),
+    # NOTE: The following could be mapped to ("Wollastonite", "Mine"). However, we decided to discard Wollastonite.
+    ("Wollastonite", "Unknown"): None,
     ("Zinc", "Crude & refined"): None,
     ("Zinc", "Ores & concentrates"): None,
     ("Zinc", "Oxides"): None,

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -701,7 +701,9 @@ FOOTNOTES = {
 # There are many historical regions with overlapping data with their successor countries.
 # Accept only overlaps on the year when the historical country stopped existing.
 # NOTE: We decided to not include region aggregates, but this is still relevant because, to create world data, we first
-# create data for continents, then build an aggregate for the world, and then remove continents.
+#  create data for continents, then build an aggregate for the world, and then remove continents.
+#  World data aggregated in this step will be used in the garden minerals step to compare it with the World data given
+#  by USGS. But the World data created in this step will then be removed and not shown in the minerals explorer.
 # NOTE: Some of the overlaps occur only for certain commodities.
 ACCEPTED_OVERLAPS = [
     # {1991: {"USSR", "Armenia"}},

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -637,7 +637,8 @@ COMMODITY_MAPPING = {
     ("Vanadium", "Vanadiferous residues"): ("Vanadium", "Vanadiferous residues"),
     ("Vanadium", "Vanadium-titanium pig iron"): None,
     ("Vanadium, mine", "Unknown"): ("Vanadium", "Mine"),
-    ("Vermiculite", "Unknown"): ("Vermiculite", "Mine"),
+    # NOTE: The following could be mapped to ("Vermiculite", "Mine"). However, we decided to discard Vemiculite.
+    ("Vermiculite", "Unknown"): None,
     ("Wollastonite", "Unknown"): ("Wollastonite", "Mine"),
     ("Zinc", "Crude & refined"): None,
     ("Zinc", "Ores & concentrates"): None,

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -90,14 +90,16 @@ COMMODITY_MAPPING = {
     ("Bentonite and fuller's earth", "Fuller's earth"): ("Clays", "Mine, fuller's earth"),
     ("Bentonite and fuller's earth", "Sepiolite"): ("Clays", "Mine, sepiolite"),
     ("Bentonite and fuller's earth", "Unknown"): None,
-    ("Beryl", "Unknown"): ("Beryl", "Mine"),
+    # NOTE: Beryl data may have a data issue: The biggest producer is Namibia, which goes from 15 in 1993 to 15000 in
+    #  2021. Discard for now.
+    ("Beryl", "Unknown"): None,
     ("Bismuth", "Compounds"): ("Bismuth", "Compounds"),
     ("Bismuth", "Metal"): ("Bismuth", "Metal"),
     ("Bismuth", "Ores & concentrates"): ("Bismuth", "Ores & concentrates"),
     ("Bismuth, mine", "Unknown"): ("Bismuth", "Mine"),
     ("Borates", "Unknown"): None,
     ("Bromine", "Compounds"): ("Bromine", "Compounds"),
-    ("Bromine", "Unknown"): ("Bromine", "Unspecified"),
+    ("Bromine", "Unknown"): ("Bromine", "Processing"),
     ("Cadmium", "Metal"): ("Cadmium", "Refinery"),
     ("Cadmium", "Other"): None,
     ("Cadmium", "Oxide"): None,

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -466,14 +466,16 @@ COMMODITY_MAPPING = {
     ("Rare earth minerals", "Bastnaesite"): None,
     ("Rare earth minerals", "Loparite"): None,
     ("Rare earth minerals", "Monazite"): None,
-    ("Rare earth minerals", "Unknown"): ("Rare earths", "Mine, ores & concentrates"),
+    # NOTE: The following could possibly be mapped to ("Rare earths", "Mine, ores & concentrates"), but it has only sparse data for a few countries.
+    ("Rare earth minerals", "Unknown"): None,
     ("Rare earth minerals", "Xenotime"): None,
     ("Rare earth oxides", "Unknown"): None,
     ("Rare earths", "Cerium compounds"): None,
     ("Rare earths", "Cerium metal"): None,
     ("Rare earths", "Ferro-cerium & other pyrophoric alloys"): None,
     ("Rare earths", "Metals"): ("Rare earths", "Refinery"),
-    ("Rare earths", "Ores & concentrates"): ("Rare earths", "Mine, ores & concentrates"),
+    # NOTE: The following could possibly be mapped to ("Rare earths", "Mine, ores & concentrates"), but it possibly is only for imports/exports data.
+    ("Rare earths", "Ores & concentrates"): None,
     ("Rare earths", "Other rare earth compounds"): None,
     ("Rare earths", "Rare earth compounds"): ("Rare earths", "Compounds"),
     ("Rhenium", "Unknown"): ("Rhenium", "Mine"),

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -580,7 +580,8 @@ COMMODITY_MAPPING = {
     ("Tantalum and niobium minerals", "Tantalite -Ta content"): None,
     ("Tantalum and niobium minerals", "Tantalum & Niobium (Nb content)"): None,
     ("Tantalum and niobium minerals", "Tantalum & Niobium (Ta content)"): None,
-    ("Tellurium, refined", "Unknown"): ("Tellurium", "Refinery"),
+    # NOTE: The following could be mapped to ("Tellurium", "Refinery"). However, we decided to discard Tellurium.
+    ("Tellurium, refined", "Unknown"): None,
     ("Tin", "Concentrates"): None,
     ("Tin", "Scrap"): None,
     ("Tin", "Tin-silver ore"): None,

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -494,7 +494,8 @@ COMMODITY_MAPPING = {
     ("Sillimanite minerals", "Mullite"): None,
     ("Sillimanite minerals", "Mullite, chamotte, dinas earth"): None,
     ("Sillimanite minerals", "Other"): None,
-    ("Sillimanite minerals", "Sillimanite"): ("Sillimanite", "Mine"),
+    # NOTE: The following could be mapped to ("Sillimanite", "Mine"), but it has very sparse data, and it's not included in USGS data.
+    ("Sillimanite minerals", "Sillimanite"): None,
     ("Sillimanite minerals", "Sillimanite minerals"): None,
     ("Sillimanite minerals", "Sillimanite minerals & dinas earth"): None,
     ("Sillimanite minerals", "Sillimanite minerals, calcined"): None,

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -86,10 +86,14 @@ COMMODITY_MAPPING = {
     ("Bauxite, alumina and aluminium", "Unwrought"): None,
     ("Bauxite, alumina and aluminium", "Unwrought & scrap"): None,
     ("Bauxite, alumina and aluminium", "Unwrought alloys"): None,
-    ("Bentonite and fuller's earth", "Attapulgite"): ("Clays", "Mine, attapulgite"),
-    ("Bentonite and fuller's earth", "Bentonite"): ("Clays", "Mine, bentonite"),
-    ("Bentonite and fuller's earth", "Fuller's earth"): ("Clays", "Mine, fuller's earth"),
-    ("Bentonite and fuller's earth", "Sepiolite"): ("Clays", "Mine, sepiolite"),
+    # NOTE: The following could be mapped to ("Clays", "Mine, attapulgite"). We decided to remove "Clays".
+    ("Bentonite and fuller's earth", "Attapulgite"): None,
+    # NOTE: The following could be mapped to ("Clays", "Mine, bentonite"). We decided to remove "Clays".
+    ("Bentonite and fuller's earth", "Bentonite"): None,
+    # NOTE: The following could be mapped to ("Clays", "Mine, fuller's earth"). We decided to remove "Clays".
+    ("Bentonite and fuller's earth", "Fuller's earth"): None,
+    # NOTE: The following could be mapped to ("Clays", "Mine, sepiolite"). We decided to remove "Clays".
+    ("Bentonite and fuller's earth", "Sepiolite"): None,
     ("Bentonite and fuller's earth", "Unknown"): None,
     # NOTE: Beryl data may have a data issue: The biggest producer is Namibia, which goes from 15 in 1993 to 15000 in
     #  2021. Discard for now.
@@ -297,7 +301,8 @@ COMMODITY_MAPPING = {
     ("Iron, steel and ferro-alloys", "Sponge"): None,
     ("Iron, steel and ferro-alloys", "Sponge & powder"): None,
     ("Iron, steel and ferro-alloys", "Tin-plate scrap"): None,
-    ("Kaolin", "Unknown"): ("Clays", "Mine, kaolin"),
+    # NOTE: The following could be mapped to ("Clays", "Mine, kaolin"). We decided to remove "Clays".
+    ("Kaolin", "Unknown"): None,
     ("Lead", "Ores & concentrates"): None,
     ("Lead", "Refined"): ("Lead", "Refinery"),
     ("Lead", "Scrap"): None,

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -487,7 +487,8 @@ COMMODITY_MAPPING = {
     ("Selenium, refined", "Unknown"): ("Selenium", "Refinery"),
     ("Sillimanite minerals", "Andalusite"): ("Andalusite", "Mine"),
     ("Sillimanite minerals", "Andalusite & kyanite"): None,
-    ("Sillimanite minerals", "Kyanite"): ("Kyanite", "Mine"),
+    # NOTE: The following could possibly be mapped to ("Kyanite", "Mine"), but it has very sparse data (and so does USGS).
+    ("Sillimanite minerals", "Kyanite"): None,
     ("Sillimanite minerals", "Kyanite & related minerals"): None,
     ("Sillimanite minerals", "Mullite"): None,
     ("Sillimanite minerals", "Mullite, chamotte, dinas earth"): None,

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -1027,9 +1027,22 @@ def run(dest_dir: str) -> None:
     # Fix some known issues in the data.
     # Molybdenum, mine for the US between 1970 and 1976 is significantly larger than in USGS.
     # And BGS notes on 1977 say "Break in series". So I will remove those points prior to 1977.
-    tb.loc[(tb["country"] == "United States") & (tb["year"] < 1977) & (tb["category"] == "Production"), "value"] = None
-    # Similarly, there is a big dip in 1977 for Turkey, with a "Break in series" note.
-    tb.loc[(tb["country"] == "Turkey") & (tb["year"] < 1977) & (tb["category"] == "Production"), "value"] = None
+    # A similar thing happens for Turkey and the USSR.
+    # Even after removing these, BGS data is larger than USGS' World. So, simply remove all points prior to 1977.
+    tb.loc[
+        (tb["commodity"] == "Molybdenum")
+        # & (tb["country"].isin(["United States", "Turkey", "USSR"]))
+        & (tb["year"] < 1977)
+        & (tb["category"] == "Production"),
+        "value",
+    ] = None
+
+    # A similar issue happens with tugsten.
+    tb.loc[
+        (tb["commodity"] == "Tungsten") & (tb["year"] < 1977) & (tb["category"] == "Production"),
+        "value",
+    ] = None
+
     ####################################################################################################################
 
     # Pivot table to have a column for each category.

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -1016,7 +1016,7 @@ def aggregate_coal(tb: Table) -> Table:
     #     px.line(compare, x="year", y="value", color="sub_commodity", markers=True, title=country).show()
 
     # Select coal production data.
-    tb_coal = tb[(tb["category"] == "Production") & (tb["commodity"]=="Coal")]
+    tb_coal = tb[(tb["category"] == "Production") & (tb["commodity"] == "Coal")]
 
     # Create a series with the sum of all coal data per country-year.
     tb_coal_sum = tb_coal.groupby(["country", "year"], observed=True, as_index=False).agg({"value": "sum"})
@@ -1033,20 +1033,64 @@ def aggregate_coal(tb: Table) -> Table:
     #         px.line(compare[compare["country"] == country], x="year", y="value", color="source", markers=True, title=country).show()
 
     # Concatenate the old data (removing the disaggregated coal data) with the aggregated coal data.
-    tb_coal_sum = tb_coal_sum.assign(**{"category": "Production", "commodity": "Coal", "sub_commodity": "Mine", "unit": "tonnes"})
+    tb_coal_sum = tb_coal_sum.assign(
+        **{"category": "Production", "commodity": "Coal", "sub_commodity": "Mine", "unit": "tonnes"}
+    )
     tb = pr.concat([tb.drop(tb_coal.index), tb_coal_sum], ignore_index=True)
 
     ####################################################################################################################
     # Remove some spurious values after visual inspection (comparing with the Statistical Review).
-    tb.loc[(tb["category"]=="Production") & (tb["country"] == "Germany") & (tb["year"] == 1992) & (tb["commodity"] == "Coal"), "value"] = None
-    tb.loc[(tb["category"]=="Production") & (tb["country"] == "Czechia") & (tb["year"] == 1992) & (tb["commodity"] == "Coal"), "value"] = None
-    tb.loc[(tb["category"]=="Production") & (tb["country"] == "Slovakia") & (tb["year"] == 1992) & (tb["commodity"] == "Coal"), "value"] = None
-    tb.loc[(tb["category"]=="Production") & (tb["country"] == "Mexico") & (tb["year"] == 2019) & (tb["commodity"] == "Coal"), "value"] = None
-    tb.loc[(tb["category"]=="Production") & (tb["country"] == "Pakistan") & (tb["year"] == 1997) & (tb["commodity"] == "Coal"), "value"] = None
-    tb.loc[(tb["category"]=="Production") & (tb["country"] == "United Kingdom") & (tb["year"] == 1986) & (tb["commodity"] == "Coal"), "value"] = None
+    tb.loc[
+        (tb["category"] == "Production")
+        & (tb["country"] == "Germany")
+        & (tb["year"] == 1992)
+        & (tb["commodity"] == "Coal"),
+        "value",
+    ] = None
+    tb.loc[
+        (tb["category"] == "Production")
+        & (tb["country"] == "Czechia")
+        & (tb["year"] == 1992)
+        & (tb["commodity"] == "Coal"),
+        "value",
+    ] = None
+    tb.loc[
+        (tb["category"] == "Production")
+        & (tb["country"] == "Slovakia")
+        & (tb["year"] == 1992)
+        & (tb["commodity"] == "Coal"),
+        "value",
+    ] = None
+    tb.loc[
+        (tb["category"] == "Production")
+        & (tb["country"] == "Mexico")
+        & (tb["year"] == 2019)
+        & (tb["commodity"] == "Coal"),
+        "value",
+    ] = None
+    tb.loc[
+        (tb["category"] == "Production")
+        & (tb["country"] == "Pakistan")
+        & (tb["year"] == 1997)
+        & (tb["commodity"] == "Coal"),
+        "value",
+    ] = None
+    tb.loc[
+        (tb["category"] == "Production")
+        & (tb["country"] == "United Kingdom")
+        & (tb["year"] == 1986)
+        & (tb["commodity"] == "Coal"),
+        "value",
+    ] = None
     # For Russia, 2018, 2019, 2020 and 2021 are much higher than the rest, and then 2022 drops in BGS data.
     # This does not happen in the Statistical Review, so it looks spurious.
-    tb.loc[(tb["category"]=="Production") & (tb["country"] == "Russia") & (tb["year"].isin([2018, 2019, 2020, 2021, 2022])) & (tb["commodity"] == "Coal"), "value"] = None
+    tb.loc[
+        (tb["category"] == "Production")
+        & (tb["country"] == "Russia")
+        & (tb["year"].isin([2018, 2019, 2020, 2021, 2022]))
+        & (tb["commodity"] == "Coal"),
+        "value",
+    ] = None
     ####################################################################################################################
 
     return tb

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -84,6 +84,12 @@ COLUMNS_TO_DISCARD = [
     "share_of_global_production|Soda ash|Natural|tonnes",
     "share_of_global_production|Soda ash|Synthetic|tonnes",
     "share_of_global_reserves|Soda ash|Natural|tonnes",
+    "production|Salt|Brine salt|tonnes",
+    "production|Salt|Evaporated salt|tonnes",
+    "production|Salt|Other salt|tonnes",
+    "production|Salt|Rock salt|tonnes",
+    "production|Salt|Salt in brine|tonnes",
+    "production|Salt|Sea salt|tonnes",
 ]
 
 # List of known deviations that should not raise an error.

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -134,22 +134,31 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
     "production|Strontium|Mine|tonnes",
     # Significant global disagreement.
     # 'production|Tellurium|Refinery|tonnes',
+    # Reasonable agreement, except for certain years, which leads to >100% shares.
+    # "production|Tin|Mine|tonnes",
+    # Significant global disagreement.
+    # 'production|Titanium|Mine, ilmenite|tonnes',
+    # Reasonable global agreement, but noisy data.
+    "production|Titanium|Mine, rutile|tonnes",
+    # Reasonable global agreement, except for recent years, where shares can probably be >100%.
+    # TODO: Consider discarding.
+    "production|Tungsten|Mine|tonnes",
+    # Reasonable global agreement. Noisy data.
+    "production|Vanadium|Mine|tonnes",
+    # Reasonable global agreement. Noisy data.
+    "production|Vermiculite|Mine|tonnes",
+    # Reasonable global agreement, except for certain countries: Mexico.
+    "production|Wollastonite|Mine|tonnes",
+    # Reasonable global agreement, except for certain countries: Mexico (big peak in 2021), India (big peak in 2021).
+    "production|Zinc|Mine|tonnes",
+    # Reasonable global agreement, except for certain countries: China, Sierra Leone.
+    "production|Zirconium and hafnium|Mine|tonnes",
 ]
 # The following list contains all columns where USGS (current and historical) overlaps with BGS.
-# It is obtained by doing:
-# (set(tb_usgs_flat.columns) | set(tb_usgs_flat)) & set(tb_bgs_flat)
-# TODO: Visually inspect all of them and then move them to COMBINE_..., leaving uncommented the ones where there is reasonable agreement.
-COMBINE_BGS_AND_USGS_COLUMNS = [
-    # 'production|Tin|Mine|tonnes',
-    # 'production|Titanium|Mine, ilmenite|tonnes',
-    # 'production|Titanium|Mine, rutile|tonnes',
-    # 'production|Tungsten|Mine|tonnes',
-    # 'production|Vanadium|Mine|tonnes',
-    # 'production|Vermiculite|Mine|tonnes',
-    # 'production|Wollastonite|Mine|tonnes',
-    # 'production|Zinc|Mine|tonnes',
-    # 'production|Zirconium and hafnium|Mine|tonnes',
-]
+# NOTE: To visually inspect certain columns, the easiest is to redefine COMBINE_BGS_AND_USGS_COLUMNS again here below,
+#  only with the columns to inspect. Then, uncomment the line columns_to_plot=COMBINE_BGS_AND_USGS_COLUMNS in run().
+
+# TODO: Consider keeping "World (BGS)" just for run sanity checks and then remove it. This we we will detect >100% shares.
 
 
 def adapt_flat_table(tb_flat: Table) -> Table:
@@ -497,7 +506,7 @@ def run(dest_dir: str) -> None:
         tb_usgs_historical_flat=tb_usgs_historical_flat,
         tb_bgs_flat=tb_bgs_flat,
         # NOTE: Uncomment to visually inspect columns where BGS and USGS data are combined.
-        columns_to_plot=COMBINE_BGS_AND_USGS_COLUMNS,
+        # columns_to_plot=COMBINE_BGS_AND_USGS_COLUMNS,
     )
 
     # Create columns for share of world (i.e. production, import, exports and reserves as a share of global).

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -55,7 +55,8 @@ DEVIATION_MAX_ACCEPTED = 10
 ACCEPTED_DEVIATIONS = [
     ("World (BGS)", "production|Iodine|Mine|tonnes", [2020, 2022]),
     ("World (BGS)", "production|Zinc|Mine|tonnes", [2021]),
-    ("World (BGS)", "production|Wollastonite|Mine|tonnes", [2022]),
+    # NOTE: We decided to discard Wollastonite.
+    # ("World (BGS)", "production|Wollastonite|Mine|tonnes", [2022]),
     ("World (BGS)", "production|Tungsten|Mine|tonnes", [2020, 2021, 2022]),
     ("World (BGS)", "production|Steel|Processing, crude|tonnes", [2020]),
     ("World (BGS)", "production|Silver|Mine|tonnes", [2020]),
@@ -171,8 +172,8 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
     # "production|Vanadium|Mine|tonnes",
     # Reasonable global agreement. Noisy data. We decided to discard Vermiculite.
     # "production|Vermiculite|Mine|tonnes",
-    # Reasonable global agreement, except for certain countries: Mexico.
-    "production|Wollastonite|Mine|tonnes",
+    # Reasonable global agreement, except for certain countries: Mexico. We decided to discard Wollastonite.
+    # "production|Wollastonite|Mine|tonnes",
     # Reasonable global agreement, except for certain countries: Mexico (big peak in 2021), India (big peak in 2021).
     "production|Zinc|Mine|tonnes",
     # Reasonable global agreement, except for certain countries: China, Sierra Leone.

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -109,24 +109,37 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
     # NOTE: between 1970 and 1970, BGS is significantly lower than USGS. This may be because US data was removed.
     #  And US data was removed in the BGS garden step (see explanation there).
     "production|Molybdenum|Mine|tonnes",
+    # Reasonable global agreement, although not for certain years.
+    "production|Nickel|Mine|tonnes",
+    # Significant global disagreement.
+    "production|Perlite|Mine|tonnes",
+    # Reasonably good agreement, except between 1970 and 1976, where BGS is significantly lower. Noisy data.
+    # Also, disagreement for certain countries: Turkey, Syria, Peru, Egypt, Australia.
+    "production|Phosphate rock|Mine|tonnes",
+    "production|Platinum group metals|Mine, palladium|tonnes",
+    "production|Platinum group metals|Mine, platinum|tonnes",
+    # Significant global disagreement.
+    # 'production|Rhenium|Mine|tonnes',
+    # Significant global disagreement.
+    # 'production|Selenium|Refinery|tonnes',
+    # Reasonably good agreement, except for recent years.
+    # Also, significant disagreement for certain countries: Poland, Mexico, Kazakhstan.
+    "production|Silver|Mine|tonnes",
+    # Significant global disagreement, leading to >100% shares of global.
+    # 'production|Soda ash|Natural|tonnes',
+    # Reasonably good agreement, except for Iran in 2020, which is an outlier in BGS data (it may be an error).
+    # This outlier is fixed after combining with USGS data.
+    "production|Steel|Processing, crude|tonnes",
+    # Reasonable agreement, except for certain years. Noisy data.
+    "production|Strontium|Mine|tonnes",
+    # Significant global disagreement.
+    # 'production|Tellurium|Refinery|tonnes',
 ]
 # The following list contains all columns where USGS (current and historical) overlaps with BGS.
 # It is obtained by doing:
 # (set(tb_usgs_flat.columns) | set(tb_usgs_flat)) & set(tb_bgs_flat)
 # TODO: Visually inspect all of them and then move them to COMBINE_..., leaving uncommented the ones where there is reasonable agreement.
 COMBINE_BGS_AND_USGS_COLUMNS = [
-    # 'production|Nickel|Mine|tonnes',
-    # 'production|Perlite|Mine|tonnes',
-    # 'production|Phosphate rock|Mine|tonnes',
-    # 'production|Platinum group metals|Mine, palladium|tonnes',
-    # 'production|Platinum group metals|Mine, platinum|tonnes',
-    # 'production|Rhenium|Mine|tonnes',
-    # 'production|Selenium|Refinery|tonnes',
-    # 'production|Silver|Mine|tonnes',
-    # 'production|Soda ash|Natural|tonnes',
-    # 'production|Steel|Processing, crude|tonnes',
-    # 'production|Strontium|Mine|tonnes',
-    # 'production|Tellurium|Refinery|tonnes',
     # 'production|Tin|Mine|tonnes',
     # 'production|Titanium|Mine, ilmenite|tonnes',
     # 'production|Titanium|Mine, rutile|tonnes',

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -367,7 +367,7 @@ def improve_metadata(tb: Table, tb_usgs_flat: Table, tb_bgs_flat: Table, tb_usgs
         notes_bgs, footnotes_bgs = _gather_notes_and_footnotes_from_metadata(tb_flat=tb_bgs_flat, column=column)
 
         # Add notes to metadata.
-        combined_notes = _combine_notes(notes_list=[notes_bgs, notes_usgs, notes_usgs_historical], separator="\n\n")
+        combined_notes = _combine_notes(notes_list=[notes_usgs_historical, notes_usgs, notes_bgs], separator="\n\n")
         if len(combined_notes) > 0:
             tb[column].metadata.description_from_producer = combined_notes
 

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -91,6 +91,7 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
     # Reasonable global agreement, except for DRC, that is much larger than World on certain years.
     # TODO: This should be investigated.
     # "production|Cobalt|Mine|tonnes",
+    "production|Cobalt|Refinery|tonnes",
     "production|Copper|Mine|tonnes",
     "production|Copper|Refinery|tonnes",
     # BGS and USGS data are informed on very separated year ranges. It's not possible to assess their agreement.
@@ -541,6 +542,10 @@ def combine_data(
     tb.loc[
         (tb["country"] != "World") & (tb["year"].isin([2008, 2021])),
         "production|Magnesium metal|Smelter|tonnes",
+    ] = None
+    tb.loc[
+        (tb["country"] != "World") & (tb["year"].isin([1992])),
+        "production|Cobalt|Refinery|tonnes",
     ] = None
 
     ####################################################################################################################

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -1,18 +1,13 @@
 """Compilation of minerals data from different origins.
 
 Currently, the three sources of minerals data are:
-* From BGS we extract production (and disregard imports/exports, which are very sparse).
+* From BGS we extract production and disregard imports/exports, which are very sparse.
 * From USGS (current) we extract production and reserves.
 * From USGS (historical) we extract production and unit value.
 
-Initially, I thought of creating long tables in the garden steps of USGS current, USGS historical, and BGS data.
-
-However, there is little overlap between the three origins (at the country-year-commodity-subcommodity-unit level).
-If we combined all production data into one column (as it would be common to do in a garden step), the resulting data
-would show as having 3 origins, whereas in reality most data points would come from just one origin.
-
-So it seems more convenient to create wide tables, where each column has its own origin, and then combine the wide
-tables (on those few columns where there is overlap).
+For debugging:
+* Add columns to PLOT_TO_COMPARE_DATA_SOURCES (defined below) to plot the data for that column separated by data source.
+* Comment/uncomment columns in COMBINE_BGS_AND_USGS_COLUMNS (defined below); if the difference between the "aggregated World" (a temporary aggregate of all data) becomes larger than USGS's World (by a certain percentage, defined by DEVIATION_MAX_ACCEPTED), an error is raised, and a plot is displayed comparing the two.
 
 """
 import warnings
@@ -117,7 +112,7 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
     "production|Mercury|Mine|tonnes",
     # Reasonable global agreement, except for certain years, and also not for certain countries: Armenia, Iran, Mexico.
     "production|Molybdenum|Mine|tonnes",
-    # Reasonable global agreement, but not for certain years, especially 2013.
+    # Reasonable global agreement, but not for certain years, especially 2013, where Indonesia has a large peak.
     # TODO: This should be investigated.
     # "production|Nickel|Mine|tonnes",
     # Significant global disagreement, leading to world shares of 191%.
@@ -165,7 +160,6 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
 # The following list contains all columns where USGS (current and historical) overlaps with BGS.
 # NOTE: To visually inspect certain columns, the easiest is to redefine COMBINE_BGS_AND_USGS_COLUMNS again here below,
 #  only with the columns to inspect. Then, uncomment the line columns_to_plot=COMBINE_BGS_AND_USGS_COLUMNS in run().
-# TODO: Consider keeping "World (BGS)" just for run sanity checks and then remove it. This we we will detect >100% shares.
 PLOT_TO_COMPARE_DATA_SOURCES = [
     # 'production|Helium|Mine|tonnes',
 ]

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -158,7 +158,7 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
     "production|Steel|Processing, crude|tonnes",
     # Reasonable agreement, except for certain years, e.g. 2012, where shares reach 160%. Noisy data.
     # "production|Strontium|Mine|tonnes",
-    # Significant global disagreement.
+    # Significant global disagreement. We decided to discard Tellurium.
     # 'production|Tellurium|Refinery|tonnes',
     # Reasonable agreement, except for certain years, which leads to >100% shares.
     # "production|Tin|Mine|tonnes",

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -43,8 +43,99 @@ SHARE_OF_GLOBAL_PREFIX = "share_of_global_"
 # Specifically, we check that the World aggregate of BGS (constructed in the BGS garden step) coincides reasonably
 # well with the World data given in USGS data.
 COMBINE_BGS_AND_USGS_COLUMNS = [
+    "production|Alumina|Refinery|tonnes",
+    "production|Aluminum|Smelter|tonnes",
+    "production|Andalusite|Mine|tonnes",
+    # Reasonable agreement overall, but disagreement during certain periods, leading to >100% shares of global.
+    # TODO: This should be investigated.
+    # 'production|Antimony|Mine|tonnes',
+    # Somewhat in agreement, but very noisy.
+    # 'production|Arsenic|Processing|tonnes',
+    # Good agreement after 2012, but prior to that, USGS is significantly larger.
+    # "production|Asbestos|Mine|tonnes",
+    # Reasonable global agreement, although not for certain countries: Mexico.
+    "production|Barite|Mine|tonnes",
+    # Reasonable global agreement, although not for certain countries: China, Russia.
+    # NOTE: Big drop in Greece 1976 in BGS data, but it has no footnotes. It could be that two zeros where missing? Unclear.
+    "production|Bauxite|Mine|tonnes",
+    # Reasonable global agreement, although not for certain countries: Denmark, Iran.
+    "production|Clays|Mine, bentonite|tonnes",
+    # Big global disagreement.
+    "production|Clays|Mine, fuller's earth|tonnes",
+    # Big global disagreement.
+    "production|Clays|Mine, kaolin|tonnes",
+    # Reasonable global agreement, except for DRC, that is much larger than World on certain years.
+    # TODO: This should be investigated.
+    # 'production|Cobalt|Mine|tonnes',
     "production|Copper|Mine|tonnes",
     "production|Copper|Refinery|tonnes",
+    # BGS and USGS data are informed on very separated year ranges. It's not possible to assess their agreement.
+    # 'production|Diamond|Mine, industrial|tonnes',
+    # BGS global data is significantly lower than USGS.
+    # 'production|Diatomite|Mine|tonnes',
+    # BGS global data is significantly larger than USGS.
+    # 'production|Feldspar|Mine|tonnes',
+    # Reasonable global agreement, although not for certain countries: Mongolia, Morocco, Pakistan.
+    "production|Fluorspar|Mine|tonnes",
+    "production|Gallium|Processing|tonnes",
+    # Significant global disagreement, leading to >100% shares of global.
+    # 'production|Germanium|Refinery|tonnes',
+    # Reasonable global agreement, although not for certain countries: Argentina, Brazil, Kazakhstan, Mali, Mexico, Papua New Guinea, Sudan.
+    "production|Gold|Mine|tonnes",
+    # Significant global disagreement, leading to >100% shares of global.
+    # TODO: This should be investigated.
+    # 'production|Graphite|Mine|tonnes',
+    # Significant global disagreement during certain years.
+    # 'production|Gypsum|Mine|tonnes',
+    # Significant global disagreement during certain years.
+    # TODO: This should be investigated.
+    # 'production|Helium|Mine|tonnes',
+    # Significant global disagreement, noisy data.
+    # 'production|Indium|Refinery|tonnes',
+    "production|Iodine|Mine|tonnes",
+    # Significant global disagreement during a large range of years.
+    # 'production|Iron ore|Mine, crude ore|tonnes',
+    # BGS global data is consistently larger than USGS since 1992, and also for Mexico, Iran, India.
+    # 'production|Iron|Smelter, pig iron|tonnes',
+    # BGS noisy data, and from USGS only US is informed.
+    "production|Kyanite|Mine|tonnes",
+    # Reasonable global agreement, although not for certain countries: Turkey, Iran.
+    "production|Lead|Mine|tonnes",
+    # Reasonable global agreement, although not for certain countries: Turkey, Russia.
+    "production|Magnesium metal|Smelter|tonnes",
+    # Reasonable global agreement, although not for certain countries: Tajikistan.
+    "production|Mercury|Mine|tonnes",
+    # Reasonable global agreement, although not for certain countries: Armenia, Iran, Mexico.
+    # NOTE: between 1970 and 1970, BGS is significantly lower than USGS. This may be because US data was removed.
+    #  And US data was removed in the BGS garden step (see explanation there).
+    "production|Molybdenum|Mine|tonnes",
+]
+# The following list contains all columns where USGS (current and historical) overlaps with BGS.
+# It is obtained by doing:
+# (set(tb_usgs_flat.columns) | set(tb_usgs_flat)) & set(tb_bgs_flat)
+# TODO: Visually inspect all of them and then move them to COMBINE_..., leaving uncommented the ones where there is reasonable agreement.
+COMBINE_BGS_AND_USGS_COLUMNS = [
+    # 'production|Nickel|Mine|tonnes',
+    # 'production|Perlite|Mine|tonnes',
+    # 'production|Phosphate rock|Mine|tonnes',
+    # 'production|Platinum group metals|Mine, palladium|tonnes',
+    # 'production|Platinum group metals|Mine, platinum|tonnes',
+    # 'production|Rhenium|Mine|tonnes',
+    # 'production|Selenium|Refinery|tonnes',
+    # 'production|Silver|Mine|tonnes',
+    # 'production|Soda ash|Natural|tonnes',
+    # 'production|Steel|Processing, crude|tonnes',
+    # 'production|Strontium|Mine|tonnes',
+    # 'production|Tellurium|Refinery|tonnes',
+    # 'production|Tin|Mine|tonnes',
+    # 'production|Titanium|Mine, ilmenite|tonnes',
+    # 'production|Titanium|Mine, rutile|tonnes',
+    # 'production|Tungsten|Mine|tonnes',
+    # 'production|Vanadium|Mine|tonnes',
+    # 'production|Vermiculite|Mine|tonnes',
+    # 'production|Wollastonite|Mine|tonnes',
+    # 'production|Zinc|Mine|tonnes',
+    # 'production|Zirconium and hafnium|Mine|tonnes',
 ]
 
 
@@ -256,7 +347,13 @@ def inspect_overlaps(
             _df_country = _df[_df["country"] == country]
             if _df_country["source"].nunique() > 1:
                 px.line(
-                    _df_country, x="year", y=column, color="source", markers=True, title=f"{column} - {country}"
+                    _df_country,
+                    x="year",
+                    y=column,
+                    color="source",
+                    markers=True,
+                    title=f"{column} - {country}",
+                    range_y=[0, None],
                 ).show()
 
 
@@ -387,7 +484,7 @@ def run(dest_dir: str) -> None:
         tb_usgs_historical_flat=tb_usgs_historical_flat,
         tb_bgs_flat=tb_bgs_flat,
         # NOTE: Uncomment to visually inspect columns where BGS and USGS data are combined.
-        # columns_to_plot=COMBINE_BGS_AND_USGS_COLUMNS,
+        columns_to_plot=COMBINE_BGS_AND_USGS_COLUMNS,
     )
 
     # Create columns for share of world (i.e. production, import, exports and reserves as a share of global).

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -58,6 +58,8 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
     # Reasonable global agreement, although not for certain countries: China, Russia.
     # NOTE: Big drop in Greece 1976 in BGS data, but it has no footnotes. It could be that two zeros where missing? Unclear.
     "production|Bauxite|Mine|tonnes",
+    # BGS global data is significantly larger than USGS.
+    # "production|Bromine|Processing|tonnes",
     # Reasonable global agreement, although not for certain countries: Denmark, Iran.
     "production|Clays|Mine, bentonite|tonnes",
     # Big global disagreement.
@@ -158,6 +160,8 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
 # NOTE: To visually inspect certain columns, the easiest is to redefine COMBINE_BGS_AND_USGS_COLUMNS again here below,
 #  only with the columns to inspect. Then, uncomment the line columns_to_plot=COMBINE_BGS_AND_USGS_COLUMNS in run().
 # TODO: Consider keeping "World (BGS)" just for run sanity checks and then remove it. This we we will detect >100% shares.
+# COMBINE_BGS_AND_USGS_COLUMNS = [
+# ]
 
 
 def adapt_flat_table(tb_flat: Table) -> Table:

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -317,9 +317,9 @@ def improve_metadata(tb: Table, tb_usgs_flat: Table, tb_bgs_flat: Table, tb_usgs
                     description_short = f"Based on mined, rather than [refined](#dod:refined-production), production. Measured in {unit}."
             elif sub_commodity.startswith("Refinery"):
                 if not metric.startswith("Share"):
-                    description_short = f"Measured in {unit}. Mineral [refining](#dod:refined-production) takes mined or raw minerals, and separates them into a final product of pure metals and minerals."
+                    description_short = f"Measured in {unit} of [refined](#dod:refined-production) material. The amounts of refined and raw materials differ because refining removes impurities and adjusts the composition to meet specific standards."
                 else:
-                    description_short = "Mineral [refining](#dod:refined-production) takes mined or raw minerals, and separates them into a final product of pure metals and minerals."
+                    description_short = "The amounts of [refined](#dod:refined-production) and raw materials differ because refining removes impurities and adjusts the composition to meet specific standards."
             elif sub_commodity.startswith("Smelter"):
                 description_short = f"Measured in {unit}. [Smelting](#dod:smelting) takes raw minerals and produces metals through high-temperature processes."
             elif sub_commodity.startswith("Processing"):

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -122,8 +122,6 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
     # 'production|Iron ore|Mine, crude ore|tonnes',
     # BGS global data is consistently larger than USGS since 1992, and also for Mexico, Iran, India.
     # 'production|Iron|Smelter, pig iron|tonnes',
-    # BGS noisy data, and from USGS only US is informed.
-    "production|Kyanite|Mine|tonnes",
     # Reasonable global agreement, although not for certain countries: Turkey, Iran.
     "production|Lead|Mine|tonnes",
     # Reasonable global agreement, although not for certain countries: Turkey, Russia.

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -327,16 +327,22 @@ def improve_metadata(tb: Table, tb_usgs_flat: Table, tb_bgs_flat: Table, tb_usgs
             tb[column].metadata.description_from_producer = combined_notes
 
         # Insert (or append) additional footnotes:
-        footnotes_additional = ""
+        footnotes_additional = []
         if metric in ["Reserves", "Share of global reserves"]:
-            footnotes_additional += "Reserves can increase over time as new mineral deposits are discovered and others become economically feasible to extract."
+            footnotes_additional.append(
+                "Reserves can increase over time as new mineral deposits are discovered and others become economically feasible to extract."
+            )
         elif metric == "Unit value":
             # footnotes_additional += "This data is expressed in constant 1998 US$ per tonne."
-            footnotes_additional += "This data is adjusted for inflation."
+            footnotes_additional.append("This data is adjusted for inflation.")
+        if column in COMBINE_BGS_AND_USGS_COLUMNS:
+            footnotes_additional.append(
+                "The sum of all countries may exceed World data on certain years (by up to 10%), due to discrepancies between data sources."
+            )
 
         # Add footnotes to metadata.
         combined_footnotes = _combine_notes(
-            notes_list=[footnotes_bgs, footnotes_usgs, footnotes_usgs_historical, footnotes_additional], separator=" "
+            notes_list=[footnotes_bgs, footnotes_usgs, footnotes_usgs_historical] + footnotes_additional, separator=" "
         )
         if len(combined_footnotes) > 0:
             if tb[column].metadata.presentation.grapher_config is None:

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -169,8 +169,8 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
     "production|Tungsten|Mine|tonnes",
     # Reasonable global agreement, except for some years, e.g. 2002, where share becomes 143%. Noisy data.
     # "production|Vanadium|Mine|tonnes",
-    # Reasonable global agreement. Noisy data.
-    "production|Vermiculite|Mine|tonnes",
+    # Reasonable global agreement. Noisy data. We decided to discard Vermiculite.
+    # "production|Vermiculite|Mine|tonnes",
     # Reasonable global agreement, except for certain countries: Mexico.
     "production|Wollastonite|Mine|tonnes",
     # Reasonable global agreement, except for certain countries: Mexico (big peak in 2021), India (big peak in 2021).

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -556,7 +556,9 @@ def combine_data(
     _raise_error_on_large_deviations(tb=tb, ds_regions=ds_regions)
 
     # It would be useful to have a global total for Coal and Petroleum, which come from BGS and are quite complete.
-    tb_global = tb[tb["country"]=="World (BGS)"][["country", "year", "production|Coal|Mine|tonnes", "production|Petroleum|Crude|tonnes"]].reset_index(drop=True)
+    tb_global = tb[tb["country"] == "World (BGS)"][
+        ["country", "year", "production|Coal|Mine|tonnes", "production|Petroleum|Crude|tonnes"]
+    ].reset_index(drop=True)
     tb_global["country"] = tb_global["country"].replace("World (BGS)", "World")
 
     # For all other indicators, remove the "World (BGS)" (aggregated in the garden BGS step), that was only kept for sanity checks.

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -68,7 +68,6 @@ ACCEPTED_DEVIATIONS = [
 COMBINE_BGS_AND_USGS_COLUMNS = [
     "production|Alumina|Refinery|tonnes",
     "production|Aluminum|Smelter|tonnes",
-    "production|Andalusite|Mine|tonnes",
     # Reasonable agreement overall, but disagreement during certain periods, leading to >100% shares of global.
     # TODO: This should be investigated.
     # 'production|Antimony|Mine|tonnes',

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -83,11 +83,14 @@ COMBINE_BGS_AND_USGS_COLUMNS = [
     # BGS global data is significantly larger than USGS.
     # "production|Bromine|Processing|tonnes",
     # Reasonable global agreement, although not for certain countries: Denmark, Iran.
-    "production|Clays|Mine, bentonite|tonnes",
+    # NOTE: We decided to remove "Clays" altogether.
+    # "production|Clays|Mine, bentonite|tonnes",
     # Big global disagreement.
-    "production|Clays|Mine, fuller's earth|tonnes",
+    # NOTE: We decided to remove "Clays" altogether.
+    # "production|Clays|Mine, fuller's earth|tonnes",
     # Big global disagreement.
-    "production|Clays|Mine, kaolin|tonnes",
+    # NOTE: We decided to remove "Clays" altogether.
+    # "production|Clays|Mine, kaolin|tonnes",
     # Reasonable global agreement, except for DRC, that is much larger than World on certain years.
     # TODO: This should be investigated.
     # "production|Cobalt|Mine|tonnes",

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -49,6 +49,43 @@ SHARE_OF_GLOBAL_PREFIX = "share_of_global_"
 # Define that percentage.
 DEVIATION_MAX_ACCEPTED = 10
 
+# At the end of the step, we remove certain minerals because they are not as critical, and add a significant amount of
+# complexity to the explorer. But we may decide to bring them back in the future.
+COLUMNS_TO_DISCARD = [
+    "production|Alumina|Refinery|tonnes",
+    "unit_value|Alumina|Refinery|constant 1998 US$ per tonne",
+    "share_of_global_production|Alumina|Refinery|tonnes",
+    "production|Bromine|Processing|tonnes",
+    "reserves|Bromine|Processing|tonnes",
+    "share_of_global_production|Bromine|Processing|tonnes",
+    "production|Diatomite|Mine|tonnes",
+    "reserves|Diatomite|Mine|tonnes",
+    "unit_value|Diatomite|Mine|constant 1998 US$ per tonne",
+    "share_of_global_production|Diatomite|Mine|tonnes",
+    "production|Indium|Refinery|tonnes",
+    "unit_value|Indium|Refinery|constant 1998 US$ per tonne",
+    "share_of_global_production|Indium|Refinery|tonnes",
+    "production|Perlite|Mine|tonnes",
+    "reserves|Perlite|Mine|tonnes",
+    "unit_value|Perlite|Mine|constant 1998 US$ per tonne",
+    "share_of_global_production|Perlite|Mine|tonnes",
+    "production|Pumice and pumicite|Mine|tonnes",
+    "unit_value|Pumice and pumicite|Mine|constant 1998 US$ per tonne",
+    "share_of_global_production|Pumice and pumicite|Mine|tonnes",
+    "production|Rhenium|Mine|tonnes",
+    "reserves|Rhenium|Mine|tonnes",
+    "share_of_global_production|Rhenium|Mine|tonnes",
+    "production|Soda ash|Natural and synthetic|tonnes",
+    "production|Soda ash|Natural|tonnes",
+    "production|Soda ash|Synthetic|tonnes",
+    "reserves|Soda ash|Natural|tonnes",
+    "unit_value|Soda ash|Natural and synthetic|constant 1998 US$ per tonne",
+    "share_of_global_production|Soda ash|Natural and synthetic|tonnes",
+    "share_of_global_production|Soda ash|Natural|tonnes",
+    "share_of_global_production|Soda ash|Synthetic|tonnes",
+    "share_of_global_reserves|Soda ash|Natural|tonnes",
+]
+
 # List of known deviations that should not raise an error.
 # The content should be (entity, column, list of years), where entity is either "World (BGS)" or "World (aggregated)".
 # Add to this list specific peaks in BGS data that will be overwritten by more recent USGS data.
@@ -691,6 +728,9 @@ def run(dest_dir: str) -> None:
     tb = improve_metadata(
         tb=tb, tb_usgs_flat=tb_usgs_flat, tb_bgs_flat=tb_bgs_flat, tb_usgs_historical_flat=tb_usgs_historical_flat
     )
+
+    # Discard some columns, since they are not as critical, and add too much complexity to the explorer.
+    tb = tb.drop(columns=COLUMNS_TO_DISCARD, errors="raise")
 
     # Run sanity checks.
     run_sanity_checks(tb=tb)

--- a/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.meta.yml
+++ b/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.meta.yml
@@ -11,20 +11,20 @@ dataset:
   title: Historical statistics for mineral and material commodities
 
 tables:
-  historical_production:
-    title: Historical statistics for mineral and material commodities
-    variables:
-      production:
-        title: Production
-        unit: tonnes
-        short_unit: t
-  historical_unit_value:
-    title: Historical statistics for mineral and material commodities
-    variables:
-      unit_value:
-        title: Unit value (in constant US dollars)
-        unit: constant 1998 US$ per tonne
-        short_unit: $/t
+  # historical_production:
+  #   title: Historical statistics for mineral and material commodities
+  #   variables:
+  #     production:
+  #       title: Production
+  #       unit: tonnes
+  #       short_unit: t
+  # historical_unit_value:
+  #   title: Historical statistics for mineral and material commodities
+  #   variables:
+  #     unit_value:
+  #       title: Unit value (in constant US dollars)
+  #       unit: constant 1998 US$ per tonne
+  #       short_unit: $/t
   historical_statistics_for_mineral_and_material_commodities_flat:
     title: Historical statistics for mineral and material commodities
     variables:

--- a/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
@@ -27,11 +27,12 @@ COMMODITY_MAPPING = {
     ("Antimony", "Total"): ("Antimony", "Mine"),
     ("Arsenic", "Total"): ("Arsenic", "Processing"),
     ("Asbestos", "Total"): ("Asbestos", "Mine"),
-    ("Ball clay", "Total"): ("Clays", "Mine, ball clay"),
+    # NOTE: The following could be mapped to ("Clays", "Mine, ball clay"). We decided to remove "Clays".
+    ("Ball clay", "Total"): None,
     ("Barite", "Total"): ("Barite", "Mine"),
     ("Bauxite", "Total"): ("Bauxite", "Mine"),
-    # NOTE: For consistency with USGS current data, rename the following.
-    ("Bentonite", "Total"): ("Clays", "Mine, bentonite"),
+    # NOTE: The following could be mapped to ("Clays", "Mine, bentonite"). We decided to remove "Clays".
+    ("Bentonite", "Total"): None,
     # NOTE: Extracted from "world_mine_production".
     ("Beryllium", "Total"): ("Beryllium", "Mine"),
     ("Beryllium", "Mine"): ("Beryllium", "Mine"),
@@ -65,9 +66,11 @@ COMMODITY_MAPPING = {
     # NOTE: In USGS historical, the notes explicitly say "World production data do not include production data for
     #  nepheline syenite.", whereas in USGS current it's unclear.
     ("Feldspar", "Total"): ("Feldspar", "Mine"),
-    ("Fire clay", "Total"): ("Clays", "Mine, fire clay"),
+    # NOTE: The following could be mapped to ("Clays", "Mine, fire clay"). We decided to remove "Clays".
+    ("Fire clay", "Total"): None,
     ("Fluorspar", "Total"): ("Fluorspar", "Mine"),
-    ("Fuller's earth", "Total"): ("Clays", "Mine, fuller's earth"),
+    # NOTE: The following could be mapped to ("Clays", "Mine, fuller's earth"). We decided to remove "Clays".
+    ("Fuller's earth", "Total"): None,
     ("Gallium", "Total"): ("Gallium", "Refinery"),
     ("Germanium", "Total"): ("Germanium", "Refinery"),
     ("Gold", "Total"): ("Gold", "Mine"),
@@ -83,7 +86,8 @@ COMMODITY_MAPPING = {
     ("Iron Oxide Pigments", "Total"): None,
     ("Iron and Steel Slag", "Total"): None,
     ("Iron ore", "Total"): ("Iron ore", "Mine, crude ore"),
-    ("Kaolin", "Total"): ("Clays", "Mine, kaolin"),
+    # NOTE: The following could be mapped to ("Clays", "Mine, kaolin"). We decided to remove "Clays".
+    ("Kaolin", "Total"): None,
     ("Lead", "Total"): ("Lead", "Mine"),
     ("Lime", "Total"): ("Lime", "Processing"),
     ("Magnesium compounds", "Total"): ("Magnesium compounds", "Mine"),
@@ -93,7 +97,8 @@ COMMODITY_MAPPING = {
     ("Metallic abrasives", "Total"): None,
     ("Mica (natural), scrap and flake", "Total"): ("Mica", "Mine, scrap and flake"),
     ("Mica (natural), sheet", "Total"): ("Mica", "Mine, sheet"),
-    ("Miscellaneous clay", "Total"): ("Clays", "Mine, miscellaneous"),
+    # NOTE: The following could be mapped to ("Clays", "Mine, miscellaneous"). We decided to remove "Clays".
+    ("Miscellaneous clay", "Total"): None,
     ("Molybdenum", "Total"): ("Molybdenum", "Mine"),
     ("Nickel", "Total"): ("Nickel", "Mine"),
     ("Niobium", "Total"): ("Niobium", "Mine"),
@@ -186,9 +191,9 @@ FOOTNOTES_PRODUCTION = {
     "production|Bauxite|Mine|tonnes": "Values are reported as dried bauxite equivalents.",
     "production|Barite|Mine|tonnes": "Values are reported as gross weight.",
     "production|Asbestos|Mine|tonnes": "Values are reported as gross weight.",
-    "production|Clays|Mine, bentonite|tonnes": "Values are reported as gross weight.",
-    "production|Clays|Mine, ball clay|tonnes": "Values are reported as gross weight.",
-    "production|Clays|Mine, fire clay|tonnes": "Values are reported as gross weight.",
+    # "production|Clays|Mine, bentonite|tonnes": "Values are reported as gross weight.",
+    # "production|Clays|Mine, ball clay|tonnes": "Values are reported as gross weight.",
+    # "production|Clays|Mine, fire clay|tonnes": "Values are reported as gross weight.",
     "production|Chromium|Mine|tonnes": "Values are reported as tonnes of contained chromium.",
     "production|Cobalt|Refinery|tonnes": "Values are reported as tonnes of cobalt content.",
     "production|Bismuth|Mine|tonnes": "Values are reported as tonnes of metal content.",

--- a/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
@@ -55,7 +55,8 @@ COMMODITY_MAPPING = {
     ("Cobalt", "Refinery"): ("Cobalt", "Refinery"),
     ("Construction sand and gravel", "Total"): ("Sand and gravel", "Mine, construction"),
     ("Copper", "Total"): ("Copper", "Mine"),
-    ("Crushed stone", "Total"): ("Crushed stone", "Mine"),
+    # NOTE: The following could be mapped to ("Crushed stone", "Mine"), but it has only US data, not global.
+    ("Crushed stone", "Total"): None,
     ("Diatomite", "Total"): ("Diatomite", "Mine"),
     ("Dimension stone", "Total"): ("Dimension stone", "Mine"),
     # NOTE: The following could be mapped to ("Iron", "Sponge"). But for now, we decided to exclude it.

--- a/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
@@ -608,6 +608,13 @@ def run(dest_dir: str) -> None:
         (tb_flat["country"].isin(["World"])) & (tb_flat["year"].isin([1913, 1914, 1921, 1922])),
         "production|Vanadium|Mine|tonnes",
     ] = None
+
+    # There is a big dip in global Magnesium metal in 1974, because of missing US data.
+    # A similar thing happens in 1999.
+    tb_flat.loc[
+        (tb_flat["country"].isin(["World"])) & (tb_flat["year"].isin([1974, 1999])),
+        "production|Magnesium metal|Smelter|tonnes",
+    ] = None
     ####################################################################################################################
 
     # Format tables conveniently.

--- a/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
@@ -58,7 +58,8 @@ COMMODITY_MAPPING = {
     # NOTE: The following could be mapped to ("Crushed stone", "Mine"), but it has only US data, not global.
     ("Crushed stone", "Total"): None,
     ("Diatomite", "Total"): ("Diatomite", "Mine"),
-    ("Dimension stone", "Total"): ("Dimension stone", "Mine"),
+    # NOTE: The following could be mapped to ("Dimension stone", "Mine"), but it has only US data, not global.
+    ("Dimension stone", "Total"): None,
     # NOTE: The following could be mapped to ("Iron", "Sponge"). But for now, we decided to exclude it.
     ("Direct Reduced Iron", "Total"): None,
     # NOTE: In USGS historical, the notes explicitly say "World production data do not include production data for

--- a/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
@@ -105,7 +105,8 @@ COMMODITY_MAPPING = {
     # NOTE: Extracted from "world_mine_production".
     ("Niobium", "Mine"): ("Niobium", "Mine"),
     ("Nitrogen (Fixed)-Ammonia", "Total"): ("Nitrogen", "Fixed ammonia"),
-    ("Peat", "Total"): ("Peat", "Mine"),
+    # NOTE: The following could be mapped to ("Peat", "Mine"). We decided to remove "Peat".
+    ("Peat", "Total"): None,
     ("Perlite", "Total"): ("Perlite", "Mine"),
     ("Phosphate rock", "Total"): ("Phosphate rock", "Mine"),
     ("Pig Iron", "Total"): ("Iron", "Smelter, pig iron"),

--- a/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
@@ -44,7 +44,8 @@ COMMODITY_MAPPING = {
     ("Boron carbide", "Total"): None,
     ("Cadmium", "Total"): ("Cadmium", "Refinery"),
     ("Cement", "Total"): ("Cement", "Processing"),
-    ("Cesium", "Total"): ("Cesium", "Mine"),
+    # NOTE: The following could be mapped to ("Cesium", "Mine"), but it has only global data until 1977.
+    ("Cesium", "Total"): None,
     ("Chromium", "Total"): ("Chromium", "Mine"),
     # NOTE: Cobalt total is only used for unit value.
     ("Cobalt", "Total"): ("Cobalt", "Value"),

--- a/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
@@ -200,7 +200,9 @@ FOOTNOTES_PRODUCTION = {
     "production|Cobalt|Refinery|tonnes": "Values are reported as tonnes of cobalt content.",
     "production|Bismuth|Mine|tonnes": "Values are reported as tonnes of metal content.",
 }
-FOOTNOTES_UNIT_VALUE = {}
+FOOTNOTES_UNIT_VALUE = {
+    "unit_value|Silicon|Processing|constant 1998 US$ per tonne": "Values refer to constant 1998 US$ per tonne of silicon content in ferrosilicon or silicon metal.",
+}
 
 
 def harmonize_commodity_subcommodity_pairs(tb: Table) -> Table:

--- a/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
@@ -122,7 +122,8 @@ COMMODITY_MAPPING = {
     ("Sulfur", "Total"): ("Sulfur", "Processing"),
     ("Talc and pyrophyllite", "Total"): ("Talc and pyrophyllite", "Mine"),
     ("Tantalum", "Total"): ("Tantalum", "Mine"),
-    ("Tellurium", "Total"): ("Tellurium", "Refinery"),
+    # NOTE: The following could be mapped to ("Tellurium", "Refinery"). However, we decided to discard Tellurium.
+    ("Tellurium", "Total"): None,
     ("Tin", "Total"): ("Tin", "Mine"),
     # NOTE: For titanium there is no global data.
     ("Titanium dioxide", "Total"): None,
@@ -593,18 +594,19 @@ def run(dest_dir: str) -> None:
         "production|Sulfur|Processing|tonnes",
     ] = None
 
-    # Tellurium refinery production is very incomplete, as pointed out in the notes.
-    # Specifically, a large range of years exclude US data because of proprietary data.
-    # To be conservative, remove all those years.
-    tb_flat.loc[
-        (tb_flat["country"].isin(["World"])) & (tb_flat["year"] >= 1976) & (tb_flat["year"] <= 2003),
-        "production|Tellurium|Refinery|tonnes",
-    ] = None
-    # Also, in some other years in the past, US production was larger than World production.
-    tb_flat.loc[
-        (tb_flat["country"].isin(["World"])) & (tb_flat["year"].isin([1930, 1933])),
-        "production|Tellurium|Refinery|tonnes",
-    ] = None
+    # NOTE: We decided to discard Tellurium.
+    # # Tellurium refinery production is very incomplete, as pointed out in the notes.
+    # # Specifically, a large range of years exclude US data because of proprietary data.
+    # # To be conservative, remove all those years.
+    # tb_flat.loc[
+    #     (tb_flat["country"].isin(["World"])) & (tb_flat["year"] >= 1976) & (tb_flat["year"] <= 2003),
+    #     "production|Tellurium|Refinery|tonnes",
+    # ] = None
+    # # Also, in some other years in the past, US production was larger than World production.
+    # tb_flat.loc[
+    #     (tb_flat["country"].isin(["World"])) & (tb_flat["year"].isin([1930, 1933])),
+    #     "production|Tellurium|Refinery|tonnes",
+    # ] = None
 
     # Vanadium mine production does not include US production in a range of years.
     # Remove those years.

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -308,8 +308,10 @@ COMMODITY_MAPPING = {
     ("Talc and pyrophyllite", "Mine production, unspecified talc and/or pyrophyllite"): None,
     ("Tantalum", "Mine production"): ("Tantalum", "Mine"),
     ("Tantalum", "Mine production, tantalum content"): ("Tantalum", "Mine"),
-    ("Tellurium", "Mine production"): ("Tellurium", "Mine"),
-    ("Tellurium", "Refinery production, tellurium content"): ("Tellurium", "Refinery"),
+    # NOTE: The following could be mapped to ("Tellurium", "Mine"). However, we decided to discard Tellurium.
+    ("Tellurium", "Mine production"): None,
+    # NOTE: The following could be mapped to ("Tellurium", "Refinery"). However, we decided to discard Tellurium.
+    ("Tellurium", "Refinery production, tellurium content"): None,
     ("Tin", "Mine production, metric tons contained tin"): ("Tin", "Mine"),
     ("Tin", "Mine production, tin content"): ("Tin", "Mine"),
     ("Titanium and titanium dioxide", "Sponge Metal Production and Sponge and Pigment Capacity"): None,

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -1082,6 +1082,12 @@ def run(dest_dir: str) -> None:
     # Drop empty columns, if any.
     tb_flat = tb_flat.dropna(axis=1, how="all").reset_index(drop=True)
 
+    ####################################################################################################################
+    # Corrections to USGS current data.
+    # Zinc mine reserves in Australia in 2022 is unreasonably high, much larger than the world.
+    tb_flat.loc[(tb_flat["country"] == "Australia") & (tb_flat["year"] == 2022), "reserves|Zinc|Mine|tonnes"] = None
+    ####################################################################################################################
+
     # Format tables conveniently.
     tb = tb.format(["country", "year", "commodity", "sub_commodity"], short_name=paths.short_name)
     tb_flat = tb_flat.format(["country", "year"], short_name=paths.short_name + "_flat")

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -107,14 +107,18 @@ COMMODITY_MAPPING = {
     ("Chromium", "Mine production, marketable chromite ore"): None,
     ("Chromium", "Mne production, grosss weight, marketable chromite ore"): None,
     ("Chromium", "Mne production, marketable chromite ore, gross weight"): None,
-    ("Clays", "Bentonite, mine production"): ("Clays", "Mine, bentonite"),
-    ("Clays", "Fuller's earth, mine production"): ("Clays", "Mine, fuller's earth"),
-    # NOTE: There is good agreement between USGS current and BGS production data for Kaolin for several countries,
-    #  including the US. But for the World (and a few other countries), USGS current is significantly higher.
-    ("Clays", "Kaolin, mine production"): ("Clays", "Mine, kaolin"),
-    ("Clays", "Mine poduction, Bentonite"): ("Clays", "Mine, bentonite"),
-    ("Clays", "Mine poduction, Fuller's earth"): ("Clays", "Mine, fuller's earth"),
-    ("Clays", "Mine poduction, Kaolin"): ("Clays", "Mine, kaolin"),
+    # NOTE: The following could be mapped to ("Clays", "Mine, bentonite"). We decided to remove "Clays".
+    ("Clays", "Bentonite, mine production"): None,
+    # NOTE: The following could be mapped to ("Clays", "Mine, fuller's earth"). We decided to remove "Clays".
+    ("Clays", "Fuller's earth, mine production"): None,
+    # NOTE: The following could be mapped to ("Clays", "Mine, kaolin"). We decided to remove "Clays".
+    ("Clays", "Kaolin, mine production"): None,
+    # NOTE: The following could be mapped to ("Clays", "Mine, bentonite"). We decided to remove "Clays".
+    ("Clays", "Mine poduction, Bentonite"): None,
+    # NOTE: The following could be mapped to ("Clays", "Mine, fuller's earth"). We decided to remove "Clays".
+    ("Clays", "Mine poduction, Fuller's earth"): None,
+    # NOTE: The following could be mapped to ("Clays", "Mine, kaolin"). We decided to remove "Clays".
+    ("Clays", "Mine poduction, Kaolin"): None,
     ("Cobalt", "Mine production, contained cobalt"): ("Cobalt", "Mine"),
     ("Cobalt", "Mine production, metric tons of contained cobalt"): ("Cobalt", "Mine"),
     ("Copper", "Mine production, contained copper"): ("Copper", "Mine"),

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -520,6 +520,10 @@ def extract_and_clean_data_for_year_and_mineral(data: Dict[int, Any], year: int,
         # whatever reason not in any of the "notes" columns).
         # For simplicity, simply remove this row.
         d = d[d["Reserves_kt"].str.lower() != "included with ilmenite"].reset_index(drop=True)
+    if (year == 2023) & (mineral == "VANADIUM"):
+        # Reserves column is called "Reserves_t", however, the numbers clearly show kilotonnes.
+        # See that the world reserves in this file are 26000 tonnes, wheres in the file for 2024 they are 19 million tonnes.
+        d = d.rename(columns={"Reserves_t": "Reserves_kt"}, errors="raise")
 
     ############################################################################################################
 

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -169,12 +169,14 @@ COMMODITY_MAPPING = {
     ("Iron oxide pigments", "Mine production, iron oxide pigments (umber)"): None,
     # NOTE: The following could be mapped to ("Kyanite", "Mine, kyanite and related minerals"), but it has very sparse data.
     ("Kyanite", "Kyanite and Related Minerals"): None,
-    ("Kyanite", "Mine production, andalusite"): ("Andalusite", "Mine"),
+    # NOTE: The following could be mapped to ("Andalusite", "Mine"), but it has sparse data (without global data).
+    ("Kyanite", "Mine production, andalusite"): None,
     # NOTE: The following could be mapped to ("Kyanite", "Mine"), but it has very sparse data (and so does BGS).
     ("Kyanite", "Mine production, kyanite"): None,
     # NOTE: The following could be mapped to ("Kyanite", "Mine, kyanite and sillimanite"), but it has very sparse data.
     ("Kyanite", "Mine production, kyanite and sillimanite"): None,
-    ("Kyanite", "andalusite"): ("Andalusite", "Mine"),
+    # NOTE: The following could be mapped to ("Andalusite", "Mine"), but it has sparse data (without global data).
+    ("Kyanite", "andalusite"): None,
     # NOTE: The following could be mapped to ("Kyanite", "Mine"), but it has very sparse data (and so does BGS).
     ("Kyanite", "kyanite"): None,
     # NOTE: The following could be mapped to ("Kyanite", "Mine, kyanite and sillimanite"), but it has very sparse data.

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -167,13 +167,18 @@ COMMODITY_MAPPING = {
     ("Iron oxide pigments", "Mine production, iron oxide pigments (ocher and red iron oxide)"): None,
     ("Iron oxide pigments", "Mine production, iron oxide pigments (ocher)"): None,
     ("Iron oxide pigments", "Mine production, iron oxide pigments (umber)"): None,
-    ("Kyanite", "Kyanite and Related Minerals"): ("Kyanite", "Mine, kyanite and related minerals"),
+    # NOTE: The following could be mapped to ("Kyanite", "Mine, kyanite and related minerals"), but it has very sparse data.
+    ("Kyanite", "Kyanite and Related Minerals"): None,
     ("Kyanite", "Mine production, andalusite"): ("Andalusite", "Mine"),
-    ("Kyanite", "Mine production, kyanite"): ("Kyanite", "Mine"),
-    ("Kyanite", "Mine production, kyanite and sillimanite"): ("Kyanite", "Mine, kyanite and sillimanite"),
+    # NOTE: The following could be mapped to ("Kyanite", "Mine"), but it has very sparse data (and so does BGS).
+    ("Kyanite", "Mine production, kyanite"): None,
+    # NOTE: The following could be mapped to ("Kyanite", "Mine, kyanite and sillimanite"), but it has very sparse data.
+    ("Kyanite", "Mine production, kyanite and sillimanite"): None,
     ("Kyanite", "andalusite"): ("Andalusite", "Mine"),
-    ("Kyanite", "kyanite"): ("Kyanite", "Mine"),
-    ("Kyanite", "kyanite and sillimanite"): ("Kyanite", "Mine, kyanite and sillimanite"),
+    # NOTE: The following could be mapped to ("Kyanite", "Mine"), but it has very sparse data (and so does BGS).
+    ("Kyanite", "kyanite"): None,
+    # NOTE: The following could be mapped to ("Kyanite", "Mine, kyanite and sillimanite"), but it has very sparse data.
+    ("Kyanite", "kyanite and sillimanite"): None,
     ("Lead", "Mine production"): ("Lead", "Mine"),
     ("Lead", "Mine production, lead content"): ("Lead", "Mine"),
     ("Lime", "Plant production"): ("Lime", "Processing"),

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -532,6 +532,10 @@ def extract_and_clean_data_for_year_and_mineral(data: Dict[int, Any], year: int,
         # Reserves column is called "Reserves_kt", however, the numbers show tonnes.
         # See that the metadata xml file mentions "Reserves_t", and the 2023 file is in tonnes.
         d = d.rename(columns={"Reserves_kt": "Reserves_t"}, errors="raise")
+    if (year == 2023) & (mineral == "RHENIUM"):
+        # Reserves column is called "Reserves_kt", however, the numbers show kilograms.
+        # See that the metadata xml file mentions "Reserves_kg", and the 2024 file is in kg.
+        d = d.rename(columns={"Reserves_kt": "Reserves_kg"}, errors="raise")
 
     ############################################################################################################
 

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -524,6 +524,10 @@ def extract_and_clean_data_for_year_and_mineral(data: Dict[int, Any], year: int,
         # Reserves column is called "Reserves_t", however, the numbers clearly show kilotonnes.
         # See that the world reserves in this file are 26000 tonnes, wheres in the file for 2024 they are 19 million tonnes.
         d = d.rename(columns={"Reserves_t": "Reserves_kt"}, errors="raise")
+    if (year == 2024) & (mineral == "TALC AND PYROPHYLLITE"):
+        # Reserves column is called "Reserves_t", however, the numbers clearly show kilotonnes.
+        # See that the metadata xml file mentions "Reserves_kt", and the 2023 file is in kilotonnes.
+        d = d.rename(columns={"Reserves_t": "Reserves_kt"}, errors="raise")
 
     ############################################################################################################
 

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -1086,6 +1086,12 @@ def run(dest_dir: str) -> None:
     # Corrections to USGS current data.
     # Zinc mine reserves in Australia in 2022 is unreasonably high, much larger than the world.
     tb_flat.loc[(tb_flat["country"] == "Australia") & (tb_flat["year"] == 2022), "reserves|Zinc|Mine|tonnes"] = None
+
+    # Asbestos mine production in Kazakhstan 2020, data says "27400", but in BGS, it is "227400", which is much more
+    # reasonable, looking at prior and posterior data. So it looks like an error in the data. Remove that point.
+    tb_flat.loc[
+        (tb_flat["country"] == "Kazakhstan") & (tb_flat["year"] == 2020), "production|Asbestos|Mine|tonnes"
+    ] = None
     ####################################################################################################################
 
     # Format tables conveniently.

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -528,6 +528,10 @@ def extract_and_clean_data_for_year_and_mineral(data: Dict[int, Any], year: int,
         # Reserves column is called "Reserves_t", however, the numbers clearly show kilotonnes.
         # See that the metadata xml file mentions "Reserves_kt", and the 2023 file is in kilotonnes.
         d = d.rename(columns={"Reserves_t": "Reserves_kt"}, errors="raise")
+    if (year == 2024) & (mineral == "SELENIUM"):
+        # Reserves column is called "Reserves_kt", however, the numbers show tonnes.
+        # See that the metadata xml file mentions "Reserves_t", and the 2023 file is in tonnes.
+        d = d.rename(columns={"Reserves_kt": "Reserves_t"}, errors="raise")
 
     ############################################################################################################
 

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -285,7 +285,8 @@ COMMODITY_MAPPING = {
         "Natural and synthetic",
     ),
     ("Soda ash", "World total production, synthetic soda ash (rounded)"): ("Soda ash", "Synthetic"),
-    ("Stone (dimension)", "Mine production, dimension stone"): ("Dimension stone", "Mine"),
+    # NOTE: The following could be mapped to ("Dimension stone", "Mine"), but it has only US data, not global.
+    ("Stone (dimension)", "Mine production, dimension stone"): None,
     ("Strontium", "Mine production"): ("Strontium", "Mine"),
     ("Strontium", "Mine production, contained strontium"): ("Strontium", "Mine"),
     ("Sulfur", "Production, all forms, contained sulfur"): ("Sulfur", "Processing"),

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -386,6 +386,7 @@ FOOTNOTES = {
     "production|Zeolites|Mine|tonnes": "Values refer to natural zeolites.",
     "reserves|Zeolites|Mine|tonnes": "Values refer to natural zeolites.",
     "production|Bismuth|Refinery|tonnes": "Values are reported in tonnes of metal content.",
+    "reserves|Platinum group metals|Mine, platinum|tonnes": "Reserves include all platinum group metals.",
 }
 
 # Dictionary of special units.

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -356,11 +356,14 @@ COMMODITY_MAPPING = {
     ("Vanadium", "Mine production, vanadium content"): ("Vanadium", "Mine"),
     # NOTE: The following could be mapped to ("Vermiculite", "Mine"). However, we decided to discard Vemiculite.
     ("Vermiculite", "Mine production"): None,
-    # NOTE: The following could be mapped to ("Vermiculite", "Mine"). However, we decided to discard Vemiculite.
-    ("Wollastonite", "Mine production"): ("Wollastonite", "Mine"),
-    ("Wollastonite", "Mine production, wollastonite"): ("Wollastonite", "Mine"),
-    ("Zeolites (natural)", "Mine production"): ("Zeolites", "Mine"),
-    ("Zeolites (natural)", "Mine production, zeolites"): ("Zeolites", "Mine"),
+    # NOTE: The following could be mapped to ("Wollastonite", "Mine"). However, we decided to discard Wollastonite.
+    ("Wollastonite", "Mine production"): None,
+    # NOTE: The following could be mapped to ("Wollastonite", "Mine"). However, we decided to discard Wollastonite.
+    ("Wollastonite", "Mine production, wollastonite"): None,
+    # NOTE: The following could be mapped to ("Zeolites", "Mine"). However, we decided to discard zeolites.
+    ("Zeolites (natural)", "Mine production"): None,
+    # NOTE: The following could be mapped to ("Zeolites", "Mine"). However, we decided to discard zeolites.
+    ("Zeolites (natural)", "Mine production, zeolites"): None,
     ("Zinc", "Mine production, zinc content of concentrates and direct shipping ores"): (
         "Zinc",
         "Mine",
@@ -393,8 +396,10 @@ FOOTNOTES = {
     "reserves|Potash|Mine|tonnes": "Values refer to ore in tonnes of potassium oxide equivalent.",
     "production|Rare earths|Mine|tonnes": "Values are reported in tonnes of rare-earth-oxide equivalent.",
     "reserves|Rare earths|Mine|tonnes": "Values are reported in tonnes of rare-earth-oxide equivalent.",
-    "production|Zeolites|Mine|tonnes": "Values refer to natural zeolites.",
-    "reserves|Zeolites|Mine|tonnes": "Values refer to natural zeolites.",
+    # NOTE: We decided to discard zeolites.
+    # "production|Zeolites|Mine|tonnes": "Values refer to natural zeolites.",
+    # NOTE: We decided to discard zeolites.
+    # "reserves|Zeolites|Mine|tonnes": "Values refer to natural zeolites.",
     "production|Bismuth|Refinery|tonnes": "Values are reported in tonnes of metal content.",
     "reserves|Platinum group metals|Mine, platinum|tonnes": "Reserves include all platinum group metals.",
 }

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -226,9 +226,12 @@ COMMODITY_MAPPING = {
     ("Platinum-group metals", "World mine production: Platinum"): ("Platinum group metals", "Mine, platinum"),
     ("Potash", "Mine production"): ("Potash", "Mine"),
     ("Potash", "Mine production, potassium oxide (K2O) equivalent"): ("Potash", "Mine"),
-    ("Pumice and pumicite", "Mine production"): ("Pumice and pumicite", "Mine"),
-    ("Pumice and pumicite", "Mine production, puice and pumicite"): ("Pumice and pumicite", "Mine"),
-    ("Pumice and pumicite", "Mine production, pumice and pumicite"): ("Pumice and pumicite", "Mine"),
+    # NOTE: The following could be mapped to ("Pumice and pumicite", "Mine").
+    # However, the resulting World aggregate is significantly larger than from USGS historical.
+    # This is possibly caused by a sudden increase in production in Turkey in 2022 and 2023, found in the 2024 file.
+    ("Pumice and pumicite", "Mine production"): None,
+    ("Pumice and pumicite", "Mine production, puice and pumicite"): None,
+    ("Pumice and pumicite", "Mine production, pumice and pumicite"): None,
     ("Rare earths", "Mine production, metric tons of rare-earth-oxide (REO) equivalent"): (
         "Rare earths",
         "Mine",

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -354,7 +354,9 @@ COMMODITY_MAPPING = {
     ("Tungsten", "Mine production, tungsten content"): ("Tungsten", "Mine"),
     ("Vanadium", "Mine production"): ("Vanadium", "Mine"),
     ("Vanadium", "Mine production, vanadium content"): ("Vanadium", "Mine"),
-    ("Vermiculite", "Mine production"): ("Vermiculite", "Mine"),
+    # NOTE: The following could be mapped to ("Vermiculite", "Mine"). However, we decided to discard Vemiculite.
+    ("Vermiculite", "Mine production"): None,
+    # NOTE: The following could be mapped to ("Vermiculite", "Mine"). However, we decided to discard Vemiculite.
     ("Wollastonite", "Mine production"): ("Wollastonite", "Mine"),
     ("Wollastonite", "Mine production, wollastonite"): ("Wollastonite", "Mine"),
     ("Zeolites (natural)", "Mine production"): ("Zeolites", "Mine"),

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -376,11 +376,12 @@ FOOTNOTES = {
     "production|Silicon|Processing|tonnes": "Values refer to silicon content of ferrosilicon and silicon metal.",
     "reserves|Bauxite|Mine|tonnes": "Values are reported as dried bauxite equivalents.",
     "production|Titanium|Mine, ilmenite|tonnes": "Values are reported as tonnes of titanium dioxide content.",
+    # "production|Titanium|Sponge|tonnes": "Values refer to titanium sponge.",
     "reserves|Titanium|Mine, ilmenite|tonnes": "Values are reported as tonnes of titanium dioxide content.",
     "production|Titanium|Mine, rutile|tonnes": "Values are reported as tonnes of titanium dioxide content.",
     "reserves|Titanium|Mine, rutile|tonnes": "Values are reported as tonnes of titanium dioxide content.",
     "production|Potash|Mine|tonnes": "Values are reported in tonnes of potassium oxide equivalent.",
-    "reserves|Potash|Mine|tonnes": "Values are reported in tonnes of potassium oxide equivalent.",
+    "reserves|Potash|Mine|tonnes": "Values refer to ore in tonnes of potassium oxide equivalent.",
     "production|Rare earths|Mine|tonnes": "Values are reported in tonnes of rare-earth-oxide equivalent.",
     "reserves|Rare earths|Mine|tonnes": "Values are reported in tonnes of rare-earth-oxide equivalent.",
     "production|Zeolites|Mine|tonnes": "Values refer to natural zeolites.",
@@ -631,8 +632,7 @@ def prepare_reserves_data(d: pd.DataFrame, metadata: Dict[str, str]) -> Optional
         elif unit_reserves == "ore_kt":
             d["Reserves_ore_kt"] *= 1e3
             d = d.rename(columns={"Reserves_ore_kt": "Reserves_t"}, errors="raise")
-            # Add a note explaining that the data is for ore.
-            d["Reserves_notes"] = [note + ["Reserves refer to ore."] for note in d["Reserves_notes"]]
+            # A footnote will mention that reserves refer to ore (see FOOTNOTES).
         elif unit_reserves in ["Mt", "mt"]:
             d[f"Reserves_{unit_reserves}"] *= 1e6
             d = d.rename(columns={f"Reserves_{unit_reserves}": "Reserves_t"}, errors="raise")
@@ -707,8 +707,7 @@ def prepare_production_data(d: pd.DataFrame, metadata: Dict[str, str]) -> Option
         # Handle special case.
         if unit_production == "Sponge_t":
             unit_production = "t"
-            # Add a note explaining that the data is for ore.
-            d["Production_notes"] = [note + ["Production refers to titanium sponge."] for note in d["Reserves_notes"]]
+            # A footnote will be added to mention that it refers to sponge (see FOOTNOTES).
         if d["Mineral"].unique().item() == "Soda ash":  # type: ignore
             # For consistency with different years, rename one of the sub-commodities (this happens at least in 2024).
             d["Type"] = d["Type"].replace({"Soda ash, Synthetic": "Soda ash, synthetic"})

--- a/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/mineral_commodity_summaries.py
@@ -225,8 +225,10 @@ COMMODITY_MAPPING = {
     ("Niobium (columbium)", "Mine production, niobium content"): ("Niobium", "Mine"),
     ("Nitrogen (fixed)-ammonia", "Plant production"): ("Nitrogen", "Fixed ammonia"),
     ("Nitrogen (fixed)-ammonia", "Plant production, ammonia - contained nitrogen"): ("Nitrogen", "Fixed ammonia"),
-    ("Peat", "Mine production"): ("Peat", "Mine"),
-    ("Peat", "Mine production, peat"): ("Peat", "Mine"),
+    # NOTE: The following could be mapped to ("Peat", "Mine"). We decided to remove "Peat".
+    ("Peat", "Mine production"): None,
+    # NOTE: The following could be mapped to ("Peat", "Mine"). We decided to remove "Peat".
+    ("Peat", "Mine production, peat"): None,
     ("Perlite", "Mine production"): ("Perlite", "Mine"),
     ("Perlite", "Mine production, perlite"): ("Perlite", "Mine"),
     ("Phosphate rock", "Mine production"): ("Phosphate rock", "Mine"),

--- a/snapshots/bgs/2024-07-09/world_mineral_statistics.zip.dvc
+++ b/snapshots/bgs/2024-07-09/world_mineral_statistics.zip.dvc
@@ -16,7 +16,7 @@ meta:
     producer: British Geological Survey
     citation_full: |-
       World Mineral Statistics, contributed by permission of the British Geological Survey (BGS). The copyright of all materials derived from the BGS's work is vested in the Natural Environment Research Council (NERC) and/or the authority that commissioned the work.
-    attribution: British Geological Survey - World Mineral Statistics (2023)
+    attribution: BGS - World Mineral Statistics (2023)
     attribution_short: BGS
 
     # Files

--- a/snapshots/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.zip.dvc
+++ b/snapshots/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.zip.dvc
@@ -6,13 +6,15 @@ meta:
     title: Historical Statistics for Mineral and Material Commodities
     description: |-
       Information on approximately 90 mineral commodities, including production, imports, exports, and stocks; reported and apparent consumption; and unit value (the real and nominal price in U.S. dollars of a metric ton of apparent consumption). For many of the commodities, data are reported as far back as 1900.
-    date_published: "2016-01-01"
+    # NOTE: The publication date is the latest year that appears in the table, in "Supply-Demand statistics" -> "Update year", in the following page:
+    # https://www.usgs.gov/centers/national-minerals-information-center/historical-statistics-mineral-and-material-commodities
+    date_published: "2023"
 
     # Citation
-    producer: United States Geological Survey Data
+    producer: United States Geological Survey
     citation_full: |-
       Kelly, T.D., and Matos, G.R., comps., 2014, Historical statistics for mineral and material commodities in the United States (2016 version): U.S. Geological Survey Data Series 140.
-    attribution: United States Geological Survey Data - Historical Statistics for Mineral and Material Commodities (2016)
+    attribution: USGS - Historical Statistics for Mineral and Material Commodities (2023)
     attribution_short: USGS
 
     # Files

--- a/snapshots/usgs/2024-07-15/mineral_commodity_summaries_2022.zip.dvc
+++ b/snapshots/usgs/2024-07-15/mineral_commodity_summaries_2022.zip.dvc
@@ -10,10 +10,10 @@ meta:
     date_published: "2022-01-31"
 
     # Citation
-    producer: United States Geological Survey Data
+    producer: United States Geological Survey
     citation_full: |-
       National Minerals Information Center, 2022, Mineral commodity summaries 2022 data release: U.S. Geological Survey data release, https://doi.org/10.5066/P9KKMCP4.
-    attribution: United States Geological Survey Data - Mineral Commodity Summaries (2022)
+    attribution: USGS - Mineral Commodity Summaries (2022)
     attribution_short: USGS
 
     # Files

--- a/snapshots/usgs/2024-07-15/mineral_commodity_summaries_2023.zip.dvc
+++ b/snapshots/usgs/2024-07-15/mineral_commodity_summaries_2023.zip.dvc
@@ -10,10 +10,10 @@ meta:
     date_published: "2023-01-31"
 
     # Citation
-    producer: United States Geological Survey Data
+    producer: United States Geological Survey
     citation_full: |-
       National Minerals Information Center, 2023, U.S. Geological Survey Mineral Commodity Summaries 2023 Data Release: U.S. Geological Survey data release, https://doi.org/10.5066/P9WCYUI6.
-    attribution: United States Geological Survey Data - Mineral Commodity Summaries (2023)
+    attribution: USGS - Mineral Commodity Summaries (2023)
     attribution_short: USGS
 
     # Files

--- a/snapshots/usgs/2024-07-15/mineral_commodity_summaries_2024.zip.dvc
+++ b/snapshots/usgs/2024-07-15/mineral_commodity_summaries_2024.zip.dvc
@@ -10,10 +10,10 @@ meta:
     date_published: "2024-01-30"
 
     # Citation
-    producer: United States Geological Survey Data
+    producer: United States Geological Survey
     citation_full: |-
       National Minerals Information Center, 2024, U.S. Geological Survey Mineral Commodity Summaries 2024 Data Release (ver. 2.0, March 2024): U.S. Geological Survey data release, https://doi.org/10.5066/P144BA54.
-    attribution: United States Geological Survey Data - Mineral Commodity Summaries (2024)
+    attribution: USGS - Mineral Commodity Summaries (2024)
     attribution_short: USGS
 
     # Files


### PR DESCRIPTION
* Combine BGS and USGS data only where they coincide (allow for shares up to 110% of USGS' World).
* Remove non-critical minerals, and other combinations with sparse or confusing data (mostly BGS).
* Implement all suggestions from the minerals bug bash.
* Fix various data issues.
* Improve metadata.