### PR TITLE
🎉 Show article citations in chart diff wizard

### DIFF
--- a/apps/wizard/app_pages/chart_diff/app.py
+++ b/apps/wizard/app_pages/chart_diff/app.py
@@ -488,6 +488,12 @@ def _show_options_display():
             key="arrange-charts-vertically",
             on_change=arrange_charts,  # type: ignore
         )
+        st.toggle(
+            "Show **article citations**",
+            key="show-article-citations",
+            value=True,
+            help="Show which articles cite each chart with links to the citation location.",
+        )
 
 
 def _show_options_misc():

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -644,6 +644,8 @@ class ChartDiffShow:
 
     def _show_citations(self) -> None:
         """Show articles that cite this chart with scroll-to-text fragment URLs."""
+        if not st.session_state.get("show-article-citations", True):
+            return
         st_show_citations(
             self.diff.slug,
             self.source_session,

--- a/apps/wizard/app_pages/chart_diff/citations.py
+++ b/apps/wizard/app_pages/chart_diff/citations.py
@@ -596,12 +596,12 @@ def st_show_citations(
         staging_url = _replace_entity_placeholders(citation.staging_url) if citation.staging_url else None
 
         if prod_url:
-            prod_cell = f"![thumb]({prod_thumb}) [View]({prod_url})"
+            prod_cell = f"[![thumb]({prod_thumb})]({prod_url})"
         else:
             prod_cell = "-"
 
         if staging_url:
-            staging_cell = f"![thumb]({staging_thumb}) [View]({staging_url})"
+            staging_cell = f"[![thumb]({staging_thumb})]({staging_url})"
         else:
             staging_cell = "-"
 


### PR DESCRIPTION
Check out the [chart-diff demo](http://staging-site-feature-article-citations-ch/etl/wizard/chart-diff).

<img width="1569" height="658" alt="image" src="https://github.com/user-attachments/assets/e0786605-a934-4944-8b2c-0459bcaebcf7" />


## Summary

Adds a new "Article Citations" section to the chart diff page that shows which articles reference the chart, either as embedded charts or hyperlinks.

**Features:**
- Unified table comparing production and staging citations side-by-side
- Thumbnail images showing the exact chart configuration used in each citation
- Scroll-to-text fragment URLs for navigating directly to the citation location in articles
- Link text highlighted in bold within the context snippet

Closes #4150

## Test plan

- [ ] Run the wizard locally with `etlwiz`
- [x] Navigate to Chart Diff page
- [x] Find a chart that has article citations (e.g., `annual-co2-emissions-per-country`)
- [x] Verify citations section appears below narrative charts
- [x] Verify thumbnails show correct chart configurations
- [x] Verify "View" links navigate to the correct article location
- [ ] Verify both production and staging columns show appropriate links

🤖 Generated with [Claude Code](https://claude.ai/code)