### PR TITLE
🐛 Fix hardcoded table_schema so it works on local grapher and staging

### DIFF
--- a/apps/wizard/utils/db.py
+++ b/apps/wizard/utils/db.py
@@ -240,7 +240,7 @@ class WizardDB:
         query = """
         SELECT *
         FROM information_schema.tables
-        WHERE table_schema = 'owid';
+        WHERE table_schema = DATABASE();
         """
         df = read_sql(query)
         return tb_name in set(df["TABLE_NAME"])


### PR DESCRIPTION
I was trying to run indicator upgrader using local grapher, and it failed because of a hardcoded `table_schema`:
```
[error    ] No variable mappings found in database. Cannot proceed.
[error    ] Use the Streamlit UI to create a variable mapping first, or manually add one to the database.
```

I see in `etl.config` that we sometimes use `owid` and sometimes `grapher`. I don't understand why there's this distinction, but this PR should ensure we pick the right one regardless of the environment (using the same method that I saw owid-grapher using [here](https://github.com/owid/owid-grapher/blob/36a2c6112c3d5bafb9c57dd5a91df9703d3a297e/devTools/db-ai-helpers/addIncomingForeignKeys.ts#L38)).
