### PR TITLE
✨ Add .render method to render Jinja templates

### DIFF
--- a/docs/architecture/metadata/structuring-yaml.md
+++ b/docs/architecture/metadata/structuring-yaml.md
@@ -259,9 +259,7 @@ The most straightforward way to check your metadata is in Admin, although that m
 
 ```python
 import etl.grapher.helpers as gh
-dim_dict = {
-  "age_group": "YEARS0-4", "sex": "Male", "cause": "Drug use disorders"
-}
+dim_dict = {"age_group": "YEARS0-4", "sex": "Male", "cause": "Drug use disorders"}
 d = gh.render_yaml_file("ghe.meta.yml", dim_dict=dim_dict)
 d["tables"]["ghe"]["variables"]["death_count"]
 ```
@@ -270,15 +268,11 @@ An alternative is examining `VariableMeta`
 
 ```python
 from owid.catalog import Dataset
-import etl.grapher.helpers as gh
 from etl import paths
 
-tb = Dataset(paths.DATA_DIR / "garden/who/2024-07-30/ghe")['ghe']
-
-# Sample a random row to get the dimension values
-dim_dict = dict(zip(tb.index.names, tb.sample(1).index[0]))
-
-gh.render_variable_meta(tb.death_count.m, dim_dict=dim_dict)
+ds = Dataset(paths.DATA_DIR / "garden/emissions/2025-02-12/ceds_air_pollutants")
+tb = ds['ceds_air_pollutants']
+tb.emissions.m.render({'pollutant': 'CO', 'sector': 'Transport'})
 ```
 
 ### Jinja Macros

--- a/etl/grapher/helpers.py
+++ b/etl/grapher/helpers.py
@@ -1,10 +1,8 @@
 import copy
-from dataclasses import dataclass, field, is_dataclass
-from functools import lru_cache
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Literal, Optional, Set, Union, cast
 
-import jinja2
 import numpy as np
 import pandas as pd
 import pymysql
@@ -12,7 +10,7 @@ import sqlalchemy
 import structlog
 from jsonschema import validate
 from owid import catalog
-from owid.catalog import Table, warnings
+from owid.catalog import Table, jinja, warnings
 from owid.catalog.utils import dynamic_yaml_load, dynamic_yaml_to_dict, underscore
 from owid.catalog.yaml_metadata import merge_with_shared_meta
 from sqlalchemy import text
@@ -25,26 +23,6 @@ from etl.files import get_schema_from_url, yaml_dump
 from etl.grapher.io import add_entity_code_and_name, trim_long_variable_name
 
 log = structlog.get_logger()
-
-jinja_env = jinja2.Environment(
-    block_start_string="<%",
-    block_end_string="%>",
-    variable_start_string="<<",
-    variable_end_string=">>",
-    comment_start_string="<#",
-    comment_end_string="#>",
-    trim_blocks=True,
-    lstrip_blocks=True,
-    undefined=jinja2.StrictUndefined,
-)
-
-
-# Helper function to raise an error with << raise("uh oh...") >>
-def raise_helper(msg):
-    raise Exception(msg)
-
-
-jinja_env.globals["raise"] = raise_helper
 
 # this might work too pd.api.types.is_integer_dtype(col)
 INT_TYPES = tuple(
@@ -149,7 +127,7 @@ def _yield_wide_table(
 
 def _metadata_for_dimensions(meta: catalog.VariableMeta, dim_dict: Dict[str, Any], column: str) -> catalog.VariableMeta:
     """Add dimensions to metadata and expand Jinja in metadata fields."""
-    # add info about dimensions to metadata
+    # Add info about dimensions to metadata
     if dim_dict:
         meta.additional_info = {
             "dimensions": {
@@ -161,27 +139,18 @@ def _metadata_for_dimensions(meta: catalog.VariableMeta, dim_dict: Dict[str, Any
             }
         }
 
-    # Add dimensions to title (which will be used as variable name in grapher)
-    if meta.title:
-        # We use template as a title
-        if _uses_jinja(meta.title):
-            title_with_dims = _expand_jinja_text(meta.title, dim_dict)
-        # Otherwise use default
-        else:
-            title_with_dims = _title_column_and_dimensions(meta.title, dim_dict)
+    # If title doesn't contain Jinja, use default title with dimensions
+    if meta.title and not jinja._uses_jinja(meta.title):
+        meta.title = _title_column_and_dimensions(meta.title, dim_dict)
 
-        meta.title = str(title_with_dims)
-
-    # traverse metadata and expand Jinja
+    # Render Jinja template with dimensions
     try:
-        meta = _expand_jinja(meta, dim_dict)
+        return meta.render(dim_dict)
     except Exception as e:
         # Reraise with more context
         raise ValueError(
             f"Error expanding Jinja in metadata for column '{column}' with dim values: {dim_dict}.\n\nVariable metadata:\n\n{yaml_dump(meta.to_dict())}"
         ) from e
-
-    return meta
 
 
 def _create_dim_dict(dim_names: List[str], dim_values: List[Any]) -> Dict[str, Any]:
@@ -235,56 +204,6 @@ def long_to_wide(long_tb: catalog.Table) -> catalog.Table:
     return wide_tb
 
 
-def _uses_jinja(text: Optional[str]):
-    if not text:
-        return False
-    return "<%" in text or "<<" in text
-
-
-@lru_cache(maxsize=None)
-def _cached_jinja_template(text: str) -> jinja2.environment.Template:
-    return jinja_env.from_string(text)
-
-
-def _expand_jinja_text(text: str, dim_dict: Dict[str, str]) -> Union[str, bool]:
-    if not _uses_jinja(text):
-        return text
-
-    try:
-        # NOTE: we're stripping the result to avoid trailing newlines
-        out = _cached_jinja_template(text).render(dim_dict).strip()
-        # Convert strings to booleans. Getting boolean directly from Jinja is not possible
-        if out in ("false", "False", "FALSE"):
-            return False
-        elif out in ("true", "True", "TRUE"):
-            return True
-        return out
-    except jinja2.exceptions.TemplateSyntaxError as e:
-        new_message = f"{e.message}\n\nDimensions:\n{dim_dict}\n\nTemplate:\n{text}\n"
-        raise e.__class__(new_message, e.lineno, e.name, e.filename) from e
-    except jinja2.exceptions.UndefinedError as e:
-        new_message = f"{e.message}\n\nDimensions:\n{dim_dict}\n\nTemplate:\n{text}\n"
-        raise e.__class__(new_message) from e
-
-
-def _expand_jinja(obj: Any, dim_dict: Dict[str, str]) -> Any:
-    """Expand Jinja in all metadata fields. This modifies the original object in place."""
-    if obj is None:
-        return None
-    elif isinstance(obj, str):
-        return _expand_jinja_text(obj, dim_dict)
-    elif is_dataclass(obj):
-        for k, v in obj.__dict__.items():
-            setattr(obj, k, _expand_jinja(v, dim_dict))
-        return obj
-    elif isinstance(obj, list):
-        return type(obj)([_expand_jinja(v, dim_dict) for v in obj])
-    elif isinstance(obj, dict):
-        return {k: _expand_jinja(v, dim_dict) for k, v in obj.items()}
-    else:
-        return obj
-
-
 def render_yaml_file(path: Union[str, Path], dim_dict: Dict[str, str]) -> Dict[str, Any]:
     """Load YAML file and render Jinja in all fields. Return a dictionary.
 
@@ -297,21 +216,7 @@ def render_yaml_file(path: Union[str, Path], dim_dict: Dict[str, str]) -> Dict[s
     """
     path_or_io = merge_with_shared_meta(Path(path))
     meta = dynamic_yaml_to_dict(dynamic_yaml_load(path_or_io))
-    return _expand_jinja(meta, dim_dict)
-
-
-def render_variable_meta(meta: catalog.VariableMeta, dim_dict: Dict[str, str]) -> catalog.VariableMeta:
-    """Render Jinja in all fields of VariableMeta. Return a new VariableMeta object.
-
-    Usage:
-        from etl.grapher import helpers as gh
-        from etl import paths
-
-        tb = Dataset(paths.DATA_DIR / "garden/who/2024-07-30/ghe")['ghe']
-        gh.render_variable_meta(tb.my_col.m, dim_dict={"sex": "male"})
-    """
-    # TODO: move this as a method to VariableMeta class
-    return _expand_jinja(meta.copy(), dim_dict)
+    return jinja._expand_jinja(meta, dim_dict)
 
 
 def _title_column_and_dimensions(title: str, dim_dict: Dict[str, Any]) -> str:

--- a/etl/steps/data/garden/emissions/2024-11-21/owid_co2.py
+++ b/etl/steps/data/garden/emissions/2024-11-21/owid_co2.py
@@ -11,11 +11,10 @@ GDP are included.
 
 """
 
-import re
-
 import numpy as np
 import pandas as pd
 from owid.catalog import Dataset, Origin, Table
+from owid.catalog.utils import remove_details_on_demand
 from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
@@ -303,16 +302,6 @@ def prepare_outputs(combined: Table, ds_regions: Dataset) -> Table:
     combined = combined.format()
 
     return combined
-
-
-def remove_details_on_demand(text: str) -> str:
-    # Remove references to details on demand from a text.
-    # Example: "This is a [description](#dod:something)." -> "This is a description."
-    regex = r"\(\#dod\:.*\)"
-    if "(#dod:" in text:
-        text = re.sub(regex, "", text).replace("[", "").replace("]", "")
-
-    return text
 
 
 def prepare_codebook(tb: Table) -> pd.DataFrame:

--- a/lib/catalog/owid/catalog/datasets.py
+++ b/lib/catalog/owid/catalog/datasets.py
@@ -157,7 +157,7 @@ class Dataset:
 
     def read(
         self,
-        name: str,
+        name: Optional[str] = None,
         reset_index: bool = True,
         safe_types: bool = True,
         reset_metadata: Literal["keep", "keep_origins", "reset"] = "keep",
@@ -177,6 +177,11 @@ class Dataset:
         :param load_data: If false, only load metadata and not the actual data. This can be useful
             when you only need to read metadata from a large dataset.
         """
+        if name is None:
+            if len(self.table_names) == 1:
+                name = self.table_names[0]
+            else:
+                raise ValueError("Multiple tables exist. Please specify the table name.")
         stem = self.path / Path(name)
 
         for format in SUPPORTED_FORMATS:

--- a/lib/catalog/owid/catalog/jinja.py
+++ b/lib/catalog/owid/catalog/jinja.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Optional, Union
 import jinja2
 import structlog
 
+from .utils import remove_details_on_demand
+
 log = structlog.get_logger()
 
 jinja_env = jinja2.Environment(
@@ -40,40 +42,44 @@ def _cached_jinja_template(text: str) -> jinja2.environment.Template:
     return jinja_env.from_string(text)
 
 
-def _expand_jinja_text(text: str, dim_dict: Dict[str, str]) -> Union[str, bool]:
+def _expand_jinja_text(text: str, dim_dict: Dict[str, str], remove_dods: bool = False) -> Union[str, bool]:
     if not _uses_jinja(text):
-        return text
+        out = text
+    else:
+        try:
+            # NOTE: we're stripping the result to avoid trailing newlines
+            out = _cached_jinja_template(text).render(dim_dict).strip()
+            # Convert strings to booleans. Getting boolean directly from Jinja is not possible
+            if out in ("false", "False", "FALSE"):
+                return False
+            elif out in ("true", "True", "TRUE"):
+                return True
+        except jinja2.exceptions.TemplateSyntaxError as e:
+            new_message = f"{e.message}\n\nDimensions:\n{dim_dict}\n\nTemplate:\n{text}\n"
+            raise e.__class__(new_message, e.lineno, e.name, e.filename) from e
+        except jinja2.exceptions.UndefinedError as e:
+            new_message = f"{e.message}\n\nDimensions:\n{dim_dict}\n\nTemplate:\n{text}\n"
+            raise e.__class__(new_message) from e
 
-    try:
-        # NOTE: we're stripping the result to avoid trailing newlines
-        out = _cached_jinja_template(text).render(dim_dict).strip()
-        # Convert strings to booleans. Getting boolean directly from Jinja is not possible
-        if out in ("false", "False", "FALSE"):
-            return False
-        elif out in ("true", "True", "TRUE"):
-            return True
-        return out
-    except jinja2.exceptions.TemplateSyntaxError as e:
-        new_message = f"{e.message}\n\nDimensions:\n{dim_dict}\n\nTemplate:\n{text}\n"
-        raise e.__class__(new_message, e.lineno, e.name, e.filename) from e
-    except jinja2.exceptions.UndefinedError as e:
-        new_message = f"{e.message}\n\nDimensions:\n{dim_dict}\n\nTemplate:\n{text}\n"
-        raise e.__class__(new_message) from e
+    if remove_dods:
+        out = remove_details_on_demand(out)
+
+    return out
 
 
-def _expand_jinja(obj: Any, dim_dict: Dict[str, str]) -> Any:
+def _expand_jinja(obj: Any, dim_dict: Dict[str, str], **kwargs) -> Any:
     """Expand Jinja in all metadata fields. This modifies the original object in place."""
     if obj is None:
         return None
     elif isinstance(obj, str):
-        return _expand_jinja_text(obj, dim_dict)
+        return _expand_jinja_text(obj, dim_dict, **kwargs)
     elif is_dataclass(obj):
         for k, v in obj.__dict__.items():
-            setattr(obj, k, _expand_jinja(v, dim_dict))
+            setattr(obj, k, _expand_jinja(v, dim_dict, **kwargs))
         return obj
     elif isinstance(obj, list):
-        return type(obj)([_expand_jinja(v, dim_dict) for v in obj])
+        return type(obj)([_expand_jinja(v, dim_dict, **kwargs) for v in obj])
     elif isinstance(obj, dict):
-        return {k: _expand_jinja(v, dim_dict) for k, v in obj.items()}
+        return {k: _expand_jinja(v, dim_dict, **kwargs) for k, v in obj.items()}
     else:
         return obj

--- a/lib/catalog/owid/catalog/jinja.py
+++ b/lib/catalog/owid/catalog/jinja.py
@@ -1,0 +1,79 @@
+from dataclasses import is_dataclass
+from functools import lru_cache
+from typing import Any, Dict, Optional, Union
+
+import jinja2
+import structlog
+
+log = structlog.get_logger()
+
+jinja_env = jinja2.Environment(
+    block_start_string="<%",
+    block_end_string="%>",
+    variable_start_string="<<",
+    variable_end_string=">>",
+    comment_start_string="<#",
+    comment_end_string="#>",
+    trim_blocks=True,
+    lstrip_blocks=True,
+    undefined=jinja2.StrictUndefined,
+)
+
+
+# Helper function to raise an error with << raise("uh oh...") >>
+def raise_helper(msg):
+    raise Exception(msg)
+
+
+jinja_env.globals["raise"] = raise_helper
+
+
+def _uses_jinja(text: Optional[str]):
+    """Check if a string uses Jinja templating."""
+    if not text:
+        return False
+    return "<%" in text or "<<" in text
+
+
+@lru_cache(maxsize=None)
+def _cached_jinja_template(text: str) -> jinja2.environment.Template:
+    return jinja_env.from_string(text)
+
+
+def _expand_jinja_text(text: str, dim_dict: Dict[str, str]) -> Union[str, bool]:
+    if not _uses_jinja(text):
+        return text
+
+    try:
+        # NOTE: we're stripping the result to avoid trailing newlines
+        out = _cached_jinja_template(text).render(dim_dict).strip()
+        # Convert strings to booleans. Getting boolean directly from Jinja is not possible
+        if out in ("false", "False", "FALSE"):
+            return False
+        elif out in ("true", "True", "TRUE"):
+            return True
+        return out
+    except jinja2.exceptions.TemplateSyntaxError as e:
+        new_message = f"{e.message}\n\nDimensions:\n{dim_dict}\n\nTemplate:\n{text}\n"
+        raise e.__class__(new_message, e.lineno, e.name, e.filename) from e
+    except jinja2.exceptions.UndefinedError as e:
+        new_message = f"{e.message}\n\nDimensions:\n{dim_dict}\n\nTemplate:\n{text}\n"
+        raise e.__class__(new_message) from e
+
+
+def _expand_jinja(obj: Any, dim_dict: Dict[str, str]) -> Any:
+    """Expand Jinja in all metadata fields. This modifies the original object in place."""
+    if obj is None:
+        return None
+    elif isinstance(obj, str):
+        return _expand_jinja_text(obj, dim_dict)
+    elif is_dataclass(obj):
+        for k, v in obj.__dict__.items():
+            setattr(obj, k, _expand_jinja(v, dim_dict))
+        return obj
+    elif isinstance(obj, list):
+        return type(obj)([_expand_jinja(v, dim_dict) for v in obj])
+    elif isinstance(obj, dict):
+        return {k: _expand_jinja(v, dim_dict) for k, v in obj.items()}
+    else:
+        return obj

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -277,8 +277,11 @@ class VariableMeta(MetaBase):
              {}
         """.format(getattr(self, "_name", None), to_html(record))
 
-    def render(self, dim_dict: Dict[str, Any]) -> "VariableMeta":
+    def render(self, dim_dict: Dict[str, Any], remove_dods: bool = False) -> "VariableMeta":
         """Render Jinja in all fields of VariableMeta. Return a new VariableMeta object.
+
+        :param dim_dict: dictionary of dimensions to render
+        :param remove_dods: remove references to details on demand from a text
 
         Usage:
             from owid.catalog import Dataset
@@ -288,7 +291,13 @@ class VariableMeta(MetaBase):
             tb = ds['ceds_air_pollutants']
             tb.emissions.m.render({'pollutant': 'CO', 'sector': 'Transport'})
         """
-        return jinja._expand_jinja(self.copy(), dim_dict)
+        meta = jinja._expand_jinja(self.copy(), dim_dict, remove_dods=remove_dods)
+
+        # Prune empty description keys
+        if meta.description_key:
+            meta.description_key = [x for x in meta.description_key if x]
+
+        return meta
 
     def copy(self, deep=True) -> Self:
         m = super().copy(deep)

--- a/lib/catalog/pyproject.toml
+++ b/lib/catalog/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "rdata==0.9",
     "owid-datautils",
     "owid-repack",
+    "jinja2>=3.1.6",
 ]
 
 [tool.uv]

--- a/lib/catalog/tests/test_jinja.py
+++ b/lib/catalog/tests/test_jinja.py
@@ -1,0 +1,23 @@
+from owid.catalog import jinja, meta
+
+
+def test_expand_jinja():
+    m = meta.VariableMeta(
+        title="Title << foo >>",
+        description_key=[
+            '<% if foo == "bar" %>This is bar<% else %>This is not bar<% endif %>',
+        ],
+        presentation=meta.VariablePresentationMeta(
+            title_variant="Variant << foo >>",
+        ),
+        display={
+            "isProjection": "<% if foo == 'bar' %>true<% else %>false<% endif %>",
+        },
+    )
+    out = jinja._expand_jinja(m, dim_dict={"foo": "bar"})
+    assert out.to_dict() == {
+        "title": "Title bar",
+        "description_key": ["This is bar"],
+        "presentation": {"title_variant": "Variant bar"},
+        "display": {"isProjection": True},
+    }

--- a/lib/catalog/tests/test_meta.py
+++ b/lib/catalog/tests/test_meta.py
@@ -154,5 +154,5 @@ def test_render_with_error():
     """.strip()
 
     var_meta = meta.VariableMeta(title=jinja_title)  # type: ignore
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         var_meta.render(dim_dict={"dim_b": "x"})

--- a/lib/catalog/tests/test_meta.py
+++ b/lib/catalog/tests/test_meta.py
@@ -148,6 +148,19 @@ def test_render():
     assert rendered_meta.title == "Title X"
 
 
+def test_render_description_key():
+    jinja_description_key = [
+        "<% if dim_a == 'x' %> Desc x <% endif %>  ",
+        "<% if dim_a == 'y' %>  Desc y <% endif %>",
+        "Desc z",
+    ]
+
+    var_meta = meta.VariableMeta(description_key=jinja_description_key)  # type: ignore
+    rendered_meta = var_meta.render(dim_dict={"dim_a": "x"})
+    assert isinstance(rendered_meta, meta.VariableMeta)
+    assert rendered_meta.description_key == ["Desc x", "Desc z"]
+
+
 def test_render_with_error():
     jinja_title = """
     <% if dim_a == "x" %>Title X<% elif dim_a == "y" %>Title Y<% else %>Default Title<% endif %>

--- a/lib/catalog/tests/test_meta.py
+++ b/lib/catalog/tests/test_meta.py
@@ -135,3 +135,24 @@ def test_from_dict():
     # list of objects should be correctly loaded as that object
     y = Y.from_dict({"x_list": [{"a": 1}]})
     assert isinstance(y.x_list[0], X)
+
+
+def test_render():
+    jinja_title = """
+    <% if dim_a == "x" %>Title X<% elif dim_a == "y" %>Title Y<% else %>Default Title<% endif %>
+    """.strip()
+
+    var_meta = meta.VariableMeta(title=jinja_title)  # type: ignore
+    rendered_meta = var_meta.render(dim_dict={"dim_a": "x"})
+    assert isinstance(rendered_meta, meta.VariableMeta)
+    assert rendered_meta.title == "Title X"
+
+
+def test_render_with_error():
+    jinja_title = """
+    <% if dim_a == "x" %>Title X<% elif dim_a == "y" %>Title Y<% else %>Default Title<% endif %>
+    """.strip()
+
+    var_meta = meta.VariableMeta(title=jinja_title)  # type: ignore
+    with pytest.raises(ValueError):
+        var_meta.render(dim_dict={"dim_b": "x"})

--- a/lib/catalog/uv.lock
+++ b/lib/catalog/uv.lock
@@ -351,7 +351,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -765,6 +765,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -798,6 +810,74 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/b9/cc0cc592e7c195fb8a650c1d5990b10175cf13b4c97465c72ec841de9e4b/jsonschema_specifications-2023.12.1.tar.gz", hash = "sha256:48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc", size = 13983 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/07/44bd408781594c4d0a027666ef27fab1e441b109dc3b76b4f836f8fd04fe/jsonschema_specifications-2023.12.1-py3-none-any.whl", hash = "sha256:87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c", size = 18482 },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8", size = 14357 },
+    { url = "https://files.pythonhosted.org/packages/04/e1/6e2194baeae0bca1fae6629dc0cbbb968d4d941469cbab11a3872edff374/MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158", size = 12393 },
+    { url = "https://files.pythonhosted.org/packages/1d/69/35fa85a8ece0a437493dc61ce0bb6d459dcba482c34197e3efc829aa357f/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579", size = 21732 },
+    { url = "https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d", size = 20866 },
+    { url = "https://files.pythonhosted.org/packages/29/28/6d029a903727a1b62edb51863232152fd335d602def598dade38996887f0/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb", size = 20964 },
+    { url = "https://files.pythonhosted.org/packages/cc/cd/07438f95f83e8bc028279909d9c9bd39e24149b0d60053a97b2bc4f8aa51/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b", size = 21977 },
+    { url = "https://files.pythonhosted.org/packages/29/01/84b57395b4cc062f9c4c55ce0df7d3108ca32397299d9df00fedd9117d3d/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c", size = 21366 },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/61ebf08d8940553afff20d1fb1ba7294b6f8d279df9fd0c0db911b4bbcfd/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171", size = 21091 },
+    { url = "https://files.pythonhosted.org/packages/11/23/ffbf53694e8c94ebd1e7e491de185124277964344733c45481f32ede2499/MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50", size = 15065 },
+    { url = "https://files.pythonhosted.org/packages/44/06/e7175d06dd6e9172d4a69a72592cb3f7a996a9c396eee29082826449bbc3/MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a", size = 15514 },
+    { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353 },
+    { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392 },
+    { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984 },
+    { url = "https://files.pythonhosted.org/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120 },
+    { url = "https://files.pythonhosted.org/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032 },
+    { url = "https://files.pythonhosted.org/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057 },
+    { url = "https://files.pythonhosted.org/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359 },
+    { url = "https://files.pythonhosted.org/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306 },
+    { url = "https://files.pythonhosted.org/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094 },
+    { url = "https://files.pythonhosted.org/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521 },
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348 },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149 },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118 },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993 },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178 },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319 },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352 },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097 },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601 },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352 },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122 },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085 },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978 },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208 },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357 },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344 },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101 },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603 },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510 },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486 },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480 },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914 },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796 },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473 },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114 },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
+    { url = "https://files.pythonhosted.org/packages/a7/ea/9b1530c3fdeeca613faeb0fb5cbcf2389d816072fab72a71b45749ef6062/MarkupSafe-3.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:eaa0a10b7f72326f1372a713e73c3f739b524b3af41feb43e4921cb529f5929a", size = 14344 },
+    { url = "https://files.pythonhosted.org/packages/4b/c2/fbdbfe48848e7112ab05e627e718e854d20192b674952d9042ebd8c9e5de/MarkupSafe-3.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:48032821bbdf20f5799ff537c7ac3d1fba0ba032cfc06194faffa8cda8b560ff", size = 12389 },
+    { url = "https://files.pythonhosted.org/packages/f0/25/7a7c6e4dbd4f867d95d94ca15449e91e52856f6ed1905d58ef1de5e211d0/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1a9d3f5f0901fdec14d8d2f66ef7d035f2157240a433441719ac9a3fba440b13", size = 21607 },
+    { url = "https://files.pythonhosted.org/packages/53/8f/f339c98a178f3c1e545622206b40986a4c3307fe39f70ccd3d9df9a9e425/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88b49a3b9ff31e19998750c38e030fc7bb937398b1f78cfa599aaef92d693144", size = 20728 },
+    { url = "https://files.pythonhosted.org/packages/1a/03/8496a1a78308456dbd50b23a385c69b41f2e9661c67ea1329849a598a8f9/MarkupSafe-3.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfad01eed2c2e0c01fd0ecd2ef42c492f7f93902e39a42fc9ee1692961443a29", size = 20826 },
+    { url = "https://files.pythonhosted.org/packages/e6/cf/0a490a4bd363048c3022f2f475c8c05582179bb179defcee4766fb3dcc18/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:1225beacc926f536dc82e45f8a4d68502949dc67eea90eab715dea3a21c1b5f0", size = 21843 },
+    { url = "https://files.pythonhosted.org/packages/19/a3/34187a78613920dfd3cdf68ef6ce5e99c4f3417f035694074beb8848cd77/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:3169b1eefae027567d1ce6ee7cae382c57fe26e82775f460f0b2778beaad66c0", size = 21219 },
+    { url = "https://files.pythonhosted.org/packages/17/d8/5811082f85bb88410ad7e452263af048d685669bbbfb7b595e8689152498/MarkupSafe-3.0.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:eb7972a85c54febfb25b5c4b4f3af4dcc731994c7da0d8a0b4a6eb0640e1d178", size = 20946 },
+    { url = "https://files.pythonhosted.org/packages/7c/31/bd635fb5989440d9365c5e3c47556cfea121c7803f5034ac843e8f37c2f2/MarkupSafe-3.0.2-cp39-cp39-win32.whl", hash = "sha256:8c4e8c3ce11e1f92f6536ff07154f9d49677ebaaafc32db9db4620bc11ed480f", size = 15063 },
+    { url = "https://files.pythonhosted.org/packages/b3/73/085399401383ce949f727afec55ec3abd76648d04b9f22e1c0e99cb4bec3/MarkupSafe-3.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:6e296a513ca3d94054c2c881cc913116e90fd030ad1c656b3869762b754f5f8a", size = 15506 },
 ]
 
 [[package]]
@@ -928,6 +1008,7 @@ dependencies = [
     { name = "dataclasses-json" },
     { name = "dynamic-yaml" },
     { name = "ipdb" },
+    { name = "jinja2" },
     { name = "jsonschema" },
     { name = "mistune" },
     { name = "owid-datautils" },
@@ -958,6 +1039,7 @@ requires-dist = [
     { name = "dataclasses-json", specifier = ">=0.6.7" },
     { name = "dynamic-yaml", specifier = ">=1.3.5" },
     { name = "ipdb", specifier = ">=0.13.9" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=3.2.0" },
     { name = "mistune", specifier = ">=3.0.1" },
     { name = "owid-datautils", editable = "../datautils" },
@@ -1206,8 +1288,6 @@ version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/10/2a30b13c61e7cf937f4adf90710776b7918ed0a9c434e2c38224732af310/psutil-6.1.0.tar.gz", hash = "sha256:353815f59a7f64cdaca1c0307ee13558a0512f6db064e92fe833784f08539c7a", size = 508565 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/2b/f4dea5d993d9cd22ad958eea828a41d5d225556123d372f02547c29c4f97/psutil-6.1.0-cp27-none-win32.whl", hash = "sha256:9118f27452b70bb1d9ab3198c1f626c2499384935aaf55388211ad982611407e", size = 246648 },
-    { url = "https://files.pythonhosted.org/packages/9f/14/4aa97a7f2e0ac33a050d990ab31686d651ae4ef8c86661fef067f00437b9/psutil-6.1.0-cp27-none-win_amd64.whl", hash = "sha256:a8506f6119cff7015678e2bce904a4da21025cc70ad283a53b099e7620061d85", size = 249905 },
     { url = "https://files.pythonhosted.org/packages/01/9e/8be43078a171381953cfee33c07c0d628594b5dbfc5157847b85022c2c1b/psutil-6.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:6e2dcd475ce8b80522e51d923d10c7871e45f20918e027ab682f94f1c6351688", size = 247762 },
     { url = "https://files.pythonhosted.org/packages/1d/cb/313e80644ea407f04f6602a9e23096540d9dc1878755f3952ea8d3d104be/psutil-6.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0895b8414afafc526712c498bd9de2b063deaac4021a3b3c34566283464aff8e", size = 248777 },
     { url = "https://files.pythonhosted.org/packages/65/8e/bcbe2025c587b5d703369b6a75b65d41d1367553da6e3f788aff91eaf5bd/psutil-6.1.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9dcbfce5d89f1d1f2546a2090f4fcf87c7f669d1d90aacb7d7582addece9fb38", size = 284259 },
@@ -1381,8 +1461,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/61/74/49f5d20c514ccc631b940cc9dfec45dcce418dc84a98463a2e2ebec33904/pycryptodomex-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:52e23a0a6e61691134aa8c8beba89de420602541afaae70f66e16060fdcd677e", size = 2257982 },
     { url = "https://files.pythonhosted.org/packages/92/4b/d33ef74e2cc0025a259936661bb53432c5bbbadc561c5f2e023bcd73ce4c/pycryptodomex-3.21.0-cp36-abi3-win32.whl", hash = "sha256:a3d77919e6ff56d89aada1bd009b727b874d464cb0e2e3f00a49f7d2e709d76e", size = 1779052 },
     { url = "https://files.pythonhosted.org/packages/5b/be/7c991840af1184009fc86267160948350d1bf875f153c97bb471ad944e40/pycryptodomex-3.21.0-cp36-abi3-win_amd64.whl", hash = "sha256:b0e9765f93fe4890f39875e6c90c96cb341767833cfa767f41b490b506fa9ec0", size = 1816307 },
-    { url = "https://files.pythonhosted.org/packages/af/ac/24125ad36778914a36f08d61ba5338cb9159382c638d9761ee19c8de822c/pycryptodomex-3.21.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:feaecdce4e5c0045e7a287de0c4351284391fe170729aa9182f6bd967631b3a8", size = 1694999 },
-    { url = "https://files.pythonhosted.org/packages/93/73/be7a54a5903508070e5508925ba94493a1f326cfeecfff750e3eb250ea28/pycryptodomex-3.21.0-pp27-pypy_73-win32.whl", hash = "sha256:365aa5a66d52fd1f9e0530ea97f392c48c409c2f01ff8b9a39c73ed6f527d36c", size = 1769437 },
     { url = "https://files.pythonhosted.org/packages/e5/9f/39a6187f3986841fa6a9f35c6fdca5030ef73ff708b45a993813a51d7d10/pycryptodomex-3.21.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3efddfc50ac0ca143364042324046800c126a1d63816d532f2e19e6f2d8c0c31", size = 1619607 },
     { url = "https://files.pythonhosted.org/packages/f8/70/60bb08e9e9841b18d4669fb69d84b64ce900aacd7eb0ebebd4c7b9bdecd3/pycryptodomex-3.21.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0df2608682db8279a9ebbaf05a72f62a321433522ed0e499bc486a6889b96bf3", size = 1653571 },
     { url = "https://files.pythonhosted.org/packages/c9/6f/191b73509291c5ff0dddec9cc54797b1d73303c12b2e4017b24678e57099/pycryptodomex-3.21.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5823d03e904ea3e53aebd6799d6b8ec63b7675b5d2f4a4bd5e3adcb512d03b37", size = 1691548 },
@@ -1972,7 +2050,7 @@ name = "tqdm"
 version = "4.66.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/83/6ba9844a41128c62e810fddddd72473201f3eacde02046066142a2d96cc5/tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad", size = 169504 }
 wheels = [

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -8,7 +8,6 @@ from owid.catalog import (
     Table,
     TableMeta,
     VariableMeta,
-    VariablePresentationMeta,
 )
 
 from etl.grapher import helpers as gh
@@ -211,28 +210,6 @@ def test_adapt_table_for_grapher_multiindex():
             out_table = gh._adapt_table_for_grapher(table, engine)
             assert out_table.index.names == ["entityId", "entityCode", "entityName", "year", "sex"]
             assert out_table.columns.tolist() == ["deaths"]
-
-
-def test_expand_jinja():
-    m = VariableMeta(
-        title="Title << foo >>",
-        description_key=[
-            '<% if foo == "bar" %>This is bar<% else %>This is not bar<% endif %>',
-        ],
-        presentation=VariablePresentationMeta(
-            title_variant="Variant << foo >>",
-        ),
-        display={
-            "isProjection": "<% if foo == 'bar' %>true<% else %>false<% endif %>",
-        },
-    )
-    out = gh._expand_jinja(m, dim_dict={"foo": "bar"})
-    assert out.to_dict() == {
-        "title": "Title bar",
-        "description_key": ["This is bar"],
-        "presentation": {"title_variant": "Variant bar"},
-        "display": {"isProjection": True},
-    }
 
 
 def test_underscore_column_and_dimensions():

--- a/uv.lock
+++ b/uv.lock
@@ -2172,14 +2172,14 @@ wheels = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.5"
+version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb", size = 244674 }
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/0f/2ba5fbcd631e3e88689309dbe978c5769e883e4b84ebfe7da30b43275c5a/jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb", size = 134596 },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
 ]
 
 [[package]]
@@ -3532,6 +3532,7 @@ dependencies = [
     { name = "dataclasses-json" },
     { name = "dynamic-yaml" },
     { name = "ipdb" },
+    { name = "jinja2" },
     { name = "jsonschema" },
     { name = "mistune" },
     { name = "owid-datautils" },
@@ -3551,6 +3552,7 @@ requires-dist = [
     { name = "dataclasses-json", specifier = ">=0.6.7" },
     { name = "dynamic-yaml", specifier = ">=1.3.5" },
     { name = "ipdb", specifier = ">=0.13.9" },
+    { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=3.2.0" },
     { name = "mistune", specifier = ">=3.0.1" },
     { name = "owid-datautils", editable = "lib/datautils" },


### PR DESCRIPTION
Replace function for rendering metadata with Jinja templates
```
import etl.grapher.helpers as gh
gh.render_variable_meta(tb.emissions.m, dim_dict={'pollutant': 'CO', 'sector': 'Transport'})
```
by
```
tb.emissions.m.render({'pollutant': 'CO', 'sector': 'Transport'})
```

As part of this, I also did:
- Move Jinja functions to owid-catalog
- Refactor dimension rendering in grapher:// step

The other function `render_yaml_file` for rendering Jinja from YAML file will be also moved in the future (to the new "YAMLMeta" object).

One disadvantage of `.render(...)` is that you need to build the garden dataset & load it to render it. It's often easier to work solely with the YAML file and use `render_yaml_file`.