### PR TITLE
📊 regions: Add Antarctica to mappable grapher regions

### DIFF
--- a/etl/steps/data/external/owid_grapher/latest/regions.py
+++ b/etl/steps/data/external/owid_grapher/latest/regions.py
@@ -33,6 +33,7 @@ MAPPABLE_COUNTRIES = [
     "ARE",
     "ARG",
     "ARM",
+    "ATA",
     "ATF",
     "ATG",
     "AUS",
@@ -234,6 +235,7 @@ MAPPABLE_COUNTRIES = [
 NO_COUNTRY_PAGE = [
     "ALA",
     "ANT",
+    "ATA",
     "ATF",
     "BES",
     "BVT",

--- a/etl/steps/data/garden/un/2023-10-30/un_members.py
+++ b/etl/steps/data/garden/un/2023-10-30/un_members.py
@@ -24,6 +24,7 @@ MAPPABLE_COUNTRIES = [
     "ARE",
     "ARG",
     "ARM",
+    "ATA",
     "ATF",
     "ATG",
     "AUS",

--- a/etl/steps/data/grapher/regions/latest/regions.py
+++ b/etl/steps/data/grapher/regions/latest/regions.py
@@ -29,6 +29,7 @@ MAPPABLE_COUNTRIES = [
     "ARE",
     "ARG",
     "ARM",
+    "ATA",
     "ATF",
     "ATG",
     "AUS",
@@ -230,6 +231,7 @@ MAPPABLE_COUNTRIES = [
 NO_COUNTRY_PAGE = [
     "ALA",
     "ANT",
+    "ATA",
     "ATF",
     "BES",
     "BVT",


### PR DESCRIPTION
Add Antarctica ("ATA") to the list of grapher mappable regions.
NOTE: The garden `regions` dataset is not affected, only the grapher regions is. I noticed that `MAPPABLE_COUNTRIES` is also hardcoded in the garden `un_members` step. This is only used as a dependency by `nuclear_weapons_treaties`. But note that adding "ATA" to that list un `un_members`doesn't make a difference, because `un_members` step only cares about mappable **countries** (with `region_type="country"`), while Antarctica has region type `other`.
