### PR TITLE
 :bug: Fix caching of staging creation time

### DIFF
--- a/apps/utils/scan_chart_diff.py
+++ b/apps/utils/scan_chart_diff.py
@@ -1,5 +1,6 @@
 import click
 import requests
+import streamlit as st
 from rich_click.rich_command import RichCommand
 from sqlalchemy.exc import OperationalError, ProgrammingError
 from structlog import get_logger
@@ -34,6 +35,9 @@ def cli(dry_run: bool) -> None:
             args.append("--dry-run")
 
         try:
+            # Make sure to clear state, otherwise we'd be using cached state from previous
+            # branch.
+            st.session_state.clear()
             owidbot_cli(args, standalone_mode=False)
         except ProgrammingError as e:
             # MySQL is being refreshed and tables are not ready


### PR DESCRIPTION
I encountered a nasty bug causing `owidbot` to post "No charts for review," even when there were actual charts for review. The issue was that `scan-chart-diff` iterates over all staging servers, but `get_staging_creation_time` was using a cached value from the key `staging_creation_time`. This resulted in `staging_creation_time` being fetched for only the first staging server and reused for the others.

This PR resolves the issue by clearing the cache with `st.session_state.clear()` before processing each staging server and by using a unique key for caching `staging_creation_time` based on the engine in use.