### PR TITLE
✨ Limit container names to 28 characters

### DIFF
--- a/etl/config.py
+++ b/etl/config.py
@@ -44,6 +44,7 @@ def _normalise_branch(branch_name):
     return re.sub(r"[\/\._]", "-", branch_name)
 
 
+# NOTE: If you edit this function, make sure to update `get_container_name` in ops repo as well
 def get_container_name(branch_name):
     normalized_branch = _normalise_branch(branch_name)
 
@@ -51,7 +52,22 @@ def get_container_name(branch_name):
     normalized_branch = normalized_branch.replace("staging-site-", "")
 
     # Ensure the container name is less than 63 characters
-    container_name = f"staging-site-{normalized_branch[:50]}"
+    # however, we truncate it to 28 characters to be consistent with Cloudflare's
+    # 28 character limit (see https://community.cloudflare.com/t/algorithm-to-generate-a-preview-dns-subdomain-from-a-branch-name/477633)
+    # TODO: these ifs were added to be backward compatible with existing branches that are longer than 28 characters
+    #   remove them once they get merged
+    if normalized_branch in (
+        "variable-selector-catalog-path",
+        "grapher-page-dynamic-thumbnail",
+        "data-fertility-rate-effective",
+        "add-reset-metadata-origin-option",
+        "data-battery-cell-prices-private",
+    ):
+        limit = 50
+    else:
+        limit = 28
+
+    container_name = f"staging-site-{normalized_branch[:limit]}"
     # Remove trailing hyphens
     return container_name.rstrip("-")
 


### PR DESCRIPTION
Fix for https://github.com/owid/owid-grapher/issues/4308

Truncate branch names after 28 characters instead of 50. (Existing branches over 28 characters are excluded)