### PR TITLE
🐝  Update {{cookiecutter.short_name}}.py

### DIFF
--- a/apps/wizard/etl_steps/cookiecutter/grapher/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.py
+++ b/apps/wizard/etl_steps/cookiecutter/grapher/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.py
@@ -14,11 +14,7 @@ def run(dest_dir: str) -> None:
     ds_garden = paths.load_dataset("{{cookiecutter.short_name}}")
 
     # Read table from garden dataset.
-    tb = ds_garden.read("{{cookiecutter.short_name}}")
-
-    #
-    # Process data.
-    #
+    tb = ds_garden.read("{{cookiecutter.short_name}}", reset_index=False)
 
     #
     # Save outputs.


### PR DESCRIPTION
Setting ds_garden.read(reset_index = False) as default.

Maybe I misunderstand, but I find that the grapher step fails unless I set an index in the grapher step. 

I _think_ it makes sense not to reset the index when reading in the table, but I'm sure I'm missing something!