### PR TITLE
🐛 clean dictionary function

### DIFF
--- a/apps/wizard/utils/__init__.py
+++ b/apps/wizard/utils/__init__.py
@@ -453,7 +453,7 @@ def clean_empty_dict(d: Union[Dict[str, Any], List[Any]]) -> Union[Dict[str, Any
         return {k: v for k, v in ((k, clean_empty_dict(v)) for k, v in d.items()) if v}
     if isinstance(d, list):
         return [v for v in map(clean_empty_dict, d) if v]
-    raise TypeError("Invalid type for argument `d`.")
+    return d
 
 
 def get_datasets_in_etl(


### PR DESCRIPTION
Error introduced in #3726 where `clean_dict_empty` was not returning a value when input type was not list or dictionary.

/schedule