### PR TITLE
📊 energy: Remove unnecessary fix in electricity mix

### DIFF
--- a/etl/steps/data/garden/energy/2026-01-26/electricity_mix.py
+++ b/etl/steps/data/garden/energy/2026-01-26/electricity_mix.py
@@ -435,7 +435,7 @@ def add_share_variables(combined: Table) -> Table:
 
 
 def fix_discrepancies_in_aggregate_regions(tb_review: Table, tb_ember: Table, combined: Table) -> Table:
-    # Firstly, remove "Other * (EI)" regions. They come from the Statistical Review, to include data that is not accounted for in any country. They needed to be included to able to create region aggregates. But Ember doesn't have these regions. If we keep them, they lead to inconsistencies, e.g. electricity shares larger than 100%.
+    # Firstly, remove "Other * (EI)" regions. They come from the Statistical Review, to include data that is not accounted for in any country. They needed to be included to be able to create region aggregates. But Ember doesn't have these regions. If we keep them, they lead to inconsistencies, e.g. electricity shares larger than 100%.
     combined = combined[~combined["country"].str.contains(r"Other.*\(EI\)", regex=True)].reset_index(drop=True)
 
     # Define the maximum median relative error between Statistical Review and Ember (for a given region and indicator).


### PR DESCRIPTION
In the electricity mix step, there used to be a fix that removed the latest data point of region aggregates, because of their limited data coverage. Now that we properly impose a minimum of 80% coverage in all aggregates consistently, that fix is not necessary. This PR removes it. The impact is minimal (I've detected that the EU didn't have data for 2025, and now it does).
