### PR TITLE
📊 agriculture: FAOSTAT fixes and improvements

### DIFF
--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
@@ -589,44 +589,27 @@ tables:
         description_processing: *agricultural_land_use_description_processing
   hypothetical_meat_consumption:
     variables:
-      animals_global:
-        title: Number of slaughtered animals to produce meat worldwide
-        unit: "animals"
-        short_unit: ""
-      animals_global_hypothetical:
-        title: Hypothetical number of slaughtered animals if everyone ate like the average citizen of a given country
-        unit: "animals"
-        short_unit: ""
-        description_short: |
-          Hypothetical number of slaughtered animals worldwide if everyone in the world ate the same quantity as the average citizen of a given country.
-        description_key:
-          - 'This is a hypothetical variable derived by Our World in Data which answers the question: "How many animals would need to be slaughtered if everyone in the world consumed the average per capita amount of a given country?". For example: "How many animals would need to be slaughtered if everyone in the world consumed the same amount of meat as the average UK citizen?".'
-        description_processing: |
-          - This indicator was calculated by multiplying global population by the per capita number of slaughtered animals of a given country.
-      animals_per_capita:
-        title: Number of slaughtered animals per person in each country
-        unit: "animals per person"
-        short_unit: ""
       global_population:
         title: World population
         unit: "people"
         short_unit: ""
-      production_global:
-        title: Total amount of meat produced worldwide
-        unit: "tonnes"
-        short_unit: "t"
-      production_global_hypothetical:
+      meat_global_hypothetical:
         title: Hypothetical global meat demand if everyone ate like the average citizen of a given country
         unit: "tonnes"
         short_unit: "t"
         description_short: |
           Hypothetical global meat demand if everyone in the world ate the same quantity as the average citizen of a given country.
         description_key:
-          - 'This is a hypothetical variable derived by Our World in Data which answers the question: "What would global meat production have to be if everyone in the world consumed the average per capita amount of a given country?". For example: "How much meat would we need to produce if everyone in the world consumed the same amount of meat as the average UK citizen?".'
+          - 'This is a hypothetical variable derived by Our World in Data which answers the question: "What would global meat demand have to be if everyone in the world consumed the average per capita amount of a given country?". For example: "How much meat would need to be provided if everyone in the world consumed as much meat as the average UK citizen?".'
+          - We do not have data on actual individual consumption. Instead, this data reflects the amount of meat available for consumption. It may include food that is wasted at the consumer level and not eaten.
         description_processing: |
           - This indicator was calculated by multiplying global population by per capita meat supply of a given country.
-      production_per_capita:
-        title: Per-capita production of meat in each country
+        presentation:
+          grapher_config:
+            note: |-
+              This data reflects the amount of meat available for consumption, not actual intake. It does not account for food waste at the consumer level.
+      meat_per_capita:
+        title: Per-capita meat supply in each country
         unit: "tonnes per person"
         short_unit: "t/person"
   cereal_allocation:

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.meta.yml
@@ -612,6 +612,24 @@ tables:
         title: Per-capita meat supply in each country
         unit: "tonnes per person"
         short_unit: "t/person"
+  hypothetical_animals_slaughtered:
+    variables:
+      animals_global:
+        title: Number of slaughtered animals to produce meat worldwide
+        unit: "animals"
+        short_unit: ""
+      animals_global_hypothetical:
+        title: Hypothetical number of land animals that would be slaughtered if all countries produced meat in the same way as a given country
+        unit: "animals"
+        short_unit: ""
+        description_key:
+          - 'This is a hypothetical variable derived by Our World in Data which answers the question: "How many animals would need to be slaughtered if all countries in the world slaughtered the same number of animals per capita?". For example: "How many animals would need to be slaughtered if all countries replicated the per capita meat production of the UK?".'
+        description_processing: |
+          - This indicator was calculated by multiplying global population by the per capita number of slaughtered animals of a given country.
+      animals_per_capita:
+        title: Number of slaughtered animals per person in each country
+        unit: "animals per person"
+        short_unit: ""
   cereal_allocation:
     variables:
       cereals_allocated_to_animal_feed:

--- a/etl/steps/data/garden/faostat/2025-03-17/additional_variables.py
+++ b/etl/steps/data/garden/faostat/2025-03-17/additional_variables.py
@@ -1002,6 +1002,19 @@ def generate_hypothetical_meat_consumption(tb_qcl: Table) -> Table:
         ["country", "year"], sort_columns=True, short_name="hypothetical_meat_consumption"
     )
 
+    ####################################################################################################################
+    # TODO: I noticed a bug (https://github.com/owid/etl/issues/4241) in the way presentation.attribution is propagated.
+    #  It causes that these specific variables show the attribution of the population dataset instead of FAOSTAT.
+    #  So, assert that the issue is happening, and if so, remove that attribution.
+    for column in tb_hypothetical_meat_consumption.columns:
+        if tb_hypothetical_meat_consumption[column].metadata.presentation is not None:
+            assert (
+                tb_hypothetical_meat_consumption[column].metadata.presentation.attribution
+                == "HYDE (2023); Gapminder (2022); UN WPP (2024)"
+            )
+            tb_hypothetical_meat_consumption[column].metadata.presentation.attribution = None
+    ####################################################################################################################
+
     return tb_hypothetical_meat_consumption
 
 

--- a/etl/steps/data/garden/faostat/2025-03-17/detected_anomalies.py
+++ b/etl/steps/data/garden/faostat/2025-03-17/detected_anomalies.py
@@ -784,6 +784,7 @@ class UnstableNumberOfPoultryBirdsInEurope(DataAnomaly):
     affected_item_codes = [
         "00001057",  # Chickens.
         "00002029",  # Poultry.
+        "00001079",  # Turkeys.
     ]
     affected_element_codes = [
         "005112",  # Stocks.

--- a/etl/steps/data/garden/faostat/2025-03-17/faostat_metadata.py
+++ b/etl/steps/data/garden/faostat/2025-03-17/faostat_metadata.py
@@ -1003,7 +1003,7 @@ def run() -> None:
     #
     # Load data.
     #
-    # Define path to current step file.
+    # Define path to current dataset step file.
     current_step_file = (CURRENT_DIR / "faostat_metadata").with_suffix(".py")
 
     # Get paths and naming conventions for current step.

--- a/etl/steps/data/grapher/faostat/2025-03-17/additional_variables.py
+++ b/etl/steps/data/grapher/faostat/2025-03-17/additional_variables.py
@@ -150,6 +150,7 @@ def run() -> None:
     tb_vegetable_oil_yields = ds_garden.read("vegetable_oil_yields", reset_index=False)
     tb_agriculture_land_use_evolution = ds_garden.read("agriculture_land_use_evolution", reset_index=False)
     tb_hypothetical_meat_consumption = ds_garden.read("hypothetical_meat_consumption", reset_index=False)
+    tb_hypothetical_animals_slaughtered = ds_garden.read("hypothetical_animals_slaughtered", reset_index=False)
     tb_cereal_allocation = ds_garden.read("cereal_allocation", reset_index=False)
     tb_maize_and_wheat = ds_garden.read("maize_and_wheat", reset_index=True)
     tb_fertilizer_exports = ds_garden.read("fertilizer_exports", reset_index=False)
@@ -200,6 +201,7 @@ def run() -> None:
             tb_vegetable_oil_yields,
             tb_agriculture_land_use_evolution,
             tb_hypothetical_meat_consumption,
+            tb_hypothetical_animals_slaughtered,
             tb_cereal_allocation,
             tb_maize_and_wheat_in_the_context_of_the_ukraine_war,
             tb_fertilizer_exports_in_the_context_of_the_ukraine_war,


### PR DESCRIPTION
* Fix issue with the number of live turkeys in EU, Europe, and HIC.
* Fix chart on the hypothetical meat demand per person (which was based on production, but it makes more sense to base it on consumption). Note that this means that the data changes significantly, and also the latest point is 2022 instead of 2023.
  * Also, fix wrong attribution (see [discussion](https://owid.slack.com/archives/C46U9LXRR/p1744109863123159)).
* Create data for a new chart on the hypothetical number of land animals slaughtered if all countries had the same per-capita meat production.
