### PR TITLE
🔧 config: default DEBUG=True on dev if unset

### DIFF
--- a/etl/config.py
+++ b/etl/config.py
@@ -86,11 +86,10 @@ ENV_IS_REMOTE = ENV in ("production", "staging")
 # When DEBUG is on
 # - run steps in the same process (speeding up ETL)
 # If DEBUG is not explicitly set, default to ENV == "dev"
-_DEBUG_RAW = env.get("DEBUG")
-if _DEBUG_RAW is None:
+if "DEBUG" not in env:
     DEBUG = ENV == "dev"
 else:
-    DEBUG = _DEBUG_RAW in ("True", "true", "1")
+    DEBUG = env.get("DEBUG") in ("True", "true", "1")
 
 # Prefer downloading datasets from catalog instead of building them
 PREFER_DOWNLOAD = env.get("PREFER_DOWNLOAD") in ("True", "true", "1")


### PR DESCRIPTION
Set DEBUG=1 when ENV=dev to make sure all data scientists / devs are using it by default (it's faster for local development, but posses risks like memory leaks when run on staging / prod)