### PR TITLE
📊 Convert slash commands to on-demand skills

### DIFF
--- a/.claude/skills/check-metadata-typos/SKILL.md
+++ b/.claude/skills/check-metadata-typos/SKILL.md
@@ -1,17 +1,20 @@
 ---
-description: Check .meta.yml and snapshot .dvc files for spelling typos using codespell
+name: check-metadata-typos
+description: Check .meta.yml and snapshot .dvc files for spelling typos using codespell. Use when user mentions typos, spelling errors, metadata quality, or wants to check metadata files for mistakes.
 ---
+
+# Check Metadata Typos
 
 Check metadata files for spelling typos using comprehensive spell checking.
 
-**First, ask the user which scope they want to check:**
+## Scope Options
+
+Ask the user which scope they want to check:
 
 1. **Current step only** - Ask the user to specify the step path (e.g., `etl/steps/data/garden/energy/2025-06-27/electricity_mix`)
 2. **All ETL metadata** - Check all active `.meta.yml` files in `etl/steps/data/{garden,meadow,grapher}/` (automatically excludes ~3,570 archived steps)
 3. **Snapshot metadata** - Check all snapshot `.dvc` files in `snapshots/` (~7,915 files)
 4. **All metadata** - Check both ETL steps and snapshot metadata files
-
-Once the user specifies the scope, proceed with the typo check using the codespell-based approach.
 
 **Note:** Archived steps and snapshots (defined in `dag/archive/*.yml`) are automatically excluded from checking as they are no longer actively maintained.
 

--- a/.claude/skills/update-dataset/SKILL.md
+++ b/.claude/skills/update-dataset/SKILL.md
@@ -1,22 +1,16 @@
 ---
-argument-hint: <namespace>/<old_version>/<name> [branch]
-description: End-to-end dataset update workflow using project subagents with progress tracking and a mandatory checkpoint after every step. New version is set to today's date automatically.
+name: update-dataset
+description: End-to-end dataset update workflow with PR creation, snapshot, meadow, garden, and grapher steps. Use when user wants to update a dataset, refresh data, run ETL update, or mentions updating dataset versions.
 ---
 
-# Update dataset (PR → snapshot → steps → grapher)
+# Update Dataset (PR → snapshot → steps → grapher)
 
-Use this command to run a complete dataset update with Claude Code subagents, keep a live progress checklist, and pause for approval at a checkpoint **after every numbered workflow step** before continuing.
-
-## Context probes
-
-- Current branch: !`git branch --show-current`
+Use this skill to run a complete dataset update with Claude Code subagents, keep a live progress checklist, and pause for approval at a checkpoint **after every numbered workflow step** before continuing.
 
 ## Inputs
 
 - `<namespace>/<old_version>/<name>`
 - Get `<new_version>` as today's date by running `date -u +"%Y-%m-%d"`
-
-
 
 Optional trailing args:
 - branch: The working branch name (defaults to current branch)
@@ -98,7 +92,7 @@ You MUST:
 
 ## Guardrails and tips
 
-- ⚠️ Never return empty tables or comment out logic as a workaround — fix the parsing/transformations instead.
+- Never return empty tables or comment out logic as a workaround — fix the parsing/transformations instead.
 - Column name changes: update garden processing code and metadata YAMLs (garden/grapher) to match schema changes.
 - Indexing: avoid leaking index columns from `reset_index()`; format tables with `tb.format(["country", "year"])` as appropriate.
 - Metadata validation errors are guidance — update YAML to add/remove variables as indicated.
@@ -114,13 +108,13 @@ You MUST:
 ## Example usage
 
 - Minimal catalog URI with explicit old version:
-  - `/update-dataset data://snapshot/irena/2024-11-15/renewable_power_generation_costs 2023-11-15 update-irena-costs`
+  - `update-dataset data://snapshot/irena/2024-11-15/renewable_power_generation_costs 2023-11-15 update-irena-costs`
 
 ---
 
 ### Common issues when data structure changes
 
-- ⚠️ SILENT FAILURES WARNING: Never return empty tables or comment code as workarounds!
+- SILENT FAILURES WARNING: Never return empty tables or comment code as workarounds!
 - Column name changes: If columns are renamed/split (e.g., single cost → local currency + PPP), update:
   - Python code references in the garden step
   - Garden metadata YAML (e.g., `food_prices_for_nutrition.meta.yml`)


### PR DESCRIPTION
## Summary

- Convert `check-metadata-typos.md` (~8KB) and `update-dataset.md` (~6KB) from slash commands to on-demand skills
- Skills are loaded only when Claude detects they're relevant to the conversation, not at session start
- Saves ~3-4k tokens from initial context

## Changes

| Before | After |
|--------|-------|
| `.claude/commands/check-metadata-typos.md` | `.claude/skills/check-metadata-typos/SKILL.md` |
| `.claude/commands/update-dataset.md` | `.claude/skills/update-dataset/SKILL.md` |

## How it works

Skills are automatically invoked when conversation mentions:
- "typos", "spelling", "metadata quality" → `check-metadata-typos`
- "update dataset", "refresh data", "ETL update" → `update-dataset`

## Test plan

- [ ] Start new Claude Code session and verify reduced initial context
- [ ] Mention "check for typos" and verify skill is invoked
- [ ] Mention "update dataset" and verify skill is invoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)