### PR TITLE
🐛 Fix indicator upgrader stripping inheritance overrides that match schema defaults

### DIFF
--- a/etl/indicator_upgrade/indicator_update.py
+++ b/etl/indicator_upgrade/indicator_update.py
@@ -94,7 +94,8 @@ def update_chart_config(
 
     The chart config contains some fields that point to the indicators in use. In the attempt to migrating these, we should update all references to the new indicators.
     """
-    updater = ChartIndicatorUpdater(indicator_mapping, schema)
+    is_inheritance_enabled = config.get("isInheritanceEnabled", False)
+    updater = ChartIndicatorUpdater(indicator_mapping, schema, is_inheritance_enabled=is_inheritance_enabled)
     config_new = updater.run(deepcopy(config))
     return config_new
 
@@ -106,6 +107,7 @@ class ChartIndicatorUpdater:
         self,
         indicator_mapping: Dict[int, int],
         schema: Dict[str, Any],
+        is_inheritance_enabled: bool = False,
     ) -> None:
         """Constructor.
 
@@ -115,10 +117,18 @@ class ChartIndicatorUpdater:
             Mapping between old and new indicator IDs.
         schema : Optional[Dict[str, Any]]
             Schema of the chart configuration. Defaults to None.
+        is_inheritance_enabled : bool
+            Whether chart inheritance is enabled. When True, we skip stripping
+            schema-default values from the config, because the admin API needs
+            the full config to correctly compute the patch against the indicator's
+            ETL config. Without this, properties like hasMapTab=false (a schema
+            default that overrides the indicator's hasMapTab=true) would be
+            stripped, causing the chart to re-inherit the indicator's value.
         """
         # Variable mapping dictionary: Old variable ID -> New variable ID
         self.indicator_mapping = indicator_mapping
         self.schema = schema
+        self.is_inheritance_enabled = is_inheritance_enabled
 
     def run(self, config: Dict[str, Any]) -> Dict[str, Any]:
         """Run the chart variable updater."""
@@ -132,8 +142,14 @@ class ChartIndicatorUpdater:
         config_new = update_chart_config_dimensions(config_new, self.indicator_mapping)
         # Update sorting
         config_new = update_chart_config_sort(config_new, self.indicator_mapping)
-        # Validate the  configuration of the chart and remove default values (if any)
-        config_new = validate_chart_config_and_remove_defaults(config_new, self.schema)
+        # Validate the configuration of the chart and remove default values (if any).
+        # Skip this for inheritance-enabled charts: the admin API computes the patch
+        # by diffing the full config against the indicator's ETL config. If we strip
+        # schema-default values here, overrides that happen to match the schema default
+        # (e.g. hasMapTab=false) but differ from the indicator default (hasMapTab=true)
+        # would be lost, causing the chart to re-inherit the indicator's value.
+        if not self.is_inheritance_enabled:
+            config_new = validate_chart_config_and_remove_defaults(config_new, self.schema)
         return config_new
 
 

--- a/tests/test_indicator_upgrade_schema.py
+++ b/tests/test_indicator_upgrade_schema.py
@@ -1,3 +1,4 @@
+from etl.indicator_upgrade.indicator_update import update_chart_config
 from etl.indicator_upgrade.schema import validate_chart_config_and_set_defaults
 
 
@@ -12,3 +13,102 @@ def test_validate_chart_config_ignores_chart_table_fields():
     config_new = validate_chart_config_and_set_defaults(config, schema=schema)
 
     assert config_new == {"title": "A chart"}
+
+
+def test_inheritance_preserves_schema_default_overrides():
+    """When inheritance is enabled, properties that match schema defaults but override
+    indicator defaults should be preserved (not stripped).
+
+    Regression test: a chart with inheritance enabled that sets hasMapTab=false
+    (schema default) to override the indicator's hasMapTab=true was getting the
+    map re-enabled after the indicator upgrader ran.
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "$schema": {"type": "string"},
+            "id": {"type": "integer"},
+            "version": {"type": "integer", "default": 1},
+            "hasMapTab": {"type": "boolean", "default": False},
+            "dimensions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "variableId": {"type": "integer"},
+                        "property": {"type": "string"},
+                    },
+                },
+            },
+            "map": {
+                "type": "object",
+                "properties": {
+                    "columnSlug": {"type": "string"},
+                },
+            },
+        },
+    }
+
+    # Chart has inheritance enabled; user disabled map (hasMapTab=false)
+    # even though the indicator's ETL config has hasMapTab=true.
+    config = {
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "id": 7742,
+        "version": 1,
+        "isInheritanceEnabled": True,
+        "hasMapTab": False,  # user's explicit override
+        "dimensions": [{"variableId": 100, "property": "y"}],
+    }
+
+    indicator_mapping = {100: 200}
+
+    config_new = update_chart_config(config, indicator_mapping, schema)
+
+    # hasMapTab=false MUST be preserved so the admin API can compute
+    # the correct patch against the indicator's hasMapTab=true.
+    assert config_new.get("hasMapTab") is False, (
+        "hasMapTab=false was stripped from an inheritance-enabled chart; "
+        "this would cause the map to be re-enabled via inheritance"
+    )
+    # Variable ID should be updated
+    assert config_new["dimensions"][0]["variableId"] == 200
+
+
+def test_no_inheritance_strips_schema_defaults():
+    """Without inheritance, schema-default values should still be stripped
+    to keep configs lean (existing behavior)."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "$schema": {"type": "string"},
+            "id": {"type": "integer"},
+            "version": {"type": "integer", "default": 1},
+            "hasMapTab": {"type": "boolean", "default": False},
+            "dimensions": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "variableId": {"type": "integer"},
+                        "property": {"type": "string"},
+                    },
+                },
+            },
+        },
+    }
+
+    config = {
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "id": 7742,
+        "version": 1,
+        "hasMapTab": False,
+        "dimensions": [{"variableId": 100, "property": "y"}],
+    }
+
+    indicator_mapping = {100: 200}
+
+    config_new = update_chart_config(config, indicator_mapping, schema)
+
+    # Without inheritance, hasMapTab=false should be stripped (matches schema default)
+    assert "hasMapTab" not in config_new
+    assert config_new["dimensions"][0]["variableId"] == 200


### PR DESCRIPTION
## Problem

When a chart has **inheritance enabled** and the user explicitly sets a property that happens to match the **schema default** but overrides the **indicator's ETL config**, the Indicator Upgrader was stripping that override. This caused the chart to re-inherit the indicator's value.

**Concrete example**: Chart 7742 has inheritance enabled. The indicator's ETL config has `hasMapTab: true` (for another chart). The user disabled the map (`hasMapTab: false`) in the chart's patch config. After running the Indicator Upgrader, the map was re-enabled.

## Root cause

`ChartIndicatorUpdater.run()` has a set-defaults → update → remove-defaults pipeline. The final `validate_chart_config_and_remove_defaults()` step strips any property whose value matches the **schema** default (e.g. `hasMapTab: false`). For inheritance-enabled charts this is wrong because the effective default is the **indicator's ETL config**, not the schema default.

After stripping, the admin API receives a config without `hasMapTab`. Since the chart has `?inheritance=enable`, the admin computes the patch by diffing against the indicator's ETL config (`hasMapTab: true`). With no override present, the chart inherits `hasMapTab: true` → map reappears.

## Fix

Skip `validate_chart_config_and_remove_defaults()` for inheritance-enabled charts. The admin API correctly computes the patch by diffing the full config against the indicator's ETL config, so it needs all explicit values preserved.

Non-inheritance charts continue to have defaults stripped as before.

## Verification

Tested end-to-end on `staging-site-data-worldbank-pip-update-98` with chart 7742:
- **Old code**: `hasMapTab` stripped → would inherit `true` from indicator → map re-enabled 🐛
- **New code**: `hasMapTab: false` preserved in patch after admin API round-trip ✅

@codex review