### PR TITLE
:bug: correct charts in old WDI

### DIFF
--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -139,7 +139,9 @@ class ChartDiff:
         If slug of the chart miss-matches between target and source sessions, an error is displayed.
         """
         if self.target_chart:
-            assert self.source_chart.slug == self.target_chart.slug, "Slug mismatch!"
+            assert (
+                self.source_chart.slug == self.target_chart.slug
+            ), f"Slug mismatch! {self.source_chart.slug} != {self.target_chart.slug}"
         return self.source_chart.slug or "no-slug"
 
     @property

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -139,9 +139,11 @@ class ChartDiff:
         If slug of the chart miss-matches between target and source sessions, an error is displayed.
         """
         if self.target_chart:
-            assert (
-                self.source_chart.slug == self.target_chart.slug
-            ), f"Slug mismatch! {self.source_chart.slug} != {self.target_chart.slug}"
+            # Only published charts have slugs
+            if self.target_chart.publishedAt is not None:
+                assert (
+                    self.source_chart.slug == self.target_chart.slug
+                ), f"Slug mismatch! {self.source_chart.slug} != {self.target_chart.slug}"
         return self.source_chart.slug or "no-slug"
 
     @property


### PR DESCRIPTION
Charts were mistakingly using the previous WDI version instead of the 2024 update. Here I am just migrating the indicators.