### PR TITLE
🐛 GBD risk: fix variable titles

### DIFF
--- a/etl/steps/data/garden/ihme_gbd/2024-05-20/gbd_risk.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2024-05-20/gbd_risk.meta.yml
@@ -18,9 +18,9 @@ tables:
         title: |-
           {macros}
           <% if measure == 'Deaths'%>
-            << format_title(metric, age, format_cause(cause), rei, 'Deaths') >>
+            << format_title(metric, age, format_cause(cause),  'Deaths',rei) >>
           <% else %>
-            << format_title(metric, age, format_cause(cause), rei, 'DALYs') >>
+            << format_title(metric, age, format_cause(cause),  'DALYs',rei) >>
           <%- endif -%>
         unit: |-
           <% if measure == 'Deaths'%>


### PR DESCRIPTION
They are currently in the wrong order, e.g. "Ambient ozone pollution from all causes attributed to deaths among individuals aged 70+ years" should be "Deaths from all causes attributed to ambient ozone pollution among individuals aged 70+ years"