### PR TITLE
🔨 explorers: migrate `minerals`

### DIFF
--- a/etl/steps/export/explorers/minerals/latest/minerals.config.yml
+++ b/etl/steps/export/explorers/minerals/latest/minerals.config.yml
@@ -1,0 +1,49 @@
+config:
+  explorerTitle: Minerals
+  explorerSubtitle: Explore the production, reserves and value of minerals.
+  isPublished: true
+  selection:
+    - World
+    - Australia
+    - Chile
+    - China
+    - United States
+  originUrl: https://ourworldindata.org/metals-minerals
+
+dimensions:
+  - slug: mineral
+    name: Mineral
+    presentation:
+      type: dropdown
+    choices: []
+
+  - slug: metric
+    name: Metric
+    presentation:
+      type: dropdown
+    choices:
+      - slug: production
+        name: Production
+      - slug: reserves
+        name: Reserves
+      - slug: unit_value
+        name: Unit value
+
+  - slug: type
+    name: Type
+    presentation:
+      type: dropdown
+    choices: []
+
+  - slug: measure
+    name: Share of global
+    presentation:
+      type: checkbox
+      choice_slug_true: share_of_global
+    choices:
+      - slug: absolute
+        name: ""
+      - slug: share_of_global
+        name: Share of global
+
+views: []

--- a/etl/steps/export/explorers/minerals/latest/minerals.py
+++ b/etl/steps/export/explorers/minerals/latest/minerals.py
@@ -1,195 +1,149 @@
-"""Load a grapher dataset and create an explorer dataset with its tsv file."""
+"""Build the Minerals explorer.
 
-import pandas as pd
+Single upstream table — `grapher/minerals/.../minerals` — with one column per
+(metric, mineral, type, unit) combination. Each column's metadata title encodes
+those four pieces as `metric|commodity|sub_commodity|unit`. This step parses
+that title, lifts the four pieces onto `m.dimensions`, and lets
+`paths.create_collection(tb=tb, ...)` auto-expand one view per column.
+
+The explorer is the YAML-driven sibling of `export://multidim/minerals/latest/minerals`
+(see `etl/steps/export/multidim/minerals/latest/minerals.py`); the construction
+logic is intentionally near-identical, with two differences:
+- Top-level `config:` carries the legacy explorer settings (explorerTitle,
+  explorerSubtitle, selection, …) instead of the multidim's title block.
+- `measure` is presented as a checkbox in the explorer (`Share of global`)
+  rather than a radio.
+
+Sparse-data handling: a small set of columns either has very few data points
+(<5 years range — show as a bar by setting `minTime` to the last year) or covers
+too few entities to make the map tab useful (`COLUMNS_WITHOUT_MAP_TAB`). Both
+are applied per-view via `set_global_config` lambdas. The `Unit value` metric
+also drops the map tab (single global price, not country-level).
+"""
+
+from owid.catalog.utils import underscore
 from structlog import get_logger
 
 from etl.helpers import PathFinder
 
-# Initialize log.
 log = get_logger()
 
-# Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
-# Prefix used for "share" columns.
-# NOTE: This must coincide with the same variable as defined in the garden minerals step.
+# Prefix used by the garden step to mark "share of global" indicators.
 SHARE_OF_GLOBAL_PREFIX = "share of global "
 
+# Columns for which the map tab is hidden (sparse geographic data not worth a map).
+COLUMNS_WITHOUT_MAP_TAB = {
+    "production_bismuth_mine_tonnes",
+    "production_boron_mine_tonnes",
+    "production_diamond_mine_and_synthetic__industrial_tonnes",
+    "production_gallium_refinery_tonnes",
+    "production_mica_mine__sheet_tonnes",
+    "production_sand_and_gravel_mine__construction_tonnes",
+    "share_of_global_production_bismuth_mine_tonnes",
+    "share_of_global_production_boron_mine_tonnes",
+    "share_of_global_production_diamond_mine_and_synthetic__industrial_tonnes",
+    "share_of_global_production_gallium_refinery_tonnes",
+    "share_of_global_production_mica_mine__sheet_tonnes",
+    "share_of_global_production_sand_and_gravel_mine__construction_tonnes",
+}
 
-def run(dest_dir: str) -> None:
-    #
-    # Load inputs.
-    #
-    # Load minerals grapher dataset and read its main table.
+
+def _column_from_view(view) -> str | None:
+    """Return the indicator's bare column name from a view's catalog path."""
+    if view.indicators.y:
+        path = view.indicators.y[0].catalogPath
+        if "#" in path:
+            return path.split("#")[-1]
+    return None
+
+
+def run() -> None:
+    config = paths.load_collection_config()
+
     ds = paths.load_dataset("minerals")
     tb = ds.read("minerals")
 
-    #
-    # Process data.
-    #
-    # Prepare graphers table of explorer.
-    variable_ids = []
-    metric_dropdown = []
-    commodity_dropdown = []
-    sub_commodity_dropdown = []
-    share_of_global = []
-    map_tab = []
-    # Given that USGS current data often has very few data points, we'll specify the minimum year in each view.
-    # This way, if there are too few data points, we'll use the latest year as the minimum year, and that way the view
-    # will become a bar chart (instead of a line chart with just a few points).
-    min_year = []
+    # Tag each column with its (mineral, metric, type, measure) dimensions.
+    sparse_min_year: dict[str, int] = {}
+    mineral_names: dict[str, str] = {}
+    type_names: dict[str, str] = {}
+
     for column in tb.drop(columns=["country", "year"]).columns:
-        # Select the
         years = tb["year"][tb[column].notnull()]
-        if len(years) > 0:
-            metric, commodity, sub_commodity, unit = tb[column].metadata.title.split("|")
-            if metric.startswith(SHARE_OF_GLOBAL_PREFIX):
-                metric = metric.replace(SHARE_OF_GLOBAL_PREFIX, "")
-                is_share_of_global = True
-            else:
-                is_share_of_global = False
-            metric = metric.replace("_", " ").capitalize()
-            commodity = commodity.capitalize()
-            # NOTE: Ideally, we should not show any unit in the subcommodity dropdown. See note below.
-            if unit.startswith("tonnes"):
-                sub_commodity = f"{sub_commodity.capitalize()} ({unit})"
-            else:
-                sub_commodity = f"{sub_commodity.capitalize()}"
+        if len(years) == 0:
+            continue
 
-            # Metric "Unit value" should not have a map tab.
-            if metric in ["Unit value"]:
-                has_map_tab = False
-            else:
-                has_map_tab = True
+        metric, commodity, sub_commodity, unit = tb[column].metadata.title.split("|")
 
-            ############################################################################################################
-            # Manually remove the map tab where it is not useful.
-            if column in [
-                "production_cesium_mine_tonnes",
-                # "production_chromium_mine_tonnes",
-                "production_diamond_mine_and_synthetic__industrial_tonnes",
-                "share_of_global_production_diamond_mine_and_synthetic__industrial_tonnes",
-                "reserves_kyanite_mine__kyanite_and_sillimanite_tonnes",
-                "production_soda_ash_synthetic_tonnes",
-                "reserves_zeolites_mine_tonnes",
-                "production_mica_mine__sheet_tonnes",
-                "share_of_global_production_mica_mine__sheet_tonnes",
-                "production_bismuth_mine_tonnes",
-                "share_of_global_production_bismuth_mine_tonnes",
-                "production_boron_mine_tonnes",
-                "share_of_global_production_boron_mine_tonnes",
-                "production_gallium_refinery_tonnes",
-                "share_of_global_production_gallium_refinery_tonnes",
-                "production_sand_and_gravel_mine__construction_tonnes",
-                "share_of_global_production_sand_and_gravel_mine__construction_tonnes",
-            ]:
-                has_map_tab = False
-            ############################################################################################################
+        if metric.startswith(SHARE_OF_GLOBAL_PREFIX):
+            metric = metric.replace(SHARE_OF_GLOBAL_PREFIX, "")
+            measure = "share_of_global"
+        else:
+            measure = "absolute"
+        metric = metric.replace("_", " ").lower()
 
-            # Append extracted values.
-            variable_ids.append([f"{ds.metadata.uri}/{tb.metadata.short_name}#{column}"])
-            metric_dropdown.append(metric)
-            commodity_dropdown.append(commodity)
-            sub_commodity_dropdown.append(sub_commodity)
-            share_of_global.append(is_share_of_global)
-            map_tab.append(has_map_tab)
+        mineral_slug = underscore(commodity)
+        type_slug = underscore(sub_commodity)
+        mineral_names[mineral_slug] = commodity
+        type_names[type_slug] = sub_commodity
 
-            if (years.max() - years.min()) < 5:
-                # If there are only a few data points, show only the latest year (as a bar chart).
-                min_year.append(years.max())
-            else:
-                # Otherwise, show all years (as a line chart).
-                min_year.append(years.min())
-    df_graphers = pd.DataFrame()
-    df_graphers["yVariableIds"] = variable_ids
-    df_graphers["Mineral Dropdown"] = commodity_dropdown
-    df_graphers["Metric Dropdown"] = metric_dropdown
-    df_graphers["Type Dropdown"] = sub_commodity_dropdown
-    df_graphers["Share of global Checkbox"] = share_of_global
-    df_graphers["minTime"] = min_year
-    df_graphers["hasMapTab"] = map_tab
+        tb[column].m.dimensions = {
+            "mineral": mineral_slug,
+            "metric": underscore(metric),
+            "type": type_slug,
+            "measure": measure,
+        }
+        tb[column].m.original_short_name = "value"
 
-    # Impose that all line charts start at zero.
-    df_graphers["yAxisMin"] = 0
+        if (years.max() - years.min()) < 5:
+            sparse_min_year[column] = int(years.max())
 
-    # NOTE: Currently, most columns have "tonnes" as unit, but often there a other units like "tonnes of gross weight".
-    # I think that, ideally, all units should be "tonnes" and we should add a footnote to clarify the unit where needed.
-    # But at least, for now, remove the "(tonnes)" from the "Type Dropdown" column if all options are in "tonnes".
-    # If there are different units within the same dropdown, we keep the brackets, to avoid overwriting.
-    remove_unit_mask = df_graphers.groupby(["Mineral Dropdown", "Metric Dropdown"])["Type Dropdown"].transform(
-        lambda x: x.str.contains("(tonnes)", regex=False).all()
+    missing = COLUMNS_WITHOUT_MAP_TAB - set(tb.columns)
+    assert not missing, f"COLUMNS_WITHOUT_MAP_TAB references unknown columns: {missing}"
+
+    c = paths.create_collection(
+        config=config,
+        tb=tb,
+        indicator_names=["value"],
+        dimensions=["mineral", "metric", "type", "measure"],
+        common_view_config={"yAxis": {"min": 0}},
+        choice_renames={
+            "mineral": mineral_names,
+            "type": type_names,
+        },
+        short_name="minerals",
+        explorer=True,
     )
-    df_graphers.loc[remove_unit_mask, "Type Dropdown"] = df_graphers.loc[remove_unit_mask, "Type Dropdown"].str.replace(
-        " (tonnes)", ""
-    )
-    # Warn if there are still mineral-metric-type combinations with multiple units.
-    multiple_units = sorted(
-        set(df_graphers[df_graphers["Type Dropdown"].str.contains("(", regex=False)]["Mineral Dropdown"])
-    )
-    if multiple_units:
-        log.warning(f"Units different from '(tonnes)' found for {multiple_units}")
 
-    # Sanity check.
-    error = "Duplicated rows in explorer."
-    assert df_graphers[
-        df_graphers.duplicated(
-            subset=["Mineral Dropdown", "Type Dropdown", "Metric Dropdown", "Share of global Checkbox"], keep=False
+    def _has_map_tab(view) -> bool:
+        col = _column_from_view(view)
+        if col in COLUMNS_WITHOUT_MAP_TAB:
+            return False
+        if view.dimensions.get("metric") == "unit_value":
+            return False
+        return True
+
+    def _min_time(view):
+        col = _column_from_view(view)
+        return sparse_min_year.get(col)
+
+    def _default_view(view) -> bool:
+        d = view.dimensions
+        return (
+            d.get("mineral") == "copper"
+            and d.get("metric") == "production"
+            and d.get("type") == "mine"
+            and d.get("measure") == "absolute"
         )
-    ].empty, error
 
-    # Sort rows conveniently.
-    df_graphers["Metric Dropdown"] = pd.Categorical(
-        df_graphers["Metric Dropdown"],
-        categories=["Production", "Reserves", "Unit value"],
-        ordered=True,
-    )
-    df_graphers = df_graphers.sort_values(["Mineral Dropdown", "Metric Dropdown", "Type Dropdown"]).reset_index(
-        drop=True
+    c.set_global_config(
+        {
+            "hasMapTab": _has_map_tab,
+            "minTime": _min_time,
+            "defaultView": _default_view,
+        }
     )
 
-    # Choose which indicator to show by default when opening the explorer.
-    df_graphers["defaultView"] = False
-    df_graphers.loc[
-        (df_graphers["Mineral Dropdown"] == "Copper")
-        & (df_graphers["Type Dropdown"] == "Mine")
-        & (df_graphers["Metric Dropdown"] == "Production")
-        & (~df_graphers["Share of global Checkbox"]),
-        "defaultView",
-    ] = True
-
-    # Prepare explorer metadata.
-    config = {
-        "explorerTitle": "Minerals",
-        "originUrl": "https://ourworldindata.org/metals-minerals",
-        "explorerSubtitle": "Explore the production, reserves and value of minerals.",
-        "selection": ["World", "Australia", "Chile", "China", "United States"],
-        "isPublished": True,
-    }
-
-    # To begin with, create linear map brackets between 0% and 100% for "share" columns.
-    # NOTE: This should be executed only the first time, to have something to start with. Then comment this code, and
-    #  continue improving map brackets using the Map Bracketer tool.
-    # NOTE: When running these lines, add df_columns as an argument in create_explorer_legacy.
-    # share_columns = sorted(
-    #     set(
-    #         sum(
-    #             df_graphers[
-    #                 (df_graphers["Metric Dropdown"].isin(["Production", "Reserves"]))
-    #                 & (df_graphers["Share of global Checkbox"])
-    #             ]["yVariableIds"].tolist(),
-    #             [],
-    #         )
-    #     )
-    # )
-    # df_columns = pd.DataFrame({"catalogPath": share_columns})
-    # df_columns["colorScaleNumericBins"] = [
-    #     [10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0] for column in share_columns
-    # ]
-    # df_columns["colorScaleScheme"] = "BuGn"
-
-    #
-    # Save outputs.
-    #
-    # Create a new explorers dataset and tsv file.
-    ds_explorer = paths.create_explorer_legacy(config=config, df_graphers=df_graphers)
-    ds_explorer.save()
+    c.save(tolerate_extra_indicators=True)


### PR DESCRIPTION
| PROD | STAGING |
|--------|--------|
| [link](https://ourworldindata.org/explorers/minerals) | [link](http://staging-site-refactor-migrate-minerals/admin/explorers/preview/minerals) |

@pabloarosado The explorer looks good! I see that there was prior work on porting this explorer to an MDIM in https://github.com/owid/etl/pull/5358. So basically here I'm borrowing most of the code from the MDIM.

Also, I've realized that there is an explorer `minerals_supply_and_demand_prospects`. I suppose that's fine to keep?