### PR TITLE
Create example analysis as part of our docs

### DIFF
--- a/docs/analyses/example-analysis/example_analysis.ipynb
+++ b/docs/analyses/example-analysis/example_analysis.ipynb
@@ -1,0 +1,202 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c32d0f47",
+   "metadata": {},
+   "source": [
+    "# Example analysis data pipeline\n",
+    "\n",
+    "This is a minimal example showing how to integrate tables and charts into Read the Docs documentation using Jupyter notebooks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "47ca31d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f34d8a5c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Country</th>\n",
+       "      <th>FAO production tonnage</th>\n",
+       "      <th>Numbers (lower)in millions</th>\n",
+       "      <th>Numbers (upper)in millions</th>\n",
+       "      <th>Numbers (midpoint)in millions</th>\n",
+       "      <th>year</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>China</td>\n",
+       "      <td>6032862</td>\n",
+       "      <td>170000</td>\n",
+       "      <td>400000</td>\n",
+       "      <td>290000</td>\n",
+       "      <td>2020</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>India</td>\n",
+       "      <td>944041</td>\n",
+       "      <td>19000</td>\n",
+       "      <td>84000</td>\n",
+       "      <td>51000</td>\n",
+       "      <td>2020</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Viet Nam</td>\n",
+       "      <td>1019752</td>\n",
+       "      <td>22000</td>\n",
+       "      <td>76000</td>\n",
+       "      <td>49000</td>\n",
+       "      <td>2020</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Indonesia</td>\n",
+       "      <td>892590</td>\n",
+       "      <td>21000</td>\n",
+       "      <td>75000</td>\n",
+       "      <td>48000</td>\n",
+       "      <td>2020</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>Ecuador</td>\n",
+       "      <td>760879</td>\n",
+       "      <td>15000</td>\n",
+       "      <td>69000</td>\n",
+       "      <td>42000</td>\n",
+       "      <td>2020</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     Country FAO production tonnage Numbers (lower)in millions  \\\n",
+       "0      China                6032862                     170000   \n",
+       "1      India                 944041                      19000   \n",
+       "2   Viet Nam                1019752                      22000   \n",
+       "3  Indonesia                 892590                      21000   \n",
+       "4    Ecuador                 760879                      15000   \n",
+       "\n",
+       "  Numbers (upper)in millions Numbers (midpoint)in millions  year  \n",
+       "0                     400000                        290000  2020  \n",
+       "1                      84000                         51000  2020  \n",
+       "2                      76000                         49000  2020  \n",
+       "3                      75000                         48000  2020  \n",
+       "4                      69000                         42000  2020  "
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Read some snapshots data:\n",
+    "df = pd.read_csv(\"https://snapshots.owid.io/ac/b0fffcb0625beb5fcb60dd3fcac5df\")\n",
+    "# NOTE: You can also read data for any ETL data step as follows:\n",
+    "# df = pd.read_feather(\"https://catalog.owid.io/garden/animal_welfare/2025-01-23/number_of_farmed_crustaceans/number_of_farmed_crustaceans.feather\")\n",
+    "display(df.head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38d21b13",
+   "metadata": {},
+   "source": [
+    "## Data Visualization\n",
+    "\n",
+    "This chart shows the relationship between total GDP and GDP per capita, with bubble sizes representing population:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3c2470bb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAJOCAYAAACqS2TfAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjUsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvWftoOwAAAAlwSFlzAAAPYQAAD2EBqD+naQAATmBJREFUeJzt3QeUVdX5P+4XpKlRECsqghUsqNi7ErHXiBp7R40de8cSey/EEnuLFXvvibEHjRp7wd5BUVEkMP/17t+a+c8gRvDLcYaZ51nrrpl77plz9+BK7nzOu/e7W9XU1NQEAAAAMMm1nvSXBAAAAJLQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAEw2jjrqqGjVqtUEnXvZZZeVc4cOHVr5uADg5wjdANAMvPjii7HxxhtHt27dokOHDjHbbLPFaqutFuecc05MbkaOHFnC9SOPPDJB5x9//PFxyy23VD4uAPg1hG4AmMw9/vjjscQSS8S///3v6N+/f5x77rmx0047RevWreOss86KyTF0H3300eMN3Ycffnh8//33DY4J3QA0ZW0aewAAwP/NcccdFx07doxnnnkmOnXq1OC1zz77LJqTNm3alAcATC5UugFgMvfWW2/Fggsu+JPAnWaaaaYGz//73//GscceG3PPPXe0b98+unfvHoceemiMGjWqwXl5fN111y3V5qyiTznllNGrV6+66vPgwYPL85zKvvjii8dzzz33k/d+9dVXy5T3zp07l/PyOrfddtv//F1y/fWMM85Yvs9qd67JzkdONx/fmu78/rvvvovLL7+87tztttvuf77H3XffHSuuuGJMPfXUMc0008Q666wT//nPf/7nzwDAryV0A8BkLtdx/+tf/4qXXnrpF8/NaedHHnlkLLbYYnHGGWfEyiuvHCeccEJsttlmPzn3zTffjC222CLWW2+9cs7w4cPL91dffXUMGDAgttpqqxKMM/RvuummMXbs2LqfzRC7zDLLxCuvvBIHH3xwnHbaaSXkbrjhhnHzzTf/7PgycJ933nnl+z/84Q9x5ZVXlsdGG2003vPztbx5kCG69txddtnlZ6+fr2fI/t3vfhcnnXRSHHHEEfHyyy/HCiusoOEaANWoAQAma/fdd1/NFFNMUR7LLrtszYEHHlhz77331vz4448Nznv++edr8qN/p512anB8//33L8cfeuihumPdunUrxx5//PG6Y3nNPDbllFPWvPvuu3XHL7jggnL84Ycfrju26qqr1vTq1avmhx9+qDs2duzYmuWWW65m3nnn/Z+/z+eff16uN3DgwJ+8lsfG/fNl6qmnrtl2221/cu6ll15azn3nnXfK82+++aamU6dONf37929w3ieffFLTsWPHnxwHgElBpRsAJnPZpfyJJ56I9ddfvzRTO/nkk2ONNdYoHczrT+e+6667ytd99923wc/vt99+5eudd97Z4PgCCywQyy67bN3zpZdeunz9/e9/H3PMMcdPjr/99tvl67Bhw+Khhx4q1e9vvvkmvvjii/L48ssvy7jeeOON+PDDD+O3dv/998dXX30Vm2++ed2Y8jHFFFOU3+Hhhx/+zccEQPOnEwkANANLLrlkWWf9448/luCdU7hz+niuqX7++edLgH733XdLR/N55pmnwc/OMsssZT14vl5f/WCdsllb6tq163iP5/Tz2mnpNTU1Zep2PsYnG7zlTYHfUob92psG4zPttNP+puMBoGUQugGgGWnXrl0J4PmYb775Yvvtt48bbrghBg4cWHdO/UZk/0tWgCfmeAbtVLu2e//99y+V7fEZN/j/FmrHleu680bDuHRFB6AKPl0AoJnKbuHp448/rmu4lsEzK77zzz9/3XmffvppmXadr08Kc801V/natm3b6Nu370T//ITeFJjY87Nje21H918zLgD4NazpBoDJXK5Frq0y11e7hrtHjx7l69prr12+nnnmmQ3OO/3008vX7Oo9KWSoXWWVVeKCCy6oC/z1ff755//z56eaaqryNW8ETIjsij4h52bVPaeQH3/88TF69OiJHhcA/Boq3QAwmdtzzz1j5MiRZYutnj17lnXdjz/+eFx33XVlv+2cYp4WWWSR2HbbbePCCy8sITW3C3v66afLHte5lVefPn0m2ZgGDRpUtuHKvbz79+9fqt9ZUc+Gbx988EFZd/5zck/wXIOe488p8rnP90ILLVQe45P7hD/wwAPl5sGss84ac845Z11zt/oycOd2ZFtvvXXZMi23Scstyt57773SRG755ZePc889d5L9GwBAEroBYDJ36qmnlnXbWdnOQJ2hO5ug7bbbbnH44YeXJmm1LrroohKAL7vsstJsLdc2H3LIIQ3WfE8KGZqfffbZso93vld2Ls8KeO/evcs+4b8kx5k3E3I/8Px9cnw/F7ozbO+8887ld/3+++/LjYXxhe6U+45nMD/xxBPjlFNOiVGjRpWGbrnPd+3NCQCYlFrlvmGT9IoAAABAYU03AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIh9upuYsWPHxkcffRTTTDNNtGrVqrGHAwAAwHjk7tvffPNNzDrrrNG69c/Xs4XuJiYDd9euXRt7GAAAAEyA999/P2afffaffV3obmKywl37H27aaadt7OEAAAAwHiNGjCgF09oM93OE7iamdkp5Bm6hGwAAoGn7pWXBGqkBAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAADQkkP3N998E/vss09069YtppxyylhuueXimWeeqXt98ODBsfrqq8f0008frVq1iueff/5nr1VTUxNrrbVWOe+WW24Z7zlffvllzD777OWcr776qu74dtttV46N+1hwwQXrzjnhhBNiySWXjGmmmSZmmmmm2HDDDeO1116bZP8WAAAATD4mi9C90047xf333x9XXnllvPjiiyVg9+3bNz788MPy+nfffRcrrLBCnHTSSb94rTPPPLME5f9lxx13jIUXXvgnx88666z4+OOP6x7vv/9+dO7cOTbZZJO6cx599NHYfffd48knnyxjHj16dBlvjhEAAICWpVVNln6bsO+//75UjW+99dZYZ5116o4vvvjipWL95z//ue7Y0KFDY84554znnnsuFl100Z9cKyvg6667bjz77LPRpUuXuPnmm0slur7zzjsvrrvuujjyyCNj1VVXjeHDh0enTp3GO7aslG+00UbxzjvvlCr8+Hz++eel4p1hfKWVVvrF33fEiBHRsWPH+Prrr2Paaaf9xfMBAAD47U1odmsTTdx///vfGDNmTHTo0KHB8Zxm/thjj03wdUaOHBlbbLFFDBo0KGaZZZbxnvPyyy/HMcccE0899VS8/fbbv3jNiy++uFTcfy5wp/wPkLIiPj6jRo0qj/r/4QAAAGgemnzozir3sssuG8cee2zMP//8MfPMM8ff/va3eOKJJ2KeeeaZ4OsMGDCgrAXfYIMNxvt6Bt/NN988TjnllJhjjjl+MXR/9NFHcffdd8c111zzs+eMHTu2rEVffvnlY6GFFhrvObkG/Oijj57g3wMA+G10P/jOxh4CQIs39MT/f7bz5GqyWNOda7lzFvxss80W7du3j7PPPrsE5NatJ2z4t912Wzz00ENlPffPOeSQQ0qo32qrrSbompdffnmZdj7u9PT6cm33Sy+9FNdee+3/fN+shtc+cp04AAAAzcNkEbrnnnvusib622+/LaH06aefLg3K5pprrgn6+Qzcb731VgnJbdq0KY/Ur1+/WGWVVerOueGGG+pez/XcaYYZZoiBAwc2uF7eALjkkkti6623jnbt2o33PffYY4+444474uGHHy6d0H9O3kTI+f/1HwAAADQPTX56eX1TTz11eWRzs3vvvTdOPvnkCfq5gw8+uHRAr69Xr15xxhlnxHrrrVee33TTTaVpW63ckmyHHXaIf/zjHyX015c3AN58883S5XxcGcj33HPP0qTtkUceKY3dAAAAaJkmi9CdATvDbI8ePUrYPeCAA6Jnz56x/fbbl9eHDRsW7733XllnnWr3xc6GafUf48q127WheNxg/cUXX5SvOeV83O7l2UBt6aWXHu867ZxSnuu8s9t6rkf/5JNPyvHsapfN3wAAAGg5Jovp5bnWOcNsBu1tttmm7MmdQbxt27Z1a7Z79+5dt6XYZpttVp6ff/75lYwlq+Ljq3LXbjmW5+S09dyWrPaR25ABAADQsjT5fbpbGvt0A0DToHs5QOMb2oS7l09odpssKt0AAAAwORK6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAADQXEP3hx9+GFtttVVMP/30MeWUU0avXr3i2WefrXv922+/jT322CNmn3328voCCywQ559//nivVVNTE2uttVa0atUqbrnllgavPfPMM7HqqqtGp06dYrrppos11lgj/v3vf9e9/tprr0WfPn1i5plnjg4dOsRcc80Vhx9+eIwePbrBdb766qvYfffdo0uXLtG+ffuYb7754q677qp7fcyYMXHEEUfEnHPOWcY799xzx7HHHlvGBgAAQMvSpjHffPjw4bH88suXsHv33XfHjDPOGG+88UYJxbX23XffeOihh+Kqq66K7t27x3333Re77bZbzDrrrLH++us3uN6ZZ55ZAve4Mrivueaa5fy//OUv8d///jcGDhxYgvf7778fbdu2LY9tttkmFltssRLMM5D3798/xo4dG8cff3y5zo8//hirrbZazDTTTHHjjTfGbLPNFu+++245v9ZJJ50U5513Xlx++eWx4IILlhsI22+/fXTs2DH22muvSv89AQAAaFoaNXRnQO3atWtceumldceyQlzf448/Httuu22sssoq5fnOO+8cF1xwQTz99NMNQvfzzz8fp512Wgm5WYWu79VXX41hw4bFMcccU94vZeheeOGFS2ieZ555SmU7H7W6desWjzzySPzjH/+oO3bJJZeU6+SYMqSnvBEw7ng32GCDWGeddepe/9vf/lbGCwAAQMvSqNPLb7vttlhiiSVik002KdXj3r17x1//+tcG5yy33HLlvJyGnlO0H3744Xj99ddj9dVXrztn5MiRscUWW8SgQYNilllm+cn79OjRo0xfv/jii0u1+vvvvy/fzz///D8JzbXefPPNuOeee2LllVduMN5ll122TC/PaegLLbRQqYLnlPL6433wwQfLGFNWzB977LEy7X18Ro0aFSNGjGjwAAAAoHlo1Er322+/XaZi5xTyQw89tKy7zinY7dq1K9XtdM4555Tqdq7pbtOmTbRu3boE85VWWqnuOgMGDChhNyvM4zPNNNOUqvWGG25Y1leneeedN+69995yzfryOkOGDClhON83q+P1x5tT3bfccsuyjjuDeU51z3XfWTlPBx98cAnOPXv2jCmmmKIE8uOOO678zPiccMIJcfTRR8fkpPvBdzb2EABavKEn/r8ZVQBA09aole5cL51rqLNanFXuDLm5jrp+o7QM3U8++WSpMv/rX/8qU8iz0vzAAw+U1/N4BuFcz/1zsrK94447lvXjea1//vOfpUqdU8Dztfquu+66ErqvueaauPPOO+PUU09tMN6syF944YWx+OKLxx//+Mc47LDDGoz3+uuvj6uvvrr8fF4n13bnNfLr+BxyyCHx9ddf1z1yjTkAAADNQ6NWunPtdXYjry+nfN90003l+wzEWQG/+eab69ZI5zrsXL+dQbZv374lcL/11lsNmpmlfv36xYorrlgq3BmAhw4dGk888USplKc8lg3bbr311thss83qfq52zXeOK6vUeSNgv/32K1XrHG+u5c7v64/3k08+KdPWs0J/wAEHlGp37TWzG3uuG8+Kdm31vr7sgJ4PAAAAmp9GDd1Zec6tuurLtdDZxCzltO181AblWhl6s+qcMuDutNNODV7PoHvGGWfEeuutV7fmO69Rv7N57fPa64xPvpbvn1/zPXO8Gdbzee2YcrwZxjNw13+vnxsvAAAALUejhu7atdg5vXzTTTctHb5z6nY+0rTTTlsamWX1OPe8zjD+6KOPxhVXXBGnn356OScbp42vedocc8xR1wk9t/nKa+S09D333LME4BNPPLGs587tylJOCc8qdgb2rDxnF/Sc+p1TyGs7lf/pT3+Kc889N/bee+9yndzeLMdefyuwDPq5hjvfP7cMe+6558pYd9hhh9/k3xQAAICmo1FD95JLLlmmjme4zYZlGZJzbXb9pmPXXntteT2P5XZdGbwz1O66664T/D7Z1Oz2228vDcuy+3hWonMNeXYnr91eLAN4bmGWlevskp7vs8cee5QbA/WnnmfztTyW09xzn+4M4AcddFCDNehHHHFEabD22Weflf3Ed9lllzjyyCMn2b8bAAAAk4dWNZkwaTKy83nHjh1LU7Ws9DdFupcDND7dy6vn8w6g8Q1twp93E5rdGrV7OQAAADRnQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQFMN3WPGjInnn38+hg8fPmlGBAAAAC01dO+zzz5x8cUX1wXulVdeORZbbLHo2rVrPPLII1WMEQAAAFpG6L7xxhtjkUUWKd/ffvvt8c4778Srr74aAwYMiMMOO6yKMQIAAEDLCN1ffPFFzDLLLOX7u+66KzbZZJOYb775YocddogXX3yxijECAABAywjdM888c7z88stlavk999wTq622Wjk+cuTImGKKKaoYIwAAAEyW2kzsD2y//fax6aabRpcuXaJVq1bRt2/fcvypp56Knj17VjFGAAAAaBmh+6ijjopevXrFe++9V6aWt2/fvhzPKvfBBx9cxRgBAACg+Yfu0aNHx5prrhnnn39+9OvXr8Fr22677aQeGwAAALScNd1t27aNF154obrRAAAAQEtupLbVVlvV7dMNAAAATMI13f/973/jkksuiQceeCAWX3zxmHrqqRu8fvrpp0/sJQEAAKBZmujQ/dJLL8Viiy1Wvn/99dcbvJbdzAEAAIBfGboffvjhif0RAAAAaJEmek13rTfffDPuvffe+P7778vzmpqaSTkuAAAAaHmh+8svv4xVV1015ptvvlh77bXj448/Lsd33HHH2G+//Sb5AL/55pvYZ599olu3bjHllFPGcsstF88880yDc1555ZVYf/31o2PHjmWN+ZJLLln2Ea/11ltvxR/+8IeYccYZY9ppp41NN900Pv300wbXyJ+fY445okOHDtGlS5fYeuut46OPPqp7/Ycffojtttuu7FHepk2b2HDDDX8y1kceeaRMsR/38cknn0zyfxcAAACaYegeMGBA2TosQ+1UU01Vd/yPf/xj3HPPPZN6fLHTTjvF/fffH1deeWW8+OKLsfrqq0ffvn3jww8/rAvUK6ywQvTs2bOE3tzS7IgjjijhOX333XflZzL8PvTQQ/HPf/4zfvzxx1hvvfVi7Nixde/Tp0+fuP766+O1116Lm266qVx34403rnt9zJgxJfTvtdde5f3/l7xG3oyofcw000yT/N8FAACApq9VzUTOC59lllnKtPJFFlkkpplmmvj3v/8dc801V7z99tux8MILx7fffjvJBpdT1/M9br311lhnnXXqjmfX9LXWWiv+/Oc/x2abbVZuAmQoH5/77ruvnDt8+PBS5U5ff/11TDfddOW1nwvQt912W6lmjxo1qly/vqx4f/XVV3HLLbc0OJ6hP8N7vlenTp1+1e88YsSIUrHPMdaOt6npfvCdjT0EgBZv6In//+ci1fB5B9D4hjbhz7sJzW4TXenOynH9CnetYcOGRfv27WNSyu3JssJcW7WulRXnxx57rFSq77zzzjLVfY011igV5aWXXrpBGM7QnFXu+mPL67Vu3bpcY3zyd7n66qvLVPZxA/eEWHTRRcsU9dVWW61U1gEAAGiZJjp0r7jiinHFFVfUPc9Am+H35JNPLlXeSSmr3Msuu2wce+yxZX11BvCrrroqnnjiiTJt+7PPPiuV9RNPPDHWXHPNUrnOtdsbbbRRPProo+UayyyzTFnnfdBBB8XIkSPLTYP999+/XKt2PXqtPCfPnX766cv0+aywT4wM2ueff36Znp6Prl27xiqrrBJDhgz52Z/JmwJ5h6T+AwAAgBYaujNcX3jhhWXKdq6NPvDAA2OhhRaKv//973HSSSdN8gHmtPGcAT/bbLOVavXZZ58dm2++ealU167J3mCDDcpa86wwH3zwwbHuuuuW8JuyedoNN9wQt99+e/zud78r5f+cGp57jec16jvggAPiueeeK+F9iimmiG222WaiurL36NEjdtlllzL9Pavkl1xySfl6xhln/OzPnHDCCWVMtY8M6gAAALTQ0J0B+/XXXy/NyzLsZuU4K8sZVueee+5JPsC8Zlats6L9/vvvx9NPPx2jR48u68hnmGGG0kl8gQUWaPAz888/f4Pu5dlILRujZWX8iy++KEE+G7HlNerL6+VU9ZwWfu2118Zdd90VTz755P9p/EsttVTZXu3nHHLIIWUNQO0jf0cAAACahza/5oeyInvYYYfFbymnfecjm5RlI7esuLdr165sD5bdwuvLmwK5xdi4MlSn7GKeATy3Cfs5tVX0nP79f/H888+Xaec/J6v3k3otPAAAAJNx6M7ge/HFF5f9sVNWmrfffvvo3LnzpB5fCdg5xTunbmfFOKeA5/Zg+X4pn+d2ZSuttFJZU57bluVU8uwkXuvSSy8t1e+cap7rwffee+8yHT2vmZ566qmy93dW77OreVbFc9uxrLLnmvJaL7/8cplSn43Wcv/wDNQpp7WnM888M+acc85YcMEFy77eF110UQn4OV0dAACAlmeiQ3eu3c49rrPavcQSS5Rjuc76mGOOKWE3w++klFOucwr2Bx98UEJ9v3794rjjjqvrKp6N03L9dq6Nzj20M0hnE7MM0LWyEp7XyLDcvXv3UqXP0F0ru7EPHjw4Bg4cWKbLZ2U6G7MdfvjhDarQa6+9drz77rt1z3v37l2+1q77zkC+3377lanrec3cQu2BBx6Y5A3mAAAAaKb7dPfq1atUf88777zSbCxlJ/DddtstHn/88XjxxRerGmuLYJ9uACb3fUubC593AI1vaEvcpzuneGc1tzZwp/x+3333/Z8NwwAAAKClmejQnVtt1a7lri+PLbLIIpNqXAAAANAy1nS/8MILdd/nuulsRJZV7WWWWaYcy221Bg0aFCeeeGJ1IwUAAIDmGLqzO3erVq3qGoalAw888CfnbbHFFqWTOAAAADCBofudd96pfiQAAADQEkN3t27dqh8JAAAAtPR9utNHH30Ujz32WHz22WcxduzYBq/lmm8AAADgV4Tuyy67LHbZZZdo165dTD/99GWtd638XugGAACAXxm6jzjiiDjyyCPjkEMOidatJ3rHMQAAAGgxJjo1jxw5MjbbbDOBGwAAAH7BRCfnHXfcMW644YaJ/TEAAABocSZ6evkJJ5wQ6667btxzzz3Rq1evaNu2bYPXTz/99Ek5PgAAAGhZofvee++NHj16lOfjNlIDAAAAfmXoPu200+KSSy6J7bbbbmJ/FAAAAFqUiV7T3b59+1h++eWrGQ0AAAC05NC99957xznnnFPNaAAAAKAlTy9/+umn46GHHoo77rgjFlxwwZ80Uhs8ePCkHB8AAAC0nNDdqVOn2GijjaoZDQAAALTk0H3ppZdWMxIAAABo6Wu6AQAAgIoq3XPOOef/3I/77bffnthLAgAAQLM00aF7n332afB89OjR8dxzz8U999wTBxxwwKQcGwAAALSs0J1bho3PoEGD4tlnn50UYwIAAIBmYZKt6V5rrbXipptumlSXAwAAgMneJAvdN954Y3Tu3HlSXQ4AAABa3vTy3r17N2ikVlNTE5988kl8/vnn8Ze//GVSjw8AAABaTujecMMNGzxv3bp1zDjjjLHKKqtEz549J+XYAAAAoGWF7oEDB1YzEgAAAGjpoTuNHTs23nzzzfjss8/K9/WttNJKk2psAAAA0LJC95NPPhlbbLFFvPvuu2U9d3251nvMmDGTcnwAAADQckL3rrvuGksssUTceeed0aVLlwZN1QAAAID/Q+h+4403yvZg88wzz8T+KAAAALQoE71P99JLL13WcwMAAACTuNK95557xn777Vf25u7Vq1e0bdu2wesLL7zwxF4SAAAAmqWJDt39+vUrX3fYYYe6Y7muO5uqaaQGAAAA/4fQ/c4770zsjwAAAECLNNGhu1u3btWMBAAAAFp6IzUAAABgwgjdAAAAUBGhGwAAACoidAMAAEBTCt1fffVVXHTRRXHIIYfEsGHDyrEhQ4bEhx9+OKnHBwAAAC2ne/kLL7wQffv2jY4dO8bQoUOjf//+0blz5xg8eHC89957ccUVV1QzUgAAAGjule599903tttuu3jjjTeiQ4cOdcfXXnvt+Pvf/z6pxwcAAAAtJ3Q/88wzscsuu/zk+GyzzRaffPLJpBoXAAAAtLzQ3b59+xgxYsRPjr/++usx44wzTqpxAQAAQMsL3euvv34cc8wxMXr06PK8VatWZS33QQcdFP369atijAAAANAyQvdpp50W3377bcw000zx/fffx8orrxzzzDNPTDPNNHHcccdVM0oAAABoCd3Ls2v5/fffH4899ljpZJ4BfLHFFisdzQEAAID/Q+iutcIKK5QHAAAAMAlDd3Ywf/jhh+Ozzz6LsWPHNnjt9NNP/zWXBAAAgGZnokP38ccfH4cffnj06NEjZp555tJIrVb97wEAAKClm+jQfdZZZ8Ull1wS2223XTUjAgAAgJbavbx169ax/PLLVzMaAAAAaMmhe8CAATFo0KBqRgMAAAAteXr5/vvvH+uss07MPffcscACC0Tbtm0bvD548OBJOT4AAABoOaF7r732Kp3L+/TpE9NPP73maQAAADCpQvfll18eN910U6l2AwAAAJNwTXfnzp3L1HIAAABgEofuo446KgYOHBgjR46c2B8FAACAFmWip5efffbZ8dZbb8XMM88c3bt3/0kjtSFDhkzK8QEAAEDLCd0bbrhhNSMBAACAlh66c2o5AAAAUEHorvWvf/0rXnnllfL9ggsuGL179/61lwIAAIBmaaJD92effRabbbZZPPLII9GpU6dy7Kuvvir7dl977bUx44wzVjFOAAAAaP7dy/fcc8/45ptv4j//+U8MGzasPF566aUYMWJE7LXXXtWMEgAAAFpCpfuee+6JBx54IOaff/66YwsssEAMGjQoVl999Uk9PgAAAGg5le6xY8f+ZJuwlMfyNQAAAOBXhu7f//73sffee8dHH31Ud+zDDz+MAQMGxKqrrjqxlwMAAIBma6JD97nnnlvWb3fv3j3mnnvu8phzzjnLsXPOOaeaUQIAAEBLWNPdtWvXGDJkSFnX/eqrr5Zjub67b9++VYwPAAAAWtY+3a1atYrVVlutPAAAAID/4/TyJ554Iu64444Gx6644ooytXymmWaKnXfeOUaNGjWhlwMAAIBmb4JD9zHHHFP25q714osvxo477limlR988MFx++23xwknnFDVOAEAAKD5hu7nn3++QXfya6+9NpZeeun461//Gvvuu2+cffbZcf3111c1TgAAAGi+oXv48OEx88wz1z1/9NFHY6211qp7vuSSS8b7778/6UcIAAAAzT10Z+B+5513yvc//vhj6WC+zDLL1L3+zTffRNu2basZJQAAADTn0L322muXtdv/+Mc/4pBDDompppoqVlxxxbrXX3jhhbJn98T68MMPY6uttorpp58+ppxyyujVq1c8++yz4z131113LZ3TzzzzzAbH119//ZhjjjmiQ4cO0aVLl9h6663jo48+anBOTn1fdNFFy7i7desWp5xyyk+u/8gjj8Riiy0W7du3j3nmmScuu+yyBq8fddRR5f3rP3r27NngnLfeeiv+8Ic/xIwzzhjTTjttbLrppvHpp59O9L8LAAAALSh0H3vssdGmTZtYeeWVyzrufLRr167u9UsuuSRWX331iXrznLK+/PLLlwr53XffHS+//HKcdtppMd100/3k3JtvvjmefPLJmHXWWX/yWp8+fUqofu211+Kmm24qwXfjjTeuez2vveWWW5bQ/tJLL8Vf/vKXOOOMM+Lcc8+tOyer+Ouss065Vq5f32effWKnnXaKe++9t8F7LbjggvHxxx/XPR577LG617777rvyb5Bh/KGHHop//vOfZVbAeuutF2PHjp2ofxsAAABa0D7dM8wwQ/z973+Pr7/+On73u9/FFFNM0eD1G264oRyfGCeddFJ07do1Lr300rpjuQXZ+Krhe+65ZwnAGYzHNWDAgLrvs4qdFfkNN9wwRo8eXQL9lVdeWZ5n6E5zzTVXqdbn++++++4lJJ9//vnlvTP0p/nnn78E6gzna6yxRt3188bDLLPMMt7fJ0P20KFD47nnnitV7nT55ZeXmwgZwrPTOwAAAC3HBFe6a3Xs2PEngTt17ty5QeV7Qtx2222xxBJLxCabbFL2+u7du3epoNeXFeKcLn7AAQeUKvMvGTZsWFx99dWx3HLL1a0xz/3Dc+p5fTmV/YMPPoh33323bh/ycUNxhu08Xt8bb7xRqu0Z3LN6/t5779W9lu+TAT6np9fK923dunWDijgAAAAtw0SH7knp7bffjvPOOy/mnXfeUsX+05/+FHvttVepDtfKanRWl/P4/3LQQQfF1FNPXdaGZxC+9dZbG4TnwYMHx4MPPlhC/Ouvv15X0c4p4umTTz5p0J095fMRI0bE999/X57nFmm5zvuee+4p484p6bmuPZvIpWwsl2PIsYwcObJMN99///1jzJgxde8zrgzq+R71HwAAADQPjRq6MwBn47Ljjz++VLl33nnn6N+/f5nqnf71r3/FWWedVYJuVpD/l6yE57Tu++67r1Tit9lmm6ipqSmv5TX32GOPWHfddUs1PsPxZpttVl7LKvSEyi3Ssiq/8MILlyB/1113xVdffVW3P3k2T8tp9rfffnuZap+zAvL1/B1/7n1OOOGEcl7tI6fbAwAA0Dw0aujOTuMLLLBAg2O5lrp2ynZ2Sv/ss89KZ/Ksducjp4Pvt99+0b1795+sOZ9vvvlitdVWi2uvvbYE4my8ljKwZ8X822+/LT+fVe2lllqqvJbTxFOu0x63y3g+z7XZORV9fDp16lTe880336w7lo3UspFbjvuLL74o68lzTXrt+4wr15bnOvnah73OAQAAWmAjtSpk5/LsOF5fTv3OZmgp13KPb511Ht9+++1/9rq1ncJz6nZ9WQGfbbbZyvd/+9vfYtllly3V6ZTfZ1Cv7/777y/Hf06G+AzYOZ5x5U2AlA3UMoDntmbjk+u/668BBwAAoPlo1NCdXcez4VlOL8/9rJ9++um48MILyyPl+ux81JfN0bIq3aNHj/L8qaeeimeeeSZWWGGF0iU8Q/ARRxxR9gyvDcxZcb7xxhtjlVVWiR9++KF0S89p4I8++mjddbOzeW4hduCBB8YOO+xQwnJOG7/zzjvrzsn12bn9V94UyH3ABw4cWIL85ptvXndOXjur9Rnmswnb3nvvXX7P2vECAADQcjRq6F5yySXL/ts5xfqYY44pW3adeeaZpSv4hJpqqqlKk7QMwNm4LKesr7nmmnH44Yc3qCBnc7YMzbnOO8P4I488UjfFPOV7Z8DOgJzryGefffa46KKLGmwXlt3OM2B/+eWXJVRn0M8p7LXV8pSV+/x9sot6ToE/7LDDGmxpBgAAQMvRqqa22xhNQnYvz4Zqub67dq/vpqb7wf9/9R+AxjH0xHUaewjNns87gMY3tAl/3k1odmvURmoAAADQnAndAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAABoqaF7zJgxccQRR8Scc84ZU045Zcw999xx7LHHRk1NTd05n376aWy33XYx66yzxlRTTRVrrrlmvPHGG3WvDxs2LPbcc8/o0aNHucYcc8wRe+21V3z99dcN3qtVq1Y/eVx77bUNzhk0aFDMP//85Tp5vSuuuOInY77hhhuiZ8+e0aFDh+jVq1fcddddlfzbAAAA0LS1iSbupJNOivPOOy8uv/zyWHDBBePZZ5+N7bffPjp27FiCc4bvDTfcMNq2bRu33nprTDvttHH66adH37594+WXX46pp546Pvroo/I49dRTY4EFFoh33303dt1113LsxhtvbPB+l156aQnttTp16lT3fY7jkEMOib/+9a+x5JJLxtNPPx39+/eP6aabLtZbb71yzuOPPx6bb755nHDCCbHuuuvGNddcU8Y3ZMiQWGihhX7DfzkAAAAaW6ua+iXjJiiD68wzzxwXX3xx3bF+/fqVSvNVV10Vr7/+eqk4v/TSSyWUp7Fjx8Yss8wSxx9/fOy0007jvW5Wo7faaqv47rvvok2b/3fvISvbN998cwnJ47PccsvF8ssvH6ecckrdsf322y+eeuqpeOyxx8rzP/7xj+Wad9xxR905yyyzTCy66KJx/vnn/+LvO2LEiHJDIavweQOhKep+8J2NPQSAFm/oies09hCaPZ93AI1vaBP+vJvQ7Nbkp5dn0H3wwQdLuE7//ve/S8Bda621yvNRo0aVrzmVu1br1q2jffv2dUF4fGr/YWoDd63dd989ZphhhlhqqaXikksuaTCNPd+r/vukDP9Z8R49enR5/sQTT5Qqe31rrLFGOQ4AAEDL0uSnlx988MHlDkKukZ5iiinKGu/jjjsuttxyy/J6Hs812jnt+4ILLijTyc8444z44IMP4uOPPx7vNb/44ouyLnznnXducPyYY46J3//+92Vd+H333Re77bZbfPvtt2Uae214vuiii0olfLHFFot//etf5XkG7rxmly5d4pNPPimV+fryeR4fnwzytTcOUv6uAAAANA9NPnRff/31cfXVV5e10Tl9/Pnnn4999tmnNE3bdttty1ruwYMHx4477hidO3cuwTwrzVkJH9/M+Qy166yzTlnbfdRRRzV4LRu21erdu3eZJp5TyWtDd76e4Tmni+e1M0znGE4++eRSXf81cu330Ucf/at+FgAAgKatyU8vP+CAA0q1e7PNNiudwLfeeusYMGBACau1Fl988RLGv/rqq1Ldvueee+LLL7+Mueaaq8G1vvnmm9IkbZpppilrtzOw/y9LL710qZjXVqJzKnlOOR85cmQMHTo03nvvvejevXu53owzzljOybXk2U29vnyex8cnK/Q51b328f777//qfysAAACaliYfujPgjltFzmp2NksbVy5iz/Cb24Vll/MNNtigQYV79dVXj3bt2sVtt932k7XZ45NBPjuT5/rw+jKszz777GUcuaVYNnurHeOyyy5b1qDXd//995fj45PXzrXl9R8AAAA0D01+enluxZVruHPddk4vf+6558qWYDvssEODTuQZtvOcF198Mfbee++y7jpDdv3AnQE+O57n89q10/lzGZ5vv/32UpHOqeMZyDMoZ/fz/fffv+59splbNk3LCvjw4cPLOLJrem5nVivfe+WVV47TTjutTGPPUJ43AC688MLf9N8NAACAxtfkQ/c555xT1lJnU7PPPvusrOXeZZdd4sgjj6w7J6eU77vvviU0ZzOzbbbZpsH67NwjO7f1SvPMM0+D67/zzjtlinhWrwcNGlSmrud67TwvQ3Xuw10rm7hlmH7ttdfK+X369Cn7cufP1++2nuvPDz/88Dj00ENj3nnnjVtuucUe3QAAAC1Qk9+nu6WxTzcAk/u+pc2FzzuAxje0CX/eNZt9ugEAAGByJXQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKAiQjcAAABUROgGAACAigjdAAAAUBGhGwAAACoidAMAAEBFhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgIoI3QAAAFARoRsAAAAqInQDAABARYRuAAAAqIjQDQAAABURugEAAKC5hu4PP/wwttpqq5h++uljyimnjF69esWzzz5b93pNTU0ceeSR0aVLl/J6375944033mhwjfXXXz/mmGOO6NChQzlv6623jo8++qju9UceeSQ22GCD8trUU08diy66aFx99dU/GcuZZ54ZPXr0KO/TtWvXGDBgQPzwww8TPN7Ro0fHQQcdVI7l+8w666yxzTbbNBgLAAAALUejhu7hw4fH8ssvH23bto277747Xn755TjttNNiuummqzvn5JNPjrPPPjvOP//8eOqpp0qYXWONNRqE4T59+sT1118fr732Wtx0003x1ltvxcYbb1z3+uOPPx4LL7xwee2FF16I7bffvoThO+64o+6ca665Jg4++OAYOHBgvPLKK3HxxRfHddddF4ceeugEj3fkyJExZMiQOOKII8rXwYMHlzHlTQEAAABanlY1WUpuJBly//nPf8Y//vGP8b6eQ8tq8X777Rf7779/Ofb111/HzDPPHJdddllsttlm4/252267LTbccMMYNWpUCcjjs84665TrXHLJJeX5HnvsUcL2gw8+WHdOvm8G/ccee2yCxjs+zzzzTCy11FLx7rvvlmr8LxkxYkR07Nix/J7TTjttNEXdD76zsYcA0OINPXGdxh5Cs+fzDqDxDW3Cn3cTmt3aRCPKcJxV60022SQeffTRmG222WK33XaL/v37l9ffeeed+OSTT8qU8lr5Sy299NLxxBNPjDd0Dxs2rEwdX2655X42cKf8h5l//vnrnuf5V111VTz99NMlJL/99ttx1113lanqEzren3ufVq1aRadOncb7et4YyEf982v/AzZVY0eNbOwhALR4TflzornweQfQ+EY04c+72rH9Yh27phG1b9++PA455JCaIUOG1FxwwQU1HTp0qLnsssvK6//85z9z9DUfffRRg5/bZJNNajbddNMGxw488MCaqaaaqpy/zDLL1HzxxRc/+77XXXddTbt27WpeeumlBsfPOuusmrZt29a0adOmXGfXXXedqPGO6/vvv69ZbLHFarbYYoufHcvAgQPLe3l4eHh4eHh4eHh4eHjEZPd4//33/0fqralp1Onl7dq1iyWWWKKsua611157lSnZWcnO47mGOhuRZRO0WptuummpHuea61pffPFFqXLnNO6jjz66VMRzzXaeV9/DDz8c6667bpx33nllXXf9ZmtZOf/zn/9cKulvvvlm7L333qWKnWu0J2S89WVTtX79+sUHH3xQrv1z0w3GrXSPHTu2/B7ZqG3csQOT7q5kNkt8//33m+wyDgD4v/J5B9XKKP3NN9+UJdGtW7dumtPLM0gvsMACDY7llO9seJZmmWWW8vXTTz9tELrzeXYgr2+GGWYoj/nmm69cI/8P5sknn4xll1227pycEr7eeuvFGWec0SBwpwzWOZV8p512Ks+zA/l3330XO++8cxx22GHlH/GXxls/cOeNgbwB8NBDD/3P/5Nr3759edT3c1PRgUkr/7fpjxAAmjufd1CdLPY26e7lWcXO7t71vf7669GtW7fy/ZxzzlmCd/3mZnnHLpub1Q/T48pqcapfQc5qczZPO+mkk0qQHld2Hh/37sQUU0xRvtZOBvil8dYP3Lmt2QMPPFAq1gAAALRMjVrpzn2ws4HZ8ccfX4JqNjG78MILyyPl9Op99tmnTPmed955SwjPinSW77M7ecoAntO7V1hhhbJ1V24XlufMPffcdcG8dkp5ThfPKd/ZnK12unjnzp3L91kBP/3006N3795108vzOnm8Nnz/0ngzcOdWZbldWE5tHzNmTN175fvk+wEAANCC1DSy22+/vWahhRYqDcp69uxZc+GFFzZ4fezYsTVHHHFEzcwzz1zOWXXVVWtee+21utdfeOGFmj59+tR07ty5vN69e/fSAO2DDz6oO2fbbbcd74L3lVdeue6c0aNH1xx11FE1c889d2mO1rVr15rddtutZvjw4RM83nfeeednF9c//PDDFf0LAhPrhx9+KE0M8ysANFc+76BpaNRGagAAANCcNeqabgAAAGjOhG4AAACoiNANAAAAFRG6AQAAoCJCNwAAAFRE6AYAAICKCN0AAABQEaEboJ6amprGHgIAAM1Im8YeAEBTCtytWrWKxx57LJ555pl4//33o3///tG9e/eYcsopG3t4ANAon4sff/xxfP311zHrrLPGVFNNFW3atImxY8dG69bqdzAh/C8FoN4fFjfffHOsv/76ce+998aTTz4Zffv2jUsvvTS++OKLxh4iAPzmn4u33HJLrLnmmtGnT59YY4014oQTToivvvqqBO4M3sAvE7oBIsofFo8//njsvvvucdppp8U999wTDz/8cHzyySdx8sknxxVXXBHDhg1r7GECwG/2uXj33XfHNttsUx5DhgyJpZdeOi644II49NBDy2ei4A0TRugGiIgxY8bEG2+8EVtvvXVsv/328fbbb0fPnj1jt912K5Xvww47LK688sr49NNPG3uoADDJ5Y3n+vLzLm9CH3744bHffvtF+/bty2yw2WabLf7xj3/EEUccoeINE6hVja5BAMWrr75aptPlGu711luvfL3oootKIM91bPlHxdFHHx277rqrdWwANBsPPPBAbLTRRvHOO+9E586dS5U7P/uuueaaWGKJJWL66aePlVZaqUwxP++888oN6jvuuCPWXnvtOPvss8vrwM/TSA1o0WvV/vvf/5aGMCkr2+n111+Pzz77LA455JDyPBuqrbrqqjHDDDPE6quvLnAD0KyssMIKZbZXhuf33nsv5phjjphiiimiX79+pXHaSSedFPPOO28cd9xx5fzFF188nn322Rg1alT8+OOPjT18aPL85Qi02MCd67Y33XTTMp0816jVn1L3+eefl+Zpuab78ssvjy+//LKs7Z5nnnkadewAMKl16NAhZp555rK0Kmd5nXnmmeV4Bu76n4t5Xvrggw9ihx12iAsvvDC6dOnSqGOHyYFKN9DiZOB+8MEHY4MNNog//vGPpaqda7azwp3r11ZcccVy13/nnXcuf4QMHz68dDOv/WMDAJqjrHDnWu2DDjqorOH+05/+VG5UzzXXXGXN93bbbVe20LzpppviueeeK1PRgV8mdAMtQv39RN99992y3+ipp54ae+65ZwnVuSVKrtXOaXLnnHNO3HDDDXHttddGu3btonfv3jHnnHM29q8AAJXM/MoA/f3338eSSy5ZGqdlsM7dPPKzM7/utNNO5Qb1iy++GN9880088cQTZbo5MGGEbqBZO+WUU8qd+t/97nfleTaJWXTRRUvVOqeLp+mmmy4222yz8n0G71zHllPrao8BQHMN3NmRPD/79t9//5h99tlLtXuvvfYqr+eN6Qze+XXgwIHl8/GHH34w8wsmktANNFu5HjunwOWWXz169CjHcrpc/mGRofrll1+uOzfv6mfIzj8ocvpcrmM7/vjjG3H0AFCdDNz33Xdf2YM7Z35tueWWdTeo8zMwm4lmB/P8zMyGafk1Cdww8WwZBjRr+YdCBu3HHnssFllkkZhmmmni448/jksvvTSOPfbYsgXYgQceWHf+yJEj49Zbby1Tymu7mQNAc5O7d+RN5gza559/fnz33XcxdOjQ+Nvf/hZTTz11CeO5J3dON//LX/5Smqx16tSpsYcNkyWhG2j2vv3221hmmWVKoP73v/9dgnd2Yr3kkkvixBNPLE3U6gdvAGjuctp4hu6MAtk49Morryzbhb355puliWgG7Jwtluflem97ccOvZ8swoNnLu/hXX311+QMiu5JnE5j8gyK3Cjv44IPL2u6jjjqqsYcJAJUZt86WzUX79OkTQ4YMibXWWitGjBhRGqblTh65u0dWwnOmWE41F7jh/0alG2i2ncqz2Uv+X1yu1065hju3CMvXcrp5Vrxz3fegQYPiiiuuKH945PYnuc4NAJpb07RHH300nnnmmfjPf/4T2267bSy//PLx5Zdfln23l1hiibrPzwEDBsQbb7wR119/fd1e3cCvJ3QDzUJuX5JrsLMTebrtttvK9PHPP/+83LnfaKONomPHjuMN3rkNSjZQcycfgOZq8ODBZYbXxhtvXJZY5VTyBRdcMC644IKYdtppyzmvvPJKXHbZZWWNd35G9urVq7GHDc2C6eXAZC3vGz777LPlbn02ehk9enT5QyG7sM4yyywx11xzldCd08fzTv4CCywQ1113XQnd+cdGrveeaaaZBG4Amq2sWudyqtNOOy0uvvjiMrsrp5HPM888dYH7pZdein333TceeOCB+Pvf/y5wwyRkyzBgsp8ul1PizjrrrNhnn33KVPI8lp3J83lab731on///mXa3AEHHFCCd/7BkfuSZpW7dosUAGiOvv766/L5uOOOO5YA3rdv39KdPD8rUy6vWmyxxeKYY44pHctnnXXWxh4yNCtCNzBZql13lmuys4Kde2zneuytt966/MFQu59o2nTTTUtAz+Cd08gzjOcd/IcffjjatWvXqL8HAFR9czobiGbo/uijj2K11VaL1VdfvUwhr12elc1Gc3nWkksu2dhDhmZJ6AYm28Cd67Nzm5Ns8pLV6lyvltuC7bLLLvHiiy/G8OHD69Z45zruDNwZwDNoH3fccQI3AM02aKfaryuuuGJpmNa1a9fYa6+94swzz6w7Pz878zMze5wA1RC6gcnuj4kM3Nl5Nbf/2m233UrI7tKlS3k9q9m5rnuPPfYoa9X+9Kc/lQZqKZvH5J6jOb08AzgANMfAnb1NHnzwwejWrVssuuii5fHXv/61TC/PfbhzivnHH38ct99+e1x44YXl/BlmmKGxhw/Nlu7lwGRn2LBhZQ/RXH+Wa7lr5Z6ibdr8v3uJZ599dplGnhXt3Xffva5RDAA0Zxmkc1ZXfkYOHTq03Gjee++9Y91114177rmnVLpzunnekM7ZYOedd14J5UB1VLqByU6u48479P369aubap4ycOfzvMuff1Tk19xr9LvvvosDDzxQ8AagWfvwww9Lv5K88Zwzv7ILea7dPvroo0sVPBuL5rZguVd37vCRn4vZDwWolko3MNm55pprYtttt40ff/yxBOv6wbtWru3OO/l33HFHaaqW0+lsCwZAc/Xcc8/FoYceWjqV597btVt+Pf3002VWWG4RltuG5Q1r4Ldln25gstO9e/dS1c7mL2ncwJ1y7Vp2Ms/1a2+99ZbADUCzr3LnzeZsivb+++/XHV9qqaXKcqucZp6hO29GA78t08uByU42hskpcbnXdu7Rnc/H7diaf3DkGrWsgtd2MAeA5irXbHfo0CH+/Oc/x4knnlh29VhppZXKa7kVWDYdbd++fSy44IKNPVRocUwvByZLWeXeYostSrOYvHOfd/Brp5XnHxw5Bf2+++6L+eabr7GHCgCTVO1N5pwyPmLEiPj+++/LtmApP/vOOOOMctP58MMPrzuefvjhhxLMgd+W0A1MlvKPiZxCXrs12LLLLlv+kMjpdU8++WTp0Nq7d+/GHiYAVBK4b7zxxtKzJD8Pc6vMnPV1+eWXR48ePeLee+8te3Hn8qv99tsvfv/73zf2sKFFE7qByVo2iDnllFNKo7RpppkmlltuubKOe955523soQFAJR5//PFYY401SpfyxRdfvATv7Fb+1VdflZvOc889d9x5551x/PHHR5cuXeLKK6+MKaecsrGHDS2W0A1M9saMGRNTTDFFYw8DACrpSp5Lpaaeeuq6Y3/5y1/i+uuvj/vvvz/atm1bjuWf9BnAcy13bhWWHnjggVL57tq1a6ONH9C9HGgG6ncvdx8RgOYgP88effTREqRz2nj2LKmVzULzURu4c612TjnPrcHefvvtEtRT3759BW5oAoRuYLJX27F83O8BYHKVn2crr7xyHHjggWVddu7YkVuCpc0337w0Tzv11FPL89rmaLmdZgbxqaaaqlHHDjRkyzAAAGhisjlaBujc/ivDdO61nc9z144555wzttxyy7jpppvKeu4M5hnI77777hK4bZUJTYs13QAA0ES7lOf67K+//jq22mqrErqPO+64sud2Ti8/99xzSwU8z5ttttni3XffLY3UFltsscYePlCP0A0AAE3QHXfcERtuuGHpQp7rtl9++eVS3c6u5X/605/KOu+PP/44br755ph99tljqaWWirnmmquxhw2MQ+gGAIAmZtSoUbHuuuuWzuWDBg2qO55TyXMP7nPOOaes7Z522mkbdZzAL7OmGwAAmpCsieVWmNksbcYZZ2ywxvvkk0+ON954I4455phybPvtt2+wnRjQ9OheDgAATUiu0c7maVnlvu6668rU8gzcGbLT3HPPHd999138+c9/rjsGNF1CNwAANKLa1Z4fffRRaZCWITvlVmHZjTw7lud089p9udPgwYPjpZdeik6dOjXauIEJY003AAA0smyQNnDgwPj0009jjTXWKN3K11xzzbjlllvKVPIRI0bEOuusEx988EHcdddd8fzzz0ePHj0ae9jABLCmGwAAGkHusd26devSlXzAgAHlkY3RrrrqqjjppJPKFPJ+/frFQgstFKeffnq8/fbb0aFDh3j66acFbpiMqHQDAMBvGLJz+niG5/Sf//ynVLmzadoJJ5xQjr366qtx+OGHx+eff162Bttss83qfr62yRow+bCmGwAAfgMZuD/88MPYZptt4sEHHyzHdt555zj11FNj6NChdef17NmzTCmfYYYZ4uKLL44LL7yw7ucFbpj8CN0AAPAbyYZouS77jDPOiNdffz0uueSSWHTRRWPIkCFx99131523wAILlO7k6Y477ihruoHJk+nlAADwG8p9tvfYY48yVfyss84qXcm322676Ny5czm++uqr15372muvlX24Z5999kYdM/DrCd0AANBIwTudc845Zb12//79yxZge++9d/Tt27exhwhMIkI3AAA0keCdjdPGjBkTRx99dPTp06exhwhMAtZ0AwBAI5h33nnj3HPPLd/vueeepUlaPs/p5PPMM09jDw+YRFS6AQCgkSve++yzT3zxxRdx9dVXR7du3co6b6B5UOkGAIBGrnifdtpppVlau3btBG5oZlS6AQCgCfjxxx9L6AaaF6EbAAAAKmJ6OQAAAFRE6AYAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBgPjkk09izz33jLnmmivat28fXbt2jfXWWy8efPDB33QcrVq1iltuueU3fU8AqFKbSq8OADR5Q4cOjeWXXz46deoUp5xySvTq1StGjx4d9957b+y+++7x6quvRlPy448/Rrt27Rp7GAAwQVS6AaCF22233UqF+emnn45+/frFfPPNFwsuuGDsu+++8eSTT5Zz3nvvvdhggw3id7/7XUw77bSx6aabxqefflp3je222y423HDDBtfdZ599YpVVVql7nt/vtddeceCBB0bnzp1jlllmiaOOOqru9e7du5evf/jDH8p4ap/nOYsuumhcdNFFMeecc0aHDh3iiiuuiOmnnz5GjRrV4D1zDFtvvXVF/1IAMPGEbgBowYYNGxb33HNPqWhPPfXUP3k9q99jx44tgTvPffTRR+P++++Pt99+O/74xz9O9Ptdfvnl5X2eeuqpOPnkk+OYY44p10vPPPNM+XrppZfGxx9/XPc8vfnmm3HTTTfF4MGD4/nnn49NNtkkxowZE7fddlvdOZ999lnceeedscMOO/zKfw0AmPRMLweAFizDbE1NTfTs2fNnz8l13S+++GK88847Za13ykpzVsMzGC+55JIT/H4LL7xwDBw4sHw/77zzxrnnnluuv9pqq8WMM85YF/SzCj7ulPJ8z9pz0hZbbFECegbwdNVVV8Ucc8zRoLoOAI1NpRsAWrAM3L/klVdeKWG7NnCnBRZYoITjfG1iZOiur0uXLqVC/Uu6devWIHCn/v37x3333RcffvhheX7ZZZeVae45NR0AmgqVbgBowbLanCH1/9osrXXr1j8J8NmMbVxt27Zt8DzfO6ev/5LxTX3v3bt3LLLIIqUCvvrqq8d//vOfMr0cAJoSlW4AaMGyodkaa6wRgwYNiu++++4nr3/11Vcx//zzx/vvv18etV5++eXyWla8U1ahcx12fbn2emJlKM+12hNqp512KhXunGbet2/fBtV4AGgKhG4AaOEycGfQXWqppUqzsjfeeKNMGz/77LNj2WWXLWE2txHbcsstY8iQIaXL+TbbbBMrr7xyLLHEEuUav//97+PZZ58tVef8+Vy3/dJLL030WLJjea7xzn3Dhw8f/ovn57ruDz74IP76179qoAZAkyR0A0ALN9dcc5Uw3adPn9hvv/1ioYUWKo3NMvyed955ZQr4rbfeGtNNN12stNJKJYTnz1x33XV118hq+RFHHFG2A8vGat98800J5hPrtNNOK93Ms2Kd08d/SceOHcs2Z7mV2bhblgFAU9CqZkI6qAAANFGrrrpq6aSelXkAaGqEbgBgspTTzx955JHYeOONyxrzHj16NPaQAOAndC8HACZLOf08g/dJJ50kcAPQZKl0AwAAQEU0UgMAAICKCN0AAABQEaEbAAAAKiJ0AwAAQEWEbgAAAKiI0A0AAAAVEboBAACgIkI3AAAAVEToBgAAgKjG/wf6mjxt2n0COwAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Create a simple bar chart\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "\n",
+    "# Bar chart of FAO production tonnage by country.\n",
+    "df_plot = df[df[\"Country\"].isin([\"China\", \"Indonesia\"])].reset_index(drop=True)\n",
+    "plt.bar(df_plot['Country'], df_plot['FAO production tonnage'])\n",
+    "plt.xlabel('Country')\n",
+    "plt.ylabel('Some numbers')\n",
+    "plt.title('Some title')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "etl",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/analyses/index.md
+++ b/docs/analyses/index.md
@@ -1,0 +1,7 @@
+# Analyses
+
+This section contains a selection of public analyses.
+
+## 📊 [Example Analysis](example-analysis/example_analysis.ipynb)
+
+A comprehensive analysis of something.

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -6,6 +6,16 @@ a:hover {
     text-align: center;
  }
 
+/* Hide Jupyter notebook execution numbers */
+.jp-InputPrompt,
+.jp-OutputPrompt {
+    display: none !important;
+}
+
+/* Hide In/Out prompts in code cells */
+div.highlight pre span.gp {
+    display: none !important;
+}
 
 /* fix some horrible jupyter cell margins */
 .jp-Cell h1 {

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,9 @@ Choose the material that most interests you:
 :material-download: I want to **access a public dataset** using an **API**<br>
 [Read more :octicons-arrow-right-24:](api/)
 
+:material-chart-line: I want to **explore public analyses** and research examples<br>
+[Read more :octicons-arrow-right-24:](analyses/)
+
 :material-upload: I am an **OWID staff** member, and want to **work with the ETL**<br>
 [Read more :octicons-arrow-right-24:](guides/index.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,6 +138,11 @@ markdown_extensions:
 plugins:
   - mkdocs-jupyter:
       ignore_h1_titles: True
+      include_source: True
+      execute: False
+      allow_errors: False
+      show_input: True
+      include_requirejs: True
   # The built-in search plugin integrates seamlessly with Material for MkDocs, adding multilingual client-side search with lunr and lunr-languages. ref: https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-search/#built-in-search-plugin
   - search
   - exclude:
@@ -275,3 +280,7 @@ nav:
       - Querying data via Datasette: "api/datasette.md"
       - Maintenance: "api/maintenance.md"
       - COVID-19: "api/covid.md"
+  - Analyses:
+      - "analyses/index.md"
+      - Example Analysis:
+          - Data pipeline: "analyses/example-analysis/example_analysis.ipynb"


### PR DESCRIPTION
[Example](http://staging-site-analyses-reporting/etl/docs/analyses/example-analysis/example_analysis/) of how we could integrate public analyses into our ETL Docs.
The example notebook includes code showing how one can read from our snapshots and data catalog directly into a pandas dataframe (without needing to use any ETL tooling).

#######################################
WARNING: This is just an experiment, do not merge.
#######################################