### PR TITLE
✨ Change 'main()' to 'run()' in snapshot templates

### DIFF
--- a/apps/wizard/etl_steps/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.py
+++ b/apps/wizard/etl_steps/cookiecutter/snapshot/{{cookiecutter.namespace}}/{{cookiecutter.snapshot_version}}/{{cookiecutter.short_name}}.py
@@ -13,23 +13,23 @@ SNAPSHOT_VERSION = Path(__file__).parent.name
 @click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
 {% if cookiecutter.dataset_manual_import == True %}
 @click.option("--path-to-file", "-f", prompt=True, type=str, help="Path to local data file.")
-def main(path_to_file: str, upload: bool) -> None:
-    # Create a new snapshot.
+def run(path_to_file: str, upload: bool) -> None:
+    # Initialize a new snapshot.
     snap = Snapshot(f"{{cookiecutter.namespace}}/{SNAPSHOT_VERSION}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}")
 
-    # Copy local data file to snapshots data folder, add file to DVC and upload to S3.
+    # Save snapshots.
     snap.create_snapshot(filename=path_to_file, upload=upload)
 
 {% else %}
-def main(upload: bool) -> None:
-    # Create a new snapshot.
+def run(upload: bool) -> None:
+    # Initialize a new snapshot.
     snap = Snapshot(f"{{cookiecutter.namespace}}/{SNAPSHOT_VERSION}/{{cookiecutter.short_name}}.{{cookiecutter.file_extension}}")
 
-    # Download data from source, add file to DVC and upload to S3.
+    # Save snapshot.
     snap.create_snapshot(upload=upload)
 
 {% endif -%}
 
 
 if __name__ == "__main__":
-    main()
+    run()


### PR DESCRIPTION
Edit the wizard template for snapshot scripts, to write `run()` instead of `main()`. This would let us develop snapshot steps more easily with the new `run-until-cursor` extension (see https://github.com/owid/etl/pull/4058 ).
