### PR TITLE
🐛 Self-heal partial dataset output to recover from interrupted runs

### DIFF
--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import uuid
 import warnings
 from collections import defaultdict
 from collections.abc import Generator, Iterable
@@ -442,7 +443,9 @@ class DataStep(Step):
             step=self.path,
             path=str(self._dest_dir),
         )
-        tmp = self._dest_dir.with_name(f".{self._dest_dir.name}.tmp.{os.getpid()}")
+        # Unique suffix per attempt so a leftover temp dir from an earlier
+        # partial cleanup never collides with the next attempt.
+        tmp = self._dest_dir.with_name(f".{self._dest_dir.name}.tmp.{uuid.uuid4().hex}")
         self._dest_dir.rename(tmp)
         shutil.rmtree(tmp, ignore_errors=True)
 

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -422,9 +422,37 @@ class DataStep(Step):
             else:
                 raise e
 
+    def _clean_partial_output(self) -> None:
+        """Remove dest_dir if it exists without index.json.
+
+        A directory without index.json indicates a previous run was interrupted
+        mid-write (e.g. shutil.rmtree partially failed, or the process was killed
+        between mkdir and metadata.save). Reading it as a Dataset would crash, so
+        clean it up and let the step re-run from scratch.
+
+        Renames the dir aside before rmtree so the original path disappears
+        atomically — avoids leaving the path half-deleted if rmtree itself races
+        with another writer (which is what creates this state in the first place).
+        """
+        if not self._dest_dir.is_dir() or (self._dest_dir / "index.json").exists():
+            return
+
+        log.warning(
+            "step.cleanup_partial_output",
+            step=self.path,
+            path=str(self._dest_dir),
+        )
+        tmp = self._dest_dir.with_name(f".{self._dest_dir.name}.tmp.{os.getpid()}")
+        self._dest_dir.rename(tmp)
+        shutil.rmtree(tmp, ignore_errors=True)
+
     def run(self) -> None:
         # make sure the enclosing folder is there
         self._dest_dir.parent.mkdir(parents=True, exist_ok=True)
+
+        # Self-heal partial output from a prior interrupted run before any read,
+        # otherwise _dataset_index_mtime below would crash on missing index.json.
+        self._clean_partial_output()
 
         if config.PREFER_DOWNLOAD:
             # if checksums match, download the dataset from the catalog
@@ -456,10 +484,7 @@ class DataStep(Step):
             else:
                 raise Exception(f"have no idea how to run step: {self.path}")
         except Exception:
-            # Clean up partial output so subsequent runs don't see an incomplete dataset
-            # (a directory without index.json would cause Dataset.__init__ to fail)
-            if self._dest_dir.is_dir() and not (self._dest_dir / "index.json").exists():
-                shutil.rmtree(self._dest_dir)
+            self._clean_partial_output()
             raise
 
         # was the index file modified? if not then `save` was not called

--- a/lib/catalog/owid/catalog/core/datasets.py
+++ b/lib/catalog/owid/catalog/core/datasets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import shutil
 import warnings
 from collections.abc import Iterator
@@ -115,7 +116,12 @@ class Dataset:
         if path.is_dir():
             if not (path / "index.json").exists():
                 raise Exception(f"refuse to overwrite non-dataset dir at: {path}")
-            shutil.rmtree(path)
+            # Atomically move aside before deletion so a partially failed rmtree
+            # (e.g. ENOTEMPTY from concurrent writers) doesn't leave the dataset
+            # path in a half-deleted state without index.json.
+            tmp = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+            path.rename(tmp)
+            shutil.rmtree(tmp, ignore_errors=True)
 
         path.mkdir(parents=True, exist_ok=True)
 

--- a/lib/catalog/owid/catalog/core/datasets.py
+++ b/lib/catalog/owid/catalog/core/datasets.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import shutil
+import uuid
 import warnings
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -118,8 +118,10 @@ class Dataset:
                 raise Exception(f"refuse to overwrite non-dataset dir at: {path}")
             # Atomically move aside before deletion so a partially failed rmtree
             # (e.g. ENOTEMPTY from concurrent writers) doesn't leave the dataset
-            # path in a half-deleted state without index.json.
-            tmp = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+            # path in a half-deleted state without index.json. The suffix is a
+            # uuid so a leftover temp dir from an earlier partial cleanup never
+            # collides with the next attempt.
+            tmp = path.with_name(f".{path.name}.tmp.{uuid.uuid4().hex}")
             path.rename(tmp)
             shutil.rmtree(tmp, ignore_errors=True)
 

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -59,6 +59,24 @@ def test_data_step():
         Dataset((paths.DATA_DIR / step_name).as_posix())
 
 
+def test_data_step_recovers_from_partial_output():
+    # Simulate a previously interrupted run that left dest_dir without index.json
+    # (e.g. shutil.rmtree partially failed mid-write). The next run should
+    # self-heal rather than crash on the corrupt state.
+    with temporary_step() as step_name:
+        _create_mock_py_file(step_name)
+        dest_dir = paths.DATA_DIR / step_name
+        dest_dir.mkdir(parents=True)
+        (dest_dir / "leftover.parquet").write_bytes(b"junk")
+        assert not (dest_dir / "index.json").exists()
+
+        DataStep(step_name, []).run()
+
+        assert (dest_dir / "index.json").exists()
+        assert not (dest_dir / "leftover.parquet").exists()
+        Dataset(dest_dir.as_posix())
+
+
 def test_data_step_becomes_dirty_when_pandas_version_changes():
     pandas_version = pd.__version__
     try:


### PR DESCRIPTION
## Summary

Lets a step like `data://open_numbers/open_numbers/latest/gapminder__systema_globalis` recover automatically after a previously interrupted run, instead of getting stuck on a corrupted dest_dir until someone SSHes in to delete it.

## What was happening

Build [10098](https://github.com/owid/etl/actions) failed on the very first step it tried to run:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '/home/owid/etl/data/open_numbers/open_numbers/latest/gapminder__systema_globalis/index.json'
```

The directory existed and was full of `*.parquet` and `*.meta.json` files, but `index.json` was missing. Reconstructed timeline:

1. An earlier build hit an `OSError: [Errno 39] Directory not empty` inside `Dataset.create_empty` → `shutil.rmtree(path)`. `rmtree` walks depth-first and got far enough to delete `index.json` before something raced and left the parquet files behind, aborting mid-deletion.
2. Build 10098 then ran. Its very first operation is `_dataset_index_mtime()` (`etl/steps/__init__.py`), which sees `dest_dir` exists → constructs `Dataset(dest_dir)` → tries to load `index.json` → `FileNotFoundError`.
3. Every retry of the deploy hit the same wall until the dir was manually removed on `etl-prod-2`.

## Fix

Two narrow changes:

- **`etl/steps/__init__.py`**: extract the existing post-failure cleanup into a `_clean_partial_output()` helper and call it at the top of `DataStep.run()` too. So a corrupt dest_dir inherited from a *previous* run is healed before any read attempts to load `index.json`. The helper renames the dir aside (`os.rename`) before `rmtree`, so the original path disappears atomically — even if the rmtree races again, the next run sees no prior dataset and proceeds cleanly.
- **`lib/catalog/owid/catalog/core/datasets.py`**: `Dataset.create_empty` does the same rename-then-`rmtree` pattern. This closes the original race that produced the corrupted state in the first place.

`has_existing_data()` was already careful about this case (checks `index.json` exists *and* every data file has a `.meta.json` sidecar), so the dirty-check / scheduler path was already fine. The hole was only in `run()`.

## Test plan

- [x] `make check` passes
- [x] `pytest tests/test_steps.py` — 13 passed (incl. new `test_data_step_recovers_from_partial_output` regression test that simulates the production failure mode)
- [x] `pytest lib/catalog/tests/test_datasets.py` — 26 passed