### PR TITLE
📊 Sync dataset schema grapher_config with upstream

### DIFF
--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -1281,6 +1281,19 @@
                             ]
                           }
                         },
+                        "focusedSeriesNames": {
+                          "type": "array",
+                          "description": "The initially focused chart elements. Is either a list of entity or variable names. Only works for line and slope charts for now.",
+                          "items": {
+                            "type": [
+                              "string"
+                            ]
+                          }
+                        },
+                        "slug": {
+                          "type": "string",
+                          "description": "Slug of the chart on Our World In Data"
+                        },
                         "baseColorScheme": {
                           "type": "string",
                           "default": "default",
@@ -1393,19 +1406,38 @@
                           "description": "Whether to hide the relative mode UI toggle. Default depends on the chart type"
                         },
                         "comparisonLines": {
-                          "description": "List of vertical comparison lines to draw",
+                          "description": "List of comparison lines to draw",
                           "type": "array",
                           "items": {
-                            "type": "object",
-                            "properties": {
-                              "label": {
-                                "type": "string"
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "description": "Comparison line of arbitrary shape defined by a formula. Defaults to yEquals = x if not specified",
+                                "properties": {
+                                  "label": {
+                                    "type": "string"
+                                  },
+                                  "yEquals": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
                               },
-                              "yEquals": {
-                                "type": "string"
+                              {
+                                "type": "object",
+                                "description": "Vertical comparison line drawn at a specific x-value",
+                                "properties": {
+                                  "label": {
+                                    "type": "string"
+                                  },
+                                  "xEquals": {
+                                    "type": "number"
+                                  }
+                                },
+                                "required": ["xEquals"],
+                                "additionalProperties": false
                               }
-                            },
-                            "additionalProperties": false
+                            ]
                           }
                         },
                         "internalNotes": {
@@ -1649,6 +1681,26 @@
                           "items": {
                             "type": "string"
                           }
+                        },
+                        "includedEntityNames": {
+                          "type": "array",
+                          "description": "Entities that should be included (opposite of excludedEntityNames). If empty, all available entities are used.",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "peerCountryStrategy": {
+                          "type": "string",
+                          "description": "Strategy for selecting peer countries for comparison",
+                          "enum": [
+                            "defaultSelection",
+                            "parentRegions",
+                            "gdpPerCapita",
+                            "population",
+                            "dataRange",
+                            "neighbors",
+                            "none"
+                          ]
                         },
                         "xAxis": {
                           "$ref": "#/$defs/axis"

--- a/tests/test_metadata_schemas.py
+++ b/tests/test_metadata_schemas.py
@@ -1,6 +1,8 @@
+import json
 import subprocess
 from pathlib import Path
 
+import requests
 import structlog
 import yaml
 from jsonschema import (
@@ -9,6 +11,7 @@ from jsonschema import (
 from jsonschema.exceptions import ValidationError
 from yaml.loader import SafeLoader
 
+from etl.config import DEFAULT_GRAPHER_SCHEMA
 from etl.files import read_json_schema
 from etl.paths import BASE_DIR, SCHEMAS_DIR, SNAPSHOTS_DIR, STEPS_DATA_DIR
 
@@ -188,3 +191,68 @@ def test_snapshot_schemas():
             validator.validate(data)
         except ValidationError as e:
             raise ValidationError(f"Validation error in file: {meta_file_path}") from e
+
+
+# Properties that only exist in the local dataset schema (not in upstream grapher schema).
+# These are ETL-specific and intentionally absent from upstream.
+LOCAL_ONLY_PROPERTIES = {"data", "includedEntities"}
+
+
+def test_grapher_config_schema_sync():
+    """Verify that our local grapher_config schema stays in sync with the upstream
+    grapher schema. Detects when upstream adds new properties that we're missing,
+    or when property definitions have diverged and may need updating.
+
+    We maintain a local copy of grapher_config properties (rather than using $ref)
+    because our meta.yml files use Jinja templates and {definitions...} references
+    that the strict upstream schema would reject.
+    """
+    # Load local schema
+    with open(SCHEMAS_DIR / "dataset-schema.json") as f:
+        dataset_schema = json.load(f)
+    local_gc = dataset_schema["properties"]["tables"]["additionalProperties"]["properties"][
+        "variables"
+    ]["additionalProperties"]["properties"]["presentation"]["properties"]["grapher_config"]
+    local_props = set(local_gc["properties"].keys())
+
+    # Fetch upstream schema
+    resp = requests.get(DEFAULT_GRAPHER_SCHEMA, timeout=20)
+    resp.raise_for_status()
+    upstream = resp.json()
+    upstream_props = set(upstream["properties"].keys())
+
+    # Check for upstream properties missing locally
+    missing = upstream_props - local_props - LOCAL_ONLY_PROPERTIES
+    if missing:
+        # Build JSON snippets for each missing property so the developer can copy-paste
+        snippets = []
+        for prop in sorted(missing):
+            defn = upstream["properties"][prop]
+            snippet = json.dumps({prop: defn}, indent=2)
+            # Indent to match the nesting level in dataset-schema.json
+            snippet = "\n".join(" " * 24 + line for line in snippet.strip("{}").strip().split("\n"))
+            snippets.append(snippet)
+
+        raise AssertionError(
+            f"Upstream grapher schema ({DEFAULT_GRAPHER_SCHEMA}) has properties missing from\n"
+            f"schemas/dataset-schema.json → grapher_config: {sorted(missing)}\n"
+            f"\n"
+            f"To fix, add these properties inside the 'grapher_config.properties' object in\n"
+            f"schemas/dataset-schema.json (before the 'additionalProperties' key):\n"
+            f"\n"
+            + "\n".join(snippets)
+            + "\n\n"
+            f"NOTE: If a property uses a strict type (e.g. enum, array) but our meta.yml files\n"
+            f"use Jinja templates in that field, relax the type to 'string' or use\n"
+            f"oneOf/anyOf to accept both. If the property is ETL-only and intentionally absent\n"
+            f"from upstream, add it to LOCAL_ONLY_PROPERTIES in this test file."
+        )
+
+    # Check for local properties removed from upstream (excluding known local-only ones)
+    removed = (local_props - LOCAL_ONLY_PROPERTIES) - upstream_props
+    if removed:
+        log.warning(
+            "Local grapher_config has properties not in upstream schema (may be deprecated)",
+            properties=sorted(removed),
+        )
+

--- a/tests/test_metadata_schemas.py
+++ b/tests/test_metadata_schemas.py
@@ -210,9 +210,9 @@ def test_grapher_config_schema_sync():
     # Load local schema
     with open(SCHEMAS_DIR / "dataset-schema.json") as f:
         dataset_schema = json.load(f)
-    local_gc = dataset_schema["properties"]["tables"]["additionalProperties"]["properties"][
-        "variables"
-    ]["additionalProperties"]["properties"]["presentation"]["properties"]["grapher_config"]
+    local_gc = dataset_schema["properties"]["tables"]["additionalProperties"]["properties"]["variables"][
+        "additionalProperties"
+    ]["properties"]["presentation"]["properties"]["grapher_config"]
     local_props = set(local_gc["properties"].keys())
 
     # Fetch upstream schema
@@ -239,13 +239,11 @@ def test_grapher_config_schema_sync():
             f"\n"
             f"To fix, add these properties inside the 'grapher_config.properties' object in\n"
             f"schemas/dataset-schema.json (before the 'additionalProperties' key):\n"
-            f"\n"
-            + "\n".join(snippets)
-            + "\n\n"
-            f"NOTE: If a property uses a strict type (e.g. enum, array) but our meta.yml files\n"
-            f"use Jinja templates in that field, relax the type to 'string' or use\n"
-            f"oneOf/anyOf to accept both. If the property is ETL-only and intentionally absent\n"
-            f"from upstream, add it to LOCAL_ONLY_PROPERTIES in this test file."
+            f"\n" + "\n".join(snippets) + "\n\n"
+            "NOTE: If a property uses a strict type (e.g. enum, array) but our meta.yml files\n"
+            "use Jinja templates in that field, relax the type to 'string' or use\n"
+            "oneOf/anyOf to accept both. If the property is ETL-only and intentionally absent\n"
+            "from upstream, add it to LOCAL_ONLY_PROPERTIES in this test file."
         )
 
     # Check for local properties removed from upstream (excluding known local-only ones)
@@ -255,4 +253,3 @@ def test_grapher_config_schema_sync():
             "Local grapher_config has properties not in upstream schema (may be deprecated)",
             properties=sorted(removed),
         )
-


### PR DESCRIPTION
Sync the `grapher_config` section in `schemas/dataset-schema.json` with the upstream grapher schema.

## What changed

**Schema fixes (`schemas/dataset-schema.json`):**
- **`comparisonLines`**: Updated from only allowing `yEquals` to an `anyOf` supporting both `yEquals` (string) and `xEquals` (number), matching the upstream grapher schema
- **Added 4 missing upstream properties**: `focusedSeriesNames`, `slug`, `includedEntityNames`, `peerCountryStrategy`

**Sync test (`tests/test_metadata_schemas.py`):**
- Added `test_grapher_config_schema_sync` — fetches the upstream grapher schema and fails if it has properties missing from our local schema, with copy-pasteable JSON snippets in the error message to make fixing easy

## Why

The `grapher_config` properties in `dataset-schema.json` are hand-maintained (we can't use `$ref` because our meta.yml files use Jinja templates that the strict upstream types would reject). This means it silently drifts out of sync. The new test catches this automatically.

@codex review