### PR TITLE
🐛 Fix `filter_to_subgraph` when passing the `only` argument

### DIFF
--- a/apps/step_update/cli.py
+++ b/apps/step_update/cli.py
@@ -342,6 +342,7 @@ class StepUpdater:
                 excludes=[],
                 downstream=False,
                 only=True,
+                exact_match=True,
             )
 
             message = "The following steps will be updated:"

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -76,13 +76,18 @@ def to_dependency_order(
     excludes: List[str],
     downstream: bool = False,
     only: bool = False,
+    exact_match: bool = False,
 ) -> List[str]:
     """
     Organize the steps in dependency order with a topological sort. In other words,
     the resulting list of steps is a valid ordering of steps such that no step is run
     before the steps it depends on. Note: this ordering is not necessarily unique.
     """
-    subgraph = filter_to_subgraph(dag, includes, downstream=downstream, only=only) if includes else dag
+    subgraph = (
+        filter_to_subgraph(dag, includes, downstream=downstream, only=only, exact_match=exact_match)
+        if includes
+        else dag
+    )
     in_order = list(graphlib.TopologicalSorter(subgraph).static_order())
 
     # filter out explicit excludes
@@ -91,7 +96,9 @@ def to_dependency_order(
     return filtered
 
 
-def filter_to_subgraph(graph: Graph, includes: Iterable[str], downstream: bool = False, only: bool = False) -> Graph:
+def filter_to_subgraph(
+    graph: Graph, includes: Iterable[str], downstream: bool = False, only: bool = False, exact_match: bool = False
+) -> Graph:
     """
     Filter the full graph to only the included nodes, and all their dependencies.
 
@@ -102,11 +109,14 @@ def filter_to_subgraph(graph: Graph, includes: Iterable[str], downstream: bool =
     dependent on B).
     """
     all_steps = graph_nodes(graph)
-    included = {s for s in all_steps if any(re.findall(pattern, s) for pattern in includes)}
+    if exact_match:
+        included = set(includes) & all_steps
+    else:
+        included = {s for s in all_steps if any(re.findall(pattern, s) for pattern in includes)}
 
     if only:
         # Only include explicitly selected nodes
-        return {step: graph.get(step, set()) & included for step in includes}
+        return {step: graph.get(step, set()) & included for step in included}
 
     if downstream:
         # Reverse the graph to find all nodes dependent on included nodes (forward deps)

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -106,7 +106,7 @@ def filter_to_subgraph(graph: Graph, includes: Iterable[str], downstream: bool =
 
     if only:
         # Only include explicitly selected nodes
-        return {step: graph.get(step, set()) & included for step in included}
+        return {step: graph.get(step, set()) & included for step in includes}
 
     if downstream:
         # Reverse the graph to find all nodes dependent on included nodes (forward deps)


### PR DESCRIPTION
I noticed that `to_dependency_order(dag=dag, includes=STEPS, only=True)` was returning a list of steps that was larger than STEPS. But if I understand correctly, `only` should avoid that, right?
This PR may fix it (but I'm not sure if that behaviour was as expected, and I'm misinterpreting the meaning of `only`).

As an example:
```
from etl.steps import load_dag, to_dependency_order
STEPS = ['data://grapher/war/2023-09-21/ucdp', 'data://garden/war/2023-09-21/ucdp']
steps = to_dependency_order(
    dag=load_dag(),
    includes=STEPS,
    excludes=[],
    downstream=False,
    only=True,
)
```
as far as I understand, should return `['data://garden/war/2023-09-21/ucdp', 'data://grapher/war/2023-09-21/ucdp']`, but instead it was returning `['data://garden/war/2023-09-21/ucdp', 'data://grapher/war/2023-09-21/ucdp',  'data://garden/war/2023-09-21/ucdp_prio']`.

(this issue [affected](https://owid.slack.com/archives/C0193RW5E2J/p1724671526845349) @lucasrodes while using StepUpdater)