### PR TITLE
✨ shorter version for path-to-file in snapshot

### DIFF
--- a/apps/wizard/etl_steps/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.py
+++ b/apps/wizard/etl_steps/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.py
@@ -12,7 +12,7 @@ SNAPSHOT_VERSION = Path(__file__).parent.name
 @click.command()
 @click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
 {% if cookiecutter.dataset_manual_import == True %}
-@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
+@click.option("--path-to-file", "-f", prompt=True, type=str, help="Path to local data file.")
 def main(path_to_file: str, upload: bool) -> None:
     # Create a new snapshot.
     snap = Snapshot(f"{{cookiecutter.namespace}}/{SNAPSHOT_VERSION}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}")

--- a/apps/wizard/etl_steps/snapshot.py
+++ b/apps/wizard/etl_steps/snapshot.py
@@ -789,7 +789,7 @@ if submitted:
 
         # Display next steps
         if form.dataset_manual_import:
-            manual_import_instructions = "--path-to-file **relative path of file**"
+            manual_import_instructions = "-f **relative path of file**"
         else:
             manual_import_instructions = ""
         st.subheader("Next steps")
@@ -845,7 +845,7 @@ if st.session_state["run_step"]:
     commands = ["uv", "run", "python", script_path]
     if form.dataset_manual_import:
         # Get snapshot local file
-        commands.extend(["--path-to-file", st.session_state["snapshot_file"]])
+        commands.extend(["-f", st.session_state["snapshot_file"]])
     command_str = f"`{' '.join(commands)}`"
 
     # Run step

--- a/etl/scripts/archive/run_all_snapshots/run_all_snapshots.py
+++ b/etl/scripts/archive/run_all_snapshots/run_all_snapshots.py
@@ -58,7 +58,7 @@ def main():
             log.info(f"Skipping {snapshot_script} because it does not have --upload flag.")
             continue
         # Skip scripts that require the use of a local file.
-        if "--path-to-file" in snapshot_text:
+        if ("--path-to-file" in snapshot_text) or ("-f " in snapshot_text):
             log.info(f"Skipping {snapshot_script} because it requires a local file.")
             continue
 


### PR DESCRIPTION
When creating default Snapshot steps with manual imports, we add the argument `path_to_file` to ingest local files.

```py
@click.option("--path-to-file", prompt=True, type=str, help="Path to local data file.")
def main(upload: bool, path_to_file: str) -> None:
  ...
```

This is needed, and we should continue with this default. However, we could have an alternative and shorter argument name, e.g. `-f`, e.g.

```py
@click.option("--path-to-file",  "-f", prompt=True, type=str, help="Path to local data file.")
def main(upload: bool, path_to_file: str) -> None:
  ...
```
