### PR TITLE
🐛 housekeeper: messages not showing chart preview

### DIFF
--- a/etl/slack_helpers.py
+++ b/etl/slack_helpers.py
@@ -116,7 +116,7 @@ def upload_image(
     # Ensure everything is uploaded before continuing
     time.sleep(seconds_wait)
 
-    return None
+    return upload_response
 
 
 def format_slack_message(method, url, status_code, req_body, res_body):


### PR DESCRIPTION
The return object from a function was wrong. Fixing it should resume chart-previews from being shared in the daily housekeeper slack message.

/schedule