### PR TITLE
:sparkles: Persist filter values in the URL for Anomalist

### DIFF
--- a/apps/anomalist/anomalist_api.py
+++ b/apps/anomalist/anomalist_api.py
@@ -409,15 +409,11 @@ def load_data_for_variables(engine: Engine, variables: list[gm.Variable]) -> pd.
     # reorder in the same order as variables
     df = df[[v.id for v in variables]]
 
-    # TODO: how should we treat non-numeric variables? We can exclude it here, but then we need to
-    # fix it in detectors
-    # HACK: set non-numeric variables to zero
+    # set non-numeric values to NaN
     df = df.apply(pd.to_numeric, errors="coerce")
-    df = df.fillna(0)
 
-    # TODO:
-    # remove countries with all nulls or all zeros or constant values
-    # df = df.loc[:, df.fillna(0).std(axis=0) != 0]
+    # remove variables with all nulls or all zeros or constant values
+    df = df.loc[:, df.fillna(0).std(axis=0) != 0]
 
     df = df.reset_index().astype({"entity_name": str})
 

--- a/apps/anomalist/anomalist_api.py
+++ b/apps/anomalist/anomalist_api.py
@@ -1,4 +1,5 @@
 import tempfile
+import time
 from pathlib import Path
 from typing import List, Literal, Optional, Tuple, cast, get_args
 
@@ -260,14 +261,16 @@ def anomaly_detection(
         with Session(engine) as session:
             dataset = gm.Dataset.load_dataset(session, dataset_id)
 
-        log.info("Loading data from S3")
+        log.info("loading_data_from_s3.start")
         variables_old = [
             variables[variable_id_old]
             for variable_id_old in variable_mapping.keys()
             if variable_mapping[variable_id_old] in [variable.id for variable in variables_in_dataset]
         ]
         variables_old_and_new = variables_in_dataset + variables_old
+        t = time.time()
         df = load_data_for_variables(engine=engine, variables=variables_old_and_new)
+        log.info("loading_data_from_s3.end", t=time.time() - t)
 
         for anomaly_type in anomaly_types:
             # Instantiate the anomaly detector.

--- a/apps/owidbot/cli.py
+++ b/apps/owidbot/cli.py
@@ -21,7 +21,8 @@ SERVICES = Literal["data-diff", "chart-diff", "grapher", "anomalist"]
 
 @click.command("owidbot", cls=RichCommand, help=__doc__)
 @click.argument("repo_branch", type=str)
-@click.option("--services", type=click.Choice(get_args(SERVICES)), multiple=True)
+# @click.option("--services", type=click.Choice(get_args(SERVICES)), multiple=True)
+@click.option("--services", type=str, multiple=True)
 @click.option(
     "--include",
     type=str,
@@ -36,7 +37,7 @@ SERVICES = Literal["data-diff", "chart-diff", "grapher", "anomalist"]
 )
 def cli(
     repo_branch: str,
-    services: List[Literal[SERVICES]],
+    services: List[str],
     include: str,
     dry_run: bool,
 ) -> None:
@@ -82,7 +83,10 @@ def cli(
             anomalist.run(branch)
 
         else:
-            raise AssertionError("Invalid service")
+            # We raise a warning instead of an error to make it backward compatible on old
+            # staging servers when adding a new service.
+            log.warning("Invalid service", service=service)
+            continue
 
     # get existing comment (do this as late as possible to avoid race conditions)
     comment = gh_utils.get_comment_from_pr(pr)

--- a/apps/wizard/app_pages/anomalist/app.py
+++ b/apps/wizard/app_pages/anomalist/app.py
@@ -33,7 +33,7 @@ from apps.wizard.app_pages.anomalist.utils import (
     get_datasets_and_mapping_inputs,
     get_scores,
 )
-from apps.wizard.utils import cached, set_states
+from apps.wizard.utils import cached, set_states, url_persist
 from apps.wizard.utils.chart_config import bake_chart_config
 from apps.wizard.utils.components import Pagination, grapher_chart, st_horizontal, tag_in_md
 from apps.wizard.utils.db import WizardDB
@@ -454,14 +454,17 @@ st.markdown(
 )
 
 with st.form(key="dataset_search"):
+    query_dataset_ids = [int(v) for v in st.query_params.get_all("anomalist_datasets_selected")]
+
     st.session_state.anomalist_datasets_selected = st.multiselect(
         "Select datasets",
         # options=cached.load_dataset_uris(),
         options=DATASETS_ALL.keys(),
         # max_selections=1,
-        default=DATASETS_NEW.keys(),
+        default=query_dataset_ids or DATASETS_NEW.keys(),
         format_func=DATASETS_ALL.get,
     )
+    st.query_params["anomalist_datasets_selected"] = st.session_state.anomalist_datasets_selected
 
     st.form_submit_button(
         "Detect anomalies",
@@ -473,7 +476,7 @@ with st.form(key="dataset_search"):
 
 # 3/ SCAN FOR ANOMALIES
 # If anomalies for dataset already exist in DB, load them. Warn user that these are being loaded from DB
-if st.session_state.anomalist_datasets_submitted:
+if not st.session_state.anomalist_anomalies or st.session_state.anomalist_datasets_submitted:
     # 3.1/ Check if anomalies are already there in DB
     with st.spinner("Loading anomalies (already detected) from database..."):
         st.session_state.anomalist_anomalies = WizardDB.load_anomalies(st.session_state.anomalist_datasets_selected)
@@ -571,9 +574,13 @@ if st.session_state.anomalist_df is not None:
         col1, col2 = st.columns([10, 4])
         # Indicator
         with col1:
-            st.multiselect(
+            options = [
+                indicator for indicator in INDICATORS_AVAILABLE if indicator in st.session_state.anomalist_indicators
+            ]
+
+            url_persist(st.multiselect)(
                 label="Indicators",
-                options=INDICATORS_AVAILABLE,
+                options=options,
                 format_func=st.session_state.anomalist_indicators.get,
                 help="Show anomalies affecting only a selection of indicators.",
                 placeholder="Select indicators",
@@ -582,7 +589,7 @@ if st.session_state.anomalist_df is not None:
 
         with col2:
             # Entity
-            st.multiselect(
+            url_persist(st.multiselect)(
                 label="Entities",
                 options=ENTITIES_AVAILABLE,
                 help="Show anomalies affecting only a selection of entities.",
@@ -613,7 +620,7 @@ if st.session_state.anomalist_df is not None:
                     key="anomalist_sorting_strategy",
                 )
             with cols[1]:
-                st.multiselect(
+                url_persist(st.multiselect)(
                     label="Detectors",
                     options=ANOMALY_TYPES_AVAILABLE,
                     format_func=ANOMALY_TYPE_NAMES.get,
@@ -623,7 +630,7 @@ if st.session_state.anomalist_df is not None:
                 )
         with col2:
             with st_horizontal():
-                st.number_input(
+                url_persist(st.number_input)(
                     "Min year",
                     value=YEAR_MIN,
                     min_value=YEAR_MIN,
@@ -631,7 +638,7 @@ if st.session_state.anomalist_df is not None:
                     step=1,
                     key="anomalist_min_year",
                 )
-                st.number_input(
+                url_persist(st.number_input)(
                     "Max year",
                     value=YEAR_MAX,
                     min_value=YEAR_MIN,

--- a/apps/wizard/app_pages/anomalist/app.py
+++ b/apps/wizard/app_pages/anomalist/app.py
@@ -464,7 +464,7 @@ with st.form(key="dataset_search"):
         default=query_dataset_ids or DATASETS_NEW.keys(),
         format_func=DATASETS_ALL.get,
     )
-    st.query_params["anomalist_datasets_selected"] = st.session_state.anomalist_datasets_selected
+    st.query_params["anomalist_datasets_selected"] = st.session_state.anomalist_datasets_selected  # type: ignore
 
     st.form_submit_button(
         "Detect anomalies",

--- a/apps/wizard/utils/db.py
+++ b/apps/wizard/utils/db.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Generator, List, Literal, Optional, Tuple
 
 import pandas as pd
 import streamlit as st
+import structlog
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -21,6 +22,8 @@ from apps.wizard.utils.paths import STREAMLIT_SECRETS, WIZARD_DB
 from etl.config import OWID_ENV, OWIDEnv
 from etl.db import get_engine, read_sql, to_sql
 from etl.grapher_model import Anomaly
+
+log = structlog.get_logger()
 
 # DB is set up
 DB_IS_SET_UP = STREAMLIT_SECRETS.exists() & WIZARD_DB.exists()
@@ -242,8 +245,10 @@ class WizardDB:
 
     @classmethod
     def load_anomalies(cls, dataset_ids: List[int], _owid_env: OWIDEnv = OWID_ENV) -> List[Anomaly]:
+        t = time.time()
         with Session(_owid_env.engine) as s:
             anomalies = Anomaly.load_anomalies(s, dataset_ids)
+        log.info("load_anomalies", t=time.time() - t)
         return anomalies
 
 

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -680,9 +680,11 @@ class Dataset(Base):
         return read_sql(query, session)
 
     @classmethod
-    def load_all_datasets(cls) -> pd.DataFrame:
+    def load_all_datasets(cls, columns: Optional[list[str]] = None) -> pd.DataFrame:
         """Get all the content of the grapher `datasets` table in DB as a dataframe."""
-        return read_sql("select * from datasets")
+        if not columns:
+            columns = ["*"]
+        return read_sql(f"select {','.join(columns)} from datasets")
 
 
 class SourceDescription(TypedDict, total=False):


### PR DESCRIPTION
- Persist selected datasets and filter values in the URL
- Display anomalies from DB at startup (don't wait for a click on "Detect anomalies")
- A couple of small performance optimizations