### PR TITLE
:bug: step named wrongly in archive dag

### DIFF
--- a/dag/archive/health.yml
+++ b/dag/archive/health.yml
@@ -248,9 +248,9 @@ steps:
 
   # Guinea Worm Eradication Program
   data://grapher/who/2023-06-30/guinea_worm:
-    - data://garden/who/2023-06-29/guinea_worm
+    - data://garden/who/2023-06-29/guinea_worm_certification
 
-    # Polio vaccine schedule - to archive
+  # Polio vaccine schedule - to archive
   data://meadow/who/2024-04-22/polio_vaccine_schedule:
     - snapshot://who/2024-04-22/polio_vaccine_schedule.xlsx
   data://garden/who/2024-04-22/polio_vaccine_schedule:


### PR DESCRIPTION
renamed a step in previous PR and did not use new name in the (archive) dag:

`data://garden/who/2023-06-29/guinea_worm -> data://garden/who/2023-06-29/guinea_worm_certification`