### PR TITLE
✨ Diff only files changed in git

### DIFF
--- a/apps/owidbot/data_diff.py
+++ b/apps/owidbot/data_diff.py
@@ -79,6 +79,7 @@ def call_etl_diff(include: str) -> list[str]:
         "diff",
         "REMOTE",
         "data/",
+        "--changed",
         "--include",
         include,
         "--exclude",

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -20,8 +20,10 @@ from rich.panel import Panel
 from rich.syntax import Syntax
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
+from apps.wizard.utils.io import get_all_changed_catalog_paths
 from etl.dag_helpers import load_dag
 from etl.files import yaml_dump
+from etl.git_helpers import get_changed_files
 from etl.tempcompare import series_equals
 
 log = structlog.get_logger()
@@ -307,6 +309,11 @@ class RemoteDataset:
     help="Compare only selected channel (subfolder of data/).",
 )
 @click.option(
+    "--changed",
+    is_flag=True,
+    help="Only compare datasets with changes in git. This can significantly speed it up.",
+)
+@click.option(
     "--include",
     type=str,
     help="Compare only datasets matching pattern.",
@@ -349,6 +356,7 @@ def cli(
     path_a: str,
     path_b: str,
     channel: Iterable[CHANNEL],
+    changed: bool,
     include: Optional[str],
     cols: Optional[str],
     tables: Optional[str],
@@ -373,19 +381,36 @@ def cli(
 
     It uses **source checksums** to find candidates for comparison. Source checksum includes all files used to generate the dataset and should be sufficient to find changed datasets, just note that we're not using checksum of the files themselves. So if you change core ETL code or some of the dependencies, e.g. change in owid-datautils-py, core ETL code or updating library version, the change won't be detected. In cases like these you should increment ETL version which is added to all source checksums (not implemented yet).
 
-    **Example 1:** Compare the remote catalog with a local one
+    **Example 1:** Compare the remote catalog with a local one for changed files
+
+    ```
+    $ etl diff REMOTE data/ --changed
+    ```
+
+    **Example 2:** Compare the remote catalog with a local one
 
     ```
     $ etl diff REMOTE data/ --include maddison
     ```
 
-    **Example 2:** Compare two local catalogs
+    **Example 3:** Compare two local catalogs
 
     ```
     $ etl diff other-data/ data/ --include maddison
     ```
     """
     console = Console(tab_size=2, soft_wrap=True)
+
+    if changed:
+        # Get all changed files in the current git repository
+        files_changed = get_changed_files()
+        catalog_paths = get_all_changed_catalog_paths(files_changed)
+
+        # Add those files to `include` regex (use positive look-aheads to match on both)
+        if include:
+            include = rf'(?=.*{include})(?=.*{"|".join(catalog_paths)})'
+        else:
+            include = "|".join(catalog_paths)
 
     path_to_ds_a = _load_catalog_datasets(path_a, channel, include, exclude)
     path_to_ds_b = _load_catalog_datasets(path_b, channel, include, exclude)

--- a/etl/git_helpers.py
+++ b/etl/git_helpers.py
@@ -155,9 +155,13 @@ def get_changed_files(
     base_branch: Optional[str] = None,
     repo_path: Union[Path, str] = BASE_DIR,
     only_committed: bool = False,
+    fetch: bool = False,
 ) -> Dict[str, Dict[str, str]]:
     """Return files that are different between the current branch and the specified base branch. This can
-    be really slow if the number of files is large."""
+    be really slow if the number of files is large.
+
+    :param fetch: If True, fetch the latest changes from the remote repository. This can be slow.
+    """
     repo = Repo(repo_path)
 
     if current_branch is None:
@@ -169,11 +173,11 @@ def get_changed_files(
 
     if base_branch is None:
         # If not specified, use "master" branch.
-        # However, if there is a "master-1" branch, that means we are on a staging server; if so, use "master-1".
-        base_branch = "master-1" if "master-1" in [branch.name for branch in repo.branches] else "master"
+        base_branch = "master"
 
     # Fetch the latest changes from the remote repository
-    repo.remotes.origin.fetch()
+    if fetch:
+        repo.remotes.origin.fetch()
 
     # Find the common ancestor of the remote base branch and the current local branch.
     # In other words, "merge_base" is the last common commit between those two branches.


### PR DESCRIPTION
When `chart-diff` detects changes, it uses both checksums and whether a dataset is a downstream dependency of any step changed in Git. This helps reduce noise when a branch isn't up to date with `master`.

This PR adds the same functionality to `data-diff` via the `--changed` flag. It also speeds up `get_changed_files` by making the `fetch` optional—saving about 2 seconds, which will benefit `chart-diff` as well.