### PR TITLE
🎉 Let export steps execute implicit grapher://grapher steps

### DIFF
--- a/dag/health.yml
+++ b/dag/health.yml
@@ -668,8 +668,8 @@ steps:
     - data://garden/health/2024-08-23/eurostat_cancer
 
   # Multi-dim indicators
-  export://multidim/health/latest/causes_of_death:
-    - grapher://grapher/ihme_gbd/2024-05-20/gbd_cause
+  # export://multidim/health/latest/causes_of_death:
+  #   - grapher://grapher/ihme_gbd/2024-05-20/gbd_cause
 
   # GBD 2021 - GBD Risk Factors cancer specific
   data-private://meadow/ihme_gbd/2024-08-26/gbd_risk_cancer:

--- a/etl/command.py
+++ b/etl/command.py
@@ -300,7 +300,12 @@ def construct_dag(dag_path: Path, private: bool, grapher: bool, export: bool) ->
                 # to ensure that any indicators required by the mdim step are already pushed to DB.
                 # To achieve that, replace "data://grapher" dependencies with "grapher://grapher".
                 # NOTE: If any dependency of the export step is a data-private://grapher step, it will need to be run with the "--private" flag, otherwise the export step may fail.
-                dag[step] = [re.sub(r"^(data|data-private)://", "grapher://", dep) if re.match(r"^data://grapher/", dep) or re.match(r"^data-private://grapher/", dep) else dep for dep in dag[step]]
+                dag[step] = [
+                    re.sub(r"^(data|data-private)://", "grapher://", dep)
+                    if re.match(r"^data://grapher/", dep) or re.match(r"^data-private://grapher/", dep)
+                    else dep
+                    for dep in dag[step]
+                ]
 
         # Finally, ensure that the added grapher://grapher steps will be executed,
         # by activating the "grapher" flag.


### PR DESCRIPTION
Let the `--export` flag execute the corresponding `grapher://grapher` steps to all `data://grapher` dependencies. This allow us to remove `grapher://grapher` dependencies, and instead have the corresponding `data://grapher` ones.

NOTE: I'm not totally sure if this will work with mdims that depend on private steps (like `export://multidim/health/latest/causes_of_death`). For now, I omitted it from the dag.
