### PR TITLE
📊 regions: Add former Sudan to Africa region

### DIFF
--- a/etl/steps/data/garden/faostat/2025-03-17/faostat_metadata.py
+++ b/etl/steps/data/garden/faostat/2025-03-17/faostat_metadata.py
@@ -1062,7 +1062,7 @@ def run() -> None:
     #
     # Save outputs.
     #
-    # Initialize a new garden dataset.
+    # Initialize new garden dataset.
     ds_grapher = paths.create_dataset(
         tables=[datasets_table, items_table, elements_table, countries_table, amendments_table],
         repack=False,

--- a/etl/steps/data/garden/regions/2023-01-01/regions.yml
+++ b/etl/steps/data/garden/regions/2023-01-01/regions.yml
@@ -65,6 +65,7 @@
     - "NGA"
     - "OWID_ERE"
     - "OWID_OFS"
+    - "OWID_SDN"
     - "REU"
     - "RWA"
     - "SDN"


### PR DESCRIPTION
I noticed that the OWID African aggregate for some agriculture indicators was a little below the original "Africa (FAO)"; this caught my attention, as our definition of Africa is the same as FAO's definition.
It seems that, even though we did have a "Sudan (former)" country defined in our regions file, this country was not added as a member of Africa. This PR includes it.
NOTE: Merge at the end of the day, as it will trigger a big run.