### PR TITLE
🔨 Refactor url_persist

### DIFF
--- a/apps/wizard/app_pages/anomalist/app.py
+++ b/apps/wizard/app_pages/anomalist/app.py
@@ -133,11 +133,13 @@ st.session_state.anomalist_trigger_detection = st.session_state.get("anomalist_t
 # Only anomalies with scores above the following thresholds will be shown by default.
 # NOTE: For some reason, streamlit raises an error when the minimum is zero.
 #  To avoid this, set it to a positive number (above, e.g. 1e-9).
-st.session_state.anomalist_min_anomaly_score = st.session_state.get("anomalist_min_anomaly_score", 0.3)
-st.session_state.anomalist_min_weighted_score = st.session_state.get("anomalist_min_weighted_score", 0.1)
-st.session_state.anomalist_min_population_score = st.session_state.get("anomalist_min_population_score", 1e-9)
-st.session_state.anomalist_min_analytics_score = st.session_state.get("anomalist_min_analytics_score", 1e-9)
-st.session_state.anomalist_min_scale_score = st.session_state.get("anomalist_min_scale_score", 1e-9)
+DEFAULT_ANOMALIST_WEIGHTS = {
+    "anomalist_min_anomaly_score": 0.3,
+    "anomalist_min_weighted_score": 0.1,
+    "anomalist_min_population_score": 1e-9,
+    "anomalist_min_analytics_score": 1e-9,
+    "anomalist_min_scale_score": 1e-9,
+}
 
 # Advanced expander.
 st.session_state.anomalist_expander_advanced_options = st.session_state.get(
@@ -788,6 +790,7 @@ if st.session_state.anomalist_df is not None:
                     max_value=1.0,
                     # step=0.001,
                     key=f"anomalist_min_{score_name}_score",
+                    value=DEFAULT_ANOMALIST_WEIGHTS[f"anomalist_min_{score_name}_score"],
                 )
 
     # 4.3/ APPLY FILTERS

--- a/apps/wizard/app_pages/similar_charts/app.py
+++ b/apps/wizard/app_pages/similar_charts/app.py
@@ -119,9 +119,10 @@ with col2:
         random_chart = st.button("Random chart", help="Get a random chart.")
 
         # Filter indicators
-        diversity_gpt = url_persist(st.checkbox, default=True)(
+        diversity_gpt = url_persist(st.checkbox)(
             "Diversity with GPT",
             key="diversity_gpt",
+            value=True,
             help="Use GPT to select 5 most diverse charts from the top 30 similar charts.",
         )
 
@@ -150,9 +151,10 @@ with col2:
     # Weights for each score
     with st.expander("Advanced options", expanded=st.session_state.sim_charts_expander_advanced_options):
         # Add text area for system prompt
-        system_prompt = url_persist(st.text_area, default=scoring.DEFAULT_SYSTEM_PROMPT)(
+        system_prompt = url_persist(st.text_area)(
             "GPT prompt for selecting diverse results",
             key="gpt_system_prompt",
+            value=scoring.DEFAULT_SYSTEM_PROMPT,
             height=150,
         )
 
@@ -165,12 +167,13 @@ with col2:
             if key not in st.session_state:
                 st.session_state[key] = scoring.DEFAULT_WEIGHTS[score_name]
 
-            url_persist(st.slider, default=scoring.DEFAULT_WEIGHTS[score_name])(
+            url_persist(st.slider)(
                 f"Weight for {score_name} score",
                 min_value=1e-9,
                 max_value=1.0,
                 # step=0.001,
                 key=key,
+                value=scoring.DEFAULT_WEIGHTS[score_name],
             )
 
             scoring_model.weights[score_name] = st.session_state[key]

--- a/apps/wizard/utils/components.py
+++ b/apps/wizard/utils/components.py
@@ -408,7 +408,7 @@ def st_toast_success(message: str) -> None:
 def update_query_params(key):
     def _update_query_params():
         value = st.session_state[key]
-        if value:
+        if value is not None:
             st.query_params.update({key: value})
         else:
             st.query_params.pop(key, None)
@@ -416,12 +416,16 @@ def update_query_params(key):
     return _update_query_params
 
 
-def url_persist(component: Any, default: Any = None) -> Any:
+def remove_query_params(key):
+    st.query_params.pop(key, None)
+
+
+def url_persist(component: Any) -> Any:
     """Wrapper around streamlit components that persist values in the URL query string.
+    If value is equal to default value, it will not be added to the query string.
+    This is useful to avoid cluttering the URL with default values.
 
     :param component: Streamlit component to wrap
-    :param default: Default value. If value is equal to default value, it will not be added to the query string.
-        This is useful to avoid cluttering the URL with default values.
 
     Usage:
         url_persist(st.multiselect)(
@@ -429,16 +433,6 @@ def url_persist(component: Any, default: Any = None) -> Any:
           ...
         )
     """
-    # Component uses list of values
-    if component == st.multiselect:
-        repeated = True
-    else:
-        repeated = False
-
-    if component == st.checkbox:
-        convert_to_bool = True
-    else:
-        convert_to_bool = False
 
     def _persist(*args, **kwargs):
         assert "key" in kwargs, "key should be passed to persist"
@@ -447,13 +441,16 @@ def url_persist(component: Any, default: Any = None) -> Any:
 
         key = kwargs["key"]
 
-        # Set default value
-        if default is not None and key not in st.query_params:
-            st.session_state[key] = default
+        # Get default from `value` field
+        default = kwargs.pop("value", None)
 
-        if not st.session_state.get(key):
-            # Obtain params from query string
-            params = _get_params(repeated, convert_to_bool, key, kwargs)
+        # If parameter is in session state, set it to the value in the query string
+        if st.session_state.get(key) is None:
+            if key in st.query_params:
+                # Obtain params from query string
+                params = _get_params(component, key)
+            else:
+                params = default
 
             # Store params in session state
             st.session_state[key] = params
@@ -464,8 +461,10 @@ def url_persist(component: Any, default: Any = None) -> Any:
 
         else:
             # Set the value in query params, but only if it isn't default
-            if default is None or st.session_state[key] != default:
+            if default is None or st.session_state.get(key) != default:
                 update_query_params(key)()
+            elif st.session_state[key] == default:
+                remove_query_params(key)
 
         kwargs["on_change"] = update_query_params(key)
 
@@ -494,27 +493,23 @@ def _check_options_params(kwargs, params):
                 raise ValueError(f"Please review the URL query. Value {params} not in options {kwargs['options']}.")
 
 
-def _get_params(repeated, convert_to_bool, key, kwargs):
+def _get_params(component, key):
     """Get params from query string.
 
     Converts the params to the correct type if needed.
     """
-    if repeated:
+    if component == st.multiselect:
         params = st.query_params.get_all(key)
         # convert to int if digit
-        params = [int(q) if q.isdigit() else q for q in params]
+        return [int(q) if q.isdigit() else q for q in params]
+    elif component == st.checkbox:
+        params = st.query_params.get(key)
+        return params == "True"
     else:
         params = st.query_params.get(key)
         if params and params.isdigit():
-            params = int(params)
+            return int(params)
         elif params and params.replace(".", "", 1).isdigit():
-            params = float(params)
-
-    if convert_to_bool:
-        params = params == "True"
-
-    # Use `value` from the component as a default value if available
-    if not params and "value" in kwargs:
-        params = kwargs.pop("value")
-
-    return params
+            return float(params)
+        else:
+            return params

--- a/apps/wizard/utils/components.py
+++ b/apps/wizard/utils/components.py
@@ -453,7 +453,8 @@ def url_persist(component: Any) -> Any:
                 params = default
 
             # Store params in session state
-            st.session_state[key] = params
+            if params is not None:
+                st.session_state[key] = params
 
             # Check if the value given for an option via the URL is actually accepted!
             # Allow empty values! NOTE: Might want to re-evaluate this, and add a flag to the function, e.g. 'allow_empty'

--- a/tests/apps/wizard/utils/test_components.py
+++ b/tests/apps/wizard/utils/test_components.py
@@ -1,0 +1,155 @@
+from unittest.mock import patch
+
+import pytest
+import streamlit as st
+
+from apps.wizard.utils.components import url_persist
+
+
+@pytest.fixture
+def mock_component():
+    """A simple mock Streamlit component that returns a marker string."""
+
+    def _component(*args, **kwargs):
+        return f"mock_component called with kwargs={kwargs}"
+
+    return _component
+
+
+class MockQueryParams(dict):
+    """
+    Mocks st.query_params so that:
+      - It's dictionary-like for 'pop', 'update', direct indexing, etc.
+      - It has a 'get_all(key)' method that returns a list of values
+        (Streamlit's actual query_params has this method).
+    """
+
+    def get_all(self, key):
+        val = self.get(key)
+        if val is None:
+            # No entry for this key => return empty list
+            return []
+        elif isinstance(val, list):
+            # If it's already a list, return it
+            return val
+        else:
+            # If it's a scalar, wrap it in a list
+            return [val]
+
+
+@pytest.fixture
+def mock_query_params():
+    """
+    Returns a fresh MockQueryParams instance for each test.
+    """
+    return MockQueryParams()
+
+
+@pytest.fixture
+def mock_session_state():
+    """
+    Returns a fresh dict for simulating st.session_state.
+    """
+    return {}
+
+
+def test_url_persist_with_no_session_no_query_default_set(mock_component, mock_query_params, mock_session_state):
+    """
+    If there's NO session_state value and NO query param,
+    the session_state should get the default.
+    Because it matches the default, st.query_params stays empty.
+    """
+    with patch.object(st, "session_state", mock_session_state):
+        st.query_params = mock_query_params
+
+        wrapped = url_persist(mock_component)
+        result = wrapped(key="test_key", value="some_default")
+
+        # The component was called
+        assert "mock_component called with kwargs" in result
+        # Session state should now have the default
+        assert st.session_state["test_key"] == "some_default"
+        # Because it's the default, not stored in query_params
+        assert "test_key" not in st.query_params
+
+
+def test_url_persist_uses_query_param_if_present(mock_component, mock_query_params, mock_session_state):
+    """
+    If there's NO existing session_state but a query param exists,
+    session_state should adopt that value from the query string.
+    """
+    with patch.object(st, "session_state", mock_session_state):
+        # Put something in query_params
+        mock_query_params["test_key"] = "from_query"
+        st.query_params = mock_query_params
+
+        wrapped = url_persist(mock_component)
+        result = wrapped(key="test_key", value="my_default")
+
+        assert "mock_component called with kwargs" in result
+        # The session_state should now have picked up the value
+        assert st.session_state["test_key"] == "from_query"
+        # We haven't changed query_params, so it remains
+        assert st.query_params["test_key"] == "from_query"
+
+
+def test_url_persist_session_state_non_default_updates_query_param(
+    mock_component, mock_query_params, mock_session_state
+):
+    """
+    If session_state already has a non-default value and there's no query param,
+    we expect update_query_params(key) => st.query_params is updated with that value.
+    """
+    with patch.object(st, "session_state", mock_session_state):
+        mock_session_state["test_key"] = "existing_value"
+        st.query_params = mock_query_params
+
+        wrapped = url_persist(mock_component)
+        result = wrapped(key="test_key", value="my_default")
+
+        assert "mock_component called with kwargs" in result
+        # Session state remains whatever was set
+        assert st.session_state["test_key"] == "existing_value"
+        # Because it's different from the default, query_params should be set
+        assert st.query_params["test_key"] == "existing_value"
+
+
+def test_url_persist_session_state_equals_default_removes_query_param(
+    mock_component, mock_query_params, mock_session_state
+):
+    """
+    If session_state has the same value as the default,
+    remove_query_params(key) => st.query_params should not have that key.
+    """
+    with patch.object(st, "session_state", mock_session_state):
+        mock_session_state["test_key"] = "same_as_default"
+        st.query_params = mock_query_params
+
+        wrapped = url_persist(mock_component)
+        result = wrapped(key="test_key", value="same_as_default")
+
+        assert "mock_component called with kwargs" in result
+        # Session state hasn't changed
+        assert st.session_state["test_key"] == "same_as_default"
+        # Because it matches the default, the query param should be removed
+        assert "test_key" not in st.query_params
+
+
+def test_url_persist_invalid_option_raises_value_error(mock_component, mock_query_params, mock_session_state):
+    """
+    If the URL contains a value not in 'options',
+    a ValueError should be raised by _check_options_params.
+    """
+    with patch.object(st, "session_state", mock_session_state):
+        mock_query_params["color"] = "red"
+        st.query_params = mock_query_params
+
+        def _comp(*args, **kwargs):
+            return "mock_component with options"
+
+        wrapped = url_persist(_comp)
+
+        with pytest.raises(ValueError) as exc_info:
+            wrapped(key="color", options=["blue", "green"])
+
+        assert "not in options" in str(exc_info.value)


### PR DESCRIPTION
`url_persist` is great, but it was completely unreadable (even after modifications by Lucas). This refactors the whole thing to make it more understandable and adds some unit tests.