### PR TITLE
Remove country_latest_data table reference

### DIFF
--- a/etl/grapher/to_db.py
+++ b/etl/grapher/to_db.py
@@ -493,15 +493,6 @@ def cleanup_ghost_variables(engine: Engine, dataset_id: int, upserted_variable_i
                 return False
 
         # then variables themselves with related data in other tables
-        con.execute(
-            text(
-                """
-            DELETE FROM country_latest_data WHERE variable_id IN :variable_ids
-        """
-            ),
-            {"variable_ids": variable_ids_to_delete},
-        )
-
         # delete relationships
         con.execute(
             text(


### PR DESCRIPTION
## Summary

- Remove the `DELETE FROM country_latest_data` statement from variable cleanup in `etl/grapher/to_db.py`
- The `country_latest_data` table is being dropped in owid/owid-grapher#6199

**Note:** This PR should be merged after or alongside owid/owid-grapher#6199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)