### PR TITLE
🚧 demo offsite mdims/explorers

### DIFF
--- a/etl/collections/model.py
+++ b/etl/collections/model.py
@@ -502,7 +502,7 @@ class Collection(MDIMBase):
         if "definitions" in data:
             data["_definitions"] = data["definitions"]
             del data["definitions"]
-        else:
+        elif "_definitions" not in data:
             data["_definitions"] = Definitions()
 
         # Now that data is in the expected shape, let the parent class handle the rest
@@ -549,6 +549,18 @@ class Collection(MDIMBase):
 
     # def save(self):  # type: ignore[override]
     #     pass
+
+    def sort_dimensions(self, slug_order: List[str]):
+        """Sort dimensions based on the given order."""
+        assert set(slug_order) == set(self.dimension_slugs), "All dimensions must be in the given order!"
+        new_dimensions = []
+        for dim in slug_order:
+            # Get the dimension from the slug
+            dim_ = next((d for d in self.dimensions if d.slug == dim), None)
+            if dim_ is None:
+                raise ValueError(f"Dimension {dim} not found in dimensions!")
+            new_dimensions.append(dim_)
+        self.dimensions = new_dimensions
 
     def save(  # type: ignore[override]
         self, owid_env: Optional[OWIDEnv] = None, tolerate_extra_indicators: bool = False, prune_dimensions: bool = True

--- a/etl/steps/export/multidim/dummy/latest/dummy.config.yml
+++ b/etl/steps/export/multidim/dummy/latest/dummy.config.yml
@@ -7,5 +7,7 @@ default_selection:
   - China
   - India
 # Both will be filled programmatically.
-dimensions: []
+dimensions:
+  - slug: metric
+    name: Metric
 views: []

--- a/etl/steps/export/multidim/dummy/latest/dummy.py
+++ b/etl/steps/export/multidim/dummy/latest/dummy.py
@@ -28,5 +28,7 @@ def run() -> None:
         config=paths.load_mdim_config(),
     )
 
+    # TODO: Translate MDIM to explorer!
+
     # Save & upload
     mdim.save()

--- a/etl/steps/export/multidim/dummy/latest/dummy.py
+++ b/etl/steps/export/multidim/dummy/latest/dummy.py
@@ -3,7 +3,7 @@
 TODO: Look in etl.collections.beta for more details.
 """
 
-from etl.collections.beta import combine_mdims
+from etl.collections.beta import combine_mdims, mdim_to_explorer
 from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
@@ -29,6 +29,8 @@ def run() -> None:
     )
 
     # TODO: Translate MDIM to explorer!
+    explorer = mdim_to_explorer(mdim)
+    explorer.save()
 
     # Save & upload
     mdim.save()


### PR DESCRIPTION
1. Present covid MDIMs: `etl/steps/export/multidim/covid/latest/covid.py`
2. Show MDIMs
    - [COVID cases](http://staging-site-wip-demo-offsite-explorers/admin/grapher/covid%2Flatest%2Fcovid%23covid_cases)
    - [COVID deaths](http://staging-site-wip-demo-offsite-explorers/admin/grapher/covid%2Flatest%2Fcovid%23covid_deaths)
3. Show files:
    - `dag/wizard.yml` (last rows show dependencies)
    - `etl/steps/export/multidim/dummy/latest/dummy.py`
4. Explain code in `dummy.py`:
    - Loading of MDIMs (two from the same step)
    - Combination of MDIMs
5. [Show _combined_ MDIM rendered](http://staging-site-wip-demo-offsite-explorers/admin/grapher/covid%2Flatest%2Fcovid%23test_combined)
6. Back to code: Translate MDIM into explorer
7. Show [Explorer rendered](http://staging-site-wip-demo-offsite-explorers/admin/explorers/preview/test_combined)