### PR TITLE
🐛 Silence sqlalchemy.exc.PendingRollbackError

### DIFF
--- a/etl/db.py
+++ b/etl/db.py
@@ -10,6 +10,7 @@ import structlog
 from deprecated import deprecated
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import PendingRollbackError
 from sqlalchemy.orm import Session
 
 from etl import config
@@ -76,7 +77,13 @@ def read_sql(sql: str, engine: Optional[Engine | Session] = None, *args, **kwarg
             with engine.connect() as con:
                 return pd.read_sql(sql, con, *args, **kwargs)
         elif isinstance(engine, Session):
-            return pd.read_sql(sql, engine.bind, *args, **kwargs)
+            try:
+                return pd.read_sql(sql, engine.bind, *args, **kwargs)
+            except PendingRollbackError as e:
+                # Rollback and retry
+                log.error("PendingRollbackError occurred", error=str(e))
+                engine.rollback()
+                return pd.read_sql(sql, engine.bind, *args, **kwargs)
         else:
             raise ValueError(f"Unsupported engine type {type(engine)}")
 


### PR DESCRIPTION
Sometimes when I open a wizard on a staging server, I get the following error. It disappears after a refresh or two, but it's still annoying. It's hard to replicate, so this fix is a shot in the dark, but it could help (and shouldn't break anything)
<img width="686" alt="image" src="https://github.com/user-attachments/assets/21abc4dc-6964-44d6-9bcd-598f197b889f" />
