### PR TITLE
🎉 catalog: Create tables method to export excel with metadata

### DIFF
--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -224,6 +224,7 @@ class Table(pd.DataFrame):
         """
         Return a codebook for this table.
         """
+
         # Define how to show attributions and URLs in the sources column.
         def _prepare_attributions(attribution: str, url_main: str) -> str:
             return f"{attribution} ( {url_main} )"
@@ -264,7 +265,7 @@ class Table(pd.DataFrame):
         **kwargs: Any,
     ) -> None:
         # Save data and codebook to an excel file.
-        with pd.ExcelWriter(excel_writer) as writer:
+        with pd.ExcelWriter(excel_writer) as writer:  # type: ignore
             super().to_excel(writer, sheet_name=sheet_name, **kwargs)
             if with_metadata:
                 self.codebook.to_excel(writer, sheet_name=metadata_sheet_name)

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -225,7 +225,8 @@ class Table(pd.DataFrame):
         Return a codebook for this table.
         """
         # Define how to show attributions and URLs in the sources column.
-        prepare_attributions = lambda attribution, url_main: f"{attribution} ( {url_main} )"
+        def _prepare_attributions(attribution: str, url_main: str) -> str:
+            return f"{attribution} ( {url_main} )"
 
         # Initialize lists to store the codebook information.
         columns = []
@@ -241,7 +242,7 @@ class Table(pd.DataFrame):
             sources.append(
                 "; ".join(
                     dict.fromkeys(
-                        prepare_attributions(
+                        _prepare_attributions(
                             origin.attribution if origin.attribution else origin.producer, origin.url_main
                         )
                         for origin in md.origins
@@ -256,7 +257,7 @@ class Table(pd.DataFrame):
 
     def to_excel(
         self,
-        excel_writer: "FilePath | WriteExcelBuffer | ExcelWriter",  # type: ignore
+        excel_writer: Any,
         with_metadata=True,
         sheet_name="data",
         metadata_sheet_name="metadata",

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -238,14 +238,30 @@ class Table(pd.DataFrame):
             titles.append(getattr(md.presentation, "title_public", None) or md.title)
             # Use short description (after removing details on demand, if any).
             descriptions.append(utils.remove_details_on_demand(md.description_short))
-            sources.append("; ".join(dict.fromkeys(prepare_attributions(origin.attribution if origin.attribution else origin.producer, origin.url_main) for origin in md.origins)))
+            sources.append(
+                "; ".join(
+                    dict.fromkeys(
+                        prepare_attributions(
+                            origin.attribution if origin.attribution else origin.producer, origin.url_main
+                        )
+                        for origin in md.origins
+                    )
+                )
+            )
 
         # Create a DataFrame with the codebook.
-        codebook = pd.DataFrame({'column': columns, 'title': titles, 'description': descriptions, 'sources': sources})
+        codebook = pd.DataFrame({"column": columns, "title": titles, "description": descriptions, "sources": sources})
 
         return codebook
 
-    def to_excel(self, excel_writer: 'FilePath | WriteExcelBuffer | ExcelWriter', with_metadata=True, sheet_name="data", metadata_sheet_name="metadata", **kwargs: Any) -> None:
+    def to_excel(
+        self,
+        excel_writer: "FilePath | WriteExcelBuffer | ExcelWriter",  # type: ignore
+        with_metadata=True,
+        sheet_name="data",
+        metadata_sheet_name="metadata",
+        **kwargs: Any,
+    ) -> None:
         # Save data and codebook to an excel file.
         with pd.ExcelWriter(excel_writer) as writer:
             super().to_excel(writer, sheet_name=sheet_name, **kwargs)

--- a/lib/catalog/owid/catalog/tables.py
+++ b/lib/catalog/owid/catalog/tables.py
@@ -219,6 +219,39 @@ class Table(pd.DataFrame):
         metadata_filename = splitext(path)[0] + ".meta.json"
         self._save_metadata(metadata_filename)
 
+    @property
+    def codebook(self) -> pd.DataFrame:
+        """
+        Return a codebook for this table.
+        """
+        # Define how to show attributions and URLs in the sources column.
+        prepare_attributions = lambda attribution, url_main: f"{attribution} ( {url_main} )"
+
+        # Initialize lists to store the codebook information.
+        columns = []
+        titles = []
+        descriptions = []
+        sources = []
+        for column in self.columns:
+            md = self[column].metadata
+            columns.append(column)
+            titles.append(getattr(md.presentation, "title_public", None) or md.title)
+            # Use short description (after removing details on demand, if any).
+            descriptions.append(utils.remove_details_on_demand(md.description_short))
+            sources.append("; ".join(dict.fromkeys(prepare_attributions(origin.attribution if origin.attribution else origin.producer, origin.url_main) for origin in md.origins)))
+
+        # Create a DataFrame with the codebook.
+        codebook = pd.DataFrame({'column': columns, 'title': titles, 'description': descriptions, 'sources': sources})
+
+        return codebook
+
+    def to_excel(self, excel_writer: 'FilePath | WriteExcelBuffer | ExcelWriter', with_metadata=True, sheet_name="data", metadata_sheet_name="metadata", **kwargs: Any) -> None:
+        # Save data and codebook to an excel file.
+        with pd.ExcelWriter(excel_writer) as writer:
+            super().to_excel(writer, sheet_name=sheet_name, **kwargs)
+            if with_metadata:
+                self.codebook.to_excel(writer, sheet_name=metadata_sheet_name)
+
     def to_feather(
         self,
         path: Any,

--- a/lib/catalog/owid/catalog/utils.py
+++ b/lib/catalog/owid/catalog/utils.py
@@ -340,3 +340,13 @@ def dataclass_from_dict(cls: Optional[Type[T]], d: Dict[str, Any]) -> T:
             init_args[field_name] = v
 
     return cls(**init_args)
+
+
+def remove_details_on_demand(text: str) -> str:
+    # Remove references to details on demand from a text.
+    # Example: "This is a [description](#dod:something)." -> "This is a description."
+    regex = r"\(\#dod\:.*\)"
+    if "(#dod:" in text:
+        text = re.sub(regex, "", text).replace("[", "").replace("]", "")
+
+    return text


### PR DESCRIPTION
Inspired by [this comment](https://owid.slack.com/archives/C3RAU3BJ9/p1739981330767749?thread_ts=1739975692.480529&cid=C3RAU3BJ9), I thought it would be useful to have a `.to_excel()` method on our `Table` that by default exports a table with a "data" and a "metadata" sheet.
The metadata sheet contains for now very limited info (colum name, title, short description, and producers with urls). I haven't put much thought on what exactly this metadata should look like, but I suppose there's no harm in adding it as-is for now, and we can improve it in the future (unless `.to_excel()` is being used elsewhere).