### PR TITLE
🔨 MDIMs: `create_mdim` and `.save` (alignment with data steps)

### DIFF
--- a/docs/guides/data-work/export-data.md
+++ b/docs/guides/data-work/export-data.md
@@ -105,7 +105,8 @@ def run(dest_dir: str) -> None:
     #
     # Save outputs.
     #
-    multidim.upsert_multidim_data_page(config=config, paths=paths)
+    mdim = paths.create_mdim(config=config)
+    mdim.save()
 
 ```
 

--- a/etl/collections/explorers.py
+++ b/etl/collections/explorers.py
@@ -9,23 +9,23 @@ from etl.collections.utils import (
     get_tables_by_name_mapping,
 )
 from etl.config import OWID_ENV, OWIDEnv
-from etl.helpers import PathFinder
+from etl.explorer import Explorer as ExplorerOld
 from etl.helpers import create_explorer as create_explorer_main
 
 
 def create_explorer(
     dest_dir: str,
     config: dict,
-    paths: PathFinder,
+    dependencies: Set[str],
     owid_env: Optional[OWIDEnv] = None,
     tolerate_extra_indicators: bool = False,
-):
+) -> ExplorerOld:
     """TODO: Replicate `etl.collections.multidim.upsert_mdim_data_page`."""
     # Read configuration as structured data
     explorer = Explorer.from_dict(config)
 
     # Edit views
-    process_views(explorer, paths.dependencies)
+    process_views(explorer, dependencies)
 
     # Create explorer (TODO: this should rather push to DB! As in with `etl.collections.multidim.upsert_mdim_data_page`)
     return _create_explorer(dest_dir, explorer, tolerate_extra_indicators, owid_env)

--- a/etl/collections/multidim.py
+++ b/etl/collections/multidim.py
@@ -14,7 +14,7 @@ from owid.catalog import Table
 from structlog import get_logger
 
 from apps.chart_sync.admin_api import AdminAPI
-from etl.collections.common import map_indicator_path_to_id, validate_collection_config
+from etl.collections.common import map_indicator_path_to_id
 from etl.collections.model import Collection, Definitions, MDIMView, pruned_json
 from etl.collections.utils import (
     get_tables_by_name_mapping,

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -26,8 +26,9 @@ from owid.walden import Catalog as WaldenCatalog
 from owid.walden import Dataset as WaldenDataset
 
 from etl import paths
-from etl.collections.explorers import Explorer as ExplorerV2
-from etl.collections.explorers import create_explorer as create_explorer_v2
+
+# from etl.collections.explorers import create_explorer as create_explorer_v2
+from etl.collections.multidim import Multidim, create_mdim
 from etl.dag_helpers import load_dag
 from etl.explorer import Explorer
 from etl.grapher.helpers import grapher_checks
@@ -644,17 +645,26 @@ class PathFinder:
             df_columns=df_columns,
         )
 
-    def create_mdim(self):
-        pass
+    def create_mdim(self, config, mdim_name: Optional[str] = None) -> Multidim:
+        """Create a Multidim object."""
+        mdim_catalog_path = f"{self.namespace}/{self.version}/{self.short_name}#{mdim_name or self.short_name}"
 
-    def create_explorer_v2(self, config, explorer_name: str, tolerate_extra_indicators: bool = False) -> Explorer:
-        return create_explorer_v2(
-            dest_dir=str(self.dest_dir),
-            config=config,
-            dependencies=self.dependencies,
-            tolerate_extra_indicators=tolerate_extra_indicators,
-            # explorer_name=explorer_name,
-        )
+        # Create Multidim
+        mdim = create_mdim(config, self.dependencies)
+
+        # Add catalog path to object
+        mdim.catalog_path = mdim_catalog_path
+
+        return mdim
+
+    # def create_explorer_v2(self, config, explorer_name: str, tolerate_extra_indicators: bool = False) -> Explorer:
+    #     return create_explorer_v2(
+    #         dest_dir=str(self.dest_dir),
+    #         config=config,
+    #         dependencies=self.dependencies,
+    #         tolerate_extra_indicators=tolerate_extra_indicators,
+    #         # explorer_name=explorer_name,
+    #     )
 
 
 def _match_dependencies(pattern: str, dependencies: set[str]) -> set[str]:

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -646,7 +646,16 @@ class PathFinder:
         )
 
     def create_mdim(self, config, mdim_name: Optional[str] = None) -> Multidim:
-        """Create a Multidim object."""
+        """Create a Multidim object.
+
+        Args:
+        -----
+
+        config: dict
+            MDIM configuration.
+        mdim_name: str
+            Name of the MDIM page. Default is short_name from mdim catalog path.
+        """
         mdim_catalog_path = f"{self.namespace}/{self.version}/{self.short_name}#{mdim_name or self.short_name}"
 
         # Create Multidim

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -26,6 +26,8 @@ from owid.walden import Catalog as WaldenCatalog
 from owid.walden import Dataset as WaldenDataset
 
 from etl import paths
+from etl.collections.explorers import Explorer as ExplorerV2
+from etl.collections.explorers import create_explorer as create_explorer_v2
 from etl.dag_helpers import load_dag
 from etl.explorer import Explorer
 from etl.grapher.helpers import grapher_checks
@@ -640,6 +642,18 @@ class PathFinder:
             config=config,
             df_graphers=df_graphers,
             df_columns=df_columns,
+        )
+
+    def create_mdim(self):
+        pass
+
+    def create_explorer_v2(self, config, explorer_name: str, tolerate_extra_indicators: bool = False) -> Explorer:
+        return create_explorer_v2(
+            dest_dir=str(self.dest_dir),
+            config=config,
+            dependencies=self.dependencies,
+            tolerate_extra_indicators=tolerate_extra_indicators,
+            # explorer_name=explorer_name,
         )
 
 

--- a/etl/steps/export/explorers/covid/latest/covid.py
+++ b/etl/steps/export/explorers/covid/latest/covid.py
@@ -41,7 +41,7 @@ def run(dest_dir: str) -> None:
     ds_explorer = create_explorer(
         dest_dir=dest_dir,
         config=config,
-        paths=paths,
+        dependencies=paths.dependencies,
         tolerate_extra_indicators=True,
     )
 

--- a/etl/steps/export/multidim/covid/latest/covid.py
+++ b/etl/steps/export/multidim/covid/latest/covid.py
@@ -36,11 +36,9 @@ def run(dest_dir: str) -> None:
         paths.log.info(fname)
         config = paths.load_mdim_config(fname)
 
-        multidim.upsert_multidim_data_page(
-            config=config,
-            paths=paths,
-            mdim_name=fname_to_mdim_name(fname),
-        )
+        mdim = paths.create_mdim(config, mdim_name=fname_to_mdim_name(fname))
+        mdim.save()
+
     # PART 2: MDIMs hybridly generated (mix of YAML file + data)
     ds = paths.load_dataset("google_mobility")
     tb = ds.read("google_mobility", load_data=False)
@@ -67,11 +65,12 @@ def run(dest_dir: str) -> None:
     # multidim.adjust_mdim_views(config, paths.dependencies_by_table_name)
 
     # Upsert to DB
-    multidim.upsert_multidim_data_page(
+    mdim = paths.create_mdim(
         config=config,
-        paths=paths,
         mdim_name=fname_to_mdim_name("covid.mobility.yml"),
     )
+
+    mdim.save()
 
 
 def fname_to_mdim_name(fname: str) -> str:

--- a/etl/steps/export/multidim/covid/latest/covid.py
+++ b/etl/steps/export/multidim/covid/latest/covid.py
@@ -16,7 +16,7 @@ MOBILITY_CONFIG_DEFAULT = {
 }
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     # PART 1: MDIMs entirely from YAML files
     # Load MDIM configurations from YAML files
     filenames = [

--- a/etl/steps/export/multidim/emissions/latest/air_pollution.py
+++ b/etl/steps/export/multidim/emissions/latest/air_pollution.py
@@ -35,11 +35,9 @@ def run() -> None:
     # TODO: should sorting be part of dimension metadata in garden channel?
     config["dimensions"][0]["choices"] = sorted(config["dimensions"][0]["choices"], key=lambda x: x["name"])
 
-    # Upsert mdim config to DB
-    multidim.upsert_multidim_data_page(
-        config=config,
-        paths=paths,
-    )
+    # Create MDIM and upsert its config to DB
+    mdim = paths.create_mdim(config=config)
+    mdim.save()
 
 
 def add_dimension(table, dimension: TableDimension, mapping: dict) -> None:

--- a/etl/steps/export/multidim/energy/latest/energy_prices.py
+++ b/etl/steps/export/multidim/energy/latest/energy_prices.py
@@ -212,7 +212,5 @@ def run() -> None:
     #
     # Save outputs.
     #
-    multidim.upsert_multidim_data_page(
-        config=config,
-        paths=paths,
-    )
+    mdim = paths.create_mdim(config=config)
+    mdim.save()

--- a/etl/steps/export/multidim/health/latest/causes_of_death.py
+++ b/etl/steps/export/multidim/health/latest/causes_of_death.py
@@ -5,7 +5,7 @@ from etl.helpers import PathFinder
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     # Load configuration from adjacent yaml file.
     config = paths.load_mdim_config()
 

--- a/etl/steps/export/multidim/health/latest/causes_of_death.py
+++ b/etl/steps/export/multidim/health/latest/causes_of_death.py
@@ -31,7 +31,5 @@ def run(dest_dir: str) -> None:
     config["views"] += config_new["views"]
     config["views"] += grouped_views
 
-    multidim.upsert_multidim_data_page(
-        config=config,
-        paths=paths,
-    )
+    mdim = paths.create_mdim(config=config)
+    mdim.save()

--- a/etl/steps/export/multidim/health/latest/vaccination_coverage.py
+++ b/etl/steps/export/multidim/health/latest/vaccination_coverage.py
@@ -33,8 +33,8 @@ def run(dest_dir: str) -> None:
     config["views"] = config_new["views"]
 
     # 4: Upsert to DB
-    multidim.upsert_multidim_data_page(
-        mdim_name="mdd-vaccination-who",
+    mdim = paths.create_mdim(
         config=config,
-        paths=paths,
+        mdim_name="mdd-vaccination-who",
     )
+    mdim.save()

--- a/etl/steps/export/multidim/health/latest/vaccination_coverage.py
+++ b/etl/steps/export/multidim/health/latest/vaccination_coverage.py
@@ -8,7 +8,7 @@ paths = PathFinder(__file__)
 
 
 # etlr multidim
-def run(dest_dir: str) -> None:
+def run() -> None:
     # engine = get_engine()
     # Load configuration from adjacent yaml file.
     config = paths.load_mdim_config()


### PR DESCRIPTION
Add `paths.create_mdim` and `Multidim.save` methods to align the structure of MDIM scripts with that of data scripts.


#### Example:
```python
def run(dest_dir: str) -> None:
    #
    # Load inputs.
    #
    # Load data on energy prices.
    ds_grapher = paths.load_dataset("energy_prices")

    # Read table of prices in euros.
    tb_annual = ds_grapher.read("energy_prices_annual")
    tb_monthly = ds_grapher.read("energy_prices_monthly")

    #
    # Process data.
    #
    # Load configuration from adjacent yaml file.
    config = paths.load_mdim_config()

    # Create views.
    config["views"] = multidim.expand_config(
        tb_annual,
        dimensions=["frequency", "source", "unit"],
        additional_config={"chartTypes": ["LineChart"], "hasMapTab": True, "tab": "map"},
    )

    #
    # Save outputs.
    #
    mdim = paths.create_mdim(config=config)
    mdim.save()

```

#### Future work:

At the moment, `paths.create_mdim` is rather simple. It creates a `Multidim` object from a given `config`. In the future, we could change this to accept arguments like `yaml_file` (or `yaml_config`), `tb`, etc. Then, this method would be responsible for combining the metadata from different sources (output of `expand_config`, YAML, ) and consolidate it into one Multidim.

#### NOTE
Ignore changes to `etl/collections/explorers`