### PR TITLE
🐛 fix dependency check in collections

### DIFF
--- a/etl/collection/core/combine.py
+++ b/etl/collection/core/combine.py
@@ -275,9 +275,10 @@ def combine_collections(
         if dim.ui_type == "checkbox" and is_explorer:
             raise NotImplementedError("Checkbox dimensions are not supported yet for Explorers.")
 
-    # Detect duplicate views
+    # Detect duplicate views + save dependencies
     seen_dims = set()
     has_duplicate_views = False
+    dependencies_combined = set()
     for collection in collections:
         # duplicate views within a collection
         collection.check_duplicate_views()
@@ -288,6 +289,9 @@ def combine_collections(
                 has_duplicate_views = True
                 break
             seen_dims.add(dims)
+
+        # Save dependencies from each collection
+        dependencies_combined |= collection.dependencies
 
     # Add collection dimension if needed
     if has_duplicate_views or force_collection_dimension:
@@ -389,6 +393,7 @@ def combine_collections(
         catalog_path=catalog_path_new,
         validate_schema=True if not is_explorer else False,
         explorer=is_explorer,
+        dependencies_combined=dependencies_combined,
     )
 
     # Log any conflicts that were resolved

--- a/etl/collection/core/utils.py
+++ b/etl/collection/core/utils.py
@@ -38,6 +38,7 @@ def create_collection_from_config(
     dependencies: Set[str],
     catalog_path: str,
     *,  # Force keyword-only arguments after this
+    dependencies_combined: set[str] | None = None,
     validate_schema: bool = True,
     explorer: bool,
 ) -> Explorer: ...
@@ -49,6 +50,7 @@ def create_collection_from_config(
     dependencies: Set[str],
     catalog_path: str,
     *,  # Force keyword-only arguments after this
+    dependencies_combined: set[str] | None = None,
     validate_schema: bool = True,
     explorer: bool = False,
 ) -> Collection: ...
@@ -59,9 +61,19 @@ def create_collection_from_config(
     dependencies: Set[str],
     catalog_path: str,
     *,  # Force keyword-only arguments after this
+    dependencies_combined: set[str] | None = None,
     validate_schema: bool = True,
     explorer: bool = False,
 ) -> Union[Explorer, Collection]:
+    """Create a Collection or Explorer instance from a configuration dictionary.
+
+    config: Configuration of the collection.
+    dependencies: Set of dependencies (dataset URIs) for the collection.
+    catalog_path: Path to the step.
+    dependencies_combined: Optional set of combined dependencies.
+    validate_schema: Whether to validate the schema of the collection.
+    explorer: Whether to create an Explorer instance instead of a Collection.
+    """
     # Read config as structured object
     if explorer:
         c = Explorer.from_dict(dict(**config, catalog_path=catalog_path))
@@ -82,6 +94,6 @@ def create_collection_from_config(
     c.check_duplicate_views()
 
     # Add dependencies to collection
-    c._dependencies = dependencies
+    c.dependencies = dependencies_combined or dependencies
 
     return c

--- a/etl/collection/model/core.py
+++ b/etl/collection/model/core.py
@@ -499,9 +499,10 @@ class Collection(MDIMBase):
 
     def validate_indicators_are_from_dependencies(self, indicators):
         """Validate that the provided indicators are from tables in datasets specified in the collections dependencies."""
+        deps = {dep.split("://", 1)[-1] if "://" in dep else dep for dep in self._dependencies}
         for indicator in indicators:
-            if not any(f"data://{indicator}".startswith(f"{dep}/") for dep in self._dependencies):
-                raise ValueError(f"Indicator {indicator} is not covered by any dependency: {self._dependencies}")
+            if not any(indicator.startswith(f"{dep}/") for dep in deps):
+                raise ValueError(f"Indicator {indicator} is not covered by any dependency: {deps}")
         return True
 
     def validate_grouped_views(self):

--- a/etl/collection/model/core.py
+++ b/etl/collection/model/core.py
@@ -81,12 +81,12 @@ class Collection(MDIMBase):
 
     _definitions: Definitions
 
+    dependencies: set[str] = field(default_factory=set)
     topic_tags: List[str] | None = None
     _default_dimensions: Dict[str, str] | None = None
 
     # Internal use. For save() method.
     _collection_type: str | None = field(init=False, default="multidim")
-    _dependencies: set[str] = field(init=False, default_factory=set)
     _group_operations_done: int = field(init=False, default=0)
 
     @classmethod
@@ -113,6 +113,10 @@ class Collection(MDIMBase):
     def __post_init__(self):
         # Sanity check
         assert "#" in self.catalog_path, "Catalog path should be in the format `path#name`."
+
+        if isinstance(self.dependencies, list):
+            # Convert list to set
+            self.dependencies = set(self.dependencies)
 
     @property
     def definitions(self) -> Definitions:
@@ -499,7 +503,7 @@ class Collection(MDIMBase):
 
     def validate_indicators_are_from_dependencies(self, indicators):
         """Validate that the provided indicators are from tables in datasets specified in the collections dependencies."""
-        deps = {dep.split("://", 1)[-1] if "://" in dep else dep for dep in self._dependencies}
+        deps = {dep.split("://", 1)[-1] if "://" in dep else dep for dep in self.dependencies}
         for indicator in indicators:
             if not any(indicator.startswith(f"{dep}/") for dep in deps):
                 raise ValueError(f"Indicator {indicator} is not covered by any dependency: {deps}")

--- a/etl/steps/export/multidim/covid/latest/covid.py
+++ b/etl/steps/export/multidim/covid/latest/covid.py
@@ -1,3 +1,4 @@
+# Force re-run
 from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.

--- a/schemas/multidim-schema.json
+++ b/schemas/multidim-schema.json
@@ -42,8 +42,15 @@
                 "demography/2023-12-15/population#age_structure"
             ],
             "examples_bad": [
-                ["energy", "energy/2024-01-01", "energy/2024-01-01/energy_mix"],
-                ["demography", "population#age_structure"]
+                [
+                    "energy",
+                    "energy/2024-01-01",
+                    "energy/2024-01-01/energy_mix"
+                ],
+                [
+                    "demography",
+                    "population#age_structure"
+                ]
             ]
         },
         "grapherConfigSchema": {
@@ -63,7 +70,10 @@
                 "https://files.ourworldindata.org/schemas/grapher-schema.008.json"
             ],
             "examples_bad": [
-                ["http://invalid-url.com/schema.json", "grapher-schema.008.json"]
+                [
+                    "http://invalid-url.com/schema.json",
+                    "grapher-schema.008.json"
+                ]
             ]
         },
         "title": {
@@ -108,9 +118,19 @@
                         "Climate Change Indicators"
                     ],
                     "examples_bad": [
-                        ["energy mix", "Energy Mix.", "Energy"],
-                        ["global population demographics", "Demographics"],
-                        ["climate change indicators", "Climate"]
+                        [
+                            "energy mix",
+                            "Energy Mix.",
+                            "Energy"
+                        ],
+                        [
+                            "global population demographics",
+                            "Demographics"
+                        ],
+                        [
+                            "climate change indicators",
+                            "Climate"
+                        ]
                     ]
                 },
                 "title_variant": {
@@ -162,9 +182,18 @@
                 "[\"Europe\", \"North America\", \"Asia\"]"
             ],
             "examples_bad": [
-                ["[]", "[\"USA\", \"PRC\"]"],
-                ["[\"Earth\"]", "[\"Global\"]"],
-                ["[\"EU\", \"NA\", \"AS\"]", "[\"Too many entities...\"]"]
+                [
+                    "[]",
+                    "[\"USA\", \"PRC\"]"
+                ],
+                [
+                    "[\"Earth\"]",
+                    "[\"Global\"]"
+                ],
+                [
+                    "[\"EU\", \"NA\", \"AS\"]",
+                    "[\"Too many entities...\"]"
+                ]
             ],
             "items": {
                 "type": "string"
@@ -194,14 +223,58 @@
                 "{\"age_group\": \"adults\", \"gender\": \"total\"}"
             ],
             "examples_bad": [
-                ["{\"nonexistent_dimension\": \"value\"}", "{\"metric\": \"nonexistent_choice\"}"],
-                ["{\"invalid_dimension\": \"adults\"}", "{\"age_group\": \"invalid_choice\"}"]
+                [
+                    "{\"nonexistent_dimension\": \"value\"}",
+                    "{\"metric\": \"nonexistent_choice\"}"
+                ],
+                [
+                    "{\"invalid_dimension\": \"adults\"}",
+                    "{\"age_group\": \"invalid_choice\"}"
+                ]
             ],
             "patternProperties": {
                 ".*": {
                     "type": "string"
                 }
             }
+        },
+        "dependencies": {
+            "type": "array",
+            "title": "Collection dependencies",
+            "description": "List of dataset URIs that this collection depends on for its indicators.",
+            "requirement_level": "optional",
+            "guidelines": [
+                [
+                    "Used internally to validate that all indicators come from specified datasets."
+                ],
+                [
+                    "Should contain dataset paths in the format 'namespace/version/dataset'."
+                ],
+                [
+                    "Can optionally include protocol prefixes like 'data://garden/namespace/version/dataset'."
+                ],
+                [
+                    "Dependencies are automatically resolved during collection creation if not explicitly provided."
+                ]
+            ],
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true,
+            "examples": [
+                "[\"energy/2024-01-01/energy_mix\", \"demography/2023-12-15/population\"]",
+                "[\"data://garden/energy/2024-01-01/energy_mix\"]"
+            ],
+            "examples_bad": [
+                [
+                    "[\"energy/renewable_share\"]",
+                    "[\"incomplete/path\"]"
+                ],
+                [
+                    "[\"data://invalid/format\"]",
+                    "[\"namespace/version\"]"
+                ]
+            ]
         },
         "topic_tags": {
             "type": "array",
@@ -225,9 +298,18 @@
                 "[\"Population Growth\", \"Demography\"]"
             ],
             "examples_bad": [
-                ["[\"energy\"]", "[\"Invalid Topic\"]"],
-                ["[\"climate change\", \"energy\"]", "[\"Too\", \"Many\", \"Tags\"]"],
-                ["[\"population growth\", \"demography\"]", "[\"Nonexistent Topic\"]"]
+                [
+                    "[\"energy\"]",
+                    "[\"Invalid Topic\"]"
+                ],
+                [
+                    "[\"climate change\", \"energy\"]",
+                    "[\"Too\", \"Many\", \"Tags\"]"
+                ],
+                [
+                    "[\"population growth\", \"demography\"]",
+                    "[\"Nonexistent Topic\"]"
+                ]
             ],
             "items": {
                 "type": "string"

--- a/tests/collections/test_collection_model.py
+++ b/tests/collections/test_collection_model.py
@@ -788,11 +788,9 @@ def test_validate_indicators_are_from_dependencies_success():
                 indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/ns/2023/dataset/table#column")]),
             )
         ],
+        dependencies={"data://grapher/ns/2023/dataset"},
         _definitions=Definitions(),
     )
-
-    # Set up dependencies that match the indicator path
-    collection._dependencies = {"data://grapher/ns/2023/dataset"}
 
     # Get indicators in use
     indicators = collection.indicators_in_use()
@@ -820,11 +818,9 @@ def test_validate_indicators_are_from_dependencies_failure():
                 indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/other/2023/otherset/table#column")]),
             )
         ],
+        dependencies={"data://grapher/ns/2023/dataset"},
         _definitions=Definitions(),
     )
-
-    # Set up dependencies (doesn't include the dataset being used)
-    collection._dependencies = {"data://grapher/ns/2023/dataset"}
 
     # Get indicators in use
     indicators = collection.indicators_in_use()
@@ -861,11 +857,9 @@ def test_validate_indicators_are_from_dependencies_multiple_dependencies():
                 ),
             )
         ],
+        dependencies={"data://grapher/ns1/2023/dataset1", "data://grapher/ns2/2023/dataset2"},
         _definitions=Definitions(),
     )
-
-    # Set up multiple dependencies
-    collection._dependencies = {"data://grapher/ns1/2023/dataset1", "data://grapher/ns2/2023/dataset2"}
 
     # Get indicators in use
     indicators = collection.indicators_in_use()
@@ -900,11 +894,9 @@ def test_validate_indicators_are_from_dependencies_partial_match():
                 ),
             )
         ],
+        dependencies={"data://grapher/ns1/2023/dataset1"},
         _definitions=Definitions(),
     )
-
-    # Set up dependencies (only covers first indicator)
-    collection._dependencies = {"data://grapher/ns1/2023/dataset1"}
 
     # Get indicators in use
     indicators = collection.indicators_in_use()
@@ -933,11 +925,9 @@ def test_validate_indicators_are_from_dependencies_empty_dependencies():
                 indicators=ViewIndicators(y=[Indicator(catalogPath="grapher/ns/2023/dataset/table#column")]),
             )
         ],
+        dependencies=set(),
         _definitions=Definitions(),
     )
-
-    # No dependencies set (empty set)
-    collection._dependencies = set()
 
     # Get indicators in use
     indicators = collection.indicators_in_use()
@@ -961,11 +951,9 @@ def test_validate_indicators_are_from_dependencies_empty_indicators():
         default_selection=["country"],
         dimensions=[Dimension(slug="country", name="Country", choices=[DimensionChoice(slug="usa", name="USA")])],
         views=[View(dimensions={"country": "usa"}, indicators=ViewIndicators(y=[]))],
+        dependencies={"data://grapher/ns/2023/dataset"},
         _definitions=Definitions(),
     )
-
-    # Set up dependencies
-    collection._dependencies = {"data://grapher/ns/2023/dataset"}
 
     # Get indicators in use (should be empty)
     indicators = collection.indicators_in_use()


### PR DESCRIPTION
Fix bug when saving collections.

There is a sanity check that validates that the indicators used in the collections have been specified as dependencies. However, this check was implemented wrongly and was leading to some unexpected errors when there were private dependencies (e.g., `data-private://`).

This PR solves this.

/schedule