### PR TITLE
✨ covid: add map as default view

### DIFF
--- a/etl/steps/data/explorers/covid/latest/covid.config.yml
+++ b/etl/steps/data/explorers/covid/latest/covid.config.yml
@@ -58,6 +58,8 @@ views:
     selectedFacetStrategy: entity
     facetYDomain: shared
     note: For some countries, all-cause deaths and COVID-19 deaths use different date schemes, in which one refers to when the death occurred and the other to when it was reported. This difference could produce an artificial lag between the two time series.
+    defaultView: "true"
+    tab: "map"
 
   # Cumulative (last 12 months)
   - indicator:

--- a/etl/steps/data/explorers/covid/latest/covid.py
+++ b/etl/steps/data/explorers/covid/latest/covid.py
@@ -139,6 +139,13 @@ def run(dest_dir: str) -> None:
             df_grapher[field] = df_grapher[field].fillna(default)
         else:
             df_grapher[field] = default
+
+    # Set dtypes
+    df_grapher = df_grapher.astype(
+        {
+            "timelineMinTime": "Int64",
+        }
+    )
     #
     # Save outputs.
     #

--- a/etl/steps/data/garden/covid/latest/cases_deaths.meta.yml
+++ b/etl/steps/data/garden/covid/latest/cases_deaths.meta.yml
@@ -285,6 +285,7 @@ tables:
         display:
           numDecimalPlaces: 0
           tolerance: 9999
+          color: "#565656"
           <<: *common_display
         presentation:
           grapher_config:
@@ -329,6 +330,7 @@ tables:
         display:
           numDecimalPlaces: 3
           tolerance: 9999
+          color: "#565656"
           name: Confirmed COVID-19 deaths (per 100,000)
           <<: *common_display
 
@@ -566,6 +568,7 @@ tables:
           numDecimalPlaces: 0
           name: Confirmed COVID-19 deaths
           tolerance: 9999
+          color: "#565656"
           <<: *common_display
         presentation:
           grapher_config:
@@ -598,6 +601,7 @@ tables:
         display:
           numDecimalPlaces: 2
           tolerance: 9999
+          color: "#565656"
           <<: *common_display
       total_deaths_per_100k_last12m:
         title: "Total confirmed deaths due to COVID-19 per 100,000 people (last 12 months)"

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality_economist/excess_mortality_economist.meta.yml
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality_economist/excess_mortality_economist.meta.yml
@@ -58,14 +58,14 @@ tables:
         title: Cumulative excess deaths (95% CI, lower bound)
         unit: "deaths"
         display:
-          color: "#DDB09E"
+          color: "#D7C2BA"
           <<: *common_display
           name: Lower bound, 95% uncertainty interval
       cumulative_estimated_daily_excess_deaths_ci_95_top:
         title: Cumulative excess deaths (95% CI, upper bound)
         unit: "deaths"
         display:
-          color: "#DDB09E"
+          color: "#D7C2BA"
           <<: *common_display
           name: Upper bound
 
@@ -99,14 +99,14 @@ tables:
         unit: "deaths per 100,000 people"
         display:
           <<: *common_display
-          color: "#DDB09E"
+          color: "#D7C2BA"
           name: Lower bound, 95% uncertainty interval
       cumulative_estimated_daily_excess_deaths_ci_95_top_per_100k:
         title: Cumulative excess deaths per 100,000 people (95% CI, upper bound)
         unit: "deaths per 100,000 people"
         display:
           <<: *common_display
-          color: "#DDB09E"
+          color: "#D7C2BA"
           name: Upper bound
 
       # Daily (7d average), absolute
@@ -122,14 +122,14 @@ tables:
         unit: "deaths"
         display:
           <<: *common_display
-          color: "#DDB09E"
+          color: "#D7C2BA"
           name: Lower bound, 95% uncertainty interval
       estimated_daily_excess_deaths_ci_95_top:
         title: Daily excess deaths (95% CI, upper bound)
         unit: "deaths"
         display:
           <<: *common_display
-          color: "#DDB09E"
+          color: "#D7C2BA"
           name: Upper bound
 
       # Daily (7d average), relative
@@ -162,14 +162,14 @@ tables:
         unit: "deaths per 100,000 people"
         display:
           <<: *common_display
-          color: "#DDB09E"
+          color: "#D7C2BA"
           name: Lower bound, 95% uncertainty interval
       estimated_daily_excess_deaths_ci_95_top_per_100k:
         title: Daily excess deaths per 100,000 people (95% CI, upper bound)
         unit: "deaths per 100,000 people"
         display:
           <<: *common_display
-          color: "#DDB09E"
+          color: "#D7C2BA"
           name: Upper bound
 
       # Cumulative last 12 months, absolute
@@ -184,14 +184,14 @@ tables:
         title: Cumulative excess deaths (95% CI, lower bound, last 12 months)
         unit: "deaths"
         display:
-          color: "#DDB09E"
+          color: "#D7C2BA"
           <<: *common_display
           name: Lower bound, 95% uncertainty interval
       cumulative_estimated_daily_excess_deaths_ci_95_top_last12m:
         title: Cumulative excess deaths (95% CI, upper bound, last 12 months)
         unit: "deaths"
         display:
-          color: "#DDB09E"
+          color: "#D7C2BA"
           <<: *common_display
           name: Upper bound
 
@@ -225,12 +225,12 @@ tables:
         unit: "deaths per 100,000 people"
         display:
           <<: *common_display
-          color: "#DDB09E"
+          color: "#D7C2BA"
           name: Lower bound, 95% uncertainty interval
       cumulative_estimated_daily_excess_deaths_ci_95_top_per_100k_last12m:
         title: Cumulative excess deaths per 100,000 people (95% CI, upper bound, last 12 months)
         unit: "deaths per 100,000 people"
         display:
           <<: *common_display
-          color: "#DDB09E"
+          color: "#D7C2BA"
           name: Upper bound


### PR DESCRIPTION
[[tracking issue](https://github.com/owid/owid-issues/issues/1619)]

- Have excess deaths (relative) as the default view, as a map.
- Improve display colours for XM data and confirmed deaths