### PR TITLE
🐛 remove bogus colon from urbanization country mapping

### DIFF
--- a/etl/steps/data/garden/un/2024-01-17/urban_agglomerations_size_class.countries.json
+++ b/etl/steps/data/garden/un/2024-01-17/urban_agglomerations_size_class.countries.json
@@ -1,5 +1,3 @@
-
-
 {
   "AFRICA": "Africa (UN)",
   "ASIA": "Asia (UN)",
@@ -239,5 +237,5 @@
   "Upper-middle-income countries": "Upper-middle-income countries (UN)",
   "Western Africa": "Western Africa (UN)",
   "Western Asia": "Western Asia (UN)",
-  "Western Europe": "Western Europe: (UN)"
+  "Western Europe": "Western Europe (UN)"
 }

--- a/etl/steps/data/garden/un/2024-01-17/urbanization_urban_rural.countries.json
+++ b/etl/steps/data/garden/un/2024-01-17/urbanization_urban_rural.countries.json
@@ -269,5 +269,5 @@
   "Upper-middle-income countries": "Upper-middle-income countries (UN)",
   "Western Africa": "Western Africa (UN)",
   "Western Asia": "Western Asia (UN)",
-  "Western Europe": "Western Europe: (UN)"
+  "Western Europe": "Western Europe (UN)"
 }


### PR DESCRIPTION
Nothing big, just randomly noticed this while [looking at the chart](https://ourworldindata.org/grapher/urban-and-rural-population-2050).