### PR TITLE
📊 Fix search API semantic search init

### DIFF
--- a/api_search/semantic_search.py
+++ b/api_search/semantic_search.py
@@ -3,6 +3,8 @@
 import threading
 from typing import Any
 
+import sentry_sdk
+
 from apps.wizard.app_pages.indicator_search.data import Indicator, _get_data_indicators_from_db
 from apps.wizard.utils.embeddings import EmbeddingsModel, get_model
 from owid_mcp.data_utils import build_catalog_info
@@ -31,6 +33,7 @@ def _initialize_semantic_search():
 
         _initialization_complete = True
     except Exception as e:
+        sentry_sdk.capture_exception(e)
         _initialization_error = str(e)
         _initialization_complete = True
 
@@ -92,6 +95,16 @@ def search_indicators(query: str, limit: int = 10) -> list[dict[str, Any]]:
 def is_ready() -> bool:
     """Check if the semantic search model is ready to handle requests."""
     return _initialization_complete and _embeddings_model is not None and _initialization_error is None
+
+
+def is_initialization_complete() -> bool:
+    """Check if initialization has finished (successfully or with error)."""
+    return _initialization_complete
+
+
+def get_initialization_error() -> str | None:
+    """Return the initialization error message, if any."""
+    return _initialization_error
 
 
 def get_model_info() -> dict[str, Any]:

--- a/api_search/v1/__init__.py
+++ b/api_search/v1/__init__.py
@@ -1,7 +1,13 @@
 import structlog
 from fastapi import APIRouter, HTTPException, Query
 
-from api_search.semantic_search import get_model_info, is_ready, search_indicators
+from api_search.semantic_search import (
+    get_initialization_error,
+    get_model_info,
+    is_initialization_complete,
+    is_ready,
+    search_indicators,
+)
 
 from .schemas import (
     INDICATOR_SEARCH_EXAMPLES,
@@ -50,11 +56,19 @@ async def search_indicators_semantic(
 
     # Check if model is ready
     if not is_ready():
-        raise HTTPException(
-            status_code=503,
-            detail="Semantic search model is still initializing. Check /indicators/info for status.",
-            headers={"Retry-After": "5"},
-        )
+        init_error = get_initialization_error()
+        if init_error is not None:
+            raise HTTPException(
+                status_code=500,
+                detail=f"Semantic search initialization failed: {init_error}",
+            )
+        if not is_initialization_complete():
+            raise HTTPException(
+                status_code=503,
+                detail="Semantic search model is still initializing. Check /indicators/info for status.",
+                headers={"Retry-After": "5"},
+            )
+        raise HTTPException(status_code=500, detail="Semantic search model not initialized")
 
     # Cap limit at 100 to match API maximum
     limit = min(limit, 100)

--- a/apps/wizard/utils/embeddings.py
+++ b/apps/wizard/utils/embeddings.py
@@ -7,17 +7,16 @@ from pathlib import Path
 from typing import Generic, TypeVar
 
 import torch
-from joblib import Memory
 from sentence_transformers import SentenceTransformer, util
 from structlog import get_logger
 
 from etl.config import DOCS_BUILD
 from etl.paths import CACHE_DIR
 
-memory = Memory(CACHE_DIR, verbose=0)
-
 # Initialize log.
 log = get_logger()
+
+DEFAULT_MODEL_NAME = "all-MiniLM-L6-v2"
 
 
 def set_device() -> str:
@@ -42,11 +41,16 @@ if "DEVICE" not in os.environ:
 DEVICE = set_device()
 
 
-@memory.cache
-def get_model(model_name: str = "all-MiniLM-L6-v2") -> SentenceTransformer:
-    "Load the pre-trained model"
-    model = SentenceTransformer(model_name)
-    return model
+def get_model(model_name: str = DEFAULT_MODEL_NAME) -> SentenceTransformer:
+    """Load the pre-trained model.
+
+    Uses the HuggingFace on-disk cache (not joblib): first call downloads the model,
+    subsequent calls skip the Hub roundtrip via local_files_only=True (~0.1s).
+    """
+    try:
+        return SentenceTransformer(model_name, local_files_only=True)
+    except OSError:
+        return SentenceTransformer(model_name)
 
 
 @dataclass
@@ -66,14 +70,10 @@ class EmbeddingsModel(Generic[TDoc]):
     embeddings: torch.Tensor
 
     def __init__(self, model: SentenceTransformer, model_name: str | None = None) -> None:
-        # Get model name
-        if model_name is None:
-            # NOTE: this is a bit of a hack, it's better to pass it explicitly
-            # TODO: fix it when we update to the latest version
-            model_name = model.tokenizer.name_or_path.split("/")[-1]  # ty: ignore
-
+        # Derive name from the model so it cannot drift from the embeddings file.
+        # Callers may override to namespace cache files (e.g. "sim_charts_title").
         self.model = model
-        self.model_name = model_name
+        self.model_name = model_name or model.tokenizer.name_or_path.split("/")[-1]
 
     @property
     def cache_file_keys(self) -> Path:


### PR DESCRIPTION
## Summary

Fixes `GET /indicators` on `search.owid.io` returning 503 for every request. Root cause was stale-pickle deserialization of `SentenceTransformer` from the joblib cache after the `sentence-transformers` major version bump (2.2.2 → >=5.1.0) in #4866 — the unpickled object was missing `tokenizer`, so `EmbeddingsModel.__init__` raised `'SentenceTransformer' object has no attribute 'tokenizer'`. The failure was swallowed by a background-thread `except Exception` and surfaced to callers as a misleading "still initializing" 503, with nothing reaching Sentry.

## Changes

**`apps/wizard/utils/embeddings.py`**
- Drop `@memory.cache` on `get_model`. Pickling a PyTorch model via joblib is fragile across dependency upgrades.
- Use `SentenceTransformer(model_name, local_files_only=True)` with an `OSError` fallback that re-fetches from HF. Measured: first load ~0.4s, subsequent ~0.08s — faster than the joblib hit (~0.1s) and no staleness hazard.
- Derive `EmbeddingsModel.model_name` from `model.tokenizer.name_or_path` (stable on 5.x). Callers may still override it to namespace cache files (e.g. `"sim_charts_title"`). Killed the outdated "hack / TODO" comment.

**`api_search/semantic_search.py`**
- Call `sentry_sdk.capture_exception(e)` in the startup background thread. `SentryAsgiMiddleware` only sees HTTP-handler exceptions, so startup crashes were invisible until now.
- Expose `is_initialization_complete()` / `get_initialization_error()` for endpoints to distinguish the two states.

**`api_search/v1/__init__.py`**
- Differentiate responses: 503 "still initializing" only while init is in progress; 500 with the real error once init has finished unsuccessfully. Previously both cases returned the same 503.

## Test plan

- [x] `get_model()` hot/cold timings measured locally
- [x] `EmbeddingsModel(model)` derives `all-MiniLM-L6-v2`; override still works
- [x] `make check` (ty) passes
- [ ] Verify on staging that `/indicators` returns real results and `/indicators/info` shows `ready: true`
- [ ] Confirm a forced init failure on staging now shows up in Sentry