### PR TITLE
📊 energy: Fix missing energy data for Saudi Arabia

### DIFF
--- a/etl/steps/data/garden/energy_institute/2024-06-20/statistical_review_of_world_energy.py
+++ b/etl/steps/data/garden/energy_institute/2024-06-20/statistical_review_of_world_energy.py
@@ -613,6 +613,24 @@ def run(dest_dir: str) -> None:
     tb = fix_missing_nuclear_energy_data(tb=tb)
 
     ####################################################################################################################
+    # Similarly to missing nuclear data, hydropower is missing from year 2000 onwards, at least for Saudi Arabia.
+    # However, in the excel data file, those values are zero.
+    # Fill those missing points with zeros.
+    error = "Expected missing data for Arabia's hydropower from 2000 on. It may be fixed, so, remove this code."
+    assert (
+        tb.loc[
+            (tb["country"] == "Saudi Arabia") & (tb["year"] >= 2000),
+            ["hydro_consumption_equivalent_ej", "hydro_electricity_generation_twh"],
+        ]
+        .isnull()
+        .all()
+        .all()
+    ), error
+    tb.loc[
+        (tb["country"] == "Saudi Arabia") & (tb["year"] >= 2000),
+        ["hydro_consumption_equivalent_ej", "hydro_electricity_generation_twh"],
+    ] = 0
+
     # Wind generation for Saudi Arabia in 2022 and 2023 is possibly wrong.
     # It goes from 0.005678 TWh in 2021 to 1.45 TWh in 2022 and 2023.
     # According to IRENA, Saudi Arabia's wind capacity was 3MW in 2022:

--- a/etl/steps/data/garden/energy_institute/2024-06-20/statistical_review_of_world_energy.py
+++ b/etl/steps/data/garden/energy_institute/2024-06-20/statistical_review_of_world_energy.py
@@ -631,7 +631,7 @@ def run(dest_dir: str) -> None:
         ["hydro_consumption_equivalent_ej", "hydro_electricity_generation_twh"],
     ] = 0
 
-    # Wind generation for Saudi Arabia in 2022 and 2023 is possibly wrong.
+    # Wind generation (and consumption) for Saudi Arabia in 2022 and 2023 is possibly wrong.
     # It goes from 0.005678 TWh in 2021 to 1.45 TWh in 2022 and 2023.
     # According to IRENA, Saudi Arabia's wind capacity was 3MW in 2022:
     # https://www.irena.org/Publications/2023/Jul/Renewable-energy-statistics-2023
@@ -644,8 +644,15 @@ def run(dest_dir: str) -> None:
     assert (
         tb[(tb["country"] == "Saudi Arabia") & (tb["year"] == 2022)]["wind_electricity_generation_twh"].item() > 1.45
     ), error
+    assert (
+        tb[(tb["country"] == "Saudi Arabia") & (tb["year"] == 2021)]["wind_consumption_equivalent_ej"].item() < 0.00006
+    ), error
+    assert (
+        tb[(tb["country"] == "Saudi Arabia") & (tb["year"] == 2022)]["wind_consumption_equivalent_ej"].item() > 0.01
+    ), error
     tb.loc[
-        (tb["country"] == "Saudi Arabia") & (tb["year"].isin([2022, 2023])), "wind_electricity_generation_twh"
+        (tb["country"] == "Saudi Arabia") & (tb["year"].isin([2022, 2023])),
+        ["wind_consumption_equivalent_ej", "wind_electricity_generation_twh"],
     ] = None
     ####################################################################################################################
 

--- a/etl/steps/data/garden/energy_institute/2024-06-20/statistical_review_of_world_energy.py
+++ b/etl/steps/data/garden/energy_institute/2024-06-20/statistical_review_of_world_energy.py
@@ -626,9 +626,9 @@ def run(dest_dir: str) -> None:
     assert (
         tb[(tb["country"] == "Saudi Arabia") & (tb["year"] == 2022)]["wind_electricity_generation_twh"].item() > 1.45
     ), error
-    tb = tb.drop(tb[(tb["country"] == "Saudi Arabia") & (tb["year"].isin([2022, 2023]))].index.tolist()).reset_index(
-        drop=True
-    )
+    tb.loc[
+        (tb["country"] == "Saudi Arabia") & (tb["year"].isin([2022, 2023])), "wind_electricity_generation_twh"
+    ] = None
     ####################################################################################################################
 
     # Create additional variables, like primary energy consumption in TWh (both direct and in input-equivalents).


### PR DESCRIPTION
We found inconsistencies in wind consumption for Saudi Arabia in the latest release of the Statistical Review. For that reason, data for 2022 and 2023 was removed. However, other indicators (not affected by this issue) could still be safely used. I have brought back that data, and kept only wind consumption as missing.