### PR TITLE
📊  UN WPP data for Cologne

### DIFF
--- a/dag/demography.yml
+++ b/dag/demography.yml
@@ -344,9 +344,13 @@ steps:
     - data://garden/demography/2024-12-06/wittgenstein_human_capital
 
   #
-  # TODO: add step name (just something recognizable)
+  # US State Population
   #
   data://meadow/demography/2025-01-23/us_state_population:
     - snapshot://demography/2025-01-23/us_state_population.csv
   data://garden/demography/2025-01-23/us_state_population:
     - data://meadow/demography/2025-01-23/us_state_population
+
+  # UN WPP data for Cologne
+  data://external/demography/latest/un_wpp_subset:
+    - data://garden/un/2024-07-12/un_wpp

--- a/etl/steps/data/external/demography/latest/un_wpp_subset.py
+++ b/etl/steps/data/external/demography/latest/un_wpp_subset.py
@@ -1,0 +1,58 @@
+from owid.catalog import Table
+from owid.catalog import processing as pr
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset("un_wpp")
+    #
+    # Process data.
+    #
+    tables = [
+        ds_garden["population"],
+        ds_garden["growth_rate"],
+        ds_garden["natural_change_rate"],
+        ds_garden["fertility_rate"],
+        ds_garden["migration"],
+        ds_garden["deaths"],
+        ds_garden["births"],
+        ds_garden["life_expectancy"],
+        ds_garden["mortality_rate"],
+    ]
+
+    simple_tables = [get_simple_data(tb) for tb in tables]
+    tb = pr.multi_merge(simple_tables, on=["country", "year", "sex", "age", "variant"], how="outer")
+    tb = tb.drop(columns=["population_density"])
+    tb["check_change"] = tb["births"] - tb["deaths"] + tb["net_migration"]
+    tb["change_diff"] = tb["population_change"] - tb["check_change"]
+
+    tb = tb.format(["country", "year", "sex", "age", "variant"])
+    ds_garden = paths.create_dataset(
+        tables=[tb],
+        check_variables_metadata=True,
+        default_metadata=ds_garden.metadata,
+        formats=["csv"],
+    )
+
+    # Save changes in the new garden dataset.
+    ds_garden.save()
+
+
+def get_simple_data(tb: Table) -> Table:
+    """
+    Getting a simple subset of the data, where only have data for all ages, both sexes and the estimated historical data, with the medium variant.
+    """
+
+    tb = tb.reset_index()
+    tb = tb[(tb["age"] == "all") & (tb["sex"] == "all")]
+    tb = tb[tb["variant"].isin(["estimates", "medium"])]
+    # tb = tb.format(["country", "year", "sex", "age", "variant"])
+    return tb

--- a/etl/steps/data/external/demography/latest/un_wpp_subset.py
+++ b/etl/steps/data/external/demography/latest/un_wpp_subset.py
@@ -27,16 +27,20 @@ def run() -> None:
         ds_garden["life_expectancy"],
         ds_garden["mortality_rate"],
     ]
+    # Reset the index for all tables to prepare for merging
+    tables = [tb.reset_index() for tb in tables]
 
-    simple_tables = [get_simple_data(tb) for tb in tables]
-    tb = pr.multi_merge(simple_tables, on=["country", "year", "sex", "age", "variant"], how="outer")
+    tb = pr.multi_merge(tables, on=["country", "year", "sex", "age", "variant"], how="outer")
     tb = tb.drop(columns=["population_density"])
-    tb["check_change"] = tb["births"] - tb["deaths"] + tb["net_migration"]
-    tb["change_diff"] = tb["population_change"] - tb["check_change"]
+    # This should be the same as population_change
+    tb["check_pop_change"] = tb["births"] - tb["deaths"] + tb["net_migration"]
+    tb["change_diff"] = tb["population_change"] - tb["check_pop_change"]
 
-    tb = tb.format(["country", "year", "sex", "age", "variant"])
+    simple_tb = get_simple_data(tb)
+    age_sex_tb = get_age_sex_data(tb)
+    full_tb = get_full_data(tb)
     ds_garden = paths.create_dataset(
-        tables=[tb],
+        tables=[simple_tb, age_sex_tb, full_tb],
         check_variables_metadata=True,
         default_metadata=ds_garden.metadata,
         formats=["csv"],
@@ -51,8 +55,88 @@ def get_simple_data(tb: Table) -> Table:
     Getting a simple subset of the data, where only have data for all ages, both sexes and the estimated historical data, with the medium variant.
     """
 
-    tb = tb.reset_index()
     tb = tb[(tb["age"] == "all") & (tb["sex"] == "all")]
     tb = tb[tb["variant"].isin(["estimates", "medium"])]
-    # tb = tb.format(["country", "year", "sex", "age", "variant"])
+    tb = tb.format(["country", "year", "sex", "age", "variant"], short_name="total_populations_medium")
+    return tb
+
+
+def get_age_sex_data(tb: Table) -> Table:
+    """
+    Getting a subset of the data, where we have data for all age groups and both sexes, with the medium variant only.
+    """
+
+    tb = tb[tb["variant"].isin(["estimates", "medium"])]
+    tb = tb[
+        tb["age"].isin(
+            [
+                "0-14",
+                "15-64",
+                "65+",
+                "all",
+                "0-4",
+                "5-9",
+                "10-14",
+                "15-19",
+                "20-24",
+                "25-29",
+                "30-34",
+                "35-39",
+                "40-44",
+                "45-49",
+                "50-54",
+                "55-59",
+                "60-64",
+                "65-69",
+                "70-74",
+                "75-79",
+                "80-84",
+                "85-89",
+                "90-94",
+                "95-99",
+                "100+",
+            ]
+        )
+    ]  # Keeping only standard age groups
+    tb = tb.format(["country", "year", "sex", "age", "variant"], short_name="age_sex_populations_medium")
+    return tb
+
+
+def get_full_data(tb: Table) -> Table:
+    """
+    Getting the full dataset, with all age standard age groups and low and high variants.
+    """
+    tb = tb[tb["variant"].isin(["estimates", "medium", "low", "high"])]
+    tb = tb[
+        tb["age"].isin(
+            [
+                "0-14",
+                "15-64",
+                "65+",
+                "all",
+                "0-4",
+                "5-9",
+                "10-14",
+                "15-19",
+                "20-24",
+                "25-29",
+                "30-34",
+                "35-39",
+                "40-44",
+                "45-49",
+                "50-54",
+                "55-59",
+                "60-64",
+                "65-69",
+                "70-74",
+                "75-79",
+                "80-84",
+                "85-89",
+                "90-94",
+                "95-99",
+                "100+",
+            ]
+        )
+    ]  # Keeping only standard age groups
+    tb = tb.format(["country", "year", "sex", "age", "variant"], short_name="all_scenarios")
     return tb


### PR DESCRIPTION
Hey @Marigold, in Cologne, my group is working on some visualisations using the UN WPP data. I wanted to make some different slices of it easily accessible, and thought using the `external` channel would be a good way to do it. Is that okay? We can always remove it after Cologne, or move the pipeline into the ETL if we end up using the outputs. 