### PR TITLE
✨ review and fix faust demography explorer details

### DIFF
--- a/etl/steps/data/garden/un/2024-07-12/un_wpp.meta.yml
+++ b/etl/steps/data/garden/un/2024-07-12/un_wpp.meta.yml
@@ -267,6 +267,7 @@ tables:
           isProjection: *projection
           roundingMode: significantFigures
           numSignificantFigures: 4
+          numDecimalPlaces: 0
         presentation:
           title_public: |-
             Annual net migration
@@ -301,6 +302,7 @@ tables:
           isProjection: *projection
           roundingMode: significantFigures
           numSignificantFigures: 4
+          numDecimalPlaces: 0
         presentation:
           title_public: |-
             <%- if age == 'all' %>

--- a/etl/steps/export/explorers/un/latest/un_wpp.manual.config.yml
+++ b/etl/steps/export/explorers/un/latest/un_wpp.manual.config.yml
@@ -599,6 +599,8 @@ views:
   # values against each fertility variant. We keep all three variants wired up here
   # so the explorer honestly reflects what UN WPP publishes, even though the chart
   # looks unchanged when the user toggles the scenario.
+  - dimensions:
+      indicator: infant_mortality_rate
       age: "0"
       sex: all
       variant: estimates

--- a/etl/steps/export/explorers/un/latest/un_wpp.py
+++ b/etl/steps/export/explorers/un/latest/un_wpp.py
@@ -138,15 +138,11 @@ def run() -> None:
         config=config_default,
         indicator_names=["deaths"],
         projection_variants=["medium"],
-        # age=0 and age=0-4 are intentionally excluded here: those views live under
-        # the `infant_deaths` / `child_deaths` indicator dropdown in the manual
-        # explorer and pointing at the same catalog path from both places makes the
-        # explorer system emit a `_1`-suffixed ySlug for the duplicate (owid-grapher#6362).
         dimensions={
-            "age": ["all"] + AGES_DEATHS_LIST,
+            "age": ["all", "0", "0-4"] + AGES_DEATHS_LIST,
             "sex": "*",
         },
-        choice_renames={"age": AGES_DEATHS},
+        choice_renames={"age": {**AGES_DEATHS, "0": "Under 1 year", "0-4": "Under 5 years"}},
     )
     view_editor.edit_views_deaths(explorer_deaths_counts, ds_grapher=ds)
     explorer_deaths_rate = explorer_creator.create_with_grouped_projections(

--- a/etl/steps/export/explorers/un/latest/un_wpp.py
+++ b/etl/steps/export/explorers/un/latest/un_wpp.py
@@ -187,24 +187,40 @@ def run() -> None:
     view_editor.edit_views_ma(explorer_ma, ds_grapher=ds)
 
     ########## Life expectancy explorer
-    explorer_le = explorer_creator.create_with_grouped_projections(
+    # At birth: all three projection scenarios (low/medium/high)
+    explorer_le_birth = explorer_creator.create_with_grouped_projections(
         table_name="life_expectancy",
         config=config_default,
         indicator_names=["life_expectancy"],
         dimensions={
-            "age": "*",
+            "age": ["0"],
+            "sex": "*",
+        },
+        choice_renames={"age": {"0": "At birth"}},
+    )
+    view_editor.edit_views_le(explorer_le_birth, ds_grapher=ds)
+
+    # At older ages: medium projections only. UN WPP's low/medium/high scenarios
+    # share identical mortality, but the source only publishes life expectancy
+    # projections at ages 15/65/80 for the medium variant.
+    explorer_le_other = explorer_creator.create_with_grouped_projections(
+        table_name="life_expectancy",
+        config=config_default,
+        indicator_names=["life_expectancy"],
+        projection_variants=["medium"],
+        dimensions={
+            "age": ["15", "65", "80"],
             "sex": "*",
         },
         choice_renames={
             "age": {
-                "0": "At birth",
                 "15": "Aged 15",
                 "65": "Aged 65",
                 "80": "Aged 80",
             }
         },
     )
-    view_editor.edit_views_le(explorer_le, ds_grapher=ds)
+    view_editor.edit_views_le(explorer_le_other, ds_grapher=ds)
 
     ########## Fertility rate explorer
     explorer_fr = explorer_creator.create_with_grouped_projections(
@@ -228,7 +244,6 @@ def run() -> None:
             "age": ["all"],
             "sex": ["all"],
         },
-        common_view_config={"type": "Percentage"},
     )
     view_editor.edit_views_rates(explorer_growth, ds_grapher=ds)
 
@@ -241,7 +256,6 @@ def run() -> None:
             "age": ["all"],
             "sex": ["all"],
         },
-        common_view_config={"type": "Percentage"},
     )
     view_editor.edit_views_rates(explorer_natchange, ds_grapher=ds)
 
@@ -265,7 +279,8 @@ def run() -> None:
         explorer_deaths_rate,
         explorer_b,
         explorer_ma,
-        explorer_le,
+        explorer_le_birth,
+        explorer_le_other,
         explorer_fr,
         explorer_growth,
         explorer_natchange,

--- a/etl/steps/export/explorers/un/latest/view_edits.py
+++ b/etl/steps/export/explorers/un/latest/view_edits.py
@@ -264,6 +264,8 @@ class ViewEditor:
                     age = match.group(1).replace("_", "-").replace("plus", "+")
                     display = {
                         "name": f"{age} years",
+                        "roundingMode": "significantFigures",
+                        "numSignificantFigures": 4,
                     }
                     if indicator.display is None:
                         indicator.display = display


### PR DESCRIPTION
## Summary

Post-deployment fixes for the Population & Demography explorer FAUST text improvements (follow-up to #5915 and #5935, tracking issue #5936).

## Fixes

- [ ] **Population by age group**: Should use 4 sig figs — added `roundingMode: significantFigures` + `numSignificantFigures: 4` to display in `view_edits.py` for `age_structure`/`population_broad` views
- [x] **Population growth rate**: Empty chart for scenario = None — removed `common_view_config={"type": "Percentage"}` from `un_wpp.py` (was incorrectly placed at view level instead of indicator display level)
- [x] **Natural population growth rate**: Same empty chart fix — removed `common_view_config={"type": "Percentage"}`
- [x] **Life expectancy**: Low and high scenarios showing only 1950-2023 for ages 15, 65, 80 — split LE explorer into birth (low/medium/high) and other ages (medium only), since UN WPP doesn't publish low/high for non-birth ages
- [x] **Deaths, child deaths, infant deaths, net migration**: Showing as "1234.00" instead of integers — added `numDecimalPlaces: 0` to `deaths` and `net_migration` display metadata in `un_wpp.meta.yml`