### PR TITLE
✨ Mpox safety 

### DIFF
--- a/snapshots/health/latest/global_health_mpox.py
+++ b/snapshots/health/latest/global_health_mpox.py
@@ -15,7 +15,8 @@ SNAPSHOT_VERSION = Path(__file__).parent.name
 def main(upload: bool) -> None:
     # Create a new snapshot.
     snap = Snapshot(f"health/{SNAPSHOT_VERSION}/global_health_mpox.csv")
-
+    tb = snap.read()
+    assert tb["Date_report_source_I"].min() > "2023-12-01", "Global.health have added data for 2023"
     # Download data from source, add file to DVC and upload to S3.
     snap.create_snapshot(upload=upload)
 


### PR DESCRIPTION
The update should fail if Global.health adds 2023 data to their dataset; we currently add this manually, so this is to prevent double-counting.