### PR TITLE
add export of queries used

### DIFF
--- a/snapshots/news/2024-05-07/country_queries.yaml
+++ b/snapshots/news/2024-05-07/country_queries.yaml
@@ -219,7 +219,7 @@ queries:
   - country: Italy
     query: ("Italy")
   - country: Ivory Coast
-    query: ("CÃ´te D'Ivoire" "C<U+00F4>te d<U+2019>Ivoire" "Côte d’Ivoire" "Ivory Coast" "Côte d'Ivoire" "Cote d'Ivoire")
+    query: ("Ivory Coast" "Cote d\'Ivoire" "Côte d’Ivoire" "Côte d\'Ivoire" "C<U+00F4>te d<U+2019>Ivoire" "CÃ´te D\'Ivoire")
   - country: Jamaica
     query: ("Jamaica")
   - country: Japan


### PR DESCRIPTION
Add an export of the queries used per country to get media mentions from Guardian API.

Motivation is to be more transparent with the end user.

/schedule