### PR TITLE
✨ cli: etl pr

### DIFF
--- a/apps/cli/__init__.py
+++ b/apps/cli/__init__.py
@@ -74,7 +74,6 @@ SUBGROUPS = {
             "map-datasets": "apps.utils.map_datasets.cli",
             "scan-chart-diff": "apps.utils.scan_chart_diff.cli",
             "draft-pr": "apps.utils.draft_pull_request.cli",
-            "pr": "apps.utils.draft_pull_request.cli",
             "profile": "apps.utils.profile.cli",
         },
     },
@@ -170,6 +169,7 @@ GROUPS = (
                 "update": "apps.step_update.cli.cli",
                 "archive": "apps.step_update.cli.archive_cli",
                 "explorer-update": "apps.explorer_update.cli.cli",
+                "pr": "apps.utils.draft_pull_request.cli",
             },
         },
         {

--- a/apps/step_update/cli.py
+++ b/apps/step_update/cli.py
@@ -362,7 +362,7 @@ class StepUpdater:
 
             # Tell user how to automatically create PR
             short_name = steps[-1].split("/")[-1].split(".")[0]
-            cmd = f'etl d draft-pr update-{short_name} --title ":bar_chart: Update {short_name}" --step-update'
+            cmd = f'etl pr update-{short_name} --title ":bar_chart: Update {short_name}" --step-update'
             log.info(f"Create PR automatically with:\n  {cmd}")
 
     def _archive_step(self, step: str) -> None:

--- a/docs/guides/data-work/update-data.md
+++ b/docs/guides/data-work/update-data.md
@@ -15,7 +15,7 @@ This guide explains the general workflow to update a dataset that already exists
     - Use the ETL Dashboard to create new versions of the steps (by duplicating the old ones).
     - ETL Dashboard will suggest to run the following command to create PR and commit steps
         ```bash
-        etl d pr update-{short_name} --title ":bar_chart: Update {short_name}" --step-update
+        etl pr update-{short_name} --title ":bar_chart: Update {short_name}" --step-update
         ```
     - Copy the command and run it. It will commit the steps and create a PR with staging server.
     - Adapt the code of the new steps and ensure ETL (e.g. `etlr step-names --grapher`) can execute them successfully.
@@ -58,15 +58,15 @@ This guide assumes you have already a [working installation of `etl`](../../../g
     ![Chart Upgrader](../../../assets/etl-dashboard-update-steps.gif)
     <figcaption>Animation of how to update steps in ETL Dashboard.</figcaption>
     </figure>
-    - Copy the recommended command from the output (i.e. `etl d pr ... --step-update`).
+    - Copy the recommended command from the output (i.e. `etl pr ... --step-update`).
     - You can close the Wizard (kill it with ++ctrl+c++).
 
-- **Run `etl d pr .. --step-update` to commit changes and create a PR**
+- **Run `etl pr .. --step-update` to commit changes and create a PR**
 
     Run the command you copied from the ETL Dashboard:
 
     ```bash
-    etl d pr update-{short_name} --title ":bar_chart: Update {short_name}" --step-update
+    etl pr update-{short_name} --title ":bar_chart: Update {short_name}" --step-update
     ```
 
     This will create a new git branch in your local repository, which will be pushed.


### PR DESCRIPTION
This amends https://github.com/owid/etl/pull/3152 to replace `etl d pr` with `etl pr.` Also, it updates the documentation accordingly.

`etl d draft-pr` is left for backwards compatibility. Might remove it once the team adopts `etl pr`.