### PR TITLE
🐝 migrate Labor Supply & Employment tag

### DIFF
--- a/etl/steps/data/garden/ilostat/2023-09-19/employment.meta.yml
+++ b/etl/steps/data/garden/ilostat/2023-09-19/employment.meta.yml
@@ -2,7 +2,7 @@ definitions:
   common:
     presentation:
       topic_tags:
-        - Labor Supply & Employment
+        - Labor Force Participation & Employment
 
 
 dataset:

--- a/etl/steps/data/garden/ilostat/2023-09-19/unemployment.meta.yml
+++ b/etl/steps/data/garden/ilostat/2023-09-19/unemployment.meta.yml
@@ -2,7 +2,7 @@ definitions:
   common:
     presentation:
       topic_tags:
-        - Labor Supply & Employment
+        - Labor Force Participation & Employment
 
 
 dataset:


### PR DESCRIPTION
A request from @bertharc to prune an econ tag: remove `Labor Supply & Employment`, setting them all to `Labor Force Participation & Employment`

We're also renaming `Labor & Employment` to `Work and Employment` - but that's not mentioned anywhere in this repo.