### PR TITLE
💄 Update metadata for CSET investment indicators

### DIFF
--- a/etl/steps/data/garden/artificial_intelligence/2026-04-27/cset.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2026-04-27/cset.meta.yml
@@ -25,12 +25,11 @@ definitions:
     - Patent data has a lag because some offices take years to publish new filings. Recent years are excluded here.
 
   description_key_investment: &description_key_investment
-    - The data covers external private-market investment in AI companies, including venture capital deals, private equity deals, and mergers and acquisitions.
-    - It excludes internal corporate R&D, capital spending, and government funding. Publicly traded companies, including large technology firms, are also excluded.
-    - Because this is only one type of funding, the data understates total global spending on AI.
-    - A small number of very large deals can drive big year-on-year swings. Broader economic conditions, such as interest rates and investor sentiment, also affect totals in ways that are not specific to AI.
-    - CSET's figure for {year} is preliminary and is likely to rise as more deals are reported. We show it to provide a more current view, but it may change as CSET updates its estimates.
-    - The "World" total only includes countries that are covered by the source, so it understates global activity.
+    - This data tracks the flow of external money into private companies. It excludes internal spending on R&D and infrastructure.
+    - On the recipient side, this only includes privately held AI companies. It excludes publicly traded companies like "Big Tech".
+    - On the investor side, this includes any equity investor — venture capital firms, private equity firms, corporate investors (including "Big Tech" companies), and sovereign wealth funds. Only equity transactions are counted; grants, debt finance, and crowdfunding are excluded.
+    - Where deal amounts aren't publicly disclosed, CSET assigns them an estimated value based on comparable deals — typically around 40% of the total.
+    - This data only covers specific types of funding, and doesn't reflect total global spending on AI.
 
   description_processing_aggregates: &description_processing_aggregates |-
     We calculate regional and global totals from the country-level data CSET provides, following our [region definitions](https://ourworldindata.org/world-region-map-definitions). Countries that are not covered by the source are excluded from these totals.
@@ -50,7 +49,10 @@ definitions:
     We calculate regional and global totals from the country-level data CSET provides, following our [region definitions](https://ourworldindata.org/world-region-map-definitions). Countries that are not covered by the source are excluded from these totals. We do not show Africa's regional total. The source covers too few African countries to produce a meaningful aggregate.
 
   investment_description_short: &investment_description_short |-
-    Money put into privately held AI companies by private investors. This excludes publicly traded companies (e.g., Big Tech companies) and companies' internal spending, such as R&D or infrastructure. Expressed in US dollars, adjusted for inflation. Data for {year} is incomplete and includes investments up to {month} {year}.
+    Money raised by privately held AI companies through venture capital, private equity, and mergers and acquisitions. This includes CSET's own estimates for deals where the amount wasn't disclosed. Expressed in US dollars, adjusted for inflation.
+
+  investment_description_short_partial: &investment_description_short_partial |-
+    Money raised by privately held AI companies through venture capital, private equity, and mergers and acquisitions. This includes CSET's own estimates for deals where the amount wasn't disclosed. Expressed in US dollars, adjusted for inflation. Data for {year} is incomplete and includes investments up to {month} {year}.
 
   investment_grapher_note: &investment_grapher_note |-
     Data is expressed in constant 2021 US$. Inflation adjustment is based on the US Consumer Price Index (CPI).
@@ -71,7 +73,7 @@ tables:
     variables:
       estimated_investment:
         <<: *processing_investment
-        title: External funding for privately held AI companies
+        title: Estimated funding raised by privately held AI companies
         unit: constant 2021 US dollars
         short_unit: $
         description_short: *investment_description_short
@@ -82,13 +84,13 @@ tables:
 
       estimated_investment_projected:
         <<: *processing_investment
-        title: Projected external funding for privately held AI companies
+        title: Estimated funding raised by privately held AI companies for incomplete years
         unit: constant 2021 US dollars
         short_unit: $
-        description_short: *investment_description_short
+        description_short: *investment_description_short_partial
         description_key:
           - *description_key_investment
-          - The values shown for the most recent year are preliminary estimates based on deals reported so far. The previous complete year is included as a starting point to connect the series on charts.
+          - The values for the most recent year are preliminary estimates based on deals reported so far.
         presentation:
           grapher_config:
             note: *investment_grapher_note

--- a/etl/steps/data/garden/artificial_intelligence/2026-04-27/cset.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2026-04-27/cset.meta.yml
@@ -28,7 +28,7 @@ definitions:
     - This data tracks the flow of external money into private companies. It excludes internal spending on R&D and infrastructure.
     - On the recipient side, this only includes privately held AI companies. It excludes publicly traded companies like "Big Tech".
     - On the investor side, this includes any equity investor — venture capital firms, private equity firms, corporate investors (including "Big Tech" companies), and sovereign wealth funds. Only equity transactions are counted; grants, debt finance, and crowdfunding are excluded.
-    - Where deal amounts aren't publicly disclosed, CSET assigns them an estimated value based on comparable deals — typically around 40% of the total.
+    - Where deal amounts aren't publicly disclosed — typically around 40% of the total — CSET assigns them an estimated value based on comparable deals.
     - This data only covers specific types of funding, and doesn't reflect total global spending on AI.
 
   description_processing_aggregates: &description_processing_aggregates |-

--- a/etl/steps/data/garden/artificial_intelligence/2026-04-27/cset.py
+++ b/etl/steps/data/garden/artificial_intelligence/2026-04-27/cset.py
@@ -2,7 +2,7 @@ import datetime
 
 import owid.catalog.processing as pr
 
-from etl.catalog_helpers import last_date_accessed
+from etl.catalog_helpers import last_date_accessed, last_date_published
 from etl.helpers import PathFinder
 
 paths = PathFinder(__file__)
@@ -83,8 +83,8 @@ def run() -> None:
         default_metadata=ds_meadow.metadata,
         yaml_params={
             "date_accessed": last_date_accessed(tb),
-            "year": last_date_accessed(tb)[-4:],
-            "month": datetime.datetime.strptime(last_date_accessed(tb), "%d %B %Y").strftime("%B"),
+            "year": last_date_published(tb)[-4:],
+            "month": datetime.datetime.strptime(last_date_published(tb), "%d %B %Y").strftime("%B"),
         },
     )
     ds_garden.save()


### PR DESCRIPTION
Hey @veronikasamborska1994,

Thanks for updating the CSET data! I was equally surprised to see the high 2026 figures on the `private-investment-in-artificial-intelligence-cset` chart, and spent some time understanding how CSET arrives at them. That investigation made me think it was a good moment to revisit the chart's metadata more broadly — we now have more years of data, fewer open questions about the 2021–2023 years, and a few wording improvements I'd like to suggest.

## The main change

I'm proposing we drop CSET's partial-year data from this chart. Their underlying method (assigning median values to undisclosed deals from comparable Crunchbase deals) seems fairly robust for full years — but for 2026 specifically, around 80% of the value is imputed, vs. ~40% in normal years, simply because there are very few disclosed deals so far to anchor the medians. That makes the 2026 figure feel too preliminary to display.

To do this with minimal disruption:

- In case we want to change this later, both `estimated_investment` and `estimated_investment_projected` indicators stay in the dataset, with the existing splitting logic untouched.
- I've just removed `estimated_investment_projected__field_all` from the chart in Grapher.

Another important reason is that using two indicators drops the data page UI, which means readers don't get to see any of the WYSK. For a tricky indicator like that, I think there are more benefits to showing all the metadata.

## What's in this PR

- `cset.py`: small tweak — the subtitle's `{month}` / `{year}` placeholders now read from `last_date_published` rather than `last_date_accessed`, so they reflect CSET's data cutoff (March 2026) rather than our snapshot date (April 2026).
- `cset.meta.yml`: rewritten title, description_short, and description_key for both indicators, plus a second description_short anchor (`investment_description_short_partial`) so the projected indicator can keep the "Data for {year} is incomplete..." clause without it bleeding into the actuals.

## What's intentionally preserved

- All processing code in `cset.py` (the meadow split into actuals/projections, the last-actual-year merge, etc.).
- The `_projected` indicator itself — it remains in the catalog and could be used later.