### PR TITLE
🎉 Let `etl pr` create worktrees

### DIFF
--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -449,6 +449,9 @@ def print_worktree_hint(worktree_path: Path, shared_data: bool = False) -> None:
     print()
     print("Then set up the env (one-time):")
     print("  uv sync")
+    print()
+    print("When you're done with this worktree, remove it with:")
+    print(f"  git worktree remove {display_path}")
     if shared_data:
         print()
         print("WARNING: data/ is a symlink to the original repo's data/, so:")

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -40,12 +40,26 @@ etl pr "some title for the PR" --direct --base-branch "develop" --work-branch "t
 # Shorter
 etl pr "some title for the PR" --direct -b "develop" -w "this-temporary-branch"
 ```
+
+**Custom use case (4)**: Create the new branch in a sibling git worktree so you can keep editing your current branch in parallel.
+
+```shell
+etl pr "some title for the PR" --worktree
+# Shorter
+etl pr "some title for the PR" -t
+# With a custom path
+etl pr "some title for the PR" -t --worktree-path /tmp/etl-mybranch
+```
+
+The new working directory is printed at the end (default: `../etl-BRANCH`); `cd` into it to start working there.
 """
 
 import hashlib
 import os
 import re
+import shutil
 import uuid
+from pathlib import Path
 from typing import cast
 
 import click
@@ -139,6 +153,19 @@ MODEL_DEFAULT = "gpt-5-mini"
     is_flag=True,
     help="We briefly use LLMs to simplify the title and use it in the branch name. Disable this by using -n flag.",
 )
+@click.option(
+    "--worktree",
+    "-t",
+    is_flag=True,
+    help="Create the new branch in a sibling git worktree (default: ../etl-BRANCH) instead of mutating the current working tree. Useful for working on multiple branches in parallel.",
+)
+@click.option(
+    "--worktree-path",
+    "worktree_path",
+    type=str,
+    default=None,
+    help="Override the worktree directory (only with --worktree). Defaults to ../etl-BRANCH.",
+)
 def cli(
     title: str,
     category: str | None,
@@ -148,6 +175,8 @@ def cli(
     direct: bool,
     private: bool,
     no_llm: bool,
+    worktree: bool,
+    worktree_path: str | None,
     # base_branch: Optional[str] = None,
 ) -> None:
     # Check that the user has set up a GitHub token.
@@ -155,6 +184,17 @@ def cli(
 
     # Validate title
     _validate_title(title)
+
+    # --worktree and --direct don't compose: --direct reuses the current branch in
+    # the current working tree, --worktree creates a new isolated working tree.
+    if worktree and direct:
+        raise click.ClickException(
+            "--worktree and --direct cannot be used together. "
+            "--direct reuses the current branch in the current working tree, "
+            "while --worktree creates a brand-new isolated working tree."
+        )
+    if worktree_path and not worktree:
+        raise click.ClickException("--worktree-path requires --worktree.")
 
     # Get category
     category = ensure_category(category)
@@ -182,15 +222,26 @@ def cli(
     # Check branches main & work make sense!
     check_branches_valid(base_branch, work_branch, remote_branches)
 
+    resolved_worktree_path: Path | None = None
+
     # Auto PR mode: Create a new branch from the base branch.
     if not direct:
         if private:
             if not work_branch.endswith("-private"):
                 work_branch = f"{work_branch}-private"
-        branch_out(repo, base_branch, work_branch)
+        if worktree:
+            resolved_worktree_path = resolve_worktree_path(work_branch, worktree_path)
+            branch_out_worktree(repo, base_branch, work_branch, resolved_worktree_path)
+            # Subsequent git operations (commit, push) must run inside the worktree.
+            repo = Repo(resolved_worktree_path)
+        else:
+            branch_out(repo, base_branch, work_branch)
 
     # Create PR
     create_pr(repo, work_branch, base_branch, pr_title)
+
+    if resolved_worktree_path is not None:
+        print_worktree_hint(resolved_worktree_path)
 
 
 def check_gh_token():
@@ -311,6 +362,57 @@ def branch_out(repo, base_branch, work_branch):
         repo.git.checkout("-b", work_branch)
     except GitCommandError as e:
         raise click.ClickException(f"Failed to create a new branch from '{base_branch}':\n{e}")
+
+
+def resolve_worktree_path(work_branch: str, override: str | None) -> Path:
+    """Resolve the absolute path where the new worktree should be created."""
+    if override:
+        return Path(override).expanduser().resolve()
+    return (BASE_DIR.parent / f"etl-{work_branch}").resolve()
+
+
+def branch_out_worktree(repo, base_branch: str, work_branch: str, worktree_path: Path) -> None:
+    """Create branch 'work_branch' from 'base_branch' inside a new git worktree at 'worktree_path'."""
+    if worktree_path.exists():
+        raise click.ClickException(
+            f"Worktree path '{worktree_path}' already exists. "
+            "Choose a different --worktree-path or remove the existing directory."
+        )
+    try:
+        log.info(f"Creating worktree at '{worktree_path}' with new branch '{work_branch}' from '{base_branch}'.")
+        repo.git.worktree("add", "-b", work_branch, str(worktree_path), base_branch)
+    except GitCommandError as e:
+        raise click.ClickException(f"Failed to create worktree at '{worktree_path}':\n{e}")
+
+    # Copy .env so the new worktree is immediately usable. .venv is intentionally not
+    # copied/symlinked — it's Python-version-specific and best recreated with `uv sync`.
+    src_env = BASE_DIR / ".env"
+    if src_env.exists():
+        shutil.copy2(src_env, worktree_path / ".env")
+        log.info(f"Copied .env to '{worktree_path / '.env'}'.")
+    else:
+        log.debug(f"No .env found at '{src_env}', skipping copy.")
+
+
+def print_worktree_hint(worktree_path: Path) -> None:
+    """Tell the user how to land in the new worktree.
+
+    A child Python process can't change its parent shell's cwd, so we just print a
+    ready-to-paste cd line.
+    """
+    # Prefer a relative path from cwd if it's shorter than the absolute path
+    # (e.g. `../etl-foo` is friendlier than the full /Users/.../etl-foo).
+    rel_path = os.path.relpath(worktree_path)
+    display_path = rel_path if len(rel_path) < len(str(worktree_path)) else str(worktree_path)
+
+    print()
+    print(f"Worktree ready at: {worktree_path}")
+    print()
+    print("To start working there, run:")
+    print(f"  cd {display_path}")
+    print()
+    print("Then set up the env (one-time):")
+    print("  uv sync")
 
 
 def create_pr(repo, work_branch, base_branch, pr_title):

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -52,6 +52,16 @@ etl pr "some title for the PR" -t --worktree-path /tmp/etl-mybranch
 ```
 
 The new working directory is printed at the end (default: `../etl-BRANCH`); `cd` into it to start working there.
+
+**Custom use case (5)**: Share the original repo's `data/` directory with the new worktree, so ETL steps don't have to recompute population, regions, etc.
+
+```shell
+etl pr "some title for the PR" -t --share-data
+```
+
+This symlinks the new worktree's `data/` to the original repo's `data/`. Caveats:
+- Don't use --share-data if you are planning to work on similar files.
+- Never `rm -rf data/` from the worktree: it deletes the symlink as well as the original data dir.
 """
 
 import hashlib
@@ -166,6 +176,12 @@ MODEL_DEFAULT = "gpt-5-mini"
     default=None,
     help="Override the worktree directory (only with --worktree). Defaults to ../etl-BRANCH.",
 )
+@click.option(
+    "--share-data",
+    "share_data",
+    is_flag=True,
+    help="Symlink the new worktree's data/ to the original repo's data/ (only with --worktree). Avoids recomputing upstream ETL steps. Don't run heavy ETL ops in both worktrees concurrently, and never `rm -rf data/` in the worktree.",
+)
 def cli(
     title: str,
     category: str | None,
@@ -177,6 +193,7 @@ def cli(
     no_llm: bool,
     worktree: bool,
     worktree_path: str | None,
+    share_data: bool,
     # base_branch: Optional[str] = None,
 ) -> None:
     # Check that the user has set up a GitHub token.
@@ -195,6 +212,8 @@ def cli(
         )
     if worktree_path and not worktree:
         raise click.ClickException("--worktree-path requires --worktree.")
+    if share_data and not worktree:
+        raise click.ClickException("--share-data requires --worktree.")
 
     # Get category
     category = ensure_category(category)
@@ -232,6 +251,8 @@ def cli(
         if worktree:
             resolved_worktree_path = resolve_worktree_path(work_branch, worktree_path)
             branch_out_worktree(repo, base_branch, work_branch, resolved_worktree_path)
+            if share_data:
+                symlink_data_dir(resolved_worktree_path)
             # Subsequent git operations (commit, push) must run inside the worktree.
             repo = Repo(resolved_worktree_path)
         else:
@@ -241,7 +262,7 @@ def cli(
     create_pr(repo, work_branch, base_branch, pr_title)
 
     if resolved_worktree_path is not None:
-        print_worktree_hint(resolved_worktree_path)
+        print_worktree_hint(resolved_worktree_path, shared_data=share_data)
 
 
 def check_gh_token():
@@ -394,7 +415,22 @@ def branch_out_worktree(repo, base_branch: str, work_branch: str, worktree_path:
         log.debug(f"No .env found at '{src_env}', skipping copy.")
 
 
-def print_worktree_hint(worktree_path: Path) -> None:
+def symlink_data_dir(worktree_path: Path) -> None:
+    """Symlink the original repo's data dir into the worktree, so ETL steps reuse cached outputs."""
+    src = BASE_DIR / "data"
+    dst = worktree_path / "data"
+    if not src.exists():
+        log.warning(f"Cannot share data: '{src}' does not exist in the original repo.")
+        return
+    if dst.exists() or dst.is_symlink():
+        # `git worktree add` shouldn't have created a `data/` (it's gitignored), but be defensive.
+        log.warning(f"'{dst}' already exists, skipping data symlink.")
+        return
+    os.symlink(src, dst)
+    log.info(f"Symlinked '{dst}' -> '{src}'.")
+
+
+def print_worktree_hint(worktree_path: Path, shared_data: bool = False) -> None:
     """Tell the user how to land in the new worktree.
 
     A child Python process can't change its parent shell's cwd, so we just print a
@@ -413,6 +449,13 @@ def print_worktree_hint(worktree_path: Path) -> None:
     print()
     print("Then set up the env (one-time):")
     print("  uv sync")
+    if shared_data:
+        print()
+        print("data/ is symlinked to the original repo.")
+        print(
+            "  WARNING: Do not run `rm -rf data/`, since this would delete both the symlink and the original data folder. "
+        )
+        print("  To remove only the symlink, use `rm data` (without a trailing slash).")
 
 
 def create_pr(repo, work_branch, base_branch, pr_title):

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -62,6 +62,31 @@ etl pr "some title for the PR" -t --share-data
 This makes the new worktree's `data/` a shortcut (symlink) to the original repo's `data/`, so both worktrees share the same ETL outputs and you don't have to recompute them. Note that data/ is a symlink to the original repo's data/, so:
 - If you run the same steps in both worktrees, they may overwrite each other's output.
 - DO NOT use `rm -rf data/`; this would wipe both the symlink and the original data folder. Instead, use `git worktree remove ../etl-[whatever-branch]` to remove a worktree.
+
+**Tips for working with worktrees**:
+
+- Open each worktree in its own VS Code window (`File > New Window` → open the worktree folder). The Claude Code extension is scoped per workspace, so two windows give you two parallel chats, one per branch.
+
+- Each worktree has its own `.venv/`, so the venv from your original repo is the wrong one once you `cd` into a worktree. To auto-activate the right venv on `cd`, add this to `~/.zshrc`:
+
+```zsh
+autoload -U add-zsh-hook
+load-py-venv() {
+    if [ -f .venv/bin/activate ]; then
+        source .venv/bin/activate
+    elif [ -f env/bin/activate ]; then
+        source env/bin/activate
+    elif [ -f venv/bin/activate ]; then
+        source venv/bin/activate
+    elif [ ! -z "$VIRTUAL_ENV" ] && [ -f poetry.toml -o -f requirements.txt ]; then
+        deactivate
+    fi
+}
+add-zsh-hook chpwd load-py-venv
+load-py-venv
+```
+
+  Without this, you can still call `.venv/bin/etl ...` explicitly from each worktree — but be aware that running the original repo's `etl`/`etlr` from a worktree dir will silently use the *original* repo's source code, DAG, and branch, not the worktree's. The failure mode is silent and confusing.
 """
 
 import hashlib
@@ -406,7 +431,7 @@ def branch_out_worktree(repo, base_branch: str, work_branch: str, worktree_path:
         raise click.ClickException(f"Failed to create worktree at '{worktree_path}':\n{e}")
 
     # Copy .env so the new worktree is immediately usable. .venv is intentionally not
-    # copied/symlinked — it's Python-version-specific and best recreated with `uv sync`.
+    # copied/symlinked — it's Python-version-specific and best recreated with `make check`.
     src_env = BASE_DIR / ".env"
     if src_env.exists():
         shutil.copy2(src_env, worktree_path / ".env")
@@ -447,8 +472,8 @@ def print_worktree_hint(worktree_path: Path, shared_data: bool = False) -> None:
     print("To start working there, run:")
     print(f"  cd {display_path}")
     print()
-    print("Then set up the env (one-time):")
-    print("  uv sync")
+    print("Then set up the env (one-time, takes a minute):")
+    print("  make check")
     print()
     print("When you're done with this worktree, remove it with:")
     print(f"  git worktree remove {display_path}")

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -63,36 +63,16 @@ This makes the new worktree's `data/` a shortcut (symlink) to the original repo'
 - If you run the same steps in both worktrees, they may overwrite each other's output.
 - DO NOT use `rm -rf data/`; this would wipe both the symlink and the original data folder. Instead, use `git worktree remove ../etl-[whatever-branch]` to remove a worktree.
 
-**Tips for working with worktrees**:
+After the command finishes, `uv sync` has already run inside the worktree, so its `.venv/` is ready to use. With a `chpwd` hook in your `~/.zshrc` that sources `.venv/bin/activate` whenever present, `cd ../etl-BRANCH` is all that's needed — activation is automatic. Without the hook, also run `source .venv/bin/activate` after the cd. Skipping activation silently routes `etl`/`etlr` to the original repo's source code.
 
-- Open each worktree in its own VS Code window (`File > New Window` → open the worktree folder). The Claude Code extension is scoped per workspace, so two windows give you two parallel chats, one per branch.
-
-- Each worktree has its own `.venv/`, so the venv from your original repo is the wrong one once you `cd` into a worktree. To auto-activate the right venv on `cd`, add this to `~/.zshrc`:
-
-```zsh
-autoload -U add-zsh-hook
-load-py-venv() {
-    if [ -f .venv/bin/activate ]; then
-        source .venv/bin/activate
-    elif [ -f env/bin/activate ]; then
-        source env/bin/activate
-    elif [ -f venv/bin/activate ]; then
-        source venv/bin/activate
-    elif [ ! -z "$VIRTUAL_ENV" ] && [ -f poetry.toml -o -f requirements.txt ]; then
-        deactivate
-    fi
-}
-add-zsh-hook chpwd load-py-venv
-load-py-venv
-```
-
-  Without this, you can still call `.venv/bin/etl ...` explicitly from each worktree — but be aware that running the original repo's `etl`/`etlr` from a worktree dir will silently use the *original* repo's source code, DAG, and branch, not the worktree's. The failure mode is silent and confusing.
+See the docs (`Working on multiple branches in parallel`) for full details and tips.
 """
 
 import hashlib
 import os
 import re
 import shutil
+import subprocess
 import uuid
 from pathlib import Path
 from typing import cast
@@ -287,7 +267,8 @@ def cli(
     create_pr(repo, work_branch, base_branch, pr_title)
 
     if resolved_worktree_path is not None:
-        print_worktree_hint(resolved_worktree_path, shared_data=share_data)
+        venv_ok = install_worktree_venv(resolved_worktree_path)
+        print_worktree_hint(resolved_worktree_path, shared_data=share_data, venv_installed=venv_ok)
 
 
 def check_gh_token():
@@ -455,7 +436,30 @@ def symlink_data_dir(worktree_path: Path) -> None:
     log.info(f"Symlinked '{dst}' -> '{src}'.")
 
 
-def print_worktree_hint(worktree_path: Path, shared_data: bool = False) -> None:
+def install_worktree_venv(worktree_path: Path) -> bool:
+    """Run `uv sync` in the new worktree to set up its `.venv/`. Returns True on success.
+
+    This matches what the project's Makefile does for the `.venv` target — see
+    `default.mk` (`uv sync --all-extras --group dev`). Doing this automatically lets
+    the user just `cd` into the new worktree afterwards (with a chpwd hook the venv
+    activates automatically; without one, only `source .venv/bin/activate` is needed).
+    """
+    log.info(f"Installing dependencies in '{worktree_path}' (one-time, ~1 min)...")
+    try:
+        subprocess.run(
+            ["uv", "sync", "--all-extras", "--group", "dev"],
+            cwd=worktree_path,
+            check=True,
+        )
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError, KeyboardInterrupt) as e:
+        log.warning(
+            f"Could not set up the venv automatically ({e}). You'll need to run `make check` inside the worktree."
+        )
+        return False
+
+
+def print_worktree_hint(worktree_path: Path, shared_data: bool = False, venv_installed: bool = False) -> None:
     """Tell the user how to land in the new worktree.
 
     A child Python process can't change its parent shell's cwd, so we just print a
@@ -469,11 +473,18 @@ def print_worktree_hint(worktree_path: Path, shared_data: bool = False) -> None:
     print()
     print(f"Worktree ready at: {worktree_path}")
     print()
-    print("To start working there, run:")
-    print(f"  cd {display_path}")
-    print()
-    print("Then set up the env (one-time, takes a minute):")
-    print("  make check")
+    if venv_installed:
+        print("To start working there, just run:")
+        print(f"  cd {display_path}")
+        print()
+        print("If you have a chpwd hook in ~/.zshrc, the venv activates automatically.")
+        print("Otherwise also run: source .venv/bin/activate")
+        print("(Skipping activation will silently use the ORIGINAL repo's source code.)")
+    else:
+        print("Auto venv setup didn't complete. Inside the worktree, run:")
+        print(f"  cd {display_path}")
+        print("  make check")
+        print("  source .venv/bin/activate")
     print()
     print("When you're done with this worktree, remove it with:")
     print(f"  git worktree remove {display_path}")

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -268,7 +268,12 @@ def cli(
 
     if resolved_worktree_path is not None:
         venv_ok = install_worktree_venv(resolved_worktree_path)
-        print_worktree_hint(resolved_worktree_path, shared_data=share_data, venv_installed=venv_ok)
+        print_worktree_hint(
+            resolved_worktree_path,
+            work_branch=work_branch,
+            shared_data=share_data,
+            venv_installed=venv_ok,
+        )
 
 
 def check_gh_token():
@@ -459,7 +464,12 @@ def install_worktree_venv(worktree_path: Path) -> bool:
         return False
 
 
-def print_worktree_hint(worktree_path: Path, shared_data: bool = False, venv_installed: bool = False) -> None:
+def print_worktree_hint(
+    worktree_path: Path,
+    work_branch: str,
+    shared_data: bool = False,
+    venv_installed: bool = False,
+) -> None:
     """Tell the user how to land in the new worktree.
 
     A child Python process can't change its parent shell's cwd, so we just print a
@@ -479,15 +489,15 @@ def print_worktree_hint(worktree_path: Path, shared_data: bool = False, venv_ins
         print()
         print("If you have a chpwd hook in ~/.zshrc, the venv activates automatically.")
         print("Otherwise also run: source .venv/bin/activate")
-        print("(Skipping activation will silently use the ORIGINAL repo's source code.)")
     else:
         print("Auto venv setup didn't complete. Inside the worktree, run:")
         print(f"  cd {display_path}")
         print("  make check")
         print("  source .venv/bin/activate")
     print()
-    print("When you're done with this worktree, remove it with:")
+    print("When you're done with this worktree, clean up with:")
     print(f"  git worktree remove {display_path}")
+    print(f"  git branch -D {work_branch}")
     if shared_data:
         print()
         print("WARNING: data/ is a symlink to the original repo's data/, so:")

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -59,9 +59,9 @@ The new working directory is printed at the end (default: `../etl-BRANCH`); `cd`
 etl pr "some title for the PR" -t --share-data
 ```
 
-This symlinks the new worktree's `data/` to the original repo's `data/`. Caveats:
-- Don't use --share-data if you are planning to work on similar files.
-- Never `rm -rf data/` from the worktree: it deletes the symlink as well as the original data dir.
+This makes the new worktree's `data/` a shortcut (symlink) to the original repo's `data/`, so both worktrees share the same ETL outputs and you don't have to recompute them. Note that data/ is a symlink to the original repo's data/, so:
+- If you run the same steps in both worktrees, they may overwrite each other's output.
+- DO NOT use `rm -rf data/`; this would wipe both the symlink and the original data folder. Instead, use `git worktree remove ../etl-[whatever-branch]` to remove a worktree.
 """
 
 import hashlib
@@ -451,11 +451,10 @@ def print_worktree_hint(worktree_path: Path, shared_data: bool = False) -> None:
     print("  uv sync")
     if shared_data:
         print()
-        print("data/ is symlinked to the original repo.")
-        print(
-            "  WARNING: Do not run `rm -rf data/`, since this would delete both the symlink and the original data folder. "
-        )
-        print("  To remove only the symlink, use `rm data` (without a trailing slash).")
+        print("WARNING: data/ is a symlink to the original repo's data/, so:")
+        print("  - If you run the same steps in both worktrees, they may overwrite each other's output.")
+        print("  - DO NOT use `rm -rf data/`; this would wipe both the symlink and the original data folder. ")
+        print("    Instead, use `git worktree remove ../etl-[whatever-branch]` to remove a worktree.")
 
 
 def create_pr(repo, work_branch, base_branch, pr_title):

--- a/docs/guides/pull-requests.md
+++ b/docs/guides/pull-requests.md
@@ -41,3 +41,36 @@ You can find an example [:fontawesome-brands-github: here](https://github.com/ow
     <img src="../../assets/pr-2.png" alt="Chart Upgrader" style="width:100%;">
     <figcaption>[GitHub action comment](https://github.com/owid/etl/pull/3563#issuecomment-2485414940), as of 19th November 2024</figcaption>
 </figure>
+
+## Working on multiple branches in parallel
+
+If you need several PRs in flight at once (e.g. several agent sessions, one per branch), `etl pr --worktree` creates the new branch in a separate **git worktree** so your current working tree is untouched:
+
+```bash
+etl pr "Update some dataset" data --worktree
+```
+
+The new worktree appears at `../etl-<branch>`. To start working there:
+
+```bash
+cd ../etl-<branch>
+make check   # one-time, sets up this worktree's .venv/
+```
+
+Use `git worktree remove ../etl-<branch>` to clean up afterwards.
+
+A couple of useful tips:
+
+- Open each worktree in its own VS Code window (`File > New Window`). The Claude Code extension is scoped per workspace, so each window gets its own chat.
+- Each worktree has its own `.venv/`. If you forget to activate the right one, the *original* repo's `etl`/`etlr` will silently use the wrong source code. A small `chpwd` hook in `~/.zshrc` that sources `.venv/bin/activate` whenever it exists in the new directory handles this automatically.
+
+### Sharing the data folder (optional)
+
+`--share-data` symlinks the new worktree's `data/` to the original's, so upstream ETL steps don't get recomputed:
+
+```bash
+etl pr "Update dataset" data --worktree --share-data
+```
+
+!!! warning
+    Never run `rm -rf data/` in a shared worktree — the trailing slash makes `rm` follow the symlink and wipe the **original** `data/`. Use `git worktree remove ../etl-<branch>` to clean up instead.

--- a/docs/guides/pull-requests.md
+++ b/docs/guides/pull-requests.md
@@ -50,19 +50,40 @@ If you need several PRs in flight at once (e.g. several agent sessions, one per 
 etl pr "Update some dataset" data --worktree
 ```
 
-The new worktree appears at `../etl-<branch>`. To start working there:
+The command creates the worktree at `../etl-<branch>` and runs `uv sync` inside it, so the worktree's `.venv/` is ready to use by the time the command finishes. To start working there:
 
 ```bash
 cd ../etl-<branch>
-make check   # one-time, sets up this worktree's .venv/
 ```
+
+Otherwise also run `source .venv/bin/activate`. Or, even better, set up auto-activation once (see below) — then `cd` alone is enough.
 
 Use `git worktree remove ../etl-<branch>` to clean up afterwards.
 
-A couple of useful tips:
+### Optional: auto-activate the venv when you `cd`
 
-- Open each worktree in its own VS Code window (`File > New Window`). The Claude Code extension is scoped per workspace, so each window gets its own chat.
-- Each worktree has its own `.venv/`. If you forget to activate the right one, the *original* repo's `etl`/`etlr` will silently use the wrong source code. A small `chpwd` hook in `~/.zshrc` that sources `.venv/bin/activate` whenever it exists in the new directory handles this automatically.
+Add this snippet to your `~/.zshrc` so the right `.venv/` activates automatically every time you `cd` into a worktree (or any project folder with a `.venv/`):
+
+```zsh
+autoload -U add-zsh-hook
+load-py-venv() {
+    if [ -f .venv/bin/activate ]; then
+        source .venv/bin/activate
+    elif [ -f env/bin/activate ]; then
+        source env/bin/activate
+    elif [ -f venv/bin/activate ]; then
+        source venv/bin/activate
+    elif [ ! -z "$VIRTUAL_ENV" ] && [ -f poetry.toml -o -f requirements.txt ]; then
+        deactivate
+    fi
+}
+add-zsh-hook chpwd load-py-venv
+load-py-venv
+```
+
+After reloading your shell (`source ~/.zshrc` or open a new terminal), you can `cd` between worktrees and the matching venv will activate on its own.
+
+Tip: open each worktree in its own VS Code window (`File > New Window`). The Claude Code extension is scoped per workspace, so each window gets its own chat.
 
 ### Sharing the data folder (optional)
 

--- a/docs/guides/pull-requests.md
+++ b/docs/guides/pull-requests.md
@@ -58,7 +58,12 @@ cd ../etl-<branch>
 
 Otherwise also run `source .venv/bin/activate`. Or, even better, set up auto-activation once (see below) — then `cd` alone is enough.
 
-Use `git worktree remove ../etl-<branch>` to clean up afterwards.
+When you're done with the worktree (typically after the PR is merged), clean up:
+
+```bash
+git worktree remove ../etl-<branch>
+git branch -D <branch>
+```
 
 ### Optional: auto-activate the venv when you `cd`
 


### PR DESCRIPTION
## Summary

Let `etl pr` create git worktrees, and optionally share the same `data` folder.

## Context

Given that it's becoming more common to work with multiple ETL branches in parallel (especially when running AI agents), it may be convenient to use git worktrees.

This PR allows "etl pr" to create worktrees easily, e.g.
```
etl pr "Testing things" data --worktree
```
This will create a new worktree and a PR from there. It will also copy the `.env` file to the new folder.

One downside of creating new ETL worktrees is that one may need to re-run many ETL steps (e.g. regions, population, WDI...) on every new worktree, which can take a long time. For this reason, this PR also gives the option to `--share-data` between worktrees, e.g.
```
etl pr "Testing things" data --worktree --share-data
```
This creates a symlink of the original data folder in the new worktree, so that one can work in the new worktree using the same local ETL catalog.

## Notes
* I have tested that it works locally with a few simple examples. I haven't yet stress-tested what happens with grapher uploads from two worktrees. In theory each worktree pushes to its own staging DB without any conflict. Of course, if one was working on the same files from the two worktrees, there could be complications; but for such cases, one shouldn't use `--share-data`.

TODO: Consider adding the following notes to the documentation, if we agree on this approach:
* When working with worktrees, I think it's convenient to automatically load the virtual environment of a given folder as soon as you enter that folder. This can be achieved by adding this snippet to the `.zshrc`:
```
# To automatically load a virtual environment when entering a directory, as long as it's called either .venv or env
autoload -U add-zsh-hook
load-py-venv() {
    if [ -f .venv/bin/activate ]; then
        # enter a virtual environment that's here
        source .venv/bin/activate
    elif [ -f env/bin/activate ]; then
        source env/bin/activate
    elif [ -f venv/bin/activate ]; then
        source venv/bin/activate
    elif [ ! -z "$VIRTUAL_ENV" ] && [ -f poetry.toml -o -f requirements.txt ]; then
        # exit a virtual environment when you enter a new project folder
        deactivate
    fi
}
add-zsh-hook chpwd load-py-venv
load-py-venv
```
* There are different ways to work with git worktrees and LLMs. I think the most convenient one is to have two separate VSCode windows, one in each folder.

* I noticed that, when working in a new worktree with a shared `data` folder as a symlink, git notices the changes in that folder (because it doesn't find `data/.gitfolder`). This is annoying, so I created [a separate PR](https://github.com/owid/etl/pull/6005) to fix this, and let git always ignore the `data` folder.
