### PR TITLE
🐛  Update string quotes in description key assertions

### DIFF
--- a/etl/steps/export/multidim/war/latest/ucdp.py
+++ b/etl/steps/export/multidim/war/latest/ucdp.py
@@ -283,7 +283,7 @@ def _set_description_key(view, tb):
     keys = tb[column].m.description_key
 
     if (view.d.estimate == "best_ci") or (view.d.indicator == "num_conflicts"):
-        assert keys[-1].startswith("We show here the 'best' death")
+        assert keys[-1].startswith('We show here the "best" death')
         keys = keys[:-1] + [None]
 
     return keys

--- a/etl/steps/export/multidim/war/latest/ucdp_prio.py
+++ b/etl/steps/export/multidim/war/latest/ucdp_prio.py
@@ -264,7 +264,7 @@ def _set_description_key(view, tb_ucdp, tb_up):
 
         # return
         if view.d.estimate == "best_ci":
-            assert keys[-1].startswith("We show here the 'best' death")
+            assert keys[-1].startswith('We show here the "best" death')
             keys = keys[:-1]  # + [None]
         return keys
     return None


### PR DESCRIPTION
Changed single quotes to double quotes in assertion strings for description keys in ucdp.py and ucdp_prio.py to ensure consistency with the expected format.