### PR TITLE
:sparkles: Prettify Anomalist scores table

### DIFF
--- a/apps/anomalist/cli.py
+++ b/apps/anomalist/cli.py
@@ -113,11 +113,14 @@ def cli(
 
     # If no variable IDs are given, load all variables from the given datasets.
     if not variable_ids:
-        assert not dataset_ids, "Cannot specify both dataset IDs and variable IDs."
-
         # Use new datasets
         if not dataset_ids:
             dataset_ids = load_datasets_new_ids(get_engine())
+
+            # Still no datasets, exit
+            if not dataset_ids:
+                log.info("No new datasets found.")
+                return
 
         # Load all variables from given datasets
         assert not variable_ids, "Cannot specify both dataset IDs and variable IDs."
@@ -126,6 +129,9 @@ def cli(
         where datasetId in %(dataset_ids)s
         """
         variable_ids = list(read_sql(q, get_engine(), params={"dataset_ids": dataset_ids})["id"])
+
+    else:
+        assert not dataset_ids, "Cannot specify both dataset IDs and variable IDs."
 
     anomaly_detection(
         anomaly_types=anomaly_types,

--- a/apps/wizard/app_pages/anomalist/app.py
+++ b/apps/wizard/app_pages/anomalist/app.py
@@ -478,10 +478,14 @@ def _score_table(df: pd.DataFrame, df_all: pd.DataFrame, indicator_id: int) -> p
     df_show = df_show[[c for c in df_show.columns if c != "views"] + ["views"]]
 
     score_cols = [c for c in df_show if "score" in c]
-    df_style = df_show.style.format("{:.2f}", subset=score_cols).background_gradient(
-        subset=score_cols,
-        vmin=0,
-        vmax=1,
+    df_style = (
+        df_show.style.format("{:.2f}", subset=score_cols)
+        .format("{:,.0f}", subset=["views"])
+        .background_gradient(
+            subset=score_cols,
+            vmin=0,
+            vmax=1,
+        )
     )
 
     return df_style

--- a/apps/wizard/app_pages/anomalist/app.py
+++ b/apps/wizard/app_pages/anomalist/app.py
@@ -360,10 +360,14 @@ def _sort_df(df: pd.DataFrame, sort_strategy: str) -> Tuple[pd.DataFrame, List[s
 
 # Functions to show the anomalies
 @st.fragment
-def show_anomaly_compact(index, df):
+def show_anomaly_compact(index, df, df_all):
     """Show anomaly compactly.
 
     Container with all anomalies of a certain type and for a concrete indicator.
+
+    :param df: DataFrame with a single anomaly type and indicator
+    :param df_all: DataFrame containing all anomalies and indicators. Could be used to enhance
+        the output.
     """
     indicator_id, an_type = index
     row = 0
@@ -431,8 +435,10 @@ def show_anomaly_compact(index, df):
             # Other entities
             with st.container(border=False):
                 st.markdown("**Select** other affected entities")
+
                 st.dataframe(
-                    df[["entity_name"] + st.session_state.anomalist_sorting_columns],
+                    # df[["entity_name"] + st.session_state.anomalist_sorting_columns],
+                    _scores_table(df, df_all, indicator_id),
                     selection_mode=["multi-row"],
                     key=key_table,
                     on_select=lambda df=df, key_table=key_table, key_selection=key_selection: _change_chart_selection(
@@ -454,6 +460,31 @@ def _change_chart_selection(df, key_table, key_selection):
 
     # Update entities in chart
     st.session_state[key_selection] = df.iloc[rows]["entity_name"].tolist()
+
+
+def _score_table(df: pd.DataFrame, df_all: pd.DataFrame, indicator_id: int) -> pd.DataFrame:
+    """Return a table of scores and other useful columns for a given indicator. Return
+    styled dataframe."""
+    # Get scores of anomalies for the same indicator
+    gf = df_all[df_all.indicator_id == indicator_id]
+    gf = gf.pivot(index=["entity_name", "year"], columns=["type"], values=["score"])["score"].add_prefix("score_")
+    gf = gf.groupby(["entity_name"]).max().reset_index()
+
+    # Select columns to display and add scores of all detectors
+    cols = ["entity_name", "score_weighted", "views"]
+    df_show = df[cols].merge(gf, on=["entity_name"], how="left")
+
+    # Put views column at the end
+    df_show = df_show[[c for c in df_show.columns if c != "views"] + ["views"]]
+
+    score_cols = [c for c in df_show if "score" in c]
+    df_style = df_show.style.format("{:.2f}", subset=score_cols).background_gradient(
+        subset=score_cols,
+        vmin=0,
+        vmax=1,
+    )
+
+    return df_style
 
 
 ######################################################################
@@ -732,7 +763,7 @@ if st.session_state.anomalist_df is not None:
 
         # Show items (only current page)
         for item in pagination.get_page_items():
-            show_anomaly_compact(item[0], item[1])
+            show_anomaly_compact(item[0], item[1], df_all=df)
 
         # Show controls only if needed
         if len(items) > items_per_page:

--- a/apps/wizard/app_pages/anomalist/app.py
+++ b/apps/wizard/app_pages/anomalist/app.py
@@ -438,7 +438,7 @@ def show_anomaly_compact(index, df, df_all):
 
                 st.dataframe(
                     # df[["entity_name"] + st.session_state.anomalist_sorting_columns],
-                    _scores_table(df, df_all, indicator_id),
+                    _score_table(df, df_all, indicator_id),
                     selection_mode=["multi-row"],
                     key=key_table,
                     on_select=lambda df=df, key_table=key_table, key_selection=key_selection: _change_chart_selection(

--- a/apps/wizard/app_pages/anomalist/utils.py
+++ b/apps/wizard/app_pages/anomalist/utils.py
@@ -120,7 +120,7 @@ def create_tables(_owid_env: OWIDEnv = OWID_ENV):
     gm.Anomaly.create_table(_owid_env.engine, if_exists="skip")
 
 
-@st.cache_data(show_spinner=False)
+# @st.cache_data(show_spinner=False)
 def get_scores(anomalies: List[gm.Anomaly]) -> pd.DataFrame:
     """Combine and reduce scores dataframe."""
     df = combine_and_reduce_scores_df(anomalies)

--- a/apps/wizard/app_pages/anomalist/utils.py
+++ b/apps/wizard/app_pages/anomalist/utils.py
@@ -120,7 +120,7 @@ def create_tables(_owid_env: OWIDEnv = OWID_ENV):
     gm.Anomaly.create_table(_owid_env.engine, if_exists="skip")
 
 
-# @st.cache_data(show_spinner=False)
+@st.cache_data(show_spinner=False)
 def get_scores(anomalies: List[gm.Anomaly]) -> pd.DataFrame:
     """Combine and reduce scores dataframe."""
     df = combine_and_reduce_scores_df(anomalies)

--- a/docs/guides/sharing-external.md
+++ b/docs/guides/sharing-external.md
@@ -4,7 +4,14 @@ tags:
 ---
 ## Sharing work with external people
 
-Sometimes it's useful to share our work with external people to get feedback before publishing it to the public. Staging servers can be made available to public by creating a branch with `-public` suffix. This will make the staging site available at https://staging-site-my-branch.tail6e23.ts.net.
+Sometimes it's useful to share our work with external people to get feedback before publishing it to the public. Staging servers can be made available to public by creating a branch with `-public` suffix. This will make the staging site available at **https://staging-site-my-branch.tail6e23.ts.net**.
+
+If you work on `my-branch` and create a `my-branch-public` branch, you'll have to sync your charts there with
+```bash
+etl chart-sync my-branch my-branch-public
+```
+If your charts don't appear on `https://staging-site-my-branch-public.tail6e23.ts.net/grapher/xyz`, try triggering manual deploy.
+
 
 ### Sharing explorers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,9 @@ wizard = [
     "plotly>=5.23.0",
     "geographiclib>=2.0",
     "pyproj>=3.6.1",
-    "streamlit-feedback>=0.1.3",]
+    "streamlit-feedback>=0.1.3",
+    "statsmodels>=0.14.4",
+]
 
 [project.scripts]
 etl = 'apps.cli:cli'

--- a/uv.lock
+++ b/uv.lock
@@ -843,6 +843,7 @@ wizard = [
     { name = "geographiclib" },
     { name = "plotly" },
     { name = "pyproj" },
+    { name = "statsmodels" },
     { name = "streamlit" },
     { name = "streamlit-ace" },
     { name = "streamlit-aggrid" },
@@ -937,6 +938,7 @@ requires-dist = [
     { name = "slack-sdk", marker = "extra == 'api'", specifier = ">=3.26.2" },
     { name = "sparqlwrapper", specifier = ">=1.8.5" },
     { name = "sqlalchemy", specifier = ">=2.0.30" },
+    { name = "statsmodels", marker = "extra == 'wizard'", specifier = ">=0.14.4" },
     { name = "streamlit", marker = "extra == 'wizard'", specifier = ">=1.39.0" },
     { name = "streamlit-ace", marker = "extra == 'wizard'", specifier = ">=0.1.1" },
     { name = "streamlit-aggrid", marker = "extra == 'wizard'", specifier = ">=0.3.4.post3" },
@@ -3219,6 +3221,19 @@ wheels = [
 ]
 
 [[package]]
+name = "patsy"
+version = "0.5.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/18/12e76e52d589c4a812a2f1fb2406b486c226b7ac263ac8ef4b5f4bb04058/patsy-0.5.6.tar.gz", hash = "sha256:95c6d47a7222535f84bff7f63d7303f2e297747a598db89cf5c67f0c0c7d2cdb", size = 398011 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/f3/1d311a09c34f14f5973bb0bb0dc3a6e007e1eda90b5492d082689936ca51/patsy-0.5.6-py2.py3-none-any.whl", hash = "sha256:19056886fd8fa71863fa32f0eb090267f21fb74be00f19f5c70b2e9d76c883c6", size = 233945 },
+]
+
+[[package]]
 name = "pdfminer-six"
 version = "20221105"
 source = { registry = "https://pypi.org/simple" }
@@ -4921,6 +4936,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/be/47/1bba49d42d63f4453f0a64a20acbf2d0bd2f5a8cde6a166ee66c074a08f8/starlette-0.36.3.tar.gz", hash = "sha256:90a671733cfb35771d8cc605e0b679d23b992f8dcfad48cc60b38cb29aeb7080", size = 2842113 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/f7/372e3953b6e6fbfe0b70a1bb52612eae16e943f4288516480860fcd4ac41/starlette-0.36.3-py3-none-any.whl", hash = "sha256:13d429aa93a61dc40bf503e8c801db1f1bca3dc706b10ef2434a36123568f044", size = 71481 },
+]
+
+[[package]]
+name = "statsmodels"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/3b/963a015dd8ea17e10c7b0e2f14d7c4daec903baf60a017e756b57953a4bf/statsmodels-0.14.4.tar.gz", hash = "sha256:5d69e0f39060dc72c067f9bb6e8033b6dccdb0bae101d76a7ef0bcc94e898b67", size = 20354802 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/2c/23bf5ad9e8a77c0c8d9750512bff89e32154dea91998114118e0e147ae67/statsmodels-0.14.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7a62f1fc9086e4b7ee789a6f66b3c0fc82dd8de1edda1522d30901a0aa45e42b", size = 10216574 },
+    { url = "https://files.pythonhosted.org/packages/ba/a5/2f09ab918296e534ea5d132e90efac51ae12ff15992d77539bbfca1158fa/statsmodels-0.14.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:46ac7ddefac0c9b7b607eed1d47d11e26fe92a1bc1f4d9af48aeed4e21e87981", size = 9912430 },
+    { url = "https://files.pythonhosted.org/packages/93/6a/b86f8c9b799dc93e5b4a3267eb809843e6328e34248a53496b96f50d732e/statsmodels-0.14.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2a337b731aa365d09bb0eab6da81446c04fde6c31976b1d8e3d3a911f0f1e07b", size = 10444673 },
+    { url = "https://files.pythonhosted.org/packages/78/44/d72c634211797ed07dd8c63ced4ae11debd7a40b24ee80e79346a526194f/statsmodels-0.14.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:631bb52159117c5da42ba94bd94859276b68cab25dc4cac86475bc24671143bc", size = 10811248 },
+    { url = "https://files.pythonhosted.org/packages/35/64/df81426924fcc48a0402534efa96cde13275629ae52f123189d16c4b75ff/statsmodels-0.14.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3bb2e580d382545a65f298589809af29daeb15f9da2eb252af8f79693e618abc", size = 10946447 },
+    { url = "https://files.pythonhosted.org/packages/5c/f9/205130cceeda0eebd5a1a58c04e060c2f87a1d63cbbe37a9caa0fcb50c68/statsmodels-0.14.4-cp310-cp310-win_amd64.whl", hash = "sha256:9729642884147ee9db67b5a06a355890663d21f76ed608a56ac2ad98b94d201a", size = 9845796 },
+    { url = "https://files.pythonhosted.org/packages/48/88/326f5f689e69d9c47a68a22ffdd20a6ea6410b53918f9a8e63380dfc181c/statsmodels-0.14.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5ed7e118e6e3e02d6723a079b8c97eaadeed943fa1f7f619f7148dfc7862670f", size = 10221032 },
+    { url = "https://files.pythonhosted.org/packages/07/0b/9a0818be42f6689ebdc7a2277ea984d6299f0809d0e0277128df4f7dc606/statsmodels-0.14.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5f537f7d000de4a1708c63400755152b862cd4926bb81a86568e347c19c364b", size = 9912219 },
+    { url = "https://files.pythonhosted.org/packages/b1/f2/91c70a3b4a3e416f76ead61b04c87bc60080d634d7fa2ab893976bdd86fa/statsmodels-0.14.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa74aaa26eaa5012b0a01deeaa8a777595d0835d3d6c7175f2ac65435a7324d2", size = 10424053 },
+    { url = "https://files.pythonhosted.org/packages/9d/4f/a96e682f82b675e4a6f3de8ad990587d8b1fde500a630a2aabcaabee11d8/statsmodels-0.14.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e332c2d9b806083d1797231280602340c5c913f90d4caa0213a6a54679ce9331", size = 10752529 },
+    { url = "https://files.pythonhosted.org/packages/4b/c6/47549345d32da1530a819a3699f6f34f9f70733a245eeb29f5e05e53f362/statsmodels-0.14.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9c8fa28dfd75753d9cf62769ba1fecd7e73a0be187f35cc6f54076f98aa3f3f", size = 10959003 },
+    { url = "https://files.pythonhosted.org/packages/4b/e4/f9e96896278308e17dfd4f60a84826c48117674c980234ee38f59ab28a12/statsmodels-0.14.4-cp311-cp311-win_amd64.whl", hash = "sha256:a6087ecb0714f7c59eb24c22781491e6f1cfffb660b4740e167625ca4f052056", size = 9853281 },
+    { url = "https://files.pythonhosted.org/packages/f5/99/654fd41a9024643ee70b239e5ebc987bf98ce9fc2693bd550bee58136564/statsmodels-0.14.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5221dba7424cf4f2561b22e9081de85f5bb871228581124a0d1b572708545199", size = 10220508 },
+    { url = "https://files.pythonhosted.org/packages/67/d8/ac30cf4cf97adaa48548be57e7cf02e894f31b45fd55bf9213358d9781c9/statsmodels-0.14.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:17672b30c6b98afe2b095591e32d1d66d4372f2651428e433f16a3667f19eabb", size = 9912317 },
+    { url = "https://files.pythonhosted.org/packages/e0/77/2440d551eaf27f9c1d3650e13b3821a35ad5b21d3a19f62fb302af9203e8/statsmodels-0.14.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab5e6312213b8cfb9dca93dd46a0f4dccb856541f91d3306227c3d92f7659245", size = 10301662 },
+    { url = "https://files.pythonhosted.org/packages/fa/e1/60a652f18996a40a7410aeb7eb476c18da8a39792c7effe67f06883e9852/statsmodels-0.14.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4bbb150620b53133d6cd1c5d14c28a4f85701e6c781d9b689b53681effaa655f", size = 10741763 },
+    { url = "https://files.pythonhosted.org/packages/81/0c/2453eec3ac25e300847d9ed97f41156de145e507391ecb5ac989e111e525/statsmodels-0.14.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb695c2025d122a101c2aca66d2b78813c321b60d3a7c86bb8ec4467bb53b0f9", size = 10879534 },
+    { url = "https://files.pythonhosted.org/packages/59/9a/e466a1b887a1441141e52dbcc98152f013d85076576da6eed2357f2016ae/statsmodels-0.14.4-cp312-cp312-win_amd64.whl", hash = "sha256:7f7917a51766b4e074da283c507a25048ad29a18e527207883d73535e0dc6184", size = 9823866 },
+    { url = "https://files.pythonhosted.org/packages/31/f8/2662e6a101315ad336f75168fa9bac71f913ebcb92a6be84031d84a0f21f/statsmodels-0.14.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b5a24f5d2c22852d807d2b42daf3a61740820b28d8381daaf59dcb7055bf1a79", size = 10186886 },
+    { url = "https://files.pythonhosted.org/packages/fa/c0/ee6e8ed35fc1ca9c7538c592f4974547bf72274bc98db1ae4a6e87481a83/statsmodels-0.14.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df4f7864606fa843d7e7c0e6af288f034a2160dba14e6ccc09020a3cf67cb092", size = 9880066 },
+    { url = "https://files.pythonhosted.org/packages/d1/97/3380ca6d8fd66cfb3d12941e472642f26e781a311c355a4e97aab2ed0216/statsmodels-0.14.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91341cbde9e8bea5fb419a76e09114e221567d03f34ca26e6d67ae2c27d8fe3c", size = 10283521 },
+    { url = "https://files.pythonhosted.org/packages/fe/2a/55c5b5c5e5124a202ea3fe0bcdbdeceaf91b4ec6164b8434acb9dd97409c/statsmodels-0.14.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1322286a7bfdde2790bf72d29698a1b76c20b8423a55bdcd0d457969d0041f72", size = 10723228 },
+    { url = "https://files.pythonhosted.org/packages/4f/76/67747e49dc758daae06f33aad8247b718cd7d224f091d2cd552681215bb2/statsmodels-0.14.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e31b95ac603415887c9f0d344cb523889cf779bc52d68e27e2d23c358958fec7", size = 10859503 },
+    { url = "https://files.pythonhosted.org/packages/1d/eb/cb8b01f5edf8f135eb3d0553d159db113a35b2948d0e51eeb735e7ae09ea/statsmodels-0.14.4-cp313-cp313-win_amd64.whl", hash = "sha256:81030108d27aecc7995cac05aa280cf8c6025f6a6119894eef648997936c2dd0", size = 9817574 },
 ]
 
 [[package]]


### PR DESCRIPTION
- Convert z-score to p-value adjusted for multiple hypothesis testing instead of ad-hoc `min(z, 3) / 3`
  - This significantly lowers GP scores
  - Whether to adjust p-value is a question... time series with a lot of points (e.g. cherry blossom) give more reasonable scores, but it could be too low overall
- Prettify table with scores and add columns for all anomalies
   <img width="636" alt="image" src="https://github.com/user-attachments/assets/6f0be579-8265-4ba9-abd1-a9d51f8e873f">
