### PR TITLE
✨ Add P10/P50/P90 threshold group and relative toggle to Incomes PIP MDim

### DIFF
--- a/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
@@ -59,6 +59,8 @@ dimensions:
         name: All deciles
       - slug: "10_40_50"
         name: Poorest 50%, middle 40% and richest 10%
+      - slug: p10_p50_p90
+        name: "Poorest 10%, median, richest 10%"
       - slug: nan
         name: ""
 

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.py
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.py
@@ -262,7 +262,9 @@ def _get_grouped_decile_subtitle(view):
 def _get_p10_p50_p90_title(view):
     """Return title for the P10/P50/P90 grouped threshold view."""
     period = view.dimensions.get("period")
-    return f"Threshold income or consumption per {period} marking marking the poorest decile, the median, and the richest decile"
+    return (
+        f"Threshold income or consumption per {period} marking the poorest decile, the median, and the richest decile"
+    )
 
 
 def _get_p10_p50_p90_subtitle(view):

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.py
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.py
@@ -129,7 +129,7 @@ def run() -> None:
                 "choices": decile_values,
                 "choice_new_slug": "all",
                 "view_config": {
-                    "hideRelativeToggle": True,
+                    "hideRelativeToggle": False,
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
@@ -152,6 +152,35 @@ def run() -> None:
         },
     )
 
+    # Group deciles 1, 5, 9 as P10/P50/P90 — only used for thr indicator
+    c.group_views(
+        groups=[
+            {
+                "dimension": "decile",
+                "choices": ["1", "5", "9"],
+                "choice_new_slug": "p10_p50_p90",
+                "view_config": {
+                    "hideRelativeToggle": False,
+                    "selectedFacetStrategy": "entity",
+                    "hasMapTab": False,
+                    "tab": "chart",
+                    "chartTypes": ["LineChart"],
+                    "hideTotalValueLabel": True,
+                    "baseColorScheme": "OwidCategoricalE",
+                    "title": "{title}",
+                    "subtitle": "{subtitle}",
+                },
+                "view_metadata": {
+                    "description_short": "{subtitle}",
+                },
+            },
+        ],
+        params={
+            "title": _get_p10_p50_p90_title,
+            "subtitle": _get_p10_p50_p90_subtitle,
+        },
+    )
+
     # Filter decile views: keep only 1, 10, all for all indicators, plus 5, 9 for thr only
     # Also remove grouped decile views for Spells (we don't want those)
     non_share = [i for i in c.dimension_choices["indicator"] if i != "share"]
@@ -162,6 +191,8 @@ def run() -> None:
             {"decile": ["10_40_50"], "indicator": non_share},
             {"decile": ["5", "9"], "indicator": non_thr},
             {"decile": ["all"], "survey_comparability": "Spells"},
+            {"decile": ["p10_p50_p90"], "indicator": non_thr},
+            {"decile": ["p10_p50_p90"], "survey_comparability": "Spells"},
         ]
     )
 
@@ -170,7 +201,7 @@ def run() -> None:
 
     # Customize grouped decile views: sort indicators and set display names
     for view in c.views:
-        if view.matches(decile="all") and view.indicators.y:
+        if view.matches(decile=["all", "p10_p50_p90"]) and view.indicators.y:
             # Sort indicators by decile number
             # For share: richest to poorest; for others: poorest to richest
             reverse_order = view.matches(indicator="share")
@@ -189,7 +220,9 @@ def run() -> None:
 
     # Add Marimekko as an additional chart type for mean and median views.
     for view in c.views:
-        if view.matches(survey_comparability="No spells") and not view.matches(decile=["all", "10_40_50"]):
+        if view.matches(survey_comparability="No spells") and not view.matches(
+            decile=["all", "10_40_50", "p10_p50_p90"]
+        ):
             view.config = view.config or {}
             view.config["chartTypes"] = ["LineChart", "DiscreteBar", "Marimekko"]
             view.indicators.set_indicator(
@@ -224,6 +257,21 @@ def _get_grouped_decile_subtitle(view):
         "share": "The share of after tax income or consumption received by each decile (tenth of the population).",
     }
     return subtitles.get(view.dimensions.get("indicator"), "")
+
+
+def _get_p10_p50_p90_title(view):
+    """Return title for the P10/P50/P90 grouped threshold view."""
+    period = view.dimensions.get("period")
+    return f"Threshold income or consumption per {period} at P10, P50 and P90"
+
+
+def _get_p10_p50_p90_subtitle(view):
+    """Return subtitle for the P10/P50/P90 grouped threshold view."""
+    period = view.dimensions.get("period")
+    return (
+        f"The level of after tax income or consumption per person per {period} at the 10th, 50th and 90th percentiles. "
+        f"{PPP_ADJUSTMENT_SUBTITLE}"
+    )
 
 
 def _build_indicator_display_names(tb):

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.py
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.py
@@ -134,7 +134,9 @@ def run() -> None:
                     "hasMapTab": False,
                     "tab": "chart",
                     "chartTypes": lambda view: (
-                        ["StackedArea", "StackedDiscreteBar"] if view.matches(indicator="share") else ["LineChart"]
+                        ["StackedArea", "StackedDiscreteBar"]
+                        if view.matches(indicator="share")
+                        else ["LineChart", "DiscreteBar"]
                     ),
                     "hideTotalValueLabel": True,
                     "baseColorScheme": "OwidCategoricalE",
@@ -164,7 +166,7 @@ def run() -> None:
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
-                    "chartTypes": ["LineChart"],
+                    "chartTypes": ["LineChart", "DiscreteBar"],
                     "hideTotalValueLabel": True,
                     "baseColorScheme": "OwidCategoricalE",
                     "title": "{title}",

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.py
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.py
@@ -262,14 +262,14 @@ def _get_grouped_decile_subtitle(view):
 def _get_p10_p50_p90_title(view):
     """Return title for the P10/P50/P90 grouped threshold view."""
     period = view.dimensions.get("period")
-    return f"Threshold income or consumption per {period} at P10, P50 and P90"
+    return f"Threshold income or consumption per {period} marking marking the poorest decile, the median, and the richest decile"
 
 
 def _get_p10_p50_p90_subtitle(view):
     """Return subtitle for the P10/P50/P90 grouped threshold view."""
     period = view.dimensions.get("period")
     return (
-        f"The level of after tax income or consumption per person per {period} at the 10th, 50th and 90th percentiles. "
+        f"The level of after tax income or consumption per person per {period} below which 10%, 50% and 90% of the population falls. "
         f"{PPP_ADJUSTMENT_SUBTITLE}"
     )
 


### PR DESCRIPTION
## Summary

Adds a **Poorest 10%, median, richest 10%** option (slug `p10_p50_p90`) as the last choice in the Group dropdown of the Incomes PIP MDim, available only for the *Income threshold for each decile* indicator. The new view renders deciles 1, 5, 9 as three facet-by-entity line charts (P10, median, P90).

Also enables the **relative-change toggle** and adds a **DiscreteBar chart tab** on both grouped threshold views:
- the new `p10_p50_p90` group
- the existing "All deciles" (`all`) group

Individual decile views already supported relative mode; only the grouped views had it hidden via `hideRelativeToggle: True`. The `share` indicator keeps its existing `StackedArea + StackedDiscreteBar` pair.

## Changes

- [`incomes_pip.config.yml`](https://github.com/owid/etl/blob/enhance-p10p50p90-thresholds-toggle/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml) — add `p10_p50_p90` choice after `10_40_50`
- [`incomes_pip.py`](https://github.com/owid/etl/blob/enhance-p10p50p90-thresholds-toggle/etl/steps/export/multidim/wb/latest/incomes_pip.py)
  - flip `hideRelativeToggle: False` on the `all` grouping
  - extend the `all` grouping's `chartTypes` lambda to include `DiscreteBar` for non-share indicators
  - new `group_views` call combining deciles 1/5/9 → `p10_p50_p90` with `hideRelativeToggle: False`, `selectedFacetStrategy: entity`, `chartTypes: [LineChart, DiscreteBar]`
  - extend `drop_views` to restrict new group to `thr` indicator and exclude Spells
  - extend sort/display-name loop to also cover `p10_p50_p90`
  - exclude the new group from the Marimekko-injection loop
  - add `_get_p10_p50_p90_title` / `_get_p10_p50_p90_subtitle` helpers

## Test plan

- [x] Rebuild: `.venv/bin/etlr export://multidim/wb/latest/incomes_pip --private --export --force --only`
- [x] Confirmed on staging: P10/P50/P90 option visible as last entry in Group dropdown for `thr`; three faceted lines render; relative toggle visible; DiscreteBar tab works.
- [x] Visually verify "All deciles" still renders with LineChart + DiscreteBar (non-share) and StackedArea + StackedDiscreteBar (share)
- [x] Confirm P10/P50/P90 is hidden when switching indicator to `mean`/`median`/`avg`/`share` or survey_comparability to "Spells"
- [x] Single-decile views unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)