### PR TITLE
📊 Fix 'income or consumption' titles for Spells views in incomes_pip

### DIFF
--- a/etl/steps/data/garden/wb/2026-03-24/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2026-03-24/world_bank_pip.meta.yml
@@ -403,10 +403,18 @@ definitions:
 
   threshold_title: |-
     {macros}
+    <% if survey_comparability == "No spells" %>
     <% if decile == "5" %>
     Threshold <<welfare_type>> {definitions.per_period} marking the <<percentiles_thr(decile) | lower>> (median)
     <%- else %>
     Threshold <<welfare_type>> {definitions.per_period} marking the <<percentiles_thr(decile) | lower>>
+    <%- endif %>
+    <%- else %>
+    <% if decile == "5" %>
+    Threshold income or consumption {definitions.per_period} marking the <<percentiles_thr(decile) | lower>> (median)
+    <%- else %>
+    Threshold income or consumption {definitions.per_period} marking the <<percentiles_thr(decile) | lower>>
+    <%- endif %>
     <%- endif %>
 
   poverty_line_subtitle: |-
@@ -1718,7 +1726,12 @@ tables:
             Mean
             <%- endif %>
           grapher_config:
-            title: Mean <<welfare_type>> {definitions.per_period}
+            title: |-
+              <% if survey_comparability == "No spells" %>
+              Mean <<welfare_type>> {definitions.per_period}
+              <%- else %>
+              Mean income or consumption {definitions.per_period}
+              <%- endif %>
             subtitle: "{definitions.ppp_adjustment_subtitle}{definitions.spells_subtitle}"
             note: "{definitions.note_ppp}"
             hasMapTab: "{definitions.hasmaptab}"
@@ -1768,7 +1781,12 @@ tables:
             Median
             <%- endif %>
           grapher_config:
-            title: Median <<welfare_type>> {definitions.per_period}
+            title: |-
+              <% if survey_comparability == "No spells" %>
+              Median <<welfare_type>> {definitions.per_period}
+              <%- else %>
+              Median income or consumption {definitions.per_period}
+              <%- endif %>
             subtitle: "{definitions.ppp_adjustment_subtitle}{definitions.spells_subtitle}"
             note: "{definitions.note_ppp}"
             hasMapTab: "{definitions.hasmaptab}"
@@ -1824,10 +1842,18 @@ tables:
           grapher_config:
             title: |-
               {macros}
+              <% if survey_comparability == "No spells" %>
               Mean <<welfare_type>> {definitions.per_period} within the <<percentiles_avg_share(decile) | lower>>
+              <%- else %>
+              Mean income or consumption {definitions.per_period} within the <<percentiles_avg_share(decile) | lower>>
+              <%- endif %>
             subtitle: |-
               {macros}
+              <% if survey_comparability == "No spells" %>
               The mean <<welfare_type>> {definitions.per_period} within the <<percentiles_avg_share(decile) | lower>> (tenth of the population). {definitions.ppp_adjustment_subtitle}{definitions.spells_subtitle}
+              <%- else %>
+              The mean income or consumption {definitions.per_period} within the <<percentiles_avg_share(decile) | lower>> (tenth of the population). {definitions.ppp_adjustment_subtitle}{definitions.spells_subtitle}
+              <%- endif %>
             note: "{definitions.note_ppp}"
             hasMapTab: "{definitions.hasmaptab}"
             tab: "{definitions.tab}"
@@ -1882,10 +1908,18 @@ tables:
           grapher_config:
             title: |-
               {macros}
+              <% if survey_comparability == "No spells" %>
               <<welfare_type.capitalize()>> share of the <<percentiles_avg_share(decile) | lower>>
+              <%- else %>
+              Income or consumption share of the <<percentiles_avg_share(decile) | lower>>
+              <%- endif %>
             subtitle: |-
               {macros}
+              <% if survey_comparability == "No spells" %>
               The share of <<welfare_type>> {definitions.welfare_type_verb} by the <<percentiles_avg_share(decile) | lower>> (tenth of the population).{definitions.spells_subtitle}
+              <%- else %>
+              The share of income or consumption received by the <<percentiles_avg_share(decile) | lower>> (tenth of the population).{definitions.spells_subtitle}
+              <%- endif %>
             note: "{definitions.note_without_ppp}"
             hasMapTab: "{definitions.hasmaptab}"
             tab: "{definitions.tab}"
@@ -1936,7 +1970,12 @@ tables:
             <%- endif %>
           grapher_config:
             title: "{definitions.threshold_title}"
-            subtitle: The level of <<welfare_type>> per person {definitions.per_period} below which <<decile>>0% of the population falls. {definitions.ppp_adjustment_subtitle}{definitions.spells_subtitle}
+            subtitle: |-
+              <% if survey_comparability == "No spells" %>
+              The level of <<welfare_type>> per person {definitions.per_period} below which <<decile>>0% of the population falls. {definitions.ppp_adjustment_subtitle}{definitions.spells_subtitle}
+              <%- else %>
+              The level of income or consumption per person {definitions.per_period} below which <<decile>>0% of the population falls. {definitions.ppp_adjustment_subtitle}{definitions.spells_subtitle}
+              <%- endif %>
             note: "{definitions.note_ppp}"
             hasMapTab: "{definitions.hasmaptab}"
             tab: "{definitions.tab}"


### PR DESCRIPTION
## Summary

In the `incomes_pip` multidim chart, Spells views (`survey_comparability = Spells`) rendered titles like **"Mean income per month"** (income only), instead of **"Mean income or consumption per month"** as in the No-spells views.

### Root cause

The MDim export leaves `config.title`/`config.subtitle` as `null` for Spells grouped views, so Grapher falls back to the indicator's `presentation.grapher_config.title`. In `world_bank_pip.meta.yml`, those titles used `<<welfare_type>>` unconditionally — which resolves to `income or consumption` for No-spells (consolidated) indicators, but to `income` or `consumption` alone for Spells indicators (whose source tables are split by welfare type).

### Fix

In the garden metadata, wrap the affected titles/subtitles with the same conditional that `description_short` already uses:

```yaml
<% if survey_comparability == "No spells" %>
Mean <<welfare_type>> {definitions.per_period}
<%- else %>
Mean income or consumption {definitions.per_period}
<%- endif %>
```

Applied to:

- `definitions.threshold_title` (used by `thr.title`)
- `incomes.mean.presentation.grapher_config.title`
- `incomes.median.presentation.grapher_config.title`
- `incomes.avg.presentation.grapher_config.title` + `subtitle`
- `incomes.share.presentation.grapher_config.title` (keeps `<<welfare_type.capitalize()>>` for No-spells) + `subtitle`
- `incomes.thr.presentation.grapher_config.subtitle`

No changes to `incomes_pip.py` or its config YAML — MDim inherits the new titles automatically.

## Test plan

- [x] Re-run garden + grapher for `wb/2026-03-24/world_bank_pip`
- [x] Script-checked all 5372 Spells columns in the rebuilt grapher dataset: every title/subtitle containing a welfare-type mention now includes "income or consumption"
- [x] `make check` passes
- [x] Staging QA: open the `incomes_pip` MDim and toggle **Breaks in data → Show** for mean / median / avg / thr / share — titles should read "income or consumption"

🤖 Generated with [Claude Code](https://claude.com/claude-code)