### PR TITLE
cleanup: remove `colorScaleEqualSizeBins`

### DIFF
--- a/etl/steps/export/explorers/biodiversity/latest/habitat_loss.config.yml
+++ b/etl/steps/export/explorers/biodiversity/latest/habitat_loss.config.yml
@@ -13,7 +13,6 @@ definitions:
     colorScaleInvert: true
     colorScaleScheme: YlOrRd
     colorScaleNumericBins: -15,;-10,;-5,;0,;5,
-    colorScaleEqualSizeBins: true
     colorScaleNumericMinValue: -20
 
   display_cropland: &display_cropland
@@ -23,7 +22,6 @@ definitions:
     colorScaleInvert: true
     colorScaleScheme: RdYlBu
     colorScaleNumericBins: -100,,;-75,,;-50,,;-25,,;0,,;25,,;50,,;75,,;100,,;250
-    colorScaleEqualSizeBins: true
     colorScaleNumericMinValue: -250
 
 config:

--- a/etl/steps/export/explorers/migration/2024-08-05/migration.py
+++ b/etl/steps/export/explorers/migration/2024-08-05/migration.py
@@ -143,7 +143,6 @@ def run(dest_dir: str) -> None:
     df_columns = pd.DataFrame(col_dicts)
 
     df_columns["colorScaleNumericMinValue"] = 0
-    df_columns["colorScaleEqualSizeBins"] = True  # equal size bins for all indicators
 
     # Save outputs.
     ds_explorer = paths.create_explorer_legacy(config=config, df_graphers=df_graphers, df_columns=df_columns)

--- a/etl/steps/export/explorers/migration/latest/migration_flows.py
+++ b/etl/steps/export/explorers/migration/latest/migration_flows.py
@@ -7,7 +7,6 @@ paths = PathFinder(__file__)
 DISPLAY_SETTINGS = {
     "colorScaleNumericMinValue": 0,
     "colorScaleNumericBins": "1000,,;3000,,;10000,,;30000,,;100000,,;300000,,;1000000,,;0",
-    "colorScaleEqualSizeBins": True,
     "colorScaleScheme": "YlGnBu",
     "colorScaleCategoricalBins": "Selected country,#AF1629,Selected country",
 }

--- a/etl/steps/export/explorers/wash/latest/water_and_sanitation.py
+++ b/etl/steps/export/explorers/wash/latest/water_and_sanitation.py
@@ -26,7 +26,6 @@ def run() -> None:
         for y in view.indicators.y:
             y.update_display(
                 {
-                    "colorScaleEqualSizeBins": True,
                     "colorScaleNumericMinValue": 0,
                 }
             )

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -147,11 +147,6 @@
             "SingleColorGradientDarkCopper"
           ]
         },
-        "equalSizeBins": {
-          "type": "boolean",
-          "default": true,
-          "description": "Whether the visual scaling for the color legend is disabled."
-        },
         "customHiddenCategories": {
           "type": "object",
           "description": "Allow hiding categories from the legend",

--- a/scripts/poverty-inequality-explorers/common_parameters.py
+++ b/scripts/poverty-inequality-explorers/common_parameters.py
@@ -27,7 +27,6 @@ from etl.config import OWID_ENV
 ####################################################################################################
 COLOR_SCALE_NUMERIC_MIN_VALUE = 0
 TOLERANCE = 5
-COLOR_SCALE_EQUAL_SIZEBINS = "true"
 NEW_LINE = "\\n\\n"
 Y_AXIS_MIN = 0
 

--- a/scripts/poverty-inequality-explorers/lis/lis_expanded_poverty_explorer.py
+++ b/scripts/poverty-inequality-explorers/lis/lis_expanded_poverty_explorer.py
@@ -78,7 +78,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_LIS
 sourceLink = SOURCE_LINK_LIS
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 yAxisMin = Y_AXIS_MIN
@@ -495,7 +494,6 @@ df_tables["dataPublishedBy"] = dataPublishedBy
 df_tables["sourceLink"] = sourceLink
 df_tables["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables["tolerance"] = tolerance
-df_tables["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Make tolerance integer (to not break the parameter in the platform)
 df_tables["tolerance"] = df_tables["tolerance"].astype("Int64")

--- a/scripts/poverty-inequality-explorers/lis/lis_incomes_across_distribution_explorer.py
+++ b/scripts/poverty-inequality-explorers/lis/lis_incomes_across_distribution_explorer.py
@@ -86,7 +86,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_LIS
 sourceLink = SOURCE_LINK_LIS
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 yAxisMin = Y_AXIS_MIN
@@ -354,7 +353,6 @@ df_tables["dataPublishedBy"] = dataPublishedBy
 df_tables["sourceLink"] = sourceLink
 df_tables["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables["tolerance"] = tolerance
-df_tables["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Make tolerance integer (to not break the parameter in the platform)
 df_tables["tolerance"] = df_tables["tolerance"].astype("Int64")

--- a/scripts/poverty-inequality-explorers/lis/lis_inequality_explorer.py
+++ b/scripts/poverty-inequality-explorers/lis/lis_inequality_explorer.py
@@ -70,7 +70,6 @@ sourceName = SOURCE_NAME_LIS
 dataPublishedBy = DATA_PUBLISHED_BY_LIS
 sourceLink = SOURCE_LINK_LIS
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 yAxisMin = Y_AXIS_MIN
@@ -222,7 +221,6 @@ df_tables["sourceName"] = sourceName
 df_tables["dataPublishedBy"] = dataPublishedBy
 df_tables["sourceLink"] = sourceLink
 df_tables["tolerance"] = tolerance
-df_tables["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Make tolerance integer (to not break the parameter in the platform)
 df_tables["tolerance"] = df_tables["tolerance"].astype("Int64")

--- a/scripts/poverty-inequality-explorers/multisource/incomes_across_distribution_explorer_comparison.py
+++ b/scripts/poverty-inequality-explorers/multisource/incomes_across_distribution_explorer_comparison.py
@@ -172,7 +172,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_PIP
 sourceLink = SOURCE_LINK_PIP
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 tableSlug = "poverty_inequality"
 new_line = NEW_LINE
 
@@ -396,7 +395,6 @@ df_tables_pip["dataPublishedBy"] = dataPublishedBy
 df_tables_pip["sourceLink"] = sourceLink
 df_tables_pip["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables_pip["tolerance"] = tolerance
-df_tables_pip["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 ###########################################################################################
 # WORLD INEQUALITY DATABASE (WID)
@@ -409,7 +407,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_WID
 sourceLink = SOURCE_LINK_WID
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 additional_description = ADDITIONAL_DESCRIPTION_WID
@@ -636,7 +633,6 @@ df_tables_wid["dataPublishedBy"] = dataPublishedBy
 df_tables_wid["sourceLink"] = sourceLink
 df_tables_wid["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables_wid["tolerance"] = tolerance
-df_tables_wid["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 ###########################################################################################
 # LUXEMBOURG INCOME STUDY (LIS)
@@ -646,7 +642,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_LIS
 sourceLink = SOURCE_LINK_LIS
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 notes_title = NOTES_TITLE_LIS
@@ -917,7 +912,6 @@ df_tables_lis["dataPublishedBy"] = dataPublishedBy
 df_tables_lis["sourceLink"] = sourceLink
 df_tables_lis["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables_lis["tolerance"] = tolerance
-df_tables_lis["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Remove all the rows that have the "equivalized" value in the equivalized column
 df_tables_lis = df_tables_lis[df_tables_lis["equivalized"] != "equivalized"].reset_index(drop=True)

--- a/scripts/poverty-inequality-explorers/multisource/inequality_explorer.py
+++ b/scripts/poverty-inequality-explorers/multisource/inequality_explorer.py
@@ -88,7 +88,6 @@ sourceName = SOURCE_NAME_PIP
 dataPublishedBy = DATA_PUBLISHED_BY_PIP
 sourceLink = SOURCE_LINK_PIP
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 additional_description = ADDITIONAL_DESCRIPTION_PIP_COMPARISON
@@ -134,7 +133,6 @@ for survey in range(len(pip_tables)):
     df_tables_pip.loc[j, "type"] = "Numeric"
     df_tables_pip.loc[j, "colorScaleNumericBins"] = "0.25;0.3;0.35;0.4;0.45;0.5;0.55;0.6"
     df_tables_pip.loc[j, "colorScaleNumericMinValue"] = 1
-    df_tables_pip.loc[j, "colorScaleEqualSizeBins"] = "true"
     df_tables_pip.loc[j, "colorScaleScheme"] = "Oranges"
     df_tables_pip.loc[j, "tableSlug"] = pip_tables["table_name"][survey]
     j += 1
@@ -155,7 +153,6 @@ for survey in range(len(pip_tables)):
     df_tables_pip.loc[j, "type"] = "Numeric"
     df_tables_pip.loc[j, "colorScaleNumericBins"] = "20;25;30;35;40;45;50"
     df_tables_pip.loc[j, "colorScaleNumericMinValue"] = 100
-    df_tables_pip.loc[j, "colorScaleEqualSizeBins"] = "true"
     df_tables_pip.loc[j, "colorScaleScheme"] = "OrRd"
     df_tables_pip.loc[j, "tableSlug"] = pip_tables["table_name"][survey]
     j += 1
@@ -176,7 +173,6 @@ for survey in range(len(pip_tables)):
     df_tables_pip.loc[j, "type"] = "Numeric"
     df_tables_pip.loc[j, "colorScaleNumericBins"] = "15;20;25;30;35"
     df_tables_pip.loc[j, "colorScaleNumericMinValue"] = 100
-    df_tables_pip.loc[j, "colorScaleEqualSizeBins"] = "true"
     df_tables_pip.loc[j, "colorScaleScheme"] = "Blues"
     df_tables_pip.loc[j, "tableSlug"] = pip_tables["table_name"][survey]
     j += 1
@@ -197,7 +193,6 @@ for survey in range(len(pip_tables)):
     df_tables_pip.loc[j, "type"] = "Numeric"
     df_tables_pip.loc[j, "colorScaleNumericBins"] = "0.5;1;1.5;2;2.5;3;3.5;4;4.5;5;5.5"
     df_tables_pip.loc[j, "colorScaleNumericMinValue"] = 0
-    df_tables_pip.loc[j, "colorScaleEqualSizeBins"] = "true"
     df_tables_pip.loc[j, "colorScaleScheme"] = "YlOrBr"
     df_tables_pip.loc[j, "tableSlug"] = pip_tables["table_name"][survey]
     j += 1
@@ -220,7 +215,6 @@ for survey in range(len(pip_tables)):
     df_tables_pip.loc[j, "type"] = "Numeric"
     df_tables_pip.loc[j, "colorScaleNumericBins"] = "3;6;9;12;15;18;21;24;27"
     df_tables_pip.loc[j, "colorScaleNumericMinValue"] = 0
-    df_tables_pip.loc[j, "colorScaleEqualSizeBins"] = "true"
     df_tables_pip.loc[j, "colorScaleScheme"] = "YlOrBr"
     df_tables_pip.loc[j, "tableSlug"] = pip_tables["table_name"][survey]
     j += 1
@@ -277,7 +271,6 @@ for tab in range(len(wid_tables)):
         df_tables_wid.loc[j, "type"] = "Numeric"
         df_tables_wid.loc[j, "colorScaleNumericBins"] = wid_welfare["scale_gini"][wel]
         df_tables_wid.loc[j, "colorScaleNumericMinValue"] = 1
-        df_tables_wid.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables_wid.loc[j, "colorScaleScheme"] = "Oranges"
         j += 1
 
@@ -298,7 +291,6 @@ for tab in range(len(wid_tables)):
         df_tables_wid.loc[j, "type"] = "Numeric"
         df_tables_wid.loc[j, "colorScaleNumericBins"] = wid_welfare["scale_top10"][wel]
         df_tables_wid.loc[j, "colorScaleNumericMinValue"] = 100
-        df_tables_wid.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables_wid.loc[j, "colorScaleScheme"] = "OrRd"
         j += 1
 
@@ -319,7 +311,6 @@ for tab in range(len(wid_tables)):
         df_tables_wid.loc[j, "type"] = "Numeric"
         df_tables_wid.loc[j, "colorScaleNumericBins"] = wid_welfare["scale_top1"][wel]
         df_tables_wid.loc[j, "colorScaleNumericMinValue"] = 0
-        df_tables_wid.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables_wid.loc[j, "colorScaleScheme"] = "OrRd"
         j += 1
 
@@ -340,7 +331,6 @@ for tab in range(len(wid_tables)):
         df_tables_wid.loc[j, "type"] = "Numeric"
         df_tables_wid.loc[j, "colorScaleNumericBins"] = wid_welfare["scale_top01"][wel]
         df_tables_wid.loc[j, "colorScaleNumericMinValue"] = 0
-        df_tables_wid.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables_wid.loc[j, "colorScaleScheme"] = "OrRd"
         j += 1
 
@@ -361,7 +351,6 @@ for tab in range(len(wid_tables)):
         df_tables_wid.loc[j, "type"] = "Numeric"
         df_tables_wid.loc[j, "colorScaleNumericBins"] = wid_welfare["scale_bottom50"][wel]
         df_tables_wid.loc[j, "colorScaleNumericMinValue"] = 100
-        df_tables_wid.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables_wid.loc[j, "colorScaleScheme"] = "Blues"
         j += 1
 
@@ -380,7 +369,6 @@ for tab in range(len(wid_tables)):
         df_tables_wid.loc[j, "type"] = "Numeric"
         df_tables_wid.loc[j, "colorScaleNumericBins"] = wid_welfare["scale_palma_ratio"][wel]
         df_tables_wid.loc[j, "colorScaleNumericMinValue"] = 0
-        df_tables_wid.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables_wid.loc[j, "colorScaleScheme"] = "YlOrBr"
         j += 1
 

--- a/scripts/poverty-inequality-explorers/multisource/inequality_explorer_comparison.py
+++ b/scripts/poverty-inequality-explorers/multisource/inequality_explorer_comparison.py
@@ -122,7 +122,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_PIP
 sourceLink = SOURCE_LINK_PIP
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 tableSlug = "poverty_inequality"
 new_line = NEW_LINE
 
@@ -249,7 +248,6 @@ df_tables_pip["dataPublishedBy"] = dataPublishedBy
 df_tables_pip["sourceLink"] = sourceLink
 df_tables_pip["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables_pip["tolerance"] = tolerance
-df_tables_pip["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 ###########################################################################################
 # WORLD INEQUALITY DATABASE (WID)
@@ -262,7 +260,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_WID
 sourceLink = SOURCE_LINK_WID
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 additional_description = ADDITIONAL_DESCRIPTION_WID
@@ -358,7 +355,6 @@ df_tables_wid["dataPublishedBy"] = dataPublishedBy
 df_tables_wid["sourceLink"] = sourceLink
 df_tables_wid["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables_wid["tolerance"] = tolerance
-df_tables_wid["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 ###########################################################################################
 # LUXEMBOURG INCOME STUDY (LIS)
@@ -368,7 +364,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_LIS
 sourceLink = SOURCE_LINK_LIS
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 notes_title = NOTES_TITLE_LIS
@@ -511,7 +506,6 @@ df_tables_lis["dataPublishedBy"] = dataPublishedBy
 df_tables_lis["sourceLink"] = sourceLink
 df_tables_lis["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables_lis["tolerance"] = tolerance
-df_tables_lis["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Remove all the rows that have the "equivalized" value in the equivalized column
 df_tables_lis = df_tables_lis[df_tables_lis["equivalized"] != "equivalized"].reset_index(drop=True)

--- a/scripts/poverty-inequality-explorers/multisource/poverty_explorer_comparison.py
+++ b/scripts/poverty-inequality-explorers/multisource/poverty_explorer_comparison.py
@@ -111,7 +111,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_PIP
 sourceLink = SOURCE_LINK_PIP
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 tableSlug = "poverty_inequality"
 new_line = NEW_LINE
 
@@ -454,7 +453,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_LIS
 sourceLink = SOURCE_LINK_LIS
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 notes_title = NOTES_TITLE_LIS
@@ -862,7 +860,6 @@ df_tables_lis["dataPublishedBy"] = dataPublishedBy
 df_tables_lis["sourceLink"] = sourceLink
 df_tables_lis["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables_lis["tolerance"] = tolerance
-df_tables_lis["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Remove all the rows that have the "equivalized" value in the equivalized column
 df_tables_lis = df_tables_lis[df_tables_lis["equivalized"] != "equivalized"].reset_index(drop=True)

--- a/scripts/poverty-inequality-explorers/wbpip/pip_expanded_poverty_explorer.py
+++ b/scripts/poverty-inequality-explorers/wbpip/pip_expanded_poverty_explorer.py
@@ -59,7 +59,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_PIP
 sourceLink = SOURCE_LINK_PIP
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 yAxisMin = Y_AXIS_MIN
@@ -412,7 +411,6 @@ df_tables["dataPublishedBy"] = dataPublishedBy
 df_tables["sourceLink"] = sourceLink
 df_tables["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables["tolerance"] = tolerance
-df_tables["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Make tolerance integer (to not break the parameter in the platform)
 df_tables["tolerance"] = df_tables["tolerance"].astype("Int64")
@@ -454,7 +452,6 @@ for i in range(len(df_tables)):
         df_spells.loc[j, "type"] = df_tables.type[i]
         df_spells.loc[j, "colorScaleNumericMinValue"] = df_tables.colorScaleNumericMinValue[i]
         df_spells.loc[j, "colorScaleNumericBins"] = df_tables.colorScaleNumericBins[i]
-        df_spells.loc[j, "colorScaleEqualSizeBins"] = df_tables.colorScaleEqualSizeBins[i]
         df_spells.loc[j, "colorScaleScheme"] = df_tables.colorScaleScheme[i]
         df_spells.loc[j, "survey_type"] = df_tables.survey_type[i]
         j += 1
@@ -473,7 +470,6 @@ for i in range(len(df_tables)):
         df_spells.loc[j, "type"] = df_tables.type[i]
         df_spells.loc[j, "colorScaleNumericMinValue"] = df_tables.colorScaleNumericMinValue[i]
         df_spells.loc[j, "colorScaleNumericBins"] = df_tables.colorScaleNumericBins[i]
-        df_spells.loc[j, "colorScaleEqualSizeBins"] = df_tables.colorScaleEqualSizeBins[i]
         df_spells.loc[j, "colorScaleScheme"] = df_tables.colorScaleScheme[i]
         df_spells.loc[j, "survey_type"] = df_tables.survey_type[i]
         j += 1

--- a/scripts/poverty-inequality-explorers/wbpip/pip_incomes_across_distribution_explorer.py
+++ b/scripts/poverty-inequality-explorers/wbpip/pip_incomes_across_distribution_explorer.py
@@ -64,7 +64,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_PIP
 sourceLink = SOURCE_LINK_PIP
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 yAxisMin = Y_AXIS_MIN
@@ -308,7 +307,6 @@ df_tables["dataPublishedBy"] = dataPublishedBy
 df_tables["sourceLink"] = sourceLink
 df_tables["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables["tolerance"] = tolerance
-df_tables["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Make tolerance integer (to not break the parameter in the platform)
 df_tables["tolerance"] = df_tables["tolerance"].astype("Int64")
@@ -351,7 +349,6 @@ for i in range(len(df_tables)):
         df_spells.loc[j, "type"] = df_tables.type[i]
         df_spells.loc[j, "colorScaleNumericMinValue"] = df_tables.colorScaleNumericMinValue[i]
         df_spells.loc[j, "colorScaleNumericBins"] = df_tables.colorScaleNumericBins[i]
-        df_spells.loc[j, "colorScaleEqualSizeBins"] = df_tables.colorScaleEqualSizeBins[i]
         df_spells.loc[j, "colorScaleScheme"] = df_tables.colorScaleScheme[i]
         df_spells.loc[j, "survey_type"] = df_tables.survey_type[i]
         j += 1
@@ -370,7 +367,6 @@ for i in range(len(df_tables)):
         df_spells.loc[j, "type"] = df_tables.type[i]
         df_spells.loc[j, "colorScaleNumericMinValue"] = df_tables.colorScaleNumericMinValue[i]
         df_spells.loc[j, "colorScaleNumericBins"] = df_tables.colorScaleNumericBins[i]
-        df_spells.loc[j, "colorScaleEqualSizeBins"] = df_tables.colorScaleEqualSizeBins[i]
         df_spells.loc[j, "colorScaleScheme"] = df_tables.colorScaleScheme[i]
         df_spells.loc[j, "survey_type"] = df_tables.survey_type[i]
         j += 1

--- a/scripts/poverty-inequality-explorers/wbpip/pip_inequality_explorer.py
+++ b/scripts/poverty-inequality-explorers/wbpip/pip_inequality_explorer.py
@@ -61,7 +61,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_PIP
 sourceLink = SOURCE_LINK_PIP
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 yAxisMin = Y_AXIS_MIN
@@ -202,7 +201,6 @@ df_tables["sourceName"] = sourceName
 df_tables["dataPublishedBy"] = dataPublishedBy
 df_tables["sourceLink"] = sourceLink
 df_tables["tolerance"] = tolerance
-df_tables["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Make tolerance integer (to not break the parameter in the platform)
 df_tables["tolerance"] = df_tables["tolerance"].astype("Int64")
@@ -245,7 +243,6 @@ for i in range(len(df_tables)):
         df_spells.loc[j, "type"] = df_tables.type[i]
         df_spells.loc[j, "colorScaleNumericMinValue"] = df_tables.colorScaleNumericMinValue[i]
         df_spells.loc[j, "colorScaleNumericBins"] = df_tables.colorScaleNumericBins[i]
-        df_spells.loc[j, "colorScaleEqualSizeBins"] = df_tables.colorScaleEqualSizeBins[i]
         df_spells.loc[j, "colorScaleScheme"] = df_tables.colorScaleScheme[i]
         df_spells.loc[j, "survey_type"] = df_tables.survey_type[i]
         j += 1
@@ -264,7 +261,6 @@ for i in range(len(df_tables)):
         df_spells.loc[j, "type"] = df_tables.type[i]
         df_spells.loc[j, "colorScaleNumericMinValue"] = df_tables.colorScaleNumericMinValue[i]
         df_spells.loc[j, "colorScaleNumericBins"] = df_tables.colorScaleNumericBins[i]
-        df_spells.loc[j, "colorScaleEqualSizeBins"] = df_tables.colorScaleEqualSizeBins[i]
         df_spells.loc[j, "colorScaleScheme"] = df_tables.colorScaleScheme[i]
         df_spells.loc[j, "survey_type"] = df_tables.survey_type[i]
         j += 1

--- a/scripts/poverty-inequality-explorers/wbpip/pip_poverty_explorer.py
+++ b/scripts/poverty-inequality-explorers/wbpip/pip_poverty_explorer.py
@@ -60,7 +60,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_PIP
 sourceLink = SOURCE_LINK_PIP
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 yAxisMin = Y_AXIS_MIN
@@ -271,7 +270,6 @@ df_tables["dataPublishedBy"] = dataPublishedBy
 df_tables["sourceLink"] = sourceLink
 df_tables["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables["tolerance"] = tolerance
-df_tables["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Make tolerance integer (to not break the parameter in the platform)
 df_tables["tolerance"] = df_tables["tolerance"].astype("Int64")
@@ -315,7 +313,6 @@ for i in range(len(df_tables)):
         df_spells.loc[j, "type"] = df_tables.type[i]
         df_spells.loc[j, "colorScaleNumericMinValue"] = df_tables.colorScaleNumericMinValue[i]
         df_spells.loc[j, "colorScaleNumericBins"] = df_tables.colorScaleNumericBins[i]
-        df_spells.loc[j, "colorScaleEqualSizeBins"] = df_tables.colorScaleEqualSizeBins[i]
         df_spells.loc[j, "colorScaleScheme"] = df_tables.colorScaleScheme[i]
         df_spells.loc[j, "survey_type"] = df_tables.survey_type[i]
         j += 1
@@ -334,7 +331,6 @@ for i in range(len(df_tables)):
         df_spells.loc[j, "type"] = df_tables.type[i]
         df_spells.loc[j, "colorScaleNumericMinValue"] = df_tables.colorScaleNumericMinValue[i]
         df_spells.loc[j, "colorScaleNumericBins"] = df_tables.colorScaleNumericBins[i]
-        df_spells.loc[j, "colorScaleEqualSizeBins"] = df_tables.colorScaleEqualSizeBins[i]
         df_spells.loc[j, "colorScaleScheme"] = df_tables.colorScaleScheme[i]
         df_spells.loc[j, "survey_type"] = df_tables.survey_type[i]
         j += 1

--- a/scripts/poverty-inequality-explorers/wbpip/pip_ppp_comparison_explorer.py
+++ b/scripts/poverty-inequality-explorers/wbpip/pip_ppp_comparison_explorer.py
@@ -66,7 +66,6 @@ dataPublishedBy = DATA_PUBLISHED_BY_PIP
 sourceLink = SOURCE_LINK_PIP
 colorScaleNumericMinValue = COLOR_SCALE_NUMERIC_MIN_VALUE
 tolerance = TOLERANCE
-colorScaleEqualSizeBins = COLOR_SCALE_EQUAL_SIZEBINS
 new_line = NEW_LINE
 
 yAxisMin = Y_AXIS_MIN
@@ -473,7 +472,6 @@ df_tables["dataPublishedBy"] = dataPublishedBy
 df_tables["sourceLink"] = sourceLink
 df_tables["colorScaleNumericMinValue"] = colorScaleNumericMinValue
 df_tables["tolerance"] = tolerance
-df_tables["colorScaleEqualSizeBins"] = colorScaleEqualSizeBins
 
 # Make tolerance integer (to not break the parameter in the platform)
 df_tables["tolerance"] = df_tables["tolerance"].astype("Int64")

--- a/scripts/poverty-inequality-explorers/wid/wid_incomes_across_distribution_explorer.py
+++ b/scripts/poverty-inequality-explorers/wid/wid_incomes_across_distribution_explorer.py
@@ -127,7 +127,6 @@ for tab in range(len(tables)):
         df_tables.loc[j, "shortUnit"] = "$"
         df_tables.loc[j, "type"] = "Numeric"
         df_tables.loc[j, "colorScaleNumericBins"] = welfare["scale_mean"][wel]
-        df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables.loc[j, "colorScaleScheme"] = "BuGn"
         j += 1
 
@@ -146,7 +145,6 @@ for tab in range(len(tables)):
         df_tables.loc[j, "shortUnit"] = "$"
         df_tables.loc[j, "type"] = "Numeric"
         # df_tables.loc[j, "colorScaleNumericBins"] = welfare["scale_median"][wel]
-        df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables.loc[j, "colorScaleScheme"] = "Blues"
         j += 1
 
@@ -166,7 +164,6 @@ for tab in range(len(tables)):
             df_tables.loc[j, "shortUnit"] = "$"
             df_tables.loc[j, "type"] = "Numeric"
             # df_tables.loc[j, "colorScaleNumericBins"] = deciles9["scale_thr"][dec9]
-            df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
             df_tables.loc[j, "colorScaleScheme"] = "Purples"
             j += 1
 
@@ -186,7 +183,6 @@ for tab in range(len(tables)):
             df_tables.loc[j, "shortUnit"] = "$"
             df_tables.loc[j, "type"] = "Numeric"
             # df_tables.loc[j, "colorScaleNumericBins"] = deciles10["scale_avg"][dec10]
-            df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
             df_tables.loc[j, "colorScaleScheme"] = "Greens"
             j += 1
 
@@ -206,7 +202,6 @@ for tab in range(len(tables)):
             df_tables.loc[j, "type"] = "Numeric"
             df_tables.loc[j, "colorScaleNumericBins"] = deciles10[f"scale_share_{welfare['slug'][wel]}"][dec10]
             df_tables.loc[j, "colorScaleNumericMinValue"] = 100
-            df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
             df_tables.loc[j, "colorScaleScheme"] = "OrRd"
             j += 1
 
@@ -226,7 +221,6 @@ for tab in range(len(tables)):
             df_tables.loc[j, "shortUnit"] = "$"
             df_tables.loc[j, "type"] = "Numeric"
             # df_tables.loc[j, "colorScaleNumericBins"] = top_pct["scale_thr"][top]
-            df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
             df_tables.loc[j, "colorScaleScheme"] = "Purples"
             j += 1
 
@@ -246,7 +240,6 @@ for tab in range(len(tables)):
             df_tables.loc[j, "shortUnit"] = "$"
             df_tables.loc[j, "type"] = "Numeric"
             # df_tables.loc[j, "colorScaleNumericBins"] = top_pct["scale_avg"][top]
-            df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
             df_tables.loc[j, "colorScaleScheme"] = "Greens"
             j += 1
 
@@ -265,7 +258,6 @@ for tab in range(len(tables)):
             df_tables.loc[j, "shortUnit"] = "%"
             df_tables.loc[j, "type"] = "Numeric"
             df_tables.loc[j, "colorScaleNumericBins"] = top_pct[f"scale_share_{welfare['slug'][wel]}"][top]
-            df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
             df_tables.loc[j, "colorScaleScheme"] = "OrRd"
             j += 1
 
@@ -286,7 +278,6 @@ for tab in range(len(tables)):
             df_tables.loc[j, "shortUnit"] = "$"
             df_tables.loc[j, "type"] = "Numeric"
             df_tables.loc[j, "colorScaleNumericBins"] = income_aggregation[f"scale_{welfare['slug'][wel]}"][agg]
-            df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
             df_tables.loc[j, "colorScaleScheme"] = "BuGn"
             df_tables.loc[j, "transform"] = (
                 f"multiplyBy p0p100_avg_{welfare['slug'][wel]} {income_aggregation['multiplier'][agg]}"
@@ -308,7 +299,6 @@ for tab in range(len(tables)):
             df_tables.loc[j, "shortUnit"] = "$"
             df_tables.loc[j, "type"] = "Numeric"
             df_tables.loc[j, "colorScaleNumericBins"] = income_aggregation[f"scale_{welfare['slug'][wel]}"][agg]
-            df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
             df_tables.loc[j, "colorScaleScheme"] = "Blues"
             df_tables.loc[j, "transform"] = (
                 f"multiplyBy median_{welfare['slug'][wel]} {income_aggregation['multiplier'][agg]}"
@@ -335,7 +325,6 @@ for tab in range(len(tables)):
                 df_tables.loc[j, "colorScaleNumericBins"] = deciles9[
                     f"scale_thr_{welfare['slug'][wel]}_{income_aggregation['aggregation'][agg]}"
                 ][dec9]
-                df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
                 df_tables.loc[j, "colorScaleScheme"] = "Purples"
                 df_tables.loc[j, "transform"] = (
                     f"multiplyBy {deciles9['wid_notation'][dec9]}_thr_{welfare['slug'][wel]} {income_aggregation['multiplier'][agg]}"
@@ -362,7 +351,6 @@ for tab in range(len(tables)):
                 df_tables.loc[j, "colorScaleNumericBins"] = deciles10[
                     f"scale_avg_{welfare['slug'][wel]}_{income_aggregation['aggregation'][agg]}"
                 ][dec10]
-                df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
                 df_tables.loc[j, "colorScaleScheme"] = "Greens"
                 df_tables.loc[j, "transform"] = (
                     f"multiplyBy {deciles10['wid_notation'][dec10]}_avg_{welfare['slug'][wel]} {income_aggregation['multiplier'][agg]}"
@@ -389,7 +377,6 @@ for tab in range(len(tables)):
                 df_tables.loc[j, "colorScaleNumericBins"] = top_pct[
                     f"scale_thr_{welfare['slug'][wel]}_{income_aggregation['aggregation'][agg]}"
                 ][top]
-                df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
                 df_tables.loc[j, "colorScaleScheme"] = "Purples"
                 df_tables.loc[j, "transform"] = (
                     f"multiplyBy {top_pct['wid_notation'][top]}_thr_{welfare['slug'][wel]} {income_aggregation['multiplier'][agg]}"
@@ -416,7 +403,6 @@ for tab in range(len(tables)):
                 df_tables.loc[j, "colorScaleNumericBins"] = top_pct[
                     f"scale_avg_{welfare['slug'][wel]}_{income_aggregation['aggregation'][agg]}"
                 ][top]
-                df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
                 df_tables.loc[j, "colorScaleScheme"] = "Greens"
                 df_tables.loc[j, "transform"] = (
                     f"multiplyBy {top_pct['wid_notation'][top]}_avg_{welfare['slug'][wel]} {income_aggregation['multiplier'][agg]}"

--- a/scripts/poverty-inequality-explorers/wid/wid_inequality_explorer.py
+++ b/scripts/poverty-inequality-explorers/wid/wid_inequality_explorer.py
@@ -105,7 +105,6 @@ for tab in range(len(tables)):
         df_tables.loc[j, "type"] = "Numeric"
         df_tables.loc[j, "colorScaleNumericBins"] = welfare["scale_gini"][wel]
         df_tables.loc[j, "colorScaleNumericMinValue"] = 1
-        df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables.loc[j, "colorScaleScheme"] = "Oranges"
         j += 1
 
@@ -126,7 +125,6 @@ for tab in range(len(tables)):
         df_tables.loc[j, "type"] = "Numeric"
         df_tables.loc[j, "colorScaleNumericBins"] = welfare["scale_top10"][wel]
         df_tables.loc[j, "colorScaleNumericMinValue"] = 100
-        df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables.loc[j, "colorScaleScheme"] = "OrRd"
         j += 1
 
@@ -147,7 +145,6 @@ for tab in range(len(tables)):
         df_tables.loc[j, "type"] = "Numeric"
         df_tables.loc[j, "colorScaleNumericBins"] = welfare["scale_top1"][wel]
         df_tables.loc[j, "colorScaleNumericMinValue"] = 0
-        df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables.loc[j, "colorScaleScheme"] = "OrRd"
         j += 1
 
@@ -168,7 +165,6 @@ for tab in range(len(tables)):
         df_tables.loc[j, "type"] = "Numeric"
         df_tables.loc[j, "colorScaleNumericBins"] = welfare["scale_top01"][wel]
         df_tables.loc[j, "colorScaleNumericMinValue"] = 0
-        df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables.loc[j, "colorScaleScheme"] = "OrRd"
         j += 1
 
@@ -189,7 +185,6 @@ for tab in range(len(tables)):
         df_tables.loc[j, "type"] = "Numeric"
         df_tables.loc[j, "colorScaleNumericBins"] = welfare["scale_bottom50"][wel]
         df_tables.loc[j, "colorScaleNumericMinValue"] = 100
-        df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables.loc[j, "colorScaleScheme"] = "Blues"
         j += 1
 
@@ -208,7 +203,6 @@ for tab in range(len(tables)):
         df_tables.loc[j, "type"] = "Numeric"
         df_tables.loc[j, "colorScaleNumericBins"] = welfare["scale_palma_ratio"][wel]
         df_tables.loc[j, "colorScaleNumericMinValue"] = 0
-        df_tables.loc[j, "colorScaleEqualSizeBins"] = "true"
         df_tables.loc[j, "colorScaleScheme"] = "YlOrBr"
         j += 1
 


### PR DESCRIPTION
We're getting rid of this setting on the grapher side of things, and it was _always_ set to `true` for a long time now anyhow.
There's not a single instance where it wasn't set to true, so...