### PR TITLE
📊 Migrate excess_mortality snapshots to meta.origin

### DIFF
--- a/.claude/skills/migrate-source-to-origin/SKILL.md
+++ b/.claude/skills/migrate-source-to-origin/SKILL.md
@@ -377,6 +377,8 @@ match `YYYY-MM-DD`, `YYYY`, or `latest`).
 
 ## Out of scope
 
-- Batch driving via `dag/migrated.yml` — invoke this skill once per file and
-  loop in your conversation.
+- Batch driving via `dag/migrated.yml`. For multi-file requests, dispatch one
+  subagent per file in parallel (Agent tool calls in a single message). Don't
+  process serially yourself — that's slow and burns context. Each subagent
+  invokes this skill independently.
 - Indicator-level metadata (garden / grapher steps) — only snapshot DVC `meta.origin`.

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/__init__.py
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/__init__.py
@@ -81,15 +81,6 @@ def run() -> None:
         formats=["csv", "feather"],
     )
 
-    # Add all sources from dependencies to dataset
-    ds_garden.metadata.sources = ds_hmd.metadata.sources + ds_wmd.metadata.sources + ds_kobak.metadata.sources
-
-    # Source in YAML file only have name, load them from dataset.
-    tb_garden = ds_garden[paths.short_name]  # need to reload it to get updated metadata
-    source_by_name = {source.name: source for source in ds_garden.metadata.sources}
-    for col in tb_garden.columns:
-        tb_garden[col].metadata.sources = [source_by_name[source.name] for source in tb_garden[col].metadata.sources]
-
     # Save changes in the new garden dataset.
     ds_garden.save()
 

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/__init__.py
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/__init__.py
@@ -19,7 +19,6 @@ This code builds the consolidated Excess Mortality dataset by Our World in Data.
 """
 
 from input import build_df
-from owid.catalog import Table
 from process import process_df
 from structlog import get_logger
 
@@ -46,8 +45,8 @@ def run() -> None:
     ds_wmd = paths.load_dataset("wmd")
     ds_kobak = paths.load_dataset("xm_karlinsky_kobak")
 
-    # Build initial dataframe
-    df = build_df(ds_hmd, ds_wmd, ds_kobak)
+    # Build initial table.
+    tb = build_df(ds_hmd, ds_wmd, ds_kobak)
 
     #
     # Process data.
@@ -57,13 +56,12 @@ def run() -> None:
     # See full extent of reasons for it in https://owid.slack.com/archives/CV5RY8F1B/p1706099289965929
     # TL;DR: HMD is creating their standard age groups for these countries from an input data that has
     # different age group binning (bigger bins). This results into unaccurate restimates.
-    df = df[~((df["entity"].isin(["Australia", "Canada"])) & (df["age"] != "all_ages"))]
+    tb = tb[~((tb["entity"].isin(["Australia", "Canada"])) & (tb["age"] != "all_ages"))]
 
     # Actual processing
     log.info("excess_mortality: processing data")
-    df = process_df(df)
-    # Create a new table with the processed data.
-    tb_garden = Table(df, short_name=paths.short_name)
+    tb_garden = process_df(tb)
+    tb_garden.metadata.short_name = paths.short_name
 
     # Last 12 months
     tb_garden = add_last12m_to_metric(tb_garden, "cum_excess_proj_all_ages", column_country="entity")

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml
@@ -576,10 +576,6 @@ tables:
           - *origin_hmd
           - *origin_wmd
           - *origin_kk
-        sources:
-          - name: Human Mortality Database
-          - name: World Mortality Dataset (2024)
-          - name: Karlinsky and Kobak (2021)
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative number of deaths from all causes compared to projection based on previous years, per million people"

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml
@@ -30,44 +30,7 @@ definitions:
           - 20
           - 50
           - 100
-  origins:
-    hmd: &origin_hmd
-      title: "Human Mortality Database"
-      producer: Human Mortality Database
-      date_published: "2025"
-      url_main: "https://www.mortality.org"
-      license:
-        name: Creative Commons BY 4.0
-        url: https://www.mortality.org/Data/UserAgreement
-      date_accessed: "2024-08-20"
-      citation_full: |-
-        HMD. Human Mortality Database. Max Planck Institute for Demographic Research (Germany), University of California, Berkeley (USA), and French Institute for Demographic Studies (France). Available at www.mortality.org.
-    wmd: &origin_wmd
-      title: "World Mortality Database"
-      producer: World Mortality Database
-      date_published: "2024"
-      url_main: "https://github.com/akarlinsky/world_mortality"
-      license:
-        name: MIT License
-        url: https://github.com/akarlinsky/world_mortality/blob/main/LICENSE
-      date_accessed: "2024-08-20"
-      citation_full: |-
-        Karlinsky & Kobak 2021, Tracking excess mortality across countries during the COVID-19 pandemic with the World Mortality Dataset, eLife https://doi.org/10.7554/eLife.69336
-    xm_kk: &origin_kk
-      title: "Excess mortality during the COVID-19 pandemic"
-      producer: Karlinsky & Kobak
-      date_published: "2024"
-      url_main: "https://github.com/dkobak/excess-mortality"
-      license:
-        name: GPL-3.0
-        url: https://github.com/dkobak/excess-mortality/blob/main/LICENSE
-      date_accessed: "2024-08-20"
-      citation_full: |-
-        Karlinsky & Kobak, 2021, Tracking excess mortality across countries during the COVID-19 pandemic with the World Mortality Dataset. eLife 10:e69336. https://elifesciences.org/articles/69336.
   common:
-    origins:
-      - *origin_hmd
-      - *origin_wmd
     description_key:
       - Excess deaths is estimated as _Excess deaths = Number of reported deaths - Number of expected deaths_. Excess mortality goes beyond confirmed COVID-19 fatalities by capturing all deaths above a projected baseline, including indirect deaths from pandemic-related disruptions.
       - All-cause mortality data is from the Human Mortality Database (HMD) Short-term Mortality Fluctuations project and the World Mortality Dataset (WMD). Both sources are updated weekly.
@@ -170,10 +133,6 @@ tables:
           includeInTable: true
           tolerance: 30
           numDecimalPlaces: 0
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
         presentation:
           grapher_config:
             title: "Excess mortality: Deaths from all causes compared to projection based on previous years"
@@ -190,10 +149,6 @@ tables:
           name: Ages 0–14
           includeInTable: true
           numDecimalPlaces: 0
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
       p_proj_15_64:
         title: p_proj_15_64
         # title: Excess mortality P-scores (projected baseline, 15–64)
@@ -204,10 +159,6 @@ tables:
           name: Ages 15–64
           includeInTable: true
           numDecimalPlaces: 0
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
       p_proj_65_74:
         title: p_proj_65_74
         # title: Excess mortality P-scores (projected baseline, 65–74)
@@ -218,10 +169,6 @@ tables:
           name: Ages 65–74
           includeInTable: true
           numDecimalPlaces: 0
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
       p_proj_75_84:
         title: p_proj_75_84
         # title: Excess mortality P-scores (projected baseline, 75–84)
@@ -232,10 +179,6 @@ tables:
           name: Ages 75–84
           includeInTable: true
           numDecimalPlaces: 0
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
       p_proj_85p:
         title: p_proj_85p
         # title: Excess mortality P-scores (projected baseline, 85+)
@@ -246,12 +189,6 @@ tables:
           name: Ages 85+
           includeInTable: true
           numDecimalPlaces: 0
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
-
-      # deaths_*_all_ages
       deaths_2010_all_ages:
         title: deaths_2010_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
@@ -382,10 +319,6 @@ tables:
         description_short: The number of excess deaths; calculated as reported deaths minus projected deaths.
         display:
           includeInTable: true
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
       excess_per_million_proj_all_ages:
         title: excess_per_million_proj_all_ages
         # title: Excess deaths per million people (projected, all ages)
@@ -393,10 +326,6 @@ tables:
         description_short: The number of excess deaths per million people in the population; calculated as reported deaths minus projected deaths.
         display:
           includeInTable: true
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
       average_deaths_2015_2019_all_ages:
         title: average_deaths_2015_2019_all_ages
         # title: Average number of deaths (2015–2019, all ages)
@@ -413,8 +342,6 @@ tables:
           name: Projected, 2020
           includeInTable: true
           numDecimalPlaces: 0
-        origins:
-          - *origin_kk
       cum_excess_proj_all_ages:
         title: cum_excess_proj_all_ages
         # title: Cumulative excess of deaths (projected, all ages)
@@ -424,10 +351,6 @@ tables:
           numDecimalPlaces: 0
           includeInTable: true
           tolerance: 30
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative number of deaths from all causes compared to projection based on previous years"
@@ -454,8 +377,6 @@ tables:
         description_short: The cumulative number of projected deaths; cumulated starting 1 January 2020
         display:
           includeInTable: true
-        origins:
-          - *origin_kk
       cum_p_proj_all_ages:
         title: cum_p_proj_all_ages
         # title: Cumulative p-score (projected, all ages)
@@ -467,10 +388,6 @@ tables:
           numDecimalPlaces: 0
           includeInTable: true
           tolerance: 30
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative deaths from all causes compared to projection based on previous years"
@@ -486,10 +403,6 @@ tables:
           numDecimalPlaces: 0
           includeInTable: true
           tolerance: 30
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative number of deaths from all causes compared to projection based on previous years, per million people"
@@ -515,22 +428,12 @@ tables:
         description_short: The week or month number in the year.
         display:
           includeInTable: true
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
       time_unit:
         title: Time unit
         unit: ""
         description_short: Denotes whether the “time” column values are weekly or monthly.
         display:
           includeInTable: true
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
-
-      # Last 12 months
       cum_excess_proj_all_ages_last12m:
         title: cum_excess_proj_all_ages_last12m
         # title: Cumulative excess of deaths (projected, all ages)
@@ -540,10 +443,6 @@ tables:
           numDecimalPlaces: 0
           includeInTable: true
           tolerance: 30
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative number of deaths from all causes compared to projection based on previous years"
@@ -572,10 +471,6 @@ tables:
           numDecimalPlaces: 0
           includeInTable: true
           tolerance: 30
-        origins:
-          - *origin_hmd
-          - *origin_wmd
-          - *origin_kk
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative number of deaths from all causes compared to projection based on previous years, per million people"

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/input.py
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/input.py
@@ -1,5 +1,5 @@
-import pandas as pd
-from owid.catalog import Dataset
+import owid.catalog.processing as pr
+from owid.catalog import Dataset, Table
 
 from etl.data_helpers.misc import check_known_columns, check_values_in_column
 
@@ -44,7 +44,7 @@ COLUMNS_IDX = [
 COLUMN_YEAR_RENAME = {col: col.replace("_", "") for col in COLUMNS_YEAR_EXPECTED}
 
 
-def build_df(ds_hmd: Dataset, ds_wmd: Dataset, ds_kobak: Dataset) -> pd.DataFrame:
+def build_df(ds_hmd: Dataset, ds_wmd: Dataset, ds_kobak: Dataset) -> Table:
     # Load estimates
     df_estimates = _build_estimates_df(ds_hmd, ds_wmd)
     # Load projections
@@ -58,39 +58,39 @@ def build_df(ds_hmd: Dataset, ds_wmd: Dataset, ds_kobak: Dataset) -> pd.DataFram
     return df
 
 
-def _build_estimates_df(ds_hmd: Dataset, ds_wmd: Dataset) -> pd.DataFrame:
+def _build_estimates_df(ds_hmd: Dataset, ds_wmd: Dataset) -> Table:
     """Some country data comes from HMD, other from WMD.
 
     We give priority to HMD data: If a country has data in both datasets, we keep the HMD data.
     """
     # Build dataframe
-    df_hmd = ds_hmd.read("hmd_stmf", reset_index=True)
-    df_hmd = df_hmd.rename(columns={"week": "time"}).assign(**{"time_unit": "weekly"})
-    df_wmd = ds_wmd.read("wmd", reset_index=True)
-    df_wmd = df_wmd[-df_wmd["entity"].isin(set(df_hmd["entity"]))]
-    df_estimates = pd.concat([df_hmd, df_wmd], ignore_index=True)
+    tb_hmd = ds_hmd.read("hmd_stmf", reset_index=True)
+    tb_hmd = tb_hmd.rename(columns={"week": "time"}).assign(**{"time_unit": "weekly"})
+    tb_wmd = ds_wmd.read("wmd", reset_index=True)
+    tb_wmd = tb_wmd[-tb_wmd["entity"].isin(set(tb_hmd["entity"]))]
+    df_estimates = pr.concat([tb_hmd, tb_wmd], ignore_index=True)
     # Run checks
     if (ds := df_estimates[COLUMNS_IDX].value_counts()).max() > 1:
         raise ValueError(f"Unexpected duplicates {ds[ds > 1]}")
-    return pd.DataFrame(df_estimates)
+    return df_estimates
 
 
-def _build_projections_df(ds_kobak: Dataset) -> pd.DataFrame:
+def _build_projections_df(ds_kobak: Dataset) -> Table:
     df_kobak = ds_kobak.read("xm_karlinsky_kobak", reset_index=True)
     df_kobak_age = ds_kobak.read("xm_karlinsky_kobak_by_age", reset_index=True)
-    df_proj = pd.concat([df_kobak, df_kobak_age], ignore_index=True)
+    df_proj = pr.concat([df_kobak, df_kobak_age], ignore_index=True)
     if (ds := df_proj[COLUMNS_IDX].value_counts()).max() > 1:
         raise ValueError(f"Unexpected duplicates {ds[ds > 1]}")
-    return pd.DataFrame(df_proj)
+    return df_proj
 
 
-def _merge_dfs(df_estimates: pd.DataFrame, df_proj: pd.DataFrame) -> pd.DataFrame:
+def _merge_dfs(df_estimates: Table, df_proj: Table) -> Table:
     # Merge estimates and projections
-    df = df_proj.merge(df_estimates, on=COLUMNS_IDX, how="outer")
+    df = pr.merge(df_proj, df_estimates, on=COLUMNS_IDX, how="outer")
     return df
 
 
-def _api_check(df: pd.DataFrame) -> None:
+def _api_check(df: Table) -> None:
     # Check columns are as expected
     check_known_columns(df, COLUMNS_EXPECTED)
     # Check values in `age`

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/process.py
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/process.py
@@ -3,8 +3,10 @@
 from datetime import datetime, timedelta
 
 import numpy as np
+import owid.catalog.processing as pr
 import pandas as pd
 from owid.catalog import Table
+from owid.catalog.core.indicators import combine_indicators_metadata
 from structlog import get_logger
 
 from etl.data_helpers import geo
@@ -19,7 +21,7 @@ paths = PathFinder(__file__)
 YEAR_MAX = 2025
 
 
-def process_df(df: pd.DataFrame) -> pd.DataFrame:
+def process_df(df: Table) -> Table:
     """Process data"""
     # Add baseline average
     log.info("\texcess_mortality: add `baseline_avg`")
@@ -45,14 +47,18 @@ def process_df(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def add_baseline_avg(df: pd.DataFrame) -> pd.DataFrame:
+def add_baseline_avg(df: Table) -> Table:
     """Add field `baseline_avg` to `df`
 
     It is estimated by averaging deaths from 2015 to 2019.
     """
     column_new_metric = "baseline_avg"
     # calculate baseline average and standard error -----
-    df[column_new_metric] = df[["2015", "2016", "2017", "2018", "2019"]].mean(axis=1)
+    baseline_columns = ["2015", "2016", "2017", "2018", "2019"]
+    df[column_new_metric] = df[baseline_columns].mean(axis=1)
+    df[column_new_metric].metadata = combine_indicators_metadata(
+        indicators=[df[col] for col in baseline_columns], name=column_new_metric
+    )
     # because there's only one Week 53 in the past 5 years, use the baseline average from Week 52 instead. ONS does this.
     cols_link = ["entity", "time_unit", "age"]
     # Get rows with time == 53
@@ -60,16 +66,16 @@ def add_baseline_avg(df: pd.DataFrame) -> pd.DataFrame:
     df_52 = df[df["time"] == 52].copy()[cols_link + [column_new_metric]]
     df_53 = df_53.merge(df_52, on=cols_link)
     df = df[df.time != 53]
-    df = pd.concat([df, df_53], ignore_index=True)
+    df = pr.concat([df, df_53], ignore_index=True)
     return df
 
 
-def add_xm_and_p_score(df: pd.DataFrame) -> pd.DataFrame:
+def add_xm_and_p_score(df: Table) -> Table:
     """Add fields `xm` and `p_score` to `df`"""
     COLUMNS_IDX = ["entity", "time", "time_unit"]
 
     # calculate both excess deaths and p-scores above both baselines: 5-yr avg and projected
-    def _add_metrics(df: pd.DataFrame, year: str):
+    def _add_metrics(df: Table, year: str):
         if year == "2020":
             suffix = ""
         elif year in [str(year) for year in range(2021, YEAR_MAX + 1)]:
@@ -94,7 +100,7 @@ def add_xm_and_p_score(df: pd.DataFrame) -> pd.DataFrame:
             )
         return df.assign(**new_indicators)
 
-    def _get_p_scores(df: pd.DataFrame) -> pd.DataFrame:
+    def _get_p_scores(df: Table) -> Table:
         # get p-scores and make wide
         cols = ["baseline_proj", "excess_avg", "p_avg", "excess_proj", "p_proj"]
         metrics = ["baseline_avg"]
@@ -106,14 +112,10 @@ def add_xm_and_p_score(df: pd.DataFrame) -> pd.DataFrame:
                     metrics.append(col_year)
         df_ = df[COLUMNS_IDX + ["age"] + metrics].copy()
         # Pivot
-        df_ = df_.pivot(index=COLUMNS_IDX, columns="age", values=metrics)
-        # Set column names
-        df_.columns = ["_".join(col) for col in df_.columns.values]
-        # Reset index
-        df_ = df_.reset_index()
+        df_ = pr.pivot(df_, index=COLUMNS_IDX, columns="age", values=metrics, join_column_levels_with="_")
         return df_
 
-    def _get_deaths(df: pd.DataFrame) -> pd.DataFrame:
+    def _get_deaths(df: Table) -> Table:
         # Get deaths
         columns_idx = COLUMNS_IDX
         columns_years = [str(year) for year in range(2010, YEAR_MAX + 1)]
@@ -127,7 +129,7 @@ def add_xm_and_p_score(df: pd.DataFrame) -> pd.DataFrame:
                 col = f"deaths_{col}_all_ages"
             return col
 
-        df_.columns = list(map(_rename_columnn, df_.columns))
+        df_ = df_.rename(columns={col: _rename_columnn(col) for col in df_.columns})
         return df_
 
     # Add metrics for each year
@@ -138,14 +140,14 @@ def add_xm_and_p_score(df: pd.DataFrame) -> pd.DataFrame:
     df_p = _get_p_scores(df)
     df_d = _get_deaths(df)
     # Merge
-    df = df_p.merge(df_d, on=COLUMNS_IDX)
+    df = pr.merge(df_p, df_d, on=COLUMNS_IDX)
     # Round metric values
     columns = [col for col in df.columns if col not in COLUMNS_IDX]
     df[columns] = df[columns].round(2)
     return df
 
 
-def make_df_long(df: pd.DataFrame) -> pd.DataFrame:
+def make_df_long(df: Table) -> Table:
     """Make `df` long"""
 
     def _build_yearly_data(df, year, remove_w53):
@@ -208,13 +210,13 @@ def make_df_long(df: pd.DataFrame) -> pd.DataFrame:
     # Rename column
     df["deaths_since_2020_all_ages"] = df["deaths_2020_all_ages"]
     # Merge
-    df = pd.concat([df] + dfs, ignore_index=True)
+    df = pr.concat([df] + dfs, ignore_index=True)
     # Format date
     df["date"] = pd.to_datetime(df["date"])
     return df
 
 
-def minor_tweaks(df: pd.DataFrame) -> pd.DataFrame:
+def minor_tweaks(df: Table) -> Table:
     """Minor df changes"""
     # create a new dataframe and get rid of columns I don't need
     columns = [
@@ -267,7 +269,7 @@ def minor_tweaks(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def add_cum_metrics(df: pd.DataFrame) -> pd.DataFrame:
+def add_cum_metrics(df: Table) -> Table:
     # calculate cumulative excess deaths and p-scores for each country
     df = (
         df.sort_values("date")
@@ -290,10 +292,10 @@ def add_cum_metrics(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def add_population(df: pd.DataFrame) -> pd.DataFrame:
+def add_population(df: Table) -> Table:
     # Load population data
     df["year"] = df["date"].dt.year
-    df = geo.add_population_to_table(Table(df), paths.load_dataset("population"), country_col="entity", year_col="year")
+    df = geo.add_population_to_table(df, paths.load_dataset("population"), country_col="entity", year_col="year")
     df = df.drop(columns=["year"])
     # Get per million metrics
     df["excess_per_million_proj_all_ages"] = df["excess_proj_all_ages"] / (df["population"] / 1e6)
@@ -303,7 +305,7 @@ def add_population(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def final_formatting(df: pd.DataFrame) -> pd.DataFrame:
+def final_formatting(df: Table) -> Table:
     # Keep columns just in case they were in use on github.com/owid/owid-datasets
     # df = df.drop(
     #     columns=[

--- a/etl/steps/data/garden/excess_mortality/latest/hmd_stmf.py
+++ b/etl/steps/data/garden/excess_mortality/latest/hmd_stmf.py
@@ -2,7 +2,7 @@
 
 from datetime import date
 
-import pandas as pd
+import owid.catalog.processing as pr
 from owid.catalog import Table
 from owid.catalog.utils import underscore
 from shared import harmonize_countries  # ty: ignore
@@ -36,10 +36,7 @@ def run() -> None:
 
     # Read table from meadow dataset.
     tb_meadow = ds_meadow["hmd_stmf"]
-    tb_meadow = tb_meadow.reset_index()
-
-    # Create a dataframe with data from the table.
-    df = pd.DataFrame(tb_meadow)
+    df = tb_meadow.reset_index()
 
     #
     # Process data.
@@ -47,8 +44,7 @@ def run() -> None:
     log.info("hmd_stmf: processing data")
     df = process(df)
 
-    # Create a new table with the processed data.
-    tb_garden = Table(df, short_name=tb_meadow.metadata.short_name)
+    tb_garden = df
 
     # Set index
     tb_garden = tb_garden.set_index(["entity", "week", "age"], verify_integrity=True)
@@ -67,7 +63,7 @@ def run() -> None:
     log.info("hmd_stmf: end")
 
 
-def process(df: pd.DataFrame) -> pd.DataFrame:
+def process(df: Table) -> Table:
     # Check dataframe fields and values
     log.info("\thmd_stmf: initial dataframe API check")
     df_api_check(df)
@@ -92,13 +88,13 @@ def process(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def df_api_check(df: pd.DataFrame) -> None:
+def df_api_check(df: Table) -> None:
     check_values_in_column(df, "year", list(range(YEAR_MIN_EXPECTED, YEAR_MAX_EXPECTED + 1)))
     check_values_in_column(df, "week", list(range(1, 54)))
     check_values_in_column(df, "sex", ["m", "f", "b"])
 
 
-def filter_entries(df: pd.DataFrame) -> pd.DataFrame:
+def filter_entries(df: Table) -> Table:
     """Filter some rows."""
     # Select only years YEAR_MIN - YEAR_MAX (2010-2019 (for baseline) and 2020-now)
     df = df[(df["year"] >= YEAR_MIN) & (df["year"] <= YEAR_MAX)]
@@ -107,7 +103,7 @@ def filter_entries(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def reshape_df(df: pd.DataFrame) -> pd.DataFrame:
+def reshape_df(df: Table) -> Table:
     """Pivot/unpivot to get data in the right format."""
     # Unpivot [Entity, Year, Week, Sex, [D*]] -> [Entity, Week, Sex, Age, [Years]]
     df = df.melt(
@@ -117,7 +113,8 @@ def reshape_df(df: pd.DataFrame) -> pd.DataFrame:
         value_name="deaths",
     )
     # Pivot wide
-    df = df.pivot(
+    df = pr.pivot(
+        df,
         index=["entity", "week", "age"],
         columns="year",
         values="deaths",
@@ -127,7 +124,7 @@ def reshape_df(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def add_uk(df: pd.DataFrame):
+def add_uk(df: Table):
     """Add UK to main dataframe.
 
     By default, the dataset only contains data for England and Wales, Scotland and Northern Ireland.
@@ -148,18 +145,18 @@ def add_uk(df: pd.DataFrame):
     # Assign Entity name
     df_uk["entity"] = "United Kingdom"
     # Add UK to main dataset
-    df = pd.concat([df, df_uk], ignore_index=True)
+    df = pr.concat([df, df_uk], ignore_index=True)
     return df
 
 
-def format_age(df: pd.DataFrame) -> pd.DataFrame:
+def format_age(df: Table) -> Table:
     """Remove 'd' from age strings."""
     df["age"] = df["age"].str.replace("d", "")
     df.loc[df["age"] == "total", "age"] = "all_ages"
     return df
 
 
-def format_columns(df: pd.DataFrame) -> pd.DataFrame:
+def format_columns(df: Table) -> Table:
     """Adapt dataframe column names to WMD-like format."""
     # Sort columns
     cols_first = ["entity", "week", "age"]

--- a/etl/steps/data/garden/excess_mortality/latest/hmd_stmf.py
+++ b/etl/steps/data/garden/excess_mortality/latest/hmd_stmf.py
@@ -35,16 +35,13 @@ def run() -> None:
     ds_meadow = paths.load_dataset("hmd_stmf")
 
     # Read table from meadow dataset.
-    tb_meadow = ds_meadow["hmd_stmf"]
-    df = tb_meadow.reset_index()
+    tb = ds_meadow["hmd_stmf"].reset_index()
 
     #
     # Process data.
     #
     log.info("hmd_stmf: processing data")
-    df = process(df)
-
-    tb_garden = df
+    tb_garden = process(tb)
 
     # Set index
     tb_garden = tb_garden.set_index(["entity", "week", "age"], verify_integrity=True)
@@ -63,104 +60,104 @@ def run() -> None:
     log.info("hmd_stmf: end")
 
 
-def process(df: Table) -> Table:
+def process(tb: Table) -> Table:
     # Check dataframe fields and values
     log.info("\thmd_stmf: initial dataframe API check")
-    df_api_check(df)
+    tb_api_check(tb)
     # Harmonize country names
     log.info("\thmd_stmf: harmonizing country names")
-    df = harmonize_countries(df, "countrycode", paths.country_mapping_path, paths.excluded_countries_path)
+    tb = harmonize_countries(tb, "countrycode", paths.country_mapping_path, paths.excluded_countries_path)
     # Filter some rows
     log.info("\thmd_stmf: filtering entries")
-    df = filter_entries(df)
+    tb = filter_entries(tb)
     # Reshape dataframe
     log.info("\thmd_stmf: reshaping dataframe")
-    df = reshape_df(df)
+    tb = reshape_tb(tb)
     # Add UK entries (sum nations)
     log.info("\thmd_stmf: adding UK entries")
-    df = add_uk(df)
+    tb = add_uk(tb)
     # Clean age display names
     log.info("\thmd_stmf: clean age display names")
-    df = format_age(df)
+    tb = format_age(tb)
     # Final touches on dataframe format
     log.info("\thmd_stmf: format columns in dataframe")
-    df = format_columns(df)
-    return df
+    tb = format_columns(tb)
+    return tb
 
 
-def df_api_check(df: Table) -> None:
-    check_values_in_column(df, "year", list(range(YEAR_MIN_EXPECTED, YEAR_MAX_EXPECTED + 1)))
-    check_values_in_column(df, "week", list(range(1, 54)))
-    check_values_in_column(df, "sex", ["m", "f", "b"])
+def tb_api_check(tb: Table) -> None:
+    check_values_in_column(tb, "year", list(range(YEAR_MIN_EXPECTED, YEAR_MAX_EXPECTED + 1)))
+    check_values_in_column(tb, "week", list(range(1, 54)))
+    check_values_in_column(tb, "sex", ["m", "f", "b"])
 
 
-def filter_entries(df: Table) -> Table:
+def filter_entries(tb: Table) -> Table:
     """Filter some rows."""
     # Select only years YEAR_MIN - YEAR_MAX (2010-2019 (for baseline) and 2020-now)
-    df = df[(df["year"] >= YEAR_MIN) & (df["year"] <= YEAR_MAX)]
+    tb = tb[(tb["year"] >= YEAR_MIN) & (tb["year"] <= YEAR_MAX)]
     # Keep only both sex data
-    df = df[df["sex"] == "b"].drop(columns=["sex"])
-    return df
+    tb = tb[tb["sex"] == "b"].drop(columns=["sex"])
+    return tb
 
 
-def reshape_df(df: Table) -> Table:
+def reshape_tb(tb: Table) -> Table:
     """Pivot/unpivot to get data in the right format."""
     # Unpivot [Entity, Year, Week, Sex, [D*]] -> [Entity, Week, Sex, Age, [Years]]
-    df = df.melt(
+    tb = tb.melt(
         id_vars=["entity", "year", "week"],
         value_vars=["d0_14", "d15_64", "d65_74", "d75_84", "d85p", "dtotal"],
         var_name="age",
         value_name="deaths",
     )
     # Pivot wide
-    df = pr.pivot(
-        df,
+    tb = pr.pivot(
+        tb,
         index=["entity", "week", "age"],
         columns="year",
         values="deaths",
     ).reset_index()
 
     # Rename columns
-    return df
+    return tb
 
 
-def add_uk(df: Table):
+def add_uk(tb: Table):
     """Add UK to main dataframe.
 
     By default, the dataset only contains data for England and Wales, Scotland and Northern Ireland.
     """
     # Get UK Nations
-    df_uk = df[df["entity"].isin(["England and Wales", "Scotland", "Northern Ireland"])].copy()
+    tb_uk = tb[tb["entity"].isin(["England and Wales", "Scotland", "Northern Ireland"])].copy()
     # Years to consider (starting from 2015)
-    column_years = list(filter(lambda x: x >= 2015, df_uk.filter(regex=r"20\d\d").columns))
+    column_years = list(filter(lambda x: x >= 2015, tb_uk.filter(regex=r"20\d\d").columns))
     # Sanity check
     # NOTE: this used to be
-    #     df_uk[[col for col in column_years if col != THIS_YEAR]].isna().sum() < 20
+    #     tb_uk[[col for col in column_years if col != THIS_YEAR]].isna().sum() < 20
     # but it started failing in 2024
-    assert (df_uk[[col for col in column_years if col <= 2023]].isna().sum() < 20).all(), (
+    assert (tb_uk[[col for col in column_years if col <= 2023]].isna().sum() < 20).all(), (
         "Too many missing values. Check values in year columns!"
     )
     # Group by and get sum
-    df_uk = df_uk.groupby(["week", "age"], as_index=False)[column_years].sum(min_count=3)
+    tb_uk = tb_uk.groupby(["week", "age"], as_index=False)[column_years].sum(min_count=3)
     # Assign Entity name
-    df_uk["entity"] = "United Kingdom"
+    tb_uk["entity"] = "United Kingdom"
     # Add UK to main dataset
-    df = pr.concat([df, df_uk], ignore_index=True)
-    return df
+    tb = pr.concat([tb, tb_uk], ignore_index=True)
+    return tb
 
 
-def format_age(df: Table) -> Table:
+def format_age(tb: Table) -> Table:
     """Remove 'd' from age strings."""
-    df["age"] = df["age"].str.replace("d", "")
-    df.loc[df["age"] == "total", "age"] = "all_ages"
-    return df
+    tb["age"] = tb["age"].str.replace("d", "")
+    tb.loc[tb["age"] == "total", "age"] = "all_ages"
+    return tb
 
 
-def format_columns(df: Table) -> Table:
+def format_columns(tb: Table) -> Table:
     """Adapt dataframe column names to WMD-like format."""
     # Sort columns
     cols_first = ["entity", "week", "age"]
-    df = df[cols_first + sorted(col for col in df.columns if col not in cols_first)]
+    tb = tb[cols_first + sorted(col for col in tb.columns if col not in cols_first)]
     # String columns
-    df.columns = [underscore(str(col)) for col in df.columns]
-    return df
+    tb.columns = [underscore(str(col)) for col in tb.columns]
+    return tb

--- a/etl/steps/data/garden/excess_mortality/latest/wmd.py
+++ b/etl/steps/data/garden/excess_mortality/latest/wmd.py
@@ -1,6 +1,6 @@
 """Load a meadow dataset and create a garden dataset."""
 
-import pandas as pd
+import owid.catalog.processing as pr
 from owid.catalog import Table
 from owid.catalog.utils import underscore
 from shared import harmonize_countries
@@ -28,10 +28,7 @@ def run() -> None:
     ds_meadow = paths.load_dataset("wmd")
 
     # Read table from meadow dataset.
-    tb_meadow = ds_meadow["wmd"].reset_index()
-
-    # Create a dataframe with data from the table.
-    df = pd.DataFrame(tb_meadow)
+    df = ds_meadow["wmd"].reset_index()
 
     #
     # Process data.
@@ -39,9 +36,7 @@ def run() -> None:
     log.info("wmd: processing data")
     df = process(df)
 
-    # Create a new table with the processed data.
-    tb_garden = Table(df, short_name=tb_meadow.metadata.short_name)
-    print(tb_garden.head())
+    tb_garden = df
 
     # Set index
     tb_garden = tb_garden.set_index(["entity", "time", "time_unit", "age"], verify_integrity=True)
@@ -61,7 +56,7 @@ def run() -> None:
     log.info("wmd: end")
 
 
-def process(df: pd.DataFrame) -> pd.DataFrame:
+def process(df: Table) -> Table:
     # Clean dataframe
     log.info("\thmd_stmf: cleaning bad values")
     df = df_clean(df)
@@ -83,7 +78,7 @@ def process(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def df_clean(df: pd.DataFrame) -> pd.DataFrame:
+def df_clean(df: Table) -> Table:
     ix = df.year == 0
     # NOTE: There are some values for FJI with year 0. Drop them as a hotfix.
     if ix.any():
@@ -92,7 +87,7 @@ def df_clean(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def df_api_check(df: pd.DataFrame) -> None:
+def df_api_check(df: Table) -> None:
     # Check years
     check_values_in_column(df, "year", list(range(YEAR_MIN_EXPECTED, YEAR_MAX_EXPECTED + 1)))
     # Check time and time_unit
@@ -104,10 +99,11 @@ def df_api_check(df: pd.DataFrame) -> None:
     check_values_in_column(df[df["time_unit"] == "weekly"], "time", list(range(1, 54)))
 
 
-def reshape_df(df: pd.DataFrame) -> pd.DataFrame:
+def reshape_df(df: Table) -> Table:
     # Make wide [...l -> [[index], [years]]
     df = (
-        df.pivot(
+        pr.pivot(
+            df,
             index=["entity", "time", "time_unit"],
             columns="year",
             values="deaths",
@@ -118,12 +114,12 @@ def reshape_df(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def format_age(df: pd.DataFrame) -> pd.DataFrame:
+def format_age(df: Table) -> Table:
     """Create column `age` with value 'all_ages'."""
     return df.assign(**{"age": "all_ages"})
 
 
-def format_columns(df: pd.DataFrame) -> pd.DataFrame:
+def format_columns(df: Table) -> Table:
     """Final touches."""
     # Sort columns
     cols_first = ["entity", "time", "time_unit", "age"]

--- a/etl/steps/data/garden/excess_mortality/latest/wmd.py
+++ b/etl/steps/data/garden/excess_mortality/latest/wmd.py
@@ -28,15 +28,13 @@ def run() -> None:
     ds_meadow = paths.load_dataset("wmd")
 
     # Read table from meadow dataset.
-    df = ds_meadow["wmd"].reset_index()
+    tb = ds_meadow["wmd"].reset_index()
 
     #
     # Process data.
     #
     log.info("wmd: processing data")
-    df = process(df)
-
-    tb_garden = df
+    tb_garden = process(tb)
 
     # Set index
     tb_garden = tb_garden.set_index(["entity", "time", "time_unit", "age"], verify_integrity=True)
@@ -56,54 +54,54 @@ def run() -> None:
     log.info("wmd: end")
 
 
-def process(df: Table) -> Table:
+def process(tb: Table) -> Table:
     # Clean dataframe
     log.info("\thmd_stmf: cleaning bad values")
-    df = df_clean(df)
+    tb = tb_clean(tb)
     # Check dataframe fields and values
     log.info("\thmd_stmf: initial dataframe API check")
-    df_api_check(df)
+    tb_api_check(tb)
     # Harmonize country names
     log.info("\twmd: harmonising country names")
-    df = harmonize_countries(df, "country_name", paths.country_mapping_path)
+    tb = harmonize_countries(tb, "country_name", paths.country_mapping_path)
     # Reshape dataframe
     log.info("\twmd: reshaping dataframe")
-    df = reshape_df(df)
+    tb = reshape_tb(tb)
     # Clean age display names
     log.info("\twmd: clean age display names")
-    df = format_age(df)
+    tb = format_age(tb)
     # Ensure columns match expected format
     log.info("\twmd: format columns in dataframe")
-    df = format_columns(df)
-    return df
+    tb = format_columns(tb)
+    return tb
 
 
-def df_clean(df: Table) -> Table:
-    ix = df.year == 0
+def tb_clean(tb: Table) -> Table:
+    ix = tb.year == 0
     # NOTE: There are some values for FJI with year 0. Drop them as a hotfix.
     if ix.any():
         log.warning(f"\t\twmd: dropping {ix.sum()} rows with year==0")
-    df = df[~ix]
-    return df
+    tb = tb[~ix]
+    return tb
 
 
-def df_api_check(df: Table) -> None:
+def tb_api_check(tb: Table) -> None:
     # Check years
-    check_values_in_column(df, "year", list(range(YEAR_MIN_EXPECTED, YEAR_MAX_EXPECTED + 1)))
+    check_values_in_column(tb, "year", list(range(YEAR_MIN_EXPECTED, YEAR_MAX_EXPECTED + 1)))
     # Check time and time_unit
-    check_values_in_column(df, "time", list(range(1, 54)))
-    check_values_in_column(df, "time_unit", ["monthly", "weekly"])
+    check_values_in_column(tb, "time", list(range(1, 54)))
+    check_values_in_column(tb, "time_unit", ["monthly", "weekly"])
     # If time_unit=="monthly", time should be in range(1, 13).
-    check_values_in_column(df[df["time_unit"] == "monthly"], "time", list(range(1, 13)))
+    check_values_in_column(tb[tb["time_unit"] == "monthly"], "time", list(range(1, 13)))
     # If time_unit=="weekly", time should be in range(1, 54).
-    check_values_in_column(df[df["time_unit"] == "weekly"], "time", list(range(1, 54)))
+    check_values_in_column(tb[tb["time_unit"] == "weekly"], "time", list(range(1, 54)))
 
 
-def reshape_df(df: Table) -> Table:
+def reshape_tb(tb: Table) -> Table:
     # Make wide [...l -> [[index], [years]]
-    df = (
+    tb = (
         pr.pivot(
-            df,
+            tb,
             index=["entity", "time", "time_unit"],
             columns="year",
             values="deaths",
@@ -111,19 +109,19 @@ def reshape_df(df: Table) -> Table:
         .sort_values(["entity", "time"])
         .reset_index()
     )
-    return df
+    return tb
 
 
-def format_age(df: Table) -> Table:
+def format_age(tb: Table) -> Table:
     """Create column `age` with value 'all_ages'."""
-    return df.assign(**{"age": "all_ages"})
+    return tb.assign(**{"age": "all_ages"})
 
 
-def format_columns(df: Table) -> Table:
+def format_columns(tb: Table) -> Table:
     """Final touches."""
     # Sort columns
     cols_first = ["entity", "time", "time_unit", "age"]
-    df = df[cols_first + sorted(col for col in df.columns if col not in cols_first)]
+    tb = tb[cols_first + sorted(col for col in tb.columns if col not in cols_first)]
     # String columns
-    df.columns = [underscore(str(col)) for col in df.columns]
-    return df
+    tb.columns = [underscore(str(col)) for col in tb.columns]
+    return tb

--- a/etl/steps/data/garden/excess_mortality/latest/xm_karlinsky_kobak.py
+++ b/etl/steps/data/garden/excess_mortality/latest/xm_karlinsky_kobak.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-import pandas as pd
+import owid.catalog.processing as pr
 from owid.catalog import Dataset, Table
 from owid.catalog.utils import underscore
 from shared import harmonize_countries
@@ -30,12 +30,8 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("xm_karlinsky_kobak")
 
     # Read table from meadow dataset.
-    tb_meadow = ds_meadow["xm_karlinsky_kobak"].reset_index()
-    tb_meadow_age = ds_meadow["xm_karlinsky_kobak_by_age"].reset_index()
-
-    # Create a dataframe with data from the table.
-    df = pd.DataFrame(tb_meadow)
-    df_age = pd.DataFrame(tb_meadow_age)
+    df = ds_meadow["xm_karlinsky_kobak"].reset_index()
+    df_age = ds_meadow["xm_karlinsky_kobak_by_age"].reset_index()
 
     #
     # Process data.
@@ -45,9 +41,8 @@ def run(dest_dir: str) -> None:
     log.info("xm_karlinsky_kobak.ages: processing data")
     df_age = process_age(df_age)
 
-    # Create a new table with the processed data.
-    tb_garden = Table(df, short_name=tb_meadow.metadata.short_name)
-    tb_garden_age = Table(df_age, short_name=tb_meadow_age.metadata.short_name)
+    tb_garden = df
+    tb_garden_age = df_age
 
     # Set index
     tb_garden = tb_garden.set_index(["entity", "time", "time_unit", "age"], verify_integrity=True)
@@ -80,7 +75,7 @@ YEAR_MIN_EXPECTED = 2020
 YEAR_MAX_EXPECTED = 2023
 
 
-def process(df: pd.DataFrame) -> pd.DataFrame:
+def process(df: Table) -> Table:
     # Check dataframe fields and values
     log.info("\txm_karlinsky_kobak.main: initial dataframe API check")
     df_api_check(df)
@@ -108,43 +103,45 @@ def process(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def df_api_check(df: pd.DataFrame) -> None:
+def df_api_check(df: Table) -> None:
     # Check years
     check_values_in_column(df, "year", list(range(YEAR_MIN_EXPECTED, YEAR_MAX_EXPECTED + 1)))
     # # Check time and time_unit
     check_values_in_column(df, "time", list(range(1, 54)))
 
 
-def filter_entries(df: pd.DataFrame) -> pd.DataFrame:
+def filter_entries(df: Table) -> Table:
     """Filter some rows."""
     # Filter 2023 while kobak_age has no data for this year
     df = df[(df["year"] >= YEAR_MIN) & (df["year"] <= YEAR_MAX)].reset_index(drop=True)
     return df
 
 
-def estimate_time_unit(df: pd.DataFrame, column_idx: list[str]) -> pd.DataFrame:
+def estimate_time_unit(df: Table, column_idx: list[str]) -> Table:
     """Deduce time unit from time column."""
-    # Ensure that for each entity and year, we don't have the same time value repeated
+    # Ensure that for each entity and year, we don't have the same time value repeated.
     assert df[column_idx].value_counts().max() == 1, "There are duplicate year-entitiy-time pairs."
+
     # Estimate time unit based on the number of different times.
-    ds = df.groupby("entity")["time"].nunique().sort_values(ascending=False)
-    ds = ds.map({12: "monthly", 53: "weekly"})
-    ds.name = "time_unit"
-    assert ds.isna().sum() == 0, (
+    time_unit_by_entity = (
+        df.groupby("entity")["time"].nunique().sort_values(ascending=False).map({12: "monthly", 53: "weekly"})
+    )
+    assert time_unit_by_entity.isna().sum() == 0, (
         "Some entities have neither 12 nor 53 time values. Therefore `time_unit` cannot be estimated!"
     )
-    # Add `time_unit` column to df
-    shape_0 = df.shape
-    df = df.merge(ds, on="entity")
-    assert shape_0[0] == df.shape[0], "Something went wrong in merging! Some rows went missing"
+
+    # Add `time_unit` column without leaving the Table framework.
+    df = df.assign(time_unit=df["entity"].map(time_unit_by_entity))
+    df["time_unit"].metadata = df["time"].metadata
     return df
 
 
-def reshape_df(df: pd.DataFrame) -> pd.DataFrame:
+def reshape_df(df: Table) -> Table:
     """Pivot/unpivot to get data in the right format."""
     # Make wide [...l -> [[index], [years]]
     df = (
-        df.pivot(
+        pr.pivot(
+            df,
             index=["entity", "time", "time_unit"],
             columns="year",
             values="deaths",
@@ -155,7 +152,7 @@ def reshape_df(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def rename_columns(df: pd.DataFrame) -> pd.DataFrame:
+def rename_columns(df: Table) -> Table:
     """Rename columns."""
     # Rename columns
     column_renaming = _get_column_renaming(df)
@@ -163,7 +160,7 @@ def rename_columns(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def _get_column_renaming(df: pd.DataFrame) -> dict[Any, str]:
+def _get_column_renaming(df: Table) -> dict[Any, str]:
     """Build column renaming dictionary."""
     # Build column rename dictionary
     template = "baseline_proj"
@@ -177,13 +174,13 @@ def _get_column_renaming(df: pd.DataFrame) -> dict[Any, str]:
     return column_renaming
 
 
-def format_age(df: pd.DataFrame) -> pd.DataFrame:
+def format_age(df: Table) -> Table:
     """Remove 'd' from age strings."""
     df["age"] = "all_ages"
     return df
 
 
-def format_columns(df: pd.DataFrame) -> pd.DataFrame:
+def format_columns(df: Table) -> Table:
     """Adapt dataframe column names to WMD-like format."""
     cols_first = ["entity", "time", "time_unit", "age"]
     column_metrics = list(_get_column_renaming(df).values())
@@ -202,7 +199,7 @@ YEAR_MIN_EXPECTED_AGE = 2020
 YEAR_MAX_EXPECTED_AGE = 2023
 
 
-def process_age(df: pd.DataFrame) -> pd.DataFrame:
+def process_age(df: Table) -> Table:
     # Check dataframe fields and values
     df_api_check_by_age(df)
     # Harmonize country names
@@ -233,7 +230,7 @@ def process_age(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def df_api_check_by_age(df: pd.DataFrame) -> None:
+def df_api_check_by_age(df: Table) -> None:
     # Check years
     check_values_in_column(df, "year", list(range(YEAR_MIN_EXPECTED_AGE, YEAR_MAX_EXPECTED_AGE + 1)))
     # Check time and time_unit
@@ -244,7 +241,7 @@ def df_api_check_by_age(df: pd.DataFrame) -> None:
     check_values_in_column(df, "age", {" D0_14", " D15_64", " D65_74", " D75_84", " D85p", " DTotal"})
 
 
-def filter_entries_by_age(df: pd.DataFrame):
+def filter_entries_by_age(df: Table):
     # Only keep both sexes
     df = df[df["sex"] == " b"].drop(columns=["sex"])
     # Don't include Australia by-age data, bc it's not from WMD
@@ -256,7 +253,7 @@ def filter_entries_by_age(df: pd.DataFrame):
     return df
 
 
-def add_uk_by_age(df: pd.DataFrame):
+def add_uk_by_age(df: Table):
     # Get UK Nations data
     df_uk = df[df["entity"].isin(["England and Wales", "Scotland", "Northern Ireland"])].copy()
     # Check time_unit
@@ -270,14 +267,15 @@ def add_uk_by_age(df: pd.DataFrame):
     df_uk["entity"] = "United Kingdom"
     df_uk["time_unit"] = time_units[0]
     # Add UK
-    df = pd.concat([df, df_uk], ignore_index=True)
+    df = pr.concat([df, df_uk], ignore_index=True)
     return df
 
 
-def reshape_df_by_age(df: pd.DataFrame):
+def reshape_df_by_age(df: Table):
     # Make wide [...] -> [[index], [years]]
     df = (
-        df.pivot(
+        pr.pivot(
+            df,
             index=["entity", "time", "time_unit", "age"],
             columns="year",
             values="deaths",
@@ -288,13 +286,13 @@ def reshape_df_by_age(df: pd.DataFrame):
     return df
 
 
-def format_age_by_age(df: pd.DataFrame):
+def format_age_by_age(df: Table):
     # Remove 'D' from age
     df["age"] = df["age"].str.replace(" D", "")
     return df
 
 
-def format_columns_by_age(df: pd.DataFrame) -> pd.DataFrame:
+def format_columns_by_age(df: Table) -> Table:
     """Adapt dataframe column names to WMD-like format."""
     cols_first = ["entity", "time", "time_unit", "age"]
     column_metrics = list(_get_column_renaming(df).values())

--- a/etl/steps/data/meadow/excess_mortality/latest/hmd_stmf.py
+++ b/etl/steps/data/meadow/excess_mortality/latest/hmd_stmf.py
@@ -2,8 +2,7 @@
 
 In this step we perform sanity checks on the expected input fields and the values that they take."""
 
-import pandas as pd
-from owid.catalog import Dataset, Table
+from owid.catalog import Dataset
 from structlog import get_logger
 
 from etl.data_helpers.misc import check_known_columns
@@ -51,13 +50,9 @@ def run(dest_dir: str) -> None:
     snap: Snapshot = paths.load_dependency("hmd_stmf.csv")
 
     # Load data from snapshot.
-    df = pd.read_csv(snap.path, skiprows=1)
-    check_known_columns(df, COLUMNS_EXPECTED)
-    #
-    # Process data.
-    #
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(df, short_name=paths.short_name, underscore=True)
+    tb = snap.read_csv(skiprows=1)
+    check_known_columns(tb, COLUMNS_EXPECTED)
+    tb = tb.underscore()
 
     #
     # Save outputs.

--- a/etl/steps/data/meadow/excess_mortality/latest/wmd.py
+++ b/etl/steps/data/meadow/excess_mortality/latest/wmd.py
@@ -2,8 +2,7 @@
 
 In this step we perform sanity checks on the expected input fields and the values that they take."""
 
-import pandas as pd
-from owid.catalog import Dataset, Table
+from owid.catalog import Dataset
 from structlog import get_logger
 
 from etl.data_helpers.misc import check_known_columns
@@ -38,13 +37,8 @@ def run(dest_dir: str) -> None:
     snap: Snapshot = paths.load_dependency("wmd.csv")
 
     # Load data from snapshot.
-    df = pd.read_csv(snap.path)
-    check_known_columns(df, COLUMNS_EXPECTED)
-    #
-    # Process data.
-    #
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(df, short_name=paths.short_name, underscore=True)
+    tb = snap.read_csv(underscore=True)
+    check_known_columns(tb, COLUMNS_EXPECTED)
     # Set index
     tb = tb.set_index(["iso3c", "year", "time"], verify_integrity=True)
 

--- a/etl/steps/data/meadow/excess_mortality/latest/xm_karlinsky_kobak.py
+++ b/etl/steps/data/meadow/excess_mortality/latest/xm_karlinsky_kobak.py
@@ -2,13 +2,11 @@
 
 In this step we perform sanity checks on the expected input fields and the values that they take."""
 
-from pathlib import Path
-
-import pandas as pd
 from owid.catalog import Dataset, Table
 from structlog import get_logger
 
 from etl.helpers import PathFinder
+from etl.snapshot import Snapshot
 from etl.steps.data.converters import convert_snapshot_metadata
 
 # Initialize logger.
@@ -44,15 +42,22 @@ def run(dest_dir: str) -> None:
     snap_ages = paths.load_snapshot("xm_karlinsky_kobak_ages.csv")
 
     # Load data from snapshot.
-    df_all = load_dataframe(snap_all.path, column_names=COLUMN_NAMES)
-    df_ages = load_dataframe(snap_ages.path, column_names=COLUMN_NAMES_AGES)
+    tb_all = load_table(snap_all, column_names=COLUMN_NAMES)
+    tb_ages = load_table(snap_ages, column_names=COLUMN_NAMES_AGES)
+    # Both files are part of the same Karlinsky and Kobak data product. Use a single origin object
+    # so downstream concatenation does not render duplicate chart sources for the same source.
+    origin = tb_all["deaths"].metadata.origins
+    for col in tb_ages.columns:
+        tb_ages[col].metadata.origins = origin
 
     #
     # Process data.
     #
-    # Create a new table and ensure all columns are snake-case.
-    tb_all = Table(df_all, short_name=paths.short_name, underscore=True)
-    tb_ages = Table(df_ages, short_name=f"{paths.short_name}_by_age", underscore=True)
+    # Ensure all columns are snake-case.
+    tb_all.metadata.short_name = paths.short_name
+    tb_all = tb_all.underscore()
+    tb_ages.metadata.short_name = f"{paths.short_name}_by_age"
+    tb_ages = tb_ages.underscore()
     # Set index
     tb_all = tb_all.set_index(["country", "year", "time"], verify_integrity=True)
     tb_ages = tb_ages.set_index(["country", "year", "age", "sex", "time"], verify_integrity=True)
@@ -76,11 +81,11 @@ def run(dest_dir: str) -> None:
     log.info("xm_karlinsky_kobak.end")
 
 
-def load_dataframe(path: Path | str, column_names: list[str]) -> pd.DataFrame:
+def load_table(snap: Snapshot, column_names: list[str]) -> Table:
     """Load the data from the latest version of the dataset."""
-    df = pd.read_csv(path, names=column_names, encoding="latin-1")
+    tb = snap.read_csv(names=column_names, encoding="latin-1")
     # Check columns
-    assert df.reset_index().shape[1] == len(column_names) + 1, (
+    assert tb.reset_index().shape[1] == len(column_names) + 1, (
         "Check columns in source! There seems to be more (or less) columns."
     )
-    return df
+    return tb

--- a/snapshots/excess_mortality/latest/hmd_stmf.csv.dvc
+++ b/snapshots/excess_mortality/latest/hmd_stmf.csv.dvc
@@ -1,6 +1,7 @@
 meta:
-  source:
-    name: Human Mortality Database
+  origin:
+    producer: Human Mortality Database
+    title: Short-term Mortality Fluctuations
     description: |-
       In response to the COVID-19 pandemic, the HMD team decided to establish a new data resource: Short-term Mortality Fluctuations (STMF) data series. Objective and internationally comparable data are crucial to determine the effectiveness of different strategies used to address epidemics. Weekly death counts provide the most objective and comparable way of assessing the scale of short-term mortality elevations across countries and time. More details about this data project can be found in the recently published paper (https://www.nature.com/articles/s41597-021-01019-1).
 
@@ -11,27 +12,15 @@ meta:
       For citing STMF data, please follow the HMD data citation guidelines (https://www.mortality.org/Research/CitationGuidelines).
 
       HMD provides an online STMF visualization toolkit (https://mpidr.shinyapps.io/stmortality).
-    url: https://www.mortality.org/Data/STMF
-    source_data_url: https://www.mortality.org/File/GetDocument/Public/STMF/Outputs/stmf.csv
-    date_accessed: 2026-05-11
-    publication_date: 2026-04-30
-    publication_year: 2026
-    published_by: |-
-      HMD. Human Mortality Database. Max Planck Institute for Demographic Research (Germany), University of California, Berkeley (USA), and French Institute for Demographic Studies (France). Available at www.mortality.org.
-  name: Short-Term Mortality Fluctuations (HMD)
-  description: |-
-    In response to the COVID-19 pandemic, the HMD team decided to establish a new data resource: Short-term Mortality Fluctuations (STMF) data series. Objective and internationally comparable data are crucial to determine the effectiveness of different strategies used to address epidemics. Weekly death counts provide the most objective and comparable way of assessing the scale of short-term mortality elevations across countries and time. More details about this data project can be found in the recently published paper (https://www.nature.com/articles/s41597-021-01019-1).
-
-    Before using the data, please consult the STMF Methodological Note (https://www.mortality.org/File/GetDocument/Public/STMF_DOC/STMFNote.pdf), which provides a more comprehensive description of this data project, including important aspects related to data collection and data processing. We also recommend that you read the STMF Metadata (https://www.mortality.org/File/GetDocument/Public/STMF_DOC/STMFmetadata.pdf). This document includes country-specific information about data availability, completeness, data sources, as well as specific features of included data.
-
-    Data will be frequently updated and new countries will be added. Data are published under CC BY 4.0 license.
-
-    For citing STMF data, please follow the HMD data citation guidelines (https://www.mortality.org/Research/CitationGuidelines).
-
-    HMD provides an online STMF visualization toolkit (https://mpidr.shinyapps.io/stmortality).
-  license:
-    name: Creative Commons BY 4.0
-    url: https://www.mortality.org/Data/UserAgreement
+    citation_full: 'HMD. Human Mortality Database. Max Planck Institute for Demographic Research (Germany), University of California, Berkeley (USA), and French Institute for Demographic Studies (France). Available at www.mortality.org.'
+    attribution_short: HMD
+    url_main: https://www.mortality.org/Data/STMF
+    url_download: https://www.mortality.org/File/GetDocument/Public/STMF/Outputs/stmf.csv
+    date_accessed: '2026-05-11'
+    date_published: '2026-04-30'
+    license:
+      name: Creative Commons BY 4.0
+      url: https://www.mortality.org/Data/UserAgreement
 outs:
   - md5: fb63d0d99a99aaa65f600221a60671c8
     size: 22520824

--- a/snapshots/excess_mortality/latest/hmd_stmf.py
+++ b/snapshots/excess_mortality/latest/hmd_stmf.py
@@ -35,7 +35,8 @@ def main(upload: bool) -> None:
     snap = modify_metadata(snap)
 
     # Download CSV
-    download_csv(snap.path, snap.m.source.source_data_url)  # ty: ignore
+    assert snap.m.origin and snap.m.origin.url_download
+    download_csv(snap.path, snap.m.origin.url_download)
 
     # Add file to DVC and upload to S3.
     snap.dvc_add(upload=upload)
@@ -87,14 +88,12 @@ def download_csv(path: Path, csv_url: str) -> None:
 
 def modify_metadata(snap: Snapshot) -> Snapshot:
     """Modify metadata"""
+    assert snap.metadata.origin
     # Get access date
-    snap.metadata.source.date_accessed = date.today()  # ty: ignore
+    snap.metadata.origin.date_accessed = date.today().isoformat()
     # Set publication date
     publication_date = _get_publication_date()
-    assert snap.metadata.source
-    snap.metadata.source.publication_date = publication_date  # ty: ignore
-    # Set publication year
-    snap.metadata.source.publication_year = publication_date.year
+    snap.metadata.origin.date_published = publication_date.isoformat()
     # Save
     snap.metadata.save()
     return snap

--- a/snapshots/excess_mortality/latest/wmd.csv.dvc
+++ b/snapshots/excess_mortality/latest/wmd.csv.dvc
@@ -1,6 +1,7 @@
 meta:
-  source:
-    name: World Mortality Dataset (2024)
+  origin:
+    producer: Karlinsky and Kobak
+    title: World Mortality Dataset
     description: |-
       World Mortality Dataset: international data on all-cause mortality.
 
@@ -8,30 +9,17 @@ meta:
 
       For a complete and up-to-date list of notes on the dataset, please refer to their GitHub page at https://github.com/akarlinsky/world_mortality/.
 
-      For the list of sources that they use, please go to https://github.com/akarlinsky/world_mortality/#sou rces.
+      For the list of sources that they use, please go to https://github.com/akarlinsky/world_mortality/#sources.
 
       Published paper available at https://elifesciences.org/articles/69336.
-    url: https://github.com/akarlinsky/world_mortality/
-    source_data_url: https://raw.githubusercontent.com/akarlinsky/world_mortality/main/world_mortality.csv
-    date_accessed: 2026-05-11
-    publication_date: "2021-06-30"
-    publication_year: 2021
-    published_by: |-
-      Karlinsky & Kobak 2021, Tracking excess mortality across countries during the COVID-19 pandemic with the World Mortality Dataset, eLife https://doi.org/10.7554/eLife.69336
-  name: World Mortality Dataset (2024)
-  description: |-
-    World Mortality Dataset: international data on all-cause mortality.
-
-    This dataset contains country-level data on all-cause mortality in 2015–2024 collected from various sources. They are currently providing data for 122 countries and territories.
-
-    For a complete and up-to-date list of notes on the dataset, please refer to their GitHub page at https://github.com/akarlinsky/world_mortality/.
-
-    For the list of sources that they use, please go to https://github.com/akarlinsky/world_mortality/#sou rces.
-
-    Published paper available at https://elifesciences.org/articles/69336.
-  license:
-    name: MIT License
-    url: https://github.com/akarlinsky/world_mortality/blob/main/LICENSE
+    citation_full: 'Karlinsky, A. and Kobak, D. (2021). Tracking excess mortality across countries during the COVID-19 pandemic with the World Mortality Dataset. eLife. https://doi.org/10.7554/eLife.69336.'
+    url_main: https://github.com/akarlinsky/world_mortality/
+    url_download: https://raw.githubusercontent.com/akarlinsky/world_mortality/main/world_mortality.csv
+    date_accessed: '2026-05-11'
+    date_published: '2021-06-30'
+    license:
+      name: MIT License
+      url: https://github.com/akarlinsky/world_mortality/blob/main/LICENSE
 outs:
   - md5: 2d9fe6fc20199dd2ec372d66d00198f5
     size: 1124479

--- a/snapshots/excess_mortality/latest/wmd.py
+++ b/snapshots/excess_mortality/latest/wmd.py
@@ -23,7 +23,8 @@ def main(upload: bool) -> None:
     snap = Snapshot(f"excess_mortality/{SNAPSHOT_VERSION}/wmd.csv")
 
     # Add date_accessed
-    snap.metadata.source.date_accessed = date.today()  # ty: ignore
+    assert snap.metadata.origin
+    snap.metadata.origin.date_accessed = date.today().isoformat()
     snap.metadata.save()
 
     # Download data from source.

--- a/snapshots/excess_mortality/latest/xm_karlinsky_kobak.csv.dvc
+++ b/snapshots/excess_mortality/latest/xm_karlinsky_kobak.csv.dvc
@@ -1,25 +1,19 @@
 meta:
-  source:
-    name: Karlinsky and Kobak (2021)
+  origin:
+    producer: Karlinsky and Kobak
+    title: Excess mortality during the COVID-19 pandemic
     description: |-
       The data are sourced from the World Mortality Dataset (https://github.com/akarlinsky/world_mortality). Excess mortality is computed relative to the baseline obtained using linear extrapolation of the 2015–19 trend (different baselines for 2020, 2021, and 2022). In each subplot in the figure below, gray lines are 2015–19, black line is baseline for 2020, red line is 2020, blue line is 2021, orange line is 2022. Countries are sorted by the total excess mortality as % of the 2020 baseline.
 
       For more details, refer to https://github.com/dkobak/excess-mortality#excess-mortality-during-the-covid-19-pandemic.
-    url: https://github.com/dkobak/excess-mortality
-    source_data_url: https://raw.githubusercontent.com/dkobak/excess-mortality/main/baselines-per-year.csv
-    date_accessed: 2026-05-11
-    publication_date: '2021-06-30'
-    publication_year: 2021
-    published_by: |-
-      Karlinsky & Kobak, 2021, Tracking excess mortality across countries during the COVID-19 pandemic with the World Mortality Dataset. eLife 10:e69336. https://elifesciences.org/articles/69336
-  name: Excess mortality during the COVID-19 pandemic
-  description: |-
-    The data are sourced from the World Mortality Dataset (https://github.com/akarlinsky/world_mortality). Excess mortality is computed relative to the baseline obtained using linear extrapolation of the 2015–19 trend (different baselines for 2020, 2021, and 2022). In each subplot in the figure below, gray lines are 2015–19, black line is baseline for 2020, red line is 2020, blue line is 2021, orange line is 2022. Countries are sorted by the total excess mortality as % of the 2020 baseline.
-
-    For more details, refer to https://github.com/dkobak/excess-mortality#excess-mortality-during-the-covid-19-pandemic.
-  license:
-    name: GPL-3.0
-    url: https://github.com/dkobak/excess-mortality/blob/main/LICENSE
+    citation_full: 'Karlinsky, A. and Kobak, D. (2021). Tracking excess mortality across countries during the COVID-19 pandemic with the World Mortality Dataset. eLife, 10:e69336. https://elifesciences.org/articles/69336.'
+    url_main: https://github.com/dkobak/excess-mortality
+    url_download: https://raw.githubusercontent.com/dkobak/excess-mortality/main/baselines-per-year.csv
+    date_accessed: '2026-05-11'
+    date_published: '2021-06-30'
+    license:
+      name: GPL-3.0
+      url: https://github.com/dkobak/excess-mortality/blob/main/LICENSE
   access_notes: Contains data by age.
 outs:
   - md5: 6fd2e56c1ef672dd9184eeea3cddc788

--- a/snapshots/excess_mortality/latest/xm_karlinsky_kobak.py
+++ b/snapshots/excess_mortality/latest/xm_karlinsky_kobak.py
@@ -29,7 +29,8 @@ def add_snapshot(uri: str, upload: bool):
     # Load snapshot
     snap = Snapshot(uri)
     # Add date_accessed
-    snap.metadata.source.date_accessed = date.today()  # ty: ignore
+    assert snap.metadata.origin
+    snap.metadata.origin.date_accessed = date.today().isoformat()
     snap.metadata.save()
     # Download file
     snap.download_from_source()

--- a/snapshots/excess_mortality/latest/xm_karlinsky_kobak_ages.csv.dvc
+++ b/snapshots/excess_mortality/latest/xm_karlinsky_kobak_ages.csv.dvc
@@ -1,24 +1,19 @@
 meta:
-  source:
-    name: Karlinsky and Kobak (2021)
+  origin:
+    producer: Karlinsky and Kobak
+    title: Excess mortality during the COVID-19 pandemic
     description: |-
       The data are sourced from the World Mortality Dataset (https://github.com/akarlinsky/world_mortality). Excess mortality is computed relative to the baseline obtained using linear extrapolation of the 2015–19 trend (different baselines for years since 2020).
-      For more details, refer to https://github.com/dkobak/excess-mortality#excess-mortality-during-the-covid-19-pandemic.
-    url: https://github.com/dkobak/excess-mortality
-    source_data_url: https://raw.githubusercontent.com/dkobak/excess-mortality/main/baselines-stmf.csv
-    date_accessed: 2026-05-11
-    publication_date: '2021-06-30'
-    publication_year: 2021
-    published_by: |-
-      Karlinsky & Kobak, 2021, Tracking excess mortality across countries during the COVID-19 pandemic with the World Mortality Dataset. eLife 10:e69336. https://elifesciences.org/articles/69336
-  name: Excess mortality during the COVID-19 pandemic
-  description: |-
-    The data are sourced from the World Mortality Dataset (https://github.com/akarlinsky/world_mortality). Excess mortality is computed relative to the baseline obtained using linear extrapolation of the 2015–19 trend (different baselines for years since 2020).
 
-    For more details, refer to https://github.com/dkobak/excess-mortality#excess-mortality-during-the-covid-19-pandemic.
-  license:
-    name: GPL-3.0
-    url: https://github.com/dkobak/excess-mortality/blob/main/LICENSE
+      For more details, refer to https://github.com/dkobak/excess-mortality#excess-mortality-during-the-covid-19-pandemic.
+    citation_full: 'Karlinsky, A. and Kobak, D. (2021). Tracking excess mortality across countries during the COVID-19 pandemic with the World Mortality Dataset. eLife, 10:e69336. https://elifesciences.org/articles/69336.'
+    url_main: https://github.com/dkobak/excess-mortality
+    url_download: https://raw.githubusercontent.com/dkobak/excess-mortality/main/baselines-stmf.csv
+    date_accessed: '2026-05-11'
+    date_published: '2021-06-30'
+    license:
+      name: GPL-3.0
+      url: https://github.com/dkobak/excess-mortality/blob/main/LICENSE
   access_notes: Contains data by age.
 outs:
   - md5: 077b2edc78cd9fcdd40c084e07d04477


### PR DESCRIPTION
## Summary

- Migrate the four `excess_mortality/latest` snapshot DVCs (`hmd_stmf`, `wmd`, `xm_karlinsky_kobak`, `xm_karlinsky_kobak_ages`) from legacy `meta.source` to `meta.origin`.
- Drop the legacy source-hydration block in the `excess_mortality` garden step (`__init__.py`) and the matching `sources:` list under the `excess_mortality` indicator in `excess_mortality.meta.yml`, now that origins flow through automatically.
- Minor refinements to the `migrate-source-to-origin` skill picked up during this migration.

The wider batch of source→origin migrations that originally lived on this branch has been split off and will land in a separate PR.

## Test plan

- [ ] `.venv/bin/etlr excess_mortality/latest/excess_mortality --private` runs cleanly.
- [ ] `make check` is green.
- [ ] Origin info on charts using excess_mortality indicators still renders (sources tab on staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)