### PR TITLE
📊 energy: Fix short attribution of electricity mix

### DIFF
--- a/etl/steps/data/garden/energy/2025-05-12/electricity_mix.meta.yml
+++ b/etl/steps/data/garden/energy/2025-05-12/electricity_mix.meta.yml
@@ -22,7 +22,6 @@ definitions:
   common:
     processing_level: major
     presentation:
-      attribution_short: Ember and Energy Institute
       topic_tags:
         - "Energy"
     # Use the following common processing description for all variables in this dataset (which is almost all of them), and then rewrite the ones that have a different processing description.


### PR DESCRIPTION
The field `presentation.attribution_short` is manually input, and it was misleading in some cases (e.g. [this chart](https://owid.slack.com/archives/C01GAN73R5W/p1748948670117129), where it was "Ember and Energy Institute" but the right attribution should have been "Ember"). For simplicity and safety, I decided to remove this field.
Alternatively, I could manually assign "Ember", or "Energy Institute" or "Various sources" (or the appropriate combination of them) from code. But I'm also worried about how the propagation of this field will affect other downstream dependencies (e.g. `owid-energy`). See [this related issue](https://github.com/owid/etl/issues/4241).