### PR TITLE
📊 agriculture: Fix issue with tea leaves production

### DIFF
--- a/etl/steps/data/garden/agriculture/2025-03-26/attainable_yields.meta.yml
+++ b/etl/steps/data/garden/agriculture/2025-03-26/attainable_yields.meta.yml
@@ -350,8 +350,9 @@ tables:
         title: Tangerines yield
       taro_yield:
         title: Taro yield
-      tea_yield:
-        title: Tea yield
+      # Tea production and yield data was removed; see faostat_qcl garden step for more details.
+      # tea_yield:
+      #   title: Tea yield
       tobacco_yield:
         title: Tobacco yield
       tomato_yield:

--- a/etl/steps/data/garden/agriculture/2025-03-26/long_term_crop_yields.meta.yml
+++ b/etl/steps/data/garden/agriculture/2025-03-26/long_term_crop_yields.meta.yml
@@ -324,8 +324,8 @@ tables:
         title: Tangerines yield
       taro_yield:
         title: Taro yield
-      tea_yield:
-        title: Tea yield
+      # tea_yield:
+      #   title: Tea yield
       tobacco_yield:
         title: Tobacco yield
       tomatoes_yield:

--- a/etl/steps/data/garden/agriculture/2025-03-26/long_term_crop_yields.meta.yml
+++ b/etl/steps/data/garden/agriculture/2025-03-26/long_term_crop_yields.meta.yml
@@ -324,6 +324,7 @@ tables:
         title: Tangerines yield
       taro_yield:
         title: Taro yield
+      # Tea production and yield data was removed; see faostat_qcl garden step for more details.
       # tea_yield:
       #   title: Tea yield
       tobacco_yield:

--- a/etl/steps/data/garden/faostat/2025-03-17/detected_anomalies.py
+++ b/etl/steps/data/garden/faostat/2025-03-17/detected_anomalies.py
@@ -354,7 +354,7 @@ class EggYieldLesothoAnomaly(DataAnomaly):
 
 
 class TeaProductionAnomaly(DataAnomaly):
-    description = "* Tea production in FAO data increased dramatically from 1990 to 1991 for many different countries (including some of the main producers, like China and India). However, data from 1991 was flagged as 'Estimated value' (while data prior to 1991 is flagged as 'Official figure'). Therefore, we removed tea production data (as well as per-capita production and yield) from 1991 onwards.\n"
+    description = "* Tea production data in FAOSTAT increases abruptly from 1990 to 1991 for many different countries (including some of the main producers, like China and India). However, data from 1991 is flagged as 'Estimated value' (while data prior to 1991 is flagged as 'Official figure'). Therefore, we decided to remove all tea production data (as well as per-capita production and yield).\n"
 
     affected_item_codes = [
         "00000667",
@@ -443,11 +443,7 @@ class TeaProductionAnomaly(DataAnomaly):
 
     def fix(self, tb):
         indexes_to_drop = tb[
-            (
-                (tb["item_code"].isin(self.affected_item_codes))
-                & (tb["element_code"].isin(self.affected_element_codes))
-                & (tb["year"] > 1990)
-            )
+            ((tb["item_code"].isin(self.affected_item_codes)) & (tb["element_code"].isin(self.affected_element_codes)))
         ].index
         tb_fixed = tb.drop(indexes_to_drop).reset_index(drop=True)
 

--- a/etl/steps/data/garden/faostat/2025-03-17/faostat_qcl.meta.yml
+++ b/etl/steps/data/garden/faostat/2025-03-17/faostat_qcl.meta.yml
@@ -382,9 +382,9 @@ tables:
       swine__pigs__00001034__stocks__005111__animals:
         presentation:
           title_public: Number of pigs
-      tea__00000667__production__005510__tonnes:
-        presentation:
-          title_public: Tea production
+      # tea__00000667__production__005510__tonnes:
+      #   presentation:
+      #     title_public: Tea production
       tobacco__00000826__production__005510__tonnes:
         presentation:
           title_public: Tobacco production
@@ -658,9 +658,9 @@ tables:
       tangerines__00000495__yield__005412__tonnes_per_hectare:
         presentation:
           title_public: Tangerine yield
-      tea__00000667__yield__005412__tonnes_per_hectare:
-        presentation:
-          title_public: Tea yield
+      # tea__00000667__yield__005412__tonnes_per_hectare:
+      #   presentation:
+      #     title_public: Tea yield
       tobacco__00000826__yield__005412__tonnes_per_hectare:
         presentation:
           title_public: Tobacco yield

--- a/etl/steps/export/explorers/faostat/latest/global_food.py
+++ b/etl/steps/export/explorers/faostat/latest/global_food.py
@@ -186,7 +186,7 @@ ITEM_CODES_QCL = [
     "00001723",  # From faostat_qcl - 'Sugar crops' (previously 'Sugar crops').
     "00001726",  # From faostat_qcl - 'Pulses' (previously 'Pulses').
     "00000162",  # From faostat_qcl - 'Sugar (raw)' (previously 'Sugar (raw)').
-    "00000667",  # From faostat_qcl - 'Tea leaves' (previously 'Tea').
+    # "00000667",  # From faostat_qcl - 'Tea leaves' (previously 'Tea').
     "00000056",  # From faostat_qcl - 'Maize (corn)' (previously 'Maize').
     "00000257",  # From faostat_qcl - 'Palm oil' (previously 'Palm oil').
     "00000393",  # From faostat_qcl - 'Cauliflowers and broccoli' (previously 'Cauliflowers and broccoli').


### PR DESCRIPTION
Tea production data in FAOSTAT QCL increased abruptly from 1990 to 1991 for many different countries (including some of the main producers, like China and India). However, data from 1991 is flagged as 'Estimated value' (while data prior to 1991 is flagged as 'Official figure'). Therefore, we decided to remove all tea production data (as well as per-capita production and yield).

This PR will remove tea production, per capita production, and yield, from the QCL dataset, the long term crop yields dataset, the attainable yields datasets, the food explorer, and the crop yields explorer.

In production, I've redirected the charts on [tea production](https://ourworldindata.org/grapher/tea-production) and [tea production by region](https://ourworldindata.org/grapher/tea-production-by-region) to [the global food explorer](https://ourworldindata.org/explorers/global-food).

For more context, see [conversation](https://owid.slack.com/archives/C3RAU3BJ9/p1756384864603899).