### PR TITLE
🐛 Fix owidbot and import from chart-diff

### DIFF
--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -112,7 +112,9 @@ def get_chart_diffs():
     )
 
     # Get indicators used in charts
-    st.session_state.indicators_in_charts = indicators_in_charts(list(st.session_state.chart_diffs.keys()))
+    st.session_state.indicators_in_charts = indicators_in_charts(
+        SOURCE_ENGINE, list(st.session_state.chart_diffs.keys())
+    )
 
     # Init, can be changed by the toggle
     st.session_state.chart_diffs_filtered = st.session_state.chart_diffs

--- a/apps/wizard/app_pages/chart_diff/utils.py
+++ b/apps/wizard/app_pages/chart_diff/utils.py
@@ -14,7 +14,6 @@ log = get_logger()
 WARN_MSG = []
 
 SOURCE = OWID_ENV
-assert OWID_ENV.env_remote != "production", "Your .env points to production DB, please use a staging environment."
 
 ANALYTICS_NUM_DAYS = 30
 
@@ -30,6 +29,7 @@ else:
 
 @st.cache_resource
 def get_engines() -> tuple[Engine, Engine]:
+    assert OWID_ENV.env_remote != "production", "Your .env points to production DB, please use a staging environment."
     return SOURCE.engine, TARGET.engine
 
 
@@ -47,9 +47,9 @@ def prettify_date(chart):
 
 
 @st.cache_data
-def indicators_in_charts(chart_ids: list[int]) -> dict[int, str]:
+def indicators_in_charts(_engine: Engine, chart_ids: list[int]) -> dict[int, str]:
     # Get a list of used indicators in chart diffs
-    with Session(SOURCE.engine) as session:
+    with Session(_engine) as session:
         indicator_ids = gm.ChartDimensions.indicators_in_charts(session, chart_ids)
         rows = gm.Variable.from_id(session, variable_id=list(indicator_ids), columns=["id", "name"])
         return {r.id: r.name for r in rows}  # type: ignore


### PR DESCRIPTION
There's an assertion in `chart_diff/utils.py` that validates that environment isn't production (to avoid syncing from prod to prod). 
```
assert OWID_ENV.env_remote != "production", "Your .env points to production DB, please use a staging environment."
```

This raises an error in owidbot, because it imports chart-diff (but use custom environments). This PR hotfixes it by moving it to `get_engines`.