### PR TITLE
 :sparkles: engineering: refactor Step paths

### DIFF
--- a/apps/metadata_migrate/cli.py
+++ b/apps/metadata_migrate/cli.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 from etl import config
 from etl import grapher_model as gm
 from etl.command import main as etl_main
-from etl.db import get_engine, read_sql
+from etl.db import CatalogPath, get_engine, read_sql
 from etl.metadata_export import merge_or_create_yaml, reorder_fields
 from etl.paths import BASE_DIR, DAG_FILE, DATA_DIR, STEP_DIR
 
@@ -122,10 +122,10 @@ def cli(
         assert variable.catalogPath, f"Variable {var_id} does not come from ETL. Migrate it there first."
 
         # extract dataset URI and columns
-        uri, cols = variable.catalogPath.split("#")
-        cols = f"^{cols}$"
-        uri = uri.split("/", 1)[1]
-        uri, table_name = uri.rsplit("/", 1)
+        catalog_path = CatalogPath(variable.catalogPath)
+        cols = f"^{catalog_path.column}$"
+        uri = catalog_path.uri
+        table_name = catalog_path.table
     else:
         grapher_config = None
 

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -52,7 +52,7 @@ from typing_extensions import Self, TypedDict
 
 from etl import config, paths
 from etl.config import GRAPHER_USER_ID
-from etl.db import read_sql
+from etl.db import CatalogPath, read_sql
 
 log = structlog.get_logger()
 
@@ -1183,7 +1183,7 @@ class Variable(Base):
     @property
     def table_name(self) -> str:
         assert self.catalogPath
-        return self.catalogPath.split("#")[0].rsplit("/", 1)[1]
+        return CatalogPath(self.catalogPath).table
 
     @property
     def step_path(self) -> Path:


### PR DESCRIPTION
Refactor Step paths like channel / namespace / version / name. Move the logic from bespoke functions to steps themselves and use `Step` properties to access them.

Add `CatalogPath` to centralize its parsing.

An idea - we could have `DatasetPath`, `VariablePath` and `StepPath` to distinguish between `data://...`, `data://...#variable`. These would behave similarly to `pathlib.Path` and support operations such as `/` or `+` / `@` (as a replacement of `#`)

## TODO
- [ ] Refactor function `get_all_changed_catalog_paths`
- [ ] Should we use dataset / name?