### PR TITLE
📊 Fix Epoch AI GPU snapshot download URL

### DIFF
--- a/snapshots/artificial_intelligence/2025-10-10/epoch_gpus.csv.dvc
+++ b/snapshots/artificial_intelligence/2025-10-10/epoch_gpus.csv.dvc
@@ -18,7 +18,7 @@ meta:
 
     # Files
     url_main: https://epoch.ai/data/machine-learning-hardware
-    url_download: https://epoch.ai/data/generated/ml_hardware.zip
+    url_download: https://epoch.ai/data/ml_hardware.zip
     date_accessed: '2026-02-27'
 
     # License
@@ -26,6 +26,6 @@ meta:
       name: CC BY 4.0
       url: https://epoch.ai/data/machine-learning-hardware
 outs:
-  - md5: bc2c2075f841ecb440051ec9d175f251
-    size: 94149
+  - md5: 551c19a2fd4606bc5a76052b29bf6de6
+    size: 94656
     path: epoch_gpus.csv


### PR DESCRIPTION
## Summary

- Fix broken download URL for the Epoch AI ML Hardware (GPUs) snapshot
- Epoch AI moved the dataset from `epoch.ai/data/generated/ml_hardware.zip` to `epoch.ai/data/ml_hardware.zip`, causing 404 errors
- Re-ran the snapshot with the corrected URL


🤖 Generated with [Claude Code](https://claude.com/claude-code)