### PR TITLE
✨ Raise error in etl pr if branch already exists locally or remotely

### DIFF
--- a/apps/utils/draft_pull_request.py
+++ b/apps/utils/draft_pull_request.py
@@ -149,7 +149,10 @@ def cli(
 
     # Update the list of remote branches in the local repository.
     origin = repo.remote(name="origin")
-    origin.fetch()
+    # NOTE: The option prune=True removes local references to branches that no longer exist on the remote repository.
+    #  Otherwise, this script might raise an error claiming that your proposed branch exists in remote, even if that
+    #  branch was already deleted.
+    origin.fetch(prune=True)
     # List all remote branches.
     remote_branches = [ref.name.split("origin/")[-1] for ref in origin.refs if ref.remote_head != "HEAD"]
 

--- a/apps/utils/draft_pull_request.py
+++ b/apps/utils/draft_pull_request.py
@@ -85,6 +85,17 @@ description = "- " + "\n- ".join(
 )
 
 
+def _branch_exists_remotely(new_branch, remote_branches):
+    if new_branch in remote_branches:
+        log.error(
+            f"New branch '{new_branch}' already exists in remote. "
+            "Either manually create a pull request from github, or use a different name for the new branch."
+        )
+        return True
+    else:
+        return False
+
+
 @click.command(name="draft-pr", cls=RichCommand, help=__doc__)
 @click.argument(
     "new-branch",
@@ -172,6 +183,11 @@ def cli(
                 "or switch to the new branch and run this tool without specifying a new branch."
             )
             return
+
+        # Ensure the new branch does not already exist remotely.
+        if _branch_exists_remotely(new_branch=new_branch, remote_branches=remote_branches):
+            return
+
         try:
             log.info(
                 f"Switching to base branch '{base_branch}', creating new branch '{new_branch}' from there, and switching to it."
@@ -182,12 +198,8 @@ def cli(
             log.error(f"Failed to create a new branch from '{base_branch}':\n{e}")
             return
 
-    # Ensure the new branch does not already exist in remote.
-    if new_branch in remote_branches:
-        log.error(
-            f"New branch '{new_branch}' already exists in remote. "
-            "Either manually create a pull request from github, or use a different name for the new branch."
-        )
+    # Ensure the new branch does not already exist remotely.
+    if _branch_exists_remotely(new_branch=new_branch, remote_branches=remote_branches):
         return
 
     log.info("Creating an empty commit.")


### PR DESCRIPTION
Currently, if you use `etl pr` with a branch name that does not exist locally, but does exist remotely, an error is raised, but after the local branch has been created.
With this PR, an error is raised and no local branch is created.

I have also changed `origin.fetch()` to `origin.fetch(prune=True)`, because often the script was raising an error, claiming that the proposed new branch already existed in remote, when it was actually removed there. If you think this can have unwanted side effects, we can do `origin.fetch(prune=prune)` and add `---prune` as an optional boolean flag (but I think there is no danger setting it to True).
