### PR TITLE
🎉 Add OWID data managers to metadata

### DIFF
--- a/etl/steps/data/garden/biodiversity/2024-01-25/cherry_blossom.meta.yml
+++ b/etl/steps/data/garden/biodiversity/2024-01-25/cherry_blossom.meta.yml
@@ -1,4 +1,6 @@
 dataset:
+  owid_data_managers:
+    - Fiona Spooner
   update_period_days: 365
 tables:
   cherry_blossom:

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -305,6 +305,8 @@ class DatasetMeta(MetaBase):
     update_period_days: Optional[int] = None
     # prohibit redistribution (disable chart download)
     non_redistributable: bool = False
+    # OWID data managers
+    owid_data_managers: Optional[List[str]] = None
 
     # an md5 checksum of the ingredients used to make this dataset
     source_checksum: Optional[str] = None

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -286,6 +286,23 @@
           "examples_bad": [["2023-01-07"], ["monthly"], ["0.2"], ["1/365"]],
           "requirement_level": "required"
         },
+        "owid_data_managers": {
+          "type": "array",
+          "description": "List of allowed OWID author names.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "Edouard Mathieu",
+              "Lucas Rodés-Guirao",
+              "Pablo Rosado",
+              "Fiona Spooner",
+              "Tuna Acisu",
+              "Pablo Arriagada",
+              "Veronika Samborska",
+              "Mojmir Vinkler"
+            ]
+          }
+        },
         "non_redistributable": {
           "type": "boolean",
           "title": "Non-redistribution of dataset ",


### PR DESCRIPTION
Implements https://github.com/owid/etl/issues/2465

Add a field `owid_data_managers` to `DatasetMeta`. The original proposal suggested setting it in snapshot and then propagating (+combining), this PR doesn't add it to Snapshot and only uses it in the garden / grapher step. I felt that it's not as useful in snapshot metadata and would unnecessarily complicate things.

The grapher step should map managers to user ids and save them in the new JSON column in `datasets` table. Alternatively, we could save just manager names (since querying on JSON fields is painful anyway).

### Notes from Data architecture meeting

- Use cases
    - Can I archive this dataset? → knowing who to ask
    - Reporting an issue on a chart → knowing who to tag
- What is involved?
    - Version A: add it to snapshots, then propagate ← harder
    - **🏆 Version B**: add it late in the YAML ← easier
- Could we do it historically/automatically?
    - **✅ Historically**: we could use Git commit history on the YAML doc for a dataset to populate the dataset
        - …but we won’t be able to do this for fast track, since owidbot did the magic
    - **✅ Automatically**: can we do something with the wizard, using who we autodetect you to be (from Tailscale info)
- Related issues
    - Charts are sometimes “owned” by the ETL user, rather than by a person
        - Could we detect the owner of owner of the indicators used in a chart?

### TODO

- [ ] Add data manager field to dataset metadata
- [ ] Fill data manager automatically when creating steps in Wizard
- [ ] Fill it historically from git history whenever possible
- [ ] Fill it when using fast-track (use IP -> Tailscale)