### PR TITLE
🔨 Refactor explorer migration

### DIFF
--- a/etl/collections/explorer_migration.py
+++ b/etl/collections/explorer_migration.py
@@ -3,179 +3,20 @@
 import re
 from collections import defaultdict
 from copy import deepcopy
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 from owid.catalog.utils import underscore
+from sqlalchemy.orm import Session
 from structlog import get_logger
+
+from etl.config import OWID_ENV, OWIDEnv
+from etl.grapher import model as gm
 
 log = get_logger()
 
-JSON_VERSION = 1
 
-FLAGS = {
-    "backgroundSeriesLimit",
-    "downloadDataLink",
-    "entityType",
-    "explorerSubtitle",
-    "explorerTitle",
-    "facet",
-    "googleSheet",
-    "hasMapTab",
-    "hideAlertBanner",
-    "hideControls",
-    "hideTitleAnnotation",
-    "indexViewsSeparately",
-    "isPublished",
-    "sourceDesc",
-    "subNavCurrentId",
-    "subNavId",
-    "subtitle",
-    "tab",
-    "thumbnail",
-    "title",
-    "type",
-    "wpBlockId",
-    "yAxisMin",
-    "ySlugs",
-    "hideAnnotationFieldsInTitle",
-}
 PATTERN_CSV = r"https://catalog\.ourworldindata\.org/(?P<group>[^/]+/[^/]+/[^/]+/[^/]+/[^/]+)\.csv"
-
-
-@dataclass
-class Statement:
-    verb: str
-    args: List[str]
-    block: Optional[List[dict]]
-
-    def is_flag(self):
-        return self.verb in FLAGS
-
-    def name(self) -> str:
-        assert self.block or self.verb == "table"
-        if not self.args or self.args[-1].startswith("http"):
-            return "_default"
-        return self.args[-1]
-
-    def __post_init__(self):
-        assert self.verb
-
-
-def parse_explorer(slug: str, explorer_file: Path) -> dict:
-    statements = parse_line_by_line(explorer_file.as_posix(), slug)
-
-    result: Dict[Any, Any] = {"_version": JSON_VERSION}
-    for s in statements:
-        if s.is_flag():
-            result[s.verb] = s.args[0] if s.args else None
-
-        elif s.verb not in ("table", "graphers", "columns"):
-            result[s.verb] = s.args
-
-        else:
-            blocks = result.setdefault("blocks", [])
-            blocks.append({"type": s.verb, "args": s.args, "block": s.block})
-
-    if "isPublished" not in result:
-        result["isPublished"] = "false"
-
-    return result
-
-
-def parse_line_by_line(explorer_file, slug) -> List[Statement]:
-    with open(explorer_file, "r", encoding="utf-8") as f:  # specify encoding to make sure it works on all OSs
-        lines = f.readlines()
-
-    # skip empty lines and comments
-    lines = [line for line in lines if line.strip() or line.startswith("##")]
-
-    data = []
-    i = 0
-    while i < len(lines):
-        parts = lines[i].rstrip("\n\t").split("\t")
-        verb = parts[0]
-        args = parts[1:]
-        i += 1
-
-        if not is_block(verb, args):
-            data.append(Statement(verb, args, None))
-            continue
-
-        # consume a multiline block
-        records, offset = read_block(lines, slug, i)
-
-        # fast forward the number of records plus the header row
-        i += offset
-
-        data.append(Statement(verb, args, records))
-
-    return data
-
-
-def is_block(verb: str, args: List[str]) -> int:
-    if verb in ("graphers", "columns"):
-        return True
-
-    return verb == "table" and not args
-
-
-def read_block(lines: List[str], slug: str, start: int) -> Tuple[List[dict], int]:
-    """
-    Read an embedded tsv block in the file.
-    """
-    # accumulate the block of lines, without the leading tab
-    block = []
-    i = start
-    while i < len(lines) and lines[i].startswith("\t"):
-        line = lines[i][1:].rstrip("\n")
-        block.append(line)
-        i += 1
-    assert len(block) == i - start
-
-    records = tsv_to_records(block, slug, start)
-
-    # only leave significant values in the records
-    prune_nulls(records)
-
-    offset = i - start
-
-    if i > 0:
-        assert len(records) == offset - 1
-
-    return records, i - start
-
-
-def prune_nulls(records):
-    for r in records:
-        for k in list(r):
-            if r[k] in (None, ""):
-                del r[k]
-
-
-def tsv_to_records(block: List[str], slug: str, start: int) -> List[dict]:
-    # do this ourselves instead of using csv.DictReader because the format coming in
-    # contains unterminated quotes and other fun that messes up the standard reader
-
-    if block[0].endswith("\t"):
-        log.warn("loose tab on block header", name=slug, line_no=start)
-
-    header = block[0].rstrip("\t").split("\t")
-    if not all(col for col in header):
-        log.error("empty column name", name=slug, line_no=start)
-        # fill in a dummy column name just to allow parsing to continue
-        for i, col in enumerate(header):
-            if not col:
-                header[i] = f"_column{i}"
-
-    records = []
-    for line in block[1:]:
-        record = dict(zip(header, line.split("\t")))
-        records.append(record)
-
-    return records
 
 
 class ExplorerMigration:
@@ -549,7 +390,16 @@ def _convert_strings_to_types(config: Any) -> Any:
         return config
 
 
-def migrate_csv_explorer(explorer_path: Union[Path, str]):
+def _get_explorer_config(owid_env: OWIDEnv, name: str) -> Dict[str, Any]:
+    # Load explorer from DB
+    with Session(owid_env.engine) as session:
+        db_exp = gm.Explorer.load_explorer(session, slug=name)
+        if db_exp is None:
+            raise ValueError(f"Explorer '{name}' not found in the database.")
+    return db_exp.config
+
+
+def migrate_csv_explorer(name: str, owid_env: Optional[OWIDEnv] = None):
     """Migrate the TSV-based config of a CSV-based explorer to the new format.
 
     Note:
@@ -558,11 +408,11 @@ def migrate_csv_explorer(explorer_path: Union[Path, str]):
 
     Local path to explorer.
     """
-    if isinstance(explorer_path, str):
-        explorer_path = Path(explorer_path)
-    name = Path(explorer_path.stem).stem
-    explorer_json = parse_explorer(name, explorer_path)
-    migration = ExplorerMigration(explorer_json, name)
+    # Load explorer from DB
+    explorer_config = _get_explorer_config(owid_env or OWID_ENV, name)
+
+    # Create ExplorerMigration object
+    migration = ExplorerMigration(explorer_config, name)
 
     if migration.types != {"csv"}:
         raise ValueError(f"{name}: Not a CSV explorer")

--- a/etl/steps/export/explorers/who/latest/migrate_influenza.ipynb
+++ b/etl/steps/export/explorers/who/latest/migrate_influenza.ipynb
@@ -13,7 +13,15 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2m2025-04-10 09:42:04\u001b[0m [\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mYou're on master branch, using local env instead of STAGING=master\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "import re\n",
     "from etl.files import yaml_dump\n",
@@ -73,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +91,22 @@
     "from etl.files import yaml_dump\n",
     "from etl.paths import EXPLORERS_DIR, STEP_DIR\n",
     "\n",
-    "config = migrate_csv_explorer(EXPLORERS_DIR / \"influenza.explorer.backup.tsv\")\n",
+    "config = migrate_csv_explorer(\"influenza\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from collections import defaultdict\n",
+    "from etl.collections.explorer_migration import migrate_csv_explorer\n",
+    "from etl.files import yaml_dump\n",
+    "from etl.paths import EXPLORERS_DIR, STEP_DIR\n",
+    "\n",
+    "config = migrate_csv_explorer(\"influenza\")\n",
     "# print(yaml.dump(config))\n",
     "# config = yaml.safe_load(yaml_dump(config))\n",
     "\n",

--- a/tests/collections/test_explorer_migration.py
+++ b/tests/collections/test_explorer_migration.py
@@ -1,4 +1,5 @@
 import re
+from unittest import mock
 
 import pytest
 
@@ -7,36 +8,103 @@ from etl.files import yaml_dump
 from etl.helpers import PathFinder
 from etl.paths import STEP_DIR
 
-influenza = """
-explorerTitle	Influenza
-explorerSubtitle	Explore global data produced by the World Health Organization on influenza symptoms and cases.
-selection	Northern Hemisphere	Southern Hemisphere
-isPublished	true
-thumbnail
-hideAlertBanner	true
-hideAnnotationFieldsInTitle	true
-yAxisMin	0
-wpBlockId	56732
-hasMapTab	true
-pickerColumnSlugs	Country
-downloadDataLink
-graphers
-	title	subtitle	ySlugs	tableSlug	type	Confirmed cases or Symptoms Radio	Metric Dropdown	Interval Radio	Surveillance type Dropdown	timelineMinTime	selectedFacetStrategy	facetYDomain	hasMapTab	note	defaultView	tab	relatedQuestionText	relatedQuestionUrl
-	Weekly reported cases of acute respiratory infections	Acute...	reported_ari_cases	flu_weekly	LineChart	Symptoms	Acute respiratory infections	Weekly		-4043
-	Monthly reported cases of acute respiratory infections	Acute...	reported_ari_cases	flu_monthly	LineChart	Symptoms	Acute respiratory infections	Monthly		-4043
-table	https://catalog.ourworldindata.org/explorers/who/latest/flu/flu.csv	flu_weekly
-columns	flu_weekly
-	slug	name	type	tolerance	sourceName	additionalInfo	colorScaleNumericMinValue	color	colorScaleScheme	colorScaleNumericBins	unit	shortUnit	sourceLink	dataPublishedBy
-	country	Country	EntityName				0
-	date	Day	Date				0
-	reported_ari_cases	Cases of acute respiratory infections	Integer	30	FluID by the World Health Organization (2023)	**Dataset Description**:\\n- FluID...release.	0		YlOrRd		reported cases		https://source	Global...
-table	https://catalog.ourworldindata.org/explorers/who/latest/flu/flu_monthly.csv	flu_monthly
-columns	flu_monthly
-	slug	name	type	tolerance	sourceName	additionalInfo	colorScaleNumericMinValue	color	colorScaleScheme	colorScaleNumericBins	unit	shortUnit	sourceLink	dataPublishedBy
-	country	Country	EntityName				0
-	month_date	Month	Date				0
-	reported_ari_cases	Reported cases of acute respiratory infections	Integer	30	FluID by the World Health Organization (2023)	**Dataset Description:**\\n- FluID...	0		YlOrRd		reported cases		https://source	Global...
-"""
+influenza_config = {
+    "_version": 1,
+    "explorerTitle": "Influenza",
+    "explorerSubtitle": "Explore global data produced by the World Health Organization on influenza symptoms and cases.",
+    "selection": ["Northern Hemisphere", "Southern Hemisphere"],
+    "isPublished": "true",
+    "thumbnail": None,
+    "hideAlertBanner": "true",
+    "hideAnnotationFieldsInTitle": "true",
+    "yAxisMin": "0",
+    "wpBlockId": "56732",
+    "hasMapTab": "true",
+    "pickerColumnSlugs": ["Country"],
+    "downloadDataLink": None,
+    "blocks": [
+        {
+            "type": "graphers",
+            "args": [],
+            "block": [
+                {
+                    "title": "Weekly reported cases of acute respiratory infections",
+                    "subtitle": "Acute...",
+                    "ySlugs": "reported_ari_cases",
+                    "tableSlug": "flu_weekly",
+                    "type": "LineChart",
+                    "Confirmed cases or Symptoms Radio": "Symptoms",
+                    "Metric Dropdown": "Acute respiratory infections",
+                    "Interval Radio": "Weekly",
+                    "timelineMinTime": "-4043",
+                },
+                {
+                    "title": "Monthly reported cases of acute respiratory infections",
+                    "subtitle": "Acute...",
+                    "ySlugs": "reported_ari_cases",
+                    "tableSlug": "flu_monthly",
+                    "type": "LineChart",
+                    "Confirmed cases or Symptoms Radio": "Symptoms",
+                    "Metric Dropdown": "Acute respiratory infections",
+                    "Interval Radio": "Monthly",
+                    "timelineMinTime": "-4043",
+                },
+            ],
+        },
+        {
+            "type": "table",
+            "args": ["https://catalog.ourworldindata.org/explorers/who/latest/flu/flu.csv", "flu_weekly"],
+            "block": None,
+        },
+        {
+            "type": "columns",
+            "args": ["flu_weekly"],
+            "block": [
+                {"slug": "country", "name": "Country", "type": "EntityName", "colorScaleNumericMinValue": "0"},
+                {"slug": "date", "name": "Day", "type": "Date", "colorScaleNumericMinValue": "0"},
+                {
+                    "slug": "reported_ari_cases",
+                    "name": "Cases of acute respiratory infections",
+                    "type": "Integer",
+                    "tolerance": "30",
+                    "sourceName": "FluID by the World Health Organization (2023)",
+                    "additionalInfo": "**Dataset Description**:\\n- FluID...release.",
+                    "colorScaleNumericMinValue": "0",
+                    "colorScaleScheme": "YlOrRd",
+                    "unit": "reported cases",
+                    "sourceLink": "https://source",
+                    "dataPublishedBy": "Global...",
+                },
+            ],
+        },
+        {
+            "type": "table",
+            "args": ["https://catalog.ourworldindata.org/explorers/who/latest/flu/flu_monthly.csv", "flu_monthly"],
+            "block": None,
+        },
+        {
+            "type": "columns",
+            "args": ["flu_monthly"],
+            "block": [
+                {"slug": "country", "name": "Country", "type": "EntityName", "colorScaleNumericMinValue": "0"},
+                {"slug": "month_date", "name": "Month", "type": "Date", "colorScaleNumericMinValue": "0"},
+                {
+                    "slug": "reported_ari_cases",
+                    "name": "Reported cases of acute respiratory infections",
+                    "type": "Integer",
+                    "tolerance": "30",
+                    "sourceName": "FluID by the World Health Organization (2023)",
+                    "additionalInfo": "**Dataset Description:**\\n- FluID...",
+                    "colorScaleNumericMinValue": "0",
+                    "colorScaleScheme": "YlOrRd",
+                    "unit": "reported cases",
+                    "sourceLink": "https://source",
+                    "dataPublishedBy": "Global...",
+                },
+            ],
+        },
+    ],
+}
 
 expected_influenza = """
 config:
@@ -127,13 +195,10 @@ views:
 """.strip()
 
 
-def test_migrate_csv_explorer(tmp_path):
-    temp_explorer = tmp_path / "influenza.explorer.tsv"
-    with open(temp_explorer, "w") as f:
-        f.write(influenza)
-
-    config = migrate_csv_explorer(temp_explorer)
-    out_yaml = yaml_dump(config)
+def test_migrate_csv_explorer():
+    with mock.patch("etl.collections.explorer_migration._get_explorer_config", return_value=influenza_config):
+        config = migrate_csv_explorer("influenza")
+        out_yaml = yaml_dump(config)
 
     assert out_yaml.strip() == expected_influenza
 
@@ -165,11 +230,6 @@ columns
 
 @pytest.mark.integration
 def test_explorer_legacy(tmp_path, monkeypatch):
-    # Create TSV file
-    tsv_path = tmp_path / "influenza.explorer.tsv"
-    with open(tsv_path, "w") as f:
-        f.write(influenza)
-
     # Monkeypatch ExplorerLegacy.save() to return its content
     from etl.collections.explorer_legacy import ExplorerLegacy
 
@@ -182,9 +242,13 @@ def test_explorer_legacy(tmp_path, monkeypatch):
     monkeypatch.setattr(ExplorerLegacy, "save", patch_save)
 
     # Dump config to YAML file
-    config = migrate_csv_explorer(tsv_path)
+    with mock.patch("etl.collections.explorer_migration._get_explorer_config", return_value=influenza_config):
+        config = migrate_csv_explorer("influenza")
+
     # Make sure explorer can deal with int values
     config["config"]["wpBlockId"] = int(config["config"]["wpBlockId"])
+
+    # Create config file
     config_path = tmp_path / "influenza.config.yml"
     with open(config_path, "w") as f:
         yaml_dump(config, f)


### PR DESCRIPTION
TSV parsing into a structured format has been moved to the Admin API. Remove the code for parsing TSV files from the explorer migration and simply load the data from the database instead.  
