### PR TITLE
🔨 upgrade style re: `dest_dir`

### DIFF
--- a/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch.py
@@ -2,13 +2,13 @@
 
 import pandas as pd
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     paths.log.info("epoch.start")
 
     #
@@ -146,7 +146,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_aggregates_affiliation.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_aggregates_affiliation.py
@@ -1,13 +1,13 @@
 """Generate aggregated table for total yearly and cumulative number of notable AI systems in each category of researcher affiliation."""
 
 from etl.catalog_helpers import last_date_accessed
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     paths.log.info("epoch_aggregates_affiliation.start")
 
     #
@@ -62,8 +62,7 @@ def run(dest_dir: str) -> None:
     #
     # Save outputs.
     #
-    ds_garden = create_dataset(
-        dest_dir,
+    ds_garden = paths.create_dataset(
         tables=[tb_agg],
         yaml_params={"date_accessed": last_date_accessed(tb), "year": last_date_accessed(tb)[-4:]},
     )

--- a/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_aggregates_domain.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_aggregates_domain.py
@@ -3,13 +3,13 @@
 import pandas as pd
 
 from etl.catalog_helpers import last_date_accessed
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     paths.log.info("epoch_aggregates_domain.start")
 
     #
@@ -92,8 +92,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir,
+    ds_garden = paths.create_dataset(
         tables=[tb_agg],
         yaml_params={"date_accessed": last_date_accessed(tb), "year": last_date_accessed(tb)[-4:]},
     )

--- a/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_compute_intensive.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_compute_intensive.py
@@ -2,13 +2,13 @@
 
 import pandas as pd
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     paths.log.info("epoch.start")
 
     #
@@ -52,7 +52,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_compute_intensive_countries.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_compute_intensive_countries.py
@@ -4,13 +4,13 @@ import shared as sh
 
 from etl.catalog_helpers import last_date_accessed
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     paths.log.info("epoch_compute_intensive_countries.start")
 
     #
@@ -52,8 +52,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir,
+    ds_garden = paths.create_dataset(
         tables=[tb_agg],
         yaml_params={"date_accessed": last_date_accessed(tb), "year": last_date_accessed(tb)[-4:]},
     )

--- a/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_compute_intensive_domain.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_compute_intensive_domain.py
@@ -3,13 +3,13 @@
 import shared as sh
 
 from etl.catalog_helpers import last_date_accessed
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     paths.log.info("epoch_compute_intensive_domain.start")
 
     #
@@ -45,8 +45,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir,
+    ds_garden = paths.create_dataset(
         tables=[tb_agg],
         yaml_params={"date_accessed": last_date_accessed(tb), "year": last_date_accessed(tb)[-4:]},
     )

--- a/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_regressions.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_regressions.py
@@ -6,7 +6,7 @@ import pandas as pd
 from owid.catalog import Table
 from sklearn.linear_model import LinearRegression
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -16,7 +16,7 @@ START_DATE = 1950
 END_DATE = 2025.2
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     paths.log.info("epoch.start")
 
     #
@@ -40,7 +40,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_adoption.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_adoption.py
@@ -2,13 +2,13 @@
 
 import owid.catalog.processing as pr
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs
     #
@@ -53,9 +53,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap_2025.metadata
-    )
+    ds_garden = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap_2025.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_bills.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_bills.py
@@ -1,13 +1,13 @@
 """Load a meadow dataset and create a garden dataset."""
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -32,7 +32,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_conferences.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_conferences.py
@@ -1,12 +1,12 @@
 """Load a meadow dataset and create a garden dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -29,7 +29,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_incidents.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_incidents.py
@@ -1,12 +1,12 @@
 """Load a meadow dataset and create a garden dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -26,7 +26,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_investment.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_investment.py
@@ -3,13 +3,13 @@
 import owid.catalog.processing as pr
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -84,24 +84,23 @@ def run(dest_dir: str) -> None:
     tb_cpi_inv = tb_cpi_inv.format(["year", "country"])
 
     # Split into seperate tables to be able to create datapages by restructuring the data
-    tb_generative = tb_cpi_inv[["generative_ai"]].copy()
+    tb_generative = tb_cpi_inv.loc[:, ["generative_ai"]].copy()
     tb_generative.metadata.short_name = "ai_investment_generative"
 
-    tb_companies = tb_cpi_inv[["companies"]].copy()
+    tb_companies = tb_cpi_inv.loc[:, ["companies"]].copy()
     tb_companies.metadata.short_name = "ai_new_companies"
 
     tb_private_investment = create_private_investment_table(tb_cpi_inv)
     tb_corporate_investment = create_corporate_investment(tb_cpi_inv)
 
-    tb_total_privata_data_page = tb_cpi_inv[["private_investment"]].copy()
+    tb_total_privata_data_page = tb_cpi_inv.loc[:, ["private_investment"]].copy()
     tb_total_privata_data_page.metadata.short_name = "ai_total_investment_private"
 
     #
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir,
+    ds_garden = paths.create_dataset(
         tables=[
             tb_generative,
             tb_private_investment,

--- a/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_jobs.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_jobs.py
@@ -1,12 +1,12 @@
 """Load a meadow dataset and create a garden dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -29,7 +29,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_robots.py
+++ b/etl/steps/data/garden/artificial_intelligence/2025-04-08/ai_robots.py
@@ -3,13 +3,13 @@
 import owid.catalog.processing as pr
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -116,8 +116,8 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir, tables=[tb_professional, tb_industrial], check_variables_metadata=True, default_metadata=snap.metadata
+    ds_garden = paths.create_dataset(
+        tables=[tb_professional, tb_industrial], check_variables_metadata=True, default_metadata=snap.metadata
     )
 
     # Save changes in the new garden dataset.

--- a/etl/steps/data/garden/biodiversity/2025-04-07/cherry_blossom.py
+++ b/etl/steps/data/garden/biodiversity/2025-04-07/cherry_blossom.py
@@ -1,7 +1,7 @@
 from owid.catalog import Table
 from structlog import get_logger
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 log = get_logger()
 
@@ -9,7 +9,7 @@ log = get_logger()
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     log.info("cherry_blossom.start")
 
     # Read dataset from meadow.
@@ -24,7 +24,7 @@ def run(dest_dir: str) -> None:
     #
     tb = tb.format(["country", "year"])
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
+    ds = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
 
     # finally save the dataset
     ds.save()

--- a/etl/steps/data/garden/bls/2025-04-12/us_consumer_prices.py
+++ b/etl/steps/data/garden/bls/2025-04-12/us_consumer_prices.py
@@ -1,6 +1,6 @@
 """Load a meadow dataset and create a garden dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -23,7 +23,7 @@ VARIABLE_NAMES = {
 }
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -52,9 +52,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir, tables=[tb_garden], check_variables_metadata=True, default_metadata=snap.metadata
-    )
+    ds_garden = paths.create_dataset(tables=[tb_garden], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/cdc/2025-03-04/pertussis_cases.py
+++ b/etl/steps/data/garden/cdc/2025-03-04/pertussis_cases.py
@@ -3,13 +3,13 @@
 from owid.catalog import processing as pr
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -36,7 +36,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/cedlas/2025-04-01/sedlac.py
+++ b/etl/steps/data/garden/cedlas/2025-04-01/sedlac.py
@@ -6,7 +6,7 @@ import owid.catalog.processing as pr
 from owid.catalog import Dataset, Table
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -38,7 +38,7 @@ INEQUALITY_GINI_TABLES = {
 }
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -80,8 +80,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir,
+    ds_garden = paths.create_dataset(
         tables=[tb, tb_no_spells],
         check_variables_metadata=True,
         default_metadata=ds_meadow.metadata,

--- a/etl/steps/data/garden/health/2025-03-04/diphtheria_deaths.py
+++ b/etl/steps/data/garden/health/2025-03-04/diphtheria_deaths.py
@@ -3,13 +3,13 @@
 from owid.catalog import Table
 from owid.catalog import processing as pr
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -44,7 +44,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb])
+    ds_garden = paths.create_dataset(tables=[tb])
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/health_expenditure/2025-03-04/health_expenditure_omm.py
+++ b/etl/steps/data/garden/health_expenditure/2025-03-04/health_expenditure_omm.py
@@ -3,7 +3,7 @@
 import owid.catalog.processing as pr
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -12,7 +12,7 @@ paths = PathFinder(__file__)
 CATEGORY_OECD = "Government/compulsory schemes"
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -63,7 +63,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_oecd.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_oecd.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/health_expenditure/2025-03-04/lindert.py
+++ b/etl/steps/data/garden/health_expenditure/2025-03-04/lindert.py
@@ -1,13 +1,13 @@
 """Load a meadow dataset and create a garden dataset."""
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -30,7 +30,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/ihme_gbd/2025-03-31/gbd_child_mortality_leading_causes.py
+++ b/etl/steps/data/garden/ihme_gbd/2025-03-31/gbd_child_mortality_leading_causes.py
@@ -1,6 +1,6 @@
 """Load a meadow dataset and create a garden dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -41,7 +41,7 @@ OWID_HIERARCHY = [
 ]
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -77,8 +77,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir,
+    ds_garden = paths.create_dataset(
         tables=[tb],
         check_variables_metadata=True,
         default_metadata=ds_garden.metadata,

--- a/etl/steps/data/garden/imf/2025-04-02/public_finances_modern_history.py
+++ b/etl/steps/data/garden/imf/2025-04-02/public_finances_modern_history.py
@@ -1,7 +1,7 @@
 """Load a meadow dataset and create a garden dataset."""
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -21,7 +21,7 @@ INDICATOR_COLUMNS = {
 }
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -51,9 +51,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata
-    )
+    ds_garden = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/lgbt_rights/2025-04-07/equaldex.py
+++ b/etl/steps/data/garden/lgbt_rights/2025-04-07/equaldex.py
@@ -7,7 +7,7 @@ from owid.catalog import Dataset, Table, VariableMeta, VariablePresentationMeta
 from owid.datautils.dataframes import map_series
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -151,7 +151,7 @@ CATEGORIES_RENAMING = {
 }
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -214,9 +214,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata
-    )
+    ds_garden = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/oecd/2025-03-04/health_expenditure_1993.py
+++ b/etl/steps/data/garden/oecd/2025-03-04/health_expenditure_1993.py
@@ -3,13 +3,13 @@
 import owid.catalog.processing as pr
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -52,7 +52,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/oecd/2025-03-11/co2_air_transport.py
+++ b/etl/steps/data/garden/oecd/2025-03-11/co2_air_transport.py
@@ -4,7 +4,7 @@ import pandas as pd
 from owid.catalog import processing as pr
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -16,7 +16,7 @@ REGIONS = ["Europe", "Asia", "North America", "South America", "Africa", "Oceani
 FRAC_ALLOWED_NANS_PER_YEAR = 0.2
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -68,9 +68,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata
-    )
+    ds_garden = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/oecd/2025-04-16/income_distribution_database.py
+++ b/etl/steps/data/garden/oecd/2025-04-16/income_distribution_database.py
@@ -8,7 +8,7 @@ from structlog import get_logger
 from tabulate import tabulate
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -42,7 +42,7 @@ AGE_GROUPS = {"From 18 to 65 years": "Working population", "Over 65 years": "Ove
 TABLEFMT = "pretty"
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -71,8 +71,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir,
+    ds_garden = paths.create_dataset(
         tables=[tb],
         check_variables_metadata=True,
         default_metadata=ds_meadow.metadata,

--- a/etl/steps/data/garden/public_health_reports/2025-03-04/diphtheria_deaths.py
+++ b/etl/steps/data/garden/public_health_reports/2025-03-04/diphtheria_deaths.py
@@ -1,13 +1,13 @@
 """Load a meadow dataset and create a garden dataset."""
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -29,7 +29,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/survey/2025-03-04/dietary_choices_uk.py
+++ b/etl/steps/data/garden/survey/2025-03-04/dietary_choices_uk.py
@@ -2,7 +2,7 @@
 
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -31,7 +31,7 @@ def run_sanity_checks(tb: Table) -> None:
     assert ((100 * abs(_tb["base"] - _tb["base_unweighted"]) / _tb["base_unweighted"]) < 1).all()
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -73,7 +73,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Initialize a new garden dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb])
+    ds_garden = paths.create_dataset(tables=[tb])
 
     # Save garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/us_census_bureau/2025-03-04/diphtheria_deaths.py
+++ b/etl/steps/data/garden/us_census_bureau/2025-03-04/diphtheria_deaths.py
@@ -1,13 +1,13 @@
 """Load a meadow dataset and create a garden dataset."""
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -29,7 +29,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/wb/2025-03-10/thousand_bins_distribution.py
+++ b/etl/steps/data/garden/wb/2025-03-10/thousand_bins_distribution.py
@@ -3,7 +3,7 @@
 from owid.catalog import Table
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -20,7 +20,7 @@ REGIONS_MAPPING = {
 }
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -49,9 +49,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata
-    )
+    ds_garden = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/wid/2025-03-14/world_inequality_database.py
+++ b/etl/steps/data/garden/wid/2025-03-14/world_inequality_database.py
@@ -13,7 +13,7 @@ from owid.catalog import Table
 from shared import add_metadata_vars, add_metadata_vars_distribution
 from tabulate import tabulate
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -30,7 +30,7 @@ TABLEFMT = "pretty"
 LONG_FORMAT = False
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -82,8 +82,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset and add the garden table.
-    ds_garden = create_dataset(
-        dest_dir,
+    ds_garden = paths.create_dataset(
         tables=[tb, tb_percentiles, tb_fiscal],
         check_variables_metadata=True,
         default_metadata=ds_meadow.metadata,

--- a/etl/steps/data/grapher/animal_welfare/2025-01-23/number_of_farmed_crustaceans.py
+++ b/etl/steps/data/grapher/animal_welfare/2025-01-23/number_of_farmed_crustaceans.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -18,5 +18,5 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True)
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch.py
@@ -4,13 +4,13 @@ import owid.catalog.processing as pr
 import pandas as pd
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -50,14 +50,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True
-    )
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_aggregates_affiliation.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_aggregates_affiliation.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -30,12 +30,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_aggregates_countries.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_aggregates_countries.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -19,12 +19,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb_garden], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_aggregates_domain.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_aggregates_domain.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,12 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_aggregates_organizations.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_aggregates_organizations.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,12 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_compute_intensive.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_compute_intensive.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -25,9 +25,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_compute_intensive_countries.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_compute_intensive_countries.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -19,12 +19,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb_garden], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_compute_intensive_domain.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_compute_intensive_domain.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,12 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_compute_intensive_organizations.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_compute_intensive_organizations.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,12 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_regressions.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-01-08/epoch_regressions.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,14 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True
-    )
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch.py
@@ -4,13 +4,13 @@ import owid.catalog.processing as pr
 import pandas as pd
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -50,14 +50,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True
-    )
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_aggregates_affiliation.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_aggregates_affiliation.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -30,12 +30,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_aggregates_countries.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_aggregates_countries.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -19,12 +19,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb_garden], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_aggregates_domain.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_aggregates_domain.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,12 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_aggregates_organizations.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_aggregates_organizations.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,12 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_compute_intensive.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_compute_intensive.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -25,9 +25,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_compute_intensive_countries.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_compute_intensive_countries.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -19,12 +19,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb_garden], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_compute_intensive_domain.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_compute_intensive_domain.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,12 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_compute_intensive_organizations.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_compute_intensive_organizations.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,12 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_regressions.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-04/epoch_regressions.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,14 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True
-    )
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-17/papers_with_code_coding.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-17/papers_with_code_coding.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,9 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-17/papers_with_code_imagenet.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-17/papers_with_code_imagenet.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,9 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-17/papers_with_code_language.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-17/papers_with_code_language.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,9 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-17/papers_with_code_math.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-17/papers_with_code_math.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,9 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-17/yougov_job_automation.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-17/yougov_job_automation.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -26,14 +26,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True
-    )
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-02-17/yougov_robots.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-02-17/yougov_robots.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -25,14 +25,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True
-    )
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch.py
@@ -4,13 +4,13 @@ import owid.catalog.processing as pr
 import pandas as pd
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, grapher_checks
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -50,9 +50,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
 
     #
     # Checks.

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch.py
@@ -4,7 +4,7 @@ import owid.catalog.processing as pr
 import pandas as pd
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -51,11 +51,6 @@ def run() -> None:
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_affiliation.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_affiliation.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, grapher_checks
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -30,7 +30,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     #
     # Checks.

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_affiliation.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_affiliation.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -31,11 +31,6 @@ def run() -> None:
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_countries.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_countries.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -20,11 +20,6 @@ def run() -> None:
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = paths.create_dataset(tables=[tb_garden], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_countries.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_countries.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, grapher_checks
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -19,7 +19,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb_garden], default_metadata=ds_garden.metadata)
 
     #
     # Checks.

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_domain.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_domain.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -29,11 +29,6 @@ def run() -> None:
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_domain.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_domain.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, grapher_checks
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,7 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     #
     # Checks.

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_organizations.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_organizations.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -29,11 +29,6 @@ def run() -> None:
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_organizations.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_aggregates_organizations.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, grapher_checks
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,7 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     #
     # Checks.

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -25,9 +25,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_countries.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_countries.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -20,11 +20,6 @@ def run() -> None:
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = paths.create_dataset(tables=[tb_garden], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_countries.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_countries.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, grapher_checks
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -19,7 +19,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb_garden], default_metadata=ds_garden.metadata)
 
     #
     # Checks.

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_domain.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_domain.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -29,11 +29,6 @@ def run() -> None:
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_domain.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_domain.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, grapher_checks
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,7 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     #
     # Checks.

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_organizations.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_organizations.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -29,11 +29,6 @@ def run() -> None:
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_organizations.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_compute_intensive_organizations.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, grapher_checks
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,7 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     #
     # Checks.

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_regressions.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_regressions.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -21,11 +21,6 @@ def run() -> None:
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
     ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_regressions.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch_regressions.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, grapher_checks
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
 
     #
     # Checks.

--- a/etl/steps/data/grapher/artificial_intelligence/2025-04-08/ai_index.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-04-08/ai_index.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -40,8 +40,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir,
+    ds_grapher = paths.create_dataset(
         tables=[
             tb_adoption,
             tb_jobs,

--- a/etl/steps/data/grapher/atus/2025-01-06/atus_who.py
+++ b/etl/steps/data/grapher/atus/2025-01-06/atus_who.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -50,8 +50,8 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb, tb_years], check_variables_metadata=True, default_metadata=ds_garden.metadata
+    ds_grapher = paths.create_dataset(
+        tables=[tb, tb_years], check_variables_metadata=True, default_metadata=ds_garden.metadata
     )
 
     # Save changes in the new grapher dataset.

--- a/etl/steps/data/grapher/biodiversity/2025-01-29/cherry_blossom.py
+++ b/etl/steps/data/grapher/biodiversity/2025-01-29/cherry_blossom.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -19,7 +19,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/biodiversity/2025-04-07/cherry_blossom.py
+++ b/etl/steps/data/grapher/biodiversity/2025-04-07/cherry_blossom.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -19,7 +19,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/bls/2025-04-12/us_consumer_prices.py
+++ b/etl/steps/data/grapher/bls/2025-04-12/us_consumer_prices.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/cancer/2025-02-17/gco_cancer_survival.py
+++ b/etl/steps/data/grapher/cancer/2025-02-17/gco_cancer_survival.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/cdc/2025-03-04/pertussis_cases.py
+++ b/etl/steps/data/grapher/cdc/2025-03-04/pertussis_cases.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,7 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/cedlas/2025-04-01/sedlac.py
+++ b/etl/steps/data/grapher/cedlas/2025-04-01/sedlac.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-07/surface_country_level_monthly_anomaly.py
+++ b/etl/steps/data/grapher/climate/2025-01-07/surface_country_level_monthly_anomaly.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -51,5 +51,5 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_pivot], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb_pivot], default_metadata=ds_garden.metadata)
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-07/surface_global_monthly_anomaly.py
+++ b/etl/steps/data/grapher/climate/2025-01-07/surface_global_monthly_anomaly.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -63,6 +63,6 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[average_anomaly], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[average_anomaly], default_metadata=ds_garden.metadata)
     ds_grapher.metadata.title = "Global monthly temperature anomalies"
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-07/surface_global_monthly_anomaly_all_countries.py
+++ b/etl/steps/data/grapher/climate/2025-01-07/surface_global_monthly_anomaly_all_countries.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -45,6 +45,6 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_global], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb_global], default_metadata=ds_garden.metadata)
     ds_grapher.metadata.title = "Global monthly temperature anomalies for all countries"
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-07/surface_temperature.py
+++ b/etl/steps/data/grapher/climate/2025-01-07/surface_temperature.py
@@ -2,13 +2,13 @@
 
 import pandas as pd
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -34,7 +34,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
     ds_grapher.metadata.title = "Surface temperatures and anomalies by country"
 
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-07/surface_temperature_annual_average.py
+++ b/etl/steps/data/grapher/climate/2025-01-07/surface_temperature_annual_average.py
@@ -4,13 +4,13 @@ import numpy as np
 import owid.catalog.processing as pr
 
 from etl.catalog_helpers import last_date_accessed
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -70,8 +70,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir,
+    ds_grapher = paths.create_dataset(
         tables=[combined],
         default_metadata=ds_garden.metadata,
         check_variables_metadata=True,

--- a/etl/steps/data/grapher/climate/2025-01-07/surface_temperature_anomalies.py
+++ b/etl/steps/data/grapher/climate/2025-01-07/surface_temperature_anomalies.py
@@ -2,13 +2,13 @@
 
 import owid.catalog.processing as pr
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -69,6 +69,6 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_merged], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb_merged], default_metadata=ds_garden.metadata)
     ds_grapher.metadata.title = "Monthly surface temperature anomalies by country"
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-07/surface_temperature_monthly.py
+++ b/etl/steps/data/grapher/climate/2025-01-07/surface_temperature_monthly.py
@@ -2,13 +2,13 @@
 
 import owid.catalog.processing as pr
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -66,6 +66,6 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_merged], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb_merged], default_metadata=ds_garden.metadata)
     ds_grapher.metadata.title = "Monthly surface temperatures by country"
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-07/total_precipitation_annual.py
+++ b/etl/steps/data/grapher/climate/2025-01-07/total_precipitation_annual.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -10,7 +10,7 @@ paths = PathFinder(__file__)
 INCOMPLETE_YEAR = 2025
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -41,8 +41,6 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata, check_variables_metadata=True)
 
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-21/climate_change_impacts_annual.py
+++ b/etl/steps/data/grapher/climate/2025-01-21/climate_change_impacts_annual.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -27,5 +27,5 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_annual], check_variables_metadata=True)
+    ds_grapher = paths.create_dataset(tables=[tb_annual], check_variables_metadata=True)
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-21/climate_change_impacts_monthly.py
+++ b/etl/steps/data/grapher/climate/2025-01-21/climate_change_impacts_monthly.py
@@ -1,13 +1,13 @@
 """Load a garden dataset and create a grapher dataset."""
 
 from etl.grapher.helpers import adapt_table_with_dates_to_grapher
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -31,5 +31,5 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True)
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-21/sea_ice_anomalies_by_month.py
+++ b/etl/steps/data/grapher/climate/2025-01-21/sea_ice_anomalies_by_month.py
@@ -2,7 +2,7 @@
 
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -103,7 +103,7 @@ def sanity_check_inputs(tb: Table) -> None:
     ).all(), error
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -166,5 +166,5 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True)
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-21/sea_ice_extent_by_decade.py
+++ b/etl/steps/data/grapher/climate/2025-01-21/sea_ice_extent_by_decade.py
@@ -5,7 +5,7 @@ import re
 import owid.catalog.processing as pr
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -142,7 +142,7 @@ def sanity_check_inputs(tb: Table) -> None:
     ).all(), error
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -199,5 +199,5 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_combined], check_variables_metadata=True)
+    ds_grapher = paths.create_dataset(tables=[tb_combined], check_variables_metadata=True)
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-01-21/sea_ice_extent_by_year.py
+++ b/etl/steps/data/grapher/climate/2025-01-21/sea_ice_extent_by_year.py
@@ -4,7 +4,7 @@ import re
 
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -115,7 +115,7 @@ def sanity_check_inputs(tb: Table) -> None:
     ).all(), error
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -166,5 +166,5 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True)
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True)
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-02-12/sst.py
+++ b/etl/steps/data/grapher/climate/2025-02-12/sst.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -40,9 +40,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/climate/2025-02-12/sst_by_month.py
+++ b/etl/steps/data/grapher/climate/2025-02-12/sst_by_month.py
@@ -2,13 +2,13 @@
 
 import pandas as pd
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -50,9 +50,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/democracy/2025-03-05/eiu.py
+++ b/etl/steps/data/grapher/democracy/2025-03-05/eiu.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -26,9 +26,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=tables, check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=tables, check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/demography/2025-01-20/deaths.py
+++ b/etl/steps/data/grapher/demography/2025-01-20/deaths.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/energy/2025-02-03/energy_prices.py
+++ b/etl/steps/data/grapher/energy/2025-02-03/energy_prices.py
@@ -1,20 +1,19 @@
 """Load garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     # Load tables from garden dataset.
     ds_garden = paths.load_dataset("energy_prices")
     tb_annual = ds_garden.read("energy_prices_annual", reset_index=False)
     tb_monthly = ds_garden.read("energy_prices_monthly", reset_index=False)
 
     # Create a new grapher dataset.
-    dataset = create_dataset(
-        dest_dir=dest_dir,
+    dataset = paths.create_dataset(
         tables=[tb_annual, tb_monthly],
         check_variables_metadata=True,
         default_metadata=ds_garden.metadata,

--- a/etl/steps/data/grapher/faostat/2025-03-17/shared.py
+++ b/etl/steps/data/grapher/faostat/2025-03-17/shared.py
@@ -39,6 +39,6 @@ def run(dest_dir: str) -> None:
     #
     # Create a new grapher dataset.
     ds_grapher = paths.create_dataset(
-        ables=[tb_garden], default_metadata=ds_garden.metadata, check_variables_metadata=True
+        tables=[tb_garden], default_metadata=ds_garden.metadata, check_variables_metadata=True
     )
     ds_grapher.save()

--- a/etl/steps/data/grapher/faostat/2025-03-17/shared.py
+++ b/etl/steps/data/grapher/faostat/2025-03-17/shared.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Define path to current folder, namespace and version of all datasets in this folder.
 CURRENT_DIR = Path(__file__).parent
@@ -38,7 +38,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset.
-    ds_grapher = create_dataset(
-        dest_dir=dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata, check_variables_metadata=True
+    ds_grapher = paths.create_dataset(
+        ables=[tb_garden], default_metadata=ds_garden.metadata, check_variables_metadata=True
     )
     ds_grapher.save()

--- a/etl/steps/data/grapher/gavi/2025-02-11/eligibility.py
+++ b/etl/steps/data/grapher/gavi/2025-02-11/eligibility.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-01-22/measles_state_level.py
+++ b/etl/steps/data/grapher/health/2025-01-22/measles_state_level.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-01-22/unaids.py
+++ b/etl/steps/data/grapher/health/2025-01-22/unaids.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -106,16 +106,10 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir,
+    ds_grapher = paths.create_dataset(
         tables=tables,
         default_metadata=ds_garden.metadata,
     )
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-02-13/vaccine_confidence.py
+++ b/etl/steps/data/grapher/health/2025-02-13/vaccine_confidence.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-02-20/measles_deaths_long_run.py
+++ b/etl/steps/data/grapher/health/2025-02-20/measles_deaths_long_run.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-02-25/diphtheria_cases.py
+++ b/etl/steps/data/grapher/health/2025-02-25/diphtheria_cases.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-02-26/polio_cases_state_level.py
+++ b/etl/steps/data/grapher/health/2025-02-26/polio_cases_state_level.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-02-27/diphtheria_cases_state_level.py
+++ b/etl/steps/data/grapher/health/2025-02-27/diphtheria_cases_state_level.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-02-27/pertussis_cases_state_level.py
+++ b/etl/steps/data/grapher/health/2025-02-27/pertussis_cases_state_level.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-02-27/tetanus_cases_state_level.py
+++ b/etl/steps/data/grapher/health/2025-02-27/tetanus_cases_state_level.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-02-27/typhoid_fever_cases_state_level.py
+++ b/etl/steps/data/grapher/health/2025-02-27/typhoid_fever_cases_state_level.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health/2025-03-04/diphtheria_deaths.py
+++ b/etl/steps/data/grapher/health/2025-03-04/diphtheria_deaths.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,7 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/health_expenditure/2025-03-04/health_expenditure_omm.py
+++ b/etl/steps/data/grapher/health_expenditure/2025-03-04/health_expenditure_omm.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,7 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/ihme_gbd/2025-03-31/gbd_child_mortality_leading_causes.py
+++ b/etl/steps/data/grapher/ihme_gbd/2025-03-31/gbd_child_mortality_leading_causes.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -17,8 +17,7 @@ def run(dest_dir: str) -> None:
     # Save outputs .
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir,
+    ds_grapher = paths.create_dataset(
         tables=[tb],
         check_variables_metadata=True,
         default_metadata=ds_garden.metadata,

--- a/etl/steps/data/grapher/imf/2025-04-02/public_finances_modern_history.py
+++ b/etl/steps/data/grapher/imf/2025-04-02/public_finances_modern_history.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/lazard/2025-02-25/levelized_cost_of_energy.py
+++ b/etl/steps/data/grapher/lazard/2025-02-25/levelized_cost_of_energy.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -29,9 +29,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/lgbt_rights/2025-04-07/equaldex.py
+++ b/etl/steps/data/grapher/lgbt_rights/2025-04-07/equaldex.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -23,11 +23,6 @@ def run() -> None:
     ds_grapher = paths.create_dataset(
         tables=[tb_garden], check_variables_metadata=True, default_metadata=ds_garden.metadata
     )
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/lgbt_rights/2025-04-07/equaldex.py
+++ b/etl/steps/data/grapher/lgbt_rights/2025-04-07/equaldex.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder, grapher_checks
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,8 +20,8 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb_garden], check_variables_metadata=True, default_metadata=ds_garden.metadata
+    ds_grapher = paths.create_dataset(
+        tables=[tb_garden], check_variables_metadata=True, default_metadata=ds_garden.metadata
     )
 
     #

--- a/etl/steps/data/grapher/lis/2025-01-24/luxembourg_income_study.py
+++ b/etl/steps/data/grapher/lis/2025-01-24/luxembourg_income_study.py
@@ -2,13 +2,13 @@
 
 from owid.catalog import warnings
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -26,8 +26,8 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     with warnings.ignore_warnings([warnings.NoOriginsWarning, warnings.DisplayNameWarning]):
-        ds_garden = create_dataset(
-            dest_dir, tables=[tb_garden], check_variables_metadata=True, default_metadata=ds_garden.metadata
+        ds_garden = paths.create_dataset(
+            tables=[tb_garden], check_variables_metadata=True, default_metadata=ds_garden.metadata
         )
 
     ds_garden.save()

--- a/etl/steps/data/grapher/met_office_hadley_centre/2025-01-21/near_surface_temperature.py
+++ b/etl/steps/data/grapher/met_office_hadley_centre/2025-01-21/near_surface_temperature.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -27,5 +27,5 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir=dest_dir, tables=[tb_garden], check_variables_metadata=True)
+    ds_grapher = paths.create_dataset(tables=[tb_garden], check_variables_metadata=True)
     ds_grapher.save()

--- a/etl/steps/data/grapher/oecd/2025-01-11/mean_age_at_marriage.py
+++ b/etl/steps/data/grapher/oecd/2025-01-11/mean_age_at_marriage.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/oecd/2025-02-19/official_development_assistance.py
+++ b/etl/steps/data/grapher/oecd/2025-02-19/official_development_assistance.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -24,9 +24,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/oecd/2025-02-25/health_expenditure.py
+++ b/etl/steps/data/grapher/oecd/2025-02-25/health_expenditure.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/oecd/2025-02-25/social_expenditure.py
+++ b/etl/steps/data/grapher/oecd/2025-02-25/social_expenditure.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/oecd/2025-03-11/co2_air_transport.py
+++ b/etl/steps/data/grapher/oecd/2025-03-11/co2_air_transport.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -24,9 +24,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/oecd/2025-04-16/income_distribution_database.py
+++ b/etl/steps/data/grapher/oecd/2025-04-16/income_distribution_database.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/ons/2025-01-12/divorces.py
+++ b/etl/steps/data/grapher/ons/2025-01-12/divorces.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -24,9 +24,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/ons/2025-01-12/divorces_by_year.py
+++ b/etl/steps/data/grapher/ons/2025-01-12/divorces_by_year.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -39,9 +39,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/ons/2025-01-21/marriages.py
+++ b/etl/steps/data/grapher/ons/2025-01-21/marriages.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -27,9 +27,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/poverty_inequality/2025-01-22/inequality_comparison.py
+++ b/etl/steps/data/grapher/poverty_inequality/2025-01-22/inequality_comparison.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/survey/2025-03-04/dietary_choices_uk.py
+++ b/etl/steps/data/grapher/survey/2025-03-04/dietary_choices_uk.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -11,7 +11,7 @@ paths = PathFinder(__file__)
 SELECTED_GROUPS = ["All adults", "18-24", "25-49", "50-64", "65+"]
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -51,7 +51,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Initialize a new grapher dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb])
+    ds_grapher = paths.create_dataset(tables=[tb])
 
     # Save grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/un/2025-01-14/married_women.py
+++ b/etl/steps/data/grapher/un/2025-01-14/married_women.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/wb/2025-01-15/poverty_projections.py
+++ b/etl/steps/data/grapher/wb/2025-01-15/poverty_projections.py
@@ -1,6 +1,6 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -9,7 +9,7 @@ paths = PathFinder(__file__)
 INDEX_COLUMNS = ["country", "year", "povertyline", "scenario"]
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -28,9 +28,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset..
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/who/2025-01-09/vaccination_introductions.py
+++ b/etl/steps/data/grapher/who/2025-01-09/vaccination_introductions.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -21,8 +21,8 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb, tb_sum], check_variables_metadata=True, default_metadata=ds_garden.metadata
+    ds_grapher = paths.create_dataset(
+        tables=[tb, tb_sum], check_variables_metadata=True, default_metadata=ds_garden.metadata
     )
 
     # Save changes in the new grapher dataset.

--- a/etl/steps/data/grapher/who/2025-01-13/polio_vaccine_schedule.py
+++ b/etl/steps/data/grapher/who/2025-01-13/polio_vaccine_schedule.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -24,9 +24,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/who/2025-01-17/mortality_database_vaccine_preventable.py
+++ b/etl/steps/data/grapher/who/2025-01-17/mortality_database_vaccine_preventable.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/who/2025-01-17/vaccine_stock_out.py
+++ b/etl/steps/data/grapher/who/2025-01-17/vaccine_stock_out.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -24,8 +24,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir,
+    ds_grapher = paths.create_dataset(
         tables=[tb, tb_agg, tb_cause, tb_global, tb_global_cause],
         check_variables_metadata=True,
         default_metadata=ds_garden.metadata,

--- a/etl/steps/data/grapher/who/2025-01-28/vaccine_safety.py
+++ b/etl/steps/data/grapher/who/2025-01-28/vaccine_safety.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/wid/2025-03-14/world_inequality_database.py
+++ b/etl/steps/data/grapher/wid/2025-03-14/world_inequality_database.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/worldbank_wdi/2025-01-24/wdi.py
+++ b/etl/steps/data/grapher/worldbank_wdi/2025-01-24/wdi.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -24,12 +24,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher, warn_title_public=False)
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/wpf/2025-01-17/famines.py
+++ b/etl/steps/data/grapher/wpf/2025-01-17/famines.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -39,9 +39,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/wpf/2025-01-17/famines_by_place.py
+++ b/etl/steps/data/grapher/wpf/2025-01-17/famines_by_place.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/wpf/2025-01-17/famines_by_regime_gdp_population.py
+++ b/etl/steps/data/grapher/wpf/2025-01-17/famines_by_regime_gdp_population.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -34,9 +34,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/wpf/2025-01-17/famines_by_trigger.py
+++ b/etl/steps/data/grapher/wpf/2025-01-17/famines_by_trigger.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -21,9 +21,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/grapher/wpf/2025-01-17/total_famines_by_year_decade.py
+++ b/etl/steps/data/grapher/wpf/2025-01-17/total_famines_by_year_decade.py
@@ -1,12 +1,12 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -20,9 +20,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(
-        dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata
-    )
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/meadow/artificial_intelligence/2025-03-12/epoch.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2025-03-12/epoch.py
@@ -2,13 +2,13 @@
 
 import numpy as np
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     paths.log.info("epoch.start")
 
     #
@@ -63,7 +63,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
 
     # Save changes in the new garden dataset.
     ds_meadow.save()

--- a/etl/steps/data/meadow/artificial_intelligence/2025-03-12/epoch_compute_intensive.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2025-03-12/epoch_compute_intensive.py
@@ -2,13 +2,13 @@
 
 import numpy as np
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -60,7 +60,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_meadow = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new meadow dataset.
     ds_meadow.save()

--- a/etl/steps/data/meadow/biodiversity/2025-04-07/cherry_blossom.py
+++ b/etl/steps/data/meadow/biodiversity/2025-04-07/cherry_blossom.py
@@ -4,7 +4,7 @@ from owid.catalog import Table
 from owid.catalog import processing as pr
 from structlog import get_logger
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 log = get_logger()
 
@@ -12,7 +12,7 @@ log = get_logger()
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     log.info("cherry_blossom.start")
 
     # retrieve snapshot
@@ -30,7 +30,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
+    ds = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
 
     # finally save the dataset
     ds.save()

--- a/etl/steps/data/meadow/cdc/2025-03-04/pertussis_cases.py
+++ b/etl/steps/data/meadow/cdc/2025-03-04/pertussis_cases.py
@@ -1,12 +1,12 @@
 """Load a snapshot and create a meadow dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -26,8 +26,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(
-        dest_dir,
+    ds_meadow = paths.create_dataset(
         tables=tables,
         check_variables_metadata=True,
         default_metadata=snap.metadata,

--- a/etl/steps/data/meadow/cedlas/2025-04-01/sedlac.py
+++ b/etl/steps/data/meadow/cedlas/2025-04-01/sedlac.py
@@ -10,7 +10,7 @@ from typing import Dict, List
 from owid.catalog import Table
 from structlog import get_logger
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 from etl.snapshot import Snapshot
 
 # Get paths and naming conventions for current step.
@@ -157,7 +157,7 @@ AGGREGATION_LEVELS = ["NATIONAL", "URBAN", "RURAL"]
 SOURCE_TEXT = "Source: SEDLAC (CEDLAS and The World Bank) based on microdata from household surveys. "
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -183,8 +183,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(
-        dest_dir,
+    ds_meadow = paths.create_dataset(
         tables=inequality_deciles_indices_tables + inequality_gini_tables + poverty_tables,
         check_variables_metadata=True,
         default_metadata=snap_poverty.metadata,

--- a/etl/steps/data/meadow/health_expenditure/2025-03-04/lindert.py
+++ b/etl/steps/data/meadow/health_expenditure/2025-03-04/lindert.py
@@ -1,12 +1,12 @@
 """Load a snapshot and create a meadow dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -29,8 +29,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(
-        dest_dir,
+    ds_meadow = paths.create_dataset(
         tables=tables,
         check_variables_metadata=True,
         default_metadata=snap.metadata,

--- a/etl/steps/data/meadow/imf/2025-04-02/public_finances_modern_history.py
+++ b/etl/steps/data/meadow/imf/2025-04-02/public_finances_modern_history.py
@@ -1,12 +1,12 @@
 """Load a snapshot and create a meadow dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -23,7 +23,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_meadow = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new meadow dataset.
     ds_meadow.save()

--- a/etl/steps/data/meadow/lgbt_rights/2025-04-07/equaldex.py
+++ b/etl/steps/data/meadow/lgbt_rights/2025-04-07/equaldex.py
@@ -1,12 +1,12 @@
 """Load a snapshot and create a meadow dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
 
@@ -52,8 +52,8 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(
-        dest_dir, tables=[tb, tb_current, tb_indices], check_variables_metadata=True, default_metadata=snap.metadata
+    ds_meadow = paths.create_dataset(
+        tables=[tb, tb_current, tb_indices], check_variables_metadata=True, default_metadata=snap.metadata
     )
 
     # Save changes in the new garden dataset.

--- a/etl/steps/data/meadow/oecd/2025-03-04/health_expenditure_1993.py
+++ b/etl/steps/data/meadow/oecd/2025-03-04/health_expenditure_1993.py
@@ -2,13 +2,13 @@
 
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -33,8 +33,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(
-        dest_dir,
+    ds_meadow = paths.create_dataset(
         tables=tables,
         check_variables_metadata=True,
         default_metadata=snap.metadata,

--- a/etl/steps/data/meadow/oecd/2025-03-11/co2_air_transport.py
+++ b/etl/steps/data/meadow/oecd/2025-03-11/co2_air_transport.py
@@ -2,13 +2,13 @@
 
 import pandas as pd
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -45,7 +45,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_meadow = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new meadow dataset.
     ds_meadow.save()

--- a/etl/steps/data/meadow/oecd/2025-04-16/income_distribution_database.py
+++ b/etl/steps/data/meadow/oecd/2025-04-16/income_distribution_database.py
@@ -1,6 +1,6 @@
 """Load a snapshot and create a meadow dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -12,7 +12,7 @@ VARS_TO_KEEP = ["Reference area", "TIME_PERIOD", "Measure", "Poverty line", "Age
 INDICATOR_NAMES = {"Reference area": "country", "TIME_PERIOD": "year", "OBS_VALUE": "value"}
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -37,7 +37,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_meadow = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new meadow dataset.
     ds_meadow.save()

--- a/etl/steps/data/meadow/public_health_reports/2025-03-04/diphtheria_deaths.py
+++ b/etl/steps/data/meadow/public_health_reports/2025-03-04/diphtheria_deaths.py
@@ -1,12 +1,12 @@
 """Load a snapshot and create a meadow dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -26,8 +26,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(
-        dest_dir,
+    ds_meadow = paths.create_dataset(
         tables=tables,
         check_variables_metadata=True,
         default_metadata=snap.metadata,

--- a/etl/steps/data/meadow/survey/2025-03-04/dietary_choices_uk.py
+++ b/etl/steps/data/meadow/survey/2025-03-04/dietary_choices_uk.py
@@ -2,13 +2,13 @@
 
 import owid.catalog.processing as pr
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -31,7 +31,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Initialize a new meadow dataset.
-    ds_meadow = create_dataset(dest_dir, tables=[tb])
+    ds_meadow = paths.create_dataset(tables=[tb])
 
     # Save meadow dataset.
     ds_meadow.save()

--- a/etl/steps/data/meadow/us_census_bureau/2025-03-04/diphtheria_deaths.py
+++ b/etl/steps/data/meadow/us_census_bureau/2025-03-04/diphtheria_deaths.py
@@ -1,12 +1,12 @@
 """Load a snapshot and create a meadow dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -26,8 +26,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(
-        dest_dir,
+    ds_meadow = paths.create_dataset(
         tables=tables,
         check_variables_metadata=True,
         default_metadata=snap.metadata,

--- a/etl/steps/data/meadow/wb/2025-03-10/thousand_bins_distribution.py
+++ b/etl/steps/data/meadow/wb/2025-03-10/thousand_bins_distribution.py
@@ -1,12 +1,12 @@
 """Load a snapshot and create a meadow dataset."""
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     #
     # Load inputs.
     #
@@ -38,7 +38,7 @@ def run(dest_dir: str) -> None:
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_meadow = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
 
     # Save changes in the new meadow dataset.
     ds_meadow.save()

--- a/etl/steps/data/meadow/wid/2025-03-14/world_inequality_database.py
+++ b/etl/steps/data/meadow/wid/2025-03-14/world_inequality_database.py
@@ -3,7 +3,7 @@
 import owid.catalog.processing as pr
 from owid.catalog import Table
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -120,7 +120,7 @@ SNAPSHOTS_DICT = {
 }
 
 
-def run(dest_dir: str) -> None:
+def run() -> None:
     # Keep snapshot info for the main snapshot
     snap_main = paths.load_snapshot("world_inequality_database.csv")
 
@@ -171,8 +171,8 @@ def run(dest_dir: str) -> None:
     tb_fiscal = tb_fiscal.format()
 
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(
-        dest_dir, tables=tables + [tb_fiscal], check_variables_metadata=True, default_metadata=snap_main.metadata
+    ds_meadow = paths.create_dataset(
+        tables=tables + [tb_fiscal], check_variables_metadata=True, default_metadata=snap_main.metadata
     )
 
     # Save changes in the new meadow dataset.


### PR DESCRIPTION
We now don't need to use `dest_dir` at all in our scripts, or import `create_dataset`. Instead, we can simply use `paths` & its methods. 

There are still several steps that use the old default, this PR aims at upgrading them.

The motivation for doing this is to keep our code up-to-date. Already implemented scripts are relevant because they are the basis for new scripts whenever we update a step. That is, to create the new script for UN WPP 2026 update, we rely start from the script from UN WPP 2024.

## Comparison of code changes

**OLD**
```py
from etl.helpers import PathFinder, create_dataset

# Get paths and naming conventions for current step.
paths = PathFinder(__file__)

def run(dest_dir: str) -> None:
    # Code
   ds_garden = create_dataset(
        dest_dir,
        tables=tables,
    )
```

**NEW**
```py
from etl.helpers import PathFinder

# Get paths and naming conventions for current step.
paths = PathFinder(__file__)

def run() -> None:
    # Code
   ds_garden = paths.create_dataset(
        tables=tables,
    )
```

## Progress
I'll only be upgrading this style in 2025 scripts.
- [x] 2025-04
- [x] 2025-03
- [x] 2025-02
- [x] 2025-01

## Extra
- Remove `grapher_checks` calls