### PR TITLE
🔨 Speedup mdim validation

### DIFF
--- a/etl/multidim.py
+++ b/etl/multidim.py
@@ -12,10 +12,10 @@ from copy import deepcopy
 from itertools import product
 from typing import Any, Dict, List, Optional, Set, Union
 
+import fastjsonschema
 import pandas as pd
 import yaml
 from deprecated import deprecated
-from jsonschema import ValidationError, validate
 from owid.catalog import Dataset, Table
 from sqlalchemy.engine import Engine
 from structlog import get_logger
@@ -419,10 +419,13 @@ def validate_schema(config: dict) -> None:
     schema_path = SCHEMAS_DIR / "multidim-schema.json"
     with open(schema_path) as f:
         schema = json.load(f)
+
+    validator = fastjsonschema.compile(schema)
+
     try:
-        validate(instance=config, schema=schema)
-    except ValidationError as e:
-        raise ValueError(f"Config validation error: {e.message}")
+        validator(config)  # type: ignore
+    except fastjsonschema.JsonSchemaException as e:
+        raise ValueError(f"Config validation error: {e.message}")  # type: ignore
 
 
 def validate_multidim_config(config: dict, engine: Engine) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dependencies = [
     "cfgrib>=0.9.15.0",
     "streamlit-aggrid>=1.0.5",
     "sentry-sdk>=2.20.0",
+    "fastjsonschema>=2.21.1",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -946,6 +946,7 @@ dependencies = [
     { name = "deprecated" },
     { name = "earthengine-api" },
     { name = "fasteners" },
+    { name = "fastjsonschema" },
     { name = "frictionless", extra = ["pandas"] },
     { name = "fsspec" },
     { name = "geopandas" },
@@ -1070,6 +1071,7 @@ requires-dist = [
     { name = "earthengine-api", specifier = ">=0.1.411" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.109.0" },
     { name = "fasteners", specifier = ">=0.19" },
+    { name = "fastjsonschema", specifier = ">=2.21.1" },
     { name = "frictionless", extras = ["pandas"], specifier = ">=5.0.3" },
     { name = "fsspec", specifier = ">=2022.11.0" },
     { name = "geographiclib", marker = "extra == 'wizard'", specifier = ">=2.0" },
@@ -3408,7 +3410,6 @@ version = "12.6.85"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/d7/c5383e47c7e9bf1c99d5bd2a8c935af2b6d705ad831a7ec5c97db4d82f4f/nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:eedc36df9e88b682efe4309aa16b5b4e78c2407eac59e8c10a6a47535164369a", size = 19744971 },
-    { url = "https://files.pythonhosted.org/packages/31/db/dc71113d441f208cdfe7ae10d4983884e13f464a6252450693365e166dcf/nvidia_nvjitlink_cu12-12.6.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cf4eaa7d4b6b543ffd69d6abfb11efdeb2db48270d94dfd3a452c24150829e41", size = 19270338 },
 ]
 
 [[package]]
@@ -4193,8 +4194,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/61/74/49f5d20c514ccc631b940cc9dfec45dcce418dc84a98463a2e2ebec33904/pycryptodomex-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:52e23a0a6e61691134aa8c8beba89de420602541afaae70f66e16060fdcd677e", size = 2257982 },
     { url = "https://files.pythonhosted.org/packages/92/4b/d33ef74e2cc0025a259936661bb53432c5bbbadc561c5f2e023bcd73ce4c/pycryptodomex-3.21.0-cp36-abi3-win32.whl", hash = "sha256:a3d77919e6ff56d89aada1bd009b727b874d464cb0e2e3f00a49f7d2e709d76e", size = 1779052 },
     { url = "https://files.pythonhosted.org/packages/5b/be/7c991840af1184009fc86267160948350d1bf875f153c97bb471ad944e40/pycryptodomex-3.21.0-cp36-abi3-win_amd64.whl", hash = "sha256:b0e9765f93fe4890f39875e6c90c96cb341767833cfa767f41b490b506fa9ec0", size = 1816307 },
-    { url = "https://files.pythonhosted.org/packages/af/ac/24125ad36778914a36f08d61ba5338cb9159382c638d9761ee19c8de822c/pycryptodomex-3.21.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:feaecdce4e5c0045e7a287de0c4351284391fe170729aa9182f6bd967631b3a8", size = 1694999 },
-    { url = "https://files.pythonhosted.org/packages/93/73/be7a54a5903508070e5508925ba94493a1f326cfeecfff750e3eb250ea28/pycryptodomex-3.21.0-pp27-pypy_73-win32.whl", hash = "sha256:365aa5a66d52fd1f9e0530ea97f392c48c409c2f01ff8b9a39c73ed6f527d36c", size = 1769437 },
     { url = "https://files.pythonhosted.org/packages/e5/9f/39a6187f3986841fa6a9f35c6fdca5030ef73ff708b45a993813a51d7d10/pycryptodomex-3.21.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3efddfc50ac0ca143364042324046800c126a1d63816d532f2e19e6f2d8c0c31", size = 1619607 },
     { url = "https://files.pythonhosted.org/packages/f8/70/60bb08e9e9841b18d4669fb69d84b64ce900aacd7eb0ebebd4c7b9bdecd3/pycryptodomex-3.21.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0df2608682db8279a9ebbaf05a72f62a321433522ed0e499bc486a6889b96bf3", size = 1653571 },
     { url = "https://files.pythonhosted.org/packages/c9/6f/191b73509291c5ff0dddec9cc54797b1d73303c12b2e4017b24678e57099/pycryptodomex-3.21.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5823d03e904ea3e53aebd6799d6b8ec63b7675b5d2f4a4bd5e3adcb512d03b37", size = 1691548 },


### PR DESCRIPTION
jsonschema is extremely slow, especially in our case, when we use references to an external file (it apparently doesn't cache remote schemas!)
```
"$ref": "https://files.ourworldindata.org/schemas/grapher-schema.006.json#/properties/subtitle"
```

Switching to `fastjsonschema` speeds up validation for energy pricees from 10s to 10ms.

(I checked other places where we do schema validation. One happens when running `data://grapher`, but that takes only about 1ms, so there's nothing to gain there.)