### PR TITLE
🎉 Instant metadata updates

### DIFF
--- a/docs/architecture/metadata/data_pages_workflow.md
+++ b/docs/architecture/metadata/data_pages_workflow.md
@@ -13,6 +13,7 @@ For illustration, the step `grapher/gcp/2023-07-10/global_carbon_budget` is cons
 
 ### Initial Configuration
 - Add `DEBUG=1` to your `.env.myname` file and any other `.env.*` files in use to expedite ETL operations. `DEBUG=1` runs all steps in a single process and removes 2s overhead from running each step.
+- Add `PREFER_DOWNLOAD=1` to your environment to use cached downloads of files instead of redownloading them each time, which can significantly speed up steps involving large file downloads.
 
 ### File Monitoring
 - Execute the ETL command with the `--watch` flag. This monitors the YAML file for changes and automatically re-executes the corresponding step. This might not be as useful for long-running steps.
@@ -20,11 +21,23 @@ For illustration, the step `grapher/gcp/2023-07-10/global_carbon_budget` is cons
 ### Data Filtering
 - If the dataset contains numerous indicators, consider using `GRAPHER_FILTER=consumption_emissions_per_capita` to filter the data to only relevant variables. This is optional for smaller datasets.
 
+### Instant YAML Updates
+- Use `INSTANT=1` environment variable to enable instant YAML updates, which bypasses the normal ETL pipeline for metadata changes. This makes YAML changes appear almost immediately in the grapher without re-running the entire ETL process.
+- Example usage: `INSTANT=1 etl grapher/gcp/2023-07-10/global_carbon_budget --grapher`
+- Note: Instant mode only works for metadata changes. Any changes to data processing in Python will still require a full ETL run.
+
+#### Limitations
+This might fail, be slow or give unexpected results in the following cases:
+
+- Garden step doesn't call `paths.create_dataset` as the last command (e.g. when it programmatically post-processes metadata)
+- Grapher code is doing some heavy lifting or flattening
+
 ### Optional Optimization
 - Include the `--only` flag in the command to further improve performance by avoiding dependency checks.
 
 ### Command Summary
 ```bash
+# Basic command with watch mode
 ENV_FILE=.env.myname GRAPHER_FILTER=consumption_emissions_per_capita etl grapher/gcp/2023-07-10/global_carbon_budget --grapher --watch --only
 ```
 !!! note
@@ -37,3 +50,15 @@ After initiating the above command, changes made to the YAML file can be reviewe
 !!! info
 
     If editing the YAML file in the **garden channel** and the step execution time is long, refresh latency will be dependent on the step's runtime. In such cases, consider developing the YAML file in the **grapher channel** before moving it into the garden channel (if the table and indicator names are identical).
+
+### Workflow Best Practices
+
+1. **Start with INSTANT mode:** Begin with `INSTANT=1` for rapid YAML changes to test metadata updates without waiting for full ETL runs.
+
+2. **Use PREFER_DOWNLOAD wisely:** Enable this for steps with large downloads to avoid repeatedly downloading the same files.
+
+3. **Local development first:** Develop on local grapher before moving to staging for faster iteration cycles.
+
+4. **Switch to full ETL runs:** Once metadata is finalized, run a complete ETL process to ensure all changes are properly integrated.
+
+5. **Combine optimization flags:** For the fastest development experience, combine `DEBUG=1`, `PREFER_DOWNLOAD=1`, and `INSTANT=1` as shown in the command summary.

--- a/etl/command.py
+++ b/etl/command.py
@@ -69,6 +69,11 @@ log = structlog.get_logger()
     help="Run private steps.",
 )
 @click.option(
+    "--instant",
+    is_flag=True,
+    help="Only apply YAML metadata in the garden step.",
+)
+@click.option(
     "--grapher/--no-grapher",
     "-g/-ng",
     default=False,
@@ -152,6 +157,7 @@ def main_cli(
     dry_run: bool = False,
     force: bool = False,
     private: bool = False,
+    instant: bool = False,
     grapher: bool = False,
     export: bool = False,
     ipdb: bool = False,
@@ -198,6 +204,9 @@ def main_cli(
     # GRAPHER_INSERT_WORKERS should be split among workers
     if workers > 1:
         config.GRAPHER_INSERT_WORKERS = config.GRAPHER_INSERT_WORKERS // workers
+
+    # Set INSTANT mode from CLI flag
+    config.INSTANT = instant
 
     kwargs = dict(
         steps=steps,

--- a/etl/config.py
+++ b/etl/config.py
@@ -196,6 +196,9 @@ CONTINUE_ON_FAILURE = env.get("CONTINUE_ON_FAILURE", "0") in ("True", "true", "1
 # of data pages for a single indicator
 GRAPHER_FILTER = env.get("GRAPHER_FILTER", None)
 
+# if set, skip the actual garden step and only apply the metadata
+INSTANT = env.get("INSTANT", "0") in ("True", "true", "1")
+
 # if set, always upload grapher data & metadata JSON files even if checksums match
 FORCE_UPLOAD = env.get("FORCE_UPLOAD") in ("True", "true", "1")
 

--- a/etl/grapher/to_db.py
+++ b/etl/grapher/to_db.py
@@ -29,7 +29,6 @@ from sqlalchemy.orm import Session
 from apps.backport.datasync import data_metadata as dm
 from apps.backport.datasync.datasync import upload_gzip_string
 from apps.chart_sync.admin_api import AdminAPI
-from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiffsLoader
 from etl import config
 from etl.db import get_engine, production_or_master_engine, read_sql
 from etl.grapher import helpers as gh
@@ -597,6 +596,10 @@ def _raise_error_for_deleted_variables(rows: pd.DataFrame) -> bool:
     if config.ENV == "staging":
         # It's possible that we merged changes to ETL, but the staging server still uses old charts. In
         # that case, we first check that the charts were really modified on our staging server.
+
+        # Load this dynamically for performance reasons
+        from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiffsLoader
+
         modified_charts = ChartDiffsLoader(config.OWID_ENV.get_engine(), production_or_master_engine()).df
         return bool(set(modified_charts.index) & set(rows.chartId))
     # Only show a warning in production. We can't raise an error because if someone merges changes to ETL

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -538,6 +538,8 @@ class DataStep(Step):
         # path can be either in a module with __init__.py or a single .py file
         module_dir = self._search_path if self._search_path.is_dir() else self._search_path.parent
 
+        # __import__("ipdb").set_trace()
+
         with isolated_env(module_dir):
             step_module = import_module(self._search_path.relative_to(paths.BASE_DIR).as_posix().replace("/", "."))
             run_module_run(step_module, self._dest_dir.as_posix())

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -40,6 +40,7 @@ from etl.config import OWID_ENV, TLS_VERIFY
 from etl.db import get_engine
 from etl.grapher import helpers as gh
 from etl.grapher import model as gm
+from etl.helpers import get_metadata_path
 from etl.snapshot import Snapshot
 
 log = structlog.get_logger()
@@ -49,6 +50,9 @@ DAG = Dict[str, Any]
 
 
 ipynb_lock = fasteners.InterProcessLock(paths.BASE_DIR / ".ipynb_lock")
+
+# Dictionary to store metadata changes for each dataset if INSTANT flag is set
+INSTANT_METADATA_DIFF = {}
 
 
 def compile_steps(
@@ -403,6 +407,11 @@ class DataStep(Step):
 
         ds_idex_mtime = self._dataset_index_mtime()
 
+        # if INSTANT flag is set, just update the metadata
+        if config.INSTANT and self.channel == "garden":
+            self._run_instant_metadata()
+            return
+
         sp = self._search_path
         if sp.with_suffix(".py").exists() or (sp / "__init__.py").exists():
             if config.DEBUG:
@@ -448,6 +457,10 @@ class DataStep(Step):
             else:
                 raise e
         exp_source_checksum = self.checksum_input()
+
+        # if INSTANT is on, we use _instant suffix in a checksum
+        if config.INSTANT and found_source_checksum:
+            found_source_checksum = found_source_checksum.replace("_instant", "")
 
         if found_source_checksum != exp_source_checksum:
             return True
@@ -529,6 +542,44 @@ class DataStep(Step):
     def _dest_dir(self) -> Path:
         return paths.DATA_DIR / self.path.lstrip("/")
 
+    def _run_instant_metadata(self) -> None:
+        """If INSTANT flag is set, instead of running the whole garden step, just load
+        the existing dataset and update its metadata. This is useful for fast-tracking
+        metadata changes without having to rerun the whole step.
+        """
+
+        meta_path = get_metadata_path(self._dest_dir.as_posix())
+        if not meta_path.exists():
+            return
+
+        ds = catalog.Dataset(self._dest_dir.as_posix())
+
+        # Read metadata before
+        table_meta_before = _load_tables_metadata(ds)
+
+        # Save dataset, but use _instant suffix in the checksum to make sure we
+        # trigger fresh run when not using INSTANT
+        ds.update_metadata(meta_path)
+        ds.metadata.source_checksum = self.checksum_input() + "_instant"
+        ds.save()
+
+        # Read metadata after
+        table_meta_after = _load_tables_metadata(ds)
+
+        INSTANT_METADATA_DIFF[ds.m.short_name] = defaultdict(list)
+
+        for table_name in ds.table_names:
+            # Find variables with metadata changes
+            for var_name in table_meta_before[table_name]["fields"]:
+                if (
+                    table_meta_before[table_name]["fields"][var_name]
+                    != table_meta_after[table_name]["fields"][var_name]
+                ):
+                    log.info("instant.update", table_name=table_name, var_name=var_name)
+                    # Add the variable to a global variable so that we can only rerun changed
+                    # variables in the grapher step
+                    INSTANT_METADATA_DIFF[ds.m.short_name][table_name].append(var_name)
+
     def _run_py_isolated(self) -> None:
         """
         Import the Python module for this step and call run() on it. This method
@@ -537,8 +588,6 @@ class DataStep(Step):
         """
         # path can be either in a module with __init__.py or a single .py file
         module_dir = self._search_path if self._search_path.is_dir() else self._search_path.parent
-
-        # __import__("ipdb").set_trace()
 
         with isolated_env(module_dir):
             step_module = import_module(self._search_path.relative_to(paths.BASE_DIR).as_posix().replace("/", "."))
@@ -770,7 +819,7 @@ class GrapherStep(Step):
 
         # dataset exists, but it is possible that we haven't inserted everything into DB
         dataset = self.dataset
-        return db.fetch_db_checksum(dataset) != self.data_step.checksum_input()
+        return db.fetch_db_checksum(dataset) != self.checksum_input()
 
     def run(self) -> None:
         import etl.grapher.to_db as db
@@ -814,9 +863,29 @@ class GrapherStep(Step):
             for table in dataset:
                 assert not table.empty, f"table {table.metadata.short_name} is empty"
 
-                # if GRAPHER_FILTER is set, only upsert matching columns
+                # if GRAPHER_FILTER is set, only upsert matching variables
                 if config.GRAPHER_FILTER:
-                    cols = table.filter(regex=config.GRAPHER_FILTER).columns.tolist()
+                    cols_regex = config.GRAPHER_FILTER
+                # if INSTANT is set, only upsert variables with changed metadata
+                elif config.INSTANT:
+                    dataset_name = dataset.m.short_name
+                    table_name = table.metadata.short_name
+
+                    # dataset wasn't run with instant, rerun it
+                    if dataset_name not in INSTANT_METADATA_DIFF:
+                        cols_regex = None
+                    else:
+                        instant_variables = INSTANT_METADATA_DIFF[dataset_name].get(table_name)
+                        if not instant_variables:
+                            # no changes in table, skip it
+                            continue
+                        else:
+                            cols_regex = "|".join(instant_variables)
+                else:
+                    cols_regex = None
+
+                if cols_regex:
+                    cols = table.filter(regex=cols_regex).columns.tolist()
                     if not cols:
                         continue
                     cols += [c for c in table.columns if c in {"year", "date", "country"} and c not in cols]
@@ -861,7 +930,16 @@ class GrapherStep(Step):
             # wait for all tables to be inserted
             [future.result() for future in as_completed(futures)]
 
-        if not config.GRAPHER_FILTER and not config.SUBSET:
+        # If INSTANT flag is set, don't clean ghost variables, but update the checksum (with _instant suffix)
+        if INSTANT_METADATA_DIFF:
+            db.set_dataset_checksum_and_editedAt(dataset_upsert_results.dataset_id, self.checksum_input())
+
+        # If filtering is on, don't set checksum. Allow the next ETL run to set it
+        elif config.GRAPHER_FILTER or config.SUBSET:
+            pass
+
+        # Otherwise, clean up ghost resources and set checksum
+        else:
             # cleaning up ghost resources could be unsuccessful if someone renamed short_name of a variable
             # and remapped it in chart-sync. In that case, we cannot delete old variables because they are still
             # needed for remapping. However, we can delete it on next ETL run
@@ -871,12 +949,15 @@ class GrapherStep(Step):
 
             # set checksum and updatedAt timestamps after all data got inserted
             if success:
-                checksum = self.data_step.checksum_input()
+                checksum = self.checksum_input()
             # if cleanup was not successful, don't set checksum and let ETL rerun it on its next try
             else:
                 checksum = "to_be_rerun"
 
             db.set_dataset_checksum_and_editedAt(dataset_upsert_results.dataset_id, checksum)
+
+    def checksum_input(self) -> str:
+        return self.data_step.checksum_input()
 
     def checksum_output(self) -> str:
         """Checksum of a grapher step is the same as checksum of the underyling data://grapher step."""
@@ -1119,3 +1200,12 @@ def isolated_env(
 
     # remove module dir from pythonpath
     sys.path.remove(working_dir.as_posix())
+
+
+def _load_tables_metadata(ds: catalog.Dataset) -> Dict[str, Dict[str, Any]]:
+    """Load metadata for all tables in a dataset."""
+    table_meta = {}
+    for table_name in ds.table_names:
+        with open(Path(ds.path) / f"{table_name}.meta.json") as f:
+            table_meta[table_name] = json.load(f)
+    return table_meta

--- a/etl/steps/data/garden/biodiversity/2025-04-07/cherry_blossom.meta.yml
+++ b/etl/steps/data/garden/biodiversity/2025-04-07/cherry_blossom.meta.yml
@@ -4,7 +4,7 @@ tables:
   cherry_blossom:
     variables:
       full_flowering_date:
-        title: Day of the year with peak cherry blossom
+        title: TEST Day of the year with peak cherry blossom
         description_short: The day of the year with the peak cherry blossom of the Prunus jamasakura species of cherry tree in Kyoto, Japan.
         unit: day of the year
         short_unit: ""

--- a/etl/steps/data/garden/biodiversity/2025-04-07/cherry_blossom.meta.yml
+++ b/etl/steps/data/garden/biodiversity/2025-04-07/cherry_blossom.meta.yml
@@ -4,7 +4,7 @@ tables:
   cherry_blossom:
     variables:
       full_flowering_date:
-        title: TEST Day of the year with peak cherry blossom
+        title: Day of the year with peak cherry blossom
         description_short: The day of the year with the peak cherry blossom of the Prunus jamasakura species of cherry tree in Kyoto, Japan.
         unit: day of the year
         short_unit: ""

--- a/etl/steps/data/garden/biodiversity/2025-04-07/cherry_blossom.meta.yml
+++ b/etl/steps/data/garden/biodiversity/2025-04-07/cherry_blossom.meta.yml
@@ -4,7 +4,7 @@ tables:
   cherry_blossom:
     variables:
       full_flowering_date:
-        title: Day of the year with peak cherry blossom.
+        title: Day of the year with peak cherry blossom
         description_short: The day of the year with the peak cherry blossom of the Prunus jamasakura species of cherry tree in Kyoto, Japan.
         unit: day of the year
         short_unit: ""

--- a/etl/steps/data/garden/biodiversity/2025-04-07/cherry_blossom.meta.yml
+++ b/etl/steps/data/garden/biodiversity/2025-04-07/cherry_blossom.meta.yml
@@ -4,7 +4,7 @@ tables:
   cherry_blossom:
     variables:
       full_flowering_date:
-        title: Day of the year with peak cherry blossom
+        title: Day of the year with peak cherry blossom.
         description_short: The day of the year with the peak cherry blossom of the Prunus jamasakura species of cherry tree in Kyoto, Japan.
         unit: day of the year
         short_unit: ""


### PR DESCRIPTION
See the problem in https://github.com/owid/etl/issues/4333.

## Solution

Instant metadata updates can be turned on with `INSTANT=1 etlr ...`. If on, instead of recalculating the garden step, it'll **load the existing garden dataset**, apply metadata YAML file and save it again. Then we detect what indicators have changed and save them in `INSTANT_METADATA_DIFF`. This dictionary will be then used in the `grapher://grapher` step to filter indicators that need to be updated.

## Notes
- It's not bulletproof, and it's always recommended to do the final run **without** `INSTANT=1` (it'll be done by the staging server)
- `data://grapher` is always run (so is `long -> wide` flattening) - if that is a bottleneck, we can try to further optimize it (though it could get tricky) with `INSTANT_METADATA_DIFF` (especially flattening)
- We're mixing env variables with `--` arguments. One might use command like `INSTANT=1 etlr ... --watch`. What's more convenient, env variables or cli args? (if we use cli args then we'd still save them into env variables to avoid passing arguments several levels deep)
- I tried it on a couple of (mid-sized) examples. Do you have a good use case I could optimize it against?

## How to test

I'm using `mars` dataset as an example, but please try to use your own dataset 🙏 

1. Run the step `etlr war/2023-09-21/mars --grapher`
2. Edit metadata of a single indicator in garden metadata YAML
3. Re-run with `INSTANT=1 etlr war/2023-09-21/mars --grapher` and verify that it's faster and that your changes are visible in Admin
5. Run `etlr war/2023-09-21/mars --grapher` to ensure the full run is triggered