### PR TITLE
🔨 refactor chart types

### DIFF
--- a/apps/wizard/utils/chart_config.py
+++ b/apps/wizard/utils/chart_config.py
@@ -42,7 +42,7 @@ CONFIG_BASE = {
     "version": 14,
     "sortOrder": "desc",
     "maxTime": "latest",
-    "chartTypes": ["LineChart"],
+    "chartTypes": ["LineChart", "DiscreteBar"],
     "hideRelativeToggle": True,
     "addCountryMode": "add-country",
     "hideAnnotationFieldsInTitle": {"entity": False, "changeInPrefix": False, "time": False},

--- a/docs/guides/data-work/export-data.md
+++ b/docs/guides/data-work/export-data.md
@@ -97,7 +97,7 @@ def run() -> None:
     config["views"] = multidim.expand_config(
         tb_annual,
         dimensions=["frequency", "source", "unit"],
-        additional_config={"chartTypes": ["LineChart"], "hasMapTab": True, "tab": "map"},
+        additional_config={"chartTypes": ["LineChart", "DiscreteBar"], "hasMapTab": True, "tab": "map"},
     )
 
     #

--- a/docs/guides/data-work/mdims.md
+++ b/docs/guides/data-work/mdims.md
@@ -181,7 +181,7 @@ def run() -> None:
     config["views"] = multidim.expand_config(
         tb_annual,
         dimensions=["frequency", "source", "unit"],
-        additional_config={"chartTypes": ["LineChart"], "hasMapTab": True, "tab": "map"},
+        additional_config={"chartTypes": ["LineChart", "DiscreteBar"], "hasMapTab": True, "tab": "map"},
     )
 
     #

--- a/etl/collection/core/expand.py
+++ b/etl/collection/core/expand.py
@@ -73,7 +73,7 @@ def expand_config(
             - See examples below for more details.
     common_view_config : Dict[str, Any] | None
         Additional config fields to add to each view, e.g.
-        {"chartTypes": ["LineChart"], "hasMapTab": True, "tab": "map"}
+        {"chartTypes": ["LineChart", "DiscreteBar"], "hasMapTab": True, "tab": "map"}
     indicator_as_dimension: bool
         Set to True to keep the indicator as a dimension. For instance, if you expand a table with multiple - dimensional - indicators (e.g. 'population', 'population_density'), a dimension is added in the config that specifies the indicator. If there are more than one indicators being expanded, the indicator information is kept as a dimension regardless of this flag.
     indicators_slug: str

--- a/etl/steps/export/explorers/agriculture/latest/crop_yields.config.yml
+++ b/etl/steps/export/explorers/agriculture/latest/crop_yields.config.yml
@@ -269,7 +269,7 @@ views:
             colorScaleNumericBins: 0.5;1;2;5;10;20
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: bananas
       metric: actual_yield
@@ -280,7 +280,7 @@ views:
             colorScaleNumericBins: 10;20;30;40;50;60;70
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: barley
       metric: actual_yield
@@ -291,7 +291,7 @@ views:
             colorScaleNumericBins: 1;2;3;4;5;6;7;8
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: barley
       metric: attainable_yield
@@ -314,7 +314,7 @@ views:
             colorScaleNumericBins: 1,,;2,,;3,,;4,,;5,,;6,,
             colorScaleScheme: YlOrRd
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: beans
@@ -326,7 +326,7 @@ views:
             colorScaleNumericBins: 0.5;1;1.5;2;2.5;3;3.5;4
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: cassava
       metric: attainable_yield
@@ -349,7 +349,7 @@ views:
             colorScaleNumericBins: 5;10;15;20;25;30;35;40
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: cassava
       metric: yield_gap
@@ -360,7 +360,7 @@ views:
             colorScaleNumericBins: 1,,;2,,;4,,;6,,;8,,;10,,;15,,
             colorScaleScheme: Oranges
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: cereals
@@ -372,7 +372,7 @@ views:
             colorScaleNumericBins: 1;2;3;4;5;6;7;8;9;10
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: cocoa_beans
       metric: actual_yield
@@ -383,7 +383,7 @@ views:
             colorScaleNumericBins: 0.1;0.2;0.5;1;2;5
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: coffee_beans
       metric: actual_yield
@@ -394,7 +394,7 @@ views:
             colorScaleNumericBins: 0.4;0.8;1.2;1.6;2;2.4;2.8
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: corn__maize
       metric: attainable_yield
@@ -417,7 +417,7 @@ views:
             colorScaleNumericBins: 1;2;5;10;20;50
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: corn__maize
       metric: yield_gap
@@ -428,7 +428,7 @@ views:
             colorScaleNumericBins: 1,,;2,,;3,,;4,,;5,,;6,,;8,,;10,,
             colorScaleScheme: YlOrRd
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: cotton
@@ -452,7 +452,7 @@ views:
             colorScaleNumericBins: 0.5;1;2;5;10
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: cotton
       metric: yield_gap
@@ -463,7 +463,7 @@ views:
             colorScaleNumericBins: 1,,;2,,;3,,;4,,;5,,;6,,
             colorScaleScheme: Purples
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: groundnut
@@ -487,7 +487,7 @@ views:
             colorScaleNumericBins: 0.2;0.5;1;2;5;10
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: groundnut
       metric: yield_gap
@@ -498,7 +498,7 @@ views:
             colorScaleNumericBins: 1,,;2,,;3,,;4,,;5,,;6,,
             colorScaleScheme: YlOrBr
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: lettuce
@@ -510,7 +510,7 @@ views:
             colorScaleNumericBins: 5;10;15;20;25;30;35;40
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: millet
       metric: attainable_yield
@@ -533,7 +533,7 @@ views:
             colorScaleNumericBins: 0.5;1;2;5;10;20
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: millet
       metric: yield_gap
@@ -544,7 +544,7 @@ views:
             colorScaleNumericBins: 0.5,,;1,,;2,,;3,,;4,,
             colorScaleScheme: YlOrBr
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: oats
@@ -557,7 +557,7 @@ views:
             colorScaleNumericBins: 1;2;3;4;5;6;7
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: oil_palm
       metric: attainable_yield
@@ -580,7 +580,7 @@ views:
             colorScaleNumericBins: 4;8;12;16;20
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: oil_palm
       metric: yield_gap
@@ -591,7 +591,7 @@ views:
             colorScaleNumericBins: 5,,;10,,;15,,;20,,;25,,
             colorScaleScheme: OrRd
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: oranges
@@ -603,7 +603,7 @@ views:
             colorScaleNumericBins: 10;20;30;40;50;60
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: peas
       metric: actual_yield
@@ -614,7 +614,7 @@ views:
             colorScaleNumericBins: 0.5;1;1.5;2;2.5;3;3.5;4
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: potato
       metric: attainable_yield
@@ -637,7 +637,7 @@ views:
             colorScaleNumericBins: 5;10;15;20;25;30;35;40;45;50
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: potato
       metric: yield_gap
@@ -648,7 +648,7 @@ views:
             colorScaleNumericBins: 5,,;10,,;15,,;20,,;25,,;30,,
             colorScaleScheme: PuRd
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: rapeseed
@@ -672,7 +672,7 @@ views:
             colorScaleNumericBins: 1;1.5;2;2.5;3;3.5;4
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: rapeseed
       metric: yield_gap
@@ -683,7 +683,7 @@ views:
             colorScaleNumericBins: 0.5,,;1,,;2,,;3,,;4,,
             colorScaleScheme: Oranges
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: rice
@@ -707,7 +707,7 @@ views:
             colorScaleNumericBins: 2;4;6;8;10;12
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: rice
       metric: yield_gap
@@ -718,7 +718,7 @@ views:
             colorScaleNumericBins: 1,,;2,,;4,,;6,,;8,,;10,,
             colorScaleScheme: Reds
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: rye
@@ -742,7 +742,7 @@ views:
             colorScaleNumericBins: 1;2;3;4;5;6
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: rye
       metric: yield_gap
@@ -753,7 +753,7 @@ views:
             colorScaleNumericBins: 1,,;2,,;3,,;4,,;5,,;6,,
             colorScaleScheme: OrRd
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: sorghum
@@ -777,7 +777,7 @@ views:
             colorScaleNumericBins: 0.5;1;1.5;2;2.5;3;3.5;4;4.5;5;5.5
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: sorghum
       metric: yield_gap
@@ -788,7 +788,7 @@ views:
             colorScaleNumericBins: 1,,;2,,;3,,;4,,;5,,;6,,
             colorScaleScheme: PuRd
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: soybean
@@ -812,7 +812,7 @@ views:
             colorScaleNumericBins: 0.5;1;1.5;2;2.5;3;3.5;4
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: soybean
       metric: yield_gap
@@ -823,7 +823,7 @@ views:
             colorScaleNumericBins: 0.5,,;1,,;2,,;3,,;4,,
             colorScaleScheme: PuBuGn
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: sugar_beet
@@ -847,7 +847,7 @@ views:
             colorScaleNumericBins: 20;40;60;80;100
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: sugar_beet
       metric: yield_gap
@@ -858,7 +858,7 @@ views:
             colorScaleNumericBins: 10,,;20,,;30,,;40,,;50,,;60,,;70,,
             colorScaleScheme: Oranges
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: sugar_cane
@@ -882,7 +882,7 @@ views:
             colorScaleNumericBins: 20;40;60;80;100;120
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: sugar_cane
       metric: yield_gap
@@ -893,7 +893,7 @@ views:
             colorScaleNumericBins: 10,,;20,,;30,,;40,,;50,,;60,,;70,,
             colorScaleScheme: Oranges
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: sunflower_seed
@@ -917,7 +917,7 @@ views:
             colorScaleNumericBins: 0.5;1;1.5;2;2.5;3;3.5
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: sunflower_seed
       metric: yield_gap
@@ -928,7 +928,7 @@ views:
             colorScaleNumericBins: 0.5,,;1,,;2,,;3,,;4,,
             colorScaleScheme: YlOrRd
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: tomato
@@ -940,7 +940,7 @@ views:
             colorScaleNumericBins: 10;20;50;100;200;500
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       crop: wheat
       metric: attainable_yield
@@ -963,7 +963,7 @@ views:
             colorScaleNumericBins: 1;2;3;4;5;6;7;8
             colorScaleScheme: PuBu
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       tab: 'map'
       defaultView: 'true'
   - dimensions:
@@ -976,7 +976,7 @@ views:
             colorScaleNumericBins: 1,,;2,,;3,,;4,,;5,,;6,,
             colorScaleScheme: OrRd
     config:
-      type: LineChart
+      type: LineChart DiscreteBar
       note: *attainable_yield_footnote
   - dimensions:
       crop: chickpeas

--- a/etl/steps/export/explorers/climate/latest/climate_change.config.yml
+++ b/etl/steps/export/explorers/climate/latest/climate_change.config.yml
@@ -81,7 +81,7 @@ views:
       yScaleToggle: false
       yAxisMin: auto
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: sea_surface_temperature_anomaly
@@ -96,7 +96,7 @@ views:
       yScaleToggle: false
       yAxisMin: auto
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: ocean_heat_content__top_700m
@@ -114,7 +114,7 @@ views:
       yScaleToggle: false
       yAxisMin: auto
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
       note: |-
         Heat content is shown for four sources: Commonwealth Scientific and Industrial Research Organisation (CSIRO); Institute of Atmospheric Physics (IAP); National Oceanic and Atmospheric Administration (NOAA); and Meteorological Research Institute (MRI).
@@ -133,7 +133,7 @@ views:
       yScaleToggle: false
       yAxisMin: auto
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
       note: |-
         Heat content is shown for four sources: Commonwealth Scientific and Industrial Research Organisation (CSIRO); Institute of Atmospheric Physics (IAP); National Oceanic and Atmospheric Administration (NOAA); and Meteorological Research Institute (MRI).
@@ -150,7 +150,7 @@ views:
       yScaleToggle: false
       yAxisMin: auto
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
       hideAnnotationFieldsInTitle: true
   - dimensions:
@@ -168,7 +168,7 @@ views:
       yScaleToggle: false
       yAxisMin: auto
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: arctic_sea_ice_extent
@@ -183,7 +183,7 @@ views:
       yScaleToggle: false
       yAxisMin: 0
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: antarctic_sea_ice_extent
@@ -198,7 +198,7 @@ views:
       yScaleToggle: false
       yAxisMin: 0
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: mass_balance_of_ice_sheets
@@ -214,7 +214,7 @@ views:
       yScaleToggle: false
       yAxisMin: -5200
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
       note: Combined measurements are based on more than 20 different studies that have been combined for each region.
   - dimensions:
@@ -230,7 +230,7 @@ views:
       yScaleToggle: false
       yAxisMin: -50
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: snow_cover
@@ -246,7 +246,7 @@ views:
       yScaleToggle: false
       yAxisMin: 0
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: co2_concentrations
@@ -261,7 +261,7 @@ views:
       yScaleToggle: false
       yAxisMin: 320
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: ch4_concentrations
@@ -276,7 +276,7 @@ views:
       yScaleToggle: false
       yAxisMin: 1600
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: n2o_concentrations
@@ -291,7 +291,7 @@ views:
       yScaleToggle: false
       yAxisMin: 300
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: co2_concentrations
@@ -306,7 +306,7 @@ views:
       yScaleToggle: false
       yAxisMin: 150
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: ch4_concentrations
@@ -320,7 +320,7 @@ views:
       yScaleToggle: false
       yAxisMin: 550
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false
   - dimensions:
       metric: n2o_concentrations
@@ -334,5 +334,5 @@ views:
       yScaleToggle: false
       yAxisMin: 250
       baseColorScheme: owid-distinct
-      type: LineChart
+      type: LineChart DiscreteBar
       hasMapTab: false

--- a/etl/steps/export/explorers/migration/latest/migration_flows.py
+++ b/etl/steps/export/explorers/migration/latest/migration_flows.py
@@ -22,7 +22,7 @@ def run() -> None:
 
     # Define common view configuration
     common_view_config = {
-        "type": "LineChart",
+        "type": "LineChart DiscreteBar",
         "hasMapTab": True,
         "tab": "map",
         "note": 'For most countries, immigrant means "born in another country". Someone who has gained citizenship in the country they live in is still counted as an immigrant if they were born elsewhere. For some countries, place of birth information is not available; in this case citizenship is used to define whether someone counts as an immigrant.',

--- a/etl/steps/export/explorers/wash/latest/migrate_wash.ipynb
+++ b/etl/steps/export/explorers/wash/latest/migrate_wash.ipynb
@@ -66,7 +66,7 @@
     "        {\n",
     "            \"config\": {\n",
     "                \"tab\": \"map\",\n",
-    "                \"type\": \"LineChart\",\n",
+    "                \"type\": \"LineChart DiscreteBar\",\n",
     "                \"hasMapTab\": True,\n",
     "                \"yScaleToggle\": False\n",
     "            }\n",

--- a/etl/steps/export/explorers/wash/latest/water_and_sanitation.config.yml
+++ b/etl/steps/export/explorers/wash/latest/water_and_sanitation.config.yml
@@ -6,7 +6,7 @@ definitions:
   common_views:
     - config:
         tab: map
-        type: LineChart
+        type: LineChart DiscreteBar
         hasMapTab: true
         yScaleToggle: false
 config:

--- a/etl/steps/export/explorers/who/latest/influenza.config.yml
+++ b/etl/steps/export/explorers/who/latest/influenza.config.yml
@@ -229,7 +229,7 @@ views:
       title: Weekly share of influenza tests that were positive
       subtitle: |-
         People who were tested had a respiratory infection with a fever, cough and onset within the last 10 days. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: |-
         The share of positive tests is calculated by dividing the number of tests that were positive to any flu strain by three possible denominators, based on data availability. If both values are available then the denominator is the sum of positive and negative tests; if not then the number specimens processed is used; if neither of those are available then the number of specimens received by the testing facility is used.
   - dimensions:
@@ -254,7 +254,7 @@ views:
       title: Monthly share of influenza tests that were positive
       subtitle: |-
         People who were tested had a respiratory infection with a fever, cough and onset within the last 10 days. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: |-
         The share of positive tests is calculated by dividing the number of tests that were positive to any flu strain by three possible denominators, based on data availability. If both values are available then the denominator is the sum of positive and negative tests; if not then the number specimens processed is used; if neither of those are available then the number of specimens received by the testing facility is used.
       defaultView: true
@@ -281,7 +281,7 @@ views:
       title: Weekly share of influenza tests that were positive, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. People who were tested had a respiratory infection with a fever, cough and onset within the last 10 days. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: |-
         The share of positive tests is calculated by dividing the number of tests that were positive to any flu strain by three possible denominators, based on data availability. If both values are available then the denominator is the sum of positive and negative tests; if not then the number specimens processed is used; if neither of those are available then the number of specimens received by the testing facility is used.
   - dimensions:
@@ -306,7 +306,7 @@ views:
       title: Monthly share of influenza tests that were positive, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. People who were tested had a respiratory infection with a fever, cough and onset within the last 10 days. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: |-
         The share of positive tests is calculated by dividing the number of tests that were positive to any flu strain by three possible denominators, based on data availability. If both values are available then the denominator is the sum of positive and negative tests; if not then the number specimens processed is used; if neither of those are available then the number of specimens received by the testing facility is used.
   - dimensions:
@@ -331,7 +331,7 @@ views:
       title: Weekly share of influenza tests that were positive, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. People who were tested had a respiratory infection with a fever, cough and onset within the last 10 days. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: |-
         The share of positive tests is calculated by dividing the number of tests that were positive to any flu strain by three possible denominators, based on data availability. If both values are available then the denominator is the sum of positive and negative tests; if not then the number specimens processed is used; if neither of those are available then the number of specimens received by the testing facility is used.
   - dimensions:
@@ -356,7 +356,7 @@ views:
       title: Monthly share of influenza tests that were positive, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. People who were tested had a respiratory infection with a fever, cough and onset within the last 10 days. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: |-
         The share of positive tests is calculated by dividing the number of tests that were positive to any flu strain by three possible denominators, based on data availability. If both values are available then the denominator is the sum of positive and negative tests; if not then the number specimens processed is used; if neither of those are available then the number of specimens received by the testing facility is used.
   - dimensions:
@@ -868,7 +868,7 @@ views:
       title: Weekly confirmed cases of influenza by surveillance type
       subtitle: |-
         This includes confirmed cases of all influenza strains. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       selectedFacetStrategy: metric
       facetYDomain: independent
       hasMapTab: false
@@ -915,7 +915,7 @@ views:
       title: Monthly confirmed cases of influenza by surveillance type
       subtitle: |-
         This includes confirmed cases of all influenza strains. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       selectedFacetStrategy: metric
       facetYDomain: independent
       hasMapTab: false
@@ -943,7 +943,7 @@ views:
       title: Weekly confirmed cases of influenza
       subtitle: |-
         This includes confirmed cases of all influenza strains. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: all_influenza_strains
@@ -965,7 +965,7 @@ views:
       title: Monthly confirmed cases of influenza
       subtitle: |-
         This includes confirmed cases of all influenza strains. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: all_influenza_strains
@@ -988,7 +988,7 @@ views:
       title: Weekly confirmed cases of influenza, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of all influenza strains.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1011,7 +1011,7 @@ views:
       title: Monthly confirmed cases of, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of all influenza strains.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1035,7 +1035,7 @@ views:
       title: Weekly confirmed cases of influenza, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of all influenza strains.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1058,7 +1058,7 @@ views:
       title: Monthly confirmed cases of influenza, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of all influenza strains.
   - dimensions:
       confirmed_cases_or_symptoms: symptoms
@@ -1101,7 +1101,7 @@ views:
       title: Weekly comparison of data on respiratory infections
       subtitle: |-
         Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       selectedFacetStrategy: metric
       facetYDomain: independent
       hasMapTab: false
@@ -1148,7 +1148,7 @@ views:
       title: Monthly comparison of data on respiratory infections
       subtitle: |-
         Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       selectedFacetStrategy: metric
       facetYDomain: independent
       hasMapTab: false
@@ -1175,7 +1175,7 @@ views:
       title: Weekly reported cases of influenza-like illnesses
       subtitle: |-
         Influenza-like illnesses are defined by the WHO as acute respiratory infections with a fever ≥38ºC, a cough, and onset of symptoms within the last 10 days. This can include diseases other than influenza, such as COVID-19.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: symptoms
       metric: influenza_like_illnesses
@@ -1197,7 +1197,7 @@ views:
       title: Monthly reported cases of influenza-like illnesses
       subtitle: |-
         Influenza-like illnesses are defined by the WHO as acute respiratory infections with a fever ≥38ºC, a cough, and onset of symptoms within the last 10 days. This can include diseases other than influenza, such as COVID-19.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: symptoms
       metric: acute_respiratory_infections
@@ -1219,7 +1219,7 @@ views:
       title: Weekly reported cases of acute respiratory infections
       subtitle: |-
         Acute respiratory illnesses are defined by the WHO as sudden/acute onset of ≥1 of the following symptoms: cough, sore throat, shortness of breath, rhinitis; and were judged by a clinician to be due to an infection. This can include diseases other than influenza, such as COVID-19.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: symptoms
       metric: acute_respiratory_infections
@@ -1241,7 +1241,7 @@ views:
       title: Monthly reported cases of acute respiratory infections
       subtitle: |-
         Acute respiratory illnesses are defined by the WHO as sudden/acute onset of ≥1 of the following symptoms: cough, sore throat, shortness of breath, rhinitis; and were judged by a clinician to be due to an infection. This can include diseases other than influenza, such as COVID-19.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: symptoms
       metric: severe_acute_respiratory_infections
@@ -1263,7 +1263,7 @@ views:
       title: Weekly reported cases of severe acute respiratory infections
       subtitle: |-
         Severe acute respiratory illnesses are defined by the WHO as acute respiratory infections with history of fever or measured fever of ≥ 38 C°, cough, with onset within the last 10 days, and which require hospitalization. This can include diseases other than influenza, such as COVID-19.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: symptoms
       metric: severe_acute_respiratory_infections
@@ -1285,7 +1285,7 @@ views:
       title: Monthly reported cases of severe acute respiratory infections
       subtitle: |-
         Severe acute respiratory illnesses are defined by the WHO as acute respiratory infections with history of fever or measured fever of ≥ 38 C°, cough, with onset within the last 10 days, and which require hospitalization. This can include diseases other than influenza, such as COVID-19.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: all_influenza_a
@@ -1308,7 +1308,7 @@ views:
       title: Weekly confirmed cases of influenza A, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of all strains of influenza A virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1331,7 +1331,7 @@ views:
       title: Monthly confirmed cases of influenza A, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of all strains of influenza A virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1355,7 +1355,7 @@ views:
       title: Weekly confirmed cases of influenza A, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of all strains of influenza A virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1378,7 +1378,7 @@ views:
       title: Monthly confirmed cases of influenza A, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of all strains of influenza A virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1402,7 +1402,7 @@ views:
       title: Weekly confirmed cases of influenza A
       subtitle: |-
         This includes confirmed cases of all strains of influenza A virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: all_influenza_a
@@ -1424,7 +1424,7 @@ views:
       title: Monthly confirmed cases of influenza A
       subtitle: |-
         This includes confirmed cases of all strains of influenza A virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_a_h1n12009
@@ -1446,7 +1446,7 @@ views:
       title: Weekly confirmed cases of influenza A H1N1 (2009), sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time. This shows the number of cases that were confirmed to have a strain of influenza A virus related to the H1N1 ("Swine flu") pandemic that emerged in 2009.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: |-
         This shows the number of cases that were confirmed to have a strain of influenza A virus related to the H1N1 ("Swine flu") pandemic that emerged in 2009.
   - dimensions:
@@ -1470,7 +1470,7 @@ views:
       title: Monthly confirmed cases of influenza A H1N1 (2009), sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: |-
         This shows the number of cases that were confirmed to have a strain of influenza A virus related to the H1N1 ("Swine flu") pandemic that emerged in 2009.
   - dimensions:
@@ -1494,7 +1494,7 @@ views:
       title: Weekly confirmed cases of influenza A H1N1 (2009), non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time. This shows the number of cases that were confirmed to have a strain of influenza A virus related to the H1N1 ("Swine flu") pandemic that emerged in 2009.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: |-
         This shows the number of cases that were confirmed to have a strain of influenza A virus related to the H1N1 ("Swine flu") pandemic that emerged in 2009.
   - dimensions:
@@ -1518,7 +1518,7 @@ views:
       title: Monthly confirmed cases of influenza A H1N1 (2009), non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time. This shows the number of cases that were confirmed to have a strain of influenza A virus related to the H1N1 ("Swine flu") pandemic that emerged in 2009.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: |-
         This shows the number of cases that were confirmed to have a strain of influenza A virus related to the H1N1 ("Swine flu") pandemic that emerged in 2009.
   - dimensions:
@@ -1542,7 +1542,7 @@ views:
       title: Weekly confirmed cases of influenza A H1N1 (2009)
       subtitle: |-
         This shows the number of cases that were confirmed to have a strain of influenza A virus related to the H1N1 ("Swine flu") pandemic that emerged in 2009. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_a_h1n12009
@@ -1564,7 +1564,7 @@ views:
       title: Monthly confirmed cases of influenza A H1N1 (2009)
       subtitle: |-
         This shows the number of cases that were confirmed to have a strain of influenza A virus related to the H1N1 ("Swine flu") pandemic that emerged in 2009. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_a_h1
@@ -1586,7 +1586,7 @@ views:
       title: Weekly confirmed cases of influenza A H1
       subtitle: |-
         This shows the number of cases that were confirmed to be of the H1 strain of influenza A virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_a_h1
@@ -1608,7 +1608,7 @@ views:
       title: Monthly confirmed cases of influenza A H1
       subtitle: |-
         This shows the number of cases that were confirmed to be of the H1 strain of influenza A virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_a_h3
@@ -1630,7 +1630,7 @@ views:
       title: Weekly confirmed cases of influenza A H3, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the H3 strain of influenza A virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1653,7 +1653,7 @@ views:
       title: Monthly confirmed cases of influenza A H3, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population.. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the H3 strain of influenza A virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1676,7 +1676,7 @@ views:
       title: Weekly confirmed cases of influenza A H3, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the H3 strain of influenza A virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1699,7 +1699,7 @@ views:
       title: Monthly confirmed cases of influenza A H3, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the H3 strain of influenza A virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1722,7 +1722,7 @@ views:
       title: Weekly confirmed cases of influenza A H3
       subtitle: |-
         This shows the number of cases that were confirmed to be of the H3 strain of influenza A virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_a_h3
@@ -1744,7 +1744,7 @@ views:
       title: Monthly confirmed cases of influenza A H3
       subtitle: |-
         This shows the number of cases that were confirmed to be of the H3 strain of influenza A virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_a_h5
@@ -1766,7 +1766,7 @@ views:
       title: Weekly confirmed cases of influenza A H5
       subtitle: |-
         This shows the number of cases that were confirmed to be of the H5 strain of influenza A virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       relatedQuestionText: How many cases of H5N1 have been reported?
       relatedQuestionUrl: https://ourworldindata.org/grapher/h5n1-flu-reported-cases
   - dimensions:
@@ -1790,7 +1790,7 @@ views:
       title: Weekly confirmed cases of influenza A H7N9
       subtitle: |-
         This shows the number of cases that were confirmed to be of the H7N9 strain of influenza A virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their subtype. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_a__unknown_subtype
@@ -1812,7 +1812,7 @@ views:
       title: Weekly confirmed cases of influenza A (unknown subtype), sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be influenza A virus, but their subtype was not confirmed.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1835,7 +1835,7 @@ views:
       title: Weekly confirmed cases of influenza A (unknown subtype), non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be influenza A virus, but their subtype was not confirmed.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1858,7 +1858,7 @@ views:
       title: Weekly confirmed cases of influenza A (unknown subtype)
       subtitle: |-
         This shows the number of cases that were confirmed to be influenza A virus, but their subtype was not confirmed. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: all_influenza_b
@@ -1881,7 +1881,7 @@ views:
       title: Weekly confirmed cases of influenza B, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of all strains of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1905,7 +1905,7 @@ views:
       title: Weekly confirmed cases of influenza B, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of all strains of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1929,7 +1929,7 @@ views:
       title: Weekly confirmed cases of influenza B
       subtitle: |-
         This includes confirmed cases of all strains of influenza B virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_b_victoria
@@ -1951,7 +1951,7 @@ views:
       title: Weekly confirmed cases of influenza B Victoria, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the Victoria lineage of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1974,7 +1974,7 @@ views:
       title: Weekly confirmed cases of influenza B Victoria, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the Victoria lineage of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -1997,7 +1997,7 @@ views:
       title: Weekly confirmed cases of influenza B Victoria
       subtitle: |-
         This shows the number of cases that were confirmed to be of the Victoria lineage of influenza B virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_b_yamagata
@@ -2019,7 +2019,7 @@ views:
       title: Weekly confirmed cases of influenza B Yamagata, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the Yamagata lineage of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2042,7 +2042,7 @@ views:
       title: Weekly confirmed cases of influenza B Yamagata, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the Yamagata lineage of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2065,7 +2065,7 @@ views:
       title: Weekly confirmed cases of influenza B Yamagata,
       subtitle: |-
         This shows the number of cases that were confirmed to be of the Yamagata lineage of influenza B virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_b__unknown_lineage
@@ -2087,7 +2087,7 @@ views:
       title: Weekly confirmed cases of influenza B (unknown subtype), sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be influenza B virus, but their lineage was not determined.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2110,7 +2110,7 @@ views:
       title: Weekly confirmed cases of influenza B (unknown subtype), non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be influenza B virus, but their lineage was not determined.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2133,7 +2133,7 @@ views:
       title: Weekly confirmed cases of influenza B (unknown subtype)
       subtitle: |-
         This shows the number of cases that were confirmed to be influenza B virus, but their lineage was not determined. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_a_h5
@@ -2156,7 +2156,7 @@ views:
       title: Monthly confirmed cases of influenza A H5
       subtitle: |-
         This shows the number of cases that were confirmed to be of the H5 strain of influenza A virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       relatedQuestionText: How many cases of H5N1 have been reported?
       relatedQuestionUrl: https://ourworldindata.org/grapher/h5n1-flu-reported-cases
   - dimensions:
@@ -2180,7 +2180,7 @@ views:
       title: Monthly confirmed cases of influenza A H7N9
       subtitle: |-
         This shows the number of cases that were confirmed to be of the H7N9 strain of influenza A virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_a__unknown_subtype
@@ -2202,7 +2202,7 @@ views:
       title: Monthly confirmed cases of influenza A (unknown subtype), sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be influenza A virus, but their subtype was not confirmed.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2225,7 +2225,7 @@ views:
       title: Monthly confirmed cases of influenza A (unknown subtype), non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be influenza A virus, but their subtype was not confirmed.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2248,7 +2248,7 @@ views:
       title: Monthly confirmed cases of influenza A (unknown subtype)
       subtitle: |-
         This shows the number of cases that were confirmed to be influenza A virus, but their subtype was not confirmed. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: all_influenza_b
@@ -2270,7 +2270,7 @@ views:
       title: Monthly confirmed cases of influenza B, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their lineage. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of any lineage of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2293,7 +2293,7 @@ views:
       title: Monthly confirmed cases of influenza B, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their lineage. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This includes confirmed cases of any lineage of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2316,7 +2316,7 @@ views:
       title: Monthly confirmed cases of influenza B
       subtitle: |-
         This includes confirmed cases of any lineage of influenza B virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their lineage. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_b_yamagata
@@ -2338,7 +2338,7 @@ views:
       title: Monthly confirmed cases of influenza B Yamagata, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the Yamagata lineage of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2361,7 +2361,7 @@ views:
       title: Monthly confirmed cases of influenza B Yamagata, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the Yamagata lineage of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2384,7 +2384,7 @@ views:
       title: Monthly confirmed cases of influenza B Yamagata
       subtitle: |-
         This shows the number of cases that were confirmed to be of the Yamagata lineage of influenza B virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_b_victoria
@@ -2406,7 +2406,7 @@ views:
       title: Monthly confirmed cases of influenza B Victoria, sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the Victoria lineage of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2429,7 +2429,7 @@ views:
       title: Monthly confirmed cases of influenza B Victoria, non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be of the Victoria lineage of influenza B virus.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2452,7 +2452,7 @@ views:
       title: Monthly confirmed cases of influenza B Victoria
       subtitle: |-
         This shows the number of cases that were confirmed to be of the Victoria lineage of influenza B virus. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
       metric: influenza_b__unknown_lineage
@@ -2474,7 +2474,7 @@ views:
       title: Monthly confirmed cases of influenza B (unknown subtype), sentinel surveillance
       subtitle: |-
         Sentinel surveillance consists of data routinely collected from sites representative of the country's population. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be influenza B virus, but their lineage was not determined.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2497,7 +2497,7 @@ views:
       title: Monthly confirmed cases of influenza B (unknown subtype), non-sentinel surveillance
       subtitle: |-
         Non-sentinel surveillance includes data from multiple sources, including outbreak investigation, universal testing, and testing at the point of care. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar
       note: This shows the number of cases that were confirmed to be influenza B virus, but their lineage was not determined.
   - dimensions:
       confirmed_cases_or_symptoms: confirmed_cases
@@ -2520,4 +2520,4 @@ views:
       title: Monthly confirmed cases of influenza B (unknown subtype)
       subtitle: |-
         This shows the number of cases that were confirmed to be influenza B virus, but their lineage was not determined. Only a fraction of potential cases of influenza are tested by labs to confirm whether they have influenza and to identify their strain. The level of testing may vary between countries and over time.
-      type: LineChart
+      type: LineChart DiscreteBar

--- a/etl/steps/export/explorers/who/latest/monkeypox.config.yml
+++ b/etl/steps/export/explorers/who/latest/monkeypox.config.yml
@@ -95,7 +95,7 @@ views:
       title: "Mpox: Daily confirmed cases"
       subtitle: |-
         7-day rolling average. Laboratory testing for mpox is limited in many countries and figures shown here only include laboratory-confirmed cases.
-      type: LineChart
+      type: LineChart DiscreteBar
       tab: map
   - dimensions:
       metric: confirmed_cases
@@ -112,7 +112,7 @@ views:
             <<: *display1
     config:
       title: "Mpox: Cumulative confirmed cases"
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       metric: confirmed_cases
       frequency: daily
@@ -143,7 +143,7 @@ views:
             <<: *display1
     config:
       title: "Mpox: Cumulative confirmed cases per million people"
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       metric: confirmed_cases
       frequency: _7_day_average
@@ -161,7 +161,7 @@ views:
       title: "Mpox: Daily confirmed cases per million people"
       subtitle: |-
         7-day rolling average. Laboratory testing for mpox is limited in many countries and figures shown here only include laboratory-confirmed cases.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       metric: confirmed_cases
       frequency: daily
@@ -202,7 +202,7 @@ views:
       title: "Mpox: Cumulative confirmed and suspected cases"
       subtitle: |-
         Confirmed cases are those that have been verified through laboratory testing. Suspected cases are those where mpox is likely based on an individual's initial clinical signs and symptoms, but the diagnosis has not yet been confirmed through laboratory testing.
-      type: LineChart
+      type: LineChart DiscreteBar
       selectedFacetStrategy: entity
       hasMapTab: "false"
       minTime: "1433"
@@ -227,7 +227,7 @@ views:
       title: "Mpox: Daily confirmed deaths"
       subtitle: |-
         7-day rolling average. Laboratory testing for mpox is limited in many countries and figures shown here only include deaths where mpox has been laboratory-confirmed.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       metric: confirmed_deaths
       frequency: cumulative
@@ -244,7 +244,7 @@ views:
             <<: *display1
     config:
       title: "Mpox: Cumulative confirmed deaths"
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       metric: confirmed_deaths
       frequency: daily
@@ -277,7 +277,7 @@ views:
             <<: *display1
     config:
       title: "Mpox: Cumulative confirmed deaths per million people"
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       metric: confirmed_deaths
       frequency: _7_day_average
@@ -296,7 +296,7 @@ views:
       title: "Mpox: Daily confirmed deaths per million people"
       subtitle: |-
         7-day rolling average. Laboratory testing for mpox is limited in many countries and figures shown here only include deaths where mpox has been laboratory-confirmed.
-      type: LineChart
+      type: LineChart DiscreteBar
   - dimensions:
       metric: confirmed_deaths
       frequency: daily

--- a/etl/steps/export/multidim/energy/latest/energy_prices.py
+++ b/etl/steps/export/multidim/energy/latest/energy_prices.py
@@ -176,7 +176,7 @@ def run() -> None:
     # Define common view configuration
     common_view_config = {
         "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
-        "chartTypes": ["LineChart"],
+        "chartTypes": ["LineChart", "DiscreteBar"],
         "hasMapTab": True,
         "tab": "map",
         "map": {

--- a/etl/steps/export/multidim/health/latest/vaccination_coverage.py
+++ b/etl/steps/export/multidim/health/latest/vaccination_coverage.py
@@ -22,7 +22,7 @@ def run() -> None:
 
     common_view_config = {
         "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
-        "chartTypes": ["LineChart", "SlopeChart"],
+        "chartTypes": ["LineChart", "SlopeChart", "DiscreteBar"],
         "hasMapTab": True,
         "tab": "chart",
     }
@@ -58,7 +58,7 @@ def run() -> None:
                     "hasMapTab": False,
                     "addCountryMode": "change-country",
                     "tab": "chart",
-                    "chartTypes": ["SlopeChart", "LineChart"],
+                    "chartTypes": ["SlopeChart", "LineChart", "DiscreteBar"],
                     "selectedFacetStrategy": "entity",
                     "title": "{title}",
                     "subtitle": "{subtitle}",

--- a/etl/steps/export/multidim/migration/latest/migration_flows.py
+++ b/etl/steps/export/multidim/migration/latest/migration_flows.py
@@ -5,7 +5,7 @@ paths = PathFinder(__file__)
 
 MULTIDIM_CONFIG = {
     "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.005.json",
-    "chartTypes": ["LineChart"],
+    "chartTypes": ["LineChart", "DiscreteBar"],
     "hasMapTab": True,
     "tab": "map",
     "map": {

--- a/etl/steps/export/multidim/wb/latest/world_bank_pip.config.yml
+++ b/etl/steps/export/multidim/wb/latest/world_bank_pip.config.yml
@@ -167,7 +167,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
       yAxis:
         max: 100
@@ -314,7 +314,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
       yAxis:
         max: 100
@@ -480,7 +480,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -624,7 +624,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -789,7 +789,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -823,7 +823,7 @@ views:
       subtitle: "{definitions.extreme_poverty_subtitle} {definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -858,7 +858,7 @@ views:
       subtitle: "{definitions.lmic_poverty_line_subtitle} {definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -893,7 +893,7 @@ views:
       subtitle: "{definitions.umic_poverty_line_subtitle} {definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -929,7 +929,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -965,7 +965,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -1001,7 +1001,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -1037,7 +1037,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -1072,7 +1072,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -1106,7 +1106,7 @@ views:
       subtitle: "{definitions.extreme_poverty_subtitle} {definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -1141,7 +1141,7 @@ views:
       subtitle: "{definitions.lmic_poverty_line_subtitle} {definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -1176,7 +1176,7 @@ views:
       subtitle: "{definitions.umic_poverty_line_subtitle} {definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -1212,7 +1212,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -1248,7 +1248,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -1284,7 +1284,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:
@@ -1320,7 +1320,7 @@ views:
       subtitle: "{definitions.ppp_adjustment_subtitle} {definitions.spells_subtitle}"
       note: "{definitions.ppp_adjustment_welfare_type_note}"
       hasMapTab: false
-      chartTypes: ["LineChart"]
+      chartTypes: ["LineChart", "DiscreteBar"]
       selectedFacetStrategy: entity
     metadata:
       description_key:

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -1537,7 +1537,8 @@
                           "type": "array",
                           "description": "Which types of chart should be shown",
                           "default": [
-                            "LineChart"
+                            "LineChart",
+                            "DiscreteBar"
                           ],
                           "items": {
                             "type": "string",

--- a/schemas/explorer-schema.json
+++ b/schemas/explorer-schema.json
@@ -440,7 +440,12 @@
                                     "DiscreteBar",
                                     "SlopeChart",
                                     "StackedDiscreteBar",
-                                    "Marimekko"
+                                    "Marimekko",
+                                    "LineChart SlopeChart",
+                                    "LineChart DiscreteBar",
+                                    "SlopeChart DiscreteBar",
+                                    "LineChart SlopeChart DiscreteBar",
+                                    "None"
                                 ]
                             },
                             "facetYDomain": {

--- a/tests/collections/test_core_create.py
+++ b/tests/collections/test_core_create.py
@@ -42,7 +42,7 @@ def create_test_config():
 def create_test_explorer_config():
     """Create a basic test configuration for explorers."""
     config = create_test_config()
-    config["config"] = {"hasMapTab": True, "chartTypes": ["LineChart"]}
+    config["config"] = {"hasMapTab": True, "chartTypes": ["LineChart", "DiscreteBar"]}
     return config
 
 

--- a/tests/collections/test_explorer_migration.py
+++ b/tests/collections/test_explorer_migration.py
@@ -38,7 +38,7 @@ influenza_config = {
                     "subtitle": "Acute...",
                     "ySlugs": "reported_ari_cases",
                     "tableSlug": "flu_weekly",
-                    "type": "LineChart",
+                    "type": "LineChart DiscreteBar",
                     "Confirmed cases or Symptoms Radio": "Symptoms",
                     "Metric Dropdown": "Acute respiratory infections",
                     "Interval Radio": "Weekly",
@@ -49,7 +49,7 @@ influenza_config = {
                     "subtitle": "Acute...",
                     "ySlugs": "reported_ari_cases",
                     "tableSlug": "flu_monthly",
-                    "type": "LineChart",
+                    "type": "LineChart DiscreteBar",
                     "Confirmed cases or Symptoms Radio": "Symptoms",
                     "Metric Dropdown": "Acute respiratory infections",
                     "Interval Radio": "Monthly",
@@ -173,7 +173,7 @@ views:
     config:
       title: Weekly reported cases of acute respiratory infections
       subtitle: Acute...
-      type: LineChart
+      type: LineChart DiscreteBar
       timelineMinTime: -4043
   - dimensions:
       confirmed_cases_or_symptoms: symptoms
@@ -196,7 +196,7 @@ views:
     config:
       title: Monthly reported cases of acute respiratory infections
       subtitle: Acute...
-      type: LineChart
+      type: LineChart DiscreteBar
       timelineMinTime: -4043
 """.strip()
 
@@ -225,8 +225,8 @@ hasMapTab	true
 pickerColumnSlugs	Country
 graphers
 	yVariableIds	Confirmed cases or Symptoms Radio	Metric Dropdown	Interval Radio	title	subtitle	type	timelineMinTime
-	grapher/who/latest/flu/flu#reported_ari_cases	Symptoms	Acute respiratory infections	Weekly	Weekly reported cases of acute respiratory infections	Acute...	LineChart	-4043
-	grapher/who/latest/flu/flu_monthly#reported_ari_cases	Symptoms	Acute respiratory infections	Monthly	Monthly reported cases of acute respiratory infections	Acute...	LineChart	-4043
+	grapher/who/latest/flu/flu#reported_ari_cases	Symptoms	Acute respiratory infections	Weekly	Weekly reported cases of acute respiratory infections	Acute...	LineChart DiscreteBar	-4043
+	grapher/who/latest/flu/flu_monthly#reported_ari_cases	Symptoms	Acute respiratory infections	Monthly	Monthly reported cases of acute respiratory infections	Acute...	LineChart DiscreteBar	-4043
 
 columns
 	catalogPath	additionalInfo	colorScaleNumericMinValue	colorScaleScheme	dataPublishedBy	name	sourceLink	sourceName	tolerance	type	unit
@@ -249,8 +249,8 @@ hasMapTab	true
 pickerColumnSlugs	Country
 graphers
 	yVariableIds	Metric Dropdown	Interval Radio	title	subtitle	type	timelineMinTime
-	grapher/who/latest/flu/flu#reported_ari_cases	Acute respiratory infections	Weekly	Weekly reported cases of acute respiratory infections	Acute...	LineChart	-4043
-	grapher/who/latest/flu/flu_monthly#reported_ari_cases	Acute respiratory infections	Monthly	Monthly reported cases of acute respiratory infections	Acute...	LineChart	-4043
+	grapher/who/latest/flu/flu#reported_ari_cases	Acute respiratory infections	Weekly	Weekly reported cases of acute respiratory infections	Acute...	LineChart DiscreteBar	-4043
+	grapher/who/latest/flu/flu_monthly#reported_ari_cases	Acute respiratory infections	Monthly	Monthly reported cases of acute respiratory infections	Acute...	LineChart DiscreteBar	-4043
 
 columns
 	catalogPath	additionalInfo	colorScaleNumericMinValue	colorScaleScheme	dataPublishedBy	name	sourceLink	sourceName	tolerance	type	unit

--- a/tests/test_explorer.py
+++ b/tests/test_explorer.py
@@ -79,7 +79,7 @@ EXPLORER_CONFIG = {
                     }
                 ]
             },
-            "config": {"title": "Mpox: Cumulative confirmed cases", "type": "LineChart"},
+            "config": {"title": "Mpox: Cumulative confirmed cases", "type": "LineChart DiscreteBar"},
         },
         # VIEW 1
         {
@@ -102,7 +102,7 @@ EXPLORER_CONFIG = {
                     }
                 ]
             },
-            "config": {"title": "Mpox: Cumulative confirmed cases", "type": "LineChart"},
+            "config": {"title": "Mpox: Cumulative confirmed cases", "type": "LineChart DiscreteBar"},
         },
         # VIEW 2
         {
@@ -125,7 +125,7 @@ EXPLORER_CONFIG = {
                     }
                 ]
             },
-            "config": {"title": "Mpox: Cumulative confirmed cases per million people", "type": "LineChart"},
+            "config": {"title": "Mpox: Cumulative confirmed cases per million people", "type": "LineChart DiscreteBar"},
         },
         # VIEW 3
         {
@@ -164,7 +164,7 @@ EXPLORER_CONFIG = {
             "config": {
                 "title": "Mpox: Cumulative confirmed and suspected cases",
                 "subtitle": "Confirmed cases are those that have been verified through laboratory testing. Suspected cases are those where mpox is likely based on an individual's initial clinical signs and symptoms, but the diagnosis has not yet been confirmed through laboratory testing.",
-                "type": "LineChart",
+                "type": "LineChart DiscreteBar",
                 "selectedFacetStrategy": "entity",
                 "hasMapTab": "false",
                 "minTime": "1433",


### PR DESCRIPTION
For line charts to switch to discrete bar charts when both handles are on the same time, we now need to explicitly include the `DiscreteBar` chart tab in `chartTypes`. If `chartTypes` isn't provided, it defaults to `["LineChart", "DiscreteBar"]`.

In this PR, I’ve added `DiscreteBar` whenever `chartTypes` is set to `LineChart`, but another option would be to just remove the chartTypes field altogether and rely on the default. Let me know which you’d prefer!