### PR TITLE
📊 update h5n1 data

### DIFF
--- a/snapshots/who/latest/avian_influenza_ah5n1.csv.dvc
+++ b/snapshots/who/latest/avian_influenza_ah5n1.csv.dvc
@@ -12,12 +12,12 @@ meta:
       Human Cases with Highly Pathogenic Avian Influenza A/H5N1. World Health Organization, Global Influenza Programme; 2024. Licence: CC BY-NC-SA 3.0 IGO. Retrieved from CDC May 23, 2024.
     attribution_short: WHO
     url_main: https://www.cdc.gov/bird-flu/php/avian-flu-summary/chart-epi-curve-ah5n1.html
-    date_accessed: 2025-05-26
-    date_published: "2025-05-22"
+    date_accessed: 2025-10-10
+    date_published: "2025-09-22"
     license:
       name: CC BY-NC-SA 3.0 IGO
       url: https://www.who.int/about/policies/publishing/copyright
 outs:
-  - md5: 8af1225d4c3c7adc5787e2f4c2eb6620
-    size: 26159
+  - md5: 47516765af68e704d1e61b46e15cb229
+    size: 26299
     path: avian_influenza_ah5n1.csv

--- a/snapshots/who/latest/avian_influenza_ah5n1.py
+++ b/snapshots/who/latest/avian_influenza_ah5n1.py
@@ -4,6 +4,8 @@ CDC provides this same data but in a machine-readable format. To download it:
 
 - Go to https://www.cdc.gov/bird-flu/php/avian-flu-summary/chart-epi-curve-ah5n1.html
 - Under the main chart, click on "Download data (CSV)".
+- Update `date_published` field in the DVC file
+- Run snapshot `etls latest/avian_influenza_ah5n1` and then `etlr latest/avian_influenza_ah5n1`
 
 To get the publication date, look at the top right part of the site.
 


### PR DESCRIPTION
- Update H5N1 data with data up to September (previously only until July)
- Fix "date of retrieve" shown on data page.  Currently shows May 26th, which was wrong.

Fixes https://github.com/owid/owid-issues/issues/2143
/schedule