### PR TITLE
📊 regions: Keep 'defined_by' field in external regions dataset

### DIFF
--- a/etl/steps/data/external/owid_grapher/latest/regions.py
+++ b/etl/steps/data/external/owid_grapher/latest/regions.py
@@ -291,9 +291,6 @@ def run(dest_dir: str) -> None:
     #
     # Process data.
     #
-    # Drop unneeded columns
-    regions = regions.drop(columns=["defined_by"], errors="raise")
-
     # Create slugs for all countries and keep track of legacy slugs.
     regions["slug"] = regions["name"].astype(str).map(slugify)
 
@@ -333,6 +330,7 @@ def run(dest_dir: str) -> None:
                 "short_name": income_group_name,
                 "region_type": "income_group",
                 "is_historical": False,
+                "defined_by": "owid",
                 "slug": slugify(income_group_name),
                 "is_mappable": False,
                 "is_unlisted": False,


### PR DESCRIPTION
Following [this conversation](https://owid.slack.com/archives/C0193RW5E2J/p1742917803787839), we decided to keep `defined_by` field in the external `regions` dataset, which used to be unnecessary (since its only value was `owid`), but now that it has multiple options it has become useful.
