### PR TITLE
🐛 Use correct UN dependency in WHO Mortality DB

### DIFF
--- a/dag/main.yml
+++ b/dag/main.yml
@@ -655,7 +655,7 @@ steps:
   data://meadow/homicide/2025-08-06/who_mort_db:
     - snapshot://homicide/2025-08-06/who_mort_db.csv
   data://garden/homicide/2025-08-06/who_mort_db:
-    - data://garden/un/2024-07-12/un_wpp
+    - data://garden/un/2022-07-11/un_wpp
     - data://meadow/homicide/2025-08-06/who_mort_db
   data://grapher/homicide/2025-08-06/who_mort_db:
     - data://garden/homicide/2025-08-06/who_mort_db


### PR DESCRIPTION
`data://garden/homicide/2025-08-06/who_mort_db` has 2024 un_wpp in dependencies, but it's actually using 2022 version (which is silently loaded in `add_population`). This doesn't affect data at all. cc @spoonerf 