### PR TITLE
🐛 anomalist: Fix bug with unknown indicators and long loading time

### DIFF
--- a/apps/anomalist/anomalist_api.py
+++ b/apps/anomalist/anomalist_api.py
@@ -297,7 +297,9 @@ def anomaly_detection(
                 datasetId=dataset_id,
                 anomalyType=anomaly_type,
             )
-            anomaly.dfScore = df_score_long
+            # We could store the full dataframe in the database, but it ends up making the load quite slow.
+            # Since we are not using it for now, we will store only the reduced dataframe.
+            # anomaly.dfScore = df_score_long
 
             # Reduce dataframe
             df_score_long_reduced = (

--- a/apps/anomalist/gp_detector.py
+++ b/apps/anomalist/gp_detector.py
@@ -76,8 +76,13 @@ class AnomalyGaussianProcessOutlier(AnomalyDetector):
 
     def get_score_df(self, df: pd.DataFrame, variable_ids: List[int], variable_mapping: Dict[int, int]) -> pd.DataFrame:
         # Convert to long format
+        df_wide = df.melt(id_vars=["entity_name", "year"])
+        # Filter to only include the specified variable IDs.
         df_wide = (
-            df.melt(id_vars=["entity_name", "year"]).set_index(["entity_name", "variable_id"]).dropna().sort_index()
+            df_wide[df_wide["variable_id"].isin(variable_ids)]
+            .set_index(["entity_name", "variable_id"])
+            .dropna()
+            .sort_index()
         )
 
         # Create a processing queue with (entity_name, variable_id) pairs


### PR DESCRIPTION
* Stop storing `dfScore`, since the load of anomalies from DB takes much longer than when only storing `dfReduced`, and we are currently not using `dfScore` anywhere.
* GP detector was searching for anomalies in all indicators in the incoming `df`. However, by construction, `df` includes data for both new and old indicators (and detecting anomalies in the old indicators is unnecessary). This was causing anomalist to raise an error. Now the detection takes half of the time for datasets for which there is an old version.
