### PR TITLE
🐝 metadata: Improve UNODC metadata and fix issue with missing spaces in Jinja

### DIFF
--- a/etl/steps/data/garden/homicide/2024-10-30/unodc.meta.yml
+++ b/etl/steps/data/garden/homicide/2024-10-30/unodc.meta.yml
@@ -6,49 +6,49 @@ definitions:
         - Homicides
 
   metric:
-    <% if unit_of_measurement == "Counts" %>
+    <%-  if unit_of_measurement == "Counts" -%>
     Number of homicides
-    <% elif unit_of_measurement == "Rate per 100,000 population" %>
+    <%-  elif unit_of_measurement == "Rate per 100,000 population" -%>
     Homicide rate per 100,000 population
-    <%- endif -%>
+    <%- - endif --%>
   sex:
-    <% if sex == "Total" %>
+    <%-  if sex == "Total" -%>
     all victims
-    <% elif sex == "Male" %>
+    <%-  elif sex == "Male" -%>
     male victims
-    <% elif sex == "Female" %>
+    <%-  elif sex == "Female" -%>
     female victims
-    <%- endif -%>
+    <%- - endif --%>
   age:
-    <% if age == "Total" %>
+    <%-  if age == "Total" -%>
     in all age-groups
-    <% elif age == "30-44" %>
+    <%-  elif age == "30-44" -%>
     aged 30-44 years
-    <% elif age == "45-59" %>
+    <%-  elif age == "45-59" -%>
     aged 45-59 years
-    <% elif age == "60 and older" %>
+    <%-  elif age == "60 and older" -%>
     aged over 60 years
-    <% elif age == "0-9" %>
+    <%-  elif age == "0-9" -%>
     aged 0-9 years
-    <% elif age == "10 -14" %>
+    <%-  elif age == "10 -14" -%>
     aged 10-14 years
-    <% elif age == "15 -17" %>
+    <%-  elif age == "15 -17" -%>
     aged 15-17 years
-    <% elif age == "18-19" %>
+    <%-  elif age == "18-19" -%>
     aged 18-19 years
-    <% elif age == "20-24" %>
+    <%-  elif age == "20-24" -%>
     aged 20-24 years
-    <% elif age == "25-29" %>
+    <%-  elif age == "25-29" -%>
     aged 25-29 years
-    <% elif age == "Unknown" %>
+    <%-  elif age == "Unknown" -%>
     of unknown age
-    <%- endif -%>
+    <%- - endif --%>
   unit:
-    <% if unit_of_measurement == "Counts" %>
+    <%-  if unit_of_measurement == "Counts" -%>
     homicides
-    <% elif sex == "Rate per 100,000 population" %>
+    <%-  elif sex == "Rate per 100,000 population" -%>
     homicides per 100,000 population
-    <%- endif -%>
+    <%- - endif --%>
 # Learn more about the available fields:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/
 dataset:
@@ -69,7 +69,7 @@ tables:
             title_public: |
               {definitions.metric} of {definitions.sex} {definitions.age} where the weapon was << category.lower() >>
           display:
-            numDecimalPlaces: <% if unit_of_measurement == "Counts" %>0<% elif unit_of_measurement == "Rate per 100,000 population" %>1<%- endif -%>
+            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- - endif --%>
     by_relationship_to_perpetrator:
       variables:
         value:
@@ -83,7 +83,7 @@ tables:
             title_public: |
               {definitions.metric} of {definitions.sex} {definitions.age} where the << category.lower() >>
           display:
-            numDecimalPlaces: <% if unit_of_measurement == "Counts" %>0<% elif unit_of_measurement == "Rate per 100,000 population" %>1<%- endif -%>
+            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- - endif --%>
     by_situational_context:
       variables:
         value:
@@ -97,7 +97,7 @@ tables:
             title_public: |
               {definitions.metric} of {definitions.sex} {definitions.age} where the situation was << category.lower() >>
           display:
-            numDecimalPlaces: <% if unit_of_measurement == "Counts" %>0<% elif unit_of_measurement == "Rate per 100,000 population" %>1<%- endif -%>
+            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- - endif --%>
     total:
       variables:
         value:
@@ -108,4 +108,4 @@ tables:
           unit: |
             {definitions.unit}
           display:
-            numDecimalPlaces: <% if unit_of_measurement == "Counts" %>0<% elif unit_of_measurement == "Rate per 100,000 population" %>1<%- endif -%>
+            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- - endif --%>

--- a/etl/steps/data/garden/homicide/2024-10-30/unodc.meta.yml
+++ b/etl/steps/data/garden/homicide/2024-10-30/unodc.meta.yml
@@ -10,7 +10,7 @@ definitions:
     Number of homicides
     <%-  elif unit_of_measurement == "Rate per 100,000 population" -%>
     Homicide rate per 100,000 population
-    <%- - endif --%>
+    <%- endif -%>
   sex:
     <%-  if sex == "Total" -%>
     all victims
@@ -18,7 +18,7 @@ definitions:
     male victims
     <%-  elif sex == "Female" -%>
     female victims
-    <%- - endif --%>
+    <%- endif -%>
   age:
     <%-  if age == "Total" -%>
     in all age-groups
@@ -42,13 +42,13 @@ definitions:
     aged 25-29 years
     <%-  elif age == "Unknown" -%>
     of unknown age
-    <%- - endif --%>
+    <%- endif -%>
   unit:
     <%-  if unit_of_measurement == "Counts" -%>
     homicides
     <%-  elif sex == "Rate per 100,000 population" -%>
     homicides per 100,000 population
-    <%- - endif --%>
+    <%- endif -%>
 # Learn more about the available fields:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/
 dataset:
@@ -69,7 +69,7 @@ tables:
             title_public: |
               {definitions.metric} of {definitions.sex} {definitions.age} where the weapon was << category.lower() >>
           display:
-            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- - endif --%>
+            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- endif -%>
     by_relationship_to_perpetrator:
       variables:
         value:
@@ -83,7 +83,7 @@ tables:
             title_public: |
               {definitions.metric} of {definitions.sex} {definitions.age} where the << category.lower() >>
           display:
-            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- - endif --%>
+            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- endif -%>
     by_situational_context:
       variables:
         value:
@@ -97,7 +97,7 @@ tables:
             title_public: |
               {definitions.metric} of {definitions.sex} {definitions.age} where the situation was << category.lower() >>
           display:
-            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- - endif --%>
+            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- endif -%>
     total:
       variables:
         value:
@@ -108,4 +108,4 @@ tables:
           unit: |
             {definitions.unit}
           display:
-            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- - endif --%>
+            numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- endif -%>

--- a/etl/steps/data/garden/homicide/2024-10-30/unodc.meta.yml
+++ b/etl/steps/data/garden/homicide/2024-10-30/unodc.meta.yml
@@ -6,9 +6,19 @@ definitions:
         - Homicides
 
   metric:
-    <% if unit_of_measurement == "Counts" %>Number of homicides<% elif unit_of_measurement == "Rate per 100,000 population" %>Homicide rate per 100,000 population<%- endif -%>
+    <% if unit_of_measurement == "Counts" %>
+    Number of homicides
+    <% elif unit_of_measurement == "Rate per 100,000 population" %>
+    Homicide rate per 100,000 population
+    <%- endif -%>
   sex:
-    <% if sex == "Total" %> all victimes<% elif sex == "Male" %>male victims<% elif sex == "Female" %>female victims<%- endif -%>
+    <% if sex == "Total" %>
+    all victims
+    <% elif sex == "Male" %>
+    male victims
+    <% elif sex == "Female" %>
+    female victims
+    <%- endif -%>
   age:
     <% if age == "Total" %>
     in all age-groups

--- a/etl/steps/data/garden/homicide/2024-10-30/unodc.meta.yml
+++ b/etl/steps/data/garden/homicide/2024-10-30/unodc.meta.yml
@@ -6,11 +6,7 @@ definitions:
         - Homicides
 
   metric:
-    <% if unit_of_measurement == "Counts" %>
-    Number of homicides
-    <% elif unit_of_measurement == "Rate per 100,000 population" %>
-    Homicide rate per 100,000 population
-    <%- endif -%>
+    <% if unit_of_measurement == "Counts" %>Number of homicides<% elif unit_of_measurement == "Rate per 100,000 population" %>Homicide rate per 100,000 population<%- endif -%>
   sex:
     <% if sex == "Total" %> all victimes<% elif sex == "Male" %>male victims<% elif sex == "Female" %>female victims<%- endif -%>
   age:

--- a/etl/steps/data/garden/homicide/2024-10-30/unodc.meta.yml
+++ b/etl/steps/data/garden/homicide/2024-10-30/unodc.meta.yml
@@ -5,50 +5,50 @@ definitions:
       topic_tags:
         - Homicides
 
-  metric:
-    <%-  if unit_of_measurement == "Counts" -%>
+  metric: |-
+    <% if unit_of_measurement == "Counts" %>
     Number of homicides
-    <%-  elif unit_of_measurement == "Rate per 100,000 population" -%>
+    <%- elif unit_of_measurement == "Rate per 100,000 population" %>
     Homicide rate per 100,000 population
-    <%- endif -%>
-  sex:
-    <%-  if sex == "Total" -%>
+    <%- endif %>
+  sex: |-
+    <% if sex == "Total" %>
     all victims
-    <%-  elif sex == "Male" -%>
+    <%- elif sex == "Male" -%>
     male victims
-    <%-  elif sex == "Female" -%>
+    <%- elif sex == "Female" -%>
     female victims
-    <%- endif -%>
-  age:
-    <%-  if age == "Total" -%>
+    <% endif %>
+  age: |-
+    <% if age == "Total" %>
     in all age-groups
-    <%-  elif age == "30-44" -%>
+    <%- elif age == "30-44" %>
     aged 30-44 years
-    <%-  elif age == "45-59" -%>
+    <%- elif age == "45-59" %>
     aged 45-59 years
-    <%-  elif age == "60 and older" -%>
+    <%- elif age == "60 and older" %>
     aged over 60 years
-    <%-  elif age == "0-9" -%>
+    <%- elif age == "0-9" %>
     aged 0-9 years
-    <%-  elif age == "10 -14" -%>
+    <%- elif age == "10 -14" %>
     aged 10-14 years
-    <%-  elif age == "15 -17" -%>
+    <%- elif age == "15 -17" %>
     aged 15-17 years
-    <%-  elif age == "18-19" -%>
+    <%- elif age == "18-19" %>
     aged 18-19 years
-    <%-  elif age == "20-24" -%>
+    <%-  elif age == "20-24" %>
     aged 20-24 years
-    <%-  elif age == "25-29" -%>
+    <%- elif age == "25-29" %>
     aged 25-29 years
-    <%-  elif age == "Unknown" -%>
+    <%- elif age == "Unknown" %>
     of unknown age
-    <%- endif -%>
-  unit:
-    <%-  if unit_of_measurement == "Counts" -%>
+    <%- endif %>
+  unit: |-
+    <% if unit_of_measurement == "Counts" %>
     homicides
-    <%-  elif sex == "Rate per 100,000 population" -%>
+    <%- elif sex == "Rate per 100,000 population" %>
     homicides per 100,000 population
-    <%- endif -%>
+    <%- endif %>
 # Learn more about the available fields:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/
 dataset:
@@ -59,53 +59,53 @@ tables:
     by_mechanisms:
       variables:
         value:
-          title: |
+          title: |-
             {definitions.metric} - << category >>
-          description_short: |
-           {definitions.metric} of {definitions.sex} {definitions.age} where the weapon was << category.lower() >>
-          unit: |
+          description_short: |-
+            {definitions.metric} of {definitions.sex} {definitions.age} where the weapon was << category.lower() >>
+          unit: |-
             {definitions.unit}
           presentation:
-            title_public: |
+            title_public: |-
               {definitions.metric} of {definitions.sex} {definitions.age} where the weapon was << category.lower() >>
           display:
             numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- endif -%>
     by_relationship_to_perpetrator:
       variables:
         value:
-          title: |
+          title: |-
             {definitions.metric} - << category >> - sex: << sex >>
-          description_short: |
+          description_short: |-
             {definitions.metric} of {definitions.sex} {definitions.age} where the << category.lower() >>
-          unit: |
+          unit: |-
             {definitions.unit}
           presentation:
-            title_public: |
+            title_public: |-
               {definitions.metric} of {definitions.sex} {definitions.age} where the << category.lower() >>
           display:
             numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- endif -%>
     by_situational_context:
       variables:
         value:
-          title: |
+          title: |-
             {definitions.metric} - << category >> - sex: << sex >>
-          description_short: |
+          description_short: |-
             {definitions.metric} of {definitions.sex} {definitions.age} where the situation was << category.lower() >>
-          unit: |
+          unit: |-
             {definitions.unit}
           presentation:
-            title_public: |
+            title_public: |-
               {definitions.metric} of {definitions.sex} {definitions.age} where the situation was << category.lower() >>
           display:
             numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- endif -%>
     total:
       variables:
         value:
-          title: |
+          title: |-
             {definitions.metric} - sex: << sex >> - age: << age >>
-          description_short: |
+          description_short: |-
             {definitions.metric} of {definitions.sex} {definitions.age}
-          unit: |
+          unit: |-
             {definitions.unit}
           display:
             numDecimalPlaces: <%-  if unit_of_measurement == "Counts" -%> 0<%-  elif unit_of_measurement == "Rate per 100,000 population" -%> 1<%- endif -%>


### PR DESCRIPTION
Hey @lucasrodes,

This is very much not urgent. I'm trying to figure out why I'm getting missing spaces after the {definitions.metric} field in the titles of [this dataset](http://staging-site-jinja-unodc/admin/datasets/6788).

I think it's a Jinja issue, I saw you made [these recent changes to Jinja formatting](https://github.com/owid/etl/commit/9e4a2a6ba28c0ac369dc1c37f08fb5372f093b0a), I think to solve a similar issue? 

Any idea what could be going on in this dataset? I tried to copy what you did but the space is still missing. 