### PR TITLE
📊 animal-welfare: Fix animal-welfare explorer issues

### DIFF
--- a/etl/steps/data/garden/animal_welfare/2025-03-26/animals_used_for_food.py
+++ b/etl/steps/data/garden/animal_welfare/2025-03-26/animals_used_for_food.py
@@ -76,7 +76,7 @@ STOCK_ITEM_CODES = {
     "00001107": "donkeys",  # Asses
     "00001110": "mules",  # Mules and hinnies
     "00001140": "rabbits",  # Rabbits
-    "00001181": "bees",  # Bees
+    # "00001181": "bees",  # Bees
     "00001126": "camels",  # Camels
     "00001072": "geese",  # Geese
     "00001150": "other rodents",  # Other rodents


### PR DESCRIPTION
Remove bees from animal welfare explorer (where metadata is wrong), as a temporary solution (see [conversation](https://owid.slack.com/archives/C03NV9Z3YSV/p1747746954674539)).
