### PR TITLE
 :bug: gbd-risk: Add missing percentages

### DIFF
--- a/etl/grapher_import.py
+++ b/etl/grapher_import.py
@@ -458,13 +458,17 @@ def cleanup_ghost_variables(engine: Engine, dataset_id: int, upserted_variable_i
         if rows:
             rows = pd.DataFrame(rows, columns=["chartId", "variableId"])
 
-            # show a warning
-            log.warning(
-                "Variables used in charts will not be deleted automatically",
-                rows=rows,
-                variables=variable_ids_to_delete,
-            )
-            return False
+            # raise an error if on staging server
+            if config.ENV == "staging":
+                raise ValueError(f"Variables used in charts will not be deleted automatically:\n{rows}")
+            else:
+                # otherwise show a warning
+                log.warning(
+                    "Variables used in charts will not be deleted automatically",
+                    rows=rows,
+                    variables=variable_ids_to_delete,
+                )
+                return False
 
         # then variables themselves with related data in other tables
         con.execute(

--- a/etl/steps/data/garden/ihme_gbd/2024-05-20/gbd_risk.py
+++ b/etl/steps/data/garden/ihme_gbd/2024-05-20/gbd_risk.py
@@ -39,7 +39,7 @@ def run(dest_dir: str) -> None:
         index_cols=["country", "year", "metric", "measure", "rei", "cause", "age"],
         regions=REGIONS,
         age_group_mapping=AGE_GROUPS_RANGES,
-        run_percent=True,
+        run_percent=False,
     )
 
     # Format the tables

--- a/etl/steps/data/garden/ihme_gbd/2024-05-20/gbd_risk.py
+++ b/etl/steps/data/garden/ihme_gbd/2024-05-20/gbd_risk.py
@@ -26,7 +26,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("gbd_risk")
 
     # Read table from meadow dataset.
-    tb = ds_meadow["gbd_risk"].reset_index()
+    tb = ds_meadow.read_table("gbd_risk", reset_index=True)
     ds_regions = paths.load_dataset("regions")
     #
     # Process data.
@@ -39,6 +39,7 @@ def run(dest_dir: str) -> None:
         index_cols=["country", "year", "metric", "measure", "rei", "cause", "age"],
         regions=REGIONS,
         age_group_mapping=AGE_GROUPS_RANGES,
+        run_percent=True,
     )
 
     # Format the tables

--- a/etl/steps/data/garden/ihme_gbd/2024-05-20/shared.py
+++ b/etl/steps/data/garden/ihme_gbd/2024-05-20/shared.py
@@ -41,7 +41,7 @@ def add_regional_aggregates(
         assert tb_percent["value"].max() <= 100 or tb_percent.shape[0] == 0
         assert tb_percent["value"].min() >= 0 or tb_percent.shape[0] == 0
         # Combine all the metrics back together
-        tb_out = pr.concat([tb_out, tb_percent], ignore_index=True)
+    tb_out = pr.concat([tb_out, tb_percent], ignore_index=True)
     assert tb_out.age.m.origins
     tb_out = tb_out.drop(columns="population")
     return tb_out


### PR DESCRIPTION
Percentages from `gbd_risk` dataset such as [this one](https://admin.owid.io/admin/variables/937511) got removed by [this commit](https://github.com/owid/etl/commit/93e92ce428abd88a98bd08b819064cbf335fec88). Because of that, ETL tries to rebuild `gbd_risk` every time it runs and then throws a warning.

This PR adds `run_percent=True` argument to regional aggregates to put them back. It also raises an error on staging servers when there are variables that cannot be deleted automatically.

