### PR TITLE
:bug: un: aggregate only columns I need in HDR dataset

### DIFF
--- a/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
+++ b/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
@@ -1,8 +1,6 @@
 definitions:
   common:
     processing_level: minor
-    description_processing: |-
-      - We calculated averages over continents and income groups by taking the population-weighted average of the countries in each group. If less than 80% of countries in an area report data for a given year, we do not calculate the average for that area.
     presentation:
       topic_tags:
         - Human Development Index (HDI)
@@ -244,13 +242,6 @@ tables:
           - "Group 5: Countries with absolute deviation from gender parity of more than 10 percent are considered countries with low equality in HDI achievements between women and men."
         display:
           numDecimalPlaces: 0
-        type: int
-        sort:
-          - 5
-          - 4
-          - 3
-          - 2
-          - 1
 
       ###########################################################
       # 4 Gender Inequality Index

--- a/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
+++ b/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
@@ -244,7 +244,7 @@ tables:
           - "Group 5: Countries with absolute deviation from gender parity of more than 10 percent are considered countries with low equality in HDI achievements between women and men."
         display:
           numDecimalPlaces: 0
-        type: ordinal
+        type: int
         sort:
           - 5
           - 4

--- a/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
+++ b/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
@@ -244,6 +244,13 @@ tables:
           - "Group 5: Countries with absolute deviation from gender parity of more than 10 percent are considered countries with low equality in HDI achievements between women and men."
         display:
           numDecimalPlaces: 0
+        type: ordinal
+        sort:
+          - 5
+          - 4
+          - 3
+          - 2
+          - 1
 
       ###########################################################
       # 4 Gender Inequality Index

--- a/etl/steps/data/garden/un/2024-04-09/undp_hdr.py
+++ b/etl/steps/data/garden/un/2024-04-09/undp_hdr.py
@@ -82,7 +82,7 @@ def region_avg(tb, ds_regions, ds_income_groups):
         tb[col + "_pop"] = tb[col] * tb["pop_total"]
         rel_cols_pop.append(col + "_pop")
 
-    # Define aggregations
+    # Define aggregations only for the columns I need
     aggregations = dict.fromkeys(
         rel_cols + rel_cols_pop,
         "sum",
@@ -99,5 +99,11 @@ def region_avg(tb, ds_regions, ds_income_groups):
     # calculate regional averages
     for col in rel_cols:
         tb[col] = tb[col + "_pop"] / tb["pop_total"]
+
+    # Add description_processing only to rel_cols
+    for col in rel_cols:
+        tb[
+            col
+        ].m.description_processing = "We calculated averages over continents and income groups by taking the population-weighted average of the countries in each group. If less than 80% of countries in an area report data for a given year, we do not calculate the average for that area."
 
     return tb[tb_cols]

--- a/etl/steps/data/garden/un/2024-04-09/undp_hdr.py
+++ b/etl/steps/data/garden/un/2024-04-09/undp_hdr.py
@@ -73,17 +73,26 @@ def region_avg(tb, ds_regions, ds_income_groups):
     """Calculate regional averages for the table, this includes continents and WB income groups"""
     # remove columns where regional average does not make sense
     tb_cols = tb.columns
-    ind_wo_avg = ["country", "year", "gii_rank", "hdi_rank", "loss", "rankdiff_hdi_phdi"]
+    ind_wo_avg = ["country", "year", "gii_rank", "hdi_rank", "loss", "rankdiff_hdi_phdi", "gdi_group"]
     rel_cols = [col for col in tb.columns if col not in ind_wo_avg]
 
     # calculate population weighted columns (helper columns)
+    rel_cols_pop = []
     for col in rel_cols:
         tb[col + "_pop"] = tb[col] * tb["pop_total"]
+        rel_cols_pop.append(col + "_pop")
+
+    # Define aggregations
+    aggregations = dict.fromkeys(
+        rel_cols + rel_cols_pop,
+        "sum",
+    )
 
     tb = geo.add_regions_to_table(
         tb,
         ds_regions=ds_regions,
         ds_income_groups=ds_income_groups,
+        aggregations=aggregations,
         frac_allowed_nans_per_year=0.2,
     )
 


### PR DESCRIPTION
@antea04 Just realized that https://github.com/owid/etl/pull/3425 aggregated all the indicators, regardless of rel_cols. I have fixed that. Take a look to see this is still what you were looking for.