### PR TITLE
🐝 Restore Pylance language server with type checking off

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
-  // Needed for ty type checker to work correctly
-  "python.languageServer": "None",
+  "python.languageServer": "Pylance",
+  // Disable Pylance type checking so it doesn't conflict with `ty` (run via `make check`).
+  "python.analysis.typeCheckingMode": "off",
   "esbonio.sphinx.confDir": "",
   "files.associations": {
     "*.dvc": "yaml"


### PR DESCRIPTION
## Summary
- Re-enable Pylance as the Python language server in `.vscode/settings.json`. The previous `"None"` value disabled all of Pylance's IDE features (hover, go-to-definition, semantic highlighting, autocomplete, refactoring).
- Disable Pylance's type checking (`python.analysis.typeCheckingMode: "off"`) so it doesn't report diagnostics that conflict with `ty` (which is the team's chosen type checker, run via `make check`'s `.venv/bin/ty check ...`).
- Net effect: editor navigation features are back, while `ty` remains the sole source of type-error diagnostics — preserving the original intent of #5376 (migrating off pyright onto ty).

## Context
The previous setting was introduced alongside the migration to `ty`. With Pylance fully off, opening a `.py` file gave no hover tooltips and Cmd+click did nothing — confirmed by inspecting `Output → Pylance` (channel missing because the server wasn't running). This change restores the IDE experience without bringing back duplicate type-check noise.

## Test plan
- [ ] Reload VS Code window, open a `.py` file, verify hover and Cmd+click navigation work.
- [ ] Run `make check` and confirm `ty` still runs and reports as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)