### PR TITLE
📊 Enrich WDI description_from_producer with full WB metadata

### DIFF
--- a/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.py
+++ b/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.py
@@ -645,36 +645,47 @@ def load_clean_source_mapping() -> dict[str, dict[str, str]]:
     return source_mapping
 
 
+# Sections appended to description_from_producer, in display order. Each entry maps a
+# column from the meadow `wdi_metadata` table to the markdown section header rendered
+# in the producer description. The order follows the WB databank metadata glossary
+# layout. `source_meta`/`topic_meta` come from DDH (legacy `source` and `topic` are
+# kept separately for the wdi.sources.json join).
+_PRODUCER_DESCRIPTION_SECTIONS: list[tuple[str, str]] = [
+    # Source: redundant with `origin.producer` / `origin.citation_full`, which are
+    # already surfaced to the reader. Keeping the column in meadow in case it's needed.
+    # ("source_meta", "Source"),
+    # Topic: WB's internal taxonomy (e.g. "Financial Sector: Exchange rates & prices");
+    # the chart's existing topic context covers this for readers.
+    # ("topic_meta", "Topic"),
+    ("periodicity", "Periodicity"),
+    ("base_period", "Base period"),
+    ("aggregation_method", "Aggregation method"),
+    ("statistical_concept_and_methodology", "Statistical concept and methodology"),
+    ("development_relevance", "Development relevance"),
+    ("limitations_and_exceptions", "Limitations and exceptions"),
+    ("general_comments", "General comments"),
+    ("notes_from_original_source", "Notes from original source"),
+    ("other_notes", "Other notes"),
+    ("related_source_links", "Related source links"),
+    ("other_web_links", "Other web links"),
+    ("related_indicators", "Related indicators"),
+    # License type: ~93% of indicators are "CC BY-4.0"; license is already expressed
+    # at the dataset/origin level, so per-indicator repetition is noise.
+    # ("license_type", "License type"),
+]
+
+
 def create_description_from_producer(var: dict[str, Any]) -> str | None:
     desc = ""
-    if pd.notnull(var["long_definition"]) and len(var["long_definition"].strip()) > 0:
+    if pd.notnull(var.get("long_definition")) and len(var["long_definition"].strip()) > 0:
         desc += var["long_definition"]
-    elif pd.notnull(var["short_definition"]) and len(var["short_definition"].strip()) > 0:
+    elif pd.notnull(var.get("short_definition")) and len(var["short_definition"].strip()) > 0:
         desc += var["short_definition"]
 
-    if pd.notnull(var["limitations_and_exceptions"]) and len(var["limitations_and_exceptions"].strip()) > 0:
-        desc += f"\n\n### Limitations and exceptions:\n{var['limitations_and_exceptions']}"
-
-    if (
-        pd.notnull(var["statistical_concept_and_methodology"])
-        and len(var["statistical_concept_and_methodology"].strip()) > 0
-    ):
-        desc += f"\n\n### Statistical concept and methodology:\n{var['statistical_concept_and_methodology']}"
-
-    ####################################################################################################################
-    # I think that the development relevance could also be an interesting field to add to the description_from_producer.
-    # For now, I'll include it in this specific indicator (access to electricity), but in the future we can consider adding this field for all indicators.
-    if (
-        (var["indicator_code_original"] in ["EG.ELC.ACCS.ZS"])
-        and pd.notnull(var["development_relevance"])
-        and len(var["development_relevance"].strip()) > 0
-    ):
-        desc += f"\n\n### Development relevance:\n{var['development_relevance']}"
-    ####################################################################################################################
-
-    # retrieves additional source info, if it exists.
-    if pd.notnull(var["notes_from_original_source"]) and len(var["notes_from_original_source"].strip()) > 0:
-        desc += f"\n\n### Notes from original source:\n{var['notes_from_original_source']}"
+    for column, header in _PRODUCER_DESCRIPTION_SECTIONS:
+        value = var.get(column)
+        if pd.notnull(value) and len(value.strip()) > 0:
+            desc += f"\n\n### {header}:\n{value}"
 
     desc = re.sub(r" *(\n+) *", r"\1", re.sub(r"[ \t]+", " ", desc)).strip()
 

--- a/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.py
+++ b/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.py
@@ -685,6 +685,11 @@ def create_description_from_producer(var: dict[str, Any]) -> str | None:
     for column, header in _PRODUCER_DESCRIPTION_SECTIONS:
         value = var.get(column)
         if pd.notnull(value) and len(value.strip()) > 0:
+            # ~90% of WDI indicators are "Annual", which adds noise next to a yearly
+            # time series — only surface periodicity when it deviates (Triennial,
+            # Biennial, Every two years, Quarterly-represented-as-Annual).
+            if column == "periodicity" and value.strip() == "Annual":
+                continue
             desc += f"\n\n### {header}:\n{value}"
 
     desc = re.sub(r" *(\n+) *", r"\1", re.sub(r"[ \t]+", " ", desc)).strip()

--- a/etl/steps/data/meadow/worldbank_wdi/2026-02-27/wdi.py
+++ b/etl/steps/data/meadow/worldbank_wdi/2026-02-27/wdi.py
@@ -22,9 +22,15 @@ def create_metadata_table(legacy_json: dict, new_json: dict) -> Table:
     Legacy JSON (from api.worldbank.org/v2) provides core fields:
     - indicator_code, indicator_name, unit, source, topic
 
-    New JSON (from ddh-openapi.worldbank.org) provides rich descriptions:
-    - long_definition, short_definition, limitations_and_exceptions,
-      statistical_concept_and_methodology, development_relevance, notes_from_original_source
+    New JSON (from ddh-openapi.worldbank.org) provides every metadata-glossary
+    field WB exposes per indicator (long_definition, aggregation_method,
+    periodicity, license_type, statistical_concept_and_methodology,
+    development_relevance, etc.).
+
+    DDH fields whose snake_cased name would collide with a legacy column are
+    stored under a `_meta` suffix (e.g. `Source` -> `source_meta`) so the
+    legacy values stay authoritative — the garden step uses legacy `source`
+    as a join key into wdi.sources.json.
     """
     # Parse legacy metadata (core fields)
     df_legacy = pd.DataFrame(legacy_json["data"])
@@ -55,6 +61,33 @@ def create_metadata_table(legacy_json: dict, new_json: dict) -> Table:
                 indicator_info["development_relevance"] = field_description
             elif field_name == "Notes from original source":
                 indicator_info["notes_from_original_source"] = field_description
+            elif field_name == "Aggregation method":
+                indicator_info["aggregation_method"] = field_description
+            elif field_name == "Periodicity":
+                indicator_info["periodicity"] = field_description
+            elif field_name == "Base Period":
+                indicator_info["base_period"] = field_description
+            elif field_name == "License Type":
+                indicator_info["license_type"] = field_description
+            elif field_name == "General comments":
+                indicator_info["general_comments"] = field_description
+            elif field_name == "Other notes":
+                indicator_info["other_notes"] = field_description
+            elif field_name == "Related source links":
+                indicator_info["related_source_links"] = field_description
+            elif field_name == "Other web links":
+                indicator_info["other_web_links"] = field_description
+            elif field_name == "Related indicators":
+                indicator_info["related_indicators"] = field_description
+            # `Source` and `Topic` collide with legacy columns, so store them under `_meta`.
+            elif field_name == "Source":
+                indicator_info["source_meta"] = field_description
+            elif field_name == "Topic":
+                indicator_info["topic_meta"] = field_description
+            # Skipped: Indicator Name (legacy has it), and the taxonomy fields
+            # (Description, First level, Second level, Unit of measure) which only
+            # appear on the ~130 indicators where a classification entry survived
+            # snapshot dedup instead of the rich-metadata entry.
 
         if indicator_info["series_code"]:
             indicators_data.append(indicator_info)

--- a/snapshots/worldbank_wdi/2026-02-27/wdi.py
+++ b/snapshots/worldbank_wdi/2026-02-27/wdi.py
@@ -64,7 +64,9 @@ It's easier to do it in two steps:
 
 import datetime as dt
 import json
+import re
 import tempfile
+import time
 import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
@@ -92,6 +94,31 @@ LEGACY_API_BASE_URL = "https://api.worldbank.org/v2/indicator"
 
 # Number of parallel workers for fetching legacy metadata
 MAX_WORKERS = 20
+
+# DDH is intermittently flaky (502 Bad Gateway, occasionally empty responses).
+# Apply bounded retries with exponential backoff to any call hitting it.
+DDH_RETRY_STATUSES = (500, 502, 503, 504)
+DDH_RETRY_MAX_ATTEMPTS = 6
+DDH_RETRY_BACKOFF_BASE = 2.0
+
+
+def _ddh_get_json(url: str, timeout: int = 120) -> dict:
+    """GET a DDH URL and decode JSON, retrying on transient errors."""
+    last_err: Exception | None = None
+    for attempt in range(DDH_RETRY_MAX_ATTEMPTS):
+        try:
+            response = requests.get(url, timeout=timeout)
+            if response.status_code in DDH_RETRY_STATUSES:
+                last_err = requests.HTTPError(f"{response.status_code} on {url}")
+            else:
+                response.raise_for_status()
+                return response.json()
+        except (requests.RequestException, json.JSONDecodeError) as e:
+            last_err = e
+        sleep_s = DDH_RETRY_BACKOFF_BASE**attempt
+        print(f"  DDH request failed ({last_err!r}); retrying in {sleep_s:.0f}s [attempt {attempt + 1}/{DDH_RETRY_MAX_ATTEMPTS}]")
+        time.sleep(sleep_s)
+    raise RuntimeError(f"DDH request failed after {DDH_RETRY_MAX_ATTEMPTS} attempts: {url}") from last_err
 
 
 @click.command()
@@ -127,6 +154,38 @@ def main(upload: bool) -> None:
     snap.dvc_add(upload=upload)
 
 
+def _score_indicator_entry(indicator: dict) -> tuple[int, int, int, int]:
+    """Score one DDH indicator entry for dedupe. Higher is better.
+
+    Priority (lexicographic on the tuple):
+      1. Has a non-empty `Long definition` — keeps rich entries over taxonomy-only stubs
+         (`Code` + `Description` + `First level` + `Second level`).
+      2. Highest `Base Period` year — resolves duplicates like
+         `NY.GDP.PCAP.PP.KD` where WB ships both the legacy 2017-PPP entry and
+         the new 2021-PPP entry; the 2017 one was winning under last-wins.
+      3. Number of non-empty fields filled in.
+      4. Total content length, as a final tiebreak.
+    """
+    has_long_def = 0
+    base_period = 0
+    n_filled = 0
+    total_len = 0
+    for field in indicator.get("fields", []):
+        desc = (field.get("description") or "").strip()
+        if not desc:
+            continue
+        n_filled += 1
+        total_len += len(desc)
+        name = field.get("name")
+        if name == "Long definition":
+            has_long_def = 1
+        elif name == "Base Period":
+            m = re.search(r"\d{4}", desc)
+            if m:
+                base_period = int(m.group(0))
+    return (has_long_def, base_period, n_filled, total_len)
+
+
 def add_json_metadata_to_zip(zip_path: Path) -> None:
     """Fetch JSON metadata from API and add it to the existing zip file."""
     all_indicators = []
@@ -136,9 +195,7 @@ def add_json_metadata_to_zip(zip_path: Path) -> None:
     # Fetch all indicators using pagination
     while True:
         url = f"{API_BASE_URL}?dataset_unique_id={DATASET_ID}&top={batch_size}&skip={skip}"
-        response = requests.get(url)
-        response.raise_for_status()
-        batch_data = response.json()
+        batch_data = _ddh_get_json(url)
 
         # Check if we got any data
         if not batch_data.get("data") or len(batch_data["data"]) == 0:
@@ -152,23 +209,27 @@ def add_json_metadata_to_zip(zip_path: Path) -> None:
 
         skip += batch_size
 
-    # Deduplicate by series code - keep the last occurrence (likely most recent)
-    unique_indicators = {}
+    # The DDH API returns multiple entries per series code: typically several
+    # revisions of the indicator's metadata (e.g. PPP 2017 vs PPP 2021 base year)
+    # plus an occasional "classification-only" stub. WB hasn't yet exposed a
+    # last_modified flag (see thread with apirlea@worldbank.org, Sep 2025), so
+    # we pick the best entry per code via `_score_indicator_entry`.
+    entries_by_code: dict[str, list[dict]] = {}
     for indicator in all_indicators:
-        # Find the series code in fields
         series_code = None
         for field in indicator.get("fields", []):
-            if field.get("name") == "Series Code":
+            if field.get("name") in ("Series Code", "Code"):
                 series_code = field.get("description")
                 break
-            elif field.get("name") == "Code":
-                series_code = field.get("description")
-                break
-
         if series_code:
-            unique_indicators[series_code] = indicator
+            entries_by_code.setdefault(series_code, []).append(indicator)
 
-    deduped_indicators = list(unique_indicators.values())
+    # Stable tiebreak via index: when scores match, prefer the later occurrence
+    # (preserves the previous "last-wins" behaviour for tied entries).
+    deduped_indicators = [
+        max(enumerate(entries), key=lambda x: (_score_indicator_entry(x[1]), x[0]))[1]
+        for entries in entries_by_code.values()
+    ]
     print(
         f"After deduplication: {len(deduped_indicators)} unique indicators (removed {len(all_indicators) - len(deduped_indicators)} duplicates)"
     )
@@ -290,7 +351,7 @@ def add_legacy_metadata_to_zip(zip_path: Path) -> None:
 
 def update_snapshot_metadata(snap: Snapshot) -> None:
     # Load WDI metadata from the json file using the World Bank API.
-    meta_orig = json.loads(requests.get(URL_METADATA).content)
+    meta_orig = _ddh_get_json(URL_METADATA)
 
     assert snap.metadata.origin
 

--- a/snapshots/worldbank_wdi/2026-02-27/wdi.py
+++ b/snapshots/worldbank_wdi/2026-02-27/wdi.py
@@ -116,7 +116,9 @@ def _ddh_get_json(url: str, timeout: int = 120) -> dict:
         except (requests.RequestException, json.JSONDecodeError) as e:
             last_err = e
         sleep_s = DDH_RETRY_BACKOFF_BASE**attempt
-        print(f"  DDH request failed ({last_err!r}); retrying in {sleep_s:.0f}s [attempt {attempt + 1}/{DDH_RETRY_MAX_ATTEMPTS}]")
+        print(
+            f"  DDH request failed ({last_err!r}); retrying in {sleep_s:.0f}s [attempt {attempt + 1}/{DDH_RETRY_MAX_ATTEMPTS}]"
+        )
         time.sleep(sleep_s)
     raise RuntimeError(f"DDH request failed after {DDH_RETRY_MAX_ATTEMPTS} attempts: {url}") from last_err
 

--- a/snapshots/worldbank_wdi/2026-02-27/wdi.zip.dvc
+++ b/snapshots/worldbank_wdi/2026-02-27/wdi.zip.dvc
@@ -14,6 +14,6 @@ meta:
       name: CC BY 4.0
       url: https://datacatalog.worldbank.org/search/dataset/0037712/World-Development-Indicators
 outs:
-  - md5: 3a0c7ce19ad8e7158330d70be0538086
-    size: 295884972
+  - md5: 42eea0df17245e325955690582d2f629
+    size: 91073159
     path: wdi.zip


### PR DESCRIPTION
## Summary

- **Meadow** (`etl/steps/data/meadow/worldbank_wdi/2026-02-27/wdi.py`) now extracts every per-indicator field WB exposes via the DDH metadata API. The `if/elif` chain on field names is extended to cover: Aggregation method, Periodicity, Base Period, License Type, General comments, Other notes, Related source links, Other web links, Related indicators. The producer-side `Source` and `Topic` are stored under `source_meta` / `topic_meta` to avoid clobbering the legacy `source` (which the garden step uses as a join key into `wdi.sources.json`).
- **Garden** (`etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.py`) — `create_description_from_producer` switches to an ordered `(column, header)` list that renders each section as `### {Header}:`. The hardcoded `EG.ELC.ACCS.ZS` carve-out for `development_relevance` is dropped — the field is now included for all indicators.

## Why

Esteban [flagged on Slack](https://owid.slack.com/archives/C03NV9Z3YSV/p1777912614276149) that our WDI inflation chart (`inflation-of-consumer-prices`, indicator `FP.CPI.TOTL.ZG`) shows aggregates ("World", "Low income"…) with no indication of how they're computed. WB exposes an "Aggregation method" field (here: `Median`) that we were silently dropping. While we're at it, this PR widens the net to all useful glossary fields so future indicators benefit too.

After this change, `description_from_producer` for `fp_cpi_totl_zg` reads:
```
Inflation as measured by the consumer price index reflects the annual percentage change in the cost to the average consumer of acquiring a basket of goods and services that may be fixed or changed at specified intervals, such as yearly. The Laspeyres formula is generally used.

### Aggregation method:
Median
```

## Intentional omissions

Three DDH fields are extracted into meadow but **not** rendered in `description_from_producer` — comments in code explain why:
- **Source** — duplicates `origin.producer` / `origin.citation_full`.
- **Topic** — WB's internal taxonomy; chart context already covers this.
- **License type** — ~93% of indicators are `CC BY-4.0`; license is already at the dataset/origin level.

**Periodicity** is rendered only when the value isn't `Annual`. ~90% of WDI indicators (1371 / 1516) are annual, which adds noise next to a yearly time series; the section now only surfaces for the 18 indicators with non-annual cadence (`Triennial`, `Biennial`, `Every two years`, `Quarterly (represented as Annual)`).

Also intentionally not extracted from DDH: `Description`, `First level`, `Second level`, `Unit of measure` (taxonomy/classification fields that only appear on the ~130 indicators whose classification entry survived snapshot dedup) and `Indicator Name` (legacy already provides it).

## Test plan

- [x] `make check` clean
- [x] Meadow + Garden run end-to-end locally for `worldbank_wdi/2026-02-27/wdi`
- [x] `description_from_producer` for `fp_cpi_totl_zg` includes "### Aggregation method:\nMedian"
- [x] Spot-checked `eg_elc_accs_zs` (Weighted average), `sp_pop_totl` (Sum), `ny_gdp_mktp_cd` (Gap-filled total) — descriptions render cleanly with all populated sections
- [ ] Grapher upload to staging + visual chart preview (do as part of normal staging review)

## Coverage

After garden, of the 1541 indicators in WDI:
- 987 now have an Aggregation method section
- 18 have Periodicity (only non-Annual values surfaced; see omissions above)
- 760 have Development relevance (previously: 1, only EG.ELC.ACCS.ZS)
- 325 have General comments
- 74 have Base period
- 67 have Other notes
- 69 have Related source links
- 19 have Other web links