### PR TITLE
Fix 'by World Bank' → 'by the World Bank' in attributions

### DIFF
--- a/etl/steps/data/garden/education/2023-07-17/education_lee_lee.meta.yml
+++ b/etl/steps/data/garden/education/2023-07-17/education_lee_lee.meta.yml
@@ -13,7 +13,7 @@ definitions:
 dataset:
   title: Human Capital in the Long Run (Lee and Lee 2016), WDI (World Bank) and UNESCO
   description: >
-    This dataset is based on 'Human Capital in the Long Run' by Lee and Lee (2016) and World Development Indicators by World Bank.
+    This dataset is based on 'Human Capital in the Long Run' by Lee and Lee (2016) and World Development Indicators by the World Bank.
     It includes indicators relating to enrollment rates in various levels of education, historic data on average years of education and educational attainment, specifically share of people with no education.
 
 tables:

--- a/etl/steps/data/garden/wb/2025-09-08/gender_statistics.py
+++ b/etl/steps/data/garden/wb/2025-09-08/gender_statistics.py
@@ -83,12 +83,12 @@ def run() -> None:
 def add_metadata_description(tb: Table, column_name: str, indicators: list) -> None:
     """Adds metadata description to a given column in tb."""
     description = (
-        f"**This indicator is a sum of {len(indicators)} different leave indicators provided by World Bank:**\n\n"
+        f"**This indicator is a sum of {len(indicators)} different leave indicators provided by the World Bank:**\n\n"
     )
     for indicator in indicators:
         if indicator in tb and hasattr(tb[indicator], "metadata"):
             description += (
-                f"The indicator '{tb[indicator].metadata.title}' is described by World Bank as:\n\n"
+                f"The indicator '{tb[indicator].metadata.title}' is described by the World Bank as:\n\n"
                 f"{tb[indicator].metadata.description_from_producer}\n\n"
             )
     tb[column_name].metadata.description_from_producer = description

--- a/etl/steps/data/garden/worldbank_wdi/2026-01-29/wdi.meta.override.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2026-01-29/wdi.meta.override.yml
@@ -837,7 +837,7 @@ tables:
           - "To learn more, read our article: [Definitions: access to electricity](https://ourworldindata.org/definition-electricity-access)."
         presentation:
           title_public: Share of the population with access to electricity
-          attribution: Data compiled from multiple sources by World Bank
+          attribution: Data compiled from multiple sources by the World Bank
           attribution_short: World Bank
           topic_tags:
             - Access to Energy
@@ -890,7 +890,7 @@ tables:
         description_processing: We calculated the share of the population without access to electricity by subtracting the share of the population with access from 100%.
         presentation:
           title_public: Share of the population with no access to electricity
-          attribution: Data compiled from multiple sources by World Bank
+          attribution: Data compiled from multiple sources by the World Bank
           attribution_short: World Bank
           topic_tags:
             - Access to Energy
@@ -921,7 +921,7 @@ tables:
         description_processing: We calculated the number of people with access to electricity by multiplying the fraction of the population with access by the total population.
         presentation:
           title_public: Number of people with access to electricity
-          attribution: Data compiled from multiple sources by World Bank
+          attribution: Data compiled from multiple sources by the World Bank
           attribution_short: World Bank
           topic_tags:
             - Access to Energy
@@ -936,7 +936,7 @@ tables:
         description_processing: We calculated the number of people without access to electricity by multiplying the fraction of the population without access by the total population.
         presentation:
           title_public: Number of people without access to electricity
-          attribution: Data compiled from multiple sources by World Bank
+          attribution: Data compiled from multiple sources by the World Bank
           attribution_short: World Bank
           topic_tags:
             - Access to Energy

--- a/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.meta.override.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.meta.override.yml
@@ -837,7 +837,7 @@ tables:
           - "To learn more, read our article: [Definitions: access to electricity](https://ourworldindata.org/definition-electricity-access)."
         presentation:
           title_public: Share of the population with access to electricity
-          attribution: Data compiled from multiple sources by World Bank
+          attribution: Data compiled from multiple sources by the World Bank
           attribution_short: World Bank
           topic_tags:
             - Access to Energy
@@ -890,7 +890,7 @@ tables:
         description_processing: We calculated the share of the population without access to electricity by subtracting the share of the population with access from 100%.
         presentation:
           title_public: Share of the population with no access to electricity
-          attribution: Data compiled from multiple sources by World Bank
+          attribution: Data compiled from multiple sources by the World Bank
           attribution_short: World Bank
           topic_tags:
             - Access to Energy
@@ -921,7 +921,7 @@ tables:
         description_processing: We calculated the number of people with access to electricity by multiplying the fraction of the population with access by the total population.
         presentation:
           title_public: Number of people with access to electricity
-          attribution: Data compiled from multiple sources by World Bank
+          attribution: Data compiled from multiple sources by the World Bank
           attribution_short: World Bank
           topic_tags:
             - Access to Energy
@@ -936,7 +936,7 @@ tables:
         description_processing: We calculated the number of people without access to electricity by multiplying the fraction of the population without access by the total population.
         presentation:
           title_public: Number of people without access to electricity
-          attribution: Data compiled from multiple sources by World Bank
+          attribution: Data compiled from multiple sources by the World Bank
           attribution_short: World Bank
           topic_tags:
             - Access to Energy


### PR DESCRIPTION
## Summary
- Fixes grammatically incorrect "by World Bank" → "by the World Bank" across active garden steps
- Affects WDI electricity access attributions and metadata in gender_statistics and education_lee_lee

## Test plan
- [ ] Verify attribution text renders correctly on charts

@codex review

🤖 Generated with [Claude Code](https://claude.com/claude-code)