### PR TITLE
 :sparkles: Add errors to chart-sync

### DIFF
--- a/apps/chart_sync/admin_api.py
+++ b/apps/chart_sync/admin_api.py
@@ -54,7 +54,8 @@ class AdminAPI(object):
             json=chart_config,
         )
         js = self._json_from_response(resp)
-        assert js["success"]
+        if not js["success"]:
+            raise AdminAPIError({"error": js["error"], "chart_config": chart_config})
         return js
 
     def update_chart(self, chart_id: int, chart_config: dict) -> dict:
@@ -64,7 +65,8 @@ class AdminAPI(object):
             json=chart_config,
         )
         js = self._json_from_response(resp)
-        assert js["success"]
+        if not js["success"]:
+            raise AdminAPIError({"error": js["error"], "chart_config": chart_config})
         return js
 
     def set_tags(self, chart_id: int, tags: List[Dict[str, Any]]) -> dict:
@@ -74,7 +76,8 @@ class AdminAPI(object):
             json={"tags": tags},
         )
         js = self._json_from_response(resp)
-        assert js["success"]
+        if not js["success"]:
+            raise AdminAPIError({"error": js["error"], "tags": tags})
         return js
 
     def put_grapher_config(self, variable_id: int, grapher_config: Dict[str, Any]) -> dict:
@@ -90,6 +93,7 @@ class AdminAPI(object):
         js = self._json_from_response(resp)
         if not js["success"]:
             raise AdminAPIError({"error": js["error"], "variable_id": variable_id, "grapher_config": grapher_config})
+<<<<<<< Updated upstream
         return js
 
     def delete_grapher_config(self, variable_id: int) -> dict:
@@ -115,6 +119,19 @@ def create_session_id(owid_env: OWIDEnv, grapher_user_id: Optional[int] = None) 
         session.commit()
 
     return session_id
+=======
+        return js
+
+    def delete_grapher_config(self, variable_id: int) -> dict:
+        resp = requests.delete(
+            self.owid_env.admin_api + f"/variables/{variable_id}/grapherConfigETL",
+            cookies={"sessionid": self.session_id},
+        )
+        js = self._json_from_response(resp)
+        if not js["success"]:
+            raise AdminAPIError({"error": js["error"], "variable_id": variable_id})
+        return js
+>>>>>>> Stashed changes
 
 
 def requests_with_retry() -> requests.Session:

--- a/apps/chart_sync/admin_api.py
+++ b/apps/chart_sync/admin_api.py
@@ -93,7 +93,6 @@ class AdminAPI(object):
         js = self._json_from_response(resp)
         if not js["success"]:
             raise AdminAPIError({"error": js["error"], "variable_id": variable_id, "grapher_config": grapher_config})
-<<<<<<< Updated upstream
         return js
 
     def delete_grapher_config(self, variable_id: int) -> dict:
@@ -102,7 +101,8 @@ class AdminAPI(object):
             cookies={"sessionid": self.session_id},
         )
         js = self._json_from_response(resp)
-        assert js["success"]
+        if not js["success"]:
+            raise AdminAPIError({"error": js["error"], "variable_id": variable_id})
         return js
 
 
@@ -119,19 +119,6 @@ def create_session_id(owid_env: OWIDEnv, grapher_user_id: Optional[int] = None) 
         session.commit()
 
     return session_id
-=======
-        return js
-
-    def delete_grapher_config(self, variable_id: int) -> dict:
-        resp = requests.delete(
-            self.owid_env.admin_api + f"/variables/{variable_id}/grapherConfigETL",
-            cookies={"sessionid": self.session_id},
-        )
-        js = self._json_from_response(resp)
-        if not js["success"]:
-            raise AdminAPIError({"error": js["error"], "variable_id": variable_id})
-        return js
->>>>>>> Stashed changes
 
 
 def requests_with_retry() -> requests.Session:

--- a/apps/chart_sync/cli.py
+++ b/apps/chart_sync/cli.py
@@ -11,12 +11,14 @@ from slack_sdk import WebClient
 from sqlalchemy.orm import Session
 
 from apps.chart_sync.admin_api import AdminAPI
-from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiff, ChartDiffsLoader
+from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiff, ChartDiffsLoader, configs_are_equal
 from apps.wizard.utils import get_staging_creation_time
 from etl import config
 from etl import grapher_model as gm
 from etl.config import OWIDEnv, get_container_name
 from etl.datadiff import _dict_diff
+
+config.enable_bugsnag()
 
 log = structlog.get_logger()
 
@@ -158,7 +160,7 @@ def cli(
                 # Chart in target exists, update it
                 if diff.target_chart:
                     # Configs are equal, no need to update
-                    if diff.configs_are_equal():
+                    if configs_are_equal(migrated_config, diff.target_chart.config):
                         log.info(
                             "chart_sync.skip",
                             slug=diff.target_chart.slug,

--- a/apps/owidbot/chart_diff.py
+++ b/apps/owidbot/chart_diff.py
@@ -24,6 +24,9 @@ def create_check_run(repo_name: str, branch: str, charts_df: pd.DataFrame, dry_r
     if charts_df.empty:
         conclusion = "neutral"
         title = "No charts for review"
+    elif charts_df[~charts_df.is_rejected].error.any():
+        conclusion = "failure"
+        title = "Some charts have errors"
     elif charts_df.is_reviewed.all():
         conclusion = "success"
         title = "All charts are reviewed"
@@ -50,7 +53,7 @@ def run(branch: str, charts_df: pd.DataFrame) -> str:
 
     chart_diff = format_chart_diff(charts_df)
 
-    if charts_df.error.any():
+    if charts_df[~charts_df.is_rejected].error.any():
         status = "⚠️"
     elif charts_df.empty or charts_df.is_reviewed.all():
         status = "✅"

--- a/apps/owidbot/chart_diff.py
+++ b/apps/owidbot/chart_diff.py
@@ -50,9 +50,9 @@ def run(branch: str, charts_df: pd.DataFrame) -> str:
 
     chart_diff = format_chart_diff(charts_df)
 
-    if charts_df.errors.any():
+    if charts_df.error.any():
         status = "⚠️"
-    if charts_df.empty or charts_df.is_reviewed.all():
+    elif charts_df.empty or charts_df.is_reviewed.all():
         status = "✅"
     else:
         status = "❌"

--- a/apps/owidbot/chart_diff.py
+++ b/apps/owidbot/chart_diff.py
@@ -86,8 +86,9 @@ def format_chart_diff(df: pd.DataFrame) -> str:
     if df.empty:
         return "No charts for review."
 
-    new = df[df.is_new]
-    modified = df[~df.is_new]
+    rejected = df[df.is_rejected]
+    new = df[df.is_new & ~df.is_rejected]
+    modified = df[~df.is_new & ~df.is_rejected]
 
     # Total charts
     num_charts = len(df)
@@ -101,6 +102,9 @@ def format_chart_diff(df: pd.DataFrame) -> str:
     num_charts_new = len(new)
     num_charts_new_reviewed = new.is_reviewed.sum()
 
+    # Rejected charts
+    num_charts_rejected = len(rejected)
+
     # Errors
     if df.error.any():
         errors = f"<li>Errors: {df.error.notnull().sum()}</li>"
@@ -113,6 +117,7 @@ def format_chart_diff(df: pd.DataFrame) -> str:
     <ul>
         <li>Modified: {num_charts_modified_reviewed}/{num_charts_modified}</li>
         <li>New: {num_charts_new_reviewed}/{num_charts_new}</li>
+        <li>Rejected: {num_charts_rejected}</li>
         {errors}
     </ul>
 </ul>

--- a/apps/owidbot/chart_diff.py
+++ b/apps/owidbot/chart_diff.py
@@ -102,7 +102,7 @@ def format_chart_diff(df: pd.DataFrame) -> str:
     num_charts_new_reviewed = new.is_reviewed.sum()
 
     # Errors
-    if df.errors.any():
+    if df.error.any():
         errors = f"<li>Errors: {df.errors.notnull().sum()}</li>"
     else:
         errors = ""

--- a/apps/owidbot/chart_diff.py
+++ b/apps/owidbot/chart_diff.py
@@ -103,7 +103,7 @@ def format_chart_diff(df: pd.DataFrame) -> str:
 
     # Errors
     if df.error.any():
-        errors = f"<li>Errors: {df.errors.notnull().sum()}</li>"
+        errors = f"<li>Errors: {df.error.notnull().sum()}</li>"
     else:
         errors = ""
 

--- a/apps/owidbot/chart_diff.py
+++ b/apps/owidbot/chart_diff.py
@@ -50,6 +50,8 @@ def run(branch: str, charts_df: pd.DataFrame) -> str:
 
     chart_diff = format_chart_diff(charts_df)
 
+    if charts_df.errors.any():
+        status = "⚠️"
     if charts_df.empty or charts_df.is_reviewed.all():
         status = "✅"
     else:
@@ -99,12 +101,19 @@ def format_chart_diff(df: pd.DataFrame) -> str:
     num_charts_new = len(new)
     num_charts_new_reviewed = new.is_reviewed.sum()
 
+    # Errors
+    if df.errors.any():
+        errors = f"<li>Errors: {df.errors.notnull().sum()}</li>"
+    else:
+        errors = ""
+
     return f"""
 <ul>
     <li>{num_charts_reviewed}/{num_charts} reviewed charts</li>
     <ul>
         <li>Modified: {num_charts_modified_reviewed}/{num_charts_modified}</li>
         <li>New: {num_charts_new_reviewed}/{num_charts_new}</li>
+        {errors}
     </ul>
 </ul>
     """.strip()

--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -74,7 +74,12 @@ def get_chart_diffs():
 
     # Sort charts
     st.session_state.chart_diffs = dict(
-        sorted(st.session_state.chart_diffs.items(), key=lambda item: item[1].latest_update, reverse=True)
+        sorted(
+            st.session_state.chart_diffs.items(),
+            # put errors first
+            key=lambda item: (item[1].error is not None, item[1].latest_update),
+            reverse=True,
+        )
     )
 
     # Init, can be changed by the toggle

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -248,7 +248,7 @@ class ChartDiff:
         checksums_diff = cls._get_checksums(source_session, target_session, chart_ids)
 
         # Get all slugs from target
-        slugs_in_target = set(read_sql("SELECT slug FROM chart_slug_redirects", target_session)["slug"]) | {"blablabla"}
+        slugs_in_target = set(read_sql("SELECT slug FROM chart_slug_redirects", target_session)["slug"])
 
         # Build chart diffs
         chart_diffs = []

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -248,7 +248,7 @@ class ChartDiff:
         checksums_diff = cls._get_checksums(source_session, target_session, chart_ids)
 
         # Get all slugs from target
-        slugs_in_target = set(read_sql("SELECT slug FROM chart_slug_redirects", target_session)["slug"])
+        slugs_in_target = cls._get_chart_slugs(target_session)
 
         # Build chart diffs
         chart_diffs = []
@@ -371,6 +371,12 @@ class ChartDiff:
             "is_new": self.is_new,
             "error": self.error,
         }
+
+    @staticmethod
+    def _get_chart_slugs(target_session: Session) -> set[str]:
+        slugs_redirects = set(read_sql("SELECT slug FROM chart_slug_redirects", target_session)["slug"])
+        slugs = set(read_sql("SELECT slug FROM chart_configs", target_session)["slug"])
+        return slugs | slugs_redirects
 
     @staticmethod
     def _get_target_charts(target_session, source_charts):

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -87,6 +87,13 @@ class ChartDiffShow:
             self.openai_api = None
 
     @property
+    def box_icon(self) -> str:
+        """Icon of the expander box."""
+        if self.diff.error:
+            return "⚠️"
+        return DISPLAY_STATE_OPTIONS[cast(str, self.diff.approval_status)]["icon"]
+
+    @property
     def box_label(self):
         """Label of the expander box.
 
@@ -98,6 +105,8 @@ class ChartDiffShow:
             tags.append(" :blue-background[:material/grade: **NEW**]")
         if self.diff.is_draft:
             tags.append(" :gray-background[:material/draft: **DRAFT**]")
+        if self.diff.error:
+            tags.append(" :red-background[:material/error: **ERROR**]")
         for change in self.diff.change_types:
             tags.append(f":red-background[:material/refresh: **{change.upper()} CHANGE**]")
 
@@ -528,7 +537,7 @@ class ChartDiffShow:
         if self.expander:
             with st.expander(
                 label=self.box_label,
-                icon=DISPLAY_STATE_OPTIONS[cast(str, self.diff.approval_status)]["icon"],
+                icon=self.box_icon,
                 expanded=not self.diff.is_reviewed,
             ):
                 self._show()

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -492,6 +492,11 @@ class ChartDiffShow:
         else:
             st.empty()
 
+        if self.diff.error:
+            st.error(f"⚠️ Error: {self.diff.error}")
+        else:
+            st.empty()
+
         # Show controls: status approval, refresh, link
         self._show_chart_diff_controls()
 


### PR DESCRIPTION
Add field `error` to `ChartDiff` object. It's used for errors that cannot be automatically fixed. We just had a case when someone replaced a chart by a different one in production (with different chart id) and kept the same slug. chart-sync tried to create a new chart, but Admin API rejected it because the slug was already taken.

This PRs shows error in chart-sync UI and in owidbot summary if chart-sync would create a new chart, but the slug is already taken.

Other changes:
- Show error messages from AdminAPI
- Enable bugsnag for chart-sync
- Skip charts that were already synced

This is how it looks
<img width="1328" alt="image" src="https://github.com/user-attachments/assets/7a8c167e-b458-47b4-ba03-5f0427dba81c">