### PR TITLE
✨ Exclude archived steps from VSCode search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,12 +36,6 @@
     "**/docs/api/*.md",
     "**/docs/architecture/*.md"
   ],
-  "files.exclude": {
-    "**/dataset_*_config.json": true,
-    "**/dataset_*_values.json": true,
-    "**/dataset_*.json.dvc": true,
-    "**/dataset_*.feather.dvc": true
-  },
   "yaml.format.printWidth": 999,
   "ruff.path": [
     ".venv/bin/ruff"

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #  Makefile
 #
 
-.PHONY: etl docs full lab test-default publish grapher dot watch clean clobber deploy api activate
+.PHONY: etl docs full lab test-default publish grapher dot watch clean clobber deploy api activate vscode-exclude-archived
 
 include default.mk
 
@@ -31,6 +31,7 @@ help:
 	@echo '  make chart-sync 	Start Chart-sync on port 8083'
 	@echo '  make test      	Run all linting and unit tests'
 	@echo '  make test-all  	Run all linting and unit tests (including for modules in lib/)'
+	@echo '  make vscode-exclude-archived  Exclude archived steps from VSCode user settings'
 	@echo '  make watch     	Run all tests, watching for changes'
 	@echo '  make watch-all 	Run all tests, watching for changes (including for modules in lib/)'
 	@echo
@@ -174,3 +175,7 @@ install-vscode-extensions:
 	else \
 		echo "⚠️ VS Code CLI (code) is not installed. Skipping extension installation."; \
 	fi
+
+vscode-exclude-archived: .venv
+	@echo '==> Excluding archived steps from VSCode user settings'
+	.venv/bin/python scripts/exclude_archived_steps.py --settings-scope user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ dev-dependencies = [
     "pandas-stubs==1.2.0.62",
     "ruff>=0.8.2",
     "ipdb>=0.13.13",
+    "commentjson>=0.9.0",
 ]
 
 [project.optional-dependencies]

--- a/scripts/exclude_archived_steps.py
+++ b/scripts/exclude_archived_steps.py
@@ -1,0 +1,69 @@
+"""Exclude archived steps from files tab and search in VSCode."""
+
+import json
+from typing import Set, Tuple
+
+from etl.paths import BASE_DIR, SNAPSHOTS_DIR, STEPS_DATA_DIR
+from etl.steps import load_dag
+
+
+def active_steps_and_snapshots() -> Tuple[Set[str], Set[str]]:
+    DAG = load_dag()
+
+    active_snapshots = set()
+    active_steps = set()
+
+    for s in set(DAG.keys()) | {x for v in DAG.values() for x in v}:
+        if s.startswith("snapshot"):
+            active_snapshots.add(s.split("://")[1])
+        else:
+            active_steps.add(s.split("://")[1])
+
+    # Strip dataset name after version
+    active_steps = {s.rsplit("/", 1)[0] for s in active_steps}
+    active_snapshots = {s.rsplit("/", 1)[0] for s in active_snapshots}
+
+    return active_steps, active_snapshots
+
+
+def snapshots_to_exclude(active_snapshots: Set[str]) -> Set[str]:
+    to_exclude = set()
+
+    for d in SNAPSHOTS_DIR.rglob("*"):
+        d = d.relative_to(SNAPSHOTS_DIR)
+        if len(d.parts) == 2:
+            if str(d) not in active_snapshots:
+                to_exclude.add(f"snapshots/{d}")
+
+    return to_exclude
+
+
+def steps_to_exclude(active_steps: Set[str]) -> Set[str]:
+    to_exclude = set()
+
+    for d in STEPS_DATA_DIR.rglob("*"):
+        d = d.relative_to(STEPS_DATA_DIR)
+        if len(d.parts) == 3 and d.parts[0] in ("meadow", "garden", "grapher"):
+            if str(d) not in active_steps:
+                to_exclude.add(f"etl/steps/data/{d}")
+
+    return to_exclude
+
+
+def main():
+    active_steps, active_snapshots = active_steps_and_snapshots()
+
+    to_exclude = {s: True for s in sorted(snapshots_to_exclude(active_snapshots) | steps_to_exclude(active_steps))}
+
+    # Update .vscode/settings file
+    # update .vscode/settings.json
+    settings = json.loads((BASE_DIR / ".vscode/settings.json").read_text())
+    settings["files.exclude"].update(to_exclude)
+    settings["search.exclude"].update(to_exclude)
+    (BASE_DIR / ".vscode/settings.json").write_text(json.dumps(settings, indent=2))
+
+    print(f"Excluded {len(to_exclude)} steps and snapshots")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/exclude_archived_steps.py
+++ b/scripts/exclude_archived_steps.py
@@ -56,7 +56,6 @@ def main():
     to_exclude = {s: True for s in sorted(snapshots_to_exclude(active_snapshots) | steps_to_exclude(active_steps))}
 
     # Update .vscode/settings file
-    # update .vscode/settings.json
     settings = json.loads((BASE_DIR / ".vscode/settings.json").read_text())
     settings["files.exclude"].update(to_exclude)
     settings["search.exclude"].update(to_exclude)

--- a/scripts/exclude_archived_steps.py
+++ b/scripts/exclude_archived_steps.py
@@ -1,6 +1,5 @@
 """Exclude archived steps from files tab and search in VSCode."""
 
-import json
 from collections import OrderedDict
 from pathlib import Path
 from typing import Set, Tuple
@@ -8,8 +7,8 @@ from typing import Set, Tuple
 import click
 import commentjson
 
+from etl.dag_helpers import load_dag
 from etl.paths import BASE_DIR, SNAPSHOTS_DIR, STEPS_DATA_DIR
-from etl.steps import load_dag
 
 
 def active_steps_and_snapshots() -> Tuple[Set[str], Set[str]]:

--- a/uv.lock
+++ b/uv.lock
@@ -655,6 +655,15 @@ wheels = [
 ]
 
 [[package]]
+name = "commentjson"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark-parser" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/76/c4aa9e408dbacee3f4de8e6c5417e5f55de7e62fb5a50300e1233a2c9cb5/commentjson-0.9.0.tar.gz", hash = "sha256:42f9f231d97d93aff3286a4dc0de39bfd91ae823d1d9eba9fa901fe0c7113dd4", size = 8653 }
+
+[[package]]
 name = "contourpy"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1035,6 +1044,7 @@ wizard = [
 dev = [
     { name = "argh" },
     { name = "boto3-stubs", extra = ["s3"] },
+    { name = "commentjson" },
     { name = "cookiecutter" },
     { name = "gspread" },
     { name = "hydra-core" },
@@ -1155,6 +1165,7 @@ provides-extras = ["api", "wizard"]
 dev = [
     { name = "argh", specifier = ">=0.31.3" },
     { name = "boto3-stubs", extras = ["s3"], specifier = ">=1.34.154" },
+    { name = "commentjson", specifier = ">=0.9.0" },
     { name = "cookiecutter", specifier = ">=2.6.0" },
     { name = "gspread", specifier = ">=5.12.4" },
     { name = "hydra-core", specifier = ">=1.3.2" },
@@ -2585,6 +2596,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/43/f8/7259f18c77adca88d5f64f9a522792e178b2691f3748817a8750c2d216ef/kiwisolver-1.4.8-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c07b29089b7ba090b6f1a669f1411f27221c3662b3a1b7010e67b59bb5a6f10b", size = 80279 },
     { url = "https://files.pythonhosted.org/packages/3a/1d/50ad811d1c5dae091e4cf046beba925bcae0a610e79ae4c538f996f63ed5/kiwisolver-1.4.8-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:65ea09a5a3faadd59c2ce96dc7bf0f364986a315949dc6374f04396b0d60e09b", size = 71762 },
 ]
+
+[[package]]
+name = "lark-parser"
+version = "0.7.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/b8/aa7d6cf2d5efdd2fcd85cf39b33584fe12a0f7086ed451176ceb7fb510eb/lark-parser-0.7.8.tar.gz", hash = "sha256:26215ebb157e6fb2ee74319aa4445b9f3b7e456e26be215ce19fdaaa901c20a4", size = 276204 }
 
 [[package]]
 name = "line-profiler"


### PR DESCRIPTION
## Motivation

Searching in VSCode can be frustrating when we keep old, archived versions of code in the repository. Quite frequently, I find myself yelling at my computer, only to realize that I was editing the wrong dataset (found through VSCode quick search). This problem has already been addressed by the [find-latest-step](https://github.com/owid/etl/tree/master/vscode_extensions/find-latest-etl-step) extension, although it lacks some capabilities of the native VSCode quick search. I don't personally use the `find-latest-etl-step` extension because it's slow on my laptop and I prefer the fuzzy matching in quick search (although other people use it).

## Solution

Identify all inactive steps and exclude them from the VSCode search toolbar and file explorer by adding them to `"files.exclude"` and `"search.exclude"` in `.vscode/settings.json`. Running the script **excluded over 600 datasets**. One disadvantage is that **all VSCode users must be aware that archived files can't be found there** and must instead be opened, for example, via `code etl/path/to/script` from the terminal.
