### PR TITLE
🐛 Fix variant display for WHO/ IHME charts

### DIFF
--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_cause_dalys.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_cause_dalys.meta.yml
@@ -5,6 +5,7 @@ definitions:
       topic_tags:
         - Global Health
         - Causes of Death
+      attribution_short: IHME
     processing_level: major
   description_key: |-
     <% if cause == "Conflict and terrorism" %>When precise information is unavailable, IHME splits the impacts of conflict and terrorism evenly across years, and across countries based on their populations.<% endif %>

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_cause_deaths.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_cause_deaths.meta.yml
@@ -5,6 +5,7 @@ definitions:
       topic_tags:
         - Global Health
         - Causes of Death
+      attribution: IHME
     processing_level: major
   description_key: |-
     <% if cause == "Conflict and terrorism" %>When precise information is unavailable, IHME splits the impacts of conflict and terrorism evenly across years, and across countries based on their populations.<% endif %>

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_child_mortality.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_child_mortality.meta.yml
@@ -5,6 +5,7 @@ definitions:
       topic_tags:
         - Global Health
         - Causes of Death
+      attribution_short: IHME
     processing_level: minor
 
   description_key: |-

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_healthy_life_expectancy.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_healthy_life_expectancy.meta.yml
@@ -4,6 +4,7 @@ definitions:
       topic_tags:
         - Life Expectancy
         - Global Health
+      attribution_short: IHME
     processing_level: major
     display:
       numDecimalPlaces: 1

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_mental_health.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_mental_health.meta.yml
@@ -3,6 +3,7 @@ definitions:
     presentation:
       topic_tags:
         - Mental Health
+      attribution_short: IHME
     processing_level: major
   short_unit: |-
     <% if metric == "Number" %>

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_mental_health_burden.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_mental_health_burden.meta.yml
@@ -4,6 +4,7 @@ definitions:
     presentation:
       topic_tags:
         - Mental Health
+      attribution_short: IHME
     processing_level: major
 
 macros: |-

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_prevalence.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_prevalence.meta.yml
@@ -4,6 +4,7 @@ definitions:
     presentation:
       topic_tags:
         - Global Health
+      attribution_short: IHME
     processing_level: major
 
 macros: |-

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_risk_cancer.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_risk_cancer.meta.yml
@@ -5,6 +5,7 @@ definitions:
       topic_tags:
         - Global Health
         - Causes of Death
+      attribution_short: IHME
       grapher_config:
         note: <% if age == "Age-standardized" %>To allow for comparisons between countries and over time, this metric is [age-standardized](#dod:age_standardized).<%- endif -%>
   sex: |-

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_risk_dalys.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_risk_dalys.meta.yml
@@ -5,6 +5,7 @@ definitions:
       topic_tags:
         - Global Health
         - Causes of Death
+      attribution_short: IHME
     processing_level: major
 
 dataset:

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_risk_deaths.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_risk_deaths.meta.yml
@@ -5,6 +5,7 @@ definitions:
       topic_tags:
         - Global Health
         - Causes of Death
+      attribution_short: IHME
     processing_level: major
 
 dataset:

--- a/etl/steps/data/garden/who/2025-04-17/mortality_database.meta.yml
+++ b/etl/steps/data/garden/who/2025-04-17/mortality_database.meta.yml
@@ -4,6 +4,7 @@ definitions:
     presentation:
       topic_tags:
         - Causes of Death
+      attribution_short: WHO
     processing_level: minor
   description_disease_producer: |-
     <% if cause == "All Causes" %>


### PR DESCRIPTION
Explicitly add IHME/ WHO as attribution_short to variable metadata. 