### PR TITLE
 :sparkles: Automatically create a branch if it does not exist

### DIFF
--- a/apps/owidbot/cli.py
+++ b/apps/owidbot/cli.py
@@ -9,7 +9,7 @@ from rich import print
 from rich_click.rich_command import RichCommand
 
 from apps.owidbot import anomalist, chart_diff, data_diff, grapher
-from etl.config import get_container_name
+from etl.config import OWIDBOT_ACCESS_TOKEN, get_container_name
 
 from . import github_utils as gh_utils
 
@@ -57,7 +57,7 @@ def cli(
     if repo_name not in get_args(REPOS):
         raise AssertionError("Invalid repo")
 
-    repo = gh_utils.get_repo(repo_name)
+    repo = gh_utils.get_repo(repo_name, access_token=OWIDBOT_ACCESS_TOKEN)
     pr = gh_utils.get_pr(repo, branch)
     if pr is None:
         log.warning(f"No open PR found for branch {branch}")

--- a/etl/steps/export/github/co2_data/latest/owid_co2.py
+++ b/etl/steps/export/github/co2_data/latest/owid_co2.py
@@ -18,12 +18,14 @@ import os
 import tempfile
 from pathlib import Path
 
+import git
 import pandas as pd
 from owid.catalog import Table
 from structlog import get_logger
 
 from apps.owidbot import github_utils as gh
 from etl.helpers import PathFinder
+from etl.paths import BASE_DIR
 
 # Initialize logger.
 log = get_logger()
@@ -211,13 +213,15 @@ def run(dest_dir: str) -> None:
     #
     # Save outputs.
     #
-    # If you want to really commit the data, use `CO2_BRANCH=my-branch etlr github/co2_data --export`
-    if os.environ.get("CO2_BRANCH"):
-        dry_run = False
-        branch = os.environ["CO2_BRANCH"]
-    else:
+    branch = git.Repo(BASE_DIR).active_branch.name
+
+    if branch == "master":
+        log.warning("You are on master branch, using dry mode.")
         dry_run = True
-        branch = "master"
+    else:
+        log.info(f"Committing files to branch {branch}")
+        # Load DRY_RUN from env or use False as default.
+        dry_run = bool(int(os.environ.get("DRY_RUN", 0)))
 
     # Uncomment to inspect changes.
     # from etl.data_helpers.misc import compare_tables
@@ -233,6 +237,8 @@ def run(dest_dir: str) -> None:
 
         prepare_and_save_outputs(tb, codebook=codebook, temp_dir_path=temp_dir_path)
 
+        gh.create_branch_if_not_exists(repo_name="co2-data", branch=branch, dry_run=dry_run)
+
         # Commit csv files to the repos.
         for file_name in ["owid-co2-data.csv", "owid-co2-codebook.csv", "README.md"]:
             with (temp_dir_path / file_name).open("r") as file_content:
@@ -244,3 +250,8 @@ def run(dest_dir: str) -> None:
                     branch=branch,
                     dry_run=dry_run,
                 )
+
+    if not dry_run:
+        log.info(
+            f"Files committed successfully to branch {branch}. Create a PR here https://github.com/owid/co2-data/compare/master...{branch}."
+        )


### PR DESCRIPTION
Implements https://github.com/owid/etl/issues/3584

- Running `etlr github/co2_data --export` creates a branch with the same name as working ETL branch and commits updated files there.
- If the branch exists, push a new commit. (@pabloarosado's suggestion was to fail, but I think it's pretty safe to add a commit given that we don't overwrite existing ones and we create a PR at the end)
- Prefer `GITHUB_TOKEN` over `OWIDBOT_ACCESS_TOKEN` (in the future, we should clean it up and use only a single env)
- Show a link to create a PR from our branch