### PR TITLE
Add review-data-pr skill and metadata clarity check

### DIFF
--- a/.claude/skills/review-data-pr/SKILL.md
+++ b/.claude/skills/review-data-pr/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: review-data-pr
+description: Review an OWID ETL data update PR end-to-end — runs the pipeline, compares snapshot fields against the previous version, verifies links, audits indicator metadata coverage, and cross-checks workflow items from /update-dataset. Trigger when the user asks to "review this PR", "review the data PR", or invokes this on an open dataset-update branch.
+metadata:
+  internal: true
+---
+
+# Review Data PR
+
+End-to-end review of a dataset-update PR. Goes deeper than `/review`: actually runs the steps, compares to the previous version, audits metadata coverage against a fixed checklist, and reports on `/update-dataset` workflow status (Slack draft, Codex review, indicator upgrade, downstream deps).
+
+## Inputs
+
+- Optional PR number. If omitted, derive it from the current branch via `gh pr list --head <branch>`.
+
+## Workflow
+
+### 1. PR metadata
+
+```bash
+gh pr view <num> --json title,body,isDraft,mergeable,statusCheckRollup,comments,reviews
+```
+
+Flag if **PR description is empty** (per user's standing rule: keep PR body in sync with substantial changes).
+
+### 2. Diff and changed files
+
+```bash
+gh pr view <num> --json files --jq '.files[] | "\(.additions)+ \(.deletions)- \(.path)"'
+```
+
+For very large diffs (>1MB) skip `gh pr diff` and read the changed files directly with `Read`.
+
+### 3. Locate the new dataset
+
+From the changed files, identify:
+- New snapshot path: `snapshots/<namespace>/<new_version>/<short_name>.<ext>.dvc` and `.py`
+- New step files: `etl/steps/data/{meadow,garden,grapher}/<namespace>/<new_version>/<short_name>.{py,meta.yml}`
+- Old version (from `dag/archive/*.yml` or by grepping for the same `<short_name>`)
+
+### 4. Run the full pipeline end-to-end
+
+```bash
+.venv/bin/etlr data://grapher/<namespace>/<new_version>/<short_name>
+.venv/bin/etlr grapher://grapher/<namespace>/<new_version>/<short_name> --grapher --force --only
+```
+
+The `--grapher` upload is required to verify MySQL ingestion and to enable later checks (chart count, indicator upgrade verification). Confirm:
+- All four steps run cleanly (snapshot pulled from S3 if `.dvc` is committed, otherwise re-fetched)
+- MySQL upload returns a `dataset id` and shows variable upserts
+- No errors / no empty tables
+
+### 5. Snapshot field comparison
+
+Read both `.dvc` files (old and new) and produce a side-by-side table for these fields:
+
+| Field | Check |
+|---|---|
+| `title` | Reasonable update if scope changed |
+| `description` | Updated to reflect new source / scope |
+| `date_published` | **Must differ from `date_accessed`** — source from `url_main` or the file. If unsure, ask. |
+| `date_accessed` | Updated to today (or run-date) |
+| `producer` / `attribution_short` | Same source, same values (unless changed deliberately) |
+| `url_main` | Status check — see step 6 |
+| `url_download` | Status check; OK to remove if data is now fetched via API |
+| `license.url` | Status check |
+
+### 6. Verify all links
+
+Run a HEAD request on every URL in both `.dvc` and `.meta.yml` files:
+
+```bash
+curl -sI "<url>" -o /dev/null -w "%{http_code}\n"
+```
+
+Anything non-2xx is a blocker.
+
+### 7. Code clarity & docs
+
+For each step file, check:
+- **Snapshot script**: docstring explains source choice; no hidden hardcoded year/date constants without `--cli-flag` parametrization (or at minimum a clear update comment)
+- **Meadow / garden / grapher**: clear top-level docstrings; no commented-out code; no silent exception handlers
+- **Garden**: harmonization uses `paths.regions.harmonize_names(tb, ...)` (the new API), not the legacy `geo.harmonize_countries`
+- **Garden assertions**: sanity checks present and not overly brittle (e.g. avoid hard-coded "X must always exceed Y" if it's not a true invariant)
+- **Grapher meta.yml**: drop it if it only duplicates the garden values — the grapher step inherits via `default_metadata=ds_garden.metadata`
+
+### 8. Outdated practices
+
+Run the canonical detector. The source of truth is [vscode_extensions/detect-outdated-practices/src/extension.ts](vscode_extensions/detect-outdated-practices/src/extension.ts). Highlights to grep manually if the extension isn't running:
+
+- `if __name__ == "__main__":` in **snapshot files** — outdated. Remove it; snapshots run via `etls` / `etl snapshot`.
+- `geo.harmonize_countries(...)` in step files — replaced by `paths.regions.harmonize_names(...)`.
+- `dest_dir` argument, `paths.load_dependency(...)`, `np.where(...)` (strips origins), `index.map(...)` — all flagged.
+
+When in doubt, run the `/check-outdated-practices` skill on the new files.
+
+### 8b. Carried-over annotations & sanity_checks (review side)
+
+`/update-dataset` steps 1c+6a (annotations) and 1d+5b (sanity_checks) define the catalog/resolve procedure. As reviewer, verify the **outcome**:
+
+- **Annotations**: scan the diff for any `# NOTE:` / `# TODO:` / `# FIXME:` / `# HACK:` / `# XXX:` that are unchanged from the old version. For each, confirm the PR body mentions whether the workaround is still needed, or that it was deleted with its code. Unresolved + undocumented = 🟡.
+- **Sanity-check log flags**: grep the diff for `SHOW_SANITY_CHECK_LOGS`, `DEBUG`, `LONG_FORMAT` set to `True`. If a debug flag was left enabled, that's a 🔴 — must be reverted.
+- **Silent deletes**: in any `sanity_checks` function, scan for `drop`, `filter`, `tb = tb[...]` — row removals that the user might miss. Make sure the PR body lists them.
+
+### 9. Indicator metadata coverage (mandatory checklist)
+
+For **every indicator** in the garden `.meta.yml`, confirm these fields are set (either on `definitions.common` or per-indicator):
+
+| Field | Notes |
+|---|---|
+| `title` | Per-indicator |
+| `unit` | Common is fine |
+| `short_unit` | Common is fine |
+| `description_short` | Per-indicator |
+| `description_key` | At least one bullet; usually common |
+| `processing_level` | `minor` or `major` |
+| `presentation.topic_tags` | At least one tag |
+| `display.numDecimalPlaces` | Common is fine |
+| `display.tolerance` | Common is fine — chart tolerance for missing years |
+| `display.name` | **Per-indicator** — required for legend labels |
+| `presentation.attribution_short` | **Set explicitly** — does NOT inherit from origin's `attribution_short` |
+
+**Conditional:**
+- If `processing_level: major`, then `description_processing` MUST exist on each indicator with that level.
+
+**NOT mandatory** (do not flag as 🔴 if missing):
+- `presentation.title_public`
+- `presentation.title_variant`
+- `presentation.attribution` (long form)
+
+**Important gotcha:** the snapshot's `origin.attribution_short` does NOT propagate to indicator-level `presentation.attribution_short` or to MySQL `variables.attributionShort`. They are independent fields. Always verify on the produced grapher table:
+
+```python
+from owid.catalog import Dataset
+ds = Dataset("data/grapher/<ns>/<v>/<short_name>")
+tb = ds["<table>"]
+print(tb["<col>"].metadata.presentation.attribution_short)  # must NOT be None
+```
+
+Or query staging MySQL:
+
+```bash
+make query SQL="SELECT shortName, attributionShort FROM variables WHERE catalogPath LIKE '%<ns>/<v>/<short_name>%'"
+```
+
+### 10. Dataset-level metadata
+
+Garden `.meta.yml` MUST include:
+
+```yaml
+dataset:
+  update_period_days: <N>
+```
+
+Even if the rest of the `dataset:` block is omitted, **never strip `update_period_days`** — it controls the auto-update cadence.
+
+### 10b. Metadata quality skills
+
+Run `/check-metadata-typos`, `/check-metadata-spacing`, `/check-metadata-style` against the new garden + grapher `.meta.yml` files. See `/update-dataset` § 6b for the full procedure (typos / spacing / style + a manual clarity checklist for general-audience readability — apply that checklist here too). Report findings as 🟡 (or 🔴 if a violation breaks rendering or makes the text outright misleading).
+
+### 11. DAG checks
+
+The archive-and-reorder procedure is in `/update-dataset` § "DAG archiving & reordering". As reviewer, verify the **outcome**:
+
+```bash
+rg "<namespace>/<old_version>/<short_name>" dag/ -g "*.yml" | grep -v "^dag/archive"   # should be empty
+rg "<namespace>/<old_version>/<short_name>" dag/archive/ -g "*.yml"                    # should match
+rg "<namespace>/<new_version>/<short_name>" dag/ -g "*.yml" | grep -v "^dag/archive"   # should be in old slot, not at bottom
+```
+
+Visual inspection of the diff for:
+- Comment headers (`# Source — dataset name.`) preserved above both archived and new entries
+- Indentation consistent (` #` vs `  #` is a frequent typo)
+- Trailing newline on the archive YAML
+- New entries placed in the old block's slot, not orphaned at the bottom (🟡 if at the bottom)
+
+### 12. Downstream dependency check
+
+Procedure in `/update-dataset` § "Downstream dependency check". One-liner:
+
+```bash
+rg "<namespace>/<old_version>/<short_name>" dag/ -g "*.yml" | grep -v "^dag/archive"
+```
+
+After excluding the dataset's own chain, any remaining hits are downstream consumers — flag 🟡 unless the PR body already documents them under a "Downstream dependencies" section.
+
+### 13. /update-dataset workflow status
+
+Verify the author completed each post-step item from `/update-dataset`. The procedures live there — here we just confirm the **outcomes**:
+
+| Item | Verify by |
+|---|---|
+| Indicator upgrade ran (§7) | `make query SQL="SELECT COUNT(*) FROM chart_dimensions cd JOIN variables v ON cd.variableId=v.id WHERE v.catalogPath LIKE '%<ns>/<new_v>/%'"` — non-zero |
+| Chart-diff bot result | PR comments include `<!--chart-diff-start-->` block ✅ |
+| Slack announcement drafted (§9) | `ls workbench/<short_name>/slack-announcement.md` and a "Slack Announcement" section in the PR body |
+| Slack chart count is **published** only (§8) | Confirm the Slack copy used `c.publishedAt IS NOT NULL`, not total chart count |
+| `@codex review` posted (§9) | `gh pr view <num> --json comments` shows the trigger comment + a Codex review |
+| Codex threads resolved (§10) | `gh api graphql -f query='{ repository(owner:"owid", name:"etl") { pullRequest(number:<num>) { reviewThreads(first:20) { nodes { isResolved } } } } }'` — all `isResolved: true` |
+| Anomalist + Chart Diff links handed off (§"Final QA hand-off") | PR body or final message includes both URLs using `get_container_name(branch)` (NOT raw branch — gets truncated at 28 chars) |
+
+### 14. Final report
+
+Structure the review with:
+
+1. **Overview** — one-paragraph summary of what the PR does
+2. **Pipeline test result** — ✅/❌ for each step + grapher upload
+3. **Snapshot comparison table** — old vs new
+4. **Indicator metadata table** — fields × indicators, ✓/❌ matrix
+5. **🔴 Blockers** — must-fix before merge
+6. **🟡 Suggestions** — nice-to-have
+7. **🟢 Informational** — observations, no action needed
+8. **Workflow gaps from /update-dataset** — PR description, Slack draft, Codex review, etc.
+
+## Severity rubric
+
+- 🔴 **Blocker**: missing mandatory metadata field, broken link, failing pipeline step, breaking change to chart data, missing `update_period_days`, missing `presentation.attribution_short`, outdated `__main__` block in snapshot, DAG reference to old version that should be archived
+- 🟡 **Suggestion**: brittle assertion, hardcoded year that should be dynamic, duplicated grapher meta.yml that could be removed, non-blocking style issues
+- 🟢 **Informational**: things to be aware of but not action items
+
+## Notes
+
+- The `/review` skill is for general PR review — this skill is the dataset-specific superset.
+- If the user explicitly asks to skip the pipeline run (e.g. "don't run it, just look"), still do steps 1–3 and 5–13, but skip step 4 and note that pipeline correctness is unverified.
+- Always include the **`--grapher`** flag when running the grapher step end-to-end — without it, MySQL ingestion is not exercised and indicator metadata in the DB is not verified.

--- a/.claude/skills/update-dataset/SKILL.md
+++ b/.claude/skills/update-dataset/SKILL.md
@@ -161,11 +161,33 @@ When you do stop, present a concise summary of the issue and what options exist.
    Do this **before** step 6b (metadata checks) so any re-runs triggered by comment-removal happen before the metadata sweep, not after.
 
 6b) Metadata quality checks — run after all ETL steps are built
-   Run all three checks on the newly built garden and grapher datasets so every issue surfaces together. Each skill writes results to the terminal; fix what comes up before moving on.
+   Run all four checks on the newly built garden and grapher datasets so every issue surfaces together. Each skill writes results to the terminal; fix what comes up before moving on.
 
    - **Typos** — `/check-metadata-typos` scoped to the current step. Run on each of the new `.meta.yml` files (garden first, then grapher). Accept or skip each suggested fix.
    - **Jinja spacing** — `/check-metadata-spacing` on the built garden and grapher datasets. Catches template artifacts like doubled spaces or stray newlines that only appear after Jinja rendering.
    - **Style guide** — `/check-metadata-style` on the grapher step. Audits user-facing fields (title, subtitle, description_short, display.name, presentation.*) against OWID's Writing and Style Guide. Rules live in `.claude/skills/check-metadata-style/STYLE_GUIDE.md`, so no Notion access is needed — but if the guide looks out of date, refresh that file from Notion in a separate PR.
+   - **Clarity for a general audience** — read every user-facing field with non-specialist eyes. The other three skills enforce structure and style; this one judges whether the text is *understandable*.
+
+   ### Clarity checklist (do manually, no skill yet)
+
+   OWID readers are not domain experts. Walk each indicator's user-facing fields and flag anything that requires inside knowledge to parse.
+
+   | Field | Clarity check |
+   |---|---|
+   | `title` / `presentation.title_public` | A non-specialist should know what the indicator measures from the title alone. Expand acronyms unless universally known (skip GDP; expand GWIS, MFI, SDG, IHME). Don't cram units into the title. |
+   | `description_short` | One or two short sentences: what the metric is and what it covers. No jargon without a gloss. Active voice. The chart subtitle is short by design — no run-on or stacked clauses. |
+   | `description_key` | Each bullet should land a distinct, useful fact. Skip filler ("this dataset is widely used"); prefer substantive caveats (coverage gaps, methodology limits, what counts/doesn't count). |
+   | `display.name` | Short legend label. Reads naturally on a chart axis/legend; doesn't restate the title. |
+   | `presentation.grapher_config.note` | Concise footnote, ≤1 sentence ideally. |
+
+   Flag and rewrite when you find:
+   - Acronyms or technical terms that aren't expanded the first time they appear
+   - Sentences that only make sense if you already know the data source
+   - Quantitative claims with no unit context (e.g. "burned area" without "in hectares" surfacing somewhere in the user-facing text)
+   - Inconsistent terminology between indicators in the same dataset (e.g. "wildfires" in one, "vegetation fires" in another)
+   - Domain phrases that have a plain-English equivalent (e.g. "anthropogenic emissions" → "human-caused emissions")
+
+   When a phrasing is ambiguous, propose a concrete rewrite — don't just flag it.
 
    If any skill rewrites a `.meta.yml`, re-run the affected step so the built catalog reflects the edits. **Add `--grapher` when the affected step is on the grapher channel** — without it the local catalog is updated but staging stays stale, so the step 7 indicator upgrade sees the old text.
    ```bash


### PR DESCRIPTION
## Summary

- New \`/review-data-pr\` skill: end-to-end review workflow for dataset-update PRs (pipeline run + grapher upload, snapshot field comparison, link verification, indicator metadata checklist, cross-check of \`/update-dataset\` workflow items)
- \`/update-dataset\` § 6b: added a manual "clarity for a general audience" checklist alongside the existing typos/spacing/style checks — single source of truth, referenced from \`/review-data-pr\`

## Why

The skill captures lessons from a recent dataset-update PR review:
- \`presentation.attribution_short\` does NOT inherit from \`origin.attribution_short\`
- \`presentation.title_public\` is **not** mandatory
- \`if __name__ == "__main__":\` is outdated in snapshot files
- \`dataset.update_period_days\` must always be present
- DAG archiving requires both archive + reorder
- Various \`/update-dataset\` workflow items (Slack draft, \`@codex review\`, Anomalist + Chart Diff hand-off) belong in any PR review

## Test plan

- [x] Invoke \`/review-data-pr\` on an open dataset-update PR and verify it covers all the items
- [x] Confirm the clarity checklist in \`/update-dataset\` § 6b reads naturally alongside the other three quality checks