### PR TITLE
📊 Add missing topic tag to air pollution multidim

### DIFF
--- a/etl/collection/model/core.py
+++ b/etl/collection/model/core.py
@@ -215,6 +215,9 @@ class Collection(MDIMBase):
         # Check that all indicators in collection exist
         validate_indicators_in_db(indicators, owid_env.engine)
 
+        # Ensure at least one topic tag is set (needed for search)
+        self.validate_topic_tags()
+
         # Run sanity checks on grouped views
         self.validate_grouped_views()
 
@@ -508,6 +511,14 @@ class Collection(MDIMBase):
             if not any(indicator.startswith(f"{dep}/") for dep in deps):
                 raise ValueError(f"Indicator {indicator} is not covered by any dependency: {deps}")
         return True
+
+    def validate_topic_tags(self):
+        """Ensure that at least one topic tag is set. Required for search."""
+        if not self.topic_tags:
+            raise ValueError(
+                f"Collection '{self.catalog_path}' must have at least one topic tag. "
+                "Add 'topic_tags' to your config YAML."
+            )
 
     def validate_grouped_views(self):
         for view in self.views:

--- a/etl/steps/export/multidim/ihme_gbd/latest/air_pollution.config.yml
+++ b/etl/steps/export/multidim/ihme_gbd/latest/air_pollution.config.yml
@@ -2,6 +2,9 @@ title:
   title: Deaths from air pollution
   title_variant: ""
 
+topic_tags:
+  - Air Pollution
+
 default_selection:
   - World
   - China


### PR DESCRIPTION
Add missing `topic_tags: [Air Pollution]` to the IHME air pollution multidim config (`ihme-deaths-air-pollution`), which was the only published multidim without any tags — needed for search.

Also add a `validate_topic_tags()` assertion in `Collection.save()` so that any multidim without at least one topic tag will raise a `ValueError` at save time, preventing this from happening again.