### PR TITLE
📊 Auxiliary staging server

### DIFF
--- a/snapshots/rff/2025-06-02/emissions_weighted_carbon_price.zip.dvc
+++ b/snapshots/rff/2025-06-02/emissions_weighted_carbon_price.zip.dvc
@@ -12,12 +12,13 @@ meta:
     attribution_short: RFF
     url_main: https://github.com/g-dolphin/ECP
     url_download: https://github.com/g-dolphin/ECP/archive/refs/heads/master.zip
-    date_accessed: '2025-06-02'
-    date_published: '2025-06-02'
+    # We re-run the snapshot because a data issue was found and the data providers fixed it a few days after the update.
+    date_accessed: '2025-06-10'
+    date_published: '2025-06-10'
     license:
       name: CC BY-NC-ND 4.0
       url: https://github.com/g-dolphin/ECP
 outs:
-  - md5: d358805ff572d17f407047921cb45860
-    size: 213159163
+  - md5: 17d1e5c3bb4ed2c0422930c7e76e002a
+    size: 190410266
     path: emissions_weighted_carbon_price.zip

--- a/snapshots/rff/2025-06-02/emissions_weighted_carbon_price.zip.dvc
+++ b/snapshots/rff/2025-06-02/emissions_weighted_carbon_price.zip.dvc
@@ -19,6 +19,6 @@ meta:
       name: CC BY-NC-ND 4.0
       url: https://github.com/g-dolphin/ECP
 outs:
-  - md5: 17d1e5c3bb4ed2c0422930c7e76e002a
-    size: 190410266
+  - md5: b25a0c2c3b9b8805f959c79812c2ad5b
+    size: 190410333
     path: emissions_weighted_carbon_price.zip

--- a/snapshots/rff/2025-06-02/world_carbon_pricing.zip.dvc
+++ b/snapshots/rff/2025-06-02/world_carbon_pricing.zip.dvc
@@ -7,19 +7,22 @@ meta:
 
       It covers national and sub-national economic mechanisms relating to carbon emissions, and was developed from several key sources: Most notably, policy documents from countries and regions themselves. Secondly, from other sources such as the International Carbon Action Partnership.
     citation_full: |-
+      Dolphin, G., Merkle, M. Emissions-weighted carbon price: sources and methods. Sci Data 11, 1017 (2024). [https://doi.org/10.1038/s41597-024-03121-6](https://doi.org/10.1038/s41597-024-03121-6).
+
       Dolphin, G., Xiahou, Q. World carbon pricing database: sources and methods. Sci Data 9, 573 (2022). The article is available in Open Access at [https://doi.org/10.1038/s41597-022-01659-x](https://doi.org/10.1038/s41597-022-01659-x).
 
       Supported by Resources for the Future.
-    attribution: Dolphin and Xiahou (2022)
+    attribution: Dolphin and Merkle (2024)
     attribution_short: RFF
     url_main: https://github.com/g-dolphin/WorldCarbonPricingDatabase/
     url_download: https://github.com/g-dolphin/WorldCarbonPricingDatabase/archive/refs/heads/master.zip
-    date_accessed: '2025-06-02'
-    date_published: '2025-06-02'
+    # We re-run the snapshot because a data issue was found and the data providers fixed it a few days after the update.
+    date_accessed: '2025-06-10'
+    date_published: '2025-06-10'
     license:
       name: CC BY-NC-ND 4.0
       url: https://github.com/g-dolphin/WorldCarbonPricingDatabase/
 outs:
-  - md5: db56f66270cfbdb58436676eca9155c0
-    size: 28135367
+  - md5: 277967cd014a6c70ddd8b826d26d33cb
+    size: 28135706
     path: world_carbon_pricing.zip


### PR DESCRIPTION
## Summary
* Ed noticed [a potential data issue](https://owid.slack.com/archives/C03N1V9KXB9/p1749108634648809?thread_ts=1748855799.031569&cid=C03N1V9KXB9) in carbon pricing data for Norway, and I contacted the data provider. They have looked into it and fixed it, so I have re-executed the snapshots.
* I have also changed the citation, to show the 2024 paper in some of the charts (while also keeping the 2022 paper in the full citation).

## Review
@Marigold there's not much to review, but I wanted to flag a few issues that happened along the way. This PR was meant to be trivial: I just wanted to re-run a snapshot and overwrite the data. However, a few odd issues occurred:
* While running the snapshot `snapshots/rff/2025-06-02/emissions_weighted_carbon_price.zip.dvc`, I got an error saying that `request_checksum_calculation` and `response_checksum_validation` were not found. So I commented out those lines in `lib/catalog/owid/catalog/s3_utils.py`, and then the snapshot script worked.
  * I have reverted the changes now and the snapshot script works well, so I don't know what changed. Maybe we can forget about this.
* I had to create this new staging server because in the original one there was some strange issue with [this chart](http://staging-site-data-carbon-pricing-fix/admin/charts/6011/edit) (which is precisely the one that needed to be updated).
* In this staging server, I was running `etlr emissions_weighted_carbon_price --grapher --force --only`, but nothing was changing in [the chart](http://staging-site-data-auxiliary-staging/admin/charts/6011/edit). I noticed in the log was returning messages like `upsert_table.skipped_no_changes catalog_path=grapher/rff/2025-06-02/emissions_weighted_carbon_price/emissions_weighted_carbon_price#co2_with_ets_as_share_of_ghg`. So it seems that ETL was noticing no changes, and therefore nothing was updated. I commented these lines in `grapher.to_db.py`:
```
    if checksums.get("dataChecksum") == checksum_data and checksums.get("metadataChecksum") == checksum_metadata:
        if verbose:
            log.info("upsert_table.skipped_no_changes", size=len(df), catalog_path=catalog_path)
        return

```
and then I could finally update the chart. I wonder if the same problem will happen in production when I merge to master.

Let me know if you want to look into any of these issues, otherwise, happy to merge and see if the data gets updated in production. Thanks!