### PR TITLE
✨ rename columns of lightweight population and gdp per capita data

### DIFF
--- a/etl/steps/data/external/owid_grapher/latest/gdp.py
+++ b/etl/steps/data/external/owid_grapher/latest/gdp.py
@@ -19,8 +19,11 @@ def run() -> None:
     idx_latest = tb_gdp.groupby("country")["year"].idxmax()
     tb = tb_gdp.loc[idx_latest, ["country", "year", "gdp_per_capita"]]
 
+    # Rename columns
+    tb = tb.rename(columns={"country": "entityName", "gdp_per_capita": "value"})
+
     # Set index and name
-    tb = tb.set_index(["country", "year"], verify_integrity=True)
+    tb = tb.set_index(["entityName", "year"], verify_integrity=True)
     tb.metadata.short_name = "gdp"
 
     # Save as CSV

--- a/etl/steps/data/external/owid_grapher/latest/population.py
+++ b/etl/steps/data/external/owid_grapher/latest/population.py
@@ -17,10 +17,12 @@ def run() -> None:
     # Get latest year per country for population
     idx_latest = tb_pop.groupby("country")["year"].idxmax()
     tb = tb_pop.loc[idx_latest, ["country", "year", "population_historical"]]
-    tb = tb.rename(columns={"population_historical": "population"})
+
+    # Rename columns
+    tb = tb.rename(columns={"country": "entityName", "population_historical": "value"})
 
     # Set index and name
-    tb = tb.set_index(["country", "year"], verify_integrity=True)
+    tb = tb.set_index(["entityName", "year"], verify_integrity=True)
     tb.metadata.short_name = "population"
 
     # Save as CSV


### PR DESCRIPTION
Renames:
- `country` -> `entityName` (country name is a bit of a misnomer because the data might include regions)
- `population`/`gdp_per_capita` -> `value` (makes it easier to parse if the column names are all fixed)