### PR TITLE
🐛 Fix duplicate rows in related_charts analytics join

### DIFF
--- a/apps/wizard/app_pages/related_charts/data.py
+++ b/apps/wizard/app_pages/related_charts/data.py
@@ -44,6 +44,16 @@ def get_raw_charts() -> pd.DataFrame:
         from chart_tags as ct
         join tags as t on ct.tagId = t.id
         group by 1
+    ),
+    analytics as (
+        select
+            SUBSTRING_INDEX(url, '/', -1) as slug,
+            max(views_7d) as views_7d,
+            max(views_14d) as views_14d,
+            max(views_365d) as views_365d
+        from analytics_pageviews
+        where url like '%%/grapher/%%'
+        group by 1
     )
     select
         c.id as chart_id,
@@ -58,7 +68,7 @@ def get_raw_charts() -> pd.DataFrame:
         a.views_365d
     from charts as c
     join chart_configs as cf on c.configId = cf.id
-    left join analytics_pageviews as a on cf.slug = SUBSTRING_INDEX(a.url, '/', -1) and a.url like '%%/grapher/%%'
+    left join analytics as a on cf.slug = a.slug
     left join tags as t on c.id = t.chart_id
     -- exclude drafts
     where cf.full->>'$.isPublished' != 'false'


### PR DESCRIPTION
## Problem

The `get_raw_charts()` function in `related_charts/data.py` was failing with an `AssertionError` because the query produced duplicate rows per chart.

The culprit was the direct `LEFT JOIN analytics_pageviews` using `SUBSTRING_INDEX(url, '/', -1)` to extract the slug. On production, the analytics table contains multiple URL variants for the same chart slug (e.g. different domains or URL prefixes), which caused the join to fan out — multiple rows per chart — breaking the uniqueness assertion on `chart_id`.

## Fix

Pre-aggregate `analytics_pageviews` into a `analytics` CTE (grouped by slug, using `MAX()` on view counts) before joining — the same pattern already used for the `tags` CTE. This guarantees at most one analytics row per slug regardless of how many URL variants exist.

@codex — could you take a look?