### PR TITLE
📊 Switch GDP step to World Bank WDI

### DIFF
--- a/dag/main.yml
+++ b/dag/main.yml
@@ -13,7 +13,7 @@ steps:
   data://external/owid_grapher/latest/population:
     - data://grapher/demography/2024-07-15/population
   data://external/owid_grapher/latest/gdp:
-    - data://grapher/ggdc/2024-04-26/maddison_project_database
+    - data://grapher/worldbank_wdi/2025-09-08/wdi
   # Create a step with a simplified countries-regions file used by the notebooks repository.
   data://external/notebooks/latest/regions:
     - data://grapher/regions/2023-01-01/regions

--- a/etl/steps/data/external/owid_grapher/latest/gdp.py
+++ b/etl/steps/data/external/owid_grapher/latest/gdp.py
@@ -10,17 +10,20 @@ paths = PathFinder(__file__)
 
 
 def run() -> None:
-    # Load GDP per capita dataset from grapher
-    ds_gdp = paths.load_dataset("maddison_project_database")
-    tb_gdp = ds_gdp["maddison_project_database"].reset_index()
+    # Load GDP per capita (PPP, constant 2021 $) from World Bank WDI
+    ds_gdp = paths.load_dataset("wdi")
+    tb_gdp = ds_gdp["wdi"].reset_index()
 
     # Get latest year per country for GDP
-    tb_gdp = tb_gdp[tb_gdp["gdp_per_capita"].notna()]
+    tb_gdp = tb_gdp[tb_gdp["ny_gdp_pcap_pp_kd"].notna()]
     idx_latest = tb_gdp.groupby("country")["year"].idxmax()
-    tb = tb_gdp.loc[idx_latest, ["country", "year", "gdp_per_capita"]]
+    tb = tb_gdp.loc[idx_latest, ["country", "year", "ny_gdp_pcap_pp_kd"]]
+
+    # Round values (no decimals needed)
+    tb["ny_gdp_pcap_pp_kd"] = tb["ny_gdp_pcap_pp_kd"].round(0).astype(int)
 
     # Rename columns
-    tb = tb.rename(columns={"country": "entity", "gdp_per_capita": "value"})
+    tb = tb.rename(columns={"country": "entity", "ny_gdp_pcap_pp_kd": "value"})
 
     # Set index and name
     tb = tb.set_index(["entity", "year"], verify_integrity=True)


### PR DESCRIPTION
## Summary

- Switch GDP per capita data source from Maddison Project Database to World Bank WDI (`ny_gdp_pcap_pp_kd` - GDP per capita, PPP, constant 2021 international $)
- Round values to integers (no decimal places needed for display purposes)
- WDI has more recent data (up to 2024) compared to Maddison

🤖 Generated with [Claude Code](https://claude.ai/code)