### PR TITLE
✨ Improve harmonization of non-owid regions

### DIFF
--- a/etl/harmonize.py
+++ b/etl/harmonize.py
@@ -223,10 +223,13 @@ class CountryRegionMapper:
         pairs = pairs[:num_suggestions]
 
         if institution is not None:
-            # Prepend option to include this region as a custom entry for the given institution (if not already there).
-            region_institution = f"{region} ({institution})"
-            if region_institution not in [pair[1] for pair in pairs]:
-                pairs = [(0, region_institution)] + pairs
+            # Prepend the option to include this region as a custom entry for the given institution.
+            # NOTE: We could only prepend the "region (institution)" entry if it's not already in the list "pairs".
+            # However, I think it's important to signal to the user if the entry already exists in the default list.
+            # So, currently, the only way to achieve that is to always show "region (institution)" as the first entry in the default list, and the subsequent entries would be the default options available.
+            # An even more ideal solution would be to have the "region (institution)" option out of the default list.
+            # But that requires some additional changes.
+            pairs = [(0, f"{region} ({institution})")] + pairs
         return [m for _, m in pairs]
 
 


### PR DESCRIPTION
This PR helps identify already existing mappings of non-OWID regions in our harmonize tool.
For example, if a hypothetical World Bank dataset contains the region "East Asia Pacific", our old harmonize tool would show as default options
```
"East Asia Pacific (WB)" (which would be a new entry)
"Asia"
"Tanzania",
... 
```
Even though we do have "East Asia and Pacific (WB)" among our defined non-OWID regions. With this PR, the harmonize tool shows the following options:
```
"East Asia Pacific (WB)" (which would be a new entry)
"East Asia and Pacific (WB)" (existing entry)
"Asia"
"Tanzania",
... 
```
It is still not ideal that the new entry is shown among the default options (ideally, it would be shown in a separate category, possibly "Custom entry". But that involves additional changes. So, for now, this is a small improvement to help harmonize non-OWID regions.
