### PR TITLE
✨ chart animation: add square-format support

### DIFF
--- a/apps/wizard/app_pages/chart_animation.py
+++ b/apps/wizard/app_pages/chart_animation.py
@@ -162,9 +162,9 @@ if st.session_state.chart_animation_show_image_settings:
         # If chart, show option to just show single year
         if tab == "chart":
             year_range_open = not st.toggle(
-                "Show only current year",
+                "Show single year",
                 value=not query_parameters["year_range_open"],
-                help="Only relevant for the chart view. If checked, the animated chart will display a sequence of bar charts with current year.",
+                help="Only relevant for the chart view. If checked, the animated chart will only display a single year per frame. For LineCharts, this means a sequence of bar charts. For ScatterCharts, this means a sequence of bubbles (and not vectors).",
             )
         else:
             year_range_open = True

--- a/apps/wizard/app_pages/chart_animation.py
+++ b/apps/wizard/app_pages/chart_animation.py
@@ -12,6 +12,7 @@ from apps.chart_animation.cli import (
     get_query_parameters_in_chart,
     get_years_in_chart,
 )
+from apps.wizard.utils import set_states
 from apps.wizard.utils.components import grapher_chart_from_url, st_horizontal, st_info
 
 # Initialize log.
@@ -23,13 +24,7 @@ st.set_page_config(
     page_icon="🪄",
 )
 
-########################################################################################################################
-# RENDER
-########################################################################################################################
-
-# Streamlit app layout.
-st.title(":material/animated_images: Chart animation")
-
+# Session state config
 # Initialize session state for generated files.
 st.session_state.chart_animation_images_folder = st.session_state.get("chart_animation_images_folder", DOWNLOADS_DIR)
 st.session_state.chart_animation_image_paths = st.session_state.get("chart_animation_image_paths", None)
@@ -46,7 +41,24 @@ st.session_state.chart_animation_years_selected = st.session_state.get(
 )
 st.session_state.chart_animation_max_num_years = MAX_NUM_YEARS
 
-# Step 1: Input chart URL and get years.
+
+# FUNCTIONS
+def add_icons_to_tabs(tab_name):
+    if tab_name == "map":
+        return ":material/map: map"
+    elif tab_name == "chart":
+        return ":material/show_chart: chart"
+    return f":material/{tab_name}: {tab_name}"
+
+
+########################################################################################################################
+# RENDER
+########################################################################################################################
+
+# Streamlit app layout.
+st.title(":material/animated_images: Chart animation")
+
+# 1/ INPUT CHART & GET YEARS
 chart_url = st.text_input(
     "Enter grapher URL",
     "",
@@ -62,48 +74,66 @@ st.session_state.chart_animation_images_folder = DOWNLOADS_DIR / slug
 if not st.session_state.chart_animation_images_folder.exists():
     # Create the default output folder if it doesn't exist.
     st.session_state.chart_animation_images_folder.mkdir(parents=True)
-st.session_state.chart_animation_gif_file = DOWNLOADS_DIR / f"{slug}.gif"
-st.session_state.chart_animation_images_exist = (
-    len([image for image in st.session_state.chart_animation_images_folder.iterdir() if image.suffix == ".png"]) > 0
+image_paths = [image for image in st.session_state.chart_animation_images_folder.iterdir() if image.suffix == ".png"]
+set_states(
+    {
+        "chart_animation_gif_file": DOWNLOADS_DIR / f"{slug}.gif",
+        "chart_animation_image_paths": image_paths,
+        "chart_animation_images_exist": len(image_paths) > 0,
+    }
 )
-st.session_state.chart_animation_image_paths = [
-    image for image in st.session_state.chart_animation_images_folder.iterdir() if image.suffix == ".png"
-]
 
-if st.button("Get chart"):
+# Button
+if st.button(
+    "Get chart",
+    type="primary",
+):
     if not chart_url:
         st.error("Please enter a valid chart URL.")
         st.stop()
     # Embed the iframe in the app.
-    st.session_state.chart_animation_years = get_years_in_chart(chart_url)
-    st.session_state.chart_animation_show_image_settings = True
+    set_states(
+        {
+            "chart_animation_years": get_years_in_chart(chart_url),
+            "chart_animation_show_image_settings": True,
+        }
+    )
 
-# Display iframe if it was fetched.
+# 2/ CONTINUE IF NO ERROR
 if st.session_state.chart_animation_show_image_settings:
-    with st.container(border=True):
+    # Display iframe if it was fetched.
+    with st.expander("**Preview**", expanded=True):
         st.session_state.chart_animation_iframe_html = grapher_chart_from_url(chart_url)
         st_info(
             "Modify chart as you wish, click on share -> copy link, and paste it in the box above.",
         )
 
-    # SHOW OPTIONS FOR CHART
-    with st.container(border=True):
-        query_parameters = get_query_parameters_in_chart(chart_url, all_years=st.session_state.chart_animation_years)
-        # Create a slider to select min and max years.
-        year_min, year_max = st.select_slider(
-            "Select year range",
-            options=st.session_state.chart_animation_years,
-            value=(query_parameters["year_min"], query_parameters["year_max"]),
-        )
+        # 2.1/ CONFIGURE INPUT: CHART EDIT
+        with st.container(border=True):
+            st.caption("**Chart settings**")
+            # Configure the chart (input to animation generation).
+            query_parameters = get_query_parameters_in_chart(
+                chart_url, all_years=st.session_state.chart_animation_years
+            )
+            with st_horizontal():
+                tab = st.segmented_control(
+                    "Select tab", ["map", "chart"], format_func=add_icons_to_tabs, default=query_parameters["tab"]
+                )
+                st.session_state.chart_animation_max_num_years = st.number_input(
+                    "Maximum number of years",
+                    value=MAX_NUM_YEARS,
+                    help="Maximum number of years to generate images for (to avoid too many API call).",
+                )
+
+            # Create a slider to select min and max years.
+            year_min, year_max = st.select_slider(
+                "Select year range",
+                options=st.session_state.chart_animation_years,
+                value=(query_parameters["year_min"], query_parameters["year_max"]),
+            )
 
         # Get the selected subset of years.
         years = [year for year in st.session_state.chart_animation_years if year_min <= year <= year_max]
-
-        st.session_state.chart_animation_max_num_years = st.number_input(
-            "Maximum number of years",
-            value=MAX_NUM_YEARS,
-            help="Maximum number of years to generate images for (to avoid too many API call).",
-        )
 
     if len(years) > st.session_state.chart_animation_max_num_years:
         st.error(
@@ -111,54 +141,71 @@ if st.session_state.chart_animation_show_image_settings:
         )
         st.stop()
 
-    # SHOW OPTIONS FOR IMAGE GENERATION
-    with st.container(border=True):
-        # Tab and year range settings.
-        def add_icons_to_tabs(tab_name):
-            if tab_name == "map":
-                return ":material/map: map"
-            elif tab_name == "chart":
-                return ":material/show_chart: chart"
-            return f":material/{tab_name}: {tab_name}"
+    # 2.2/ SHOW OPTIONS FOR IMAGE GENERATION
+    with st.expander("**Output settings**", expanded=True):
+        with st_horizontal():
+            # Choose: GIF or Video
+            output_type = st.segmented_control(
+                "Output format",
+                ["GIF", "Video"],
+                default="GIF",
+            )
+            # Social media?
+            output_style = st.segmented_control(
+                "Output style",
+                ["Classic", "Square format"],
+                default="Classic",
+                help="Use 'square format' for mobile or social media.",
+            )
+            social_media_square = output_style == "Square format"
 
-        # tab = st.radio("Select tab", ["map", "chart"], horizontal=True)
-        tab = st.segmented_control(
-            "Select tab", ["map", "chart"], format_func=add_icons_to_tabs, default=query_parameters["tab"]
+        st.session_state.chart_animation_gif_file = st.session_state.chart_animation_gif_file.with_suffix(
+            ".gif" if output_type == "GIF" else ".mp4"
         )
 
+        # If chart, show option to just show single year
         if tab == "chart":
-            year_range_open = st.toggle(
-                "Year range open",
-                value=query_parameters["year_range_open"],
-                help="Only relevant for the chart view. If checked, the year range will be open. Uncheck if you want to generate a sequence of bar charts.",
+            year_range_open = not st.toggle(
+                "Chart: Only show current year",
+                value=not query_parameters["year_range_open"],
+                help="Only relevant for the chart view. If checked, the animated chart will display a sequence of bar charts with current year.",
             )
         else:
             year_range_open = True
 
-        # GIF settings.
-        # output_type = st.radio("Output Type", ["GIF", "Video"], horizontal=True)
-        output_type = st.segmented_control("Output Type", ["GIF", "Video"], default="GIF")
-        st.session_state.chart_animation_gif_file = st.session_state.chart_animation_gif_file.with_suffix(
-            ".gif" if output_type == "GIF" else ".mp4"
-        )
-        remove_duplicates = st.toggle("Remove duplicate frames", value=True)
-        social_media_square = st.toggle("Square format for social media", value=False)
-        with st_horizontal():
-            repetitions_last_frame = st.number_input("Repetitions of Last Frame", value=0, step=1)
-            if output_type == "GIF":
-                loop_count = st.number_input("Number of Loops (0 = Infinite)", value=0, step=1)
-            duration = st.number_input("Duration (ms)", value=200, step=10)
-            # duration_of = st.radio(
-            #     "Duration of",
-            #     ["Each frame", "Entire animation"],
-            #     horizontal=True,
-            #     help="Choose if the duration parameter refers to each frame, or the entire animation. Note that each frame cannot be shorter than 20ms.",
-            # )
-            duration_of = st.segmented_control(
-                "Duration of",
-                ["Each frame", "Entire animation"],
-                help="Choose if the duration parameter refers to each frame, or the entire animation. Note that each frame cannot be shorter than 20ms.",
+        with st.container(border=True):
+            st.caption("**Frame settings**")
+            remove_duplicates = not st.toggle(
+                "Allow duplicate frames",
+                value=False,
+                help="Some charts may have duplicate frames. If checked, these frames will be shown.",
             )
+
+            with st_horizontal():
+                duration = st.number_input(
+                    "Duration (ms)",
+                    value=200,
+                    step=10,
+                    help="Duration (in ms) of each frame, or the entire animation.",
+                    # label_visibility="collapsed",
+                )
+                duration_of = st.segmented_control(
+                    "Duration of",
+                    ["Each frame", "Entire animation"],
+                    help="Choose if the duration parameter refers to each frame, or the entire animation. Note that each frame cannot be shorter than 20ms.",
+                    default="Each frame",
+                    # label_visibility="collapsed",
+                )
+                repetitions_last_frame = st.number_input(
+                    "Duration of the last frame (ms)",
+                    min_value=duration,
+                    value=duration,
+                    step=duration,
+                    help="",
+                )
+                repetitions_last_frame = repetitions_last_frame // duration - 1
+                if output_type == "GIF":
+                    loop_count = st.number_input("Number of Loops (0 = Infinite)", value=0, step=1)
 
     # Fetch all needed images (skipping the ones that already exist).
     st.session_state.chart_animation_image_paths = get_images_from_chart_url(
@@ -183,32 +230,33 @@ if st.session_state.chart_animation_show_image_settings:
     ]
 
     # GIF/Video generation.
-    if output_type == "GIF":
-        st.session_state.chart_animation_gif_file = create_gif_from_images(
-            image_paths=image_paths_selected,
-            output_file=st.session_state.chart_animation_gif_file,
-            duration=duration,
-            loops=loop_count,  # type: ignore
-            remove_duplicate_frames=remove_duplicates,
-            repetitions_last_frame=repetitions_last_frame,
-            duration_of_animation=duration_of == "Entire animation",
-        )
-        # GIF preview.
-        st_info('Animation preview. Right click and "Save Image As..." to download it.')
-        st.image(str(st.session_state.chart_animation_gif_file), use_container_width=True)
-    else:
-        st.session_state.chart_animation_gif_file = create_mp4_from_images(
-            image_paths=image_paths_selected,
-            output_file=st.session_state.chart_animation_gif_file,
-            duration=duration,
-            remove_duplicate_frames=remove_duplicates,
-            repetitions_last_frame=repetitions_last_frame,
-            duration_of_animation=duration_of == "Entire animation",
-        )
-        # Video preview
-        st_info('Animation preview. Right click and "Save video as..." to download it.')
-        with open(str(st.session_state.chart_animation_gif_file), "rb") as video_file:
-            st.video(video_file.read(), format="video/mp4", autoplay=True)
+    with st.spinner("Generating animation. This can take few seconds..."):
+        if output_type == "GIF":
+            st.session_state.chart_animation_gif_file = create_gif_from_images(
+                image_paths=image_paths_selected,
+                output_file=st.session_state.chart_animation_gif_file,
+                duration=duration,
+                loops=loop_count,  # type: ignore
+                remove_duplicate_frames=remove_duplicates,
+                repetitions_last_frame=repetitions_last_frame,
+                duration_of_animation=duration_of == "Entire animation",
+            )
+            # GIF preview.
+            st.image(str(st.session_state.chart_animation_gif_file), use_container_width=True)
+            st_info('Animation preview. Right click and "Save Image As..." to download it.')
+        else:
+            st.session_state.chart_animation_gif_file = create_mp4_from_images(
+                image_paths=image_paths_selected,
+                output_file=st.session_state.chart_animation_gif_file,
+                duration=duration,
+                remove_duplicate_frames=remove_duplicates,
+                repetitions_last_frame=repetitions_last_frame,
+                duration_of_animation=duration_of == "Entire animation",
+            )
+            # Video preview
+            with open(str(st.session_state.chart_animation_gif_file), "rb") as video_file:
+                st.video(video_file.read(), format="video/mp4", autoplay=True)
+            st_info('Animation preview. Right click and "Save video as..." to download it.')
 
     # Button to delete all images in the folder.
     if st.button(

--- a/apps/wizard/app_pages/chart_animation.py
+++ b/apps/wizard/app_pages/chart_animation.py
@@ -147,12 +147,17 @@ if st.session_state.chart_animation_show_image_settings:
             if output_type == "GIF":
                 loop_count = st.number_input("Number of Loops (0 = Infinite)", value=0, step=1)
             duration = st.number_input("Duration (ms)", value=200, step=10)
-        duration_of = st.radio(
-            "Duration of",
-            ["Each frame", "Entire animation"],
-            horizontal=True,
-            help="Choose if the duration parameter refers to each frame, or the entire animation. Note that each frame cannot be shorter than 20ms.",
-        )
+            # duration_of = st.radio(
+            #     "Duration of",
+            #     ["Each frame", "Entire animation"],
+            #     horizontal=True,
+            #     help="Choose if the duration parameter refers to each frame, or the entire animation. Note that each frame cannot be shorter than 20ms.",
+            # )
+            duration_of = st.segmented_control(
+                "Duration of",
+                ["Each frame", "Entire animation"],
+                help="Choose if the duration parameter refers to each frame, or the entire animation. Note that each frame cannot be shorter than 20ms.",
+            )
 
     # Fetch all needed images (skipping the ones that already exist).
     st.session_state.chart_animation_image_paths = get_images_from_chart_url(

--- a/apps/wizard/app_pages/chart_animation.py
+++ b/apps/wizard/app_pages/chart_animation.py
@@ -75,13 +75,9 @@ if not st.session_state.chart_animation_images_folder.exists():
     # Create the default output folder if it doesn't exist.
     st.session_state.chart_animation_images_folder.mkdir(parents=True)
 image_paths = [image for image in st.session_state.chart_animation_images_folder.iterdir() if image.suffix == ".png"]
-set_states(
-    {
-        "chart_animation_gif_file": DOWNLOADS_DIR / f"{slug}.gif",
-        "chart_animation_image_paths": image_paths,
-        "chart_animation_images_exist": len(image_paths) > 0,
-    }
-)
+st.session_state.chart_animation_gif_file = DOWNLOADS_DIR / f"{slug}.gif"
+st.session_state.chart_animation_image_paths = image_paths
+st.session_state.chart_animation_images_exist = len(image_paths) > 0
 
 # Button
 if st.button(

--- a/apps/wizard/app_pages/chart_animation.py
+++ b/apps/wizard/app_pages/chart_animation.py
@@ -166,7 +166,7 @@ if st.session_state.chart_animation_show_image_settings:
         # If chart, show option to just show single year
         if tab == "chart":
             year_range_open = not st.toggle(
-                "Chart: Only show current year",
+                "Show only current year",
                 value=not query_parameters["year_range_open"],
                 help="Only relevant for the chart view. If checked, the animated chart will display a sequence of bar charts with current year.",
             )
@@ -201,7 +201,7 @@ if st.session_state.chart_animation_show_image_settings:
                     min_value=duration,
                     value=duration,
                     step=duration,
-                    help="",
+                    help="Increase this to make the last frame last longer.",
                 )
                 repetitions_last_frame = repetitions_last_frame // duration - 1
                 if output_type == "GIF":

--- a/docs/guides/upgrade-python-version.md
+++ b/docs/guides/upgrade-python-version.md
@@ -1,0 +1,16 @@
+---
+status: new
+---
+
+To upgrade the version of Python used in the ETL pipeline, follow these steps on the ETL terminal:
+
+1. Remove the current environment configuration:
+   ```
+   rm -rf .venv
+   ```
+2. Rebuild the environment with the new Python version (replace xx.x with the desired version):
+   ```
+   PYTHON_VERSION=3.xx.x make .venv
+   ```
+
+The ETL currently supports versions 3.9 to 3.12.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,6 +224,7 @@ nav:
           - Regular updates: "guides/auto-regular-updates.md"
           - Pull requests: "guides/pull-requests.md"
       - Servers & settings:
+          - Upgrade Python version: "guides/upgrade-python-version.md"
           - Environments: "guides/environment.md"
           - Staging servers: "guides/staging-servers.md"
           - Public servers: "guides/sharing-external.md"


### PR DESCRIPTION
Builds on https://github.com/owid/etl/pull/3627/files

- Add square format support.
- Change use of `st.container` to `st.expander`. This way the user can collapse these.
- Improve presentation of output settings:
  - Add help message to most widgets.
  - Add dedicated section for "frame settings"
  - Change duration of last frame to be in `ms` (instead of number of frames)
  - Change "Remove duplicate frames" to "Allow duplicate frames". By default this is not checked.
  - Change label "Year range open" to "Show only current year". I found the previous label a bit confusing.
- Other changes to improve script readability
