### PR TITLE
Run make check before each commit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,15 +16,15 @@
         ]
       }
     ],
-    "PostToolUse": [
+    "PreToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
-            "command": "f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty'); case \"$f\" in \"$CLAUDE_PROJECT_DIR\"/*.py) cd \"$CLAUDE_PROJECT_DIR\" && make check || exit 2 ;; esac",
-            "asyncRewake": true,
-            "statusMessage": "make check"
+            "command": "cd \"$CLAUDE_PROJECT_DIR\" && out=$(make check 2>&1) || { echo \"$out\" >&2; exit 2; }",
+            "if": "Bash(git commit *)",
+            "statusMessage": "make check (pre-commit)"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,19 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // .tool_response.filePath // empty'); case \"$f\" in \"$CLAUDE_PROJECT_DIR\"/*.py) cd \"$CLAUDE_PROJECT_DIR\" && make check || exit 2 ;; esac",
+            "asyncRewake": true,
+            "statusMessage": "make check"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

Adds a blocking `PreToolUse` hook to [.claude/settings.json](.claude/settings.json) so Claude Code runs `make check` before any `git commit *` it issues. If the check fails, the commit is blocked and the output is fed back to the agent.

## Behavior

- **Trigger:** `PreToolUse` on `Bash`, narrowed by `if: "Bash(git commit *)"`. Other bash commands are not intercepted.
- **Mode:** Synchronous and blocking — exit 2 stops the commit and returns the captured output as feedback.
- **Output:** Captured into `out=$(make check 2>&1)`. Silent on success; full output on failure.
- **UI:** `statusMessage: "make check (pre-commit)"` in the spinner during the run (~2–3 s).

## Why

CLAUDE.md mandates `make check` before committing. Earlier iteration ran the hook on every `Write|Edit` to a `.py` file, which was noisy on WIP edits and silent on success (impossible to tell if it ran). Scoping to commit time:

- Runs once per commit, not per edit.
- Enforces the rule at the actual gate it protects (commits → git history).
- Failures are unmissable — the commit is blocked.

## Test plan

- [x] Pipe-tested: `out=$(make check 2>&1)` → 16 lines silenced on success.
- [x] `jq -e` validates the new JSON and the `if` permission rule lands at the right schema path.
- [x] Hook fires from the live session (verified earlier with a sentinel file).
- [ ] After this PR is merged, confirm a fresh session blocks a commit when `make check` fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)