### PR TITLE
💄 yet even still more edits to war mdims

### DIFF
--- a/etl/collection/core/utils.py
+++ b/etl/collection/core/utils.py
@@ -81,4 +81,7 @@ def create_collection_from_config(
     # Validate duplicate views
     c.check_duplicate_views()
 
+    # Add dependencies to collection
+    c._dependencies = dependencies
+
     return c

--- a/etl/collection/model/view.py
+++ b/etl/collection/model/view.py
@@ -356,7 +356,7 @@ class View(MDIMBase):
 
         return indicators
 
-    def matches(self, _or=False, **kwargs):
+    def matches(self, **kwargs):
         """Evaluate if a view matches a set of dimensions.
 
         kwargs:

--- a/etl/collection/model/view.py
+++ b/etl/collection/model/view.py
@@ -356,6 +356,32 @@ class View(MDIMBase):
 
         return indicators
 
+    def matches(self, _or=False, **kwargs):
+        """Evaluate if a view matches a set of dimensions.
+
+        kwargs:
+            Key-value pairs representing the dimension names and values to match. Keys are function arguments, and values are the argument values, which can either be a single value or a list of values. If a list, it evaluates to True if any value is matched.
+
+        ```python
+        for v in c.views:
+            if v.matches(age="all", sex="female"):
+                pass
+            elif v.matches(age=[0, 10]):
+                pass
+        ```
+        """
+        for dim_name, dim_value in kwargs.items():
+            if dim_name not in self.dimensions:
+                raise ValueError(f"Dimension '{dim_name}' not found in view dimensions: {self.dimensions.keys()}")
+            if hasattr(dim_value, "__iter__") and not isinstance(dim_value, (str, bytes)):
+                # If the dimension value is a list, check if it matches any of the values in the view dimensions
+                if dim_value and self.dimensions[dim_name] not in dim_value:
+                    return False
+            elif isinstance(dim_value, (str, int, float)):
+                if self.dimensions[dim_name] != dim_value:
+                    return False
+        return True
+
 
 def merge_common_metadata_by_dimension(
     common_config,

--- a/etl/steps/export/multidim/war/latest/ucdp.py
+++ b/etl/steps/export/multidim/war/latest/ucdp.py
@@ -67,12 +67,7 @@ def run() -> None:
             assert v.indicators.y is not None
             v.indicators.y[0].display = {"name": choice_names[v.d.conflict_type]}
 
-        if (
-            (v.d.indicator == "deaths")
-            & (v.d.conflict_type == "all")
-            & (v.d.estimate == "best")
-            & (v.d.people == "all")
-        ):
+        if v.matches(indicator="deaths", conflict_type="all", estimate="best", people="all"):
             assert v.indicators.y is not None
             assert len(v.indicators.y) == 1
             v.indicators.y[0].catalogPath = v.indicators.y[0].catalogPath.replace(tb.m.uri, tb_pre.m.uri)

--- a/etl/steps/export/multidim/war/latest/ucdp.py
+++ b/etl/steps/export/multidim/war/latest/ucdp.py
@@ -38,46 +38,44 @@ def run() -> None:
 
     # Filter unnecessary columns
     tb = tb.filter(regex="^country|^year|^number_deaths_ongoing|^number_ongoing_conflicts__")
-    tb_pre = tb_pre.filter(regex="^country|^year|^number_deaths_ongoing|^number_ongoing_conflicts__")
 
     #
     # (optional) Adjust dimensions if needed
     #
     tb = adjust_dimensions(tb)
-    tb_pre = adjust_dimensions(tb_pre)
 
     #
     # Create collection object
     #
-    choices = {tb[col].m.dimensions["conflict_type"] for col in tb.columns if col not in {"country", "year"}} - {"all"}
 
     c = paths.create_collection(
         config=config,
         short_name="ucdp",
-        tb=[tb, tb_pre],
+        tb=tb,
         indicator_names=[
-            [
-                "deaths",
-                "death_rate",
-                "num_conflicts",
-            ],
-            ["deaths"],
-        ],
-        dimensions=[
-            {"conflict_type": list(choices), "estimate": "*", "people": "*"},
-            {"conflict_type": ["all"], "estimate": "*", "people": "*"},
+            "deaths",
+            "death_rate",
+            "num_conflicts",
         ],
         common_view_config=COMMON_CONFIG,
-        indicator_as_dimension=True,
     )
 
     # Edit indicator-level display settings
     choice_names = c.get_choice_names("conflict_type")
-    for view in c.views:
-        for slug, name in choice_names.items():
-            if view.d.conflict_type == slug:
-                assert view.indicators.y is not None
-                view.indicators.y[0].display = {"name": name}
+    for v in c.views:
+        if v.d.conflict_type in choice_names:
+            assert v.indicators.y is not None
+            v.indicators.y[0].display = {"name": choice_names[v.d.conflict_type]}
+
+        if (
+            (v.d.indicator == "deaths")
+            & (v.d.conflict_type == "all")
+            & (v.d.estimate == "best")
+            & (v.d.people == "all")
+        ):
+            assert v.indicators.y is not None
+            assert len(v.indicators.y) == 1
+            v.indicators.y[0].catalogPath = v.indicators.y[0].catalogPath.replace(tb.m.uri, tb_pre.m.uri)
 
     # Aggregate views
     c.group_views(
@@ -339,7 +337,7 @@ def _set_subtitle(view):
         # Define subtitle
         if view.d.indicator == "deaths":
             subtitle = subtitle_template.format(placeholder=f" in {dod}")
-            if view.d.conflict_type == "all":
+            if view.matches(conflict_type="all", estimate="best", people="all"):
                 subtitle += " The data for 2025 is preliminary and was last updated in June 2025."
             return subtitle
         elif view.d.indicator == "death_rate":

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -456,6 +456,13 @@ class TableMeta(MetaBase):
              {}
         """.format(short_name, to_html(record))
 
+    @property
+    def uri(self) -> str:
+        """Return unique URI for this table."""
+        assert self.dataset, "TableMeta.dataset is not set"
+        assert self.short_name, "TableMeta.short_name is not set"
+        return f"{self.dataset.uri}/{self.short_name}"
+
 
 def to_html(record: Any) -> str | None:
     if isinstance(record, dict):

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -461,7 +461,8 @@ class TableMeta(MetaBase):
         """Return unique URI for this table."""
         assert self.dataset, "TableMeta.dataset is not set"
         assert self.short_name, "TableMeta.short_name is not set"
-        return f"{self.dataset.uri}/{self.short_name}"
+        dataset_uri = self.dataset.uri.rstrip('/')
+        return f"{dataset_uri}/{self.short_name}"
 
 
 def to_html(record: Any) -> str | None:

--- a/lib/catalog/owid/catalog/meta.py
+++ b/lib/catalog/owid/catalog/meta.py
@@ -461,7 +461,7 @@ class TableMeta(MetaBase):
         """Return unique URI for this table."""
         assert self.dataset, "TableMeta.dataset is not set"
         assert self.short_name, "TableMeta.short_name is not set"
-        dataset_uri = self.dataset.uri.rstrip('/')
+        dataset_uri = self.dataset.uri.rstrip("/")
         return f"{dataset_uri}/{self.short_name}"
 
 

--- a/tests/collections/test_collection_model.py
+++ b/tests/collections/test_collection_model.py
@@ -768,3 +768,204 @@ def test_grouped_view_validation_with_incomplete_metadata():
         warning_messages = [str(warning.message) for warning in w]
         missing_desc_short = [msg for msg in warning_messages if "missing 'description_short'" in msg]
         assert len(missing_desc_short) >= 1
+
+
+def test_validate_indicators_are_from_dependencies_success():
+    """
+    Test Collection.validate_indicators_are_from_dependencies - passes when indicators match dependencies.
+    
+    Example: If collection has dependency "data://garden/ns/2023/dataset" and uses 
+    indicator "garden/ns/2023/dataset/table#column", validation should pass.
+    """
+    collection = Collection(
+        catalog_path="test#table",
+        title={"en": "Test"},
+        default_selection=["country"],
+        dimensions=[Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")])],
+        views=[
+            View(
+                dimensions={"country": "usa"}, 
+                indicators=ViewIndicators(y=[Indicator(catalogPath="garden/ns/2023/dataset/table#column")])
+            )
+        ],
+        _definitions=Definitions(),
+    )
+    
+    # Set up dependencies
+    collection._dependencies = {"data://garden/ns/2023/dataset"}
+    
+    # Get indicators in use
+    indicators = collection.indicators_in_use()
+    
+    # Should pass validation
+    result = collection.validate_indicators_are_from_dependencies(indicators)
+    assert result is True
+
+
+def test_validate_indicators_are_from_dependencies_failure():
+    """
+    Test Collection.validate_indicators_are_from_dependencies - fails when indicators don't match dependencies.
+    
+    Example: If collection has dependency "data://garden/ns/2023/dataset" but uses 
+    indicator from "garden/other/2023/otherset", validation should fail.
+    """
+    collection = Collection(
+        catalog_path="test#table",
+        title={"en": "Test"},
+        default_selection=["country"],
+        dimensions=[Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")])],
+        views=[
+            View(
+                dimensions={"country": "usa"}, 
+                indicators=ViewIndicators(y=[Indicator(catalogPath="garden/other/2023/otherset/table#column")])
+            )
+        ],
+        _definitions=Definitions(),
+    )
+    
+    # Set up dependencies (doesn't include the dataset being used)
+    collection._dependencies = {"data://garden/ns/2023/dataset"}
+    
+    # Get indicators in use
+    indicators = collection.indicators_in_use()
+    
+    # Should fail validation
+    with pytest.raises(ValueError, match="Indicator garden/other/2023/otherset/table#column is not covered by any dependency"):
+        collection.validate_indicators_are_from_dependencies(indicators)
+
+
+def test_validate_indicators_are_from_dependencies_multiple_dependencies():
+    """
+    Test Collection.validate_indicators_are_from_dependencies - works with multiple dependencies.
+    
+    Example: Collection with multiple dependencies should validate indicators from any of them.
+    """
+    collection = Collection(
+        catalog_path="test#table",
+        title={"en": "Test"},
+        default_selection=["country", "metric"],
+        dimensions=[
+            Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")]),
+            Dimension(slug="metric", name="Metric", choices=[DimensionChoice(slug="cases", name="Cases")])
+        ],
+        views=[
+            View(
+                dimensions={"country": "usa", "metric": "cases"}, 
+                indicators=ViewIndicators(y=[
+                    Indicator(catalogPath="garden/ns1/2023/dataset1/table#column1"),
+                    Indicator(catalogPath="garden/ns2/2023/dataset2/table#column2")
+                ])
+            )
+        ],
+        _definitions=Definitions(),
+    )
+    
+    # Set up multiple dependencies
+    collection._dependencies = {
+        "data://garden/ns1/2023/dataset1",
+        "data://garden/ns2/2023/dataset2"
+    }
+    
+    # Get indicators in use
+    indicators = collection.indicators_in_use()
+    
+    # Should pass validation - both indicators covered by dependencies
+    result = collection.validate_indicators_are_from_dependencies(indicators)
+    assert result is True
+
+
+def test_validate_indicators_are_from_dependencies_partial_match():
+    """
+    Test Collection.validate_indicators_are_from_dependencies - fails when only some indicators match.
+    
+    Example: If one indicator matches dependencies but another doesn't, validation should fail.
+    """
+    collection = Collection(
+        catalog_path="test#table",
+        title={"en": "Test"},
+        default_selection=["country", "metric"],
+        dimensions=[
+            Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")]),
+            Dimension(slug="metric", name="Metric", choices=[DimensionChoice(slug="cases", name="Cases")])
+        ],
+        views=[
+            View(
+                dimensions={"country": "usa", "metric": "cases"}, 
+                indicators=ViewIndicators(y=[
+                    Indicator(catalogPath="garden/ns1/2023/dataset1/table#column1"),  # Covered
+                    Indicator(catalogPath="garden/other/2023/uncovered/table#column2")  # Not covered
+                ])
+            )
+        ],
+        _definitions=Definitions(),
+    )
+    
+    # Set up dependencies (only covers first indicator)
+    collection._dependencies = {"data://garden/ns1/2023/dataset1"}
+    
+    # Get indicators in use
+    indicators = collection.indicators_in_use()
+    
+    # Should fail validation for the uncovered indicator
+    with pytest.raises(ValueError, match="Indicator garden/other/2023/uncovered/table#column2 is not covered by any dependency"):
+        collection.validate_indicators_are_from_dependencies(indicators)
+
+
+def test_validate_indicators_are_from_dependencies_empty_dependencies():
+    """
+    Test Collection.validate_indicators_are_from_dependencies - fails when no dependencies set.
+    
+    Example: Collection with indicators but no dependencies should fail validation.
+    """
+    collection = Collection(
+        catalog_path="test#table",
+        title={"en": "Test"},
+        default_selection=["country"],
+        dimensions=[Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")])],
+        views=[
+            View(
+                dimensions={"country": "usa"}, 
+                indicators=ViewIndicators(y=[Indicator(catalogPath="garden/ns/2023/dataset/table#column")])
+            )
+        ],
+        _definitions=Definitions(),
+    )
+    
+    # No dependencies set (empty set)
+    collection._dependencies = set()
+    
+    # Get indicators in use
+    indicators = collection.indicators_in_use()
+    
+    # Should fail validation
+    with pytest.raises(ValueError, match="Indicator garden/ns/2023/dataset/table#column is not covered by any dependency"):
+        collection.validate_indicators_are_from_dependencies(indicators)
+
+
+def test_validate_indicators_are_from_dependencies_empty_indicators():
+    """
+    Test Collection.validate_indicators_are_from_dependencies - passes when no indicators used.
+    
+    Example: Collection with no indicators should pass validation regardless of dependencies.
+    """
+    collection = Collection(
+        catalog_path="test#table",
+        title={"en": "Test"},
+        default_selection=["country"],
+        dimensions=[Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")])],
+        views=[
+            View(dimensions={"country": "usa"}, indicators=ViewIndicators(y=[]))
+        ],
+        _definitions=Definitions(),
+    )
+    
+    # Set up dependencies
+    collection._dependencies = {"data://garden/ns/2023/dataset"}
+    
+    # Get indicators in use (should be empty)
+    indicators = collection.indicators_in_use()
+    assert len(indicators) == 0
+    
+    # Should pass validation
+    result = collection.validate_indicators_are_from_dependencies(indicators)
+    assert result is True

--- a/tests/collections/test_collection_model.py
+++ b/tests/collections/test_collection_model.py
@@ -774,8 +774,8 @@ def test_validate_indicators_are_from_dependencies_success():
     """
     Test Collection.validate_indicators_are_from_dependencies - passes when indicators match dependencies.
     
-    Example: If collection has dependency "data://garden/ns/2023/dataset" and uses 
-    indicator "garden/ns/2023/dataset/table#column", validation should pass.
+    Example: If collection has dependency "data://grapher/ns/2023/dataset" and uses 
+    indicator "grapher/ns/2023/dataset/table#column", validation should pass.
     """
     collection = Collection(
         catalog_path="test#table",
@@ -785,14 +785,14 @@ def test_validate_indicators_are_from_dependencies_success():
         views=[
             View(
                 dimensions={"country": "usa"}, 
-                indicators=ViewIndicators(y=[Indicator(catalogPath="garden/ns/2023/dataset/table#column")])
+                indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/ns/2023/dataset/table#column")])
             )
         ],
         _definitions=Definitions(),
     )
     
-    # Set up dependencies
-    collection._dependencies = {"data://garden/ns/2023/dataset"}
+    # Set up dependencies that match the indicator path
+    collection._dependencies = {"data://grapher/ns/2023/dataset"}
     
     # Get indicators in use
     indicators = collection.indicators_in_use()
@@ -806,8 +806,8 @@ def test_validate_indicators_are_from_dependencies_failure():
     """
     Test Collection.validate_indicators_are_from_dependencies - fails when indicators don't match dependencies.
     
-    Example: If collection has dependency "data://garden/ns/2023/dataset" but uses 
-    indicator from "garden/other/2023/otherset", validation should fail.
+    Example: If collection has dependency "data://grapher/ns/2023/dataset" but uses 
+    indicator from "grapher/other/2023/otherset", validation should fail.
     """
     collection = Collection(
         catalog_path="test#table",
@@ -817,20 +817,20 @@ def test_validate_indicators_are_from_dependencies_failure():
         views=[
             View(
                 dimensions={"country": "usa"}, 
-                indicators=ViewIndicators(y=[Indicator(catalogPath="garden/other/2023/otherset/table#column")])
+                indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/other/2023/otherset/table#column")])
             )
         ],
         _definitions=Definitions(),
     )
     
     # Set up dependencies (doesn't include the dataset being used)
-    collection._dependencies = {"data://garden/ns/2023/dataset"}
+    collection._dependencies = {"data://grapher/ns/2023/dataset"}
     
     # Get indicators in use
     indicators = collection.indicators_in_use()
     
     # Should fail validation
-    with pytest.raises(ValueError, match="Indicator garden/other/2023/otherset/table#column is not covered by any dependency"):
+    with pytest.raises(ValueError, match="Indicator grapher/other/2023/otherset/table#column is not covered by any dependency"):
         collection.validate_indicators_are_from_dependencies(indicators)
 
 
@@ -852,8 +852,8 @@ def test_validate_indicators_are_from_dependencies_multiple_dependencies():
             View(
                 dimensions={"country": "usa", "metric": "cases"}, 
                 indicators=ViewIndicators(y=[
-                    Indicator(catalogPath="garden/ns1/2023/dataset1/table#column1"),
-                    Indicator(catalogPath="garden/ns2/2023/dataset2/table#column2")
+                    Indicator(catalogPath="grapher/ns1/2023/dataset1/table#column1"),
+                    Indicator(catalogPath="grapher/ns2/2023/dataset2/table#column2")
                 ])
             )
         ],
@@ -862,8 +862,8 @@ def test_validate_indicators_are_from_dependencies_multiple_dependencies():
     
     # Set up multiple dependencies
     collection._dependencies = {
-        "data://garden/ns1/2023/dataset1",
-        "data://garden/ns2/2023/dataset2"
+        "data://grapher/ns1/2023/dataset1",
+        "data://grapher/ns2/2023/dataset2"
     }
     
     # Get indicators in use
@@ -892,8 +892,8 @@ def test_validate_indicators_are_from_dependencies_partial_match():
             View(
                 dimensions={"country": "usa", "metric": "cases"}, 
                 indicators=ViewIndicators(y=[
-                    Indicator(catalogPath="garden/ns1/2023/dataset1/table#column1"),  # Covered
-                    Indicator(catalogPath="garden/other/2023/uncovered/table#column2")  # Not covered
+                    Indicator(catalogPath="grapher/ns1/2023/dataset1/table#column1"),  # Covered
+                    Indicator(catalogPath="grapher/other/2023/uncovered/table#column2")  # Not covered
                 ])
             )
         ],
@@ -901,13 +901,13 @@ def test_validate_indicators_are_from_dependencies_partial_match():
     )
     
     # Set up dependencies (only covers first indicator)
-    collection._dependencies = {"data://garden/ns1/2023/dataset1"}
+    collection._dependencies = {"data://grapher/ns1/2023/dataset1"}
     
     # Get indicators in use
     indicators = collection.indicators_in_use()
     
     # Should fail validation for the uncovered indicator
-    with pytest.raises(ValueError, match="Indicator garden/other/2023/uncovered/table#column2 is not covered by any dependency"):
+    with pytest.raises(ValueError, match="Indicator grapher/other/2023/uncovered/table#column2 is not covered by any dependency"):
         collection.validate_indicators_are_from_dependencies(indicators)
 
 
@@ -925,7 +925,7 @@ def test_validate_indicators_are_from_dependencies_empty_dependencies():
         views=[
             View(
                 dimensions={"country": "usa"}, 
-                indicators=ViewIndicators(y=[Indicator(catalogPath="garden/ns/2023/dataset/table#column")])
+                indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/ns/2023/dataset/table#column")])
             )
         ],
         _definitions=Definitions(),
@@ -938,7 +938,7 @@ def test_validate_indicators_are_from_dependencies_empty_dependencies():
     indicators = collection.indicators_in_use()
     
     # Should fail validation
-    with pytest.raises(ValueError, match="Indicator garden/ns/2023/dataset/table#column is not covered by any dependency"):
+    with pytest.raises(ValueError, match="Indicator grapher/ns/2023/dataset/table#column is not covered by any dependency"):
         collection.validate_indicators_are_from_dependencies(indicators)
 
 
@@ -960,7 +960,7 @@ def test_validate_indicators_are_from_dependencies_empty_indicators():
     )
     
     # Set up dependencies
-    collection._dependencies = {"data://garden/ns/2023/dataset"}
+    collection._dependencies = {"data://grapher/ns/2023/dataset"}
     
     # Get indicators in use (should be empty)
     indicators = collection.indicators_in_use()

--- a/tests/collections/test_collection_model.py
+++ b/tests/collections/test_collection_model.py
@@ -773,8 +773,8 @@ def test_grouped_view_validation_with_incomplete_metadata():
 def test_validate_indicators_are_from_dependencies_success():
     """
     Test Collection.validate_indicators_are_from_dependencies - passes when indicators match dependencies.
-    
-    Example: If collection has dependency "data://grapher/ns/2023/dataset" and uses 
+
+    Example: If collection has dependency "data://grapher/ns/2023/dataset" and uses
     indicator "grapher/ns/2023/dataset/table#column", validation should pass.
     """
     collection = Collection(
@@ -784,19 +784,19 @@ def test_validate_indicators_are_from_dependencies_success():
         dimensions=[Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")])],
         views=[
             View(
-                dimensions={"country": "usa"}, 
-                indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/ns/2023/dataset/table#column")])
+                dimensions={"country": "usa"},
+                indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/ns/2023/dataset/table#column")]),
             )
         ],
         _definitions=Definitions(),
     )
-    
+
     # Set up dependencies that match the indicator path
     collection._dependencies = {"data://grapher/ns/2023/dataset"}
-    
+
     # Get indicators in use
     indicators = collection.indicators_in_use()
-    
+
     # Should pass validation
     result = collection.validate_indicators_are_from_dependencies(indicators)
     assert result is True
@@ -805,8 +805,8 @@ def test_validate_indicators_are_from_dependencies_success():
 def test_validate_indicators_are_from_dependencies_failure():
     """
     Test Collection.validate_indicators_are_from_dependencies - fails when indicators don't match dependencies.
-    
-    Example: If collection has dependency "data://grapher/ns/2023/dataset" but uses 
+
+    Example: If collection has dependency "data://grapher/ns/2023/dataset" but uses
     indicator from "grapher/other/2023/otherset", validation should fail.
     """
     collection = Collection(
@@ -816,28 +816,30 @@ def test_validate_indicators_are_from_dependencies_failure():
         dimensions=[Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")])],
         views=[
             View(
-                dimensions={"country": "usa"}, 
-                indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/other/2023/otherset/table#column")])
+                dimensions={"country": "usa"},
+                indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/other/2023/otherset/table#column")]),
             )
         ],
         _definitions=Definitions(),
     )
-    
+
     # Set up dependencies (doesn't include the dataset being used)
     collection._dependencies = {"data://grapher/ns/2023/dataset"}
-    
+
     # Get indicators in use
     indicators = collection.indicators_in_use()
-    
+
     # Should fail validation
-    with pytest.raises(ValueError, match="Indicator grapher/other/2023/otherset/table#column is not covered by any dependency"):
+    with pytest.raises(
+        ValueError, match="Indicator grapher/other/2023/otherset/table#column is not covered by any dependency"
+    ):
         collection.validate_indicators_are_from_dependencies(indicators)
 
 
 def test_validate_indicators_are_from_dependencies_multiple_dependencies():
     """
     Test Collection.validate_indicators_are_from_dependencies - works with multiple dependencies.
-    
+
     Example: Collection with multiple dependencies should validate indicators from any of them.
     """
     collection = Collection(
@@ -846,29 +848,28 @@ def test_validate_indicators_are_from_dependencies_multiple_dependencies():
         default_selection=["country", "metric"],
         dimensions=[
             Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")]),
-            Dimension(slug="metric", name="Metric", choices=[DimensionChoice(slug="cases", name="Cases")])
+            Dimension(slug="metric", name="Metric", choices=[DimensionChoice(slug="cases", name="Cases")]),
         ],
         views=[
             View(
-                dimensions={"country": "usa", "metric": "cases"}, 
-                indicators=ViewIndicators(y=[
-                    Indicator(catalogPath="grapher/ns1/2023/dataset1/table#column1"),
-                    Indicator(catalogPath="grapher/ns2/2023/dataset2/table#column2")
-                ])
+                dimensions={"country": "usa", "metric": "cases"},
+                indicators=ViewIndicators(
+                    y=[
+                        Indicator(catalogPath="grapher/ns1/2023/dataset1/table#column1"),
+                        Indicator(catalogPath="grapher/ns2/2023/dataset2/table#column2"),
+                    ]
+                ),
             )
         ],
         _definitions=Definitions(),
     )
-    
+
     # Set up multiple dependencies
-    collection._dependencies = {
-        "data://grapher/ns1/2023/dataset1",
-        "data://grapher/ns2/2023/dataset2"
-    }
-    
+    collection._dependencies = {"data://grapher/ns1/2023/dataset1", "data://grapher/ns2/2023/dataset2"}
+
     # Get indicators in use
     indicators = collection.indicators_in_use()
-    
+
     # Should pass validation - both indicators covered by dependencies
     result = collection.validate_indicators_are_from_dependencies(indicators)
     assert result is True
@@ -877,7 +878,7 @@ def test_validate_indicators_are_from_dependencies_multiple_dependencies():
 def test_validate_indicators_are_from_dependencies_partial_match():
     """
     Test Collection.validate_indicators_are_from_dependencies - fails when only some indicators match.
-    
+
     Example: If one indicator matches dependencies but another doesn't, validation should fail.
     """
     collection = Collection(
@@ -886,35 +887,39 @@ def test_validate_indicators_are_from_dependencies_partial_match():
         default_selection=["country", "metric"],
         dimensions=[
             Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")]),
-            Dimension(slug="metric", name="Metric", choices=[DimensionChoice(slug="cases", name="Cases")])
+            Dimension(slug="metric", name="Metric", choices=[DimensionChoice(slug="cases", name="Cases")]),
         ],
         views=[
             View(
-                dimensions={"country": "usa", "metric": "cases"}, 
-                indicators=ViewIndicators(y=[
-                    Indicator(catalogPath="grapher/ns1/2023/dataset1/table#column1"),  # Covered
-                    Indicator(catalogPath="grapher/other/2023/uncovered/table#column2")  # Not covered
-                ])
+                dimensions={"country": "usa", "metric": "cases"},
+                indicators=ViewIndicators(
+                    y=[
+                        Indicator(catalogPath="grapher/ns1/2023/dataset1/table#column1"),  # Covered
+                        Indicator(catalogPath="grapher/other/2023/uncovered/table#column2"),  # Not covered
+                    ]
+                ),
             )
         ],
         _definitions=Definitions(),
     )
-    
+
     # Set up dependencies (only covers first indicator)
     collection._dependencies = {"data://grapher/ns1/2023/dataset1"}
-    
+
     # Get indicators in use
     indicators = collection.indicators_in_use()
-    
+
     # Should fail validation for the uncovered indicator
-    with pytest.raises(ValueError, match="Indicator grapher/other/2023/uncovered/table#column2 is not covered by any dependency"):
+    with pytest.raises(
+        ValueError, match="Indicator grapher/other/2023/uncovered/table#column2 is not covered by any dependency"
+    ):
         collection.validate_indicators_are_from_dependencies(indicators)
 
 
 def test_validate_indicators_are_from_dependencies_empty_dependencies():
     """
     Test Collection.validate_indicators_are_from_dependencies - fails when no dependencies set.
-    
+
     Example: Collection with indicators but no dependencies should fail validation.
     """
     collection = Collection(
@@ -924,28 +929,30 @@ def test_validate_indicators_are_from_dependencies_empty_dependencies():
         dimensions=[Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")])],
         views=[
             View(
-                dimensions={"country": "usa"}, 
-                indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/ns/2023/dataset/table#column")])
+                dimensions={"country": "usa"},
+                indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/ns/2023/dataset/table#column")]),
             )
         ],
         _definitions=Definitions(),
     )
-    
+
     # No dependencies set (empty set)
     collection._dependencies = set()
-    
+
     # Get indicators in use
     indicators = collection.indicators_in_use()
-    
+
     # Should fail validation
-    with pytest.raises(ValueError, match="Indicator grapher/ns/2023/dataset/table#column is not covered by any dependency"):
+    with pytest.raises(
+        ValueError, match="Indicator grapher/ns/2023/dataset/table#column is not covered by any dependency"
+    ):
         collection.validate_indicators_are_from_dependencies(indicators)
 
 
 def test_validate_indicators_are_from_dependencies_empty_indicators():
     """
     Test Collection.validate_indicators_are_from_dependencies - passes when no indicators used.
-    
+
     Example: Collection with no indicators should pass validation regardless of dependencies.
     """
     collection = Collection(
@@ -953,19 +960,17 @@ def test_validate_indicators_are_from_dependencies_empty_indicators():
         title={"en": "Test"},
         default_selection=["country"],
         dimensions=[Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")])],
-        views=[
-            View(dimensions={"country": "usa"}, indicators=ViewIndicators(y=[]))
-        ],
+        views=[View(dimensions={"country": "usa"}, indicators=ViewIndicators(y=[]))],
         _definitions=Definitions(),
     )
-    
+
     # Set up dependencies
     collection._dependencies = {"data://grapher/ns/2023/dataset"}
-    
+
     # Get indicators in use (should be empty)
     indicators = collection.indicators_in_use()
     assert len(indicators) == 0
-    
+
     # Should pass validation
     result = collection.validate_indicators_are_from_dependencies(indicators)
     assert result is True

--- a/tests/collections/test_model_dimension_view.py
+++ b/tests/collections/test_model_dimension_view.py
@@ -319,16 +319,18 @@ def test_view_matches_empty_list():
     """
     Test View.matches with empty list (edge case).
     
-    Example: matches(age=[]) should return False as empty list matches nothing.
+    Example: matches(age=[]) should return True as empty list means no restrictions.
+    This makes sense - an empty list means "don't filter on this dimension".
     """
     view = View(
         dimensions={"country": "usa", "age": "adult"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
     
-    # Empty list should not match anything
-    assert not view.matches(age=[])
-    assert not view.matches(country=[])
+    # Empty list should match anything (no restrictions)
+    assert view.matches(age=[])
+    assert view.matches(country=[])
+    assert view.matches(age=[], country="usa")  # Mix of empty list and exact match
 
 
 def test_view_matches_mixed_types():

--- a/tests/collections/test_model_dimension_view.py
+++ b/tests/collections/test_model_dimension_view.py
@@ -214,3 +214,216 @@ def test_view_expand_paths_and_indicators_used():
         "grapher/ns/latest/ds/table#ind1",  # From explicit indicators
         "grapher/ns/latest/ds/other#ind2",  # From config.sortColumnSlug
     }
+
+
+def test_view_matches_single_dimension_exact():
+    """
+    Test View.matches with single dimension exact matching.
+    
+    Example: View with dimensions {"country": "usa", "age": "adult"} should match
+    country="usa" but not country="uk".
+    """
+    view = View(
+        dimensions={"country": "usa", "age": "adult"},
+        indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
+    )
+    
+    # Should match exact dimension value
+    assert view.matches(country="usa")
+    assert view.matches(age="adult")
+    
+    # Should not match different values
+    assert not view.matches(country="uk")
+    assert not view.matches(age="child")
+
+
+def test_view_matches_multiple_dimensions():
+    """
+    Test View.matches with multiple dimension matching.
+    
+    Example: View should match only when ALL specified dimensions match.
+    """
+    view = View(
+        dimensions={"country": "usa", "age": "adult", "sex": "female"},
+        indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
+    )
+    
+    # Should match when all specified dimensions match
+    assert view.matches(country="usa", age="adult")
+    assert view.matches(country="usa", sex="female")
+    assert view.matches(age="adult", sex="female")
+    assert view.matches(country="usa", age="adult", sex="female")
+    
+    # Should not match when any dimension doesn't match
+    assert not view.matches(country="usa", age="child")  # age mismatch
+    assert not view.matches(country="uk", age="adult")   # country mismatch
+    assert not view.matches(country="usa", age="adult", sex="male")  # sex mismatch
+
+
+def test_view_matches_list_values():
+    """
+    Test View.matches with list of acceptable values.
+    
+    Example: matches(age=["adult", "child"]) should match if view.age is either "adult" OR "child".
+    """
+    view_adult = View(
+        dimensions={"country": "usa", "age": "adult"},
+        indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
+    )
+    
+    view_child = View(
+        dimensions={"country": "usa", "age": "child"},
+        indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
+    )
+    
+    view_elderly = View(
+        dimensions={"country": "usa", "age": "elderly"},
+        indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
+    )
+    
+    # Should match when view's dimension value is in the list
+    assert view_adult.matches(age=["adult", "child"])
+    assert view_child.matches(age=["adult", "child"])
+    
+    # Should not match when view's dimension value is not in the list
+    assert not view_elderly.matches(age=["adult", "child"])
+    
+    # Test with multiple dimensions, some with lists
+    assert view_adult.matches(country="usa", age=["adult", "child"])
+    assert not view_adult.matches(country="uk", age=["adult", "child"])  # country mismatch
+
+
+def test_view_matches_numeric_values():
+    """
+    Test View.matches with numeric values (int, float).
+    
+    Example: Views with numeric dimension values should match properly.
+    """
+    view = View(
+        dimensions={"year": "2023", "score": "95.5", "rank": "1"},
+        indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
+    )
+    
+    # Should match numeric values (note: dimensions are stored as strings)
+    assert view.matches(year="2023")
+    assert view.matches(score="95.5")
+    assert view.matches(rank="1")
+    
+    # Should not match different numeric values
+    assert not view.matches(year="2022")
+    assert not view.matches(score="95.6")
+    assert not view.matches(rank="2")
+
+
+def test_view_matches_empty_list():
+    """
+    Test View.matches with empty list (edge case).
+    
+    Example: matches(age=[]) should return False as empty list matches nothing.
+    """
+    view = View(
+        dimensions={"country": "usa", "age": "adult"},
+        indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
+    )
+    
+    # Empty list should not match anything
+    assert not view.matches(age=[])
+    assert not view.matches(country=[])
+
+
+def test_view_matches_mixed_types():
+    """
+    Test View.matches with mixed argument types (strings and lists).
+    
+    Example: matches(country="usa", age=["adult", "child"]) mixes string and list matching.
+    """
+    view = View(
+        dimensions={"country": "usa", "age": "adult", "sex": "female"},
+        indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
+    )
+    
+    # Mix of exact match and list match
+    assert view.matches(country="usa", age=["adult", "child"])
+    assert view.matches(country=["usa", "canada"], age="adult")
+    assert view.matches(country=["usa", "canada"], age=["adult", "child"])
+    
+    # Should fail if any condition fails
+    assert not view.matches(country="uk", age=["adult", "child"])  # country mismatch
+    assert not view.matches(country=["canada", "mexico"], age="adult")  # country not in list
+    assert not view.matches(country="usa", age=["child", "elderly"])  # age not in list
+
+
+def test_view_matches_nonexistent_dimension():
+    """
+    Test View.matches raises ValueError for non-existent dimensions.
+    
+    Example: Trying to match on dimension not present in view should raise ValueError.
+    """
+    view = View(
+        dimensions={"country": "usa", "age": "adult"},
+        indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
+    )
+    
+    # Should raise ValueError for dimension not in view
+    with pytest.raises(ValueError, match="Dimension 'region' not found in view dimensions"):
+        view.matches(region="north_america")
+    
+    with pytest.raises(ValueError, match="Dimension 'income' not found in view dimensions"):
+        view.matches(country="usa", income="high")
+
+
+def test_view_matches_string_vs_bytes():
+    """
+    Test View.matches properly handles string vs bytes distinction.
+    
+    Example: String values should be treated as single values, not iterables.
+    """
+    view = View(
+        dimensions={"country": "usa", "category": "health"},
+        indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
+    )
+    
+    # String should be treated as single value, not iterable
+    assert view.matches(country="usa")  # exact string match
+    assert view.matches(category="health")  # exact string match
+    
+    # Should not match substring iterations
+    assert not view.matches(country="us")  # partial match should fail
+    assert not view.matches(category="heal")  # partial match should fail
+
+
+def test_view_matches_complex_scenario():
+    """
+    Test View.matches with complex real-world scenario.
+    
+    Example: Multi-dimensional view with various matching patterns as might be used
+    in an actual data collection filtering scenario.
+    """
+    view = View(
+        dimensions={
+            "country": "usa", 
+            "age_group": "adult", 
+            "sex": "female", 
+            "year": "2023",
+            "metric": "population"
+        },
+        indicators=ViewIndicators.from_dict({"y": "table#population_count"}),
+    )
+    
+    # Various realistic matching scenarios
+    assert view.matches(country="usa")  # Filter by country only
+    assert view.matches(country="usa", year="2023")  # Filter by country and year
+    assert view.matches(sex="female", metric="population")  # Filter by sex and metric
+    assert view.matches(age_group=["adult", "elderly"], sex="female")  # Mix of list and exact
+    
+    # Complex multi-criteria filtering
+    assert view.matches(
+        country=["usa", "canada"], 
+        age_group="adult", 
+        year=["2022", "2023"]
+    )
+    
+    # Should fail when criteria don't match
+    assert not view.matches(country="usa", sex="male")  # sex mismatch
+    assert not view.matches(country=["canada", "mexico"])  # country not in list
+    assert not view.matches(year=["2020", "2021", "2022"])  # year not in list

--- a/tests/collections/test_model_dimension_view.py
+++ b/tests/collections/test_model_dimension_view.py
@@ -219,7 +219,7 @@ def test_view_expand_paths_and_indicators_used():
 def test_view_matches_single_dimension_exact():
     """
     Test View.matches with single dimension exact matching.
-    
+
     Example: View with dimensions {"country": "usa", "age": "adult"} should match
     country="usa" but not country="uk".
     """
@@ -227,11 +227,11 @@ def test_view_matches_single_dimension_exact():
         dimensions={"country": "usa", "age": "adult"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
-    
+
     # Should match exact dimension value
     assert view.matches(country="usa")
     assert view.matches(age="adult")
-    
+
     # Should not match different values
     assert not view.matches(country="uk")
     assert not view.matches(age="child")
@@ -240,54 +240,54 @@ def test_view_matches_single_dimension_exact():
 def test_view_matches_multiple_dimensions():
     """
     Test View.matches with multiple dimension matching.
-    
+
     Example: View should match only when ALL specified dimensions match.
     """
     view = View(
         dimensions={"country": "usa", "age": "adult", "sex": "female"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
-    
+
     # Should match when all specified dimensions match
     assert view.matches(country="usa", age="adult")
     assert view.matches(country="usa", sex="female")
     assert view.matches(age="adult", sex="female")
     assert view.matches(country="usa", age="adult", sex="female")
-    
+
     # Should not match when any dimension doesn't match
     assert not view.matches(country="usa", age="child")  # age mismatch
-    assert not view.matches(country="uk", age="adult")   # country mismatch
+    assert not view.matches(country="uk", age="adult")  # country mismatch
     assert not view.matches(country="usa", age="adult", sex="male")  # sex mismatch
 
 
 def test_view_matches_list_values():
     """
     Test View.matches with list of acceptable values.
-    
+
     Example: matches(age=["adult", "child"]) should match if view.age is either "adult" OR "child".
     """
     view_adult = View(
         dimensions={"country": "usa", "age": "adult"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
-    
+
     view_child = View(
         dimensions={"country": "usa", "age": "child"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
-    
+
     view_elderly = View(
         dimensions={"country": "usa", "age": "elderly"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
-    
+
     # Should match when view's dimension value is in the list
     assert view_adult.matches(age=["adult", "child"])
     assert view_child.matches(age=["adult", "child"])
-    
+
     # Should not match when view's dimension value is not in the list
     assert not view_elderly.matches(age=["adult", "child"])
-    
+
     # Test with multiple dimensions, some with lists
     assert view_adult.matches(country="usa", age=["adult", "child"])
     assert not view_adult.matches(country="uk", age=["adult", "child"])  # country mismatch
@@ -296,19 +296,19 @@ def test_view_matches_list_values():
 def test_view_matches_numeric_values():
     """
     Test View.matches with numeric values (int, float).
-    
+
     Example: Views with numeric dimension values should match properly.
     """
     view = View(
         dimensions={"year": "2023", "score": "95.5", "rank": "1"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
-    
+
     # Should match numeric values (note: dimensions are stored as strings)
     assert view.matches(year="2023")
     assert view.matches(score="95.5")
     assert view.matches(rank="1")
-    
+
     # Should not match different numeric values
     assert not view.matches(year="2022")
     assert not view.matches(score="95.6")
@@ -318,7 +318,7 @@ def test_view_matches_numeric_values():
 def test_view_matches_empty_list():
     """
     Test View.matches with empty list (edge case).
-    
+
     Example: matches(age=[]) should return True as empty list means no restrictions.
     This makes sense - an empty list means "don't filter on this dimension".
     """
@@ -326,7 +326,7 @@ def test_view_matches_empty_list():
         dimensions={"country": "usa", "age": "adult"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
-    
+
     # Empty list should match anything (no restrictions)
     assert view.matches(age=[])
     assert view.matches(country=[])
@@ -336,19 +336,19 @@ def test_view_matches_empty_list():
 def test_view_matches_mixed_types():
     """
     Test View.matches with mixed argument types (strings and lists).
-    
+
     Example: matches(country="usa", age=["adult", "child"]) mixes string and list matching.
     """
     view = View(
         dimensions={"country": "usa", "age": "adult", "sex": "female"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
-    
+
     # Mix of exact match and list match
     assert view.matches(country="usa", age=["adult", "child"])
     assert view.matches(country=["usa", "canada"], age="adult")
     assert view.matches(country=["usa", "canada"], age=["adult", "child"])
-    
+
     # Should fail if any condition fails
     assert not view.matches(country="uk", age=["adult", "child"])  # country mismatch
     assert not view.matches(country=["canada", "mexico"], age="adult")  # country not in list
@@ -358,18 +358,18 @@ def test_view_matches_mixed_types():
 def test_view_matches_nonexistent_dimension():
     """
     Test View.matches raises ValueError for non-existent dimensions.
-    
+
     Example: Trying to match on dimension not present in view should raise ValueError.
     """
     view = View(
         dimensions={"country": "usa", "age": "adult"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
-    
+
     # Should raise ValueError for dimension not in view
     with pytest.raises(ValueError, match="Dimension 'region' not found in view dimensions"):
         view.matches(region="north_america")
-    
+
     with pytest.raises(ValueError, match="Dimension 'income' not found in view dimensions"):
         view.matches(country="usa", income="high")
 
@@ -377,18 +377,18 @@ def test_view_matches_nonexistent_dimension():
 def test_view_matches_string_vs_bytes():
     """
     Test View.matches properly handles string vs bytes distinction.
-    
+
     Example: String values should be treated as single values, not iterables.
     """
     view = View(
         dimensions={"country": "usa", "category": "health"},
         indicators=ViewIndicators.from_dict({"y": "table#indicator"}),
     )
-    
+
     # String should be treated as single value, not iterable
     assert view.matches(country="usa")  # exact string match
     assert view.matches(category="health")  # exact string match
-    
+
     # Should not match substring iterations
     assert not view.matches(country="us")  # partial match should fail
     assert not view.matches(category="heal")  # partial match should fail
@@ -397,34 +397,24 @@ def test_view_matches_string_vs_bytes():
 def test_view_matches_complex_scenario():
     """
     Test View.matches with complex real-world scenario.
-    
+
     Example: Multi-dimensional view with various matching patterns as might be used
     in an actual data collection filtering scenario.
     """
     view = View(
-        dimensions={
-            "country": "usa", 
-            "age_group": "adult", 
-            "sex": "female", 
-            "year": "2023",
-            "metric": "population"
-        },
+        dimensions={"country": "usa", "age_group": "adult", "sex": "female", "year": "2023", "metric": "population"},
         indicators=ViewIndicators.from_dict({"y": "table#population_count"}),
     )
-    
+
     # Various realistic matching scenarios
     assert view.matches(country="usa")  # Filter by country only
     assert view.matches(country="usa", year="2023")  # Filter by country and year
     assert view.matches(sex="female", metric="population")  # Filter by sex and metric
     assert view.matches(age_group=["adult", "elderly"], sex="female")  # Mix of list and exact
-    
+
     # Complex multi-criteria filtering
-    assert view.matches(
-        country=["usa", "canada"], 
-        age_group="adult", 
-        year=["2022", "2023"]
-    )
-    
+    assert view.matches(country=["usa", "canada"], age_group="adult", year=["2022", "2023"])
+
     # Should fail when criteria don't match
     assert not view.matches(country="usa", sex="male")  # sex mismatch
     assert not view.matches(country=["canada", "mexico"])  # country not in list


### PR DESCRIPTION
- Use preliminary UCDP data only in default view
- Some views were missing (`conflict_type='all'` for other than `indicator='deaths'`
- FEATURE: `tb.m.uri` to get table URI
- FEATURE: `View.matches` to match specific set of dimensions
- FEATURE: Add check of indicators. They should come from dependencies.


/schedule