### PR TITLE
📊 Update ReadTheDocs build image to Ubuntu 24.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
   commands:

--- a/lib/datautils/.readthedocs.yaml
+++ b/lib/datautils/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools: {python: "3.8"}
   jobs:
     pre_create_environment:


### PR DESCRIPTION
Ubuntu 20.04 is being deprecated on ReadTheDocs on June 1, 2026. This updates both `.readthedocs.yaml` files to use `ubuntu-24.04`.