### PR TITLE
🔨 (etl) replace hideLegend with hideSeriesLabels

### DIFF
--- a/.claude/skills/chart-editing/SKILL.md
+++ b/.claude/skills/chart-editing/SKILL.md
@@ -39,7 +39,7 @@ map:
       Banned: '#4881c6'
       No laws: '#b6a28c'
     customNumericColorsActive: true
-$schema: https://files.ourworldindata.org/schemas/grapher-schema.009.json
+$schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 originUrl: /animal-welfare
 dimensions:
   - property: y

--- a/apps/wizard/utils/chart_config.py
+++ b/apps/wizard/utils/chart_config.py
@@ -29,7 +29,7 @@ CONFIG_BASE = {
     },
     "hideTotalValueLabel": False,
     "hideTimeline": False,
-    "hideLegend": False,
+    "hideSeriesLabels": False,
     "tab": "chart",
     "logo": "owid",
     "$schema": DEFAULT_GRAPHER_SCHEMA,

--- a/etl/collection/model/schema_types.py
+++ b/etl/collection/model/schema_types.py
@@ -269,7 +269,7 @@ class _ViewConfigBase(TypedDict, total=False):
     hideAnnotationFieldsInTitle: HideAnnotationFieldsInTitleConfig
     hideConnectedScatterLines: bool
     hideFacetControl: bool
-    hideLegend: bool
+    hideSeriesLabels: bool
     hideLogo: bool
     hideRelativeToggle: bool
     hideScatterLabels: bool

--- a/etl/config.py
+++ b/etl/config.py
@@ -293,7 +293,7 @@ GITHUB_API_URL = f"{GITHUB_API_BASE}/pulls"
 TLS_VERIFY = bool(int(env.get("TLS_VERIFY", 1)))
 
 # Default schema for presentation.grapher_config in metadata. Try to keep it up to date with the latest schema.
-DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schema.009.json"
+DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
 
 # Google Cloud service account path (used for BigQuery)
 GOOGLE_APPLICATION_CREDENTIALS = env.get("GOOGLE_APPLICATION_CREDENTIALS")

--- a/etl/files.py
+++ b/etl/files.py
@@ -413,7 +413,7 @@ def read_json_schema(path: Union[Path, str]) -> Dict[str, Any]:
 def get_schema_from_url(schema_url: str) -> dict:
     """Get the schema of a chart configuration. Schema URL is saved in config["$schema"] and looks like:
 
-    https://files.ourworldindata.org/schemas/grapher-schema.009.json
+    https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
     More details on available versions can be found
     at https://github.com/owid/owid-grapher/tree/master/packages/%40ourworldindata/grapher/src/schema

--- a/etl/steps/data/garden/growth/2024-01-04/gdp_historical.meta.yml
+++ b/etl/steps/data/garden/growth/2024-01-04/gdp_historical.meta.yml
@@ -75,7 +75,7 @@ tables:
             selectedEntityNames:
               - World
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices.
-            hideLegend: true
+            hideSeriesLabels: true
       gdp_per_capita:
         title: GDP per capita
         unit: international-$ in 2017 prices
@@ -124,5 +124,5 @@ tables:
             selectedEntityNames:
               - World
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices.
-            hideLegend: true
+            hideSeriesLabels: true
 

--- a/etl/steps/data/garden/growth/2024-04-29/gdp_historical.meta.yml
+++ b/etl/steps/data/garden/growth/2024-04-29/gdp_historical.meta.yml
@@ -65,7 +65,7 @@ tables:
             selectedEntityNames:
               - World
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2011 prices.
-            hideLegend: true
+            hideSeriesLabels: true
 
       gdp_per_capita:
         title: GDP per capita
@@ -101,5 +101,5 @@ tables:
             selectedEntityNames:
               - World
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2011 prices.
-            hideLegend: true
+            hideSeriesLabels: true
 

--- a/etl/steps/data/garden/growth/2024-05-16/gdp_historical.meta.yml
+++ b/etl/steps/data/garden/growth/2024-05-16/gdp_historical.meta.yml
@@ -73,7 +73,7 @@ tables:
             selectedEntityNames:
               - World
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices.
-            hideLegend: true
+            hideSeriesLabels: true
 
       gdp_per_capita:
         title: GDP per capita
@@ -108,5 +108,5 @@ tables:
             selectedEntityNames:
               - World
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices.
-            hideLegend: true
+            hideSeriesLabels: true
 

--- a/etl/steps/data/grapher/wb/2017-04-16/world_gdp.meta.yml
+++ b/etl/steps/data/grapher/wb/2017-04-16/world_gdp.meta.yml
@@ -54,4 +54,4 @@ tables:
             selectedEntityNames:
               - World
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2011 prices.
-            hideLegend: true
+            hideSeriesLabels: true

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -1324,9 +1324,9 @@
                           },
                           "additionalProperties": false
                         },
-                        "hideLegend": {
+                        "hideSeriesLabels": {
                           "type": "boolean",
-                          "description": "Hide legend in chart.",
+                          "description": "Hide series labels in chart.",
                           "default": false
                         },
                         "hideLogo": {

--- a/schemas/explorer-schema.json
+++ b/schemas/explorer-schema.json
@@ -238,19 +238,19 @@
                         "description": "A subset of the grapher config.",
                         "properties": {
                             "$schema": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/$schema"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/$schema"
                             },
                             "addCountryMode": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/addCountryMode"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/addCountryMode"
                             },
                             "compareEndPointsOnly": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/compareEndPointsOnly"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/compareEndPointsOnly"
                             },
                             "selectedEntityColors": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/selectedEntityColors"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/selectedEntityColors"
                             },
                             "relatedQuestions": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/relatedQuestions"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/relatedQuestions"
                             },
                             "relatedQuestionText": {
                                 "type": "string",
@@ -261,155 +261,152 @@
                                 "description": "URL for a related question link"
                             },
                             "title": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/title"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/title"
                             },
                             "map": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/map"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/map"
                             },
                             "maxTime": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/maxTime"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/maxTime"
                             },
                             "subtitle": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/subtitle"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/subtitle"
                             },
                             "selectedEntityNames": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/selectedEntityNames"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/selectedEntityNames"
                             },
                             "focusedSeriesNames": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/focusedSeriesNames"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/focusedSeriesNames"
                             },
                             "baseColorScheme": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/baseColorScheme"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/baseColorScheme"
                             },
                             "yAxis": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/yAxis"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/yAxis"
                             },
                             "tab": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/tab"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/tab"
                             },
                             "matchingEntitiesOnly": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/matchingEntitiesOnly"
-                            },
-                            "hideLegend": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideLegend"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/matchingEntitiesOnly"
                             },
                             "hideLogo": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideLogo"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideLogo"
                             },
                             "timelineMinTime": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/timelineMinTime"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/timelineMinTime"
                             },
                             "variantName": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/variantName"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/variantName"
                             },
                             "hideTimeline": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideTimeline"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideTimeline"
                             },
                             "originUrl": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/originUrl"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/originUrl"
                             },
                             "colorScale": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/colorScale"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/colorScale"
                             },
                             "scatterPointLabelStrategy": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/scatterPointLabelStrategy"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/scatterPointLabelStrategy"
                             },
                             "selectedFacetStrategy": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/selectedFacetStrategy"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/selectedFacetStrategy"
                             },
                             "sourceDesc": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/sourceDesc"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/sourceDesc"
                             },
                             "invertColorScheme": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/invertColorScheme"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/invertColorScheme"
                             },
                             "hideRelativeToggle": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideRelativeToggle"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideRelativeToggle"
                             },
                             "comparisonLines": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/comparisonLines"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/comparisonLines"
                             },
                             "internalNotes": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/internalNotes"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/internalNotes"
                             },
                             "version": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/version"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/version"
                             },
                             "logo": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/logo"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/logo"
                             },
                             "entityType": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/entityType"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/entityType"
                             },
                             "facettingLabelByYVariables": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/facettingLabelByYVariables"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/facettingLabelByYVariables"
                             },
                             "note": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/note"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/note"
                             },
                             "chartTypes": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/chartTypes"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/chartTypes"
                             },
                             "hasMapTab": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hasMapTab"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hasMapTab"
                             },
                             "stackMode": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/stackMode"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/stackMode"
                             },
                             "minTime": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/minTime"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/minTime"
                             },
                             "hideAnnotationFieldsInTitle": {
                                 "type": "boolean",
                                 "description": "Whether to hide annotation fields in the title"
                             },
                             "excludedEntityNames": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/excludedEntityNames"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/excludedEntityNames"
                             },
                             "xAxis": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/xAxis"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/xAxis"
                             },
                             "timelineMaxTime": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/timelineMaxTime"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/timelineMaxTime"
                             },
                             "hideConnectedScatterLines": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideConnectedScatterLines"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideConnectedScatterLines"
                             },
                             "showNoDataArea": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/showNoDataArea"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/showNoDataArea"
                             },
                             "zoomToSelection": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/zoomToSelection"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/zoomToSelection"
                             },
                             "showYearLabels": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/showYearLabels"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/showYearLabels"
                             },
                             "hideTotalValueLabel": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideTotalValueLabel"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideTotalValueLabel"
                             },
                             "hideScatterLabels": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideScatterLabels"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideScatterLabels"
                             },
                             "sortBy": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/sortBy"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/sortBy"
                             },
                             "sortOrder": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/sortOrder"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/sortOrder"
                             },
                             "sortColumnSlug": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/sortColumnSlug"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/sortColumnSlug"
                             },
                             "hideFacetControl": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideFacetControl"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideFacetControl"
                             },
                             "includedEntityNames": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/includedEntityNames"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/includedEntityNames"
                             },
                             "entityTypePlural": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/entityTypePlural"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/entityTypePlural"
                             },
                             "missingDataStrategy": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/missingDataStrategy"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/missingDataStrategy"
                             },
                             "yScaleToggle": {
                                 "type": "boolean",

--- a/schemas/multidim-schema.json
+++ b/schemas/multidim-schema.json
@@ -67,12 +67,12 @@
                 ]
             ],
             "examples": [
-                "https://files.ourworldindata.org/schemas/grapher-schema.009.json"
+                "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
             ],
             "examples_bad": [
                 [
                     "http://invalid-url.com/schema.json",
-                    "grapher-schema.009.json"
+                    "grapher-schema.010.json"
                 ]
             ]
         },
@@ -710,169 +710,169 @@
                         ],
                         "properties": {
                             "$schema": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/$schema"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/$schema"
                             },
                             "addCountryMode": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/addCountryMode"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/addCountryMode"
                             },
                             "compareEndPointsOnly": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/compareEndPointsOnly"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/compareEndPointsOnly"
                             },
                             "selectedEntityColors": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/selectedEntityColors"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/selectedEntityColors"
                             },
                             "relatedQuestions": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/relatedQuestions"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/relatedQuestions"
                             },
                             "title": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/title"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/title"
                             },
                             "map": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/map"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/map"
                             },
                             "maxTime": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/maxTime"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/maxTime"
                             },
                             "subtitle": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/subtitle"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/subtitle"
                             },
                             "selectedEntityNames": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/selectedEntityNames"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/selectedEntityNames"
                             },
                             "focusedSeriesNames": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/focusedSeriesNames"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/focusedSeriesNames"
                             },
                             "baseColorScheme": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/baseColorScheme"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/baseColorScheme"
                             },
                             "yAxis": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/yAxis"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/yAxis"
                             },
                             "tab": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/tab"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/tab"
                             },
                             "matchingEntitiesOnly": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/matchingEntitiesOnly"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/matchingEntitiesOnly"
                             },
-                            "hideLegend": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideLegend"
+                            "hideSeriesLabels": {
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideSeriesLabels"
                             },
                             "hideLogo": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideLogo"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideLogo"
                             },
                             "timelineMinTime": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/timelineMinTime"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/timelineMinTime"
                             },
                             "variantName": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/variantName"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/variantName"
                             },
                             "hideTimeline": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideTimeline"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideTimeline"
                             },
                             "originUrl": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/originUrl"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/originUrl"
                             },
                             "colorScale": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/colorScale"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/colorScale"
                             },
                             "scatterPointLabelStrategy": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/scatterPointLabelStrategy"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/scatterPointLabelStrategy"
                             },
                             "selectedFacetStrategy": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/selectedFacetStrategy"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/selectedFacetStrategy"
                             },
                             "sourceDesc": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/sourceDesc"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/sourceDesc"
                             },
                             "invertColorScheme": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/invertColorScheme"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/invertColorScheme"
                             },
                             "hideRelativeToggle": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideRelativeToggle"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideRelativeToggle"
                             },
                             "comparisonLines": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/comparisonLines"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/comparisonLines"
                             },
                             "internalNotes": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/internalNotes"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/internalNotes"
                             },
                             "version": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/version"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/version"
                             },
                             "logo": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/logo"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/logo"
                             },
                             "entityType": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/entityType"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/entityType"
                             },
                             "facettingLabelByYVariables": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/facettingLabelByYVariables"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/facettingLabelByYVariables"
                             },
                             "note": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/note"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/note"
                             },
                             "chartTypes": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/chartTypes"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/chartTypes"
                             },
                             "hasMapTab": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hasMapTab"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hasMapTab"
                             },
                             "stackMode": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/stackMode"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/stackMode"
                             },
                             "minTime": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/minTime"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/minTime"
                             },
                             "hideAnnotationFieldsInTitle": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideAnnotationFieldsInTitle"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideAnnotationFieldsInTitle"
                             },
                             "excludedEntityNames": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/excludedEntityNames"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/excludedEntityNames"
                             },
                             "xAxis": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/xAxis"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/xAxis"
                             },
                             "timelineMaxTime": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/timelineMaxTime"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/timelineMaxTime"
                             },
                             "hideConnectedScatterLines": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideConnectedScatterLines"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideConnectedScatterLines"
                             },
                             "showNoDataArea": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/showNoDataArea"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/showNoDataArea"
                             },
                             "zoomToSelection": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/zoomToSelection"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/zoomToSelection"
                             },
                             "showYearLabels": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/showYearLabels"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/showYearLabels"
                             },
                             "hideTotalValueLabel": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideTotalValueLabel"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideTotalValueLabel"
                             },
                             "hideScatterLabels": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideScatterLabels"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideScatterLabels"
                             },
                             "sortBy": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/sortBy"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/sortBy"
                             },
                             "sortOrder": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/sortOrder"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/sortOrder"
                             },
                             "sortColumnSlug": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/sortColumnSlug"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/sortColumnSlug"
                             },
                             "hideFacetControl": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/hideFacetControl"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/hideFacetControl"
                             },
                             "includedEntityNames": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/includedEntityNames"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/includedEntityNames"
                             },
                             "entityTypePlural": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/entityTypePlural"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/entityTypePlural"
                             },
                             "missingDataStrategy": {
-                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/missingDataStrategy"
+                                "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/missingDataStrategy"
                             }
                         },
                         "additionalProperties": false
@@ -969,7 +969,7 @@
                             "Common overrides include name, unit, and color settings."
                         ]
                     ],
-                    "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.009.json#/properties/dimensions/items/properties/display"
+                    "$ref": "https://files.ourworldindata.org/schemas/grapher-schema.010.json#/properties/dimensions/items/properties/display"
                 }
             },
             "required": [


### PR DESCRIPTION
> [!IMPORTANT]
> Wait for PRs in owid-grapher to land before merging

Renames the chart config's `hideLegend` to `hideSeriesLabels`. Because this is a breaking change, the config schema version is bumped from 009 to 010.

For line charts, slope charts and stacked area charts, `hideLegend` is renamed to `hideSeriesLabels`. For all other chart types, `hideLegend` is dropped.

As far as I can see, all charts here that currently use the `hideLegend` are line charts, so I renamed them to `hideSeriesLabels`

The ETL unit tests are failing because there's no config schema yet at https://files.ourworldindata.org/schemas/grapher-schema.010.json. I guess, I'll wait for the owid-grapher PR to land, then run the test suite again?

I don't understand some of the differences reported by data-diff - seem to be unrelated.