### PR TITLE
🐛 Cleanup _load_population

### DIFF
--- a/dag/environment.yml
+++ b/dag/environment.yml
@@ -13,7 +13,7 @@ steps:
     - snapshot://unep/2023-03-17/consumption_controlled_substances.other_fully_halogenated.xlsx
   data://garden/unep/2023-03-17/consumption_controlled_substances:
     - data://meadow/unep/2023-03-17/consumption_controlled_substances
-    - data://garden/owid/latest/key_indicators
+    - data://garden/demography/2023-03-31/population
   data://grapher/unep/2023-03-17/consumption_controlled_substances:
     - data://garden/unep/2023-03-17/consumption_controlled_substances
   # NASA Ozone Watch

--- a/etl/command.py
+++ b/etl/command.py
@@ -308,6 +308,9 @@ def construct_dag(dag_path: Path, private: bool, grapher: bool, export: bool) ->
                 if dep.startswith("grapher://"):
                     dag[dep] = steps[dep]
 
+    # Validate the DAG
+    _check_dag_completeness(dag)
+
     return dag
 
 
@@ -671,6 +674,16 @@ def _check_public_private_steps(dag: DAG) -> None:
     common = private_steps & public_steps
     if common:
         raise ValueError(f"Dataset has both public and private version: {common}")
+
+
+def _check_dag_completeness(dag: DAG) -> None:
+    """Make sure the DAG is complete, i.e. all dependencies are there."""
+    for step, deps in dag.items():
+        for dep in deps:
+            if re.match(r"^(snapshot|walden|snapshot-private|walden-private|github|etag)://", dep):
+                pass
+            elif dep not in dag:
+                raise ValueError(f"Step {step} depends {dep} which is not in the DAG.")
 
 
 if __name__ == "__main__":

--- a/etl/steps/data/garden/demography/2023-03-31/population/__init__.py
+++ b/etl/steps/data/garden/demography/2023-03-31/population/__init__.py
@@ -170,13 +170,16 @@ def add_regions(df: Table) -> Table:
 
     # re-estimate region aggregates
     for region in regions:
+        countries_that_must_have_data = geo.list_countries_in_region_that_must_have_data(
+            region=region,
+            population=df,
+        )
         # TODO: Check if keeping the default countries_that_must_have_data, num_allowed_nans_per_year, and
         #   frac_allowed_nans_per_year makes makes no difference. In that case, keep default.
         df = geo.add_region_aggregates(
             df=df,
             region=region,
-            population=df,
-            countries_that_must_have_data="auto",
+            countries_that_must_have_data=countries_that_must_have_data,
             num_allowed_nans_per_year=None,
             frac_allowed_nans_per_year=0.2,
         )

--- a/etl/steps/data/garden/eth/2023-03-15/ethnic_power_relations.py
+++ b/etl/steps/data/garden/eth/2023-03-15/ethnic_power_relations.py
@@ -204,7 +204,6 @@ def add_regional_aggregations(df: pd.DataFrame) -> pd.DataFrame:
             region=region,
             aggregations=aggregations,
             countries_that_must_have_data=[],
-            population=df,
             num_allowed_nans_per_year=None,
             frac_allowed_nans_per_year=0.2,
         )

--- a/etl/steps/data/garden/owid/latest/key_indicators/utils.py
+++ b/etl/steps/data/garden/owid/latest/key_indicators/utils.py
@@ -22,6 +22,10 @@ def add_regions(df: pd.DataFrame, population: pd.DataFrame) -> pd.DataFrame:
     ]
     df = df.loc[-df.country.isin(regions)]
     for region in regions:
+        countries_that_must_have_data = geo.list_countries_in_region_that_must_have_data(
+            region=region,
+            population=population,
+        )
         # TODO: this should be ideally
         # countries_in_region = geo.list_members_of_region(region=region, ds_regions=ds_regions, ds_income_groups=ds_income_groups)
         # df = geo.add_region_aggregates(df=df, region=region, countries_in_region=countries_in_region, population=population)
@@ -30,8 +34,7 @@ def add_regions(df: pd.DataFrame, population: pd.DataFrame) -> pd.DataFrame:
         df = geo.add_region_aggregates(
             df=df,
             region=region,
-            population=population,
-            countries_that_must_have_data="auto",
+            countries_that_must_have_data=countries_that_must_have_data,
             num_allowed_nans_per_year=None,
             frac_allowed_nans_per_year=0.2,
         )

--- a/etl/steps/data/garden/state_capacity/2023-10-19/state_capacity_dataset.py
+++ b/etl/steps/data/garden/state_capacity/2023-10-19/state_capacity_dataset.py
@@ -98,7 +98,6 @@ def regional_aggregations(tb: Table) -> Table:
             aggregations={"capacity_pop": "sum", "population": "sum"},
             countries_that_must_have_data=[],
             frac_allowed_nans_per_year=0.3,
-            population=tb_regions,
         )
 
     # Keep only regions

--- a/etl/steps/data/garden/un/2023-08-02/comtrade_pandemics.py
+++ b/etl/steps/data/garden/un/2023-08-02/comtrade_pandemics.py
@@ -189,16 +189,22 @@ def add_regions(tb: Table, ds_regions: Dataset) -> Table:
         "South America",
         "Oceania",
     ]
+    # Load population
+    population = paths.load_dataset("population").read("population")
     for region in regions:
         countries_in_region = geo.list_members_of_region(
             region=region,
             ds_regions=ds_regions,
         )
+        countries_that_must_have_data = geo.list_countries_in_region_that_must_have_data(
+            region=region,
+            population=population,
+        )
         tb_region = geo.add_region_aggregates(
             tb,
             region,
             countries_in_region=countries_in_region,
-            countries_that_must_have_data="auto",
+            countries_that_must_have_data=countries_that_must_have_data,
             num_allowed_nans_per_year=None,
             frac_allowed_nans_per_year=0.2,
         )

--- a/tests/data_helpers/test_geo.py
+++ b/tests/data_helpers/test_geo.py
@@ -79,7 +79,7 @@ class TestAddPopulationToDataframe:
                 "population": [30, 20],
             }
         )
-        assert geo._add_population_to_dataframe(df=df_in).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in, tb_population=mock_population).equals(df_out)
 
     def test_countries_and_years_in_population_just_one(self):
         df_in = pd.DataFrame({"country": ["Country 2", "Country 2"], "year": [2020, 2019]})
@@ -90,7 +90,7 @@ class TestAddPopulationToDataframe:
                 "population": [40, 30],
             }
         )
-        assert geo._add_population_to_dataframe(df=df_in).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in, tb_population=mock_population).equals(df_out)
 
     def test_one_country_in_and_another_not_in_population(self):
         df_in = pd.DataFrame({"country": ["Country 1", "Country 3"], "year": [2020, 2021]})
@@ -101,7 +101,7 @@ class TestAddPopulationToDataframe:
                 "population": [10, np.nan],
             }
         )
-        assert geo._add_population_to_dataframe(df=df_in).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in, tb_population=mock_population).equals(df_out)
 
     def test_no_countries_in_population(self):
         df_in = pd.DataFrame({"country": ["Country_04", "Country_04"], "year": [2000, 2000]})
@@ -112,7 +112,9 @@ class TestAddPopulationToDataframe:
                 "population": [np.nan, np.nan],
             }
         )
-        assert geo._add_population_to_dataframe(df=df_in, warn_on_missing_countries=False).equals(df_out)
+        assert geo._add_population_to_dataframe(
+            df=df_in, tb_population=mock_population, warn_on_missing_countries=False
+        ).equals(df_out)
 
     def test_countries_in_population_but_not_for_given_years(self):
         df_in = pd.DataFrame({"country": ["Country 2", "Country 1"], "year": [2000, 2000]})
@@ -123,7 +125,7 @@ class TestAddPopulationToDataframe:
                 "population": [np.nan, np.nan],
             }
         )
-        assert geo._add_population_to_dataframe(df=df_in).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in, tb_population=mock_population).equals(df_out)
 
     def test_countries_in_population_but_a_year_in_and_another_not_in_population(self):
         df_in = pd.DataFrame({"country": ["Country 2", "Country 1"], "year": [2019, 2000]})
@@ -134,7 +136,7 @@ class TestAddPopulationToDataframe:
                 "population": [30, np.nan],
             }
         )
-        assert geo._add_population_to_dataframe(df=df_in).equals(df_out)
+        assert geo._add_population_to_dataframe(df=df_in, tb_population=mock_population).equals(df_out)
 
     def test_change_country_and_year_column_names(self):
         df_in = pd.DataFrame({"Country": ["Country 2", "Country 1"], "Year": [2019, 2021]})
@@ -145,7 +147,9 @@ class TestAddPopulationToDataframe:
                 "population": [30, 20],
             }
         )
-        assert geo._add_population_to_dataframe(df=df_in, country_col="Country", year_col="Year").equals(df_out)
+        assert geo._add_population_to_dataframe(
+            df=df_in, tb_population=mock_population, country_col="Country", year_col="Year"
+        ).equals(df_out)
 
     def test_warn_if_countries_missing(self):
         df_in = pd.DataFrame({"country": ["Country_04", "Country_04"], "year": [2000, 2000]})
@@ -157,7 +161,9 @@ class TestAddPopulationToDataframe:
             }
         )
         with warns(UserWarning):
-            geo._add_population_to_dataframe(df=df_in, warn_on_missing_countries=True).equals(df_out)
+            geo._add_population_to_dataframe(
+                df=df_in, tb_population=mock_population, warn_on_missing_countries=True
+            ).equals(df_out)
 
 
 @patch("builtins.open", new=mock_opens)

--- a/tests/data_helpers/test_geo.py
+++ b/tests/data_helpers/test_geo.py
@@ -68,7 +68,6 @@ def mock_population_load(*args, **kwargs):
     return mock_population
 
 
-@patch.object(geo, "_load_population", mock_population_load)
 class TestAddPopulationToDataframe:
     def test_all_countries_and_years_in_population(self):
         df_in = pd.DataFrame({"country": ["Country 2", "Country 1"], "year": [2019, 2021]})


### PR DESCRIPTION
We've recently deprecated `key_indicators` dataset, but the function `_load_population` was still using them. I removed it and updated `geo.*` functions accordingly. (Some steps were breaking our nightly build)