### PR TITLE
📊 Add electricity demand per capita

### DIFF
--- a/etl/steps/data/garden/energy/2024-06-20/electricity_mix.meta.yml
+++ b/etl/steps/data/garden/energy/2024-06-20/electricity_mix.meta.yml
@@ -363,6 +363,16 @@ tables:
           numDecimalPlaces: 0
         presentation:
           title_public: Total electricity generation per person
+      per_capita_total_demand__kwh:
+        title: Per capita electricity demand - kWh
+        short_unit: kWh
+        unit: kilowatt-hours
+        description_short: *description_short_per_capita
+        display:
+          name: Total electricity
+          numDecimalPlaces: 0
+        presentation:
+          title_public: Total electricity demand per person
       per_capita_wind_generation__kwh:
         title: Wind electricity per capita - kWh
         short_unit: kWh

--- a/etl/steps/data/garden/energy/2024-06-20/electricity_mix.py
+++ b/etl/steps/data/garden/energy/2024-06-20/electricity_mix.py
@@ -190,6 +190,7 @@ def add_per_capita_variables(combined: Table, ds_population: Dataset) -> Table:
         "renewable_generation__twh",
         "solar_generation__twh",
         "total_generation__twh",
+        "total_demand__twh",
         "wind_generation__twh",
         "solar_and_wind_generation__twh",
     ]


### PR DESCRIPTION
Add per capita electricity demand to electricity mix dataset.
For more context, per capita demand existed in the `yearly_electricity` dataset, but was not used. Now, in the `electricity_mix` dataset, it is calculated again, together with the rest of per capita variables (by dividing by population).
