### PR TITLE
✨ adjust mdim api

### DIFF
--- a/etl/collections/beta.py
+++ b/etl/collections/beta.py
@@ -335,12 +335,12 @@ def combine_mdims(
                 slug=MDIM_SLUG,
                 name=mdim_dimension_name,
                 choices=[
-                    DimensionChoice(slug=mdim.name, name=choice),
+                    DimensionChoice(slug=mdim.short_name, name=choice),
                 ],
             )
             mdim.dimensions = [dimension_mdim] + mdim.dimensions
             for v in mdim.views:
-                v.dimensions[MDIM_SLUG] = mdim.name
+                v.dimensions[MDIM_SLUG] = mdim.short_name
 
     # 0) Preliminary work #
     # Create dictionary with MDIMs, so to have identifiers for them
@@ -404,7 +404,7 @@ def combine_mdims(
             log.warning(f"(dimension={dimension_slug}, choice={choice_slug})")
             for _, subgroup in group.groupby("choice_slug_id"):
                 collection_ids = subgroup["collection_id"].unique().tolist()
-                explorer_names = [mdims_by_id[i].name for i in collection_ids]
+                explorer_names = [mdims_by_id[i].short_name for i in collection_ids]
                 record = subgroup[cols_choices].drop_duplicates().to_dict("records")
                 assert len(record) == 1, "Unexpected, please report!"
                 log.warning(f" MDIMs {explorer_names} map to {record[0]}")

--- a/etl/collections/beta.py
+++ b/etl/collections/beta.py
@@ -246,7 +246,7 @@ def combine_explorers(explorers: List[Explorer], explorer_name: str, config: Dic
             log.warning(f"(dimension={dimension_slug}, choice={choice_slug})")
             for _, subgroup in group.groupby("choice_slug_id"):
                 explorer_ids = subgroup["explorer_id"].unique().tolist()
-                explorer_names = [explorers_by_id[i].explorer_name for i in explorer_ids]
+                explorer_names = [explorers_by_id[i].short_name for i in explorer_ids]
                 record = subgroup[cols_choices].drop_duplicates().to_dict("records")
                 assert len(record) == 1, "Unexpected, please report!"
                 log.warning(f" Explorers {explorer_names} map to {record[0]}")
@@ -454,7 +454,7 @@ def _combine_dimensions(
     return dimensions
 
 
-def _update_choice_slugs_in_views(choice_slug_changes, collection_by_id):
+def _update_choice_slugs_in_views(choice_slug_changes, collection_by_id) -> Mapping[str, Union[Multidim, Explorer]]:
     """Access each explorer, and update choice slugs in views"""
     for collection_id, change in choice_slug_changes.items():
         # Get collection

--- a/etl/collections/beta.py
+++ b/etl/collections/beta.py
@@ -245,7 +245,7 @@ def combine_explorers(explorers: List[Explorer], explorer_name: str, config: Dic
             # Now group by 'value' to see which col3 values correspond to each unique 'value'
             log.warning(f"(dimension={dimension_slug}, choice={choice_slug})")
             for _, subgroup in group.groupby("choice_slug_id"):
-                explorer_ids = subgroup["explorer_id"].unique().tolist()
+                explorer_ids = subgroup["collection_id"].unique().tolist()
                 explorer_names = [explorers_by_id[i].short_name for i in explorer_ids]
                 record = subgroup[cols_choices].drop_duplicates().to_dict("records")
                 assert len(record) == 1, "Unexpected, please report!"

--- a/etl/collections/beta.py
+++ b/etl/collections/beta.py
@@ -29,7 +29,7 @@ import pandas as pd
 from owid.catalog import Table
 from structlog import get_logger
 
-from etl.collections.explorer import Explorer, expand_config
+from etl.collections.explorer import Explorer, create_explorer, expand_config
 from etl.collections.model import Dimension, DimensionChoice
 from etl.collections.multidim import Multidim, combine_config_dimensions, create_mdim
 from etl.collections.utils import has_duplicate_table_names
@@ -170,7 +170,12 @@ def create_explorer_experimental(
     return explorer
 
 
-def combine_explorers(explorers: List[Explorer], explorer_name: str, config: Dict[str, str]):
+def combine_explorers(
+    explorers: List[Explorer],
+    explorer_name: str,
+    config: Dict[str, str],
+    dependencies: Optional[Set[str]] = None,
+):
     """Combine multiple explorers into a single one.
 
     Notes:
@@ -230,10 +235,15 @@ def combine_explorers(explorers: List[Explorer], explorer_name: str, config: Dic
     catalog_path = explorers[0].catalog_path.split("#")[0] + "#" + explorer_name
 
     # 4) Create final explorer #
-    explorer = Explorer(
-        config=config,
-        dimensions=dimensions,
-        views=views,
+    explorer_config = {
+        "config": config,
+        "dimensions": dimensions,
+        "views": views,
+        "catalog_path": catalog_path,
+    }
+    explorer = create_explorer(
+        config=explorer_config,
+        dependencies=dependencies if dependencies is not None else set(),
         catalog_path=catalog_path,
     )
 

--- a/etl/collections/common.py
+++ b/etl/collections/common.py
@@ -1,42 +1,20 @@
 """Common tooling for MDIMs/Explorers."""
 
 from copy import deepcopy
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Set, Union
 
 import pandas as pd
 from owid.catalog import Table
-from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
 import etl.grapher.model as gm
-from etl.collections.model import Collection
 from etl.collections.utils import (
+    get_tables_by_name_mapping,
     records_to_dictionary,
-    validate_indicators_in_db,
 )
 from etl.config import OWID_ENV, OWIDEnv
 
 INDICATORS_SLUG = "indicator"
-
-
-def validate_collection_config(collection: Collection, engine: Engine, tolerate_extra_indicators: bool) -> None:
-    """Fundamental validation of the configuration of a collection (explorer or MDIM):
-
-    - Ensure that the views reference valid dimensions.
-    - Ensure that there are no duplicate views.
-    - Ensure that all indicators in the collection are in the database.
-
-    NOTE: On top of this validation, one may want to apply further validations on MDIMs or Explorers specifically.
-    """
-    # Ensure that all views are in choices
-    collection.validate_views_with_dimensions()
-
-    # Validate duplicate views
-    collection.check_duplicate_views()
-
-    # Check that all indicators in mdim exist
-    indicators = collection.indicators_in_use(tolerate_extra_indicators)
-    validate_indicators_in_db(indicators, engine)
 
 
 def map_indicator_path_to_id(catalog_path: str, owid_env: Optional[OWIDEnv] = None) -> str | int:
@@ -221,6 +199,62 @@ def expand_config(
     )
 
     return config_partial
+
+
+def process_views(
+    mdim_or_explorer,
+    dependencies: Set[str],
+    combine_metadata_when_mult: bool = False,
+):
+    """Process views in Explorer configuration.
+
+    TODO: See if we can converge to one solution with etl.collections.multidim.process_views.
+    """
+    # Get table information (table URI) by (i) table name and (ii) dataset_name/table_name
+    tables_by_name = get_tables_by_name_mapping(dependencies)
+
+    for view in mdim_or_explorer.views:
+        # Expand paths
+        view.expand_paths(tables_by_name)
+
+        # Combine metadata/config with definitions.common_views
+        if (mdim_or_explorer.definitions is not None) and (mdim_or_explorer.definitions.common_views is not None):
+            view.combine_with_common(mdim_or_explorer.definitions.common_views)
+
+        # Combine metadata in views which contain multiple indicators
+        if combine_metadata_when_mult and view.metadata_is_needed:  # Check if view "contains multiple indicators"
+            # TODO
+            # view["metadata"] = build_view_metadata_multi(indicators, tables_by_uri)
+            # log.info(
+            #     f"View with multiple indicators detected. You should edit its `metadata` field to reflect that! This will be done programmatically in the future. Check view with dimensions {view.dimensions}"
+            # )
+            pass
+
+
+def create_mdim_or_explorer(
+    obj,
+    config: dict,
+    dependencies: Set[str],
+    catalog_path: str,
+    validate_schema: bool = True,
+):
+    # Read config as structured object
+    mdim_or_explorer = obj.from_dict(dict(**config, catalog_path=catalog_path))
+
+    # Edit views
+    process_views(mdim_or_explorer, dependencies=dependencies)
+
+    # Validate config
+    if validate_schema:
+        mdim_or_explorer.validate_schema()
+
+    # Ensure that all views are in choices
+    mdim_or_explorer.validate_views_with_dimensions()
+
+    # Validate duplicate views
+    mdim_or_explorer.check_duplicate_views()
+
+    return mdim_or_explorer
 
 
 ####################################################################################################

--- a/etl/collections/explorer.py
+++ b/etl/collections/explorer.py
@@ -116,6 +116,7 @@ def create_explorer(
         config,
         dependencies,
         catalog_path,
+        validate_schema=False,
     )
 
     return explorer

--- a/etl/collections/model.py
+++ b/etl/collections/model.py
@@ -11,13 +11,14 @@ import json
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Dict, List, Optional, Self, TypeGuard, TypeVar, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, TypeGuard, TypeVar, Union
 
 import fastjsonschema
 import pandas as pd
 import yaml
 from owid.catalog.meta import GrapherConfig, MetaBase
 from structlog import get_logger
+from typing_extensions import Self
 
 from etl.collections.exceptions import DuplicateCollectionViews
 from etl.collections.utils import merge_common_metadata_by_dimension, validate_indicators_in_db

--- a/etl/collections/multidim.py
+++ b/etl/collections/multidim.py
@@ -14,11 +14,15 @@ from owid.catalog import Table
 from structlog import get_logger
 
 from apps.chart_sync.admin_api import AdminAPI
-from etl.collections.common import combine_config_dimensions, expand_config, map_indicator_path_to_id
-from etl.collections.model import Collection, Definitions, MDIMView, pruned_json
-from etl.collections.utils import camelize, get_tables_by_name_mapping
+from etl.collections.common import (
+    combine_config_dimensions,
+    create_mdim_or_explorer,
+    expand_config,
+    map_indicator_path_to_id,
+)
+from etl.collections.model import Collection, pruned_json
+from etl.collections.utils import camelize
 from etl.config import OWIDEnv
-from etl.paths import SCHEMAS_DIR
 
 # Initialize logger.
 log = get_logger()
@@ -38,11 +42,9 @@ __all__ = [
 class Multidim(Collection):
     """Model for MDIM configuration."""
 
-    views: List[MDIMView]
     title: Dict[str, str]
     default_selection: List[str]
     topic_tags: Optional[List[str]] = None
-    definitions: Optional[Definitions] = None
 
     def __post_init__(self):
         """We set it here because of simplicity.
@@ -108,51 +110,13 @@ def create_mdim(
     dependencies: Set[str],
     catalog_path: str,
 ) -> Multidim:
-    # Read config as structured object
-    mdim = Multidim.from_dict(dict(**config, catalog_path=catalog_path))
-
-    # Edit views
-    process_views(mdim, dependencies=dependencies)
-
-    # Validate config
-    mdim.validate_schema(SCHEMAS_DIR / "multidim-schema.json")
-
-    # Ensure that all views are in choices
-    mdim.validate_views_with_dimensions()
-
-    # Validate duplicate views
-    mdim.check_duplicate_views()
-
+    mdim = create_mdim_or_explorer(
+        Multidim,
+        config,
+        dependencies,
+        catalog_path,
+    )
     return mdim
-
-
-def process_views(mdim: Multidim, dependencies: Set[str]):
-    """Process views in MDIM configuration.
-
-    This includes:
-        - Make sure that catalog paths for indicators are complete.
-        - TODO: Process views with multiple indicators to have adequate metadata
-    """
-    # Get table information by table name, and table URI
-    tables_by_name = get_tables_by_name_mapping(dependencies)
-    # tables_by_uri = get_tables_by_uri_mapping(tables_by_name)  # This is to be used when processing views with multiple indicators
-
-    # Go through all views and expand catalog paths
-    for view in mdim.views:
-        # Update indicators for each dimension, making sure they have the complete URI
-        view.expand_paths(tables_by_name)
-
-        # Combine metadata/config with definitions.common_views
-        if (mdim.definitions is not None) and (mdim.definitions.common_views is not None):
-            view.combine_with_common(mdim.definitions.common_views)
-
-        # Combine metadata in views which contain multiple indicators
-        if view.metadata_is_needed:  # Check if view "contains multiple indicators"
-            # TODO
-            # view["metadata"] = build_view_metadata_multi(indicators, tables_by_uri)
-            log.info(
-                f"View with multiple indicators detected. You should edit its `metadata` field to reflect that! This will be done programmatically in the future. Check view with dimensions {view.dimensions}"
-            )
 
 
 def build_view_metadata_multi(indicators: List[Dict[str, str]], tables_by_uri: Dict[str, Table]):

--- a/etl/steps/export/explorers/un/latest/utils.py
+++ b/etl/steps/export/explorers/un/latest/utils.py
@@ -66,7 +66,7 @@ class ExplorerCreator:
 
         explorer = combine_explorers(
             explorers=[explorer, explorer_proj],
-            explorer_name=explorer.explorer_name,
+            explorer_name=explorer.short_name,
             config=explorer.config,
         )
 


### PR DESCRIPTION
- Abstract some methods in `Explorer` and `Multidim`: `process_views`, `create_*`.
- Change some class attributes for clarity.
- Other minor cosmetic changes.

Future:
I am considering moving classes `Explorer` and `Multidim` to module `etl.collections.model`. Having both classes in one single place could help us. Also, we could then simplify all the logic from `etl.collections.multidim`, `etl.collections.explorer` and ``etl.collections.common`... maybe just have one module instead of three.


/schedule