### PR TITLE
🔨 Use expand_config in energy prices mdim

### DIFF
--- a/docs/guides/data-work/export-data.md
+++ b/docs/guides/data-work/export-data.md
@@ -71,7 +71,7 @@ views:
 
 ```
 
-The `dimensions` field specifies selectors, and the `views` field defines views for the selection. Since there are numerous possible configurations, `views` are usually generated programmatically (using function `etl.multidim.generate_views_for_dimensions`).
+The `dimensions` field specifies selectors, and the `views` field defines views for the selection. Since there are numerous possible configurations, `views` are usually generated programmatically (using function `etl.multidim.expand_config`).
 
 You can also combine manually defined views with generated ones. See the `etl.multidim` module for available helper functions or refer to examples from `etl/steps/export/multidim/`. Feel free to add or modify the helper functions as needed.
 
@@ -96,11 +96,9 @@ def run(dest_dir: str) -> None:
     config = paths.load_mdim_config()
 
     # Create views.
-    config["views"] = multidim.generate_views_for_dimensions(
-        dimensions=config["dimensions"],
-        tables=[tb_annual, tb_monthly],
-        dimensions_order_in_slug=("frequency", "source", "unit"),
-        warn_on_missing_combinations=False,
+    config["views"] = multidim.expand_config(
+        tb_annual,
+        dimensions=["frequency", "source", "unit"],
         additional_config={"chartTypes": ["LineChart"], "hasMapTab": True, "tab": "map"},
     )
 

--- a/etl/multidim.py
+++ b/etl/multidim.py
@@ -688,7 +688,9 @@ class MDIMConfigExpander:
         # If no indicator name is provided, there should only be one in the table!
         if indicator_name is None:
             if len(indicator_names) != 1:
-                raise ValueError("There are multiple indicators, but no `indicator_name` was provided.")
+                raise ValueError(
+                    f"There are multiple indicators {indicator_names}, but no `indicator_name` was provided."
+                )
             # If only one indicator available, set it as the indicator name
             indicator_name = indicator_names[0]
         # If indicator name is given, make sure it is present in the table!
@@ -833,110 +835,6 @@ def _check_intersection_iters(
         raise ValueError(
             f"Unexpected items: {', '.join([f'`{d}`' for d in items_unexpected])}. Please review `{key_name}`!"
         )
-
-
-####################################################################################################
-# DEPRECATED FUNCTIONS
-####################################################################################################
-@deprecated("This function relies on specific column naming convention. Use `expand_config` instead.")
-def generate_views_for_dimensions(
-    dimensions, tables, dimensions_order_in_slug=None, additional_config=None, warn_on_missing_combinations=True
-):
-    """Generate individual views for all possible combinations of dimensions in a list of flattened tables.
-
-    Parameters
-    ----------
-    dimensions : List[Dict[str, Any]]
-        Dimensions, as given in the configuration of the multidim step, e.g.
-        [
-            {'slug': 'frequency', 'name': 'Frequency', 'choices': [{'slug': 'annual','name': 'Annual'}, {'slug': 'monthly', 'name': 'Monthly'}]},
-            {'slug': 'source', 'name': 'Energy source', 'choices': [{'slug': 'electricity', 'name': 'Electricity'}, {'slug': 'gas', 'name': 'Gas'}]},
-            ...
-        ]
-    tables : List[Table]
-        Tables whose indicator views will be generated.
-    dimensions_order_in_slug : Tuple[str], optional
-        Dimension names, as they appear in "dimensions", and in the order in which they are spelled out in indicator names. For example, if indicator names are, e.g. annual_electricity_euros, then dimensions_order_in_slug would be ("frequency", "source", "unit").
-    additional_config : _type_, optional
-        Additional config fields to add to each view, e.g.
-        {"chartTypes": ["LineChart"], "hasMapTab": True, "tab": "map"}
-    warn_on_missing_combinations : bool, optional
-        True to warn if any combination of dimensions is not found among the indicators in the given tables.
-
-    Returns
-    -------
-    results : List[Dict[str, Any]]
-        Views configuration, e.g.
-        [
-            {'dimensions': {'frequency': 'annual', 'source': 'electricity', 'unit': 'euro'}, 'indicators': {'y': 'grapher/energy/2024-11-20/energy_prices/energy_prices_annual#annual_electricity_household_total_price_including_taxes_euro'},
-            {'dimensions': {'frequency': 'annual', 'source': 'electricity', 'unit': 'pps'}, 'indicators': {'y': 'grapher/energy/2024-11-20/energy_prices/energy_prices_annual#annual_electricity_household_total_price_including_taxes_pps'},
-            ...
-        ]
-
-    """
-    # Extract all choices for each dimension as (slug, choice_slug) pairs.
-    choices = {dim["slug"]: [choice["slug"] for choice in dim["choices"]] for dim in dimensions}
-    dimension_slugs_in_config = set(choices.keys())
-
-    # Sanity check for dimensions_order_in_slug.
-    if dimensions_order_in_slug:
-        dimension_slugs_in_order = set(dimensions_order_in_slug)
-
-        # Check if any slug in the order is missing from the config.
-        missing_slugs = dimension_slugs_in_order - dimension_slugs_in_config
-        if missing_slugs:
-            raise ValueError(
-                f"The following dimensions are in 'dimensions_order_in_slug' but not in the config: {missing_slugs}"
-            )
-
-        # Check if any slug in the config is missing from the order.
-        extra_slugs = dimension_slugs_in_config - dimension_slugs_in_order
-        if extra_slugs:
-            log.warning(
-                f"The following dimensions are in the config but not in 'dimensions_order_in_slug': {extra_slugs}"
-            )
-
-        # Reorder choices to match the specified order.
-        choices = {dim: choices[dim] for dim in dimensions_order_in_slug if dim in choices}
-
-    # Generate all combinations of the choices.
-    all_combinations = list(product(*choices.values()))
-
-    # Create the views.
-    results = []
-    for combination in all_combinations:
-        # Map dimension slugs to the chosen values.
-        dimension_mapping = {dim_slug: choice for dim_slug, choice in zip(choices.keys(), combination)}
-        slug_combination = "_".join(combination)
-
-        # Find relevant tables for the current combination.
-        relevant_table = []
-        for table in tables:
-            if slug_combination in table:
-                relevant_table.append(table)
-
-        # Handle missing or multiple table matches.
-        if len(relevant_table) == 0:
-            if warn_on_missing_combinations:
-                log.warning(f"Combination {slug_combination} not found in tables")
-            continue
-        elif len(relevant_table) > 1:
-            log.warning(f"Combination {slug_combination} found in multiple tables: {relevant_table}")
-
-        # Construct the indicator path.
-        indicator_path = f"{relevant_table[0].metadata.dataset.uri}/{relevant_table[0].metadata.short_name}#{trim_long_variable_name(slug_combination)}"
-        indicators = {
-            "y": indicator_path,
-        }
-        # Append the combination to results.
-        results.append({"dimensions": dimension_mapping, "indicators": indicators})
-
-    if additional_config:
-        # Include additional fields in all results.
-        for result in results:
-            result.update({"config": additional_config})
-
-    return results
 
 
 def group_views(views: list[dict[str, Any]], by: list[str]) -> list[dict[str, Any]]:

--- a/etl/steps/data/grapher/energy/2025-02-03/energy_prices.py
+++ b/etl/steps/data/grapher/energy/2025-02-03/energy_prices.py
@@ -5,12 +5,35 @@ from etl.helpers import PathFinder, create_dataset
 # Get paths and naming conventions.
 paths = PathFinder(__file__)
 
+DIMENSIONS = {
+    "frequency": ["annual", "monthly"],
+    "source": ["electricity", "gas"],
+    "consumer": ["household", "non_household", "all"],
+    "price_component": [
+        "total_price_including_taxes",
+        "wholesale",
+        "consumer_price_components",
+        "energy_and_supply",
+        "network_costs",
+        "taxes_fees_levies_and_charges",
+        "capacity_taxes",
+        "environmental_taxes",
+        "nuclear_taxes",
+        "renewable_taxes",
+        "value_added_tax_vat",
+        "other",
+    ],
+    "unit": ["euro", "pps"],
+}
+
 
 def run(dest_dir: str) -> None:
     # Load tables from garden dataset.
     ds_garden = paths.load_dataset("energy_prices")
     tb_annual = ds_garden.read("energy_prices_annual", reset_index=False)
     tb_monthly = ds_garden.read("energy_prices_monthly", reset_index=False)
+
+    # Add dimensions info to metadata.
 
     # Create a new grapher dataset.
     dataset = create_dataset(
@@ -20,3 +43,32 @@ def run(dest_dir: str) -> None:
         default_metadata=ds_garden.metadata,
     )
     dataset.save()
+
+
+def add_dimensions_to_metadata(tb: Table, dim_options: Dict[str, List[str]]) -> List[str]:
+    # Generate all combinations of the choices.
+    all_combinations = list(product(*choices.values()))
+
+    # Create the views.
+    results = []
+    for combination in all_combinations:
+        # Map dimension slugs to the chosen values.
+        dimension_mapping = {dim_slug: choice for dim_slug, choice in zip(choices.keys(), combination)}
+        slug_combination = "_".join(combination)
+
+    for col in tb:
+        filters = []
+        for dim, values in dim_options.items():
+            filters.append({"name": dim, "value": [v for v in values if v in col][0]})
+
+        tb[col].metadata.additional_info = {
+            "dimensions": {
+                "originalShortName": col.split("_")[0],
+                "short_name": col,
+                "filters": filters,
+            }
+        }
+
+        use_cols.append(col)
+
+    return use_cols

--- a/etl/steps/export/multidim/energy/latest/energy_prices.py
+++ b/etl/steps/export/multidim/energy/latest/energy_prices.py
@@ -24,15 +24,26 @@ def run(dest_dir: str) -> None:
 
     dimensions = ["frequency", "source", "consumer", "price_component", "unit"]
 
+    # Get possible dimension values
+    dim_options = {}
+    for dim in config["dimensions"]:
+        dim_options[dim["slug"]] = [c["slug"] for c in dim["choices"]]
+
     # Add dimensions to the metadata of the table.
     # e.g. annual_gas_household_other_pps -> gas, household, other, pps
     for tb in [tb_annual, tb_monthly]:
         for col in tb:
+            filters = []
+            for dim in dimensions:
+                print(dim)
+                print(dim_options[dim])
+                filters.append({"name": dim, "value": [v for v in dim_options[dim] if v in col][0]})
+
             tb[col].metadata.additional_info = {
                 "dimensions": {
                     "originalShortName": col.split("_")[0],
                     "short_name": col,
-                    "filters": [{"name": dim, "value": v} for dim, v in zip(dimensions, col.split("_"))],
+                    "filters": filters,
                 }
             }
 


### PR DESCRIPTION
I've started this with the intention of merging `generate_views_for_dimensions` with `expand_config`. The plan was to add information about dimensions to `tb[col].m.additional_info` and then let `expand_config` do its magic.

It turned out that getting dimensions from a flattened indicator is harder than expected. Putting a band-aid on it in the export step didn't feel right. It'd only work if we were setting this information when flattening (i.e. in the garden steps).

Parking this until we get more experience with mdims.