### PR TITLE
📊 fix: PREFER_DOWNLOAD for private datasets uses private bucket

### DIFF
--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -699,8 +699,11 @@ class DataStep(Step):
 
         r2 = s3_utils.connect_r2_cached()
 
+        # Private datasets have their data files in a separate private bucket
+        bucket = config.R2_BUCKET if self.is_public else config.R2_BUCKET_PRIVATE
+
         # Get available formats of a dataset
-        s3_files = s3_utils.list_s3_objects(f"s3://owid-catalog/{self.path}/", client=s3_utils.connect_r2_cached())
+        s3_files = s3_utils.list_s3_objects(f"s3://{bucket}/{self.path}/", client=s3_utils.connect_r2_cached())
         available_formats = {f.split(".")[-1] for f in s3_files} - {"json"}
 
         # if one of the format is in DEFAULT_FORMATS, download it
@@ -714,7 +717,7 @@ class DataStep(Step):
         include = [".meta.json"] + [f".{format}" for format in download_formats]
 
         s3_utils.download_s3_folder(
-            f"s3://owid-catalog/{self.path}/",
+            f"s3://{bucket}/{self.path}/",
             self._dest_dir,
             client=r2,
             include=include,


### PR DESCRIPTION
## What does this PR do?

Since [PR #5603](https://github.com/owid/etl/pull/5603) moved private dataset data files to a separate `owid-catalog-private` R2 bucket, the `PREFER_DOWNLOAD` feature was broken for private datasets.

`_download_dataset_from_catalog` was hardcoding `s3://owid-catalog/` for all datasets. Private data files are no longer there — only metadata (`.meta.json`, `index.json`) stays in the public bucket. So `PREFER_DOWNLOAD` on a private step would "succeed" (download the index) but leave the dataset empty with no tables.

## Fix

Use `config.R2_BUCKET_PRIVATE` (`owid-catalog-private`) when `self.is_public` is `False`, and `config.R2_BUCKET` (`owid-catalog`) for public datasets.

## Testing

Verified with `garden/ihme_gbd/2024-05-20/gbd_risk` (a 162MB non-redistributable private dataset):

```bash
PREFER_DOWNLOAD=1 etlr garden/ihme_gbd/2024-05-20/gbd_risk --private --only --force
# → Downloaded garden/ihme_gbd/2024-05-20/gbd_risk from catalog ✓
# → gbd_risk.feather (162MB) present locally ✓
```