### PR TITLE
 :hammer: indicator upgrader: use real users

### DIFF
--- a/apps/wizard/app_pages/indicator_upgrade/charts_update.py
+++ b/apps/wizard/app_pages/indicator_upgrade/charts_update.py
@@ -10,6 +10,7 @@ from structlog import get_logger
 import etl.grapher_model as gm
 from apps.chart_sync.admin_api import AdminAPI
 from apps.wizard.utils import set_states, st_page_link, st_toast_error
+from apps.wizard.utils.cached import get_grapher_user_id
 from apps.wizard.utils.db import WizardDB
 from etl.config import OWID_ENV
 from etl.helpers import get_schema_from_url
@@ -93,7 +94,7 @@ def get_affected_charts_and_preview(indicator_mapping: Dict[int, int]) -> List[g
 def push_new_charts(charts: List[gm.Chart]) -> None:
     """Updating charts in the database."""
     # API to interact with the admin tool
-    api = AdminAPI(OWID_ENV)
+    api = AdminAPI(OWID_ENV, grapher_user_id=get_grapher_user_id(st.context.headers["X-Forwarded-For"]))
     # Update charts
     progress_text = "Updating charts..."
     bar = st.progress(0, progress_text)
@@ -113,7 +114,7 @@ def push_new_charts(charts: List[gm.Chart]) -> None:
                 chart_id = chart.config["id"]
             else:
                 raise ValueError(f"Chart {chart} does not have an ID in config.")
-            api.update_chart(chart_id=chart_id, chart_config=config_new, user_id=chart.lastEditedByUserId)
+            api.update_chart(chart_id=chart_id, chart_config=config_new)
             # Show progress bar
             percent_complete = int(100 * (i + 1) / len(charts))
             bar.progress(percent_complete, text=f"{progress_text} {percent_complete}%")

--- a/apps/wizard/utils/cached.py
+++ b/apps/wizard/utils/cached.py
@@ -177,6 +177,7 @@ def load_latest_population():
 
 @st.cache_data
 def get_tailscale_ip_to_user_map():
+    """Get the mapping of Tailscale IPs to user display names."""
     proc = subprocess.run(["tailscale", "status", "--json"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
     if proc.returncode != 0:
@@ -205,6 +206,7 @@ def get_tailscale_ip_to_user_map():
 
 @st.cache_data
 def get_grapher_user_id(user_ip: str) -> Optional[int]:
+    """Get the Grapher user ID associated with the given Tailscale IP address."""
     # Get Tailscale IP-to-User mapping
     ip_to_user_map = get_tailscale_ip_to_user_map()
 

--- a/apps/wizard/utils/cached.py
+++ b/apps/wizard/utils/cached.py
@@ -177,7 +177,7 @@ def load_latest_population():
 
 @st.cache_data
 def get_tailscale_ip_to_user_map():
-    """Get the mapping of Tailscale IPs to user display names."""
+    """Get the mapping of Tailscale IPs to github usernames."""
     proc = subprocess.run(["tailscale", "status", "--json"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
 
     if proc.returncode != 0:
@@ -190,16 +190,16 @@ def get_tailscale_ip_to_user_map():
     # Map user IDs to display names
     user_id_to_name = {}
     for user_id, user_info in status.get("User", {}).items():
-        if "DisplayName" in user_info:
-            user_id_to_name[int(user_id)] = user_info["DisplayName"]
+        if "LoginName" in user_info:
+            user_id_to_name[int(user_id)] = user_info["LoginName"]
 
     # Map IPs to user display names
     for peer in status.get("Peer", {}).values():
         user_id = peer.get("UserID")
-        display_name = user_id_to_name.get(user_id)
-        if display_name:
+        login_name = user_id_to_name.get(user_id)
+        if login_name:
             for ip in peer.get("TailscaleIPs", []):
-                ip_to_user[ip] = display_name
+                ip_to_user[ip] = login_name
 
     return ip_to_user
 

--- a/apps/wizard/utils/cached.py
+++ b/apps/wizard/utils/cached.py
@@ -1,17 +1,24 @@
+import json
 import logging
+import subprocess
 from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 import streamlit as st
+import structlog
 from owid.catalog import find
 from sqlalchemy.orm import Session
 
+import etl.grapher_model as gm
 from apps.utils.map_datasets import get_grapher_changes
 from etl import grapher_io as gio
 from etl.config import OWID_ENV, OWIDEnv
+from etl.db import get_engine
 from etl.git_helpers import get_changed_files
 from etl.grapher_model import Anomaly, Variable
 from etl.version_tracker import VersionTracker
+
+log = structlog.get_logger()
 
 # silence WARNING streamlit.runtime.caching.cache_data_api: No runtime found, using MemoryCacheStorageManager
 logging.getLogger("streamlit.runtime.caching.cache_data_api").setLevel(logging.ERROR)
@@ -166,3 +173,51 @@ def load_latest_population():
     ).rename(columns={"country": "entity_name"}, errors="raise")
 
     return population
+
+
+@st.cache_data
+def get_tailscale_ip_to_user_map():
+    proc = subprocess.run(["tailscale", "status", "--json"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    if proc.returncode != 0:
+        log.warning(f"Error getting Tailscale status: {proc.stderr}")
+        return {}
+
+    status = json.loads(proc.stdout)
+    ip_to_user = {}
+
+    # Map user IDs to display names
+    user_id_to_name = {}
+    for user_id, user_info in status.get("User", {}).items():
+        if "DisplayName" in user_info:
+            user_id_to_name[int(user_id)] = user_info["DisplayName"]
+
+    # Map IPs to user display names
+    for peer in status.get("Peer", {}).values():
+        user_id = peer.get("UserID")
+        display_name = user_id_to_name.get(user_id)
+        if display_name:
+            for ip in peer.get("TailscaleIPs", []):
+                ip_to_user[ip] = display_name
+
+    return ip_to_user
+
+
+@st.cache_data
+def get_grapher_user_id(user_ip: str) -> Optional[int]:
+    # Get Tailscale IP-to-User mapping
+    ip_to_user_map = get_tailscale_ip_to_user_map()
+
+    # Get the Tailscale display name / github username associated with the client's IP address
+    github_user_name = ip_to_user_map.get(user_ip)
+
+    if not github_user_name:
+        return None
+
+    with Session(get_engine()) as session:
+        grapher_user = gm.User.load_user(session, github_user_name)
+
+    if grapher_user:
+        return grapher_user.id
+    else:
+        return None

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -254,14 +254,15 @@ class User(Base):
     createdAt: Mapped[datetime] = mapped_column(DateTime, server_default=text("CURRENT_TIMESTAMP"), init=False)
     isActive: Mapped[int] = mapped_column(TINYINT(1), server_default=text("'1'"))
     fullName: Mapped[str] = mapped_column(VARCHAR(255))
+    githubUsername: Mapped[str] = mapped_column(VARCHAR(255))
     password: Mapped[Optional[str]] = mapped_column(VARCHAR(128))
     lastLogin: Mapped[Optional[datetime]] = mapped_column(DateTime)
     updatedAt: Mapped[Optional[datetime]] = mapped_column(DateTime, init=False)
     lastSeen: Mapped[Optional[datetime]] = mapped_column(DateTime)
 
     @classmethod
-    def load_user(cls, session: Session, full_name: str) -> Optional["User"]:
-        return session.scalars(select(cls).where(cls.fullName == full_name)).one_or_none()
+    def load_user(cls, session: Session, github_username: str) -> Optional["User"]:
+        return session.scalars(select(cls).where(cls.githubUsername == github_username)).one_or_none()
 
 
 class ChartRevisions(Base):

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -259,6 +259,10 @@ class User(Base):
     updatedAt: Mapped[Optional[datetime]] = mapped_column(DateTime, init=False)
     lastSeen: Mapped[Optional[datetime]] = mapped_column(DateTime)
 
+    @classmethod
+    def load_user(cls, session: Session, full_name: str) -> Optional["User"]:
+        return session.scalars(select(cls).where(cls.fullName == full_name)).one_or_none()
+
 
 class ChartRevisions(Base):
     __tablename__ = "chart_revisions"


### PR DESCRIPTION
## Problem

When the indicator upgrader updates charts, the edits appear to be made by the last person who manually edited the chart, not by the person who ran the upgrade. This can cause confusion, especially when Slack notifications show updates attributed to users who haven’t interacted with the chart.

This PR addresses the issue by assigning updates to the user who runs the indicator upgrader. However, a drawback is that bulk upgrades (e.g., population or WDI) will be attributed to a single user, even if they are unrelated to the charts.

---

## Implementation

- Added a function to detect the user and their `id` in Streamlit.
- Updated the indicator upgrader to use the detected user when making chart updates (instead of attributing them to the last editor).