### PR TITLE
Show reviewed charts by default when chart IDs are selected

### DIFF
--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -156,9 +156,6 @@ def filter_chart_diffs():
             st.session_state.chart_diffs_filtered = {
                 k: v for k, v in st.session_state.chart_diffs_filtered.items() if v.chart_id in chart_ids
             }
-            # Automatically show reviewed charts when chart IDs are selected
-            if "show_reviewed" not in st.query_params:
-                st.query_params["show_reviewed"] = "true"
         if "indicator_id" in st.query_params:
             indicator_ids = list(map(int, st.query_params.get_all("indicator_id")))
 
@@ -335,7 +332,7 @@ def _show_options_filters():
     st.toggle(
         "**Show** reviewed charts",
         key="show-reviewed-charts",
-        value="show_reviewed" in st.query_params or "chart_id" in st.query_params,
+        value="show_reviewed" in st.query_params,
         on_change=show_reviewed,  # type: ignore
         help="Show only chart diffs that are pending approval (or rejection).",
     )

--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -156,6 +156,9 @@ def filter_chart_diffs():
             st.session_state.chart_diffs_filtered = {
                 k: v for k, v in st.session_state.chart_diffs_filtered.items() if v.chart_id in chart_ids
             }
+            # Automatically show reviewed charts when chart IDs are selected
+            if "show_reviewed" not in st.query_params:
+                st.query_params["show_reviewed"] = "true"
         if "indicator_id" in st.query_params:
             indicator_ids = list(map(int, st.query_params.get_all("indicator_id")))
 

--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -332,7 +332,7 @@ def _show_options_filters():
     st.toggle(
         "**Show** reviewed charts",
         key="show-reviewed-charts",
-        value="show_reviewed" in st.query_params,
+        value="show_reviewed" in st.query_params or "chart_id" in st.query_params,
         on_change=show_reviewed,  # type: ignore
         help="Show only chart diffs that are pending approval (or rejection).",
     )

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -637,7 +637,7 @@ class ChartDiffShow:
         # Copy link
         if self.show_link:
             # with col3:
-            query_params = f"chart_id={self.diff.chart_id}"
+            query_params = f"chart_id={self.diff.chart_id}&show_reviewed="
             # st.caption(f"**{OWID_ENV.wizard_url}?{query_params}**")
             if OWID_ENV.wizard_url != OWID_ENV.wizard_url_remote:
                 url = f"{OWID_ENV.wizard_url_remote}/chart-diff?{query_params}"


### PR DESCRIPTION
## Summary
• Modified chart-diff app to show reviewed charts by default when specific chart IDs are selected
• The "Show reviewed charts" toggle now defaults to True when chart IDs are present in query params
• Preserves existing behavior when no chart IDs are selected (toggle defaults to False)

## Test plan
- [ ] Navigate to chart-diff without selecting chart IDs - verify "Show reviewed charts" toggle is off by default
- [ ] Select specific chart IDs - verify "Show reviewed charts" toggle is on by default and reviewed charts are visible
- [ ] Manually toggle the "Show reviewed charts" setting - verify it works regardless of chart ID selection

🤖 Generated with [Claude Code](https://claude.ai/code)