### PR TITLE
🐛 Fix Anomalist not showing entities by default

### DIFF
--- a/apps/wizard/app_pages/anomalist/app.py
+++ b/apps/wizard/app_pages/anomalist/app.py
@@ -416,8 +416,8 @@ def show_anomaly_compact(index, df):
     # Get relevant metadata for this view
     # By default, the entity with highest score, but user may have selected other ones!
     entity_default = df.iloc[row]["entity_name"]
-    entities = st.session_state.get(f"selected_entities_{key}", entity_default)
-    entities = entities if entities != [] else [entity_default]
+    entities = st.session_state.get(key_selection, [entity_default])
+    entities = entities if entities else [entity_default]
 
     # entities = df["entity_id"].tolist()
     year_default = df.iloc[row]["year"]


### PR DESCRIPTION
Currently, Anomalist shows empty charts, and the user needs to pick the first entity in the table to see anything.
<img width="1504" height="686" alt="Screenshot 2026-04-27 at 14 42 01" src="https://github.com/user-attachments/assets/29576af9-b4e0-414b-9976-a8a1a79bd9df" />

This PR ensures that charts always show the first entity by default.
<img width="1391" height="863" alt="Screenshot 2026-04-27 at 14 47 08" src="https://github.com/user-attachments/assets/446b2d58-a528-4245-b293-0f26608f552b" />

This solution is not ideal, because the table on the side does not have the first entity checked by default. But I think doing that would be a bigger refactor, which might not be worth it.