### PR TITLE
✨ add URL-query support in some wizard apps

### DIFF
--- a/apps/chart_animation/cli.py
+++ b/apps/chart_animation/cli.py
@@ -19,7 +19,7 @@ log = get_logger()
 DOWNLOADS_DIR = Path.home() / ".chart_animation"
 
 # Default maximum number of years to fetch images for.
-MAX_NUM_YEARS = 100
+MAX_NUM_YEARS = 151
 
 
 def get_chart_metadata(chart_url):
@@ -86,40 +86,6 @@ def get_years_in_chart(chart_url):
         )
     )
     return years
-
-
-def get_query_parameters_in_chart(chart_url, all_years):
-    # Select default values.
-    year_range_open = True
-    year_start, year_end = min(all_years), max(all_years)
-    tab = "map"
-
-    # Attempt to get those parameters from the chart URL.
-    query_params = parse_qs(urlparse(chart_url).query)
-    if "time" in query_params:
-        time = query_params["time"][0]
-        if ".." in time:
-            year_range_open = True
-            year_start, year_end = time.split("..")
-            if year_start == "earliest":
-                year_start = min(all_years)
-            if year_end == "latest":
-                year_end = max(all_years)
-        else:
-            year_range_open = False
-            year_start = int(time)
-            year_end = year_start
-    if "tab" in query_params:
-        tab = query_params["tab"][0]
-
-    params = {
-        "year_range_open": year_range_open,
-        "year_min": int(year_start),
-        "year_max": int(year_end),
-        "tab": tab,
-    }
-
-    return params
 
 
 def modify_chart_url(chart_url, year, year_range_open, tab, social_media_square):

--- a/apps/wizard/app_pages/chart_animation.py
+++ b/apps/wizard/app_pages/chart_animation.py
@@ -191,7 +191,7 @@ if st.session_state.chart_animation_show_image_settings:
                 chart_url, all_years=st.session_state.chart_animation_years
             )
             # Actually get the tab value
-            st.write(query_parameters)
+
             with st_horizontal():
                 tab = st.segmented_control(
                     "Select tab", ["map", "chart"], format_func=add_icons_to_tabs, default=query_parameters["tab"]
@@ -301,7 +301,10 @@ if st.session_state.chart_animation_show_image_settings:
     image_paths_selected = [
         st.session_state.chart_animation_images_folder
         / create_image_file_name(
-            year=year, year_range_open=year_range_open, tab=tab, social_media_square=social_media_square
+            year=year,
+            year_range_open=year_range_open,
+            tab=tab,
+            social_media_square=social_media_square,
         )
         for year in years
     ]

--- a/apps/wizard/config/config.yml
+++ b/apps/wizard/config/config.yml
@@ -58,6 +58,7 @@ etl:
       image_url: "https://greatescapepublishing.com/wp-content/uploads/2019/11/30463274482_90aff8a230_c.jpg"
       disable:
         "production": True
+        "staging": True
     data:
       title: "Data step"
       entrypoint: etl_steps/data.py
@@ -66,6 +67,7 @@ etl:
       description: "Meadow, Garden, Grapher."
       disable:
         "production": True
+        "staging": True
     fasttrack:
       title: "Fast Track"
       alias: fasttrack

--- a/apps/wizard/utils/components.py
+++ b/apps/wizard/utils/components.py
@@ -471,6 +471,12 @@ def url_persist(component: Any, default: Any = None) -> Any:
                 params = kwargs.pop("value")
 
             st.session_state[key] = params
+
+            if "options" in kwargs:
+                # Set default value in query params
+                if params not in kwargs["options"]:
+                    raise ValueError(f"Please review the URL query. Value {params} not in options {kwargs['options']}.")
+
         else:
             # Set the value in query params, but only if it isn't default
             if default is None or st.session_state[key] != default:


### PR DESCRIPTION
In streamlit, there is the [st.query_params](https://docs.streamlit.io/develop/api-reference/caching-and-state/st.query_params) function, which allows you to query the app via the URL.

This can be useful to link users to specific app views from external apps (e.g. the admin).


App candidates where querying makes sense:

- [x] Chart animation
  - Can link it from chart edit page
- [x] Similar charts
  - Can use it for the _housekeeper_