### PR TITLE
🎉 Notify about deleted charts

### DIFF
--- a/apps/chart_sync/cli.py
+++ b/apps/chart_sync/cli.py
@@ -368,7 +368,7 @@ The following {chart_word} exist(s) in production but not in staging and may hav
 
 {chart_list}
 
-Make sure to delete them from production if this was intentional.
+chart-sync doesn't delete charts. Make sure to delete them from production if this was intentional.
     """.strip()
 
     print(message)


### PR DESCRIPTION
Send notifications about deleted charts from staging to Slack. An example

```
⚠ *ETL chart-sync: 1 Deleted Chart Detected* from `notify-deleted-charts`

The following chart exist(s) in production but not in staging and may have been deleted:

• Chart 8511: `the-us-spends-far-more-on-health-than-any-other-g7-country` - <https://admin.owid.io/admin/charts/8511/edit|View on Production>

chart-sync doesn't delete charts. Make sure to delete them from production if this was intentional.
```

Let's start with this and see how often it comes up. In the future, we might decide to go all the way and automate deletion (see https://github.com/owid/etl/issues/5004).