### PR TITLE
📊 war: Fix issue in war data

### DIFF
--- a/etl/steps/data/garden/war/2023-09-21/cow.py
+++ b/etl/steps/data/garden/war/2023-09-21/cow.py
@@ -392,8 +392,10 @@ def combine_tables(tb_extra: Table, tb_nonstate: Table, tb_inter: Table, tb_intr
     )
     # Keep correct year coverage by conflict type
     tb = tb[
+        # ALL (2003)
+        ((tb["conflict_type"].isin(["all"])) & (tb["year"] <= 2003))
         # EXTRA, NON-STATE, ALL (2007)
-        ((tb["conflict_type"].isin([CTYPE_EXTRA, CTYPE_NONSTATE, "all"])) & (tb["year"] <= 2007))
+        | ((tb["conflict_type"].isin([CTYPE_EXTRA, CTYPE_NONSTATE])) & (tb["year"] <= 2007))
         # INTER, STATE-BASED (2010)
         | ((tb["conflict_type"].isin([CTYPE_INTER, CTYPE_SBASED])) & (tb["year"] <= 2010))
         # INTRA (2014)

--- a/etl/steps/data/garden/war/2023-09-21/cow.py
+++ b/etl/steps/data/garden/war/2023-09-21/cow.py
@@ -121,7 +121,13 @@ END_YEAR_MAX_EXTRA = 2007
 END_YEAR_MAX_INTRA = 2014
 END_YEAR_MAX_INTER = 2003
 END_YEAR_MAX_NONSTATE = 2005
-END_YEAR_MAX = min([END_YEAR_MAX_EXTRA, END_YEAR_MAX_INTRA, END_YEAR_MAX_INTER, END_YEAR_MAX_NONSTATE])
+# The following parameter defines the last year that we allow for combined data.
+# All combined data after that year will be removed.
+# A priori, it seems reasonable that this year should be the minimum of the years defined above (since we shouldn't combine data from different sources on years where not all sources are informed).
+# However, it seems that inter-state data does *not* end in 2003, but later than 2007 (unclear when exactly, but it does not matter for now). There has simply been no interstate conflict between 2003 and 2007.
+# Therefore, instead of setting this limit to the minimum of the years above, we manually set it to 2007.
+# END_YEAR_MAX = min([END_YEAR_MAX_EXTRA, END_YEAR_MAX_INTRA, END_YEAR_MAX_INTER, END_YEAR_MAX_NONSTATE])
+END_YEAR_MAX = 2007
 # Conflict types
 CTYPE_EXTRA = "extra-state"
 CTYPE_INTRA = "intra-state"
@@ -392,10 +398,8 @@ def combine_tables(tb_extra: Table, tb_nonstate: Table, tb_inter: Table, tb_intr
     )
     # Keep correct year coverage by conflict type
     tb = tb[
-        # ALL (2003)
-        ((tb["conflict_type"].isin(["all"])) & (tb["year"] <= 2003))
         # EXTRA, NON-STATE, ALL (2007)
-        | ((tb["conflict_type"].isin([CTYPE_EXTRA, CTYPE_NONSTATE])) & (tb["year"] <= 2007))
+        ((tb["conflict_type"].isin([CTYPE_EXTRA, CTYPE_NONSTATE, "all"])) & (tb["year"] <= 2007))
         # INTER, STATE-BASED (2010)
         | ((tb["conflict_type"].isin([CTYPE_INTER, CTYPE_SBASED])) & (tb["year"] <= 2010))
         # INTRA (2014)


### PR DESCRIPTION
The number of deaths in wars in the [Conflicts](https://ourworldindata.org/explorers/conflict-data) and [Conflicts Data Source](https://ourworldindata.org/explorers/conflict-data-source) explorers is zero between 2004 and 2007 (see [discussion](https://owid.slack.com/archives/C03NV9Z3YSV/p1742583191931629)). These zeros seem to be spurious.

I think these spurious zeros are created at some point when combining different tables. I have removed those zeros, so that the data ends in 2003 (minimum year for which all tables have data).

You can compare the old and new (corrected) Conflicts Data Source explorer [here](http://staging-site-data-fix-war/etl/wizard/explorer-diff?explorer=conflict-data-source&conflict-data-source_Measure=Conflict+deaths&conflict-data-source_Data+source=Correlates+of+War+%E2%80%93+Wars&conflict-data-source_Conflict+type=All+armed+conflicts&conflict-data-source_Conflict+sub-type=All+sub-types&conflict-data-source_Sub-measure=All+ongoing+conflicts).