### PR TITLE
 :sparkles: Make OWID continents ambiguous in harmonizer

### DIFF
--- a/etl/harmonize.py
+++ b/etl/harmonize.py
@@ -144,6 +144,7 @@ class CountryRegionMapper:
     # known aliases of our canonical geo-regions
     aliases: Dict[str, str]
     valid_names: Set[str]
+    owid_continents: Set[str]
 
     def __init__(self) -> None:
         try:
@@ -172,6 +173,11 @@ class CountryRegionMapper:
 
         self.aliases = aliases
         self.valid_names = valid_names
+
+        # continents defined by OWID that require explicit confirmation
+        self.owid_continents = set(
+            rc_df[(rc_df.defined_by == "owid") & (rc_df.region_type.isin({"continent", "aggregate"}))].name
+        ) - {"World"}
 
     def __contains__(self, key: str) -> bool:
         return key.lower() in self.aliases
@@ -324,15 +330,20 @@ class Harmonizer:
         for region in self.geo:
             if region in self.mapping:
                 # we did this one in a previous run
-                continue
+                pass
 
-            if region in self.mapper:
+            elif region in self.mapper.owid_continents:
+                # continents require explicit confirmation to avoid accidental mappings to "Asia" instead of "Asia (UN)"
+                ambiguous.append(region)
+
+            elif region in self.mapper:
                 # it's an exact match for a country/region or its known aliases
                 name = self.mapper[region]
                 self.mapping[region] = name
-                continue
 
-            ambiguous.append(region)
+            else:
+                # unknown country
+                ambiguous.append(region)
 
         # logging
         if logging == "ipython":
@@ -579,7 +590,6 @@ class Harmonizer:
     def export_excluded_countries(self):
         if not self.excluded:
             return
-
         if self.output_file is None:
             raise ValueError("`output_file` not provided")
         assert ".countries." in str(self.output_file), "Output file is not in **/*.countries.json format"


### PR DESCRIPTION
Implement suggestion from [this issue](https://github.com/owid/etl/issues/3457#issuecomment-2454993299) by @spoonerf 
> I think the ideal situation would be that it always asks about Asia, Europe, North America, South America and Oceania and that these are not automatically mapped. However, if this is tricky, I'd say it's a pretty minor pain point, so maybe not worth spending too much time on.

The Harmonizer CLI now consistently makes OWID continents ambiguous. It's best used in combination with `--institution WB` to prioritize `Asia (WB)` as the first choice.

@lucasrodes are you ok with this change as a harmonizer's father?