### PR TITLE
:bug: Improve chart-sync

### DIFF
--- a/apps/wizard/app_pages/indicator_upgrade/app.py
+++ b/apps/wizard/app_pages/indicator_upgrade/app.py
@@ -29,7 +29,7 @@ from apps.wizard import utils
 from apps.wizard.app_pages.indicator_upgrade.charts_update import get_affected_charts_and_preview, push_new_charts
 from apps.wizard.app_pages.indicator_upgrade.dataset_selection import build_dataset_form
 from apps.wizard.app_pages.indicator_upgrade.indicator_mapping import render_indicator_mapping
-from apps.wizard.app_pages.indicator_upgrade.utils import get_datasets, get_schema
+from apps.wizard.app_pages.indicator_upgrade.utils import get_datasets
 from etl.match_variables import SIMILARITY_NAMES
 
 # logger
@@ -57,8 +57,6 @@ st.markdown("Update indicators to their new versions.")  # Get datasets (might t
 
 # Get all datasets
 DATASETS = get_datasets()
-# Get schema
-SCHEMA_CHART_CONFIG = get_schema()
 # Session states
 utils.set_states(
     {
@@ -150,7 +148,7 @@ if st.session_state.submitted_datasets:
         if st.session_state.submitted_charts:
             if isinstance(charts, list) and len(charts) > 0:
                 st.toast("Updating charts...")
-                push_new_charts(charts, SCHEMA_CHART_CONFIG)
+                push_new_charts(charts)
 
 ##########################################################################################
 # 4 UPDATE CHARTS

--- a/apps/wizard/app_pages/indicator_upgrade/charts_update.py
+++ b/apps/wizard/app_pages/indicator_upgrade/charts_update.py
@@ -1,6 +1,6 @@
 """Handle submission of chart updates."""
 from http.client import RemoteDisconnected
-from typing import Any, Dict, List
+from typing import Dict, List
 from urllib.error import URLError
 
 import pandas as pd
@@ -9,7 +9,7 @@ from structlog import get_logger
 
 import etl.grapher_model as gm
 from apps.chart_sync.admin_api import AdminAPI
-from apps.wizard.utils import set_states, st_page_link, st_toast_error
+from apps.wizard.utils import get_schema_from_url, set_states, st_page_link, st_toast_error
 from etl.config import OWID_ENV
 from etl.db import get_engine
 from etl.indicator_upgrade.indicator_update import find_charts_from_variable_ids, update_chart_config
@@ -89,7 +89,7 @@ def get_affected_charts_and_preview(indicator_mapping: Dict[int, int]) -> List[g
     return charts
 
 
-def push_new_charts(charts: List[gm.Chart], schema_chart_config: Dict[str, Any]) -> None:
+def push_new_charts(charts: List[gm.Chart]) -> None:
     """Updating charts in the database."""
     # API to interact with the admin tool
     engine = get_engine()
@@ -105,7 +105,7 @@ def push_new_charts(charts: List[gm.Chart], schema_chart_config: Dict[str, Any])
             config_new = update_chart_config(
                 chart.config,
                 st.session_state.indicator_mapping,
-                schema_chart_config,
+                get_schema_from_url(chart.config["$schema"]),
             )
             # Push new chart to DB
             if chart.id:

--- a/apps/wizard/app_pages/indicator_upgrade/utils.py
+++ b/apps/wizard/app_pages/indicator_upgrade/utils.py
@@ -10,7 +10,6 @@ from structlog import get_logger
 from apps.utils.map_datasets import get_grapher_changes
 from etl.db import config, get_all_datasets, get_connection, get_dataset_charts, get_variables_in_dataset
 from etl.git_helpers import get_changed_files
-from etl.indicator_upgrade.schema import get_schema_chart_config
 from etl.match_variables import find_mapping_suggestions, preliminary_mapping
 from etl.version_tracker import VersionTracker
 
@@ -124,20 +123,6 @@ def get_datasets_from_db() -> pd.DataFrame:
         )
     else:
         return datasets.sort_values("name")
-
-
-@st.cache_data(show_spinner=False)
-def get_schema() -> Dict[str, Any]:
-    """Load datasets."""
-    with st.spinner("Retrieving schema..."):
-        try:
-            schema = get_schema_chart_config()
-        except OperationalError as e:
-            raise OperationalError(
-                f"Could not retrieve the schema. Try reloading the page. If the error persists, please report an issue. Error: {e.__traceback__}"
-            )
-        else:
-            return schema
 
 
 @st.cache_data(max_entries=1, ttl=60 * 10)

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -1567,7 +1567,14 @@ def _remap_variable_ids(config: Union[List, Dict[str, Any]], remap_ids: Dict[int
             if k == "variableId":
                 out[k] = remap_ids[int(v)]
             # columnSlug is actually a variable id, but stored as a string (it wasn't a great decision)
-            elif k == "columnSlug":
+            elif k in ("columnSlug", "sortColumnSlug"):
+                out[k] = str(remap_ids[int(v)])
+            # if new fields with variable ids are added, try to handle them and raise a warning
+            elif isinstance(v, int) and v in remap_ids:
+                log.warning("remap_variable_ids.new_field", field=k, value=v)
+                out[k] = remap_ids[v]
+            elif isinstance(v, str) and v.isdigit() and int(v) in remap_ids:
+                log.warning("remap_variable_ids.new_field", field=k, value=v)
                 out[k] = str(remap_ids[int(v)])
             else:
                 out[k] = _remap_variable_ids(v, remap_ids)

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -1559,7 +1559,7 @@ def _json_is(json_field: Any, key: str, val: Any) -> Any:
         return json_field[key] == val
 
 
-def _remap_variable_ids(config: Union[List, Dict[str, Any]], remap_ids: Dict[int, int]) -> Any:
+def _remap_variable_ids(config: Union[List, Dict[str, Any], Any], remap_ids: Dict[int, int]) -> Any:
     """Replace variableIds from chart config using `remap_ids` mapping."""
     if isinstance(config, dict):
         out = {}

--- a/etl/indicator_upgrade/indicator_update.py
+++ b/etl/indicator_upgrade/indicator_update.py
@@ -5,7 +5,7 @@ These functions are used when there are updates on variables. They are used in t
 
 
 from copy import deepcopy
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Set
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -15,7 +15,6 @@ import etl.grapher_model as gm
 from etl.db import get_engine
 from etl.indicator_upgrade.schema import (
     fix_errors_in_schema,
-    get_schema_chart_config,
     validate_chart_config_and_remove_defaults,
     validate_chart_config_and_set_defaults,
 )
@@ -52,7 +51,7 @@ def find_charts_from_variable_ids(variable_ids: Set[int]) -> List[gm.Chart]:
 def update_chart_config(
     config: Dict[str, Any],
     indicator_mapping: Dict[int, int],
-    schema: Optional[Dict[str, Any]] = None,
+    schema: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Update indicator references to the new ones.
 
@@ -69,7 +68,7 @@ class ChartIndicatorUpdater:
     def __init__(
         self,
         indicator_mapping: Dict[int, int],
-        schema: Optional[Dict[str, Any]] = None,
+        schema: Dict[str, Any],
     ) -> None:
         """Constructor.
 
@@ -82,8 +81,6 @@ class ChartIndicatorUpdater:
         """
         # Variable mapping dictionary: Old variable ID -> New variable ID
         self.indicator_mapping = indicator_mapping
-        if schema is None:
-            self.schema = get_schema_chart_config()
         self.schema = schema
 
     def run(self, config: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/test_grapher_model.py
+++ b/tests/test_grapher_model.py
@@ -8,3 +8,28 @@ def test_source_description():
     s = gm.Source(**d)  # type: ignore
     assert "link" in s.description
     assert s.description["link"] == "ABC"
+
+
+def test_remap_variable_ids():
+    config = {
+        "dimensions": [
+            {
+                "variableId": 988133,
+                "color": "#3182bd",
+            }
+        ],
+        "sortColumnSlug": "988133",
+        "columnSlug": "988133",
+        "unknownStrColumnSlug": "988133",
+        "unknownIntColumnSlug": 988133,
+    }
+
+    remap_ids = {988133: 123456}
+
+    new_config = gm._remap_variable_ids(config, remap_ids)
+
+    assert new_config["dimensions"][0]["variableId"] == 123456
+    assert new_config["sortColumnSlug"] == "123456"
+    assert new_config["columnSlug"] == "123456"
+    assert new_config["unknownStrColumnSlug"] == "123456"
+    assert new_config["unknownIntColumnSlug"] == 123456


### PR DESCRIPTION
Couple of bugfixes for `chart-sync`

- Don't use default grapher schema `004`, but always load the schema specified in `config["$schema"]` (otherwise we get errors in chart-diff)
- Remap variableId of `sortColumnSlug`, this was previously left out (also try mapping new unknown fields)