### PR TITLE
Changes for compatibility with pandas 3.0

### DIFF
--- a/lib/datautils/owid/datautils/dataframes.py
+++ b/lib/datautils/owid/datautils/dataframes.py
@@ -108,7 +108,7 @@ def compare(
     # Compare, column by column, the elements of the two dataframes.
     compared = pd.DataFrame()
     for col in columns:
-        if (df1[col].dtype in (object, "category")) or (df2[col].dtype in (object, "category")):
+        if (df1[col].dtype in (object, "category", "string")) or (df2[col].dtype in (object, "category", "string")):
             # Apply a direct comparison for strings or categories
             compared_row = df1[col].values == df2[col].values
         else:
@@ -461,6 +461,13 @@ def map_series(
         # Replace those nans with their original values, except if they were actually meant to be mapped to nan.
         # For example, if {"bad_value": np.nan} was part of the mapping, do not replace those nans back to "bad_value".
 
+        # if we are setting values from the original series, ensure we have the same dtype
+        try:
+            series_mapped = series_mapped.astype(series.dtype, copy=False)
+        except ValueError:
+            # casting NaNs to integer will fail
+            pass
+
         # Detect values in the mapping that were intended to be mapped to nan.
         values_mapped_to_nan = [
             original_value for original_value, target_value in mapping.items() if pd.isnull(target_value)
@@ -537,7 +544,7 @@ def concatenate(objs: List[pd.DataFrame], **kwargs: Any) -> pd.DataFrame:
         uc = union_categoricals([df[col] for df in objs], ignore_order=ignore_order)
         # Change to union category for all dataframes
         for df in objs:
-            df.loc[:, col] = pd.Categorical(df[col].values, categories=uc.categories)
+            df[col] = pd.Categorical(df[col].values, categories=uc.categories)
 
     with warnings.catch_warnings():
         warnings.simplefilter(action="ignore", category=FutureWarning)
@@ -631,6 +638,14 @@ def combine_two_overlapping_dataframes(
     # Align both dataframes on their common indexes.
     # Give priority to df1 on overlapping values.
     combined, df2 = df1.align(df2)
+
+    new_columns = df2.columns.difference(df1.columns)
+    for col in new_columns:
+        try:
+            combined[col] = combined[col].astype(df2[col].dtype, copy=False)
+        except ValueError:
+            # casting NaNs to integer will fail
+            pass
 
     # Fill missing values in df1 with values from df2.
     combined = combined.fillna(df2)

--- a/lib/datautils/tests/test_dataframes.py
+++ b/lib/datautils/tests/test_dataframes.py
@@ -326,13 +326,14 @@ class TestGroupbyAggregate:
             }
         ).set_index("year")
         df_out["value_03"] = df_out["value_03"].astype(object)
-        assert dataframes.groupby_agg(
+        result = dataframes.groupby_agg(
             df_in,
             ["year"],
             aggregations=None,
             num_allowed_nans=None,
             frac_allowed_nans=None,
-        ).equals(df_out)
+        )
+        assert result.equals(df_out)
 
     def test_default_aggregate_with_num_allowed_nans_zero(self):
         df_in = pd.DataFrame(

--- a/lib/repack/owid/repack/__init__.py
+++ b/lib/repack/owid/repack/__init__.py
@@ -62,7 +62,7 @@ def repack_series(s: pd.Series) -> pd.Series:
     if s.dtype.name in ("Int64", "int64", "UInt64", "uint64"):
         return shrink_integer(s)
 
-    if s.dtype.name in ("object", "string", "float64", "Float64"):
+    if s.dtype.name in ("object", "str", "string", "float64", "Float64"):
         for strategy in [to_int, to_float, to_category]:
             try:
                 return strategy(s)

--- a/lib/repack/tests/test_repack.py
+++ b/lib/repack/tests/test_repack.py
@@ -179,7 +179,7 @@ def test_repack_float_object_to_float32():
 
 def test_repack_category():
     s = pd.Series(["a", "b", "c", None])
-    assert s.dtype == np.object_
+    assert s.dtype == np.object_ or s.dtype == "str"
 
     v = repack.repack_series(s)
     assert v.dtype == "category"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "rioxarray>=0.15.1",
     "html2text>=2020.1.16",
     "pygithub>=2.3.0",
-    "pandas>2.3",
+    "pandas==2.2.2",
     "sqlalchemy>=2.0.30",
     "pymysql>=1.1.1",
     "tiktoken>=0.7.0",
@@ -74,7 +74,6 @@ owid-datautils = { path = "lib/datautils", editable = true }
 owid-repack = { path = "lib/repack", editable = true }
 walden = { path = "lib/walden", editable = true }
 sqlacodegen = { git = "https://github.com/agronholm/sqlacodegen.git" }
-pandas = { path = "../pandas-2.3" }
 
 [tool.uv]
 dev-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "rioxarray>=0.15.1",
     "html2text>=2020.1.16",
     "pygithub>=2.3.0",
-    "pandas==2.2.2",
+    "pandas>2.3",
     "sqlalchemy>=2.0.30",
     "pymysql>=1.1.1",
     "tiktoken>=0.7.0",
@@ -74,6 +74,7 @@ owid-datautils = { path = "lib/datautils", editable = true }
 owid-repack = { path = "lib/repack", editable = true }
 walden = { path = "lib/walden", editable = true }
 sqlacodegen = { git = "https://github.com/agronholm/sqlacodegen.git" }
+pandas = { path = "../pandas-2.3" }
 
 [tool.uv]
 dev-dependencies = [

--- a/tests/data_helpers/test_geo.py
+++ b/tests/data_helpers/test_geo.py
@@ -192,17 +192,14 @@ class TestHarmonizeCountries:
         df_out = pd.DataFrame({"country": [np.nan, np.nan], "some_variable": [1, 2]})
         df_out["country"] = df_out["country"].astype("str")
 
-        df_in2 = geo.harmonize_countries(
+        result = geo.harmonize_countries(
             df=df_in,
             countries_file="MOCK_COUNTRIES_FILE",
             make_missing_countries_nan=True,
             warn_on_unused_countries=False,
             warn_on_missing_countries=False,
         )
-        assert dataframes.are_equal(
-            df1=df_out,
-            df2=df_in2,
-        )[0]
+        assert dataframes.are_equal(df1=df_out, df2=result)[0]
 
     def test_one_unknown_country_made_nan_and_a_known_country_changed(self):
         df_in = pd.DataFrame({"country": ["Country 1", "country_02"], "some_variable": [1, 2]})
@@ -221,10 +218,9 @@ class TestHarmonizeCountries:
     def test_on_dataframe_with_no_countries(self):
         df_in = pd.DataFrame({"country": []})
         df_out = pd.DataFrame({"country": []})
-        assert dataframes.are_equal(
-            df1=df_out,
-            df2=geo.harmonize_countries(df=df_in, countries_file="MOCK_COUNTRIES_FILE", warn_on_unused_countries=False),
-        )[0]
+        df_out["country"] = df_out["country"].astype(object)
+        result = geo.harmonize_countries(df=df_in, countries_file="MOCK_COUNTRIES_FILE", warn_on_unused_countries=False)
+        assert dataframes.are_equal(df1=df_out, df2=result)[0]
 
     def test_change_country_column_name(self):
         df_in = pd.DataFrame({"Country": ["country_02"]})

--- a/tests/data_helpers/test_geo.py
+++ b/tests/data_helpers/test_geo.py
@@ -190,16 +190,18 @@ class TestHarmonizeCountries:
     def test_two_unknown_countries_made_nan(self):
         df_in = pd.DataFrame({"country": ["Country 1", "country_04"], "some_variable": [1, 2]})
         df_out = pd.DataFrame({"country": [np.nan, np.nan], "some_variable": [1, 2]})
-        df_out["country"] = df_out["country"].astype(object)
+        df_out["country"] = df_out["country"].astype("str")
+
+        df_in2 = geo.harmonize_countries(
+            df=df_in,
+            countries_file="MOCK_COUNTRIES_FILE",
+            make_missing_countries_nan=True,
+            warn_on_unused_countries=False,
+            warn_on_missing_countries=False,
+        )
         assert dataframes.are_equal(
             df1=df_out,
-            df2=geo.harmonize_countries(
-                df=df_in,
-                countries_file="MOCK_COUNTRIES_FILE",
-                make_missing_countries_nan=True,
-                warn_on_unused_countries=False,
-                warn_on_missing_countries=False,
-            ),
+            df2=df_in2,
         )[0]
 
     def test_one_unknown_country_made_nan_and_a_known_country_changed(self):
@@ -219,7 +221,6 @@ class TestHarmonizeCountries:
     def test_on_dataframe_with_no_countries(self):
         df_in = pd.DataFrame({"country": []})
         df_out = pd.DataFrame({"country": []})
-        df_out["country"] = df_out["country"].astype(object)
         assert dataframes.are_equal(
             df1=df_out,
             df2=geo.harmonize_countries(df=df_in, countries_file="MOCK_COUNTRIES_FILE", warn_on_unused_countries=False),


### PR DESCRIPTION
I ran all the tests locally with the env updated to use a local pandas 2.3.0dev checkout instead of the pinned pandas 2.2.2, and then with using the `PANDAS_COPY_ON_WRITE=1` and `PANDAS_FUTURE_INFER_STRING=1` environment variables set to enable the future behaviour.

The changes in this PR is what I needed to get the tests passing (or mostly, some tests are still failing because of needing a fix upstream in pandas). There are some more deprecation warnings that would need to be addressed, but I mostly focused on failures because of the new string dtype. 

Opening this here so you can see what I did. Not sure if this should actually already get merged because it's not tested on CI with the future version (although if it doesn't break anything with current pandas, that might also do no harm), but in any case you have it when you would update in the future.