### PR TITLE
💄 Inequality MDims feedback

### DIFF
--- a/etl/steps/data/garden/lis/2026-03-16/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2026-03-16/luxembourg_income_study.meta.yml
@@ -89,7 +89,7 @@ definitions:
     <%- elif poverty_line == "30" %>
     A poverty line of {definitions.poverty_line_per_day} represents definitions of national poverty lines in high-income countries.
     <%- elif poverty_line in ["40% of the median", "50% of the median", "60% of the median"] %>
-    This is a measure of _relative_ poverty – it captures the share of people whose income is low by the standards typical in their own country.
+    This is a measure of _relative_ poverty — it captures the share of people whose income is low by the standards typical in their own country.
     <%- endif %>
 
   description_key_extreme_poverty_additional: |-
@@ -114,7 +114,7 @@ definitions:
 
   description_key_equivalence_scale: |-
     <% if equivalence_scale == "square root" %>
-    Income has been equivalized – adjusted to account for household size and composition, since people in the same household can share costs like rent and heating. LIS does this using the square root equivalence scale: household income is divided by the square root of the number of household members.
+    Income has been equivalized — adjusted to account for household size and composition, since people in the same household can share costs like rent and heating. LIS does this using the square root equivalence scale: household income is divided by the square root of the number of household members.
     <%- elif equivalence_scale == "per capita" %>
     Income is per capita, which means that each person (including children) is attributed an equal share of the total income received by all members of their household.
     <%- endif %>
@@ -236,7 +236,7 @@ definitions:
     <%- elif poverty_line in poverty_line_umic %>
     The poverty line of {definitions.poverty_line_per_day} is set by the World Bank to be representative of the definitions of poverty adopted in upper-middle-income countries. {definitions.ppp_adjustment_subtitle} {definitions.subtitle_welfare_type}
     <%- elif poverty_line in ["40% of the median", "50% of the median", "60% of the median"] %>
-    Relative poverty is measured in terms of a poverty line that rises and falls over time with average incomes – in this case set at <<poverty_line>> income. {definitions.subtitle_welfare_type}
+    Relative poverty is measured in terms of a poverty line that rises and falls over time with average incomes — in this case set at <<poverty_line>> income. {definitions.subtitle_welfare_type}
     <%- else %>
     {definitions.ppp_adjustment_subtitle} {definitions.subtitle_welfare_type}
     <%- endif %>

--- a/etl/steps/data/garden/lis/2026-03-16/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2026-03-16/luxembourg_income_study.meta.yml
@@ -222,7 +222,7 @@ definitions:
   threshold_title: |-
     {macros}
     <% if decile == 5 %>
-    Threshold income {definitions.per_period} marking the <<percentiles_thr(decile) | lower>> (median) ({definitions.welfare_type})
+    Median income {definitions.per_period} ({definitions.welfare_type})
     <%- else %>
     Threshold income {definitions.per_period} marking the <<percentiles_thr(decile) | lower>> ({definitions.welfare_type})
     <%- endif %>

--- a/etl/steps/data/garden/lis/2026-03-16/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2026-03-16/luxembourg_income_study.meta.yml
@@ -114,7 +114,7 @@ definitions:
 
   description_key_equivalence_scale: |-
     <% if equivalence_scale == "square root" %>
-    Income has been equivalized – adjusted to account for the household size and composition, to consider the fact that people in the same household can share costs like rent and heating. LIS uses the square root equivalence scale: household income is divided by the square root of the number of household members.
+    Income has been equivalized – adjusted to account for household size and composition, since people in the same household can share costs like rent and heating. LIS does this using the square root equivalence scale: household income is divided by the square root of the number of household members.
     <%- elif equivalence_scale == "per capita" %>
     Income is per capita, which means that each person (including children) is attributed an equal share of the total income received by all members of their household.
     <%- endif %>

--- a/etl/steps/data/garden/lis/2026-03-16/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2026-03-16/luxembourg_income_study.meta.yml
@@ -130,7 +130,7 @@ definitions:
     Incomes are distributed very unequally, both between countries and within them. This data lets you compare how income is distributed across the population and how those levels have changed over time. We discuss this in more detail on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_lis: |-
-    The data comes from the Luxembourg Income Study (LIS), which takes the original microdata from national household surveys and harmonizes it — reconstructing incomes using a common set of definitions across countries. This makes the data more comparable across countries than other sources, but at the cost of covering fewer countries.
+    The data comes from the Luxembourg Income Study (LIS), which takes the original data from national household surveys and harmonizes it — reconstructing incomes using a common set of definitions across countries. This makes the data more comparable across countries than other sources, but at the cost of covering fewer countries.
 
   description_key_gini: |-
     Incomes are distributed very unequally, both between countries and within them. The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality. We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss income inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).

--- a/etl/steps/data/garden/lis/2026-03-16/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2026-03-16/luxembourg_income_study.meta.yml
@@ -127,22 +127,22 @@ definitions:
     <%- endif %>
 
   description_key_inequality: |-
-    Incomes are distributed very unequally, both between countries and within them. This data lets you compare how income is distributed across the population and how those levels have changed over time. We discuss this in more detail on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    Incomes are distributed very unequally, both between countries and within them. This data lets you compare how income is distributed across the population and how those levels have changed over time. We discuss this in more detail on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_lis: |-
     The data comes from the Luxembourg Income Study (LIS), which takes the original microdata from national household surveys and harmonizes it — reconstructing incomes using a common set of definitions across countries. This makes the data more comparable across countries than other sources, but at the cost of covering fewer countries.
 
   description_key_gini: |-
-    Incomes are distributed very unequally, both between countries and within them. The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality. We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss income inequality more broadly on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    Incomes are distributed very unequally, both between countries and within them. The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality. We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss income inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_palma_ratio : |-
-    Incomes are distributed very unequally, both between countries and within them. The Palma ratio captures this by comparing the income share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% receive twice as much as the poorest 40%. We discuss income inequality more broadly on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    Incomes are distributed very unequally, both between countries and within them. The Palma ratio captures this by comparing the income share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% receive twice as much as the poorest 40%. We discuss income inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_mean: |-
-    This data shows the mean (average) income per person. Because incomes are unevenly distributed, with a small number of people on very high incomes, the mean is typically higher than what most people have. To see the income of a typical person, you can look at the median income instead. We discuss how incomes are distributed in more detail on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    This data shows the mean (average) income per person. Because incomes are unevenly distributed, with a small number of people on very high incomes, the mean is typically higher than what most people have. To see the income of a typical person, you can look at the median income instead. We discuss how incomes are distributed in more detail on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_median: |-
-    This data shows the median income per person — the level below which half the population falls. Unlike the mean, the median is not pulled up by the incomes of the richest, so it better reflects what a typical person has. You can switch to mean income using the chart controls. We discuss how incomes are distributed in more detail on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    This data shows the median income per person — the level below which half the population falls. Unlike the mean, the median is not pulled up by the incomes of the richest, so it better reflects what a typical person has. You can switch to mean income using the chart controls. We discuss how incomes are distributed in more detail on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_avg: |-
     This data shows the mean (average) income per person within decile groups — each representing a tenth of the population, ranked by income. For example, the poorest decile is the poorest 10% of people in a country.

--- a/etl/steps/data/garden/wb/2026-03-24/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2026-03-24/world_bank_pip.meta.yml
@@ -225,19 +225,19 @@ definitions:
     <%- endif %>
 
   description_key_inequality: |-
-    Incomes are distributed very unequally, both between countries and within them. This data lets you compare how income is distributed across the population and how those levels have changed over time. We discuss this in more detail on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    Incomes are distributed very unequally, both between countries and within them. This data lets you compare how income is distributed across the population and how those levels have changed over time. We discuss this in more detail on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_gini: |-
-    Incomes are distributed very unequally, both between countries and within them. The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality. We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss income inequality more broadly on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    Incomes are distributed very unequally, both between countries and within them. The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality. We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss income inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_palma_ratio : |-
-    Incomes are distributed very unequally, both between countries and within them. The Palma ratio captures this by comparing the income share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% receive twice as much as the poorest 40%. We discuss income inequality more broadly on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    Incomes are distributed very unequally, both between countries and within them. The Palma ratio captures this by comparing the income share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% receive twice as much as the poorest 40%. We discuss income inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_mean: |-
-    This data shows the mean (average) income or consumption per person. Because incomes are unevenly distributed, with a small number of people on very high incomes, the mean is typically higher than what most people have. To see the income of a typical person, you can look at the median income instead. We discuss how incomes are distributed in more detail on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    This data shows the mean (average) income or consumption per person. Because incomes are unevenly distributed, with a small number of people on very high incomes, the mean is typically higher than what most people have. To see the income of a typical person, you can look at the median income instead. We discuss how incomes are distributed in more detail on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_median: |-
-    This data shows the median income or consumption per person — the level below which half the population falls. Unlike the mean, the median is not pulled up by the incomes of the richest, so it better reflects what a typical person has. We discuss how incomes are distributed in more detail on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    This data shows the median income or consumption per person — the level below which half the population falls. Unlike the mean, the median is not pulled up by the incomes of the richest, so it better reflects what a typical person has. We discuss how incomes are distributed in more detail on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_avg: |-
     This data shows the mean (average) income or consumption per person within decile groups — each representing a tenth of the population, ranked by income. For example, the poorest decile is the poorest 10% of people in a country.

--- a/etl/steps/data/garden/wb/2026-03-24/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2026-03-24/world_bank_pip.meta.yml
@@ -198,7 +198,7 @@ definitions:
     Depending on the country and year, the data refers either to income (after taxes and benefits) or to consumption, [per capita](#dod:per-capita). These are not perfectly comparable — consumption tends to be more evenly distributed than income. For most countries, we have only one option available. But when there is a mix of consumption and income data points, we process the data to keep one observation per country and year.
 
   description_key_welfare_type_spells: |-
-    The data comes from the World Bank's Poverty and Inequality Platform (PIP), which draws on national household surveys. Depending on the country and year, the data refers either to income (after taxes and benefits) or to consumption, [per capita](#dod:per-capita). These are not perfectly comparable — consumption tends to be more evenly distributed than income. This chart shows the data with income and consumption measures separately.
+    The data comes from the World Bank's Poverty and Inequality Platform (PIP), which draws on national household surveys. Depending on the country and year, the data refers either to income (after taxes and benefits) or to consumption, [per capita](#dod:per-capita). These are not perfectly comparable — consumption tends to be more evenly distributed than income. Comparability can also break _within_ either measure when survey methods or measurement change over time. This chart shows each comparable series separately.
 
   description_key_welfare_type: |-
     <% if welfare_type is defined and survey_comparability is defined and survey_comparability == "No spells" %>

--- a/etl/steps/data/garden/wb/2026-03-24/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2026-03-24/world_bank_pip.meta.yml
@@ -411,13 +411,13 @@ definitions:
     {macros}
     <% if survey_comparability == "No spells" %>
     <% if decile == "5" %>
-    Threshold <<welfare_type>> {definitions.per_period} marking the <<percentiles_thr(decile) | lower>> (median)
+    Median <<welfare_type>> {definitions.per_period}
     <%- else %>
     Threshold <<welfare_type>> {definitions.per_period} marking the <<percentiles_thr(decile) | lower>>
     <%- endif %>
     <%- else %>
     <% if decile == "5" %>
-    Threshold income or consumption {definitions.per_period} marking the <<percentiles_thr(decile) | lower>> (median)
+    Median income or consumption {definitions.per_period}
     <%- else %>
     Threshold income or consumption {definitions.per_period} marking the <<percentiles_thr(decile) | lower>>
     <%- endif %>

--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
@@ -157,13 +157,13 @@ definitions:
     This is a measure of _relative_ poverty – it captures the share of people whose {definitions.concept_welfare_type} is low by the standards typical in their own country.
 
   description_key_top_incomes: |-
-    Incomes are distributed very unequally, both between countries and within them. A large share of total income is concentrated among the very richest, making the top of the distribution important to understand. Read more in our topic page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    Incomes are distributed very unequally, both between countries and within them. A large share of total income is concentrated among the very richest, making the top of the distribution important to understand. Read more in our topic page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_gini: |-
-    Incomes are distributed very unequally, both between countries and within them. The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality. We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss income inequality more broadly on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    Incomes are distributed very unequally, both between countries and within them. The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality. We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss income inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_palma_ratio: |-
-    Incomes are distributed very unequally, both between countries and within them. The Palma ratio captures this by comparing the income share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% receive twice as much as the poorest 40%. We discuss income inequality more broadly on our page on [Economic Inequality](https://ourworldindata.org/economic-inequality).
+    Incomes are distributed very unequally, both between countries and within them. The Palma ratio captures this by comparing the income share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% receive twice as much as the poorest 40%. We discuss income inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_share: |-
     This data shows the share of total income that goes to specific groups of the population. For example, if the richest decile receives 40% of total income, it means the richest 10% of people share 40% of all income between them.

--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
@@ -197,7 +197,7 @@ definitions:
   title_threshold: |-
     {macros}
     <% if quantile == "p50p60" %>
-    "Median {definitions.concept_welfare_type} {definitions.per_period}{definitions.concept_welfare_type_for_title}"
+    Median {definitions.concept_welfare_type} {definitions.per_period}{definitions.concept_welfare_type_for_title}
     <%- else %>
     Threshold {definitions.concept_welfare_type} {definitions.per_period} marking the <<quantiles_thr(quantile) | lower>>{definitions.concept_welfare_type_for_title}
     <%- endif %>

--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
@@ -197,7 +197,7 @@ definitions:
   title_threshold: |-
     {macros}
     <% if quantile == "p50p60" %>
-    Threshold {definitions.concept_welfare_type} {definitions.per_period} marking the <<quantiles_thr(quantile) | lower>> (median){definitions.concept_welfare_type_for_title}
+    "Median {definitions.concept_welfare_type} {definitions.per_period}{definitions.concept_welfare_type_for_title}"
     <%- else %>
     Threshold {definitions.concept_welfare_type} {definitions.per_period} marking the <<quantiles_thr(quantile) | lower>>{definitions.concept_welfare_type_for_title}
     <%- endif %>

--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
@@ -154,7 +154,7 @@ definitions:
     <%- endif %>
 
   description_key_relative_poverty: |-
-    This is a measure of _relative_ poverty – it captures the share of people whose {definitions.concept_welfare_type} is low by the standards typical in their own country.
+    This is a measure of _relative_ poverty — it captures the share of people whose {definitions.concept_welfare_type} is low by the standards typical in their own country.
 
   description_key_top_incomes: |-
     Incomes are distributed very unequally, both between countries and within them. A large share of total income is concentrated among the very richest, making the top of the distribution important to understand. Read more in our topic page on [economic inequality](https://ourworldindata.org/economic-inequality).
@@ -885,7 +885,7 @@ tables:
         presentation:
           grapher_config:
             title: "Relative poverty: Share of the population below <<poverty_line>> (<<welfare_type>>)"
-            subtitle: Relative poverty is measured in terms of a poverty line that rises and falls over time with average incomes – in this case set at <<poverty_line>> {definitions.concept_welfare_type}. {definitions.subtitle_welfare_type}
+            subtitle: Relative poverty is measured in terms of a poverty line that rises and falls over time with average incomes — in this case set at <<poverty_line>> {definitions.concept_welfare_type}. {definitions.subtitle_welfare_type}
             note: "{definitions.note_before_tax}"
             hasMapTab: true
             tab: map

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
@@ -29,18 +29,21 @@ dimensions:
     choices:
       - slug: mean
         name: Mean income
+        description: The average income across the whole population
       - slug: median
         name: Median income
+        description: The level of income which 50% of the population falls below, and 50% fall above
       - slug: thr
-        name: Income threshold
-        description: The income level below which 10%, 20%, 30%, etc. of the population falls
+        name: Threshold income
+        description: The level of income below which 10%, 20%, 30%, etc. of the population falls
         group: By decile
       - slug: avg
         name: "Mean income "
+        description: The average level of income of each decile (tenth) of the population
         group: By decile
       - slug: share
-        name: Income share
-        description: The share of income received by each income group
+        name: Share of income
+        description: The share of income received by each decile (tenth) of the population
         group: By decile
 
   - name: Group

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
@@ -31,14 +31,17 @@ dimensions:
         name: Mean income
       - slug: median
         name: Median income
-      - slug: avg
-        name: Mean income, by decile
       - slug: thr
-        name: Income threshold for each decile
+        name: Income threshold
         description: The income level below which 10%, 20%, 30%, etc. of the population falls
+        group: By decile
+      - slug: avg
+        name: "Mean income "
+        group: By decile
       - slug: share
-        name: Income share of each decile
+        name: Income share
         description: The share of income received by each income group
+        group: By decile
 
   - name: Group
     slug: decile

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
@@ -29,21 +29,21 @@ dimensions:
     choices:
       - slug: mean
         name: Mean income or consumption
-        # description:
+        description: The average income or consumption across the whole population
       - slug: median
         name: Median income or consumption
-        # description:
+        description: The level of income or consumption which 50% of the population falls below, and 50% fall above
       - slug: thr
-        name: Income threshold
-        description: The income or consumption level below which 10%, 20%, 30%, etc. of the population falls
+        name: Threshold income or consumption
+        description: The level of income or consumption below which 10%, 20%, 30%, etc. of the population falls
         group: By decile
       - slug: avg
-        name: Mean income
-        # description:
+        name: "Mean income or consumption "
+        description: The average level of income or consumption of each decile (tenth) of the population
         group: By decile
       - slug: share
-        name: Income share
-        description: The share of income or consumption received by each income group
+        name: Share of income or consumption
+        description: The share of income or consumption received by each decile (tenth) of the population
         group: By decile
 
   - name: Group

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
@@ -33,15 +33,18 @@ dimensions:
       - slug: median
         name: Median income or consumption
         # description:
-      - slug: avg
-        name: Mean income or consumption, by decile
-        # description:
       - slug: thr
-        name: Income threshold for each decile
+        name: Income threshold
         description: The income or consumption level below which 10%, 20%, 30%, etc. of the population falls
+        group: By decile
+      - slug: avg
+        name: Mean income
+        # description:
+        group: By decile
       - slug: share
-        name: Income share of each decile
+        name: Income share
         description: The share of income or consumption received by each income group
+        group: By decile
 
   - name: Group
     slug: decile


### PR DESCRIPTION
## Summary

- Address feedback from Ed and Bastian in the `#bug-bash-inequality-mdims` Slack channel on the inequality MDims.
- Incorporate Joe's feedback on the selectors in the "Incomes across the distribution" charts (PIP and LIS).
- Style-guide cleanups across PIP, LIS, and WID garden metadata:
  - Lowercase `[economic inequality](…)` link text in inline mentions.
  - Replace en-dashes (`–`) with em-dashes (`—`) for asides per the OWID Writing & Style Guide.
- Clarify wording in PIP/LIS/WID descriptions:
  - Equivalence-scale explanation (LIS).
  - Chart title for the median threshold simplified to "Median income …" instead of "Threshold income … marking the 5th decile (median)".
  - PIP "welfare type / spells" description: note that even within income or within consumption, methodology changes can break comparability, so the chart shows each comparable run of surveys as a separate series.

## Test plan

- [x] `etlr incomes_pip --grapher --export` runs cleanly
- [x] `etlr incomes_lis --grapher --export` runs cleanly
- [x] Visual check of dropdown labels and chart text on staging