### PR TITLE
📊 Fix WHO FluID meadow step crash

### DIFF
--- a/etl/steps/data/meadow/who/latest/fluid.py
+++ b/etl/steps/data/meadow/who/latest/fluid.py
@@ -23,7 +23,8 @@ def run(dest_dir: str) -> None:
     snap = paths.load_snapshot("fluid.csv")
 
     # Load data from snapshot.
-    df = pd.read_csv(snap.path)
+    # low_memory=False prevents mixed-type inference across CSV chunks (iso_year was inferred as object).
+    df = pd.read_csv(snap.path, low_memory=False)
     #
     # Process data.
     #
@@ -35,6 +36,14 @@ def run(dest_dir: str) -> None:
     # Convert columns with mixed types to string
     tb["trend"] = tb["trend"].astype(str)
     tb["isoyw"] = tb["isoyw"].astype(str)
+    # Source data has a malformed row with a date in iso_year — coerce to numeric and drop it.
+    iso_year_numeric = pd.to_numeric(tb["iso_year"], errors="coerce")
+    invalid_mask = iso_year_numeric.isna() & tb["iso_year"].notna()
+    if invalid_mask.any():
+        for _, row in tb[invalid_mask].iterrows():
+            log.warning(f"Dropping malformed row with non-numeric iso_year: {row.to_dict()}")
+    tb["iso_year"] = iso_year_numeric
+    tb = tb.dropna(subset=["iso_year"])
     tb = tb.rename(columns={"country_area_territory": "country"})
 
     # Convert object columns that should be numeric to numeric


### PR DESCRIPTION
## Bug Fix: WHO FluID meadow step crash

The `data://meadow/who/latest/fluid` step was crashing with:

```
ValueError: Column iso_year is still object. Consider converting it to str.
```

### Root cause

Two issues combine to cause the crash:

1. **`pd.read_csv()` with default `low_memory=True`** reads the CSV in chunks, and when chunks disagree on column types, the column gets `object` dtype. Column 7 (`iso_year`) was affected.

2. **One malformed row in the source data** has shifted columns — a date value (`2024-09-01`) ends up in the `iso_year` field — which poisons type inference.

The `repack` step then rejects the `object`-typed `iso_year` column.

### Fix

- Add `low_memory=False` to `pd.read_csv()` to prevent chunked mixed-type inference
- Coerce `iso_year` to numeric and drop the one malformed row

@codex review