### PR TITLE
Mark all skills as internal to prevent external indexing

### DIFF
--- a/.claude/skills/chart-editing/SKILL.md
+++ b/.claude/skills/chart-editing/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: chart-editing
 description: Edit and preview .chart.yml files for OWID graph steps. Use when user wants to edit chart config, preview charts, change chart appearance, or work with graph step chart files.
+metadata:
+  internal: true
 ---
 
 # Chart Editing

--- a/.claude/skills/check-chart-preview/SKILL.md
+++ b/.claude/skills/check-chart-preview/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: check-chart-preview
 description: Check chart or multidim preview on the staging server using a browser. Use when user wants to visually verify a chart renders correctly on staging, take a screenshot of a chart, or QA a chart/mdim preview.
+metadata:
+  internal: true
 ---
 
 # Check Chart/Mdim Preview on Staging

--- a/.claude/skills/check-metadata-typos/SKILL.md
+++ b/.claude/skills/check-metadata-typos/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: check-metadata-typos
 description: Check .meta.yml and snapshot .dvc files for spelling typos using codespell. Use when user mentions typos, spelling errors, metadata quality, or wants to check metadata files for mistakes.
+metadata:
+  internal: true
 ---
 
 # Check Metadata Typos

--- a/.claude/skills/check-outdated-practices/skill.md
+++ b/.claude/skills/check-outdated-practices/skill.md
@@ -1,6 +1,8 @@
 ---
 name: check-outdated-practices
 description: Check ETL step files for outdated coding patterns and offer to fix them. Use when user mentions outdated practices, legacy code patterns, modernizing steps, or wants to check code quality of ETL steps.
+metadata:
+  internal: true
 ---
 
 # Check Outdated Practices

--- a/.claude/skills/create-multidim/SKILL.md
+++ b/.claude/skills/create-multidim/SKILL.md
@@ -5,6 +5,8 @@ allowed-tools:
 - "WebFetch"
 - "Bash(.venv/bin/etl:*)"
 - "Bash(mkdir:*)"
+metadata:
+  internal: true
 ---
 
 # Creating Multidim Charts

--- a/.claude/skills/create-snapshot/SKILL.md
+++ b/.claude/skills/create-snapshot/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: create-snapshot
 description: Create a new snapshot (DVC file + Python script) from a url_main and optional url_download. Fetches the page, extracts metadata with AI, confirms with user, writes files, and runs the snapshot. Use when the user wants to add a new data source or create a snapshot from a URL.
+metadata:
+  internal: true
 ---
 
 # Create Snapshot

--- a/.claude/skills/etl-profiling/SKILL.md
+++ b/.claude/skills/etl-profiling/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: etl-profiling
 description: Profile and optimize ETL step performance — CPU time, memory usage, and I/O bottlenecks. Use when an ETL step is slow, uses too much memory, or when the user asks to profile, optimize, or speed up a step. Covers profiling commands, categorical dtype optimization, vectorization, SUBSET filtering for fast dev runs, and iterative diagnose→fix→reprofile workflow.
+metadata:
+  internal: true
 ---
 
 # ETL Step Profiling & Optimization

--- a/.claude/skills/fix-dependabot/SKILL.md
+++ b/.claude/skills/fix-dependabot/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: fix-dependabot
 description: Resolve Dependabot security alerts on owid/etl by upgrading vulnerable dependencies. Use when the user mentions "dependabot", "security alerts", "vulnerability", "CVE", "security fixes", "dependabot alerts", or wants to fix vulnerable packages. Also trigger when the user pastes a GitHub Dependabot URL or asks about outdated/insecure dependencies.
+metadata:
+  internal: true
 ---
 
 # Fix Dependabot Alerts

--- a/.claude/skills/migrate-dataset/SKILL.md
+++ b/.claude/skills/migrate-dataset/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: migrate-dataset
 description: Migrate a legacy OWID dataset (no catalogPath) into the ETL pipeline. Use when user wants to migrate, backport, or convert a legacy dataset by ID, or mentions datasets without catalogPath.
+metadata:
+  internal: true
 ---
 
 # Migrate Legacy Dataset

--- a/.claude/skills/owid-metadata-generation/SKILL.md
+++ b/.claude/skills/owid-metadata-generation/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: owid-metadata-generation
 description: Use when creating or enriching metadata for OWID ETL datasets - generates comprehensive YAML metadata from dataset inspection, data exploration, and web research following OWID metadata standards. Trigger when writing or editing *.meta.yml files, when a garden step has empty or minimal metadata, or when user asks to improve/add/enrich metadata.
+metadata:
+  internal: true
 ---
 
 # OWID Metadata Generation

--- a/.claude/skills/remapping-ghost-variables/SKILL.md
+++ b/.claude/skills/remapping-ghost-variables/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: remapping-ghost-variables
 description: Fix ghost variable warnings by remapping charts from old to new variable IDs. Use when ETL grapher step shows "Variables used in charts will not be deleted automatically", when indicator short_names were renamed and charts still reference old variables, or when the user mentions ghost variables, orphaned indicators, or chart variable remapping.
+metadata:
+  internal: true
 ---
 
 # Remapping Ghost Variables

--- a/.claude/skills/streamlit-app/SKILL.md
+++ b/.claude/skills/streamlit-app/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: streamlit-app
 description: Create or modify Streamlit apps in the Wizard. Use when building new wizard apps, adding Streamlit pages, or working with apps/wizard/ code.
+metadata:
+  internal: true
 ---
 
 # Streamlit Apps in Wizard

--- a/.claude/skills/update-dataset/SKILL.md
+++ b/.claude/skills/update-dataset/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: update-dataset
 description: End-to-end dataset update workflow with PR creation, snapshot, meadow, garden, and grapher steps. Use when user wants to update a dataset, refresh data, run ETL update, or mentions updating dataset versions.
+metadata:
+  internal: true
 ---
 
 # Update Dataset (PR → snapshot → steps → grapher)

--- a/.claude/skills/vscode-extension-dev/SKILL.md
+++ b/.claude/skills/vscode-extension-dev/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: vscode-extension-dev
 description: Develop, build, and test VSCode extensions in this repo. Use when editing extension source code, compiling TypeScript, packaging .vsix files, or installing extensions for testing.
+metadata:
+  internal: true
 ---
 
 # VSCode Extension Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Our World in Data's ETL system - a content-addressable data pipeline with DAG-ba
 - **Always run `make check` before committing**
 - If not told otherwise, save outputs to `ai/` directory.
 - **Notebooks**: Always create AND execute immediately using `uv run jupyter nbconvert --to notebook --execute --inplace <path>`
+- **Skills**: When creating new skills in `.claude/skills/`, always include `metadata: { internal: true }` in the SKILL.md frontmatter unless the user explicitly asks for the skill to be public. This prevents external skill indexes from crawling and listing our internal skills.
 
 
 ## Pipeline Overview


### PR DESCRIPTION
## Summary

- Added `metadata: { internal: true }` to all 14 skills in `.claude/skills/`
- Added a rule to CLAUDE.md requiring this flag on new skills by default

External skill marketplaces (skills.sh, skillsmp.com) were crawling our public repo and listing our internal skills. The `metadata.internal` flag is the standard mechanism from the [skills CLI](https://github.com/vercel-labs/skills) to hide skills from discovery — they'll only be installable when `INSTALL_INTERNAL_SKILLS=1` is set.

Our skills still work normally for anyone with the repo cloned. This only affects external index visibility.

## Test plan

- [ ] Verify skills still load in Claude Code (`claude --debug`)
- [ ] Confirm `npx skills add owid/etl --list` no longer shows skills (without `INSTALL_INTERNAL_SKILLS=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)