### PR TITLE
📊 energy: Make energy impacts explorer indicator based

### DIFF
--- a/dag/energy.yml
+++ b/dag/energy.yml
@@ -111,6 +111,20 @@ steps:
   export://multidim/energy/latest/energy_prices:
     - data://grapher/energy/2025-02-03/energy_prices
   #
+  # UNECE - Life Cycle Assessment of Electricity Generation Options.
+  #
+  data://meadow/unece/2026-05-04/life_cycle_assessment_of_electricity:
+    - snapshot://unece/2026-05-04/life_cycle_assessment_of_electricity.pdf
+  data://garden/unece/2026-05-04/life_cycle_assessment_of_electricity:
+    - data://meadow/unece/2026-05-04/life_cycle_assessment_of_electricity
+  data://grapher/unece/2026-05-04/life_cycle_assessment_of_electricity:
+    - data://garden/unece/2026-05-04/life_cycle_assessment_of_electricity
+  #
+  # Impacts of energy production explorer.
+  #
+  export://explorers/energy/latest/impacts_of_energy_sources:
+    - data://grapher/unece/2026-05-04/life_cycle_assessment_of_electricity
+  #
   # IRENA - Renewable energy patents.
   #
   data://meadow/irena/2025-06-20/renewable_energy_patents:

--- a/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.meta.yml
+++ b/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.meta.yml
@@ -4,7 +4,7 @@ definitions:
   description_key_land_use: &description-key-land-use
     - *description-key-common
     - The land use of different energy sources can vary significantly, depending on the context of the production site - its location; climate; and choices around the density and spacing of equipment. For example, the spacing of wind turbines and solar panels will affect how much land is needed per unit of electricity output.
-    - Wind energy is not included in these comparisons of average land use figures. This is because the land use of wind energy can be measured in several ways and is distinctly different from the land use of other energy technologies. Land between wind turbines can be used for other purposes (such as farming), which is not the case for other energy sources. The spacing of turbines and the context of the site means that its land use is highly variable. For this reason we don't provide an average land use figure for wind in this data. However, we do included figures for wind in [our article on this topic](https://ourworldindata.org/land-use-per-energy-source).
+    - Wind energy is not included in these comparisons of average land use figures. This is because the land use of wind energy can be measured in several ways and is distinctly different from the land use of other energy technologies. Land between wind turbines can be used for other purposes (such as farming), which is not the case for other energy sources. The spacing of turbines and the context of the site means that its land use is highly variable. For this reason we don't provide an average land use figure for wind in this data. However, we do include figures for wind in [our article on this topic](https://ourworldindata.org/land-use-per-energy-source).
   description_key_metal_mineral_use: &description-key-metal-mineral-use
     - *description-key-common
     - The metal and mineral requirements for each source are based on the requirements of the actual amount of material extracted from the ground, which includes all the losses throughout the extraction, refining and fabrication processes.
@@ -39,7 +39,7 @@ tables:
         title: Freshwater eutrophication per unit of electricity
         unit: grams of phosphorus-equivalents per megawatt-hour
         short_unit: gP-eq/MWh
-        description_short: "Freshwater eutrophication is caused by the emissions of phosphorus compounds to freshwater: either rivers or lakes. This is measured in grams of phosphorous emitted per unit of electricity production."
+        description_short: "Freshwater eutrophication is caused by the emissions of phosphorus compounds to freshwater: either rivers or lakes. This is measured in grams of phosphorus emitted per unit of electricity production."
         description_key:
           - *description-key-common
         display:

--- a/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.meta.yml
+++ b/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.meta.yml
@@ -1,0 +1,193 @@
+definitions:
+  common:
+    processing_level: minor
+    presentation:
+      topic_tags:
+        - Energy
+        - Energy Mix
+    description_key:
+      - This dataset is based on a meta-analysis of life-cycle impacts of electricity production carried out by UNECE. It covers not only the direct impacts of an electricity source (for example, the land used for individual power plants) but also any supply-chain inputs (for example, land used upstream in supply chains, such as mining for fuels or raw materials).
+      - The meta-analysis considered measurements across all twelve UNECE regions; here we present the global average across these values.
+      - For some impacts — land use, for example — there can be significant differences between the maximum and minimum values for a given source depending on context, such as the climate of a given location, or choices around spacing and density of electricity sources.
+    description_processing: |-
+      The values were extracted manually from tables in the UNECE Life Cycle Assessment of Electricity Generation Options report (March 2022 final version). UNECE does not publish a CSV or Excel companion file.
+
+      A separate corrigendum to the report on land-use figures was published in July 2022 and is available at https://unece.org/sites/default/files/2022-07/Corrigendum%20to%20UNECE%20LCA%20report%20-%20land%20use.pdf
+
+  metals_note: &metals_note |-
+    Material requirements are based on the actual amount of material extracted from the ground, which includes all the losses throughout the extraction, refining and fabrication processes. These figures are towards the high end of estimates that measure based on the final amount of materials required per unit of electricity.
+
+dataset:
+  update_period_days: 0
+  title: Life-cycle impacts of energy sources (UNECE)
+
+tables:
+  life_cycle_assessment_of_electricity:
+    title: Life-cycle impacts of energy sources (UNECE)
+    variables:
+      ghg_emissions:
+        title: Greenhouse gas emissions per unit of electricity
+        unit: kilograms of CO₂-equivalents per megawatt-hour
+        short_unit: kgCO₂e/MWh
+        description_short: Lifecycle greenhouse gas emissions per unit of electricity, including emissions from the burning of fuels, mining of materials and production of energy technologies.
+        display:
+          name: Greenhouse gas emissions
+          numDecimalPlaces: 0
+      freshwater_eutrophication:
+        title: Freshwater eutrophication per unit of electricity
+        unit: grams of phosphorus-equivalents per megawatt-hour
+        short_unit: gP-eq/MWh
+        description_short: Freshwater eutrophication is caused by emissions of phosphorus compounds to rivers or lakes, measured in grams of phosphorus emitted per unit of electricity production.
+        display:
+          name: Freshwater eutrophication
+          numDecimalPlaces: 0
+      ionising_radiation:
+        title: Ionising radiation per unit of electricity
+        unit: kilograms of U-235-equivalents per megawatt-hour
+        short_unit: kg U-235eq/MWh
+        description_short: Ionising radiation impacts per unit of electricity produced, expressed in U-235 equivalents.
+        display:
+          name: Ionising radiation
+          numDecimalPlaces: 1
+      water_use:
+        title: Dissipated water use per unit of electricity
+        unit: cubic metres per megawatt-hour
+        short_unit: m³/MWh
+        description_short: Dissipated water that is not immediately returned to the local environment (e.g. evaporated, or used as an ingredient in a chemical product), measured per megawatt-hour of electricity production.
+        display:
+          name: Water use
+          numDecimalPlaces: 0
+      metal_mineral_use:
+        title: Metal and mineral requirements per unit of electricity
+        unit: grams of antimony-equivalents per megawatt-hour
+        short_unit: g Sb-eq/MWh
+        description_short: Mineral and metal inputs distilled into a single figure, measured in grams of antimony (Sb) equivalents per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Total material use
+          numDecimalPlaces: 2
+      noncarcinogenic_toxicity:
+        title: Non-carcinogenic toxicity per unit of electricity
+        unit: comparative toxic units per terawatt-hour
+        short_unit: CTUh/TWh
+        description_short: Non-carcinogenic toxicity impacts on human health per terawatt-hour of electricity, expressed in comparative toxic units.
+        display:
+          name: Non-carcinogenic toxicity
+          numDecimalPlaces: 1
+      carcinogenic_toxicity:
+        title: Carcinogenic toxicity per unit of electricity
+        unit: comparative toxic units per terawatt-hour
+        short_unit: CTUh/TWh
+        description_short: Carcinogenic toxicity impacts on human health per terawatt-hour of electricity, expressed in comparative toxic units.
+        display:
+          name: Carcinogenic toxicity
+          numDecimalPlaces: 1
+      land_use_energy:
+        title: Land use per unit of electricity
+        unit: square metres per megawatt-hour
+        short_unit: m²/MWh
+        description_short: Total land used per unit of electricity production, including direct land use (e.g. the area of a power plant or solar farm) and indirect land use from mining of fuels and materials.
+        display:
+          name: Land use
+          numDecimalPlaces: 1
+      aluminium_use:
+        title: Aluminium requirements per unit of electricity
+        unit: grams per megawatt-hour
+        short_unit: g/MWh
+        description_short: Aluminium required per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Aluminium
+          numDecimalPlaces: 2
+      chromium_use:
+        title: Chromium requirements per unit of electricity
+        unit: grams per megawatt-hour
+        short_unit: g/MWh
+        description_short: Chromium required per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Chromium
+          numDecimalPlaces: 2
+      cobalt_use:
+        title: Cobalt requirements per unit of electricity
+        unit: grams per megawatt-hour
+        short_unit: g/MWh
+        description_short: Cobalt required per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Cobalt
+          numDecimalPlaces: 3
+      copper_use:
+        title: Copper requirements per unit of electricity
+        unit: grams per megawatt-hour
+        short_unit: g/MWh
+        description_short: Copper required per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Copper
+          numDecimalPlaces: 2
+      manganese_use:
+        title: Manganese requirements per unit of electricity
+        unit: grams per megawatt-hour
+        short_unit: g/MWh
+        description_short: Manganese required per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Manganese
+          numDecimalPlaces: 2
+      molybdenum_use:
+        title: Molybdenum requirements per unit of electricity
+        unit: grams per megawatt-hour
+        short_unit: g/MWh
+        description_short: Molybdenum required per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Molybdenum
+          numDecimalPlaces: 2
+      nickel_use:
+        title: Nickel requirements per unit of electricity
+        unit: grams per megawatt-hour
+        short_unit: g/MWh
+        description_short: Nickel required per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Nickel
+          numDecimalPlaces: 2
+      silicon_use:
+        title: Silicon requirements per unit of electricity
+        unit: grams per megawatt-hour
+        short_unit: g/MWh
+        description_short: Silicon required per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Silicon
+          numDecimalPlaces: 2
+      zinc_use:
+        title: Zinc requirements per unit of electricity
+        unit: grams per megawatt-hour
+        short_unit: g/MWh
+        description_short: Zinc required per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Zinc
+          numDecimalPlaces: 2
+      uranium_use:
+        title: Uranium requirements per unit of electricity
+        unit: grams per megawatt-hour
+        short_unit: g/MWh
+        description_short: Uranium required per megawatt-hour of electricity produced.
+        description_key:
+          - *metals_note
+        display:
+          name: Uranium
+          numDecimalPlaces: 3

--- a/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.meta.yml
+++ b/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.meta.yml
@@ -32,6 +32,7 @@ tables:
         description_short: Lifecycle greenhouse gas emissions per unit of electricity, including emissions from the burning of fuels, mining of materials and production of energy technologies.
         display:
           name: Greenhouse gas emissions
+          shortUnit: kgCO₂e
           numDecimalPlaces: 0
       freshwater_eutrophication:
         title: Freshwater eutrophication per unit of electricity
@@ -40,6 +41,7 @@ tables:
         description_short: Freshwater eutrophication is caused by emissions of phosphorus compounds to rivers or lakes, measured in grams of phosphorus emitted per unit of electricity production.
         display:
           name: Freshwater eutrophication
+          shortUnit: gP-eq
           numDecimalPlaces: 0
       ionising_radiation:
         title: Ionising radiation per unit of electricity
@@ -48,6 +50,7 @@ tables:
         description_short: Ionising radiation impacts per unit of electricity produced, expressed in U-235 equivalents.
         display:
           name: Ionising radiation
+          shortUnit: kg U-235eq
           numDecimalPlaces: 1
       water_use:
         title: Dissipated water use per unit of electricity
@@ -56,6 +59,7 @@ tables:
         description_short: Dissipated water that is not immediately returned to the local environment (e.g. evaporated, or used as an ingredient in a chemical product), measured per megawatt-hour of electricity production.
         display:
           name: Water use
+          shortUnit: m³
           numDecimalPlaces: 0
       metal_mineral_use:
         title: Metal and mineral requirements per unit of electricity
@@ -66,6 +70,7 @@ tables:
           - *metals_note
         display:
           name: Total material use
+          shortUnit: g
           numDecimalPlaces: 2
       noncarcinogenic_toxicity:
         title: Non-carcinogenic toxicity per unit of electricity
@@ -74,6 +79,7 @@ tables:
         description_short: Non-carcinogenic toxicity impacts on human health per terawatt-hour of electricity, expressed in comparative toxic units.
         display:
           name: Non-carcinogenic toxicity
+          shortUnit: CTUh
           numDecimalPlaces: 1
       carcinogenic_toxicity:
         title: Carcinogenic toxicity per unit of electricity
@@ -82,6 +88,7 @@ tables:
         description_short: Carcinogenic toxicity impacts on human health per terawatt-hour of electricity, expressed in comparative toxic units.
         display:
           name: Carcinogenic toxicity
+          shortUnit: CTUh
           numDecimalPlaces: 1
       land_use_energy:
         title: Land use per unit of electricity
@@ -90,6 +97,7 @@ tables:
         description_short: Total land used per unit of electricity production, including direct land use (e.g. the area of a power plant or solar farm) and indirect land use from mining of fuels and materials.
         display:
           name: Land use
+          shortUnit: m²
           numDecimalPlaces: 1
       aluminium_use:
         title: Aluminium requirements per unit of electricity
@@ -100,6 +108,7 @@ tables:
           - *metals_note
         display:
           name: Aluminium
+          shortUnit: g
           numDecimalPlaces: 2
       chromium_use:
         title: Chromium requirements per unit of electricity
@@ -110,6 +119,7 @@ tables:
           - *metals_note
         display:
           name: Chromium
+          shortUnit: g
           numDecimalPlaces: 2
       cobalt_use:
         title: Cobalt requirements per unit of electricity
@@ -120,6 +130,7 @@ tables:
           - *metals_note
         display:
           name: Cobalt
+          shortUnit: g
           numDecimalPlaces: 3
       copper_use:
         title: Copper requirements per unit of electricity
@@ -130,6 +141,7 @@ tables:
           - *metals_note
         display:
           name: Copper
+          shortUnit: g
           numDecimalPlaces: 2
       manganese_use:
         title: Manganese requirements per unit of electricity
@@ -140,6 +152,7 @@ tables:
           - *metals_note
         display:
           name: Manganese
+          shortUnit: g
           numDecimalPlaces: 2
       molybdenum_use:
         title: Molybdenum requirements per unit of electricity
@@ -150,6 +163,7 @@ tables:
           - *metals_note
         display:
           name: Molybdenum
+          shortUnit: g
           numDecimalPlaces: 2
       nickel_use:
         title: Nickel requirements per unit of electricity
@@ -160,6 +174,7 @@ tables:
           - *metals_note
         display:
           name: Nickel
+          shortUnit: g
           numDecimalPlaces: 2
       silicon_use:
         title: Silicon requirements per unit of electricity
@@ -170,6 +185,7 @@ tables:
           - *metals_note
         display:
           name: Silicon
+          shortUnit: g
           numDecimalPlaces: 2
       zinc_use:
         title: Zinc requirements per unit of electricity
@@ -180,6 +196,7 @@ tables:
           - *metals_note
         display:
           name: Zinc
+          shortUnit: g
           numDecimalPlaces: 2
       uranium_use:
         title: Uranium requirements per unit of electricity
@@ -190,4 +207,5 @@ tables:
           - *metals_note
         display:
           name: Uranium
+          shortUnit: g
           numDecimalPlaces: 3

--- a/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.meta.yml
+++ b/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.meta.yml
@@ -4,18 +4,6 @@ definitions:
     presentation:
       topic_tags:
         - Energy
-        - Energy Mix
-    description_key:
-      - This dataset is based on a meta-analysis of life-cycle impacts of electricity production carried out by UNECE. It covers not only the direct impacts of an electricity source (for example, the land used for individual power plants) but also any supply-chain inputs (for example, land used upstream in supply chains, such as mining for fuels or raw materials).
-      - The meta-analysis considered measurements across all twelve UNECE regions; here we present the global average across these values.
-      - For some impacts — land use, for example — there can be significant differences between the maximum and minimum values for a given source depending on context, such as the climate of a given location, or choices around spacing and density of electricity sources.
-    description_processing: |-
-      The values were extracted manually from tables in the UNECE Life Cycle Assessment of Electricity Generation Options report (March 2022 final version). UNECE does not publish a CSV or Excel companion file.
-
-      A separate corrigendum to the report on land-use figures was published in July 2022 and is available at https://unece.org/sites/default/files/2022-07/Corrigendum%20to%20UNECE%20LCA%20report%20-%20land%20use.pdf
-
-  metals_note: &metals_note |-
-    Material requirements are based on the actual amount of material extracted from the ground, which includes all the losses throughout the extraction, refining and fabrication processes. These figures are towards the high end of estimates that measure based on the final amount of materials required per unit of electricity.
 
 dataset:
   update_period_days: 0
@@ -38,7 +26,7 @@ tables:
         title: Freshwater eutrophication per unit of electricity
         unit: grams of phosphorus-equivalents per megawatt-hour
         short_unit: gP-eq/MWh
-        description_short: Freshwater eutrophication is caused by emissions of phosphorus compounds to rivers or lakes, measured in grams of phosphorus emitted per unit of electricity production.
+        description_short: "Freshwater eutrophication is caused by the emissions of phosphorus compounds to freshwater: either rivers or lakes. This is measured in grams of phosphorous emitted per unit of electricity production."
         display:
           name: Freshwater eutrophication
           shortUnit: gP-eq
@@ -56,7 +44,7 @@ tables:
         title: Dissipated water use per unit of electricity
         unit: cubic metres per megawatt-hour
         short_unit: m³/MWh
-        description_short: Dissipated water that is not immediately returned to the local environment (e.g. evaporated, or used as an ingredient in a chemical product), measured per megawatt-hour of electricity production.
+        description_short: Dissipated water includes all uses that immediately deprive the local environment of using water. This therefore gives some indication of local scarcity of a water resource. For example, water immediately returned to the environment (in river, ocean, or groundwater) is not counted, while water used as an ingredient for a chemical product, or evaporated, is counted.
         display:
           name: Water use
           shortUnit: m³
@@ -65,9 +53,7 @@ tables:
         title: Metal and mineral requirements per unit of electricity
         unit: grams of antimony-equivalents per megawatt-hour
         short_unit: g Sb-eq/MWh
-        description_short: Mineral and metal inputs distilled into a single figure, measured in grams of antimony (Sb) equivalents per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
+        description_short: Energy technologies require a range of mineral and metal inputs. Here they are distilled into a single figure of material requirements, which is measured in grams of Sb-equivalents per megawatt-hour of electricity produced.
         display:
           name: Total material use
           shortUnit: g
@@ -104,8 +90,6 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Aluminium required per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
         display:
           name: Aluminium
           shortUnit: g
@@ -115,8 +99,6 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Chromium required per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
         display:
           name: Chromium
           shortUnit: g
@@ -126,8 +108,6 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Cobalt required per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
         display:
           name: Cobalt
           shortUnit: g
@@ -137,8 +117,6 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Copper required per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
         display:
           name: Copper
           shortUnit: g
@@ -148,8 +126,6 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Manganese required per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
         display:
           name: Manganese
           shortUnit: g
@@ -159,8 +135,6 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Molybdenum required per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
         display:
           name: Molybdenum
           shortUnit: g
@@ -170,8 +144,6 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Nickel required per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
         display:
           name: Nickel
           shortUnit: g
@@ -181,8 +153,6 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Silicon required per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
         display:
           name: Silicon
           shortUnit: g
@@ -192,8 +162,6 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Zinc required per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
         display:
           name: Zinc
           shortUnit: g
@@ -203,8 +171,6 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Uranium required per megawatt-hour of electricity produced.
-        description_key:
-          - *metals_note
         display:
           name: Uranium
           shortUnit: g

--- a/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.meta.yml
+++ b/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.meta.yml
@@ -1,4 +1,15 @@
 definitions:
+  description_key_common: &description-key-common |-
+    The data shows the global average values for a given impact for each source. Note, however, this can vary significantly depending on the specific context.
+  description_key_land_use: &description-key-land-use
+    - *description-key-common
+    - The land use of different energy sources can vary significantly, depending on the context of the production site - its location; climate; and choices around the density and spacing of equipment. For example, the spacing of wind turbines and solar panels will affect how much land is needed per unit of electricity output.
+    - Wind energy is not included in these comparisons of average land use figures. This is because the land use of wind energy can be measured in several ways and is distinctly different from the land use of other energy technologies. Land between wind turbines can be used for other purposes (such as farming), which is not the case for other energy sources. The spacing of turbines and the context of the site means that its land use is highly variable. For this reason we don't provide an average land use figure for wind in this data. However, we do included figures for wind in [our article on this topic](https://ourworldindata.org/land-use-per-energy-source).
+  description_key_metal_mineral_use: &description-key-metal-mineral-use
+    - *description-key-common
+    - The metal and mineral requirements for each source are based on the requirements of the actual amount of material extracted from the ground, which includes all the losses throughout the extraction, refining and fabrication processes.
+    - These figures will be towards the high end of estimates which measure based on the final amount of materials required per unit of electricity.
+
   common:
     processing_level: minor
     presentation:
@@ -7,17 +18,19 @@ definitions:
 
 dataset:
   update_period_days: 0
-  title: Life-cycle impacts of energy sources (UNECE)
+  title: Life-cycle Assessment of Electricity Sources
 
 tables:
   life_cycle_assessment_of_electricity:
-    title: Life-cycle impacts of energy sources (UNECE)
+    title: Life-cycle impacts of electricity sources
     variables:
       ghg_emissions:
         title: Greenhouse gas emissions per unit of electricity
         unit: kilograms of CO₂-equivalents per megawatt-hour
         short_unit: kgCO₂e/MWh
         description_short: Lifecycle greenhouse gas emissions per unit of electricity, including emissions from the burning of fuels, mining of materials and production of energy technologies.
+        description_key:
+          - *description-key-common
         display:
           name: Greenhouse gas emissions
           shortUnit: kgCO₂e
@@ -27,6 +40,8 @@ tables:
         unit: grams of phosphorus-equivalents per megawatt-hour
         short_unit: gP-eq/MWh
         description_short: "Freshwater eutrophication is caused by the emissions of phosphorus compounds to freshwater: either rivers or lakes. This is measured in grams of phosphorous emitted per unit of electricity production."
+        description_key:
+          - *description-key-common
         display:
           name: Freshwater eutrophication
           shortUnit: gP-eq
@@ -36,6 +51,8 @@ tables:
         unit: kilograms of U-235-equivalents per megawatt-hour
         short_unit: kg U-235eq/MWh
         description_short: Ionising radiation impacts per unit of electricity produced, expressed in U-235 equivalents.
+        description_key:
+          - *description-key-common
         display:
           name: Ionising radiation
           shortUnit: kg U-235eq
@@ -45,6 +62,8 @@ tables:
         unit: cubic metres per megawatt-hour
         short_unit: m³/MWh
         description_short: Dissipated water includes all uses that immediately deprive the local environment of using water. This therefore gives some indication of local scarcity of a water resource. For example, water immediately returned to the environment (in river, ocean, or groundwater) is not counted, while water used as an ingredient for a chemical product, or evaporated, is counted.
+        description_key:
+          - *description-key-common
         display:
           name: Water use
           shortUnit: m³
@@ -54,6 +73,7 @@ tables:
         unit: grams of antimony-equivalents per megawatt-hour
         short_unit: g Sb-eq/MWh
         description_short: Energy technologies require a range of mineral and metal inputs. Here they are distilled into a single figure of material requirements, which is measured in grams of Sb-equivalents per megawatt-hour of electricity produced.
+        description_key: *description-key-metal-mineral-use
         display:
           name: Total material use
           shortUnit: g
@@ -63,6 +83,8 @@ tables:
         unit: comparative toxic units per terawatt-hour
         short_unit: CTUh/TWh
         description_short: Non-carcinogenic toxicity impacts on human health per terawatt-hour of electricity, expressed in comparative toxic units.
+        description_key:
+          - *description-key-common
         display:
           name: Non-carcinogenic toxicity
           shortUnit: CTUh
@@ -72,6 +94,8 @@ tables:
         unit: comparative toxic units per terawatt-hour
         short_unit: CTUh/TWh
         description_short: Carcinogenic toxicity impacts on human health per terawatt-hour of electricity, expressed in comparative toxic units.
+        description_key:
+          - *description-key-common
         display:
           name: Carcinogenic toxicity
           shortUnit: CTUh
@@ -81,6 +105,7 @@ tables:
         unit: square metres per megawatt-hour
         short_unit: m²/MWh
         description_short: Total land used per unit of electricity production, including direct land use (e.g. the area of a power plant or solar farm) and indirect land use from mining of fuels and materials.
+        description_key: *description-key-land-use
         display:
           name: Land use
           shortUnit: m²
@@ -90,6 +115,8 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Aluminium required per megawatt-hour of electricity produced.
+        description_key:
+          - *description-key-common
         display:
           name: Aluminium
           shortUnit: g
@@ -99,6 +126,8 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Chromium required per megawatt-hour of electricity produced.
+        description_key:
+          - *description-key-common
         display:
           name: Chromium
           shortUnit: g
@@ -108,6 +137,8 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Cobalt required per megawatt-hour of electricity produced.
+        description_key:
+          - *description-key-common
         display:
           name: Cobalt
           shortUnit: g
@@ -117,6 +148,8 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Copper required per megawatt-hour of electricity produced.
+        description_key:
+          - *description-key-common
         display:
           name: Copper
           shortUnit: g
@@ -126,6 +159,8 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Manganese required per megawatt-hour of electricity produced.
+        description_key:
+          - *description-key-common
         display:
           name: Manganese
           shortUnit: g
@@ -135,6 +170,8 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Molybdenum required per megawatt-hour of electricity produced.
+        description_key:
+          - *description-key-common
         display:
           name: Molybdenum
           shortUnit: g
@@ -144,6 +181,8 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Nickel required per megawatt-hour of electricity produced.
+        description_key:
+          - *description-key-common
         display:
           name: Nickel
           shortUnit: g
@@ -153,6 +192,8 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Silicon required per megawatt-hour of electricity produced.
+        description_key:
+          - *description-key-common
         display:
           name: Silicon
           shortUnit: g
@@ -162,6 +203,8 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Zinc required per megawatt-hour of electricity produced.
+        description_key:
+          - *description-key-common
         display:
           name: Zinc
           shortUnit: g
@@ -171,6 +214,8 @@ tables:
         unit: grams per megawatt-hour
         short_unit: g/MWh
         description_short: Uranium required per megawatt-hour of electricity produced.
+        description_key:
+          - *description-key-common
         display:
           name: Uranium
           shortUnit: g

--- a/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.py
+++ b/etl/steps/data/garden/unece/2026-05-04/life_cycle_assessment_of_electricity.py
@@ -1,0 +1,19 @@
+"""Garden step for UNECE's Life Cycle Assessment of Electricity Generation Options."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_meadow = paths.load_dataset("life_cycle_assessment_of_electricity")
+    tb = ds_meadow.read("life_cycle_assessment_of_electricity", reset_index=False)
+
+    #
+    # Save outputs.
+    #
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden.save()

--- a/etl/steps/data/grapher/unece/2026-05-04/life_cycle_assessment_of_electricity.py
+++ b/etl/steps/data/grapher/unece/2026-05-04/life_cycle_assessment_of_electricity.py
@@ -1,0 +1,28 @@
+"""Load garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_garden = paths.load_dataset("life_cycle_assessment_of_electricity")
+    tb = ds_garden.read("life_cycle_assessment_of_electricity")
+
+    #
+    # Process data.
+    #
+    # Adapt to grapher format.
+    tb = tb.rename(columns={"source": "country"}, errors="raise")
+
+    # Improve table format.
+    tb = tb.format()
+
+    #
+    # Save outputs.
+    #
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/unece/2026-05-04/life_cycle_assessment_of_electricity.py
+++ b/etl/steps/data/meadow/unece/2026-05-04/life_cycle_assessment_of_electricity.py
@@ -1,8 +1,4 @@
-"""Meadow step for UNECE's Life Cycle Assessment of Electricity Generation Options.
-
-The values are hardcoded here because UNECE only publishes the report as a PDF (no CSV/Excel companion
-file). Numbers were extracted manually from the report tables.
-"""
+"""Meadow step for UNECE's Life Cycle Assessment of Electricity Generation Options."""
 
 from io import StringIO
 
@@ -51,13 +47,11 @@ def run() -> None:
     # Load the PDF snapshot purely to attach origin metadata to the dataset.
     snap = paths.load_snapshot("life_cycle_assessment_of_electricity.pdf")
 
-    # Read the hardcoded data.
-    df = pd.read_csv(StringIO(DATA_CSV))
-
     #
     # Process data.
     #
-    tb = snap.read_from_df(df)
+    # Create a table with the provided data.
+    tb = snap.read_from_df(pd.read_csv(StringIO(DATA_CSV)))
 
     # Improve table format
     tb = tb.format(["source", "year"])

--- a/etl/steps/data/meadow/unece/2026-05-04/life_cycle_assessment_of_electricity.py
+++ b/etl/steps/data/meadow/unece/2026-05-04/life_cycle_assessment_of_electricity.py
@@ -1,0 +1,69 @@
+"""Meadow step for UNECE's Life Cycle Assessment of Electricity Generation Options.
+
+The values are hardcoded here because UNECE only publishes the report as a PDF (no CSV/Excel companion
+file). Numbers were extracted manually from the report tables.
+"""
+
+from io import StringIO
+
+import pandas as pd
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+# Hardcoded UNECE LCA dataset, as extracted from the report.
+# Columns:
+#   country: energy source (entity name in grapher)
+#   year: reference year (2021)
+#   ghg_emissions: kgCO₂e per MWh of electricity
+#   freshwater_eutrophication: gP per MWh
+#   ionising_radiation: kg U-235eq per MWh
+#   water_use: m³ per MWh (dissipated water)
+#   metal_mineral_use: g Sb-eq per MWh (aggregate metal & mineral resource use)
+#   noncarcinogenic_toxicity: CTUh per TWh
+#   carcinogenic_toxicity: CTUh per TWh
+#   land_use_energy: m² per MWh (total land use, agricultural + urban)
+#   <metal>_use: g per MWh of the named metal/mineral
+DATA_CSV = """\
+source,year,ghg_emissions,freshwater_eutrophication,ionising_radiation,water_use,metal_mineral_use,noncarcinogenic_toxicity,carcinogenic_toxicity,land_use_energy,aluminium_use,chromium_use,cobalt_use,copper_use,manganese_use,molybdenum_use,nickel_use,silicon_use,zinc_use,uranium_use
+Coal,2021,970,569,4.6,120,0.41,67.18200559,5.641832881,14.87955245,87.15591977,6.9789653,0.108972169,23.61598205,32.12075048,0.535186099,22.26953786,5.152621678,5.385991811,0.165987938
+Coal with carbon capture (CCS),2021,294,803,7.2,214,0.62,100.7651659,8.036335549,21.05666248,125.9268275,12.10116405,0.169206799,38.3858166,47.38975134,0.867455938,33.79679497,8.019610477,8.694418215,0.260518467
+Concentrating solar (tower),2021,36,16,3.7,14,0.49,3.997340298,3.10217554,19.90502557,45.66615268,2.777962065,0.069425816,16.7145236,68.95614946,0.57282762,61.67175391,3.726307049,4.786800158,0.115539759
+Concentrating solar (trough),2021,56,17,6.2,20,0.82,5.996898425,8.010367261,18.30369699,138.913462,302.2217422,0.051752542,21.62710897,41.65127845,0.556990746,18.86751841,2.665371628,8.556139209,0.149231218
+Gas,2021,439,12,3.8,45,0.19,10.4910731,1.707698479,1.03878475,6.974502869,1.652091977,0.025787183,11.06214674,14.95569878,0.261004767,7.128887546,1.321724106,1.92993926,0.182800561
+Gas with carbon capture (CCS),2021,134,14,4.8,79,0.25,16.51834613,2.113574688,1.267328923,9.425186823,2.616413717,0.035481497,14.50252955,18.72971238,0.340246417,9.29921951,1.80250271,2.611412066,0.222535856
+Hydropower,2021,117,10,9.2,13,0.48,17.20163385,2.027132817,33.38814344,10.59268132,0.56621962,0.005483707,2.31314122,3.891382618,0.053515197,2.298588073,0.290326272,2.833241942,0.005680107
+Nuclear,2021,5.6,6,14,132,0.34,5.547858042,0.556147578,0.329269362,6.73E-07,7.206685648,0.043816807,20.87381416,2.911532358,0.444579714,4.483992015,2.27127915,7.110832409,29.21409051
+Offshore wind,2021,17,8,1.3,8,1.14,3.709391977,6.442777929,,31.28834573,60.95610468,0.094323146,42.78459439,60.46022869,1.365798716,68.08782867,5.097326617,21.51810694,0.029771219
+Onshore wind,2021,11,6,0.8,7,0.59,2.589179141,5.691849621,,48.39935472,67.24389382,0.084338787,31.66020034,53.80523501,1.001955917,66.31579678,4.561034295,3.349423385,0.0308136
+"Solar PV, cadmium (on-ground)",2021,16,11,1.6,8,1.94,4.694007368,4.359403935,12.64669492,67.23034635,4.196432698,0.112711877,85.12835161,100.3577308,2.237840085,18.7337031,6.074499695,11.71154046,0.050230822
+"Solar PV, cadmium (roof)",2021,19,18,1.7,10,3.34,9.488325657,1.443611966,1.166272627,377.4837066,6.336762573,0.196525697,145.0897063,6.486472195,3.326621535,9.825423585,10.57127489,17.20000104,0.050152021
+"Solar PV, silicon (on-ground)",2021,52,35,7.4,35,5.63,10.20600227,5.240132697,19.22501836,297.275764,9.008961502,0.136193084,101.8131346,114.6878414,2.532059974,21.26661383,7.330207014,47.3345221,0.248623461
+"Solar PV, silicon (roof)",2021,53,49,8,38,9.12,17.77012917,2.085931785,3.090883422,277.1881546,14.00192024,0.31439426,232.6698952,8.440249784,5.271683101,16.28085942,16.89183752,63.45794246,0.263858708
+"""
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    # Load the PDF snapshot purely to attach origin metadata to the dataset.
+    snap = paths.load_snapshot("life_cycle_assessment_of_electricity.pdf")
+
+    # Read the hardcoded data.
+    df = pd.read_csv(StringIO(DATA_CSV))
+
+    #
+    # Process data.
+    #
+    tb = snap.read_from_df(df)
+
+    # Improve table format
+    tb = tb.format(["source", "year"])
+
+    #
+    # Save outputs.
+    #
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
+    ds_meadow.save()

--- a/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.config.yml
+++ b/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.config.yml
@@ -8,6 +8,7 @@ definitions:
         yScaleToggle: false
         baseColorScheme: owid-distinct
         hideTimeline: true
+        originUrl: https://ourworldindata.org/energy
 
 config:
   explorerTitle: Impacts of Energy Production

--- a/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.config.yml
+++ b/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.config.yml
@@ -7,7 +7,7 @@ definitions:
         hasMapTab: false
         yScaleToggle: false
         baseColorScheme: owid-distinct
-        hideAnnotationFieldsInTitle: true
+        hideTimeline: true
 
 config:
   explorerTitle: Impacts of Energy Production
@@ -16,6 +16,7 @@ config:
   entityType: source
   hasMapTab: false
   hideAlertBanner: true
+  hideAnnotationFieldsInTitle: true
   selection:
     - Coal
     - Gas

--- a/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.config.yml
+++ b/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.config.yml
@@ -93,7 +93,7 @@ views:
     config:
       title: Land use per unit of electricity
       subtitle: |-
-        Land use is measured as the total amount of land needed per unit of electricity production. This includes direct land use – the land used by a power plant, or solar farm – plus indirect land use from the mining of fuels and materials. This is measured in per megawatt-hour of electricity production.
+        Land use is measured as the total amount of land needed per unit of electricity production. This includes direct land use - the land used by a power plant, or solar farm - plus indirect land use from the mining of fuels and materials. This is measured per megawatt-hour of electricity production.
       note: |-
         This is shown as the average land use of different energy technologies. There can be significant variability depending on location, materials, and infrastructure decisions. See our related article for the full range of land use comparisons.
       relatedQuestionUrl: https://ourworldindata.org/land-use-per-energy-source

--- a/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.config.yml
+++ b/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.config.yml
@@ -1,0 +1,231 @@
+definitions:
+  metals_note: &metals_note |-
+    Requirements are based on the actual amount of material extracted from the ground, which includes all the losses throughout the extraction, refining and fabrication processes. These figures will be towards the high end of estimates which measure based on the final amount of materials required per unit of electricity.
+  common_views:
+    - config:
+        type: DiscreteBar
+        hasMapTab: false
+        yScaleToggle: false
+        baseColorScheme: owid-distinct
+        hideAnnotationFieldsInTitle: true
+
+config:
+  explorerTitle: Impacts of Energy Production
+  explorerSubtitle: Explore the environmental and health impacts of electricity sources.
+  isPublished: true
+  entityType: source
+  hasMapTab: false
+  hideAlertBanner: true
+  wpBlockId: "47482"
+  selection:
+    - Coal
+    - Gas
+    - Nuclear
+    - Onshore wind
+    - Offshore wind
+    - Hydropower
+    - Solar PV, silicon (on-ground)
+    - Solar PV, cadmium (on-ground)
+
+dimensions:
+  - slug: impact_metric
+    name: Impact metric
+    choices:
+      - slug: ghg_emissions
+        name: Greenhouse gas emissions
+      - slug: land_use
+        name: Land use
+      - slug: water_use
+        name: Water use
+      - slug: metal_mineral_use
+        name: Metal and mineral use
+      - slug: freshwater_eutrophication
+        name: Freshwater eutrophication
+    presentation:
+      type: dropdown
+  - slug: sub_metric
+    name: Sub-metric
+    choices:
+      - slug: total
+        name: Total material use
+      - slug: aluminium
+        name: Aluminium
+      - slug: chromium
+        name: Chromium
+      - slug: cobalt
+        name: Cobalt
+      - slug: copper
+        name: Copper
+      - slug: manganese
+        name: Manganese
+      - slug: molybdenum
+        name: Molybdenum
+      - slug: nickel
+        name: Nickel
+      - slug: silicon
+        name: Silicon
+      - slug: zinc
+        name: Zinc
+      - slug: uranium
+        name: Uranium
+      - slug: na
+        name: ""
+    presentation:
+      type: dropdown
+
+views:
+  - dimensions:
+      impact_metric: ghg_emissions
+      sub_metric: na
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#ghg_emissions
+    config:
+      title: Greenhouse gas emissions per unit of electricity
+      subtitle: |-
+        Lifecycle greenhouse gas emissions measure amount of total greenhouse gases emitted over a technology's full supply chain. This includes emissions from the burning of fuels, in addition to those generated through the mining of materials, and production of energy technologies. This is measured per megawatt-hour of electricity.
+  - dimensions:
+      impact_metric: land_use
+      sub_metric: na
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#land_use_energy
+    config:
+      title: Land use per unit of electricity
+      subtitle: |-
+        Land use is measured as the total amount of land needed per unit of electricity production. This includes direct land use – the land used by a power plant, or solar farm – plus indirect land use from the mining of fuels and materials. This is measured in per megawatt-hour of electricity production.
+      note: |-
+        This is shown as the average land use of different energy technologies. There can be significant variability depending on location, materials, and infrastructure decisions. See our related article for the full range of land use comparisons.
+      relatedQuestionUrl: https://ourworldindata.org/land-use-per-energy-source
+      relatedQuestionText: How does the land use of different energy sources compare?
+  - dimensions:
+      impact_metric: water_use
+      sub_metric: na
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#water_use
+    config:
+      title: Dissipated water use per unit of electricity
+      subtitle: |-
+        Dissipated water is water that is not immediately returned to the local environment. For example, water immediately returned to a river, ocean, or groundwater is not counted, while water used as an ingredient for a chemical product, or evaporated, is. This is measured per megawatt-hour of electricity production.
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: total
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#metal_mineral_use
+    config:
+      title: Metal and mineral requirements per unit of electricity
+      subtitle: |-
+        Energy technologies require a range of mineral and metal inputs. Here they are distilled into a single figure of material requirements, which is measured in grams of Sb-equivalents per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: aluminium
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#aluminium_use
+    config:
+      title: Aluminium requirements per unit of electricity
+      subtitle: Material requirements are measured in grams per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: chromium
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#chromium_use
+    config:
+      title: Chromium requirements per unit of electricity
+      subtitle: Material requirements are measured in grams per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: cobalt
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#cobalt_use
+    config:
+      title: Cobalt requirements per unit of electricity
+      subtitle: Material requirements are measured in grams per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: copper
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#copper_use
+    config:
+      title: Copper requirements per unit of electricity
+      subtitle: Material requirements are measured in grams per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: manganese
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#manganese_use
+    config:
+      title: Manganese requirements per unit of electricity
+      subtitle: Material requirements are measured in grams per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: molybdenum
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#molybdenum_use
+    config:
+      title: Molybdenum requirements per unit of electricity
+      subtitle: Material requirements are measured in grams per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: nickel
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#nickel_use
+    config:
+      title: Nickel requirements per unit of electricity
+      subtitle: Material requirements are measured in grams per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: silicon
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#silicon_use
+    config:
+      title: Silicon requirements per unit of electricity
+      subtitle: Material requirements are measured in grams per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: zinc
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#zinc_use
+    config:
+      title: Zinc requirements per unit of electricity
+      subtitle: Material requirements are measured in grams per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: metal_mineral_use
+      sub_metric: uranium
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#uranium_use
+    config:
+      title: Uranium requirements per unit of electricity
+      subtitle: Material requirements are measured in grams per megawatt-hour of electricity produced.
+      note: *metals_note
+  - dimensions:
+      impact_metric: freshwater_eutrophication
+      sub_metric: na
+    indicators:
+      y:
+        - catalogPath: life_cycle_assessment_of_electricity#freshwater_eutrophication
+    config:
+      title: Freshwater eutrophication per unit of electricity
+      subtitle: |-
+        Freshwater eutrophication is caused by the emissions of phosphorus compounds to freshwater: either rivers or lakes. This is measured in grams of phosphorous emitted per unit of electricity production.

--- a/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.config.yml
+++ b/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.config.yml
@@ -16,7 +16,6 @@ config:
   entityType: source
   hasMapTab: false
   hideAlertBanner: true
-  wpBlockId: "47482"
   selection:
     - Coal
     - Gas

--- a/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.py
+++ b/etl/steps/export/explorers/energy/latest/impacts_of_energy_sources.py
@@ -1,0 +1,23 @@
+"""Load grapher dataset and create the Impacts of Energy Production explorer tsv file."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    config = paths.load_collection_config()
+
+    #
+    # Save outputs.
+    #
+    c = paths.create_collection(
+        config=config,
+        short_name="impacts-of-energy-sources",
+        explorer=True,
+    )
+
+    c.save(tolerate_extra_indicators=True)

--- a/snapshots/unece/2026-05-04/life_cycle_assessment_of_electricity.pdf.dvc
+++ b/snapshots/unece/2026-05-04/life_cycle_assessment_of_electricity.pdf.dvc
@@ -1,0 +1,33 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Integrated Life-cycle Assessment of Electricity Sources
+    description: |-
+      Comparative life-cycle assessment of current and future commercial-scale electricity generation technologies (coal, natural gas, hydropower, nuclear, concentrated solar power, photovoltaics, and wind), considering the full life-cycle (extraction of raw materials, manufacturing, construction, operation, and end-of-life management).
+
+      The content of the report was updated with a [corrigendum](https://unece.org/sites/default/files/2022-07/Corrigendum%20to%20UNECE%20LCA%20report%20-%20land%20use.pdf).
+    date_published: "2021-10-29"
+
+    # Citation
+    producer: UNECE
+    citation_full: |-
+      UNECE - Integrated Life-cycle Assessment of Electricity Sources (2022). United Nations Economic Commission for Europe.
+
+    # Files
+    url_main: https://unece.org/sed/documents/2021/10/reports/life-cycle-assessment-electricity-generation-options
+    # The PDF has to be downloaded manually from:
+    # https://unece.org/sites/default/files/2022-04/LCA_3_FINAL%20March%202022.pdf
+    # And then:
+    # etls life_cycle_assessment --path-to-file <path_to_downloaded_file>
+    date_accessed: "2026-05-04"
+
+    # License
+    license:
+      name: © UNECE 2022
+      url: https://unece.org/terms-and-conditions-use-united-nations-websites
+outs:
+  - md5: fc29b2975f251cf7189c3f956371f6eb
+    size: 12167719
+    path: life_cycle_assessment_of_electricity.pdf

--- a/snapshots/unece/2026-05-04/life_cycle_assessment_of_electricity.pdf.dvc
+++ b/snapshots/unece/2026-05-04/life_cycle_assessment_of_electricity.pdf.dvc
@@ -5,7 +5,7 @@ meta:
     # Data product / Snapshot
     title: Integrated Life-cycle Assessment of Electricity Sources
     description: |-
-      Comparative life-cycle assessment of current and future commercial-scale electricity generation technologies (coal, natural gas, hydropower, nuclear, concentrated solar power, photovoltaics, and wind), considering the full life-cycle (extraction of raw materials, manufacturing, construction, operation, and end-of-life management).
+      This dataset is based on the large meta-analysis of the impacts of electricity production carried out by the UNECE's Lifecycle Assessment of Electricity Generation Options assessment. This is based on literature review of life-cycle assessments of electricity sources: these not only include the direct impacts of an electricity source (for example, the land used for individual power plants) but also include any supply chain inputs (for example, land use upstream in supply chains, such as mining for fuel or raw materials. This meta-analysis included measurements across all regions; here we present the global average across these values. Note that for some impacts - land use, for example - there can be significant differences in the maximum and minimum values for a given source depending on context, such as the climate of a given location; choices around spacing and density of electricity sources etc.
 
       The content of the report was updated with a [corrigendum](https://unece.org/sites/default/files/2022-07/Corrigendum%20to%20UNECE%20LCA%20report%20-%20land%20use.pdf).
     date_published: "2021-10-29"


### PR DESCRIPTION
Convert the [old](https://ourworldindata.org/explorers/impacts-of-energy-sources) (csv-based) explorer on the impacts of energy production into a [new](http://staging-site-data-energyimpacts-indicator/admin/explorers/preview/impacts-of-energy-sources) (indicator based) explorer.

I've also removed the wordpress block underneath, and included its content as part of the metadata of the relevant indicators.

