### PR TITLE
📊 Fix explicit un_wpp loading in population helper callers

### DIFF
--- a/dag/health.yml
+++ b/dag/health.yml
@@ -1292,6 +1292,7 @@ steps:
     - data://meadow/tuberculosis/2026-02-05/burden_disaggregated
     - data://garden/regions/2023-01-01/regions
     - data://garden/demography/2024-07-15/population
+    - data://garden/un/2022-07-11/un_wpp
   data://grapher/tuberculosis/2026-02-05/burden_disaggregated:
     - data://garden/tuberculosis/2026-02-05/burden_disaggregated
 
@@ -1301,7 +1302,7 @@ steps:
   data-private://garden/ihme_gbd/2026-02-07/gbd_mental_health:
     - data-private://meadow/ihme_gbd/2026-02-07/gbd_mental_health
     - data://garden/regions/2023-01-01/regions
-    - data://garden/un/2024-07-12/un_wpp
+    - data://garden/un/2022-07-11/un_wpp
   data-private://grapher/ihme_gbd/2026-02-07/gbd_mental_health:
     - data-private://garden/ihme_gbd/2026-02-07/gbd_mental_health
 
@@ -1311,7 +1312,7 @@ steps:
   data-private://garden/ihme_gbd/2026-02-07/gbd_cause_deaths:
     - data-private://meadow/ihme_gbd/2026-02-07/gbd_cause_deaths
     - data://garden/regions/2023-01-01/regions
-    - data://garden/un/2024-07-12/un_wpp
+    - data://garden/un/2022-07-11/un_wpp
   data-private://grapher/ihme_gbd/2026-02-07/gbd_cause_deaths:
     - data-private://garden/ihme_gbd/2026-02-07/gbd_cause_deaths
 
@@ -1321,7 +1322,7 @@ steps:
   data-private://garden/ihme_gbd/2026-02-07/gbd_cause_dalys:
     - data-private://meadow/ihme_gbd/2026-02-07/gbd_cause_dalys
     - data://garden/regions/2023-01-01/regions
-    - data://garden/un/2024-07-12/un_wpp
+    - data://garden/un/2022-07-11/un_wpp
   data-private://grapher/ihme_gbd/2026-02-07/gbd_cause_dalys:
     - data-private://garden/ihme_gbd/2026-02-07/gbd_cause_dalys
 
@@ -1331,7 +1332,7 @@ steps:
   data-private://garden/ihme_gbd/2026-02-07/gbd_prevalence:
     - data-private://meadow/ihme_gbd/2026-02-07/gbd_prevalence
     - data://garden/regions/2023-01-01/regions
-    - data://garden/un/2024-07-12/un_wpp
+    - data://garden/un/2022-07-11/un_wpp
   data-private://grapher/ihme_gbd/2026-02-07/gbd_prevalence:
     - data-private://garden/ihme_gbd/2026-02-07/gbd_prevalence
   data-private://grapher/ihme_gbd/2026-02-07/gbd_incidence:
@@ -1343,7 +1344,7 @@ steps:
   data-private://garden/ihme_gbd/2026-02-07/gbd_risk_deaths:
     - data-private://meadow/ihme_gbd/2026-02-07/gbd_risk_deaths
     - data://garden/regions/2023-01-01/regions
-    - data://garden/un/2024-07-12/un_wpp
+    - data://garden/un/2022-07-11/un_wpp
   data-private://grapher/ihme_gbd/2026-02-07/gbd_risk_deaths:
     - data-private://garden/ihme_gbd/2026-02-07/gbd_risk_deaths
 
@@ -1353,7 +1354,7 @@ steps:
   data-private://garden/ihme_gbd/2026-02-07/gbd_risk_dalys:
     - data-private://meadow/ihme_gbd/2026-02-07/gbd_risk_dalys
     - data://garden/regions/2023-01-01/regions
-    - data://garden/un/2024-07-12/un_wpp
+    - data://garden/un/2022-07-11/un_wpp
   data-private://grapher/ihme_gbd/2026-02-07/gbd_risk_dalys:
     - data-private://garden/ihme_gbd/2026-02-07/gbd_risk_dalys
 

--- a/etl/data_helpers/population.py
+++ b/etl/data_helpers/population.py
@@ -7,8 +7,6 @@ from owid.catalog import Dataset
 from owid.datautils.dataframes import map_series
 from structlog import get_logger
 
-from etl.paths import DATA_DIR
-
 # Initialize logger.
 log = get_logger()
 
@@ -73,10 +71,10 @@ def add_population(
         assert df[age_col].notnull().all(), f"Column {age_col} contains missing values!"
 
     if ds_un_wpp is None:
-        ds_un_wpp_path = DATA_DIR / "garden/un/2022-07-11/un_wpp"
-        log.warning(f"Dataset {ds_un_wpp_path} is silently being loaded.")
-        # Load granular population dataset
-        ds_un_wpp = Dataset(ds_un_wpp_path)
+        raise ValueError(
+            "ds_un_wpp must be provided. Load it explicitly with paths.load_dataset('un_wpp') and ensure "
+            "data://garden/un/2022-07-11/un_wpp is in the step's DAG dependencies."
+        )
     pop = ds_un_wpp.read("population_granular", safe_types=False)  # type: ignore
     # Keep only variant='medium'
     pop = pop[pop["variant"] == "medium"].drop(columns=["variant"])

--- a/etl/steps/data/garden/ihme_gbd/2024-05-20/gbd_risk.py
+++ b/etl/steps/data/garden/ihme_gbd/2024-05-20/gbd_risk.py
@@ -28,6 +28,7 @@ def run(dest_dir: str) -> None:
     # Read table from meadow dataset.
     tb = ds_meadow.read("gbd_risk", reset_index=True)
     ds_regions = paths.load_dataset("regions")
+    ds_un_wpp = paths.load_dataset("un_wpp")
     #
     # Process data.
     #
@@ -36,6 +37,7 @@ def run(dest_dir: str) -> None:
     tb = add_regional_aggregates(
         tb=tb,
         ds_regions=ds_regions,
+        ds_un_wpp=ds_un_wpp,
         index_cols=["country", "year", "metric", "measure", "rei", "cause", "age"],
         regions=REGIONS,
         age_group_mapping=AGE_GROUPS_RANGES,

--- a/etl/steps/data/garden/ihme_gbd/2024-05-20/shared.py
+++ b/etl/steps/data/garden/ihme_gbd/2024-05-20/shared.py
@@ -10,6 +10,7 @@ from etl.data_helpers.population import add_population
 def add_regional_aggregates(
     tb: Table,
     ds_regions: Dataset,
+    ds_un_wpp: Dataset,
     index_cols: List[str],
     regions: List[str],
     age_group_mapping: Dict[str, List[int]],
@@ -29,7 +30,7 @@ def add_regional_aggregates(
     tb_rate = tb[tb["metric"] == "Rate"].copy()
 
     # Calculate region aggregates for Number
-    tb_number = add_regions_to_number(tb_number, age_group_mapping, ds_regions, index_cols, regions)
+    tb_number = add_regions_to_number(tb_number, age_group_mapping, ds_regions, ds_un_wpp, index_cols, regions)
     # Calculate region aggregates for Rate
     tb_rate_regions = add_regions_to_rate(tb_number, regions)
     tb_rate = pr.concat([tb_rate, tb_rate_regions], ignore_index=True)  # type: ignore
@@ -82,6 +83,7 @@ def add_regions_to_number(
     tb_number: Table,
     age_group_mapping: Dict[str, List[int]],
     ds_regions: Dataset,
+    ds_un_wpp: Dataset,
     index_cols: List[str],
     regions: List[str],
 ) -> Table:
@@ -97,6 +99,7 @@ def add_regions_to_number(
             sex_group_all="Both",
             sex_group_female="Female",
             sex_group_male="Male",
+            ds_un_wpp=ds_un_wpp,
         )
     else:
         tb_number = add_population(
@@ -105,6 +108,7 @@ def add_regions_to_number(
             year_col="year",
             age_col="age",
             age_group_mapping=age_group_mapping,
+            ds_un_wpp=ds_un_wpp,
         )
     assert tb_number["value"].notna().all(), "Values are missing in the Number table, check configuration"
     # Add region aggregates - for Number

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_cause_dalys.py
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_cause_dalys.py
@@ -29,6 +29,7 @@ def run() -> None:
     # Drop population_group_name as it only contains 'All Population'
     tb = tb.drop(columns=["population_group_name"])
     ds_regions = paths.load_dataset("regions")
+    ds_un_wpp = paths.load_dataset("un_wpp")
     #
     # Process data.
     #
@@ -37,6 +38,7 @@ def run() -> None:
     tb = add_regional_aggregates(
         tb=tb,
         ds_regions=ds_regions,
+        ds_un_wpp=ds_un_wpp,
         index_cols=["country", "year", "metric", "measure", "cause", "age"],
         regions=REGIONS,
         age_group_mapping=AGE_GROUPS_RANGES,

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_cause_deaths.py
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_cause_deaths.py
@@ -31,6 +31,7 @@ def run() -> None:
     # Drop population_group_name as it only contains 'All Population'
     tb = tb.drop(columns=["population_group_name"])
     ds_regions = paths.load_dataset("regions")
+    ds_un_wpp = paths.load_dataset("un_wpp")
     #
     # Process data.
     #
@@ -39,6 +40,7 @@ def run() -> None:
     tb = add_regional_aggregates(
         tb=tb,
         ds_regions=ds_regions,
+        ds_un_wpp=ds_un_wpp,
         index_cols=["country", "year", "metric", "measure", "cause", "age"],
         regions=REGIONS,
         age_group_mapping=AGE_GROUPS_RANGES,

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_mental_health.py
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_mental_health.py
@@ -36,6 +36,7 @@ def run() -> None:
     ds_meadow = paths.load_dataset("gbd_mental_health")
     # Load regions dataset.
     ds_regions = paths.load_dataset("regions")
+    ds_un_wpp = paths.load_dataset("un_wpp")
     # Read table from meadow dataset.
     tb = ds_meadow["gbd_mental_health"].reset_index()
     tb = tb.drop(columns=["population_group_name"])
@@ -44,6 +45,7 @@ def run() -> None:
     tb = add_regional_aggregates(
         tb,
         ds_regions,
+        ds_un_wpp,
         index_cols=["country", "year", "metric", "cause", "age", "sex"],
         regions=REGIONS,
         age_group_mapping=AGE_GROUPS_RANGES,

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_prevalence.py
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_prevalence.py
@@ -36,6 +36,7 @@ def run() -> None:
     tb = tb.drop(columns=["population_group_name"])
     # Load regions dataset.
     ds_regions = paths.load_dataset("regions")
+    ds_un_wpp = paths.load_dataset("un_wpp")
 
     # If subset is defined, filter the data to given causes.
     if SUBSET:
@@ -49,6 +50,7 @@ def run() -> None:
     tb = add_regional_aggregates(
         tb,
         ds_regions,
+        ds_un_wpp,
         index_cols=["country", "year", "metric", "measure", "cause", "age"],
         regions=REGIONS,
         age_group_mapping=AGE_GROUPS_RANGES,

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_risk_dalys.py
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_risk_dalys.py
@@ -28,6 +28,7 @@ def run() -> None:
     tb = ds_meadow.read("gbd_risk_dalys", reset_index=True)
     tb = tb.drop(columns=["population_group_name"])
     ds_regions = paths.load_dataset("regions")
+    ds_un_wpp = paths.load_dataset("un_wpp")
     #
     # Process data.
     #
@@ -36,6 +37,7 @@ def run() -> None:
     tb = add_regional_aggregates(
         tb=tb,
         ds_regions=ds_regions,
+        ds_un_wpp=ds_un_wpp,
         index_cols=["country", "year", "metric", "measure", "rei", "cause", "age"],
         regions=REGIONS,
         age_group_mapping=AGE_GROUPS_RANGES,

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_risk_deaths.py
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/gbd_risk_deaths.py
@@ -28,6 +28,7 @@ def run() -> None:
     tb = ds_meadow.read("gbd_risk_deaths", reset_index=True)
     tb = tb.drop(columns=["population_group_name"])
     ds_regions = paths.load_dataset("regions")
+    ds_un_wpp = paths.load_dataset("un_wpp")
     #
     # Process data.
     #
@@ -36,6 +37,7 @@ def run() -> None:
     tb = add_regional_aggregates(
         tb=tb,
         ds_regions=ds_regions,
+        ds_un_wpp=ds_un_wpp,
         index_cols=["country", "year", "metric", "measure", "rei", "cause", "age"],
         regions=REGIONS,
         age_group_mapping=AGE_GROUPS_RANGES,

--- a/etl/steps/data/garden/ihme_gbd/2026-02-07/shared.py
+++ b/etl/steps/data/garden/ihme_gbd/2026-02-07/shared.py
@@ -10,6 +10,7 @@ from etl.data_helpers.population import add_population
 def add_regional_aggregates(
     tb: Table,
     ds_regions: Dataset,
+    ds_un_wpp: Dataset,
     index_cols: List[str],
     regions: List[str],
     age_group_mapping: Dict[str, List[int]],
@@ -29,7 +30,7 @@ def add_regional_aggregates(
     tb_rate = tb[tb["metric"] == "Rate"].copy()
 
     # Calculate region aggregates for Number
-    tb_number = add_regions_to_number(tb_number, age_group_mapping, ds_regions, index_cols, regions)
+    tb_number = add_regions_to_number(tb_number, age_group_mapping, ds_regions, ds_un_wpp, index_cols, regions)
     # Calculate region aggregates for Rate
     tb_rate_regions = add_regions_to_rate(tb_number, regions)
     tb_rate = pr.concat([tb_rate, tb_rate_regions], ignore_index=True)  # type: ignore
@@ -82,6 +83,7 @@ def add_regions_to_number(
     tb_number: Table,
     age_group_mapping: Dict[str, List[int]],
     ds_regions: Dataset,
+    ds_un_wpp: Dataset,
     index_cols: List[str],
     regions: List[str],
 ) -> Table:
@@ -97,6 +99,7 @@ def add_regions_to_number(
             sex_group_all="Both",
             sex_group_female="Female",
             sex_group_male="Male",
+            ds_un_wpp=ds_un_wpp,
         )
     else:
         tb_number = add_population(
@@ -105,6 +108,7 @@ def add_regions_to_number(
             year_col="year",
             age_col="age",
             age_group_mapping=age_group_mapping,
+            ds_un_wpp=ds_un_wpp,
         )
     assert tb_number["value"].notna().all(), "Values are missing in the Number table, check configuration"
 

--- a/etl/steps/data/garden/tuberculosis/2026-02-05/burden_disaggregated.py
+++ b/etl/steps/data/garden/tuberculosis/2026-02-05/burden_disaggregated.py
@@ -1,7 +1,7 @@
 """Load a meadow dataset and create a garden dataset."""
 
 import numpy as np
-from owid.catalog import Table
+from owid.catalog import Dataset, Table
 from owid.catalog import processing as pr
 
 from etl.data_helpers import geo
@@ -59,12 +59,14 @@ def run() -> None:
     ds_regions = paths.load_dataset("regions")
     # Load income groups dataset.
     ds_income_groups = paths.load_dataset("income_groups")
+    # Load UN WPP population dataset.
+    ds_un_wpp = paths.load_dataset("un_wpp")
     #
     # Process data.
     #
     tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
     tb = tb.drop(columns=["measure", "unit"])
-    tb = add_population_column(tb)
+    tb = add_population_column(tb, ds_un_wpp)
     tb = combining_sexes_for_all_age_groups(tb)
     tb = geo.add_regions_to_table(
         tb,
@@ -112,7 +114,7 @@ def combining_sexes_for_all_age_groups(tb: Table) -> Table:
     return tb
 
 
-def add_population_column(tb: Table) -> Table:
+def add_population_column(tb: Table, ds_un_wpp: Dataset) -> Table:
     """
     Adding the population for each age-group, in rows where the risk factor is "all".
     """
@@ -128,6 +130,7 @@ def add_population_column(tb: Table) -> Table:
         sex_group_male="m",
         age_col="age_group",
         age_group_mapping=AGE_GROUPS_RANGES,
+        ds_un_wpp=ds_un_wpp,
     )
     tb_no_pop["population"] = np.nan
     tb = pr.concat([tb_pop, tb_no_pop], axis=0, ignore_index=True, short_name=paths.short_name)


### PR DESCRIPTION
## Problem

`etl.data_helpers.population.add_population()` had a silent fallback that loaded `garden/un/2022-07-11/un_wpp` automatically when `ds_un_wpp` was not passed. This caused two issues:
- A silent warning that was easy to miss
- A hard crash when `2022-07-11/un_wpp` wasn't available locally (e.g. several `ihme_gbd/2026-02-07` steps had `2024-07-12/un_wpp` in their DAG instead, so the 2022 version was never downloaded)

## Fix

- **`population.py`**: replaced the silent fallback with a `ValueError` so future callers get an immediate, clear error instead of a silent load
- **`ihme_gbd/2024-05-20/shared.py` and `ihme_gbd/2026-02-07/shared.py`**: added `ds_un_wpp` parameter to `add_regional_aggregates()` and `add_regions_to_number()`, passed it down to `add_population()`
- **All callers** of `add_regional_aggregates` now explicitly load `ds_un_wpp = paths.load_dataset("un_wpp")` and pass it
- **DAG fixes**: `ihme_gbd/2026-02-07` steps had `2024-07-12/un_wpp` as dependency (wrong — that dataset has a different schema that `population.py` doesn't support); changed to `2022-07-11/un_wpp`; added `2022-07-11/un_wpp` to `tuberculosis/2026-02-05/burden_disaggregated`