### PR TITLE
Fix typo in harmonize countries guide

### DIFF
--- a/docs/guides/harmonize-countries.md
+++ b/docs/guides/harmonize-countries.md
@@ -93,7 +93,7 @@ Beginning interactive harmonization...
    7) [skip]
 ```
 
-The output mapping is saved in `mapping.json`. If this file existed before, it will resume teh session from where it left off.
+The output mapping is saved in `mapping.json`. If this file existed before, it will resume the session from where it left off.
 
 ## Using the interactive shell
 


### PR DESCRIPTION
## Summary
- fix typo in harmonize-countries guide

## Testing
- `make test` *(fails: EHOSTUNREACH while installing npm package)*