### PR TITLE
✨ Support chart inheritance in chart-sync

### DIFF
--- a/apps/chart_sync/admin_api.py
+++ b/apps/chart_sync/admin_api.py
@@ -63,10 +63,21 @@ class AdminAPI(object):
         return js
 
     def create_chart(self, chart_config: dict, user_id: Optional[int] = None) -> dict:
+        # Extract isInheritanceEnabled from config and prepare request params
+        config = chart_config.copy()
+        is_inheritance_enabled = config.pop("isInheritanceEnabled", None)
+
+        # Build request parameters
+        params = {}
+        if is_inheritance_enabled is not None:
+            inheritance_param = "enable" if is_inheritance_enabled else "disable"
+            params["inheritance"] = inheritance_param
+
         resp = requests.post(
             self.owid_env.admin_api + "/charts",
             cookies={"sessionid": self._get_session_id(user_id)},
-            json=chart_config,
+            json=config,
+            params=params,
         )
         js = self._json_from_response(resp)
         if not js["success"]:
@@ -74,10 +85,21 @@ class AdminAPI(object):
         return js
 
     def update_chart(self, chart_id: int, chart_config: dict, user_id: Optional[int] = None) -> dict:
+        # Extract isInheritanceEnabled from config and prepare request params
+        config = chart_config.copy()
+        is_inheritance_enabled = config.pop("isInheritanceEnabled", None)
+
+        # Build request parameters
+        params = {}
+        if is_inheritance_enabled is not None:
+            inheritance_param = "enable" if is_inheritance_enabled else "disable"
+            params["inheritance"] = inheritance_param
+
         resp = requests.put(
             f"{self.owid_env.admin_api}/charts/{chart_id}",
             cookies={"sessionid": self._get_session_id(user_id)},
-            json=chart_config,
+            json=config,
+            params=params,
         )
         js = self._json_from_response(resp)
         if not js["success"]:

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -402,6 +402,7 @@ class Chart(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
     configId: Mapped[bytes] = mapped_column(CHAR(36))
+    isInheritanceEnabled: Mapped[int] = mapped_column(TINYINT(1), server_default=text("'1'"))
     createdAt: Mapped[datetime] = mapped_column(DateTime, server_default=text("CURRENT_TIMESTAMP"), init=False)
     lastEditedAt: Mapped[datetime] = mapped_column(DateTime)
     lastEditedByUserId: Mapped[int] = mapped_column(Integer)
@@ -423,7 +424,10 @@ class Chart(Base):
 
     @hybrid_property
     def config(self) -> dict[str, Any]:  # type: ignore
-        return self.chart_config.full
+        config = self.chart_config.full.copy()
+        # Add isInheritanceEnabled to config so it's included in comparisons
+        config["isInheritanceEnabled"] = bool(self.isInheritanceEnabled)
+        return config
 
     @config.expression
     def config(cls):


### PR DESCRIPTION
Issue https://github.com/owid/etl/issues/1563#issuecomment-2925684371

Chart config inheritance wasn't detected in `chart-sync` because it's not part of chart config, but a separate column in `variables` table. As a workaround, we artificially add it to chart `config` and then remove right before sending the config to Admin API. I don't know whether I've found all places where we use `configs_are_equal` and so added a couple of asserts as guardrails.

## How to review

Check out [chart-diff for this server](http://staging-site-fix-inheritance-sync/etl/wizard/chart-diff). You should see one chart with enabled inheritance. (It's not shown by owidbot because it runs on `master`)