### PR TITLE
🐛 fix `Collection.group_views` indicator instance

### DIFF
--- a/etl/collection/model/core.py
+++ b/etl/collection/model/core.py
@@ -3,6 +3,7 @@
 import json
 import re
 from collections import defaultdict
+from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Union
@@ -586,7 +587,7 @@ def _combine_view_indicators(views: List[View]):
             )
         if view.indicators.y is None:
             raise ValueError("View must have y indicators to be combined.")
-        y_indicators.extend(view.indicators.y)
+        y_indicators.extend(deepcopy(view.indicators.y))
 
     indicators = ViewIndicators(y=y_indicators)
     return indicators


### PR DESCRIPTION
There is an issue with `group_views`, where new views use the same `Indicator` instance as those used to create it. The problem is that a user changes anything on an indicator in a new view will also affect the "old" views.

This PR ensures that the new views reinstantiate the `Indicator` class.

This was detected in a view, where the legends didn't make sense

<img width="960" alt="image" src="https://github.com/user-attachments/assets/48c14dbb-2108-41e1-a265-4a0260476d79" />

/schedule