### PR TITLE
🎉 Various improvements on chart sync and chart diff

### DIFF
--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -286,10 +286,59 @@ def sort_chart_diffs():
 def set_chart_diffs_to_pending(engine: Engine) -> None:
     """Set approval status of all chart diffs to pending."""
     st.markdown("**Do you want to set all charts-diffs to pending?** this will loose all your progress on reviews.")
+    st.info(
+        "💡 **Note:** This may take a moment. After completed, you may need to refresh the page to see the updated chart statuses."
+    )
     if st.button("Yes", type="primary"):
         with Session(engine) as session:
             for _, chart_diff in st.session_state.chart_diffs.items():
                 chart_diff.unreview(session)
+        st.rerun()
+
+
+@st.dialog(title="Set all pending charts to Approved")
+def set_chart_diffs_to_approved(engine: Engine) -> None:
+    """Set approval status of all pending chart diffs to approved."""
+    pending_non_conflict_count = len(
+        [chart for chart in st.session_state.chart_diffs.values() if chart.is_pending and not chart.in_conflict]
+    )
+    pending_conflict_count = len(
+        [chart for chart in st.session_state.chart_diffs.values() if chart.is_pending and chart.in_conflict]
+    )
+    st.markdown(
+        f"**Do you want to approve all {pending_non_conflict_count} pending (non-conflicted) chart diffs?** This will approve them for sync to production."
+    )
+    if pending_conflict_count > 0:
+        st.warning(
+            f"⚠️ **Note:** {pending_conflict_count} pending charts with conflicts will be skipped. Consider first using the 'Resolve all conflicts' button, or manually inspect them."
+        )
+    st.info(
+        "💡 **Note:** This may take a moment. After completed, you may need to refresh the page to see the updated chart statuses."
+    )
+    if st.button("Yes", type="primary"):
+        with Session(engine) as session:
+            for _, chart_diff in st.session_state.chart_diffs.items():
+                if chart_diff.is_pending and not chart_diff.in_conflict:  # Skip conflicted charts
+                    chart_diff.approve(session)
+        st.rerun()
+
+
+@st.dialog(title="Resolve all conflicts (Accept staging changes)")
+def resolve_all_conflicts_accept_staging(engine: Engine) -> None:
+    """Resolve all conflicts by accepting staging changes and approve charts."""
+    conflict_count = len([chart for chart in st.session_state.chart_diffs.values() if chart.in_conflict])
+    st.markdown(
+        f"**Do you want to resolve all {conflict_count} conflicts by accepting staging changes?** This will override any changes made in production when merging this to production."
+    )
+    st.info(
+        "💡 **Note:** This may take a moment. After completed, you may need to refresh the page to see the updated chart statuses."
+    )
+    if st.button("Yes, accept staging changes", type="primary"):
+        with Session(engine) as session:
+            for _, chart_diff in st.session_state.chart_diffs.items():
+                if chart_diff.in_conflict:
+                    chart_diff.set_conflict_to_resolved(session)
+                    chart_diff.approve(session)
         st.rerun()
 
 
@@ -446,12 +495,26 @@ def _show_options_misc():
     with st.container(border=True):
         st.markdown("Danger zone ⚠️")
         if st.button(
+            "Resolve all conflicts **(Accept staging changes)**",
+            key="resolve-all-conflicts",
+            help="This will accept all staging changes for charts with conflicts. Use with caution!",
+        ):
+            resolve_all_conflicts_accept_staging(SOURCE_ENGINE)
+
+        if st.button(
             "Set all charts to **Pending**",
             key="unapprove-all-charts",
             # on_click=lambda e=SOURCE_ENGINE: set_chart_diffs_to_pending(e),
             help="This sets the status of all chart diffs to 'Pending'. This means that you will need to review them again.",
         ):
             set_chart_diffs_to_pending(SOURCE_ENGINE)
+
+        if st.button(
+            "Set all pending charts to **Approved**",
+            key="approve-all-pending-charts",
+            help="This approves all pending (non-conflicted) chart diffs for sync to production. Charts with conflicts will be skipped.",
+        ):
+            set_chart_diffs_to_approved(SOURCE_ENGINE)
 
 
 def _show_options():

--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -285,7 +285,7 @@ def sort_chart_diffs():
 @st.dialog(title="Set all charts to Pending")
 def set_chart_diffs_to_pending(engine: Engine) -> None:
     """Set approval status of all chart diffs to pending."""
-    st.markdown("**Do you want to set all charts-diffs to pending?** this will loose all your progress on reviews.")
+    st.markdown("**Do you want to set all charts-diffs to pending?** this will lose all your progress on reviews.")
     st.info(
         "💡 **Note:** This may take a moment. After completed, you may need to refresh the page to see the updated chart statuses."
     )

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -339,6 +339,7 @@ class ChartDiff:
         source_session: Session,
         target_session: Session,
         estimate_relevance: bool = True,
+        ignore_conflicts: bool = False,
     ) -> List["ChartDiff"]:
         """Get chart diffs from chart ids.
 
@@ -362,7 +363,7 @@ class ChartDiff:
 
         # Get approval status
         # approval_statuses = cls._get_approval_statuses(source_session, chart_ids, source_charts, target_charts)
-        approvals = cls._get_approvals(source_session, chart_ids, source_charts, target_charts)
+        approvals = cls._get_approvals(source_session, chart_ids, source_charts, target_charts, ignore_conflicts)
 
         # Get conflicts
         conflicts = cls._get_conflicts(source_session, chart_ids, target_charts)
@@ -611,20 +612,33 @@ class ChartDiff:
 
     @staticmethod
     def _get_approvals(
-        source_session, chart_ids, source_charts, target_charts
+        source_session, chart_ids, source_charts, target_charts, ignore_conflicts=False
     ) -> Dict[int, Optional[gm.ChartDiffApprovals]]:
-        target_updated_ats = []
-        for chart_id in chart_ids:
-            if target_charts.get(chart_id) is not None:
-                target_updated_ats.append(target_charts[chart_id].updatedAt)  # type: ignore
-            else:
-                target_updated_ats.append(None)
-        approvals = gm.ChartDiffApprovals.latest_chart_approval_batch(
-            source_session,
-            chart_ids,
-            [source_charts[chart_id].updatedAt for chart_id in chart_ids],
-            target_updated_ats,
-        )
+        if ignore_conflicts:
+            # If ignore_conflicts is True, get the latest approval state of each chart, without timestamp matching
+            approvals = [
+                source_session.query(gm.ChartDiffApprovals)
+                .filter(gm.ChartDiffApprovals.chartId == chart_id)
+                .order_by(gm.ChartDiffApprovals.updatedAt.desc())
+                .first()
+                for chart_id in chart_ids
+            ]
+        else:
+            # Normal timestamp-based lookup
+            target_updated_ats = []
+            for chart_id in chart_ids:
+                if target_charts.get(chart_id) is not None:
+                    target_updated_ats.append(target_charts[chart_id].updatedAt)  # type: ignore
+                else:
+                    target_updated_ats.append(None)
+
+            approvals = gm.ChartDiffApprovals.latest_chart_approval_batch(
+                source_session,
+                chart_ids,
+                [source_charts[chart_id].updatedAt for chart_id in chart_ids],
+                target_updated_ats,
+            )
+
         approvals = dict(zip(chart_ids, approvals))
         return approvals
 
@@ -711,6 +725,7 @@ class ChartDiffsLoader:
         chart_ids: Optional[List[int]] = None,
         source_session: Optional[Session] = None,
         target_session: Optional[Session] = None,
+        ignore_conflicts: bool = False,
     ) -> List[ChartDiff]:
         """Optimised version of get_diffs."""
         if chart_ids:
@@ -725,6 +740,7 @@ class ChartDiffsLoader:
                 df_charts=df_charts,
                 source_session=source_session,
                 target_session=target_session,
+                ignore_conflicts=ignore_conflicts,
             )
         else:
             with Session(self.source_engine) as source_session, Session(self.target_engine) as target_session:
@@ -732,6 +748,7 @@ class ChartDiffsLoader:
                     df_charts=df_charts,
                     source_session=source_session,
                     target_session=target_session,
+                    ignore_conflicts=ignore_conflicts,
                 )
 
         self._diffs = chart_diffs


### PR DESCRIPTION
This PR adds some features to chart-sync and chart-diff:
* Add `--ignore-conflicts` option to chart-sync.
* Add button to fix all conflicts in chart diff (accepting staging changes).
* Add button to approve all (non-conflicted) pending charts in chart diff.

These features are particularly useful for big data updates, when you have a baseline PR (merging duplicated steps to master) and a subbranch (merging adapted steps to the baseline branch). After doing all the code and chart work in the subbranch staging server and merging the PR, the workflow would be to:
* Run: `etl chart-sync staging-site-sub-branch staging-site-baseline-branch --ignore-conflicts`
* In the chart diff of the baseline branch server, press the button to fix all conflicts, and then press the button to approve all pending charts.

Does this logic make sense? It's still not ideal that we need to do these additional manual steps, but it's still much better than having to deal with conflicts, and having to manually approve all charts twice (see [discussion](https://owid.slack.com/archives/C0193RW5E2J/p1752681966291009)).