### PR TITLE
🐛 child mortality anomalies

### DIFF
--- a/etl/steps/data/garden/un/2024-09-11/igme.py
+++ b/etl/steps/data/garden/un/2024-09-11/igme.py
@@ -48,10 +48,13 @@ def run(dest_dir: str) -> None:
     tb = filter_data(tb)
     tb = round_down_year(tb)
 
-    # add regional data for count variables
-    tb = add_regional_totals_for_counts(tb, ds_regions)
-    # add regional population weighted averages for rate variables
-    tb = add_population_weighted_regional_averages_for_rates(tb, ds_population, ds_regions)
+    # get regional data for count variables
+    tb_counts_regions = regional_aggregates_counts(tb, ds_regions, ds_population, threshold=0.8)
+    # get regional population weighted averages for rate variables
+    tb_rates_regions = population_weighted_regional_averages(tb, ds_population, ds_regions, threshold=0.8)
+
+    # Adding regional aggregates to table
+    tb = pr.concat([tb, tb_counts_regions, tb_rates_regions])
 
     # Removing commas from the unit of measure
     tb["unit_of_measure"] = tb["unit_of_measure"].str.replace(",", "", regex=False)
@@ -94,80 +97,92 @@ def run(dest_dir: str) -> None:
     ds_garden.save()
 
 
-def add_regional_totals_for_counts(tb: Table, ds_regions: Dataset) -> Table:
-    """
-    Adding regional sums for variables that are counts
-    """
+def regional_aggregates_counts(tb: Table, ds_regions: Dataset, ds_population: Dataset, threshold: float = 0.8) -> Table:
+    """Adds regional aggregates for count variables. Only includes year and regions where enough countries have data such that the population coverage is above the threshold.
+    Returns: Table with regional aggregates for count variables. ONLY includes regions"""
+
     tb_counts = tb[tb["unit_of_measure"] == "Number of deaths"]
 
-    tb_all_regions = Table()
-    for region in REGIONS:
-        regions = geo.list_members_of_region(region=region, ds_regions=ds_regions)
-        tb_region = tb_counts[tb_counts["country"].isin(regions)]
-        tb_region = (
-            tb_region.groupby(["year", "indicator", "sex", "wealth_quintile"])[
-                ["obs_value", "lower_bound", "upper_bound"]
-            ]
-            .sum()
-            .reset_index()
-        )
-        tb_region["country"] = region
-        tb_region["unit_of_measure"] = "Number of deaths"
-        tb_all_regions = pr.concat([tb_all_regions, tb_region])
+    tb_counts = geo.add_population_to_table(tb_counts, ds_population)
+    tb_counts = tb_counts.dropna(subset=["population"])
 
-    tb = pr.concat([tb, tb_all_regions])
+    # add regions to table (summing obs_value, lower_bound and upper_bound and population)
+    tb_counts = geo.add_regions_to_table(
+        tb_counts,
+        ds_regions,
+        index_columns=["country", "year", "indicator", "sex", "unit_of_measure", "wealth_quintile"],
+    )
 
-    return tb
+    # filtering only on regions
+    tb_counts = tb_counts[tb_counts["country"].isin(REGIONS)]
+
+    # renaming population column and adding total population (for regions)
+    tb_counts = tb_counts.rename(columns={"population": "population_covered"})
+    tb_counts = geo.add_population_to_table(tb_counts, ds_population, population_col="total_population")
+
+    # calculating share of population covered and filtering on years above threshold
+    tb_counts["share_of_population"] = tb_counts["population_covered"] / tb_counts["total_population"]
+    tb_counts = tb_counts[tb_counts["share_of_population"] >= threshold]
+
+    tb_counts = tb_counts.drop(columns=["population_covered", "total_population", "share_of_population"])
+
+    return tb_counts
 
 
 def population_weighted_regional_averages(
     tb: Table, ds_population: Dataset, ds_regions: Dataset, threshold: float = 0.8
 ) -> Table:
-    """Adds population-weighted averages of death rates for the regions. Only includes year and regions where enough countries have data such that the population coverage is above the threshold."""
-    tb_full = tb.copy(deep=True)
+    """Adds population-weighted averages of death rates for the regions. Only includes year and regions where enough countries have data such that the population coverage is above the threshold.
+    Returns: Table with population-weighted averages of death rates for the regions. ONLY includes regions"""
 
-    tb = tb[tb["unit_of_measure"] != "Number of deaths"]
+    tb_rates = tb[tb["unit_of_measure"] != "Number of deaths"]
 
     # adding population to the table and dropping rows with missing population
-    tb = geo.add_population_to_table(tb, ds_population)
-    tb = tb.dropna(subset=["population"])
+    tb_rates = geo.add_population_to_table(tb_rates, ds_population)
+    tb_rates = tb_rates.dropna(subset=["population"])
 
     # calculating column for population weighted death rates
-    tb["obs_value_pop"] = tb["obs_value"] * tb["population"]
-    tb = tb.drop(columns=["lower_bound", "upper_bound"])
+    tb_rates["obs_value_pop"] = tb_rates["obs_value"] * tb_rates["population"]
+    tb_rates["lower_bound_pop"] = tb_rates["lower_bound"] * tb_rates["population"]
+    tb_rates["upper_bound_pop"] = tb_rates["upper_bound"] * tb_rates["population"]
+    tb_rates = tb_rates.drop(columns=["lower_bound", "upper_bound", "obs_value"])
 
     # adding regions to the table (summing obs_value_pop, obs_value and population)
-    tb = geo.add_regions_to_table(
-        tb, ds_regions, index_columns=["country", "year", "indicator", "sex", "unit_of_measure", "wealth_quintile"]
+    tb_rates = geo.add_regions_to_table(
+        tb_rates,
+        ds_regions,
+        index_columns=["country", "year", "indicator", "sex", "unit_of_measure", "wealth_quintile"],
     )
+
+    # filtering only on regions
+    tb_rates = tb_rates[tb_rates["country"].isin(REGIONS)]
 
     # renaming population column and adding total population (for regions)
-    tb = tb.rename(columns={"population": "population_covered"})
-    tb = geo.add_population_to_table(tb, ds_population, population_col="total_population")
+    tb_rates = tb_rates.rename(columns={"population": "population_covered"})
+    tb_rates = geo.add_population_to_table(tb_rates, ds_population, population_col="total_population")
 
     # calculating population weighted death rates & share of population covered
-    tb["obs_value_rates"] = tb["obs_value_pop"] / tb["population_covered"]
-    tb["share_of_population"] = tb["population_covered"] / tb["total_population"]
+    tb_rates["obs_value"] = tb_rates["obs_value_pop"] / tb_rates["population_covered"]
+    tb_rates["lower_bound"] = tb_rates["lower_bound_pop"] / tb_rates["population_covered"]
+    tb_rates["upper_bound"] = tb_rates["upper_bound_pop"] / tb_rates["population_covered"]
+    tb_rates["share_of_population"] = tb_rates["population_covered"] / tb_rates["total_population"]
 
     # filtering out regions where the share of population covered is below the threshold
-    tb = tb[tb["share_of_population"] >= threshold]
+    tb_rates = tb_rates[tb_rates["share_of_population"] >= threshold]
 
     # dropping unnecessary columns
-    tb = tb.drop(
-        columns=["obs_value", "obs_value_pop", "population_covered", "total_population", "share_of_population"]
+    tb_rates = tb_rates.drop(
+        columns=[
+            "obs_value_pop",
+            "lower_bound_pop",
+            "upper_bound_pop",
+            "population_covered",
+            "total_population",
+            "share_of_population",
+        ]
     )
 
-    # merging the full table to restore upper and lower bound and obs_value for countries
-    tb = pr.merge(
-        tb, tb_full, on=["country", "year", "indicator", "sex", "unit_of_measure", "wealth_quintile"], how="outer"
-    )
-
-    # filling in missing values (=regions) with the population weighted rates
-    tb["obs_value"] = tb["obs_value"].fillna(tb["obs_value_rates"])
-
-    tb = tb.drop(columns=["obs_value_rates"])
-
-    return tb
+    return tb_rates
 
 
 def convert_to_percentage(tb: Table) -> Table:

--- a/etl/steps/data/garden/un/2024-09-16/long_run_child_mortality.py
+++ b/etl/steps/data/garden/un/2024-09-16/long_run_child_mortality.py
@@ -60,12 +60,6 @@ def run(dest_dir: str) -> None:
     # Combine with full Gapminder dataset
     tb_combined_full = pr.merge(tb_combined_full, tb_surviving, on=["country", "year"], how="left")
 
-    # filter out regions < 1950 temporarily
-    tb_combined_full = tb_combined_full[
-        (tb_combined_full["year"] >= 1950) | (~tb_combined_full["country"].isin(REGIONS))
-    ]
-    tb_combined_sel = tb_combined_sel[(tb_combined_sel["year"] >= 1950) | (~tb_combined_sel["country"].isin(REGIONS))]
-
     # Save outputs.
     tb_combined_full = tb_combined_full.drop(columns=["source"]).format(["country", "year"])
     tb_combined_sel = tb_combined_sel.drop(columns=["source"]).format(["country", "year"])


### PR DESCRIPTION
Fix for [this issue](https://owid.slack.com/archives/C03NV9Z3YSV/p1738774206362549), where regional aggregates for child mortality rates fluctuate strongly. This is caused by new countries being added to regional aggregates over time, influencing the overall rate.

I have now changed the regional aggregates to only be calculated if data was available for >80% of the population. This smoothes out the lines and removes most data before ca 1965 (different for different regions).

There are two charts I had issues with:
- [Life satisfaction vs. child mortality](http://staging-site-bug-child-mortality-anomalie/admin/charts/250/edit) - For some reason the Cantril ladder score does not pull the latest year into the scatter plot (it is stuck on 2015). I assume it has something to do with [this bug](https://owid.slack.com/archives/C46U9LXRR/p1739242868670479) - I am happy to leave it for now and would try to update it once the bug is resolved. 
- [Child mortality in the past vs. today](http://staging-site-bug-child-mortality-anomalie/admin/charts/867/edit) - This is a draft chart without any entities selected and the same data as in other available line charts. I would delete it. 