### PR TITLE
📊 energy: Alternative energy prices page using a different deflator

### DIFF
--- a/etl/steps/data/garden/eurostat/2025-02-03/gas_and_electricity_prices.py
+++ b/etl/steps/data/garden/eurostat/2025-02-03/gas_and_electricity_prices.py
@@ -877,7 +877,11 @@ def run(dest_dir: str) -> None:
     # As recommended by Eurostat, we will use only the following:
     # [TOT_X_NRG] Overall index excluding energy
     # Excluding the energy component helps in depicting the prices adjusted for the underlying inflationary trends, without being distorted by the volatility typically associated with energy commodities. In this respect, adjusted prices will include the impact of the energy cost changes.
-    tb_hicp = tb_hicp[tb_hicp["coicop"] == "TOT_X_NRG"].reset_index(drop=True)
+    ####################################################################################################################
+    # TODO: This is a temporary test. We will use the general HICP instead of the one excluding energy, to compare.
+    # tb_hicp = tb_hicp[tb_hicp["coicop"] == "TOT_X_NRG"].reset_index(drop=True)
+    tb_hicp = tb_hicp[tb_hicp["coicop"] == "CP00"].reset_index(drop=True)
+    ####################################################################################################################
 
     # Calculate average HICP for each country and year.
     tb_hicp["year"] = tb_hicp["date"].str[0:4].astype(int)


### PR DESCRIPTION
[We decided](https://owid.slack.com/archives/C03NA1B2P1U/p1738837436873989?thread_ts=1738255112.881299&cid=C03NA1B2P1U) to follow the original approach (https://github.com/owid/etl/pull/3919) of deflating with HICP (excluding energy). So we can close this without merging.
