### PR TITLE
🔨 update grapher schema to latest version

### DIFF
--- a/apps/wizard/app_pages/map_brackets.py
+++ b/apps/wizard/app_pages/map_brackets.py
@@ -138,7 +138,7 @@ def create_default_chart_config_for_variable(metadata: Dict[str, Any]) -> Dict[s
     """Create a default chart for a variable with id `variable_id`."""
     chart_config = {
         "hasMapTab": True,
-        "hasChartTab": False,
+        "chartTypes": [],
         "tab": "map",
         "map": {
             # "timeTolerance": 0,

--- a/apps/wizard/utils/chart_config.py
+++ b/apps/wizard/utils/chart_config.py
@@ -31,7 +31,7 @@ CONFIG_BASE = {
     "hideLegend": False,
     "tab": "chart",
     "logo": "owid",
-    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
+    "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.006.json",
     "showYearLabels": False,
     "id": 807,
     "selectedFacetStrategy": "none",
@@ -41,7 +41,7 @@ CONFIG_BASE = {
     "version": 14,
     "sortOrder": "desc",
     "maxTime": "latest",
-    "type": "LineChart",
+    "chartTypes": ["LineChart"],
     "hideRelativeToggle": True,
     "addCountryMode": "add-country",
     "hideAnnotationFieldsInTitle": {"entity": False, "changeInPrefix": False, "time": False},
@@ -65,7 +65,6 @@ CONFIG_BASE = {
     "missingDataStrategy": "auto",
     "isPublished": False,
     "timelineMinTime": "earliest",
-    "hasChartTab": True,
     "timelineMaxTime": "latest",
     "sortBy": "total",
 }
@@ -84,7 +83,7 @@ def bake_chart_config(
 
     Bakes a very basic config, which will be enough most of the times. If you want a more complex config, use this as a baseline to adjust to your needs.
 
-    Note: You can find more details on our Grapher API at https://files.ourworldindata.org/schemas/grapher-schema.005.json.
+    Note: You can find more details on our Grapher API at https://files.ourworldindata.org/schemas/grapher-schema.latest.json.
 
     """
     # Define chart config

--- a/apps/wizard/utils/components.py
+++ b/apps/wizard/utils/components.py
@@ -76,7 +76,7 @@ def grapher_chart(
 
     You can either plot a given chart config (using chart_config) or plot an indicator with its default metadata using either catalog_path, variable_id or variable.
 
-    Note: You can find more details on our Grapher API at https://files.ourworldindata.org/schemas/grapher-schema.005.json.
+    Note: You can find more details on our Grapher API at https://files.ourworldindata.org/schemas/grapher-schema.latest.json.
 
     Parameters
     ----------

--- a/etl/config.py
+++ b/etl/config.py
@@ -222,7 +222,7 @@ GITHUB_TOKEN = env.get("GITHUB_TOKEN", None)
 TLS_VERIFY = bool(int(env.get("TLS_VERIFY", 1)))
 
 # Default schema for presentation.grapher_config in metadata. Try to keep it up to date with the latest schema.
-DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schema.005.json"
+DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schema.006.json"
 
 
 def enable_bugsnag() -> None:

--- a/etl/grapher_model.py
+++ b/etl/grapher_model.py
@@ -294,6 +294,13 @@ class ChartConfig(Base):
     slug: Mapped[Optional[str]] = mapped_column(
         String(255), Computed("(json_unquote(json_extract(`full`, '$.slug')))", persisted=True)
     )
+    chartType: Mapped[Optional[str]] = mapped_column(
+        String(255),
+        Computed(
+            "(CASE WHEN full ->> '$.chartTypes' IS NULL THEN 'LineChart' ELSE full ->> '$.chartTypes[0]' END)",
+            persisted=True,
+        ),
+    )
     createdAt: Mapped[datetime] = mapped_column(DateTime, server_default=text("CURRENT_TIMESTAMP"), nullable=False)
     updatedAt: Mapped[Optional[datetime]] = mapped_column(DateTime, onupdate=func.current_timestamp())
 

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -1206,7 +1206,7 @@ def map_indicator_path_to_id(catalog_path: str) -> str | int:
 def get_schema_from_url(schema_url: str) -> dict:
     """Get the schema of a chart configuration. Schema URL is saved in config["$schema"] and looks like:
 
-    https://files.ourworldindata.org/schemas/grapher-schema.005.json
+    https://files.ourworldindata.org/schemas/grapher-schema.006.json
 
     More details on available versions can be found
     at https://github.com/owid/owid-grapher/tree/master/packages/%40ourworldindata/grapher/src/schema.

--- a/etl/indicator_upgrade/schema.py
+++ b/etl/indicator_upgrade/schema.py
@@ -69,7 +69,7 @@ def validate_chart_config_and_set_defaults(
         raise Exception(f"Could not validate schema for chart {config['id']}: {e}")
     # Add minTime if not set (no default provided in schema)
     # Kinda hacky
-    if config_new["type"] not in {"StackedDiscreteBar", "Marimekko", "DiscreteBar"}:
+    if config_new["chartTypes"][0] not in {"StackedDiscreteBar", "Marimekko", "DiscreteBar"}:
         if "minTime" not in config_new:
             config_new["minTime"] = "earliest"
     return config_new

--- a/etl/steps/data/garden/animal_welfare/2023-09-05/bullfighting_laws.meta.yml
+++ b/etl/steps/data/garden/animal_welfare/2023-09-05/bullfighting_laws.meta.yml
@@ -27,6 +27,6 @@ tables:
             note: "Countries where bullfighting is not banned may have sub-national bans. Partially banned means that the bull cannot be severely injured or killed during the event."
             subtitle: >-
               Bullfighting is a physical contest that involves a bullfighter attempting to subdue, immobilize, or kill a bull.
-            hasChartTab: false
+            chartTypes: []
             hasMapTab: true
             tab: map

--- a/etl/steps/data/garden/animal_welfare/2024-06-04/bullfighting_laws.meta.yml
+++ b/etl/steps/data/garden/animal_welfare/2024-06-04/bullfighting_laws.meta.yml
@@ -27,6 +27,6 @@ tables:
             note: "Countries where bullfighting is not banned may have sub-national bans. Partially banned means that the bull cannot be severely injured or killed during the event."
             subtitle: >-
               Bullfighting is a physical contest that involves a bullfighter attempting to subdue, immobilize, or kill a bull.
-            hasChartTab: false
+            chartTypes: []
             hasMapTab: true
             tab: map

--- a/etl/steps/data/garden/harvard/2023-09-18/colonial_dates_dataset.meta.yml
+++ b/etl/steps/data/garden/harvard/2023-09-18/colonial_dates_dataset.meta.yml
@@ -108,7 +108,7 @@ tables:
           grapher_config:
             hideAnnotationFieldsInTitle:
               time: true
-            hasChartTab: false
+            chartTypes: []
             hasMapTab: true
             tab: map
             map:

--- a/etl/steps/data/garden/wb/2024-01-17/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2024-01-17/world_bank_pip.meta.yml
@@ -445,7 +445,7 @@ tables:
               This data is expressed in [international-$](#dod:int_dollar_abbreviation) at
               2017 prices. Depending on the country and year, it relates to income measured
               after taxes and benefits, or to consumption, [per capita](#dod:per-capita).
-            type: StackedArea
+            chartTypes: ["StackedArea"]
             addCountryMode: disabled
             hideRelativeToggle: false
             originUrl: https://ourworldindata.org/poverty

--- a/etl/steps/data/garden/wb/2024-03-27/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2024-03-27/world_bank_pip.meta.yml
@@ -487,7 +487,7 @@ tables:
               This data is expressed in [international-$](#dod:int_dollar_abbreviation) at
               2017 prices. Depending on the country and year, it relates to income measured
               after taxes and benefits, or to consumption, [per capita](#dod:per-capita).
-            type: StackedArea
+            chartTypes: ["StackedArea"]
             addCountryMode: disabled
             hideRelativeToggle: false
             originUrl: https://ourworldindata.org/poverty

--- a/etl/steps/data/garden/wb/2024-10-07/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2024-10-07/world_bank_pip.meta.yml
@@ -493,7 +493,7 @@ tables:
               This data is expressed in [international-$](#dod:int_dollar_abbreviation) at
               2017 prices. Depending on the country and year, it relates to income measured
               after taxes and benefits, or to consumption, [per capita](#dod:per-capita).
-            type: StackedArea
+            chartTypes: ["StackedArea"]
             addCountryMode: disabled
             hideRelativeToggle: false
             originUrl: https://ourworldindata.org/poverty

--- a/etl/steps/data/grapher/wb/2022-10-03/extreme_poverty_by_region.meta.yml
+++ b/etl/steps/data/grapher/wb/2022-10-03/extreme_poverty_by_region.meta.yml
@@ -80,7 +80,7 @@ tables:
               This data is expressed in [international-$](#dod:int_dollar_abbreviation) at
               2017 prices. Depending on the country and year, it relates to income measured
               after taxes and benefits, or to consumption, [per capita](#dod:per-capita).
-            type: StackedArea
+            chartTypes: ["StackedArea"]
             addCountryMode: disabled
             hideRelativeToggle: false
             originUrl: https://ourworldindata.org/poverty

--- a/etl/steps/export/explorers/covid/latest/covid.config.yml
+++ b/etl/steps/export/explorers/covid/latest/covid.config.yml
@@ -492,7 +492,7 @@ views:
     title: COVID-19 vaccines administered, initial doses and boosters
     subtitle: Total number of doses administered, broken down by whether they are part of the initial protocol or booster doses.
     hasMapTab: False
-    type: StackedDiscreteBar
+    chartTypes: ["StackedDiscreteBar"]
   - indicator:
       - grapher/covid/latest/vaccinations_global/vaccinations_global#total_vaccinations_no_boosters_per_hundred_interpolated
       - grapher/covid/latest/vaccinations_global/vaccinations_global#total_boosters_per_hundred
@@ -503,7 +503,7 @@ views:
     title: COVID-19 vaccines administered per 100 people, initial doses and boosters
     subtitle: Total number of doses administered, broken down by whether they are part of the initial protocol or booster doses, divided by the total population of the country.
     hasMapTab: False
-    type: StackedDiscreteBar
+    chartTypes: ["StackedDiscreteBar"]
 
   #######################
   # People vaccinated
@@ -622,7 +622,7 @@ views:
     sortBy: column
     sortColumnSlug: Omicron
     hideTotalValueLabel: True
-    type: StackedDiscreteBar
+    chartTypes: ["StackedDiscreteBar"]
     note: This share may not reflect the complete breakdown of cases, since only a fraction of all cases are sequenced. Recently-discovered or actively-monitored variants may be overrepresented, as suspected cases of these variants are likely to be sequenced preferentially or faster than other cases.
   #######################
   # Omicron variant (share)

--- a/etl/steps/export/explorers/minerals/latest/minerals_supply_and_demand_prospects.py
+++ b/etl/steps/export/explorers/minerals/latest/minerals_supply_and_demand_prospects.py
@@ -86,7 +86,7 @@ def run(dest_dir: str) -> None:
     df_graphers["yAxisMin"] = 0
 
     # Make all views stacked area charts.
-    df_graphers["type"] = "StackedArea"
+    df_graphers["chartTypes"] = ["StackedArea"]
 
     # Sanity check.
     error = "Duplicated rows in explorer."

--- a/etl/steps/export/multidim/covid/latest/covid.cases_tests.yml
+++ b/etl/steps/export/multidim/covid/latest/covid.cases_tests.yml
@@ -23,7 +23,7 @@ views:
       y: grapher/covid/latest/testing/testing#new_tests_7day_smoothed
       x: grapher/covid/latest/cases_deaths/cases_deaths#new_cases_7_day_avg_right
     config:
-      type: ScatterPlot
+      chartTypes: ["ScatterPlot"]
   - dimensions:
       normalize: per_capita
     indicators:
@@ -31,7 +31,7 @@ views:
       x: grapher/covid/latest/cases_deaths/cases_deaths#new_cases_per_million_7_day_avg_right
       color: 123
     config:
-      type: ScatterPlot
+      chartTypes: ["ScatterPlot"]
       map:
         colorScale:
           binningStrategy: equalInterval

--- a/etl/steps/export/multidim/covid/latest/covid.covax.yml
+++ b/etl/steps/export/multidim/covid/latest/covid.covax.yml
@@ -67,7 +67,7 @@ views:
       subtitle: Doses donated to the COVAX initiative by each country.
       note: COVAX is a worldwide initiative aimed at equitable access to COVID-19 vaccines. It is directed by Gavi, CEPI, and the WHO.
       originUrl: ourworldindata.org/coronavirus
-      type: StackedDiscreteBar
+      chartTypes: ["StackedDiscreteBar"]
       sortBy: column
       sortColumnSlug: "{definitions.table}#delivered"
       dimensions:
@@ -100,7 +100,7 @@ views:
       subtitle: Doses donated to the COVAX initiative by each country, per person living in the donating country.
       note: COVAX is a worldwide initiative aimed at equitable access to COVID-19 vaccines. It is directed by Gavi, CEPI, and the WHO. Gross domestic product is expressed in U.S. Dollars; it is sourced from the World Bank and OECD.
       originUrl: ourworldindata.org/coronavirus
-      type: StackedDiscreteBar
+      chartTypes: ["StackedDiscreteBar"]
 
   - dimensions:
       normalize: per_dose
@@ -115,7 +115,7 @@ views:
       subtitle: Doses donated to the COVAX initiative by each country, per dose administered domestically.
       note: COVAX is a worldwide initiative aimed at equitable access to COVID-19 vaccines. It is directed by Gavi, CEPI, and the WHO. Gross domestic product is expressed in U.S. Dollars; it is sourced from the World Bank and OECD.
       originUrl: ourworldindata.org/coronavirus
-      type: StackedDiscreteBar
+      chartTypes: ["StackedDiscreteBar"]
 
   - dimensions:
       normalize: per_gdp
@@ -130,5 +130,4 @@ views:
       subtitle: Doses donated to the COVAX initiative by each country, per million dollars of GDP of the donating country.
       note: COVAX is a worldwide initiative aimed at equitable access to COVID-19 vaccines. It is directed by Gavi, CEPI, and the WHO. Gross domestic product is expressed in U.S. Dollars; it is sourced from the World Bank and OECD.
       originUrl: ourworldindata.org/coronavirus
-      type: StackedDiscreteBar
-
+      chartTypes: ["StackedDiscreteBar"]

--- a/etl/steps/export/multidim/covid/latest/covid.vax_breakdowns.yml
+++ b/etl/steps/export/multidim/covid/latest/covid.vax_breakdowns.yml
@@ -55,7 +55,6 @@ views:
         - "{definitions.table}#total_vaccinations__vaccine_skycovione"
         - "{definitions.table}#total_vaccinations__vaccine_valneva"
     config:
-      type: "StackedArea"
+      chartTypes: ["StackedArea"]
       selectedEntityNames:
         - European Union (27)
-

--- a/etl/steps/export/multidim/energy/latest/energy.yml
+++ b/etl/steps/export/multidim/energy/latest/energy.yml
@@ -89,7 +89,7 @@ views:
         - "grapher/energy/2024-06-20/energy_mix/energy_mix#wind__twh__equivalent"
     config:
       $schema: https://files.ourworldindata.org/schemas/grapher-schema.005.json
-      type: StackedArea
+      chartTypes: ["StackedArea"]
       tab: chart
       title: Total consumed energy by source
       subtitle: "[Primary energy](#dod:primaryenergy) consumption is measured in [terawatt-hours](#dod:watt-hours), using the [substitution method](#dod:substitutionmethod)."
@@ -107,7 +107,7 @@ views:
         - "grapher/energy/2024-06-20/energy_mix/energy_mix#wind_per_capita__kwh__equivalent"
     config:
       $schema: https://files.ourworldindata.org/schemas/grapher-schema.005.json
-      type: StackedArea
+      chartTypes: ["StackedArea"]
   - dimensions:
       source: all
       metric: total

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -1072,11 +1072,6 @@
                           "default": false,
                           "description": "Exclude entities that do not belong in any color group"
                         },
-                        "hasChartTab": {
-                          "type": "boolean",
-                          "default": true,
-                          "description": "Whether to show the (non-map) chart tab"
-                        },
                         "data": {
                           "type": "object",
                           "description": "Obsolete name - used only to store the available entities",
@@ -1287,21 +1282,24 @@
                             ]
                           ]
                         },
-                        "type": {
-                          "type": "string",
-                          "description": "Which type of chart should be shown (hasMapChart can be used to always also show a map chart)",
-                          "default": "LineChart",
-                          "enum": [
-                            "LineChart",
-                            "ScatterPlot",
-                            "StackedArea",
-                            "DiscreteBar",
-                            "StackedDiscreteBar",
-                            "SlopeChart",
-                            "StackedBar",
-                            "WorldMap",
-                            "Marimekko"
-                          ]
+                        "chartTypes": {
+                          "type": "array",
+                          "description": "Which types of chart should be shown",
+                          "default": ["LineChart"],
+                          "items": {
+                            "type": "string",
+                            "enum": [
+                              "LineChart",
+                              "ScatterPlot",
+                              "StackedArea",
+                              "DiscreteBar",
+                              "StackedDiscreteBar",
+                              "SlopeChart",
+                              "StackedBar",
+                              "WorldMap",
+                              "Marimekko"
+                            ]
+                          }
                         },
                         "hasMapTab": {
                           "type": "boolean",

--- a/schemas/multidim-schema.json
+++ b/schemas/multidim-schema.json
@@ -139,8 +139,8 @@
                                 "type": "string",
                                 "description": "Url of the concrete schema version to use to validate this document",
                                 "format": "uri",
-                                "default": "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
-                                "const": "https://files.ourworldindata.org/schemas/grapher-schema.005.json"
+                                "default": "https://files.ourworldindata.org/schemas/grapher-schema.006.json",
+                                "const": "https://files.ourworldindata.org/schemas/grapher-schema.006.json"
                             },
                             "id": {
                                 "type": "integer",
@@ -266,11 +266,6 @@
                                 "type": "boolean",
                                 "default": false,
                                 "description": "Exclude entities that do not belong in any color group"
-                            },
-                            "hasChartTab": {
-                                "type": "boolean",
-                                "default": true,
-                                "description": "Whether to show the (non-map) chart tab"
                             },
                             "hideLegend": {
                                 "type": "boolean",
@@ -564,20 +559,23 @@
                                 "type": "string",
                                 "description": "Big title text of the chart"
                             },
-                            "type": {
-                                "type": "string",
-                                "description": "Which type of chart should be shown (hasMapChart can be used to always also show a map chart)",
-                                "default": "LineChart",
-                                "enum": [
-                                    "LineChart",
-                                    "ScatterPlot",
-                                    "StackedArea",
-                                    "DiscreteBar",
-                                    "StackedDiscreteBar",
-                                    "SlopeChart",
-                                    "StackedBar",
-                                    "Marimekko"
-                                ]
+                            "chartTypes": {
+                                "type": "array",
+                                "description": "Which types of chart should be shown",
+                                "default": ["LineChart"],
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                      "LineChart",
+                                      "ScatterPlot",
+                                      "StackedArea",
+                                      "DiscreteBar",
+                                      "StackedDiscreteBar",
+                                      "SlopeChart",
+                                      "StackedBar",
+                                      "Marimekko"
+                                  ]
+                                }
                             },
                             "hasMapTab": {
                                 "type": "boolean",


### PR DESCRIPTION
Sibling PR to https://github.com/owid/owid-grapher/pull/4159 that makes changes to the database and chart config schema.

Changes include:
- Added derived column `chart_configs.chartType`
- For chart configs:
    - Removed field `type` that is replaced by `chartTypes`
        - `type` used to refer to a single chart type, like `"LineChart"`
        - `chartTypes` refers to a list of chart types, like `["LineChart", "SlopeChart"]`
        - For now, the only valid chart type combination is `["LineChart", "SlopeChart"]`. We might add support for more chart type combinations in the future, but that will be a slow process. A lot of words to say: It is usually safe to assume the first element in `chartTypes` is the "type" of the chart
    - Removed field `hasChartTab`. If you want to know whether a Grapher has a chart tab, you can check whether `chart_configs.chartType` is null (if it is, then Grapher has no chart tab)