### PR TITLE
🐛 fix population omm

### DIFF
--- a/etl/steps/data/garden/demography/2024-07-15/population.meta.yml
+++ b/etl/steps/data/garden/demography/2024-07-15/population.meta.yml
@@ -6,6 +6,7 @@ definitions:
       attribution: HYDE (2023); Gapminder (2022); UN WPP (2024)
     processing_level: major
     description_processing: |-
+      ### Combination of different sources
       The population data is constructed by combining data from multiple sources:
 
       - 10,000 BCE - 1799: Historical estimates by HYDE (v3.3).
@@ -15,6 +16,15 @@ definitions:
       - 1950-2023: Population records by the UN World Population Prospects (2024 revision).
 
       - 2024-2100: Projections based on Medium variant by the UN World Population Prospects (2024 revision).
+
+      ### Regional aggregates
+      **Continents and other region aggregates**
+      For most of the years, we've estimated regional aggregates by summing the population of countries in each region. We've relied on [our continents](https://ourworldindata.org/world-region-map-definitions#our-world-in-data) and [World Bank income group definitions](https://ourworldindata.org/grapher/world-bank-income-groups). The only exception is before 1800, where we've used HYDE's estimates on continents (but not income groups).
+
+      **World**:
+      - <1800: We've used HYDE's estimates.
+      - 1800-1950: We've estimated the World population by summing all available countries in the dataset, ensuring that we do not double-count any country.
+      - >1950: We've relied on UN WPP's estimates.
 
 tables:
   # Table with reduced metadata (to be used when estimating per-capita or other derived indicators)

--- a/etl/steps/data/garden/demography/2024-07-15/population.meta.yml
+++ b/etl/steps/data/garden/demography/2024-07-15/population.meta.yml
@@ -2,15 +2,15 @@ definitions:
   others:
     regional_aggregates_processing: |-
       ### Regional aggregates
-      **Continents and other region aggregates**
+
+      **Continents and other region aggregates**:
+
       For most of the years, we've estimated regional aggregates by summing the population of countries in each region. We've relied on [our continents](https://ourworldindata.org/world-region-map-definitions#our-world-in-data) and [World Bank income group definitions](https://ourworldindata.org/grapher/world-bank-income-groups). The only exception is before 1800, where we've used HYDE's estimates on continents (but not income groups).
 
       **World**:
-      - <1800: We've used HYDE's estimates.
+      - Before 1800: We've used HYDE's estimates.
       - 1800-1950: We've estimated the World population by summing all available countries in the dataset, ensuring that we do not double-count any country.
-      - >1950: We've relied on UN WPP's estimates.
-
-      {definitions.others.regional_aggregates_processing}
+      - After 1950: We've relied on UN WPP's estimates.
 
   common:
     presentation:
@@ -29,6 +29,8 @@ definitions:
       - 1950-2023: Population records by the UN World Population Prospects (2024 revision).
 
       - 2024-2100: Projections based on Medium variant by the UN World Population Prospects (2024 revision).
+
+      {definitions.others.regional_aggregates_processing}
 
 tables:
   # Table with reduced metadata (to be used when estimating per-capita or other derived indicators)
@@ -105,6 +107,7 @@ tables:
         unit: "%"
         short_unit: "%"
         description_processing: |-
+          ### Combination of different sources
           The data is constructed by combining data from multiple sources:
 
           - 1700 BCE - 1799: Historical estimates by HYDE (v3.3). Growth rate estimated over 50-year periods.
@@ -123,6 +126,7 @@ tables:
       presentation:
         attribution: HYDE (2023); Gapminder (2022); UN WPP (2024)
       description_processing: |-
+        ### Combination of different sources
         The population data is constructed by combining data from multiple sources:
 
         - 10,000 BCE - 1799: Historical estimates by HYDE (v3.3).
@@ -164,6 +168,7 @@ tables:
         description_short: |-
           Average exponential rate of growth of the population over a given period. It is calculated as ln(P2/P1) where P1 and P2 are the populations on subsequent years. Available from 1700 to 2023, based on data and estimates from different sources.
         description_processing: |-
+          ### Combination of different sources
           The data is constructed by combining data from multiple sources:
 
           - 1700 BCE - 1799: Historical estimates by HYDE (v3.3). Growth rate estimated over 50-year periods.

--- a/etl/steps/data/garden/demography/2024-07-15/population.meta.yml
+++ b/etl/steps/data/garden/demography/2024-07-15/population.meta.yml
@@ -1,4 +1,17 @@
 definitions:
+  others:
+    regional_aggregates_processing: |-
+      ### Regional aggregates
+      **Continents and other region aggregates**
+      For most of the years, we've estimated regional aggregates by summing the population of countries in each region. We've relied on [our continents](https://ourworldindata.org/world-region-map-definitions#our-world-in-data) and [World Bank income group definitions](https://ourworldindata.org/grapher/world-bank-income-groups). The only exception is before 1800, where we've used HYDE's estimates on continents (but not income groups).
+
+      **World**:
+      - <1800: We've used HYDE's estimates.
+      - 1800-1950: We've estimated the World population by summing all available countries in the dataset, ensuring that we do not double-count any country.
+      - >1950: We've relied on UN WPP's estimates.
+
+      {definitions.others.regional_aggregates_processing}
+
   common:
     presentation:
       topic_tags:
@@ -16,15 +29,6 @@ definitions:
       - 1950-2023: Population records by the UN World Population Prospects (2024 revision).
 
       - 2024-2100: Projections based on Medium variant by the UN World Population Prospects (2024 revision).
-
-      ### Regional aggregates
-      **Continents and other region aggregates**
-      For most of the years, we've estimated regional aggregates by summing the population of countries in each region. We've relied on [our continents](https://ourworldindata.org/world-region-map-definitions#our-world-in-data) and [World Bank income group definitions](https://ourworldindata.org/grapher/world-bank-income-groups). The only exception is before 1800, where we've used HYDE's estimates on continents (but not income groups).
-
-      **World**:
-      - <1800: We've used HYDE's estimates.
-      - 1800-1950: We've estimated the World population by summing all available countries in the dataset, ensuring that we do not double-count any country.
-      - >1950: We've relied on UN WPP's estimates.
 
 tables:
   # Table with reduced metadata (to be used when estimating per-capita or other derived indicators)
@@ -111,6 +115,8 @@ tables:
 
           - 2024-2100: Projections based on Medium variant by the UN World Population Prospects (2024 revision). Growth rate estimated over 1-year periods.
 
+          {definitions.others.regional_aggregates_processing}
+
   # Historical data
   historical:
     common:
@@ -124,6 +130,8 @@ tables:
         - 1800 - 1949: Historical estimates by Gapminder (v7).
 
         - 1950-2023: Population records by the UN World Population Prospects (2024 revision).
+
+        {definitions.others.regional_aggregates_processing}
 
     variables:
       population_historical:
@@ -163,6 +171,8 @@ tables:
           - 1800 - 1949: Historical estimates by Gapminder (v7). Growth rate estimated over 50-year periods until 1900, then 10-year periods.
 
           - 1950-2023: Population records by the UN World Population Prospects (2024 revision). Growth rate estimated over 1-year periods.
+
+          {definitions.others.regional_aggregates_processing}
         unit: "{tables.population_growth_rate.variables.growth_rate.unit}"
         short_unit: "{tables.population_growth_rate.variables.growth_rate.short_unit}"
 

--- a/etl/steps/data/garden/demography/2024-07-15/population.py
+++ b/etl/steps/data/garden/demography/2024-07-15/population.py
@@ -14,7 +14,6 @@ from typing import Dict, List, Tuple
 
 import numpy as np
 import owid.catalog.processing as pr
-import pandas as pd
 from owid.catalog import Dataset, License, Origin, Table
 from utils import (
     COUNTRIES_FORMER_EQUIVALENTS,

--- a/etl/steps/data/garden/demography/2024-07-15/population.py
+++ b/etl/steps/data/garden/demography/2024-07-15/population.py
@@ -3,6 +3,10 @@
 Notes:
 
     - "Gapminder SG" stands for "Gapminder Systema Globalis"
+    - On regional estimates:
+        - Continents: We re-estimate the values for WPP and Gapminder. For HYDE, we use the original values.
+        - Income groups: TODO
+        - World: We re-estimate the values for . For X, we use the original values.
 """
 
 import json
@@ -180,6 +184,15 @@ def format_hyde(tb: Table) -> Table:
     }
     # Rename columns
     tb = tb.rename(columns=columns_rename, errors="raise").loc[:, COLUMS_RELEVANT_POP]
+
+    # Exclude HYDE-specific countries
+    countries_exclude = [
+        "Asia (excl. China and India)",
+        "South America (excl. Brazil)",
+        "Europe (excl. Russia)",
+    ]
+    tb = tb.loc[~tb.country.isin(countries_exclude)]
+
     # Set source identifier
     tb["source"] = "hyde"
     return tb
@@ -360,103 +373,105 @@ def select_source(tb: Table) -> Table:
 def add_regions(tb: Table, ds_regions: Dataset, ds_income_groups: Dataset) -> Table:
     """Add continents and income groups."""
     paths.log.info("population: adding regions...")
-    regions = [
-        "Europe",
-        "Asia",
-        "North America",
-        "South America",
-        "Africa",
-        "Oceania",
-        "High-income countries",
-        "Low-income countries",
-        "Lower-middle-income countries",
-        "Upper-middle-income countries",
-        "European Union (27)",
-    ]
-    # make sure to exclude regions if already present
-    tb = tb.loc[~tb["country"].isin(regions)]
+    # 0/ Initial definitions
+    ## Country data needed to estimate region aggregates
+    continents_required = {
+        "Asia": ["China", "India", "Indonesia", "Pakistan", "Bangladesh"],
+        "Africa": ["Nigeria", "Ethiopia", "Egypt"],
+        "North America": ["United States", "Canada", "Mexico"],
+        "South America": ["Brazil", "Argentina", "Colombia", "Peru"],
+        "Oceania": ["Australia", "New Zealand"],
+        "Europe": ["Russia", "Germany", "France", "United Kingdom", "Italy", "Spain"],
+    }
+    regions_required = {
+        "High-income countries": [
+            "United States",
+            "Japan",
+            "Germany",
+            "France",
+            "United Kingdom",
+            "Italy",
+            "South Korea",
+            "Russia",
+        ],
+        "Upper-middle-income countries": [
+            "China",
+            "Brazil",
+            "Indonesia",
+            "Mexico",
+            "Iran",
+        ],
+        "Lower-middle-income countries": [
+            "India",
+            "Pakistan",
+            "Nigeria",
+            "Bangladesh",
+            "Philippines",
+            "Egypt",
+            "Kenya",
+            "Vietnam",
+        ],
+        "Low-income countries": [
+            # "Ethiopia", Currently not classified as low-income by the World Bank, but historically it was.
+            "Democratic Republic of Congo",
+            "Uganda",
+        ],
+        "European Union (27)": ["Germany", "France", "Italy", "Spain"],
+    }
+    continents = list(continents_required.keys())
+    regions = list(regions_required.keys())
+
+    def _aggregate(tb, regions_required_countries):
+        regions_ = list(regions_required_countries.keys())
+        tb_agg = geo.add_regions_to_table(
+            tb=tb,
+            regions=regions_,
+            aggregations={"population": "sum"},
+            ds_regions=ds_regions,
+            ds_income_groups=ds_income_groups,
+            num_allowed_nans_per_year=None,
+            frac_allowed_nans_per_year=0.2,
+            countries_that_must_have_data=regions_required_countries,
+        )
+        return tb_agg.loc[tb_agg["country"].isin(regions_)]
+
+    # Get rid of historical regions
+    ## Otherwise this are counted when estimating region values, and may lead to double-counts
+    tb_regions = ds_regions["regions"]
+    historical_regions = set(tb_regions.loc[tb_regions["is_historical"], "name"])
+    tb_agg = tb.loc[~tb["country"].isin(historical_regions)].copy()
+
+    # 1/ Estimate aggregates for HYDE ------
+    ## <1800 and exclude regions (keep continents)
+    tb_agg_hyde = tb_agg.loc[(tb_agg["year"] < YEAR_START_GAPMINDER) & (~tb_agg["country"].isin(regions))].copy()
+    # re-estimate region aggregates
+    tb_agg_hyde = _aggregate(
+        tb=tb_agg_hyde,
+        regions_required_countries=regions_required,
+    )
+
+    # 2/ Estimate aggregates post-HYDE (Gapminder + WPP) ------
+    ## ≥1800 and exclude regions + continents
+    tb_agg = tb_agg.loc[(tb_agg["year"] >= YEAR_START_GAPMINDER) & ~tb_agg["country"].isin(regions + continents)].copy()
+    # Interpolate table
+    tb_agg = geo.interpolate_table(
+        tb_agg[tb_agg["year"] >= YEAR_START_GAPMINDER],
+        "country",
+        "year",
+    )
+    # re-estimate region aggregates
+    tb_agg = _aggregate(
+        tb=tb_agg,
+        regions_required_countries=regions_required | continents_required,
+    )
 
     # keep sources per countries, remove from tb
-    # remove from tb: otherwsie geo.add_region_aggregates will add this column too
+    # remove from tb: otherwise geo.add_region_aggregates will add this column too
     sources = tb.loc[:, ["country", "year", "source"]].copy()
     tb = tb.drop(columns=["source"])
 
-    # Build table specifically for estimating regions: (1) no historical regions, (2) interpolation of country values
-
-    ## (1) remove historical regions
-    ## This is because it looks like historical countries are being considered when estimating values for regions.
-    tb_regions = ds_regions["regions"]
-    historical_regions = set(tb_regions.loc[tb_regions["is_historical"], "name"])
-    tb_aggregates = tb.loc[~tb["country"].isin(historical_regions)].copy()
-
-    ## (2) interpolate population for countries
-    tb_aggregates = geo.interpolate_table(tb_aggregates, "country", "year")
-
-    # re-estimate region aggregates
-    aggregations = {"population": "sum"}
-    tb_aggregates = geo.add_regions_to_table(
-        tb=tb_aggregates,
-        regions=regions,
-        aggregations=aggregations,
-        ds_regions=ds_regions,
-        ds_income_groups=ds_income_groups,
-        num_allowed_nans_per_year=None,
-        frac_allowed_nans_per_year=0.2,
-        countries_that_must_have_data={
-            # Continents
-            "Asia": ["China", "India", "Indonesia", "Pakistan", "Bangladesh"],
-            "Africa": ["Nigeria", "Ethiopia", "Egypt"],
-            "North America": ["United States", "Canada", "Mexico"],
-            "South America": ["Brazil", "Argentina", "Colombia", "Peru"],
-            "Oceania": ["Australia", "New Zealand"],
-            "Europe": ["Russia", "Germany", "France", "United Kingdom", "Italy", "Spain"],
-            # Income groups
-            "High-income countries": [
-                "United States",
-                "Japan",
-                "Germany",
-                "France",
-                "United Kingdom",
-                "Italy",
-                "South Korea",
-                "Russia",
-            ],
-            "Upper-middle-income countries": [
-                "China",
-                "Brazil",
-                "Indonesia",
-                "Mexico",
-                "Iran",
-            ],
-            "Lower-middle-income countries": [
-                "India",
-                "Pakistan",
-                "Nigeria",
-                "Bangladesh",
-                "Philippines",
-                "Egypt",
-                "Kenya",
-                "Vietnam",
-            ],
-            "Low-income countries": [
-                # "Ethiopia", Currently not classified as low-income by the World Bank, but historically it was.
-                "Democratic Republic of Congo",
-                "Uganda",
-            ],
-        },
-    )
-    tb_aggregates = tb_aggregates.loc[tb_aggregates["country"].isin(regions)]
-
-    # Add historical countries back
-    tb = pr.concat([tb, tb_aggregates], ignore_index=True)
-
-    # tb = tb.loc[
-    #     (
-    #         (tb["country"].isin(regions) & (tb["year"] < 1800) & (tb["year"] % 100 != 0))
-    #         | (tb["country"].isin(regions) & (tb["year"] < 1800) & (tb["year"] % 10 != 0))
-    #     )
-
-    # ]
+    # 3/ Combine aggregates with original data
+    tb = pr.concat([tb, tb_agg, tb_agg_hyde], ignore_index=True)
 
     # add sources back
     # these are only added to countries, not aggregates
@@ -497,11 +512,11 @@ def add_world(tb: Table) -> Table:
     ), "World data found in HYDE outside of [-10000, 1940]!"
 
     # Filter 'World' in HYDE for period [1800, 1950]
-    tb_world = tb.loc[
-        (tb["country"] == "World") & (tb["year"] > YEAR_START_HYDE) & (tb["year"] < YEAR_START_GAPMINDER)
-    ].copy()
+    # tb_world = tb.loc[
+    #     (tb["country"] == "World") & (tb["year"] > YEAR_START_HYDE) & (tb["year"] < YEAR_START_GAPMINDER)
+    # ].copy()
 
-    # Estimate World using reigons
+    # Estimate World using regions
     continents = [
         "Europe",
         "Asia",
@@ -510,17 +525,23 @@ def add_world(tb: Table) -> Table:
         "Africa",
         "Oceania",
     ]
-    # Estimate "World" population for years without HYDE and UN WPP data
+    # Estimate "World" population for years without UN WPP data. Previously we avoided doing it so for HYDE, but then we could have sum(regions) != World for that period, which is odd.
+    mask_pre_wpp = tb["year"] < YEAR_START_WPP
     tb_world = (
-        tb_world[
-            (tb_world["country"].isin(continents))
-            & (tb_world["year"] > YEAR_START_HYDE)
-            & (tb_world["year"] < YEAR_START_WPP)
+        tb[
+            (tb["country"].isin(continents))
+            # & (tb_world["year"] > YEAR_START_HYDE)
+            & mask_pre_wpp
         ]
         .groupby("year", as_index=False)["population"]
         .sum(numeric_only=True)
         .assign(country="World")
     )
+
+    # Remove 'World' from tb
+    tb = tb.loc[mask_pre_wpp & (tb["country"] != "World")]
+
+    # Merge original tb (without World pre-WPP) with World estimates (pre-WPP)
     tb = pr.concat([tb, tb_world], ignore_index=True).sort_values(["country", "year"])
 
     # add sources for world


### PR DESCRIPTION
There is an issue with early population data, where we were inflating data for some continents. This was due to wrongly back-propagating in time data values for some countries (e.g. value for Serbia in 1950 would be assigned to all years pre 1950), which then made the regional aggregate estimation use wrong numbers.

I've now changed the strategy to just rely on HYDE values pre 1800 also for continents.


/schedule