### PR TITLE
📊 Add StackedDiscreteBar to income multidims

### DIFF
--- a/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
@@ -104,6 +104,9 @@ views:
       note: ""
       hasMapTab: false
       chartTypes: ["StackedArea", "StackedDiscreteBar"]
+      hideTotalValueLabel: true
+      sortBy: column
+      sortColumnSlug: inequality#share_top_10__welfare_type_dhi__equivalence_scale_square_root
       selectedFacetStrategy: entity
       baseColorScheme: OwidCategoricalE
     metadata:
@@ -131,6 +134,9 @@ views:
       note: ""
       hasMapTab: false
       chartTypes: ["StackedArea", "StackedDiscreteBar"]
+      hideTotalValueLabel: true
+      sortBy: column
+      sortColumnSlug: inequality#share_top_10__welfare_type_mi__equivalence_scale_square_root
       selectedFacetStrategy: entity
       baseColorScheme: OwidCategoricalE
     metadata:

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
@@ -54,12 +54,8 @@ dimensions:
         name: "Richest 10%"
       - slug: all
         name: All deciles
-      # - slug: all_bar
-      #   name: All deciles (bar chart)
       - slug: "10_40_50"
         name: Poorest 50%, middle 40% and richest 10%
-      # - slug: "10_40_50_bar"
-      #   name: Richest and poorest groups (bar chart)
       - slug: nan
         name: ""
 
@@ -107,7 +103,7 @@ views:
       subtitle: The share of income received by different income groups. Income here is measured after taxes and benefits.
       note: ""
       hasMapTab: false
-      chartTypes: ["StackedArea"]
+      chartTypes: ["StackedArea", "StackedDiscreteBar"]
       selectedFacetStrategy: entity
       baseColorScheme: OwidCategoricalE
     metadata:
@@ -134,68 +130,8 @@ views:
       subtitle: The share of income received by different income groups. Income here is measured before taxes and benefits.
       note: ""
       hasMapTab: false
-      chartTypes: ["StackedArea"]
+      chartTypes: ["StackedArea", "StackedDiscreteBar"]
       selectedFacetStrategy: entity
       baseColorScheme: OwidCategoricalE
     metadata:
       description_short: "The share of income received by different income groups: the richest 10%, the poorest 50% and the 40% in the middle. Income here is measured before taxes and benefits."
-
-  # - dimensions:
-  #     indicator: share
-  #     decile: "10_40_50_bar"
-  #     period: nan
-  #     welfare_type: dhi
-  #   indicators:
-  #     y:
-  #       - catalogPath: inequality#share_bottom_50__welfare_type_dhi__equivalence_scale_square_root
-  #         display:
-  #           name: "Poorest 50%"
-  #       - catalogPath: inequality#share_middle_40__welfare_type_dhi__equivalence_scale_square_root
-  #         display:
-  #           name: "Middle 40%"
-  #       - catalogPath: inequality#share_top_10__welfare_type_dhi__equivalence_scale_square_root
-  #         display:
-  #           name: "Richest 10%"
-  #   config:
-  #     title: Distribution of income across richer and poorer groups (after tax)
-  #     subtitle: The share of income received by different income groups. Income here is measured after taxes and benefits.
-  #     note: ""
-  #     hasMapTab: false
-  #     chartTypes: ["StackedDiscreteBar"]
-  #     selectedFacetStrategy: entity
-  #     baseColorScheme: OwidCategoricalE
-  #     hideTotalValueLabel: true
-  #     sortBy: column
-  #     sortColumnSlug: inequality#share_top_10__welfare_type_dhi__equivalence_scale_square_root
-  #   metadata:
-  #     description_short: "The share of income received by different income groups: the richest 10%, the poorest 50% and the 40% in the middle. Income here is measured after taxes and benefits."
-
-  # - dimensions:
-  #     indicator: share
-  #     decile: "10_40_50_bar"
-  #     period: nan
-  #     welfare_type: mi
-  #   indicators:
-  #     y:
-  #       - catalogPath: inequality#share_bottom_50__welfare_type_mi__equivalence_scale_square_root
-  #         display:
-  #           name: "Poorest 50%"
-  #       - catalogPath: inequality#share_middle_40__welfare_type_mi__equivalence_scale_square_root
-  #         display:
-  #           name: "Middle 40%"
-  #       - catalogPath: inequality#share_top_10__welfare_type_mi__equivalence_scale_square_root
-  #         display:
-  #           name: "Richest 10%"
-  #   config:
-  #     title: Distribution of income across richer and poorer groups (before tax)
-  #     subtitle: The share of income received by different income groups. Income here is measured before taxes and benefits.
-  #     note: ""
-  #     hasMapTab: false
-  #     chartTypes: ["StackedDiscreteBar"]
-  #     selectedFacetStrategy: entity
-  #     baseColorScheme: OwidCategoricalE
-  #     hideTotalValueLabel: true
-  #     sortBy: column
-  #     sortColumnSlug: inequality#share_top_10__welfare_type_mi__equivalence_scale_square_root
-  #   metadata:
-  #     description_short: "The share of income received by different income groups: the richest 10%, the poorest 50% and the 40% in the middle. Income here is measured before taxes and benefits."

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.py
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.py
@@ -56,9 +56,7 @@ def run() -> None:
         and slug
         not in (
             "all",
-            # "all_bar",
             "10_40_50",
-            # "10_40_50_bar",
         )
     ]
     c.group_views(
@@ -72,7 +70,9 @@ def run() -> None:
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
-                    "chartTypes": lambda view: ["StackedArea"] if view.matches(indicator="share") else ["LineChart"],
+                    "chartTypes": lambda view: (
+                        ["StackedArea", "StackedDiscreteBar"] if view.matches(indicator="share") else ["LineChart"]
+                    ),
                     "baseColorScheme": "OwidCategoricalE",
                     "title": "{title}",
                     "subtitle": "{subtitle}",
@@ -81,25 +81,6 @@ def run() -> None:
                     "description_short": "{subtitle}",
                 },
             },
-            # {
-            #     "dimension": "decile",
-            #     "choices": decile_values,
-            #     "choice_new_slug": "all_bar",
-            #     "view_config": {
-            #         "hideRelativeToggle": True,
-            #         "selectedFacetStrategy": "entity",
-            #         "hasMapTab": False,
-            #         "tab": "chart",
-            #         "chartTypes": ["StackedDiscreteBar"],
-            #         "hideTotalValueLabel": True,
-            #         "baseColorScheme": "OwidCategoricalE",
-            #         "title": "{title}",
-            #         "subtitle": "{subtitle}",
-            #     },
-            #     "view_metadata": {
-            #         "description_short": "{subtitle}",
-            #     },
-            # },
         ],
         params={
             "title": _get_grouped_decile_title,
@@ -113,14 +94,7 @@ def run() -> None:
     c.drop_views(
         [
             {"decile": ["2", "3", "4", "6", "7", "8"]},
-            {
-                "decile": [
-                    # "all_bar",
-                    "10_40_50",
-                    # "10_40_50_bar",
-                ],
-                "indicator": non_share,
-            },
+            {"decile": ["10_40_50"], "indicator": non_share},
             {"decile": ["5", "9"], "indicator": non_thr},
         ]
     )
@@ -130,21 +104,10 @@ def run() -> None:
 
     # Customize grouped decile views: sort indicators and set display names
     for view in c.views:
-        if (view.matches(decile="all") or view.matches(decile="all_bar")) and view.indicators.y:
+        if view.matches(decile="all") and view.indicators.y:
             # Sort indicators by decile number
             reverse_order = view.matches(indicator="share")
-            # if view.matches(decile="all_bar"):
-            #     reverse_order = not reverse_order
             view.indicators.y = sorted(view.indicators.y, key=_get_decile_number, reverse=reverse_order)
-
-            # For all_bar: set sortBy (depends on sorted indicator order)
-            # if view.matches(decile="all_bar"):
-            #     decile_10_ind = next((ind for ind in view.indicators.y if _get_decile_number(ind) == 10), None)
-            #     if decile_10_ind:
-            #         if view.config is None:
-            #             view.config = {}
-            #         view.config["sortBy"] = "column"
-            #         view.config["sortColumnSlug"] = decile_10_ind.catalogPath
 
             # Set display names
             for ind in view.indicators.y:
@@ -187,12 +150,7 @@ def run() -> None:
         [
             {
                 "welfare_type": ["before_vs_after"],
-                "decile": [
-                    "all",
-                    # "all_bar",
-                    "10_40_50",
-                    # "10_40_50_bar",
-                ],
+                "decile": ["all", "10_40_50"],
             }
         ]
     )

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.py
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.py
@@ -73,6 +73,7 @@ def run() -> None:
                     "chartTypes": lambda view: (
                         ["StackedArea", "StackedDiscreteBar"] if view.matches(indicator="share") else ["LineChart"]
                     ),
+                    "hideTotalValueLabel": True,
                     "baseColorScheme": "OwidCategoricalE",
                     "title": "{title}",
                     "subtitle": "{subtitle}",
@@ -108,6 +109,11 @@ def run() -> None:
             # Sort indicators by decile number
             reverse_order = view.matches(indicator="share")
             view.indicators.y = sorted(view.indicators.y, key=_get_decile_number, reverse=reverse_order)
+
+            # Set sortBy to first indicator in the list
+            view.config = view.config or {}
+            view.config["sortBy"] = "column"
+            view.config["sortColumnSlug"] = view.indicators.y[0].catalogPath
 
             # Set display names
             for ind in view.indicators.y:

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
@@ -57,12 +57,8 @@ dimensions:
         name: "Richest 10%"
       - slug: all
         name: All deciles
-      # - slug: all_bar
-      #   name: All deciles (bar chart)
       - slug: "10_40_50"
         name: Poorest 50%, middle 40% and richest 10%
-      # - slug: "10_40_50_bar"
-      #   name: Richest and poorest groups (bar chart)
       - slug: nan
         name: ""
 
@@ -111,39 +107,8 @@ views:
       subtitle: The share of income received by different income groups.
       note: Depending on the country and year, the data relates to income (measured after taxes and benefits) or to consumption, [per capita](#dod:per-capita).
       hasMapTab: false
-      chartTypes: ["StackedArea"]
+      chartTypes: ["StackedArea", "StackedDiscreteBar"]
       selectedFacetStrategy: entity
       baseColorScheme: OwidCategoricalE
     metadata:
       description_short: "The share of income received by different income groups: the richest 10%, the poorest 50% and the 40% in the middle."
-
-  # - dimensions:
-  #     indicator: share
-  #     decile: "10_40_50_bar"
-  #     period: nan
-  #     table: Income or consumption consolidated
-  #     survey_comparability: No spells
-  #   indicators:
-  #     y:
-  #       - catalogPath: inequality#bottom50_share__welfare_type_income_or_consumption__table_income_or_consumption_consolidated__survey_comparability_no_spells
-  #         display:
-  #           name: "Poorest 50%"
-  #       - catalogPath: inequality#middle40_share__welfare_type_income_or_consumption__table_income_or_consumption_consolidated__survey_comparability_no_spells
-  #         display:
-  #           name: "Middle 40%"
-  #       - catalogPath: incomes#share__ppp_version_2021__welfare_type_income_or_consumption__decile_10__table_income_or_consumption_consolidated__survey_comparability_no_spells
-  #         display:
-  #           name: "Richest 10%"
-  #   config:
-  #     title: Distribution of income across richer and poorer groups
-  #     subtitle: The share of income received by different income groups.
-  #     note: Depending on the country and year, the data relates to income (measured after taxes and benefits) or to consumption, [per capita](#dod:per-capita).
-  #     hasMapTab: false
-  #     chartTypes: ["StackedDiscreteBar"]
-  #     selectedFacetStrategy: entity
-  #     baseColorScheme: OwidCategoricalE
-  #     sortBy: column
-  #     sortColumnSlug: incomes#share__ppp_version_2021__welfare_type_income_or_consumption__decile_10__table_income_or_consumption_consolidated__survey_comparability_no_spells
-  #     hideTotalValueLabel: true
-  #   metadata:
-  #     description_short: "The share of income received by different income groups: the richest 10%, the poorest 50% and the 40% in the middle."

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
@@ -108,6 +108,9 @@ views:
       note: Depending on the country and year, the data relates to income (measured after taxes and benefits) or to consumption, [per capita](#dod:per-capita).
       hasMapTab: false
       chartTypes: ["StackedArea", "StackedDiscreteBar"]
+      hideTotalValueLabel: true
+      sortBy: column
+      sortColumnSlug: incomes#share__ppp_version_2021__welfare_type_income_or_consumption__decile_10__table_income_or_consumption_consolidated__survey_comparability_no_spells
       selectedFacetStrategy: entity
       baseColorScheme: OwidCategoricalE
     metadata:

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.py
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.py
@@ -119,9 +119,7 @@ def run() -> None:
         and slug
         not in (
             "all",
-            # "all_bar",
             "10_40_50",
-            # "10_40_50_bar",
         )
     ]
     c.group_views(
@@ -135,7 +133,9 @@ def run() -> None:
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
-                    "chartTypes": lambda view: ["StackedArea"] if view.matches(indicator="share") else ["LineChart"],
+                    "chartTypes": lambda view: (
+                        ["StackedArea", "StackedDiscreteBar"] if view.matches(indicator="share") else ["LineChart"]
+                    ),
                     "baseColorScheme": "OwidCategoricalE",
                     "title": "{title}",
                     "subtitle": "{subtitle}",
@@ -144,25 +144,6 @@ def run() -> None:
                     "description_short": "{subtitle}",
                 },
             },
-            # {
-            #     "dimension": "decile",
-            #     "choices": decile_values,
-            #     "choice_new_slug": "all_bar",
-            #     "view_config": {
-            #         "hideRelativeToggle": True,
-            #         "selectedFacetStrategy": "entity",
-            #         "hasMapTab": False,
-            #         "tab": "chart",
-            #         "chartTypes": ["StackedDiscreteBar"],
-            #         "hideTotalValueLabel": True,
-            #         "baseColorScheme": "OwidCategoricalE",
-            #         "title": "{title}",
-            #         "subtitle": "{subtitle}",
-            #     },
-            #     "view_metadata": {
-            #         "description_short": "{subtitle}",
-            #     },
-            # },
         ],
         params={
             "title": _get_grouped_decile_title,
@@ -177,22 +158,9 @@ def run() -> None:
     c.drop_views(
         [
             {"decile": ["2", "3", "4", "6", "7", "8"]},
-            {
-                "decile": [
-                    # "all_bar",
-                    "10_40_50",
-                    # "10_40_50_bar",
-                ],
-                "indicator": non_share,
-            },
+            {"decile": ["10_40_50"], "indicator": non_share},
             {"decile": ["5", "9"], "indicator": non_thr},
-            {
-                "decile": [
-                    "all",
-                    # "all_bar",
-                ],
-                "survey_comparability": "Spells",
-            },
+            {"decile": ["all"], "survey_comparability": "Spells"},
         ]
     )
 
@@ -201,23 +169,11 @@ def run() -> None:
 
     # Customize grouped decile views: sort indicators and set display names
     for view in c.views:
-        if (view.matches(decile="all") or view.matches(decile="all_bar")) and view.indicators.y:
+        if view.matches(decile="all") and view.indicators.y:
             # Sort indicators by decile number
             # For share: richest to poorest; for others: poorest to richest
-            # For all_bar: inverse order
             reverse_order = view.matches(indicator="share")
-            # if view.matches(decile="all_bar"):
-            #     reverse_order = not reverse_order
             view.indicators.y = sorted(view.indicators.y, key=_get_decile_number, reverse=reverse_order)
-
-            # For all_bar views, set sortBy to column and sortColumnSlug to decile 10 indicator
-            # if view.matches(decile="all_bar"):
-            #     decile_10_ind = next((ind for ind in view.indicators.y if _get_decile_number(ind) == 10), None)
-            #     if decile_10_ind:
-            #         if view.config is None:
-            #             view.config = {}
-            #         view.config["sortBy"] = "column"
-            #         view.config["sortColumnSlug"] = decile_10_ind.catalogPath
 
             # Set display names extracted from original indicator titles
             for ind in view.indicators.y:
@@ -227,14 +183,7 @@ def run() -> None:
 
     # Add Marimekko as an additional chart type for mean and median views.
     for view in c.views:
-        if view.matches(survey_comparability="No spells") and not view.matches(
-            decile=[
-                "all",
-                # "all_bar",
-                "10_40_50",
-                # "10_40_50_bar",
-            ]
-        ):
+        if view.matches(survey_comparability="No spells") and not view.matches(decile=["all", "10_40_50"]):
             view.config = view.config or {}
             view.config["chartTypes"] = ["LineChart", "DiscreteBar", "Marimekko"]
             view.indicators.set_indicator(

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.py
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.py
@@ -136,6 +136,7 @@ def run() -> None:
                     "chartTypes": lambda view: (
                         ["StackedArea", "StackedDiscreteBar"] if view.matches(indicator="share") else ["LineChart"]
                     ),
+                    "hideTotalValueLabel": True,
                     "baseColorScheme": "OwidCategoricalE",
                     "title": "{title}",
                     "subtitle": "{subtitle}",
@@ -174,6 +175,11 @@ def run() -> None:
             # For share: richest to poorest; for others: poorest to richest
             reverse_order = view.matches(indicator="share")
             view.indicators.y = sorted(view.indicators.y, key=_get_decile_number, reverse=reverse_order)
+
+            # Set sortBy to last indicator in the list
+            view.config = view.config or {}
+            view.config["sortBy"] = "column"
+            view.config["sortColumnSlug"] = view.indicators.y[0].catalogPath
 
             # Set display names extracted from original indicator titles
             for ind in view.indicators.y:

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.config.yml
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.config.yml
@@ -72,6 +72,9 @@ views:
       note: Income is measured before payment of taxes and non-pension benefits, but after the payment of public and private pensions.
       hasMapTab: false
       chartTypes: ["StackedArea", "StackedDiscreteBar"]
+      hideTotalValueLabel: true
+      sortBy: column
+      sortColumnSlug: inequality#share_top_1__welfare_type_before_tax__extrapolated_no
       selectedFacetStrategy: entity
       baseColorScheme: OwidCategoricalE
     metadata:
@@ -100,6 +103,9 @@ views:
       note: ""
       hasMapTab: false
       chartTypes: ["StackedArea", "StackedDiscreteBar"]
+      hideTotalValueLabel: true
+      sortBy: column
+      sortColumnSlug: inequality#share_top_1__welfare_type_after_tax__extrapolated_no
       selectedFacetStrategy: entity
       baseColorScheme: OwidCategoricalE
     metadata:

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.config.yml
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.config.yml
@@ -33,12 +33,8 @@ dimensions:
         name: Richest 10%
       - slug: all
         name: All deciles
-      # - slug: all_bar
-      #   name: All deciles (bar chart)
       - slug: "10_40_50"
         name: Poorest 50%, middle 40%, next 9% and richest 1%
-      # - slug: "10_40_50_bar"
-      #   name: Richest and poorest groups (bar chart)
 
   - name: Income measure
     slug: welfare_type
@@ -75,7 +71,7 @@ views:
       subtitle: The share of income received by different income groups. Income here is measured before taxes and benefits.
       note: Income is measured before payment of taxes and non-pension benefits, but after the payment of public and private pensions.
       hasMapTab: false
-      chartTypes: ["StackedArea"]
+      chartTypes: ["StackedArea", "StackedDiscreteBar"]
       selectedFacetStrategy: entity
       baseColorScheme: OwidCategoricalE
     metadata:
@@ -103,70 +99,8 @@ views:
       subtitle: The share of income received by different income groups. Income here is measured after taxes and benefits.
       note: ""
       hasMapTab: false
-      chartTypes: ["StackedArea"]
+      chartTypes: ["StackedArea", "StackedDiscreteBar"]
       selectedFacetStrategy: entity
       baseColorScheme: OwidCategoricalE
     metadata:
       description_short: "The share of income received by different income groups: the richest 1%, the next 9%, the poorest 50% and the 40% in the middle. Income here is measured after taxes and benefits."
-
-  # - dimensions:
-  #     quantile: "10_40_50_bar"
-  #     welfare_type: before tax
-  #   indicators:
-  #     y:
-  #       - catalogPath: inequality#share_bottom_50__welfare_type_before_tax__extrapolated_no
-  #         display:
-  #           name: "Poorest 50%"
-  #       - catalogPath: inequality#share_middle_40__welfare_type_before_tax__extrapolated_no
-  #         display:
-  #           name: "Middle 40%"
-  #       - catalogPath: inequality#share_top_90_99__welfare_type_before_tax__extrapolated_no
-  #         display:
-  #           name: "Next 9%"
-  #       - catalogPath: inequality#share_top_1__welfare_type_before_tax__extrapolated_no
-  #         display:
-  #           name: "Richest 1%"
-  #   config:
-  #     title: Distribution of income across richer and poorer groups (before tax)
-  #     subtitle: The share of income received by different income groups. Income here is measured before taxes and benefits.
-  #     note: Income is measured before payment of taxes and non-pension benefits, but after the payment of public and private pensions.
-  #     hasMapTab: false
-  #     chartTypes: ["StackedDiscreteBar"]
-  #     selectedFacetStrategy: entity
-  #     baseColorScheme: OwidCategoricalE
-  #     hideTotalValueLabel: true
-  #     sortBy: column
-  #     sortColumnSlug: inequality#share_top_1__welfare_type_before_tax__extrapolated_no
-  #   metadata:
-  #     description_short: "The share of income received by different income groups: the richest 1%, the next 9%, the poorest 50% and the 40% in the middle. Income here is measured before taxes and benefits."
-
-  # - dimensions:
-  #     quantile: "10_40_50_bar"
-  #     welfare_type: after tax
-  #   indicators:
-  #     y:
-  #       - catalogPath: inequality#share_bottom_50__welfare_type_after_tax__extrapolated_no
-  #         display:
-  #           name: "Poorest 50%"
-  #       - catalogPath: inequality#share_middle_40__welfare_type_after_tax__extrapolated_no
-  #         display:
-  #           name: "Middle 40%"
-  #       - catalogPath: inequality#share_top_90_99__welfare_type_after_tax__extrapolated_no
-  #         display:
-  #           name: "Next 9%"
-  #       - catalogPath: inequality#share_top_1__welfare_type_after_tax__extrapolated_no
-  #         display:
-  #           name: "Richest 1%"
-  #   config:
-  #     title: Distribution of income across richer and poorer groups (after tax)
-  #     subtitle: The share of income received by different income groups. Income here is measured after taxes and benefits.
-  #     note: ""
-  #     hasMapTab: false
-  #     chartTypes: ["StackedDiscreteBar"]
-  #     selectedFacetStrategy: entity
-  #     baseColorScheme: OwidCategoricalE
-  #     hideTotalValueLabel: true
-  #     sortBy: column
-  #     sortColumnSlug: inequality#share_top_1__welfare_type_after_tax__extrapolated_no
-  #   metadata:
-  #     description_short: "The share of income received by different income groups: the richest 1%, the next 9%, the poorest 50% and the 40% in the middle. Income here is measured after taxes and benefits."

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.py
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.py
@@ -70,30 +70,13 @@ def run() -> None:
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
-                    "chartTypes": ["StackedArea"],
+                    "chartTypes": ["StackedArea", "StackedDiscreteBar"],
                     "baseColorScheme": "OwidCategoricalE",
                     "title": "{title}",
                     "subtitle": "{subtitle}",
                 },
                 "view_metadata": {"description_short": "{subtitle}"},
             },
-            # {
-            #     "dimension": "quantile",
-            #     "choices": decile_values,
-            #     "choice_new_slug": "all_bar",
-            #     "view_config": {
-            #         "hideRelativeToggle": True,
-            #         "selectedFacetStrategy": "entity",
-            #         "hasMapTab": False,
-            #         "tab": "chart",
-            #         "chartTypes": ["StackedDiscreteBar"],
-            #         "hideTotalValueLabel": True,
-            #         "baseColorScheme": "OwidCategoricalE",
-            #         "title": "{title}",
-            #         "subtitle": "{subtitle}",
-            #     },
-            #     "view_metadata": {"description_short": "{subtitle}"},
-            # },
         ],
         params={
             "title": _get_grouped_quantile_title,
@@ -107,9 +90,7 @@ def run() -> None:
         "Richest 1%",
         "10",
         "10_40_50",
-        # "10_40_50_bar",
         "all",
-        # "all_bar",
     }
     c.drop_views({"quantile": [q for q in c.dimension_choices["quantile"] if q not in keep_quantiles]})
 
@@ -119,20 +100,9 @@ def run() -> None:
     # Customize grouped quantile views: sort indicators and set display names
     for view in c.views:
         quantile = view.dimensions.get("quantile")
-        if quantile in ["all", "all_bar"] and view.indicators.y:
-            # Sort indicators by decile number
-            # For all: richest to poorest; for all_bar: poorest to richest
-            reverse_order = quantile == "all"
-            view.indicators.y = sorted(view.indicators.y, key=_get_decile_number, reverse=reverse_order)
-
-            # For all_bar views, set sortBy to column and sortColumnSlug to decile 10 indicator
-            # if quantile == "all_bar":
-            #     decile_10_ind = next((ind for ind in view.indicators.y if _get_decile_number(ind) == 10), None)
-            #     if decile_10_ind:
-            #         if view.config is None:
-            #             view.config = {}
-            #         view.config["sortBy"] = "column"
-            #         view.config["sortColumnSlug"] = decile_10_ind.catalogPath
+        if quantile == "all" and view.indicators.y:
+            # Sort indicators by decile number (richest to poorest)
+            view.indicators.y = sorted(view.indicators.y, key=_get_decile_number, reverse=True)
 
             # Set display names extracted from original indicator titles
             for ind in view.indicators.y:
@@ -173,12 +143,7 @@ def run() -> None:
     c.drop_views(
         {
             "welfare_type": ["before_vs_after"],
-            "quantile": [
-                "10_40_50",
-                # "10_40_50_bar",
-                "all",
-                # "all_bar",
-            ],
+            "quantile": ["10_40_50", "all"],
         }
     )
 
@@ -231,12 +196,7 @@ def run() -> None:
     c.drop_views(
         {
             "welfare_type": ["before_vs_after_scatter"],
-            "quantile": [
-                "10_40_50",
-                # "10_40_50_bar",
-                "all",
-                # "all_bar",
-            ],
+            "quantile": ["10_40_50", "all"],
         }
     )
 

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.py
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.py
@@ -71,6 +71,7 @@ def run() -> None:
                     "hasMapTab": False,
                     "tab": "chart",
                     "chartTypes": ["StackedArea", "StackedDiscreteBar"],
+                    "hideTotalValueLabel": True,
                     "baseColorScheme": "OwidCategoricalE",
                     "title": "{title}",
                     "subtitle": "{subtitle}",
@@ -103,6 +104,11 @@ def run() -> None:
         if quantile == "all" and view.indicators.y:
             # Sort indicators by decile number (richest to poorest)
             view.indicators.y = sorted(view.indicators.y, key=_get_decile_number, reverse=True)
+
+            # Set sortBy to first indicator in the list
+            view.config = view.config or {}
+            view.config["sortBy"] = "column"
+            view.config["sortColumnSlug"] = view.indicators.y[0].catalogPath
 
             # Set display names extracted from original indicator titles
             for ind in view.indicators.y:


### PR DESCRIPTION
## Summary
- Add `StackedDiscreteBar` as an additional chart type for `all` (share indicator) and `10_40_50` views in incomes_pip, incomes_wid, and incomes_lis multidims
- Add `hideTotalValueLabel` and `sortBy`/`sortColumnSlug` config to StackedDiscreteBar views
- Remove all commented-out `all_bar` and `10_40_50_bar` code from Python and YAML config files

## Test plan
- [x] Run `etlr export/multidim/wb/latest/incomes_pip --private`
- [x] Run `etlr export/multidim/wid/latest/incomes_wid --private`
- [x] Run `etlr export/multidim/lis/latest/incomes_lis --private`
- [x] Verify StackedDiscreteBar toggle appears on share views for `all` and `10_40_50` decile choices
- [x] Verify bar charts hide total value label and sort by the first indicator column

🤖 Generated with [Claude Code](https://claude.com/claude-code)