### PR TITLE
fix typo in GWP metadata

### DIFF
--- a/etl/steps/data/garden/emissions/2023-11-06/global_warming_potential_factors.meta.yml
+++ b/etl/steps/data/garden/emissions/2023-11-06/global_warming_potential_factors.meta.yml
@@ -27,7 +27,7 @@ tables:
         description_short: "[Global warming potential](#dod:gwp) measures the relative warming impact of one unit mass of a greenhouse gas relative to carbon dioxide."
         description_key:
         - Global warming potential (GWP) values are used to convert greenhouse gases into a carbon dioxide equivalent metric by multiplying emissions in mass terms by their respective GWP factors.
-        - For example, a GWP value of 25 for a certain gas means that one tonne of that ags has 25 times the warming impact of one tonne of carbon dioxide.
+        - For example, a GWP value of 25 for a certain gas means that one tonne of that gas has 25 times the warming impact of one tonne of carbon dioxide.
         processing_level: minor
         display:
           numDecimalPlaces: 1


### PR DESCRIPTION
fixing a typo in http://staging-site-gwp-typo/grapher/global-warming-potential-of-greenhouse-gases-over-100-year-timescale-gwp