### PR TITLE
✨ Switch from bugsnag to sentry

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -15,7 +15,7 @@ It doesn't work for old non-ETL datasets and older steps that don't use `create_
 
 ## Observability
 
-If env `SLACK_API_TOKEN` is set, it'll send all requests & responses to a slack channel (with highlighted warnings). There's also a bugsnag integration for error monitoring.
+If env `SLACK_API_TOKEN` is set, it'll send all requests & responses to a slack channel (with highlighted warnings). There's also a sentry integration for error monitoring.
 
 ## Instructions
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,8 +1,7 @@
-import bugsnag
 import structlog
-from bugsnag.asgi import BugsnagMiddleware
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 from api.v1 import v1
 from etl import config
@@ -11,9 +10,7 @@ from etl.slack_helpers import format_slack_message, send_slack_message
 
 log = structlog.get_logger()
 
-bugsnag.configure(
-    api_key=config.BUGSNAG_API_KEY,
-)
+config.enable_sentry()
 
 engine = get_engine()
 
@@ -30,7 +27,7 @@ def get_application():
     )
 
     _app.add_middleware(
-        BugsnagMiddleware,
+        SentryAsgiMiddleware,
     )
 
     return _app

--- a/apps/backport/backport.py
+++ b/apps/backport/backport.py
@@ -26,7 +26,7 @@ from etl.snapshot import Snapshot, SnapshotMeta
 
 from . import utils
 
-config.enable_bugsnag()
+config.enable_sentry()
 
 log = structlog.get_logger()
 

--- a/apps/backport/datasync/datasync.py
+++ b/apps/backport/datasync/datasync.py
@@ -14,7 +14,7 @@ from etl import config
 
 log = structlog.get_logger()
 
-config.enable_bugsnag()
+config.enable_sentry()
 
 
 def upload_gzip_dict(d: Dict[str, Any], s3_path: str, private: bool = False) -> None:

--- a/apps/backport/migrate/migrate.py
+++ b/apps/backport/migrate/migrate.py
@@ -17,7 +17,7 @@ from etl.files import yaml_dump
 from etl.metadata_export import metadata_export
 from etl.paths import DAG_DIR, SNAPSHOTS_DIR, STEP_DIR
 
-config.enable_bugsnag()
+config.enable_sentry()
 
 log = structlog.get_logger()
 

--- a/apps/chart_sync/cli.py
+++ b/apps/chart_sync/cli.py
@@ -18,7 +18,7 @@ from etl.datadiff import _dict_diff
 from etl.grapher import model as gm
 from etl.slack_helpers import send_slack_message
 
-config.enable_bugsnag()
+config.enable_sentry()
 
 log = structlog.get_logger()
 

--- a/apps/utils/scan_chart_diff.py
+++ b/apps/utils/scan_chart_diff.py
@@ -8,7 +8,7 @@ from structlog import get_logger
 from apps.owidbot.cli import cli as owidbot_cli
 from etl import config
 
-config.enable_bugsnag()
+config.enable_sentry()
 
 log = get_logger()
 

--- a/apps/wizard/app.py
+++ b/apps/wizard/app.py
@@ -17,6 +17,9 @@ args = utils.parse_args_from_cmd()
 if args.debug:
     PROFILER = utils.start_profiler()
 
+# Enable Sentry if SENTRY_DSN is in .env
+utils.enable_sentry_for_streamlit()
+
 ###########################################
 # DEFINE PAGES
 ###########################################

--- a/apps/wizard/app_pages/fasttrack/app.py
+++ b/apps/wizard/app_pages/fasttrack/app.py
@@ -48,8 +48,8 @@ DAG_FASTTRACK_PATH = DAG_DIR / "fasttrack.yml"
 config_style_html()
 # Logger
 log = get_logger()
-# Bugsnag
-wizard_utils.enable_bugsnag_for_streamlit()
+# Sentry
+wizard_utils.enable_sentry_for_streamlit()
 
 
 # Initialize session state

--- a/apps/wizard/app_pages/fasttrack/app.py
+++ b/apps/wizard/app_pages/fasttrack/app.py
@@ -48,8 +48,6 @@ DAG_FASTTRACK_PATH = DAG_DIR / "fasttrack.yml"
 config_style_html()
 # Logger
 log = get_logger()
-# Sentry
-wizard_utils.enable_sentry_for_streamlit()
 
 
 # Initialize session state

--- a/etl/command.py
+++ b/etl/command.py
@@ -36,7 +36,7 @@ from etl.steps import (
     select_dirty_steps,
 )
 
-config.enable_bugsnag()
+config.enable_sentry()
 
 # NOTE: I tried enabling this, but ran into weird errors with unit tests and inconsistencies
 #   with owid libraries. It's better to wait for an official pandas 3.0 release and update

--- a/etl/config.py
+++ b/etl/config.py
@@ -16,9 +16,9 @@ from os import environ as env
 from pathlib import Path
 from typing import List, Literal, Optional, cast
 
-import bugsnag
 import git
 import pandas as pd
+import sentry_sdk
 import structlog
 from dotenv import dotenv_values, load_dotenv
 from sqlalchemy.engine import Engine
@@ -224,7 +224,7 @@ ADMIN_HOST = env.get("ADMIN_HOST", f"http://staging-site-{STAGING}" if STAGING e
 # because that would resolve to LXC container instead of the actual server
 TAILSCALE_ADMIN_HOST = "http://owid-admin-prod.tail6e23.ts.net"
 
-BUGSNAG_API_KEY = env.get("BUGSNAG_API_KEY")
+SENTRY_DSN = env.get("SENTRY_DSN")
 
 OPENAI_API_KEY = env.get("OPENAI_API_KEY", None)
 
@@ -251,11 +251,11 @@ DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schem
 GOOGLE_APPLICATION_CREDENTIALS = env.get("GOOGLE_APPLICATION_CREDENTIALS")
 
 
-def enable_bugsnag() -> None:
-    if BUGSNAG_API_KEY:
-        bugsnag.configure(
-            api_key=BUGSNAG_API_KEY,
-        )  # type: ignore
+def enable_sentry() -> None:
+    if SENTRY_DSN:
+        sentry_sdk.init(
+            dsn=SENTRY_DSN,
+        )
 
 
 # Wizard config

--- a/etl/prune.py
+++ b/etl/prune.py
@@ -10,7 +10,7 @@ from owid.catalog import CHANNEL, LocalCatalog
 from etl import config, paths
 from etl.command import construct_dag
 
-config.enable_bugsnag()
+config.enable_sentry()
 
 log = structlog.get_logger()
 

--- a/etl/publish.py
+++ b/etl/publish.py
@@ -23,7 +23,7 @@ from owid.catalog.s3_utils import connect_r2
 from etl import config, files
 from etl.paths import DATA_DIR
 
-config.enable_bugsnag()
+config.enable_sentry()
 
 
 class CannotPublish(Exception):

--- a/etl/reindex.py
+++ b/etl/reindex.py
@@ -13,7 +13,7 @@ from owid.catalog import CHANNEL, LocalCatalog
 from etl import config
 from etl.paths import DATA_DIR
 
-config.enable_bugsnag()
+config.enable_sentry()
 
 
 @click.command(name="reindex")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "rich-click>=1.7.3",
     "tenacity>=8.0.1",
     "simplejson>=3.17.6",
-    "bugsnag>=4.2.1",
     "xlrd>=2.0.1",
     "PyPDF2>=2.11.1",
     "ruamel.yaml>=0.17.21",
@@ -70,6 +69,7 @@ dependencies = [
     "pyreadr>=0.5.2",
     "cfgrib>=0.9.15.0",
     "streamlit-aggrid>=1.0.5",
+    "sentry-sdk>=2.20.0",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -447,18 +447,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bugsnag"
-version = "4.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "webob" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/ee/6ce7a0a7c0b882543e3417df54b12a4fcfc94ba6997201175710b8ca3183/bugsnag-4.7.1.tar.gz", hash = "sha256:98408fe17d4a7f300a56535407a6448b9844d9b528c44527908868fc3646e873", size = 73492 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/72/ba7771ae6495a25c158e733ad3854b4ab77e3e2e445cff24c3cdf87669e8/bugsnag-4.7.1-py3-none-any.whl", hash = "sha256:4537ff3c200890d26e28079e31729c041a9ffe84a803860ea8adefe535aac7df", size = 45784 },
-]
-
-[[package]]
 name = "cachetools"
 version = "5.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -952,7 +940,6 @@ name = "etl"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "bugsnag" },
     { name = "cdsapi" },
     { name = "cfgrib" },
     { name = "click" },
@@ -997,6 +984,7 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "selenium" },
+    { name = "sentry-sdk" },
     { name = "sh" },
     { name = "shapely" },
     { name = "simplejson" },
@@ -1075,7 +1063,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bugsnag", specifier = ">=4.2.1" },
     { name = "cdsapi", specifier = ">=0.7.0" },
     { name = "cfgrib", specifier = ">=0.9.15.0" },
     { name = "click", specifier = ">=8.0.1" },
@@ -1128,6 +1115,7 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.11.2" },
     { name = "selenium", specifier = ">=4.15.1" },
     { name = "sentence-transformers", marker = "extra == 'wizard'", specifier = ">=2.2.2" },
+    { name = "sentry-sdk", specifier = ">=2.20.0" },
     { name = "sh", specifier = "==1.14.3" },
     { name = "shapely", specifier = ">=2.0.3" },
     { name = "simplejson", specifier = ">=3.17.6" },
@@ -5530,6 +5518,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/e8/6a366c0cd5e129dda6ecb20ff097f70b18182c248d4c27e813c21f98992a/sentry_sdk-2.20.0.tar.gz", hash = "sha256:afa82713a92facf847df3c6f63cec71eb488d826a50965def3d7722aa6f0fdab", size = 300125 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/0f/6f7e6cd0f4a141752caef3f79300148422fdf2b8b68b531f30b2b0c0cbda/sentry_sdk-2.20.0-py2.py3-none-any.whl", hash = "sha256:c359a1edf950eb5e80cffd7d9111f3dbeef57994cb4415df37d39fda2cf22364", size = 322576 },
+]
+
+[[package]]
 name = "setuptools"
 version = "75.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6767,15 +6768,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774 },
-]
-
-[[package]]
-name = "webob"
-version = "1.8.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/0b/1732085540b01f65e4e7999e15864fe14cd18b12a95731a43fd6fd11b26a/webob-1.8.9.tar.gz", hash = "sha256:ad6078e2edb6766d1334ec3dee072ac6a7f95b1e32ce10def8ff7f0f02d56589", size = 279775 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/bd/c336448be43d40be28e71f2e0f3caf7ccb28e2755c58f4c02c065bfe3e8e/WebOb-1.8.9-py2.py3-none-any.whl", hash = "sha256:45e34c58ed0c7e2ecd238ffd34432487ff13d9ad459ddfd77895e67abba7c1f9", size = 115364 },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements https://github.com/owid/etl/issues/3881

- Switch from Bugsnag to Sentry
- Fix function `enable_sentry_for_streamlit` that's forwarding exceptions from streamlit to Sentry
- Run `enable_sentry_for_streamlit` when importing `apps.wizard.utils` to enable it for all our apps (running it in utils module looks fishy, but I couldn't find a better way. It doesn't work when run from `apps/wizard/app.py`)