### PR TITLE
🐛 covid cases and deaths

### DIFF
--- a/snapshots/covid/latest/cases_deaths.csv.dvc
+++ b/snapshots/covid/latest/cases_deaths.csv.dvc
@@ -12,22 +12,22 @@ meta:
 
       All data represent date of reporting as opposed to date of symptom onset. All data are subject to continuous verification and may change based on retrospective updates to accurately reflect trends, changes in country case definitions and/or reporting practices. Significant data errors detected or reported to WHO may be corrected at more frequent intervals.
 
-      New case and death counts from the Region of the Americas
+      **New case and death counts from the Region of the Americas**
       Starting from the week commencing on 11 September 2023, the source of the data from the Region of the Americas was switched to the aggregated national surveillances, received through the COVID-19, Influenza, RSV and Other Respiratory Viruses program in the Americas. Data have been included retrospectively since 31 July 2023.
 
-      Rates
+      **Rates**
       <0.001 per 100,000 population may be rounded to 0.
     citation_full: 'WHO COVID-19 Dashboard. Geneva: World Health Organization, 2020. Available online: https://covid19.who.int/'
     attribution_short: WHO
     version_producer: WHO COVID-19 Dashboard - Daily cases and deaths
     url_main: https://covid19.who.int/
-    url_download: https://covid19.who.int/WHO-COVID-19-global-data.csv
-    date_accessed: 2024-11-28
+    url_download: https://srhdpeuwpubsa.blob.core.windows.net/whdh/COVID/WHO-COVID-19-global-daily-data.csv
+    date_accessed: 2024-11-29
     date_published: '2024-07-07'
     license:
       name: CC BY 4.0
       url: https://data.who.int/dashboards/covid19/
 outs:
-  - md5: 2f146457985eaacb73d38e5cb1aec995
-    size: 2860436
+  - md5: 676e00c3829772b1e6669aaa122105ea
+    size: 19387822
     path: cases_deaths.csv

--- a/snapshots/covid/latest/cases_deaths.py
+++ b/snapshots/covid/latest/cases_deaths.py
@@ -1,4 +1,13 @@
-"""Script to create a snapshot of dataset."""
+"""Script to create a snapshot of dataset.
+
+As of 2024-11-29, the WHO reports three files for cases & deaths:
+
+- [NEW] Daily frequency reporting of new COVID-19 cases and deaths by date reported to WHO: Mostly weekly data, but occasionally daily data (especially past data).
+- Weekly COVID-19 cases and deaths by date reported to WHO: Reports weekly values. This is what we have been using since we switched from JHU to WHO.
+- Latest reported counts of COVID-19 cases and deaths: Reports latest values (only latest date is available)
+
+
+"""
 
 from datetime import date
 from pathlib import Path


### PR DESCRIPTION
Link https://covid19.who.int/WHO-COVID-19-global-data.csv for updating COVID cases & deaths stopped working. It redirects to a dashboard now.

**Solution**
WHO has changed the file links.

So far we had been using their file with weekly reports. Now, they started occasionally reporting daily values in a new file. I've switched to this file.

/schedule