### PR TITLE
 :sparkles: Convert dtypes to safe types Float64, Int64 and string

### DIFF
--- a/apps/backport/migrate/garden_cookiecutter/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.py
+++ b/apps/backport/migrate/garden_cookiecutter/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.py
@@ -11,7 +11,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     #
     snap = paths.load_snapshot()
-    tb = snap.read().set_index(["country", "year"])
+    tb = snap.read(safe_types=False).set_index(["country", "year"])
 
     #
     # Save outputs.

--- a/apps/wizard/etl_steps/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.py
+++ b/apps/wizard/etl_steps/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("{{cookiecutter.short_name}}")
 
     # Read table from meadow dataset.
-    tb = ds_meadow["{{cookiecutter.short_name}}"].reset_index()
+    tb = ds_meadow.read("{{cookiecutter.short_name}}")
 
     #
     # Process data.

--- a/apps/wizard/etl_steps/cookiecutter/grapher/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.py
+++ b/apps/wizard/etl_steps/cookiecutter/grapher/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     ds_garden = paths.load_dataset("{{cookiecutter.short_name}}")
 
     # Read table from garden dataset.
-    tb = ds_garden["{{cookiecutter.short_name}}"]
+    tb = ds_garden.read("{{cookiecutter.short_name}}")
 
     #
     # Process data.

--- a/default.mk
+++ b/default.mk
@@ -47,7 +47,7 @@ check-default:
 	@git fetch -q origin master
 	@RELATIVE_PATH=$$(pwd | sed "s|^$$(git rev-parse --show-toplevel)/||"); \
 	CHANGED_PY_FILES=$$(git diff --name-only origin/master HEAD -- . && git diff --name-only && git ls-files --others --exclude-standard | grep '\.py'); \
-	CHANGED_PY_FILES=$$(echo "$$CHANGED_PY_FILES" | sed "s|^$$RELATIVE_PATH/||" | grep '\.py' | xargs -I {} sh -c 'test -f {} && echo {}'); \
+	CHANGED_PY_FILES=$$(echo "$$CHANGED_PY_FILES" | sed "s|^$$RELATIVE_PATH/||" | grep '\.py' | xargs -I {} sh -c 'test -f {} && echo {}' | grep -v '{}'); \
 	if [ -n "$$CHANGED_PY_FILES" ]; then \
 		echo "$$CHANGED_PY_FILES" | xargs ruff check --fix; \
 		echo "$$CHANGED_PY_FILES" | xargs ruff format; \

--- a/etl/command.py
+++ b/etl/command.py
@@ -38,6 +38,12 @@ from etl.steps import (
 
 config.enable_bugsnag()
 
+# NOTE: I tried enabling this, but ran into weird errors with unit tests and inconsistencies
+#   with owid libraries. It's better to wait for an official pandas 3.0 release and update
+#   it all at once.
+# Use string[pyarrow] by default, this will become True in pandas 3.0
+# pd.options.future.infer_string = True
+
 # if the number of open files allowed is less than this, increase it
 LIMIT_NOFILE = 4096
 

--- a/etl/data_helpers/geo.py
+++ b/etl/data_helpers/geo.py
@@ -601,7 +601,7 @@ def _add_population_to_dataframe(
 
     # Load population data.
     if ds_population is not None:
-        population = ds_population.read_table("population")
+        population = ds_population.read("population", safe_types=False)
     else:
         population = _load_population()
     population = population.rename(
@@ -1363,7 +1363,7 @@ def make_table_population_daily(ds_population: Dataset, year_min: int, year_max:
     Uses linear interpolation.
     """
     # Load population table
-    population = ds_population.read_table("population")
+    population = ds_population.read("population", safe_types=False)
     # Filter only years of interest
     population = population[(population["year"] >= year_min) & (population["year"] <= year_max)]
     # Create date column

--- a/etl/data_helpers/population.py
+++ b/etl/data_helpers/population.py
@@ -76,7 +76,7 @@ def add_population(
         log.warning(f"Dataset {ds_un_wpp_path} is silently being loaded.")
         # Load granular population dataset
         ds_un_wpp = Dataset(ds_un_wpp_path)
-    pop = ds_un_wpp.read_table("population_granular")  # type: ignore
+    pop = ds_un_wpp.read("population_granular", safe_types=False)  # type: ignore
     # Keep only variant='medium'
     pop = pop[pop["variant"] == "medium"].drop(columns=["variant"])
     # Keep only metric='population'

--- a/etl/grapher_helpers.py
+++ b/etl/grapher_helpers.py
@@ -35,7 +35,9 @@ jinja_env = Environment(
 )
 
 # this might work too pd.api.types.is_integer_dtype(col)
-INT_TYPES = tuple({f"{n}{b}" for n in ("int", "Int", "uint", "UInt") for b in ("8", "16", "32", "64")})
+INT_TYPES = tuple(
+    {f"{n}{b}{p}" for n in ("int", "Int", "uint", "UInt") for b in ("8", "16", "32", "64") for p in ("", "[pyarrow]")}
+)
 
 
 def as_table(df: pd.DataFrame, table: catalog.Table) -> catalog.Table:

--- a/etl/grapher_io.py
+++ b/etl/grapher_io.py
@@ -484,7 +484,7 @@ def variable_data_table_from_catalog(
     tbs = []
     for (ds_path, table_name), variables in to_read.items():
         try:
-            tb = Dataset(DATA_DIR / ds_path).read_table(table_name)
+            tb = Dataset(DATA_DIR / ds_path).read(table_name, safe_types=False)
         except FileNotFoundError as e:
             raise FileNotFoundError(f"Dataset {ds_path} not found in local catalog.") from e
 

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -100,7 +100,7 @@ def grapher_checks(ds: catalog.Dataset, warn_title_public: bool = True) -> None:
                 year = tab["year"]
             else:
                 year = tab.index.get_level_values("year")
-            assert year.dtype in gh.INT_TYPES, f"year must be of an integer type but was: {tab['year'].dtype}"
+            assert year.dtype in gh.INT_TYPES, f"year must be of an integer type but was: {year.dtype}"
         elif {"date", "country"} <= set(tab.all_columns):
             pass
         else:

--- a/etl/scripts/anomalies/detect_anomalies.py
+++ b/etl/scripts/anomalies/detect_anomalies.py
@@ -87,7 +87,7 @@ def load_data_for_dataset_id(dataset_id: int) -> Tuple[pd.DataFrame, List[gm.Var
     #     log.info(f"Loading data from local ETL file: {etl_file}")
     #     ds_etl = catalog.Dataset(etl_file)
     #     if ds_etl.table_names == [ds.shortName]:
-    #         df = pd.DataFrame(ds_etl.read_table(ds.shortName))  # type: ignore
+    #         df = pd.DataFrame(ds_etl.read(ds.shortName))  # type: ignore
     #     # Change column names to variable ids.
     #     df = df.rename(columns={column: ds_variable_ids[column] for column in df.columns if column in ds_variable_ids}, errors="raise").rename(columns={"country": "entity_name"}, errors="raise")
 

--- a/etl/steps/data/garden/agriculture/2023-10-04/share_of_agriculture_in_gdp.py
+++ b/etl/steps/data/garden/agriculture/2023-10-04/share_of_agriculture_in_gdp.py
@@ -11,7 +11,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     #
     snap = paths.load_snapshot()
-    tb = snap.read().set_index(["country", "year"])
+    tb = snap.read(safe_types=False).set_index(["country", "year"])
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/animal_welfare/2024-09-13/fur_laws.py
+++ b/etl/steps/data/garden/animal_welfare/2024-09-13/fur_laws.py
@@ -65,11 +65,11 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset and read its main table.
     ds_meadow = paths.load_dataset("fur_laws")
-    tb = ds_meadow.read_table("fur_laws")
+    tb = ds_meadow.read("fur_laws")
 
     # Load regions dataset and read its main table.
     ds_regions = paths.load_dataset("regions")
-    tb_regions = ds_regions.read_table("regions")
+    tb_regions = ds_regions.read("regions")
 
     #
     # Process data.

--- a/etl/steps/data/garden/artificial_intelligence/2023-06-14/ai_national_strategy.py
+++ b/etl/steps/data/garden/artificial_intelligence/2023-06-14/ai_national_strategy.py
@@ -49,8 +49,8 @@ def run(dest_dir: str) -> None:
     # Process data.
     #
     tb: Table = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
-    tb["released_national_strategy_on_ai"] = tb["released_national_strategy_on_ai"].replace(
-        {0: "In development", 1: "Released"}
+    tb["released_national_strategy_on_ai"] = (
+        tb["released_national_strategy_on_ai"].astype("string").replace({"0": "In development", "1": "Released"})
     )
     df_merged = pd.merge(countries_national_ai, tb, on=["country", "year"], how="outer")
     df_merged.sort_values(by=["year"], inplace=True)

--- a/etl/steps/data/garden/artificial_intelligence/2024-02-05/chess.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-02-05/chess.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("chess.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/garden/artificial_intelligence/2024-02-15/epoch_llms.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-02-15/epoch_llms.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch_llms.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb["training_computation_petaflop"] = tb["Approx Compute (FLOP)"] / 1e15
     tb = tb.drop("Approx Compute (FLOP)", axis=1)
     tb["MMLU avg"] *= 100

--- a/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_adoption.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_adoption.py
@@ -11,7 +11,7 @@ paths = PathFinder(__file__)
 
 def run(dest_dir: str) -> None:
     #
-    # Load inputs.
+    # Load inputs
     #
     # Retrieve snapshots for 2024 and 2023 data.
     snap_2024 = paths.load_snapshot("ai_adoption.csv")
@@ -22,14 +22,14 @@ def run(dest_dir: str) -> None:
     tb_2023 = snap_2023.read()
 
     #
-    # Process data.
+    # Process data
     #
     tb_2023["% of Respondents"] *= 100
     tb_2023 = tb_2023.rename(columns={"Geographic Area": "country", "% of Respondents": "pct_of_respondents"})
     # Select the rows where 'year' is 2021 as 2022 is already in 2024 AI index data
     tb_2021 = tb_2023[tb_2023["Year"] == 2021].copy()
 
-    tb_2024["% of respondents"] = tb_2024["% of respondents"].str.replace("%", "")
+    tb_2024["% of respondents"] = tb_2024["% of respondents"].str.replace("%", "").astype(float)
     tb_2024 = tb_2024.rename(columns={"Geographic Area": "country", "% of respondents": "pct_of_respondents"})
 
     tb_2021.rename(columns={"Geographic Area": "country"}, inplace=True)

--- a/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_bills.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_bills.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ai_bills.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_conferences.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_conferences.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ai_conferences.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_incidents.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_incidents.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ai_incidents.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_investment.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_investment.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ai_investment.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # Read US consumer prices table from garden dataset.
     ds_us_cpi = paths.load_dataset("us_consumer_prices")

--- a/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_jobs.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_jobs.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ai_jobs.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_phds.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_phds.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ai_phds.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_robots.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_robots.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ai_robots.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_strategies.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-06-28/ai_strategies.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ai_strategies.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_aggregates_domain.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_aggregates_domain.meta.yml
@@ -1,6 +1,6 @@
 # NOTE: To learn more about the fields, hover over their names.
 definitions:
-  desc_update: The 2024 data is incomplete and was last updated {TODAY}.
+  desc_update: The 2024 data is incomplete and was last updated {date_accessed}.
   common:
     processing_level: major
     presentation:

--- a/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_aggregates_domain.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_aggregates_domain.py
@@ -1,5 +1,7 @@
 """Generate aggregated table for total yearly and cumulative number of notable AI systems for each domain."""
 
+import datetime as dt
+
 import pandas as pd
 
 from etl.helpers import PathFinder, create_dataset
@@ -87,11 +89,17 @@ def run(dest_dir: str) -> None:
     # Set the index to year and domain
     tb_agg = tb_agg.format(["year", "domain"])
 
+    date_acessed = tb_agg.yearly_count.m.origins[0].date_accessed
+
     #
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb_agg])
+    ds_garden = create_dataset(
+        dest_dir,
+        tables=[tb_agg],
+        yaml_params={"date_accessed": dt.datetime.strptime(date_acessed, "%Y-%m-%d").strftime("%d %B %Y")},
+    )
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_compute_intensive_countries.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_compute_intensive_countries.meta.yml
@@ -1,6 +1,6 @@
 # NOTE: To learn more about the fields, hover over their names.
 definitions:
-  desc_update: The 2024 data is incomplete and was last updated {TODAY}.
+  desc_update: The 2024 data is incomplete and was last updated {date_accessed}.
   common:
     processing_level: major
     presentation:

--- a/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_compute_intensive_countries.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_compute_intensive_countries.py
@@ -1,5 +1,7 @@
 """Generate aggregated table for total yearly and cumulative number of compute intensive AI systems in each country."""
 
+import datetime as dt
+
 import shared as sh
 
 from etl.data_helpers import geo
@@ -47,11 +49,17 @@ def run(dest_dir: str) -> None:
     # Set the index to year and country
     tb_agg = tb_agg.format(["year", "country"])
 
+    date_acessed = tb_agg.yearly_count.m.origins[0].date_accessed
+
     #
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb_agg])
+    ds_garden = create_dataset(
+        dest_dir,
+        tables=[tb_agg],
+        yaml_params={"date_accessed": dt.datetime.strptime(date_acessed, "%Y-%m-%d").strftime("%d %B %Y")},
+    )
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_compute_intensive_domain.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_compute_intensive_domain.meta.yml
@@ -1,6 +1,6 @@
 # NOTE: To learn more about the fields, hover over their names.
 definitions:
-  desc_update: The 2024 data is incomplete and was last updated {TODAY}.
+  desc_update: The 2024 data is incomplete and was last updated {date_accessed}.
   common:
     processing_level: major
     presentation:

--- a/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_compute_intensive_domain.py
+++ b/etl/steps/data/garden/artificial_intelligence/2024-11-03/epoch_compute_intensive_domain.py
@@ -1,5 +1,7 @@
 """Generate aggregated table for total yearly and cumulative number of compute intensive AI systems for each domain."""
 
+import datetime as dt
+
 import shared as sh
 
 from etl.helpers import PathFinder, create_dataset
@@ -40,11 +42,17 @@ def run(dest_dir: str) -> None:
     # Set the index to year and domain
     tb_agg = tb_agg.format(["year", "domain"])
 
+    date_acessed = tb_agg.yearly_count.m.origins[0].date_accessed
+
     #
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb_agg])
+    ds_garden = create_dataset(
+        dest_dir,
+        tables=[tb_agg],
+        yaml_params={"date_accessed": dt.datetime.strptime(date_acessed, "%Y-%m-%d").strftime("%d %B %Y")},
+    )
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
+++ b/etl/steps/data/garden/bgs/2024-07-09/world_mineral_statistics.py
@@ -1053,7 +1053,7 @@ def aggregate_coal(tb: Table) -> Table:
 
     # Visually compare the resulting series with the one from the Statistical Review of World Energy.
     # from etl.paths import DATA_DIR
-    # tb_sr = Dataset(DATA_DIR / "garden/energy_institute/2024-06-20/statistical_review_of_world_energy").read_table("statistical_review_of_world_energy")
+    # tb_sr = Dataset(DATA_DIR / "garden/energy_institute/2024-06-20/statistical_review_of_world_energy").read("statistical_review_of_world_energy")
     # tb_sr = tb_sr[["country", "year", 'coal_production_mt']].rename(columns={"coal_production_mt": "value"})
     # tb_sr["value"] *= 1e6
     # compare = pr.concat([tb_sr.assign(**{"source": "EI"}), tb_coal_sum.assign(**{"source": "BGS"})], ignore_index=True)
@@ -1132,7 +1132,7 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset and read its main table.
     ds_meadow = paths.load_dataset("world_mineral_statistics")
-    tb = ds_meadow.read_table("world_mineral_statistics")
+    tb = ds_meadow.read("world_mineral_statistics", safe_types=False)
 
     # Load regions dataset.
     ds_regions = paths.load_dataset("regions")

--- a/etl/steps/data/garden/biodiversity/2022/living_planet_index.py
+++ b/etl/steps/data/garden/biodiversity/2022/living_planet_index.py
@@ -11,7 +11,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     #
     snap = paths.load_snapshot()
-    tb = snap.read().set_index(["country", "year"])
+    tb = snap.read(safe_types=False).set_index(["country", "year"])
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/biodiversity/2024-01-25/cherry_blossom.py
+++ b/etl/steps/data/garden/biodiversity/2024-01-25/cherry_blossom.py
@@ -12,9 +12,9 @@ paths = PathFinder(__file__)
 def run(dest_dir: str) -> None:
     log.info("cherry_blossom.start")
 
-    # read dataset from meadow
+    # Read dataset from meadow.
     ds_meadow = paths.load_dataset("cherry_blossom")
-    tb = ds_meadow["cherry_blossom"].reset_index()
+    tb = ds_meadow.read("cherry_blossom")
 
     # Calculate a 20,40 and 50 year average
     tb = calculate_multiple_year_average(tb)

--- a/etl/steps/data/garden/biodiversity/2024-08-12/invasive_species.py
+++ b/etl/steps/data/garden/biodiversity/2024-08-12/invasive_species.py
@@ -16,10 +16,10 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("invasive_species")
 
     # Read table from meadow dataset.
-    tb_cont = ds_meadow["continental"].reset_index()
+    tb_cont = ds_meadow.read("continental")
     tb_cont = tb_cont.rename(columns={"continent": "country"})
 
-    tb_glob = ds_meadow["global"].reset_index()
+    tb_glob = ds_meadow.read("global")
     # Combine the global and continental datasets
     tb = pr.concat([tb_cont, tb_glob])
     # Not clear from the paper what this group includes, and there aren't many of them so I'll drop it for now

--- a/etl/steps/data/garden/biodiversity/2024-09-30/living_planet_index_completeness.py
+++ b/etl/steps/data/garden/biodiversity/2024-09-30/living_planet_index_completeness.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("living_planet_index_completeness")
 
     # Read table from meadow dataset.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/garden/biodiversity/2024-09-30/living_planet_index_share.py
+++ b/etl/steps/data/garden/biodiversity/2024-09-30/living_planet_index_share.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("living_planet_index_share")
 
     # Read table from meadow dataset.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/garden/covid/2024-11-05/github_stats.py
+++ b/etl/steps/data/garden/covid/2024-11-05/github_stats.py
@@ -47,24 +47,24 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("github_stats")
 
     # Combine PR & issues tables.
-    tb_issues = ds_meadow.read_table("github_stats_issues")
-    # tb_pr = ds_meadow.read_table("github_stats_pr")
+    tb_issues = ds_meadow.read("github_stats_issues")
+    # tb_pr = ds_meadow.read("github_stats_pr")
     tb_issues = make_table_issues(tb_issues)
 
     # Get list of all comments (including issue/pr description)
-    tb_comments = ds_meadow.read_table("github_stats_issues_comments")
-    tb_comments_pr = ds_meadow.read_table("github_stats_pr_comments")
+    tb_comments = ds_meadow.read("github_stats_issues_comments")
+    tb_comments_pr = ds_meadow.read("github_stats_pr_comments")
     tb_comments = make_table_comments(tb_comments, tb_comments_pr)
 
     # Get the list of all users
-    tb_users = ds_meadow.read_table("github_stats_issues_users")
-    tb_users_pr = ds_meadow.read_table("github_stats_pr_users")
+    tb_users = ds_meadow.read("github_stats_issues_users")
+    tb_users_pr = ds_meadow.read("github_stats_pr_users")
     tb_users = pr.concat([tb_users, tb_users_pr], ignore_index=True)
     tb_users = tb_users.drop_duplicates(subset=["user_id"])
     assert tb_users.user_login.notna().all(), "Some missing usernames!"
 
     # # Commits
-    # tb_commits = ds_meadow.read_table("github_stats_commits")
+    # tb_commits = ds_meadow.read("github_stats_commits")
 
     #
     # Process data.

--- a/etl/steps/data/garden/covid/latest/cases_deaths.py
+++ b/etl/steps/data/garden/covid/latest/cases_deaths.py
@@ -39,7 +39,7 @@ def run(dest_dir: str) -> None:
     ds_population = paths.load_dataset("population")
 
     # Read table from meadow dataset.
-    tb = ds_meadow.read_table("cases_deaths")
+    tb = ds_meadow.read("cases_deaths")
 
     #
     # Process data.
@@ -175,15 +175,15 @@ def discard_rows(tb: Table):
     print("Discarding rows…")
     # For all rows where new_cases or new_deaths is negative, we keep the cumulative value but set
     # the daily change to NA. This also sets the 7-day rolling average to NA for the next 7 days.
-    tb.loc[tb["new_cases"] < 0, "new_cases"] = np.nan
-    tb.loc[tb["new_deaths"] < 0, "new_deaths"] = np.nan
+    tb.loc[tb["new_cases"] < 0, "new_cases"] = pd.NA
+    tb.loc[tb["new_deaths"] < 0, "new_deaths"] = pd.NA
 
     # Custom data corrections
     for ldc in LARGE_DATA_CORRECTIONS:
-        tb.loc[(tb["country"] == ldc[0]) & (tb["date"].astype(str) == ldc[1]), f"new_{ldc[2]}"] = np.nan
+        tb.loc[(tb["country"] == ldc[0]) & (tb["date"].astype(str) == ldc[1]), f"new_{ldc[2]}"] = pd.NA
 
     for ldc in LARGE_DATA_CORRECTIONS_SINCE:
-        tb.loc[(tb["country"] == ldc[0]) & (tb["date"].astype(str) >= ldc[1]), f"new_{ldc[2]}"] = np.nan
+        tb.loc[(tb["country"] == ldc[0]) & (tb["date"].astype(str) >= ldc[1]), f"new_{ldc[2]}"] = pd.NA
 
     # Sort (legacy)
     tb = tb.sort_values(["country", "date"])
@@ -216,8 +216,8 @@ def add_period_aggregates(tb: Table, prefix: str, periods: int):
     )
 
     # Set NaNs where the original data was NaN
-    tb.loc[tb["new_cases"].isnull(), cases_colname] = np.nan
-    tb.loc[tb["new_deaths"].isnull(), deaths_colname] = np.nan
+    tb.loc[tb["new_cases"].isnull(), cases_colname] = pd.NA
+    tb.loc[tb["new_deaths"].isnull(), deaths_colname] = pd.NA
 
     return tb
 
@@ -247,7 +247,7 @@ def add_doubling_days(tb: Table) -> Table:
     for col, spec in DOUBLING_DAYS_SPEC.items():
         value_col = spec["value_col"]
         periods = spec["periods"]
-        tb.loc[tb[value_col] == 0, value_col] = np.nan
+        tb.loc[tb[value_col] == 0, value_col] = pd.NA
         tb[col] = (
             tb.groupby("country", as_index=False)[value_col]
             .pct_change(periods=periods, fill_method=None)
@@ -336,6 +336,8 @@ def add_cfr(tb: Table) -> Table:
         return pd.NA
 
     tb["cfr"] = 100 * tb["total_deaths"] / tb["total_cases"]
+    # 0/0 returns np.nan and not pd.NA which would be more natural for Float64
+    tb["cfr"] = tb["cfr"].mask(np.isnan(tb["cfr"]), pd.NA)
     tb["cfr_100_cases"] = tb.apply(_apply_row_cfr_100, axis=1)
     tb["cfr_100_cases"] = tb["cfr_100_cases"].copy_metadata(tb["cfr"])
 
@@ -348,7 +350,7 @@ def add_cfr(tb: Table) -> Table:
     tb.loc[
         (tb["cfr_short_term"] < 0) | (tb["cfr_short_term"] > 10) | (tb["date"].astype(str) < "2020-09-01"),
         "cfr_short_term",
-    ] = np.nan
+    ] = pd.NA
 
     # Replace inf
     cols = [

--- a/etl/steps/data/garden/covid/latest/cases_deaths.py
+++ b/etl/steps/data/garden/covid/latest/cases_deaths.py
@@ -336,8 +336,6 @@ def add_cfr(tb: Table) -> Table:
         return pd.NA
 
     tb["cfr"] = 100 * tb["total_deaths"] / tb["total_cases"]
-    # 0/0 returns np.nan and not pd.NA which would be more natural for Float64
-    tb["cfr"] = tb["cfr"].mask(np.isnan(tb["cfr"]), pd.NA)
     tb["cfr_100_cases"] = tb.apply(_apply_row_cfr_100, axis=1)
     tb["cfr_100_cases"] = tb["cfr_100_cases"].copy_metadata(tb["cfr"])
 

--- a/etl/steps/data/garden/covid/latest/countries_reporting.py
+++ b/etl/steps/data/garden/covid/latest/countries_reporting.py
@@ -19,8 +19,8 @@ def run(dest_dir: str) -> None:
     ds_vax = paths.load_dataset("vaccinations_global")
 
     # Read table from meadow dataset.
-    tb = ds_meadow.read_table("vaccinations")
-    tb_latest = ds_vax.read_table("vaccinations_global")
+    tb = ds_meadow.read("vaccinations", safe_types=False)
+    tb_latest = ds_vax.read("vaccinations_global", safe_types=False)
 
     # 1/ LATEST DATA
     ## 1.1/ Process main table

--- a/etl/steps/data/garden/covid/latest/covax.py
+++ b/etl/steps/data/garden/covid/latest/covax.py
@@ -17,7 +17,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("covax")
 
     # Read table from meadow dataset.
-    tb = ds_meadow.read_table("covax")
+    tb = ds_meadow.read("covax")
 
     #
     # Process data.

--- a/etl/steps/data/garden/covid/latest/infections_model.py
+++ b/etl/steps/data/garden/covid/latest/infections_model.py
@@ -17,7 +17,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("infections_model")
 
     # Read table from meadow dataset.
-    tb = ds_meadow.read_table("infections_model")
+    tb = ds_meadow.read("infections_model")
 
     #
     # Process data.

--- a/etl/steps/data/garden/covid/latest/shared.py
+++ b/etl/steps/data/garden/covid/latest/shared.py
@@ -84,7 +84,7 @@ def make_table_population_daily(ds_population: Dataset, year_min: int, year_max:
     Uses linear interpolation.
     """
     # Load population table
-    population = ds_population.read_table("population")
+    population = ds_population.read("population")
     # Filter only years of interest
     population = population[(population["year"] >= year_min) & (population["year"] <= year_max)]
     # Create date column
@@ -179,7 +179,7 @@ def make_monotonic(tb: Table, max_removed_rows=10) -> Table:
 
     tb = tb.sort_values("date")
     metrics = ("total_vaccinations", "people_vaccinated", "people_fully_vaccinated")
-    tb[list(metrics)] = tb[list(metrics)].astype(float)
+    tb[list(metrics)] = tb[list(metrics)].astype("float64[pyarrow]")
     for metric in metrics:
         while not tb[metric].ffill().fillna(0).is_monotonic_increasing:
             diff = tb[metric].ffill().shift(-1) - tb[metric].ffill()

--- a/etl/steps/data/garden/covid/latest/vaccinations_us.py
+++ b/etl/steps/data/garden/covid/latest/vaccinations_us.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("vaccinations_us")
 
     # Read table from meadow dataset.
-    tb = ds_meadow["vaccinations_us"].reset_index()
+    tb = ds_meadow.read("vaccinations_us")
 
     #
     # Process data.

--- a/etl/steps/data/garden/democracy/2024-03-07/bmr.py
+++ b/etl/steps/data/garden/democracy/2024-03-07/bmr.py
@@ -310,15 +310,15 @@ def add_years_in_democracy(tb: Table) -> Table:
         - num_years_in_democracy_ws: Total number of years in democracy with women's suffrage.
     """
     ### Count the number of years since the country first became a democracy. Transition NaN -> 1 is considered as 0 -> 1.
-    tb["num_years_in_democracy_consecutive"] = tb.groupby(["country", tb["regime"].fillna(0).eq(0).cumsum()])[
-        "regime"
-    ].cumsum()
+    tb["num_years_in_democracy_consecutive"] = tb.groupby(
+        ["country", tb["regime"].fillna(0).eq(0).astype(int).cumsum()]
+    )["regime"].cumsum()
     tb["num_years_in_democracy_consecutive"] = tb["num_years_in_democracy_consecutive"].astype(float)
     tb["num_years_in_democracy"] = tb.groupby("country")["regime"].cumsum()
     ## Add democracy age (including women's suffrage) / experience
     ### Count the number of years since the country first became a democracy. Transition NaN -> 1 is considered as 0 -> 1.
     tb["num_years_in_democracy_ws_consecutive"] = tb.groupby(
-        ["country", tb["regime_womsuffr"].fillna(0).eq(0).cumsum()]
+        ["country", tb["regime_womsuffr"].fillna(0).eq(0).astype(int).cumsum()]
     )["regime_womsuffr"].cumsum()
     tb["num_years_in_democracy_ws_consecutive"] = tb["num_years_in_democracy_ws_consecutive"].astype(float)
     tb["num_years_in_democracy_ws"] = tb.groupby("country")["regime_womsuffr"].cumsum()

--- a/etl/steps/data/garden/democracy/2024-03-07/lexical_index.py
+++ b/etl/steps/data/garden/democracy/2024-03-07/lexical_index.py
@@ -250,7 +250,8 @@ def add_age_and_experience(tb: Table) -> Table:
         # Replace category numbers with labels (age in *)
         mapping = {num: label for num, label in REGIME_LABELS.items() if num <= col[2]}
         mask = (tb[col_age] == 0) | (tb[col_age].isna())
-        tb.loc[mask, col_age] = tb.loc[mask, col[0]].replace(mapping)
+        tb[col_age] = tb[col_age].astype(object)
+        tb.loc[mask, col_age] = tb.loc[mask, col[0]].astype(object).replace(mapping)
 
     return tb
 

--- a/etl/steps/data/garden/demography/2022-12-08/population/__init__.py
+++ b/etl/steps/data/garden/demography/2022-12-08/population/__init__.py
@@ -13,6 +13,7 @@ Four sources are used overall:
         Provides data on former countries, and complements other sources with data on missing years for some countries.
         More on this dataset please refer to module gapminder_sg.
 """
+
 import os
 from copy import deepcopy
 from typing import List, cast

--- a/etl/steps/data/garden/demography/2024-07-18/population_doubling_times.py
+++ b/etl/steps/data/garden/demography/2024-07-18/population_doubling_times.py
@@ -8,6 +8,7 @@ NOTE 1: For now, this step and its Grapher counterpart are only capturing this d
 NOTE 2: In the future, we might want to have other countries and regions in this dataset. In that scenario, please review all the code below and Grapher's.
 
 """
+
 from typing import cast
 
 import numpy as np
@@ -130,7 +131,7 @@ def get_target_years(tb: Table) -> Table:
     ## 2. Check if the sign of the population error changes (from negative to positive)
     ## Keep start and end year of target-crossing
     ## Tag target-crossing with a number (so that we know that the start- and end-years belong to the same target-crossing)
-    tb["target_crossing"] = np.sign(tb["population_error"]).diff() > 0
+    tb["target_crossing"] = np.sign(tb["population_error"]).diff().fillna(0) > 0
     tb["target_crossing"] = np.where(tb["target_crossing"], tb["target_crossing"].cumsum(), 0)
     tb["target_crossing"] = tb["target_crossing"] + tb["target_crossing"].shift(-1).fillna(0)
 

--- a/etl/steps/data/garden/education/2017-09-30/public_expenditure.py
+++ b/etl/steps/data/garden/education/2017-09-30/public_expenditure.py
@@ -11,7 +11,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     #
     snap = paths.load_snapshot()
-    tb = snap.read().set_index(["country", "year"])
+    tb = snap.read(safe_types=False).set_index(["country", "year"])
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/education/2018-04-18/literacy_rates.py
+++ b/etl/steps/data/garden/education/2018-04-18/literacy_rates.py
@@ -11,7 +11,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     #
     snap = paths.load_snapshot()
-    tb = snap.read().set_index(["country", "year"])
+    tb = snap.read(safe_types=False).set_index(["country", "year"])
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/ember/2024-05-08/yearly_electricity.py
+++ b/etl/steps/data/garden/ember/2024-05-08/yearly_electricity.py
@@ -7,6 +7,7 @@ version, where data needed to be combined with the European Electricity Review).
 from typing import Dict
 
 import owid.catalog.processing as pr
+import pandas as pd
 from owid.catalog import Dataset, Table, utils
 from structlog import get_logger
 
@@ -452,10 +453,11 @@ def run(dest_dir: str) -> None:
     # Therefore, we make nan all aggregate data in all yearly electricity tables prior to 2000.
     for table_name in tables:
         for column in tables[table_name].columns:
-            tables[table_name][
+            tables[table_name].loc[
                 (tables[table_name].index.get_level_values(0).isin(geo.REGIONS))
-                & (tables[table_name].index.get_level_values(1) < 2000)
-            ] = None
+                & (tables[table_name].index.get_level_values(1) < 2000),
+                :,
+            ] = pd.NA
     ####################################################################################################################
 
     # Combine all tables into one.

--- a/etl/steps/data/garden/eth/2023-03-15/ethnic_power_relations.py
+++ b/etl/steps/data/garden/eth/2023-03-15/ethnic_power_relations.py
@@ -251,10 +251,7 @@ def run(dest_dir: str) -> None:
     ds_meadow: Dataset = paths.load_dependency("growup")
 
     # Read table from meadow dataset.
-    tb_meadow = ds_meadow["growup"]
-
-    # Create a dataframe with data from the table.
-    df = pd.DataFrame(tb_meadow).reset_index()
+    df = pd.DataFrame(ds_meadow.read("growup", safe_types=False))
 
     #
     # Process data.

--- a/etl/steps/data/garden/faostat/2024-03-14/faostat_food_explorer.py
+++ b/etl/steps/data/garden/faostat/2024-03-14/faostat_food_explorer.py
@@ -498,7 +498,7 @@ def process_combined_data(tb: Table, ds_population: Dataset) -> Table:
     # Fill gaps in OWID population with FAO population (for "* (FAO)" countries, i.e. countries that were not
     # harmonized and for which there is no OWID population).
     # Then drop "fao_population", since it is no longer needed.
-    tb_wide["population"] = tb_wide["population"].fillna(tb_wide["fao_population"])
+    tb_wide["population"] = tb_wide["population"].astype("Float64").fillna(tb_wide["fao_population"]).astype("Float64")
     tb_wide = tb_wide.drop(columns="fao_population")
 
     assert len(tb_wide.columns[tb_wide.isnull().all(axis=0)]) == 0, "Unexpected columns with only nan values."

--- a/etl/steps/data/garden/gapminder/2019-05-25/fertility_rate.py
+++ b/etl/steps/data/garden/gapminder/2019-05-25/fertility_rate.py
@@ -11,7 +11,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     #
     snap = paths.load_snapshot()
-    tb = snap.read().set_index(["country", "year"])
+    tb = snap.read(safe_types=False).set_index(["country", "year"])
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/gcp/2024-11-13/global_carbon_budget.py
+++ b/etl/steps/data/garden/gcp/2024-11-13/global_carbon_budget.py
@@ -150,11 +150,11 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset and read all its tables.
     ds_meadow = paths.load_dataset("global_carbon_budget")
-    tb_co2 = ds_meadow.read_table("global_carbon_budget_fossil_co2_emissions")
-    tb_historical = ds_meadow.read_table("global_carbon_budget_historical_budget")
-    tb_consumption = ds_meadow.read_table("global_carbon_budget_consumption_emissions")
-    tb_production = ds_meadow.read_table("global_carbon_budget_production_emissions")
-    tb_land_use = ds_meadow.read_table("global_carbon_budget_land_use_change")
+    tb_co2 = ds_meadow.read("global_carbon_budget_fossil_co2_emissions", safe_types=False)
+    tb_historical = ds_meadow.read("global_carbon_budget_historical_budget", safe_types=False)
+    tb_consumption = ds_meadow.read("global_carbon_budget_consumption_emissions", safe_types=False)
+    tb_production = ds_meadow.read("global_carbon_budget_production_emissions", safe_types=False)
+    tb_land_use = ds_meadow.read("global_carbon_budget_land_use_change", safe_types=False)
 
     # Load primary energy consumption dataset and read its main table.
     ds_energy = paths.load_dataset("primary_energy_consumption")

--- a/etl/steps/data/garden/growth/2024-05-16/gdp_historical.py
+++ b/etl/steps/data/garden/growth/2024-05-16/gdp_historical.py
@@ -179,7 +179,7 @@ def create_estimations_from_growth(
             tb[f"{var}_estimated"] = to_adjust_value * tb[f"{var}_scalar"]
 
             # Rename the estimated variables without the suffix
-            tb[f"{var}"] = tb[f"{var}{to_adjust_var_suffix}"].fillna(tb[f"{var}_estimated"])
+            tb[f"{var}"] = tb[f"{var}{to_adjust_var_suffix}"].astype("Float64").fillna(tb[f"{var}_estimated"])
 
     # Specify "World" entity for each row
     tb["country"] = "World"

--- a/etl/steps/data/garden/happiness/2024-06-09/happiness.py
+++ b/etl/steps/data/garden/happiness/2024-06-09/happiness.py
@@ -29,8 +29,8 @@ def run(dest_dir: str) -> None:
     ds_income_groups = paths.load_dataset("income_groups")
 
     # Read table datasets.
-    tb_this_year = ds_meadow["happiness"].reset_index()
-    tb_prev_years = ds_prev_years["happiness"]
+    tb_this_year = ds_meadow.read("happiness")
+    tb_prev_years = ds_prev_years.read("happiness")
 
     # combine meadow data with previous years
     tb_this_year["cantril_ladder_score"] = tb_this_year["ladder_score"]

--- a/etl/steps/data/garden/ihme_gbd/2024-05-20/gbd_risk.py
+++ b/etl/steps/data/garden/ihme_gbd/2024-05-20/gbd_risk.py
@@ -26,7 +26,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("gbd_risk")
 
     # Read table from meadow dataset.
-    tb = ds_meadow.read_table("gbd_risk", reset_index=True)
+    tb = ds_meadow.read("gbd_risk", reset_index=True)
     ds_regions = paths.load_dataset("regions")
     #
     # Process data.

--- a/etl/steps/data/garden/irena/2024-10-29/renewable_power_generation_costs.py
+++ b/etl/steps/data/garden/irena/2024-10-29/renewable_power_generation_costs.py
@@ -13,8 +13,8 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset and read its tables.
     ds_meadow = paths.load_dataset("renewable_power_generation_costs")
-    tb = ds_meadow.read_table("renewable_power_generation_costs")
-    tb_solar_pv = ds_meadow.read_table("solar_photovoltaic_module_prices", reset_index=False)
+    tb = ds_meadow.read("renewable_power_generation_costs")
+    tb_solar_pv = ds_meadow.read("solar_photovoltaic_module_prices", reset_index=False)
 
     #
     # Process data.

--- a/etl/steps/data/garden/irena/2024-11-01/renewable_capacity_statistics.py
+++ b/etl/steps/data/garden/irena/2024-11-01/renewable_capacity_statistics.py
@@ -334,7 +334,7 @@ def run(dest_dir: str) -> None:
     #
     # Load dataset from Meadow and read its main table.
     ds_meadow = paths.load_dataset("renewable_capacity_statistics")
-    tb = ds_meadow.read_table("renewable_capacity_statistics")
+    tb = ds_meadow.read("renewable_capacity_statistics")
 
     # Load regions dataset.
     ds_regions = paths.load_dataset("regions")

--- a/etl/steps/data/garden/irena/2024-11-15/renewable_power_generation_costs.py
+++ b/etl/steps/data/garden/irena/2024-11-15/renewable_power_generation_costs.py
@@ -13,8 +13,8 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset and read its tables.
     ds_meadow = paths.load_dataset("renewable_power_generation_costs")
-    tb = ds_meadow.read_table("renewable_power_generation_costs")
-    tb_solar_pv = ds_meadow.read_table("solar_photovoltaic_module_prices", reset_index=False)
+    tb = ds_meadow.read("renewable_power_generation_costs", safe_types=False)
+    tb_solar_pv = ds_meadow.read("solar_photovoltaic_module_prices", reset_index=False, safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/garden/itopf/2024-10-16/oil_spills.py
+++ b/etl/steps/data/garden/itopf/2024-10-16/oil_spills.py
@@ -30,7 +30,7 @@ def run(dest_dir: str) -> None:
         )
         # set NaN everywhere except start of a decade
         tb.loc[mask, "decadal_" + str(column)] = tb.loc[mask, "decadal_" + str(column)].where(
-            tb.loc[mask, "year"] % 10 == 0, np.nan
+            tb.loc[mask, "year"].astype(int) % 10 == 0, np.nan
         )
 
     # Replace any '__' in column names with a space (done because of double _ in some variable names)

--- a/etl/steps/data/garden/iucn/2022-12-08/threatened_and_evaluated_species.py
+++ b/etl/steps/data/garden/iucn/2022-12-08/threatened_and_evaluated_species.py
@@ -11,7 +11,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     #
     snap = paths.load_snapshot()
-    tb = snap.read().set_index(["country", "year"])
+    tb = snap.read(safe_types=False).set_index(["country", "year"])
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/lgbt_rights/2023-04-27/lgbti_policy_index.py
+++ b/etl/steps/data/garden/lgbt_rights/2023-04-27/lgbti_policy_index.py
@@ -56,7 +56,7 @@ def run(dest_dir: str) -> None:
     ds_population = paths.load_dataset("population")
 
     # Read table from meadow dataset.
-    tb = ds_meadow["lgbti_policy_index"].reset_index()
+    tb = ds_meadow.read("lgbti_policy_index")
 
     #
     # Process data.

--- a/etl/steps/data/garden/minerals/2024-07-15/minerals.py
+++ b/etl/steps/data/garden/minerals/2024-07-15/minerals.py
@@ -627,7 +627,7 @@ def combine_data(
 
     # # Visually compare the resulting Coal and Oil global data with the ones from the Statistical Review of World Energy.
     # from etl.paths import DATA_DIR
-    # tb_sr = Dataset(DATA_DIR / "garden/energy_institute/2024-06-20/statistical_review_of_world_energy").read_table("statistical_review_of_world_energy")
+    # tb_sr = Dataset(DATA_DIR / "garden/energy_institute/2024-06-20/statistical_review_of_world_energy").read("statistical_review_of_world_energy")
     # tb_sr = tb_sr[tb_sr["country"]=="World"][["country", "year", 'coal_production_mt', 'oil_production_mt']].rename(columns={"coal_production_mt": "production|Coal|Mine|tonnes", "oil_production_mt": "production|Petroleum|Crude|tonnes"})
     # tb_sr[["production|Coal|Mine|tonnes", "production|Petroleum|Crude|tonnes"]] *= 1e6
     # for column in ["production|Coal|Mine|tonnes", "production|Petroleum|Crude|tonnes"]:
@@ -703,11 +703,9 @@ def run(dest_dir: str) -> None:
     ds_usgs = paths.load_dataset("mineral_commodity_summaries")
 
     # Read tables.
-    tb_usgs_historical_flat = ds_usgs_historical.read_table(
-        "historical_statistics_for_mineral_and_material_commodities_flat"
-    )
-    tb_usgs_flat = ds_usgs.read_table("mineral_commodity_summaries_flat")
-    tb_bgs_flat = ds_bgs.read_table("world_mineral_statistics_flat")
+    tb_usgs_historical_flat = ds_usgs_historical.read("historical_statistics_for_mineral_and_material_commodities_flat")
+    tb_usgs_flat = ds_usgs.read("mineral_commodity_summaries_flat")
+    tb_bgs_flat = ds_bgs.read("world_mineral_statistics_flat")
 
     # Load regions dataset.
     # NOTE: It will only be used for sanity checks.

--- a/etl/steps/data/garden/moatsos/2023-10-09/moatsos_historical_poverty.py
+++ b/etl/steps/data/garden/moatsos/2023-10-09/moatsos_historical_poverty.py
@@ -35,7 +35,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("moatsos_historical_poverty")
 
     # Read table from meadow dataset.
-    tb = ds_meadow["moatsos_historical_poverty"].reset_index()
+    tb = ds_meadow.read("moatsos_historical_poverty", safe_types=False)
 
     #
     # Process data.
@@ -113,10 +113,12 @@ def smooth_estimates(tb: Table, poverty_lines: list) -> Table:
 
     # Select decadal years, FIRST_YEAR and LAST_YEAR (HISTORICAL AND FULL)
     tb_smooth = tb_smooth[
-        (tb_smooth["year"] % 10 == 0) | (tb_smooth["year"] == FIRST_YEAR) | (tb_smooth["year"] == LAST_YEAR_HISTORICAL)
+        (tb_smooth["year"].astype(int) % 10 == 0)
+        | (tb_smooth["year"] == FIRST_YEAR)
+        | (tb_smooth["year"] == LAST_YEAR_HISTORICAL)
     ].reset_index(drop=True)
     tb_smooth_cbn = tb_smooth_cbn[
-        (tb_smooth_cbn["year"] % 10 == 0)
+        (tb_smooth_cbn["year"].astype(int) % 10 == 0)
         | (tb_smooth_cbn["year"] == FIRST_YEAR)
         | (tb_smooth_cbn["year"] == LAST_YEAR_FULL)
     ].reset_index(drop=True)

--- a/etl/steps/data/garden/oecd/2024-04-10/income_distribution_database.py
+++ b/etl/steps/data/garden/oecd/2024-04-10/income_distribution_database.py
@@ -72,7 +72,10 @@ def run(dest_dir: str) -> None:
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
     ds_garden = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata
+        dest_dir,
+        tables=[tb],
+        check_variables_metadata=True,
+        default_metadata=ds_meadow.metadata,
     )
 
     # Save changes in the new garden dataset.

--- a/etl/steps/data/garden/oecd/2024-04-30/affordable_housing_database.py
+++ b/etl/steps/data/garden/oecd/2024-04-30/affordable_housing_database.py
@@ -164,8 +164,7 @@ def run(dest_dir: str) -> None:
     tb = pr.merge(tb, tb_strategy, on=["country", "year"], how="outer", short_name=paths.short_name)
 
     # Fill nan in type_of_strategy with Not applicable
-    tb["type_of_strategy"] = tb["type_of_strategy"].astype(str)
-    tb.loc[tb["type_of_strategy"] == "nan", "type_of_strategy"] = "Not applicable"
+    tb["type_of_strategy"] = tb["type_of_strategy"].astype("string").fillna("Not applicable")
 
     tb = tb.format(["country", "year"])
 

--- a/etl/steps/data/garden/papers/2023-10-20/anthromes.py
+++ b/etl/steps/data/garden/papers/2023-10-20/anthromes.py
@@ -259,6 +259,6 @@ def assign_land_use_types(tb: Table) -> Table:
         70: "No land",
     }
 
-    tb["value"] = tb["value"].replace(land_use_dict)
+    tb["value"] = tb["value"].astype(object).replace(land_use_dict)
 
     return tb

--- a/etl/steps/data/garden/state_capacity/2023-10-19/state_capacity_dataset.py
+++ b/etl/steps/data/garden/state_capacity/2023-10-19/state_capacity_dataset.py
@@ -19,7 +19,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("state_capacity_dataset")
 
     # Read table from meadow dataset.
-    tb = ds_meadow["state_capacity_dataset"].reset_index()
+    tb = ds_meadow.read("state_capacity_dataset")
 
     #
     # Process data.
@@ -64,7 +64,7 @@ def run(dest_dir: str) -> None:
 def regional_aggregations(tb: Table) -> Table:
     # Load population data.
     tb_pop = paths.load_dataset("population")
-    tb_pop = tb_pop["population"].reset_index()
+    tb_pop = tb_pop.read("population")
 
     tb_regions = tb.copy()
 

--- a/etl/steps/data/garden/tourism/2024-08-17/unwto_gdp.py
+++ b/etl/steps/data/garden/tourism/2024-08-17/unwto_gdp.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("unwto_gdp")
 
     # Read table from meadow dataset.
-    tb = ds_meadow.read_table("unwto_gdp")
+    tb = ds_meadow.read("unwto_gdp")
     #
     # Process data.
     #

--- a/etl/steps/data/garden/tuberculosis/2023-11-27/budget.py
+++ b/etl/steps/data/garden/tuberculosis/2023-11-27/budget.py
@@ -37,7 +37,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("data_dictionary.csv")
     # Read table from meadow dataset.
     tb = ds_meadow["budget"].reset_index()
-    dd = snap.read()
+    dd = snap.read(safe_types=False)
     # Process data.
     #
     tb = add_variable_description_from_producer(tb, dd)

--- a/etl/steps/data/garden/tuberculosis/2023-11-27/burden_estimates.py
+++ b/etl/steps/data/garden/tuberculosis/2023-11-27/burden_estimates.py
@@ -41,7 +41,7 @@ def run(dest_dir: str) -> None:
     ds_population = paths.load_dataset("population")
 
     # Load data dictionary from snapshot.
-    dd = snap.read()
+    dd = snap.read(safe_types=False)
     # Read table from meadow dataset.
     tb = ds_meadow["burden_estimates"].reset_index()
     tb = tb.drop(columns=["iso2", "iso3", "iso_numeric", "g_whoregion"])

--- a/etl/steps/data/garden/tuberculosis/2023-11-27/drug_resistance_surveillance.py
+++ b/etl/steps/data/garden/tuberculosis/2023-11-27/drug_resistance_surveillance.py
@@ -32,7 +32,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("drug_resistance_surveillance")
     snap = paths.load_snapshot("data_dictionary.csv")
     # Load data dictionary from snapshot.
-    dd = snap.read()
+    dd = snap.read(safe_types=False)
     # Load regions dataset.
     ds_regions = paths.load_dataset("regions")
     # Load income groups dataset.

--- a/etl/steps/data/garden/tuberculosis/2023-11-27/expenditure.py
+++ b/etl/steps/data/garden/tuberculosis/2023-11-27/expenditure.py
@@ -20,7 +20,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("data_dictionary.csv")
     # Read table from meadow dataset.
     tb = ds_meadow["expenditure"].reset_index()
-    dd = snap.read()
+    dd = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/garden/tuberculosis/2023-11-27/laboratories.py
+++ b/etl/steps/data/garden/tuberculosis/2023-11-27/laboratories.py
@@ -38,7 +38,7 @@ def run(dest_dir: str) -> None:
 
     ds_pop = ds_un_wpp["population"].reset_index()
     # Load data dictionary from snapshot.
-    dd = snap.read()
+    dd = snap.read(safe_types=False)
     # Read table from meadow dataset.
     tb = ds_meadow["laboratories"].reset_index()
 

--- a/etl/steps/data/garden/tuberculosis/2023-11-27/notifications.py
+++ b/etl/steps/data/garden/tuberculosis/2023-11-27/notifications.py
@@ -36,7 +36,7 @@ def run(dest_dir: str) -> None:
     # Load income groups dataset.
     ds_income_groups = paths.load_dataset("income_groups")
     # Load data dictionary from snapshot.
-    dd = snap.read()
+    dd = snap.read(safe_types=False)
     # Read table from meadow dataset.
     tb = ds_meadow["notifications"].reset_index()
     #

--- a/etl/steps/data/garden/tuberculosis/2023-11-27/outcomes.py
+++ b/etl/steps/data/garden/tuberculosis/2023-11-27/outcomes.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("outcomes")
     snap = paths.load_snapshot("data_dictionary.csv")
     # Load data dictionary from snapshot.
-    dd = snap.read()
+    dd = snap.read(safe_types=False)
     # Read table from meadow dataset.
     tb = ds_meadow["outcomes"].reset_index()
 

--- a/etl/steps/data/garden/tuberculosis/2023-11-27/unhlm_commitments.py
+++ b/etl/steps/data/garden/tuberculosis/2023-11-27/unhlm_commitments.py
@@ -17,7 +17,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("unhlm_commitments")
     snap = paths.load_snapshot("data_dictionary.csv")
     # Load data dictionary from snapshot.
-    dd = snap.read()
+    dd = snap.read(safe_types=False)
     # Read table from meadow dataset.
     tb = ds_meadow["unhlm_commitments"].reset_index()
 

--- a/etl/steps/data/garden/un/2023-10-02/un_wpp_lt.py
+++ b/etl/steps/data/garden/un/2023-10-02/un_wpp_lt.py
@@ -61,8 +61,15 @@ def run(dest_dir: str) -> None:
     # Rename columns, select columns
     tb = tb.rename(columns=COLUMNS_RENAME)
 
+    # DTypes
+    tb = tb.astype(
+        {
+            "age": str,
+        }
+    )
+
     # Change 100 -> 100+
-    tb.loc[tb["age"] == 100, "age"] = "100+"
+    tb.loc[tb["age"] == "100", "age"] = "100+"
 
     # Scale central death rates
     paths.log.info("scale indicators to make them more.")
@@ -77,13 +84,6 @@ def run(dest_dir: str) -> None:
     # Harmonize sex sex
     tb["sex"] = tb["sex"].map({"Total": "both", "Male": "male", "Female": "female"})
     assert tb["sex"].notna().all(), "NaNs detected after mapping sex values!"
-
-    # DTypes
-    tb = tb.astype(
-        {
-            "age": str,
-        }
-    )
 
     # Set index
     tb = tb.set_index(COLUMNS_INDEX, verify_integrity=True)[COLUMNS_INDICATORS]

--- a/etl/steps/data/garden/un/2023-10-30/un_members.py
+++ b/etl/steps/data/garden/un/2023-10-30/un_members.py
@@ -24,7 +24,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("un_members")
 
     # Read table from meadow dataset.
-    tb = ds_meadow["un_members"].reset_index()
+    tb = ds_meadow.read("un_members")
 
     #
     # Process data.
@@ -66,7 +66,7 @@ def data_processing(tb: Table) -> Table:
     # Create membership_status column, which is "Member" when year is greater or equal to admission year, and "Not a member" otherwise.
     # I copy the admission column first to keep metadata
 
-    tb["membership_status"] = tb["admission"].copy()
+    tb["membership_status"] = tb["admission"].copy().astype(object)
     tb.loc[tb["year"] < tb["admission"], "membership_status"] = "Not a member"
     tb.loc[tb["year"] >= tb["admission"], "membership_status"] = "Member"
 

--- a/etl/steps/data/garden/un/2024-07-16/migrant_stock.py
+++ b/etl/steps/data/garden/un/2024-07-16/migrant_stock.py
@@ -130,17 +130,17 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("migrant_stock")
     # Read tables from meadow dataset.
     # destination and origin table
-    tb_do = ds_meadow.read_table("migrant_stock_dest_origin")
+    tb_do = ds_meadow.read("migrant_stock_dest_origin")
     # destination table, total numbers and shares
-    tb_d_total = ds_meadow.read_table("migrant_stock_dest_total")
-    tb_d_share = ds_meadow.read_table("migrant_stock_dest_share")
+    tb_d_total = ds_meadow.read("migrant_stock_dest_total")
+    tb_d_share = ds_meadow.read("migrant_stock_dest_share")
     # origin table
-    tb_o = ds_meadow.read_table("migrant_stock_origin")
+    tb_o = ds_meadow.read("migrant_stock_origin")
     # table for data by sex and age
-    tb_sa_total = ds_meadow.read_table("migrant_stock_sex_age_total")
-    tb_sa_share = ds_meadow.read_table("migrant_stock_sex_age_share")
+    tb_sa_total = ds_meadow.read("migrant_stock_sex_age_total")
+    tb_sa_share = ds_meadow.read("migrant_stock_sex_age_share")
     # population data
-    tb_pop = ds_meadow.read_table("total_population")
+    tb_pop = ds_meadow.read("total_population")
 
     ## data on destination and origin
     # Remove aggregated regions from the dataset.

--- a/etl/steps/data/garden/un/2024-07-25/refugee_data.py
+++ b/etl/steps/data/garden/un/2024-07-25/refugee_data.py
@@ -21,8 +21,8 @@ def run(dest_dir: str) -> None:
     ds_resettlement = paths.load_dataset("resettlement")
 
     # Read table from meadow dataset.
-    tb = ds_meadow.read_table("refugee_data")
-    tb_resettlement = ds_resettlement.read_table("resettlement")
+    tb = ds_meadow.read("refugee_data")
+    tb_resettlement = ds_resettlement.read("resettlement")
 
     # filter out data before data availability starts (s. https://www.unhcr.org/refugee-statistics/methodology/, "Data publication timeline")
     tb["asylum_seekers"] = tb.apply(lambda x: x["asylum_seekers"] if x["year"] > 1999 else pd.NA, axis=1)

--- a/etl/steps/data/garden/un/2024-07-25/resettlement.py
+++ b/etl/steps/data/garden/un/2024-07-25/resettlement.py
@@ -17,7 +17,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("resettlement")
 
     # Read table from meadow dataset.
-    tb = ds_meadow.read_table("resettlement")
+    tb = ds_meadow.read("resettlement")
 
     # filter out data before data availability starts (s. https://www.unhcr.org/refugee-statistics/methodology/, "Data publication timeline")
     tb["resettlement_arrivals"] = tb.apply(lambda x: x["resettlement_arrivals"] if x["year"] > 1958 else pd.NA, axis=1)

--- a/etl/steps/data/garden/un/2024-08-27/un_sdg.py
+++ b/etl/steps/data/garden/un/2024-08-27/un_sdg.py
@@ -27,7 +27,7 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("un_sdg")
 
     # Read table from meadow dataset.
-    tb_meadow = ds_meadow.read_table("un_sdg")
+    tb_meadow = ds_meadow.read("un_sdg", safe_types=False)
 
     # Create long and short units columns
     tb = create_units(tb_meadow)

--- a/etl/steps/data/garden/unicef/2024-07-30/child_migration.py
+++ b/etl/steps/data/garden/unicef/2024-07-30/child_migration.py
@@ -79,7 +79,7 @@ def run(dest_dir: str) -> None:
     ds_population = paths.load_dataset("population")
 
     # Read table from meadow dataset.
-    tb = ds_meadow.read_table("child_migration")
+    tb = ds_meadow.read("child_migration")
 
     # combine indicator, statistical population and unit columns (to get one indicator per combination)
 

--- a/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
+++ b/etl/steps/data/garden/usgs/2024-07-15/historical_statistics_for_mineral_and_material_commodities.py
@@ -330,7 +330,7 @@ def prepare_us_production(tb: Table, tb_metadata: Table) -> Table:
         mapping={"W": None},
         warn_on_missing_mappings=False,
         warn_on_unused_mappings=True,
-    ).astype({"production": float})
+    ).astype({"production": "float64[pyarrow]"})
     # Add notes to the table, using the extracted metadata.
     for column in ["production"]:
         mask = tb_metadata[column].notnull()
@@ -490,10 +490,8 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("historical_statistics_for_mineral_and_material_commodities")
 
     # Read tables of data and extracted metadata from meadow dataset.
-    tb = ds_meadow.read_table("historical_statistics_for_mineral_and_material_commodities")
-    tb_metadata = ds_meadow.read_table("historical_statistics_for_mineral_and_material_commodities_metadata").astype(
-        "string"
-    )
+    tb = ds_meadow.read("historical_statistics_for_mineral_and_material_commodities")
+    tb_metadata = ds_meadow.read("historical_statistics_for_mineral_and_material_commodities_metadata").astype("string")
 
     #
     # Process data.

--- a/etl/steps/data/garden/war/2023-09-21/cow.py
+++ b/etl/steps/data/garden/war/2023-09-21/cow.py
@@ -681,6 +681,7 @@ def make_table_intra(tb: Table) -> Table:
         tb.groupby("warnum")["intnl"].nunique().max() == 1
     ), "An intra-state conflict is not expected to change between international / non-international!"
     mask = tb["intnl"] == 1
+    tb["conflict_type"] = tb["conflict_type"].astype(object)
     tb.loc[mask, "conflict_type"] = CTYPE_INTRA_INTL
     tb.loc[-mask, "conflict_type"] = CTYPE_INTRA_NINTL
 

--- a/etl/steps/data/garden/war/2024-01-11/nuclear_weapons_proliferation.py
+++ b/etl/steps/data/garden/war/2024-01-11/nuclear_weapons_proliferation.py
@@ -52,6 +52,7 @@ def run(dest_dir: str) -> None:
         .groupby(["status", "year"], as_index=False)
         .count()
         .pivot(index="year", columns="status", join_column_levels_with="_")
+        .rename(columns={"year_<NA>": "year"})
     )
 
     # Rename columns conveniently.

--- a/etl/steps/data/garden/war/2024-08-26/ucdp.py
+++ b/etl/steps/data/garden/war/2024-08-26/ucdp.py
@@ -79,13 +79,13 @@ def run(dest_dir: str) -> None:
 
     # Read table from GW codes
     ds_gw = paths.load_dataset("gleditsch")
-    tb_regions = ds_gw.read_table("gleditsch_regions")
+    tb_regions = ds_gw.read("gleditsch_regions")
     tb_codes = ds_gw["gleditsch_countries"]
 
     # Load maps table
     short_name = "nat_earth_110"
     ds_maps = paths.load_dataset(short_name)
-    tb_maps = ds_maps.read_table(short_name)
+    tb_maps = ds_maps.read(short_name)
 
     # Load population
     ds_population = paths.load_dataset("population")
@@ -98,7 +98,7 @@ def run(dest_dir: str) -> None:
 
     # Load relevant tables
     tb_ged = (
-        ds_meadow.read_table("ucdp_ged")
+        ds_meadow.read("ucdp_ged")
         .reset_index()
         .astype(
             {
@@ -113,7 +113,7 @@ def run(dest_dir: str) -> None:
         )
     )
     tb_conflict = (
-        ds_meadow.read_table("ucdp_battle_related_conflict")
+        ds_meadow.read("ucdp_battle_related_conflict")
         .reset_index()
         .astype(
             {
@@ -123,14 +123,14 @@ def run(dest_dir: str) -> None:
             }
         )
     )
-    tb_prio = ds_meadow.read_table("ucdp_prio_armed_conflict")
+    tb_prio = ds_meadow.read("ucdp_prio_armed_conflict")
 
     # Keep only active conflicts
     paths.log.info("keep active conflicts")
     tb_ged = tb_ged.loc[tb_ged["active_year"] == 1]
 
     # Change region named "Asia" to "Asia and Oceania" (in GED)
-    tb_ged["region"] = tb_ged["region"].cat.rename_categories({"Asia": "Asia and Oceania"})
+    tb_ged["region"] = tb_ged["region"].replace({"Asia": "Asia and Oceania"})
 
     # Create `conflict_type` column
     paths.log.info("add field `conflict_type`")
@@ -350,8 +350,9 @@ def add_conflict_type(tb_ged: Table, tb_conflict: Table) -> Table:
     # Create `conflict_type` column as a combination of `type_of_violence` and `type_of_conflict`.
     tb_ged["conflict_type"] = (
         tb_ged["type_of_conflict"]
+        .astype(object)
         .replace(TYPE_OF_CONFLICT_MAPPING)
-        .fillna(tb_ged["type_of_violence"].replace(TYPE_OF_VIOLENCE_MAPPING))
+        .fillna(tb_ged["type_of_violence"].astype(object).replace(TYPE_OF_VIOLENCE_MAPPING))
     )
 
     # Sanity check
@@ -917,7 +918,7 @@ def estimate_metrics_participants_prio(tb_prio: Table, tb_codes: Table) -> Table
     tb_country["participated_in_conflict"].m.origins = tb_prio["gwno_a"].m.origins
 
     # Format conflict tyep
-    tb_country["conflict_type"] = tb_country["type_of_conflict"].replace(TYPE_OF_CONFLICT_MAPPING)
+    tb_country["conflict_type"] = tb_country["type_of_conflict"].astype(object).replace(TYPE_OF_CONFLICT_MAPPING)
     tb_country = tb_country.drop(columns=["type_of_conflict"])
 
     # Prepare GW table

--- a/etl/steps/data/garden/wb/2017-04-16/world_gdp.py
+++ b/etl/steps/data/garden/wb/2017-04-16/world_gdp.py
@@ -11,7 +11,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     #
     snap = paths.load_snapshot()
-    tb = snap.read().set_index(["country", "year"])
+    tb = snap.read(safe_types=False).set_index(["country", "year"])
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/wb/2022-10-03/extreme_poverty_by_region.py
+++ b/etl/steps/data/garden/wb/2022-10-03/extreme_poverty_by_region.py
@@ -11,7 +11,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     #
     snap = paths.load_snapshot()
-    tb = snap.read().set_index(["country", "year"])
+    tb = snap.read(safe_types=False).set_index(["country", "year"])
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/wb/2022-10-03/world_bank_pip.py
+++ b/etl/steps/data/garden/wb/2022-10-03/world_bank_pip.py
@@ -11,7 +11,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     #
     snap = paths.load_snapshot()
-    tb = snap.read().set_index(["country", "year"])
+    tb = snap.read(safe_types=False).set_index(["country", "year"])
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/wb/2024-09-09/food_prices_for_nutrition.py
+++ b/etl/steps/data/garden/wb/2024-09-09/food_prices_for_nutrition.py
@@ -74,12 +74,12 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset and read its main table.
     ds_meadow = paths.load_dataset("food_prices_for_nutrition")
-    tb = ds_meadow.read_table("food_prices_for_nutrition")
+    tb = ds_meadow.read("food_prices_for_nutrition")
 
     # Load the World Development Indicators (WDI) dataset to get the U.S. Consumer Price Index (CPI),
     # which will be used to correct for inflation and express costs in constant 2021 PPP$.
     ds_wdi = paths.load_dataset("wdi")
-    tb_wdi = ds_wdi.read_table("wdi")
+    tb_wdi = ds_wdi.read("wdi")
 
     #
     # Process data.

--- a/etl/steps/data/garden/who/2022-09-30/ghe.py
+++ b/etl/steps/data/garden/who/2022-09-30/ghe.py
@@ -50,7 +50,7 @@ def run(dest_dir: str) -> None:
     regions = paths.load_dataset("regions")["regions"]
     # Load WHO Standard population
     snap = paths.load_snapshot("standard_age_distribution.csv")
-    who_standard = snap.read()
+    who_standard = snap.read(safe_types=False)
     who_standard = format_who_standard(who_standard)
     # Read population dataset
     ds_population = paths.load_dataset("un_wpp")

--- a/etl/steps/data/garden/who/2023-03-09/gho_suicides.py
+++ b/etl/steps/data/garden/who/2023-03-09/gho_suicides.py
@@ -97,6 +97,8 @@ def process_ratio(df: pd.DataFrame) -> pd.DataFrame:
     df_female = df[df["sex"] == "female"].drop(columns=["sex"])
     # Merge data by year and country
     df_ratio = df_male.merge(df_female, on=["country", "year"], suffixes=("_m", "_f"))
+    # Don't divide by zero
+    df_ratio = df_ratio[df_ratio.suicide_rate_f != 0]
     # Estimate ratio
     df_ratio["suicide_rate_male_to_female"] = df_ratio["suicide_rate_m"] / df_ratio["suicide_rate_f"]
     # Keep only relevant columns

--- a/etl/steps/data/garden/who/2024-07-26/mortality_database.py
+++ b/etl/steps/data/garden/who/2024-07-26/mortality_database.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset.
     ds_meadow = paths.load_dataset("mortality_database")
-    tb = ds_meadow.read_table("mortality_database")
+    tb = ds_meadow.read("mortality_database", safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/garden/who/2024-07-30/ghe.py
+++ b/etl/steps/data/garden/who/2024-07-30/ghe.py
@@ -71,7 +71,7 @@ AGE_GROUPS_MAP = {
 def run(dest_dir: str) -> None:
     # read dataset from meadow
     ds_meadow = paths.load_dataset()
-    tb = ds_meadow.read_table("ghe")
+    tb = ds_meadow.read("ghe")
     tb = tb.drop(columns="flag_level")
 
     tb = rename_table_for_compatibility(tb)
@@ -84,7 +84,7 @@ def run(dest_dir: str) -> None:
     regions = paths.load_dataset("regions")["regions"]
     # Load WHO Standard population
     snap = paths.load_snapshot("standard_age_distribution.csv")
-    who_standard = snap.read()
+    who_standard = snap.read(safe_types=False)
     who_standard = format_who_standard(who_standard)
     # Read population dataset
     ds_population = paths.load_dataset("un_wpp")

--- a/etl/steps/data/garden/who/2024-08-06/mortality_database_cancer.py
+++ b/etl/steps/data/garden/who/2024-08-06/mortality_database_cancer.py
@@ -15,7 +15,8 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset.
     ds_meadow = paths.load_dataset("mortality_database_cancer")
-    tb = ds_meadow.read_table("mortality_database_cancer")
+    tb = ds_meadow.read("mortality_database_cancer", safe_types=False)
+
     #
     # Process data.
     #

--- a/etl/steps/data/garden/who/2024-08-06/mortality_database_cancer_most_common.py
+++ b/etl/steps/data/garden/who/2024-08-06/mortality_database_cancer_most_common.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Load meadow dataset.
     ds_meadow = paths.load_dataset("mortality_database_cancer")
-    tb = ds_meadow.read_table("mortality_database_cancer")
+    tb = ds_meadow.read("mortality_database_cancer")
 
     #
     # Process data.

--- a/etl/steps/data/garden/wid/2024-05-24/world_inequality_database.py
+++ b/etl/steps/data/garden/wid/2024-05-24/world_inequality_database.py
@@ -6,7 +6,6 @@ NOTE: To extract the log of the process (to review sanity checks, for example), 
 
 """
 
-
 import owid.catalog.processing as pr
 from owid.catalog import Table
 from shared import add_metadata_vars, add_metadata_vars_distribution

--- a/etl/steps/data/grapher/animal_welfare/2024-09-13/fur_laws.py
+++ b/etl/steps/data/grapher/animal_welfare/2024-09-13/fur_laws.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset and read its main table.
     ds_garden = paths.load_dataset("fur_laws")
-    tb = ds_garden.read_table("fur_laws")
+    tb = ds_garden.read("fur_laws")
 
     #
     # Process data.

--- a/etl/steps/data/grapher/artificial_intelligence/2024-10-01/epoch.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2024-10-01/epoch.py
@@ -81,7 +81,7 @@ def find_max_label_and_concat(tb, column, label):
     max_value = -float("inf")
     rows_to_keep = []
 
-    for _, row in tb.iterrows():
+    for _, row in tb.dropna(subset=[column]).iterrows():
         if row[column] > max_value:
             max_value = row[column]
             rows_to_keep.append(row)

--- a/etl/steps/data/grapher/artificial_intelligence/2024-11-03/epoch.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2024-11-03/epoch.py
@@ -1,6 +1,7 @@
 """Load a garden dataset and create a grapher dataset."""
 
 import owid.catalog.processing as pr
+import pandas as pd
 from owid.catalog import Table
 
 from etl.helpers import PathFinder, create_dataset, grapher_checks
@@ -82,7 +83,7 @@ def find_max_label_and_concat(tb, column, label):
     rows_to_keep = []
 
     for _, row in tb.iterrows():
-        if row[column] > max_value:
+        if not pd.isna(row[column]) and row[column] > max_value:
             max_value = row[column]
             rows_to_keep.append(row)
 

--- a/etl/steps/data/grapher/climate/2024-07-23/sea_ice_anomalies_by_month.py
+++ b/etl/steps/data/grapher/climate/2024-07-23/sea_ice_anomalies_by_month.py
@@ -110,7 +110,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset.
     ds_garden = paths.load_dataset("sea_ice_index")
-    tb = ds_garden.read_table("sea_ice_index")
+    tb = ds_garden.read("sea_ice_index")
 
     #
     # Process data.

--- a/etl/steps/data/grapher/climate/2024-07-23/sea_ice_extent_by_decade.py
+++ b/etl/steps/data/grapher/climate/2024-07-23/sea_ice_extent_by_decade.py
@@ -148,7 +148,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset.
     ds_garden = paths.load_dataset("sea_ice_index")
-    tb = ds_garden.read_table("sea_ice_index")
+    tb = ds_garden.read("sea_ice_index")
 
     #
     # Process data.

--- a/etl/steps/data/grapher/climate/2024-07-23/sea_ice_extent_by_year.py
+++ b/etl/steps/data/grapher/climate/2024-07-23/sea_ice_extent_by_year.py
@@ -121,7 +121,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset.
     ds_garden = paths.load_dataset("sea_ice_index")
-    tb = ds_garden.read_table("sea_ice_index")
+    tb = ds_garden.read("sea_ice_index")
 
     #
     # Process data.

--- a/etl/steps/data/grapher/climate/2024-09-30/sea_ice_anomalies_by_month.py
+++ b/etl/steps/data/grapher/climate/2024-09-30/sea_ice_anomalies_by_month.py
@@ -110,7 +110,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset.
     ds_garden = paths.load_dataset("sea_ice_index")
-    tb = ds_garden.read_table("sea_ice_index")
+    tb = ds_garden.read("sea_ice_index")
 
     #
     # Process data.

--- a/etl/steps/data/grapher/climate/2024-09-30/sea_ice_extent_by_decade.py
+++ b/etl/steps/data/grapher/climate/2024-09-30/sea_ice_extent_by_decade.py
@@ -148,7 +148,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset.
     ds_garden = paths.load_dataset("sea_ice_index")
-    tb = ds_garden.read_table("sea_ice_index")
+    tb = ds_garden.read("sea_ice_index")
 
     #
     # Process data.

--- a/etl/steps/data/grapher/climate/2024-09-30/sea_ice_extent_by_year.py
+++ b/etl/steps/data/grapher/climate/2024-09-30/sea_ice_extent_by_year.py
@@ -121,7 +121,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset.
     ds_garden = paths.load_dataset("sea_ice_index")
-    tb = ds_garden.read_table("sea_ice_index")
+    tb = ds_garden.read("sea_ice_index")
 
     #
     # Process data.

--- a/etl/steps/data/grapher/climate/2024-11-18/sea_ice_anomalies_by_month.py
+++ b/etl/steps/data/grapher/climate/2024-11-18/sea_ice_anomalies_by_month.py
@@ -110,7 +110,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset.
     ds_garden = paths.load_dataset("sea_ice_index")
-    tb = ds_garden.read_table("sea_ice_index")
+    tb = ds_garden.read("sea_ice_index", safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/grapher/climate/2024-11-18/sea_ice_extent_by_decade.py
+++ b/etl/steps/data/grapher/climate/2024-11-18/sea_ice_extent_by_decade.py
@@ -148,7 +148,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset.
     ds_garden = paths.load_dataset("sea_ice_index")
-    tb = ds_garden.read_table("sea_ice_index")
+    tb = ds_garden.read("sea_ice_index", safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/grapher/climate/2024-11-18/sea_ice_extent_by_year.py
+++ b/etl/steps/data/grapher/climate/2024-11-18/sea_ice_extent_by_year.py
@@ -121,7 +121,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset.
     ds_garden = paths.load_dataset("sea_ice_index")
-    tb = ds_garden.read_table("sea_ice_index")
+    tb = ds_garden.read("sea_ice_index", safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/grapher/covid/2024-11-05/github_stats.py
+++ b/etl/steps/data/grapher/covid/2024-11-05/github_stats.py
@@ -16,8 +16,8 @@ def run(dest_dir: str) -> None:
     #
     # Process data.
     #
-    tb_usr_contrib = ds_garden.read_table("user_contributions")
-    tb_contrib = ds_garden.read_table("contributions")
+    tb_usr_contrib = ds_garden.read("user_contributions")
+    tb_contrib = ds_garden.read("contributions")
 
     # Add entity
     tb_usr_contrib["country"] = "World"

--- a/etl/steps/data/grapher/demography/2023-03-31/population.py
+++ b/etl/steps/data/grapher/demography/2023-03-31/population.py
@@ -3,7 +3,6 @@ import re
 from copy import deepcopy
 from typing import Any, List
 
-import numpy as np
 from owid.catalog import Table
 
 from etl.helpers import PathFinder, create_dataset
@@ -172,10 +171,6 @@ def _create_metric_version_from_mask(
     Table
         Table with the new column.
     """
-    # Get dtype
-    dtype = table[metric].dtype
-    if np.issubdtype(table[metric].dtype, np.integer):
-        dtype = "Int64"
     metric_new = f"{metric}_{metric_suffix}"
     table.loc[mask, metric_new] = deepcopy(table.loc[mask, metric])
     table[metric_new].metadata = deepcopy(table[metric].metadata)
@@ -190,4 +185,8 @@ def _create_metric_version_from_mask(
             display_name = table[metric_new].metadata.title
         table[metric_new].metadata.display["name"] = f"{display_name} {display_name_suffix}"
     table[metric_new].metadata.description = description
+    # Get dtype
+    dtype = table[metric].dtype
+    if "int" in str(dtype).lower():
+        dtype = "Int64"
     return table.astype({metric_new: dtype})

--- a/etl/steps/data/grapher/fasttrack/latest/welfare_broiler_chickens.py
+++ b/etl/steps/data/grapher/fasttrack/latest/welfare_broiler_chickens.py
@@ -9,7 +9,7 @@ def run(dest_dir: str) -> None:
     snap = Snapshot("fasttrack/latest/welfare_broiler_chickens.csv")
 
     # load data
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # add table, update metadata from *.meta.yml and save
     ds = create_dataset(dest_dir, tables=[tb.set_index(["country", "year"])], default_metadata=snap.metadata)

--- a/etl/steps/data/grapher/iea/2024-07-04/critical_minerals_demand_by_scenario.py
+++ b/etl/steps/data/grapher/iea/2024-07-04/critical_minerals_demand_by_scenario.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset and read its main table.
     ds_garden = paths.load_dataset("critical_minerals")
-    tb_demand_by_scenario_flat = ds_garden.read_table("demand_by_scenario")
+    tb_demand_by_scenario_flat = ds_garden.read("demand_by_scenario")
 
     #
     # Process data.

--- a/etl/steps/data/grapher/iea/2024-07-04/critical_minerals_demand_by_technology.py
+++ b/etl/steps/data/grapher/iea/2024-07-04/critical_minerals_demand_by_technology.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset and read its main table.
     ds_garden = paths.load_dataset("critical_minerals")
-    tb_demand_by_technology_flat = ds_garden.read_table("demand_by_technology")
+    tb_demand_by_technology_flat = ds_garden.read("demand_by_technology")
 
     #
     # Process data.

--- a/etl/steps/data/grapher/iea/2024-07-04/critical_minerals_supply_by_country.py
+++ b/etl/steps/data/grapher/iea/2024-07-04/critical_minerals_supply_by_country.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     #
     # Load garden dataset and read its main table.
     ds_garden = paths.load_dataset("critical_minerals")
-    tb_supply_by_country_flat = ds_garden.read_table("supply_by_country")
+    tb_supply_by_country_flat = ds_garden.read("supply_by_country")
 
     #
     # Process data.

--- a/etl/steps/data/grapher/owid/latest/key_indicators.py
+++ b/etl/steps/data/grapher/owid/latest/key_indicators.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from typing import Any, List
 
-import numpy as np
 from owid import catalog
 
 from etl.paths import DATA_DIR
@@ -91,10 +90,6 @@ def _add_metric_new(
     display_name_suffix: str,
     description: str = "",
 ) -> catalog.Table:
-    # Get dtype
-    dtype = table[metric].dtype
-    if np.issubdtype(table[metric].dtype, np.integer):
-        dtype = "Int64"
     metric_new = f"{metric}_{metric_suffix}"
     table.loc[mask, metric_new] = deepcopy(table.loc[mask, metric])
     table[metric_new].metadata = deepcopy(table[metric].metadata)
@@ -105,4 +100,10 @@ def _add_metric_new(
             "name"
         ] = f"{table[metric_new].metadata.display['name']} {display_name_suffix}"
     table[metric_new].metadata.description = description
+
+    # Get dtype
+    dtype = table[metric].dtype
+    if "int" in str(dtype).lower():
+        dtype = "Int64"
+
     return table.astype({metric_new: dtype})

--- a/etl/steps/data/grapher/un/2024-08-27/un_sdg.py
+++ b/etl/steps/data/grapher/un/2024-08-27/un_sdg.py
@@ -51,7 +51,7 @@ def run(dest_dir: str) -> None:
 
         log.info("un_sdg.process", table_name=var)
 
-        tb = ds_garden.read_table(var)
+        tb = ds_garden.read(var, safe_types=False)
 
         tb = create_table(tb)
 

--- a/etl/steps/data/meadow/agriculture/2024-05-23/fao_1949.py
+++ b/etl/steps/data/meadow/agriculture/2024-05-23/fao_1949.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("fao_1949.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/agriculture/2024-05-23/fao_2000.py
+++ b/etl/steps/data/meadow/agriculture/2024-05-23/fao_2000.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("fao_2000.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/agriculture/2024-05-23/fogel_2004.py
+++ b/etl/steps/data/meadow/agriculture/2024-05-23/fogel_2004.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("fogel_2004.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/agriculture/2024-05-23/grigg_1995.py
+++ b/etl/steps/data/meadow/agriculture/2024-05-23/grigg_1995.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("grigg_1995.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/agriculture/2024-05-23/harris_et_al_2015.py
+++ b/etl/steps/data/meadow/agriculture/2024-05-23/harris_et_al_2015.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("harris_et_al_2015.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/agriculture/2024-05-23/jonsson_1998.py
+++ b/etl/steps/data/meadow/agriculture/2024-05-23/jonsson_1998.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("jonsson_1998.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/ahdi/2023-09-08/augmented_hdi.py
+++ b/etl/steps/data/meadow/ahdi/2023-09-08/augmented_hdi.py
@@ -32,7 +32,7 @@ def run(dest_dir: str) -> None:
     for sheet, sheet_name in excel_sheets.items():
         # Retrieve snapshots
         snap = paths.load_snapshot("augmented_hdi.xlsx")
-        tb = snap.read(sheet_name=sheet, skiprows=1)
+        tb = snap.read(safe_types=False, sheet_name=sheet, skiprows=1)
 
         snap_region = paths.load_snapshot("augmented_hdi_region.xlsx")
         tb_region = snap_region.read(sheet_name=sheet + 1, skiprows=2)

--- a/etl/steps/data/meadow/animal_welfare/2023-10-24/fur_laws.py
+++ b/etl/steps/data/meadow/animal_welfare/2023-10-24/fur_laws.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read data.
     snap = paths.load_snapshot("fur_laws.xlsx")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/antibiotics/2024-10-09/gram.py
+++ b/etl/steps/data/meadow/antibiotics/2024-10-09/gram.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gram.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/antibiotics/2024-10-09/gram_children.py
+++ b/etl/steps/data/meadow/antibiotics/2024-10-09/gram_children.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gram_children.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/antibiotics/2024-10-09/gram_level.py
+++ b/etl/steps/data/meadow/antibiotics/2024-10-09/gram_level.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gram_level.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/antibiotics/2024-10-23/animuse_year.py
+++ b/etl/steps/data/meadow/antibiotics/2024-10-23/animuse_year.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("animuse_year.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/antibiotics/2024-10-23/tracss.py
+++ b/etl/steps/data/meadow/antibiotics/2024-10-23/tracss.py
@@ -30,7 +30,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("tracss.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/2023-06-21/epoch.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2023-06-21/epoch.py
@@ -24,7 +24,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch.csv")
 
     # Read snapshot
-    df = snap.read()
+    df = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/artificial_intelligence/2024-04-02/dynabench.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-04-02/dynabench.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     # Load data from snapshot.
     column_names = ["benchmark", "date", "performance"]
 
-    tb = snap.read(sheet_name="Chart Data", header=None, names=column_names)
+    tb = snap.read(safe_types=False, sheet_name="Chart Data", header=None, names=column_names)
 
     tb["date"] = tb["date"].astype(str)  # Convert to string for extracting year
     tb["date"] = tb["date"].str[:4]  # Extract year from date

--- a/etl/steps/data/meadow/artificial_intelligence/2024-06-03/epoch.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-06-03/epoch.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch.csv")
 
     # Read snapshot
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/2024-06-06/epoch_compute_cost.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-06-06/epoch_compute_cost.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch_compute_cost.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/artificial_intelligence/2024-06-19/epoch_compute_intensive.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-06-19/epoch_compute_intensive.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch_compute_intensive.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/2024-07-10/epoch.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-07-10/epoch.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch.csv")
 
     # Read snapshot
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/2024-07-11/epoch_gpus.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-07-11/epoch_gpus.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch_gpus.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/artificial_intelligence/2024-07-16/cset.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-07-16/cset.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("cset.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/2024-08-05/epoch.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-08-05/epoch.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch.csv")
 
     # Read snapshot
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/2024-08-05/epoch_compute_intensive.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-08-05/epoch_compute_intensive.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch_compute_intensive.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/2024-09-09/epoch.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-09-09/epoch.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch.csv")
 
     # Read snapshot
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/2024-09-09/epoch_compute_intensive.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-09-09/epoch_compute_intensive.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch_compute_intensive.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/2024-10-01/epoch.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-10-01/epoch.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch.csv")
 
     # Read snapshot
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/2024-10-01/epoch_compute_intensive.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2024-10-01/epoch_compute_intensive.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch_compute_intensive.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/artificial_intelligence/latest/epoch.py
+++ b/etl/steps/data/meadow/artificial_intelligence/latest/epoch.py
@@ -22,7 +22,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("epoch.csv")
 
     # Read snapshot
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/aviation_safety_network/2024-06-05/aviation_statistics.py
+++ b/etl/steps/data/meadow/aviation_safety_network/2024-06-05/aviation_statistics.py
@@ -38,7 +38,7 @@ def run(dest_dir: str) -> None:
     snap_by_nature = paths.load_snapshot("aviation_statistics_by_nature.csv")
 
     # Load data from snapshots.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb_by_period = snap_by_period.read()
     tb_by_nature = snap_by_nature.read()
 

--- a/etl/steps/data/meadow/biodiversity/2023-01-11/cherry_blossom.py
+++ b/etl/steps/data/meadow/biodiversity/2023-01-11/cherry_blossom.py
@@ -17,7 +17,7 @@ def run(dest_dir: str) -> None:
 
     # retrieve snapshot
     snap = Snapshot("biodiversity/2023-01-11/cherry_blossom.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # clean and transform data
     tb = clean_data(tb)

--- a/etl/steps/data/meadow/biodiversity/2024-08-12/invasive_species.py
+++ b/etl/steps/data/meadow/biodiversity/2024-08-12/invasive_species.py
@@ -18,11 +18,11 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("invasive_species.xlsx")
     origins = [snap.metadata.origin]
 
-    tb_cont = snap.read(sheet_name="ContinentalTrends")
+    tb_cont = snap.read(safe_types=False, sheet_name="ContinentalTrends")
     tb_cont = format_continental_trends(tb_cont)
     tb_cont = tb_cont.format(["year", "continent"], short_name="continental")
 
-    tb_glob = snap.read(sheet_name="GlobalTrends")
+    tb_glob = snap.read(safe_types=False, sheet_name="GlobalTrends")
     tb_glob["country"] = "World"
     tb_glob = tb_glob.format(["country", "year"], short_name="global")
     # Adding the origins in

--- a/etl/steps/data/meadow/biodiversity/2024-09-30/living_planet_index.py
+++ b/etl/steps/data/meadow/biodiversity/2024-09-30/living_planet_index.py
@@ -27,7 +27,7 @@ def run(dest_dir: str) -> None:
     all_tbs = Table()
     # Load data from snapshot.
     for sheet_name in sheet_names:
-        tb = snap.read(sheet_name=sheet_name)
+        tb = snap.read(safe_types=False, sheet_name=sheet_name)
         tb = tb[
             [
                 "Unnamed: 0",

--- a/etl/steps/data/meadow/bls/2024-05-16/us_consumer_prices.py
+++ b/etl/steps/data/meadow/bls/2024-05-16/us_consumer_prices.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("us_consumer_prices.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # Process data.
     tb = tb.set_index(["Series ID", "Year", "Period"], verify_integrity=True)

--- a/etl/steps/data/meadow/cancer/2024-08-30/gco_alcohol.py
+++ b/etl/steps/data/meadow/cancer/2024-08-30/gco_alcohol.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gco_alcohol.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/cancer/2024-09-06/gco_infections.py
+++ b/etl/steps/data/meadow/cancer/2024-09-06/gco_infections.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gco_infections.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.
@@ -22,7 +22,7 @@ def run(dest_dir: str) -> None:
     # Drop unnecessary columns.
     tb = tb.drop(columns=["id", "code", "ncases_sites", "ncases_all", "ir_att", "ir", "asr"])
 
-    tb["sex"] = tb["sex"].replace({0: "both", 1: "males", 2: "females"})
+    tb["sex"] = tb["sex"].astype(str).replace({"0": "both", "1": "males", "2": "females"})
 
     # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
     tb = tb.format(["country", "year", "sex", "agent", "cancer"])

--- a/etl/steps/data/meadow/cancer/2024-09-13/diagnosis_routes_by_route.py
+++ b/etl/steps/data/meadow/cancer/2024-09-13/diagnosis_routes_by_route.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("diagnosis_routes_by_route.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     tb = tb[["Year", "Site", "Stage", "Route", "Count", "Percentage"]]
     tb = tb.rename(columns={"Count": "count_by_route", "Percentage": "percentage_by_route"})

--- a/etl/steps/data/meadow/cancer/2024-09-13/diagnosis_routes_by_stage.py
+++ b/etl/steps/data/meadow/cancer/2024-09-13/diagnosis_routes_by_stage.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("diagnosis_routes_by_stage.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     tb = tb[["Year", "Site", "Stage", "Route", "Count", "Percentage"]]
     tb = tb.rename(columns={"Count": "count_by_stage", "Percentage": "percentage_by_stage"})

--- a/etl/steps/data/meadow/cancer/2024-09-13/diagnosis_routes_survival.py
+++ b/etl/steps/data/meadow/cancer/2024-09-13/diagnosis_routes_survival.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("diagnosis_routes_survival.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     tb = tb[["Year", "Site", "Geography", "Gender", "Length", "Route", "Patients", "Survival"]]
     tb = tb.rename(columns={"Geography": "country"})

--- a/etl/steps/data/meadow/cancer/2024-10-13/gco_cancer_over_time_cervical.py
+++ b/etl/steps/data/meadow/cancer/2024-10-13/gco_cancer_over_time_cervical.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gco_cancer_over_time_cervical.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/cancer/2024-10-13/gco_cancer_today_cervical.py
+++ b/etl/steps/data/meadow/cancer/2024-10-13/gco_cancer_today_cervical.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gco_cancer_today_cervical.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/cedlas/2024-03-08/sedlac.py
+++ b/etl/steps/data/meadow/cedlas/2024-03-08/sedlac.py
@@ -199,7 +199,7 @@ def load_tables_from_snapshot(snap: Snapshot, sheets: Dict) -> List[Table]:
     """Load all the sheets from the snapshot."""
     tables = []
     for sheet in sheets:
-        tb = snap.read(sheet_name=sheet, header=sheets[sheet]["header"])
+        tb = snap.read(safe_types=False, sheet_name=sheet, header=sheets[sheet]["header"])
         tb.metadata.short_name = sheets[sheet]["short_name"]
 
         tables.append(tb)

--- a/etl/steps/data/meadow/cedlas/2024-07-31/sedlac_poverty_2016.py
+++ b/etl/steps/data/meadow/cedlas/2024-07-31/sedlac_poverty_2016.py
@@ -106,7 +106,7 @@ def load_tables_from_snapshot(snap: Snapshot, sheets: Dict) -> List[Table]:
     """Load all the sheets from the snapshot."""
     tables = []
     for sheet in sheets:
-        tb = snap.read(sheet_name=sheet, header=sheets[sheet]["header"])
+        tb = snap.read(safe_types=False, sheet_name=sheet, header=sheets[sheet]["header"])
         tb.metadata.short_name = sheets[sheet]["short_name"]
 
         tables.append(tb)

--- a/etl/steps/data/meadow/cedlas/2024-07-31/sedlac_poverty_2018.py
+++ b/etl/steps/data/meadow/cedlas/2024-07-31/sedlac_poverty_2018.py
@@ -106,7 +106,7 @@ def load_tables_from_snapshot(snap: Snapshot, sheets: Dict) -> List[Table]:
     """Load all the sheets from the snapshot."""
     tables = []
     for sheet in sheets:
-        tb = snap.read(sheet_name=sheet, header=sheets[sheet]["header"])
+        tb = snap.read(safe_types=False, sheet_name=sheet, header=sheets[sheet]["header"])
         tb.metadata.short_name = sheets[sheet]["short_name"]
 
         tables.append(tb)

--- a/etl/steps/data/meadow/chartbook/2024-03-21/altimir_1986.py
+++ b/etl/steps/data/meadow/chartbook/2024-03-21/altimir_1986.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("altimir_1986.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-04-22/concialdi.py
+++ b/etl/steps/data/meadow/chartbook/2024-04-22/concialdi.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("concialdi.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
     tb = tb.format(["country", "year"])

--- a/etl/steps/data/meadow/chartbook/2024-05-23/wealth_france.py
+++ b/etl/steps/data/meadow/chartbook/2024-05-23/wealth_france.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("wealth_france.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # Add country
     tb["country"] = "France"

--- a/etl/steps/data/meadow/chartbook/2024-08-01/hancock_1971_australia.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-01/hancock_1971_australia.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("hancock_1971_australia.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-02/ingles_1981_australia.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-02/ingles_1981_australia.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ingles_1981_australia.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-05/atkinson_2008_australia.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-05/atkinson_2008_australia.py
@@ -16,8 +16,8 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("atkinson_2008_australia.xls")
 
     # Load data from snapshot.
-    tb_oecd_lms = snap.read(sheet_name="Table A.3 (OECD LMS)", usecols="C:I", skiprows=2)
-    tb_eeh = snap.read(sheet_name="Table A.5 (EEH)", usecols="C:I", skiprows=3)
+    tb_oecd_lms = snap.read(safe_types=False, sheet_name="Table A.3 (OECD LMS)", usecols="C:I", skiprows=2)
+    tb_eeh = snap.read(safe_types=False, sheet_name="Table A.5 (EEH)", usecols="C:I", skiprows=3)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-05/katic_leigh_2015_australia.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-05/katic_leigh_2015_australia.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("katic_leigh_2015_australia.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Top wealth data", usecols="B,I", skiprows=4)
+    tb = snap.read(safe_types=False, sheet_name="Top wealth data", usecols="B,I", skiprows=4)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-08/langoni_1972_brazil.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-08/langoni_1972_brazil.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("langoni_1972_brazil.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-09/love_1979_canada.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-09/love_1979_canada.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("love_1979_canada.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-09/wolfson_1986_canada.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-09/wolfson_1986_canada.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("wolfson_1986_canada.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-14/atkinson_2008_canada.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-14/atkinson_2008_canada.py
@@ -16,9 +16,9 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("atkinson_2008_canada.xls")
 
     # Load data from snapshot.
-    tb_oecd_lms = snap.read(sheet_name="Table C.3 (OECD LMS)", usecols="C,G", skiprows=2)
-    tb_census = snap.read(sheet_name="Table C.4 (Census)", usecols="C,Y", skiprows=3)
-    tb_manufacturing = snap.read(sheet_name="Table C.5 (Manf)", usecols="C,I", skiprows=2)
+    tb_oecd_lms = snap.read(safe_types=False, sheet_name="Table C.3 (OECD LMS)", usecols="C,G", skiprows=2)
+    tb_census = snap.read(safe_types=False, sheet_name="Table C.4 (Census)", usecols="C,Y", skiprows=3)
+    tb_manufacturing = snap.read(safe_types=False, sheet_name="Table C.5 (Manf)", usecols="C,I", skiprows=2)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-15/davies_di_matteo_2020_canada.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-15/davies_di_matteo_2020_canada.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("davies_di_matteo_2020_canada.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-15/jantti_2010_finland.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-15/jantti_2010_finland.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("jantti_2010_finland.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-16/atkinson_2008_finland.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-16/atkinson_2008_finland.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("atkinson_2008_finland.xls")
 
     # Load data from snapshot
-    tb = snap.read(sheet_name="Table F.3 (E and J", usecols="C,E", skiprows=2)
+    tb = snap.read(safe_types=False, sheet_name="Table F.3 (E and J", usecols="C,E", skiprows=2)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-19/becker_1997_germany.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-19/becker_1997_germany.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("becker_1997_germany.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-19/riihela_et_al_2003_finland.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-19/riihela_et_al_2003_finland.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("riihela_et_al_2003_finland.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-08-19/roine_waldenstrom_2015.py
+++ b/etl/steps/data/meadow/chartbook/2024-08-19/roine_waldenstrom_2015.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("roine_waldenstrom_2015.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-10-24/atkinson_2008_germany.py
+++ b/etl/steps/data/meadow/chartbook/2024-10-24/atkinson_2008_germany.py
@@ -19,7 +19,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("atkinson_2008_germany.xls")
 
     # Load data from snapshot
-    tb = snap.read(sheet_name="Table H.4", usecols="C,I", skiprows=2)
+    tb = snap.read(safe_types=False, sheet_name="Table H.4", usecols="C,I", skiprows=2)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-10-24/becker_1997_germany_relative_poverty.py
+++ b/etl/steps/data/meadow/chartbook/2024-10-24/becker_1997_germany_relative_poverty.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("becker_1997_germany_relative_poverty.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/chartbook/2024-10-25/albers_et_al_2020_germany.py
+++ b/etl/steps/data/meadow/chartbook/2024-10-25/albers_et_al_2020_germany.py
@@ -17,7 +17,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("albers_et_al_2020_germany.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Tabelle1")
+    tb = snap.read(safe_types=False, sheet_name="Tabelle1")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/climate/2024-01-26/antarctic_ice_core_co2_concentration.py
+++ b/etl/steps/data/meadow/climate/2024-01-26/antarctic_ice_core_co2_concentration.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and load data.
     snap = paths.load_snapshot("antarctic_ice_core_co2_concentration.xls")
-    tb = snap.read(sheet_name="CO2 Composite", skiprows=14)
+    tb = snap.read(safe_types=False, sheet_name="CO2 Composite", skiprows=14)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/countries/2023-09-25/isd.py
+++ b/etl/steps/data/meadow/countries/2023-09-25/isd.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("isd.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/2024-11-05/github_stats.py
+++ b/etl/steps/data/meadow/covid/2024-11-05/github_stats.py
@@ -12,26 +12,28 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot.
     # Issues
-    tb_issues = paths.read_snap_table("github_stats_issues.csv").sort_values("date_created")
-    tb_issues_com = paths.read_snap_table("github_stats_issues_comments.csv").sort_values("date_created")
-    tb_issues_usr = paths.read_snap_table("github_stats_issues_users.csv").rename(
+    tb_issues = paths.read_snap_table("github_stats_issues.csv", safe_types=False).sort_values("date_created")
+    tb_issues_com = paths.read_snap_table("github_stats_issues_comments.csv", safe_types=False).sort_values(
+        "date_created"
+    )
+    tb_issues_usr = paths.read_snap_table("github_stats_issues_users.csv", safe_types=False).rename(
         columns={
             "index": "user_id",
         }
     )
 
     # PRs
-    tb_pr = paths.read_snap_table("github_stats_pr.csv").sort_values("date_created")
-    tb_pr_com = paths.read_snap_table("github_stats_pr_comments.csv").sort_values("date_created")
-    tb_pr_usr = paths.read_snap_table("github_stats_pr_users.csv").rename(
+    tb_pr = paths.read_snap_table("github_stats_pr.csv", safe_types=False).sort_values("date_created")
+    tb_pr_com = paths.read_snap_table("github_stats_pr_comments.csv", safe_types=False).sort_values("date_created")
+    tb_pr_usr = paths.read_snap_table("github_stats_pr_users.csv", safe_types=False).rename(
         columns={
             "index": "user_id",
         }
     )
 
     # Commits
-    tb_commits = paths.read_snap_table("github_stats_commits.csv").sort_values("date")
-    tb_commits_usr = paths.read_snap_table("github_stats_commits_users.csv").rename(
+    tb_commits = paths.read_snap_table("github_stats_commits.csv", safe_types=False).sort_values("date")
+    tb_commits_usr = paths.read_snap_table("github_stats_commits_users.csv", safe_types=False).rename(
         columns={
             "index": "user_id",
         }

--- a/etl/steps/data/meadow/covid/latest/cases_deaths.py
+++ b/etl/steps/data/meadow/covid/latest/cases_deaths.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("cases_deaths.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/latest/covax.py
+++ b/etl/steps/data/meadow/covid/latest/covax.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("covax.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/latest/hospital.py
+++ b/etl/steps/data/meadow/covid/latest/hospital.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("hospital.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/latest/john_hopkins_university.py
+++ b/etl/steps/data/meadow/covid/latest/john_hopkins_university.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("john_hopkins_university.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/latest/sweden_covid.py
+++ b/etl/steps/data/meadow/covid/latest/sweden_covid.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("sweden_covid.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/latest/testing.py
+++ b/etl/steps/data/meadow/covid/latest/testing.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("testing.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/latest/tracking_r.py
+++ b/etl/steps/data/meadow/covid/latest/tracking_r.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("tracking_r.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/latest/uk_covid.py
+++ b/etl/steps/data/meadow/covid/latest/uk_covid.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("uk_covid.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # Format date
     tb = year_to_date(tb, zero_day="2020-01-01")

--- a/etl/steps/data/meadow/covid/latest/vaccinations_age.py
+++ b/etl/steps/data/meadow/covid/latest/vaccinations_age.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("vaccinations_age.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/latest/vaccinations_global.py
+++ b/etl/steps/data/meadow/covid/latest/vaccinations_global.py
@@ -23,7 +23,7 @@ def run(dest_dir: str) -> None:
     snap_who = paths.load_snapshot("vaccinations_global_who.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb_who = snap_who.read()
 
     #

--- a/etl/steps/data/meadow/covid/latest/vaccinations_manufacturer.py
+++ b/etl/steps/data/meadow/covid/latest/vaccinations_manufacturer.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("vaccinations_manufacturer.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/latest/vaccinations_us.py
+++ b/etl/steps/data/meadow/covid/latest/vaccinations_us.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("vaccinations_us.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/covid/latest/yougov.py
+++ b/etl/steps/data/meadow/covid/latest/yougov.py
@@ -27,7 +27,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve aux table
     snap = paths.load_snapshot("yougov_extra_mapping.csv")
-    tb_mapping = snap.read()
+    tb_mapping = snap.read(safe_types=False)
     tb_mapping = process_mapping_table(tb_mapping)
 
     # Retrieve country snapshots.
@@ -45,7 +45,7 @@ def run(dest_dir: str) -> None:
 
     # Retrieve composite table
     snap_composite = paths.load_snapshot("yougov_composite.csv")
-    tb_composite = snap_composite.read()
+    tb_composite = snap_composite.read(safe_types=False)
 
     #
     # Process data.
@@ -58,6 +58,7 @@ def run(dest_dir: str) -> None:
     tb = tb.dropna(subset=["date"])
 
     # Format
+    tb = tb.sort_values(["country", "date"]).reset_index(drop=True)
     tb["identifier"] = tb.index
     tb = tb.format(["identifier"])
     tb_mapping = tb_mapping.format(["code_name"])

--- a/etl/steps/data/meadow/democracy/2024-03-07/bmr.py
+++ b/etl/steps/data/meadow/democracy/2024-03-07/bmr.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("bmr.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/democracy/2024-05-01/ert.py
+++ b/etl/steps/data/meadow/democracy/2024-05-01/ert.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ert.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/democracy/2024-05-09/lexical_index.py
+++ b/etl/steps/data/meadow/democracy/2024-05-09/lexical_index.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("lexical_index.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/democracy/2024-05-13/polity.py
+++ b/etl/steps/data/meadow/democracy/2024-05-13/polity.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("polity.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/democracy/2024-05-16/fh.py
+++ b/etl/steps/data/meadow/democracy/2024-05-16/fh.py
@@ -18,12 +18,12 @@ def run(dest_dir: str) -> None:
     #
     # Load ratings snapshot as a table
     snap = paths.load_snapshot("fh_ratings.xlsx")
-    tb_ratings_countries = snap.read(sheet_name="Country Ratings, Statuses ", header=[1, 2])
-    tb_ratings_territories = snap.read(sheet_name="Territory Ratings, Statuses", header=[1, 2])
+    tb_ratings_countries = snap.read(safe_types=False, sheet_name="Country Ratings, Statuses ", header=[1, 2])
+    tb_ratings_territories = snap.read(safe_types=False, sheet_name="Territory Ratings, Statuses", header=[1, 2])
 
     # Load scores snapshot as a table
     snap = paths.load_snapshot("fh_scores.xlsx")
-    tb_scores = snap.read(sheet_name="FIW06-24")
+    tb_scores = snap.read(safe_types=False, sheet_name="FIW06-24")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/democracy/2024-05-21/bti.py
+++ b/etl/steps/data/meadow/democracy/2024-05-21/bti.py
@@ -64,7 +64,7 @@ def load_data(snap: Snapshot) -> Table:
     tbs = []
     for year in range(2006, YEAR_MAX + 1, 2):
         # Read
-        tb_ = snap.read(sheet_name=f"BTI {year}")
+        tb_ = snap.read(safe_types=False, sheet_name=f"BTI {year}")
         # Column check
         columns_missing = set(COLUMNS) - set(tb_.columns)
         if columns_missing:

--- a/etl/steps/data/meadow/democracy/2024-05-22/claassen_mood.py
+++ b/etl/steps/data/meadow/democracy/2024-05-22/claassen_mood.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("claassen_mood.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/democracy/2024-05-22/claassen_satisfaction.py
+++ b/etl/steps/data/meadow/democracy/2024-05-22/claassen_satisfaction.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("claassen_satisfaction.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/democracy/2024-05-22/eiu.py
+++ b/etl/steps/data/meadow/democracy/2024-05-22/eiu.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
 
     # Retieve data from Gapminder
     snap = paths.load_snapshot("eiu_gapminder.csv")
-    tb_gm = snap.read()
+    tb_gm = snap.read(safe_types=False)
 
     # Retrieve data from EIU (single year reports)
     shortnames = [
@@ -26,7 +26,7 @@ def run(dest_dir: str) -> None:
     tbs = []
     for name in shortnames:
         snap = paths.load_snapshot(f"{name}.csv")
-        tb = snap.read()
+        tb = snap.read(safe_types=False)
         tbs.append(tb)
 
     # Correct data by Gapminder

--- a/etl/steps/data/meadow/demography/2023-10-10/zijdeman_et_al_2015.py
+++ b/etl/steps/data/meadow/demography/2023-10-10/zijdeman_et_al_2015.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("zijdeman_et_al_2015.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Data Long Format")
+    tb = snap.read(safe_types=False, sheet_name="Data Long Format")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/demography/2023-11-08/modal_age_death.py
+++ b/etl/steps/data/meadow/demography/2023-11-08/modal_age_death.py
@@ -19,7 +19,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("modal_age_death.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(header=1)
+    tb = snap.read(safe_types=False, header=1)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/demography/2023-12-20/population_fariss.py
+++ b/etl/steps/data/meadow/demography/2023-12-20/population_fariss.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("population_fariss.rds")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/dummy/2020-01-01/dummy.py
+++ b/etl/steps/data/meadow/dummy/2020-01-01/dummy.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("dummy.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/dummy/2020-01-01/dummy_full.py
+++ b/etl/steps/data/meadow/dummy/2020-01-01/dummy_full.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("dummy_full.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/ember/2024-05-08/yearly_electricity.py
+++ b/etl/steps/data/meadow/ember/2024-05-08/yearly_electricity.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     #
     # Load snapshot and read its data.
     snap = paths.load_snapshot("yearly_electricity.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/emdat/2023-09-20/natural_disasters.py
+++ b/etl/steps/data/meadow/emdat/2023-09-20/natural_disasters.py
@@ -44,7 +44,7 @@ def run(dest_dir: str) -> None:
     # Load snapshot.
     snap = paths.load_snapshot("natural_disasters.xlsx")
     with warnings.catch_warnings(record=True):
-        tb = snap.read(sheet_name="emdat data", skiprows=6)
+        tb = snap.read(safe_types=False, sheet_name="emdat data", skiprows=6)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/emdat/2024-04-11/natural_disasters.py
+++ b/etl/steps/data/meadow/emdat/2024-04-11/natural_disasters.py
@@ -42,7 +42,7 @@ def run(dest_dir: str) -> None:
     #
     # Load snapshot.
     snap = paths.load_snapshot("natural_disasters.xlsx")
-    tb = snap.read(sheet_name="EM-DAT Data")
+    tb = snap.read(safe_types=False, sheet_name="EM-DAT Data")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/emissions/2023-10-24/emission_factors.py
+++ b/etl/steps/data/meadow/emissions/2023-10-24/emission_factors.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("emission_factors.xls")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/emissions/2023-11-06/global_warming_potential_factors.py
+++ b/etl/steps/data/meadow/emissions/2023-11-06/global_warming_potential_factors.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("global_warming_potential_factors.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/ess/2023-08-02/ess_trust.py
+++ b/etl/steps/data/meadow/ess/2023-08-02/ess_trust.py
@@ -87,7 +87,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ess_trust.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/forests/2024-05-08/ifl.py
+++ b/etl/steps/data/meadow/forests/2024-05-08/ifl.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ifl.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/forests/2024-07-10/tree_cover_loss_by_driver.py
+++ b/etl/steps/data/meadow/forests/2024-07-10/tree_cover_loss_by_driver.py
@@ -17,7 +17,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot.
     snap = paths.load_snapshot("dominant_driver.xlsx")
-    tb = snap.read(sheet_name="data")
+    tb = snap.read(safe_types=False, sheet_name="data")
     tb = tb.drop(columns=["iso"])
     tb = tb.rename(columns={"loss year": "year", "Driver of loss": "category", "Tree cover loss (ha)": "area"})
     # Some large countries are broken down into smaller regions in the dataset, so we need to aggregate them here

--- a/etl/steps/data/meadow/gapminder/2023-09-18/under_five_mortality.py
+++ b/etl/steps/data/meadow/gapminder/2023-09-18/under_five_mortality.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("under_five_mortality.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Data & sources by observation")
+    tb = snap.read(safe_types=False, sheet_name="Data & sources by observation")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/gapminder/2023-09-21/under_five_mortality.py
+++ b/etl/steps/data/meadow/gapminder/2023-09-21/under_five_mortality.py
@@ -21,7 +21,7 @@ def run(dest_dir: str) -> None:
     tb = Table()
     # Load data from snapshot.
     for sheet in sheet_names:
-        tb_sheet = snap.read(sheet_name=sheet)
+        tb_sheet = snap.read(safe_types=False, sheet_name=sheet)
         tb = pr.concat([tb, tb_sheet])
 
     tb.metadata = snap.to_table_metadata()

--- a/etl/steps/data/meadow/gapminder/2023-09-22/total_fertility_rate.py
+++ b/etl/steps/data/meadow/gapminder/2023-09-22/total_fertility_rate.py
@@ -21,7 +21,7 @@ def run(dest_dir: str) -> None:
     tb = Table()
     # Load data from snapshot.
     for sheet in sheet_names:
-        tb_sheet = snap.read(sheet_name=sheet)
+        tb_sheet = snap.read(safe_types=False, sheet_name=sheet)
         tb = pr.concat([tb, tb_sheet])
 
     tb.metadata = snap.to_table_metadata()

--- a/etl/steps/data/meadow/gapminder/2024-07-08/maternal_mortality.py
+++ b/etl/steps/data/meadow/gapminder/2024-07-08/maternal_mortality.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("maternal_mortality.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # drop source & comment columns
     tb = tb.drop(

--- a/etl/steps/data/meadow/ggdc/2022-12-23/maddison_database.py
+++ b/etl/steps/data/meadow/ggdc/2022-12-23/maddison_database.py
@@ -14,9 +14,9 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("maddison_database.xlsx")
 
     # Load data from snapshot.
-    tb_pop = snap.read(sheet_name="Population", skiprows=2)
-    tb_gdp = snap.read(sheet_name="GDP", skiprows=2)
-    tb_gdppc = snap.read(sheet_name="PerCapita GDP", skiprows=2)
+    tb_pop = snap.read(safe_types=False, sheet_name="Population", skiprows=2)
+    tb_gdp = snap.read(safe_types=False, sheet_name="GDP", skiprows=2)
+    tb_gdppc = snap.read(safe_types=False, sheet_name="PerCapita GDP", skiprows=2)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/ggdc/2024-01-19/maddison_federico_paper.py
+++ b/etl/steps/data/meadow/ggdc/2024-01-19/maddison_federico_paper.py
@@ -17,11 +17,11 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("maddison_federico_paper.xlsx")
 
     # Load data from snapshot.
-    tb_africa = snap.read(sheet_name="Africa", skiprows=3)
-    tb_americas = snap.read(sheet_name="Americas", skiprows=3)
-    tb_asia = snap.read(sheet_name="Asia", skiprows=3)
-    tb_europe = snap.read(sheet_name="Europe", skiprows=3)
-    tb_oceania = snap.read(sheet_name="Oceania", skiprows=3)
+    tb_africa = snap.read(safe_types=False, sheet_name="Africa", skiprows=3)
+    tb_americas = snap.read(safe_types=False, sheet_name="Americas", skiprows=3)
+    tb_asia = snap.read(safe_types=False, sheet_name="Asia", skiprows=3)
+    tb_europe = snap.read(safe_types=False, sheet_name="Europe", skiprows=3)
+    tb_oceania = snap.read(safe_types=False, sheet_name="Oceania", skiprows=3)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/ggdc/2024-04-26/maddison_project_database.py
+++ b/etl/steps/data/meadow/ggdc/2024-04-26/maddison_project_database.py
@@ -36,8 +36,8 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("maddison_project_database.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Full data")
-    tb_regions = snap.read(sheet_name="Regional data", skiprows=1)
+    tb = snap.read(safe_types=False, sheet_name="Full data")
+    tb_regions = snap.read(safe_types=False, sheet_name="Regional data", skiprows=1)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/happiness/2024-06-09/happiness.py
+++ b/etl/steps/data/meadow/happiness/2024-06-09/happiness.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("happiness.xls")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # add year and country columns
     tb["year"] = 2023  # 2024 report -> 2023 data

--- a/etl/steps/data/meadow/health/2023-08-09/unaids.py
+++ b/etl/steps/data/meadow/health/2023-08-09/unaids.py
@@ -22,7 +22,7 @@ def run(dest_dir: str) -> None:
 
     # Load data from snapshot.
     log.info("health.unaids: loading data from snapshot")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/health/2024-03-21/gmh_countdown.py
+++ b/etl/steps/data/meadow/health/2024-03-21/gmh_countdown.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gmh_countdown.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/health/2024-04-02/organ_donation_and_transplantation.py
+++ b/etl/steps/data/meadow/health/2024-04-02/organ_donation_and_transplantation.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("organ_donation_and_transplantation.xlsx")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # Population column has a bad formatting, so, for now, store it as a string.
     tb = tb.astype({"POPULATION": str})

--- a/etl/steps/data/meadow/health/2024-04-12/polio_free_countries.py
+++ b/etl/steps/data/meadow/health/2024-04-12/polio_free_countries.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("polio_free_countries.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb = tb.format()
     #
     # Save outputs.

--- a/etl/steps/data/meadow/health/2024-04-12/polio_status.py
+++ b/etl/steps/data/meadow/health/2024-04-12/polio_status.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("polio_status.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # Process data.
     #

--- a/etl/steps/data/meadow/health/2024-06-11/isaps_plastic_surgery.py
+++ b/etl/steps/data/meadow/health/2024-06-11/isaps_plastic_surgery.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("isaps_plastic_surgery.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Global")
+    tb = snap.read(safe_types=False, sheet_name="Global")
 
     # Add entity World
     tb["country"] = "World"

--- a/etl/steps/data/meadow/health/2024-08-23/eurostat_cancer.py
+++ b/etl/steps/data/meadow/health/2024-08-23/eurostat_cancer.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("eurostat_cancer.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/health/2024-09-05/seattle_pathogens.py
+++ b/etl/steps/data/meadow/health/2024-09-05/seattle_pathogens.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("seattle_pathogens.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/idmc/2024-08-02/internal_displacement.py
+++ b/etl/steps/data/meadow/idmc/2024-08-02/internal_displacement.py
@@ -33,7 +33,7 @@ def run(dest_dir: str) -> None:
     ds_pop = paths.load_dataset("population")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # rename and drop columns
     tb = tb.drop(columns=COLUMNS_TO_DROP, errors="raise")

--- a/etl/steps/data/meadow/igh/2024-07-05/better_data_homelessness.py
+++ b/etl/steps/data/meadow/igh/2024-07-05/better_data_homelessness.py
@@ -46,7 +46,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("better_data_homelessness.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="BDP 2024")
+    tb = snap.read(safe_types=False, sheet_name="BDP 2024")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_cause.py
+++ b/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_cause.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gbd_cause.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     # standardize column names
     tb = clean_data(tb)
     # fix percent values - they aren't consistently presented as either 0-1, or 0-100.

--- a/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_child_mortality.py
+++ b/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_child_mortality.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gbd_child_mortality.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     # standardize column names
     tb = clean_data(tb)
     # fix percent values - they aren't consistently presented as either 0-1, or 0-100.

--- a/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_drug_risk.py
+++ b/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_drug_risk.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gbd_drug_risk.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     # standardize column names
     tb = clean_data(tb)
     # fix percent values - they aren't consistently presented as either 0-1, or 0-100.

--- a/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_mental_health.py
+++ b/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_mental_health.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gbd_mental_health.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # standardize column names
     tb = clean_data(tb)

--- a/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_mental_health_burden.py
+++ b/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_mental_health_burden.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gbd_mental_health_burden.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # standardize column names
     tb = clean_data(tb)

--- a/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_prevalence.py
+++ b/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_prevalence.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gbd_prevalence.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     # standardize column names
     tb = clean_data(tb)
     #

--- a/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_risk.py
+++ b/etl/steps/data/meadow/ihme_gbd/2024-05-20/gbd_risk.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gbd_risk.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     # standardize column names
     tb = clean_data(tb)
     # fix percent values - they aren't consistently presented as either 0-1, or 0-100.

--- a/etl/steps/data/meadow/ihme_gbd/2024-05-20/impairments.py
+++ b/etl/steps/data/meadow/ihme_gbd/2024-05-20/impairments.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("impairments.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/ihme_gbd/2024-08-26/gbd_risk_cancer.py
+++ b/etl/steps/data/meadow/ihme_gbd/2024-08-26/gbd_risk_cancer.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gbd_risk_cancer.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     # standardize column names
     tb = clean_data(tb)
     # fix percent values - they aren't consistently presented as either 0-1, or 0-100.

--- a/etl/steps/data/meadow/imf/2024-06-12/public_finances_modern_history.py
+++ b/etl/steps/data/meadow/imf/2024-06-12/public_finances_modern_history.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("public_finances_modern_history.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="data")
+    tb = snap.read(safe_types=False, sheet_name="data")
 
     # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
     tb = tb.format(["country", "year"])

--- a/etl/steps/data/meadow/insee/2024-03-21/inequality_france_1999.py
+++ b/etl/steps/data/meadow/insee/2024-03-21/inequality_france_1999.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("inequality_france_1999.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/insee/2024-04-05/inequality_france.py
+++ b/etl/steps/data/meadow/insee/2024-04-05/inequality_france.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("inequality_france.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(header=2)
+    tb = snap.read(safe_types=False, header=2)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/insee/2024-04-25/insee_premiere_1875.py
+++ b/etl/steps/data/meadow/insee/2024-04-25/insee_premiere_1875.py
@@ -37,8 +37,8 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("insee_premiere_1875.xlsx")
 
     # Load data from snapshot.
-    tb_inequality = snap.read(sheet_name="Figure 2", skiprows=2)
-    tb_poverty = snap.read(sheet_name="Figure 3", skiprows=2)
+    tb_inequality = snap.read(safe_types=False, sheet_name="Figure 2", skiprows=2)
+    tb_poverty = snap.read(safe_types=False, sheet_name="Figure 3", skiprows=2)
 
     # Process data.
     tb_inequality = process_inequality_data(tb=tb_inequality, columns=COLUMNS_INEQUALITY, short_name="inequality")

--- a/etl/steps/data/meadow/insee/2024-04-26/relative_poverty_france.py
+++ b/etl/steps/data/meadow/insee/2024-04-26/relative_poverty_france.py
@@ -24,7 +24,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("relative_poverty_france.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Données", skiprows=3)
+    tb = snap.read(safe_types=False, sheet_name="Données", skiprows=3)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/irena/2023-12-12/renewable_energy_patents.py
+++ b/etl/steps/data/meadow/irena/2023-12-12/renewable_energy_patents.py
@@ -23,7 +23,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot.
     snap = paths.load_snapshot("renewable_energy_patents.xlsx")
-    tb = snap.read(sheet_name="INSPIRE_data")
+    tb = snap.read(safe_types=False, sheet_name="INSPIRE_data")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/ivs/2023-11-27/integrated_values_survey.py
+++ b/etl/steps/data/meadow/ivs/2023-11-27/integrated_values_survey.py
@@ -149,7 +149,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("integrated_values_survey.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/lgbt_rights/2023-04-27/lgbti_policy_index.py
+++ b/etl/steps/data/meadow/lgbt_rights/2023-04-27/lgbti_policy_index.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("lgbti_policy_index.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Sheet1")
+    tb = snap.read(safe_types=False, sheet_name="Sheet1")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/lgbt_rights/2024-06-03/equaldex.py
+++ b/etl/steps/data/meadow/lgbt_rights/2024-06-03/equaldex.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap_indices = paths.load_snapshot("equaldex_indices.csv")
 
     # Load data from snapshots.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb_current = snap_current.read()
     tb_indices = snap_indices.read()
 

--- a/etl/steps/data/meadow/lgbt_rights/2024-06-11/criminalization_mignot.py
+++ b/etl/steps/data/meadow/lgbt_rights/2024-06-11/criminalization_mignot.py
@@ -23,7 +23,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("criminalization_mignot.csv")
 
     # Load data from snapshot.
-    tb = snap.read(header=None, names=COLUMN_NAMES)
+    tb = snap.read(safe_types=False, header=None, names=COLUMN_NAMES)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/lis/2024-06-13/luxembourg_income_study.py
+++ b/etl/steps/data/meadow/lis/2024-06-13/luxembourg_income_study.py
@@ -76,7 +76,7 @@ def edit_snapshots_and_add_to_dataset(
         for tb_name, tb_ids in snapshots_dict.items():
             # Retrieve snapshot.
             snap = paths.load_snapshot(f"{tb_name}{age_suffix}.csv")
-            tb = snap.read()
+            tb = snap.read(safe_types=False)
 
             tb[[col for col in tb.columns if col not in tb_ids]] = tb[
                 [col for col in tb.columns if col not in tb_ids]

--- a/etl/steps/data/meadow/moatsos/2023-10-09/moatsos_historical_poverty.py
+++ b/etl/steps/data/meadow/moatsos/2023-10-09/moatsos_historical_poverty.py
@@ -18,25 +18,25 @@ def run(dest_dir: str) -> None:
     # Retrieve snapshot and load data
     # OECD (Cost of Basic Needs and $1.90 poverty line (2011 PPP))
     snap = paths.load_snapshot("moatsos_historical_poverty_oecd.csv")
-    tb_oecd = snap.read()
+    tb_oecd = snap.read(safe_types=False)
 
     # $5, $10, $30 poverty lines (2011 PPP)
     snap = paths.load_snapshot("moatsos_historical_poverty_5.csv")
-    tb_5 = snap.read()
+    tb_5 = snap.read(safe_types=False)
 
     snap = paths.load_snapshot("moatsos_historical_poverty_10.csv")
-    tb_10 = snap.read()
+    tb_10 = snap.read(safe_types=False)
 
     snap = paths.load_snapshot("moatsos_historical_poverty_30.csv")
-    tb_30 = snap.read()
+    tb_30 = snap.read(safe_types=False)
 
     # CBN share for countries
     snap = paths.load_snapshot("moatsos_historical_poverty_oecd_countries_share.xlsx")
-    tb_cbn_share_countries = snap.read(sheet_name="Sheet1", header=2)
+    tb_cbn_share_countries = snap.read(safe_types=False, sheet_name="Sheet1", header=2)
 
     # CBN number for regions
     snap = paths.load_snapshot("moatsos_historical_poverty_oecd_regions_number.xlsx")
-    tb_cbn_number = snap.read(sheet_name="g9-4", header=17)
+    tb_cbn_number = snap.read(safe_types=False, sheet_name="g9-4", header=17)
 
     # Merge and format tables
     tables = [tb_oecd, tb_5, tb_10, tb_30]

--- a/etl/steps/data/meadow/neglected_tropical_diseases/2024-05-02/lymphatic_filariasis.py
+++ b/etl/steps/data/meadow/neglected_tropical_diseases/2024-05-02/lymphatic_filariasis.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("lymphatic_filariasis.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/neglected_tropical_diseases/2024-05-02/schistosomiasis.py
+++ b/etl/steps/data/meadow/neglected_tropical_diseases/2024-05-02/schistosomiasis.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("schistosomiasis.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/neglected_tropical_diseases/2024-05-02/soil_transmitted_helminthiases.py
+++ b/etl/steps/data/meadow/neglected_tropical_diseases/2024-05-02/soil_transmitted_helminthiases.py
@@ -17,7 +17,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("soil_transmitted_helminthiases.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb = tb.drop(columns="country_code")
 
     #

--- a/etl/steps/data/meadow/news/2024-05-08/guardian_mentions.py
+++ b/etl/steps/data/meadow/news/2024-05-08/guardian_mentions.py
@@ -14,11 +14,11 @@ def run(dest_dir: str) -> None:
     ## Attention (via tags)
     snap = paths.load_snapshot("guardian_mentions.csv")
     ## Load data from snapshot.
-    tb_tags = snap.read()
+    tb_tags = snap.read(safe_types=False)
     ## Attention (via mentions)
     snap = paths.load_snapshot("guardian_mentions_raw.csv")
     ## Load data from snapshot.
-    tb_mentions = snap.read()
+    tb_mentions = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/news/2024-05-23/gdelt_v2.py
+++ b/etl/steps/data/meadow/news/2024-05-23/gdelt_v2.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gdelt_v2.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/oecd/2023-09-21/plastic_aquatic_leakage.py
+++ b/etl/steps/data/meadow/oecd/2023-09-21/plastic_aquatic_leakage.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("plastic_aquatic_leakage.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/oecd/2023-09-21/plastic_aquatic_leakage_projections.py
+++ b/etl/steps/data/meadow/oecd/2023-09-21/plastic_aquatic_leakage_projections.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("plastic_aquatic_leakage_projections.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/oecd/2023-09-21/plastic_emissions.py
+++ b/etl/steps/data/meadow/oecd/2023-09-21/plastic_emissions.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("plastic_emissions.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/oecd/2023-09-21/plastic_environment_leakage_projections.py
+++ b/etl/steps/data/meadow/oecd/2023-09-21/plastic_environment_leakage_projections.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("plastic_environment_leakage_projections.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/oecd/2023-09-21/plastic_fate_regions.py
+++ b/etl/steps/data/meadow/oecd/2023-09-21/plastic_fate_regions.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("plastic_fate_regions.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     # Process data.
     #
     columns_to_use = ["Location", "Plastic end of life fates", "Time", "Value"]

--- a/etl/steps/data/meadow/oecd/2023-09-21/plastic_fate_regions_projections.py
+++ b/etl/steps/data/meadow/oecd/2023-09-21/plastic_fate_regions_projections.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("plastic_fate_regions_projections.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/oecd/2023-09-21/plastic_use_application.py
+++ b/etl/steps/data/meadow/oecd/2023-09-21/plastic_use_application.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("plastic_use_application.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/oecd/2023-09-21/plastic_use_polymer.py
+++ b/etl/steps/data/meadow/oecd/2023-09-21/plastic_use_polymer.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("plastic_use_polymer.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/oecd/2023-09-21/plastic_use_projections.py
+++ b/etl/steps/data/meadow/oecd/2023-09-21/plastic_use_projections.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("plastic_use_projections.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/oecd/2023-09-21/plastic_waste_2019.py
+++ b/etl/steps/data/meadow/oecd/2023-09-21/plastic_waste_2019.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("plastic_waste_2019.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/oecd/2023-10-11/life_expectancy_birth.py
+++ b/etl/steps/data/meadow/oecd/2023-10-11/life_expectancy_birth.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("life_expectancy_birth.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/oecd/2024-02-23/health_expenditure.py
+++ b/etl/steps/data/meadow/oecd/2024-02-23/health_expenditure.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("health_expenditure.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/oecd/2024-04-10/income_distribution_database.py
+++ b/etl/steps/data/meadow/oecd/2024-04-10/income_distribution_database.py
@@ -20,7 +20,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("income_distribution_database.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/oecd/2024-04-30/affordable_housing_database.py
+++ b/etl/steps/data/meadow/oecd/2024-04-30/affordable_housing_database.py
@@ -205,22 +205,22 @@ def run(dest_dir: str) -> None:
 
     # Load data from snapshot.
     # Point-in-time data
-    tb_point_in_time = snap.read(sheet_name="HC3.1.1", usecols="L:P", skiprows=2, na_values=[".."])
+    tb_point_in_time = snap.read(safe_types=False, sheet_name="HC3.1.1", usecols="L:P", skiprows=2, na_values=[".."])
 
     # Flow data
-    tb_flow = snap.read(sheet_name="HC3.1.1", usecols="S:W", skiprows=2, na_values=[".."])
+    tb_flow = snap.read(safe_types=False, sheet_name="HC3.1.1", usecols="S:W", skiprows=2, na_values=[".."])
 
     # Share of women
-    tb_women = snap.read(sheet_name="HC3.1.2", usecols="R:S", skiprows=1, na_values=[".."])
+    tb_women = snap.read(safe_types=False, sheet_name="HC3.1.2", usecols="R:S", skiprows=1, na_values=[".."])
 
     # Index of people experiencing homelessness
-    tb_index = snap.read(sheet_name="HC3.1.3", usecols="L:S", skiprows=6, na_values=[".."])
+    tb_index = snap.read(safe_types=False, sheet_name="HC3.1.3", usecols="L:S", skiprows=6, na_values=[".."])
 
     # Share trends
-    tb_share = snap.read(sheet_name="HC3.1.4", usecols="Q:AE", skiprows=6, na_values=[".."])
+    tb_share = snap.read(safe_types=False, sheet_name="HC3.1.4", usecols="Q:AE", skiprows=6, na_values=[".."])
 
     # Number of people experiencing homelessness
-    tb_number = snap.read(sheet_name="Table_HC3.1.A2", skiprows=3, na_values=[".."])
+    tb_number = snap.read(safe_types=False, sheet_name="Table_HC3.1.A2", skiprows=3, na_values=[".."])
 
     #
     # Process data.

--- a/etl/steps/data/meadow/oecd/2024-07-01/passenger_travel.py
+++ b/etl/steps/data/meadow/oecd/2024-07-01/passenger_travel.py
@@ -21,7 +21,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("passenger_travel.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # drop columns not needed
     tb = tb[COLS_TO_KEEP.keys()]

--- a/etl/steps/data/meadow/oecd/2024-07-01/road_accidents.py
+++ b/etl/steps/data/meadow/oecd/2024-07-01/road_accidents.py
@@ -22,7 +22,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("road_accidents.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # drop unneeded columns
     tb = tb[COLS_TO_KEEP.keys()]

--- a/etl/steps/data/meadow/oecd/2024-08-08/tackling_inequalities_brazil_2010.py
+++ b/etl/steps/data/meadow/oecd/2024-08-08/tackling_inequalities_brazil_2010.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("tackling_inequalities_brazil_2010.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/oecd/2024-08-15/decile_ratios.py
+++ b/etl/steps/data/meadow/oecd/2024-08-15/decile_ratios.py
@@ -23,7 +23,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("decile_ratios.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/oecd/2024-08-19/ppp_exchange_rates.py
+++ b/etl/steps/data/meadow/oecd/2024-08-19/ppp_exchange_rates.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ppp_exchange_rates.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     columns_to_use = ["Reference area", "Transaction", "TIME_PERIOD", "OBS_VALUE"]
 
     tb = tb[columns_to_use]

--- a/etl/steps/data/meadow/oecd/2024-08-21/co2_air_transport.py
+++ b/etl/steps/data/meadow/oecd/2024-08-21/co2_air_transport.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("co2_air_transport.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     columns_to_use = [
         "Reference area",
         "Frequency of observation",

--- a/etl/steps/data/meadow/ons/2024-03-20/hours_and_earnings_uk.py
+++ b/etl/steps/data/meadow/ons/2024-03-20/hours_and_earnings_uk.py
@@ -33,7 +33,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("hours_and_earnings_uk.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Table 5", header=2)
+    tb = snap.read(safe_types=False, sheet_name="Table 5", header=2)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/papers/2023-10-20/anthromes.py
+++ b/etl/steps/data/meadow/papers/2023-10-20/anthromes.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("anthromes.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/papers/2023-12-12/farmer_lafond_2016.py
+++ b/etl/steps/data/meadow/papers/2023-12-12/farmer_lafond_2016.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     #
     # Load snapshot.
     snap = paths.load_snapshot("farmer_lafond_2016.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Prepare data.

--- a/etl/steps/data/meadow/papers/2023-12-12/nemet_2009.py
+++ b/etl/steps/data/meadow/papers/2023-12-12/nemet_2009.py
@@ -22,7 +22,7 @@ def run(dest_dir: str) -> None:
     #
     # Load snapshot.
     snap = paths.load_snapshot("nemet_2009.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/papers/2024-03-26/bayliss_smith_wanmali_1984.py
+++ b/etl/steps/data/meadow/papers/2024-03-26/bayliss_smith_wanmali_1984.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("bayliss_smith_wanmali_1984.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/papers/2024-03-26/brassley_2000.py
+++ b/etl/steps/data/meadow/papers/2024-03-26/brassley_2000.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("brassley_2000.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/papers/2024-03-26/broadberry_et_al_2015.py
+++ b/etl/steps/data/meadow/papers/2024-03-26/broadberry_et_al_2015.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("broadberry_et_al_2015.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/papers/2024-03-26/wuepper_et_al_2020.py
+++ b/etl/steps/data/meadow/papers/2024-03-26/wuepper_et_al_2020.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("wuepper_et_al_2020.xlsx")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/papers/2024-10-25/ipsos.py
+++ b/etl/steps/data/meadow/papers/2024-10-25/ipsos.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("ipsos.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb = tb.rename(columns={"Entity": "country", "Year": "year"}, errors="raise").drop(columns=["Code"])
     #
     # Process data.

--- a/etl/steps/data/meadow/pew/2024-06-03/same_sex_marriage.py
+++ b/etl/steps/data/meadow/pew/2024-06-03/same_sex_marriage.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("same_sex_marriage.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/sipri/2024-07-08/military_expenditure.py
+++ b/etl/steps/data/meadow/sipri/2024-07-08/military_expenditure.py
@@ -27,11 +27,17 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("military_expenditure.xlsx")
 
     # Load data from snapshot.
-    tb_constant_usd = snap.read(sheet_name="Constant (2022) US$", skiprows=5, na_values=["...", "xxx"])
-    tb_constant_usd_regions = snap.read(sheet_name="Regional totals", skiprows=13, na_values=["...", "xxx"])
-    tb_share_gdp = snap.read(sheet_name="Share of GDP", skiprows=5, na_values=["...", "xxx"])
-    tb_per_capita = snap.read(sheet_name="Per capita", skiprows=6, na_values=["...", "xxx"])
-    tb_share_govt_spending = snap.read(sheet_name="Share of Govt. spending", skiprows=7, na_values=["...", "xxx"])
+    tb_constant_usd = snap.read(
+        safe_types=False, sheet_name="Constant (2022) US$", skiprows=5, na_values=["...", "xxx"]
+    )
+    tb_constant_usd_regions = snap.read(
+        safe_types=False, sheet_name="Regional totals", skiprows=13, na_values=["...", "xxx"]
+    )
+    tb_share_gdp = snap.read(safe_types=False, sheet_name="Share of GDP", skiprows=5, na_values=["...", "xxx"])
+    tb_per_capita = snap.read(safe_types=False, sheet_name="Per capita", skiprows=6, na_values=["...", "xxx"])
+    tb_share_govt_spending = snap.read(
+        safe_types=False, sheet_name="Share of Govt. spending", skiprows=7, na_values=["...", "xxx"]
+    )
 
     #
     # Process data.

--- a/etl/steps/data/meadow/space/2024-01-03/near_earth_asteroids.py
+++ b/etl/steps/data/meadow/space/2024-01-03/near_earth_asteroids.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("near_earth_asteroids.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/space/2024-01-04/object_launches.py
+++ b/etl/steps/data/meadow/space/2024-01-04/object_launches.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("object_launches.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/state_capacity/2023-10-19/state_capacity_dataset.py
+++ b/etl/steps/data/meadow/state_capacity/2023-10-19/state_capacity_dataset.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("state_capacity_dataset.dta")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/state_capacity/2023-11-10/information_capacity_dataset.py
+++ b/etl/steps/data/meadow/state_capacity/2023-11-10/information_capacity_dataset.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("information_capacity_dataset.dta")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/statins/2023-10-05/bmj_2022.py
+++ b/etl/steps/data/meadow/statins/2023-10-05/bmj_2022.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("bmj_2022.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # Process data.
     #
@@ -55,6 +55,7 @@ def run(dest_dir: str) -> None:
     essential_med_tb["year"] = 2017
     essential_med_tb["indicator"] = "Essential medicine list"
     essential_med_tb = essential_med_tb.rename(columns={"statins_essential_medicine_2017": "value"})
+    essential_med_tb["value"] = essential_med_tb["value"].astype(str)
     essential_med_tb["value"].replace("-", np.nan, inplace=True)
     essential_med_tb["value"].replace("No", 0, inplace=True)
     essential_med_tb["value"].replace("Yes", 1, inplace=True)

--- a/etl/steps/data/meadow/statins/2023-10-05/lancet_2022.py
+++ b/etl/steps/data/meadow/statins/2023-10-05/lancet_2022.py
@@ -14,11 +14,11 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("lancet_2022.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # Remove all characters after "(" in statin use (confidence boundaries for statin use)
-    tb["statin_use_secondary"] = tb["statin_use_secondary"].str.split("(").str[0].str.strip().astype(float)
-    tb["statin_use_primary"] = tb["statin_use_primary"].str.split("(").str[0].str.strip().astype(float)
+    tb["statin_use_secondary"] = tb["statin_use_secondary"].str.split("(").str[0].str.strip().astype("float[pyarrow]")
+    tb["statin_use_primary"] = tb["statin_use_primary"].str.split("(").str[0].str.strip().astype("float[pyarrow]")
     # Drop rows that contain only NaN values and row with Grenadines (actually belongs to St. Vincent and the Grenadines, row above)
     tb = tb[tb["country"] != "Grenadines"]
     tb = tb.dropna(how="all")

--- a/etl/steps/data/meadow/statistics_canada/2024-08-09/gini_coefficients.py
+++ b/etl/steps/data/meadow/statistics_canada/2024-08-09/gini_coefficients.py
@@ -26,7 +26,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gini_coefficients.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/statistics_canada/2024-08-09/relative_poverty.py
+++ b/etl/steps/data/meadow/statistics_canada/2024-08-09/relative_poverty.py
@@ -17,7 +17,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("relative_poverty.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/survey/2023-08-04/latinobarometro_trust.py
+++ b/etl/steps/data/meadow/survey/2023-08-04/latinobarometro_trust.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("latinobarometro_trust.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/survey/2023-08-07/afrobarometer_trust.py
+++ b/etl/steps/data/meadow/survey/2023-08-07/afrobarometer_trust.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("afrobarometer_trust.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/technology/2023-11-28/dna_sequencing.py
+++ b/etl/steps/data/meadow/technology/2023-11-28/dna_sequencing.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("dna_sequencing.xls")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/tourism/2024-08-17/unwto.py
+++ b/etl/steps/data/meadow/tourism/2024-08-17/unwto.py
@@ -40,7 +40,7 @@ def run(dest_dir: str) -> None:
 
     tbs = []
     for sheet_name in sheet_names_to_load:
-        tb = snap.read(sheet_name=sheet_name, header=2)
+        tb = snap.read(safe_types=False, sheet_name=sheet_name, header=2)
 
         # Drop unnecessary columns
         columns_to_drop = ["C.", "S.", "C. & S.", "Units", "Notes", "Series", "Unnamed: 38", "Unnamed: 39"]

--- a/etl/steps/data/meadow/tourism/2024-08-17/unwto_environment.py
+++ b/etl/steps/data/meadow/tourism/2024-08-17/unwto_environment.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("unwto_environment.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/tourism/2024-08-17/unwto_gdp.py
+++ b/etl/steps/data/meadow/tourism/2024-08-17/unwto_gdp.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("unwto_gdp.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/tuberculosis/2023-11-27/burden_estimates.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-11-27/burden_estimates.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("burden_estimates.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/tuberculosis/2023-12-01/budget.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-12-01/budget.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("budget.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb = tb.drop(columns=["iso2", "iso3", "iso_numeric", "g_whoregion"])
     # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
     tb = tb.underscore().set_index(["country", "year"], verify_integrity=True).sort_index()

--- a/etl/steps/data/meadow/tuberculosis/2023-12-04/burden_disaggregated.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-12-04/burden_disaggregated.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("burden_disaggregated.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/tuberculosis/2023-12-04/drug_resistance_surveillance.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-12-04/drug_resistance_surveillance.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("drug_resistance_surveillance.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb = tb.drop(columns=["iso2", "iso3", "iso_numeric", "g_whoregion"])
     #
     # Process data.

--- a/etl/steps/data/meadow/tuberculosis/2023-12-05/expenditure.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-12-05/expenditure.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("expenditure.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb = tb.drop(columns=["iso2", "iso3", "iso_numeric", "g_whoregion"])
 
     #

--- a/etl/steps/data/meadow/tuberculosis/2023-12-06/laboratories.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-12-06/laboratories.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("laboratories.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/tuberculosis/2023-12-06/latent.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-12-06/latent.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("latent.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/tuberculosis/2023-12-11/notifications.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-12-11/notifications.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("notifications.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/tuberculosis/2023-12-11/outcomes.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-12-11/outcomes.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("outcomes.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/tuberculosis/2023-12-12/outcomes_disagg.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-12-12/outcomes_disagg.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("outcomes_disagg.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/tuberculosis/2023-12-12/unhlm_commitments.py
+++ b/etl/steps/data/meadow/tuberculosis/2023-12-12/unhlm_commitments.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("unhlm_commitments.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/un/2018/igme.py
+++ b/etl/steps/data/meadow/un/2018/igme.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("igme.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb = tb.rename(columns={"REF_AREA_NAME": "country", "REF_DATE": "year"})
     columns_to_keep = [
         "country",

--- a/etl/steps/data/meadow/un/2023-10-30/un_members.py
+++ b/etl/steps/data/meadow/un/2023-10-30/un_members.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("un_members.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/un/2024-01-17/urban_agglomerations_300k.py
+++ b/etl/steps/data/meadow/un/2024-01-17/urban_agglomerations_300k.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("urban_agglomerations_300k.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/un/2024-01-17/urban_agglomerations_definition.py
+++ b/etl/steps/data/meadow/un/2024-01-17/urban_agglomerations_definition.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("urban_agglomerations_definition.xls")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/un/2024-01-17/urban_agglomerations_largest_cities.py
+++ b/etl/steps/data/meadow/un/2024-01-17/urban_agglomerations_largest_cities.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("urban_agglomerations_largest_cities.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/un/2024-01-17/urban_agglomerations_size_class.py
+++ b/etl/steps/data/meadow/un/2024-01-17/urban_agglomerations_size_class.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("urban_agglomerations_size_class.xls")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/un/2024-01-17/urbanization_urban_rural.py
+++ b/etl/steps/data/meadow/un/2024-01-17/urbanization_urban_rural.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("urbanization_urban_rural.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/un/2024-07-11/un_wpp.py
+++ b/etl/steps/data/meadow/un/2024-07-11/un_wpp.py
@@ -129,10 +129,10 @@ def read_estimates_and_projections_from_snap(short_name: str) -> Table:
     snap = paths.load_snapshot(short_name)
     # Read tables
     # TODO: Add support for Low, and High variants
-    tb_estimates = snap.read(sheet_name="Estimates")
-    tb_projections_medium = snap.read(sheet_name="Medium")
-    # tb_projections_low = snap.read(sheet_name="Low")
-    # tb_projections_high = snap.read(sheet_name="High")
+    tb_estimates = snap.read(safe_types=False, sheet_name="Estimates")
+    tb_projections_medium = snap.read(safe_types=False, sheet_name="Medium")
+    # tb_projections_low = snap.read(safe_types=False, sheet_name="Low")
+    # tb_projections_high = snap.read(safe_types=False, sheet_name="High")
     # Merge tables
     tb = concat(
         [

--- a/etl/steps/data/meadow/un/2024-07-12/un_wpp.py
+++ b/etl/steps/data/meadow/un/2024-07-12/un_wpp.py
@@ -350,10 +350,10 @@ def read_from_xlsx(short_name: str) -> Table:
     # Read snap
     snap = paths.load_snapshot(short_name)
     # Read tables
-    tb_estimates = snap.read(sheet_name="Estimates", skiprows=16)
-    tb_projections_medium = snap.read(sheet_name="Medium variant", skiprows=16)
-    tb_projections_low = snap.read(sheet_name="Low variant", skiprows=16)
-    tb_projections_high = snap.read(sheet_name="High variant", skiprows=16)
+    tb_estimates = snap.read(safe_types=False, sheet_name="Estimates", skiprows=16)
+    tb_projections_medium = snap.read(safe_types=False, sheet_name="Medium variant", skiprows=16)
+    tb_projections_low = snap.read(safe_types=False, sheet_name="Low variant", skiprows=16)
+    tb_projections_high = snap.read(safe_types=False, sheet_name="High variant", skiprows=16)
     # Merge tables
     tb = concat(
         [

--- a/etl/steps/data/meadow/un/2024-08-27/un_sdg.py
+++ b/etl/steps/data/meadow/un/2024-08-27/un_sdg.py
@@ -100,7 +100,7 @@ def run(dest_dir: str) -> None:
     log.info("un_sdg.start")
     snap = paths.load_snapshot("un_sdg.feather")
 
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/un/2024-09-11/igme.py
+++ b/etl/steps/data/meadow/un/2024-09-11/igme.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("igme.zip")
 
     # Load data from snapshot.
-    tb = snap.read_in_archive("UN IGME 2023.csv", low_memory=False)
+    tb = snap.read_in_archive("UN IGME 2023.csv", low_memory=False, safe_types=False)
     #
     # Process data.
     #

--- a/etl/steps/data/meadow/unicef/2024-07-30/child_migration.py
+++ b/etl/steps/data/meadow/unicef/2024-07-30/child_migration.py
@@ -38,7 +38,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("child_migration.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # Rename columns.
     tb = tb[COLUMNS_TO_KEEP]

--- a/etl/steps/data/meadow/unu_wider/2023-11-01/government_revenue_dataset.py
+++ b/etl/steps/data/meadow/unu_wider/2023-11-01/government_revenue_dataset.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("government_revenue_dataset.dta")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/unu_wider/2024-04-22/world_income_inequality_database.py
+++ b/etl/steps/data/meadow/unu_wider/2024-04-22/world_income_inequality_database.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("world_income_inequality_database.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Sheet1")
+    tb = snap.read(safe_types=False, sheet_name="Sheet1")
 
     # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
     tb = tb.format(

--- a/etl/steps/data/meadow/urbanization/2024-10-14/ghsl_degree_of_urbanisation.py
+++ b/etl/steps/data/meadow/urbanization/2024-10-14/ghsl_degree_of_urbanisation.py
@@ -62,7 +62,7 @@ def run(dest_dir: str) -> None:
 
 def load_and_process_sheet(snap, sheet_name: str, columns_to_drop: list) -> Table:
     # Load data from snapshot.
-    tb = snap.read(sheet_name=sheet_name)
+    tb = snap.read(safe_types=False, sheet_name=sheet_name)
 
     # Remove rows where all values are NaNs.
     tb = tb.dropna(how="all")

--- a/etl/steps/data/meadow/usda_ers/2024-05-23/food_availability.py
+++ b/etl/steps/data/meadow/usda_ers/2024-05-23/food_availability.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshots and read their data.
     snap = paths.load_snapshot("food_availability.xls")
-    data = snap.read(sheet_name="Totals", skiprows=1)
+    data = snap.read(safe_types=False, sheet_name="Totals", skiprows=1)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/war/2023-09-21/mars.py
+++ b/etl/steps/data/meadow/war/2023-09-21/mars.py
@@ -22,7 +22,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("war_mars.xls")
 
     # Read excel
-    tb = snap.read(sheet_name="ProjectMarsV1.1")
+    tb = snap.read(safe_types=False, sheet_name="ProjectMarsV1.1")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/war/2023-09-21/prio_v31.py
+++ b/etl/steps/data/meadow/war/2023-09-21/prio_v31.py
@@ -22,7 +22,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("prio_v31.xls")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/war/2023-11-29/chupilkin_koczan.py
+++ b/etl/steps/data/meadow/war/2023-11-29/chupilkin_koczan.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("chupilkin_koczan.dta")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/war/2024-01-08/strategic_nuclear_forces.py
+++ b/etl/steps/data/meadow/war/2024-01-08/strategic_nuclear_forces.py
@@ -12,11 +12,11 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshots of dyadic data.
     snap = paths.load_snapshot("strategic_nuclear_forces.xlsx")
-    tb_dyadic = snap.read()
+    tb_dyadic = snap.read(safe_types=False)
 
     # Retrieve snapshots of monadic data.
     snap = paths.load_snapshot("strategic_nuclear_forces_monadic.xlsx")
-    tb_monadic = snap.read()
+    tb_monadic = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/war/2024-01-11/nuclear_threat_initiative_overview.py
+++ b/etl/steps/data/meadow/war/2024-01-11/nuclear_threat_initiative_overview.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its main table.
     snap = paths.load_snapshot("nuclear_threat_initiative_overview.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/war/2024-01-23/nuclear_weapons_treaties.py
+++ b/etl/steps/data/meadow/war/2024-01-23/nuclear_weapons_treaties.py
@@ -24,7 +24,7 @@ def run(dest_dir: str) -> None:
     for treaty_short_name, treaty_title in TREATIES.items():
         # Retrieve snapshot and read its data.
         snap = paths.load_snapshot(f"{treaty_short_name}.csv")
-        tb = snap.read().assign(**{"treaty": treaty_title})
+        tb = snap.read(safe_types=False).assign(**{"treaty": treaty_title})
         data.append(tb)
 
     #

--- a/etl/steps/data/meadow/war/2024-01-30/strategic_nuclear_forces.py
+++ b/etl/steps/data/meadow/war/2024-01-30/strategic_nuclear_forces.py
@@ -12,11 +12,11 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshots of dyadic data.
     snap = paths.load_snapshot("strategic_nuclear_forces.xlsx")
-    tb_dyadic = snap.read()
+    tb_dyadic = snap.read(safe_types=False)
 
     # Retrieve snapshots of monadic data.
     snap = paths.load_snapshot("strategic_nuclear_forces_monadic.xlsx")
-    tb_monadic = snap.read()
+    tb_monadic = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/wash/2024-01-06/who.py
+++ b/etl/steps/data/meadow/wash/2024-01-06/who.py
@@ -20,7 +20,7 @@ def run(dest_dir: str) -> None:
     # Retrieve snapshot.
     snap = paths.load_snapshot("who.csv")
     snap_regions = paths.load_snapshot("who_regions.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb_reg = snap_regions.read()
     # Prepare data.
     tb = tb.drop(columns=["iso3"], axis=1)

--- a/etl/steps/data/meadow/wb/2023-11-21/worldwide_bureaucracy_indicators.py
+++ b/etl/steps/data/meadow/wb/2023-11-21/worldwide_bureaucracy_indicators.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("worldwide_bureaucracy_indicators.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/wb/2023-12-29/gender_statistics.py
+++ b/etl/steps/data/meadow/wb/2023-12-29/gender_statistics.py
@@ -8,7 +8,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("gender_statistics.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb = tb.format(["country", "year", "wb_seriescode"])
 
     # Drop indicator_name column series column as it should be roughgly the same as indicator_name column (long definition of the indicator)

--- a/etl/steps/data/meadow/wb/2024-01-17/world_bank_pip.py
+++ b/etl/steps/data/meadow/wb/2024-01-17/world_bank_pip.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     # Retrieve snapshots.
     # For key indicators
     snap = paths.load_snapshot("world_bank_pip.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # For percentiles
     snap_percentiles = paths.load_snapshot("world_bank_pip_percentiles.csv")

--- a/etl/steps/data/meadow/wb/2024-01-22/thousand_bins_distribution.py
+++ b/etl/steps/data/meadow/wb/2024-01-22/thousand_bins_distribution.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("thousand_bins_distribution.dta")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/wb/2024-03-11/income_groups.py
+++ b/etl/steps/data/meadow/wb/2024-03-11/income_groups.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     #
     # Load snapshot and read its data.
     snap = paths.load_snapshot("income_groups.xlsx")
-    tb = snap.read(sheet_name="Country Analytical History")
+    tb = snap.read(safe_types=False, sheet_name="Country Analytical History")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/wb/2024-03-27/world_bank_pip.py
+++ b/etl/steps/data/meadow/wb/2024-03-27/world_bank_pip.py
@@ -13,7 +13,7 @@ def run(dest_dir: str) -> None:
     # Retrieve snapshots.
     # For key indicators
     snap = paths.load_snapshot("world_bank_pip.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # For percentiles
     snap_percentiles = paths.load_snapshot("world_bank_pip_percentiles.csv")

--- a/etl/steps/data/meadow/wb/2024-07-29/income_groups.py
+++ b/etl/steps/data/meadow/wb/2024-07-29/income_groups.py
@@ -18,7 +18,7 @@ def run(dest_dir: str) -> None:
     #
     # Load snapshot and read its data.
     snap = paths.load_snapshot("income_groups.xlsx")
-    tb = snap.read(sheet_name="Country Analytical History")
+    tb = snap.read(safe_types=False, sheet_name="Country Analytical History")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/wb/2024-09-09/food_prices_for_nutrition.py
+++ b/etl/steps/data/meadow/wb/2024-09-09/food_prices_for_nutrition.py
@@ -46,7 +46,7 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot and read its data.
     snap = paths.load_snapshot("food_prices_for_nutrition.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/wb/2024-10-07/world_bank_pip.py
+++ b/etl/steps/data/meadow/wb/2024-10-07/world_bank_pip.py
@@ -13,15 +13,15 @@ def run(dest_dir: str) -> None:
     # Retrieve snapshots.
     # For key indicators
     snap = paths.load_snapshot("world_bank_pip.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # For percentiles
     snap_percentiles = paths.load_snapshot("world_bank_pip_percentiles.csv")
-    tb_percentiles = snap_percentiles.read()
+    tb_percentiles = snap_percentiles.read(safe_types=False)
 
     # For regional definitions
     snap_regions = paths.load_snapshot("world_bank_pip_regions.csv")
-    tb_regions = snap_regions.read()
+    tb_regions = snap_regions.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/who/2022-09-30/ghe.py
+++ b/etl/steps/data/meadow/who/2022-09-30/ghe.py
@@ -8,7 +8,7 @@ paths = PathFinder(__file__)
 
 def run(dest_dir: str) -> None:
     snap = paths.load_snapshot()
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # clean and transform data
     tb = clean_data(tb)

--- a/etl/steps/data/meadow/who/2024-04-08/polio_afp.py
+++ b/etl/steps/data/meadow/who/2024-04-08/polio_afp.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("polio_afp.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     tb = tb.rename(columns={"Country / Territory / Region": "country", "Year": "year"})
     #
     # Process data.

--- a/etl/steps/data/meadow/who/2024-04-09/polio_historical.py
+++ b/etl/steps/data/meadow/who/2024-04-09/polio_historical.py
@@ -16,7 +16,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("polio_historical.xls")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="Polio")
+    tb = snap.read(safe_types=False, sheet_name="Polio")
 
     #
     # Process data.

--- a/etl/steps/data/meadow/who/2024-04-22/polio_vaccine_schedule.py
+++ b/etl/steps/data/meadow/who/2024-04-22/polio_vaccine_schedule.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("polio_vaccine_schedule.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/who/2024-04-26/avian_influenza_ah5n1.py
+++ b/etl/steps/data/meadow/who/2024-04-26/avian_influenza_ah5n1.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("avian_influenza_ah5n1.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/who/2024-07-26/mortality_database.py
+++ b/etl/steps/data/meadow/who/2024-07-26/mortality_database.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("mortality_database.feather")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/who/2024-07-30/ghe.py
+++ b/etl/steps/data/meadow/who/2024-07-30/ghe.py
@@ -8,7 +8,7 @@ paths = PathFinder(__file__)
 
 def run(dest_dir: str) -> None:
     snap = paths.load_snapshot()
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     # clean and transform data
     tb = clean_data(tb)

--- a/etl/steps/data/meadow/who/2024-08-06/mortality_database_cancer.py
+++ b/etl/steps/data/meadow/who/2024-08-06/mortality_database_cancer.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("mortality_database_cancer.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/who/latest/avian_influenza_ah5n1.py
+++ b/etl/steps/data/meadow/who/latest/avian_influenza_ah5n1.py
@@ -15,7 +15,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("avian_influenza_ah5n1.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/who/latest/monkeypox.py
+++ b/etl/steps/data/meadow/who/latest/monkeypox.py
@@ -14,7 +14,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("monkeypox.csv")
 
     # Load data from snapshot.
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
 
     #
     # Process data.

--- a/etl/steps/data/meadow/wpf/2024-10-03/famines.py
+++ b/etl/steps/data/meadow/wpf/2024-10-03/famines.py
@@ -76,7 +76,7 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("famines.xlsx")
 
     # Load data from snapshot.
-    tb = snap.read(sheet_name="0. Spreadsheet for disseminatio")
+    tb = snap.read(safe_types=False, sheet_name="0. Spreadsheet for disseminatio")
 
     #
     # Process data.

--- a/etl/steps/export/explorers/covid/latest/covid.py
+++ b/etl/steps/export/explorers/covid/latest/covid.py
@@ -69,7 +69,7 @@ def run(dest_dir: str) -> None:
 
     # Load necessry tables
     # ds = paths.load_dataset("cases_deaths")
-    # tb = ds.read_table("cases_deaths")
+    # tb = ds.read("cases_deaths")
 
     # Read all tables
     # tables = {}

--- a/etl/steps/export/explorers/migration/2024-08-05/migration.py
+++ b/etl/steps/export/explorers/migration/2024-08-05/migration.py
@@ -27,12 +27,12 @@ def run(dest_dir: str) -> None:
     ds_wdi = paths.load_dataset("wdi")
     ds_idmc = paths.load_dataset("internal_displacement")
 
-    tb_child_mig = ds_unicef.read_table("child_migration")
-    tb_refugee_data = ds_unhcr.read_table("refugee_data")
-    tb_migrant_stock = ds_undesa.read_table("migrant_stock")
-    tb_un_wpp_full = ds_un_wpp.read_table("migration")
-    tb_wdi = ds_wdi.read_table("wdi")
-    tb_idmc = ds_idmc.read_table("internal_displacement")
+    tb_child_mig = ds_unicef.read("child_migration")
+    tb_refugee_data = ds_unhcr.read("refugee_data")
+    tb_migrant_stock = ds_undesa.read("migrant_stock")
+    tb_un_wpp_full = ds_un_wpp.read("migration")
+    tb_wdi = ds_wdi.read("wdi")
+    tb_idmc = ds_idmc.read("internal_displacement")
 
     tbs_and_ds = [
         (tb_child_mig, ds_unicef),

--- a/etl/steps/export/explorers/minerals/latest/minerals.py
+++ b/etl/steps/export/explorers/minerals/latest/minerals.py
@@ -22,7 +22,7 @@ def run(dest_dir: str) -> None:
     #
     # Load minerals grapher dataset and read its main table.
     ds = paths.load_dataset("minerals")
-    tb = ds.read_table("minerals")
+    tb = ds.read("minerals")
 
     #
     # Process data.

--- a/etl/steps/export/explorers/minerals/latest/minerals_supply_and_demand_prospects.py
+++ b/etl/steps/export/explorers/minerals/latest/minerals_supply_and_demand_prospects.py
@@ -18,11 +18,11 @@ def run(dest_dir: str) -> None:
     #
     # Load minerals grapher dataset on demand by technology.
     ds_demand = paths.load_dataset("critical_minerals_demand_by_technology")
-    tb_demand = ds_demand.read_table("demand_by_technology")
+    tb_demand = ds_demand.read("demand_by_technology")
 
     # Load minerals grapher dataset on supply by country.
     ds_supply = paths.load_dataset("critical_minerals_supply_by_country")
-    tb_supply = ds_supply.read_table("supply_by_country")
+    tb_supply = ds_supply.read("supply_by_country")
 
     #
     # Process data.

--- a/etl/steps/export/github/who/latest/monkeypox.py
+++ b/etl/steps/export/github/who/latest/monkeypox.py
@@ -12,7 +12,7 @@ def run(dest_dir: str) -> None:
     # Load inputs.
     #
     ds = paths.load_dataset("monkeypox")
-    tb = ds.read_table("monkeypox")
+    tb = ds.read("monkeypox")
 
     # Process it for backwards compatibility.
     tb = tb.rename(columns={"country": "location"}).drop(columns=["suspected_cases_cumulative", "annotation"])

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -11,12 +11,14 @@ from glob import glob
 from os import environ
 from os.path import join
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Literal, Optional, Union
+from typing import Any, Dict, Iterator, List, Literal, Optional, Union, cast
 
 import numpy as np
 import pandas as pd
 import yaml
 from _hashlib import HASH
+
+from owid.repack import to_safe_types
 
 from . import tables, utils
 from .meta import SOURCE_EXISTS_OPTIONS, DatasetMeta, TableMeta
@@ -153,12 +155,14 @@ class Dataset:
             table_filename = join(self.path, table.metadata.checked_name + f".{format}")
             table.to(table_filename, repack=repack)
 
-    def read_table(self, name: str, reset_index: bool = True) -> tables.Table:
+    def read(self, name: str, reset_index: bool = True, safe_types: bool = True) -> tables.Table:
         """Read dataset's table from disk. Alternative to ds[table_name], but
         with more options to optimize the reading.
 
         :param reset_index: If true, don't set primary keys of the table. This can make loading
             large datasets with multi-indexes much faster.
+        :param safe_types: If true, convert numeric columns to Float64 and Int64 and categorical
+            columns to string[pyarrow]. This can significantly increase memory usage.
         """
         stem = self.path / Path(name)
 
@@ -166,14 +170,15 @@ class Dataset:
             path = stem.with_suffix(f".{format}")
             if path.exists():
                 t = tables.Table.read(path, primary_key=[] if reset_index else None)
-                # dataset metadata might have been updated, refresh it
                 t.metadata.dataset = self.metadata
+                if safe_types:
+                    t = cast(tables.Table, to_safe_types(t))
                 return t
 
         raise KeyError(f"Table `{name}` not found, available tables: {', '.join(self.table_names)}")
 
     def __getitem__(self, name: str) -> tables.Table:
-        return self.read_table(name, reset_index=False)
+        return self.read(name, reset_index=False, safe_types=False)
 
     def __contains__(self, name: str) -> bool:
         return any((Path(self.path) / name).with_suffix(f".{format}").exists() for format in SUPPORTED_FORMATS)

--- a/lib/catalog/owid/catalog/variables.py
+++ b/lib/catalog/owid/catalog/variables.py
@@ -195,6 +195,12 @@ class Variable(pd.Series):
         return self.__mul__(other)
 
     def __truediv__(self, other: Union[Scalar, Series, "Variable"]) -> "Variable":  # type: ignore
+        if is_nullable_series(self) or is_nullable_series(other):
+            # 0/0 should return pd.NA, not np.nan
+            zero_div_zero = (other == 0) & (self == 0)
+            if zero_div_zero.any():
+                other = other.replace({0: pd.NA})  # type: ignore
+
         variable_name = self.name or UNNAMED_VARIABLE
         variable = Variable(super().__truediv__(other), name=variable_name)
         variable.metadata = combine_variables_metadata(variables=[self, other], operation="/", name=variable_name)
@@ -585,3 +591,24 @@ def copy_metadata(from_variable: Variable, to_variable: Variable, inplace: bool 
         new_variable = to_variable.copy()
         new_variable.metadata = from_variable.metadata.copy()
         return new_variable
+
+
+def is_nullable_series(s: Any) -> bool:
+    """Check if a series has a nullable pandas dtype."""
+    if not hasattr(s, "dtype"):
+        return False
+
+    nullable_types = {
+        "Int8",
+        "Int16",
+        "Int32",
+        "Int64",
+        "UInt8",
+        "UInt16",
+        "UInt32",
+        "UInt64",
+        "Float32",
+        "Float64",
+        "boolean",
+    }
+    return str(s.dtype) in nullable_types

--- a/lib/catalog/pyproject.toml
+++ b/lib/catalog/pyproject.toml
@@ -17,12 +17,12 @@ dependencies = [
     "Unidecode>=1.3.4",
     "PyYAML>=6.0.1",
     "structlog>=21.5.0",
-    "owid-repack>=0.1.1",
     "dynamic-yaml>=1.3.5",
     "mistune>=3.0.1",
-    "dataclasses-json==0.5.8",
+    "dataclasses-json>=0.6.7",
     "rdata==0.9",
     "owid-datautils",
+    "owid-repack",
 ]
 
 [tool.uv]
@@ -38,6 +38,7 @@ dev-dependencies = [
 
 [tool.uv.sources]
 owid-datautils = { path = "../datautils", editable = true }
+owid-repack = { path = "../repack", editable = true }
 
 [tool.ruff]
 extend = "../../pyproject.toml"

--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -599,3 +599,12 @@ def test_variable_rolling(variable_1: Variable):
     # make sure we are not modifying the original table
     rolling.m.title = "new"
     assert v.m.title != "new"
+
+
+def test_truediv_zero_division() -> None:
+    v1 = Variable([0, 1, 2], name="v1")
+    v2 = Variable([0, 1, 2], name="v2")
+    result = v1 / v2
+    assert result.isnull()[0]  # Check that 0/0 results in pandas NaN
+    assert not result.isnull()[1]  # Check that 1/1 does not result in NaN
+    assert not result.isnull()[2]  # Check that 2/2 does not result in NaN

--- a/lib/catalog/uv.lock
+++ b/lib/catalog/uv.lock
@@ -367,16 +367,15 @@ wheels = [
 
 [[package]]
 name = "dataclasses-json"
-version = "0.5.8"
+version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "marshmallow" },
-    { name = "marshmallow-enum" },
     { name = "typing-inspect" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/63/10cdc14908f3c9fdb9c21631275d2805853f6156b761a391e6f8918377e1/dataclasses-json-0.5.8.tar.gz", hash = "sha256:6572ac08ad9340abcb74fd8c4c8e9752db2a182a402c8e871d0a8aa119e3804e", size = 44113 }
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/bc/892e03650133583d5babbb7c7e5c1be6b68df86829c91fdc30cca996630d/dataclasses_json-0.5.8-py3-none-any.whl", hash = "sha256:65b167c15fdf9bde27569c09ac18dd39bf1cc5b7998525024cb4678d2653946c", size = 26211 },
+    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686 },
 ]
 
 [[package]]
@@ -653,18 +652,6 @@ wheels = [
 ]
 
 [[package]]
-name = "marshmallow-enum"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "marshmallow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/8c/ceecdce57dfd37913143087fffd15f38562a94f0d22823e3c66eac0dca31/marshmallow-enum-1.5.1.tar.gz", hash = "sha256:38e697e11f45a8e64b4a1e664000897c659b60aa57bfa18d44e226a9920b6e58", size = 4013 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/59/ef3a3dc499be447098d4a89399beb869f813fee1b5a57d5d79dee2c1bf51/marshmallow_enum-1.5.1-py2.py3-none-any.whl", hash = "sha256:57161ab3dbfde4f57adeb12090f39592e992b9c86d206d02f6bd03ebec60f072", size = 4186 },
-]
-
-[[package]]
 name = "matplotlib-inline"
 version = "0.1.7"
 source = { registry = "https://pypi.org/simple" }
@@ -798,14 +785,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.21.13" },
-    { name = "dataclasses-json", specifier = "==0.5.8" },
+    { name = "dataclasses-json", specifier = ">=0.6.7" },
     { name = "dynamic-yaml", specifier = ">=1.3.5" },
     { name = "ipdb", specifier = ">=0.13.9" },
     { name = "jsonschema", specifier = ">=3.2.0" },
     { name = "mistune", specifier = ">=3.0.1" },
     { name = "owid-datautils", editable = "../datautils" },
-    { name = "owid-repack", specifier = ">=0.1.1" },
-    { name = "pandas", specifier = "==2.2.1" },
+    { name = "owid-repack", editable = "../repack" },
+    { name = "pandas", specifier = ">=2.2.1" },
     { name = "pyarrow", specifier = ">=10.0.1" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "rdata", specifier = "==0.9" },
@@ -849,7 +836,7 @@ requires-dist = [
     { name = "colorama", specifier = ">=0.4.4" },
     { name = "gdown", specifier = ">=4.5.2" },
     { name = "gsheets", specifier = ">=0.6.1" },
-    { name = "pandas", specifier = "==2.2.1" },
+    { name = "pandas", specifier = ">=2.2.1" },
     { name = "pyarrow", specifier = ">=10.0.1" },
     { name = "pydrive2", specifier = ">=1.15.0" },
     { name = "structlog", specifier = ">=21.5.0" },
@@ -875,15 +862,27 @@ dev = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.3"
-source = { registry = "https://pypi.org/simple" }
+version = "0.1.4"
+source = { editable = "../repack" }
 dependencies = [
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pyarrow" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/5f/6b750fd47f0ac9074fb146c4a9dec6efc483eb73d6b26b9245f25059737e/owid_repack-0.1.3.tar.gz", hash = "sha256:b65075af87c63945795801a2d7fd744f3d9a47ce7faa20736f389051655bff4a", size = 4124 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/a9/8388e07e9a6e4da1188e2df3f85849808a44d8fd6765510c9d8a3a1d54a5/owid_repack-0.1.3-py3-none-any.whl", hash = "sha256:c1a5e58964e4d83db6377f286cfc1c766aa60ae58d9a37003bdcda0194957b26", size = 4532 },
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy", specifier = ">=1.24.0" },
+    { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pyarrow", specifier = ">=10.0.1,<18.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "ipdb", specifier = ">=0.13.13" },
+    { name = "pyright", specifier = "==1.1.373" },
+    { name = "pytest", specifier = ">=7.2.0" },
+    { name = "ruff", specifier = "==0.1.6" },
 ]
 
 [[package]]
@@ -897,7 +896,7 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "2.2.1"
+version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -905,36 +904,49 @@ dependencies = [
     { name = "pytz" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/59/2afa81b9fb300c90531803c0fd43ff4548074fa3e8d0f747ef63b3b5e77a/pandas-2.2.1.tar.gz", hash = "sha256:0ab90f87093c13f3e8fa45b48ba9f39181046e8f3317d3aadb2fffbb1b978572", size = 4395256 }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/f4495f8ab5a58b1eeee06b5abd811e0a93f7b75acdc89380797f99bdf91a/pandas-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8df8612be9cd1c7797c93e1c5df861b2ddda0b48b08f2c3eaa0702cf88fb5f88", size = 12543124 },
-    { url = "https://files.pythonhosted.org/packages/4f/19/0ae5f1557badfcae1052c1397041a2c5441e9f31e1c7b0cce7f8bc585f4e/pandas-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0f573ab277252ed9aaf38240f3b54cfc90fff8e5cab70411ee1d03f5d51f3944", size = 11285572 },
-    { url = "https://files.pythonhosted.org/packages/5d/d2/df8047f8c3648eb6b3ee86ef7ee811ad01e55b47a14ea02fe36d601e12cd/pandas-2.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f02a3a6c83df4026e55b63c1f06476c9aa3ed6af3d89b4f04ea656ccdaaaa359", size = 15629656 },
-    { url = "https://files.pythonhosted.org/packages/19/df/8d789d96a9e338cf28cb7978fa93ef5da53137624b7ef032f30748421c2b/pandas-2.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c38ce92cb22a4bea4e3929429aa1067a454dcc9c335799af93ba9be21b6beb51", size = 13024911 },
-    { url = "https://files.pythonhosted.org/packages/11/a1/9d5505c6c56740f7ed8bd78c8756fb76aeff1c706b30e6930ddf90693aee/pandas-2.2.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:c2ce852e1cf2509a69e98358e8458775f89599566ac3775e70419b98615f4b06", size = 16275635 },
-    { url = "https://files.pythonhosted.org/packages/d6/99/378e9108cf3562c7c6294249f1bfd3be08325af5e96af435fb221dd1c320/pandas-2.2.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:53680dc9b2519cbf609c62db3ed7c0b499077c7fefda564e330286e619ff0dd9", size = 13880082 },
-    { url = "https://files.pythonhosted.org/packages/93/26/2a695303a4a3194014dca7cb5d5ce08f0d2c6baa344fb5f562c642e77b2b/pandas-2.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:94e714a1cca63e4f5939cdce5f29ba8d415d85166be3441165edd427dc9f6bc0", size = 11592785 },
-    { url = "https://files.pythonhosted.org/packages/f1/8b/617792ad1feef330e87d7459584a1f91aa8aea373d8b168ac5d24fddd808/pandas-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f821213d48f4ab353d20ebc24e4faf94ba40d76680642fb7ce2ea31a3ad94f9b", size = 12564385 },
-    { url = "https://files.pythonhosted.org/packages/a5/78/1d859bfb619c067e3353ed079248ae9532c105c4e018fa9a776d04b34572/pandas-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c70e00c2d894cb230e5c15e4b1e1e6b2b478e09cf27cc593a11ef955b9ecc81a", size = 11303028 },
-    { url = "https://files.pythonhosted.org/packages/91/bf/8c57707e440f944ba2cf3d6f6ae6c29883fac20fbe5d2ad485229149f273/pandas-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e97fbb5387c69209f134893abc788a6486dbf2f9e511070ca05eed4b930b1b02", size = 15594865 },
-    { url = "https://files.pythonhosted.org/packages/d4/47/1ccf9f62d2674d3ca3e95452c5f9dd114234d1535dec77c96528bf6a31fc/pandas-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101d0eb9c5361aa0146f500773395a03839a5e6ecde4d4b6ced88b7e5a1a6403", size = 13034628 },
-    { url = "https://files.pythonhosted.org/packages/e3/da/9522ba4b32b20a344c37a970d7835d261df1427d943e02d48820253833ee/pandas-2.2.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7d2ed41c319c9fb4fd454fe25372028dfa417aacb9790f68171b2e3f06eae8cd", size = 16243608 },
-    { url = "https://files.pythonhosted.org/packages/e0/c3/da6ffa0d3d510c378f6e46496cf7f84f35e15836d0de4e9880f40247eb60/pandas-2.2.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:af5d3c00557d657c8773ef9ee702c61dd13b9d7426794c9dfeb1dc4a0bf0ebc7", size = 13884355 },
-    { url = "https://files.pythonhosted.org/packages/61/11/1812ef6cbd7433ad240f72161ce5f84c4c450cede4db080365d371d29117/pandas-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:06cf591dbaefb6da9de8472535b185cba556d0ce2e6ed28e21d919704fef1a9e", size = 11602637 },
-    { url = "https://files.pythonhosted.org/packages/ed/b9/660353ce2b1bd5b6e0f5c992836d91909c0da1ccb59c16565ad0a37e839d/pandas-2.2.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:88ecb5c01bb9ca927ebc4098136038519aa5d66b44671861ffab754cae75102c", size = 12493183 },
-    { url = "https://files.pythonhosted.org/packages/19/4e/6a7f400d4b65f82e37eefa7dbbe3e6f0a4fa542ca7ebb68c787eeebdc497/pandas-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:04f6ec3baec203c13e3f8b139fb0f9f86cd8c0b94603ae3ae8ce9a422e9f5bee", size = 11335860 },
-    { url = "https://files.pythonhosted.org/packages/d7/2b/3e00e92a6b430313da68b15e925c6dba05f672d716cf3b02bcd3d0381974/pandas-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a935a90a76c44fe170d01e90a3594beef9e9a6220021acfb26053d01426f7dc2", size = 15189183 },
-    { url = "https://files.pythonhosted.org/packages/78/f4/19f1dda9ab1eaa38301e445925f92b303d415d4c4115e56c0d62774421f7/pandas-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c391f594aae2fd9f679d419e9a4d5ba4bce5bb13f6a989195656e7dc4b95c8f0", size = 12742656 },
-    { url = "https://files.pythonhosted.org/packages/6f/cd/8b84912b5bfab19b1fcea2f732d2e3a2d134d558f141e9dffa5dbfd9d23b/pandas-2.2.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9d1265545f579edf3f8f0cb6f89f234f5e44ba725a34d86535b1a1d38decbccc", size = 15861331 },
-    { url = "https://files.pythonhosted.org/packages/11/e7/65bf50aff86da6554cdffdcd87ced857c79a29dfaf1d85fdf97955d76d02/pandas-2.2.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:11940e9e3056576ac3244baef2fedade891977bcc1cb7e5cc8f8cc7d603edc89", size = 13410754 },
-    { url = "https://files.pythonhosted.org/packages/71/00/6beaeeba7f075d15ea167a5caa039b861e58ff2f58a5b659abb9b544c8f6/pandas-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:4acf681325ee1c7f950d058b05a820441075b0dd9a2adf5c4835b9bc056bf4fb", size = 11478767 },
-    { url = "https://files.pythonhosted.org/packages/1a/f6/621a5a90727c839aafd4a2e40f8fab4645efb534f96454d31a257ce693ed/pandas-2.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9bd8a40f47080825af4317d0340c656744f2bfdb6819f818e6ba3cd24c0e1397", size = 12561981 },
-    { url = "https://files.pythonhosted.org/packages/bc/57/8c61a6b2f9798349748701938dfed6d645bd329bfd96245ad98245238b6f/pandas-2.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:df0c37ebd19e11d089ceba66eba59a168242fc6b7155cba4ffffa6eccdfb8f16", size = 11301393 },
-    { url = "https://files.pythonhosted.org/packages/3e/a6/6dbcb4b72687c8df8f3dca5f16b296b4ae5c9fa3084a32a165113d594b71/pandas-2.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:739cc70eaf17d57608639e74d63387b0d8594ce02f69e7a0b046f117974b3019", size = 15646609 },
-    { url = "https://files.pythonhosted.org/packages/1a/5e/71bb0eef0dc543f7516d9ddeca9ee8dc98207043784e3f7e6c08b4a6b3d9/pandas-2.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9d3558d263073ed95e46f4650becff0c5e1ffe0fc3a015de3c79283dfbdb3df", size = 13040474 },
-    { url = "https://files.pythonhosted.org/packages/60/f0/765326197f1759004d07a3e5e060cecfc90fd7af22eadd4cb02ef5e74555/pandas-2.2.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4aa1d8707812a658debf03824016bf5ea0d516afdea29b7dc14cf687bc4d4ec6", size = 16261844 },
-    { url = "https://files.pythonhosted.org/packages/5f/96/0f208a3f7bb6f930060c1930fe4d2d24ce491d044a6ace1cb6cc52d3a319/pandas-2.2.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:76f27a809cda87e07f192f001d11adc2b930e93a2b0c4a236fde5429527423be", size = 13914313 },
-    { url = "https://files.pythonhosted.org/packages/41/a3/349df1721beb447142b8b11e27875a3da00f85d713f1a4bed0afb3a62e14/pandas-2.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:1ba21b1d5c0e43416218db63037dbe1a01fc101dc6e6024bcad08123e48004ab", size = 11610656 },
+    { url = "https://files.pythonhosted.org/packages/aa/70/c853aec59839bceed032d52010ff5f1b8d87dc3114b762e4ba2727661a3b/pandas-2.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1948ddde24197a0f7add2bdc4ca83bf2b1ef84a1bc8ccffd95eda17fd836ecb5", size = 12580827 },
+    { url = "https://files.pythonhosted.org/packages/99/f2/c4527768739ffa4469b2b4fff05aa3768a478aed89a2f271a79a40eee984/pandas-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:381175499d3802cde0eabbaf6324cce0c4f5d52ca6f8c377c29ad442f50f6348", size = 11303897 },
+    { url = "https://files.pythonhosted.org/packages/ed/12/86c1747ea27989d7a4064f806ce2bae2c6d575b950be087837bdfcabacc9/pandas-2.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d9c45366def9a3dd85a6454c0e7908f2b3b8e9c138f5dc38fed7ce720d8453ed", size = 66480908 },
+    { url = "https://files.pythonhosted.org/packages/44/50/7db2cd5e6373ae796f0ddad3675268c8d59fb6076e66f0c339d61cea886b/pandas-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86976a1c5b25ae3f8ccae3a5306e443569ee3c3faf444dfd0f41cda24667ad57", size = 13064210 },
+    { url = "https://files.pythonhosted.org/packages/61/61/a89015a6d5536cb0d6c3ba02cebed51a95538cf83472975275e28ebf7d0c/pandas-2.2.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b8661b0238a69d7aafe156b7fa86c44b881387509653fdf857bebc5e4008ad42", size = 16754292 },
+    { url = "https://files.pythonhosted.org/packages/ce/0d/4cc7b69ce37fac07645a94e1d4b0880b15999494372c1523508511b09e40/pandas-2.2.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37e0aced3e8f539eccf2e099f65cdb9c8aa85109b0be6e93e2baff94264bdc6f", size = 14416379 },
+    { url = "https://files.pythonhosted.org/packages/31/9e/6ebb433de864a6cd45716af52a4d7a8c3c9aaf3a98368e61db9e69e69a9c/pandas-2.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:56534ce0746a58afaf7942ba4863e0ef81c9c50d3f0ae93e9497d6a41a057645", size = 11598471 },
+    { url = "https://files.pythonhosted.org/packages/a8/44/d9502bf0ed197ba9bf1103c9867d5904ddcaf869e52329787fc54ed70cc8/pandas-2.2.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66108071e1b935240e74525006034333f98bcdb87ea116de573a6a0dccb6c039", size = 12602222 },
+    { url = "https://files.pythonhosted.org/packages/52/11/9eac327a38834f162b8250aab32a6781339c69afe7574368fffe46387edf/pandas-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7c2875855b0ff77b2a64a0365e24455d9990730d6431b9e0ee18ad8acee13dbd", size = 11321274 },
+    { url = "https://files.pythonhosted.org/packages/45/fb/c4beeb084718598ba19aa9f5abbc8aed8b42f90930da861fcb1acdb54c3a/pandas-2.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd8d0c3be0515c12fed0bdbae072551c8b54b7192c7b1fda0ba56059a0179698", size = 15579836 },
+    { url = "https://files.pythonhosted.org/packages/cd/5f/4dba1d39bb9c38d574a9a22548c540177f78ea47b32f99c0ff2ec499fac5/pandas-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c124333816c3a9b03fbeef3a9f230ba9a737e9e5bb4060aa2107a86cc0a497fc", size = 13058505 },
+    { url = "https://files.pythonhosted.org/packages/b9/57/708135b90391995361636634df1f1130d03ba456e95bcf576fada459115a/pandas-2.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:63cc132e40a2e084cf01adf0775b15ac515ba905d7dcca47e9a251819c575ef3", size = 16744420 },
+    { url = "https://files.pythonhosted.org/packages/86/4a/03ed6b7ee323cf30404265c284cee9c65c56a212e0a08d9ee06984ba2240/pandas-2.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29401dbfa9ad77319367d36940cd8a0b3a11aba16063e39632d98b0e931ddf32", size = 14440457 },
+    { url = "https://files.pythonhosted.org/packages/ed/8c/87ddf1fcb55d11f9f847e3c69bb1c6f8e46e2f40ab1a2d2abadb2401b007/pandas-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:3fc6873a41186404dad67245896a6e440baacc92f5b716ccd1bc9ed2995ab2c5", size = 11617166 },
+    { url = "https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b1d432e8d08679a40e2a6d8b2f9770a5c21793a6f9f47fdd52c5ce1948a5a8a9", size = 12529893 },
+    { url = "https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5a1595fe639f5988ba6a8e5bc9649af3baf26df3998a0abe56c02609392e0a4", size = 11363475 },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/4bba3f03f7d07207481fed47f5b35f556c7441acddc368ec43d6643c5777/pandas-2.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5de54125a92bb4d1c051c0659e6fcb75256bf799a732a87184e5ea503965bce3", size = 15188645 },
+    { url = "https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb8ae78d8af97f849404f21411c95062db1496aeb3e56f146f0355c9989319", size = 12739445 },
+    { url = "https://files.pythonhosted.org/packages/20/e8/45a05d9c39d2cea61ab175dbe6a2de1d05b679e8de2011da4ee190d7e748/pandas-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dfcb5ee8d4d50c06a51c2fffa6cff6272098ad6540aed1a76d15fb9318194d8", size = 16359235 },
+    { url = "https://files.pythonhosted.org/packages/1d/99/617d07a6a5e429ff90c90da64d428516605a1ec7d7bea494235e1c3882de/pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a", size = 14056756 },
+    { url = "https://files.pythonhosted.org/packages/29/d4/1244ab8edf173a10fd601f7e13b9566c1b525c4f365d6bee918e68381889/pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13", size = 11504248 },
+    { url = "https://files.pythonhosted.org/packages/64/22/3b8f4e0ed70644e85cfdcd57454686b9057c6c38d2f74fe4b8bc2527214a/pandas-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f00d1345d84d8c86a63e476bb4955e46458b304b9575dcf71102b5c705320015", size = 12477643 },
+    { url = "https://files.pythonhosted.org/packages/e4/93/b3f5d1838500e22c8d793625da672f3eec046b1a99257666c94446969282/pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3508d914817e153ad359d7e069d752cdd736a247c322d932eb89e6bc84217f28", size = 11281573 },
+    { url = "https://files.pythonhosted.org/packages/f5/94/6c79b07f0e5aab1dcfa35a75f4817f5c4f677931d4234afcd75f0e6a66ca/pandas-2.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22a9d949bfc9a502d320aa04e5d02feab689d61da4e7764b62c30b991c42c5f0", size = 15196085 },
+    { url = "https://files.pythonhosted.org/packages/e8/31/aa8da88ca0eadbabd0a639788a6da13bb2ff6edbbb9f29aa786450a30a91/pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a255b2c19987fbbe62a9dfd6cff7ff2aa9ccab3fc75218fd4b7530f01efa24", size = 12711809 },
+    { url = "https://files.pythonhosted.org/packages/ee/7c/c6dbdb0cb2a4344cacfb8de1c5808ca885b2e4dcfde8008266608f9372af/pandas-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:800250ecdadb6d9c78eae4990da62743b857b470883fa27f652db8bdde7f6659", size = 16356316 },
+    { url = "https://files.pythonhosted.org/packages/57/b7/8b757e7d92023b832869fa8881a992696a0bfe2e26f72c9ae9f255988d42/pandas-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6374c452ff3ec675a8f46fd9ab25c4ad0ba590b71cf0656f8b6daa5202bca3fb", size = 14022055 },
+    { url = "https://files.pythonhosted.org/packages/3b/bc/4b18e2b8c002572c5a441a64826252ce5da2aa738855747247a971988043/pandas-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:61c5ad4043f791b61dd4752191d9f07f0ae412515d59ba8f005832a532f8736d", size = 11481175 },
+    { url = "https://files.pythonhosted.org/packages/76/a3/a5d88146815e972d40d19247b2c162e88213ef51c7c25993942c39dbf41d/pandas-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3b71f27954685ee685317063bf13c7709a7ba74fc996b84fc6821c59b0f06468", size = 12615650 },
+    { url = "https://files.pythonhosted.org/packages/9c/8c/f0fd18f6140ddafc0c24122c8a964e48294acc579d47def376fef12bcb4a/pandas-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:38cf8125c40dae9d5acc10fa66af8ea6fdf760b2714ee482ca691fc66e6fcb18", size = 11290177 },
+    { url = "https://files.pythonhosted.org/packages/ed/f9/e995754eab9c0f14c6777401f7eece0943840b7a9fc932221c19d1abee9f/pandas-2.2.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba96630bc17c875161df3818780af30e43be9b166ce51c9a18c1feae342906c2", size = 14651526 },
+    { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013 },
+    { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620 },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436 },
+    { url = "https://files.pythonhosted.org/packages/ca/8c/8848a4c9b8fdf5a534fe2077af948bf53cd713d77ffbcd7bd15710348fd7/pandas-2.2.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bc6b93f9b966093cb0fd62ff1a7e4c09e6d546ad7c1de191767baffc57628f39", size = 12595535 },
+    { url = "https://files.pythonhosted.org/packages/9c/b9/5cead4f63b6d31bdefeb21a679bc5a7f4aaf262ca7e07e2bc1c341b68470/pandas-2.2.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5dbca4c1acd72e8eeef4753eeca07de9b1db4f398669d5994086f788a5d7cc30", size = 11319822 },
+    { url = "https://files.pythonhosted.org/packages/31/af/89e35619fb573366fa68dc26dad6ad2c08c17b8004aad6d98f1a31ce4bb3/pandas-2.2.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8cd6d7cc958a3910f934ea8dbdf17b2364827bb4dafc38ce6eef6bb3d65ff09c", size = 15625439 },
+    { url = "https://files.pythonhosted.org/packages/3d/dd/bed19c2974296661493d7acc4407b1d2db4e2a482197df100f8f965b6225/pandas-2.2.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99df71520d25fade9db7c1076ac94eb994f4d2673ef2aa2e86ee039b6746d20c", size = 13068928 },
+    { url = "https://files.pythonhosted.org/packages/31/a3/18508e10a31ea108d746c848b5a05c0711e0278fa0d6f1c52a8ec52b80a5/pandas-2.2.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:31d0ced62d4ea3e231a9f228366919a5ea0b07440d9d4dac345376fd8e1477ea", size = 16783266 },
+    { url = "https://files.pythonhosted.org/packages/c4/a5/3429bd13d82bebc78f4d78c3945efedef63a7cd0c15c17b2eeb838d1121f/pandas-2.2.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7eee9e7cea6adf3e3d24e304ac6b8300646e2a5d1cd3a3c2abed9101b0846761", size = 14450871 },
+    { url = "https://files.pythonhosted.org/packages/2f/49/5c30646e96c684570925b772eac4eb0a8cb0ca590fa978f56c5d3ae73ea1/pandas-2.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:4850ba03528b6dd51d6c5d273c46f183f39a9baf3f0143e566b89450965b105e", size = 11618011 },
 ]
 
 [[package]]

--- a/lib/repack/owid/repack/__init__.py
+++ b/lib/repack/owid/repack/__init__.py
@@ -59,10 +59,12 @@ def repack_frame(
 
 
 def repack_series(s: pd.Series) -> pd.Series:
-    if s.dtype.name in ("Int64", "int64", "UInt64", "uint64"):
-        return shrink_integer(s)
+    dtype_name = s.dtype.name.replace("[pyarrow]", "").replace("[pyarrow_numpy]", "").lower()
 
-    if s.dtype.name in ("object", "string", "float64", "Float64"):
+    if dtype_name in ("int64", "uint64"):
+        return shrink_integer(s.astype("Int64"))
+
+    if dtype_name in ("object", "str", "string", "float64"):
         for strategy in [to_int, to_float, to_category]:
             try:
                 return strategy(s)
@@ -72,11 +74,21 @@ def repack_series(s: pd.Series) -> pd.Series:
     return s
 
 
+def _to_float(s: pd.Series) -> pd.Series:
+    """Convert series to Float64. Replace numpy NaNs with NA. This can
+    happen when original series is an object and contains 'nan' string."""
+    s = s.astype("Float64")
+    s = s.mask(np.isnan(s), pd.NA)
+    return s
+
+
 def to_int(s: pd.Series) -> pd.Series:
     # values could be integers or strings
-    v = s.astype("float64").astype("Int64")
+    s = _to_float(s)
+    v = s.astype("Int64")
 
-    if not series_eq(v, s, cast=float):
+    # casting to float converts strings to floats, that doesn't work with float64[pyarrow]
+    if not series_eq(v, s):
         raise ValueError()
 
     # it's an integer, now pack it smaller
@@ -87,21 +99,16 @@ def shrink_integer(s: pd.Series) -> pd.Series:
     """
     Take an Int64 series and make it as small as possible.
     """
-    assert s.dtype.name in ("Int64", "int64", "UInt64", "uint64")
+    assert s.dtype == "Int64"
 
     if s.isnull().all():
         # shrink all NaNs to Int8
         return s.astype("Int8")
-    elif s.isnull().any():
+    else:
         if s.min() < 0:
             series = ["Int32", "Int16", "Int8"]
         else:
             series = ["UInt32", "UInt16", "UInt8"]
-    else:
-        if s.min() < 0:
-            series = ["int32", "int16", "int8"]
-        else:
-            series = ["uint32", "uint16", "uint8"]
 
     for dtype in series:
         v = s.astype(dtype)
@@ -114,11 +121,20 @@ def shrink_integer(s: pd.Series) -> pd.Series:
 
 
 def to_float(s: pd.Series) -> pd.Series:
-    options = ["float32", "float64"]
+    return shrink_float(_to_float(s))
+
+
+def shrink_float(s: pd.Series) -> pd.Series:
+    """
+    Take a Float64 series and make it as small as possible.
+    """
+    assert s.dtype.name.replace("[pyarrow]", "") in ("float64", "Float64", "double"), s.dtype
+
+    options = ["Float32", "Float64"]
     for dtype in options:
         v = s.astype(dtype)
 
-        if series_eq(s, v, float):
+        if series_eq(s, v):
             return v
 
     raise ValueError()
@@ -133,7 +149,7 @@ def to_category(s: pd.Series) -> pd.Series:
     return s.astype("category")
 
 
-def series_eq(lhs: pd.Series, rhs: pd.Series, cast: Any, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
+def series_eq(lhs: pd.Series, rhs: pd.Series, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
     """
     Check that series are equal, but unlike normal floating point checks where
     NaN != NaN, we want missing or null values to be reported as equal to each
@@ -144,11 +160,33 @@ def series_eq(lhs: pd.Series, rhs: pd.Series, cast: Any, rtol: float = 1e-5, ato
     if len(lhs) != len(rhs):
         return False
 
-    # improve performance by calling native astype method
-    if cast == float:
-        func = lambda s: s.astype(float)  # noqa: E731
-    else:
-        # NOTE: this would be extremely slow in practice
-        func = lambda s: s.apply(cast)  # noqa: E731
+    return np.allclose(lhs, rhs, rtol=rtol, atol=atol, equal_nan=True)
 
-    return np.allclose(func(lhs), func(rhs), rtol=rtol, atol=atol, equal_nan=True)
+
+def _safe_dtype(dtype: Any) -> str:
+    """Determine the appropriate dtype string based on pandas dtype."""
+    if pd.api.types.is_integer_dtype(dtype):
+        return "Int64"
+    elif pd.api.types.is_float_dtype(dtype):
+        return "Float64"
+    elif pd.api.types.is_bool_dtype(dtype):
+        return "boolean"
+    elif isinstance(dtype, pd.CategoricalDtype):
+        return "string[pyarrow]"
+    elif dtype == object:
+        return "string[pyarrow]"
+    else:
+        return dtype
+
+
+def to_safe_types(t: pd.DataFrame) -> pd.DataFrame:
+    """Convert numeric columns to Float64 and Int64 and categorical
+    columns to string[pyarrow]."""
+    t = t.astype({col: _safe_dtype(t[col].dtype) for col in t.columns})
+
+    if isinstance(t.index, pd.MultiIndex):
+        t.index = t.index.set_levels([level.astype(_safe_dtype(level.dtype)) for level in t.index.levels])
+    else:
+        t.index = t.index.astype(_safe_dtype(t.index.dtype))
+
+    return t

--- a/lib/repack/pyproject.toml
+++ b/lib/repack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-repack"
-version = "0.1.3"
+version = "0.1.4"
 description = "Pack Pandas data frames into smaller, more memory-efficient data types."
 authors = [
     {name = "Our World in Data", email = "tech@ourworldindata.org"},
@@ -9,7 +9,9 @@ license = "MIT"
 requires-python = ">=3.9"
 dependencies = [
     "numpy>=1.24.0",
-    "pandas>=2.2.1"
+    "pandas>=2.2.3",
+    # there are problems with installing 18.0.0, but we should undo this once it's fixed
+    "pyarrow>=10.0.1,<18.0.0",
 ]
 
 [tool.uv]
@@ -17,6 +19,7 @@ dev-dependencies = [
     "pytest>=7.2.0",
     "pyright==1.1.373",
     "ruff==0.1.6",
+    "ipdb>=0.13.13",
 ]
 
 [tool.ruff]

--- a/lib/repack/tests/test_repack.py
+++ b/lib/repack/tests/test_repack.py
@@ -16,8 +16,8 @@ def test_repack_non_object_columns():
     df2 = df.copy()
     df2 = repack.repack_frame(df2, {})
 
-    assert df2.myint.dtype.name == "uint8"
-    assert df2.myfloat.dtype.name == "float32"
+    assert df2.myint.dtype.name == "UInt8"
+    assert df2.myfloat.dtype.name == "Float32"
     assert_frame_equal(df, df2, check_dtype=False)
 
 
@@ -27,6 +27,9 @@ def test_repack_object_columns():
             "myint": [1, 2, None, 3],
             "myfloat": [1.2, 2.0, 3.0, None],
             "mycat": ["a", None, "b", "c"],
+            "myintstr": [1, 2, 3, "4"],
+            "nans1": [1, 2, 3, pd.NA],
+            "nans2": [1, 2.1, 3, np.nan],
         },
         dtype="object",
     )
@@ -35,8 +38,11 @@ def test_repack_object_columns():
 
     df_repack = repack.repack_frame(df_repack)
     assert df_repack.myint.dtype.name == "UInt8"
-    assert df_repack.myfloat.dtype.name == "float32"
+    assert df_repack.myfloat.dtype.name == "Float32"
     assert df_repack.mycat.dtype.name == "category"
+    assert df_repack.myintstr.dtype.name == "UInt8"
+    assert df_repack.nans1.dtype.name == "UInt8"
+    assert df_repack.nans2.dtype.name == "Float32"
 
 
 def test_repack_frame_with_index():
@@ -63,13 +69,13 @@ def test_repack_integer_strings():
 def test_repack_float_strings():
     s = pd.Series(["10", "22.2", "30"])
     v = repack.repack_series(s)
-    assert v.dtype.name == "float32"
+    assert v.dtype.name == "Float32"
 
 
 def test_repack_uint64():
     s = pd.Series([10, 20], dtype="uint64")
     v = repack.repack_series(s)
-    assert v.dtype.name == "uint8"
+    assert v.dtype.name == "UInt8"
 
 
 def test_repack_int8_boundaries():
@@ -78,15 +84,15 @@ def test_repack_int8_boundaries():
 
     # check the lower boundary
     s[0] = info.min
-    assert repack.repack_series(s).dtype.name == "int8"
+    assert repack.repack_series(s).dtype.name == "Int8"
     s[0] -= 1
-    assert repack.repack_series(s).dtype.name == "int16"
+    assert repack.repack_series(s).dtype.name == "Int16"
 
     # check the upper boundary
     s[0] = info.max
-    assert repack.repack_series(s).dtype.name == "int8"
+    assert repack.repack_series(s).dtype.name == "Int8"
     s[0] += 1
-    assert repack.repack_series(s).dtype.name == "int16"
+    assert repack.repack_series(s).dtype.name == "Int16"
 
 
 def test_repack_int16_boundaries():
@@ -95,15 +101,15 @@ def test_repack_int16_boundaries():
 
     # check the lower boundary
     s[0] = info.min
-    assert repack.repack_series(s).dtype.name == "int16"
+    assert repack.repack_series(s).dtype.name == "Int16"
     s[0] -= 1
-    assert repack.repack_series(s).dtype.name == "int32"
+    assert repack.repack_series(s).dtype.name == "Int32"
 
     # check the upper boundary
     s[0] = info.max
-    assert repack.repack_series(s).dtype.name == "int16"
+    assert repack.repack_series(s).dtype.name == "Int16"
     s[0] += 1
-    assert repack.repack_series(s).dtype.name == "int32"
+    assert repack.repack_series(s).dtype.name == "Int32"
 
 
 def test_repack_int32_boundaries():
@@ -112,15 +118,15 @@ def test_repack_int32_boundaries():
 
     # check the lower boundary
     s[0] = info.min
-    assert repack.repack_series(s).dtype.name == "int32"
+    assert repack.repack_series(s).dtype.name == "Int32"
     s[0] -= 1
-    assert repack.repack_series(s).dtype.name == "int64"
+    assert repack.repack_series(s).dtype.name == "Int64"
 
     # check the upper boundary
     s[0] = info.max
-    assert repack.repack_series(s).dtype.name == "int32"
+    assert repack.repack_series(s).dtype.name == "Int32"
     s[0] += 1
-    assert repack.repack_series(s).dtype.name == "int64"
+    assert repack.repack_series(s).dtype.name == "Int64"
 
 
 def test_repack_uint_boundaries():
@@ -128,27 +134,27 @@ def test_repack_uint_boundaries():
     # uint8
     info: Any = np.iinfo(np.uint8)
     s[0] = info.max
-    assert repack.repack_series(s).dtypes.name == "uint8"
+    assert repack.repack_series(s).dtypes.name == "UInt8"
 
     s[0] += 1
-    assert repack.repack_series(s).dtypes.name == "uint16"
+    assert repack.repack_series(s).dtypes.name == "UInt16"
 
     # uint16
     info2: Any = np.iinfo(np.uint16)
     s[0] = info2.max
-    assert repack.repack_series(s).dtypes.name == "uint16"
+    assert repack.repack_series(s).dtypes.name == "UInt16"
 
     s[0] += 1
-    assert repack.repack_series(s).dtypes.name == "uint32"
+    assert repack.repack_series(s).dtypes.name == "UInt32"
 
     # uint32
     info3: Any = np.iinfo(np.uint32)
     s[0] = info3.max
-    assert repack.repack_series(s).dtypes.name == "uint32"
+    assert repack.repack_series(s).dtypes.name == "UInt32"
 
     # we don't bother using uint64, we just use int64
     s[0] += 1
-    assert repack.repack_series(s).dtypes.name == "int64"
+    assert repack.repack_series(s).dtypes.name == "Int64"
 
 
 def test_repack_int():
@@ -160,7 +166,7 @@ def test_repack_int():
 def test_repack_int_no_null():
     s = pd.Series([1, 2, 3]).astype("object")
     v = repack.repack_series(s)
-    assert v.dtype == "uint8"
+    assert v.dtype == "UInt8"
 
 
 def test_repack_float_to_int():
@@ -174,7 +180,19 @@ def test_repack_float_object_to_float32():
     s = pd.Series([1, 2, None, 3.3], dtype="object")
 
     v = repack.repack_series(s)
-    assert v.dtype == "float32"
+    assert v.dtype == "Float32"
+
+
+def test_repack_object_with_nan_string():
+    s = pd.Series([1, 2, "nan"], dtype="object")
+    v = repack.repack_series(s)
+    assert v.dtype == "UInt8"
+    assert v.isnull().sum() == 1
+
+    s = pd.Series([1, 2.2, "nan"], dtype="object")
+    v = repack.repack_series(s)
+    assert v.dtype == "Float32"
+    assert v.isnull().sum() == 1
 
 
 def test_repack_category():
@@ -188,13 +206,13 @@ def test_repack_category():
 def test_shrink_integers_uint8():
     s = pd.Series([1, 2, 3], dtype="Int64")
     v = repack.shrink_integer(s)
-    assert v.dtype.name == "uint8"
+    assert v.dtype.name == "UInt8"
 
 
 def test_shrink_integers_int8():
     s = pd.Series([1, 2, 3, -3], dtype="Int64")
     v = repack.shrink_integer(s)
-    assert v.dtype.name == "int8"
+    assert v.dtype.name == "Int8"
 
 
 def test_repack_frame_keep_dtypes():
@@ -204,7 +222,7 @@ def test_repack_frame_keep_dtypes():
     df2 = repack.repack_frame(df2, dtypes={"myint": float})
 
     assert df2.myint.dtype.name == "float64"
-    assert df2.myfloat.dtype.name == "float32"
+    assert df2.myfloat.dtype.name == "Float32"
 
 
 def test_repack_int64_all_nans():
@@ -222,11 +240,15 @@ def test_repack_float64_all_nans():
 def test_series_eq():
     a = pd.Series([1, np.nan], dtype="float64")
     b = pd.Series([2, np.nan], dtype="float64")
-    assert not repack.series_eq(a, b, cast=float)
+    assert not repack.series_eq(a, b)
 
     a = pd.Series([1, np.nan], dtype="float64")
     b = pd.Series([1, np.nan], dtype="float64")
-    assert repack.series_eq(a, b, cast=float)
+    assert repack.series_eq(a, b)
+
+    a = pd.Series([1, np.nan], dtype="float64")
+    b = pd.Series([1, np.nan], dtype="float64").astype("Float64")
+    assert repack.series_eq(a, b)
 
 
 def test_repack_object_np_str():
@@ -238,7 +260,7 @@ def test_repack_object_np_str():
 def test_repack_with_inf():
     s = pd.Series([0, np.inf], dtype=object)
     v = repack.repack_series(s)
-    assert v.dtype.name == "float32"
+    assert v.dtype.name == "Float32"
 
 
 def test_repack_with_datetime():
@@ -253,3 +275,79 @@ def test_repack_string_type():
 
     v = repack.repack_series(s)
     assert v.dtype == "category"
+
+
+def test_to_safe_types():
+    # Create a DataFrame with various dtypes
+    df = pd.DataFrame(
+        {
+            "int_col": [1, 2, 3],
+            "float_col": [1.1, 2.2, 3.3],
+            "cat_col": pd.Categorical(["a", "b", "c"]),
+            "object_col": ["x", "y", "z"],
+        }
+    )
+
+    # Set an index with integer dtype
+    df.set_index("int_col", inplace=True)
+
+    # Apply the to_safe_types function
+    df_safe = repack.to_safe_types(df)
+
+    # Check that the dtypes have been converted appropriately
+    assert df_safe.index.dtype == "Int64"
+    assert df_safe["float_col"].dtype == "Float64"
+    assert df_safe["cat_col"].dtype == "string[pyarrow]"
+    assert df_safe["object_col"].dtype == "string[pyarrow]"
+
+
+def test_to_safe_types_multiindex():
+    # Create a DataFrame with MultiIndex
+    df = pd.DataFrame(
+        {
+            "int_col": [1, 2, 3],
+            "cat_col": pd.Categorical(["a", "b", "c"]),
+            "float_col": [1.1, 2.2, 3.3],
+        }
+    )
+    df.set_index(["int_col", "cat_col"], inplace=True)
+
+    # Apply the to_safe_types function
+    df_safe = repack.to_safe_types(df)
+
+    # Check index levels
+    assert df_safe.index.levels[0].dtype == "Int64"  # type: ignore
+    assert df_safe.index.levels[1].dtype == "string[pyarrow]"  # type: ignore
+    # Check column dtype
+    assert df_safe["float_col"].dtype == "Float64"
+
+
+def test_to_safe_types_with_nan():
+    # Create a DataFrame with NaN values
+    df = pd.DataFrame(
+        {
+            "int_col": [1, 2, 3],
+            "int_with_nan": [1, np.nan, 3],
+            "nullable_int_with_nan": [1, np.nan, 3],
+            "float_col": [1.1, np.nan, 3.3],
+            "cat_col": pd.Categorical(["a", None, "c"]),
+        }
+    )
+    df.set_index("float_col", inplace=True)
+    df["nullable_int_with_nan"] = df["nullable_int_with_nan"].astype("Int32")
+
+    # Apply the to_safe_types function
+    df_safe = repack.to_safe_types(df)
+
+    # Check that NaN values are handled correctly
+    assert df_safe.index.dtype == "Float64"
+    assert df_safe["int_col"].dtype == "Int64"
+    # NOTE: ints with nans end up as floats, but if they are nullable ints they remain as Int64 (which is our case
+    # since we store everything as nullable types)
+    assert df_safe["int_with_nan"].dtype == "Float64"
+    assert df_safe["nullable_int_with_nan"].dtype == "Int64"
+    assert df_safe["cat_col"].dtype == "string[pyarrow]"
+
+    # Ensure that the NA value in 'cat_col' remains pd.NA and not the string "NA"
+    assert pd.isna(df_safe["cat_col"].iloc[1])
+    assert df_safe["cat_col"].iloc[1] is pd.NA

--- a/lib/repack/uv.lock
+++ b/lib/repack/uv.lock
@@ -7,12 +7,33 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/1d/f03bcb60c4a3212e15f99a56085d93093a497718adf828d050b9d675da81/asttokens-2.4.1.tar.gz", hash = "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0", size = 62284 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl", hash = "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24", size = 27764 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "decorator"
+version = "5.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/0c/8d907af351aa16b42caae42f9d6aa37b900c67308052d10fdce809f8d952/decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330", size = 35016 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186", size = 9073 },
 ]
 
 [[package]]
@@ -25,12 +46,81 @@ wheels = [
 ]
 
 [[package]]
+name = "executing"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e3/7d45f492c2c4a0e8e0fad57d081a7c8a0286cdd86372b070cca1ec0caa1e/executing-2.1.0.tar.gz", hash = "sha256:8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab", size = 977485 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl", hash = "sha256:8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf", size = 25805 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+]
+
+[[package]]
+name = "ipdb"
+version = "0.13.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "ipython" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/1b/7e07e7b752017f7693a0f4d41c13e5ca29ce8cbcfdcc1fd6c4ad8c0a27a0/ipdb-0.13.13.tar.gz", hash = "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726", size = 17042 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/4c/b075da0092003d9a55cf2ecc1cae9384a1ca4f650d51b00fc59875fe76f6/ipdb-0.13.13-py3-none-any.whl", hash = "sha256:45529994741c4ab6d2388bfa5d7b725c2cf7fe9deffabdb8a6113aa5ed449ed4", size = 12130 },
+]
+
+[[package]]
+name = "ipython"
+version = "8.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/b9/3ba6c45a6df813c09a48bac313c22ff83efa26cbb55011218d925a46e2ad/ipython-8.18.1.tar.gz", hash = "sha256:ca6f079bb33457c66e233e4580ebfc4128855b4cf6370dddd73842a9563e8a27", size = 5486330 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/6b/d9fdcdef2eb6a23f391251fde8781c38d42acd82abe84d054cb74f7863b0/ipython-8.18.1-py3-none-any.whl", hash = "sha256:e8267419d72d81955ec1177f8a29aaa90ac80ad647499201119e2f05e99aa397", size = 808161 },
+]
+
+[[package]]
+name = "jedi"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/99/99b493cec4bf43176b678de30f81ed003fd6a647a301b9c927280c600f0a/jedi-0.19.1.tar.gz", hash = "sha256:cf0496f3651bc65d7174ac1b7d043eff454892c708a87d1b683e57b569927ffd", size = 1227821 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/9f/bc63f0f0737ad7a60800bfd472a4836661adae21f9c2535f3957b1e54ceb/jedi-0.19.1-py2.py3-none-any.whl", hash = "sha256:e983c654fe5c02867aef4cdfce5a2fbb4a50adc0af145f70504238f18ef5e7e0", size = 1569361 },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.1.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/5b/a36a337438a14116b16480db471ad061c36c3694df7c2084a0da7ba538b7/matplotlib_inline-0.1.7.tar.gz", hash = "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90", size = 8159 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl", hash = "sha256:df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca", size = 9899 },
 ]
 
 [[package]]
@@ -87,15 +177,17 @@ wheels = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pyarrow" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "ipdb" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
@@ -104,11 +196,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=1.24.0" },
-    { name = "pandas", specifier = "==2.2.1" },
+    { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pyarrow", specifier = ">=10.0.1,<18.0.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ipdb", specifier = ">=0.13.13" },
     { name = "pyright", specifier = "==1.1.373" },
     { name = "pytest", specifier = ">=7.2.0" },
     { name = "ruff", specifier = "==0.1.6" },
@@ -125,7 +219,7 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "2.2.1"
+version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -133,36 +227,70 @@ dependencies = [
     { name = "pytz" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/59/2afa81b9fb300c90531803c0fd43ff4548074fa3e8d0f747ef63b3b5e77a/pandas-2.2.1.tar.gz", hash = "sha256:0ab90f87093c13f3e8fa45b48ba9f39181046e8f3317d3aadb2fffbb1b978572", size = 4395256 }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/f4495f8ab5a58b1eeee06b5abd811e0a93f7b75acdc89380797f99bdf91a/pandas-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8df8612be9cd1c7797c93e1c5df861b2ddda0b48b08f2c3eaa0702cf88fb5f88", size = 12543124 },
-    { url = "https://files.pythonhosted.org/packages/4f/19/0ae5f1557badfcae1052c1397041a2c5441e9f31e1c7b0cce7f8bc585f4e/pandas-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0f573ab277252ed9aaf38240f3b54cfc90fff8e5cab70411ee1d03f5d51f3944", size = 11285572 },
-    { url = "https://files.pythonhosted.org/packages/5d/d2/df8047f8c3648eb6b3ee86ef7ee811ad01e55b47a14ea02fe36d601e12cd/pandas-2.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f02a3a6c83df4026e55b63c1f06476c9aa3ed6af3d89b4f04ea656ccdaaaa359", size = 15629656 },
-    { url = "https://files.pythonhosted.org/packages/19/df/8d789d96a9e338cf28cb7978fa93ef5da53137624b7ef032f30748421c2b/pandas-2.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c38ce92cb22a4bea4e3929429aa1067a454dcc9c335799af93ba9be21b6beb51", size = 13024911 },
-    { url = "https://files.pythonhosted.org/packages/11/a1/9d5505c6c56740f7ed8bd78c8756fb76aeff1c706b30e6930ddf90693aee/pandas-2.2.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:c2ce852e1cf2509a69e98358e8458775f89599566ac3775e70419b98615f4b06", size = 16275635 },
-    { url = "https://files.pythonhosted.org/packages/d6/99/378e9108cf3562c7c6294249f1bfd3be08325af5e96af435fb221dd1c320/pandas-2.2.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:53680dc9b2519cbf609c62db3ed7c0b499077c7fefda564e330286e619ff0dd9", size = 13880082 },
-    { url = "https://files.pythonhosted.org/packages/93/26/2a695303a4a3194014dca7cb5d5ce08f0d2c6baa344fb5f562c642e77b2b/pandas-2.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:94e714a1cca63e4f5939cdce5f29ba8d415d85166be3441165edd427dc9f6bc0", size = 11592785 },
-    { url = "https://files.pythonhosted.org/packages/f1/8b/617792ad1feef330e87d7459584a1f91aa8aea373d8b168ac5d24fddd808/pandas-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f821213d48f4ab353d20ebc24e4faf94ba40d76680642fb7ce2ea31a3ad94f9b", size = 12564385 },
-    { url = "https://files.pythonhosted.org/packages/a5/78/1d859bfb619c067e3353ed079248ae9532c105c4e018fa9a776d04b34572/pandas-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c70e00c2d894cb230e5c15e4b1e1e6b2b478e09cf27cc593a11ef955b9ecc81a", size = 11303028 },
-    { url = "https://files.pythonhosted.org/packages/91/bf/8c57707e440f944ba2cf3d6f6ae6c29883fac20fbe5d2ad485229149f273/pandas-2.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e97fbb5387c69209f134893abc788a6486dbf2f9e511070ca05eed4b930b1b02", size = 15594865 },
-    { url = "https://files.pythonhosted.org/packages/d4/47/1ccf9f62d2674d3ca3e95452c5f9dd114234d1535dec77c96528bf6a31fc/pandas-2.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101d0eb9c5361aa0146f500773395a03839a5e6ecde4d4b6ced88b7e5a1a6403", size = 13034628 },
-    { url = "https://files.pythonhosted.org/packages/e3/da/9522ba4b32b20a344c37a970d7835d261df1427d943e02d48820253833ee/pandas-2.2.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:7d2ed41c319c9fb4fd454fe25372028dfa417aacb9790f68171b2e3f06eae8cd", size = 16243608 },
-    { url = "https://files.pythonhosted.org/packages/e0/c3/da6ffa0d3d510c378f6e46496cf7f84f35e15836d0de4e9880f40247eb60/pandas-2.2.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:af5d3c00557d657c8773ef9ee702c61dd13b9d7426794c9dfeb1dc4a0bf0ebc7", size = 13884355 },
-    { url = "https://files.pythonhosted.org/packages/61/11/1812ef6cbd7433ad240f72161ce5f84c4c450cede4db080365d371d29117/pandas-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:06cf591dbaefb6da9de8472535b185cba556d0ce2e6ed28e21d919704fef1a9e", size = 11602637 },
-    { url = "https://files.pythonhosted.org/packages/ed/b9/660353ce2b1bd5b6e0f5c992836d91909c0da1ccb59c16565ad0a37e839d/pandas-2.2.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:88ecb5c01bb9ca927ebc4098136038519aa5d66b44671861ffab754cae75102c", size = 12493183 },
-    { url = "https://files.pythonhosted.org/packages/19/4e/6a7f400d4b65f82e37eefa7dbbe3e6f0a4fa542ca7ebb68c787eeebdc497/pandas-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:04f6ec3baec203c13e3f8b139fb0f9f86cd8c0b94603ae3ae8ce9a422e9f5bee", size = 11335860 },
-    { url = "https://files.pythonhosted.org/packages/d7/2b/3e00e92a6b430313da68b15e925c6dba05f672d716cf3b02bcd3d0381974/pandas-2.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a935a90a76c44fe170d01e90a3594beef9e9a6220021acfb26053d01426f7dc2", size = 15189183 },
-    { url = "https://files.pythonhosted.org/packages/78/f4/19f1dda9ab1eaa38301e445925f92b303d415d4c4115e56c0d62774421f7/pandas-2.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c391f594aae2fd9f679d419e9a4d5ba4bce5bb13f6a989195656e7dc4b95c8f0", size = 12742656 },
-    { url = "https://files.pythonhosted.org/packages/6f/cd/8b84912b5bfab19b1fcea2f732d2e3a2d134d558f141e9dffa5dbfd9d23b/pandas-2.2.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9d1265545f579edf3f8f0cb6f89f234f5e44ba725a34d86535b1a1d38decbccc", size = 15861331 },
-    { url = "https://files.pythonhosted.org/packages/11/e7/65bf50aff86da6554cdffdcd87ced857c79a29dfaf1d85fdf97955d76d02/pandas-2.2.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:11940e9e3056576ac3244baef2fedade891977bcc1cb7e5cc8f8cc7d603edc89", size = 13410754 },
-    { url = "https://files.pythonhosted.org/packages/71/00/6beaeeba7f075d15ea167a5caa039b861e58ff2f58a5b659abb9b544c8f6/pandas-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:4acf681325ee1c7f950d058b05a820441075b0dd9a2adf5c4835b9bc056bf4fb", size = 11478767 },
-    { url = "https://files.pythonhosted.org/packages/1a/f6/621a5a90727c839aafd4a2e40f8fab4645efb534f96454d31a257ce693ed/pandas-2.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9bd8a40f47080825af4317d0340c656744f2bfdb6819f818e6ba3cd24c0e1397", size = 12561981 },
-    { url = "https://files.pythonhosted.org/packages/bc/57/8c61a6b2f9798349748701938dfed6d645bd329bfd96245ad98245238b6f/pandas-2.2.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:df0c37ebd19e11d089ceba66eba59a168242fc6b7155cba4ffffa6eccdfb8f16", size = 11301393 },
-    { url = "https://files.pythonhosted.org/packages/3e/a6/6dbcb4b72687c8df8f3dca5f16b296b4ae5c9fa3084a32a165113d594b71/pandas-2.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:739cc70eaf17d57608639e74d63387b0d8594ce02f69e7a0b046f117974b3019", size = 15646609 },
-    { url = "https://files.pythonhosted.org/packages/1a/5e/71bb0eef0dc543f7516d9ddeca9ee8dc98207043784e3f7e6c08b4a6b3d9/pandas-2.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9d3558d263073ed95e46f4650becff0c5e1ffe0fc3a015de3c79283dfbdb3df", size = 13040474 },
-    { url = "https://files.pythonhosted.org/packages/60/f0/765326197f1759004d07a3e5e060cecfc90fd7af22eadd4cb02ef5e74555/pandas-2.2.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4aa1d8707812a658debf03824016bf5ea0d516afdea29b7dc14cf687bc4d4ec6", size = 16261844 },
-    { url = "https://files.pythonhosted.org/packages/5f/96/0f208a3f7bb6f930060c1930fe4d2d24ce491d044a6ace1cb6cc52d3a319/pandas-2.2.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:76f27a809cda87e07f192f001d11adc2b930e93a2b0c4a236fde5429527423be", size = 13914313 },
-    { url = "https://files.pythonhosted.org/packages/41/a3/349df1721beb447142b8b11e27875a3da00f85d713f1a4bed0afb3a62e14/pandas-2.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:1ba21b1d5c0e43416218db63037dbe1a01fc101dc6e6024bcad08123e48004ab", size = 11610656 },
+    { url = "https://files.pythonhosted.org/packages/aa/70/c853aec59839bceed032d52010ff5f1b8d87dc3114b762e4ba2727661a3b/pandas-2.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1948ddde24197a0f7add2bdc4ca83bf2b1ef84a1bc8ccffd95eda17fd836ecb5", size = 12580827 },
+    { url = "https://files.pythonhosted.org/packages/99/f2/c4527768739ffa4469b2b4fff05aa3768a478aed89a2f271a79a40eee984/pandas-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:381175499d3802cde0eabbaf6324cce0c4f5d52ca6f8c377c29ad442f50f6348", size = 11303897 },
+    { url = "https://files.pythonhosted.org/packages/ed/12/86c1747ea27989d7a4064f806ce2bae2c6d575b950be087837bdfcabacc9/pandas-2.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d9c45366def9a3dd85a6454c0e7908f2b3b8e9c138f5dc38fed7ce720d8453ed", size = 66480908 },
+    { url = "https://files.pythonhosted.org/packages/44/50/7db2cd5e6373ae796f0ddad3675268c8d59fb6076e66f0c339d61cea886b/pandas-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86976a1c5b25ae3f8ccae3a5306e443569ee3c3faf444dfd0f41cda24667ad57", size = 13064210 },
+    { url = "https://files.pythonhosted.org/packages/61/61/a89015a6d5536cb0d6c3ba02cebed51a95538cf83472975275e28ebf7d0c/pandas-2.2.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b8661b0238a69d7aafe156b7fa86c44b881387509653fdf857bebc5e4008ad42", size = 16754292 },
+    { url = "https://files.pythonhosted.org/packages/ce/0d/4cc7b69ce37fac07645a94e1d4b0880b15999494372c1523508511b09e40/pandas-2.2.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37e0aced3e8f539eccf2e099f65cdb9c8aa85109b0be6e93e2baff94264bdc6f", size = 14416379 },
+    { url = "https://files.pythonhosted.org/packages/31/9e/6ebb433de864a6cd45716af52a4d7a8c3c9aaf3a98368e61db9e69e69a9c/pandas-2.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:56534ce0746a58afaf7942ba4863e0ef81c9c50d3f0ae93e9497d6a41a057645", size = 11598471 },
+    { url = "https://files.pythonhosted.org/packages/a8/44/d9502bf0ed197ba9bf1103c9867d5904ddcaf869e52329787fc54ed70cc8/pandas-2.2.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66108071e1b935240e74525006034333f98bcdb87ea116de573a6a0dccb6c039", size = 12602222 },
+    { url = "https://files.pythonhosted.org/packages/52/11/9eac327a38834f162b8250aab32a6781339c69afe7574368fffe46387edf/pandas-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7c2875855b0ff77b2a64a0365e24455d9990730d6431b9e0ee18ad8acee13dbd", size = 11321274 },
+    { url = "https://files.pythonhosted.org/packages/45/fb/c4beeb084718598ba19aa9f5abbc8aed8b42f90930da861fcb1acdb54c3a/pandas-2.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd8d0c3be0515c12fed0bdbae072551c8b54b7192c7b1fda0ba56059a0179698", size = 15579836 },
+    { url = "https://files.pythonhosted.org/packages/cd/5f/4dba1d39bb9c38d574a9a22548c540177f78ea47b32f99c0ff2ec499fac5/pandas-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c124333816c3a9b03fbeef3a9f230ba9a737e9e5bb4060aa2107a86cc0a497fc", size = 13058505 },
+    { url = "https://files.pythonhosted.org/packages/b9/57/708135b90391995361636634df1f1130d03ba456e95bcf576fada459115a/pandas-2.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:63cc132e40a2e084cf01adf0775b15ac515ba905d7dcca47e9a251819c575ef3", size = 16744420 },
+    { url = "https://files.pythonhosted.org/packages/86/4a/03ed6b7ee323cf30404265c284cee9c65c56a212e0a08d9ee06984ba2240/pandas-2.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29401dbfa9ad77319367d36940cd8a0b3a11aba16063e39632d98b0e931ddf32", size = 14440457 },
+    { url = "https://files.pythonhosted.org/packages/ed/8c/87ddf1fcb55d11f9f847e3c69bb1c6f8e46e2f40ab1a2d2abadb2401b007/pandas-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:3fc6873a41186404dad67245896a6e440baacc92f5b716ccd1bc9ed2995ab2c5", size = 11617166 },
+    { url = "https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b1d432e8d08679a40e2a6d8b2f9770a5c21793a6f9f47fdd52c5ce1948a5a8a9", size = 12529893 },
+    { url = "https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5a1595fe639f5988ba6a8e5bc9649af3baf26df3998a0abe56c02609392e0a4", size = 11363475 },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/4bba3f03f7d07207481fed47f5b35f556c7441acddc368ec43d6643c5777/pandas-2.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5de54125a92bb4d1c051c0659e6fcb75256bf799a732a87184e5ea503965bce3", size = 15188645 },
+    { url = "https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb8ae78d8af97f849404f21411c95062db1496aeb3e56f146f0355c9989319", size = 12739445 },
+    { url = "https://files.pythonhosted.org/packages/20/e8/45a05d9c39d2cea61ab175dbe6a2de1d05b679e8de2011da4ee190d7e748/pandas-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dfcb5ee8d4d50c06a51c2fffa6cff6272098ad6540aed1a76d15fb9318194d8", size = 16359235 },
+    { url = "https://files.pythonhosted.org/packages/1d/99/617d07a6a5e429ff90c90da64d428516605a1ec7d7bea494235e1c3882de/pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a", size = 14056756 },
+    { url = "https://files.pythonhosted.org/packages/29/d4/1244ab8edf173a10fd601f7e13b9566c1b525c4f365d6bee918e68381889/pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13", size = 11504248 },
+    { url = "https://files.pythonhosted.org/packages/64/22/3b8f4e0ed70644e85cfdcd57454686b9057c6c38d2f74fe4b8bc2527214a/pandas-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f00d1345d84d8c86a63e476bb4955e46458b304b9575dcf71102b5c705320015", size = 12477643 },
+    { url = "https://files.pythonhosted.org/packages/e4/93/b3f5d1838500e22c8d793625da672f3eec046b1a99257666c94446969282/pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3508d914817e153ad359d7e069d752cdd736a247c322d932eb89e6bc84217f28", size = 11281573 },
+    { url = "https://files.pythonhosted.org/packages/f5/94/6c79b07f0e5aab1dcfa35a75f4817f5c4f677931d4234afcd75f0e6a66ca/pandas-2.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22a9d949bfc9a502d320aa04e5d02feab689d61da4e7764b62c30b991c42c5f0", size = 15196085 },
+    { url = "https://files.pythonhosted.org/packages/e8/31/aa8da88ca0eadbabd0a639788a6da13bb2ff6edbbb9f29aa786450a30a91/pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a255b2c19987fbbe62a9dfd6cff7ff2aa9ccab3fc75218fd4b7530f01efa24", size = 12711809 },
+    { url = "https://files.pythonhosted.org/packages/ee/7c/c6dbdb0cb2a4344cacfb8de1c5808ca885b2e4dcfde8008266608f9372af/pandas-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:800250ecdadb6d9c78eae4990da62743b857b470883fa27f652db8bdde7f6659", size = 16356316 },
+    { url = "https://files.pythonhosted.org/packages/57/b7/8b757e7d92023b832869fa8881a992696a0bfe2e26f72c9ae9f255988d42/pandas-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6374c452ff3ec675a8f46fd9ab25c4ad0ba590b71cf0656f8b6daa5202bca3fb", size = 14022055 },
+    { url = "https://files.pythonhosted.org/packages/3b/bc/4b18e2b8c002572c5a441a64826252ce5da2aa738855747247a971988043/pandas-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:61c5ad4043f791b61dd4752191d9f07f0ae412515d59ba8f005832a532f8736d", size = 11481175 },
+    { url = "https://files.pythonhosted.org/packages/76/a3/a5d88146815e972d40d19247b2c162e88213ef51c7c25993942c39dbf41d/pandas-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3b71f27954685ee685317063bf13c7709a7ba74fc996b84fc6821c59b0f06468", size = 12615650 },
+    { url = "https://files.pythonhosted.org/packages/9c/8c/f0fd18f6140ddafc0c24122c8a964e48294acc579d47def376fef12bcb4a/pandas-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:38cf8125c40dae9d5acc10fa66af8ea6fdf760b2714ee482ca691fc66e6fcb18", size = 11290177 },
+    { url = "https://files.pythonhosted.org/packages/ed/f9/e995754eab9c0f14c6777401f7eece0943840b7a9fc932221c19d1abee9f/pandas-2.2.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba96630bc17c875161df3818780af30e43be9b166ce51c9a18c1feae342906c2", size = 14651526 },
+    { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013 },
+    { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620 },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436 },
+    { url = "https://files.pythonhosted.org/packages/ca/8c/8848a4c9b8fdf5a534fe2077af948bf53cd713d77ffbcd7bd15710348fd7/pandas-2.2.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bc6b93f9b966093cb0fd62ff1a7e4c09e6d546ad7c1de191767baffc57628f39", size = 12595535 },
+    { url = "https://files.pythonhosted.org/packages/9c/b9/5cead4f63b6d31bdefeb21a679bc5a7f4aaf262ca7e07e2bc1c341b68470/pandas-2.2.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5dbca4c1acd72e8eeef4753eeca07de9b1db4f398669d5994086f788a5d7cc30", size = 11319822 },
+    { url = "https://files.pythonhosted.org/packages/31/af/89e35619fb573366fa68dc26dad6ad2c08c17b8004aad6d98f1a31ce4bb3/pandas-2.2.3-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8cd6d7cc958a3910f934ea8dbdf17b2364827bb4dafc38ce6eef6bb3d65ff09c", size = 15625439 },
+    { url = "https://files.pythonhosted.org/packages/3d/dd/bed19c2974296661493d7acc4407b1d2db4e2a482197df100f8f965b6225/pandas-2.2.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99df71520d25fade9db7c1076ac94eb994f4d2673ef2aa2e86ee039b6746d20c", size = 13068928 },
+    { url = "https://files.pythonhosted.org/packages/31/a3/18508e10a31ea108d746c848b5a05c0711e0278fa0d6f1c52a8ec52b80a5/pandas-2.2.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:31d0ced62d4ea3e231a9f228366919a5ea0b07440d9d4dac345376fd8e1477ea", size = 16783266 },
+    { url = "https://files.pythonhosted.org/packages/c4/a5/3429bd13d82bebc78f4d78c3945efedef63a7cd0c15c17b2eeb838d1121f/pandas-2.2.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7eee9e7cea6adf3e3d24e304ac6b8300646e2a5d1cd3a3c2abed9101b0846761", size = 14450871 },
+    { url = "https://files.pythonhosted.org/packages/2f/49/5c30646e96c684570925b772eac4eb0a8cb0ca590fa978f56c5d3ae73ea1/pandas-2.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:4850ba03528b6dd51d6c5d273c46f183f39a9baf3f0143e566b89450965b105e", size = 11618011 },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz", hash = "sha256:eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d", size = 400609 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl", hash = "sha256:a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18", size = 103650 },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772 },
 ]
 
 [[package]]
@@ -172,6 +300,84 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/4f/feb5e137aff82f7c7f3248267b97451da3644f6cdc218edfe549fb354127/prompt_toolkit-3.0.48.tar.gz", hash = "sha256:d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90", size = 424684 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/6a/fd08d94654f7e67c52ca30523a178b3f8ccc4237fce4be90d39c938a831a/prompt_toolkit-3.0.48-py3-none-any.whl", hash = "sha256:f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e", size = 386595 },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993 },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842 },
+]
+
+[[package]]
+name = "pyarrow"
+version = "17.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/4e/ea6d43f324169f8aec0e57569443a38bab4b398d09769ca64f7b4d467de3/pyarrow-17.0.0.tar.gz", hash = "sha256:4beca9521ed2c0921c1023e68d097d0299b62c362639ea315572a58f3f50fd28", size = 1112479 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/5d/78d4b040bc5ff2fc6c3d03e80fca396b742f6c125b8af06bcf7427f931bc/pyarrow-17.0.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:a5c8b238d47e48812ee577ee20c9a2779e6a5904f1708ae240f53ecbee7c9f07", size = 28994846 },
+    { url = "https://files.pythonhosted.org/packages/3b/73/8ed168db7642e91180330e4ea9f3ff8bab404678f00d32d7df0871a4933b/pyarrow-17.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:db023dc4c6cae1015de9e198d41250688383c3f9af8f565370ab2b4cb5f62655", size = 27165908 },
+    { url = "https://files.pythonhosted.org/packages/81/36/e78c24be99242063f6d0590ef68c857ea07bdea470242c361e9a15bd57a4/pyarrow-17.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da1e060b3876faa11cee287839f9cc7cdc00649f475714b8680a05fd9071d545", size = 39264209 },
+    { url = "https://files.pythonhosted.org/packages/18/4c/3db637d7578f683b0a8fb8999b436bdbedd6e3517bd4f90c70853cf3ad20/pyarrow-17.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75c06d4624c0ad6674364bb46ef38c3132768139ddec1c56582dbac54f2663e2", size = 39862883 },
+    { url = "https://files.pythonhosted.org/packages/81/3c/0580626896c842614a523e66b351181ed5bb14e5dfc263cd68cea2c46d90/pyarrow-17.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:fa3c246cc58cb5a4a5cb407a18f193354ea47dd0648194e6265bd24177982fe8", size = 38723009 },
+    { url = "https://files.pythonhosted.org/packages/ee/fb/c1b47f0ada36d856a352da261a44d7344d8f22e2f7db3945f8c3b81be5dd/pyarrow-17.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f7ae2de664e0b158d1607699a16a488de3d008ba99b3a7aa5de1cbc13574d047", size = 39855626 },
+    { url = "https://files.pythonhosted.org/packages/19/09/b0a02908180a25d57312ab5919069c39fddf30602568980419f4b02393f6/pyarrow-17.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:5984f416552eea15fd9cee03da53542bf4cddaef5afecefb9aa8d1010c335087", size = 25147242 },
+    { url = "https://files.pythonhosted.org/packages/f9/46/ce89f87c2936f5bb9d879473b9663ce7a4b1f4359acc2f0eb39865eaa1af/pyarrow-17.0.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:1c8856e2ef09eb87ecf937104aacfa0708f22dfeb039c363ec99735190ffb977", size = 29028748 },
+    { url = "https://files.pythonhosted.org/packages/8d/8e/ce2e9b2146de422f6638333c01903140e9ada244a2a477918a368306c64c/pyarrow-17.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2e19f569567efcbbd42084e87f948778eb371d308e137a0f97afe19bb860ccb3", size = 27190965 },
+    { url = "https://files.pythonhosted.org/packages/3b/c8/5675719570eb1acd809481c6d64e2136ffb340bc387f4ca62dce79516cea/pyarrow-17.0.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6b244dc8e08a23b3e352899a006a26ae7b4d0da7bb636872fa8f5884e70acf15", size = 39269081 },
+    { url = "https://files.pythonhosted.org/packages/5e/78/3931194f16ab681ebb87ad252e7b8d2c8b23dad49706cadc865dff4a1dd3/pyarrow-17.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b72e87fe3e1db343995562f7fff8aee354b55ee83d13afba65400c178ab2597", size = 39864921 },
+    { url = "https://files.pythonhosted.org/packages/d8/81/69b6606093363f55a2a574c018901c40952d4e902e670656d18213c71ad7/pyarrow-17.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:dc5c31c37409dfbc5d014047817cb4ccd8c1ea25d19576acf1a001fe07f5b420", size = 38740798 },
+    { url = "https://files.pythonhosted.org/packages/4c/21/9ca93b84b92ef927814cb7ba37f0774a484c849d58f0b692b16af8eebcfb/pyarrow-17.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e3343cb1e88bc2ea605986d4b94948716edc7a8d14afd4e2c097232f729758b4", size = 39871877 },
+    { url = "https://files.pythonhosted.org/packages/30/d1/63a7c248432c71c7d3ee803e706590a0b81ce1a8d2b2ae49677774b813bb/pyarrow-17.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:a27532c38f3de9eb3e90ecab63dfda948a8ca859a66e3a47f5f42d1e403c4d03", size = 25151089 },
+    { url = "https://files.pythonhosted.org/packages/d4/62/ce6ac1275a432b4a27c55fe96c58147f111d8ba1ad800a112d31859fae2f/pyarrow-17.0.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:9b8a823cea605221e61f34859dcc03207e52e409ccf6354634143e23af7c8d22", size = 29019418 },
+    { url = "https://files.pythonhosted.org/packages/8e/0a/dbd0c134e7a0c30bea439675cc120012337202e5fac7163ba839aa3691d2/pyarrow-17.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f1e70de6cb5790a50b01d2b686d54aaf73da01266850b05e3af2a1bc89e16053", size = 27152197 },
+    { url = "https://files.pythonhosted.org/packages/cb/05/3f4a16498349db79090767620d6dc23c1ec0c658a668d61d76b87706c65d/pyarrow-17.0.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0071ce35788c6f9077ff9ecba4858108eebe2ea5a3f7cf2cf55ebc1dbc6ee24a", size = 39263026 },
+    { url = "https://files.pythonhosted.org/packages/c2/0c/ea2107236740be8fa0e0d4a293a095c9f43546a2465bb7df34eee9126b09/pyarrow-17.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:757074882f844411fcca735e39aae74248a1531367a7c80799b4266390ae51cc", size = 39880798 },
+    { url = "https://files.pythonhosted.org/packages/f6/b0/b9164a8bc495083c10c281cc65064553ec87b7537d6f742a89d5953a2a3e/pyarrow-17.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9ba11c4f16976e89146781a83833df7f82077cdab7dc6232c897789343f7891a", size = 38715172 },
+    { url = "https://files.pythonhosted.org/packages/f1/c4/9625418a1413005e486c006e56675334929fad864347c5ae7c1b2e7fe639/pyarrow-17.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b0c6ac301093b42d34410b187bba560b17c0330f64907bfa4f7f7f2444b0cf9b", size = 39874508 },
+    { url = "https://files.pythonhosted.org/packages/ae/49/baafe2a964f663413be3bd1cf5c45ed98c5e42e804e2328e18f4570027c1/pyarrow-17.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:392bc9feabc647338e6c89267635e111d71edad5fcffba204425a7c8d13610d7", size = 25099235 },
+    { url = "https://files.pythonhosted.org/packages/43/e0/a898096d35be240aa61fb2d54db58b86d664b10e1e51256f9300f47565e8/pyarrow-17.0.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:13d7a460b412f31e4c0efa1148e1d29bdf18ad1411eb6757d38f8fbdcc8645fb", size = 29007881 },
+    { url = "https://files.pythonhosted.org/packages/59/22/f7d14907ed0697b5dd488d393129f2738629fa5bcba863e00931b7975946/pyarrow-17.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9b564a51fbccfab5a04a80453e5ac6c9954a9c5ef2890d1bcf63741909c3f8df", size = 27178117 },
+    { url = "https://files.pythonhosted.org/packages/bf/ee/661211feac0ed48467b1d5c57298c91403809ec3ab78b1d175e1d6ad03cf/pyarrow-17.0.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32503827abbc5aadedfa235f5ece8c4f8f8b0a3cf01066bc8d29de7539532687", size = 39273896 },
+    { url = "https://files.pythonhosted.org/packages/af/61/bcd9b58e38ead6ad42b9ed00da33a3f862bc1d445e3d3164799c25550ac2/pyarrow-17.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a155acc7f154b9ffcc85497509bcd0d43efb80d6f733b0dc3bb14e281f131c8b", size = 39875438 },
+    { url = "https://files.pythonhosted.org/packages/75/63/29d1bfcc57af73cde3fc3baccab2f37548de512dbe0ab294b033cd203516/pyarrow-17.0.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:dec8d129254d0188a49f8a1fc99e0560dc1b85f60af729f47de4046015f9b0a5", size = 38735092 },
+    { url = "https://files.pythonhosted.org/packages/39/f4/90258b4de753df7cc61cefb0312f8abcf226672e96cc64996e66afce817a/pyarrow-17.0.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:a48ddf5c3c6a6c505904545c25a4ae13646ae1f8ba703c4df4a1bfe4f4006bda", size = 39867610 },
+    { url = "https://files.pythonhosted.org/packages/e7/f6/b75d4816c32f1618ed31a005ee635dd1d91d8164495d94f2ea092f594661/pyarrow-17.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:42bf93249a083aca230ba7e2786c5f673507fa97bbd9725a1e2754715151a204", size = 25148611 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
 ]
 
 [[package]]
@@ -258,6 +464,20 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521 },
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -267,10 +487,37 @@ wheels = [
 ]
 
 [[package]]
+name = "traitlets"
+version = "5.14.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
 name = "tzdata"
 version = "2024.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/74/5b/e025d02cb3b66b7b76093404392d4b44343c69101cc85f4d180dd5784717/tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd", size = 190559 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/58/f9c9e6be752e9fcb8b6a0ee9fb87e6e7a1f6bcab2cdc73f02bb7ba91ada0/tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252", size = 345370 },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "rioxarray>=0.15.1",
     "html2text>=2020.1.16",
     "pygithub>=2.3.0",
-    "pandas==2.2.2",
+    "pandas==2.2.3",
     "sqlalchemy>=2.0.30",
     "pymysql>=1.1.1",
     "tiktoken>=0.7.0",

--- a/snapshots/health/latest/global_health_mpox.py
+++ b/snapshots/health/latest/global_health_mpox.py
@@ -15,7 +15,7 @@ SNAPSHOT_VERSION = Path(__file__).parent.name
 def main(upload: bool) -> None:
     # Create a new snapshot.
     snap = Snapshot(f"health/{SNAPSHOT_VERSION}/global_health_mpox.csv")
-    tb = snap.read()
+    tb = snap.read(safe_types=False)
     assert tb["Date_report_source_I"].min() > "2023-12-01", "Global.health have added data for 2023"
     # Download data from source, add file to DVC and upload to S3.
     snap.create_snapshot(upload=upload)

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -62,5 +62,5 @@ def test_new_data(tmp_path):
         "\t\t[yellow]~ Dim [b]country[/b]",
         "\t\t\t\t[violet]+ New values: 1 / 3 (33.33%)\n\t\t\t\t[violet]  country\n\t\t\t\t[violet]       FR",
         "\t\t[yellow]~ Column [b]a[/b] (new [u]data[/u], changed [u]data[/u])",
-        "\t\t\t\t[violet]+ New values: 1 / 3 (33.33%)\n\t\t\t\t[violet]  country  a\n\t\t\t\t[violet]       FR  3\n\t\t\t\t[violet]~ Changed values: 1 / 3 (33.33%)\n\t\t\t\t[violet]  country  a -  a +\n\t\t\t\t[violet]       US  3.0    2",
+        "\t\t\t\t[violet]+ New values: 1 / 3 (33.33%)\n\t\t\t\t[violet]  country  a\n\t\t\t\t[violet]       FR  3\n\t\t\t\t[violet]~ Changed values: 1 / 3 (33.33%)\n\t\t\t\t[violet]  country  a -  a +\n\t\t\t\t[violet]       US    3    2",
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -650,16 +650,15 @@ wheels = [
 
 [[package]]
 name = "dataclasses-json"
-version = "0.5.8"
+version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "marshmallow" },
-    { name = "marshmallow-enum" },
     { name = "typing-inspect" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/63/10cdc14908f3c9fdb9c21631275d2805853f6156b761a391e6f8918377e1/dataclasses-json-0.5.8.tar.gz", hash = "sha256:6572ac08ad9340abcb74fd8c4c8e9752db2a182a402c8e871d0a8aa119e3804e", size = 44113 }
+sdist = { url = "https://files.pythonhosted.org/packages/64/a4/f71d9cf3a5ac257c993b5ca3f93df5f7fb395c725e7f1e6479d2514173c3/dataclasses_json-0.6.7.tar.gz", hash = "sha256:b6b3e528266ea45b9535223bc53ca645f5208833c29229e847b3f26a1cc55fc0", size = 32227 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/bc/892e03650133583d5babbb7c7e5c1be6b68df86829c91fdc30cca996630d/dataclasses_json-0.5.8-py3-none-any.whl", hash = "sha256:65b167c15fdf9bde27569c09ac18dd39bf1cc5b7998525024cb4678d2653946c", size = 26211 },
+    { url = "https://files.pythonhosted.org/packages/c3/be/d0d44e092656fe7a06b55e6103cbce807cdbdee17884a5367c68c9860853/dataclasses_json-0.6.7-py3-none-any.whl", hash = "sha256:0dbf33f26c8d5305befd61b39d2b3414e8a407bedc2834dea9b8d642666fb40a", size = 28686 },
 ]
 
 [[package]]
@@ -912,7 +911,7 @@ requires-dist = [
     { name = "owid-catalog", editable = "lib/catalog" },
     { name = "owid-datautils", editable = "lib/datautils" },
     { name = "owid-repack", editable = "lib/repack" },
-    { name = "pandas", specifier = "==2.2.2" },
+    { name = "pandas", specifier = "==2.2.3" },
     { name = "papermill", specifier = ">=2.3.3" },
     { name = "pdfplumber", specifier = ">=0.9.0" },
     { name = "plotly", marker = "extra == 'wizard'", specifier = ">=5.23.0" },
@@ -2453,18 +2452,6 @@ wheels = [
 ]
 
 [[package]]
-name = "marshmallow-enum"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "marshmallow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/8c/ceecdce57dfd37913143087fffd15f38562a94f0d22823e3c66eac0dca31/marshmallow-enum-1.5.1.tar.gz", hash = "sha256:38e697e11f45a8e64b4a1e664000897c659b60aa57bfa18d44e226a9920b6e58", size = 4013 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/59/ef3a3dc499be447098d4a89399beb869f813fee1b5a57d5d79dee2c1bf51/marshmallow_enum-1.5.1-py2.py3-none-any.whl", hash = "sha256:57161ab3dbfde4f57adeb12090f39592e992b9c86d206d02f6bd03ebec60f072", size = 4186 },
-]
-
-[[package]]
 name = "matplotlib"
 version = "3.9.1.post1"
 source = { registry = "https://pypi.org/simple" }
@@ -3155,13 +3142,13 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.21.13" },
-    { name = "dataclasses-json", specifier = "==0.5.8" },
+    { name = "dataclasses-json", specifier = ">=0.6.7" },
     { name = "dynamic-yaml", specifier = ">=1.3.5" },
     { name = "ipdb", specifier = ">=0.13.9" },
     { name = "jsonschema", specifier = ">=3.2.0" },
     { name = "mistune", specifier = ">=3.0.1" },
     { name = "owid-datautils", editable = "lib/datautils" },
-    { name = "owid-repack", specifier = ">=0.1.1" },
+    { name = "owid-repack", editable = "lib/repack" },
     { name = "pandas", specifier = ">=2.2.1" },
     { name = "pyarrow", specifier = ">=10.0.1" },
     { name = "pyyaml", specifier = ">=6.0.1" },
@@ -3232,21 +3219,24 @@ dev = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "lib/repack" }
 dependencies = [
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pyarrow" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=1.24.0" },
-    { name = "pandas", specifier = ">=2.2.1" },
+    { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pyarrow", specifier = ">=10.0.1,<18.0.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ipdb", specifier = ">=0.13.13" },
     { name = "pyright", specifier = "==1.1.373" },
     { name = "pytest", specifier = ">=7.2.0" },
     { name = "ruff", specifier = "==0.1.6" },
@@ -3272,7 +3262,7 @@ wheels = [
 
 [[package]]
 name = "pandas"
-version = "2.2.2"
+version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -3280,29 +3270,42 @@ dependencies = [
     { name = "pytz" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/d9/ecf715f34c73ccb1d8ceb82fc01cd1028a65a5f6dbc57bfa6ea155119058/pandas-2.2.2.tar.gz", hash = "sha256:9e79019aba43cb4fda9e4d983f8e88ca0373adbb697ae9c6c43093218de28b54", size = 4398391 }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/2d/39600d073ea70b9cafdc51fab91d69c72b49dd92810f24cb5ac6631f387f/pandas-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:90c6fca2acf139569e74e8781709dccb6fe25940488755716d1d354d6bc58bce", size = 12551798 },
-    { url = "https://files.pythonhosted.org/packages/fd/4b/0cd38e68ab690b9df8ef90cba625bf3f93b82d1c719703b8e1b333b2c72d/pandas-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c7adfc142dac335d8c1e0dcbd37eb8617eac386596eb9e1a1b77791cf2498238", size = 11287392 },
-    { url = "https://files.pythonhosted.org/packages/01/c6/d3d2612aea9b9f28e79a30b864835dad8f542dcf474eee09afeee5d15d75/pandas-2.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4abfe0be0d7221be4f12552995e58723c7422c80a659da13ca382697de830c08", size = 15634823 },
-    { url = "https://files.pythonhosted.org/packages/89/1b/12521efcbc6058e2673583bb096c2b5046a9df39bd73eca392c1efed24e5/pandas-2.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8635c16bf3d99040fdf3ca3db669a7250ddf49c55dc4aa8fe0ae0fa8d6dcc1f0", size = 13032214 },
-    { url = "https://files.pythonhosted.org/packages/e4/d7/303dba73f1c3a9ef067d23e5afbb6175aa25e8121be79be354dcc740921a/pandas-2.2.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:40ae1dffb3967a52203105a077415a86044a2bea011b5f321c6aa64b379a3f51", size = 16278302 },
-    { url = "https://files.pythonhosted.org/packages/ba/df/8ff7c5ed1cc4da8c6ab674dc8e4860a4310c3880df1283e01bac27a4333d/pandas-2.2.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8e5a0b00e1e56a842f922e7fae8ae4077aee4af0acb5ae3622bd4b4c30aedf99", size = 13892866 },
-    { url = "https://files.pythonhosted.org/packages/69/a6/81d5dc9a612cf0c1810c2ebc4f2afddb900382276522b18d128213faeae3/pandas-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:ddf818e4e6c7c6f4f7c8a12709696d193976b591cc7dc50588d3d1a6b5dc8772", size = 11621592 },
-    { url = "https://files.pythonhosted.org/packages/1b/70/61704497903d43043e288017cb2b82155c0d41e15f5c17807920877b45c2/pandas-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:696039430f7a562b74fa45f540aca068ea85fa34c244d0deee539cb6d70aa288", size = 12574808 },
-    { url = "https://files.pythonhosted.org/packages/16/c6/75231fd47afd6b3f89011e7077f1a3958441264aca7ae9ff596e3276a5d0/pandas-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8e90497254aacacbc4ea6ae5e7a8cd75629d6ad2b30025a4a8b09aa4faf55151", size = 11304876 },
-    { url = "https://files.pythonhosted.org/packages/97/2d/7b54f80b93379ff94afb3bd9b0cd1d17b48183a0d6f98045bc01ce1e06a7/pandas-2.2.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58b84b91b0b9f4bafac2a0ac55002280c094dfc6402402332c0913a59654ab2b", size = 15602548 },
-    { url = "https://files.pythonhosted.org/packages/fc/a5/4d82be566f069d7a9a702dcdf6f9106df0e0b042e738043c0cc7ddd7e3f6/pandas-2.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6d2123dc9ad6a814bcdea0f099885276b31b24f7edf40f6cdbc0912672e22eee", size = 13031332 },
-    { url = "https://files.pythonhosted.org/packages/92/a2/b79c48f530673567805e607712b29814b47dcaf0d167e87145eb4b0118c6/pandas-2.2.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:2925720037f06e89af896c70bca73459d7e6a4be96f9de79e2d440bd499fe0db", size = 16286054 },
-    { url = "https://files.pythonhosted.org/packages/40/c7/47e94907f1d8fdb4868d61bd6c93d57b3784a964d52691b77ebfdb062842/pandas-2.2.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0cace394b6ea70c01ca1595f839cf193df35d1575986e484ad35c4aeae7266c1", size = 13879507 },
-    { url = "https://files.pythonhosted.org/packages/ab/63/966db1321a0ad55df1d1fe51505d2cdae191b84c907974873817b0a6e849/pandas-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:873d13d177501a28b2756375d59816c365e42ed8417b41665f346289adc68d24", size = 11634249 },
-    { url = "https://files.pythonhosted.org/packages/dd/49/de869130028fb8d90e25da3b7d8fb13e40f5afa4c4af1781583eb1ff3839/pandas-2.2.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9dfde2a0ddef507a631dc9dc4af6a9489d5e2e740e226ad426a05cabfbd7c8ef", size = 12500886 },
-    { url = "https://files.pythonhosted.org/packages/db/7c/9a60add21b96140e22465d9adf09832feade45235cd22f4cb1668a25e443/pandas-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e9b79011ff7a0f4b1d6da6a61aa1aa604fb312d6647de5bad20013682d1429ce", size = 11340320 },
-    { url = "https://files.pythonhosted.org/packages/b0/85/f95b5f322e1ae13b7ed7e97bd999160fa003424711ab4dc8344b8772c270/pandas-2.2.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cb51fe389360f3b5a4d57dbd2848a5f033350336ca3b340d1c53a1fad33bcad", size = 15204346 },
-    { url = "https://files.pythonhosted.org/packages/40/10/79e52ef01dfeb1c1ca47a109a01a248754ebe990e159a844ece12914de83/pandas-2.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eee3a87076c0756de40b05c5e9a6069c035ba43e8dd71c379e68cab2c20f16ad", size = 12733396 },
-    { url = "https://files.pythonhosted.org/packages/35/9d/208febf8c4eb5c1d9ea3314d52d8bd415fd0ef0dd66bb24cc5bdbc8fa71a/pandas-2.2.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:3e374f59e440d4ab45ca2fffde54b81ac3834cf5ae2cdfa69c90bc03bde04d76", size = 15858913 },
-    { url = "https://files.pythonhosted.org/packages/99/d1/2d9bd05def7a9e08a92ec929b5a4c8d5556ec76fae22b0fa486cbf33ea63/pandas-2.2.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:43498c0bdb43d55cb162cdc8c06fac328ccb5d2eabe3cadeb3529ae6f0517c32", size = 13417786 },
-    { url = "https://files.pythonhosted.org/packages/22/a5/a0b255295406ed54269814bc93723cfd1a0da63fb9aaf99e1364f07923e5/pandas-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:d187d355ecec3629624fccb01d104da7d7f391db0311145817525281e2804d23", size = 11498828 },
+    { url = "https://files.pythonhosted.org/packages/aa/70/c853aec59839bceed032d52010ff5f1b8d87dc3114b762e4ba2727661a3b/pandas-2.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1948ddde24197a0f7add2bdc4ca83bf2b1ef84a1bc8ccffd95eda17fd836ecb5", size = 12580827 },
+    { url = "https://files.pythonhosted.org/packages/99/f2/c4527768739ffa4469b2b4fff05aa3768a478aed89a2f271a79a40eee984/pandas-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:381175499d3802cde0eabbaf6324cce0c4f5d52ca6f8c377c29ad442f50f6348", size = 11303897 },
+    { url = "https://files.pythonhosted.org/packages/ed/12/86c1747ea27989d7a4064f806ce2bae2c6d575b950be087837bdfcabacc9/pandas-2.2.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d9c45366def9a3dd85a6454c0e7908f2b3b8e9c138f5dc38fed7ce720d8453ed", size = 66480908 },
+    { url = "https://files.pythonhosted.org/packages/44/50/7db2cd5e6373ae796f0ddad3675268c8d59fb6076e66f0c339d61cea886b/pandas-2.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:86976a1c5b25ae3f8ccae3a5306e443569ee3c3faf444dfd0f41cda24667ad57", size = 13064210 },
+    { url = "https://files.pythonhosted.org/packages/61/61/a89015a6d5536cb0d6c3ba02cebed51a95538cf83472975275e28ebf7d0c/pandas-2.2.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b8661b0238a69d7aafe156b7fa86c44b881387509653fdf857bebc5e4008ad42", size = 16754292 },
+    { url = "https://files.pythonhosted.org/packages/ce/0d/4cc7b69ce37fac07645a94e1d4b0880b15999494372c1523508511b09e40/pandas-2.2.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:37e0aced3e8f539eccf2e099f65cdb9c8aa85109b0be6e93e2baff94264bdc6f", size = 14416379 },
+    { url = "https://files.pythonhosted.org/packages/31/9e/6ebb433de864a6cd45716af52a4d7a8c3c9aaf3a98368e61db9e69e69a9c/pandas-2.2.3-cp310-cp310-win_amd64.whl", hash = "sha256:56534ce0746a58afaf7942ba4863e0ef81c9c50d3f0ae93e9497d6a41a057645", size = 11598471 },
+    { url = "https://files.pythonhosted.org/packages/a8/44/d9502bf0ed197ba9bf1103c9867d5904ddcaf869e52329787fc54ed70cc8/pandas-2.2.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66108071e1b935240e74525006034333f98bcdb87ea116de573a6a0dccb6c039", size = 12602222 },
+    { url = "https://files.pythonhosted.org/packages/52/11/9eac327a38834f162b8250aab32a6781339c69afe7574368fffe46387edf/pandas-2.2.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7c2875855b0ff77b2a64a0365e24455d9990730d6431b9e0ee18ad8acee13dbd", size = 11321274 },
+    { url = "https://files.pythonhosted.org/packages/45/fb/c4beeb084718598ba19aa9f5abbc8aed8b42f90930da861fcb1acdb54c3a/pandas-2.2.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd8d0c3be0515c12fed0bdbae072551c8b54b7192c7b1fda0ba56059a0179698", size = 15579836 },
+    { url = "https://files.pythonhosted.org/packages/cd/5f/4dba1d39bb9c38d574a9a22548c540177f78ea47b32f99c0ff2ec499fac5/pandas-2.2.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c124333816c3a9b03fbeef3a9f230ba9a737e9e5bb4060aa2107a86cc0a497fc", size = 13058505 },
+    { url = "https://files.pythonhosted.org/packages/b9/57/708135b90391995361636634df1f1130d03ba456e95bcf576fada459115a/pandas-2.2.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:63cc132e40a2e084cf01adf0775b15ac515ba905d7dcca47e9a251819c575ef3", size = 16744420 },
+    { url = "https://files.pythonhosted.org/packages/86/4a/03ed6b7ee323cf30404265c284cee9c65c56a212e0a08d9ee06984ba2240/pandas-2.2.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29401dbfa9ad77319367d36940cd8a0b3a11aba16063e39632d98b0e931ddf32", size = 14440457 },
+    { url = "https://files.pythonhosted.org/packages/ed/8c/87ddf1fcb55d11f9f847e3c69bb1c6f8e46e2f40ab1a2d2abadb2401b007/pandas-2.2.3-cp311-cp311-win_amd64.whl", hash = "sha256:3fc6873a41186404dad67245896a6e440baacc92f5b716ccd1bc9ed2995ab2c5", size = 11617166 },
+    { url = "https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b1d432e8d08679a40e2a6d8b2f9770a5c21793a6f9f47fdd52c5ce1948a5a8a9", size = 12529893 },
+    { url = "https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5a1595fe639f5988ba6a8e5bc9649af3baf26df3998a0abe56c02609392e0a4", size = 11363475 },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/4bba3f03f7d07207481fed47f5b35f556c7441acddc368ec43d6643c5777/pandas-2.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5de54125a92bb4d1c051c0659e6fcb75256bf799a732a87184e5ea503965bce3", size = 15188645 },
+    { url = "https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb8ae78d8af97f849404f21411c95062db1496aeb3e56f146f0355c9989319", size = 12739445 },
+    { url = "https://files.pythonhosted.org/packages/20/e8/45a05d9c39d2cea61ab175dbe6a2de1d05b679e8de2011da4ee190d7e748/pandas-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dfcb5ee8d4d50c06a51c2fffa6cff6272098ad6540aed1a76d15fb9318194d8", size = 16359235 },
+    { url = "https://files.pythonhosted.org/packages/1d/99/617d07a6a5e429ff90c90da64d428516605a1ec7d7bea494235e1c3882de/pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a", size = 14056756 },
+    { url = "https://files.pythonhosted.org/packages/29/d4/1244ab8edf173a10fd601f7e13b9566c1b525c4f365d6bee918e68381889/pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13", size = 11504248 },
+    { url = "https://files.pythonhosted.org/packages/64/22/3b8f4e0ed70644e85cfdcd57454686b9057c6c38d2f74fe4b8bc2527214a/pandas-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f00d1345d84d8c86a63e476bb4955e46458b304b9575dcf71102b5c705320015", size = 12477643 },
+    { url = "https://files.pythonhosted.org/packages/e4/93/b3f5d1838500e22c8d793625da672f3eec046b1a99257666c94446969282/pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3508d914817e153ad359d7e069d752cdd736a247c322d932eb89e6bc84217f28", size = 11281573 },
+    { url = "https://files.pythonhosted.org/packages/f5/94/6c79b07f0e5aab1dcfa35a75f4817f5c4f677931d4234afcd75f0e6a66ca/pandas-2.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22a9d949bfc9a502d320aa04e5d02feab689d61da4e7764b62c30b991c42c5f0", size = 15196085 },
+    { url = "https://files.pythonhosted.org/packages/e8/31/aa8da88ca0eadbabd0a639788a6da13bb2ff6edbbb9f29aa786450a30a91/pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a255b2c19987fbbe62a9dfd6cff7ff2aa9ccab3fc75218fd4b7530f01efa24", size = 12711809 },
+    { url = "https://files.pythonhosted.org/packages/ee/7c/c6dbdb0cb2a4344cacfb8de1c5808ca885b2e4dcfde8008266608f9372af/pandas-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:800250ecdadb6d9c78eae4990da62743b857b470883fa27f652db8bdde7f6659", size = 16356316 },
+    { url = "https://files.pythonhosted.org/packages/57/b7/8b757e7d92023b832869fa8881a992696a0bfe2e26f72c9ae9f255988d42/pandas-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6374c452ff3ec675a8f46fd9ab25c4ad0ba590b71cf0656f8b6daa5202bca3fb", size = 14022055 },
+    { url = "https://files.pythonhosted.org/packages/3b/bc/4b18e2b8c002572c5a441a64826252ce5da2aa738855747247a971988043/pandas-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:61c5ad4043f791b61dd4752191d9f07f0ae412515d59ba8f005832a532f8736d", size = 11481175 },
+    { url = "https://files.pythonhosted.org/packages/76/a3/a5d88146815e972d40d19247b2c162e88213ef51c7c25993942c39dbf41d/pandas-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3b71f27954685ee685317063bf13c7709a7ba74fc996b84fc6821c59b0f06468", size = 12615650 },
+    { url = "https://files.pythonhosted.org/packages/9c/8c/f0fd18f6140ddafc0c24122c8a964e48294acc579d47def376fef12bcb4a/pandas-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:38cf8125c40dae9d5acc10fa66af8ea6fdf760b2714ee482ca691fc66e6fcb18", size = 11290177 },
+    { url = "https://files.pythonhosted.org/packages/ed/f9/e995754eab9c0f14c6777401f7eece0943840b7a9fc932221c19d1abee9f/pandas-2.2.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba96630bc17c875161df3818780af30e43be9b166ce51c9a18c1feae342906c2", size = 14651526 },
+    { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013 },
+    { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620 },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436 },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements https://github.com/owid/etl/issues/3277

Adds new parameter `ds.read_table("my_table", safe_types=True)` that converts all types to "safe" types `Float64`, `Int64` or `string[python]`. It's true by default.

(We've also considered the name `unpack` in the past instead of `safe_types`. I don't have a preference.)

## int64 vs Int64

Should we use numpy's `int64` type or nullable pandas type `Int64` (or even pyarrow types)? This PR goes with nullable types, but there are some hidden risks to it:
- Mixing `np.nan` and `pd.NA` creates a nightmare of compatibility issues. We should always use `pd.NA`
- Sometimes `np.nan` sneaks in, for instance division 0/0 returns `np.nan` even if we work with nullable types
```python
a = pd.Series([0]).astype("Int64")
b = pd.Series([0]).astype("Int64")
# the first item is np.nan, not pd.NA!
c = a / b
# this is actually False, `pd.isnull` doesn't detect np.nan when dtype is Int64
pd.isnull(c)
# this doesn't work either...
c.fillna(pd.NA)
# only this fixes it
c.mask(np.isnan(c), pd.NA)
```

## TODO before merging:
- [x] Increment ETL_EPOCH and make sure old datasets don't change
- [x] Undo ETL_EPOCH increment