### PR TITLE
🐛 fix entities in GHO

### DIFF
--- a/etl/steps/data/garden/who/2024-01-03/gho.countries.json
+++ b/etl/steps/data/garden/who/2024-01-03/gho.countries.json
@@ -241,5 +241,6 @@
   "Tokelau": "Tokelau",
   "Turks and Caicos Islands": "Turks and Caicos Islands",
   "USA": "United States",
-  "World": "World"
+  "World": "World",
+  "GlobalGlobal": "World"
 }

--- a/etl/steps/data/garden/who/2024-01-03/gho.excluded_countries.json
+++ b/etl/steps/data/garden/who/2024-01-03/gho.excluded_countries.json
@@ -10,7 +10,6 @@
   "Asia (142)",
   "Least Developed Countries (LDCs)",
   "Northern America (21)",
-  "GlobalGlobal",
   "Europe (150)",
   "Small Island developing States (SIDS)",
   "Small island developing States (SIDS)",

--- a/etl/steps/data/garden/who/2024-01-03/gho.excluded_countries.json
+++ b/etl/steps/data/garden/who/2024-01-03/gho.excluded_countries.json
@@ -10,7 +10,6 @@
   "Asia (142)",
   "Least Developed Countries (LDCs)",
   "Northern America (21)",
-  "Northern America",
   "GlobalGlobal",
   "Europe (150)",
   "Small Island developing States (SIDS)",

--- a/etl/steps/data/garden/who/2024-01-03/gho.excluded_countries.json
+++ b/etl/steps/data/garden/who/2024-01-03/gho.excluded_countries.json
@@ -1,7 +1,19 @@
 [
-    "Africa (2) (UN)",
-    "Americas (UN)",
-    "Asia (142) (UN)",
-    "Europe (150) (UN)",
-    "Oceania (9) (UN)"
+  "Africa (2) (UN)",
+  "Americas (UN)",
+  "Asia (142) (UN)",
+  "Europe (150) (UN)",
+  "Oceania (9) (UN)",
+  "Africa (2) (UN)",
+  "Asia (142) (UN)",
+  "Africa (2)",
+  "Asia (142)",
+  "Least Developed Countries (LDCs)",
+  "Northern America (21)",
+  "Northern America",
+  "GlobalGlobal",
+  "Europe (150)",
+  "Small Island developing States (SIDS)",
+  "Small island developing States (SIDS)",
+  "Landlocked developing countries (LLDCs)"
 ]

--- a/etl/steps/data/garden/who/2024-01-03/gho.py
+++ b/etl/steps/data/garden/who/2024-01-03/gho.py
@@ -205,13 +205,24 @@ def check_overlapping_names(tb: Table) -> None:
         raise ValueError(f"index names are overlapping with column names: {overlapping_names}")
 
 
-def drop_excess_region_sources(tb: Table, priority_regions: list[str]) -> Table:
-    """Drop specific region sources if there are more than two different sources for a given indicator, in the order of preference given below"""
-    if tb["region_source"].nunique() > 2:
+def drop_excess_region_sources(tb: pd.DataFrame, priority_regions: list[str]) -> pd.DataFrame:
+    """
+    Drop specific region sources if there are more than two different sources for a given indicator,
+    in the order of preference given in `priority_regions`.
+    Keep rows where `region_source` is NaN.
+    """
+    if tb["region_source"].nunique(dropna=True) > 2:  # Only count non-NaN values
         unique_sources = tb["region_source"].dropna().unique().tolist()
+
+        # Sort sources based on priority list
         unique_sources.sort(key=lambda x: priority_regions.index(x) if x in priority_regions else float("inf"))
+
+        # Keep only the top 2 priority sources
         sources_to_keep = unique_sources[:2]
-        tb = tb[tb["region_source"].isin(sources_to_keep)]
+
+        # Filter the DataFrame but KEEP NaN values
+        tb = tb[tb["region_source"].isin(sources_to_keep) | tb["region_source"].isna()]
+
     return tb
 
 


### PR DESCRIPTION
Some odd-looking entities were still being included in the data, so just removing those. 

We also had cases where regions from five different sources were being used, so now we just take the top two of ["World Bank", "WHO", "UNICEF", "UN", "UN SDG"], if there are more than two sources of regions being provided for a particular indicator.