### PR TITLE
🔨 Refactor causes of death mdim and remove expand_views_with_access_db

### DIFF
--- a/dag/health.yml
+++ b/dag/health.yml
@@ -668,8 +668,8 @@ steps:
     - data://garden/health/2024-08-23/eurostat_cancer
 
   # Multi-dim indicators
-  # export://multidim/health/latest/causes_of_death:
-  #   - data-private://grapher/ihme_gbd/2024-05-20/gbd_cause
+  export://multidim/health/latest/causes_of_death:
+    - data-private://grapher/ihme_gbd/2024-05-20/gbd_cause
 
   # GBD 2021 - GBD Risk Factors cancer specific
   data-private://meadow/ihme_gbd/2024-08-26/gbd_risk_cancer:

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -587,7 +587,7 @@ class PathFinder:
         elif channel == "walden":
             step_name = f"{channel}{is_private_suffix}://{namespace}/{version}/{short_name}"
         elif channel is None:
-            step_name = rf"(?:snapshot{is_private_suffix}:/|walden{is_private_suffix}:/|data{is_private_suffix}://meadow|data{is_private_suffix}://garden|data://grapher|data://explorers)/{namespace}/{version}/{short_name}$"
+            step_name = rf"(?:snapshot{is_private_suffix}:/|walden{is_private_suffix}:/|data{is_private_suffix}://meadow|data{is_private_suffix}://garden|data{is_private_suffix}://grapher|data://explorers)/{namespace}/{version}/{short_name}$"
         else:
             raise UnknownChannel
 

--- a/etl/multidim.py
+++ b/etl/multidim.py
@@ -1,4 +1,3 @@
-import json
 import re
 from copy import deepcopy
 from itertools import product
@@ -6,7 +5,6 @@ from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 import yaml
-from deprecated import deprecated
 from owid.catalog import Dataset, Table
 from sqlalchemy.engine import Engine
 from structlog import get_logger
@@ -24,7 +22,7 @@ log = get_logger()
 DIMENSIONS = ["y", "x", "size", "color"]
 
 
-def upsert_multidim_data_page(slug: str, config: dict, engine: Engine, dependencies: list[str] = []) -> None:
+def upsert_multidim_data_page(slug: str, config: dict, engine: Engine, dependencies: set[str] = set()) -> None:
     """
     :param dependencies: List of dependencies for mdim. In most cases just use `dependencies=paths.dependencies`.
 
@@ -48,7 +46,7 @@ def upsert_multidim_data_page(slug: str, config: dict, engine: Engine, dependenc
     admin_api.put_mdim_config(slug, config)
 
 
-def expand_catalog_paths(config: dict, dependencies: list[str]) -> None:
+def expand_catalog_paths(config: dict, dependencies: set[str]) -> None:
     """Expand catalog paths in views to full dataset URIs.
 
     This function updates the given configuration dictionary in-place by modifying the dimension ('y', 'x', 'size', 'color') entries under "indicators" in each view. If an entry does not contain a '/',
@@ -255,88 +253,6 @@ def replace_catalog_paths_with_ids(config):
                         )
 
     return config
-
-
-@deprecated(
-    "This function relies on DB-access. Instead we should rely only on ETL local files. Use `expand_config` instead."
-)
-def expand_views_with_access_db(config: dict, combinations: dict[str, str], table: str, engine: Engine) -> list[dict]:
-    """Use dimensions from multidim config file and create views from all possible
-    combinations of dimensions. Grapher table must use the same dimensions as the
-    multidim config file. If the dimension is missing from groupby, it will be set to "all".
-
-    :params config: multidim config file
-    :params combinations: dictionary with dimension names as keys and values as dimension values, use * for all values
-        e.g. {"metric": "*", "age": "*", "cause": "All causes"}
-    :params table: catalog path of the grapher table
-    :params engine: SQLAlchemy engine
-    """
-
-    # Get all allowed values from choices
-    choices = {}
-    for choice_dict in config["dimensions"]:
-        allowed_values = []
-        for choice in choice_dict["choices"]:
-            allowed_values.append(choice["name"])
-        choices[choice_dict["slug"]] = allowed_values
-
-    df = fetch_variables_from_table(table, engine)
-
-    # Filter by allowed values
-    for dim_name, allowed_values in choices.items():
-        df = df[df[dim_name].isin(allowed_values)]
-
-    groupby = [k for k, v in combinations.items() if v == "*"]
-
-    views = []
-    for key, group in df.groupby(groupby):
-        dims = {dim_name: dim_value for dim_name, dim_value in zip(groupby, key)}
-
-        # Add values that are not * to dimensions
-        for k, v in combinations.items():
-            if v != "*":
-                dims[k] = v
-
-        # Create view with catalog paths
-        catalog_paths = group["catalogPath"].tolist()
-        views.append(
-            {
-                "dimensions": dims,
-                "indicators": {
-                    "y": catalog_paths if len(catalog_paths) > 1 else catalog_paths[0],
-                },
-            }
-        )
-
-    return views
-
-
-def fetch_variables_from_table(table: str, engine: Engine) -> pd.DataFrame:
-    # fetch variables from MySQL
-    q = f"""
-    select
-        id,
-        catalogPath,
-        dimensions
-    from variables
-    where catalogPath like '{table}%%'
-    """
-    df = read_sql(q, engine)
-
-    if df.empty:
-        raise ValueError(f"No data found for table {table}")
-
-    # add dimensions as columns
-    dims = []
-    for r in df.itertuples():
-        d = {}
-        for dim_filter in json.loads(r.dimensions)["filters"]:  # type: ignore
-            d[dim_filter["name"]] = dim_filter["value"]
-        dims.append(d)
-
-    df_dims = pd.DataFrame(dims, index=df.index)
-
-    return df.join(df_dims)
 
 
 def generate_views_for_dimensions(

--- a/etl/multidim.py
+++ b/etl/multidim.py
@@ -791,3 +791,26 @@ def _check_intersection_iters(
         raise ValueError(
             f"Unexpected items: {', '.join([f'`{d}`' for d in items_unexpected])}. Please review `{key_name}`!"
         )
+
+
+def group_views(views: dict[str, Any], by: list[str]) -> list[dict[str, Any]]:
+    """
+    Group views by the specified dimensions. Concatenate indicators for the same group.
+    """
+    views = deepcopy(views)
+
+    grouped_views = {}
+    for view in views:
+        # Group key
+        key = tuple(view["dimensions"][dim] for dim in by)  # type: ignore
+
+        if key not in grouped_views:
+            # Turn indicators into a list
+            view["indicators"]["y"] = [view["indicators"]["y"]]  # type: ignore
+
+            # Add to dictionary
+            grouped_views[key] = view
+        else:
+            grouped_views[key]["indicators"]["y"].append(view["indicators"]["y"])  # type: ignore
+
+    return list(grouped_views.values())

--- a/etl/multidim.py
+++ b/etl/multidim.py
@@ -793,24 +793,34 @@ def _check_intersection_iters(
         )
 
 
-def group_views(views: dict[str, Any], by: list[str]) -> list[dict[str, Any]]:
+def group_views(views: list[dict[str, Any]], by: list[str]) -> list[dict[str, Any]]:
     """
     Group views by the specified dimensions. Concatenate indicators for the same group.
+
+    :param views: List of views dictionaries.
+    :param by: List of dimensions to group by.
     """
     views = deepcopy(views)
 
     grouped_views = {}
     for view in views:
         # Group key
-        key = tuple(view["dimensions"][dim] for dim in by)  # type: ignore
+        key = tuple(view["dimensions"][dim] for dim in by)
 
         if key not in grouped_views:
-            # Turn indicators into a list
-            view["indicators"]["y"] = [view["indicators"]["y"]]  # type: ignore
+            # Ensure 'y' is a single indicator before turning it into a list
+            assert not isinstance(view["indicators"]["y"], list), "Expected 'y' to be a single indicator, not a list"
+
+            if set(view["indicators"].keys()) != {"y"}:
+                raise NotImplementedError(
+                    "Only 'y' indicator is supported in groupby. Adapt the code for other fields."
+                )
+
+            view["indicators"]["y"] = [view["indicators"]["y"]]
 
             # Add to dictionary
             grouped_views[key] = view
         else:
-            grouped_views[key]["indicators"]["y"].append(view["indicators"]["y"])  # type: ignore
+            grouped_views[key]["indicators"]["y"].append(view["indicators"]["y"])
 
     return list(grouped_views.values())

--- a/etl/steps/export/multidim/health/latest/causes_of_death.py
+++ b/etl/steps/export/multidim/health/latest/causes_of_death.py
@@ -1,4 +1,6 @@
+import copy
 from pathlib import Path
+from typing import Any
 
 from etl import multidim
 from etl.db import get_engine
@@ -20,13 +22,43 @@ def run(dest_dir: str) -> None:
     # NOTE: using load_data=False which only loads metadata significantly speeds this up
     table = paths.load_dataset("gbd_cause").read("gbd_cause_deaths", load_data=False)
 
-    # Individual causes
-    config["views"] += multidim.expand_views_with_access_db(
-        config, {"metric": "*", "age": "*", "cause": "*"}, table, engine
-    )
-    # Show all causes in a single view
-    config["views"] += multidim.expand_views_with_access_db(
-        config, {"metric": "*", "age": "*", "cause": "Side-by-side comparison of causes"}, table, engine
-    )
+    # Get all combinations of dimensions
+    config_new = multidim.expand_config(table, dimensions=["cause", "age", "metric"])
 
-    multidim.upsert_multidim_data_page("mdd-causes-of-death", config, engine)
+    config["dimensions"][0]["choices"] += [
+        c for c in config_new["dimensions"][0]["choices"] if c["slug"] != "All causes"
+    ]
+
+    # Group age and metric views under "Side-by-side comparison of causes"
+    grouped_views = group_views(config_new["views"], by=["age", "metric"])
+    for view in grouped_views:
+        view["dimensions"]["cause"] = "Side-by-side comparison of causes"
+
+    # Add views to config
+    config["views"] += config_new["views"]
+    config["views"] += grouped_views
+
+    multidim.upsert_multidim_data_page("mdd-causes-of-death", config, engine, dependencies=paths.dependencies)
+
+
+def group_views(views: dict[str, Any], by: list[str]) -> list[dict[str, Any]]:
+    """
+    Group views by the specified dimensions. Concatenate indicators for the same group.
+    """
+    views = copy.deepcopy(views)
+
+    grouped_views = {}
+    for view in views:
+        # Group key
+        key = tuple(view["dimensions"][dim] for dim in by)  # type: ignore
+
+        if key not in grouped_views:
+            # Turn indicators into a list
+            view["indicators"]["y"] = [view["indicators"]["y"]]  # type: ignore
+
+            # Add to dictionary
+            grouped_views[key] = view
+        else:
+            grouped_views[key]["indicators"]["y"].append(view["indicators"]["y"])  # type: ignore
+
+    return list(grouped_views.values())

--- a/etl/steps/export/multidim/health/latest/causes_of_death.yml
+++ b/etl/steps/export/multidim/health/latest/causes_of_death.yml
@@ -15,96 +15,7 @@ dimensions:
       - description: Aggregate of all causes
         name: All causes
         slug: All causes
-      - description: null
-        name: Cardiovascular diseases
-        slug: Cardiovascular diseases
-      - description: null
-        name: Neoplasms
-        slug: Neoplasms
-      - description: null
-        name: Chronic respiratory diseases
-        slug: Chronic respiratory diseases
-      - description: null
-        name: Digestive diseases
-        slug: Digestive diseases
-      - description: null
-        name: Lower respiratory infections
-        slug: Lower respiratory infections
-      - description: null
-        name: Neonatal disorders
-        slug: Neonatal disorders
-      - description: null
-        name: Alzheimer's disease and other dementias
-        slug: Alzheimer's disease and other dementias
-      - description: null
-        name: Diabetes mellitus
-        slug: Diabetes mellitus
-      - description: null
-        name: Diarrheal diseases
-        slug: Diarrheal diseases
-      - description: null
-        name: Meningitis
-        slug: Meningitis
-      - description: null
-        name: Parkinson's disease
-        slug: Parkinson's disease
-      - description: null
-        name: Nutritional deficiencies
-        slug: Nutritional deficiencies
-      - description: null
-        name: Malaria
-        slug: Malaria
-      - description: null
-        name: Drowning
-        slug: Drowning
-      - description: null
-        name: Interpersonal violence
-        slug: Interpersonal violence
-      - description: null
-        name: Maternal disorders
-        slug: Maternal disorders
-      - description: null
-        name: HIV/AIDS
-        slug: HIV/AIDS
-      - description: null
-        name: Drug use disorders
-        slug: Drug use disorders
-      - description: null
-        name: Tuberculosis
-        slug: Tuberculosis
-      - description: null
-        name: Alcohol use disorders
-        slug: Alcohol use disorders
-      - description: null
-        name: Self-harm
-        slug: Self-harm
-      - description: null
-        name: Exposure to forces of nature
-        slug: Exposure to forces of nature
-      - description: null
-        name: Environmental heat and cold exposure
-        slug: Environmental heat and cold exposure
-      - description: null
-        name: Conflict and terrorism
-        slug: Conflict and terrorism
-      - description: null
-        name: Chronic kidney disease
-        slug: Chronic kidney disease
-      - description: null
-        name: Poisonings
-        slug: Poisonings
-      - description: null
-        name: Road injuries
-        slug: Road injuries
-      - description: null
-        name: Fire, heat, and hot substances
-        slug: Fire, heat, and hot substances
-      - description: null
-        name: Acute hepatitis
-        slug: Acute hepatitis
-      - description: null
-        name: COVID-19
-        slug: COVID-19
+      # Additional causes will be added programmatically.
   - name: Age group
     slug: age
     choices:
@@ -141,7 +52,5 @@ dimensions:
       - description: null
         name: Rate
         slug: Rate
-dimensions_title: by cause
-name: Causes of death
 
 views: []


### PR DESCRIPTION
- Remove `expand_views_with_access_db` function, move the grouping of indicators into lists to `group_views`
- Fix some type issues with DAG
- Enable mdim for causes of death again

Here's the [mdim page](http://staging-site-mdim-causes-of-deaths/admin/grapher/mdd-causes-of-death?cause=All+causes&age=All+ages&metric=Number) on a staging server.