### PR TITLE
Add PyPI publishing workflow for owid-datautils

### DIFF
--- a/.github/workflows/publish-owid-datautils.yml
+++ b/.github/workflows/publish-owid-datautils.yml
@@ -1,0 +1,58 @@
+name: Publish owid-datautils
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'lib/datautils/pyproject.toml'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Publish owid-datautils to PyPI. Make sure you have bumped the version in datautils/pyproject.toml.'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 2  # Need previous commit to detect version changes
+
+    - name: Check if version was bumped
+      run: |
+        # Get the version line from current and previous commit
+        CURRENT_VERSION=$(grep '^version = ' lib/datautils/pyproject.toml | head -1)
+        PREVIOUS_VERSION=$(git show HEAD~1:lib/datautils/pyproject.toml | grep '^version = ' | head -1)
+
+        echo "Current version: $CURRENT_VERSION"
+        echo "Previous version: $PREVIOUS_VERSION"
+
+        if [ "$CURRENT_VERSION" = "$PREVIOUS_VERSION" ]; then
+          echo "❌ Version was not bumped in lib/datautils/pyproject.toml"
+          echo "Please increment the version before publishing."
+          exit 1
+        fi
+
+        echo "✅ Version was bumped, proceeding with publish"
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install UV
+      run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    - name: Publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
+
+      run: |
+        cd lib/datautils &&
+        rm -rf dist &&
+        uv build &&
+        uvx twine upload dist/*

--- a/lib/catalog/.flake8
+++ b/lib/catalog/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-# Ignore some errors, since we autoformat them away already wherever possible
-# from https://github.com/psf/black/blob/main/.flake8
-ignore = E203, E266, E501, W503

--- a/lib/datautils/.flake8
+++ b/lib/datautils/.flake8
@@ -1,7 +1,0 @@
-[flake8]
-# Ignore some errors, since we autoformat them away already wherever possible
-# from https://github.com/psf/black/blob/main/.flake8
-# ignore = E203, E266, E501, W503
-# should align black and flake8 'rules'
-ignore = D107, W503, E203, B028, S202
-max-line-length = 120

--- a/lib/datautils/README.md
+++ b/lib/datautils/README.md
@@ -9,10 +9,14 @@
 
 ## Install
 
-Currently no release has been published. You can install the version under development directly from GitHub:
+```
+pip install owid-datautils
+```
+
+Or install the latest development version directly from GitHub:
 
 ```
-pip install git+https://github.com/owid/owid-datautils-py
+pip install git+https://github.com/owid/etl.git#subdirectory=lib/datautils
 ```
 
 ## Development
@@ -38,36 +42,39 @@ make test
 
 ### Other useful commands
 
-#### Report
+#### Code Quality
 
 ```
-make report
+make check
 ```
 
-Generate coverage and linting reportings. It is equivalent to running first `make report-coverage` and then
-`make report-linting`. It also launches a local server so you can access the reports via localhost:8000 URL.
-
-The generated reports are saved as `./reports/coverage` and `./reports/linting` (both HTML directories).
-
-##### Coverage
+Format, lint, and typecheck changed files from master branch using `ruff` and `pyright`.
 
 ```
-make report-coverage
+make format
 ```
 
-This will print how much of the source code is covered by the implemented tests. Additionally, it generates an HTML
-directory (`.reports/coverage`), which provides a frendly view of the source code coverage.
-
-##### Linting
+Format code using `ruff`.
 
 ```
-make report-linting
+make lint
 ```
 
-Check if the source code passes all flake8 styling tests. Additionally, it generages an HTML directory
-(`.reports/linting`), which provides a friendly view of the style issues (if any).
+Lint code using `ruff`.
 
-Flake8 configuration can be tweaked in [.flake8](.flake8) file.
+```
+make check-typing
+```
+
+Run type checking using `pyright`.
+
+#### Coverage
+
+```
+make coverage
+```
+
+Run unit tests with coverage reporting.
 
 #### Versioning
 

--- a/lib/datautils/pyproject.toml
+++ b/lib/datautils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-datautils"
-version = "0.6.0"
+version = "0.6.1"
 description = "Data utils library by the Data Team at Our World in Data"
 authors = [
     {name = "Our World in Data", email = "tech@ourworldindata.org"},

--- a/lib/repack/.flake8
+++ b/lib/repack/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-# Ignore some errors, since we autoformat them away already wherever possible
-# from https://github.com/psf/black/blob/main/.flake8
-ignore = E203, E266, E501, W503


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automatically publish `owid-datautils` to PyPI when version is bumped in `pyproject.toml`
- Updates README to reflect current tooling (ruff/pyright instead of flake8)
- Removes obsolete `.flake8` config files from all lib/ packages
- Bumps owid-datautils version to 0.6.1

## Test plan
- [ ] Verify workflow triggers on version bump in `lib/datautils/pyproject.toml`
- [ ] Test manual workflow dispatch via GitHub Actions UI
- [ ] Confirm README accurately reflects current development commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)