### PR TITLE
 :sparkles: Add max_time and n_jobs to GP

### DIFF
--- a/apps/anomalist/anomalist_api.py
+++ b/apps/anomalist/anomalist_api.py
@@ -235,7 +235,6 @@ def anomaly_detection(
             if variable_mapping[variable_id_old] in [variable.id for variable in variables_in_dataset]
         ]
         variables_old_and_new = variables_in_dataset + variables_old
-        # TODO: It would be more convenient if df had a dummy index, instead of resetting here.
         df = load_data_for_variables(engine=engine, variables=variables_old_and_new)
 
         for anomaly_type in anomaly_types:

--- a/apps/anomalist/detectors.py
+++ b/apps/anomalist/detectors.py
@@ -32,8 +32,14 @@ def estimate_bard_epsilon(series: pd.Series) -> float:
 
 
 def get_long_format_score_df(df_score: pd.DataFrame) -> pd.DataFrame:
-    # Create a reduced score dataframe.
-    df_score_long = df_score.melt(id_vars=["entity_name", "year"], var_name="variable_id", value_name="anomaly_score")
+    # Output is already in long format
+    if set(df_score.columns) == {"entity_name", "year", "variable_id", "anomaly_score"}:
+        df_score_long = df_score
+    else:
+        # Create a reduced score dataframe.
+        df_score_long = df_score.melt(
+            id_vars=["entity_name", "year"], var_name="variable_id", value_name="anomaly_score"
+        )
 
     # Drop NaN anomalies.
     df_score_long = df_score_long.dropna(subset=["anomaly_score"])

--- a/apps/anomalist/gp_detector.py
+++ b/apps/anomalist/gp_detector.py
@@ -48,27 +48,24 @@ def _processing_queue(items: list[tuple[str, int]]) -> List[tuple]:
     probs = np.array([population.get(entity, np.nan) for entity, variable_id in items])
 
     # Fill any missing values with the mean probability
-    probs = np.nan_to_num(probs, nan=np.nanmean(probs))
-
-    # Normalize the probabilities to sum to 1
-    probs = probs / probs.sum()
+    probs = np.nan_to_num(probs, nan=np.nanmean(probs))  # type: ignore
 
     # Randomly shuffle the items based on their probabilities
     items_index = np.random.choice(
         len(items),
         size=len(items),
         replace=False,
-        p=probs,
+        p=probs / probs.sum(),
     )
 
     # Return the shuffled list of items
-    return np.array(items, dtype=object)[items_index]
+    return np.array(items, dtype=object)[items_index]  # type: ignore
 
 
 class AnomalyGaussianProcessOutlier(AnomalyDetector):
     anomaly_type = "gp_outlier"
 
-    def __init__(self, max_time: Optional[float] = None, n_jobs: int = 4):
+    def __init__(self, max_time: Optional[float] = None, n_jobs: int = 1):
         self.max_time = max_time
         self.n_jobs = n_jobs
 

--- a/apps/anomalist/gp_detector.py
+++ b/apps/anomalist/gp_detector.py
@@ -84,8 +84,6 @@ class AnomalyGaussianProcessOutlier(AnomalyDetector):
 
         results = []
 
-        items = items[:1000]
-
         # Iterate through each (entity_name, variable_id) pair in the processing queue
         for entity_name, variable_id in tqdm(items):
             # Stop processing if the maximum time is reached


### PR DESCRIPTION
- Stop detecting anomalies after `max_time` in GP. They are processed in random order, but with probability proportional to country population (entities without population are given mean probability). It's **not being used yet**, but will be useful when we start detecting anomalies in production
- Add `n_jobs` for multiprocessing. This works poorly on my shitty laptop, but might provide speed up on our beefy server
- Return long format from GP detector and handle it in anomalist_api