### PR TITLE
🔨 Replace streamlit_card with native st.container+st.page_link

### DIFF
--- a/apps/wizard/home.py
+++ b/apps/wizard/home.py
@@ -1,13 +1,9 @@
 """Home page of wizard."""
 
-from copy import deepcopy
-from typing import Any
-
 import streamlit as st
-from streamlit_card import card
 
 from apps.wizard.config import WIZARD_CONFIG
-from apps.wizard.utils.components import st_wizard_page_link
+from apps.wizard.utils.components import st_wizard_card, st_wizard_page_link
 
 st.set_page_config(
     page_title="Wizard: Home",
@@ -49,55 +45,6 @@ def st_show_home():
         )
         st.caption(f"streamlit {st.__version__}", width="content")
 
-    # Generic tools
-    ## Default styling for the cards (Wizard apps are presented as cards)
-    default_styles = {
-        "card": {
-            "width": "100%",
-            "height": "80px",
-            "padding": "0px",
-            "margin": "0px",
-            "font-size": ".8rem",
-            "font-family": "Helvetica",
-        },
-        "filter": {
-            "background-color": "rgba(0, 0, 0, 0.55)"  # <- make the image not dimmed anymore
-        },
-        "text": {
-            "font-size": "1rem",
-            # "font-weight": "normal",
-            "margin": "0px",
-            "padding": "0px",
-        },
-    }
-
-    def create_card(
-        entrypoint: str,
-        title: str,
-        image_url: str,
-        text: str | list[str] = "",
-        custom_styles: dict[str, Any] | None = None,
-        small: bool = False,
-    ) -> None:
-        """Create card."""
-        styles = deepcopy(default_styles)
-        if small:
-            styles["card"]["height"] = "50px"
-
-        if custom_styles:
-            styles["card"].update(custom_styles)
-        go_to_page = card(
-            title=title,
-            image=image_url,
-            text=text,
-            # text=f"Press {i + 1}",
-            # text=["This is a test card", "This is a subtext"],
-            styles=styles,
-            on_click=lambda: None,  # ty: ignore[invalid-argument-type]
-        )
-        if go_to_page:
-            st.switch_page(entrypoint)
-
     #########################
     # ETL Steps
     #########################
@@ -105,98 +52,70 @@ def st_show_home():
     st.markdown(WIZARD_CONFIG["etl"]["description"])
     steps = WIZARD_CONFIG["etl"]["steps"]
 
-    # We present two channels to create an ETL step chain:
-    # 1. Classic: Snapshot -> Data
-    # 2. Fast Track
-
-    # 1/ CLASSIC: Snapshot + Data
+    # 1/ CLASSIC: Snapshot -> Data -> Collection (no captions, match original)
     if steps["fasttrack"]["enable"]:
-        col1, col2, col3 = st.columns([1, 2, 1])
-        with col1:
-            create_card(
-                entrypoint=steps["snapshot"]["entrypoint"],
-                title=steps["snapshot"]["title"],
-                image_url=steps["snapshot"]["image_url"],
-                custom_styles={"height": "100px"},
-            )
-        with col2:
-            create_card(
-                entrypoint=steps["data"]["entrypoint"],
-                title=steps["data"]["title"],
-                image_url=steps["data"]["image_url"],
-                custom_styles={"height": "100px"},
-            )
-        with col3:
-            create_card(
-                entrypoint=steps["collection"]["entrypoint"],
-                title=steps["collection"]["title"],
-                image_url=steps["collection"]["image_url"],
-                custom_styles={"height": "100px"},
-            )
+        _render_cards_row(
+            [steps["snapshot"], steps["data"], steps["collection"]],
+            height=100,
+            col_widths=[1, 2, 1],
+            show_caption=False,
+        )
 
     # 2/ FAST TRACK
     if steps["fasttrack"]["enable"]:
         col1, _ = st.columns([3, 1])
         with col1:
-            create_card(
-                entrypoint=steps["fasttrack"]["entrypoint"],
-                title=steps["fasttrack"]["title"],
-                image_url=steps["fasttrack"]["image_url"],
-                custom_styles={"height": "50px"},
-            )
+            _render_card(steps["fasttrack"], height=50, show_caption=False)
 
     #########################
     # Sections
     #########################
-    # Determine number of rows
     sections = WIZARD_CONFIG["sections"]
-    num_sections = len(sections)
-    num_rows = num_sections // MAX_COLS_PER_ROW + 1
-
+    num_rows = len(sections) // MAX_COLS_PER_ROW + 1
     for row in range(num_rows):
         cols = st.columns(MAX_COLS_PER_ROW)
         for i, section in enumerate(sections[row * MAX_COLS_PER_ROW : (row + 1) * MAX_COLS_PER_ROW]):
+            apps = [app for app in section["apps"] if app["enable"]]
+            if not apps:
+                continue
             with cols[i]:
-                apps = [app for app in section["apps"] if app["enable"]]
-                if apps:
-                    st.markdown(f"## {section['title']}")
-                    st.markdown(section["description"])
-                    for app in apps:
-                        text = [
-                            app["description"],
-                        ]
-                        create_card(
-                            entrypoint=app["entrypoint"],
-                            title=app["title"],
-                            image_url=app["image_url"],
-                            text=text,
-                        )
+                st.markdown(f"## {section['title']}")
+                st.markdown(section["description"])
+                for app in apps:
+                    _render_card(app)
 
     #########################
     # Legacy
     #########################
-    # st.divider()
-
     if "legacy" in WIZARD_CONFIG:
-        section_legacy = WIZARD_CONFIG["legacy"]
-        apps = [app for app in section_legacy["apps"] if app["enable"]]
-        if apps:
-            st.warning(section_legacy["description"])
-            columns = st.columns(len(apps))
-            for i, app in enumerate(apps):
-                text = [
-                    app["description"],
-                ]
-                # if "maintainer" in app:
-                #     text.append(f"maintainer: {app['maintainer']}")
-                if app["enable"]:
-                    with columns[i]:
-                        create_card(
-                            entrypoint=app["entrypoint"],
-                            title=app["title"],
-                            image_url=app["image_url"],
-                            text=text,
-                        )
+        legacy_apps = [app for app in WIZARD_CONFIG["legacy"]["apps"] if app["enable"]]
+        if legacy_apps:
+            st.warning(WIZARD_CONFIG["legacy"]["description"])
+            _render_cards_row(legacy_apps)
+
+
+def _render_card(item: dict, height: int = 80, show_caption: bool = True) -> None:
+    """Render a single wizard card from a WIZARD_CONFIG app/step dict."""
+    st_wizard_card(
+        entrypoint=item["entrypoint"],
+        title=item["title"],
+        image_url=item["image_url"],
+        caption=item.get("description", "") if show_caption else "",
+        height=height,
+    )
+
+
+def _render_cards_row(
+    items: list[dict],
+    height: int = 80,
+    col_widths: list[int] | None = None,
+    show_caption: bool = True,
+) -> None:
+    """Render a row of wizard cards across Streamlit columns."""
+    cols = st.columns(col_widths or len(items))
+    for col, item in zip(cols, items):
+        with col:
+            _render_card(item, height=height, show_caption=show_caption)
 
 
 # Show the home page

--- a/apps/wizard/utils/components.py
+++ b/apps/wizard/utils/components.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import random
+import re
 import urllib.parse
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -485,6 +486,154 @@ def st_title_with_expert(title: str, icon: str | None = None, **kwargs):
             width="content",
             border=False,
         )
+
+
+# ---------------------------------------------------------------------------
+# st_wizard_card — native replacement for the legacy `streamlit_card` component.
+# Renders a clickable card (background image + dark overlay + centered label and
+# optional caption) using only st.container + st.page_link, styled via CSS
+# targeting the container's `st-key-wcard-<slug>` class. Used on the Wizard
+# home page and any other page that needs image-tile navigation.
+#
+# `!important` is kept only where Streamlit's own themed styles would otherwise
+# win on specificity (background, color, border, text-decoration).
+# The whole card is clickable: `a::after` stretches an invisible overlay over
+# the card; the caption sits above it with `pointer-events: none` so clicks on
+# the caption fall through to the anchor below.
+# ---------------------------------------------------------------------------
+_WIZARD_CARD_CSS = """
+<style>
+div[class*="st-key-wcard-"] {
+    position: relative;
+    min-height: var(--card-h, 80px);
+    border-radius: 8px;
+    overflow: hidden;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    transition: filter 120ms ease, transform 120ms ease;
+    cursor: pointer;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: stretch;
+}
+div[class*="st-key-wcard-"]:hover {
+    filter: brightness(1.15);
+    transform: translateY(-1px);
+}
+/* Inner Streamlit wrappers: transparent, full width */
+div[class*="st-key-wcard-"] [data-testid="stVerticalBlock"],
+div[class*="st-key-wcard-"] [data-testid="stElementContainer"],
+div[class*="st-key-wcard-"] [data-testid="stPageLink"],
+div[class*="st-key-wcard-"] .stPageLink {
+    background: transparent !important;
+    border: none !important;
+    width: 100%;
+    gap: 0.1rem;
+}
+/* The page_link anchor: content sits naturally; ::after is the whole-card
+   invisible hit target so clicks anywhere navigate. */
+div[class*="st-key-wcard-"] a {
+    background: transparent !important;
+    border: none !important;
+    text-decoration: none !important;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    padding: 0.15rem 0.75rem;
+}
+div[class*="st-key-wcard-"] a::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+}
+/* All text inside the card → white, centered */
+div[class*="st-key-wcard-"] a,
+div[class*="st-key-wcard-"] a *,
+div[class*="st-key-wcard-"] [data-testid="stCaptionContainer"] * {
+    color: #fff !important;
+    text-align: center;
+    margin: 0;
+}
+div[class*="st-key-wcard-"] a p,
+div[class*="st-key-wcard-"] a strong {
+    font-weight: 700;
+    font-size: 1.3rem;
+    line-height: 1.2;
+}
+/* Caption stays visible above the hit overlay, but clicks pass through */
+div[class*="st-key-wcard-"] [data-testid="stCaptionContainer"] {
+    position: relative;
+    z-index: 2;
+    pointer-events: none;
+    padding: 0 0.75rem;
+}
+div[class*="st-key-wcard-"] [data-testid="stCaptionContainer"] * {
+    font-weight: 600;
+    font-size: 0.9rem;
+    line-height: 1.2;
+}
+</style>
+"""
+
+
+def _wizard_card_slug(s: str) -> str:
+    """Turn an entrypoint path into a stable CSS-safe key suffix."""
+    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")
+
+
+def _wizard_card_css_url(image_url: str) -> str:
+    """Escape a URL for use inside a CSS ``url('...')`` expression."""
+    return image_url.replace("\\", "\\\\").replace("'", "%27")
+
+
+def st_wizard_card(
+    entrypoint: str,
+    title: str,
+    image_url: str,
+    caption: str = "",
+    height: int = 80,
+) -> None:
+    """Render a clickable image-tile card that links to ``entrypoint``.
+
+    A native replacement for ``streamlit_card.card`` — no React iframe, uses
+    ``st.page_link`` for real multi-page navigation, styled with CSS. The
+    entire card is clickable, not just the title.
+
+    Parameters
+    ----------
+    entrypoint
+        Page path accepted by ``st.page_link`` (e.g. ``"apps/wizard/etl_steps/snapshot.py"``).
+    title
+        Card title (rendered as a bold white label).
+    image_url
+        URL used as the card's background image (a dark overlay is blended on top).
+    caption
+        Optional caption rendered below the title.
+    height
+        Minimum card height in pixels.
+    """
+    # Shared CSS is idempotent; emit on every call so it is present on every rerun.
+    st.markdown(_WIZARD_CARD_CSS, unsafe_allow_html=True)
+    key = f"wcard-{_wizard_card_slug(entrypoint)}"
+    overlay = "linear-gradient(rgba(0,0,0,0.55), rgba(0,0,0,0.55))"
+    bg = f"{overlay}, url('{_wizard_card_css_url(image_url)}')" if image_url else overlay
+    st.markdown(
+        f"<style>div.st-key-{key} {{ --card-h: {height}px; background-image: {bg}; }}</style>",
+        unsafe_allow_html=True,
+    )
+    with st.container(border=False, key=key):
+        try:
+            st.page_link(entrypoint, label=f"**{title}**")
+        except streamlit.errors.StreamlitPageNotFoundError:
+            # Not running as a multi-page app (e.g. `streamlit run home.py`).
+            st.markdown(f"**{title}**")
+        if caption:
+            st.caption(caption)
 
 
 def preview_file(


### PR DESCRIPTION
## Summary
Replace the legacy `streamlit_card` component (last released May 2024, React iframe per card) with a native Streamlit implementation built on `st.container(key=…)` + `st.page_link`, styled via CSS.

## What changed
- **New helper `st_wizard_card`** in `apps/wizard/utils/components.py` — renders a clickable image-tile card using an `st.container` + `st.page_link`. Zero iframes, real multi-page navigation.
- **Whole card is clickable** via an `a::after` overlay; the caption sits above with `pointer-events: none` so clicks fall through to the anchor.
- **`home.py` slimmed** from ~200 → ~115 lines. The three card-rendering loops (Classic/Fast Track, Sections, Legacy) now share `_render_card` and `_render_cards_row` helpers.
- **`streamlit_card` dep** can be removed next time `streamlit-extras` is bumped — it is only pulled in transitively.

## Why
- `streamlit_card` has been stale since May 2024.
- It renders each card in its own iframe, which slows the wizard home page.
- It doesn't play with `st.page_link`, forcing an `on_click` → `st.switch_page` round-trip.
- Styling via Python dicts of CSS didn't inherit the Streamlit theme.

## Verified in browser (localhost:8053)
- 23 cards render on the home page.
- Heights preserved: 100px (Classic row), 50px (Fast Track), 80px (section cards).
- Captions present on section cards (e.g. "Step upgrader" → "Update ETL steps"), absent on Classic row (matches original).
- Clicking the card container (not just the link text) navigates correctly — e.g. clicking the Step upgrader card background routes to `/dashboard`.
- No JS console errors.

## Test plan
- [ ] Visit wizard home; confirm all cards render with background images + dark overlay + centered white titles.
- [ ] Confirm captions appear on section cards (Update / Data tools / Search / etc.) and NOT on Classic row / Fast Track.
- [ ] Click the background area of a card (not the title) and confirm navigation.
- [ ] Hover a card and confirm the subtle brightness/lift animation.