### PR TITLE
📊 agriculture: Fix missing milk yield indicator

### DIFF
--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
@@ -686,3 +686,15 @@ tables:
           - Imports, exports, and domestic supply encompass the total of all items across the following groups: cereals and grains, pulses, starchy roots, fruits and vegetables, oils and fats, sugar, meat, dairy and eggs, alcoholic beverages, and an other products. The latter group includes miscellaneous items such as spices, offals, and other minor commodities.
         display:
           numDecimalPlaces: 1
+  milk_per_cow:
+    variables:
+      milk_per_cow:
+        title: Milk production per cow
+        unit: kilograms per cow
+        short_unit: kg
+        description_short: |
+          Average annual production of raw milk per cow.
+        description_key:
+          - This indicator is calculated by dividing the total production of raw milk from cattle by the number of cows used for milk production.
+        description_processing: |
+          - This indicator is calculated by dividing the total production of raw milk from cattle by the number of cows used for milk production.

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
@@ -693,9 +693,7 @@ tables:
         unit: kilograms per cow
         short_unit: kg
         description_short: |
-          Average annual production of raw milk per cow.
-        description_key:
-          - This indicator is calculated by dividing the total production of raw milk from cattle by the number of cows used for milk production.
+          Average annual milk production per cow. The values are estimated by dividing the total production of raw milk from cattle by the number of cows used for milk production.
         description_processing: |
           - This indicator is calculated by dividing the total production of raw milk from cattle by the number of cows used for milk production.
       cows_used_for_milk:

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
@@ -693,10 +693,11 @@ tables:
         unit: kilograms per animal
         short_unit: kg
         description_short: |
-          Average annual milk production per animal. The values are estimated by dividing the total production of milk by the number of animals used for milk production.
+          Average annual milk production per animal. Values are estimated by dividing the production of milk (from cattle, sheep, goats, and other animals) by the number of animals used for milk production.
         description_key:
-          - This indicator is calculated by dividing the total production of milk by the number of animals used for milk production.
+          - This indicator is calculated by dividing the net production of milk by the number of animals used for milk production.
           - In most countries, milk production is predominantly from cows, but the data includes milk from other species like sheep and goats.
+          - Net milk production refers to the total production of whole fresh milk, excluding the milk sucked by young animals but including the milked quantities used to feed livestock.
         description_processing: |
           - This indicator is calculated by dividing the total production of milk by the number of animals used for milk production.
       animals_used_for_milk:

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
@@ -698,4 +698,12 @@ tables:
           - This indicator is calculated by dividing the total production of raw milk from cattle by the number of cows used for milk production.
         description_processing: |
           - This indicator is calculated by dividing the total production of raw milk from cattle by the number of cows used for milk production.
+      cows_used_for_milk:
+        title: Number of cows used for milk production
+        unit: animals
+        short_unit: ""
+      milk_production:
+        title: Raw milk production from cattle
+        unit: tonnes
+        short_unit: t
   # NOTE: If you add any tables, remember to mention them as well in the grapher step!

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
@@ -686,22 +686,25 @@ tables:
           - Imports, exports, and domestic supply encompass the total of all items across the following groups: cereals and grains, pulses, starchy roots, fruits and vegetables, oils and fats, sugar, meat, dairy and eggs, alcoholic beverages, and an other products. The latter group includes miscellaneous items such as spices, offals, and other minor commodities.
         display:
           numDecimalPlaces: 1
-  milk_per_cow:
+  milk_per_animal:
     variables:
-      milk_per_cow:
-        title: Milk production per cow
-        unit: kilograms per cow
+      milk_per_animal:
+        title: Milk production per animal
+        unit: kilograms per animal
         short_unit: kg
         description_short: |
-          Average annual milk production per cow. The values are estimated by dividing the total production of raw milk from cattle by the number of cows used for milk production.
+          Average annual milk production per animal. The values are estimated by dividing the total production of milk by the number of animals used for milk production.
+        description_key:
+          - This indicator is calculated by dividing the total production of milk by the number of animals used for milk production.
+          - In most countries, milk production is predominantly from cows, but the data includes milk from other species like sheep and goats.
         description_processing: |
-          - This indicator is calculated by dividing the total production of raw milk from cattle by the number of cows used for milk production.
-      cows_used_for_milk:
-        title: Number of cows used for milk production
+          - This indicator is calculated by dividing the total production of milk by the number of animals used for milk production.
+      animals_used_for_milk:
+        title: Number of animals used for milk production
         unit: animals
         short_unit: ""
       milk_production:
-        title: Raw milk production from cattle
+        title: Milk production
         unit: tonnes
         short_unit: t
   # NOTE: If you add any tables, remember to mention them as well in the grapher step!

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
@@ -698,3 +698,4 @@ tables:
           - This indicator is calculated by dividing the total production of raw milk from cattle by the number of cows used for milk production.
         description_processing: |
           - This indicator is calculated by dividing the total production of raw milk from cattle by the number of cows used for milk production.
+  # NOTE: If you add any tables, remember to mention them as well in the grapher step!

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.py
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.py
@@ -1219,10 +1219,10 @@ def generate_net_exports_as_share_of_supply(tb_fbsc: Table) -> Table:
     return tb
 
 
-def generate_milk_per_cow(tb_qcl: Table) -> Table:
-    # FAOSTAT QCL used to have yield for milk (milk per cow), but it was removed at some point (that combination of item and element is empty in the 2025 release).
-    # Numerically, it seems that their old milk yield indicator coincides with production / slaughtered animals.
-    # So I will reproduce that indicator using their latest data on production and number of cows.
+def generate_milk_per_animal(tb_qcl: Table) -> Table:
+    # FAOSTAT QCL used to have yield for milk (milk per animal), but it was removed at some point (that combination of item and element is empty in the 2025 release).
+    # Numerically, it seems that their old milk yield indicator coincides with production / number of animals.
+    # So I will reproduce that indicator using their latest data on production and number of milk animals.
 
     # Firstly, check if yield is still missing in the data.
     error = "Yield for milk is not missing in the data anymore. Consider reusing it instead of calculating it."
@@ -1234,14 +1234,14 @@ def generate_milk_per_cow(tb_qcl: Table) -> Table:
     UNIT_FOR_PRODUCTION = "tonnes"
     # Element code for "Milk animals".
     ELEMENT_CODE_FOR_MILK_ANIMALS = "005318"
-    # Unit for element of animals.
+    # Unit for element of milk animals.
     UNIT_FOR_ANIMALS = "animals"
-    # Item code for "Raw milk of cattle".
-    ITEM_CODE_FOR_COW_MILK = "00000882"
+    # Item code for "Milk".
+    ITEM_CODE_FOR_MILK = "00001780"
 
     # Select the relevant items/elements/units.
     tb_milk = tb_qcl[
-        (tb_qcl["item_code"] == ITEM_CODE_FOR_COW_MILK)
+        (tb_qcl["item_code"] == ITEM_CODE_FOR_MILK)
         & (tb_qcl["element_code"].isin([ELEMENT_CODE_FOR_PRODUCTION, ELEMENT_CODE_FOR_MILK_ANIMALS]))
     ].reset_index(drop=True)
 
@@ -1255,27 +1255,25 @@ def generate_milk_per_cow(tb_qcl: Table) -> Table:
     ).rename(
         columns={
             ELEMENT_CODE_FOR_PRODUCTION: "milk_production",
-            ELEMENT_CODE_FOR_MILK_ANIMALS: "cows_used_for_milk",
+            ELEMENT_CODE_FOR_MILK_ANIMALS: "animals_used_for_milk",
         },
         errors="raise",
     )
 
-    # Add column for milk production per cow.
+    # Add column for milk production per animal.
     # NOTE: We change the units from tonnes to kg.
-    tb_milk["milk_per_cow"] = 1000 * tb_milk["milk_production"] / tb_milk["cows_used_for_milk"]
+    tb_milk["milk_per_animal"] = 1000 * tb_milk["milk_production"] / tb_milk["animals_used_for_milk"]
 
     # Sanity checks.
-    error = "Unexpected missing data in the calculation of milk per cow."
-    assert tb_milk[tb_milk["milk_per_cow"].isnull()].empty, error
-    error = "Unexpected infinite values in the calculation of milk per cow."
-    assert not np.isinf(tb_milk["milk_per_cow"]).any(), error
-    error = "Yield per cow is unexpectedly high."
-    assert (tb_milk["milk_per_cow"] <= 15000).all(), error
+    error = "Unexpected infinite values in the calculation of milk per animal."
+    assert not np.isinf(tb_milk["milk_per_animal"]).any(), error
+    error = "Yield per animal is unexpectedly high."
+    assert (tb_milk["milk_per_animal"] <= 15000).all(), error
 
     # Improve table format.
-    tb_milk_per_cow = tb_milk.format(["country", "year"], short_name="milk_per_cow")
+    tb_milk_per_animal = tb_milk.format(["country", "year"], short_name="milk_per_animal")
 
-    return tb_milk_per_cow
+    return tb_milk_per_animal
 
 
 def run() -> None:
@@ -1352,7 +1350,7 @@ def run() -> None:
     tb_net_exports_as_share_of_supply = generate_net_exports_as_share_of_supply(tb_fbsc=tb_fbsc)
 
     # Create atable for milk production per animal.
-    tb_milk_per_cow = generate_milk_per_cow(tb_qcl=tb_qcl)
+    tb_milk_per_animal = generate_milk_per_animal(tb_qcl=tb_qcl)
 
     #
     # Save outputs.
@@ -1374,7 +1372,7 @@ def run() -> None:
             tb_maize_and_wheat,
             tb_fertilizer_exports,
             tb_net_exports_as_share_of_supply,
-            tb_milk_per_cow,
+            tb_milk_per_animal,
         ],
     )
     ds_garden.save()

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.py
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.py
@@ -1224,6 +1224,10 @@ def generate_milk_per_cow(tb_qcl: Table) -> Table:
     # Numerically, it seems that their old milk yield indicator coincides with production / slaughtered animals.
     # So I will reproduce that indicator using their latest data on production and number of cows.
 
+    # Firstly, check if yield is still missing in the data.
+    error = "Yield for milk is not missing in the data anymore. Consider reusing it instead of calculating it."
+    assert tb_qcl[(tb_qcl["item_code"] == "00001780") & (tb_qcl["element_code"] == "005420")].empty, error
+
     # Element code for "Production".
     ELEMENT_CODE_FOR_PRODUCTION = "005510"
     # Unit for element of production.

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.py
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.py
@@ -1219,6 +1219,61 @@ def generate_net_exports_as_share_of_supply(tb_fbsc: Table) -> Table:
     return tb
 
 
+def generate_milk_per_cow(tb_qcl: Table) -> Table:
+    # FAOSTAT QCL used to have yield for milk (milk per cow), but it was removed at some point (that combination of item and element is empty in the 2025 release).
+    # Numerically, it seems that their milk coincided with production / slaughtered animals.
+    # So I will reproduce that indicator using their latest data on production and number of cows.
+
+    # Element code for "Production".
+    ELEMENT_CODE_FOR_PRODUCTION = "005510"
+    # Unit for element of production.
+    UNIT_FOR_PRODUCTION = "tonnes"
+    # Element code for "Milk animals".
+    ELEMENT_CODE_FOR_MILK_ANIMALS = "005318"
+    # Unit for element of animals.
+    UNIT_FOR_ANIMALS = "animals"
+    # Item code for "Raw milk of cattle".
+    ITEM_CODE_FOR_COW_MILK = "00000882"
+
+    # Select the relevant items/elements/units.
+    tb_milk = tb_qcl[
+        (tb_qcl["item_code"] == ITEM_CODE_FOR_COW_MILK)
+        & (tb_qcl["element_code"].isin([ELEMENT_CODE_FOR_PRODUCTION, ELEMENT_CODE_FOR_MILK_ANIMALS]))
+    ].reset_index(drop=True)
+
+    # Sanity check.
+    error = "Units of milk production or milk animals have changed."
+    assert set(tb_milk["unit"]) == {UNIT_FOR_PRODUCTION, UNIT_FOR_ANIMALS}, error
+
+    # Transpose data and rename columns conveniently.
+    tb_milk = tb_milk.pivot(
+        index=["country", "year"], columns="element_code", values="value", join_column_levels_with="_"
+    ).rename(
+        columns={
+            ELEMENT_CODE_FOR_PRODUCTION: "milk_production",
+            ELEMENT_CODE_FOR_MILK_ANIMALS: "cows_used_for_milk",
+        },
+        errors="raise",
+    )
+
+    # Add column for milk production per cow.
+    # NOTE: We change the units from tonnes to kg.
+    tb_milk["milk_per_cow"] = 1000 * tb_milk["milk_production"] / tb_milk["cows_used_for_milk"]
+
+    # Sanity checks.
+    error = "Unexpected missing data in the calculation of milk per cow."
+    assert tb_milk[tb_milk["milk_per_cow"].isnull()].empty, error
+    error = "Unexpected infinite values in the calculation of milk per cow."
+    assert not np.isinf(tb_milk["milk_per_cow"]).any(), error
+    error = "Yield per cow is unexpectedly high."
+    assert (tb_milk["milk_per_cow"] <= 15000).all(), error
+
+    # Improve table format.
+    tb_milk_per_cow = tb_milk.format(["country", "year"], short_name="milk_per_cow")
+
+    return tb_milk_per_cow
+
+
 def run() -> None:
     #
     # Load inputs.
@@ -1292,6 +1347,9 @@ def run() -> None:
     # Create table for food trade as a share of consumption.
     tb_net_exports_as_share_of_supply = generate_net_exports_as_share_of_supply(tb_fbsc=tb_fbsc)
 
+    # Create atable for milk production per animal.
+    tb_milk_per_cow = generate_milk_per_cow(tb_qcl=tb_qcl)
+
     #
     # Save outputs.
     #
@@ -1312,6 +1370,7 @@ def run() -> None:
             tb_maize_and_wheat,
             tb_fertilizer_exports,
             tb_net_exports_as_share_of_supply,
+            tb_milk_per_cow,
         ],
     )
     ds_garden.save()

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.py
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.py
@@ -1221,7 +1221,7 @@ def generate_net_exports_as_share_of_supply(tb_fbsc: Table) -> Table:
 
 def generate_milk_per_cow(tb_qcl: Table) -> Table:
     # FAOSTAT QCL used to have yield for milk (milk per cow), but it was removed at some point (that combination of item and element is empty in the 2025 release).
-    # Numerically, it seems that their milk coincided with production / slaughtered animals.
+    # Numerically, it seems that their old milk yield indicator coincides with production / slaughtered animals.
     # So I will reproduce that indicator using their latest data on production and number of cows.
 
     # Element code for "Production".

--- a/etl/steps/data/grapher/faostat/2025-03-17/additional_variables.py
+++ b/etl/steps/data/grapher/faostat/2025-03-17/additional_variables.py
@@ -154,7 +154,7 @@ def run() -> None:
     tb_maize_and_wheat = ds_garden.read("maize_and_wheat", reset_index=True)
     tb_fertilizer_exports = ds_garden.read("fertilizer_exports", reset_index=False)
     tb_net_exports_as_share_of_supply = ds_garden.read("net_exports_as_share_of_supply", reset_index=False)
-    tb_milk_per_cow = ds_garden.read("milk_per_cow", reset_index=False)
+    tb_milk_per_animal = ds_garden.read("milk_per_animal", reset_index=False)
 
     #
     # Process data.
@@ -204,7 +204,7 @@ def run() -> None:
             tb_maize_and_wheat_in_the_context_of_the_ukraine_war,
             tb_fertilizer_exports_in_the_context_of_the_ukraine_war,
             tb_net_exports_as_share_of_supply,
-            tb_milk_per_cow,
+            tb_milk_per_animal,
         ],
         default_metadata=ds_garden.metadata,
     )

--- a/etl/steps/data/grapher/faostat/2025-03-17/additional_variables.py
+++ b/etl/steps/data/grapher/faostat/2025-03-17/additional_variables.py
@@ -154,6 +154,7 @@ def run() -> None:
     tb_maize_and_wheat = ds_garden.read("maize_and_wheat", reset_index=True)
     tb_fertilizer_exports = ds_garden.read("fertilizer_exports", reset_index=False)
     tb_net_exports_as_share_of_supply = ds_garden.read("net_exports_as_share_of_supply", reset_index=False)
+    tb_milk_per_cow = ds_garden.read("milk_per_cow", reset_index=False)
 
     #
     # Process data.
@@ -203,6 +204,7 @@ def run() -> None:
             tb_maize_and_wheat_in_the_context_of_the_ukraine_war,
             tb_fertilizer_exports_in_the_context_of_the_ukraine_war,
             tb_net_exports_as_share_of_supply,
+            tb_milk_per_cow,
         ],
         default_metadata=ds_garden.metadata,
     )


### PR DESCRIPTION
FAOSTAT QCL used to have yield for milk (i.e. milk per animal, used in [this chart](https://ourworldindata.org/grapher/milk-yields-per-animal)), but it was removed at some point: that combination of item and element is empty in the 2025 release.
Numerically, it seems that their old milk yield indicator coincides reasonably well with production / animals, so I used that as an estimate. For some countries, however, the new data seems to be significantly larger (see e.g. Saudi Arabia or Mexico in [chart diff](http://staging-site-data-milk-yield-fix/etl/wizard/chart-diff)).
I have changed the subtitle to clarify that this is an estimate, and how it's calculated.

