### PR TITLE
🐝  Standardize quotes for "best" death estimates

### DIFF
--- a/etl/steps/data/garden/war/2025-06-13/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2025-06-13/ucdp.meta.yml
@@ -89,7 +89,7 @@ definitions:
         This includes [interstate conflicts](#dod:interstate-ucdp), [civil conflicts](#dod:intrastate-ucdp), [colonial conflicts](#dod:extrasystemic-ucdp), [non-state conflicts](#dod:nonstate-ucdp), and [violence against civilians](#dod:onesided-ucdp).
         <%- endif %>
       - UCDP identifies conflict deaths [based on news reports, other contemporary sources, and academic research](https://www.uu.se/en/department/peace-and-conflict-research/research/ucdp/ucdp-methodology).
-      - "We show here the 'best' death estimates as identified by UCDP. They also report high and low estimates."
+      - "We show here the \"best\" death estimates as identified by UCDP. They also report high and low estimates."
 
   number_deaths_type:
     description_short: |-

--- a/etl/steps/data/garden/war/2025-06-16/ucdp_prio.meta.yml
+++ b/etl/steps/data/garden/war/2025-06-16/ucdp_prio.meta.yml
@@ -78,7 +78,7 @@ definitions:
       - |-
         [UCDP](https://www.uu.se/en/department/peace-and-conflict-research/research/ucdp/ucdp-methodology) and [PRIO](https://www.semanticscholar.org/paper/Monitoring-Trends-in-Global-Combat%3A-A-New-Dataset-Lacina-Gleditsch/0c4ff27fff986bc30112ac59ad6afbd7b719ad17?p2df) identify conflict deaths based on news reports, other contemporary sources, and academic research.
       - |-
-        We show here the 'best' death estimates as identified by UCDP and PRIO. They also report high and low estimates.
+        We show here the "best" death estimates as identified by UCDP and PRIO. They also report high and low estimates.
 
   common:
     presentation:

--- a/etl/steps/data/garden/war/latest/ucdp_preview.meta.yml
+++ b/etl/steps/data/garden/war/latest/ucdp_preview.meta.yml
@@ -100,7 +100,7 @@ definitions:
       - UCDP identifies conflict deaths [based on news reports, other contemporary sources, and academic research](https://www.uu.se/en/department/peace-and-conflict-research/research/ucdp/ucdp-methodology).
       - *key_point_pre_1
       - *key_point_pre_2
-      - "We show here the 'best' death estimates as identified by UCDP. They also report high and low estimates."
+      - "We show here the \"best\" death estimates as identified by UCDP. They also report high and low estimates."
 
   number_deaths_type:
     description_short: |-

--- a/etl/steps/export/multidim/war/latest/ucdp.py
+++ b/etl/steps/export/multidim/war/latest/ucdp.py
@@ -354,7 +354,7 @@ def _set_subtitle(view):
 def _set_note(view):
     """Set subtitle based on view dimensions."""
     if view.d.estimate == "best_ci":
-        return "'Best' estimates as identified by UCDP."
+        return '"Best" estimates as identified by UCDP.'
     elif view.d.indicator == "num_conflicts":
         return "Some conflicts affect several countries and regions. The sum across all countries and regions can therefore be higher than the total number."
     return None

--- a/etl/steps/export/multidim/war/latest/ucdp_prio.py
+++ b/etl/steps/export/multidim/war/latest/ucdp_prio.py
@@ -356,4 +356,4 @@ def _set_note(view):
     if view.d.indicator in ("wars_ongoing", "wars_ongoing_country_rate"):
         return "Some conflicts affect several regions. The sum across all regions can therefore be higher than the total number."
     if view.d.indicator in ("deaths", "death_rate") and (view.d.estimate == "best_ci"):
-        return "'Best' estimates as identified by UCDP and PRIO."
+        return '"Best" estimates as identified by UCDP and PRIO.'


### PR DESCRIPTION
Replaced single quotes with escaped double quotes around "best" death estimates in metadata and export scripts for consistency in UCDP and PRIO references.