### PR TITLE
✨ fix decimal places in age structure

### DIFF
--- a/etl/steps/export/explorers/un/latest/view_edits.py
+++ b/etl/steps/export/explorers/un/latest/view_edits.py
@@ -264,6 +264,7 @@ class ViewEditor:
                     age = match.group(1).replace("_", "-").replace("plus", "+")
                     display: dict[str, Any] = {"name": f"{age} years"}
                     if indicator_name == "age_structure":
+                        display["roundingMode"] = "decimalPlaces"
                         display["numDecimalPlaces"] = 1
                     if indicator.display is None:
                         indicator.display = display


### PR DESCRIPTION
Small follow-up fix to [#5944](https://github.com/owid/etl/pull/5944): the `numDecimalPlaces: 1` setting for the **age_structure** indicator wasn't being applied because the display config was missing `roundingMode: decimalPlaces`. Without it, the default significant-figures rounding takes over and overrides `numDecimalPlaces`.

This one-line change ensures age structure views in the Population & Demography explorer render with 1 decimal place as intended.

Part of the broader FAUST improvement effort tracked in [owid-issues#2084](https://github.com/owid/owid-issues/issues/2084).

/schedule

Closes https://github.com/owid/owid-issues/issues/2084