### PR TITLE
📊 energy: Fix inflation adjustment in IRENAs data

### DIFF
--- a/dag/energy.yml
+++ b/dag/energy.yml
@@ -329,6 +329,7 @@ steps:
   data://garden/irena/2025-08-22/renewable_power_generation_costs:
     - data://meadow/irena/2025-08-22/renewable_power_generation_costs
     - data://meadow/irena/2024-11-15/renewable_power_generation_costs
+    - data://garden/economics/2025-08-29/owid_deflator
   #
   # IRENA - Renewable power generation costs.
   #

--- a/etl/steps/data/garden/irena/2025-08-22/renewable_power_generation_costs.meta.yml
+++ b/etl/steps/data/garden/irena/2025-08-22/renewable_power_generation_costs.meta.yml
@@ -3,7 +3,7 @@ definitions:
     processing_level: major
     description_processing: |-
       - The resulting costs are compiled from two IRENA reports: Renewable Power Generation Costs in 2024 (primarily for data from 2010 onwards) and Renewable Power Generation Costs in 2023 (for earlier data not included in the latest report).
-      - Data from the Renewable Power Generation Costs in 2023 report (expressed in constant 2023 US dollars) was converted to constant 2024 US dollars using the US GDP deflator, to account for the effects of inflation. The deflator data is available from the [World Bank World Development Indicators](https://data.worldbank.org/indicator/NY.GDP.DEFL.ZS?locations=US).
+      - Data from the Renewable Power Generation Costs in 2023 report (expressed in constant 2023 US dollars) was converted to constant 2024 US dollars using the GDP deflator, to account for the effects of inflation in each country. The deflator data is available from the [World Bank World Development Indicators](https://data.worldbank.org/indicator/NY.GDP.DEFL.ZS.AD).
     presentation:
       topic_tags:
         - Energy

--- a/etl/steps/data/garden/irena/2025-08-22/renewable_power_generation_costs.meta.yml
+++ b/etl/steps/data/garden/irena/2025-08-22/renewable_power_generation_costs.meta.yml
@@ -3,7 +3,7 @@ definitions:
     processing_level: major
     description_processing: |-
       - The resulting costs are compiled from two IRENA reports: Renewable Power Generation Costs in 2024 (primarily for data from 2010 onwards) and Renewable Power Generation Costs in 2023 (for earlier data not included in the latest report).
-      - Data from the Renewable Power Generation Costs in 2023 report (expressed in constant 2023 US dollars) was converted to constant 2024 US dollars using the GDP deflator, to account for the effects of inflation in each country. The deflator data is available from the [World Bank World Development Indicators](https://data.worldbank.org/indicator/NY.GDP.DEFL.ZS.AD).
+      - Data from the Renewable Power Generation Costs in 2023 report (expressed in constant 2023 US dollars) was converted to constant 2024 US dollars using the GDP deflator, to account for the effects of inflation in each country. The deflator data is available from the [World Bank World Development Indicators](https://data.worldbank.org/indicator/NY.GDP.DEFL.ZS.AD). Global data was adjusted using the US GDP deflator.
     presentation:
       topic_tags:
         - Energy

--- a/etl/steps/data/garden/irena/2025-08-22/renewable_power_generation_costs.py
+++ b/etl/steps/data/garden/irena/2025-08-22/renewable_power_generation_costs.py
@@ -32,6 +32,9 @@ def adjust_old_data_for_inflation(tb_old, tb_deflator, tb):
         "World",
         "South Korea",
     }
+    # Remove South Korea from the old data, since it's the only country for which we can't adjust prices to 2024 USD.
+    tb_old = tb_old[tb_old["country"] != "South Korea"].reset_index(drop=True)
+
     # Calculate the adjustment factor.
     tb_deflator["adjustment"] = tb_deflator[2024] / tb_deflator[2023]
 
@@ -48,8 +51,7 @@ def adjust_old_data_for_inflation(tb_old, tb_deflator, tb):
         # Sanity check.
         error = f"Unexpected units for column {column}."
         assert tb[column].metadata.unit == f"constant {LATEST_YEAR} US$ per kilowatt-hour", error
-        # Fill adjustment factor with 1 for countries for which we can't do the adjustment (namely South Korea).
-        tb_old[column] *= tb_old["adjustment"].fillna(1)
+        tb_old[column] *= tb_old["adjustment"]
         tb_old[column].metadata.unit = tb[column].metadata.unit
 
     tb_old = tb_old.drop(columns=["adjustment"], errors="raise")

--- a/etl/steps/data/garden/irena/2025-08-22/renewable_power_generation_costs.py
+++ b/etl/steps/data/garden/irena/2025-08-22/renewable_power_generation_costs.py
@@ -38,6 +38,13 @@ def adjust_old_data_for_inflation(tb_old, tb_deflator, tb):
     # Calculate the adjustment factor.
     tb_deflator["adjustment"] = tb_deflator[2024] / tb_deflator[2023]
 
+    ################################################################################################################
+    # Remove metadata from WDI (which is used as an auxiliary dataset) to avoid it leaking into the new indicators.
+    # NOTE: This problem of metadata propagation of auxiliary dataset needs to be fixed. For now, this is a patch.
+    tb_deflator["adjustment"].metadata.origins = []
+    tb_deflator["adjustment"].metadata.description_from_producer = None
+    ################################################################################################################
+
     # Add adjustment column to old table.
     tb_old = tb_old.merge(tb_deflator[["country", "adjustment"]], on=["country"], how="left")
 


### PR DESCRIPTION
Use each country's GDP deflator (linked series) to adjust IRENA's renewable power generation costs (to convert data in constant 2023 USD to constant 2024 USD).

* [x] Fix description from producer (it is from WDI). Consider removing WDI's attribution (given that it's used as an auxiliary dataset), so it doesn't appear in the charts as one of the sources.
