### PR TITLE
🐛 Use correct GRAPHER_USER_ID from env when working locally

### DIFF
--- a/apps/chart_sync/admin_api.py
+++ b/apps/chart_sync/admin_api.py
@@ -13,7 +13,7 @@ from requests.exceptions import HTTPError
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from etl.config import DEFAULT_GRAPHER_SCHEMA, GRAPHER_USER_ID, OWIDEnv
+from etl.config import DEFAULT_GRAPHER_SCHEMA, ENV_GRAPHER_USER_ID, OWIDEnv
 from etl.grapher import model as gm
 
 log = structlog.get_logger()
@@ -25,7 +25,7 @@ def is_502_error(exception):
 
 
 class AdminAPI(object):
-    def __init__(self, owid_env: OWIDEnv, grapher_user_id: Optional[int] = GRAPHER_USER_ID):
+    def __init__(self, owid_env: OWIDEnv, grapher_user_id: Optional[int] = ENV_GRAPHER_USER_ID):
         self.owid_env = owid_env
         self.session_id = create_session_id(owid_env, grapher_user_id)
 
@@ -139,8 +139,8 @@ def create_session_id(owid_env: OWIDEnv, grapher_user_id: int) -> str:
         user = session.get(gm.User, grapher_user_id)
         # User is not in a database, use GRAPHER_USER_ID from .env
         if not user:
-            user = session.get(gm.User, GRAPHER_USER_ID)
-            assert user, f"User with id {GRAPHER_USER_ID} not found in the database. Initially tried to use user with id {grapher_user_id}."
+            user = session.get(gm.User, ENV_GRAPHER_USER_ID)
+            assert user, f"User with id {ENV_GRAPHER_USER_ID} not found in the database. Initially tried to use user with id {grapher_user_id}."
         session_id = _create_user_session(session, user.email)
         session.commit()
 

--- a/apps/wizard/app_pages/indicator_upgrade/charts_update.py
+++ b/apps/wizard/app_pages/indicator_upgrade/charts_update.py
@@ -96,7 +96,7 @@ def get_affected_charts_and_preview(indicator_mapping: Dict[int, int]) -> List[g
 def push_new_charts(charts: List[gm.Chart]) -> None:
     """Updating charts in the database."""
     # Use Tailscale user if it is available, otherwise use GRAPHER_USER_ID from env
-    grapher_user_id = get_grapher_user(st.context.headers.get("X-Forwarded-For")).id
+    grapher_user_id = get_grapher_user().id
 
     # API to interact with the admin tool
     api = AdminAPI(OWID_ENV, grapher_user_id=grapher_user_id)

--- a/apps/wizard/app_pages/indicator_upgrade/charts_update.py
+++ b/apps/wizard/app_pages/indicator_upgrade/charts_update.py
@@ -11,7 +11,7 @@ from structlog import get_logger
 import etl.grapher.model as gm
 from apps.chart_sync.admin_api import AdminAPI
 from apps.wizard.utils import set_states
-from apps.wizard.utils.cached import get_grapher_user_id
+from apps.wizard.utils.cached import get_grapher_user
 from apps.wizard.utils.components import st_toast_error, st_wizard_page_link
 from apps.wizard.utils.db import WizardDB
 from etl.config import OWID_ENV
@@ -96,10 +96,7 @@ def get_affected_charts_and_preview(indicator_mapping: Dict[int, int]) -> List[g
 def push_new_charts(charts: List[gm.Chart]) -> None:
     """Updating charts in the database."""
     # Use Tailscale user if it is available, otherwise use GRAPHER_USER_ID from env
-    if "X-Forwarded-For" in st.context.headers:
-        grapher_user_id = get_grapher_user_id(st.context.headers["X-Forwarded-For"])
-    else:
-        grapher_user_id = None
+    grapher_user_id = get_grapher_user(st.context.headers.get("X-Forwarded-For")).id
 
     # API to interact with the admin tool
     api = AdminAPI(OWID_ENV, grapher_user_id=grapher_user_id)

--- a/apps/wizard/utils/cached.py
+++ b/apps/wizard/utils/cached.py
@@ -226,7 +226,7 @@ def get_grapher_user(user_ip: Optional[str]) -> gm.User:
     # Use local env variable if user_ip is not provided (when on localhost)
     if user_ip is None:
         with Session(get_engine()) as session:
-            assert ENV_GRAPHER_USER_ID, "ENV_GRAPHER_USER_ID is not set!"
+            assert ENV_GRAPHER_USER_ID, "GRAPHER_USER_ID is not set!"
             return gm.User.load_user(session, id=int(ENV_GRAPHER_USER_ID))
 
     # Get Tailscale IP-to-User mapping

--- a/etl/config.py
+++ b/etl/config.py
@@ -97,12 +97,16 @@ R2_SNAPSHOTS_PRIVATE = "owid-snapshots-private"
 R2_SNAPSHOTS_PUBLIC_READ = "https://snapshots.owid.io"
 
 # publishing to grapher's MySQL db
-GRAPHER_USER_ID = env.get("GRAPHER_USER_ID")
+GRAPHER_USER_ID = int(env["GRAPHER_USER_ID"]) if "GRAPHER_USER_ID" in env else None
 DB_NAME = env.get("DB_NAME", "grapher")
 DB_HOST = env.get("DB_HOST", "localhost")
 DB_PORT = int(env.get("DB_PORT", "3306"))
 DB_USER = env.get("DB_USER", "root")
 DB_PASS = env.get("DB_PASS", "")
+
+# save original GRAPHER_USER_ID from env for later use, because it'll be overwritten when
+# we use staging servers
+ENV_GRAPHER_USER_ID = GRAPHER_USER_ID
 
 DB_IS_PRODUCTION = DB_NAME == "live_grapher"
 
@@ -267,7 +271,7 @@ OWIDEnvType = Literal["production", "dev", "staging", "unknown"]
 class Config:
     """Configuration for OWID environment which is a subset of etl.config."""
 
-    GRAPHER_USER_ID: int | str | None
+    GRAPHER_USER_ID: int | None
     DB_USER: str
     DB_NAME: str
     DB_PASS: str

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -310,8 +310,13 @@ class User(Base):
     lastSeen: Mapped[Optional[datetime]] = mapped_column(DateTime)
 
     @classmethod
-    def load_user(cls, session: Session, github_username: str) -> Optional["User"]:
-        return session.scalars(select(cls).where(cls.githubUsername == github_username)).one_or_none()
+    def load_user(cls, session: Session, id: Optional[int] = None, github_username: Optional[str] = None) -> "User":
+        if id:
+            return session.scalars(select(cls).where(cls.id == id)).one()
+        elif github_username:
+            return session.scalars(select(cls).where(cls.githubUsername == github_username)).one()
+        else:
+            raise ValueError("Either id or github_username must be provided")
 
 
 class ChartRevisions(Base):


### PR DESCRIPTION
There was a bug when working with indicator upgrader locally that used Admin grapher user id instead of the one defined in `.env`. This was caused by overwriting `GRAPHER_USER_ID` when working on a staging server. This PR adds new variable `ENV_GRAPHER_USER_ID` that doesn't get overwritten.

In addition to that, it slightly refactors function for getting grapher user id from Tailscale IP.