### PR TITLE
🔨 Refactor run(dest_dir)

### DIFF
--- a/etl/run_python_step.py
+++ b/etl/run_python_step.py
@@ -10,6 +10,7 @@ import rich_click as click
 from ipdb import launch_ipdb_on_exception
 
 from etl.paths import BASE_PACKAGE, STEP_DIR
+from etl.steps import run_module_run
 
 
 @click.command(name="run-python-step")
@@ -53,15 +54,7 @@ def _import_and_run(step_type: str, path: str, dest_dir: str) -> None:
         raise Exception(f'no run() method defined for module "{module}"')
 
     # run the step itself
-    try:
-        # This should work when using the new run functions that don't require dest_dir as an argument.
-        module.run()
-    except TypeError as e:
-        # For backwards compatibility, execute the run function assuming it has dest_dir as an argument.
-        if "missing 1 required positional argument: 'dest_dir'" in str(e):
-            module.run(dest_dir)
-        else:
-            raise
+    run_module_run(module, dest_dir)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Decide whether to pass `dest_dir` or not by inspecting function arguments rather than catching TypeError. The latter has the disadvantage of being included in the traceback when step fails.