### PR TITLE
📊 Fix missing Switzerland electricity data

### DIFF
--- a/etl/steps/data/garden/energy/2024-06-20/electricity_mix.py
+++ b/etl/steps/data/garden/energy/2024-06-20/electricity_mix.py
@@ -445,6 +445,18 @@ def run(dest_dir: str) -> None:
         .empty
     ), error
     tb_review.loc[tb_review["country"] == "Oceania", affected_columns] = None
+
+    # Coal generation in Ember data is missing.
+    # The reason may be that Switzerland stopped using coal for electricity before year 2000:
+    # https://data.worldbank.org/indicator/EG.ELC.COAL.ZS?locations=CH
+    # Ideally, the data should be zero, instead of missing.
+    error = "Expected missing data for Switzerland coal generation. That may no longer be the case. Remove this code."
+    assert (
+        tb_ember.loc[(tb_ember["country"] == "Switzerland") & (tb_ember["year"] > 1999)]["coal_generation__twh"]
+        .isnull()
+        .all()
+    ), error
+    tb_ember.loc[(tb_ember["country"] == "Switzerland") & (tb_ember["year"] > 1999), "coal_generation__twh"] = 0
     ####################################################################################################################
 
     # Combine both tables, giving priority to Ember data (on overlapping values).


### PR DESCRIPTION
As [pointed out by a user](https://app.frontapp.com/open/msg_m22n0zm?key=keI6IIXFC5xF8wnTFSikLPYcC_q7YoBh) (and [discussed](https://owid.slack.com/archives/C3RAU3BJ9/p1723646495890999?thread_ts=1723619090.242089&cid=C3RAU3BJ9)), Switzerland was missing in [this chart](https://ourworldindata.org/grapher/electricity-prod-source-stacked). The reason is that Ember's Yearly Electricity Review does not have data for Switzerland's coal electricity production. But instead of missing, it should simply be zero (at least since 2000, where the data starts). I've set those nans to zero.