### PR TITLE
📊 Fix circular related dependency in regions

### DIFF
--- a/etl/steps/data/garden/regions/2023-01-01/regions.yml
+++ b/etl/steps/data/garden/regions/2023-01-01/regions.yml
@@ -934,8 +934,6 @@
   aliases:
     - "Svalbard & Jan Mayen Isl."
     - "Svalbard and Jan Mayen Islands"
-  related:
-    - "NOR"
 - code: "OWID_TRS"
   name: "Transnistria"
   region_type: "other"


### PR DESCRIPTION
@lucasrodes this is a minor suggested change, given that you are editing regions now. There is this circular dependency between Norway and Svalbard and Jan Mayen in therms of their "relatedness".

For more context, we use this field mostly to identify overseas territories. By convention, we declare this relatedness only in one direction, e.g. France is related to French Guiana (but French Guiana is not related to France).
I don't think anyone is using the "related" field in ETL steps, but I think it's useful sometimes for offline analyses.