### PR TITLE
📜 Add inequality visualization technical documentation

### DIFF
--- a/.claude/skills/create-analysis-doc/SKILL.md
+++ b/.claude/skills/create-analysis-doc/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: create-analysis-doc
+description: Draft a technical companion document for an OWID analysis, visualization, or data product in the `docs/analyses/` style. Use when the user wants to write technical documentation that explains the methodology, data sources, and limitations of an analysis — typically as a companion page for an article or a bespoke visualization. Trigger phrases include "write a technical documentation", "methodology doc", "companion doc for the ... article", "explain this analysis".
+metadata:
+  internal: true
+---
+
+# Create technical analysis documentation
+
+Produce a companion methodology document in the style of the existing publications under [docs/analyses/](../../../docs/analyses/) (e.g. `biofuels_land_use/index.md`, `media_deaths/methodology.md`, `slavery_historical_data/index.md`).
+
+The goal is a document a reader can use as the "technical appendix" to a public-facing article: it describes the data sources, the processing applied, the methodological choices and their justification, known limitations, and links to both the source code (ETL steps, visualization components) and the external datasets.
+
+## 1. Gather inputs from the user
+
+Before writing anything, ask the user for the following. Present them as a checklist so they can answer in one go:
+
+**Required**
+
+- **Title** of the analysis / visualization (will become the `# H1` of the doc).
+- **Short name** — snake_case, used as the folder name under `docs/analyses/` (e.g. `inequality_visualization`). If not provided, suggest one based on the title.
+- **ETL scripts** — paths to the meadow / garden / grapher / external steps that process the data. Read each one to understand what transformations are applied.
+- **External data source URLs** — the canonical pages for every upstream dataset used (e.g. World Bank PIP, FAOSTAT, WDI indicator pages). These populate the "Data sources" section.
+
+**Optional but strongly encouraged**
+
+- **Companion article URL** — the OWID article this doc supports. If not yet published, leave `[TODO: article URL]` as a placeholder in the intro.
+- **Visualization code paths** — if the analysis is backed by a bespoke component in `owid-grapher` (e.g. `bespoke/projects/<name>/`), ask for the entry point and any key utility files. Read them to describe display choices and methodological details at the visualization level.
+- **Author name(s)** — default to the current git user if not given, with today's date in the header.
+- **Known limitations** — things the user wants to flag explicitly (e.g. survey coverage gaps, interpolation assumptions).
+
+Confirm the collected inputs back to the user before drafting — don't silently proceed if something is missing or ambiguous.
+
+## 2. Read the scripts and external pages
+
+Before writing a single section, actually **read the code** and the external dataset pages. Notes to take:
+
+- **For each ETL step**: what does it take in, what does it output, what transformations are applied, what sanity checks are run, what the update cadence is. Pay particular attention to non-obvious decisions (manual override lists, hard-coded thresholds, filter criteria) — these are the things readers won't discover by themselves and that belong in the methodology section.
+- **For each visualization script**: what computations are done at display time vs. upstream, what display choices (log vs. linear, smoothing parameters, color assignments) are being made, and why.
+- **For each external source**: what welfare concept it measures, what year coverage, what the intended use case is, what its known caveats are.
+
+If the user mentions an article, use `WebFetch` to read it so the doc's framing matches the article's framing.
+
+## 3. Draft to `ai/<short_name>.md` first
+
+Per project convention, initial drafts go to `ai/`. Once the user approves, the file is copied to `docs/analyses/<short_name>/index.md`.
+
+Use this **document structure** as a starting skeleton. Adapt sections for the specific analysis — not every doc needs every section, and some analyses will need entirely new ones.
+
+```markdown
+# Title of the analysis
+
+!!! info ""
+    :octicons-person-16: **[Author](https://ourworldindata.org/team/author)** • :octicons-calendar-16: <date> *(last edit)* • [**:octicons-mail-16: Feedback**](mailto:info@ourworldindata.org?subject=Feedback%20on%20technical%20publication%20-%20<title>)
+
+## Introduction
+
+(2–3 short paragraphs. First: what the analysis/visualization is and what article it accompanies. Second: what this document covers and how it relates to the article. Third: a one-line summary of the data sources — this acts as a bridge to the next section.)
+
+## Data sources
+
+### <Source 1>
+
+(Prose intro. Then sub-subsections for specific datasets within that source.)
+
+#### <Specific dataset>
+- What the file contains, at what granularity, in what units.
+- How the source builds it (e.g. survey methodology, interpolation rules).
+- Release cadence and coverage.
+- Any caveats about the raw data (top-income coverage, welfare concept differences, etc.). Use `!!! warning "Title"` for hard caveats.
+- File structure (columns) if relevant.
+- Collapse long lists (country enumerations, indicator lists) into `??? quote "..."` blocks.
+
+### <Source 2>
+
+(Same pattern.)
+
+## Methodology
+
+### <Processing step 1>
+
+(What the ETL step does. Link directly to the garden/meadow/external step file on GitHub.)
+
+### <Analytical method 1 — e.g. KDE, smoothing, aggregation>
+
+(Explain the method. Lead with intuition, then the arithmetic. Include a parameter table if relevant. Use `!!! info "Why X?"` to answer obvious "why did you choose this?" questions inline.)
+
+## <Additional H2 sections — only as needed>
+
+(Add one or more extra top-level sections here when the analysis has specific concerns that deserve their own walk-through, separate from the generic "Methodology" heading. Do not add placeholder sections just because another doc had them — only include headings whose content is genuinely warranted by this analysis.)
+
+## Limitations
+
+(Bullet list. Each point leads with a **bold term** and then a short paragraph. Prefer to include every limitation the user or the source materials have flagged.)
+
+## References
+
+**Our World in Data source code**
+
+- Visualization component (with GitHub URL)
+- ETL steps (meadow, garden, grapher), each with GitHub URL
+- Snapshots (with GitHub URL)
+
+**External datasets and references**
+
+- Upstream data sources, each with a direct link
+- Methodology pages published by the upstream providers
+- Any related external literature
+```
+
+### When to add extra H2 sections
+
+The canonical skeleton above (Introduction, Data sources, Methodology, Limitations, References) is the minimum. Add extra H2 sections only when the analysis has a concern substantive enough to deserve its own heading — never add a section just because another doc had it. Some signals that an extra section is warranted:
+
+- **The analysis has a headline metric whose computation is non-trivial.** Give that computation its own H2 and walk through a concrete worked example (e.g. the "Share of population below a poverty line" section in the inequality-visualization doc, or "How we estimate land used for biofuels" in the biofuels-land-use doc).
+- **The visualization lets the user toggle units, currencies, or time intervals, and those toggles involve non-obvious conversion logic.** Describe the base unit, the conversion factor, and where any manual decisions live.
+- **A representation choice (log/linear axis, smoothing parameters, color palette, binning strategy) is substantive enough to affect interpretation.** Explain what the choice is and why it was made — but only if the reasoning is non-obvious.
+- **There is an analysis-specific workflow that doesn't fit under "Methodology"** — e.g. query construction rules, sampling design, manual adjudication lists, validation procedures.
+
+If the analysis is simple enough to cover in the canonical four sections, leave it at four.
+
+## 4. Apply the style conventions
+
+Consistency with the existing analyses docs is important — they deploy through Zensical (mkdocs-material-compatible) and rely on specific admonition syntax:
+
+- **Header metadata**: `!!! info ""` (empty title) with person/calendar/feedback icons.
+- **Callouts**: `!!! note`, `!!! warning`, `!!! info "Title"`, `!!! tip`.
+- **Collapsible long content**: `??? quote "Title"` — used for country lists, full query listings, anything that would dominate the page when expanded inline.
+- **Tables** for parameter lists, indicator codes, lookup mappings, rule summaries.
+- **Worked examples with concrete numbers** — prefer "Brazil has 250 bins below the line, which is 25%" over abstract algebra.
+- **Bold on first mention** for key terms (e.g. **International Dollars**, **PPP factor**, **bin**).
+- **Mathematical typography**: use subscripts (log₂, not log2), proper minus signs, and Unicode for fractions only when they'd aid readability.
+- **Links in markdown `[text](url)` syntax** — no bare URLs. Link GitHub files to their `owid/<repo>/blob/master/...` path so they stay valid as code changes.
+- **Prefer prose over deeply nested bullets** — if a bullet list has three levels of nesting, rewrite as paragraphs with a short concluding list.
+
+## 5. Writing principles (lessons from past sessions)
+
+- **Lead with intuition, not implementation.** Readers want to understand the *idea* before the code. For a computation like "share below the line", first explain "each bin represents 1/1000 of the population; count bins below, divide by 1000" — then mention the `(k / 10) * pop` expression and *why* it collapses that way.
+- **Explain "why" not just "what".** Every methodological choice (log scale, fixed KDE bandwidth, PPP-over-WDI preference, 3% reconciliation threshold) should come with a one-sentence justification. If you don't know why, ask the user — don't guess.
+- **Be explicit about approximations and error bounds.** If the computation miscounts by ≤0.05 pp, say so. Readers trust a doc that surfaces its own limitations.
+- **Separate the upstream decision from the downstream display.** When a module only formats pre-processed data (like `incomePlotUtils.ts` only formatting pre-converted currency values), call that out — readers shouldn't have to guess where the transformation happens.
+- **Collapse long lists.** A 218-country enumeration in the body destroys readability. A `??? quote` block keeps the content available without forcing it on every reader.
+- **Keep the References section structured.** Group OWID source code separately from external datasets — readers who want to inspect the code have different needs from those who want the upstream source.
+
+## 6. Review with the user
+
+Once the draft is in `ai/<short_name>.md`, ask the user to review. Expect multiple rounds of edits — technical documentation often benefits from iteration, especially:
+
+- Corrections to methodological framing (a specialist reader may reframe approximations or point out the wrong level of detail).
+- Filling in placeholders (article URLs, author names, exact data cadence).
+- Expanding limitations or adding concrete country examples.
+
+Only move to the deployment step once the user explicitly signs off.
+
+## 7. Deployment (after user approval)
+
+The file needs to move from `ai/` to `docs/analyses/` and be registered so it appears on `docs.owid.io`:
+
+```bash
+mkdir -p docs/analyses/<short_name>
+cp ai/<short_name>.md docs/analyses/<short_name>/index.md
+```
+
+Then ask the user whether they also want the two registration steps done now or in a follow-up:
+
+1. **Nav entry in [zensical.toml](../../../zensical.toml)** — add one line to the analyses block (search for the `"analyses/index.md"` entry):
+   ```toml
+   { "<User-facing title>" = "analyses/<short_name>/index.md" },
+   ```
+2. **Landing-page card in [docs/analyses/index.md](../../../docs/analyses/index.md)** — add a `!!! note ""` block following the existing pattern (short blurb, Methodology button linking to the doc).
+
+Preview with `make docs.serve` at `http://localhost:9010/analyses/<short_name>/`.
+
+## 8. PR workflow
+
+If the user wants a PR for the doc, follow the project's standard flow ([CLAUDE.md → Git Workflow](../../../CLAUDE.md)):
+
+```bash
+.venv/bin/etl pr "<Title>" docs
+git add docs/analyses/<short_name>/index.md [zensical.toml] [docs/analyses/index.md]
+git commit -m "📜🤖 <Title>"
+git push -u origin <branch>
+gh pr edit <number> --body "..."
+gh pr comment <number> --body "@codex review"
+```
+
+Use the **📜 docs emoji** (plus 🤖 for AI-assisted work). The PR body should include:
+
+- A "Summary" section describing what the doc covers at a high level.
+- A "Follow-ups" section listing anything not done in this PR (nav entry, landing-page card, unresolved placeholders).
+- A "Test plan" checklist (local render check with `make docs.serve`, external link check, collapsible-block check).

--- a/.claude/skills/create-analysis-doc/SKILL.md
+++ b/.claude/skills/create-analysis-doc/SKILL.md
@@ -161,15 +161,36 @@ mkdir -p docs/analyses/<short_name>
 cp ai/<short_name>.md docs/analyses/<short_name>/index.md
 ```
 
-Then ask the user whether they also want the two registration steps done now or in a follow-up:
+Then ask the user whether they also want the two registration steps done now or in a follow-up. Both are required for the doc to show up on docs.owid.io; skipping them leaves the file orphaned:
 
-1. **Nav entry in [zensical.toml](../../../zensical.toml)** — add one line to the analyses block (search for the `"analyses/index.md"` entry):
-   ```toml
-   { "<User-facing title>" = "analyses/<short_name>/index.md" },
-   ```
-2. **Landing-page card in [docs/analyses/index.md](../../../docs/analyses/index.md)** — add a `!!! note ""` block following the existing pattern (short blurb, Methodology button linking to the doc).
+1. **Nav entry in [zensical.toml](../../../zensical.toml)** — add one line inside the `"Technical publications"` array (search for the block starting with `"analyses/index.md"`), placed last in the list to keep ordering predictable:
 
-Preview with `make docs.serve` at `http://localhost:9010/analyses/<short_name>/`.
+    ```toml
+    { "<User-facing title>" = "analyses/<short_name>/index.md" },
+    ```
+
+2. **Landing-page card in [docs/analyses/index.md](../../../docs/analyses/index.md)** — append a `!!! note ""` block at the end of the file, using this template:
+
+    ```markdown
+    !!! note ""
+
+        ## <User-facing title>
+        This document is a technical companion to <the article title>](<article URL>), which <one sentence on what the article is about>.
+
+        [:material-book-open-variant: Methodology](<short_name>/index.md){ .md-button }
+    ```
+
+    If the analysis has supporting artefacts (notebook, Colab, data download), add extra buttons following the patterns already used on the landing page — for example:
+
+    ```markdown
+    [:material-notebook: Notebook](<short_name>/<notebook>.html){ .md-button }
+    [:material-play-circle: Run in Colab](https://colab.research.google.com/github/owid/etl/blob/master/docs/analyses/<short_name>/<notebook>.ipynb){ .md-button }
+    [:material-download: Download data (ZIP)](<zip URL>){ .md-button }
+    ```
+
+    Only include buttons for artefacts that actually exist — don't leave broken links.
+
+Preview with `make docs.serve` at `http://localhost:9010/analyses/<short_name>/` (both the new page and the landing page) to confirm the card and nav entry render correctly before raising the PR.
 
 ## 8. PR workflow
 

--- a/.claude/skills/create-analysis-doc/SKILL.md
+++ b/.claude/skills/create-analysis-doc/SKILL.md
@@ -175,7 +175,7 @@ Then ask the user whether they also want the two registration steps done now or 
     !!! note ""
 
         ## <User-facing title>
-        This document is a technical companion to <the article title>](<article URL>), which <one sentence on what the article is about>.
+        This document is a technical companion to [<the article title>](<article URL>), which <one sentence on what the article is about>.
 
         [:material-book-open-variant: Methodology](<short_name>/index.md){ .md-button }
     ```

--- a/.claude/skills/create-analysis-doc/SKILL.md
+++ b/.claude/skills/create-analysis-doc/SKILL.md
@@ -137,6 +137,7 @@ Consistency with the existing analyses docs is important — they deploy through
 - **Worked examples with concrete numbers** — prefer "Brazil has 250 bins below the line, which is 25%" over abstract algebra.
 - **Bold on first mention** for key terms (e.g. **International Dollars**, **PPP factor**, **bin**).
 - **Mathematical typography**: use subscripts (log₂, not log2), proper minus signs, and Unicode for fractions only when they'd aid readability.
+- **Escape dollar signs in body text** (`\$3 / day`, `\$1,000`). Zensical/mkdocs-material interprets unescaped `$...$` pairs as inline math, so a sentence like "from $0.25 to $1,000" will render as a math expression. Dollar signs inside fenced code blocks don't need escaping.
 - **Links in markdown `[text](url)` syntax** — no bare URLs. Link GitHub files to their `owid/<repo>/blob/master/...` path so they stay valid as code changes.
 - **Prefer prose over deeply nested bullets** — if a bullet list has three levels of nesting, rewrite as paragraphs with a short concluding list.
 - **Use first-person plural voice** ("we rely on", "we import", "we harmonize") throughout the prose — the doc is a team walkthrough, not a neutral reference manual.

--- a/.claude/skills/create-analysis-doc/SKILL.md
+++ b/.claude/skills/create-analysis-doc/SKILL.md
@@ -57,33 +57,33 @@ Use this **document structure** as a starting skeleton. Adapt sections for the s
 
 (2–3 short paragraphs. First: what the analysis/visualization is and what article it accompanies. Second: what this document covers and how it relates to the article. Third: a one-line summary of the data sources — this acts as a bridge to the next section.)
 
-## Data sources
+## Data source: <provider + short description of what we use it for>
 
-### <Source 1>
+(One H2 per primary provider. The heading names the provider, not the dataset — e.g. "Data source: Global incomes data from the World Bank". Open with one or two sentences naming the provider and the role its data plays in the analysis.)
 
-(Prose intro. Then sub-subsections for specific datasets within that source.)
+### <Specific dataset from this provider>
 
-#### <Specific dataset>
-- What the file contains, at what granularity, in what units.
+(Prose describing what the file contains, at what granularity, in what units. Use bold lead-ins like `**Where does the data come from?**` to structure sub-topics without creating extra headings.)
+
 - How the source builds it (e.g. survey methodology, interpolation rules).
 - Release cadence and coverage.
-- Any caveats about the raw data (top-income coverage, welfare concept differences, etc.). Use `!!! warning "Title"` for hard caveats.
-- File structure (columns) if relevant.
+- Welfare-concept, unit, or methodological caveats.
+- Use `!!! warning "Title"` for hard caveats (e.g. top-income undercoverage, known measurement gaps).
 - Collapse long lists (country enumerations, indicator lists) into `??? quote "..."` blocks.
 
-### <Source 2>
+### Data processing
 
-(Same pattern.)
+(What our ETL does with the raw file — harmonization, unit conversions, sanity checks, manual overrides. Include this sub-section only if the processing is non-trivial enough that a reader benefits from seeing it described. If a short ETL function directly illustrates a methodological claim the reader might want to verify, paste it inside a fenced code block; if the processing is routine, a prose sentence and a GitHub link are enough.)
 
-## Methodology
+(Repeat the `## Data source: ...` pattern once per primary provider.)
 
-### <Processing step 1>
+## <Name this after what the analysis produces — e.g. "Plotting income distributions", "Estimating historical emissions", "Ranking cities by X">
 
-(What the ETL step does. Link directly to the garden/meadow/external step file on GitHub.)
+(Name the section after what the analysis *does*, not "Methodology" in the abstract. Group related method steps together under one H2 named by the analysis output. Fall back to "Methodology" only when the analysis is genuinely generic.)
 
-### <Analytical method 1 — e.g. KDE, smoothing, aggregation>
+### <Method step — e.g. "Estimating the shape of the distributions">
 
-(Explain the method. Lead with intuition, then the arithmetic. Include a parameter table if relevant. Use `!!! info "Why X?"` to answer obvious "why did you choose this?" questions inline.)
+(Explain the method. Lead with intuition, then the arithmetic. Use `!!! info "Why X?"` to answer obvious "why did you choose this?" questions inline (e.g. "Why a log scale?"). If a short code snippet from the actual implementation would clarify the method, paste it in a fenced code block — otherwise don't.)
 
 ## <Additional H2 sections — only as needed>
 
@@ -91,7 +91,13 @@ Use this **document structure** as a starting skeleton. Adapt sections for the s
 
 ## Limitations
 
-(Bullet list. Each point leads with a **bold term** and then a short paragraph. Prefer to include every limitation the user or the source materials have flagged.)
+(Pick the structure that fits the length and complexity of the analysis.)
+
+**Option A — flat bullet list.** Works for short docs or when all limitations are at the same conceptual level. Each bullet leads with a **bold term** and then a short paragraph.
+
+**Option B — two-tier, prose then bullets.** Works for longer docs where data-source limitations and visualization-level decisions are both worth discussing. Open with narrative paragraphs on the data-source limitations (inheritable from the source — survey coverage, interpolation, top-income bias, etc.), connected by transitions like *"First, ... Second, ... In addition to this, ..."*. Then introduce a bulleted list of visualization-level decisions with a sentence like *"Beyond these data limitations, there are decisions we made that affect the visualization:"* and list the choices as bullets.
+
+Always include every limitation the user or the source materials have flagged — prefer overinclusion to quiet omissions.
 
 ## References
 
@@ -116,6 +122,7 @@ The canonical skeleton above (Introduction, Data sources, Methodology, Limitatio
 - **The visualization lets the user toggle units, currencies, or time intervals, and those toggles involve non-obvious conversion logic.** Describe the base unit, the conversion factor, and where any manual decisions live.
 - **A representation choice (log/linear axis, smoothing parameters, color palette, binning strategy) is substantive enough to affect interpretation.** Explain what the choice is and why it was made — but only if the reasoning is non-obvious.
 - **There is an analysis-specific workflow that doesn't fit under "Methodology"** — e.g. query construction rules, sampling design, manual adjudication lists, validation procedures.
+- **The method has tunable parameters that readers might question** (KDE bandwidth/extent/bins, smoothing windows, clustering thresholds, etc.). Add a nested `#### How sensitive are the results to the choice of parameters?` subsection under the method description. Briefly list each parameter and say whether the visible results would change meaningfully if it were set differently. Skip this subsection entirely for methods without tunable parameters.
 
 If the analysis is simple enough to cover in the canonical four sections, leave it at four.
 
@@ -132,6 +139,8 @@ Consistency with the existing analyses docs is important — they deploy through
 - **Mathematical typography**: use subscripts (log₂, not log2), proper minus signs, and Unicode for fractions only when they'd aid readability.
 - **Links in markdown `[text](url)` syntax** — no bare URLs. Link GitHub files to their `owid/<repo>/blob/master/...` path so they stay valid as code changes.
 - **Prefer prose over deeply nested bullets** — if a bullet list has three levels of nesting, rewrite as paragraphs with a short concluding list.
+- **Use first-person plural voice** ("we rely on", "we import", "we harmonize") throughout the prose — the doc is a team walkthrough, not a neutral reference manual.
+- **Source-code excerpts are optional, not required.** Paste a short function (≤ ~30 lines) inside a fenced code block only when it directly illustrates a methodological claim a reader might want to verify against the actual implementation. For docs whose methodology is purely conceptual, skip code blocks entirely and rely on the GitHub links in the References section.
 
 ## 5. Writing principles (lessons from past sessions)
 
@@ -141,6 +150,8 @@ Consistency with the existing analyses docs is important — they deploy through
 - **Separate the upstream decision from the downstream display.** When a module only formats pre-processed data (like `incomePlotUtils.ts` only formatting pre-converted currency values), call that out — readers shouldn't have to guess where the transformation happens.
 - **Collapse long lists.** A 218-country enumeration in the body destroys readability. A `??? quote` block keeps the content available without forcing it on every reader.
 - **Keep the References section structured.** Group OWID source code separately from external datasets — readers who want to inspect the code have different needs from those who want the upstream source.
+- **If the computation involves an approximation, pair it with a validation.** When the doc states "this method is off by at most X", follow that paragraph inside the same `!!! note` callout with a quantified cross-check against an authoritative source (PIP's own published numbers, a peer-reviewed paper, the source dataset's own headline series). Format: paragraph 1 = theoretical bound, paragraph 2 = empirical check. Skip this for docs that don't make approximation claims.
+- **If the visualization has user-facing toggles** (currency switch, unit toggle, time-interval, log/linear scale, regional-vs-country view), add a short `!!! note "What changes when you switch X, and what doesn't?"` callout inside the relevant section. Spell out what stays the same (shape of curves, rankings, shares) and what changes (axis labels, displayed values). Skip this for static charts or charts without meaningful toggles.
 
 ## 6. Review with the user
 

--- a/.claude/skills/create-analysis-doc/SKILL.md
+++ b/.claude/skills/create-analysis-doc/SKILL.md
@@ -137,7 +137,7 @@ Consistency with the existing analyses docs is important — they deploy through
 - **Worked examples with concrete numbers** — prefer "Brazil has 250 bins below the line, which is 25%" over abstract algebra.
 - **Bold on first mention** for key terms (e.g. **International Dollars**, **PPP factor**, **bin**).
 - **Mathematical typography**: use subscripts (log₂, not log2), proper minus signs, and Unicode for fractions only when they'd aid readability.
-- **Escape dollar signs in body text** (`\$3 / day`, `\$1,000`). Zensical/mkdocs-material interprets unescaped `$...$` pairs as inline math, so a sentence like "from $0.25 to $1,000" will render as a math expression. Dollar signs inside fenced code blocks don't need escaping.
+- **Dollar signs in body text render as plain `$`** on this site. The project's KaTeX config intentionally omits `$...$` as an inline-math delimiter (in [docs/javascripts/katex.js](../../../docs/javascripts/katex.js)), precisely so sentences like "from $0.25 to $1,000" don't get swept up as math. Use `\(...\)` for inline math when it's actually needed, and `$$...$$` for display math. Don't escape monetary dollar signs with a backslash — the backslash is consumed during Markdown→HTML and doesn't do anything useful here.
 - **Links in markdown `[text](url)` syntax** — no bare URLs. Link GitHub files to their `owid/<repo>/blob/master/...` path so they stay valid as code changes.
 - **Prefer prose over deeply nested bullets** — if a bullet list has three levels of nesting, rewrite as paragraphs with a short concluding list.
 - **Use first-person plural voice** ("we rely on", "we import", "we harmonize") throughout the prose — the doc is a team walkthrough, not a neutral reference manual.

--- a/.claude/skills/create-analysis-doc/SKILL.md
+++ b/.claude/skills/create-analysis-doc/SKILL.md
@@ -143,6 +143,20 @@ Consistency with the existing analyses docs is important — they deploy through
 - **Use first-person plural voice** ("we rely on", "we import", "we harmonize") throughout the prose — the doc is a team walkthrough, not a neutral reference manual.
 - **Source-code excerpts are optional, not required.** Paste a short function (≤ ~30 lines) inside a fenced code block only when it directly illustrates a methodological claim a reader might want to verify against the actual implementation. For docs whose methodology is purely conceptual, skip code blocks entirely and rely on the GitHub links in the References section.
 
+### If the content came from Google Docs
+
+Docs drafted in Google Docs and exported to Markdown consistently arrive with a fixed set of artefacts. This happens whenever the author iterates in GDocs and re-pastes; expect to see the same problems every time. Rewrite the affected file in one pass to clean them up:
+
+- **Escaped admonition markers** — `\!\!\! info ""` → `!!! info ""`. The exported form also crams the title and first paragraph onto a single line (`\!\!\! info "Title" Body text...`) — split it so the `!!!` line has only the type and title, and the body is indented on the next line with 4 spaces.
+- **Headings wrapped in bold** — `## **Text**` → `## Text`. Exported on every heading level (H1, H2, H3, H4).
+- **Escaped brackets in links** — `\["Title"\](url)` → `"Title" (url)` or a real Markdown link `[Title](url)`.
+- **Escaped characters where none are needed** — `\[`, `\]`, `\.`, `\=`, `\~`, `\-`, `\_`, `\)` around numbers, units, or file names (`1990\.`, `2010 \= 100`, `int\_dollar\_conversions.py`, `(base 2\)`, `\~592M`). Remove the backslashes.
+- **Collapsible block content inside a fenced code block** — the `??? note "..."` or `??? quote "..."` exports with its contents in a ```` ``` ```` fence below it, which makes mkdocs render the list as code instead of as the admonition body. Remove the fences and indent each line of content with 4 spaces so it's nested inside the admonition.
+- **Curly quotes in admonition titles** — `"Title"` (Unicode `"`/`"`) → `"Title"` (straight ASCII). Curly quotes in admonition titles can break the title parser; elsewhere in prose they're harmless.
+- **Sub-bullets indented with 2 spaces** — Python-Markdown wants 4-space indentation for nested bullets. If a nested list renders flat, check the indentation.
+
+Smart quotes, em dashes, and other typographic characters *inside* prose are fine to leave alone — mkdocs-material renders them correctly.
+
 ## 5. Writing principles (lessons from past sessions)
 
 - **Lead with intuition, not implementation.** Readers want to understand the *idea* before the code. For a computation like "share below the line", first explain "each bin represents 1/1000 of the population; count bins below, divide by 1000" — then mention the `(k / 10) * pop` expression and *why* it collapses that way.

--- a/docs/analyses/index.md
+++ b/docs/analyses/index.md
@@ -48,3 +48,10 @@ This is just a sneak peek into some of our data work. But note that all our code
     This document is a technical companion to the article ["Tracking historical progress against slavery and forced labor: a long-run data view"](https://ourworldindata.org/slavery).
 
     [:material-book-open-variant: Methodology](slavery_historical_data/index.md){ .md-button }
+
+!!! note ""
+
+    ## Visualizing global inequality
+    This document is a technical companion to our [inequality page](https://ourworldindata.org/economic-inequality) and the article "Visualizing global inequality". It describes the World Bank PIP data underlying the income distribution plots, the currency-conversion and kernel density methodology, and the known limitations.
+
+    [:material-book-open-variant: Methodology](inequality_visualization/index.md){ .md-button }

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -2,65 +2,66 @@
 status: new
 ---
 
-# **Visualizing global inequality**
+# Visualizing global inequality
 
-\!\!\! info "" :octicons-person-16: [**Pablo Arriagada**](https://ourworldindata.org/team/pablo-arriagada)**, [Bertha Rohenkohl](https://ourworldindata.org/team/bertha-rohenkohl), [Marcel Gerber](https://ourworldindata.org/team), [Joe Hasell](https://ourworldindata.org/team/joe-hasell)** • :octicons-calendar-16: April 21, 2026 *(last edit)* • [**:octicons-mail-16: Feedback**](mailto:info@ourworldindata.org?subject=Feedback%20on%20technical%20publication%20-%20Visualizing%20global%20inequality)
+!!! info ""
+    :octicons-person-16: **[Pablo Arriagada](https://ourworldindata.org/team/pablo-arriagada), [Bertha Rohenkohl](https://ourworldindata.org/team/bertha-rohenkohl), [Marcel Gerber](https://ourworldindata.org/team), [Joe Hasell](https://ourworldindata.org/team/joe-hasell)** • :octicons-calendar-16: April 21, 2026 *(last edit)* • [**:octicons-mail-16: Feedback**](mailto:info@ourworldindata.org?subject=Feedback%20on%20technical%20publication%20-%20Visualizing%20global%20inequality)
 
-## **Introduction**
+## Introduction
 
-This document describes how our team produced an interactive visualization of global income distributions, presented in our article \[“Visualizing global inequality”\](TODO: add link).
+This document describes how our team produced an interactive visualization of global income distributions, presented in our article "Visualizing global inequality" (TODO: add link).
 
-Most available tools focus on inequality within individual countries. This tool brings together inequalities within countries and between countries into a single view, letting users compare countries’ and regions’ income distributions side by side and explore how many people live below any chosen income threshold.
+Most available tools focus on inequality within individual countries. This tool brings together inequalities within countries and between countries into a single view, letting users compare countries' and regions' income distributions side by side and explore how many people live below any chosen income threshold.
 
 Here, we cover the data sources, data processing, the key methodological choices, and the known limitations of the approach.
 
-\!\!\! note The interactive visualization is a bespoke component of the [`owid-grapher` repository](https://github.com/owid/owid-grapher). You can browse the code \[here\](TODO: add link).
+!!! note
+    The interactive visualization is a bespoke component of the [`owid-grapher` repository](https://github.com/owid/owid-grapher). You can browse the code here (TODO: add link).
 
-## **Data source: Global incomes data from the World Bank**
+## Data source: Global incomes data from the World Bank
 
 The data comes from the World Bank. More specifically, we rely on the following dataset:
 
 * [1000 binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) from the [Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/) — contains data on the global income distribution from 1990 to the present, which is the backbone of the visualization. For each year, it contains 1000 bins of income or consumption per country.
 
-### **1000 binned global distribution**
+### 1000 binned global distribution
 
 The [1000 binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) file contains, for each country and year, **1000 quantile groups** (or "bins") of the average income (or consumption) per capita of the population. Each bin represents one thousandth of the country's population, ordered from bin number 1 (the poorest 0.1%) to bin number 1000 (the richest 0.1%).
 
 Income is expressed in **2021 [international dollars](https://ourworldindata.org/international-dollars)**, and is adjusted for inflation and differences in living costs between countries.
 
-The data is available from 1990 until the year of the latest data release..
+The data is available from 1990 until the year of the latest data release.
 
 **Where does the income data come from?**  The most common source of data on the incomes of people around the world is household surveys — studies that ask thousands of households in a country how much they earn or spend. These income and consumption expenditure surveys are conducted at the country level, and the World Bank collects and standardizes this data through the Poverty and Inequality Platform (PIP).
 
 Some technical aspects of the data are worth highlighting:
 
 * Because not all countries run household surveys every year, PIP fills the gaps: it interpolates between survey years and extrapolates to the present. These projections are based on the assumption that incomes or consumption expenditures grow in line with the growth rates observed in national accounts data. For more details, see Chapter 5 of the Poverty and Inequality Platform [Methodology Handbook](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html).
-* The dataset combines income and consumption expenditure surveys because not every country asks about the same welfare concept. In high-income countries, the surveys typically capture people’s incomes, while in low- and middle-income countries, they measure consumption expenditure — what households spend on goods and services. A small number of countries report both. The two concepts are closely related but not the same: income equals consumption plus savings. Therefore, the global data is a mix of income and consumption expenditure data, making inequality estimates less comparable across countries that use different measures. The 1000-binned file itself does not label each country-year series as income or consumption, although that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles) under "Data sources".
-* In many poorer countries, a large share of people don’t have any monetary income — they grow food for their own use or trade goods and services outside of markets. This data accounts for that by adding the estimated value of non-monetary income and home production.
+* The dataset combines income and consumption expenditure surveys because not every country asks about the same welfare concept. In high-income countries, the surveys typically capture people's incomes, while in low- and middle-income countries, they measure consumption expenditure — what households spend on goods and services. A small number of countries report both. The two concepts are closely related but not the same: income equals consumption plus savings. Therefore, the global data is a mix of income and consumption expenditure data, making inequality estimates less comparable across countries that use different measures. The 1000-binned file itself does not label each country-year series as income or consumption, although that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles) under "Data sources".
+* In many poorer countries, a large share of people don't have any monetary income — they grow food for their own use or trade goods and services outside of markets. This data accounts for that by adding the estimated value of non-monetary income and home production.
 
-\!\!\! warning "Top-income coverage" Survey data is not very good at capturing incomes at the top of the distribution. The extremely rich are few in number, they are harder to reach, and less likely to participate in surveys even when contacted. And even when they participate, surveys tend to undercount their income — particularly income received from capital, business ownership, and complex financial arrangements. Other sources, such as the [World Inequality Database](https://wid.world/methodology/), attempt to adjust for this by combining surveys with data from tax records and national accounts. But PIP is the only global dataset covering this many countries with a consistent concept that most closely matches what countries report in their own statistics and what people would think of as "income".
+!!! warning "Top-income coverage"
+    Survey data is not very good at capturing incomes at the top of the distribution. The extremely rich are few in number, they are harder to reach, and less likely to participate in surveys even when contacted. And even when they participate, surveys tend to undercount their income — particularly income received from capital, business ownership, and complex financial arrangements. Other sources, such as the [World Inequality Database](https://wid.world/methodology/), attempt to adjust for this by combining surveys with data from tax records and national accounts. But PIP is the only global dataset covering this many countries with a consistent concept that most closely matches what countries report in their own statistics and what people would think of as "income".
 
-### **Data structure**
+### Data structure
 
-The raw file is organized with columns identifying the country, the [World Bank region](https://datahelpdesk.worldbank.org/knowledgebase/articles/906519-world-bank-country-and-lending-groups), the quantile (from 1 to 1000), and the welfare indicator representing the average daily income or consumption per capita in that quantile. An additional column reports the population in each quantile (in millions of people) — namely, the country's total population divided by 1000\. Population values come from the World Development Indicators (or, where it is unavailable, from the fallback sources listed in [PIP's methodology](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html#population)).
+The raw file is organized with columns identifying the country, the [World Bank region](https://datahelpdesk.worldbank.org/knowledgebase/articles/906519-world-bank-country-and-lending-groups), the quantile (from 1 to 1000), and the welfare indicator representing the average daily income or consumption per capita in that quantile. An additional column reports the population in each quantile (in millions of people) — namely, the country's total population divided by 1000. Population values come from the World Development Indicators (or, where it is unavailable, from the fallback sources listed in [PIP's methodology](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html#population)).
 
 This data covers **218 economies** across seven World Bank regions.
 
 ??? quote "Full list of 218 economies included (by World Bank region)"
 
-```
-- **East Asia and Pacific**: American Samoa; Australia; Brunei Darussalam; Cambodia; China; Fiji; French Polynesia; Guam; Hong Kong SAR, China; Indonesia; Japan; Kiribati; Korea, Dem. Rep.; Korea, Rep.; Lao PDR; Macao SAR, China; Malaysia; Marshall Islands; Micronesia, Fed. Sts.; Mongolia; Myanmar; Nauru; New Caledonia; New Zealand; Northern Mariana Islands; Palau; Papua New Guinea; Philippines; Samoa; Singapore; Solomon Islands; Taiwan, China; Thailand; Timor-Leste; Tonga; Tuvalu; Vanuatu; Viet Nam.
-- **Europe and Central Asia**: Albania; Andorra; Armenia; Austria; Azerbaijan; Belarus; Belgium; Bosnia and Herzegovina; Bulgaria; Channel Islands; Croatia; Cyprus; Czechia; Denmark; Estonia; Faeroe Islands; Finland; France; Georgia; Germany; Gibraltar; Greece; Greenland; Hungary; Iceland; Ireland; Isle of Man; Italy; Kazakhstan; Kosovo; Kyrgyz Republic; Latvia; Liechtenstein; Lithuania; Luxembourg; Moldova; Monaco; Montenegro; Netherlands; North Macedonia; Norway; Poland; Portugal; Romania; Russian Federation; San Marino; Serbia; Slovak Republic; Slovenia; Spain; Sweden; Switzerland; Tajikistan; Turkmenistan; Türkiye; Ukraine; United Kingdom; Uzbekistan.
-- **Latin America and the Caribbean**: Antigua and Barbuda; Argentina; Aruba; Bahamas, The; Barbados; Belize; Bolivia; Brazil; British Virgin Islands; Cayman Islands; Chile; Colombia; Costa Rica; Cuba; Curaçao; Dominica; Dominican Republic; Ecuador; El Salvador; Grenada; Guatemala; Guyana; Haiti; Honduras; Jamaica; Mexico; Nicaragua; Panama; Paraguay; Peru; Puerto Rico (U.S.); Sint Maarten (Dutch part); St. Kitts and Nevis; St. Lucia; St. Martin (French part); St. Vincent and the Grenadines; Suriname; Trinidad and Tobago; Turks and Caicos Islands; Uruguay; Venezuela, RB; Virgin Islands (U.S.).
-- **Middle East, North Africa, Afghanistan and Pakistan**: Lebanon; Libya; Malta; Morocco; Oman; Pakistan; Qatar; Saudi Arabia; Syrian Arab Republic; Tunisia; United Arab Emirates; West Bank and Gaza; Yemen, Rep.
-- **North America**: Bermuda; Canada; United States.
-- **South Asia**: Bangladesh; Bhutan; India; Maldives; Nepal; Sri Lanka.
-- **Sub-Saharan Africa**: Angola; Benin; Botswana; Burkina Faso; Burundi; Cabo Verde; Cameroon; Central African Republic; Chad; Comoros; Congo, Dem. Rep.; Congo, Rep.; Côte d'Ivoire; Equatorial Guinea; Eritrea; Eswatini; Ethiopia; Gabon; Gambia, The; Ghana; Guinea; Guinea-Bissau; Kenya; Lesotho; Liberia; Madagascar; Malawi; Mali; Mauritania; Mauritius; Mozambique; Namibia; Niger; Nigeria; Rwanda; Senegal; Seychelles; Sierra Leone; Somalia; South Africa; South Sudan; Sudan; São Tomé and Príncipe; Tanzania; Togo; Uganda; Zambia; Zimbabwe.
-```
+    - **East Asia and Pacific**: American Samoa; Australia; Brunei Darussalam; Cambodia; China; Fiji; French Polynesia; Guam; Hong Kong SAR, China; Indonesia; Japan; Kiribati; Korea, Dem. Rep.; Korea, Rep.; Lao PDR; Macao SAR, China; Malaysia; Marshall Islands; Micronesia, Fed. Sts.; Mongolia; Myanmar; Nauru; New Caledonia; New Zealand; Northern Mariana Islands; Palau; Papua New Guinea; Philippines; Samoa; Singapore; Solomon Islands; Taiwan, China; Thailand; Timor-Leste; Tonga; Tuvalu; Vanuatu; Viet Nam.
+    - **Europe and Central Asia**: Albania; Andorra; Armenia; Austria; Azerbaijan; Belarus; Belgium; Bosnia and Herzegovina; Bulgaria; Channel Islands; Croatia; Cyprus; Czechia; Denmark; Estonia; Faeroe Islands; Finland; France; Georgia; Germany; Gibraltar; Greece; Greenland; Hungary; Iceland; Ireland; Isle of Man; Italy; Kazakhstan; Kosovo; Kyrgyz Republic; Latvia; Liechtenstein; Lithuania; Luxembourg; Moldova; Monaco; Montenegro; Netherlands; North Macedonia; Norway; Poland; Portugal; Romania; Russian Federation; San Marino; Serbia; Slovak Republic; Slovenia; Spain; Sweden; Switzerland; Tajikistan; Turkmenistan; Türkiye; Ukraine; United Kingdom; Uzbekistan.
+    - **Latin America and the Caribbean**: Antigua and Barbuda; Argentina; Aruba; Bahamas, The; Barbados; Belize; Bolivia; Brazil; British Virgin Islands; Cayman Islands; Chile; Colombia; Costa Rica; Cuba; Curaçao; Dominica; Dominican Republic; Ecuador; El Salvador; Grenada; Guatemala; Guyana; Haiti; Honduras; Jamaica; Mexico; Nicaragua; Panama; Paraguay; Peru; Puerto Rico (U.S.); Sint Maarten (Dutch part); St. Kitts and Nevis; St. Lucia; St. Martin (French part); St. Vincent and the Grenadines; Suriname; Trinidad and Tobago; Turks and Caicos Islands; Uruguay; Venezuela, RB; Virgin Islands (U.S.).
+    - **Middle East, North Africa, Afghanistan and Pakistan**: Lebanon; Libya; Malta; Morocco; Oman; Pakistan; Qatar; Saudi Arabia; Syrian Arab Republic; Tunisia; United Arab Emirates; West Bank and Gaza; Yemen, Rep.
+    - **North America**: Bermuda; Canada; United States.
+    - **South Asia**: Bangladesh; Bhutan; India; Maldives; Nepal; Sri Lanka.
+    - **Sub-Saharan Africa**: Angola; Benin; Botswana; Burkina Faso; Burundi; Cabo Verde; Cameroon; Central African Republic; Chad; Comoros; Congo, Dem. Rep.; Congo, Rep.; Côte d'Ivoire; Equatorial Guinea; Eritrea; Eswatini; Ethiopia; Gabon; Gambia, The; Ghana; Guinea; Guinea-Bissau; Kenya; Lesotho; Liberia; Madagascar; Malawi; Mali; Mauritania; Mauritius; Mozambique; Namibia; Niger; Nigeria; Rwanda; Senegal; Seychelles; Sierra Leone; Somalia; South Africa; South Sudan; Sudan; São Tomé and Príncipe; Tanzania; Togo; Uganda; Zambia; Zimbabwe.
 
-### **Data processing**
+### Data processing
 
-We import the data and harmonize country and region names against our internal reference, convert population estimates from millions to persons, and run sanity checks to confirm that there are no negative values for the average income, and that it is monotonically non-decreasing for each country (that is, each average income must be greater than or equal to the average of the previous quantile). We haven’t detected any violations in the current data.
+We import the data and harmonize country and region names against our internal reference, convert population estimates from millions to persons, and run sanity checks to confirm that there are no negative values for the average income, and that it is monotonically non-decreasing for each country (that is, each average income must be greater than or equal to the average of the previous quantile). We haven't detected any violations in the current data.
 
 ```py
 def sanity_checks(tb: Table) -> Table:
@@ -89,15 +90,16 @@ def sanity_checks(tb: Table) -> Table:
     return tb
 ```
 
-## **Plotting income distributions**
+## Plotting income distributions
 
-### **Estimating the shape of the income distributions**
+### Estimating the shape of the income distributions
 
 The data for each country is a list of 1000 average daily income values (for each bin). To turn these data points into the smooth income distribution curves shown in the visualization, we use a technique called [kernel density estimation (KDE)](https://en.wikipedia.org/wiki/Kernel_density_estimation).
 
 The curve is produced by feeding the 1000 averages for a given country-year through a KDE function, with all incomes first converted to a logarithmic scale.
 
-\!\!\! info "Working in log scale" Income data spans several orders of magnitude — from less than a dollar a day to thousands. To handle this range, we work with the logarithm (base 2\) of each income value. In log space, the distance between $1 and $2 is the same as between $50 and $100, which gives the lower end of the distribution the same visual resolution as the upper end.
+!!! info "Working in log scale"
+    Income data spans several orders of magnitude — from less than a dollar a day to thousands. To handle this range, we work with the logarithm (base 2) of each income value. In log space, the distance between $1 and $2 is the same as between $50 and $100, which gives the lower end of the distribution the same visual resolution as the upper end.
 
 Three parameters control the shape of this curve: the smoothness of the estimate (**bandwidth**), the income range it covers (**extent**), and the resolution of the output (**bins**).
 
@@ -128,16 +130,16 @@ export function kdeLog(pointsLog2: number[]) {
 
 After the density is computed in log space, the x-values are converted back to dollar amounts (by computing 2^x), so the curve can be plotted directly against income in international dollars.
 
-#### **How sensitive are the results to the choice of parameters?**
+#### How sensitive are the results to the choice of parameters?
 
 * Bandwidth: (TBC with Marcel)
 * Extent:
-  * No values are below int.-$ 0.25 a day
-  * 30 countries have bins with average income values higher than int.-$ 1000 a day; with most in the richest 0.1%. These countries have a combined population of \~592M but only roughly 611k people (about 0.1% of the combined population) fall into bins whose average income exceeds this threshold. Visually, this trims the very tip of the right tail for those distributions.
+    * No values are below int.-$ 0.25 a day
+    * 30 countries have bins with average income values higher than int.-$ 1000 a day; with most in the richest 0.1%. These countries have a combined population of ~592M but only roughly 611k people (about 0.1% of the combined population) fall into bins whose average income exceeds this threshold. Visually, this trims the very tip of the right tail for those distributions.
 * Bins: (TBC with Marcel)
-  * We do not test the number of bins (200); this controls only the resolution of the curve, and values above \~100 produce visually identical results. \- is this true?
+    * We do not test the number of bins (200); this controls only the resolution of the curve, and values above ~100 produce visually identical results. - is this true?
 
-### **Calculating the share of the population below a given income threshold**
+### Calculating the share of the population below a given income threshold
 
 We can now compute the share of the population living below a chosen poverty line (or any income threshold) for any combination of countries, regions, and the world.
 
@@ -145,11 +147,12 @@ For each country, we find the highest bin in the 1000 bin distribution whose ave
 
 For regions and the world aggregate, we weight by population. We sum the number of people below the line across all constituent countries and divide by the total population of the group.
 
-\!\!\! note "How accurate is this?" Because we have 1000 bins rather than the full income distribution, we can't know exactly where the line falls inside a bin — each bin is assigned entirely above or below the line based on its average income. A bin whose average is just below the line might contain some people who are above it, and vice versa. In the worst case, this is off by half a bin, i.e. 0.05 percentage points of the population. Keeping the computation this simple also makes it fast enough to recompute every time the user chooses a different line.
+!!! note "How accurate is this?"
+    Because we have 1000 bins rather than the full income distribution, we can't know exactly where the line falls inside a bin — each bin is assigned entirely above or below the line based on its average income. A bin whose average is just below the line might contain some people who are above it, and vice versa. In the worst case, this is off by half a bin, i.e. 0.05 percentage points of the population. Keeping the computation this simple also makes it fast enough to recompute every time the user chooses a different line.
 
-We cross-checked the method against PIP's own extrapolated poverty series at 2021 international dollars, for seven lines between $3 and $40 / day. At the country, regional, and global level, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin discretization allows. Since the visualization shows poverty shares without decimal points, these differences are not visible on the chart.
+    We cross-checked the method against PIP's own extrapolated poverty series at 2021 international dollars, for seven lines between $3 and $40 / day. At the country, regional, and global level, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin discretization allows. Since the visualization shows poverty shares without decimal points, these differences are not visible on the chart.
 
-## **Currency conversions**
+## Currency conversions
 
 The income data we use is originally expressed in constant 2021 international dollars per day, as we mentioned above. This means the data is adjusted for inflation and for differences in living costs between countries.
 
@@ -157,22 +160,21 @@ International dollars are a synthetic currency that adjusts for differences in l
 
 To let users view values and explore the chart in their local currency (for example, British pounds, US dollars, or Euros), we compute a conversion factor for each country that converts 2021 international dollars into local currency units at recent prices.
 
-\!\!\! note “What changes when you switch currency, and what doesn't?”
+!!! note "What changes when you switch currency, and what doesn't?"
+    Switching currency multiplies every income value by the same conversion factor — it rescales the axis, but doesn't change the shape of any distribution or the relative position of countries. The underlying PPP adjustment remains unchanged. The data is already adjusted for living costs between countries, so switching the view to euros or pounds doesn't undo that — the chart just shows you values in a different currency.
 
-Switching currency multiplies every income value by the same conversion factor — it rescales the axis, but doesn't change the shape of any distribution or the relative position of countries. The underlying PPP adjustment remains unchanged. The data is already adjusted for living costs between countries, so switching the view to euros or pounds doesn't undo that — the chart just shows you values in a different currency.
-
-####  **Data sources**
+#### Data sources
 
 We need two datasets from the World Bank: a Purchasing Power Parity (PPP) conversion factor to go from international dollars to local currency, and a price index to adjust for inflation.
 
 For the Purchasing Power Parity factors (PPPs):
 
-* Our primary source is the [World Bank’s Poverty and Inequality Platform](https://pip.worldbank.org/) (PIP) — the same source used for the income distributions above — which publishes the conversion factors it uses internally to translate local currency into 2021 international dollars.
+* Our primary source is the [World Bank's Poverty and Inequality Platform](https://pip.worldbank.org/) (PIP) — the same source used for the income distributions above — which publishes the conversion factors it uses internally to translate local currency into 2021 international dollars.
 * We complement this with [PPP conversion factors from the World Development Indicators](https://data.worldbank.org/indicator/PA.NUS.PRVT.PP) (WDI) (indicator PA.NUS.PRVT.PP) for countries where PIP's values are unavailable or where WDI better reflects the current currency situation.
 
-For the inflation adjustment, we use the World Development Indicators’ [Consumer price index (2010 \= 100\)](https://data.worldbank.org/indicator/FP.CPI.TOTL) (indicator code `FP.CPI.TOTL`). We use the CPI deflator because the underlying data measures household income and consumption, and CPI most closely tracks the prices that households face.
+For the inflation adjustment, we use the World Development Indicators' [Consumer price index (2010 = 100)](https://data.worldbank.org/indicator/FP.CPI.TOTL) (indicator code `FP.CPI.TOTL`). We use the CPI deflator because the underlying data measures household income and consumption, and CPI most closely tracks the prices that households face.
 
-#### **Data processing**
+#### Data processing
 
 PIP and WDI both derive their PPP factors from the same underlying data (the [International Comparison Program's 2021 round](https://www.worldbank.org/en/programs/icp)), but their numbers don't always agree, because they apply different methodologies.
 
@@ -182,30 +184,29 @@ When only one source is available for a country, we use that. In practice, WDI h
 
 When both PIP and WDI have values, but they disagree by more than 3%, we choose manually using some decision rules. Some common situations are:
 
-* WDI is preferred when it accounts for a recent currency redenomination that PIP does not — for example, the Belarusian ruble in 2016, the Mauritanian ouguiya in 2017, or Croatia's adoption of the Euro in 2023\.
-  * In a small number of borderline cases (e.g. France at 3.2%), the PIP value is retained.
-  * When the disagreement can’t be resolved easily, we drop the currency from the selection menu. For example, there are large differences in countries with complex currency histories (Zimbabwe, Liberia), ongoing currency transitions (Curaçao and Sint Maarten), or unresolved multi-currency situations (Palestine).
-  * We also exclude the currency of countries where the PIP income distribution represents only an urban or rural subpopulation rather than the whole population — e.g. the (urban) rows for Argentina, Bolivia, Colombia, Ecuador, Honduras, Suriname, and Uruguay, and the (urban)/(rural) rows for China, Ethiopia, and Rwanda. For some of these cases, such as Argentina and China, the WDI value can be used instead, so these countries remain on the selector; others without a WDI fallback are excluded entirely.
+* WDI is preferred when it accounts for a recent currency redenomination that PIP does not — for example, the Belarusian ruble in 2016, the Mauritanian ouguiya in 2017, or Croatia's adoption of the Euro in 2023.
+* In a small number of borderline cases (e.g. France at 3.2%), the PIP value is retained.
+* When the disagreement can't be resolved easily, we drop the currency from the selection menu. For example, there are large differences in countries with complex currency histories (Zimbabwe, Liberia), ongoing currency transitions (Curaçao and Sint Maarten), or unresolved multi-currency situations (Palestine).
+* We also exclude the currency of countries where the PIP income distribution represents only an urban or rural subpopulation rather than the whole population — e.g. the (urban) rows for Argentina, Bolivia, Colombia, Ecuador, Honduras, Suriname, and Uruguay, and the (urban)/(rural) rows for China, Ethiopia, and Rwanda. For some of these cases, such as Argentina and China, the WDI value can be used instead, so these countries remain on the selector; others without a WDI fallback are excluded entirely.
 
-The list of manual overrides is maintained in int\_dollar\_conversions.py and validated on every run.
+The list of manual overrides is maintained in `int_dollar_conversions.py` and validated on every run.
 
-#### **Converting to a local currency**
+#### Converting to a local currency
 
 When the user switches to a different currency, every income value is multiplied by a **conversion factor** specific to that currency.
 
 The conversion factor for each country is the product of two components.
 
-1\. The **PPP factor** converts from international dollars to local currencies at 2021 prices (effectively reversing the PPP adjustment that the World Bank applied to the original data).
+1. The **PPP factor** converts from international dollars to local currencies at 2021 prices (effectively reversing the PPP adjustment that the World Bank applied to the original data).
+2. The **CPI factor** adjusts for inflation between 2021 and the most recent year of CPI data available for that country. The adjustment is simply `CPI[latest year] / CPI[2021]`. The latest CPI year varies by country — for most it is close to the present, but for some it may be an earlier year.
 
-2\. The **CPI factor** adjusts for inflation between 2021 and the most recent year of CPI data available for that country. The adjustment is simply CPI\[latest year\] / CPI\[2021\]. The latest CPI year varies by country — for most it is close to the present, but for some it may be an earlier year.
+The final conversion factor is the product of these two: `PPP_factor × CPI_factor`, rounded to 5 significant figures. Multiplying an international dollar value by it therefore gives an amount in local currency at the latest available year's price level.
 
-The final conversion factor is the product of these two: `PPP_factor × CPI_factor`, rounded to 5 significant figures. Multiplying an international dollar value by therefore gives an amount in local currency at the latest available year's price level.
-
-#### **Time intervals**
+#### Time intervals
 
 The raw data is expressed as daily values. When the user switches to a monthly or yearly view, we multiply every value by a fixed factor: 365/12 for monthly, 365 for yearly. If a currency conversion is also active, both factors are applied together in a single step.
 
-## **Limitations**
+## Limitations
 
 The big strength of the World Bank dataset we are using here is that it is one of the few sources that can give us this global perspective on income inequality. But the data comes with important caveats.
 
@@ -213,7 +214,7 @@ First, there are some comparability issues across countries. As we discussed ear
 
 Second, incomes at the top of the distribution are often missed or underreported in surveys. The very wealthy are few, hard to reach, and less likely to participate — and even when they do, surveys tend to miss income from capital, business ownership, and complex financial arrangements. The right tail of every distribution shown here is likely compressed relative to reality.
 
-In addition to this, observations for many countries are estimated, not observed. The 1000 bins dataset is constructed to have one observation for every country and year since 1990\. To do this, the World Bank team interpolates between survey years and also extrapolate from the last survey year to the present year. There are many assumptions involved in this, in particular, the extrapolations. In those years, the distribution and poverty estimates may not fully reflect the reality of the country. They are best read as approximate levels of income relative to other countries, rather than as precise point estimates. The PIP team recommends care when looking at specific filled values for individual countries. The poverty and inequality statistics published directly by PIP are estimated from the actual survey data, not from this filled dataset.
+In addition to this, observations for many countries are estimated, not observed. The 1000 bins dataset is constructed to have one observation for every country and year since 1990. To do this, the World Bank team interpolates between survey years and also extrapolate from the last survey year to the present year. There are many assumptions involved in this, in particular, the extrapolations. In those years, the distribution and poverty estimates may not fully reflect the reality of the country. They are best read as approximate levels of income relative to other countries, rather than as precise point estimates. The PIP team recommends care when looking at specific filled values for individual countries. The poverty and inequality statistics published directly by PIP are estimated from the actual survey data, not from this filled dataset.
 
 Beyond these data limitations, there are decisions we made that affect the visualization:
 
@@ -221,7 +222,7 @@ Beyond these data limitations, there are decisions we made that affect the visua
 - As we discussed before, by using bin averages rather than individual-level data, we are missing within-bin inequality. [As the PIP team notes](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution), this results in a lower level of within-country inequality than the survey data would show.
 - For the inflation adjustment, the CPI indicator lags the current year. The latest available year in WDI's CPI series is typically one or two years behind the present. Values shown in local currency are therefore in prices from one or two years ago, which is still a reasonable approximation of present-day monetary values in most economies, though less so in countries experiencing rapid inflation.
 
-## **References**
+## References
 
 **Our World in Data source code**
 
@@ -235,5 +236,5 @@ Beyond these data limitations, there are decisions we made that affect the visua
 - [PIP methodology](https://datanalytics.worldbank.org/PIP-Methodology/)
 - [1000-binned global distribution dataset catalog](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution)
 - [PPP conversion factor, households (WDI, `PA.NUS.PRVT.PP`)](https://data.worldbank.org/indicator/PA.NUS.PRVT.PP)
-- [Consumer price index, 2010 \= 100 (WDI, `FP.CPI.TOTL`)](https://data.worldbank.org/indicator/FP.CPI.TOTL)
+- [Consumer price index, 2010 = 100 (WDI, `FP.CPI.TOTL`)](https://data.worldbank.org/indicator/FP.CPI.TOTL)
 - [International Comparison Program (ICP)](https://www.worldbank.org/en/programs/icp)

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -1,3 +1,7 @@
+---
+status: new
+---
+
 # Visualizing global inequality
 
 !!! info ""

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -22,13 +22,11 @@ Here, we cover the data sources, data processing, the key methodological choices
 
 The data comes from the World Bank. More specifically, we rely on the following dataset:
 
-* [1000 binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) from the [Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/) — contains data on the global income distribution from 1990 to the present, which is the backbone of the visualization. For each year, it contains 1000 bins of income or consumption per country.
+* [1000 binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) from the [Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/) — contains data on the global income distribution from 1990 to the present, which is the backbone of the visualization.
 
-### 1000 binned global distribution
+The [1000 binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) file contains, for each country and year, 1000 quantile groups (or "bins") of the average income (or consumption) per capita of the population. Each bin represents one thousandth of the country's population, ordered from bin number 1 (the poorest 0.1%) to bin number 1000 (the richest 0.1%).
 
-The [1000 binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) file contains, for each country and year, **1000 quantile groups** (or "bins") of the average income (or consumption) per capita of the population. Each bin represents one thousandth of the country's population, ordered from bin number 1 (the poorest 0.1%) to bin number 1000 (the richest 0.1%).
-
-Income is expressed in **2021 [international dollars](https://ourworldindata.org/international-dollars)**, and is adjusted for inflation and differences in living costs between countries.
+Income is expressed in 2021 [international dollars](https://ourworldindata.org/international-dollars), and is adjusted for inflation and differences in living costs between countries.
 
 The data is available from 1990 until the year of the latest data release.
 
@@ -36,8 +34,8 @@ The data is available from 1990 until the year of the latest data release.
 
 Some technical aspects of the data are worth highlighting:
 
-* Because not all countries run household surveys every year, PIP fills the gaps: it interpolates between survey years and extrapolates to the present. These projections are based on the assumption that incomes or consumption expenditures grow in line with the growth rates observed in national accounts data. For more details, see Chapter 5 of the Poverty and Inequality Platform [Methodology Handbook](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html).
-* The dataset combines income and consumption expenditure surveys because not every country asks about the same welfare concept. In high-income countries, the surveys typically capture people's incomes, while in low- and middle-income countries, they measure consumption expenditure — what households spend on goods and services. A small number of countries report both. The two concepts are closely related but not the same: income equals consumption plus savings. Therefore, the global data is a mix of income and consumption expenditure data, making inequality estimates less comparable across countries that use different measures. The 1000-binned file itself does not label each country-year series as income or consumption, although that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles) under "Data sources".
+* Because not all countries run household surveys every year, PIP fills the gaps: it interpolates between survey years and extrapolates to the present. These estimates are based on the assumption that incomes or consumption expenditures grow in line with the growth rates observed in national accounts data. For more details, see Chapter 5 of the Poverty and Inequality Platform [Methodology Handbook](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html).
+* The dataset combines income and consumption expenditure surveys because not every country asks about the same welfare concept. In high-income countries, the surveys typically capture people's incomes, while in low- and middle-income countries, they measure consumption expenditure — what households spend on goods and services. A small number of countries report both. The two concepts are closely related but not the same: income equals consumption plus savings. Therefore, the global data is a mix of income and consumption expenditure data, making inequality estimates less comparable across countries that use different measures. The 1000 binned file itself does not label each country-year series as income or consumption, although that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles) under "Data sources".
 * In many poorer countries, a large share of people don't have any monetary income — they grow food for their own use or trade goods and services outside of markets. This data accounts for that by adding the estimated value of non-monetary income and home production.
 
 !!! warning "Top-income coverage"
@@ -101,7 +99,7 @@ The curve is produced by feeding the 1000 averages for a given country-year thro
 !!! info "Working in log scale"
     Income data spans several orders of magnitude — from less than a dollar a day to thousands. To handle this range, we work with the logarithm (base 2) of each income value. In log space, the distance between $1 and $2 is the same as between $50 and $100, which gives the lower end of the distribution the same visual resolution as the upper end.
 
-Three parameters control the shape of this curve: the smoothness of the estimate (**bandwidth**), the income range it covers (**extent**), and the resolution of the output (**bins**).
+Three parameters control the shape of this curve: the smoothness of the estimate (**bandwidth**), the income range it covers (**extent**), and the resolution of the output (**bins**). They are defined as follows:
 
 ```ts
 // KDE_BANDWIDTH controls how smooth the resulting curve is. Smaller values follow the data more closely.
@@ -112,7 +110,7 @@ export const KDE_EXTENT = [0.25, 1000].map(Math.log2) as [number, number]
 export const KDE_NUM_BINS = 200
 ```
 
-We then use the [`fast-kde`](https://github.com/uwdata/fast-kde) JavaScript library with the following parameters (for all countries in the data):
+We then use the [`fast-kde`](https://github.com/uwdata/fast-kde) JavaScript library with the same parameters (for all countries in the data):
 
 ```ts
 export function kdeLog(pointsLog2: number[]) {
@@ -130,7 +128,7 @@ export function kdeLog(pointsLog2: number[]) {
 
 After the density is computed in log space, the x-values are converted back to dollar amounts (by computing 2^x), so the curve can be plotted directly against income in international dollars.
 
-#### How sensitive are the results to the choice of parameters?
+#### How sensitive are the results to the choice of parameters? [in progress]
 
 * Bandwidth: (TBC with Marcel)
 * Extent:
@@ -143,14 +141,14 @@ After the density is computed in log space, the x-values are converted back to d
 
 We can now compute the share of the population living below a chosen poverty line (or any income threshold) for any combination of countries, regions, and the world.
 
-For each country, we find the highest bin in the 1000 bin distribution whose average income falls (strictly) below the chosen line. That position tells us how many bins — and therefore how many people — are below it. Dividing by the country's total population gives the share of the population below that line. For example, if 250 of the 1000 bins in Brazil fall below a chosen line, then 25% of Brazilians are estimated to live below it.
+For each country, we find the highest bin in the 1000-bin distribution whose average income falls (strictly) below the chosen line. That position tells us how many bins — and therefore how many people — are below it. Dividing by the country's total population gives the share of the population below that line. For example, if 250 of the 1000 bins in Brazil fall below a chosen line, then 25% of Brazilians are estimated to live below it.
 
 For regions and the world aggregate, we weight by population. We sum the number of people below the line across all constituent countries and divide by the total population of the group.
 
 !!! info "How accurate is this?"
-    Because we have 1000 bins rather than the full income distribution, we can't know exactly where the line falls inside a bin — each bin is assigned entirely above or below the line based on its average income. A bin whose average is just below the line might contain some people who are above it, and vice versa. In the worst case, this is off by half a bin, i.e. 0.05 percentage points of the population. Keeping the computation this simple also makes it fast enough to recompute every time the user chooses a different line.
+    Because we have 1000 bins rather than the full income distribution, we can't know exactly where the line falls inside a bin — each bin is assigned entirely above or below the line based on its average income. A bin whose average is just below the line might contain some people who are above it, and vice versa. In the worst case, this is off by half a bin, i.e., 0.05 percentage points of the population. Keeping the computation this simple also makes it fast enough to recompute every time the user chooses a different line.
 
-    We cross-checked the method against PIP's own extrapolated poverty series at 2021 international dollars, for seven lines between $3 and $40 / day. At the country, regional, and global level, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin discretization allows. Since the visualization shows poverty shares without decimal points, these minor differences are not visible on the chart.
+    We cross-checked the shares shown here against PIP's own extrapolated poverty series at 2021 international dollars for the most recent year available, for seven lines between $3 and $40 / day. At the country, regional, and global levels, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin data allows. Since the visualization shows poverty shares without decimal points, these minor differences are not visible on the chart.
 
 ## Currency conversions
 
@@ -210,16 +208,16 @@ The raw data is expressed as daily values. When the user switches to a monthly o
 
 The big strength of the World Bank dataset we are using here is that it is one of the few sources that can give us this global perspective on income inequality. But the data comes with important caveats.
 
-First, there are some comparability issues across countries. As we discussed earlier, the PIP collects household survey data from national statistics offices and works to make that data as comparable across countries as possible. But countries don't all measure the same thing, with some surveys focusing on capturing income, and others on consumption expenditure. These two concepts are related (income equals consumption plus savings) but they are not the same. Income tends to be more unequally distributed than consumption, so when comparing distributions across countries, we should pay attention to this — part of the visible difference can reflect the welfare concept rather than a real gap.
+First, not all countries measure the same thing. As we discussed earlier, the PIP collects household survey data from national statistics offices and works to make that data as comparable across countries as possible. But countries don't all measure the same thing, with some surveys focusing on capturing income, and others on consumption expenditure. These two concepts are related (income equals consumption plus savings), but they are not the same. Income tends to be more unequally distributed than consumption, so when comparing distributions across countries, we should pay attention to this — part of the visible difference can reflect the welfare concept rather than a real gap.
 
 Second, incomes at the top of the distribution are often missed or underreported in surveys. The very wealthy are few, hard to reach, and less likely to participate — and even when they do, surveys tend to miss income from capital, business ownership, and complex financial arrangements. The right tail of every distribution shown here is likely compressed relative to reality.
 
-In addition to this, observations for many countries are estimated, not observed. The 1000 bins dataset is constructed to have one observation for every country and year since 1990. To do this, the World Bank team interpolates between survey years and also extrapolate from the last survey year to the present year. There are many assumptions involved in this, in particular, the extrapolations. In those years, the distribution and poverty estimates may not fully reflect the reality of the country. They are best read as approximate levels of income relative to other countries, rather than as precise point estimates. The PIP team recommends care when looking at specific filled values for individual countries. The poverty and inequality statistics published directly by PIP are estimated from the actual survey data, not from this filled dataset.
+In addition to this, observations for many countries are estimated, not observed. The 1000 bins dataset is constructed to have one observation for every country and year since 1990. To do this, the World Bank team interpolates between survey years and also extrapolates from the last survey year to the present year. There are many assumptions involved in this, in particular, the extrapolations. In those years, the distribution and poverty estimates may not fully reflect the reality of the country. They are best read as approximate levels of income relative to other countries, rather than as precise point estimates. The PIP team recommends care when looking at specific filled values for individual countries. The poverty and inequality statistics published directly by PIP are estimated from the actual survey data, not from this filled dataset.
 
 Beyond these data limitations, there are decisions we made that affect the visualization:
 
-- The KDE curves are smoothed to show the general shape of the income distribution. They should not be used to read off the precise shares. The share of population below a line figures come from the bin data directly, not from the area under the curve. The curves are also evaluated over daily incomes from $0.25 to $1,000. No countries have bins below $0.25, but 30 countries have bins above $1,000 — typically only for the richest 0.1%. For those countries, the very tip of the right tail of the curve is visually trimmed.
-- As we discussed before, by using bin averages rather than individual-level data, we are missing within-bin inequality. [As the PIP team notes](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution), this results in a lower level of within-country inequality than the survey data would show.
+- The KDE curves are smoothed to show the general shape of the income distribution. They should not be used to read off the precise shares. The share of the population below a line comes from the bin data directly, not from the area under the curve. The curves are also evaluated over daily incomes from $0.25 to $1,000. No countries have bins below $0.25, but 30 countries have bins above $1,000 — typically only for the richest 0.1%. For those countries, the very tip of the right tail of the curve is visually trimmed.
+- As we discussed before, by using bin averages rather than individual-level data, we are missing within-bin inequality.
 - For the inflation adjustment, the CPI indicator lags the current year. The latest available year in WDI's CPI series is typically one or two years behind the present. Values shown in local currency are therefore in prices from one or two years ago, which is still a reasonable approximation of present-day monetary values in most economies, though less so in countries experiencing rapid inflation.
 
 ## References
@@ -232,9 +230,10 @@ Beyond these data limitations, there are decisions we made that affect the visua
 
 **External datasets and references**
 
-- [World Bank Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/)
-- [PIP methodology](https://datanalytics.worldbank.org/PIP-Methodology/)
-- [1000-binned global distribution dataset catalog](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution)
+- World Bank. Poverty and Inequality Platform [Data set]. World Bank Group. [https://pip.worldbank.org](https://pip.worldbank.org/)
+- Mahler, Daniel Gerszon; Yonzan, Nishant; Lakner, Christoph (2022). The Impact of COVID-19 on Global Inequality and Poverty. Policy Research Working Papers; 10198. © World Bank, Washington, DC. [https://openknowledge.worldbank.org/entities/publication/54fae299-8800-585f-9f18-a42514f8d83b](https://openknowledge.worldbank.org/entities/publication/54fae299-8800-585f-9f18-a42514f8d83b) updated with Poverty and Inequality Platform.
+- [1000-binned global distribution dataset](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution), the updated link to the dataset above.
+- [Poverty and Inequality Platform Methodology Handbook](https://datanalytics.worldbank.org/PIP-Methodology/)
 - [PPP conversion factor, households (WDI, `PA.NUS.PRVT.PP`)](https://data.worldbank.org/indicator/PA.NUS.PRVT.PP)
 - [Consumer price index, 2010 = 100 (WDI, `FP.CPI.TOTL`)](https://data.worldbank.org/indicator/FP.CPI.TOTL)
 - [International Comparison Program (ICP)](https://www.worldbank.org/en/programs/icp)

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -49,7 +49,7 @@ The raw file is organized with columns identifying the country, the [World Bank 
 
 This data covers **218 economies** across seven World Bank regions.
 
-??? quote "Full list of 218 economies included (by World Bank region)"
+??? note "Full list of 218 economies included (by World Bank region)"
 
     - **East Asia and Pacific**: American Samoa; Australia; Brunei Darussalam; Cambodia; China; Fiji; French Polynesia; Guam; Hong Kong SAR, China; Indonesia; Japan; Kiribati; Korea, Dem. Rep.; Korea, Rep.; Lao PDR; Macao SAR, China; Malaysia; Marshall Islands; Micronesia, Fed. Sts.; Mongolia; Myanmar; Nauru; New Caledonia; New Zealand; Northern Mariana Islands; Palau; Papua New Guinea; Philippines; Samoa; Singapore; Solomon Islands; Taiwan, China; Thailand; Timor-Leste; Tonga; Tuvalu; Vanuatu; Viet Nam.
     - **Europe and Central Asia**: Albania; Andorra; Armenia; Austria; Azerbaijan; Belarus; Belgium; Bosnia and Herzegovina; Bulgaria; Channel Islands; Croatia; Cyprus; Czechia; Denmark; Estonia; Faeroe Islands; Finland; France; Georgia; Germany; Gibraltar; Greece; Greenland; Hungary; Iceland; Ireland; Isle of Man; Italy; Kazakhstan; Kosovo; Kyrgyz Republic; Latvia; Liechtenstein; Lithuania; Luxembourg; Moldova; Monaco; Montenegro; Netherlands; North Macedonia; Norway; Poland; Portugal; Romania; Russian Federation; San Marino; Serbia; Slovak Republic; Slovenia; Spain; Sweden; Switzerland; Tajikistan; Turkmenistan; Türkiye; Ukraine; United Kingdom; Uzbekistan.

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -99,7 +99,7 @@ The data for each country is a list of 1000 average daily income values (for eac
 The curve is produced by feeding the 1000 averages for a given country-year through a KDE function, with all incomes first converted to a logarithmic scale.
 
 !!! info "Working in log scale"
-    Income data spans several orders of magnitude — from less than a dollar a day to thousands. To handle this range, we work with the logarithm (base 2) of each income value. In log space, the distance between $1 and $2 is the same as between $50 and $100, which gives the lower end of the distribution the same visual resolution as the upper end.
+    Income data spans several orders of magnitude — from less than a dollar a day to thousands. To handle this range, we work with the logarithm (base 2) of each income value. In log space, the distance between \$1 and \$2 is the same as between \$50 and \$100, which gives the lower end of the distribution the same visual resolution as the upper end.
 
 Three parameters control the shape of this curve: the smoothness of the estimate (**bandwidth**), the income range it covers (**extent**), and the resolution of the output (**bins**).
 
@@ -150,7 +150,7 @@ For regions and the world aggregate, we weight by population. We sum the number 
 !!! note "How accurate is this?"
     Because we have 1000 bins rather than the full income distribution, we can't know exactly where the line falls inside a bin — each bin is assigned entirely above or below the line based on its average income. A bin whose average is just below the line might contain some people who are above it, and vice versa. In the worst case, this is off by half a bin, i.e. 0.05 percentage points of the population. Keeping the computation this simple also makes it fast enough to recompute every time the user chooses a different line.
 
-    We cross-checked the method against PIP's own extrapolated poverty series at 2021 international dollars, for seven lines between $3 and $40 / day. At the country, regional, and global level, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin discretization allows. Since the visualization shows poverty shares without decimal points, these differences are not visible on the chart.
+    We cross-checked the method against PIP's own extrapolated poverty series at 2021 international dollars, for seven lines between \$3 and \$40 / day. At the country, regional, and global level, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin discretization allows. Since the visualization shows poverty shares without decimal points, these differences are not visible on the chart.
 
 ## Currency conversions
 
@@ -218,7 +218,7 @@ In addition to this, observations for many countries are estimated, not observed
 
 Beyond these data limitations, there are decisions we made that affect the visualization:
 
-- The KDE curves are smoothed to show the general shape of the income distribution. They should not be used to read off the precise shares. The share of population below a line figures come from the bin data directly, not from the area under the curve. The curves are also evaluated over daily incomes from $0.25 to $1,000. No countries have bins below $0.25, but 30 countries have bins above $1,000 — typically only for the richest 0.1%. For those countries, the very tip of the right tail of the curve is visually trimmed.
+- The KDE curves are smoothed to show the general shape of the income distribution. They should not be used to read off the precise shares. The share of population below a line figures come from the bin data directly, not from the area under the curve. The curves are also evaluated over daily incomes from \$0.25 to \$1,000. No countries have bins below \$0.25, but 30 countries have bins above \$1,000 — typically only for the richest 0.1%. For those countries, the very tip of the right tail of the curve is visually trimmed.
 - As we discussed before, by using bin averages rather than individual-level data, we are missing within-bin inequality. [As the PIP team notes](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution), this results in a lower level of within-country inequality than the survey data would show.
 - For the inflation adjustment, the CPI indicator lags the current year. The latest available year in WDI's CPI series is typically one or two years behind the present. Values shown in local currency are therefore in prices from one or two years ago, which is still a reasonable approximation of present-day monetary values in most economies, though less so in countries experiencing rapid inflation.
 

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -2,180 +2,226 @@
 status: new
 ---
 
-# Visualizing global inequality
+# **Visualizing global inequality**
 
-!!! info ""
-    :octicons-person-16: **[Pablo Arriagada](https://ourworldindata.org/team/pablo-arriagada)** • :octicons-calendar-16: April 21, 2026 *(last edit)* • [**:octicons-mail-16: Feedback**](mailto:info@ourworldindata.org?subject=Feedback%20on%20technical%20publication%20-%20Visualizing%20global%20inequality)
+\!\!\! info "" :octicons-person-16: [**Pablo Arriagada**](https://ourworldindata.org/team/pablo-arriagada)**, [Bertha Rohenkohl](https://ourworldindata.org/team/bertha-rohenkohl), [Marcel Gerber](https://ourworldindata.org/team), [Joe Hasell](https://ourworldindata.org/team/joe-hasell)** • :octicons-calendar-16: April 21, 2026 *(last edit)* • [**:octicons-mail-16: Feedback**](mailto:info@ourworldindata.org?subject=Feedback%20on%20technical%20publication%20-%20Visualizing%20global%20inequality)
 
-## Introduction
+## **Introduction**
 
-In our [economic inequality page](https://ourworldindata.org/economic-inequality) and the article "Visualizing global inequality" ([TODO: article URL]), we include a bespoke interactive visualization that shows how income is distributed across countries and regions around the world. The tool lets readers compare income distributions side by side and explore how many people live below any chosen poverty line — from extreme poverty thresholds to the median income of a rich country.
+This document describes how our team produced an interactive visualization of global income distributions, presented in our article \[“Visualizing global inequality”\](TODO: add link).
 
-This document is the technical companion to that visualization. It describes the data sources we rely on, the processing applied in our ETL pipeline, the methodological choices behind the smoothed distribution curves and the share-below-line computation, and the known limitations of the approach. The visualization itself is a bespoke component of the [`owid-grapher` repository](https://github.com/owid/owid-grapher); links to the relevant source code are gathered in the [References](#references) section at the end.
+Most available tools focus on inequality within individual countries. This tool brings together inequalities within countries and between countries into a single view, letting users compare countries’ and regions’ income distributions side by side and explore how many people live below any chosen income threshold.
 
-The inputs come from two different World Bank sources: the [Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/), which publishes the binned global income distribution that is the backbone of the visualization, and the [World Development Indicators (WDI)](https://datatopics.worldbank.org/world-development-indicators/), from which we take supplementary Purchasing Power Parity factors and Consumer Price Index data for currency conversion.
+Here, we cover the data sources, data processing, the key methodological choices, and the known limitations of the approach.
 
-## Data sources
+\!\!\! note The interactive visualization is a bespoke component of the [`owid-grapher` repository](https://github.com/owid/owid-grapher). You can browse the code \[here\](TODO: add link).
 
-### World Bank Poverty and Inequality Platform (PIP)
+## **Data source: Global incomes data from the World Bank**
 
-PIP provides the core inputs for this visualization: the income distribution data and the PPP factors used to express incomes in international dollars.
+The data comes from the World Bank. More specifically, we rely on the following dataset:
 
-#### 1000-binned global distribution
+* [1000 binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) from the [Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/) — contains data on the global income distribution from 1990 to the present, which is the backbone of the visualization. For each year, it contains 1000 bins of income or consumption per country.
 
-The [1000-binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) file contains, for each country and year, **1000 quantiles** (or "bins") of the average income or consumption per capita of the population. Each bin represents one thousandth of the country's population, ordered from the poorest 0.1% up to the richest 0.1%. Income is measured in **2021 [international dollars](https://ourworldindata.org/international-dollars)**, adjusted for differences in inflation and living costs between countries.
+### **1000 binned global distribution**
 
-The data is available from **1990 until the year of the data release**, and is updated twice a year (typically around March and September), alongside the main PIP updates.
+The [1000 binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) file contains, for each country and year, **1000 quantile groups** (or "bins") of the average income (or consumption) per capita of the population. Each bin represents one thousandth of the country's population, ordered from bin number 1 (the poorest 0.1%) to bin number 1000 (the richest 0.1%).
 
-**Where the numbers come from.** PIP's distributions are derived from household surveys, where people are asked about their income or consumption. Because only a handful of countries run such surveys every year, PIP interpolates between survey years and extrapolates to the most recent year using estimates and projections of GDP per capita growth. See [PIP's methodology](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html) for the full procedure.
+Income is expressed in **2021 [international dollars](https://ourworldindata.org/international-dollars)**, and is adjusted for inflation and differences in living costs between countries.
 
-**Income vs. consumption.** PIP combines income and consumption surveys because not every country asks about the same welfare concept: most Western countries report income, while most countries in Africa and parts of Asia report consumption. A small number of countries report both. Comparing **inequality** estimates across the two concepts should be done with caution, since income is typically much more unequally distributed than consumption. Comparing **poverty** estimates is less problematic: most people in poverty are unable to save, so their income and consumption are close to identical. The 1000-binned file itself does not label each country-year series as income or consumption — that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles) under "Data sources".
+The data is available from 1990 until the year of the latest data release..
 
-!!! warning "Top-income coverage"
-    Survey data is not very good at capturing incomes at the top of the distribution. The richest are harder to reach, they are few, they are less likely to respond, and when they do respond, they tend to underreport — whether because of complex financial arrangements or fear of tax authorities. Other sources, such as the [World Inequality Database](https://wid.world/methodology/), attempt to correct for this, but PIP remains the only global dataset whose income concept matches what countries report in their own statistics and what people understand as "income".
+**Where does the income data come from?**  The most common source of data on the incomes of people around the world is household surveys — studies that ask thousands of households in a country how much they earn or spend. These income and consumption expenditure surveys are conducted at the country level, and the World Bank collects and standardizes this data through the Poverty and Inequality Platform (PIP).
 
-**File structure.** The raw file is organized with columns identifying the country, the [World Bank region](https://datahelpdesk.worldbank.org/knowledgebase/articles/906519-world-bank-country-and-lending-groups), the quantile (from 1 to 1000), and the welfare indicator representing income or consumption per capita in that quantile. An additional column reports the population in each quantile — namely the country's total population divided by 1000, with population values coming from WDI (or, where WDI is unavailable, from the fallback sources listed in [PIP's methodology](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html#population)).
+Some technical aspects of the data are worth highlighting:
 
-PIP's 1000-binned file covers **218 economies** across seven World Bank regions.
+* Because not all countries run household surveys every year, PIP fills the gaps: it interpolates between survey years and extrapolates to the present. These projections are based on the assumption that incomes or consumption expenditures grow in line with the growth rates observed in national accounts data. For more details, see Chapter 5 of the Poverty and Inequality Platform [Methodology Handbook](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html).
+* The dataset combines income and consumption expenditure surveys because not every country asks about the same welfare concept. In high-income countries, the surveys typically capture people’s incomes, while in low- and middle-income countries, they measure consumption expenditure — what households spend on goods and services. A small number of countries report both. The two concepts are closely related but not the same: income equals consumption plus savings. Therefore, the global data is a mix of income and consumption expenditure data, making inequality estimates less comparable across countries that use different measures. The 1000-binned file itself does not label each country-year series as income or consumption, although that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles) under "Data sources".
+* In many poorer countries, a large share of people don’t have any monetary income — they grow food for their own use or trade goods and services outside of markets. This data accounts for that by adding the estimated value of non-monetary income and home production.
 
-??? quote "Full list of 218 economies included (by region)"
+\!\!\! warning "Top-income coverage" Survey data is not very good at capturing incomes at the top of the distribution. The extremely rich are few in number, they are harder to reach, and less likely to participate in surveys even when contacted. And even when they participate, surveys tend to undercount their income — particularly income received from capital, business ownership, and complex financial arrangements. Other sources, such as the [World Inequality Database](https://wid.world/methodology/), attempt to adjust for this by combining surveys with data from tax records and national accounts. But PIP is the only global dataset covering this many countries with a consistent concept that most closely matches what countries report in their own statistics and what people would think of as "income".
 
-    - **East Asia and Pacific**: American Samoa; Australia; Brunei Darussalam; Cambodia; China; Fiji; French Polynesia; Guam; Hong Kong SAR, China; Indonesia; Japan; Kiribati; Korea, Dem. Rep.; Korea, Rep.; Lao PDR; Macao SAR, China; Malaysia; Marshall Islands; Micronesia, Fed. Sts.; Mongolia; Myanmar; Nauru; New Caledonia; New Zealand; Northern Mariana Islands; Palau; Papua New Guinea; Philippines; Samoa; Singapore; Solomon Islands; Taiwan, China; Thailand; Timor-Leste; Tonga; Tuvalu; Vanuatu; Viet Nam.
-    - **Europe and Central Asia**: Albania; Andorra; Armenia; Austria; Azerbaijan; Belarus; Belgium; Bosnia and Herzegovina; Bulgaria; Channel Islands; Croatia; Cyprus; Czechia; Denmark; Estonia; Faeroe Islands; Finland; France; Georgia; Germany; Gibraltar; Greece; Greenland; Hungary; Iceland; Ireland; Isle of Man; Italy; Kazakhstan; Kosovo; Kyrgyz Republic; Latvia; Liechtenstein; Lithuania; Luxembourg; Moldova; Monaco; Montenegro; Netherlands; North Macedonia; Norway; Poland; Portugal; Romania; Russian Federation; San Marino; Serbia; Slovak Republic; Slovenia; Spain; Sweden; Switzerland; Tajikistan; Turkmenistan; Türkiye; Ukraine; United Kingdom; Uzbekistan.
-    - **Latin America and the Caribbean**: Antigua and Barbuda; Argentina; Aruba; Bahamas, The; Barbados; Belize; Bolivia; Brazil; British Virgin Islands; Cayman Islands; Chile; Colombia; Costa Rica; Cuba; Curaçao; Dominica; Dominican Republic; Ecuador; El Salvador; Grenada; Guatemala; Guyana; Haiti; Honduras; Jamaica; Mexico; Nicaragua; Panama; Paraguay; Peru; Puerto Rico (U.S.); Sint Maarten (Dutch part); St. Kitts and Nevis; St. Lucia; St. Martin (French part); St. Vincent and the Grenadines; Suriname; Trinidad and Tobago; Turks and Caicos Islands; Uruguay; Venezuela, RB; Virgin Islands (U.S.).
-    - **Middle East, North Africa, Afghanistan and Pakistan**: Lebanon; Libya; Malta; Morocco; Oman; Pakistan; Qatar; Saudi Arabia; Syrian Arab Republic; Tunisia; United Arab Emirates; West Bank and Gaza; Yemen, Rep.
-    - **North America**: Bermuda; Canada; United States.
-    - **South Asia**: Bangladesh; Bhutan; India; Maldives; Nepal; Sri Lanka.
-    - **Sub-Saharan Africa**: Angola; Benin; Botswana; Burkina Faso; Burundi; Cabo Verde; Cameroon; Central African Republic; Chad; Comoros; Congo, Dem. Rep.; Congo, Rep.; Côte d'Ivoire; Equatorial Guinea; Eritrea; Eswatini; Ethiopia; Gabon; Gambia, The; Ghana; Guinea; Guinea-Bissau; Kenya; Lesotho; Liberia; Madagascar; Malawi; Mali; Mauritania; Mauritius; Mozambique; Namibia; Niger; Nigeria; Rwanda; Senegal; Seychelles; Sierra Leone; Somalia; South Africa; South Sudan; Sudan; São Tomé and Príncipe; Tanzania; Togo; Uganda; Zambia; Zimbabwe.
+### **Data structure**
 
-#### PPP conversion factors used by PIP
+The raw file is organized with columns identifying the country, the [World Bank region](https://datahelpdesk.worldbank.org/knowledgebase/articles/906519-world-bank-country-and-lending-groups), the quantile (from 1 to 1000), and the welfare indicator representing the average daily income or consumption per capita in that quantile. An additional column reports the population in each quantile (in millions of people) — namely, the country's total population divided by 1000\. Population values come from the World Development Indicators (or, where it is unavailable, from the fallback sources listed in [PIP's methodology](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html#population)).
 
-PIP also publishes the **Purchasing Power Parity (PPP) conversion factors** used internally to express each country's income in international dollars. We use these as the primary source for the currency-conversion logic described later in this document, complemented by WDI's factors when the two disagree.
+This data covers **218 economies** across seven World Bank regions.
 
-### World Development Indicators (WDI)
+??? quote "Full list of 218 economies included (by World Bank region)"
 
-WDI contributes two additional series used to convert international dollar values into a user-selected local currency at current prices:
+```
+- **East Asia and Pacific**: American Samoa; Australia; Brunei Darussalam; Cambodia; China; Fiji; French Polynesia; Guam; Hong Kong SAR, China; Indonesia; Japan; Kiribati; Korea, Dem. Rep.; Korea, Rep.; Lao PDR; Macao SAR, China; Malaysia; Marshall Islands; Micronesia, Fed. Sts.; Mongolia; Myanmar; Nauru; New Caledonia; New Zealand; Northern Mariana Islands; Palau; Papua New Guinea; Philippines; Samoa; Singapore; Solomon Islands; Taiwan, China; Thailand; Timor-Leste; Tonga; Tuvalu; Vanuatu; Viet Nam.
+- **Europe and Central Asia**: Albania; Andorra; Armenia; Austria; Azerbaijan; Belarus; Belgium; Bosnia and Herzegovina; Bulgaria; Channel Islands; Croatia; Cyprus; Czechia; Denmark; Estonia; Faeroe Islands; Finland; France; Georgia; Germany; Gibraltar; Greece; Greenland; Hungary; Iceland; Ireland; Isle of Man; Italy; Kazakhstan; Kosovo; Kyrgyz Republic; Latvia; Liechtenstein; Lithuania; Luxembourg; Moldova; Monaco; Montenegro; Netherlands; North Macedonia; Norway; Poland; Portugal; Romania; Russian Federation; San Marino; Serbia; Slovak Republic; Slovenia; Spain; Sweden; Switzerland; Tajikistan; Turkmenistan; Türkiye; Ukraine; United Kingdom; Uzbekistan.
+- **Latin America and the Caribbean**: Antigua and Barbuda; Argentina; Aruba; Bahamas, The; Barbados; Belize; Bolivia; Brazil; British Virgin Islands; Cayman Islands; Chile; Colombia; Costa Rica; Cuba; Curaçao; Dominica; Dominican Republic; Ecuador; El Salvador; Grenada; Guatemala; Guyana; Haiti; Honduras; Jamaica; Mexico; Nicaragua; Panama; Paraguay; Peru; Puerto Rico (U.S.); Sint Maarten (Dutch part); St. Kitts and Nevis; St. Lucia; St. Martin (French part); St. Vincent and the Grenadines; Suriname; Trinidad and Tobago; Turks and Caicos Islands; Uruguay; Venezuela, RB; Virgin Islands (U.S.).
+- **Middle East, North Africa, Afghanistan and Pakistan**: Lebanon; Libya; Malta; Morocco; Oman; Pakistan; Qatar; Saudi Arabia; Syrian Arab Republic; Tunisia; United Arab Emirates; West Bank and Gaza; Yemen, Rep.
+- **North America**: Bermuda; Canada; United States.
+- **South Asia**: Bangladesh; Bhutan; India; Maldives; Nepal; Sri Lanka.
+- **Sub-Saharan Africa**: Angola; Benin; Botswana; Burkina Faso; Burundi; Cabo Verde; Cameroon; Central African Republic; Chad; Comoros; Congo, Dem. Rep.; Congo, Rep.; Côte d'Ivoire; Equatorial Guinea; Eritrea; Eswatini; Ethiopia; Gabon; Gambia, The; Ghana; Guinea; Guinea-Bissau; Kenya; Lesotho; Liberia; Madagascar; Malawi; Mali; Mauritania; Mauritius; Mozambique; Namibia; Niger; Nigeria; Rwanda; Senegal; Seychelles; Sierra Leone; Somalia; South Africa; South Sudan; Sudan; São Tomé and Príncipe; Tanzania; Togo; Uganda; Zambia; Zimbabwe.
+```
 
-- [**PPP conversion factor, households and NPISHs Final consumption expenditure (LCU per international $)**](https://data.worldbank.org/indicator/PA.NUS.PRVT.PP) — indicator code `PA.NUS.PRVT.PP`. Used as a complement to PIP's PPP factors when the two sources disagree for a given country.
-- [**Consumer price index (2010 = 100)**](https://data.worldbank.org/indicator/FP.CPI.TOTL) — indicator code `FP.CPI.TOTL`. Used to adjust values from 2021 prices to the latest year available in the series.
+### **Data processing**
 
-## Methodology
+We import the data and harmonize country and region names against our internal reference, convert population estimates from millions to persons, and run sanity checks to confirm that there are no negative values for the average income, and that it is monotonically non-decreasing for each country (that is, each average income must be greater than or equal to the average of the previous quantile). We haven’t detected any violations in the current data.
 
-### 1000-binned distribution processing
+```py
+def sanity_checks(tb: Table) -> Table:
+    """
+    Check that there are no negative values for avg.
+    Check that data is monotonically increasing in quantile.
+    """
+    # Check that there are no negative values for avg.
 
-Only minor processing is applied to the 1000-binned distribution in our ETL. The [garden step](https://github.com/owid/etl/blob/master/etl/steps/data/garden/wb/2026-03-25/thousand_bins_distribution.py) harmonizes country and region names against our internal reference, multiplies the per-bin population estimates by 1,000,000 (so the column lands in units of people rather than millions), and runs sanity checks to confirm that the per-quantile average income is **monotonically non-decreasing** within each country-year (each average must be greater than or equal to the average in the previous quantile). No monotonicity violations have been detected so far.
+    mask = tb["avg"] < 0
+    if not tb[mask].empty:
+        paths.log.info(f"There are {len(tb[mask])} negative values for avg and will be transformed to zero.")
+        tb["avg"] = tb["avg"].clip(lower=0)
 
-The raw snapshot lives at [`snapshots/wb/2026-03-25/thousand_bins_distribution.dta.dvc`](https://github.com/owid/etl/blob/master/snapshots/wb/2026-03-25/thousand_bins_distribution.dta.dvc).
+    # Check that data is monotonically increasing in avg by country, year and quantile.
+    tb = tb.sort_values(by=["country", "year", "quantile"]).reset_index(drop=True)
 
-### Kernel density plots
+    mask = tb.groupby(["country", "year"])["avg"].diff() < 0
 
-The visualization shows each country's income distribution as a **smoothed density curve** rather than a histogram. The curve is produced by feeding the 1000 per-bin averages, for a given country-year, through a kernel density estimator, with all inputs first converted to the log₂ scale.
+    if not tb[mask].empty:
+        paths.log.info(f"There are {len(tb[mask])} values for avg that are not monotonically increasing.")
+        paths.log.info("These values will be transformed to the previous value.")
 
-!!! info "Why a log scale?"
-    Income is strongly right-skewed — a handful of very high incomes pull the mean far above the median. On a linear axis, most of the distribution collapses into a spike near zero. A log scale turns multiplicative differences into equal visual distances, which matches how people experience income changes (a doubling of income matters similarly at $2/day and $200/day) and produces distribution curves that can be meaningfully compared across countries and years. Income also tends to follow a **log-normal distribution** — the logarithm of income is approximately normally distributed — so a log-axis curve is close to bell-shaped and easy to read.
+        tb.loc[mask, "avg"] = tb.groupby(["country", "year"])["avg"].shift(1).loc[mask]
 
-We use a Gaussian [kernel density estimator](https://en.wikipedia.org/wiki/Kernel_density_estimation) via the [`fast-kde`](https://github.com/uwdata/fast-kde) JavaScript library with the following parameters:
+    return tb
+```
 
-| Parameter    | Value                       | Meaning                                                                                       |
-| ------------ | --------------------------- | --------------------------------------------------------------------------------------------- |
-| `bandwidth`  | `0.1` (on log₂ scale)       | Controls how smooth the resulting curve is. Smaller values follow the data more closely.      |
-| `extent`     | `[log₂(0.25), log₂(1000)]`  | Range over which the density is evaluated, i.e., daily incomes from $0.25 to $1,000.          |
-| `bins`       | `200`                       | Number of points at which the density is evaluated.                                           |
+## **Plotting income distributions**
 
-After the density is computed, we exponentiate the `x` coordinate labels (`2^x`) so the chart can plot them against income in international dollars on an intuitive axis.
+### **Estimating the shape of the income distributions**
 
-### Share of population below a poverty line
+The data for each country is a list of 1000 average daily income values (for each bin). To turn these data points into the smooth income distribution curves shown in the visualization, we use a technique called [kernel density estimation (KDE)](https://en.wikipedia.org/wiki/Kernel_density_estimation).
 
-From the 1000-binned distributions, we compute **the share of the population living below a chosen income line** for any combination of countries, regions, and the world aggregate.
+The curve is produced by feeding the 1000 averages for a given country-year through a KDE function, with all incomes first converted to a logarithmic scale.
 
-Each country-year comes as a list of 1000 numbers describing the income distribution: the average income of the poorest 0.1% of the population, then the next 0.1%, and so on up to the richest 0.1%. Each of those slices — we'll call them **bins** — represents the same number of people: one thousandth of the country's population.
+\!\!\! info "Working in log scale" Income data spans several orders of magnitude — from less than a dollar a day to thousands. To handle this range, we work with the logarithm (base 2\) of each income value. In log space, the distance between $1 and $2 is the same as between $50 and $100, which gives the lower end of the distribution the same visual resolution as the upper end.
 
-**For a single country**, the answer to "how many people earn less than $X a day?" is easy:
+Three parameters control the shape of this curve: the smoothness of the estimate (**bandwidth**), the income range it covers (**extent**), and the resolution of the output (**bins**).
 
-1. Count how many of the 1000 bins have an average income below $X. Call this count `k`.
-2. Since each bin is one thousandth of the population, the share of people below the line is simply `k / 1000`, or equivalently `k / 10` as a percentage.
+```ts
+// KDE_BANDWIDTH controls how smooth the resulting curve is. Smaller values follow the data more closely.
+export const KDE_BANDWIDTH = 0.1
+// KDE_EXTENT is the range over which the density is evaluated, i.e., daily incomes from $0.25 to $1,000.
+export const KDE_EXTENT = [0.25, 1000].map(Math.log2) as [number, number]
+// KDE_NUM_BINS is the number of points at which the density is evaluated.
+export const KDE_NUM_BINS = 200
+```
 
-For example, if 250 of the 1000 bins in Brazil fall below the line, then roughly **25%** of Brazilians earn less than the line.
+We then use the [`fast-kde`](https://github.com/uwdata/fast-kde) JavaScript library with the following parameters (for all countries in the data):
 
-**For a region or the world**, we can't just average the country percentages — that would give India and Luxembourg equal weight. We need to weight by population: a country with more people contributes more to the aggregate. The rule we use is:
+```ts
+export function kdeLog(pointsLog2: number[]) {
+    const k = fastKde.density1d(pointsLog2, {
+        bandwidth: KDE_BANDWIDTH,
+        extent: KDE_EXTENT,
+        bins: KDE_NUM_BINS,
+    })
+    return [...k.points()].map((p) => ({
+        ...p,
+        x: Math.pow(2, p.x),
+    })) as Array<{ x: number; y: number }>
+}
+```
 
-> share below line (region) = total people below the line across all countries in the region ÷ total population of the region
+After the density is computed in log space, the x-values are converted back to dollar amounts (by computing 2^x), so the curve can be plotted directly against income in international dollars.
 
-Concretely, for each country in the region, we compute the number of people below the line (`k × (country population ÷ 1000)`), add those up, and divide by the region's total population. The world aggregate works the same way, summing across all countries.
+#### **How sensitive are the results to the choice of parameters?**
 
-!!! note "Approximation"
-    Because we only have 1000 bins rather than the full income distribution, we can't know exactly where the line falls *inside* a bin. In the worst case this miscounts about half a bin, i.e. 0.05 percentage points of the entity's population — well below the resolution shown in the chart (whole percentage points). Keeping the computation this simple also makes it fast enough to recompute every time the user drags the poverty-line slider.
+* Bandwidth: (TBC with Marcel)
+* Extent:
+  * No values are below int.-$ 0.25 a day
+  * 30 countries have bins with average income values higher than int.-$ 1000 a day; with most in the richest 0.1%. These countries have a combined population of \~592M but only roughly 611k people (about 0.1% of the combined population) fall into bins whose average income exceeds this threshold. Visually, this trims the very tip of the right tail for those distributions.
+* Bins: (TBC with Marcel)
+  * We do not test the number of bins (200); this controls only the resolution of the curve, and values above \~100 produce visually identical results. \- is this true?
 
-### Currency
+### **Calculating the share of the population below a given income threshold**
 
-The chart lets the user switch **which currency** to display income in — international dollars (the default) or any of several local currencies like GBP, EUR, INR, etc.
+We can now compute the share of the population living below a chosen poverty line (or any income threshold) for any combination of countries, regions, and the world.
 
-#### What the underlying data is measured in
+For each country, we find the highest bin in the 1000 bin distribution whose average income falls (strictly) below the chosen line. That position tells us how many bins — and therefore how many people — are below it. Dividing by the country's total population gives the share of the population below that line. For example, if 250 of the 1000 bins in Brazil fall below a chosen line, then 25% of Brazilians are estimated to live below it.
 
-All the stored income values are in **international dollars per day**. International dollars are a synthetic currency, built from Purchasing Power Parity (PPP) adjustments, that make incomes comparable across countries by accounting for the fact that the same nominal dollar buys more in, say, Vietnam than in Switzerland. A person earning $5/day in international dollars has roughly the same material standard of living whether they live in Hanoi or Zurich — which they would not if we simply converted their local income using market exchange rates. You can find more information about international dollars in [our dedicated article](https://ourworldindata.org/international-dollars).
+For regions and the world aggregate, we weight by population. We sum the number of people below the line across all constituent countries and divide by the total population of the group.
 
-Using international dollars as the base unit also means a fixed poverty line (e.g. the World Bank's $3/day) has a consistent meaning across every country on the chart.
+\!\!\! note "How accurate is this?" Because we have 1000 bins rather than the full income distribution, we can't know exactly where the line falls inside a bin — each bin is assigned entirely above or below the line based on its average income. A bin whose average is just below the line might contain some people who are above it, and vice versa. In the worst case, this is off by half a bin, i.e. 0.05 percentage points of the population. Keeping the computation this simple also makes it fast enough to recompute every time the user chooses a different line.
 
-#### Converting to a local currency
+We cross-checked the method against PIP's own extrapolated poverty series at 2021 international dollars, for seven lines between $3 and $40 / day. At the country, regional, and global level, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin discretization allows. Since the visualization shows poverty shares without decimal points, these differences are not visible on the chart.
 
-When the user switches to a different currency, every income value is multiplied by a **conversion factor** specific to that currency. The factor is built upstream by an ETL step — [`int_dollar_conversions.py`](https://github.com/owid/etl/blob/master/etl/steps/data/external/owid_grapher/latest/int_dollar_conversions.py) — and fetched at runtime from the resulting JSON table, [`int_dollar_conversions.json`](https://owid-public.owid.io/marcel-bespoke-data-viz-02-2026/poverty-plots/int_dollar_conversions.json). The factor is the product of two components:
+## **Currency conversions**
 
-- **PPP factor** — converts international dollars (2021) to **local currency units (LCU) at 2021 prices**. Sourced from the World Bank, either from the [Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/) or from [World Development Indicators (WDI)](https://databank.worldbank.org/source/world-development-indicators).
-- **CPI factor** — inflates LCU values from 2021 prices to **the latest available year's prices** for that country, using CPI data from WDI (`fp_cpi_totl`). The factor is `CPI[latest] / CPI[2021]`, so it is country-specific both in magnitude and in which year "latest" refers to.
+The income data we use is originally expressed in constant 2021 international dollars per day, as we mentioned above. This means the data is adjusted for inflation and for differences in living costs between countries.
 
-Multiplying an international dollar value by `PPP_factor × CPI_factor` therefore gives an amount in local currency at the latest available year's price level.
+International dollars are a synthetic currency that adjusts for differences in living costs between countries, so that incomes are comparable globally. They are constructed using Purchasing Power Parity (PPP) conversion factors, which measure how many units of a country's local currency are needed to buy the same basket of goods that one US dollar would buy in the United States. You can read more about it in our article [What are international dollars?](https://ourworldindata.org/international-dollars)
 
-##### How the PPP factor is chosen
+To let users view values and explore the chart in their local currency (for example, British pounds, US dollars, or Euros), we compute a conversion factor for each country that converts 2021 international dollars into local currency units at recent prices.
 
-PIP and WDI publish PPP values derived from the same underlying data (the [International Comparison Program](https://www.worldbank.org/en/programs/icp)'s 2021 round), but their numbers don't always match exactly, because they apply different downstream methodologies. The ETL step reconciles the two as follows:
+\!\!\! note “What changes when you switch currency, and what doesn't?”
 
-1. **If PIP and WDI agree within 3%**, use PIP — most of our poverty data comes from PIP, so aligning currency units with PIP keeps the whole pipeline internally consistent.
-2. **If only one source has a value for a country**, use whichever has it. In practice, WDI covers a wider set of small territories (American Samoa, Cayman Islands, Greenland, Puerto Rico, etc.), while PIP is the only source for a handful of others (Taiwan, Venezuela, Yemen).
-3. **If both have values but differ by more than 3%**, the country is manually adjudicated against a curated override list. Typical cases include:
-    - **WDI preferred** when it reflects a recent currency redenomination that PIP hasn't caught up with — for example, the Belarusian ruble (2016, 1 BYN = 10,000 BYR), the Mauritanian ouguiya (2017, 1 MRU = 10 MRO), or Croatia's adoption of the Euro (2023).
-    - **Country dropped** when the disagreement can't be resolved cleanly: large deviations in countries with complex currency histories (Zimbabwe, Liberia), ongoing currency transitions (Curaçao and Sint Maarten moving from the Antillean to the Caribbean Guilder in 2025), or unresolved multi-currency situations (Palestine).
-    - **Country dropped** when the PIP entry represents only an urban or rural subpopulation rather than the whole country — e.g. the `(urban)` rows for Argentina, Bolivia, Colombia, Ecuador, Honduras, Suriname, and Uruguay, and the `(urban)`/`(rural)` rows for China, Ethiopia, and Rwanda. For Argentina and China, the country-level WDI value is used instead, so these countries remain on the chart; others without a WDI fallback are excluded entirely.
+Switching currency multiplies every income value by the same conversion factor — it rescales the axis, but doesn't change the shape of any distribution or the relative position of countries. The underlying PPP adjustment remains unchanged. The data is already adjusted for living costs between countries, so switching the view to euros or pounds doesn't undo that — the chart just shows you values in a different currency.
 
-The list of manual overrides lives in the ETL step itself and is validated on every run: if a country newly falls outside the 3% agreement band and isn't in the list, the build fails. This forces us to make an explicit decision rather than silently absorbing new disagreements.
+####  **Data sources**
 
-The UI uses IP-based country detection (via the [`detect-country.owid.io`](https://detect-country.owid.io/) service) to auto-suggest the user's local currency when the page loads, but the user can freely override it.
+We need two datasets from the World Bank: a Purchasing Power Parity (PPP) conversion factor to go from international dollars to local currency, and a price index to adjust for inflation.
 
-### Time interval
+For the Purchasing Power Parity factors (PPPs):
 
-The chart also lets the user pick the time interval displayed. The raw data is per day. Switching to monthly or yearly multiplies every value by a fixed factor:
+* Our primary source is the [World Bank’s Poverty and Inequality Platform](https://pip.worldbank.org/) (PIP) — the same source used for the income distributions above — which publishes the conversion factors it uses internally to translate local currency into 2021 international dollars.
+* We complement this with [PPP conversion factors from the World Development Indicators](https://data.worldbank.org/indicator/PA.NUS.PRVT.PP) (WDI) (indicator PA.NUS.PRVT.PP) for countries where PIP's values are unavailable or where WDI better reflects the current currency situation.
 
-| Interval | Factor   |
-| -------- | -------- |
-| daily    | `1`      |
-| monthly  | `365/12` |
-| yearly   | `365`    |
+For the inflation adjustment, we use the World Development Indicators’ [Consumer price index (2010 \= 100\)](https://data.worldbank.org/indicator/FP.CPI.TOTL) (indicator code `FP.CPI.TOTL`). We use the CPI deflator because the underlying data measures household income and consumption, and CPI most closely tracks the prices that households face.
 
-Currency and time-interval factors are multiplicative, so they combine into a single `combinedFactor` that is applied once to each value before display.
+#### **Data processing**
 
-### Colors
+PIP and WDI both derive their PPP factors from the same underlying data (the [International Comparison Program's 2021 round](https://www.worldbank.org/en/programs/icp)), but their numbers don't always agree, because they apply different methodologies.
 
-Each country, region, and the world aggregate has a color assigned to it. We use a local copy of Our World in Data's **Distinct Colors** palette, designed so that adjacent items in a chart remain visually separable.
+When PPP conversion factors are available from PIP and WDI, and they agree within 3%, we use PIP. This is the case for roughly 80% of countries with available PPP data.
 
-#### Fixed colors
+When only one source is available for a country, we use that. In practice, WDI has a broader coverage of small territories (American Samoa, Cayman Islands, Greenland, Puerto Rico, etc.), while PIP is the only source for a few others (Taiwan, Venezuela, Yemen).
 
-Two assignments are fixed:
+When both PIP and WDI have values, but they disagree by more than 3%, we choose manually using some decision rules. Some common situations are:
 
-- **World** is always shown in **Purple** (`#6d3e91`).
-- The seven World Bank regional aggregates each map to a specific palette color. The mapping is stable so that, for example, Sub-Saharan Africa is always Mauve across the whole tool.
+* WDI is preferred when it accounts for a recent currency redenomination that PIP does not — for example, the Belarusian ruble in 2016, the Mauritanian ouguiya in 2017, or Croatia's adoption of the Euro in 2023\.
+  * In a small number of borderline cases (e.g. France at 3.2%), the PIP value is retained.
+  * When the disagreement can’t be resolved easily, we drop the currency from the selection menu. For example, there are large differences in countries with complex currency histories (Zimbabwe, Liberia), ongoing currency transitions (Curaçao and Sint Maarten), or unresolved multi-currency situations (Palestine).
+  * We also exclude the currency of countries where the PIP income distribution represents only an urban or rural subpopulation rather than the whole population — e.g. the (urban) rows for Argentina, Bolivia, Colombia, Ecuador, Honduras, Suriname, and Uruguay, and the (urban)/(rural) rows for China, Ethiopia, and Rwanda. For some of these cases, such as Argentina and China, the WDI value can be used instead, so these countries remain on the selector; others without a WDI fallback are excluded entirely.
 
-#### Country colors
+The list of manual overrides is maintained in int\_dollar\_conversions.py and validated on every run.
 
-For countries — where there are too many entities to pre-assign colors — we rotate through a **palette of seven colors** in the order the countries are received. The world aggregate, if present in the same selection, is always overridden back to Purple, so it stands out visually from any country that happens to land on the same slot.
+#### **Converting to a local currency**
 
-## Limitations
+When the user switches to a different currency, every income value is multiplied by a **conversion factor** specific to that currency.
 
-- **Mixed income and consumption series.** As described in the [sources](#1000-binned-global-distribution) section, PIP's distributions combine series measured as either income or as consumption expenditure, depending on which concept each country reports in its household surveys. Because income is typically more unequally distributed than consumption, cross-country comparisons of inequality between income-based and consumption-based series should be read with care — part of the visible difference can reflect the welfare concept rather than a real inequality gap. Comparisons of poverty shares between the two types of series are less problematic, since people in poverty rarely save, and their income and consumption tend to coincide. The 1000-binned file does not label each country-year series by welfare concept; that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles).
-- **Top-income undercoverage.** Also described in the [sources](#1000-binned-global-distribution) section, the underlying data comes from household surveys, which do not accurately represent incomes at the top of the distribution due to underreporting, lower response rates, and the small number of very wealthy individuals.
-- **Interpolated and extrapolated years.** For country-years with no survey available, PIP either interpolates between surveys or extrapolates using GDP per capita growth. In those years, the distribution and poverty estimates may not fully reflect the reality of that specific country-year; they should be read as levels of income compared against other countries in the region or globally, rather than as exact point estimates.
-- **Smoothed curves.** The KDE curves are smoothed to show the shape of the distribution in general terms. The exact area under any portion of the curve does not necessarily correspond to the precise share of the population in that income range — the share-below-line figures (which come from the bin data directly, not from the smoothed curve) should be used for that.
-- **CPI lags the current year.** The latest available year in WDI's CPI series is typically one or two years behind the present. Values shown in local currency are therefore in prices from one or two years ago, which is still a reasonable approximation of present-day monetary values in most economies.
+The conversion factor for each country is the product of two components.
 
-## References
+1\. The **PPP factor** converts from international dollars to local currencies at 2021 prices (effectively reversing the PPP adjustment that the World Bank applied to the original data).
+
+2\. The **CPI factor** adjusts for inflation between 2021 and the most recent year of CPI data available for that country. The adjustment is simply CPI\[latest year\] / CPI\[2021\]. The latest CPI year varies by country — for most it is close to the present, but for some it may be an earlier year.
+
+The final conversion factor is the product of these two: `PPP_factor × CPI_factor`, rounded to 5 significant figures. Multiplying an international dollar value by therefore gives an amount in local currency at the latest available year's price level.
+
+#### **Time intervals**
+
+The raw data is expressed as daily values. When the user switches to a monthly or yearly view, we multiply every value by a fixed factor: 365/12 for monthly, 365 for yearly. If a currency conversion is also active, both factors are applied together in a single step.
+
+## **Limitations**
+
+The big strength of the World Bank dataset we are using here is that it is one of the few sources that can give us this global perspective on income inequality. But the data comes with important caveats.
+
+First, there are some comparability issues across countries. As we discussed earlier, the PIP collects household survey data from national statistics offices and works to make that data as comparable across countries as possible. But countries don't all measure the same thing, with some surveys focusing on capturing income, and others on consumption expenditure. These two concepts are related (income equals consumption plus savings) but they are not the same. Income tends to be more unequally distributed than consumption, so when comparing distributions across countries, we should pay attention to this — part of the visible difference can reflect the welfare concept rather than a real gap.
+
+Second, incomes at the top of the distribution are often missed or underreported in surveys. The very wealthy are few, hard to reach, and less likely to participate — and even when they do, surveys tend to miss income from capital, business ownership, and complex financial arrangements. The right tail of every distribution shown here is likely compressed relative to reality.
+
+In addition to this, observations for many countries are estimated, not observed. The 1000 bins dataset is constructed to have one observation for every country and year since 1990\. To do this, the World Bank team interpolates between survey years and also extrapolate from the last survey year to the present year. There are many assumptions involved in this, in particular, the extrapolations. In those years, the distribution and poverty estimates may not fully reflect the reality of the country. They are best read as approximate levels of income relative to other countries, rather than as precise point estimates. The PIP team recommends care when looking at specific filled values for individual countries. The poverty and inequality statistics published directly by PIP are estimated from the actual survey data, not from this filled dataset.
+
+Beyond these data limitations, there are decisions we made that affect the visualization:
+
+- The KDE curves are smoothed to show the general shape of the income distribution. They should not be used to read off the precise shares. The share of population below a line figures come from the bin data directly, not from the area under the curve. The curves are also evaluated over daily incomes from $0.25 to $1,000. No countries have bins below $0.25, but 30 countries have bins above $1,000 — typically only for the richest 0.1%. For those countries, the very tip of the right tail of the curve is visually trimmed.
+- As we discussed before, by using bin averages rather than individual-level data, we are missing within-bin inequality. [As the PIP team notes](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution), this results in a lower level of within-country inequality than the survey data would show.
+- For the inflation adjustment, the CPI indicator lags the current year. The latest available year in WDI's CPI series is typically one or two years behind the present. Values shown in local currency are therefore in prices from one or two years ago, which is still a reasonable approximation of present-day monetary values in most economies, though less so in countries experiencing rapid inflation.
+
+## **References**
 
 **Our World in Data source code**
 
@@ -189,5 +235,5 @@ For countries — where there are too many entities to pre-assign colors — we 
 - [PIP methodology](https://datanalytics.worldbank.org/PIP-Methodology/)
 - [1000-binned global distribution dataset catalog](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution)
 - [PPP conversion factor, households (WDI, `PA.NUS.PRVT.PP`)](https://data.worldbank.org/indicator/PA.NUS.PRVT.PP)
-- [Consumer price index, 2010 = 100 (WDI, `FP.CPI.TOTL`)](https://data.worldbank.org/indicator/FP.CPI.TOTL)
+- [Consumer price index, 2010 \= 100 (WDI, `FP.CPI.TOTL`)](https://data.worldbank.org/indicator/FP.CPI.TOTL)
 - [International Comparison Program (ICP)](https://www.worldbank.org/en/programs/icp)

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -84,7 +84,7 @@ We use a Gaussian [kernel density estimator](https://en.wikipedia.org/wiki/Kerne
 
 After the density is computed, we exponentiate the `x` coordinate labels (`2^x`) so the chart can plot them against income in international dollars on an intuitive axis.
 
-## Share of population below a poverty line
+### Share of population below a poverty line
 
 From the 1000-binned distributions, we compute **the share of the population living below a chosen income line** for any combination of countries, regions, and the world aggregate.
 
@@ -106,17 +106,17 @@ Concretely, for each country in the region, we compute the number of people belo
 !!! note "Approximation"
     Because we only have 1000 bins rather than the full income distribution, we can't know exactly where the line falls *inside* a bin. In the worst case this miscounts about half a bin, i.e. 0.05 percentage points of the entity's population — well below the resolution shown in the chart (whole percentage points). Keeping the computation this simple also makes it fast enough to recompute every time the user drags the poverty-line slider.
 
-## Currency
+### Currency
 
 The chart lets the user switch **which currency** to display income in — international dollars (the default) or any of several local currencies like GBP, EUR, INR, etc.
 
-### What the underlying data is measured in
+#### What the underlying data is measured in
 
 All the stored income values are in **international dollars per day**. International dollars are a synthetic currency, built from Purchasing Power Parity (PPP) adjustments, that make incomes comparable across countries by accounting for the fact that the same nominal dollar buys more in, say, Vietnam than in Switzerland. A person earning $5/day in international dollars has roughly the same material standard of living whether they live in Hanoi or Zurich — which they would not if we simply converted their local income using market exchange rates. You can find more information about international dollars in [our dedicated article](https://ourworldindata.org/international-dollars).
 
 Using international dollars as the base unit also means a fixed poverty line (e.g. the World Bank's $3/day) has a consistent meaning across every country on the chart.
 
-### Converting to a local currency
+#### Converting to a local currency
 
 When the user switches to a different currency, every income value is multiplied by a **conversion factor** specific to that currency. The factor is built upstream by an ETL step — [`int_dollar_conversions.py`](https://github.com/owid/etl/blob/master/etl/steps/data/external/owid_grapher/latest/int_dollar_conversions.py) — and fetched at runtime from the resulting JSON table, [`int_dollar_conversions.json`](https://owid-public.owid.io/marcel-bespoke-data-viz-02-2026/poverty-plots/int_dollar_conversions.json). The factor is the product of two components:
 
@@ -125,7 +125,7 @@ When the user switches to a different currency, every income value is multiplied
 
 Multiplying an international dollar value by `PPP_factor × CPI_factor` therefore gives an amount in local currency at the latest available year's price level.
 
-#### How the PPP factor is chosen
+##### How the PPP factor is chosen
 
 PIP and WDI publish PPP values derived from the same underlying data (the [International Comparison Program](https://www.worldbank.org/en/programs/icp)'s 2021 round), but their numbers don't always match exactly, because they apply different downstream methodologies. The ETL step reconciles the two as follows:
 
@@ -140,7 +140,7 @@ The list of manual overrides lives in the ETL step itself and is validated on ev
 
 The UI uses IP-based country detection (via the [`detect-country.owid.io`](https://detect-country.owid.io/) service) to auto-suggest the user's local currency when the page loads, but the user can freely override it.
 
-## Time interval
+### Time interval
 
 The chart also lets the user pick the time interval displayed. The raw data is per day. Switching to monthly or yearly multiplies every value by a fixed factor:
 
@@ -152,18 +152,18 @@ The chart also lets the user pick the time interval displayed. The raw data is p
 
 Currency and time-interval factors are multiplicative, so they combine into a single `combinedFactor` that is applied once to each value before display.
 
-## Colors
+### Colors
 
 Each country, region, and the world aggregate has a color assigned to it. We use a local copy of Our World in Data's **Distinct Colors** palette, designed so that adjacent items in a chart remain visually separable.
 
-### Fixed colors
+#### Fixed colors
 
 Two assignments are fixed:
 
 - **World** is always shown in **Purple** (`#6d3e91`).
 - The seven World Bank regional aggregates each map to a specific palette color. The mapping is stable so that, for example, Sub-Saharan Africa is always Mauve across the whole tool.
 
-### Country colors
+#### Country colors
 
 For countries — where there are too many entities to pre-assign colors — we rotate through a **palette of seven colors** in the order the countries are received. The world aggregate, if present in the same selection, is always overridden back to Purple, so it stands out visually from any country that happens to land on the same slot.
 

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -99,7 +99,7 @@ The data for each country is a list of 1000 average daily income values (for eac
 The curve is produced by feeding the 1000 averages for a given country-year through a KDE function, with all incomes first converted to a logarithmic scale.
 
 !!! info "Working in log scale"
-    Income data spans several orders of magnitude — from less than a dollar a day to thousands. To handle this range, we work with the logarithm (base 2) of each income value. In log space, the distance between \$1 and \$2 is the same as between \$50 and \$100, which gives the lower end of the distribution the same visual resolution as the upper end.
+    Income data spans several orders of magnitude — from less than a dollar a day to thousands. To handle this range, we work with the logarithm (base 2) of each income value. In log space, the distance between $1 and $2 is the same as between $50 and $100, which gives the lower end of the distribution the same visual resolution as the upper end.
 
 Three parameters control the shape of this curve: the smoothness of the estimate (**bandwidth**), the income range it covers (**extent**), and the resolution of the output (**bins**).
 
@@ -150,7 +150,7 @@ For regions and the world aggregate, we weight by population. We sum the number 
 !!! note "How accurate is this?"
     Because we have 1000 bins rather than the full income distribution, we can't know exactly where the line falls inside a bin — each bin is assigned entirely above or below the line based on its average income. A bin whose average is just below the line might contain some people who are above it, and vice versa. In the worst case, this is off by half a bin, i.e. 0.05 percentage points of the population. Keeping the computation this simple also makes it fast enough to recompute every time the user chooses a different line.
 
-    We cross-checked the method against PIP's own extrapolated poverty series at 2021 international dollars, for seven lines between \$3 and \$40 / day. At the country, regional, and global level, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin discretization allows. Since the visualization shows poverty shares without decimal points, these differences are not visible on the chart.
+    We cross-checked the method against PIP's own extrapolated poverty series at 2021 international dollars, for seven lines between $3 and $40 / day. At the country, regional, and global level, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin discretization allows. Since the visualization shows poverty shares without decimal points, these differences are not visible on the chart.
 
 ## Currency conversions
 
@@ -218,7 +218,7 @@ In addition to this, observations for many countries are estimated, not observed
 
 Beyond these data limitations, there are decisions we made that affect the visualization:
 
-- The KDE curves are smoothed to show the general shape of the income distribution. They should not be used to read off the precise shares. The share of population below a line figures come from the bin data directly, not from the area under the curve. The curves are also evaluated over daily incomes from \$0.25 to \$1,000. No countries have bins below \$0.25, but 30 countries have bins above \$1,000 — typically only for the richest 0.1%. For those countries, the very tip of the right tail of the curve is visually trimmed.
+- The KDE curves are smoothed to show the general shape of the income distribution. They should not be used to read off the precise shares. The share of population below a line figures come from the bin data directly, not from the area under the curve. The curves are also evaluated over daily incomes from $0.25 to $1,000. No countries have bins below $0.25, but 30 countries have bins above $1,000 — typically only for the richest 0.1%. For those countries, the very tip of the right tail of the curve is visually trimmed.
 - As we discussed before, by using bin averages rather than individual-level data, we are missing within-bin inequality. [As the PIP team notes](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution), this results in a lower level of within-country inequality than the survey data would show.
 - For the inflation adjustment, the CPI indicator lags the current year. The latest available year in WDI's CPI series is typically one or two years behind the present. Values shown in local currency are therefore in prices from one or two years ago, which is still a reasonable approximation of present-day monetary values in most economies, though less so in countries experiencing rapid inflation.
 

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -147,10 +147,10 @@ For each country, we find the highest bin in the 1000 bin distribution whose ave
 
 For regions and the world aggregate, we weight by population. We sum the number of people below the line across all constituent countries and divide by the total population of the group.
 
-!!! note "How accurate is this?"
+!!! info "How accurate is this?"
     Because we have 1000 bins rather than the full income distribution, we can't know exactly where the line falls inside a bin — each bin is assigned entirely above or below the line based on its average income. A bin whose average is just below the line might contain some people who are above it, and vice versa. In the worst case, this is off by half a bin, i.e. 0.05 percentage points of the population. Keeping the computation this simple also makes it fast enough to recompute every time the user chooses a different line.
 
-    We cross-checked the method against PIP's own extrapolated poverty series at 2021 international dollars, for seven lines between $3 and $40 / day. At the country, regional, and global level, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin discretization allows. Since the visualization shows poverty shares without decimal points, these differences are not visible on the chart.
+    We cross-checked the method against PIP's own extrapolated poverty series at 2021 international dollars, for seven lines between $3 and $40 / day. At the country, regional, and global level, every comparison agrees with PIP to within 0.1 percentage points — the full precision the 1000-bin discretization allows. Since the visualization shows poverty shares without decimal points, these minor differences are not visible on the chart.
 
 ## Currency conversions
 
@@ -160,7 +160,7 @@ International dollars are a synthetic currency that adjusts for differences in l
 
 To let users view values and explore the chart in their local currency (for example, British pounds, US dollars, or Euros), we compute a conversion factor for each country that converts 2021 international dollars into local currency units at recent prices.
 
-!!! note "What changes when you switch currency, and what doesn't?"
+!!! info "What changes when you switch currency, and what doesn't?"
     Switching currency multiplies every income value by the same conversion factor — it rescales the axis, but doesn't change the shape of any distribution or the relative position of countries. The underlying PPP adjustment remains unchanged. The data is already adjusted for living costs between countries, so switching the view to euros or pounds doesn't undo that — the chart just shows you values in a different currency.
 
 #### Data sources

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -1,22 +1,23 @@
-# **Visualizing global inequality**
+# Visualizing global inequality
 
-\!\!\! info "" :octicons-person-16: [**Pablo Arriagada**](https://ourworldindata.org/team/pablo-arriagada) • :octicons-calendar-16: April 21, 2026 *(last edit)* • [**:octicons-mail-16: Feedback**](mailto:info@ourworldindata.org?subject=Feedback%20on%20technical%20publication%20-%20Visualizing%20global%20inequality)
+!!! info ""
+    :octicons-person-16: **[Pablo Arriagada](https://ourworldindata.org/team/pablo-arriagada)** • :octicons-calendar-16: April 21, 2026 *(last edit)* • [**:octicons-mail-16: Feedback**](mailto:info@ourworldindata.org?subject=Feedback%20on%20technical%20publication%20-%20Visualizing%20global%20inequality)
 
-## **Introduction**
+## Introduction
 
-In our [economic inequality page](https://ourworldindata.org/economic-inequality) and the article \["Visualizing global inequality"\](\[TODO: article URL\]), we include a bespoke interactive visualization that shows how income is distributed across countries and regions around the world. The tool lets readers compare income distributions side by side and explore how many people live below any chosen poverty line — from extreme poverty thresholds to the median income of a rich country.
+In our [economic inequality page](https://ourworldindata.org/economic-inequality) and the article "Visualizing global inequality" ([TODO: article URL]), we include a bespoke interactive visualization that shows how income is distributed across countries and regions around the world. The tool lets readers compare income distributions side by side and explore how many people live below any chosen poverty line — from extreme poverty thresholds to the median income of a rich country.
 
 This document is the technical companion to that visualization. It describes the data sources we rely on, the processing applied in our ETL pipeline, the methodological choices behind the smoothed distribution curves and the share-below-line computation, and the known limitations of the approach. The visualization itself is a bespoke component of the [`owid-grapher` repository](https://github.com/owid/owid-grapher); links to the relevant source code are gathered in the [References](#references) section at the end.
 
 The inputs come from two different World Bank sources: the [Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/), which publishes the binned global income distribution that is the backbone of the visualization, and the [World Development Indicators (WDI)](https://datatopics.worldbank.org/world-development-indicators/), from which we take supplementary Purchasing Power Parity factors and Consumer Price Index data for currency conversion.
 
-## **Data sources**
+## Data sources
 
-### **World Bank Poverty and Inequality Platform (PIP)**
+### World Bank Poverty and Inequality Platform (PIP)
 
 PIP provides the core inputs for this visualization: the income distribution data and the PPP factors used to express incomes in international dollars.
 
-#### **1000-binned global distribution**
+#### 1000-binned global distribution
 
 The [1000-binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) file contains, for each country and year, **1000 quantiles** (or "bins") of the average income or consumption per capita of the population. Each bin represents one thousandth of the country's population, ordered from the poorest 0.1% up to the richest 0.1%. Income is measured in **2021 [international dollars](https://ourworldindata.org/international-dollars)**, adjusted for differences in inflation and living costs between countries.
 
@@ -26,7 +27,8 @@ The data is available from **1990 until the year of the data release**, and is u
 
 **Income vs. consumption.** PIP combines income and consumption surveys because not every country asks about the same welfare concept: most Western countries report income, while most countries in Africa and parts of Asia report consumption. A small number of countries report both. Comparing **inequality** estimates across the two concepts should be done with caution, since income is typically much more unequally distributed than consumption. Comparing **poverty** estimates is less problematic: most people in poverty are unable to save, so their income and consumption are close to identical. The 1000-binned file itself does not label each country-year series as income or consumption — that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles) under "Data sources".
 
-\!\!\! warning "Top-income coverage" Survey data is not very good at capturing incomes at the top of the distribution. The richest are harder to reach, they are few, they are less likely to respond, and when they do respond, they tend to underreport — whether because of complex financial arrangements or fear of tax authorities. Other sources, such as the [World Inequality Database](https://wid.world/methodology/), attempt to correct for this, but PIP remains the only global dataset whose income concept matches what countries report in their own statistics and what people understand as "income".
+!!! warning "Top-income coverage"
+    Survey data is not very good at capturing incomes at the top of the distribution. The richest are harder to reach, they are few, they are less likely to respond, and when they do respond, they tend to underreport — whether because of complex financial arrangements or fear of tax authorities. Other sources, such as the [World Inequality Database](https://wid.world/methodology/), attempt to correct for this, but PIP remains the only global dataset whose income concept matches what countries report in their own statistics and what people understand as "income".
 
 **File structure.** The raw file is organized with columns identifying the country, the [World Bank region](https://datahelpdesk.worldbank.org/knowledgebase/articles/906519-world-bank-country-and-lending-groups), the quantile (from 1 to 1000), and the welfare indicator representing income or consumption per capita in that quantile. An additional column reports the population in each quantile — namely the country's total population divided by 1000, with population values coming from WDI (or, where WDI is unavailable, from the fallback sources listed in [PIP's methodology](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html#population)).
 
@@ -34,52 +36,51 @@ PIP's 1000-binned file covers **218 economies** across seven World Bank regions.
 
 ??? quote "Full list of 218 economies included (by region)"
 
-```
-- **East Asia and Pacific**: American Samoa; Australia; Brunei Darussalam; Cambodia; China; Fiji; French Polynesia; Guam; Hong Kong SAR, China; Indonesia; Japan; Kiribati; Korea, Dem. Rep.; Korea, Rep.; Lao PDR; Macao SAR, China; Malaysia; Marshall Islands; Micronesia, Fed. Sts.; Mongolia; Myanmar; Nauru; New Caledonia; New Zealand; Northern Mariana Islands; Palau; Papua New Guinea; Philippines; Samoa; Singapore; Solomon Islands; Taiwan, China; Thailand; Timor-Leste; Tonga; Tuvalu; Vanuatu; Viet Nam.
-- **Europe and Central Asia**: Albania; Andorra; Armenia; Austria; Azerbaijan; Belarus; Belgium; Bosnia and Herzegovina; Bulgaria; Channel Islands; Croatia; Cyprus; Czechia; Denmark; Estonia; Faeroe Islands; Finland; France; Georgia; Germany; Gibraltar; Greece; Greenland; Hungary; Iceland; Ireland; Isle of Man; Italy; Kazakhstan; Kosovo; Kyrgyz Republic; Latvia; Liechtenstein; Lithuania; Luxembourg; Moldova; Monaco; Montenegro; Netherlands; North Macedonia; Norway; Poland; Portugal; Romania; Russian Federation; San Marino; Serbia; Slovak Republic; Slovenia; Spain; Sweden; Switzerland; Tajikistan; Turkmenistan; Türkiye; Ukraine; United Kingdom; Uzbekistan.
-- **Latin America and the Caribbean**: Antigua and Barbuda; Argentina; Aruba; Bahamas, The; Barbados; Belize; Bolivia; Brazil; British Virgin Islands; Cayman Islands; Chile; Colombia; Costa Rica; Cuba; Curaçao; Dominica; Dominican Republic; Ecuador; El Salvador; Grenada; Guatemala; Guyana; Haiti; Honduras; Jamaica; Mexico; Nicaragua; Panama; Paraguay; Peru; Puerto Rico (U.S.); Sint Maarten (Dutch part); St. Kitts and Nevis; St. Lucia; St. Martin (French part); St. Vincent and the Grenadines; Suriname; Trinidad and Tobago; Turks and Caicos Islands; Uruguay; Venezuela, RB; Virgin Islands (U.S.).
-- **Middle East, North Africa, Afghanistan and Pakistan**: Lebanon; Libya; Malta; Morocco; Oman; Pakistan; Qatar; Saudi Arabia; Syrian Arab Republic; Tunisia; United Arab Emirates; West Bank and Gaza; Yemen, Rep.
-- **North America**: Bermuda; Canada; United States.
-- **South Asia**: Bangladesh; Bhutan; India; Maldives; Nepal; Sri Lanka.
-- **Sub-Saharan Africa**: Angola; Benin; Botswana; Burkina Faso; Burundi; Cabo Verde; Cameroon; Central African Republic; Chad; Comoros; Congo, Dem. Rep.; Congo, Rep.; Côte d'Ivoire; Equatorial Guinea; Eritrea; Eswatini; Ethiopia; Gabon; Gambia, The; Ghana; Guinea; Guinea-Bissau; Kenya; Lesotho; Liberia; Madagascar; Malawi; Mali; Mauritania; Mauritius; Mozambique; Namibia; Niger; Nigeria; Rwanda; Senegal; Seychelles; Sierra Leone; Somalia; South Africa; South Sudan; Sudan; São Tomé and Príncipe; Tanzania; Togo; Uganda; Zambia; Zimbabwe.
-```
+    - **East Asia and Pacific**: American Samoa; Australia; Brunei Darussalam; Cambodia; China; Fiji; French Polynesia; Guam; Hong Kong SAR, China; Indonesia; Japan; Kiribati; Korea, Dem. Rep.; Korea, Rep.; Lao PDR; Macao SAR, China; Malaysia; Marshall Islands; Micronesia, Fed. Sts.; Mongolia; Myanmar; Nauru; New Caledonia; New Zealand; Northern Mariana Islands; Palau; Papua New Guinea; Philippines; Samoa; Singapore; Solomon Islands; Taiwan, China; Thailand; Timor-Leste; Tonga; Tuvalu; Vanuatu; Viet Nam.
+    - **Europe and Central Asia**: Albania; Andorra; Armenia; Austria; Azerbaijan; Belarus; Belgium; Bosnia and Herzegovina; Bulgaria; Channel Islands; Croatia; Cyprus; Czechia; Denmark; Estonia; Faeroe Islands; Finland; France; Georgia; Germany; Gibraltar; Greece; Greenland; Hungary; Iceland; Ireland; Isle of Man; Italy; Kazakhstan; Kosovo; Kyrgyz Republic; Latvia; Liechtenstein; Lithuania; Luxembourg; Moldova; Monaco; Montenegro; Netherlands; North Macedonia; Norway; Poland; Portugal; Romania; Russian Federation; San Marino; Serbia; Slovak Republic; Slovenia; Spain; Sweden; Switzerland; Tajikistan; Turkmenistan; Türkiye; Ukraine; United Kingdom; Uzbekistan.
+    - **Latin America and the Caribbean**: Antigua and Barbuda; Argentina; Aruba; Bahamas, The; Barbados; Belize; Bolivia; Brazil; British Virgin Islands; Cayman Islands; Chile; Colombia; Costa Rica; Cuba; Curaçao; Dominica; Dominican Republic; Ecuador; El Salvador; Grenada; Guatemala; Guyana; Haiti; Honduras; Jamaica; Mexico; Nicaragua; Panama; Paraguay; Peru; Puerto Rico (U.S.); Sint Maarten (Dutch part); St. Kitts and Nevis; St. Lucia; St. Martin (French part); St. Vincent and the Grenadines; Suriname; Trinidad and Tobago; Turks and Caicos Islands; Uruguay; Venezuela, RB; Virgin Islands (U.S.).
+    - **Middle East, North Africa, Afghanistan and Pakistan**: Lebanon; Libya; Malta; Morocco; Oman; Pakistan; Qatar; Saudi Arabia; Syrian Arab Republic; Tunisia; United Arab Emirates; West Bank and Gaza; Yemen, Rep.
+    - **North America**: Bermuda; Canada; United States.
+    - **South Asia**: Bangladesh; Bhutan; India; Maldives; Nepal; Sri Lanka.
+    - **Sub-Saharan Africa**: Angola; Benin; Botswana; Burkina Faso; Burundi; Cabo Verde; Cameroon; Central African Republic; Chad; Comoros; Congo, Dem. Rep.; Congo, Rep.; Côte d'Ivoire; Equatorial Guinea; Eritrea; Eswatini; Ethiopia; Gabon; Gambia, The; Ghana; Guinea; Guinea-Bissau; Kenya; Lesotho; Liberia; Madagascar; Malawi; Mali; Mauritania; Mauritius; Mozambique; Namibia; Niger; Nigeria; Rwanda; Senegal; Seychelles; Sierra Leone; Somalia; South Africa; South Sudan; Sudan; São Tomé and Príncipe; Tanzania; Togo; Uganda; Zambia; Zimbabwe.
 
-#### **PPP conversion factors used by PIP**
+#### PPP conversion factors used by PIP
 
 PIP also publishes the **Purchasing Power Parity (PPP) conversion factors** used internally to express each country's income in international dollars. We use these as the primary source for the currency-conversion logic described later in this document, complemented by WDI's factors when the two disagree.
 
-### **World Development Indicators (WDI)**
+### World Development Indicators (WDI)
 
-WDI contributes two additional series used to convert International Dollar values into a user-selected local currency at current prices:
+WDI contributes two additional series used to convert international dollar values into a user-selected local currency at current prices:
 
 - [**PPP conversion factor, households and NPISHs Final consumption expenditure (LCU per international $)**](https://data.worldbank.org/indicator/PA.NUS.PRVT.PP) — indicator code `PA.NUS.PRVT.PP`. Used as a complement to PIP's PPP factors when the two sources disagree for a given country.
-- [**Consumer price index (2010 \= 100\)**](https://data.worldbank.org/indicator/FP.CPI.TOTL) — indicator code `FP.CPI.TOTL`. Used to adjust values from 2021 prices to the latest year available in the series.
+- [**Consumer price index (2010 = 100)**](https://data.worldbank.org/indicator/FP.CPI.TOTL) — indicator code `FP.CPI.TOTL`. Used to adjust values from 2021 prices to the latest year available in the series.
 
-## **Methodology**
+## Methodology
 
-### **1000-binned distribution processing**
+### 1000-binned distribution processing
 
 Only minor processing is applied to the 1000-binned distribution in our ETL. The [garden step](https://github.com/owid/etl/blob/master/etl/steps/data/garden/wb/2026-03-25/thousand_bins_distribution.py) harmonizes country and region names against our internal reference, multiplies the per-bin population estimates by 1,000,000 (so the column lands in units of people rather than millions), and runs sanity checks to confirm that the per-quantile average income is **monotonically non-decreasing** within each country-year (each average must be greater than or equal to the average in the previous quantile). No monotonicity violations have been detected so far.
 
 The raw snapshot lives at [`snapshots/wb/2026-03-25/thousand_bins_distribution.dta.dvc`](https://github.com/owid/etl/blob/master/snapshots/wb/2026-03-25/thousand_bins_distribution.dta.dvc).
 
-### **Kernel density plots**
+### Kernel density plots
 
 The visualization shows each country's income distribution as a **smoothed density curve** rather than a histogram. The curve is produced by feeding the 1000 per-bin averages, for a given country-year, through a kernel density estimator, with all inputs first converted to the log₂ scale.
 
-\!\!\! info "Why a log scale?" Income is strongly right-skewed — a handful of very high incomes pull the mean far above the median. On a linear axis, most of the distribution collapses into a spike near zero. A log scale turns multiplicative differences into equal visual distances, which matches how people experience income changes (a doubling of income matters similarly at $2/day and $200/day) and produces distribution curves that can be meaningfully compared across countries and years. Income also tends to follow a **log-normal distribution** — the logarithm of income is approximately normally distributed — so a log-axis curve is close to bell-shaped and easy to read.
+!!! info "Why a log scale?"
+    Income is strongly right-skewed — a handful of very high incomes pull the mean far above the median. On a linear axis, most of the distribution collapses into a spike near zero. A log scale turns multiplicative differences into equal visual distances, which matches how people experience income changes (a doubling of income matters similarly at $2/day and $200/day) and produces distribution curves that can be meaningfully compared across countries and years. Income also tends to follow a **log-normal distribution** — the logarithm of income is approximately normally distributed — so a log-axis curve is close to bell-shaped and easy to read.
 
 We use a Gaussian [kernel density estimator](https://en.wikipedia.org/wiki/Kernel_density_estimation) via the [`fast-kde`](https://github.com/uwdata/fast-kde) JavaScript library with the following parameters:
 
-| Parameter | Value | Meaning |
-| :---- | :---- | :---- |
-| `bandwidth` | `0.1` (on log₂ scale) | Controls how smooth the resulting curve is. Smaller values follow the data more closely. |
-| `extent` | `[log₂(0.25), log₂(1000)]` | Range over which the density is evaluated, i.e., daily incomes from $0.25 to $1,000. |
-| `bins` | `200` | Number of points at which the density is evaluated. |
+| Parameter    | Value                       | Meaning                                                                                       |
+| ------------ | --------------------------- | --------------------------------------------------------------------------------------------- |
+| `bandwidth`  | `0.1` (on log₂ scale)       | Controls how smooth the resulting curve is. Smaller values follow the data more closely.      |
+| `extent`     | `[log₂(0.25), log₂(1000)]`  | Range over which the density is evaluated, i.e., daily incomes from $0.25 to $1,000.          |
+| `bins`       | `200`                       | Number of points at which the density is evaluated.                                           |
 
 After the density is computed, we exponentiate the `x` coordinate labels (`2^x`) so the chart can plot them against income in international dollars on an intuitive axis.
 
-## **Share of population below a poverty line**
+## Share of population below a poverty line
 
 From the 1000-binned distributions, we compute **the share of the population living below a chosen income line** for any combination of countries, regions, and the world aggregate.
 
@@ -94,74 +95,75 @@ For example, if 250 of the 1000 bins in Brazil fall below the line, then roughly
 
 **For a region or the world**, we can't just average the country percentages — that would give India and Luxembourg equal weight. We need to weight by population: a country with more people contributes more to the aggregate. The rule we use is:
 
-share below line (region) \= total people below the line across all countries in the region ÷ total population of the region
+> share below line (region) = total people below the line across all countries in the region ÷ total population of the region
 
 Concretely, for each country in the region, we compute the number of people below the line (`k × (country population ÷ 1000)`), add those up, and divide by the region's total population. The world aggregate works the same way, summing across all countries.
 
-\!\!\! note "Approximation" Because we only have 1000 bins rather than the full income distribution, we can't know exactly where the line falls *inside* a bin. In the worst case this miscounts about half a bin, i.e. 0.05 percentage points of the entity's population — well below the resolution shown in the chart (whole percentage points). Keeping the computation this simple also makes it fast enough to recompute every time the user drags the poverty-line slider.
+!!! note "Approximation"
+    Because we only have 1000 bins rather than the full income distribution, we can't know exactly where the line falls *inside* a bin. In the worst case this miscounts about half a bin, i.e. 0.05 percentage points of the entity's population — well below the resolution shown in the chart (whole percentage points). Keeping the computation this simple also makes it fast enough to recompute every time the user drags the poverty-line slider.
 
-## **Currency**
+## Currency
 
 The chart lets the user switch **which currency** to display income in — international dollars (the default) or any of several local currencies like GBP, EUR, INR, etc.
 
-### **What the underlying data is measured in**
+### What the underlying data is measured in
 
-All the stored income values are in **international dollars per day**. international dollars are a synthetic currency, built from Purchasing Power Parity (PPP) adjustments, that make incomes comparable across countries by accounting for the fact that the same nominal dollar buys more in, say, Vietnam than in Switzerland. A person earning $5/day in international dollars has roughly the same material standard of living whether they live in Hanoi or Zurich — which they would not if we simply converted their local income using market exchange rates. You can find more information about international dollars in [our dedicated article](https://ourworldindata.org/international-dollars).
+All the stored income values are in **international dollars per day**. International dollars are a synthetic currency, built from Purchasing Power Parity (PPP) adjustments, that make incomes comparable across countries by accounting for the fact that the same nominal dollar buys more in, say, Vietnam than in Switzerland. A person earning $5/day in international dollars has roughly the same material standard of living whether they live in Hanoi or Zurich — which they would not if we simply converted their local income using market exchange rates. You can find more information about international dollars in [our dedicated article](https://ourworldindata.org/international-dollars).
 
 Using international dollars as the base unit also means a fixed poverty line (e.g. the World Bank's $3/day) has a consistent meaning across every country on the chart.
 
-### **Converting to a local currency**
+### Converting to a local currency
 
 When the user switches to a different currency, every income value is multiplied by a **conversion factor** specific to that currency. The factor is built upstream by an ETL step — [`int_dollar_conversions.py`](https://github.com/owid/etl/blob/master/etl/steps/data/external/owid_grapher/latest/int_dollar_conversions.py) — and fetched at runtime from the resulting JSON table, [`int_dollar_conversions.json`](https://owid-public.owid.io/marcel-bespoke-data-viz-02-2026/poverty-plots/int_dollar_conversions.json). The factor is the product of two components:
 
 - **PPP factor** — converts international dollars (2021) to **local currency units (LCU) at 2021 prices**. Sourced from the World Bank, either from the [Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/) or from [World Development Indicators (WDI)](https://databank.worldbank.org/source/world-development-indicators).
 - **CPI factor** — inflates LCU values from 2021 prices to **the latest available year's prices** for that country, using CPI data from WDI (`fp_cpi_totl`). The factor is `CPI[latest] / CPI[2021]`, so it is country-specific both in magnitude and in which year "latest" refers to.
 
-Multiplying an International Dollar value by `PPP_factor × CPI_factor` therefore gives an amount in local currency at the latest available year's price level.
+Multiplying an international dollar value by `PPP_factor × CPI_factor` therefore gives an amount in local currency at the latest available year's price level.
 
-#### **How the PPP factor is chosen**
+#### How the PPP factor is chosen
 
 PIP and WDI publish PPP values derived from the same underlying data (the [International Comparison Program](https://www.worldbank.org/en/programs/icp)'s 2021 round), but their numbers don't always match exactly, because they apply different downstream methodologies. The ETL step reconciles the two as follows:
 
 1. **If PIP and WDI agree within 3%**, use PIP — most of our poverty data comes from PIP, so aligning currency units with PIP keeps the whole pipeline internally consistent.
 2. **If only one source has a value for a country**, use whichever has it. In practice, WDI covers a wider set of small territories (American Samoa, Cayman Islands, Greenland, Puerto Rico, etc.), while PIP is the only source for a handful of others (Taiwan, Venezuela, Yemen).
 3. **If both have values but differ by more than 3%**, the country is manually adjudicated against a curated override list. Typical cases include:
-   - **WDI preferred** when it reflects a recent currency redenomination that PIP hasn't caught up with — for example, the Belarusian ruble (2016, 1 BYN \= 10,000 BYR), the Mauritanian ouguiya (2017, 1 MRU \= 10 MRO), or Croatia's adoption of the Euro (2023).
-   - **Country dropped** when the disagreement can't be resolved cleanly: large deviations in countries with complex currency histories (Zimbabwe, Liberia), ongoing currency transitions (Curaçao and Sint Maarten moving from the Antillean to the Caribbean Guilder in 2025), or unresolved multi-currency situations (Palestine).
-   - **Country dropped** when the PIP entry represents only an urban or rural subpopulation rather than the whole country — e.g. the `(urban)` rows for Argentina, Bolivia, Colombia, Ecuador, Honduras, Suriname, and Uruguay, and the `(urban)`/`(rural)` rows for China, Ethiopia, and Rwanda. For Argentina and China, the country-level WDI value is used instead, so these countries remain on the chart; others without a WDI fallback are excluded entirely.
+    - **WDI preferred** when it reflects a recent currency redenomination that PIP hasn't caught up with — for example, the Belarusian ruble (2016, 1 BYN = 10,000 BYR), the Mauritanian ouguiya (2017, 1 MRU = 10 MRO), or Croatia's adoption of the Euro (2023).
+    - **Country dropped** when the disagreement can't be resolved cleanly: large deviations in countries with complex currency histories (Zimbabwe, Liberia), ongoing currency transitions (Curaçao and Sint Maarten moving from the Antillean to the Caribbean Guilder in 2025), or unresolved multi-currency situations (Palestine).
+    - **Country dropped** when the PIP entry represents only an urban or rural subpopulation rather than the whole country — e.g. the `(urban)` rows for Argentina, Bolivia, Colombia, Ecuador, Honduras, Suriname, and Uruguay, and the `(urban)`/`(rural)` rows for China, Ethiopia, and Rwanda. For Argentina and China, the country-level WDI value is used instead, so these countries remain on the chart; others without a WDI fallback are excluded entirely.
 
 The list of manual overrides lives in the ETL step itself and is validated on every run: if a country newly falls outside the 3% agreement band and isn't in the list, the build fails. This forces us to make an explicit decision rather than silently absorbing new disagreements.
 
 The UI uses IP-based country detection (via the [`detect-country.owid.io`](https://detect-country.owid.io/) service) to auto-suggest the user's local currency when the page loads, but the user can freely override it.
 
-## **Time interval**
+## Time interval
 
 The chart also lets the user pick the time interval displayed. The raw data is per day. Switching to monthly or yearly multiplies every value by a fixed factor:
 
-| Interval | Factor |
-| :---- | :---- |
-| daily | `1` |
-| monthly | `365/12` |
-| yearly | `365` |
+| Interval | Factor   |
+| -------- | -------- |
+| daily    | `1`      |
+| monthly  | `365/12` |
+| yearly   | `365`    |
 
 Currency and time-interval factors are multiplicative, so they combine into a single `combinedFactor` that is applied once to each value before display.
 
-## **Colors**
+## Colors
 
 Each country, region, and the world aggregate has a color assigned to it. We use a local copy of Our World in Data's **Distinct Colors** palette, designed so that adjacent items in a chart remain visually separable.
 
-### **Fixed colors**
+### Fixed colors
 
 Two assignments are fixed:
 
 - **World** is always shown in **Purple** (`#6d3e91`).
 - The seven World Bank regional aggregates each map to a specific palette color. The mapping is stable so that, for example, Sub-Saharan Africa is always Mauve across the whole tool.
 
-### **Country colors**
+### Country colors
 
 For countries — where there are too many entities to pre-assign colors — we rotate through a **palette of seven colors** in the order the countries are received. The world aggregate, if present in the same selection, is always overridden back to Purple, so it stands out visually from any country that happens to land on the same slot.
 
-## **Limitations**
+## Limitations
 
 - **Mixed income and consumption series.** As described in the [sources](#1000-binned-global-distribution) section, PIP's distributions combine series measured as either income or as consumption expenditure, depending on which concept each country reports in its household surveys. Because income is typically more unequally distributed than consumption, cross-country comparisons of inequality between income-based and consumption-based series should be read with care — part of the visible difference can reflect the welfare concept rather than a real inequality gap. Comparisons of poverty shares between the two types of series are less problematic, since people in poverty rarely save, and their income and consumption tend to coincide. The 1000-binned file does not label each country-year series by welfare concept; that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles).
 - **Top-income undercoverage.** Also described in the [sources](#1000-binned-global-distribution) section, the underlying data comes from household surveys, which do not accurately represent incomes at the top of the distribution due to underreporting, lower response rates, and the small number of very wealthy individuals.
@@ -169,7 +171,7 @@ For countries — where there are too many entities to pre-assign colors — we 
 - **Smoothed curves.** The KDE curves are smoothed to show the shape of the distribution in general terms. The exact area under any portion of the curve does not necessarily correspond to the precise share of the population in that income range — the share-below-line figures (which come from the bin data directly, not from the smoothed curve) should be used for that.
 - **CPI lags the current year.** The latest available year in WDI's CPI series is typically one or two years behind the present. Values shown in local currency are therefore in prices from one or two years ago, which is still a reasonable approximation of present-day monetary values in most economies.
 
-## **References**
+## References
 
 **Our World in Data source code**
 
@@ -183,5 +185,5 @@ For countries — where there are too many entities to pre-assign colors — we 
 - [PIP methodology](https://datanalytics.worldbank.org/PIP-Methodology/)
 - [1000-binned global distribution dataset catalog](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution)
 - [PPP conversion factor, households (WDI, `PA.NUS.PRVT.PP`)](https://data.worldbank.org/indicator/PA.NUS.PRVT.PP)
-- [Consumer price index, 2010 \= 100 (WDI, `FP.CPI.TOTL`)](https://data.worldbank.org/indicator/FP.CPI.TOTL)
+- [Consumer price index, 2010 = 100 (WDI, `FP.CPI.TOTL`)](https://data.worldbank.org/indicator/FP.CPI.TOTL)
 - [International Comparison Program (ICP)](https://www.worldbank.org/en/programs/icp)

--- a/docs/analyses/inequality_visualization/index.md
+++ b/docs/analyses/inequality_visualization/index.md
@@ -1,0 +1,187 @@
+# **Visualizing global inequality**
+
+\!\!\! info "" :octicons-person-16: [**Pablo Arriagada**](https://ourworldindata.org/team/pablo-arriagada) • :octicons-calendar-16: April 21, 2026 *(last edit)* • [**:octicons-mail-16: Feedback**](mailto:info@ourworldindata.org?subject=Feedback%20on%20technical%20publication%20-%20Visualizing%20global%20inequality)
+
+## **Introduction**
+
+In our [economic inequality page](https://ourworldindata.org/economic-inequality) and the article \["Visualizing global inequality"\](\[TODO: article URL\]), we include a bespoke interactive visualization that shows how income is distributed across countries and regions around the world. The tool lets readers compare income distributions side by side and explore how many people live below any chosen poverty line — from extreme poverty thresholds to the median income of a rich country.
+
+This document is the technical companion to that visualization. It describes the data sources we rely on, the processing applied in our ETL pipeline, the methodological choices behind the smoothed distribution curves and the share-below-line computation, and the known limitations of the approach. The visualization itself is a bespoke component of the [`owid-grapher` repository](https://github.com/owid/owid-grapher); links to the relevant source code are gathered in the [References](#references) section at the end.
+
+The inputs come from two different World Bank sources: the [Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/), which publishes the binned global income distribution that is the backbone of the visualization, and the [World Development Indicators (WDI)](https://datatopics.worldbank.org/world-development-indicators/), from which we take supplementary Purchasing Power Parity factors and Consumer Price Index data for currency conversion.
+
+## **Data sources**
+
+### **World Bank Poverty and Inequality Platform (PIP)**
+
+PIP provides the core inputs for this visualization: the income distribution data and the PPP factors used to express incomes in international dollars.
+
+#### **1000-binned global distribution**
+
+The [1000-binned global distribution](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution) file contains, for each country and year, **1000 quantiles** (or "bins") of the average income or consumption per capita of the population. Each bin represents one thousandth of the country's population, ordered from the poorest 0.1% up to the richest 0.1%. Income is measured in **2021 [international dollars](https://ourworldindata.org/international-dollars)**, adjusted for differences in inflation and living costs between countries.
+
+The data is available from **1990 until the year of the data release**, and is updated twice a year (typically around March and September), alongside the main PIP updates.
+
+**Where the numbers come from.** PIP's distributions are derived from household surveys, where people are asked about their income or consumption. Because only a handful of countries run such surveys every year, PIP interpolates between survey years and extrapolates to the most recent year using estimates and projections of GDP per capita growth. See [PIP's methodology](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html) for the full procedure.
+
+**Income vs. consumption.** PIP combines income and consumption surveys because not every country asks about the same welfare concept: most Western countries report income, while most countries in Africa and parts of Asia report consumption. A small number of countries report both. Comparing **inequality** estimates across the two concepts should be done with caution, since income is typically much more unequally distributed than consumption. Comparing **poverty** estimates is less problematic: most people in poverty are unable to save, so their income and consumption are close to identical. The 1000-binned file itself does not label each country-year series as income or consumption — that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles) under "Data sources".
+
+\!\!\! warning "Top-income coverage" Survey data is not very good at capturing incomes at the top of the distribution. The richest are harder to reach, they are few, they are less likely to respond, and when they do respond, they tend to underreport — whether because of complex financial arrangements or fear of tax authorities. Other sources, such as the [World Inequality Database](https://wid.world/methodology/), attempt to correct for this, but PIP remains the only global dataset whose income concept matches what countries report in their own statistics and what people understand as "income".
+
+**File structure.** The raw file is organized with columns identifying the country, the [World Bank region](https://datahelpdesk.worldbank.org/knowledgebase/articles/906519-world-bank-country-and-lending-groups), the quantile (from 1 to 1000), and the welfare indicator representing income or consumption per capita in that quantile. An additional column reports the population in each quantile — namely the country's total population divided by 1000, with population values coming from WDI (or, where WDI is unavailable, from the fallback sources listed in [PIP's methodology](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html#population)).
+
+PIP's 1000-binned file covers **218 economies** across seven World Bank regions.
+
+??? quote "Full list of 218 economies included (by region)"
+
+```
+- **East Asia and Pacific**: American Samoa; Australia; Brunei Darussalam; Cambodia; China; Fiji; French Polynesia; Guam; Hong Kong SAR, China; Indonesia; Japan; Kiribati; Korea, Dem. Rep.; Korea, Rep.; Lao PDR; Macao SAR, China; Malaysia; Marshall Islands; Micronesia, Fed. Sts.; Mongolia; Myanmar; Nauru; New Caledonia; New Zealand; Northern Mariana Islands; Palau; Papua New Guinea; Philippines; Samoa; Singapore; Solomon Islands; Taiwan, China; Thailand; Timor-Leste; Tonga; Tuvalu; Vanuatu; Viet Nam.
+- **Europe and Central Asia**: Albania; Andorra; Armenia; Austria; Azerbaijan; Belarus; Belgium; Bosnia and Herzegovina; Bulgaria; Channel Islands; Croatia; Cyprus; Czechia; Denmark; Estonia; Faeroe Islands; Finland; France; Georgia; Germany; Gibraltar; Greece; Greenland; Hungary; Iceland; Ireland; Isle of Man; Italy; Kazakhstan; Kosovo; Kyrgyz Republic; Latvia; Liechtenstein; Lithuania; Luxembourg; Moldova; Monaco; Montenegro; Netherlands; North Macedonia; Norway; Poland; Portugal; Romania; Russian Federation; San Marino; Serbia; Slovak Republic; Slovenia; Spain; Sweden; Switzerland; Tajikistan; Turkmenistan; Türkiye; Ukraine; United Kingdom; Uzbekistan.
+- **Latin America and the Caribbean**: Antigua and Barbuda; Argentina; Aruba; Bahamas, The; Barbados; Belize; Bolivia; Brazil; British Virgin Islands; Cayman Islands; Chile; Colombia; Costa Rica; Cuba; Curaçao; Dominica; Dominican Republic; Ecuador; El Salvador; Grenada; Guatemala; Guyana; Haiti; Honduras; Jamaica; Mexico; Nicaragua; Panama; Paraguay; Peru; Puerto Rico (U.S.); Sint Maarten (Dutch part); St. Kitts and Nevis; St. Lucia; St. Martin (French part); St. Vincent and the Grenadines; Suriname; Trinidad and Tobago; Turks and Caicos Islands; Uruguay; Venezuela, RB; Virgin Islands (U.S.).
+- **Middle East, North Africa, Afghanistan and Pakistan**: Lebanon; Libya; Malta; Morocco; Oman; Pakistan; Qatar; Saudi Arabia; Syrian Arab Republic; Tunisia; United Arab Emirates; West Bank and Gaza; Yemen, Rep.
+- **North America**: Bermuda; Canada; United States.
+- **South Asia**: Bangladesh; Bhutan; India; Maldives; Nepal; Sri Lanka.
+- **Sub-Saharan Africa**: Angola; Benin; Botswana; Burkina Faso; Burundi; Cabo Verde; Cameroon; Central African Republic; Chad; Comoros; Congo, Dem. Rep.; Congo, Rep.; Côte d'Ivoire; Equatorial Guinea; Eritrea; Eswatini; Ethiopia; Gabon; Gambia, The; Ghana; Guinea; Guinea-Bissau; Kenya; Lesotho; Liberia; Madagascar; Malawi; Mali; Mauritania; Mauritius; Mozambique; Namibia; Niger; Nigeria; Rwanda; Senegal; Seychelles; Sierra Leone; Somalia; South Africa; South Sudan; Sudan; São Tomé and Príncipe; Tanzania; Togo; Uganda; Zambia; Zimbabwe.
+```
+
+#### **PPP conversion factors used by PIP**
+
+PIP also publishes the **Purchasing Power Parity (PPP) conversion factors** used internally to express each country's income in international dollars. We use these as the primary source for the currency-conversion logic described later in this document, complemented by WDI's factors when the two disagree.
+
+### **World Development Indicators (WDI)**
+
+WDI contributes two additional series used to convert International Dollar values into a user-selected local currency at current prices:
+
+- [**PPP conversion factor, households and NPISHs Final consumption expenditure (LCU per international $)**](https://data.worldbank.org/indicator/PA.NUS.PRVT.PP) — indicator code `PA.NUS.PRVT.PP`. Used as a complement to PIP's PPP factors when the two sources disagree for a given country.
+- [**Consumer price index (2010 \= 100\)**](https://data.worldbank.org/indicator/FP.CPI.TOTL) — indicator code `FP.CPI.TOTL`. Used to adjust values from 2021 prices to the latest year available in the series.
+
+## **Methodology**
+
+### **1000-binned distribution processing**
+
+Only minor processing is applied to the 1000-binned distribution in our ETL. The [garden step](https://github.com/owid/etl/blob/master/etl/steps/data/garden/wb/2026-03-25/thousand_bins_distribution.py) harmonizes country and region names against our internal reference, multiplies the per-bin population estimates by 1,000,000 (so the column lands in units of people rather than millions), and runs sanity checks to confirm that the per-quantile average income is **monotonically non-decreasing** within each country-year (each average must be greater than or equal to the average in the previous quantile). No monotonicity violations have been detected so far.
+
+The raw snapshot lives at [`snapshots/wb/2026-03-25/thousand_bins_distribution.dta.dvc`](https://github.com/owid/etl/blob/master/snapshots/wb/2026-03-25/thousand_bins_distribution.dta.dvc).
+
+### **Kernel density plots**
+
+The visualization shows each country's income distribution as a **smoothed density curve** rather than a histogram. The curve is produced by feeding the 1000 per-bin averages, for a given country-year, through a kernel density estimator, with all inputs first converted to the log₂ scale.
+
+\!\!\! info "Why a log scale?" Income is strongly right-skewed — a handful of very high incomes pull the mean far above the median. On a linear axis, most of the distribution collapses into a spike near zero. A log scale turns multiplicative differences into equal visual distances, which matches how people experience income changes (a doubling of income matters similarly at $2/day and $200/day) and produces distribution curves that can be meaningfully compared across countries and years. Income also tends to follow a **log-normal distribution** — the logarithm of income is approximately normally distributed — so a log-axis curve is close to bell-shaped and easy to read.
+
+We use a Gaussian [kernel density estimator](https://en.wikipedia.org/wiki/Kernel_density_estimation) via the [`fast-kde`](https://github.com/uwdata/fast-kde) JavaScript library with the following parameters:
+
+| Parameter | Value | Meaning |
+| :---- | :---- | :---- |
+| `bandwidth` | `0.1` (on log₂ scale) | Controls how smooth the resulting curve is. Smaller values follow the data more closely. |
+| `extent` | `[log₂(0.25), log₂(1000)]` | Range over which the density is evaluated, i.e., daily incomes from $0.25 to $1,000. |
+| `bins` | `200` | Number of points at which the density is evaluated. |
+
+After the density is computed, we exponentiate the `x` coordinate labels (`2^x`) so the chart can plot them against income in international dollars on an intuitive axis.
+
+## **Share of population below a poverty line**
+
+From the 1000-binned distributions, we compute **the share of the population living below a chosen income line** for any combination of countries, regions, and the world aggregate.
+
+Each country-year comes as a list of 1000 numbers describing the income distribution: the average income of the poorest 0.1% of the population, then the next 0.1%, and so on up to the richest 0.1%. Each of those slices — we'll call them **bins** — represents the same number of people: one thousandth of the country's population.
+
+**For a single country**, the answer to "how many people earn less than $X a day?" is easy:
+
+1. Count how many of the 1000 bins have an average income below $X. Call this count `k`.
+2. Since each bin is one thousandth of the population, the share of people below the line is simply `k / 1000`, or equivalently `k / 10` as a percentage.
+
+For example, if 250 of the 1000 bins in Brazil fall below the line, then roughly **25%** of Brazilians earn less than the line.
+
+**For a region or the world**, we can't just average the country percentages — that would give India and Luxembourg equal weight. We need to weight by population: a country with more people contributes more to the aggregate. The rule we use is:
+
+share below line (region) \= total people below the line across all countries in the region ÷ total population of the region
+
+Concretely, for each country in the region, we compute the number of people below the line (`k × (country population ÷ 1000)`), add those up, and divide by the region's total population. The world aggregate works the same way, summing across all countries.
+
+\!\!\! note "Approximation" Because we only have 1000 bins rather than the full income distribution, we can't know exactly where the line falls *inside* a bin. In the worst case this miscounts about half a bin, i.e. 0.05 percentage points of the entity's population — well below the resolution shown in the chart (whole percentage points). Keeping the computation this simple also makes it fast enough to recompute every time the user drags the poverty-line slider.
+
+## **Currency**
+
+The chart lets the user switch **which currency** to display income in — international dollars (the default) or any of several local currencies like GBP, EUR, INR, etc.
+
+### **What the underlying data is measured in**
+
+All the stored income values are in **international dollars per day**. international dollars are a synthetic currency, built from Purchasing Power Parity (PPP) adjustments, that make incomes comparable across countries by accounting for the fact that the same nominal dollar buys more in, say, Vietnam than in Switzerland. A person earning $5/day in international dollars has roughly the same material standard of living whether they live in Hanoi or Zurich — which they would not if we simply converted their local income using market exchange rates. You can find more information about international dollars in [our dedicated article](https://ourworldindata.org/international-dollars).
+
+Using international dollars as the base unit also means a fixed poverty line (e.g. the World Bank's $3/day) has a consistent meaning across every country on the chart.
+
+### **Converting to a local currency**
+
+When the user switches to a different currency, every income value is multiplied by a **conversion factor** specific to that currency. The factor is built upstream by an ETL step — [`int_dollar_conversions.py`](https://github.com/owid/etl/blob/master/etl/steps/data/external/owid_grapher/latest/int_dollar_conversions.py) — and fetched at runtime from the resulting JSON table, [`int_dollar_conversions.json`](https://owid-public.owid.io/marcel-bespoke-data-viz-02-2026/poverty-plots/int_dollar_conversions.json). The factor is the product of two components:
+
+- **PPP factor** — converts international dollars (2021) to **local currency units (LCU) at 2021 prices**. Sourced from the World Bank, either from the [Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/) or from [World Development Indicators (WDI)](https://databank.worldbank.org/source/world-development-indicators).
+- **CPI factor** — inflates LCU values from 2021 prices to **the latest available year's prices** for that country, using CPI data from WDI (`fp_cpi_totl`). The factor is `CPI[latest] / CPI[2021]`, so it is country-specific both in magnitude and in which year "latest" refers to.
+
+Multiplying an International Dollar value by `PPP_factor × CPI_factor` therefore gives an amount in local currency at the latest available year's price level.
+
+#### **How the PPP factor is chosen**
+
+PIP and WDI publish PPP values derived from the same underlying data (the [International Comparison Program](https://www.worldbank.org/en/programs/icp)'s 2021 round), but their numbers don't always match exactly, because they apply different downstream methodologies. The ETL step reconciles the two as follows:
+
+1. **If PIP and WDI agree within 3%**, use PIP — most of our poverty data comes from PIP, so aligning currency units with PIP keeps the whole pipeline internally consistent.
+2. **If only one source has a value for a country**, use whichever has it. In practice, WDI covers a wider set of small territories (American Samoa, Cayman Islands, Greenland, Puerto Rico, etc.), while PIP is the only source for a handful of others (Taiwan, Venezuela, Yemen).
+3. **If both have values but differ by more than 3%**, the country is manually adjudicated against a curated override list. Typical cases include:
+   - **WDI preferred** when it reflects a recent currency redenomination that PIP hasn't caught up with — for example, the Belarusian ruble (2016, 1 BYN \= 10,000 BYR), the Mauritanian ouguiya (2017, 1 MRU \= 10 MRO), or Croatia's adoption of the Euro (2023).
+   - **Country dropped** when the disagreement can't be resolved cleanly: large deviations in countries with complex currency histories (Zimbabwe, Liberia), ongoing currency transitions (Curaçao and Sint Maarten moving from the Antillean to the Caribbean Guilder in 2025), or unresolved multi-currency situations (Palestine).
+   - **Country dropped** when the PIP entry represents only an urban or rural subpopulation rather than the whole country — e.g. the `(urban)` rows for Argentina, Bolivia, Colombia, Ecuador, Honduras, Suriname, and Uruguay, and the `(urban)`/`(rural)` rows for China, Ethiopia, and Rwanda. For Argentina and China, the country-level WDI value is used instead, so these countries remain on the chart; others without a WDI fallback are excluded entirely.
+
+The list of manual overrides lives in the ETL step itself and is validated on every run: if a country newly falls outside the 3% agreement band and isn't in the list, the build fails. This forces us to make an explicit decision rather than silently absorbing new disagreements.
+
+The UI uses IP-based country detection (via the [`detect-country.owid.io`](https://detect-country.owid.io/) service) to auto-suggest the user's local currency when the page loads, but the user can freely override it.
+
+## **Time interval**
+
+The chart also lets the user pick the time interval displayed. The raw data is per day. Switching to monthly or yearly multiplies every value by a fixed factor:
+
+| Interval | Factor |
+| :---- | :---- |
+| daily | `1` |
+| monthly | `365/12` |
+| yearly | `365` |
+
+Currency and time-interval factors are multiplicative, so they combine into a single `combinedFactor` that is applied once to each value before display.
+
+## **Colors**
+
+Each country, region, and the world aggregate has a color assigned to it. We use a local copy of Our World in Data's **Distinct Colors** palette, designed so that adjacent items in a chart remain visually separable.
+
+### **Fixed colors**
+
+Two assignments are fixed:
+
+- **World** is always shown in **Purple** (`#6d3e91`).
+- The seven World Bank regional aggregates each map to a specific palette color. The mapping is stable so that, for example, Sub-Saharan Africa is always Mauve across the whole tool.
+
+### **Country colors**
+
+For countries — where there are too many entities to pre-assign colors — we rotate through a **palette of seven colors** in the order the countries are received. The world aggregate, if present in the same selection, is always overridden back to Purple, so it stands out visually from any country that happens to land on the same slot.
+
+## **Limitations**
+
+- **Mixed income and consumption series.** As described in the [sources](#1000-binned-global-distribution) section, PIP's distributions combine series measured as either income or as consumption expenditure, depending on which concept each country reports in its household surveys. Because income is typically more unequally distributed than consumption, cross-country comparisons of inequality between income-based and consumption-based series should be read with care — part of the visible difference can reflect the welfare concept rather than a real inequality gap. Comparisons of poverty shares between the two types of series are less problematic, since people in poverty rarely save, and their income and consumption tend to coincide. The 1000-binned file does not label each country-year series by welfare concept; that information is available in [PIP's country profiles](https://pip.worldbank.org/country-profiles).
+- **Top-income undercoverage.** Also described in the [sources](#1000-binned-global-distribution) section, the underlying data comes from household surveys, which do not accurately represent incomes at the top of the distribution due to underreporting, lower response rates, and the small number of very wealthy individuals.
+- **Interpolated and extrapolated years.** For country-years with no survey available, PIP either interpolates between surveys or extrapolates using GDP per capita growth. In those years, the distribution and poverty estimates may not fully reflect the reality of that specific country-year; they should be read as levels of income compared against other countries in the region or globally, rather than as exact point estimates.
+- **Smoothed curves.** The KDE curves are smoothed to show the shape of the distribution in general terms. The exact area under any portion of the curve does not necessarily correspond to the precise share of the population in that income range — the share-below-line figures (which come from the bin data directly, not from the smoothed curve) should be used for that.
+- **CPI lags the current year.** The latest available year in WDI's CPI series is typically one or two years behind the present. Values shown in local currency are therefore in prices from one or two years ago, which is still a reasonable approximation of present-day monetary values in most economies.
+
+## **References**
+
+**Our World in Data source code**
+
+- [Visualization component — `incomePlotUtils.ts`](https://github.com/owid/owid-grapher/blob/master/bespoke/projects/income-plots/src/utils/incomePlotUtils.ts) and the entry point at [`src/index.tsx`](https://github.com/owid/owid-grapher/blob/master/bespoke/projects/income-plots/src/index.tsx) and [`src/components/App.tsx`](https://github.com/owid/owid-grapher/blob/master/bespoke/projects/income-plots/src/components/App.tsx).
+- [Currency conversions ETL step — `int_dollar_conversions.py`](https://github.com/owid/etl/blob/master/etl/steps/data/external/owid_grapher/latest/int_dollar_conversions.py).
+- [1000-binned distribution garden step — `thousand_bins_distribution.py`](https://github.com/owid/etl/blob/master/etl/steps/data/garden/wb/2026-03-25/thousand_bins_distribution.py), and the raw [snapshot definition](https://github.com/owid/etl/blob/master/snapshots/wb/2026-03-25/thousand_bins_distribution.dta.dvc).
+
+**External datasets and references**
+
+- [World Bank Poverty and Inequality Platform (PIP)](https://pip.worldbank.org/)
+- [PIP methodology](https://datanalytics.worldbank.org/PIP-Methodology/)
+- [1000-binned global distribution dataset catalog](https://datacatalog.worldbank.org/search/dataset/0064304/1000-binned-global-distribution)
+- [PPP conversion factor, households (WDI, `PA.NUS.PRVT.PP`)](https://data.worldbank.org/indicator/PA.NUS.PRVT.PP)
+- [Consumer price index, 2010 \= 100 (WDI, `FP.CPI.TOTL`)](https://data.worldbank.org/indicator/FP.CPI.TOTL)
+- [International Comparison Program (ICP)](https://www.worldbank.org/en/programs/icp)

--- a/docs/guides/demo.md
+++ b/docs/guides/demo.md
@@ -415,7 +415,7 @@ The ETL pipeline[^1] processes data from multiple international organizations[^2
 
 ### Inline Math
 
-The growth rate can be calculated as $r = \frac{P_t - P_{t-1}}{P_{t-1}} \times 100$, where $P_t$ is the current population.
+The growth rate can be calculated as \(r = \frac{P_t - P_{t-1}}{P_{t-1}} \times 100\), where \(P_t\) is the current population.
 
 ### Block Math
 

--- a/docs/javascripts/katex.js
+++ b/docs/javascripts/katex.js
@@ -2,7 +2,6 @@ document$.subscribe(({ body }) => {
     renderMathInElement(body, {
       delimiters: [
         { left: "$$",  right: "$$",  display: true },
-        { left: "$",   right: "$",   display: false },
         { left: "\\(", right: "\\)", display: false },
         { left: "\\[", right: "\\]", display: true }
       ],

--- a/zensical.toml
+++ b/zensical.toml
@@ -128,6 +128,7 @@ nav = [
         { "Our COVID work" = "api/covid.md" },
         { "Land use for biofuels vs. solar" = "analyses/biofuels_land_use/index.md" },
         { "Tracking historical progress against slavery and forced labor: a long-run data view" = "analyses/slavery_historical_data/index.md" },
+        { "Visualizing global inequality" = "analyses/inequality_visualization/index.md" },
     ] },
 ]
 


### PR DESCRIPTION
## Summary

Adds a technical companion document for the global inequality visualization (the income-plots bespoke component in `owid-grapher`) at `docs/analyses/inequality_visualization/index.md`, registers it in the docs nav and on the analyses landing page, and adds a reusable Claude Code skill that captures the patterns used to produce it.

## The new doc

Sections covered:
- **Data sources**: PIP 1000-binned global distribution (with the full 218-country list in a collapsible block) and the WDI series used for currency conversion.
- **Methodology**: minor ETL processing applied to the 1000-binned data, and the Gaussian KDE parameters used to produce the smoothed distribution curves (including a note on why the chart uses a log₂ scale).
- **Share of population below a poverty line**: the per-country and population-weighted aggregation used to compute the below-line share from the 1000 bins.
- **Currency**: how International Dollars get converted to a user-selected local currency, including the PPP × CPI factor derivation and the PIP-vs-WDI reconciliation rules from `etl/steps/data/external/owid_grapher/latest/int_dollar_conversions.py`.
- **Time interval, Colors, Limitations, References**.

The doc is now registered in `zensical.toml` and has a card on `docs/analyses/index.md`.

## The new skill (`create-analysis-doc`)

Prompts the user for the title, scripts, external data sources, and optional article URL, then drafts a doc to `ai/<short_name>.md` following a canonical five-section skeleton (Introduction, Data sources, Methodology, Limitations, References) with guidance on when to add extra H2 sections. Covers style conventions (mkdocs-material admonitions, collapsible blocks, tables, worked examples), writing principles (lead with intuition, explain why, flag approximations), and the deployment flow (draft in `ai/` → copy to `docs/analyses/` → register in `zensical.toml` → add landing-page card → PR).

Marked as `metadata.internal: true` per CLAUDE.md convention.

## Follow-ups (not in this PR)

- Fill in the `[TODO: article URL]` placeholder in the Introduction once the accompanying article URL is finalized.

## Test plan

- [x] Run `make docs.serve` locally, visit `http://localhost:9010/analyses/inequality_visualization/` and confirm the page renders cleanly under Zensical/mkdocs-material.
- [x] Verify the new entry appears in the nav sidebar and that the landing page (`/analyses/`) shows the new card with a working Methodology button.
- [ ] Check that the collapsible country list expands correctly.
- [ ] Check that all external links resolve (PIP, WDI indicators, ICP, OWID international-dollars article, GitHub source links).
- [ ] Confirm the `create-analysis-doc` skill is picked up by Claude Code (appears in the skills registry) and that a test invocation prompts for inputs as designed.