### PR TITLE
🐛 gbd: add missing dependency on `un_wpp`

### DIFF
--- a/dag/health.yml
+++ b/dag/health.yml
@@ -463,6 +463,7 @@ steps:
   data-private://garden/ihme_gbd/2024-05-20/gbd_prevalence:
     - data-private://meadow/ihme_gbd/2024-05-20/gbd_prevalence
     - data://garden/regions/2023-01-01/regions
+    - data://garden/un/2022-07-11/un_wpp
   data-private://grapher/ihme_gbd/2024-05-20/gbd_prevalence:
     - data-private://garden/ihme_gbd/2024-05-20/gbd_prevalence
   data-private://grapher/ihme_gbd/2024-05-20/gbd_incidence:


### PR DESCRIPTION
I noticed this missing dependency when I was running a full ETL rebuild, and it was failing because of this.