### PR TITLE
🐛 fix slugs in collections

### DIFF
--- a/etl/collection/model/core.py
+++ b/etl/collection/model/core.py
@@ -288,6 +288,15 @@ class Collection(MDIMBase):
             ## Dimension slug
             assert dim.slug in dimension_mapping, "Dimension slug not found in mapping!"
             dim.slug = dimension_mapping[dim.slug]
+            ## Presentation: choice_slug_true
+            if dim.presentation and dim.presentation.choice_slug_true:
+                # Check if the choice slug is in the mapping
+                if dim.presentation.choice_slug_true not in choice_mapping[dim.slug]:
+                    raise ValueError(
+                        f"Choice slug {dim.presentation.choice_slug_true} not found in mapping for dimension {dim.slug}!"
+                    )
+                # Set the new slug
+                dim.presentation.choice_slug_true = choice_mapping[dim.slug][dim.presentation.choice_slug_true]
 
         # 4) Snake case all slugs in views based on the mapping from 1. Raise error if any slug is not found in the mapping.
         for view in self.views:

--- a/etl/collection/model/core.py
+++ b/etl/collection/model/core.py
@@ -245,7 +245,10 @@ class Collection(MDIMBase):
         """
 
         def _validated_underscore(text):
-            text = underscore(text)
+            if text == "":
+                text = "na"
+            else:
+                text = underscore(text)
             # Validate that the text contains only lowercase letters and underscores
             if not re.match(r"^[a-z][a-z0-9_]*$|^_[a-z0-9][a-z0-9_]*$", text):
                 raise ValueError(
@@ -261,7 +264,22 @@ class Collection(MDIMBase):
             for dim_slug, choice_slugs in dimension_choices.items()
         }
 
-        # 1) Snake case all slugs in dimensions+choices
+        # 2) Check that all mappings are not repeated (dimension_mapping)
+        # Check that all dimension slugs are unique and raise error with duplicates
+        def ensure_unique(mapping: Dict[str, str], mapping_name: str):
+            if len(set(mapping.values())) != len(mapping):
+                duplicates = [
+                    slug for slug, count in pd.Series(list(mapping.values())).value_counts().items() if count > 1
+                ]
+                raise ValueError(
+                    f"Duplicate {mapping_name} slugs found: {duplicates}\n\n (note: if 'na', source could be in empty slug)"
+                )
+
+        ensure_unique(dimension_mapping, "dimension")
+        for dim_slug, choices in choice_mapping.items():
+            ensure_unique(choices, f"choice slugs for dimension {dim_slug}")
+
+        # 3) Snake case all slugs in dimensions + choices
         for dim in self.dimensions:
             ## Choice slug
             for choice in dim.choices:
@@ -271,7 +289,7 @@ class Collection(MDIMBase):
             assert dim.slug in dimension_mapping, "Dimension slug not found in mapping!"
             dim.slug = dimension_mapping[dim.slug]
 
-        # 2) Snake case all slugs in views based on the mapping from 1. Raise error if any slug is not found in the mapping.
+        # 4) Snake case all slugs in views based on the mapping from 1. Raise error if any slug is not found in the mapping.
         for view in self.views:
             view_dimensions = {}
             for dim_slug, choice_slug in view.dimensions.items():

--- a/etl/steps/export/explorers/faostat/latest/global_food.py
+++ b/etl/steps/export/explorers/faostat/latest/global_food.py
@@ -526,8 +526,8 @@ def run():
         default_view={
             "item": "maize",
             "metric": "production",
-            "unit": "na",
-            "per_capita": "false",
+            "unit": "",
+            "per_capita": "False",
         },
     )
 
@@ -541,20 +541,9 @@ def run():
     # Make per capita a checkbox and unit a radio button.
     for dimension in config["dimensions"]:
         if dimension["slug"] == "per_capita":
-            dimension["presentation"] = {"type": "checkbox", "choice_slug_true": "true"}
+            dimension["presentation"] = {"type": "checkbox", "choice_slug_true": "True"}
         if dimension["slug"] == "unit":
             dimension["presentation"] = {"type": "radio"}
-
-    # Slugify dimensions and views
-    for dim in config["dimensions"]:
-        for choice in dim["choices"]:
-            if choice["slug"] == "":
-                choice["slug"] = "na"
-            else:
-                choice["slug"] = underscore(choice["slug"])
-
-    for view in config["views"]:
-        view["dimensions"] = {d: "na" if not v else underscore(v) for d, v in view["dimensions"].items()}
 
     #
     # Save outputs.


### PR DESCRIPTION
- Map empty slugs `""` to `"na"` when exporting.
- We were snake-casing dimension and choice slugs, but forgetting about `choice[].presentation.choice_slug_true`, if existant.

### Checks
- [x] Run `etlr explorers/ --export --private --force --only`
- [x] Run `etlr multidim/ --export --private --force --only`


/schedule