### PR TITLE
✨ Create explorers from scratch

### DIFF
--- a/etl/collections/explorer_legacy.py
+++ b/etl/collections/explorer_legacy.py
@@ -686,6 +686,7 @@ def _create_explorer_legacy(
             name=explorer_name,
         )
     else:
+        raise NotImplementedError("Updating explorer in DB has been deprecated. Create it from scratch instead.")
         # Load explorer from database.
         explorer = ExplorerLegacy.from_db(explorer_name)
 

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -675,7 +675,6 @@ class PathFinder:
         config: Dict[str, Any],
         df_graphers: pd.DataFrame,
         df_columns: Optional[pd.DataFrame] = None,
-        reset: bool = False,
     ) -> ExplorerLegacy:
         """This function is used to create an Explorer object using the legacy configuration.
 
@@ -703,7 +702,6 @@ class PathFinder:
             df_graphers=df_graphers,
             explorer_name=explorer_name,
             df_columns=df_columns,
-            reset=reset,
         )
 
         return explorer


### PR DESCRIPTION
Explorers are currently updated by loading from the DB, updating the TSV, and saving it back. While this can be useful for quick hotfixes (e.g. updating URLs), it's ultimately a recipe for disaster. All explorers in ETL should be created from scratch.

Once all explorers are fixed, we should set `reset=True` by default in `create_explorer_legacy`. We can also simplify `ExplorerLegacy` by removing the code that loads TSV files into DataFrames.

## Affected Explorers
- minerals
- air-pollution

Run `etlr export://explorers/ --private --export --only --force` on this branch to refresh all explorers and see which ones differ in explorer diff.