### PR TITLE
update-dataset: add §6c metadata coverage + link verification

### DIFF
--- a/.claude/skills/review-data-pr/SKILL.md
+++ b/.claude/skills/review-data-pr/SKILL.md
@@ -67,13 +67,7 @@ Read both `.dvc` files (old and new) and produce a side-by-side table for these 
 
 ### 6. Verify all links
 
-Run a HEAD request on every URL in both `.dvc` and `.meta.yml` files:
-
-```bash
-curl -sI "<url>" -o /dev/null -w "%{http_code}\n"
-```
-
-Anything non-2xx is a blocker.
+Run the HEAD-check loop from `/update-dataset` § 6c on every URL in the new `.dvc` and `.meta.yml` files. Anything non-2xx is a 🔴 blocker.
 
 ### 7. Code clarity & docs
 
@@ -102,59 +96,18 @@ When in doubt, run the `/check-outdated-practices` skill on the new files.
 - **Sanity-check log flags**: grep the diff for `SHOW_SANITY_CHECK_LOGS`, `DEBUG`, `LONG_FORMAT` set to `True`. If a debug flag was left enabled, that's a 🔴 — must be reverted.
 - **Silent deletes**: in any `sanity_checks` function, scan for `drop`, `filter`, `tb = tb[...]` — row removals that the user might miss. Make sure the PR body lists them.
 
-### 9. Indicator metadata coverage (mandatory checklist)
+### 9. Indicator metadata coverage & dataset block
 
-For **every indicator** in the garden `.meta.yml`, confirm these fields are set (either on `definitions.common` or per-indicator):
+The mandatory-fields checklist, the `dataset.update_period_days` requirement, and the `presentation.attribution_short` non-inheritance gotcha all live in `/update-dataset` § 6c. As reviewer, build the indicator × field matrix from that checklist and flag any missing field as 🔴.
 
-| Field | Notes |
-|---|---|
-| `title` | Per-indicator |
-| `unit` | Common is fine |
-| `short_unit` | Common is fine |
-| `description_short` | Per-indicator |
-| `description_key` | At least one bullet; usually common |
-| `processing_level` | `minor` or `major` |
-| `presentation.topic_tags` | At least one tag |
-| `display.numDecimalPlaces` | Common is fine |
-| `display.tolerance` | Common is fine — chart tolerance for missing years |
-| `display.name` | **Per-indicator** — required for legend labels |
-| `presentation.attribution_short` | **Set explicitly** — does NOT inherit from origin's `attribution_short` |
-
-**Conditional:**
-- If `processing_level: major`, then `description_processing` MUST exist on each indicator with that level.
-
-**NOT mandatory** (do not flag as 🔴 if missing):
-- `presentation.title_public`
-- `presentation.title_variant`
-- `presentation.attribution` (long form)
-
-**Important gotcha:** the snapshot's `origin.attribution_short` does NOT propagate to indicator-level `presentation.attribution_short` or to MySQL `variables.attributionShort`. They are independent fields. Always verify on the produced grapher table:
-
-```python
-from owid.catalog import Dataset
-ds = Dataset("data/grapher/<ns>/<v>/<short_name>")
-tb = ds["<table>"]
-print(tb["<col>"].metadata.presentation.attribution_short)  # must NOT be None
-```
-
-Or query staging MySQL:
+Quick verification that `presentation.attribution_short` actually landed on the produced indicators (origin's value does NOT propagate):
 
 ```bash
 make query SQL="SELECT shortName, attributionShort FROM variables WHERE catalogPath LIKE '%<ns>/<v>/<short_name>%'"
 ```
+Any `NULL` row is a 🔴.
 
-### 10. Dataset-level metadata
-
-Garden `.meta.yml` MUST include:
-
-```yaml
-dataset:
-  update_period_days: <N>
-```
-
-Even if the rest of the `dataset:` block is omitted, **never strip `update_period_days`** — it controls the auto-update cadence.
-
-### 10b. Metadata quality skills
+### 10. Metadata quality skills
 
 Run `/check-metadata-typos`, `/check-metadata-spacing`, `/check-metadata-style` against the new garden + grapher `.meta.yml` files. See `/update-dataset` § 6b for the full procedure (typos / spacing / style + a manual clarity checklist for general-audience readability — apply that checklist here too). Report findings as 🟡 (or 🔴 if a violation breaks rendering or makes the text outright misleading).
 

--- a/.claude/skills/update-dataset/SKILL.md
+++ b/.claude/skills/update-dataset/SKILL.md
@@ -36,6 +36,7 @@ Assumptions:
 - [ ] Grapher step: run + verify (skip diffs), or explicitly mark N/A
 - [ ] Re-evaluate each catalogued `# NOTE:` / `# TODO:` against fresh data; delete resolved workarounds + comments together, or record status in PR body
 - [ ] Check metadata: typos, Jinja spacing, style guide compliance
+- [ ] Verify indicator-metadata coverage, `dataset.update_period_days`, and that all URLs resolve (HEAD-check)
 - [ ] Commit, push, and update PR description
 - [ ] Run indicator upgrade on staging and persist report
 - [ ] Pick 1–3 chart views for the public announcement
@@ -197,6 +198,56 @@ When you do stop, present a concise summary of the issue and what options exist.
    .venv/bin/etlr grapher/<namespace>/<new_version>/<short_name> --grapher --private --force --only
    ```
    Then re-run the relevant check to confirm zero remaining violations.
+
+6c) Indicator metadata coverage, dataset block, and link verification
+   The other quality checks catch *content* issues; this step catches *missing fields* and *broken URLs* before they reach review.
+
+   **Mandatory fields per indicator.** For every indicator in the garden `.meta.yml`, confirm these are set (either on `definitions.common` or per-indicator):
+
+   | Field | Notes |
+   |---|---|
+   | `title` | Per-indicator |
+   | `unit` | Common is fine |
+   | `short_unit` | Common is fine |
+   | `description_short` | Per-indicator |
+   | `description_key` | At least one bullet; usually common |
+   | `processing_level` | `minor` or `major` |
+   | `presentation.topic_tags` | At least one tag |
+   | `display.numDecimalPlaces` | Common is fine |
+   | `display.tolerance` | Common is fine — chart tolerance for missing years |
+   | `display.name` | **Per-indicator** — required for legend labels |
+   | `presentation.attribution_short` | **Set explicitly** — does NOT inherit from the origin's `attribution_short` (verified: MySQL `variables.attributionShort` stays `NULL` if it's only on the origin). Place under `definitions.common.presentation` for the common case. |
+
+   Conditional: if `processing_level: major`, every indicator with that level MUST also have `description_processing`.
+
+   Not mandatory (skip if you don't need them): `presentation.title_public`, `presentation.title_variant`, `presentation.attribution`.
+
+   **Dataset block.** Garden `.meta.yml` MUST include `update_period_days`:
+   ```yaml
+   dataset:
+     update_period_days: <N>
+   ```
+   This controls the auto-update cadence. Even when the rest of the `dataset:` block is empty, **never strip `update_period_days`** — leave the block in place with just that field.
+
+   **Link verification.** Run a HEAD request on every URL in the new `.dvc` and `.meta.yml` files. Anything non-2xx is a hard blocker:
+   ```bash
+   for url in $(rg -No "https?://[^\"' ]+" snapshots/<namespace>/<new_version>/ etl/steps/data/{garden,grapher}/<namespace>/<new_version>/ | sort -u); do
+       printf "%s  %s\n" "$(curl -sI -o /dev/null -w '%{http_code}' --max-time 10 "$url")" "$url"
+   done
+   ```
+   Fix broken `url_main`, `url_download`, `license.url`, or any URL referenced from `description` / `description_key` before continuing.
+
+   **Verification.** After editing, re-run the affected step (with `--grapher` if grapher) so the catalog reflects the changes. Then confirm `presentation.attribution_short` actually landed:
+   ```python
+   from owid.catalog import Dataset
+   ds = Dataset("data/grapher/<ns>/<v>/<short_name>")
+   tb = ds["<table>"]
+   print(tb["<col>"].metadata.presentation.attribution_short)  # must NOT be None
+   ```
+   Or after the staging upload:
+   ```bash
+   make query SQL="SELECT shortName, attributionShort FROM variables WHERE catalogPath LIKE '%<ns>/<v>/<short_name>%'"
+   ```
 
 7) Indicator upgrade (optional, staging only)
    - First upload the new grapher dataset to the staging DB (required before the upgrader can detect it):


### PR DESCRIPTION
## Summary

Consolidate three quality checks into a new \`/update-dataset\` § 6c so the author addresses them at creation time, not just at review:

- **Mandatory indicator-metadata fields checklist** (title, unit, short_unit, description_short, description_key, processing_level, presentation.topic_tags, display.numDecimalPlaces, display.tolerance, display.name, presentation.attribution_short — plus description_processing when processing_level is major). The \`presentation.attribution_short\` non-inheritance gotcha is called out explicitly.
- **\`dataset.update_period_days\` requirement** — never strip this from the garden meta.
- **Link verification** — HEAD-curl loop over every URL in the new \`.dvc\` and \`.meta.yml\` files.

\`/review-data-pr\` § 6 and § 9 now reference § 6c instead of duplicating its content, so authors and reviewers work from the same source of truth.

## Why

Today these issues only get caught at PR review (frequently as 🔴 blockers), forcing back-and-forth. Surfacing them in the creation workflow prevents most of them from ever reaching review.

## Test plan

- [ ] Run \`/update-dataset\` mentally through § 6c on the next dataset update and confirm the steps are actionable
- [ ] Re-invoke \`/review-data-pr\` and confirm the metadata-coverage section produces the same output via the reference