### PR TITLE
🐛 Fix inconsistency between MySQL and JSONs in R2

### DIFF
--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -19,7 +19,6 @@ You might have to run `uv pip install mysqlclient` to install missing MySQLDb.
 import copy
 import io
 import json
-import random
 from datetime import date, datetime, timezone
 from enum import Enum
 from pathlib import Path


### PR DESCRIPTION
Fixes https://github.com/owid/etl/issues/3902

It removes hacky logic when upserting variables. Now it uses only `catalogPath` which should simplify things and prevent bugs like [this](https://github.com/owid/etl/issues/3902).