### PR TITLE
📊 emissions: Remove unnecessary columns in external step

### DIFF
--- a/etl/steps/data/external/emissions/2026-03-05/gdp_and_co2_decoupling.py
+++ b/etl/steps/data/external/emissions/2026-03-05/gdp_and_co2_decoupling.py
@@ -50,8 +50,19 @@ def run() -> None:
         * 100
     )
 
-    # Drop reference columns.
-    tb_result = tb_result.drop(columns=["ref_gdp", "ref_emissions"])
+    # Drop unnecessary columns.
+    tb_result = tb_result.drop(
+        columns=[
+            "ref_gdp",
+            "ref_emissions",
+            "consumption_emissions_per_capita",
+            "gdp_per_capita",
+            "gdp_per_capita_smooth",
+            "consumption_emissions_per_capita_smooth",
+            "peak_emissions_year",
+        ],
+        errors="raise",
+    )
 
     # Improve table format.
     tb_result = tb_result.format(["country", "year"], short_name=paths.short_name)


### PR DESCRIPTION
Remove unnecessary columns in external step of GDP vs emissions decoupling.
