### PR TITLE
🐛 Fix or patch insight search

### DIFF
--- a/apps/wizard/config/config.yml
+++ b/apps/wizard/config/config.yml
@@ -172,13 +172,15 @@ sections:
     description: |-
       Browse our content.
     apps:
-      - title: "Insight search"
-        alias: insight_search
-        description: "Browse DIs"
-        maintainer: "@pablo"
-        entrypoint: app_pages/insight_search/app.py
-        icon: ":material/search:"
-        image_url: "https://img.freepik.com/premium-photo/librarian-cataloging-new-books-library-database_1237301-1719.jpg"
+      # This app is causing a segmentation fault (I couldn't figure out why).
+      # Given that we have the data insights admin search, this app may not be needed anymore.
+      # - title: "Insight search"
+      #   alias: insight_search
+      #   description: "Browse DIs"
+      #   maintainer: "@pablo"
+      #   entrypoint: app_pages/insight_search/app.py
+      #   icon: ":material/search:"
+      #   image_url: "https://img.freepik.com/premium-photo/librarian-cataloging-new-books-library-database_1237301-1719.jpg"
       - title: "Indicator search"
         alias: indicator_search
         description: "Find similar indicators"

--- a/tests/apps/wizard/app_pages/test_apps.py
+++ b/tests/apps/wizard/app_pages/test_apps.py
@@ -217,17 +217,17 @@ def test_app_explorer():
     assert not at.exception
 
 
-@pytest.mark.integration
-@pytest.mark.usefixtures("set_config")
-def test_app_insight_search():
-    at = AppTest.from_file(str(WIZARD_DIR / "app_pages/insight_search/app.py"), default_timeout=DEFAULT_TIMEOUT).run()
+# @pytest.mark.integration
+# @pytest.mark.usefixtures("set_config")
+# def test_app_insight_search():
+#     at = AppTest.from_file(str(WIZARD_DIR / "app_pages/insight_search/app.py"), default_timeout=DEFAULT_TIMEOUT).run()
 
-    # Set Author
-    assert len(at.multiselect) == 1
-    at.multiselect
-    at.multiselect[0].set_value(["Max Roser"]).run()
+#     # Set Author
+#     assert len(at.multiselect) == 1
+#     at.multiselect
+#     at.multiselect[0].set_value(["Max Roser"]).run()
 
-    assert not at.exception
+#     assert not at.exception
 
 
 # @pytest.mark.integration


### PR DESCRIPTION
Hey @Marigold, insight search is causing a segmentation fault when trying to execute it locally, and its integration test is failing (e.g. [here](https://buildkite.com/our-world-in-data/etl-automated-staging-environment/builds/20512#01979be3-4c8a-4532-85f5-5aebb216fd3b), although, interestingly, the app does work [in production](https://etl.owid.io/wizard/insight_search)). I couldn't figure out what's going on, so I've removed the app and the test. If you have an idea of what could be happening, feel free to have a look. Otherwise, I think we can live without it (now that we have [the DI search in the admin](https://admin.owid.io/admin/data-insights)). thanks!