### PR TITLE
📊 Autoupdate wildfires

### DIFF
--- a/apps/autoupdate/cli.py
+++ b/apps/autoupdate/cli.py
@@ -130,8 +130,12 @@ def run_updates(
         # Parse the original YAML content
         original_outs = yaml.safe_load(original_dvc_content)["outs"][0]
 
-        # Try to execute snapshot.
-        subprocess.run(["python", snapshot_script, "--upload"], check=True, capture_output=True, text=True)
+        # Try to execute snapshot and print error output if it fails.
+        try:
+            subprocess.run(["python", snapshot_script, "--upload"], check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as e:
+            log.error(f"Snapshot script failed: {snapshot_script}\nstdout:\n{e.stdout}\nstderr:\n{e.stderr}")
+            raise
 
         # Load md5 and size from the (possibly) updated file
         with open(dvc_file, "r") as f:

--- a/scripts/update-wildfires.sh
+++ b/scripts/update-wildfires.sh
@@ -9,6 +9,10 @@ set -e
 
 start_time=$(date +%s)
 
+echo '--- Wildfires are now updated via autoupdate'
+
+exit 0;
+
 echo '--- Update wildfires'
 cd /home/owid/etl
 

--- a/snapshots/climate/latest/weekly_wildfires.csv.dvc
+++ b/snapshots/climate/latest/weekly_wildfires.csv.dvc
@@ -1,3 +1,5 @@
+autoupdate:
+  name: Wildfires
 meta:
   origin:
     producer: Global Wildfire Information System

--- a/snapshots/climate/latest/weekly_wildfires.py
+++ b/snapshots/climate/latest/weekly_wildfires.py
@@ -58,7 +58,10 @@ def main(upload: bool) -> None:
     snap = Snapshot(f"climate/{SNAPSHOT_VERSION}/weekly_wildfires.csv")
 
     # Load existing snapshot for comparison at the end of the script.
-    orig_snapshot_df = snap.read()
+    try:
+        orig_snapshot_df = snap.read()
+    except FileNotFoundError:
+        orig_snapshot_df = None
 
     # Initialize an empty list to hold DataFrames for wildfire data.
     dfs_fires = []
@@ -175,7 +178,7 @@ def main(upload: bool) -> None:
     # Combine both fires and emissions data into a final DataFrame.
     df_final = pd.concat([dfs_fires, dfs_emissions])
 
-    if len(df_final) < len(orig_snapshot_df):
+    if orig_snapshot_df is not None and len(df_final) < len(orig_snapshot_df):
         raise ValueError(
             f"New snapshot has fewer rows ({len(df_final)}) than the original snapshot {len(orig_snapshot_df)}. API could be down or data is missing."
         )


### PR DESCRIPTION
Replace automatic wildfires updates by `autoupdate:` that creates a PR which needs to be approved and merged.

Updating wildfires have always been tricky, their API isn't very stable and we sometimes get incomplete data. I'm leaving the original script in etl in case we want to roll back.