### PR TITLE
✨ rename entityName to entity for grapher lightweight data

### DIFF
--- a/etl/steps/data/external/owid_grapher/latest/gdp.py
+++ b/etl/steps/data/external/owid_grapher/latest/gdp.py
@@ -20,10 +20,10 @@ def run() -> None:
     tb = tb_gdp.loc[idx_latest, ["country", "year", "gdp_per_capita"]]
 
     # Rename columns
-    tb = tb.rename(columns={"country": "entityName", "gdp_per_capita": "value"})
+    tb = tb.rename(columns={"country": "entity", "gdp_per_capita": "value"})
 
     # Set index and name
-    tb = tb.set_index(["entityName", "year"], verify_integrity=True)
+    tb = tb.set_index(["entity", "year"], verify_integrity=True)
     tb.metadata.short_name = "gdp"
 
     # Save as CSV

--- a/etl/steps/data/external/owid_grapher/latest/population.py
+++ b/etl/steps/data/external/owid_grapher/latest/population.py
@@ -19,10 +19,10 @@ def run() -> None:
     tb = tb_pop.loc[idx_latest, ["country", "year", "population_historical"]]
 
     # Rename columns
-    tb = tb.rename(columns={"country": "entityName", "population_historical": "value"})
+    tb = tb.rename(columns={"country": "entity", "population_historical": "value"})
 
     # Set index and name
-    tb = tb.set_index(["entityName", "year"], verify_integrity=True)
+    tb = tb.set_index(["entity", "year"], verify_integrity=True)
     tb.metadata.short_name = "population"
 
     # Save as CSV


### PR DESCRIPTION
I noticed `entityName` is transformed into `entityname` in the downstream data files ([example](https://catalog.ourworldindata.org/external/owid_grapher/latest/population/population.json)). I prefer just `entity` in that case