### PR TITLE
🎉 Similar charts

### DIFF
--- a/apps/wizard/app_pages/similar_charts/app.py
+++ b/apps/wizard/app_pages/similar_charts/app.py
@@ -6,8 +6,7 @@ from structlog import get_logger
 
 from apps.wizard.app_pages.similar_charts import data, scoring
 from apps.wizard.utils import embeddings as emb
-from apps.wizard.utils import url_persist
-from apps.wizard.utils.components import Pagination, st_horizontal, st_multiselect_wider
+from apps.wizard.utils.components import Pagination, st_horizontal, st_multiselect_wider, url_persist
 from etl.config import OWID_ENV
 
 DEVICE = "cpu"

--- a/apps/wizard/app_pages/similar_charts/app.py
+++ b/apps/wizard/app_pages/similar_charts/app.py
@@ -113,11 +113,16 @@ with col2:
         chart_slug = random.sample(charts, 1)[0].slug
         st.session_state["chart_search_text"] = chart_slug
 
-    chart_search_text = url_persist(st.text_input)(
-        # chart_search_text = st.text_input(
+    # chart_search_text = url_persist(st.text_input)(
+    #     key="chart_search_text",
+    #     label="Chart slug or ID",
+    #     placeholder="Type something...",
+    # )
+
+    chart_search_text = url_persist(st.selectbox)(
+        "Select a chart",
         key="chart_search_text",
-        label="Chart slug or ID or text search",
-        placeholder="Type something...",
+        options=[c.slug for c in charts],
     )
 
     # Advanced expander.
@@ -160,11 +165,13 @@ chosen_chart = next(
     None,
 )
 if not chosen_chart:
-    # Find a chart by title
-    chart_id = scoring_model.similar_chart_by_title(chart_search_text)
-    chosen_chart = next((chart for chart in charts if chart.chart_id == chart_id), None)
-    assert chosen_chart
+    st.error(f"Chart with slug {chart_search_text} not found.")
 
+    # # Find a chart by title
+    # chart_id = scoring_model.similar_chart_by_title(chart_search_text)
+    # chosen_chart = next((chart for chart in charts if chart.chart_id == chart_id), None)
+
+assert chosen_chart
 
 # Display chosen chart
 with col1:

--- a/apps/wizard/app_pages/similar_charts/app.py
+++ b/apps/wizard/app_pages/similar_charts/app.py
@@ -1,0 +1,220 @@
+import random
+
+import pandas as pd
+import streamlit as st
+from structlog import get_logger
+
+from apps.wizard.app_pages.similar_charts import data, scoring
+from apps.wizard.utils import embeddings as emb
+from apps.wizard.utils import url_persist
+from apps.wizard.utils.components import Pagination, st_horizontal, st_multiselect_wider
+from etl.config import OWID_ENV
+
+DEVICE = "cpu"
+
+# Initialize log.
+log = get_logger()
+
+# PAGE CONFIG
+st.set_page_config(
+    page_title="Wizard: Similar Charts",
+    page_icon="🪄",
+    layout="wide",
+)
+
+########################################################################################################################
+# FUNCTIONS
+########################################################################################################################
+
+
+def st_chart_info(chart: data.Chart):
+    chart_url = OWID_ENV.chart_site(chart.slug)
+    title = f"#### [{chart.title}]({chart_url})"
+    if chart.gpt_reason:
+        title += " 🤖"
+    st.markdown(title)
+    st.markdown(f"Slug: {chart.slug}")
+    st.markdown(f"Subtitle: {chart.subtitle}")
+    st.markdown(f"Tags: **{', '.join(chart.tags)}**")
+    st.markdown(f"Pageviews: **{chart.views_365d}**")
+
+
+def st_display_chart(
+    chart: data.Chart,
+    sim_components: pd.DataFrame = pd.DataFrame(),
+):
+    with st.container(border=True):
+        col1, col2 = st.columns(2)
+        with col1:
+            st_chart_info(chart)
+        with col2:
+            st.markdown(f"#### Similarity: {chart.similarity:.0%}")
+            st.table(sim_components.loc[chart.chart_id].to_frame("score").style.format("{:.0%}"))
+            if chart.gpt_reason:
+                st.markdown(f"**GPT Diversity Reason**:\n{chart.gpt_reason}")
+
+    return
+
+
+def split_input_string(input_string: str) -> tuple[str, list[str], list[str]]:
+    """Break input string into query, includes and excludes."""
+    # Break input string into query, includes and excludes
+    query = []
+    includes = []
+    excludes = []
+    for term in input_string.split():
+        if term.startswith("+"):
+            includes.append(term[1:].lower())
+        elif term.startswith("-"):
+            excludes.append(term[1:].lower())
+        else:
+            query.append(term)
+
+    return " ".join(query), includes, excludes
+
+
+def indicator_query(indicator: dict) -> str:
+    return indicator["name"] + " " + indicator["description"] + " " + (indicator["catalogPath"] or "")
+
+
+def chart_text(chart: dict) -> str:
+    return chart["title"]
+
+
+@st.cache_data(show_spinner=False, max_entries=1)
+def get_and_fit_model(charts: list[data.Chart]) -> scoring.ScoringModel:
+    scoring_model = scoring.ScoringModel(emb.get_model())
+    scoring_model.fit(charts)
+    return scoring_model
+
+
+########################################################################################################################
+# Fetch all data indicators.
+charts = data.get_charts()
+# Get scoring model.
+scoring_model = get_and_fit_model(charts)
+
+########################################################################################################################
+
+
+########################################################################################################################
+# RENDER
+########################################################################################################################
+
+# Streamlit app layout.
+st.title(":material/search: Similar charts")
+
+col1, col2 = st.columns(2)
+with col2:
+    st_multiselect_wider()
+    with st_horizontal():
+        random_chart = st.button("Random chart", help="Get a random chart.")
+
+        # Filter indicators
+        diversity_gpt = url_persist(st.checkbox, default=True)(
+            "Diversity with GPT",
+            key="diversity_gpt",
+            help="Use GPT to select 5 most diverse charts from the top 30 similar charts.",
+        )
+
+    # Random chart was pressed or no search text
+    if random_chart or not st.query_params.get("chart_search_text"):
+        chart_slug = random.sample(charts, 1)[0].slug
+        st.session_state["chart_search_text"] = chart_slug
+
+    chart_search_text = url_persist(st.text_input)(
+        # chart_search_text = st.text_input(
+        key="chart_search_text",
+        label="Chart slug or ID or text search",
+        placeholder="Type something...",
+    )
+
+    # Advanced expander.
+    st.session_state.sim_charts_expander_advanced_options = st.session_state.get(
+        "sim_charts_expander_advanced_options", False
+    )
+
+    # Weights for each score
+    with st.expander("Advanced options", expanded=st.session_state.sim_charts_expander_advanced_options):
+        # Add text area for system prompt
+        system_prompt = url_persist(st.text_area, default=scoring.DEFAULT_SYSTEM_PROMPT)(
+            "GPT prompt for selecting diverse results",
+            key="gpt_system_prompt",
+            height=150,
+        )
+
+        for score_name in ["title", "subtitle", "tags", "pageviews", "share_indicator"]:
+            # For some reason, if the slider minimum value is zero, streamlit raises an error when the slider is
+            # dragged to the minimum. Set it to a small, non-zero number.
+            key = f"w_{score_name}"
+
+            # Set default values
+            if key not in st.session_state:
+                st.session_state[key] = scoring.DEFAULT_WEIGHTS[score_name]
+
+            url_persist(st.slider, default=scoring.DEFAULT_WEIGHTS[score_name])(
+                f"Weight for {score_name} score",
+                min_value=1e-9,
+                max_value=1.0,
+                # step=0.001,
+                key=key,
+            )
+
+            scoring_model.weights[score_name] = st.session_state[key]
+
+
+# Find a chart based on inputs
+chosen_chart = next(
+    (chart for chart in charts if chart.slug == chart_search_text or str(chart.chart_id) == chart_search_text),
+    None,
+)
+if not chosen_chart:
+    # Find a chart by title
+    chart_id = scoring_model.similar_chart_by_title(chart_search_text)
+    chosen_chart = next((chart for chart in charts if chart.chart_id == chart_id), None)
+    assert chosen_chart
+
+
+# Display chosen chart
+with col1:
+    st_chart_info(chosen_chart)
+
+
+# Horizontal divider
+st.markdown("---")
+
+sim_dict = scoring_model.similarity(chosen_chart)
+sim_components = scoring_model.similarity_components(chosen_chart)
+
+for chart in charts:
+    chart.similarity = sim_dict[chart.chart_id]
+
+sorted_charts = sorted(charts, key=lambda x: x.similarity, reverse=True)  # type: ignore
+
+# Postprocess charts with GPT and prioritize diversity
+if diversity_gpt:
+    slugs_to_reasons = scoring.gpt_diverse_charts(chosen_chart, sorted_charts, system_prompt=system_prompt)
+    for chart in sorted_charts:
+        if chart.slug in slugs_to_reasons:
+            chart.gpt_reason = slugs_to_reasons[chart.slug]
+
+    # Put charts that are diverse at the top
+    # sorted_charts = sorted(sorted_charts, key=lambda x: (x.gpt_reason is not None, x.similarity), reverse=True)
+
+# Use pagination
+items_per_page = 20
+pagination = Pagination(
+    items=sorted_charts,
+    items_per_page=items_per_page,
+    pagination_key=f"pagination-di-search-{chosen_chart.slug}",
+)
+
+if len(charts) > items_per_page:
+    pagination.show_controls(mode="bar")
+
+# Show items (only current page)
+for item in pagination.get_page_items():
+    # Don't show the chosen chart
+    if item.slug == chosen_chart.slug:
+        continue
+    st_display_chart(item, sim_components)

--- a/apps/wizard/app_pages/similar_charts/data.py
+++ b/apps/wizard/app_pages/similar_charts/data.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+import streamlit as st
+
+from apps.wizard.utils.embeddings import Doc
+from etl.db import read_sql
+
+
+@dataclass
+class Chart(Doc):
+    chart_id: int
+    title: str
+    subtitle: str
+    note: str
+    tags: list[str]
+    slug: str
+    views_7d: Optional[int] = None
+    views_14d: Optional[int] = None
+    views_365d: Optional[int] = None
+    gpt_reason: Optional[str] = None
+
+
+def get_raw_charts() -> pd.DataFrame:
+    """Get all charts that exist in the database."""
+    # Get all data indicators from the database.
+    query = """
+    with tags as (
+        select
+            ct.chartId as chart_id,
+            -- t.name as tag_name,
+            -- t.slug as tag_slug,
+            group_concat(t.name separator ';') as tags
+        from chart_tags as ct
+        join tags as t on ct.tagId = t.id
+        group by 1
+    )
+    select
+        c.id as chart_id,
+        cf.slug,
+        cf.full->>'$.title' as title,
+        cf.full->>'$.subtitle' as subtitle,
+        cf.full->>'$.note' as note,
+        t.tags,
+        a.views_7d,
+        a.views_14d,
+        a.views_365d
+    from charts as c
+    join chart_configs as cf on c.configId = cf.id
+    join analytics_pageviews as a on cf.slug = SUBSTRING_INDEX(a.url, '/', -1) and a.url like '%%/grapher/%%'
+    left join tags as t on c.id = t.chart_id
+    -- TODO: remove in prod
+    -- test it on charts with 'human' in the title
+    -- where lower(cf.full->>'$.title') like '%%human%%'
+    -- exclude drafts
+    where cf.full->>'$.isPublished' != 'false'
+    """
+    df = read_sql(query)
+
+    # charts must have unique id
+    assert df["chart_id"].nunique() == df.shape[0]
+
+    return df
+
+
+@st.cache_data(show_spinner=False, persist="disk")
+def get_charts() -> list[Chart]:
+    with st.spinner("Loading charts..."):
+        # Get charts from the database..
+        df = get_raw_charts()
+
+        charts = df.to_dict(orient="records")
+
+    ret = []
+    for c in charts:
+        c["tags"] = c["tags"].split(";") if c["tags"] else []
+        ret.append(Chart(**c))  # type: ignore
+
+    return ret

--- a/apps/wizard/app_pages/similar_charts/scoring.py
+++ b/apps/wizard/app_pages/similar_charts/scoring.py
@@ -1,0 +1,197 @@
+import json
+import time
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+from sentence_transformers import SentenceTransformer
+from structlog import get_logger
+
+from apps.utils.gpt import GPTQuery, OpenAIWrapper
+from apps.wizard.app_pages.similar_charts.data import Chart
+from apps.wizard.utils import embeddings as emb
+from etl.db import read_sql
+
+DEVICE = "cpu"
+
+# Initialize log.
+log = get_logger()
+
+
+# These are the default thresholds for the different scores.
+DEFAULT_WEIGHTS = {
+    "title": 0.4,
+    "subtitle": 0.1,
+    "tags": 0.1,
+    "pageviews": 0.3,
+    "share_indicator": 0.1,
+}
+
+PREFIX_SYSTEM_PROMPT = """
+You are an expert in recommending visual data insights.
+Your task: From a given chosen chart and a list of candidate charts, recommend up to 5 charts that are most relevant.
+
+Requirements:
+"""
+
+DEFAULT_SYSTEM_PROMPT = """
+- Relevance should be based on thematic or conceptual similarity, but **avoid charts with very similar titles**.
+- If fewer than 5 good matches are found, select only those that are truly relevant.
+- Ensure diversity among the chosen charts.
+- Provide concise reasoning for each recommendation.
+""".strip()
+
+SUFFIX_SYSTEM_PROMPT = """
+The response should be in valid JSON format, mapping chart_slugs to their reasons for selection.
+"""
+
+
+class ScoringModel:
+    charts: list[Chart]
+
+    # Embeddings for chart titles and subtitles
+    model: SentenceTransformer
+    emb_title: emb.EmbeddingsModel
+    emb_subtitle: emb.EmbeddingsModel
+
+    # Weights for the different scores
+    weights: dict[str, float]
+
+    def __init__(self, model: SentenceTransformer, weights: Optional[dict[str, float]] = None) -> None:
+        self.model = model
+        self.weights = weights or DEFAULT_WEIGHTS.copy()
+
+    def fit(self, charts: list[Chart]):
+        self.charts = charts
+
+        # Get embeddings for title and subtitle
+        self.emb_title = emb.EmbeddingsModel(self.model, model_name="sim_charts_title")
+        self.emb_title.fit(charts, text=lambda d: d.title)
+
+        self.emb_subtitle = emb.EmbeddingsModel(self.model, model_name="sim_charts_subtitle")
+        self.emb_subtitle.fit(charts, text=lambda d: d.subtitle)
+
+    def set_weights(self, weights: dict[str, float]):
+        self.weights = weights
+
+    def similarity(self, chart: Chart) -> dict[int, float]:
+        assert self.weights is not None, "Weights must be set before calling similarity"
+
+        scores = self.similarity_components(chart)
+
+        # Get weights and normalize them
+        # w = pd.Series(self.weights)
+        # w = w / w.sum()
+
+        # Calculate total score
+        return scores.sum(axis=1).to_dict()
+
+    def similar_chart_by_title(self, title: str) -> int:
+        title_scores = self.emb_title.calculate_similarity(title)
+        d = dict(zip([c.chart_id for c in self.charts], title_scores))
+
+        # Return chart_id with the highest score
+        return max(d, key=d.get)  # type: ignore
+
+    def similarity_components(self, chart: Chart) -> pd.DataFrame:
+        log.info("similarity_components.start", n_docs=len(self.charts))
+        t = time.time()
+
+        title_scores = self.emb_title.calculate_similarity(chart.title)
+        subtitle_scores = self.emb_subtitle.calculate_similarity(chart.subtitle or "")
+
+        q = """
+        select
+            chartId
+        from chart_dimensions as cd
+        where variableId in (
+        select variableId from chart_dimensions where chartId = %s
+        )
+        """
+        charts_sharing_indicator = set(read_sql(q, params=(chart.chart_id,))["chartId"])
+
+        # Attach the similarity scores to the documents.
+        ret = []
+        for i, c in enumerate(self.charts):
+            ret.append(
+                {
+                    "chart_id": c.chart_id,
+                    "title": title_scores[i],
+                    "subtitle": subtitle_scores[i],
+                    # score 1 if there is at least one tag in common, 0 otherwise
+                    "tags": float(bool(set(c.tags) & set(chart.tags))),
+                    "pageviews": c.views_365d or 0,
+                    "share_indicator": float(c.chart_id in charts_sharing_indicator),
+                }
+            )
+
+        ret = pd.DataFrame(ret).set_index("chart_id")
+
+        assert ret.index.duplicated().sum() == 0
+
+        # Empty subtitles are given a score of 0
+        if chart.subtitle == "":
+            ret["subtitle"] = 0
+
+        # Scale pageviews to [0, 1]
+        ret["pageviews"] = np.log(ret["pageviews"] + 1)
+        ret["pageviews"] = (ret["pageviews"] - ret["pageviews"].min()) / (
+            ret["pageviews"].max() - ret["pageviews"].min()
+        )
+
+        # Get weights and normalize them
+        w = pd.Series(self.weights)
+        w = w / w.sum()
+
+        # Multiply scores by weights
+        ret = (ret * w).fillna(0)
+
+        # Reorder
+        ret = ret[["title", "subtitle", "tags", "share_indicator", "pageviews"]]
+
+        log.info("similarity_components.end", t=time.time() - t)
+
+        return ret
+
+
+@st.cache_data(show_spinner=True, persist="disk")
+def gpt_diverse_charts(
+    chosen_chart: Chart, _charts: list[Chart], _n: int = 30, system_prompt=DEFAULT_SYSTEM_PROMPT
+) -> dict[str, str]:
+    """Get diverse charts using GPT-4o. Return a dictionary with chart slugs as keys and reasons as values."""
+    n = _n
+    charts = _charts
+
+    system_prompt = "\n".join([PREFIX_SYSTEM_PROMPT, system_prompt, SUFFIX_SYSTEM_PROMPT])
+
+    user_prompt = f"""
+    Please consider the chosen chart and the following {n} candidate charts.
+
+    Identify 5 of the most relevant candidates according to the system's requirements.
+    Output a JSON object with the chosen chart_slugs as keys and a brief reason for selection as values.
+
+    Chosen chart:
+    {json.dumps({"title": chosen_chart.title, "subtitle": chosen_chart.subtitle, "chart_slug": chosen_chart.slug}, indent=2)}
+
+    Preselected charts:
+    {json.dumps([{"title": c.title, "subtitle": c.subtitle, "chart_slug": c.slug} for c in charts[:n]], indent=2)}
+    """
+
+    api = OpenAIWrapper()
+    query = GPTQuery(
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0,
+    )
+    log.info("add_gpt_diversity.start")
+    t = time.time()
+    response = api.query_gpt(query=query, model="gpt-4o", response_format={"type": "json"})
+    assert response
+    log.info("add_gpt_diversity.end", cost=response.cost, t=time.time() - t)
+
+    js = json.loads(response.choices[0].message.content.replace("```json", "").replace("```", ""))  # type: ignore
+
+    return js

--- a/apps/wizard/config/config.yml
+++ b/apps/wizard/config/config.yml
@@ -183,6 +183,13 @@ sections:
         entrypoint: app_pages/indicator_search/app.py
         icon: ":material/search:"
         image_url: "https://img.freepik.com/premium-photo/librarian-cataloging-new-books-library-database_1237301-1719.jpg"
+      - title: "Similar charts"
+        alias: similar_charts
+        description: "Find similar charts"
+        maintainer: "@mojmir"
+        entrypoint: app_pages/similar_charts/app.py
+        icon: ":material/bar_chart:"
+        image_url: "https://img.freepik.com/premium-photo/librarian-cataloging-new-books-library-database_1237301-1719.jpg"
 
   - title: "Misc"
     description: |-


### PR DESCRIPTION
A Streamlit prototype for finding similar charts to the selected one. Initially, it was searching for similar charts based solely on the semantic similarity of chart titles and subtitles, but later, many more "features" were added and combined into a similarity score. It was created to provide an intuition for how well automatic chart recommendations could work. However, the selection will likely evolve into a semi-automatic process (this app could then be leveraged for labeling).

It's not yet clear what "similar chart" means. Should we show very similar charts ("narrow"), a "wide" selection, or charts that are not so similar but perhaps more interesting?

## Scoring

Similarity is calculated as a weighted average of the following sub-scores (all between 0 and 1):
- **title**: semantic similarity of the title to other charts
- **subtitle**: semantic similarity of the subtitle to other charts
- **tags**: 1 if a chart shares at least one tag, 0 otherwise
- **share_indicator**: 1 if a chart shares an indicator, 0 otherwise
- **pageviews**: normalized `log(365d pageviews)` between 0 and 1

Weights were chosen intuitively. Analytical data to make this less subjective would be helpful, but first, we need to agree on what "similar" actually means.

## Diversity

Some recommendations, such as those for [political-regime](http://staging-site-similar-charts/etl/wizard/similar_charts?chart_search_text=political-regime), show many charts that are essentially the same chart, just from different providers. While it could be useful to inform users about different providers, it would be better to present more diverse charts. Similarly, some recommended charts, such as for [armed-forces-personnel](http://staging-site-similar-charts/etl/wizard/similar_charts?chart_search_text=armed-forces-personnel), often include the same indicator, presented as a share of the total population or a similar derivation.

To address this, I asked GPT to find a set of 5 diverse charts among the top 30 similar charts. These charts are marked with a 🤖 symbol, and the reason for their selection is displayed alongside them. This approach helps improve diversity and is relatively inexpensive ($0.01 per query, so doing it for 5000 charts wouldn't be prohibitively costly).

## How to review

Check out a few random charts with `Diversity with GPT` turned on. Are these recommendations reasonable? Is GPT providing additional value? Do you have any ideas for improving either the scoring system or the UI?

## Other use cases

This tool could be used to find "duplicate charts" or modified to assist with reviewing the [least viewed charts](https://github.com/owid/owid-issues/issues/1777).
