### PR TITLE
📊 war: ucdp check on type=unknown

### DIFF
--- a/etl/steps/data/garden/war/2024-11-22/ucdp_preview.py
+++ b/etl/steps/data/garden/war/2024-11-22/ucdp_preview.py
@@ -168,8 +168,10 @@ def run(dest_dir: str) -> None:
     paths.log.info("add field `conflict_type`")
     tb = add_conflict_type(tb_ged, tb_conflict)
 
+    # Sanity-check that the number of 'unknown' types of some conflicts is controlled
     # NOTE: Export summary of conflicts that have no category assigned
-    # tb_summary = get_summary_unknown(tb)
+    tb_summary = get_summary_unknown(tb)
+    assert len(tb_summary) / tb["conflict_new_id"].nunique() < 0.01, "Too many conflicts without a category assigned!"
     # tb_summary.to_csv("summary.csv")
 
     # Get country-level stuff

--- a/etl/steps/data/garden/war/2024-11-22/ucdp_preview.py
+++ b/etl/steps/data/garden/war/2024-11-22/ucdp_preview.py
@@ -169,7 +169,7 @@ def run(dest_dir: str) -> None:
     tb = add_conflict_type(tb_ged, tb_conflict)
 
     # NOTE: Export summary of conflicts that have no category assigned
-    tb_summary = get_summary_unknown(tb)
+    # tb_summary = get_summary_unknown(tb)
     # tb_summary.to_csv("summary.csv")
 
     # Get country-level stuff


### PR DESCRIPTION
Assign conflict type of conflicts in 2024 based on the latest available categorization. This is the case when the conflict was going on in the year before CED data (i.e. before 2024).

/schedule