### PR TITLE
 :bug: Deprecate charts.list_charts

### DIFF
--- a/lib/catalog/README.md
+++ b/lib/catalog/README.md
@@ -45,17 +45,6 @@ Notice that the last part of the URL is the chart's slug, its identifier, in thi
 df = charts.get_data('life-expectancy')
 ```
 
-To see what charts are available, you can list them all.
-
-```python
->>> slugs = charts.list_charts()
->>> slugs[:5]
-['above-ground-biomass-in-forest-per-hectare',
- 'above-or-below-extreme-poverty-line-world-bank',
- 'abs-change-energy-consumption',
- 'absolute-change-co2',
- 'absolute-gains-in-mean-female-height']
-```
 
 ### Data science API
 

--- a/lib/catalog/owid/catalog/charts.py
+++ b/lib/catalog/owid/catalog/charts.py
@@ -6,7 +6,7 @@
 #
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Optional
 
 import pandas as pd
 

--- a/lib/catalog/owid/catalog/charts.py
+++ b/lib/catalog/owid/catalog/charts.py
@@ -15,7 +15,6 @@ from .internal import (
     LicenseError,  # noqa
     _fetch_bundle,
     _GrapherBundle,
-    _list_charts,
 )
 
 
@@ -51,14 +50,6 @@ class Chart:
 
     def __eq__(self, value: object) -> bool:
         return isinstance(value, Chart) and value.slug == self.slug
-
-
-def list_charts() -> List[str]:
-    """
-    List all available charts published on Our World in Data, representing each via
-    a short slug that you can use with `get_data()`.
-    """
-    return sorted(_list_charts())
 
 
 def get_data(slug_or_url: str) -> pd.DataFrame:

--- a/lib/catalog/owid/catalog/internal.py
+++ b/lib/catalog/owid/catalog/internal.py
@@ -162,10 +162,3 @@ def _fetch_bundle(slug: str) -> _GrapherBundle:
         if d.metadata.get("origins"):
             origins.append(d.metadata.pop("origins"))
     return _GrapherBundle(config, dimensions, origins)
-
-
-def _list_charts() -> List[str]:
-    content = requests.get("https://ourworldindata.org/charts").content.decode("utf-8")
-    links = re.findall('"(/grapher/[^"]+)"', content)
-    slugs = [link.strip('"').split("/")[-1] for link in links]
-    return sorted(set(slugs))

--- a/lib/catalog/owid/catalog/internal.py
+++ b/lib/catalog/owid/catalog/internal.py
@@ -6,7 +6,6 @@
 
 import datetime as dt
 import json
-import re
 from dataclasses import dataclass
 from typing import Dict, List, Literal
 

--- a/lib/catalog/tests/test_charts.py
+++ b/lib/catalog/tests/test_charts.py
@@ -37,15 +37,6 @@ def test_fetch_non_redistributable_chart():
         chart.get_data()
 
 
-def test_list_charts():
-    slugs = charts.list_charts()
-    assert len(slugs) > 0
-    assert "life-expectancy" in slugs
-
-    # all unique
-    assert len(slugs) == len(set(slugs))
-
-
 def test_fetch_missing_chart():
     with pytest.raises(charts.ChartNotFoundError):
         charts.Chart("this-chart-does-not-exist").bundle


### PR DESCRIPTION
With the introduction of data catalog, we no longer have a way to get a list of slugs for all charts. This was used in `charts.list_charts()` function in data catalog.

I don't know how often was this function used. If we want to keep it, we'd have to add an endpoint that would return all charts slugs or call public Datasette.