### PR TITLE
📊 Fix explorer migration tests

### DIFF
--- a/tests/collections/test_explorer_migration.py
+++ b/tests/collections/test_explorer_migration.py
@@ -280,6 +280,9 @@ def test_explorer_legacy_1(tmp_path, monkeypatch):
     # Make sure explorer can deal with int values
     config["config"]["wpBlockId"] = int(config["config"]["wpBlockId"])
 
+    # Add topic tags required for validation
+    config["topic_tags"] = ["Influenza"]
+
     # Create config file
     config_path = tmp_path / "influenza.config.yml"
     with open(config_path, "w") as f:
@@ -330,6 +333,9 @@ def test_explorer_legacy_2(tmp_path, monkeypatch):
 
     # Make sure explorer can deal with int values
     config["config"]["wpBlockId"] = int(config["config"]["wpBlockId"])
+
+    # Add topic tags required for validation
+    config["topic_tags"] = ["Influenza"]
 
     # Create config file
     config_path = tmp_path / "influenza.config.yml"


### PR DESCRIPTION
## Fix explorer migration tests

The `test_explorer_legacy_1` and `test_explorer_legacy_2` tests in `tests/collections/test_explorer_migration.py` were failing because `Collection.save()` now validates that at least one topic tag is set (via `validate_topic_tags()`).

The test configs created by `migrate_csv_explorer()` didn't include `topic_tags`, causing a `ValueError`.

**Fix:** Add `topic_tags: ["Influenza"]` to the config dict at the top level before writing the YAML config file, in both test functions.