### PR TITLE
📊 emissions: Bring log scale control back to air pollution explorer

### DIFF
--- a/etl/steps/export/explorers/emissions/latest/air_pollution.py
+++ b/etl/steps/export/explorers/emissions/latest/air_pollution.py
@@ -219,6 +219,7 @@ def run(dest_dir: str) -> None:
         "explorerTitle": "Air Pollution",
         "explorerSubtitle": "Explore historical emissions of air pollutants across the world.",
         "selection": ["China", "India", "United Kingdom", "United States", "World"],
+        "yScaleToggle": True,
         "isPublished": True,
     }
 


### PR DESCRIPTION
When moving the air pollution explorer to an ETL indicator-based explorer, we lost the toggle for linear-log scale. This PR brings it back.
