### PR TITLE
Fix typo: 'isolation' → 'insulation' in housing metadata

### DIFF
--- a/etl/steps/data/garden/housing/2025-07-11/korevaar.meta.yml
+++ b/etl/steps/data/garden/housing/2025-07-11/korevaar.meta.yml
@@ -106,8 +106,8 @@ tables:
         unit: "%"
         short_unit: "%"
       isolation_pct:
-        title: Percentage of households with isolation
-        description_short: Percentage of households that have isolation. {{ definitions.notes.historic_records }}
+        title: Percentage of households with insulation
+        description_short: Percentage of households that have insulation. {{ definitions.notes.historic_records }}
         unit: "%"
         short_unit: "%"
       gas_pct:


### PR DESCRIPTION
## Summary
- Fixed typo in Korevaar housing dataset metadata
- Changed `isolation_pct` variable description from "isolation" to "insulation" 
- This refers to building insulation, not isolation

## Changes
- Updated title and description_short for `isolation_pct` variable in `korevaar.meta.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)