### PR TITLE
 :honeybee: engineering: enable explorers on staging servers

### DIFF
--- a/docs/architecture/workflow/index.md
+++ b/docs/architecture/workflow/index.md
@@ -285,11 +285,9 @@ TSV files for explorers are created using the `create_explorer` function, usuall
 ds_explorer = create_explorer(dest_dir=dest_dir, config=config, df_graphers=df_graphers)
 ds_explorer.save()
 ```
-
 !!! info "Creating explorers on staging servers"
 
-    Explorers can be created / edited on staging servers and then manually migrated to production. Every staging server creates a branch in the `owid-content` repository. Editing explorers in Admin or running `create_explorer` function pushes changes to that branch. Once the PR is merged, the branch gets pushed as to `owid-content` repository (not to the `master` branch, but its own branch). You then have to manually
-    create a PR from that branch and merge it to `master`.
+  Explorers can be created or edited on staging servers and then manually migrated to production. Each staging server creates a branch in the `owid-content` repository. Editing explorers in Admin or running the `create_explorer` function pushes changes to that branch. Once the PR is merged, the branch gets pushed to the `owid-content` repository (not to the `master` branch, but its own branch). You then need to manually create a PR from that branch and merge it into `master`.
 
 
 ### Creating multi-dimensional indicators

--- a/docs/architecture/workflow/index.md
+++ b/docs/architecture/workflow/index.md
@@ -286,6 +286,12 @@ ds_explorer = create_explorer(dest_dir=dest_dir, config=config, df_graphers=df_g
 ds_explorer.save()
 ```
 
+!!! info "Creating explorers on staging servers"
+
+    Explorers can be created / edited on staging servers and then manually migrated to production. Every staging server creates a branch in the `owid-content` repository. Editing explorers in Admin or running `create_explorer` function pushes changes to that branch. Once the PR is merged, the branch gets pushed as to `owid-content` repository (not to the `master` branch, but its own branch). You then have to manually
+    create a PR from that branch and merge it to `master`.
+
+
 ### Creating multi-dimensional indicators
 
 Multi-dimensional indicators are powered by a configuration that is typically created from a YAML file. The structure of the YAML file looks like this:

--- a/etl/explorer.py
+++ b/etl/explorer.py
@@ -15,7 +15,7 @@ import pandas as pd
 from structlog import get_logger
 
 from etl import config
-from etl.files import upload_file_to_server
+from etl.files import download_file_from_server, run_command_on_server, upload_file_to_server
 from etl.grapher_io import get_variables_data
 from etl.paths import EXPLORERS_DIR
 
@@ -194,6 +194,10 @@ class Explorer:
         """
         path = (Path(EXPLORERS_DIR) / name).with_suffix(".explorer.tsv")
 
+        # If working on staging server, pull the file from there and replace the local owid-content version
+        if cls._on_staging():
+            download_file_from_server(path, f"owid@{config.DB_HOST}:~/owid-content/explorers/{name}.explorer.tsv")
+
         # Build explorer from file
         explorer = cls.from_file(str(path), name=name)
 
@@ -208,6 +212,10 @@ class Explorer:
         # Write parsed content to file.
         path.write_text(self.content)
 
+    @staticmethod
+    def _on_staging() -> bool:
+        return config.STAGING and "staging-site" in config.DB_HOST and "staging-site-master" not in config.DB_HOST  # type: ignore
+
     def to_owid_content(self, path: Optional[Union[str, Path]] = None):
         """Save your config in owid-content and push to server if applicable.
 
@@ -221,10 +229,14 @@ class Explorer:
         self.export(path)
 
         # Upload it to staging server.
-        if config.STAGING:
-            if isinstance(path, str):
-                path = Path(path)
-            upload_file_to_server(path, f"owid@{config.DB_HOST}:~/owid-content/explorers/")
+        if self._on_staging():
+            upload_file_to_server(Path(path), f"owid@{config.DB_HOST}:~/owid-content/explorers/")
+
+            # Commit on the staging server
+            run_command_on_server(
+                f"owid@{config.DB_HOST}",
+                "cd owid-content && git add . && git diff-index --quiet HEAD || git commit -m ':robot: Update explorer from ETL'",
+            )
 
     def save(self, path: Optional[Union[str, Path]] = None) -> None:
         """See docs for `to_owid_content`."""


### PR DESCRIPTION
Enable editing of explorers on staging servers.

- New staging servers create a branch in `owid-content`
- Explorer steps in ETL commits to that branch on the staging server (previously all changes were uncommitted) (e.g. `etlr explorers/minerals --export`)
- Editing Explorer TSV from Admin commits to the branch
- Merging the branch pushes the branch to `owid-content` repo. It doesn't automatically merge it with master, but one can create a PR from it and merge manually