### PR TITLE
📊 Migrate fasttrack snapshots from source to origin

### DIFF
--- a/.claude/skills/migrate-source-to-origin/SKILL.md
+++ b/.claude/skills/migrate-source-to-origin/SKILL.md
@@ -31,13 +31,24 @@ skill once per file in a loop.
 
 ## Workflow
 
-1. **Read the DVC file.** Note:
-   - The legacy `meta.source` block (and any sibling `meta.name`,
-     `meta.description`, `meta.license`). `meta.name` is OWID's internal
-     label, NOT the producer's title.
-   - If a prior `meta.origin` already exists, you're replacing it — but
-     still treat the legacy `meta.source` (if present) as the source of truth.
-   - The `outs:` block (and any other top-level YAML keys) — preserve verbatim.
+1. **Read the DVC file.** Identify the legacy shape:
+   - **`meta.source:` block** (the common form). Sibling `meta.name`,
+     `meta.description`, `meta.license` may also exist.
+   - **Flat top-level fields under `meta:`** (older shape, no `source:`
+     wrapper): `source_name`, `source_published_by`, `publication_year`,
+     `publication_date`, `url`, `source_data_url`, `license_url`,
+     `license_name`, `description`, `date_accessed`, `is_public`,
+     `file_extension`, plus the internal `name`. Treat these as if they
+     lived under `meta.source.*` — same field rules apply. Drop
+     `namespace`/`short_name`/`version`/`file_extension`/`wdir` — they're
+     derived from the file path.
+
+   `meta.name` is OWID's internal label, NOT the producer's title — drop it.
+
+   If a prior `meta.origin` already exists, you're replacing it — but
+   still treat the legacy fields (if present) as the source of truth.
+
+   The `outs:` block (and any other top-level YAML keys) — preserve verbatim.
 
 2. **Apply STEP 1 (coincidence test)** — see below — to decide whether
    `title_snapshot` and `description_snapshot` should be set at all.
@@ -61,11 +72,57 @@ skill once per file in a loop.
    one-liner instead of `Edit`. Most files don't have such comments, so
    `Edit` is fine by default.
 
-7. **Validate** the rewritten file:
+7. **Audit the diff** before validating. Read every legacy field and
+   confirm it maps somewhere in the new origin (or has a documented
+   reason to drop). Watch for these common silent drops:
+   - "Accessed YYYY-MM-DD" tail inside legacy `published_by` — drop from
+     `citation_full` only because `date_accessed` carries the same fact.
+   - Expanded methodology phrases in legacy description (e.g. "including
+     journal articles, …") — keep verbatim in `description`, do not
+     compress.
+   - Downstream `dataset.description` that adds info beyond what the
+     snapshot's description had — lift into `origin.description` (see
+     "Downstream sweep" below).
+
+8. **Validate** the rewritten file:
    ```bash
    .venv/bin/python -c "from etl.snapshot import SnapshotMeta; SnapshotMeta.load_from_yaml('<dvc_path>')"
    ```
    If this fails, read the error, fix the YAML or the offending field, and retry.
+
+9. **Downstream sweep (when migrating snapshots in active chains).**
+   Snapshots used by active garden/grapher steps often have matching
+   `dataset.sources:`, `all_sources:`, or variable-level `sources:` /
+   `descriptions:` blocks in the downstream meta.yml that duplicate the
+   snapshot's source info. After the snapshot is migrated, scan each
+   downstream meta.yml:
+   - If `dataset.description` adds info beyond the snapshot's
+     `description`, lift the extra into `origin.description`.
+   - If a variable's `description_key` / `descriptions:` anchor carries
+     per-source notes (e.g. "OWID uses WHO data for the following
+     countries: …"), move those into the relevant snapshot's
+     `origin.description_snapshot` (see the OWID-curated slice notes case
+     under `description_snapshot`). The notes then travel with the origin
+     to every chart that uses the snapshot.
+   - **Variable-level `description:` → `description_short:` (do NOT lift
+     to `origin.description`).** The legacy variable `description` field
+     is a concept definition for the indicator (renders as the chart's
+     subtitle/data-page short blurb), not source metadata. Rename it to
+     `description_short:` at the same variable level. Lifting it into
+     the snapshot's `origin.description` is wrong — it muddies the
+     producer's data-product description with indicator-concept prose
+     and removes the text from where charts actually display it.
+   - Then strip the now-redundant `sources:`, `licenses:`, `descriptions:`,
+     `all_sources:`, and `dataset.sources:` blocks from the downstream
+     meta.yml.
+   - The downstream `.py` may need refactoring too: `pd.read_csv(snap.path)`
+     and `Table(df, ...)` patterns drop column origins. Use
+     `snap.read_csv()` + `pr.concat` so origins flow through Table
+     operations all the way to grapher.
+
+   Optional for one-off snapshot migrations; mandatory when the
+   downstream meta.yml carries rich source-level prose or when the
+   chain's grapher step combines multiple snapshots.
 
 ---
 
@@ -197,9 +254,32 @@ Bank WDI, OECD reports, etc.), you MAY add one short factual sentence
 identifying what the database is — never two sentences.
 
 ### `description_snapshot` (default omitted)
-Set ONLY when STEP 1 says they differ. Verbatim from the legacy
-`source.description` — the paragraphs about this specific slice. When
-they coincide, omit and put everything in `description`.
+Set in two cases:
+1. **Producer-defined slice (STEP 1 says they differ).** Verbatim from
+   the legacy `source.description` — the paragraphs about this specific
+   slice.
+2. **OWID-curated slice notes.** When the snapshot feeds a combined
+   indicator and the downstream grapher meta.yml has source-specific
+   notes ("OWID uses WHO data for the following countries: …",
+   per-source methodology asides), lift those notes here so they travel
+   with the origin into every chart that uses the snapshot — instead of
+   leaving them in `description_key` or `descriptions:` anchors at the
+   variable level.
+
+When the snapshot coincides with the data product AND has no OWID-curated
+slice notes, omit `description_snapshot` and put everything in `description`.
+
+**Source-property prose belongs on origin, not on variables.** When the
+legacy `dataset.description` contains data-interpretation caveats that
+are properties of how the producer reports the data (e.g. "Negative
+values imply that quantities destroyed or exported exceeded the sum of
+production and imports, so they came from stockpiles"), these are
+source facts — they belong in `origin.description` (or
+`description_snapshot`). Do NOT lift them into variable-level
+`description_key` / `description_short`, which are for
+indicator-concept text. Origin prose travels with the snapshot to every
+chart that uses it; variable-level fields are indicator-specific and
+don't follow the source.
 
 ### `citation_full` (required)
 Producer's preferred citation; long is OK. Start capital, end with a period,
@@ -210,6 +290,13 @@ citation, it goes here.
 Set ONLY when there is a well-known acronym or short brand strictly shorter and more
 recognizable than `producer` (e.g. `FAO`, `WHO`, `V-Dem`). If `producer` is already
 short (`Fouquin and Hugot`, `World Bank`, `NASA`), omit. No year, no period.
+
+**Pairing pattern.** When the institution has a well-known acronym, spell
+out the full name as `producer` and put the acronym in `attribution_short`:
+`producer: World Health Organization` + `attribution_short: WHO`;
+`producer: Food and Agriculture Organization of the United Nations` +
+`attribution_short: FAO`. This gives the data-source pane the full name
+and the chart byline a compact acronym.
 
 ### `version_producer` (default omitted, ≤255 chars)
 Set ONLY when the producer issues a series of releases AND uses a release identifier
@@ -223,6 +310,10 @@ IDs, not versions — never use them here.
 pick a year that is part of a coverage range (`1827–2014`) or a projection
 (`2030–2050`).
 
+**Precision.** When the legacy has both `publication_year: 2022` and
+`publication_date: 2022-09-01`, prefer the full date. Same goes for any
+explicit month/day mentioned in the legacy description.
+
 ### `url_main` and `url_download` (default omitted when no URLs in legacy)
 URLs the legacy provides — typically in `source.url`,
 `source.source_data_url`, or as inline links in `source.description`.
@@ -232,11 +323,11 @@ landing-page URL goes to `url_main`, the direct-download URL to
 `url_download`. URLs in the legacy must not be silently dropped.
 
 ### `date_accessed` (required)
-`YYYY-MM-DD`. Plausibility test: a plausible `date_accessed` is no later
-than ~1 month after the snapshot's version directory date. Anything
-later (e.g. snapshot in `2020/` but `date_accessed: 2026-03-05`) is
-almost always the legacy-migration tool stamping the day it ran, not a
-real access date — treat it as missing.
+`YYYY-MM-DD`. Plausibility test: any `date_accessed` from **2026-03 or
+later** on an older snapshot is likely the legacy-migration tool
+stamping the day it ran, not a real access date. Earlier dates — even
+ones years after the snapshot's version directory — are real OWID
+re-access dates and should be trusted.
 
 Resolution order:
 1. Use `source.date_accessed` if plausible by the test above.
@@ -377,8 +468,9 @@ match `YYYY-MM-DD`, `YYYY`, or `latest`).
 
 ## Out of scope
 
-- Batch driving via `dag/migrated.yml`. For multi-file requests, dispatch one
-  subagent per file in parallel (Agent tool calls in a single message). Don't
-  process serially yourself — that's slow and burns context. Each subagent
-  invokes this skill independently.
-- Indicator-level metadata (garden / grapher steps) — only snapshot DVC `meta.origin`.
+- Batch driving via `dag/migrated.yml` — invoke this skill once per file and
+  loop in your conversation.
+- Authoring indicator-level metadata from scratch — only snapshot DVC
+  `meta.origin` and the cleanup of duplicate source info in downstream
+  garden/grapher meta.yml + `.py` (see "Downstream sweep" in Workflow
+  step 9).

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ vscode_extensions/*/.vscode-test/
 vscode_extensions/*/out/
 
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 CLAUDE.local.md
 
 workbench/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,10 @@ Add 🤖 after emoji for AI-written code: `🔨🤖 Refactor country mapping`
 ### Preserving metadata/origins in steps
 
 - **No `np.where`** — strips origins. Use `tb["col"] = tb["b"]; tb.loc[mask, "col"] = tb.loc[mask, "a"]`
+- **No `pd.concat`** — strips origins. Use `pr.concat` (`from owid.catalog import processing as pr`)
 - **No `index.map()`** to pull columns from another table — loses origins. Use `tb.join(other[["col"]], how="left")`
 - **`snap.read_csv/json/excel/feather/...`** — prefer over manual file reading + `pd.DataFrame`
+- **Don't re-wrap `snap.read_csv()` output in `Table(...)`** — the Table constructor with a plain DataFrame argument drops column-level origins. Mutate the returned Table directly: `tb = snap.read_csv(); tb = tb.dropna(...)`
 - **`paths.regions.harmonize_names(tb, country_col=..., countries_file=...)`** — current harmonization API (replaces `geo.harmonize_countries`)
 - **`Table.format()`** needs both `country` and `year`. For year-less tables: `set_index("country")` + set `tb.metadata.short_name`
 - **`*.meta.yml`**: omit `dataset:` block — inherited from origin. Only define `tables:` → `variables:`

--- a/etl/steps/data/garden/andrew/2019-12-03/co2_mitigation_curves.meta.yml
+++ b/etl/steps/data/garden/andrew/2019-12-03/co2_mitigation_curves.meta.yml
@@ -1,48 +1,21 @@
 dataset:
   title: CO2 mitigation curves for 1.5 and 2 Celsius (Andrew & GCP, 2019)
-  sources:
-    -
-      name: Robbie Andrews (2019); Global Carbon Project (2018); IPCC SR15 (2018)
-      published_by: Robbie Andrew
-      date_accessed: 2022-09-28
-      url: https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml
-      description: Data comes from historical emissions to 2017 from CDIAC/Global Carbon Project, projection to 2018 from Global Carbon Project (Le Quéré et al. 2018)
 
 tables:
   co2_mitigation_curves_1p5celsius:
     title: CO2 mitigation curves for 1.5°C
-    description: |
-      Data denotes the range of CO2 mitigation curves for a range of 'start year scenarios': Scenarios are based on the annual emission reductions necessary to keep global temperature rise below 1.5°C if emissions mitigation was to start in a given year.
-
-      For example, 'Start in 2010' marks the necessary future emissions pathway to have a >66% chance of keeping global average temperatures below 1.5°C warming if global CO2 emissions mitigation had started in 2010, very quickly peaking then falling.
-
-      Data is sourced from Robbie Andrew, and available for download [here](http://folk.uio.no/roberan/t/global_mitigation_curves.shtml).
-
-      Historical emissions to 2017 are sourced from CDIAC/Global Carbon Project, projection to 2018 from Global Carbon Project (Le Quéré et al. 2018).
-
-      Global cumulative CO2 emissions budgets are from the IPCC Special Report on 1.5°C (Rogelj et al 2018): 420 GtCO2 for a 66% of 1.5°C and 1170 GtCO2 for a 66% of 2°C. Mitigation curves describe approximately exponential decay pathways such that the quota is never exceeded (see Raupach et al., 2014).
     variables:
       emissions:
         title: CO2 mitigation curves to meet a 1.5C target
         short_unit: Gt
         unit: gigatonnes
-        description: The range of CO2 mitigation curves to have a >66% chance of keeping global average temperature rise below 1.5°C. Scenarios measure future global annual emissions necessary based on a given start year for emissions mitigation.
+        description_short: The range of CO2 mitigation curves to have a >66% chance of keeping global average temperature rise below 1.5°C. Scenarios measure future global annual emissions necessary based on a given start year for emissions mitigation.
 
   co2_mitigation_curves_2celsius:
     title: CO2 mitigation curves for 2°C
-    description: |
-      Data denotes the range of CO2 mitigation curves for a range of 'start year scenarios': Scenarios are based on the annual emission reductions necessary to keep global temperature rise below 2°C if emissions mitigation was to start in a given year.
-
-      For example, 'Start in 2010' marks the necessary future emissions pathway to have a >66% chance of keeping global average temperatures below 2°C warming if global CO2 emissions mitigation had started in 2010, very quickly peaking then falling.
-
-      Data is sourced from Robbie Andrew, and available for download [here](http://folk.uio.no/roberan/t/global_mitigation_curves.shtml).
-
-      Historical emissions to 2017 are sourced from CDIAC/Global Carbon Project, projection to 2018 from Global Carbon Project (Le Quéré et al. 2018).
-
-      Global cumulative CO2 emissions budgets are from the IPCC Special Report on 1.5°C (Rogelj et al 2018): 420 GtCO2 for a 66% of 1.5°C and 1170 GtCO2 for a 66% of 2°C. Mitigation curves describe approximately exponential decay pathways such that the quota is never exceeded (see Raupach et al., 2014).
     variables:
       emissions:
         title: CO2 mitigation curves to meet a 2C target
         short_unit: Gt
         unit: gigatonnes
-        description: The range of CO2 mitigation curves to have a >66% chance of keeping global average temperature rise below 2°C. Scenarios measure future global annual emissions necessary based on a given start year for emissions mitigation.
+        description_short: The range of CO2 mitigation curves to have a >66% chance of keeping global average temperature rise below 2°C. Scenarios measure future global annual emissions necessary based on a given start year for emissions mitigation.

--- a/etl/steps/data/garden/artificial_intelligence/2023-06-26/ai_wrp_2021.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2023-06-26/ai_wrp_2021.meta.yml
@@ -1,34 +1,9 @@
-dataset:
-  title: World Risk Poll - AI questions (2021)
-  description: >-
-    Spread across four themed reports, the 2021 World Risk Poll covers the biggest risks facing people and communities globally,
-    ranging from road crashes, severe weather, climate change and disaster resilience, to work-related harm, violence and
-    harassment at work, and use of personal data. It will be repeated at least two more times, in 2023 and 2025.
-
-
-    This data includes aggregates of survey responses to the following two questions:
-
-
-    1) Will artificial intelligence help or harm people in the next 20 years?
-
-
-    2) Would you feel safe in a car driven by computer without a human driver?
-  licenses:
-  - name: Lloyd's Register Foundation 2018
-    url: https://wrp.lrfoundation.org.uk/terms-of-use/
-  sources:
-  - name: Lloyd's Register Foundation (2022)
-    url: https://wrp.lrfoundation.org.uk/data-resources/
-    source_data_url: https://wrp.lrfoundation.org.uk/wp-content/uploads/2023/05/lrf_wrp_2021_full_data.zip
-    date_accessed: '2023-06-26'
-    publication_year: 2022
-    published_by: World Risk Poll 2021, Lloyd's Register Foundation (2022)
 tables:
   ai_wrp_2021:
     variables:
       yes__would_feel_safe:
         title: Yes, would feel safe
-        description: Share of respondents who responded "Yes, would feel safe" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "Yes, would feel safe" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -36,7 +11,7 @@ tables:
 
       no__would_not_feel_safe:
         title: No, would not feel safe
-        description: Share of respondents who responded "No, would not feel safe" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "No, would not feel safe" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -44,7 +19,7 @@ tables:
 
       mostly_help:
         title: "Mostly help"
-        description: Share of respondents who responded "Mostly help" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "Mostly help" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -52,7 +27,7 @@ tables:
 
       mostly_harm:
         title: "Mostly harm"
-        description: Share of respondents who responded "Mostly harm" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "Mostly harm" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -60,7 +35,7 @@ tables:
 
       neither:
         title: "Neither"
-        description: Share of respondents who responded "Neither" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "Neither" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -68,7 +43,7 @@ tables:
 
       dk_no_op:
         title: "Don't have an opinion, Don't know - help/harm question"
-        description: Share of respondents said "Don't have an opinion" or "Don't know" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents said "Don't have an opinion" or "Don't know" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -77,7 +52,7 @@ tables:
 
       other_help_harm:
         title: "Don't have an opinion, Don't know, or Refused - help/harm question"
-        description: Share of respondents said "Don't have an opinion", "Don't know" or refused the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents said "Don't have an opinion", "Don't know" or refused the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -86,7 +61,7 @@ tables:
 
       other_yes_no:
         title: "Don't know or Refused - self-driving cars question"
-        description: Share of respondents who refused to answer the question or said "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
+        description_short: Share of respondents who refused to answer the question or said "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
         unit: '%'
         short_unit: '%'
         display:
@@ -95,7 +70,7 @@ tables:
 
       refused__help_harm:
         title: "Refused - help/harm question"
-        description: Share of respondents who refused to answer the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who refused to answer the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -104,7 +79,7 @@ tables:
 
       dk__cars:
         title: "Don't know - self-driving cars question"
-        description: Share of respondents who said  "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
+        description_short: Share of respondents who said  "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
         unit: '%'
         short_unit: '%'
         display:
@@ -113,7 +88,7 @@ tables:
 
       refused__cars:
         title: "Refused - self-driving cars question"
-        description: Share of respondents who refused to answer the question or said "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
+        description_short: Share of respondents who refused to answer the question or said "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
         unit: '%'
         short_unit: '%'
         display:

--- a/etl/steps/data/garden/artificial_intelligence/2023-06-26/ai_wrp_2021.py
+++ b/etl/steps/data/garden/artificial_intelligence/2023-06-26/ai_wrp_2021.py
@@ -3,7 +3,7 @@
 from typing import cast
 
 import numpy as np
-import pandas as pd
+import owid.catalog.processing as pr
 from owid.catalog import Dataset, Table
 from structlog import get_logger
 
@@ -28,13 +28,18 @@ def run(dest_dir: str) -> None:
     # Read table from meadow dataset.
     tb = ds_meadow["wrp_2021"]
 
+    # Capture origins from a source column so we can propagate them through
+    # downstream pivots/value_counts/pivot_table operations, which create
+    # entirely new columns and drop column-level origins.
+    source_origins = list(tb["q8"].metadata.origins)
+
     #
     # Process data.
     #
     log.info("wrp_2021.harmonize_countries")
-    tb: Table = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
-    df = pd.DataFrame(tb)
-    # List of column names to keep in DataFrame (q8 and q9 are AI related)
+    tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
+
+    # List of column names to keep (q8 and q9 are AI related)
     select_cols = [
         "country",
         "year",
@@ -48,13 +53,13 @@ def run(dest_dir: str) -> None:
         "q9",
     ]
 
-    # Filter DataFrame to keep only the AI related columns
-    df = df[select_cols]
+    # Filter to keep only the AI related columns
+    tb = tb[select_cols]
 
-    # Map numerical values to categorical for certain columns in the DataFrame
-    df = map_values(df)
+    # Map numerical values to categorical for certain columns
+    tb = map_values(tb)
 
-    # List of columns to split the DataFrame by when calculating question responses
+    # List of columns to split by when calculating question responses
     columns_to_split_by = ["country", "gender", "education", "income_5", "emp_2010", "agegroups4", "globalregion"]
 
     # Dictionary to map response codes to labels for question 9
@@ -70,31 +75,21 @@ def run(dest_dir: str) -> None:
     # Dictionary to map response codes to labels for question 8
     dict_q8 = {1: "Yes, would feel safe", 2: "No, would not feel safe", 98: "DK(cars)", 99: "Refused(cars)"}
 
-    # Create a list of DataFrames for each column_to_split_by for question 8
-    df_q8_list = []
-    for column in columns_to_split_by:
-        df_q8_list.append(question_extract("q8", df, column, dict_q8))
+    # Build per-split tables for question 8 and concatenate
+    tb_q8_list = [question_extract("q8", tb, column, dict_q8) for column in columns_to_split_by]
+    tb_q8_c = pr.concat(tb_q8_list, ignore_index=True)
 
-    # Concatenate all the q8 DataFrames in the list to create a combined DataFrame
-    df_q8_c = pd.concat(df_q8_list)
-    df_q8_c.reset_index(drop=True, inplace=True)
+    # Build per-split tables for question 9 and concatenate
+    tb_q9_list = [question_extract("q9", tb, column, dict_q9) for column in columns_to_split_by]
+    tb_q9_c = pr.concat(tb_q9_list, ignore_index=True)
 
-    # Create a list of DataFrames for each column_to_split_by for question 9
-    df_q9_list = []
-    for column in columns_to_split_by:
-        df_q9_list.append(question_extract("q9", df, column, dict_q9))
-
-    # Concatenate all the q9 DataFrames in the list to create a combined DataFrame
-    df_q9_c = pd.concat(df_q9_list)
-    df_q9_c.reset_index(drop=True, inplace=True)
-
-    # Merge the two combined DataFrames on common columns
-    df_merge = pd.merge(df_q9_c, df_q8_c, on=columns_to_split_by + ["year"], how="outer")
+    # Merge the two combined tables on common columns
+    tb_merge = pr.merge(tb_q9_c, tb_q8_c, on=columns_to_split_by + ["year"], how="outer")
 
     # Now split categories (gender, income etc) into separate columns
-    # Copy df without categories (gender, income etc)
-    df_without_categories = (
-        df_merge[
+    # Copy tb without categories (gender, income etc)
+    tb_without_categories = (
+        tb_merge[
             [
                 "country",
                 "year",
@@ -114,7 +109,7 @@ def run(dest_dir: str) -> None:
         .copy()
     )
 
-    merge_rest = calculate_world_data(df_merge, df_without_categories)
+    merge_rest = calculate_world_data(tb_merge, tb_without_categories)
 
     tb = Table(merge_rest, short_name=paths.short_name, underscore=True)
 
@@ -124,6 +119,10 @@ def run(dest_dir: str) -> None:
     tb[["dk_no_op", "other_help_harm", "other_yes_no"]] = tb[["dk_no_op", "other_help_harm", "other_yes_no"]].replace(
         0.0, np.nan
     )
+
+    # Re-stamp origins onto every output column (pivots/value_counts dropped them).
+    for col in tb.columns:
+        tb[col].metadata.origins = list(source_origins)
 
     #
     # Save outputs.
@@ -137,24 +136,16 @@ def run(dest_dir: str) -> None:
     log.info("ai_wrp_2021.end")
 
 
-def calculate_percentage(df, column, valid_responses_dict, column_to_split_by):
+def calculate_percentage(tb, column, valid_responses_dict, column_to_split_by):
     """
-    Calculates the percentage of valid responses for a given column in a DataFrame, split by another column.
-    Args:
-        df (DataFrame): The input DataFrame.
-        column (str): The column name to calculate the percentage.
-        valid_responses_dict (dict): A dictionary mapping vali
-        d response codes to their corresponding labels.
-        column_to_split_by (str): The column name to split by.
-    Returns:
-        DataFrame: A DataFrame with columns: the column_to_split_by, "year", "column", "count", and "percentage".
+    Calculates the percentage of valid responses for a given column in a table, split by another column.
     """
     # Filter out invalid responses
-    valid_responses = df[column].isin(valid_responses_dict.keys())
-    df_filtered = df[[column_to_split_by, "year", column]][valid_responses].reset_index(drop=True)
+    valid_responses = tb[column].isin(valid_responses_dict.keys())
+    tb_filtered = tb[[column_to_split_by, "year", column]][valid_responses].reset_index(drop=True)
 
     # Group by country and year
-    grouped = df_filtered.groupby([column_to_split_by, "year"], observed=True)
+    grouped = tb_filtered.groupby([column_to_split_by, "year"], observed=True)
 
     # Count valid responses
     counts = grouped[column].value_counts().reset_index(name="count")
@@ -170,22 +161,14 @@ def calculate_percentage(df, column, valid_responses_dict, column_to_split_by):
     return counts
 
 
-def question_extract(q, df, column_to_split_by, dict_q):
+def question_extract(q, tb, column_to_split_by, dict_q):
     """
-    Computes the share of responses for a given column in a DataFrame, split by another column.
-    Args:
-        q (str): The question column name.
-        df (DataFrame): The input DataFrame.
-        column_to_split_by (str): The column name to split by.
-        dict_q (dict): A dictionary mapping valid response codes to their corresponding labels.
-    Returns:
-        DataFrame: A DataFrame with columns: "year", column_to_split_by, and either "Mostly help" or "Yes, would feel safe" depending on the question column.
+    Computes the share of responses for a given column in a table, split by another column.
     """
-    # Calculate percentage for worries about a terrorist attack
-    counts_q = calculate_percentage(df, q, dict_q, column_to_split_by)
+    counts_q = calculate_percentage(tb, q, dict_q, column_to_split_by)
 
     # Select relevant columns
-    select_df = counts_q[
+    select_tb = counts_q[
         [
             column_to_split_by,
             "year",
@@ -194,17 +177,17 @@ def question_extract(q, df, column_to_split_by, dict_q):
         ]
     ]
 
-    # Pivot the DataFrame
-    pivoted_df = select_df.pivot(
+    # Pivot the table
+    pivoted_tb = select_tb.pivot(
         index=[column_to_split_by, "year"],
         columns=q,
         values="percentage",
     )
-    pivoted_df.reset_index(inplace=True)
-    pivoted_df.columns.name = None
+    pivoted_tb = pivoted_tb.reset_index()
+    pivoted_tb.columns.name = None
 
     if q == "q9":
-        return pivoted_df[
+        return pivoted_tb[
             [
                 "year",
                 column_to_split_by,
@@ -217,21 +200,21 @@ def question_extract(q, df, column_to_split_by, dict_q):
             ]
         ]
     else:
-        return pivoted_df[
+        return pivoted_tb[
             ["year", column_to_split_by, "Yes, would feel safe", "No, would not feel safe", "DK(cars)", "Refused(cars)"]
         ]
 
 
-def calculate_world_data(df_merge, df_without_categories):
+def calculate_world_data(tb_merge, tb_without_categories):
     # Select rows with categories (NaN country rows)
-    world_df = df_merge[df_merge["country"].isna()].copy()
-    world_df.reset_index(drop=True, inplace=True)
+    world_tb = tb_merge[tb_merge["country"].isna()].copy()
+    world_tb = world_tb.reset_index(drop=True)
 
     # Set country as World
-    world_df["country"] = world_df["country"].astype(str)
-    world_df.loc[world_df["country"] == "nan", "country"] = "World"
+    world_tb["country"] = world_tb["country"].astype(str)
+    world_tb.loc[world_tb["country"] == "nan", "country"] = "World"
 
-    # Calculate the percentage of valid responses for "Mostly help", "Mostly harm", "Neither" in a DataFrame,
+    # Calculate the percentage of valid responses for "Mostly help", "Mostly harm", "Neither" in a table,
     # split by gender, income etc.
     columns_to_calculate = [
         "Mostly help",
@@ -243,37 +226,33 @@ def calculate_world_data(df_merge, df_without_categories):
     ]
     merge_help_harm_all = None
     for column in columns_to_calculate:
-        conc_df = pivot_by_category(world_df, column)
+        conc_tb = pivot_by_category(world_tb, column)
         if merge_help_harm_all is None:
-            merge_help_harm_all = conc_df
+            merge_help_harm_all = conc_tb
         else:
-            merge_help_harm_all = pd.merge(merge_help_harm_all, conc_df, on=["year", "country"], how="outer")
+            merge_help_harm_all = pr.merge(merge_help_harm_all, conc_tb, on=["year", "country"], how="outer")
 
-    # Calculate the percentage of valid responses for "Yes, would feel safe" in a DataFrame, split by gender, income etc.
+    # Calculate the percentage of valid responses for "Yes, would feel safe" in a table, split by gender, income etc.
     columns_to_calculate = ["Yes, would feel safe", "No, would not feel safe", "DK(cars)", "Refused(cars)"]
     merge_yes_no = None
     for column in columns_to_calculate:
-        conc_df = pivot_by_category(world_df, column)
+        conc_tb = pivot_by_category(world_tb, column)
         if merge_yes_no is None:
-            merge_yes_no = conc_df
+            merge_yes_no = conc_tb
         else:
-            merge_yes_no = pd.merge(merge_yes_no, conc_df, on=["year", "country"], how="outer")
+            merge_yes_no = pr.merge(merge_yes_no, conc_tb, on=["year", "country"], how="outer")
 
-    # Merge all dataframes into one
-    merge_categorized = pd.merge(merge_help_harm_all, merge_yes_no, on=["year", "country"], how="outer")
-    merge_rest = pd.merge(df_without_categories, merge_categorized, on=["year", "country"], how="outer")
+    # Merge all tables into one
+    merge_categorized = pr.merge(merge_help_harm_all, merge_yes_no, on=["year", "country"], how="outer")
+    merge_rest = pr.merge(tb_without_categories, merge_categorized, on=["year", "country"], how="outer")
 
-    merge_rest.set_index(["year", "country"], inplace=True)
+    merge_rest = merge_rest.set_index(["year", "country"])
     return merge_rest
 
 
-def map_values(df):
+def map_values(tb):
     """
-    Maps numerical values to categorical for certain columns in the DataFrame.
-    Args:
-        df (DataFrame): The input DataFrame.
-    Returns:
-        DataFrame: The DataFrame with mapped values for "gender", "education", "income_5", "emp_2010", "agegroups4", "globalregion" columns.
+    Maps numerical values to categorical for certain columns in the table.
     """
     gender = {1: "Male", 2: "Female"}
 
@@ -314,43 +293,34 @@ def map_values(df):
         15: "Australia and New Zealand",
     }
 
-    df["gender"] = df["gender"].map(gender)
-    df["education"] = df["education"].map(education_level)
-    df["income_5"] = df["income_5"].map(wealth_quintile)
-    df["emp_2010"] = df["emp_2010"].map(employment_status)
-    df["agegroups4"] = df["agegroups4"].map(age_group)
-    df["globalregion"] = df["globalregion"].map(region)
+    tb["gender"] = tb["gender"].map(gender)
+    tb["education"] = tb["education"].map(education_level)
+    tb["income_5"] = tb["income_5"].map(wealth_quintile)
+    tb["emp_2010"] = tb["emp_2010"].map(employment_status)
+    tb["agegroups4"] = tb["agegroups4"].map(age_group)
+    tb["globalregion"] = tb["globalregion"].map(region)
 
-    return df
+    return tb
 
 
-def pivot_by_category(df, question):
+def pivot_by_category(tb, question):
     """
-    Pivot the input DataFrame by categories and a specific question.
-
-    Parameters:
-        df (DataFrame): Input DataFrame to pivot.
-        question (str): The specific question to pivot on.
-
-    Returns:
-        DataFrame: Concatenated pivot tables with suffixed column names.
-
+    Pivot the input table by categories and a specific question.
     """
-    # Create an empty list to store the pivot tables
     pivot_tables = []
     cols_pivot = ["gender", "education", "income_5", "emp_2010", "agegroups4", "globalregion"]
 
-    # Iterate over each pivot column
     for pivot_col in cols_pivot:
-        # Pivot the dataframe for the current pivot column
-        pivoted_df = pd.pivot_table(df, values=question, index=["country", "year"], columns=pivot_col, observed=True)
-        # Append the pivot table to the list
-        pivot_tables.append(pivoted_df)
+        pivoted_tb = tb.pivot_table(values=question, index=["country", "year"], columns=pivot_col, observed=True)
+        pivot_tables.append(pivoted_tb)
 
     # Concatenate all the pivot tables along the columns
-    conc_df = pd.concat(pivot_tables, axis=1)
+    conc_tb = pr.concat(pivot_tables, axis=1)
 
     # Add suffix to column names
-    conc_df = conc_df.add_suffix("_" + question)
+    conc_tb = conc_tb.add_suffix("_" + question)
 
-    return conc_df
+    # Reset index so ["year", "country"] become columns for downstream merging.
+    conc_tb = conc_tb.reset_index()
+
+    return conc_tb

--- a/etl/steps/data/garden/artificial_intelligence/2023-06-26/ai_wrp_2021_grouped.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2023-06-26/ai_wrp_2021_grouped.meta.yml
@@ -1,34 +1,9 @@
-dataset:
-  title: World Risk Poll - AI questions, grouped by gender, income, education, age and region (2021)
-  description: >-
-    Spread across four themed reports, the 2021 World Risk Poll covers the biggest risks facing people and communities globally,
-    ranging from road crashes, severe weather, climate change and disaster resilience, to work-related harm, violence and
-    harassment at work, and use of personal data. It will be repeated at least two more times, in 2023 and 2025.
-
-
-    This data includes aggregates of survey responses to the following two questions:
-
-
-    1) Will artificial intelligence help or harm people in the next 20 years?
-
-
-    2) Would you feel safe in a car driven by computer without a human driver?
-  licenses:
-  - name: Lloyd's Register Foundation 2018
-    url: https://wrp.lrfoundation.org.uk/terms-of-use/
-  sources:
-  - name: Lloyd's Register Foundation (2022)
-    url: https://wrp.lrfoundation.org.uk/data-resources/
-    source_data_url: https://wrp.lrfoundation.org.uk/wp-content/uploads/2023/05/lrf_wrp_2021_full_data.zip
-    date_accessed: '2023-06-26'
-    publication_year: 2022
-    published_by: World Risk Poll 2021, Lloyd's Register Foundation (2022)
 tables:
   ai_wrp_2021_grouped:
     variables:
       yes__would_feel_safe_value:
         title: Yes, would feel safe
-        description: Share of respondents who responded "Yes, would feel safe" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "Yes, would feel safe" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -36,7 +11,7 @@ tables:
 
       no__would_not_feel_safe_value:
         title: No, would not feel safe
-        description: Share of respondents who responded "No, would not feel safe" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "No, would not feel safe" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -44,7 +19,7 @@ tables:
 
       mostly_help_value:
         title: "Mostly help"
-        description: Share of respondents who responded "Mostly help" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "Mostly help" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -52,7 +27,7 @@ tables:
 
       mostly_harm_value:
         title: "Mostly harm"
-        description: Share of respondents who responded "Mostly harm" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "Mostly harm" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -60,7 +35,7 @@ tables:
 
       neither_value:
         title: "Neither"
-        description: Share of respondents who responded "Neither" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "Neither" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -68,7 +43,7 @@ tables:
 
       dk_no_op_value:
         title: "Don't have an opinion, Don't know help/harm question"
-        description: Share of respondents said "Don't have an opinion" or "Don't know" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents said "Don't have an opinion" or "Don't know" to the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -77,7 +52,7 @@ tables:
 
       other_help_harm_value:
         title: "Don't have an opinion, Don't know help/harm question or refused"
-        description: Share of respondents said "Don't have an opinion", "Don't know" or refused the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents said "Don't have an opinion", "Don't know" or refused the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -86,7 +61,7 @@ tables:
 
       other_yes_no_value:
         title: "Don't know or Refused - self-driving cars question"
-        description: Share of respondents who refused to answer the question or said "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
+        description_short: Share of respondents who refused to answer the question or said "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
         unit: '%'
         short_unit: '%'
         display:
@@ -95,7 +70,7 @@ tables:
 
       refused__help_harm_value:
         title: "Refused - help/harm question"
-        description: Share of respondents who refused to answer the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who refused to answer the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -104,7 +79,7 @@ tables:
 
       dk__cars_value:
         title: "Don't know - self-driving cars question"
-        description: Share of respondents who refused to answer the question or said "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
+        description_short: Share of respondents who refused to answer the question or said "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
         unit: '%'
         short_unit: '%'
         display:
@@ -113,7 +88,7 @@ tables:
 
       refused__cars_value:
         title: "Refused - self-driving cars question"
-        description: Share of respondents who refused to answer the question or said "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
+        description_short: Share of respondents who refused to answer the question or said "Don't know" to the question "Would you feel safe in a car driven by a computer without a human driver?".
         unit: '%'
         short_unit: '%'
         display:
@@ -121,7 +96,7 @@ tables:
           numDecimalPlaces: 0
       dk__help_harm_value:
         title: "DK -  help/harm question"
-        description: Share of respondents who responded "Don't know" to answer the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "Don't know" to answer the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:
@@ -130,7 +105,7 @@ tables:
 
       dont_have_an_opinion_value:
         title: "Don't have an opinion -  help/harm question"
-        description: Share of respondents who responded "Don't have an opinion" to answer the question "Will Artificial Intelligence help or harm people in the next 20 years?".
+        description_short: Share of respondents who responded "Don't have an opinion" to answer the question "Will Artificial Intelligence help or harm people in the next 20 years?".
         unit: '%'
         short_unit: '%'
         display:

--- a/etl/steps/data/garden/artificial_intelligence/2023-06-26/ai_wrp_2021_grouped.py
+++ b/etl/steps/data/garden/artificial_intelligence/2023-06-26/ai_wrp_2021_grouped.py
@@ -2,7 +2,7 @@
 
 from typing import cast
 
-import pandas as pd
+import owid.catalog.processing as pr
 from owid.catalog import Dataset, Table
 from structlog import get_logger
 
@@ -14,29 +14,28 @@ log = get_logger()
 paths = PathFinder(__file__)
 
 
-def melt_and_clean(df: pd.DataFrame, col_name: str, excluded_columns: list[str]) -> pd.DataFrame:
+def melt_and_clean(tb: Table, col_name: str, excluded_columns: list[str]) -> Table:
     """
-    Melt and clean dataframe based on column name.
+    Melt and clean table based on column name.
     """
-    melted_df = pd.melt(
-        df.reset_index(),
+    melted_tb = tb.reset_index().melt(
         id_vars=["year", "country"],
-        value_vars=[col for col in df.columns if col_name in col and col not in excluded_columns],
+        value_vars=[col for col in tb.columns if col_name in col and col not in excluded_columns],
     )
-    melted_df["group"] = (
-        melted_df["variable"].str.split("_" + col_name, expand=True)[0].str.replace("_", " ").str.title()
+    melted_tb["group"] = (
+        melted_tb["variable"].str.split("_" + col_name, expand=True)[0].str.replace("_", " ").str.title()
     )
-    melted_df.rename(columns={"value": f"{col_name}_value"}, inplace=True)
-    melted_df = melted_df[melted_df[f"{col_name}_value"].notnull()]
-    return melted_df[["year", f"{col_name}_value", "group"]]
+    melted_tb = melted_tb.rename(columns={"value": f"{col_name}_value"})
+    melted_tb = melted_tb[melted_tb[f"{col_name}_value"].notnull()]
+    return melted_tb[["year", f"{col_name}_value", "group"]]
 
 
 def run(dest_dir: str) -> None:
     log.info("ai_wrp_2021_grouped.start")
 
-    # Load meadow dataset.
+    # Load garden dataset.
     ds_garden = cast(Dataset, paths.load_dependency("ai_wrp_2021"))
-    df = pd.DataFrame(ds_garden["ai_wrp_2021"])
+    tb = ds_garden["ai_wrp_2021"]
 
     columns_to_melt = [
         "yes__would_feel_safe",
@@ -68,17 +67,14 @@ def run(dest_dir: str) -> None:
         "dont_have_an_opinion",
     ]
 
-    # Using a dictionary to store the melted dataframes.
-    melted_dfs = {}
+    # Melt each column.
+    melted_tbs = {column: melt_and_clean(tb, column, excluded_columns) for column in columns_to_melt}
 
-    for column in columns_to_melt:
-        melted_dfs[column] = melt_and_clean(df, column, excluded_columns)
+    merge_all = melted_tbs[columns_to_melt[0]]
 
-    merge_all = melted_dfs[columns_to_melt[0]]
-
-    # Merge all melted dataframes together.
+    # Merge all melted tables together.
     for column in columns_to_melt[1:]:
-        merge_all = pd.merge(merge_all, melted_dfs[column], on=["year", "group"], how="outer")
+        merge_all = pr.merge(merge_all, melted_tbs[column], on=["year", "group"], how="outer")
 
     # Derive additional columns (mainly to avoid grapher errors)
     merge_all["other_yes_no_value"] = merge_all["dk__cars_value"] + merge_all["refused__cars_value"]
@@ -111,17 +107,18 @@ def run(dest_dir: str) -> None:
         "Employed Part Time Want Full Time": "Employed Part-Time (Seeking Full-Time)",
     }
 
-    merge_all["group"].replace(group_replacements, inplace=True)
-    merge_all.set_index(["year", "group"], inplace=True)
+    merge_all["group"] = merge_all["group"].replace(group_replacements)
+    merge_all = merge_all.set_index(["year", "group"])
+    merge_all.metadata.short_name = paths.short_name
 
-    # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(
+    # Create a new garden dataset with the same metadata as the input dataset.
+    ds_garden_out = create_dataset(
         dest_dir,
-        tables=[Table(merge_all, short_name=paths.short_name, underscore=True)],
+        tables=[merge_all],
         default_metadata=ds_garden.metadata,
     )
 
     # Save changes in the new garden dataset.
-    ds_garden.save()
+    ds_garden_out.save()
 
     log.info("ai_wrp_2021_grouped.end")

--- a/etl/steps/data/garden/clio_infra/2017-09-09/clio_infra__biological_standards_of_living__baten_and_blum__2015.meta.yml
+++ b/etl/steps/data/garden/clio_infra/2017-09-09/clio_infra__biological_standards_of_living__baten_and_blum__2015.meta.yml
@@ -7,36 +7,13 @@ tables:
         title: Height (Baten and Blum 2015)
         unit: cm
         short_unit: cm
-        description: Heights by birth decade and country, both before and after 1800.
-        sources:
-          - name: Height (Baten and Blum 2015)
-            description: |-
-              Additional information: Methodologies used for data collection and processing. Reconstruction of heights by birth decade using a variety of different sources. Please see link for the complete list.
-            url: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/IAEKLA
-            date_accessed: 2017-09-09
-            published_by: |-
-              For the post-1800 period: Baten, Joerg and Matthias Blum, “Growing Taller, but Unequal: Biological Well-Being in World Regions and Its Determinants, 1810-1989.” Economic History of Developing Regions (2012)
-
-              For the pre-1800 period: Koepke, Nikola and Baten, Joerg "The Biological Standard of Living in Europe During the Last Two Millennia," in European Review of Economic History 9-1 (2005)
+        description_short: Heights by birth decade and country, both before and after 1800.
       height_gini__baten_and_blum_2015:
         title: Height Gini (Baten and Blum 2015)
         unit: Gini
         short_unit: Gini
-        description: |-
+        description_short: |-
           Proxy for inequality of human health and welfare. The higher a country's gini coefficient, the greater the degree of inequality.
-        sources:
-          - name: Height Gini (Baten and Blum 2015)
-            description: |-
-              Additional information: Methodologies used for data collection and processing. Reconstruction of height ginis by birth decade using a variety of different sources. The height gini is a transformation of the coefficient of height inequality, based on Moradi and Baten’s formula: g htgini=-33.5 + 20.5*cv.
-
-              Data quality: As good as possible, but counter-checking and improvement welcome. Interpretations on individual country level should be done with careful checking.  An important caveat is many individual countries cannot be measured without a substantial amount of measurement error. The tendencies of anthropometric inequality by world region (in which country-specific measurement error tends to average out) is probably informative.
-
-
-              Publisher source: Data collated from a host of academic papers. Please refer to the link for the complete list.
-            url: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/HKZPR9
-            date_accessed: 2017-09-09
-            published_by: |-
-              Jörg Baten and Matthias Blum, “Anthropometric within-country Inequality and the Estimation of Skill Premia with Anthropometric Indicators”, Review of Economics -- Jahrbuch fuer Wirtschaftswissenschaften (2011)
     dimensions:
       - name: year
         slug: year

--- a/etl/steps/data/garden/clio_infra/2017-09-09/clio_infra__human_capital.meta.yml
+++ b/etl/steps/data/garden/clio_infra/2017-09-09/clio_infra__human_capital.meta.yml
@@ -6,75 +6,33 @@ tables:
       average_years_of_education__van_leeuwen__van_leeuwen_li_2015:
         title: Average years of education (van Leeuwen,  van Leeuwen-Li 2015)
         unit: years of formal schooling
-        description: Average years of education for the total population aged 15 years and older.
-        sources:
-          - name: Average years of education (van Leeuwen,  van Leeuwen-Li 2015)
-            description: 'Publisher source: Central statistical agencies, historical reconstructions.'
-            url: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/KCBMKI
-            date_accessed: 2017-09-09
-            published_by: Clio-Infra
+        description_short: Average years of education for the total population aged 15 years and older.
       book_titles_per_capita__fink_jensen_2015:
         title: Book titles per capita (Fink-Jensen 2015)
         unit: Unique booktitles per million inhabitants
         short_unit: Unique booktitles
-        description: The number of new book titles publisher per year, per million inhabitants in a given country for the
+        description_short: The number of new book titles publisher per year, per million inhabitants in a given country for the
           period 1500 - 2010.
-        sources:
-          - name: Book titles per capita (Fink-Jensen 2015)
-            description: |-
-              Publisher source: Combination of datasets and publications that contain data on book production for different regions and periods.
-              Includes CLIO Infra data.
-            url: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/AOQMAZ
-            date_accessed: 2017-09-09
-            published_by: Clio-Infra
       composite_wellbeing_index__rijpma_2017:
         title: Composite wellbeing index (Rijpma 2017)
         unit: Composite measure of wellbeing
-        description: The composite measure is a linear combination of 9 Clio-Infra variables created through a latent variable
+        description_short: The composite measure is a linear combination of 9 Clio-Infra variables created through a latent variable
           model.
-        sources:
-          - name: Composite wellbeing index (Rijpma 2017)
-            description: 'Publisher source: Composite measure constructed from 9 variables from the CLIO-Infra project.'
-            url: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/QIPFQF
-            date_accessed: 2017-09-09
-            published_by: Clio-Infra
       educational_inequality_gini_coefficient__van_leeuwen_and_van_leeuwen_li_2015:
         title: Educational inequality gini coefficient (van Leeuwen and van Leeuwen-Li 2015)
         unit: Gini
         short_unit: Gini
-        description: The greater the gini coefficient, the larger the gap in educational inequality.
-        sources:
-          - name: Educational inequality gini coefficient (van Leeuwen and van Leeuwen-Li 2015)
-            description: 'Publisher source: Central statistical agencies, historical reconstructions.'
-            url: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/KORKQW
-            date_accessed: 2017-09-09
-            published_by: Clio-Infra
+        description_short: The greater the gini coefficient, the larger the gap in educational inequality.
       numeracy__total__baten_2015:
         title: Numeracy (total) (Baten 2015)
         unit: ABCC index (%)
         short_unit: '%'
-        description: |-
+        description_short: |-
           Numeracy estimates (ABCC) by birth decade and country, both before and after 1800. Use "age heaping"; that is, where age data frequently displays excess frequencies at attractive numbers, e.g. multiples of five, to measure cognitive ability in quantitative reasoning.
-        sources:
-          - name: Numeracy (total) (Baten 2015)
-            description: 'Publisher source: Reconstruction of data using a variety of sources, incl. scholarly research.'
-            url: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/GEQKCG
-            date_accessed: 2017-09-09
-            published_by: Clio-Infra
       universities_founded__foldvari_2015:
         title: Universities founded (Foldvari 2015)
         unit: number of universities founded in a year
-        description: Number of universities founded within a given year, within the current borders of a particular country.
-        sources:
-          - name: Universities founded (Foldvari 2015)
-            description: |-
-              Additional information: Author's note: The quantity and quality of available information on universities vary by period and geographical area. Even the definition of university is not universal: in some countries even colleges offering undergradute programmes can be named universities (Latin America, Japan, Near East). Please see source for further information.
-
-
-              Publisher source: Central statistical agencies, historical reconstructions.
-            url: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/KVRJPW
-            date_accessed: 2017-09-09
-            published_by: Clio-Infra
+        description_short: Number of universities founded within a given year, within the current borders of a particular country.
     dimensions:
       - name: year
         slug: year

--- a/etl/steps/data/garden/demography/2018-11-19/infant_mortality_rates_in_uk__ons__2018.meta.yml
+++ b/etl/steps/data/garden/demography/2018-11-19/infant_mortality_rates_in_uk__ons__2018.meta.yml
@@ -1,5 +1,3 @@
-dataset:
-  title: Infant Mortality Rates in UK (ONS, 2018)
 tables:
   infant_mortality_rates_in_uk__ons__2018:
     variables:
@@ -8,81 +6,21 @@ tables:
         unit: ''
         display:
           name: deaths per 1,000 total births
-        sources:
-          - name: Infant Mortality Rates in UK (ONS, 2018)
-            description: |-
-              Infant mortality rates as reported by the UK Office for National Statistics (ONS). Infant mortality rates have be subdivided into categories depending on the age of the infant as follows:
-
-              - Perinatal – stillbirths and early neonatal deaths.
-              - Neonatal – deaths of those aged under 28 days.
-              - Postneonatal – deaths of those aged between 28 days and 1 year.
-              - Infant – deaths of those aged under 1 year.
-
-              Neonatal and postneonatal are reported as the number of deaths per 1,000 live births. Perinatal and infant mortality is reported as the number of deaths per 1,000 total births (the sum of stillbirths and live births). Note that stillbirths are only recorded for births with 24 weeks of gestation or more (i.e. stillbirths less than 24 weeks gestation are not recorded).
-            url: |-
-              https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/childhoodinfantandperinatalmortalityinenglandandwales/2016
-            date_accessed: 2018-11-19
-            published_by: UK Office for National Statistics (ONS)
       neonatal_mortality__less_than_28_days:
         title: Neonatal mortality (less than 28 days)
         unit: deaths per 1,000 live births
         display:
           name: Neonatal mortality (less than 28 days)
-        sources:
-          - name: Infant Mortality Rates in UK (ONS, 2018)
-            description: |-
-              Infant mortality rates as reported by the UK Office for National Statistics (ONS). Infant mortality rates have be subdivided into categories depending on the age of the infant as follows:
-
-              - Perinatal – stillbirths and early neonatal deaths.
-              - Neonatal – deaths of those aged under 28 days.
-              - Postneonatal – deaths of those aged between 28 days and 1 year.
-              - Infant – deaths of those aged under 1 year.
-
-              Neonatal and postneonatal are reported as the number of deaths per 1,000 live births. Perinatal and infant mortality is reported as the number of deaths per 1,000 total births (the sum of stillbirths and live births). Note that stillbirths are only recorded for births with 24 weeks of gestation or more (i.e. stillbirths less than 24 weeks gestation are not recorded).
-            url: |-
-              https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/childhoodinfantandperinatalmortalityinenglandandwales/2016
-            date_accessed: 2018-11-19
-            published_by: UK Office for National Statistics (ONS)
       perinatal_mortality__stillbirths_and_early_neonatal:
         title: Perinatal mortality (stillbirths and early neonatal)
         unit: deaths per 1,000 total births
         display:
           name: Perinatal mortality (stillbirths and early neonatal)
-        sources:
-          - name: Infant Mortality Rates in UK (ONS, 2018)
-            description: |-
-              Infant mortality rates as reported by the UK Office for National Statistics (ONS). Infant mortality rates have be subdivided into categories depending on the age of the infant as follows:
-
-              - Perinatal – stillbirths and early neonatal deaths.
-              - Neonatal – deaths of those aged under 28 days.
-              - Postneonatal – deaths of those aged between 28 days and 1 year.
-              - Infant – deaths of those aged under 1 year.
-
-              Neonatal and postneonatal are reported as the number of deaths per 1,000 live births. Perinatal and infant mortality is reported as the number of deaths per 1,000 total births (the sum of stillbirths and live births). Note that stillbirths are only recorded for births with 24 weeks of gestation or more (i.e. stillbirths less than 24 weeks gestation are not recorded).
-            url: |-
-              https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/childhoodinfantandperinatalmortalityinenglandandwales/2016
-            date_accessed: 2018-11-19
-            published_by: UK Office for National Statistics (ONS)
       postneonatal_mortality__aged_28_days_to_1_year:
         title: Postneonatal mortality (aged 28 days to 1 year)
         unit: deaths per 1,000 live births
         display:
           name: Postneonatal mortality (aged 28 days to 1 year)
-        sources:
-          - name: Infant Mortality Rates in UK (ONS, 2018)
-            description: |-
-              Infant mortality rates as reported by the UK Office for National Statistics (ONS). Infant mortality rates have be subdivided into categories depending on the age of the infant as follows:
-
-              - Perinatal – stillbirths and early neonatal deaths.
-              - Neonatal – deaths of those aged under 28 days.
-              - Postneonatal – deaths of those aged between 28 days and 1 year.
-              - Infant – deaths of those aged under 1 year.
-
-              Neonatal and postneonatal are reported as the number of deaths per 1,000 live births. Perinatal and infant mortality is reported as the number of deaths per 1,000 total births (the sum of stillbirths and live births). Note that stillbirths are only recorded for births with 24 weeks of gestation or more (i.e. stillbirths less than 24 weeks gestation are not recorded).
-            url: |-
-              https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/childhoodinfantandperinatalmortalityinenglandandwales/2016
-            date_accessed: 2018-11-19
-            published_by: UK Office for National Statistics (ONS)
     dimensions:
       - name: year
         slug: year

--- a/etl/steps/data/garden/demography/2023-06-27/world_population_comparison.meta.yml
+++ b/etl/steps/data/garden/demography/2023-06-27/world_population_comparison.meta.yml
@@ -1,40 +1,7 @@
-dataset:
-  title: Historical world population comparison (various sources, 2023.1)
-  description: >-
-    Among others these are the original source:
-
-
-    • McEvedy, Colin and Richard Jones, 1978, "Atlas of World Population History", Facts on File, New York, pp. 342-351.
-
-    • Biraben, Jean-Noel, 1980, "An Essay Concerning Mankind's Evolution, Population", Selected Papers, December, table 2.
-
-    • Durand, John D., 1974, "Historical Estimates of World Population: An Evaluation", University of Pennsylvania, Population Center, Analytical and Technical Reports, Number 10, table 2.
-
-    • Haub, Carl, 1995, "How Many People Have Ever Lived on Earth?" Population Today, February, p. 5.
-
-    • Thomlinson, Ralph, 1975, "Demographic Problems, Controversy Over Population Control", Second Edition, Table 1.
-
-    • United Nations, 1999, The World at Six Billion, Table 1, "World Population From" Year 0 to Stabilization, p. 5,
-
-    • U.S. Census Bureau (USCB), 2012, Total Midyear Population for the World: 1950-2050.
-
-    • Michael Kremer (1993) "Population Growth and Technological Change: One Million B.C. to 1990", Quarterly Journal of Economics., August 1993, pp.681-716.
-
-    • Klein Goldewijk K, Beusen A, Janssen P (2010) "Long term dynamic modeling of global population and built-up area in a spatially explicit way: HYDE 3.1". The Holocene 20:565-573.
-
-    • Klein Goldewijk, K., A. Beusen, J.Doelman and E. Stehfest (2017), "Anthropogenic land use estimates for the Holocene; HYDE 3.2", Earth System Science Data, 9, 927-953"
-
-    • Gapminder v7 (2022)
-
-    • United Nations, Department of Economic and Social Affairs, Population Division (2022). "World Population Prospects 2022"
-  sources:
-  - name: Multiple sources compiled by Our World in Data (2023)
-    published_by: Multiple sources compiled by Our World in Data (2023)
-
 tables:
   world_population_comparison:
     variables:
       world_population:
         title: World population
         unit: people
-        description: Total world population.
+        description_short: Total world population.

--- a/etl/steps/data/garden/demography/2023-06-27/world_population_comparison.py
+++ b/etl/steps/data/garden/demography/2023-06-27/world_population_comparison.py
@@ -1,119 +1,71 @@
-from typing import cast
-
-import pandas as pd
-from owid.catalog import Dataset, Table
+from owid.catalog import Table
+from owid.catalog import processing as pr
 from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 log = get_logger()
 
 
 def run(dest_dir: str) -> None:
     log.info("world_population_comparison: start")
-    # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/2023-06-19/world_population_comparison.csv").path)
+    snap = Snapshot("fasttrack/2023-06-19/world_population_comparison.csv")
+    tb = snap.read_csv()
 
-    # create empty dataframe and table
-    tb = Table(data, short_name=P.short_name)
-
-    # Add sources
     tb_hyde = get_hyde_32()
     tb_gapminder = get_gapminder_v7()
     tb_un = get_un_2022()
     tb_owid = get_owid()
-    tb = (
-        pd.concat([tb, tb_hyde, tb_gapminder, tb_un, tb_owid], ignore_index=True)
-        .set_index(["country", "year"])
-        .sort_index()
-    )
-    tb.metadata.short_name = P.short_name
+    tb = pr.concat([tb, tb_hyde, tb_gapminder, tb_un, tb_owid], ignore_index=True)
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
 
-    # add table, update metadata from *.meta.yml and save
-    print(tb)
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()
     log.info("world_population_comparison: end")
 
 
 def get_hyde_32() -> Table:
-    """Load HYDE 3.2 data and format accordingly."""
     log.info("world_population_comparison: load hyde")
-    ds = cast(Dataset, P.load_dependency(namespace="hyde", short_name="baseline"))
+    ds = paths.load_dataset("baseline", namespace="hyde")
     tb = ds["population"].reset_index()
-    # Get only World data, add source name
     tb = tb.groupby("year", as_index=False)[["population"]].sum()
-    tb.loc[:, "country"] = "HYDE 3.2 (2017)"
-
-    # Rename population column
-    tb = tb.rename(columns={"population": "world_population"})
-    return tb
+    tb["country"] = "HYDE 3.2 (2017)"
+    return tb.rename(columns={"population": "world_population"})
 
 
 def get_gapminder_v7() -> Table:
-    """Load Gapminder v7 data and format accordingly."""
     log.info("world_population_comparison: load gapminder")
-    ds = cast(Dataset, P.load_dependency(namespace="gapminder", short_name="population"))
+    ds = paths.load_dataset("population", namespace="gapminder")
     tb = ds["population"].reset_index()
-    # Get only World data, add source name
     tb = tb.groupby("year", as_index=False)[["population"]].sum()
-    tb.loc[:, "country"] = "Gapminder v7 (2022)"
-
-    # Rename population column
-    tb = tb.rename(columns={"population": "world_population"})
-    return tb
+    tb["country"] = "Gapminder v7 (2022)"
+    return tb.rename(columns={"population": "world_population"})
 
 
 def get_un_2022() -> Table:
-    """Load UN 2022 data and format accordingly.
-
-    Both historical estimates and medium variant projections are loaded.
-    """
+    """Load UN 2022 data — historical estimates and medium variant projections."""
     log.info("world_population_comparison: load un wpp")
-    ds = cast(Dataset, P.load_dependency(namespace="un", short_name="un_wpp"))
+    ds = paths.load_dataset("un_wpp", namespace="un")
     tb = ds["population"].reset_index()
-    # Get estimates: only World data, all sexes and ages, add source name
-    tb_estimates = tb[
-        (tb["location"] == "World")
-        & (tb["sex"] == "all")
-        & (tb["age"] == "all")
-        & (tb["variant"] == "estimates")
-        & (tb["metric"] == "population")
-    ]
-    tb_estimates = tb_estimates[["year", "value"]]
-    tb_estimates.loc[:, "country"] = "UN (2022 revision)"
-    # Get projections: only World data, all sexes and ages, add source name
-    tb_proj = tb[
-        (tb["location"] == "World")
-        & (tb["sex"] == "all")
-        & (tb["age"] == "all")
-        & (tb["variant"] == "medium")
-        & (tb["metric"] == "population")
-    ]
-    tb_proj = tb_proj[["year", "value"]]
-    tb_proj.loc[:, "country"] = "UN, medium variant projection (2022 revision)"
 
-    # Merge estimates & projections
-    tb = pd.concat([tb_estimates, tb_proj], ignore_index=True)
+    common = (tb["location"] == "World") & (tb["sex"] == "all") & (tb["age"] == "all") & (tb["metric"] == "population")
+    tb_estimates = tb[common & (tb["variant"] == "estimates")][["year", "value"]]
+    tb_estimates["country"] = "UN (2022 revision)"
+    tb_proj = tb[common & (tb["variant"] == "medium")][["year", "value"]]
+    tb_proj["country"] = "UN, medium variant projection (2022 revision)"
 
-    # Rename population column
-    tb = tb.rename(columns={"value": "world_population"})  # ty: ignore
-    return tb
+    tb = pr.concat([tb_estimates, tb_proj], ignore_index=True)
+    return tb.rename(columns={"value": "world_population"})
 
 
 def get_owid() -> Table:
-    """Load Gapminder v7 data and format accordingly."""
+    """Load OWID population dataset."""
     log.info("world_population_comparison: load owid")
-    ds = cast(Dataset, P.load_dependency(namespace="demography", short_name="population"))
+    ds = paths.load_dataset("population", namespace="demography")
     tb = ds["population"].reset_index()
-    # Get only World data, add source name
     tb = tb[tb["country"] == "World"]
     tb["country"] = "OWID based on HYDE 3.2, Gapminder v7 and UN 2022"
     tb = tb[["country", "year", "population"]]
-
-    # Rename population column
-    tb = tb.rename(columns={"population": "world_population"})
-
-    return tb
+    return tb.rename(columns={"population": "world_population"})

--- a/etl/steps/data/garden/education/2023-08-09/clio_infra_education.meta.yml
+++ b/etl/steps/data/garden/education/2023-08-09/clio_infra_education.meta.yml
@@ -1,36 +1,11 @@
 dataset:
   title: Historical numeracy and years of schooling estimates (Clio Infra)
-  description: &desc >-
-    This dataset contains historical estimates of average years of education and numeracy estimates.
-    It also includes historical estimates of Gini coefficient of inequality in educational attainment (years of education) and Gini and gender coefficient of inequality for both educational attainment and numeracy.
-
-  licenses:
-  - url: https://creativecommons.org/publicdomain/zero/1.0/
-  sources:
-  - name: Clio Infra
-    date_accessed: '2023-08-09'
-    description:  *desc
-    url: https://clio-infra.eu/Indicators/NumeracyTotal.html#datasets
-    source_data_url: https://clio-infra.eu/index.html
-    publication_date: '2013-12-26'
-    publication_year: 2013
-    published_by: >-
-      van Zanden, J., et al. (eds.) (2014), How Was Life?: Global Well-being since 1820, OECD Publishing, Paris, https://doi.org/10.1787/9789264214262-en.;
-
-
-      van Leeuwen, Bas; van Leeuwen-Li, Jieli, 2015, "Average Years of Education", https://hdl.handle.net/10622/KCBMKI, IISH Data Collection, V1
-
-
-      Carmichael, Sarah; Dilli, Selin; Rijpma, Auke, 2015, "Gender Equality Years of Education", https://hdl.handle.net/10622/OTHFUK, IISH Data Collection, V1
-
-
-      van Leeuwen, Bas; van Leeuwen-Li, Jieli, 2015, "Educational Inequality Gini Coefficient", https://hdl.handle.net/10622/KORKQW, IISH Data Collection, V1
 tables:
   clio_infra_education:
     variables:
       years_of_education:
         title: Historical estimates of average years of education
-        description: The average years of education in the total population aged 15 years and older is given for the period 1870-2010.
+        description_short: The average years of education in the total population aged 15 years and older is given for the period 1870-2010.
         unit: years
         short_unit: ''
         display:
@@ -38,7 +13,7 @@ tables:
 
       years_of_education_gini:
         title: Historical estimates of average years of education, Gini inequality index
-        description: >-
+        description_short: >-
           The Gini coefficient measures the inequality in the spread of education in the total population aged 15 years and older.
 
 
@@ -51,7 +26,7 @@ tables:
 
       years_of_education_gender:
         title: Historical estimates of average years of education, gender differences
-        description: >-
+        description_short: >-
           Ratio of girls to boys in average years of schooling by country and decade.
 
 
@@ -69,7 +44,7 @@ tables:
 
       numeracy:
         title:  Historical numeracy estimates
-        description: >-
+        description_short: >-
           Age heaping is observed in age data collection, where people tend to report their ages in rounded figures, often ending in 0 or 5, rather than their exact age.
           For example, individiauals might state their age as 30, 35, or 40 and avoid being precise with figures like 31, 36, or 39. This is believed to happen more often in populations that lack basic numeracy skills.
 
@@ -85,7 +60,7 @@ tables:
 
       numeracy_gender:
         title: Historical numeracy estimates, gender differences
-        description: >-
+        description_short: >-
             Age heaping is observed in age data collection, where people tend to report their ages in rounded figures, often ending in 0 or 5, rather than their exact age.
             For example, individiauals might state their age as 30, 35, or 40 and avoid being precise with figures like 31, 36, or 39. This is believed to happen more often in populations that lack basic numeracy skills.
 

--- a/etl/steps/data/garden/gapminder/2019-05-25/fertility_rate.meta.yml
+++ b/etl/steps/data/garden/gapminder/2019-05-25/fertility_rate.meta.yml
@@ -1,5 +1,3 @@
-dataset:
-  title: Fertility Rate (Selected Gapminder, v12) (2017)
 tables:
   fertility_rate:
     variables:
@@ -8,6 +6,4 @@ tables:
         unit: children per woman
         display:
           name: Fertility rate
-        description: Total fertility rate represents the number of children that would be born to a woman if she were to live
-          to the end of her childbearing years and bear children in accordance with age-specific fertility rates of the specified
-          year.
+        description_short: Total fertility rate represents the number of children that would be born to a woman if she were to live to the end of her childbearing years and bear children in accordance with age-specific fertility rates of the specified year.

--- a/etl/steps/data/garden/homicide/2024-07-30/homicide_long_run_omm.meta.yml
+++ b/etl/steps/data/garden/homicide/2024-07-30/homicide_long_run_omm.meta.yml
@@ -1,7 +1,3 @@
-dataset:
-  title: Long run homicide rates (1250-2022; Eisner, WHO, UNODC)
-  sources:
-    - name: OWID based on Eisner (2014); United Nations Office of Drugs and Crime (2022); WHO Mortality Database (2024)
 tables:
   homicide_long_run_omm:
     variables:
@@ -17,13 +13,6 @@ tables:
           Historical estimates of homicide rates are derived from national vital statistics and judicial archives. The older data is often fragmented and subject to a number of biases including: geographic bias, incomplete records, changing age structure, wound treatment, and the lethality of weapons.
         short_unit: ""
         unit: "homicides per 100,000 people"
-        origins:
-          - title: Eisner (2014)
-            date_published: "2014"
-            producer: Eisner (2014)
-            citation_full: "Eisner, M. (2014) “From Swords to Words: Does Macro-Level Change in Self-Control Predict Long-Term Variation in Levels of Homicide?” In Why Crime Rates Fall and Why They Don’t, edited by Michael Tonry. Vol. 43 of Crime and Justice: A Review of Research, edited by Michael Tonry. Chicago: University of Chicago Press"
-            url_main: https://www.jstor.org/stable/10.1086/677662?read-now=1&seq=16#page_scan_tab_contents
-            date_accessed: "2024-01-03"
         display:
           numDecimalPlaces: 2
       death_rate_per_100_000_population_eisner_who:

--- a/etl/steps/data/garden/homicide/2024-07-30/homicide_long_run_omm.py
+++ b/etl/steps/data/garden/homicide/2024-07-30/homicide_long_run_omm.py
@@ -1,7 +1,6 @@
 from owid.catalog import Table
 from owid.catalog import processing as pr
 from owid.catalog.utils import underscore
-from owid.datautils import dataframes
 from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
@@ -31,7 +30,7 @@ def run(dest_dir: str) -> None:
     tb_eisner = tb_eisner.rename(
         columns={"death_rate_per_100_000_population": "death_rate_per_100_000_population_eisner"}
     ).drop(columns="source")
-    tb_combined = dataframes.multi_merge([tb_eisner, tb_who_long], on=["country", "year"], how="outer")
+    tb_combined = pr.merge(tb_eisner, tb_who_long, on=["country", "year"], how="outer")
 
     # We only want entities for which long-run data is available in grapher - so let's drop all the others
 

--- a/etl/steps/data/garden/iucn/2022-12-08/threatened_and_evaluated_species.meta.yml
+++ b/etl/steps/data/garden/iucn/2022-12-08/threatened_and_evaluated_species.meta.yml
@@ -1,5 +1,3 @@
-dataset:
-  title: Threatened and evaluated species (IUCN Red List)
 tables:
   threatened_and_evaluated_species:
     variables:
@@ -9,8 +7,7 @@ tables:
         display:
           name: Number of described species
           numDecimalPlaces: 0
-        description: The total number of known/described species. This does not mean these species have been assessed for
-          their extinction risk level.
+        description_short: The total number of known/described species. This does not mean these species have been assessed for their extinction risk level.
       number_of_species_evaluated_for_the_iucn_red_list:
         title: Number of species evaluated for the IUCN Red List
         unit: species
@@ -22,17 +19,14 @@ tables:
         unit: species
         display:
           name: Number of species threatened with extinction
-        description: >-
-          The IUCN Red List has assessed only a small share of the total known species in the world. This means the number
-          of species threatened with extinction is likely to be a significant underestimate of the total number of species
-          at risk.
+        description_short: |-
+          The IUCN Red List has assessed only a small share of the total known species in the world. This means the number of species threatened with extinction is likely to be a significant underestimate of the total number of species at risk.
 
 
           This is particularly true for understudied groups such as insects, plants and fungi.
 
 
-          'Threatened' species are those that are categorized as 'Critically endangered', 'Endangered' or 'Vulnerable' on
-          the IUCN Red List.
+          'Threatened' species are those that are categorized as 'Critically endangered', 'Endangered' or 'Vulnerable' on the IUCN Red List.
       share_of_described_species_that_have_been_evaluated:
         title: Share of described species that have been evaluated
         unit: '%'
@@ -46,5 +40,4 @@ tables:
         short_unit: '%'
         display:
           name: Share of species threatened with extinction
-        description: The share of known species threatened with extinction is only available for a few taxonomic groups where
-          more than 80% of species have been assessed.
+        description_short: The share of known species threatened with extinction is only available for a few taxonomic groups where more than 80% of species have been assessed.

--- a/etl/steps/data/garden/postnatal_care/2022-09-19/postnatal_care.meta.yml
+++ b/etl/steps/data/garden/postnatal_care/2022-09-19/postnatal_care.meta.yml
@@ -1,29 +1,8 @@
-dataset:
-  namespace: postnatal_care
-  short_name: postnatal_care
-  title: Postnatal care coverage (% mothers) - Health Nutrition and Population Statistics
-    (2022)
-  description: Percentage of women with a postnatal checkup in the first two days
-    after birth.
-  licenses:
-  - name: Creative Commons BY 4.0
-    url: https://www.worldbank.org/en/about/legal/terms-of-use-for-datasets
-  version: '2022-09-19'
-  sources:
-  - name: World Bank (2022)
-    published_by: Health Nutrition and Population Statistics - World Bank (2022)
-    url: https://databank.worldbank.org/source/health-nutrition-and-population-statistics/Series/SH.STA.PNVC.ZS#
-    date_accessed: '2022-10-31'
-    publication_date: '2022-09-19'
-    publication_year: 2022
 tables:
   postnatal_care:
-    title: Postnatal care coverage (% mothers) - Health Nutrition and Population Statistics
-      (2022)
-    description: Percentage of women with a postnatal checkup in the first two days
-      after birth.
     variables:
       postnatal_care_coverage:
         title: postnatal_care_coverage
+        description_short: Percentage of women with a postnatal checkup in the first two days after birth.
         short_unit: '%'
         unit: '%'

--- a/etl/steps/data/garden/postnatal_care/2022-09-19/postnatal_care.py
+++ b/etl/steps/data/garden/postnatal_care/2022-09-19/postnatal_care.py
@@ -1,78 +1,29 @@
-import json
-from typing import cast
+"""Load a meadow dataset and create a garden dataset."""
 
-import pandas as pd
-from owid.catalog import Dataset, Table
-from owid.catalog.utils import underscore_table
-from structlog import get_logger
-
-from etl.data_helpers import geo
 from etl.helpers import PathFinder
-from etl.paths import DATA_DIR
 
-log = get_logger()
-
-# naming conventions
-N = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
-    log.info("postnatal_care.start")
+def run() -> None:
+    # Load meadow dataset and table.
+    ds_meadow = paths.load_dataset("postnatal_care")
+    tb = ds_meadow["postnatal_care"].reset_index()
 
-    # read dataset from meadow
-    ds_meadow = Dataset(DATA_DIR / "meadow/postnatal_care/2022-09-19/postnatal_care")
-    tb_meadow = ds_meadow["postnatal_care"]
+    # Harmonize country names (and drop excluded countries).
+    tb = paths.regions.harmonize_names(
+        tb,
+        country_col="country",
+        countries_file=paths.country_mapping_path,
+        excluded_countries_file=paths.excluded_countries_path,
+    )
 
-    df = pd.DataFrame(tb_meadow)
+    # Drop rows without postnatal care coverage data and round values.
+    tb = tb.dropna(subset=["postnatal_care_coverage"])
+    tb["postnatal_care_coverage"] = tb["postnatal_care_coverage"].astype(float).round(2)
 
-    log.info("postnatal_care.exclude_countries")
-    df = exclude_countries(df)
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
 
-    log.info("postnatal_care.harmonize_countries")
-    df = harmonize_countries(df)
-    log.info("drop out empty rows")
-    df = df.dropna()
-    df["postnatal_care_coverage"] = df["postnatal_care_coverage"].astype(float).round(2)
-    ds_garden = Dataset.create_empty(dest_dir)
-    ds_garden.metadata = ds_meadow.metadata
-
-    tb_garden = underscore_table(Table(df))
-    tb_garden.metadata = tb_meadow.metadata
-    for col in tb_garden.columns:
-        tb_garden[col].metadata = tb_meadow[col].metadata
-
-    ds_garden.metadata.update_from_yaml(N.metadata_path)
-    tb_garden.update_metadata_from_yaml(N.metadata_path, "postnatal_care")
-    tb_garden = tb_garden.reset_index()
-    ds_garden.add(tb_garden)
+    # Save garden dataset.
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
     ds_garden.save()
-
-    log.info("postnatal_care.end")
-
-
-def load_excluded_countries() -> list[str]:
-    with open(N.excluded_countries_path) as f:
-        data = json.load(f)
-        assert isinstance(data, list)
-    return data
-
-
-def exclude_countries(df: pd.DataFrame) -> pd.DataFrame:
-    excluded_countries = load_excluded_countries()
-    return cast(pd.DataFrame, df.loc[~df.country.isin(excluded_countries)])
-
-
-def harmonize_countries(df: pd.DataFrame) -> pd.DataFrame:
-    unharmonized_countries = df["country"]
-    df = geo.harmonize_countries(df=df, countries_file=str(N.country_mapping_path))
-
-    missing_countries = set(unharmonized_countries[df.country.isnull()])
-    if any(missing_countries):
-        raise RuntimeError(
-            "The following raw country names have not been harmonized. "
-            f"Please: (a) edit {N.country_mapping_path} to include these country "
-            f"names; or (b) add them to {N.excluded_countries_path}."
-            f"Raw country names: {missing_countries}"
-        )
-
-    return df

--- a/etl/steps/data/garden/un/2024-09-11/igme.meta.yml
+++ b/etl/steps/data/garden/un/2024-09-11/igme.meta.yml
@@ -149,8 +149,6 @@ tables:
         display:
           name: <<indicator>>
           numDecimalPlaces: <% if 'rate' in indicator %>2<% else %>0<%- endif -%>
-        sources:
-          - name: United Nations Inter-agency Group for Child Mortality Estimation (2018; 2024)
         presentation:
           attribution: United Nations Inter-agency Group for Child Mortality Estimation (2018; 2024)
           title_public: <<indicator>>

--- a/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.meta.yml
+++ b/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.meta.yml
@@ -1,32 +1,9 @@
-# (Inherited from meadow, remove if not different.)
-all_sources:
-  - source_testing: &source-testing
-      name: UN Environment Programme (2023)
-      published_by: UN Environment Programme # (if different to short citation). Example: Testing Full Citation
-      url: https://ozone.unep.org/countries/data-table
-      date_accessed: 2023-03-17
-      publication_date: 2023-03-16
-      publication_year: 2023
-      # description: Source description.
-
-# (Inherited from meadow, remove if not different.)
-dataset:
-  title: Consumption of controlled substances (UNEP, 2023)
-  description: |
-    Data on the consumption of controlled substances in ODP tonnes or in CO2-eq tonnes
-
-    Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
-
-  sources:
-    - *source-testing
-
 tables:
   consumption_controlled_substances:
-    # (Inherited from meadow, remove if not different.)
     variables:
       consumption:
         title: Consumption of controlled substance
-        description: |
+        description_short: |-
           Consumption of various controlled substances. These include Bromochloromethane (BCM), Carbon Tetrachloride (CTC), Chlorofluorocarbons (CFCs), Hydrobromofluorocarbons (HBFCs), Hydrochlorofluorocarbons (HCFCs), Hydrofluorocarbons (HFCs), Methyl Bromide (MB), Methyl Chloroform (TCA) and Other Fully Halogenated CFCs.
         short_unit: "tonnes"
         unit: "ODP tonnes"
@@ -34,7 +11,7 @@ tables:
           numDecimalPlaces: 1
       consumption_zf:
         title: Consumption of controlled substance (zero-filled)
-        description: |
+        description_short: |-
           Consumption of various controlled substances. These include Bromochloromethane (BCM), Carbon Tetrachloride (CTC), Chlorofluorocarbons (CFCs), Hydrobromofluorocarbons (HBFCs), Hydrochlorofluorocarbons (HCFCs), Hydrofluorocarbons (HFCs), Methyl Bromide (MB), Methyl Chloroform (TCA) and Other Fully Halogenated CFCs.
 
           We assign zero to missing values for a given (year, country, chemical) triple. This is due to technical reasons, so that we are able to plot this variable using our Grapher stacked are charts.
@@ -44,7 +21,7 @@ tables:
           numDecimalPlaces: 1
       consumption_rel_1986:
         title: Consumption of controlled substance (relative to 1986)
-        description: |
+        description_short: |-
           Consumption of various controlled substances. These include Bromochloromethane (BCM), Carbon Tetrachloride (CTC), Chlorofluorocarbons (CFCs), Hydrobromofluorocarbons (HBFCs), Hydrochlorofluorocarbons (HCFCs), Hydrofluorocarbons (HFCs), Methyl Bromide (MB), Methyl Chloroform (TCA) and Other Fully Halogenated CFCs.
 
           This is measured as an index relative to emissions in the year 1986 (1986 = 100).

--- a/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.py
+++ b/etl/steps/data/garden/unep/2023-03-17/consumption_controlled_substances.py
@@ -2,8 +2,8 @@
 
 import json
 
-import pandas as pd
 from owid.catalog import Table
+from owid.catalog import processing as pr
 from structlog import get_logger
 
 from etl.data_helpers import geo
@@ -26,16 +26,13 @@ def run(dest_dir: str) -> None:
     ds_meadow = paths.load_dataset("consumption_controlled_substances")
 
     # Read table from meadow dataset.
-    tb_meadow = ds_meadow["consumption_controlled_substances"]
-
-    # Create a dataframe with data from the table.
-    df = pd.DataFrame(tb_meadow)
+    tb = ds_meadow["consumption_controlled_substances"].reset_index()
 
     #
     # Process data.
     #
     log.info("consumption_controlled_substances: process data, creating table")
-    tb_garden = df_to_table(df)
+    tb_garden = process_table(tb)
     #
     # Save outputs.
     #
@@ -49,53 +46,52 @@ def run(dest_dir: str) -> None:
     log.info("consumption_controlled_substances: end")
 
 
-def df_to_table(df: pd.DataFrame) -> Table:
+def process_table(tb: Table) -> Table:
     # Dropna
-    df = df.dropna(subset=["consumption"]).astype({"consumption": "float32"})
+    tb = tb.dropna(subset=["consumption"]).astype({"consumption": "float32"})
     # Check country mapping
     _check_country_mapping()
     # Harmonize countries
     log.info("consumption_controlled_substances: harmonizing countries")
-    df = geo.harmonize_countries(df=df, countries_file=paths.country_mapping_path)
+    tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
     # Add EU28
     log.info("consumption_controlled_substances: add regions")
-    df = add_regions(df)
+    tb = add_regions(tb)
     # Estimate total consumption of ozone-depleting substances (summation over all chemicals except HFCs)
     log.info("consumption_controlled_substances: estimating total")
     chemicals_ignore = [
         "Hydrofluorocarbons (HFCs)",
     ]
-    df_depleting = df[~df["chemical"].isin(chemicals_ignore)]
-    df_total = (
-        df_depleting.groupby(["country", "year"], observed=True, as_index=False)[["consumption"]]
+    tb_depleting = tb[~tb["chemical"].isin(chemicals_ignore)]
+    tb_total = (
+        tb_depleting.groupby(["country", "year"], observed=True, as_index=False)[["consumption"]]
         .sum()
         .assign(chemical="All (Ozone-depleting)")
     )
-    df = pd.concat([df, df_total], ignore_index=True).sort_values(["country", "year", "chemical"])
+    tb = pr.concat([tb, tb_total], ignore_index=True).sort_values(["country", "year", "chemical"])
     # Add zero-filled column
-    df = add_consumption_zerofilled(df)
+    tb = add_consumption_zerofilled(tb)
     # Add consumption relative to 1986
-    df = add_consumption_rel_1986(df)
+    tb = add_consumption_rel_1986(tb)
     # Remove data for regions in last year
-    df = remove_last_year_for_regions(df)
+    tb = remove_last_year_for_regions(tb)
     # Set indices
-    df = df.set_index(["country", "year", "chemical"])
+    tb = tb.set_index(["country", "year", "chemical"])
     # Drop NaNs and set dtype
-    df = df.astype({"consumption": "float32", "consumption_zf": "float32"})
-    # Create a new table with the processed data.
-    tb_garden = Table(df, short_name=paths.short_name)
-    return tb_garden
+    tb = tb.astype({"consumption": "float32", "consumption_zf": "float32"})
+    tb.metadata.short_name = paths.short_name
+    return tb
 
 
-def add_regions(df: pd.DataFrame) -> pd.DataFrame:
+def add_regions(tb: Table) -> Table:
     id_vars = ["country", "year"]
     var_name = "chemical"
     value_name = "consumption"
     # Add data for the World
-    df_world = df.groupby(["year", "chemical"], as_index=False)[[value_name]].sum().assign(country="World")
-    df = pd.concat([df, df_world], ignore_index=True)
+    tb_world = tb.groupby(["year", "chemical"], as_index=False)[[value_name]].sum().assign(country="World")
+    tb = pr.concat([tb, tb_world], ignore_index=True)
     # Pivot
-    df_pivot = df.pivot(index=id_vars, columns=[var_name], values=value_name).reset_index()
+    tb_pivot = tb.pivot(index=id_vars, columns=[var_name], values=value_name).reset_index()
     # Add continent data
     regions = ["Asia", "Africa", "North America", "South America", "Oceania"]
     # Load population
@@ -105,24 +101,24 @@ def add_regions(df: pd.DataFrame) -> pd.DataFrame:
             region=region,
             population=population,
         )
-        df_pivot = add_region_aggregates(
-            df_pivot,
+        tb_pivot = add_region_aggregates(
+            tb_pivot,
             region=region,
             countries_that_must_have_data=countries_that_must_have_data,
             frac_allowed_nans_per_year=0.2,
             num_allowed_nans_per_year=None,
         )
     # Unpivot back
-    df = df_pivot.melt(id_vars=id_vars, var_name=var_name, value_name=value_name).dropna(subset=[value_name])
+    tb = tb_pivot.melt(id_vars=id_vars, var_name=var_name, value_name=value_name).dropna(subset=[value_name])
     # Add EU28 data
-    df = add_eu28(df)
+    tb = add_eu28(tb)
     # Add Europe data
-    df = add_europe(df)
-    return df
+    tb = add_europe(tb)
+    return tb
 
 
-def add_eu28(df: pd.DataFrame) -> pd.DataFrame:
-    """Add EU28 data to the dataframe.
+def add_eu28(tb: Table) -> Table:
+    """Add EU28 data to the table.
 
     This dataset provides data for European Union as a changing entity (i.e. member states vary over time). This
     function estimates EU 28, as a fixed entity, by summing up the data for all EU 28 members over time.
@@ -134,40 +130,40 @@ def add_eu28(df: pd.DataFrame) -> pd.DataFrame:
     # Get list of all EU28 members
     eu28_members = list_countries_in_region("European Union (27)") + ["United Kingdom", "European Union"]
     # Add EU28 data
-    df = _add_region(df, eu28_members, "European Union (28)")
-    return df
+    tb = _add_region(tb, eu28_members, "European Union (28)")
+    return tb
 
 
-def add_europe(df: pd.DataFrame) -> pd.DataFrame:
-    assert "European Union (28)" in df.country.unique(), (
+def add_europe(tb: Table) -> Table:
+    assert "European Union (28)" in tb.country.unique(), (
         "Check data! It looks like `European Union (28)` is not present."
     )
     # EU states
     europe_members = list_countries_in_region("Europe") + ["European Union (28)"]
-    assert len(set(df.country).intersection(europe_members)) == 18, (
+    assert len(set(tb.country).intersection(europe_members)) == 18, (
         "Check data! It might be that individual EU 28 member states are still present."
     )
     # Add EU data
-    df = _add_region(df, europe_members, "Europe", remove_members=False)
-    return df
+    tb = _add_region(tb, europe_members, "Europe", remove_members=False)
+    return tb
 
 
-def _add_region(df: pd.DataFrame, members: list[str], region: str, remove_members: bool = True) -> pd.DataFrame:
+def _add_region(tb: Table, members: list[str], region: str, remove_members: bool = True) -> Table:
     """Aggregate data for a region.
 
     This function is useful when adding regions that are not currently considered by etl.data_helpers.geo.add_region_aggregates.
     For instance "Europe Union (28)". Or when a region is built differently, e.g. Europe = EU 28 + ...
     """
     # Mask
-    msk_region = df["country"].isin(members)
-    df_region = df[msk_region].copy()
-    df_region["country"] = region
-    df_region = df_region.groupby(["country", "year", "chemical"], as_index=False)[["consumption"]].sum()
+    msk_region = tb["country"].isin(members)
+    tb_region = tb[msk_region].copy()
+    tb_region["country"] = region
+    tb_region = tb_region.groupby(["country", "year", "chemical"], as_index=False)[["consumption"]].sum()
     if remove_members:
-        df = pd.concat([df[~msk_region], df_region], ignore_index=True)
+        tb = pr.concat([tb[~msk_region], tb_region], ignore_index=True)
     else:
-        df = pd.concat([df, df_region], ignore_index=True)
-    return df
+        tb = pr.concat([tb, tb_region], ignore_index=True)
+    return tb
 
 
 def _check_country_mapping():
@@ -179,30 +175,30 @@ def _check_country_mapping():
     )
 
 
-def add_consumption_zerofilled(df: pd.DataFrame) -> pd.DataFrame:
+def add_consumption_zerofilled(tb: Table) -> Table:
     id_vars = ["country", "year"]
     var_name = "chemical"
     value_name = "consumption"
-    df = df.pivot(index=id_vars, columns=[var_name], values=value_name).reset_index()
-    df = df.melt(id_vars=id_vars, var_name=var_name, value_name=value_name)
-    df["consumption_zf"] = df["consumption"].fillna(0)
-    return df
+    tb = tb.pivot(index=id_vars, columns=[var_name], values=value_name).reset_index()
+    tb = tb.melt(id_vars=id_vars, var_name=var_name, value_name=value_name)
+    tb["consumption_zf"] = tb["consumption"].fillna(0)
+    return tb
 
 
-def add_consumption_rel_1986(df: pd.DataFrame) -> pd.DataFrame:
+def add_consumption_rel_1986(tb: Table) -> Table:
     """Add column with ratio of consumption to 1986 consumption."""
     # Initial columns and new column names
-    columns = list(df.columns)
+    columns = list(tb.columns)
     new_col = "consumption_rel_1986"
     # Get consumption in 1986, where it is not zero
-    df_1986 = df[(df["year"] == 1986) & (df["consumption"] > 0)]
+    tb_1986 = tb[(tb["year"] == 1986) & (tb["consumption"] > 0)]
     # Merge and estimate ratio
-    df = df.merge(df_1986, on=["country", "chemical"], suffixes=("", "_1986"), how="left")
-    df[new_col] = (100 * df["consumption"] / df["consumption_1986"]).round(2)
-    return df[columns + [new_col]]
+    tb = tb.merge(tb_1986, on=["country", "chemical"], suffixes=("", "_1986"), how="left")
+    tb[new_col] = (100 * tb["consumption"] / tb["consumption_1986"]).round(2)
+    return tb[columns + [new_col]]
 
 
-def remove_last_year_for_regions(df: pd.DataFrame) -> pd.DataFrame:
+def remove_last_year_for_regions(tb: Table) -> Table:
     """Remove datapoint for latest available year in regions.
 
     Data for latest year for regions is usually an underestimate, because just a subset of countries have reported data."""
@@ -217,6 +213,6 @@ def remove_last_year_for_regions(df: pd.DataFrame) -> pd.DataFrame:
         "South America",
         "World",
     ]
-    last_year = df["year"].max()
-    df = df[~((df["year"] == last_year) & (df["country"].isin(REGIONS)))]
-    return df
+    last_year = tb["year"].max()
+    tb = tb[~((tb["year"] == last_year) & (tb["country"].isin(REGIONS)))]
+    return tb

--- a/etl/steps/data/garden/unicef/2023-06-16/diarrhea.py
+++ b/etl/steps/data/garden/unicef/2023-06-16/diarrhea.py
@@ -1,8 +1,5 @@
 """Load a meadow dataset and create a garden dataset."""
 
-from typing import cast
-
-from owid.catalog import Dataset, Table
 from structlog import get_logger
 
 from etl.data_helpers import geo
@@ -21,7 +18,7 @@ def run(dest_dir: str) -> None:
     # Load inputs.
     #
     # Load meadow dataset.
-    ds_meadow = cast(Dataset, paths.load_dependency("diarrhea"))
+    ds_meadow = paths.load_dataset("diarrhea")
 
     # Read table from meadow dataset.
     tb = ds_meadow["diarrhea"]
@@ -30,11 +27,16 @@ def run(dest_dir: str) -> None:
     # Process data.
     #
     log.info("diarrhea.harmonize_countries")
-    tb: Table = geo.harmonize_countries(
+    tb = geo.harmonize_countries(
         df=tb, countries_file=paths.country_mapping_path, excluded_countries_file=paths.excluded_countries_path
     )
 
-    tb = tb.pivot_table(values="value", index=["country", "year"], columns="indicator")
+    # The source data contains a single duplicate (Rwanda 2000 ORS) where one row has a value and another is NaN.
+    # Drop NaN rows so each (country, year, indicator) is unique, then pivot while preserving metadata.
+    tb = tb.dropna(subset=["value"]).drop_duplicates(subset=["country", "year", "indicator"])
+    tb = tb.pivot(index=["country", "year"], columns="indicator", values="value", join_column_levels_with="")
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
     #
     # Save outputs.
     #

--- a/etl/steps/data/garden/war/2023-01-18/bouthoul_carrere_1978.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/bouthoul_carrere_1978.meta.yml
@@ -1,26 +1,3 @@
-all_sources:
-  - source_testing: &source-testing
-      name: Bouthoul and Carrère (1978)
-      published_by: "Bouthoul, Gaston, René Carrère, and Gernot Köhler. 1978. A list of the 366 Major Armed Conflicts of the Period 1740-1974. Peace Research 10(3): 83-108."
-      url: https://www.jstor.org/stable/23609587
-      date_accessed: 2023-01-09
-      publication_date: 1978-07-01
-      publication_year: 1978
-      # description: Source description.
-
-dataset:
-  title: Major armed conflicts and deaths (Bouthoul and Carrère, 1978)
-  namespace: war
-  short_name: bouthoul_carrere_1978
-  version: 2023-01-18
-  description: |
-    This dataset provides information on direct and indirect military and civilian deaths from major armed conflicts, drawn from the article by Bouthoul and Carrère (1978).
-  licenses:
-    - name: JSTOR
-      url: https://about.jstor.org/terms/
-  sources:
-    - *source-testing
-
 tables:
   bouthoul_carrere_1978:
     variables: {}
@@ -29,8 +6,6 @@ tables:
       #   unit: arbitrary units
       #   short_unit: au
       #   description: Full description of testing variable.
-      #   sources:
-      #     - *source-testing
       #   display:
       #     entityAnnotationsMap: Test annotation
       #     numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-01-18/clodfelter_2017.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/clodfelter_2017.meta.yml
@@ -1,26 +1,3 @@
-all_sources:
-  - source_testing: &source-testing
-      name: Clodfelter (2017)
-      published_by: "Clodfelter, Micheal. 2017. Warfare and Armed Conflicts: A Statistical Encyclopedia of Casualty and other Figures, 1492-2015. Fourth edition. McFarland & Company."
-      url: https://books.google.es/books/about/Warfare_and_Armed_Conflicts.html?id=kNzCDgAAQBAJ&redir_esc=y
-      date_accessed: 2023-01-09
-      publication_date: 2017-04-24
-      publication_year: 2017
-      # description: Source description.
-
-dataset:
-  title: Wars, deaths, and casualties (Clodfelter, 2017)
-  namespace: war
-  short_name: clodfelter_2017
-  version: 2023-01-18
-  description: |
-    This dataset provides information on direct and indirect military and civilian deaths and casualties from wars, drawn from the book by Clodfelter (2017).
-  licenses:
-    - name: McFarland, 2017
-      url: https://mcfarlandbooks.com/product/warfare-and-armed-conflicts/
-  sources:
-    - *source-testing
-
 tables:
   clodfelter_2017:
     variables: {}
@@ -29,8 +6,6 @@ tables:
       #   unit: arbitrary units
       #   short_unit: au
       #   description: Full description of testing variable.
-      #   sources:
-      #     - *source-testing
       #   display:
       #     entityAnnotationsMap: Test annotation
       #     numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-01-18/clodfelter_2017.py
+++ b/etl/steps/data/garden/war/2023-01-18/clodfelter_2017.py
@@ -1,6 +1,5 @@
 """Load a meadow dataset and create a garden dataset."""
 
-import pandas as pd
 from owid.catalog import Dataset, Table
 from shared import make_tables, table_to_clean_df
 from structlog import get_logger
@@ -26,17 +25,16 @@ def run(dest_dir: str) -> None:
     ds_meadow: Dataset = paths.load_dependency(SHORT_NAME)
     # Read table from meadow dataset.
     tb_meadow = ds_meadow[SHORT_NAME]
-    # Create a dataframe with data from the table.
 
     #
     # Process data.
     #
     log.info(f"{SHORT_NAME}: processing dataframe")
-    df = clean_df(tb_meadow)
+    tb = clean_table(tb_meadow)
 
     # Create a new table with the processed data.
     log.info(f"{SHORT_NAME}: generating tables")
-    tables = make_tables(df, SHORT_NAME)
+    tables = make_tables(tb, SHORT_NAME)
 
     #
     # Save outputs.
@@ -51,12 +49,12 @@ def run(dest_dir: str) -> None:
     log.info(f"{SHORT_NAME}: end")
 
 
-def clean_df(tb: Table) -> pd.DataFrame:
+def clean_table(tb: Table) -> Table:
     # Remove outliers
     tb = _remove_outliers(tb)
     # Standardize names of conflict participants
-    df = table_to_clean_df(tb)
-    return df
+    tb = table_to_clean_df(tb)
+    return tb
 
 
 def _remove_outliers(tb: Table) -> Table:

--- a/etl/steps/data/garden/war/2023-01-18/dunnigan_martel_1987.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/dunnigan_martel_1987.meta.yml
@@ -1,25 +1,3 @@
-all_sources:
-  - source_testing: &source-testing
-      name: Dunnigan and Martel (1987)
-      published_by: Dunnigan, James, and William Martel. 1987. How to Stop a War. Doubleday.
-      url: https://books.google.es/books/about/How_to_Stop_a_War.html?id=lg7cAAAAMAAJ
-      date_accessed: 2023-01-09
-      publication_date: 1987-10-01
-      publication_year: 1987
-      # description: Source description.
-
-dataset:
-  title: Wars and deaths (Dunnigan and Martel, 1987)
-  namespace: war
-  short_name: dunnigan_martel_1987
-  version: 2023-01-18
-  description: |
-    This dataset provides information on military and civilian deaths from wars, drawn from the book by Dunnigan and Martel (1987).
-  licenses:
-    - name: Doubleday (1987)
-  sources:
-    - *source-testing
-
 tables:
   dunnigan_martel_1987:
     variables: {}
@@ -28,8 +6,6 @@ tables:
       #   unit: arbitrary units
       #   short_unit: au
       #   description: Full description of testing variable.
-      #   sources:
-      #     - *source-testing
       #   display:
       #     entityAnnotationsMap: Test annotation
       #     numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-01-18/eckhardt_1991.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/eckhardt_1991.meta.yml
@@ -1,35 +1,3 @@
-all_sources:
-  - source_testing: &source-testing
-      name: Eckhardt (1991)
-      published_by: "Eckhardt, William. 1991. Wars and War-Related Deaths, 1500-1990. In: Ruth Sivard: World Military and Social Expenditures. World Priorities."
-      url: https://ruthsivard.com/wmse91.html
-      date_accessed: 2023-01-09
-      publication_date: 1991-01-01
-      publication_year: 1991
-      # description: Source description.
-
-dataset:
-  title: Wars and deaths (Eckhardt, 1991)
-  namespace: war
-  short_name: eckhardt_1991
-  version: 2023-01-18
-  description: |
-    This dataset provides information on military and civilian deaths from wars, drawn from the chapter by Eckhardt (1991).
-  licenses:
-    - name: World Priorities
-  sources:
-    - *source-testing
-
 tables:
   eckhardt_1991:
     variables: {}
-      # testing_variable:
-      #   title: Testing variable title
-      #   unit: arbitrary units
-      #   short_unit: au
-      #   description: Full description of testing variable.
-      #   sources:
-      #     - *source-testing
-      #   display:
-      #     entityAnnotationsMap: Test annotation
-      #     numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-01-18/eckhardt_1991.py
+++ b/etl/steps/data/garden/war/2023-01-18/eckhardt_1991.py
@@ -1,6 +1,5 @@
 """Load a meadow dataset and create a garden dataset."""
 
-import pandas as pd
 from owid.catalog import Dataset, Table
 from shared import make_tables, table_to_clean_df
 from structlog import get_logger
@@ -26,17 +25,16 @@ def run(dest_dir: str) -> None:
     ds_meadow: Dataset = paths.load_dependency(SHORT_NAME)
     # Read table from meadow dataset.
     tb_meadow = ds_meadow[SHORT_NAME]
-    # Create a dataframe with data from the table.
 
     #
     # Process data.
     #
     log.info(f"{SHORT_NAME}: processing dataframe")
-    df = clean_df(tb_meadow)
+    tb = clean_table(tb_meadow)
 
     # Create a new table with the processed data.
     log.info(f"{SHORT_NAME}: generating tables")
-    tables = make_tables(df, SHORT_NAME)
+    tables = make_tables(tb, SHORT_NAME)
 
     #
     # Save outputs.
@@ -51,7 +49,7 @@ def run(dest_dir: str) -> None:
     log.info(f"{SHORT_NAME}: end")
 
 
-def clean_df(tb: Table) -> pd.DataFrame:
+def clean_table(tb: Table) -> Table:
     # Standardize names of conflict participants
-    df = table_to_clean_df(tb)
-    return df
+    tb = table_to_clean_df(tb)
+    return tb

--- a/etl/steps/data/garden/war/2023-01-18/kaye_1985.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/kaye_1985.meta.yml
@@ -1,25 +1,3 @@
-all_sources:
-  - source_testing: &source-testing
-      name: Kaye et al. (1985)
-      published_by: "Kaye, G.D., D.A. Grant, and E.J. Emond. 1985. Major Armed Conflict: A Compendium of Interstate and Intrastate Conflict, 1720 to 1985. Operational Research and Analysis Establishment Report No. R 95, Department of National Defence Canada."
-      url: https://books.google.es/books/about/Major_Armed_Conflict.html?id=Xce_PwAACAAJ&redir_esc=y
-      date_accessed: 2023-01-09
-      publication_date: 1985-11-01
-      publication_year: 1985
-      # description: Source description.
-
-dataset:
-  title: Major armed conflicts and deaths (Kaye et al., 1985)
-  namespace: war
-  short_name: kaye_1985
-  version: 2023-01-18
-  description: |
-    This dataset provides information on direct and indirect military and civilian deaths from major armed conflicts, drawn from the report by Kaye et al. (1985).
-  licenses:
-    - name: Department of National Defence, Canada, Operational Research and Analysis Establishment, 1985
-  sources:
-    - *source-testing
-
 tables:
   kaye_1985:
     variables: {}
@@ -28,8 +6,6 @@ tables:
       #   unit: arbitrary units
       #   short_unit: au
       #   description: Full description of testing variable.
-      #   sources:
-      #     - *source-testing
       #   display:
       #     entityAnnotationsMap: Test annotation
       #     numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-01-18/kaye_1985.py
+++ b/etl/steps/data/garden/war/2023-01-18/kaye_1985.py
@@ -1,6 +1,5 @@
 """Load a meadow dataset and create a garden dataset."""
 
-import pandas as pd
 from owid.catalog import Dataset, Table
 from shared import make_tables, table_to_clean_df
 from structlog import get_logger
@@ -26,17 +25,16 @@ def run(dest_dir: str) -> None:
     ds_meadow: Dataset = paths.load_dependency(SHORT_NAME)
     # Read table from meadow dataset.
     tb_meadow = ds_meadow[SHORT_NAME]
-    # Create a dataframe with data from the table.
 
     #
     # Process data.
     #
     log.info(f"{SHORT_NAME}: processing dataframe")
-    df = clean_df(tb_meadow)
+    tb = clean_table(tb_meadow)
 
     # Create a new table with the processed data.
     log.info(f"{SHORT_NAME}: generating tables")
-    tables = make_tables(df, SHORT_NAME)
+    tables = make_tables(tb, SHORT_NAME)
 
     #
     # Save outputs.
@@ -51,7 +49,7 @@ def run(dest_dir: str) -> None:
     log.info(f"{SHORT_NAME}: end")
 
 
-def clean_df(tb: Table) -> pd.DataFrame:
+def clean_table(tb: Table) -> Table:
     # Standardize names of conflict participants
-    df = table_to_clean_df(tb)
-    return df
+    tb = table_to_clean_df(tb)
+    return tb

--- a/etl/steps/data/garden/war/2023-01-18/shared.py
+++ b/etl/steps/data/garden/war/2023-01-18/shared.py
@@ -42,7 +42,7 @@ COLUMNS_COMMON_NOTES = [
 _INDEX_COLNAME_AUX = "index"
 
 
-def make_tables(df: pd.DataFrame, short_name: str) -> list[Table]:
+def make_tables(tb: Table, short_name: str) -> list[Table]:
     """Make tables.
 
     There are three tables created:
@@ -50,13 +50,13 @@ def make_tables(df: pd.DataFrame, short_name: str) -> list[Table]:
         - Notes table: Table linking entries in the main table with specific notes.
         - Bulk ID table: Mapping between IDs in the main table and bulk IDs. Bulk IDs are legacy IDs. This table might be removed in the future.
     """
-    df = _add_range_index(df)
+    tb = _add_range_index(tb)
     # Main table
-    tb_main = make_table_main(df, short_name)
+    tb_main = make_table_main(tb, short_name)
     # Notes table
-    tb_notes = make_table_notes(df)
+    tb_notes = make_table_notes(tb)
     # Bulk ID table
-    tb_bulk_id = make_table_bulk_id(df)
+    tb_bulk_id = make_table_bulk_id(tb)
     # Return
     tables = [
         tb_main,
@@ -69,59 +69,57 @@ def make_tables(df: pd.DataFrame, short_name: str) -> list[Table]:
     return tables
 
 
-def table_to_clean_df(tb: Table, entities_with_comma: list[str] | None = None) -> pd.DataFrame:
-    """Clean data"""
-    # Table to DataFrame
-    df = pd.DataFrame(tb)
+def table_to_clean_df(tb: Table, entities_with_comma: list[str] | None = None) -> Table:
+    """Clean data (preserves Table type and column-level origins)."""
     # Check for duplicate conflicts (currently in debug mode)
-    check_duplicates(df, logging=True, filename=tb.metadata.dataset.short_name)
+    check_duplicates(tb, logging=True, filename=tb.metadata.dataset.short_name)
     # Clean participants
-    df = clean_participants(df, entities_with_comma=entities_with_comma)
+    tb = clean_participants(tb, entities_with_comma=entities_with_comma)
     # Remove expected duplicates and check that there are no more duplicates
-    # check_duplicates(df, force_error=True)
-    if df.duplicated().any():
+    # check_duplicates(tb, force_error=True)
+    if tb.duplicated().any():
         raise ValueError("Why was this not cought?!")
-    return df
+    return tb
 
 
-def make_table_main(df: pd.DataFrame, short_name: str) -> Table:
+def make_table_main(tb: Table, short_name: str) -> Table:
     """Create main table.
 
     The resulting table contains all the columns from `COLUMNS_COMMON`, and those available from `COLUMNS_EXTRA`."""
     # Get available extra columns
-    df = df[COLUMNS_COMMON + _extra_columns(df) + [_INDEX_COLNAME_AUX]].set_index(_INDEX_COLNAME_AUX)
+    tb = tb[COLUMNS_COMMON + _extra_columns(tb) + [_INDEX_COLNAME_AUX]].set_index(_INDEX_COLNAME_AUX)
     # Check for duplicates
-    msk = df.duplicated()
+    msk = tb.duplicated()
     if msk.any():
-        raise ValueError(f"{msk.sum()} rows in table are duplicated! {df[msk]}")
-    tb = Table(df, short_name=short_name)
+        raise ValueError(f"{msk.sum()} rows in table are duplicated! {tb[msk]}")
+    tb.metadata.short_name = short_name
     return tb
 
 
-def make_table_notes(df: pd.DataFrame) -> Table:
+def make_table_notes(tb: Table) -> Table:
     """Create notes table.
 
     For each row in the main table, there might be a note. This table links each row in the main table with a note. If there
     are no notes, the table will be empty (which should be hadnled later)
     """
-    df = df[COLUMNS_COMMON_NOTES + [_INDEX_COLNAME_AUX]].dropna().set_index(_INDEX_COLNAME_AUX)
-    tb = Table(df, short_name="notes")
+    tb = tb[COLUMNS_COMMON_NOTES + [_INDEX_COLNAME_AUX]].dropna().set_index(_INDEX_COLNAME_AUX)
+    tb.metadata.short_name = "notes"
     return tb
 
 
-def make_table_bulk_id(df: pd.DataFrame) -> Table:
-    df = df[["bulk_id", _INDEX_COLNAME_AUX]].set_index(_INDEX_COLNAME_AUX)
-    tb = Table(df, short_name="bulk_id")
+def make_table_bulk_id(tb: Table) -> Table:
+    tb = tb[["bulk_id", _INDEX_COLNAME_AUX]].set_index(_INDEX_COLNAME_AUX)
+    tb.metadata.short_name = "bulk_id"
     return tb
 
 
 def clean_participants(
-    df: pd.DataFrame,
+    df: Table,
     mapping: dict[str, str] | None = None,
     entities_with_comma: list[str] | None = None,
     default_separator: str = ", ",
     new_separator: str = "; ",
-) -> pd.DataFrame:
+) -> Table:
     """Clean the names of the participants in each conflicts.
 
     Typical cleaning includes:

--- a/etl/steps/data/garden/war/2023-01-18/sorokin_1937.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/sorokin_1937.meta.yml
@@ -1,26 +1,3 @@
-all_sources:
-  - source_testing: &source-testing
-      name: Sorokin (1937)
-      published_by: "Sorokin, Pitirim. 1937. Social and cultural dynamics. Volume Three: Fluctuation of Social Relationships, Wars, and Revolution. American Book Company."
-      url: https://doi.org/10.2307/2143975
-      date_accessed: 2023-01-09
-      publication_date: 1937-12-01
-      publication_year: 1937
-      # description: Source description.
-
-dataset:
-  title: Wars and casualties (Sorokin, 1937)
-  namespace: war
-  short_name: sorokin_1937
-  version: 2023-01-18
-  description: |
-    This dataset provides information on direct military casualties from wars, drawn from the book by Sorokin (1937).
-  licenses:
-    - name: JSTOR
-      url: https://about.jstor.org/terms/
-  sources:
-    - *source-testing
-
 tables:
   sorokin_1937:
     variables: {}
@@ -29,8 +6,6 @@ tables:
       #   unit: arbitrary units
       #   short_unit: au
       #   description: Full description of testing variable.
-      #   sources:
-      #     - *source-testing
       #   display:
       #     entityAnnotationsMap: Test annotation
       #     numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-01-18/sutton_1971.meta.yml
+++ b/etl/steps/data/garden/war/2023-01-18/sutton_1971.meta.yml
@@ -1,22 +1,3 @@
-all_sources:
-  - source_testing: &source-testing
-      name: Sutton (1972)
-      published_by: Sutton, Antony. 1972. Wars and Revolutions in the Nineteenth Century. Hoover Institution Archives.
-      url: https://searchworks.stanford.edu/view/3023823
-      date_accessed: 2023-01-09
-      publication_year: 1971
-      # description: Source description.
-
-dataset:
-  title: Wars, revolutions, and deaths – Sutton
-  namespace: war
-  short_name: sutton_1971
-  version: 2023-01-18
-  description: |
-    This dataset provides information on deaths from wars and revolutions, using data from Sutton (1972).
-  sources:
-    - *source-testing
-
 tables:
   sutton_1971:
     variables: {}
@@ -25,8 +6,6 @@ tables:
       #   unit: arbitrary units
       #   short_unit: au
       #   description: Full description of testing variable.
-      #   sources:
-      #     - *source-testing
       #   display:
       #     entityAnnotationsMap: Test annotation
       #     numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2023-01-18/sutton_1971.py
+++ b/etl/steps/data/garden/war/2023-01-18/sutton_1971.py
@@ -1,6 +1,5 @@
 """Load a meadow dataset and create a garden dataset."""
 
-import pandas as pd
 from owid.catalog import Dataset, Table
 from shared import make_tables, table_to_clean_df
 from structlog import get_logger
@@ -26,17 +25,16 @@ def run(dest_dir: str) -> None:
     ds_meadow: Dataset = paths.load_dependency(SHORT_NAME)
     # Read table from meadow dataset.
     tb_meadow = ds_meadow[SHORT_NAME]
-    # Create a dataframe with data from the table.
 
     #
     # Process data.
     #
     log.info(f"{SHORT_NAME}: processing dataframe")
-    df = clean_df(tb_meadow)
+    tb = clean_table(tb_meadow)
 
     # Create a new table with the processed data.
     log.info(f"{SHORT_NAME}: generating tables")
-    tables = make_tables(df, SHORT_NAME)
+    tables = make_tables(tb, SHORT_NAME)
 
     #
     # Save outputs.
@@ -51,7 +49,7 @@ def run(dest_dir: str) -> None:
     log.info(f"{SHORT_NAME}: end")
 
 
-def clean_df(tb: Table) -> pd.DataFrame:
+def clean_table(tb: Table) -> Table:
     # Standardize names of conflict participants
-    df = table_to_clean_df(tb)
-    return df
+    tb = table_to_clean_df(tb)
+    return tb

--- a/etl/steps/data/garden/waste/2018-02-15/waste_production_and_management.meta.yml
+++ b/etl/steps/data/garden/waste/2018-02-15/waste_production_and_management.meta.yml
@@ -1,154 +1,24 @@
-dataset:
-  title: Waste Production and Management
 tables:
   waste_production_and_management:
     variables:
       amounts_of_municipal_waste__total:
         title: Amounts of Municipal Waste - Total
         unit: Thousand Tons
-        sources:
-          - name: Amounts of Municipal Waste - Total
-            description: |-
-              Publication year: 2007
-              Unit: Thousand Tons
-              Abstract
-              Waste collected and treated by or for municipalities. It covers waste from households, including bulky waste, similar waste from commerce and trade, office buildings, institutions and small businesses, yard and garden waste, street sweepings, the contents of litter containers, and market cleansing waste. The definition excludes waste from municipal sewage networks and treatment, as well as municipal construction and demolition waste
-              Point of contact
-              Role: Originator
-              Person: Organization for Economic Co-Operation and Development (OECD)
-              Organization: ----
-              Email: env.contact@oecd.org
-
-              Temporal extent
-              Covered time: 1980 - 2005
-              Geographic extent
-              Coverage: World
-            url: http://ede.grid.unep.ch/
-            date_accessed: 2018-02-15
-            published_by: United Nations Environment Programme
       municipal_waste_collection:
         title: Municipal Waste Collection
         unit: Thousand Tons
-        sources:
-          - name: Municipal Waste Collection
-            description: |-
-              Publication year: 2009-08-01
-              Unit: Thousand Tons
-              Abstract
-              Municipal waste includes waste originating from: households, commerce and trade, small businesses, office buildings and institutions (schools, hospitals, government buildings).  It also includes bulky waste (e.g. white goods, old furniture, mattresses) and waste  from selected municipal services, e.g. waste from park and garden maintenance, waste from street cleaning services (street sweepings, the content of litter containers, market cleansing waste), if managed as waste.  The definition excludes waste from municipal sewage network and treatment, municipal construction and demolition waste.
-
-              Municipal waste collected refers to waste collected by or on behalf of municipalities, as well as municipal waste collected by the private sector. It includes mixed waste, and fractions collected separately for recovery operations (through door-to-door collection  and/or through voluntary deposits).
-              Percentage of total population served by municipal waste collection refers to the percentage proportion of the total population covered by regular municipal waste removal service in relation to the total population of the country.
-              Point of contact
-              Role: Originator
-              Person: United Nations Statistics Division (UNSD)
-              Organization: Director
-              Email: statistics@un.org
-
-              Temporal extent
-              Covered time: 1990 - 2007
-              Geographic extent
-              Coverage: World
-            url: http://ede.grid.unep.ch/
-            date_accessed: 2018-02-15
-            published_by: United Nations Environment Programme
       participation_in_treaties__basel_convention:
         title: Participation in Treaties - Basel Convention
         unit: Number of Parties Subscribing each Year
-        sources:
-          - name: Participation in Treaties - Basel Convention
-            description: |-
-              Publication year: 2013-12-01
-              Unit: Number of Parties Subscribing each Year
-              Abstract
-              The Basel Convention on the Control of Tranboundary Movements of Hazardous Wastes and their Disposal was adopted in 1989 and entered into force on 5 May 1992.
-              Point of contact
-              Role: Originator
-              Person: United Nations Office of Legal Affairs (OLA)
-              Organization: ----
-              Email: ----
-
-              Temporal extent
-              Covered time: 1989 - 2013-12-01
-              Geographic extent
-              Coverage: World
-            url: http://ede.grid.unep.ch/
-            date_accessed: 2018-02-15
-            published_by: United Nations Environment Programme
       participation_in_treaties__rotterdam_convention:
         title: Participation in Treaties - Rotterdam Convention
         unit: Number of Parties Subscribing each Year
-        sources:
-          - name: Participation in Treaties - Rotterdam Convention
-            description: |-
-              Publication year: 2013-12-01
-              Unit: Number of Parties Subscribing each Year
-              Abstract
-              The Convention establishes the principle that export of a chemical covered by the Convention can only take place with the prior informed consent of the importing party.  The Convention establishes a "Prior Informed Consent procedure," a means for formally obtaining and disseminating the decisions of importing countries as to whether they wish to receive future shipments of specified chemicals and for ensuring compliance with these decisions by exporting countries.
-              The Convention initially covers 22 pesticides (including five severely hazardous pesticide formulations) and 5 industrial chemicals, but many more are expected to be added in the future.  The Conference of the Parties will decide on the inclusion of chemicals.
-              Point of contact
-              Role: Originator
-              Person: United Nations Office of Legal Affairs (OLA)
-              Organization: ----
-              Email: ----
-
-              Temporal extent
-              Covered time: 1999 - 2013-12-01
-              Geographic extent
-              Coverage: World
-            url: http://ede.grid.unep.ch/
-            date_accessed: 2018-02-15
-            published_by: United Nations Environment Programme
       waste_recycling_rates__glass:
         title: Waste Recycling Rates - Glass
         unit: Percent of Apparent Consumption
-        sources:
-          - name: Waste Recycling Rates - Glass
-            description: |-
-              Publication year: 2007
-              Unit: Percent of Apparent Consumption
-              Abstract
-              Recycling is defined as reuse of material in a production process that diverts it from the waste stream, except for recycling within industrial plants and the reuse of material as fuel.
-              "Recycling rates" are the ratios of the quantity collected for recycling to the apparent consumption (economic notion of domestic production of the respective material + imports - exports).
-              It should, however, be noted that definitions may vary from one country to another. In particular, total amounts of waste produced, rather than apparent consumption, may be used in some areas to derive recycling rates.
-              Point of contact
-              Role: Originator
-              Person: Organization for Economic Co-Operation and Development (OECD)
-              Organization: ----
-              Email: env.contact@oecd.org
-
-              Temporal extent
-              Covered time: 1980 - 2005
-              Geographic extent
-              Coverage: World
-            url: http://ede.grid.unep.ch/
-            date_accessed: 2018-02-15
-            published_by: United Nations Environment Programme
       waste_recycling_rates__paper_and_cardboard:
         title: Waste Recycling Rates - Paper and Cardboard
         unit: Percent of Apparent Consumption
-        sources:
-          - name: Waste Recycling Rates - Paper and Cardboard
-            description: |-
-              Publication year: 2007
-              Unit: Percent of Apparent Consumption
-              Abstract
-              Recycling is defined as reuse of material in a production process that diverts it from the waste stream, except for recycling within industrial plants and the reuse of material as fuel.
-              "Recycling rates" are the ratios of the quantity collected for recycling to the apparent consumption (economic notion of domestic production of the respective material + imports - exports).
-              It should, however, be noted that definitions may vary from one country to another. In particular, total amounts of waste produced, rather than apparent consumption, may be used in some areas to derive recycling rates.
-              Point of contact
-              Role: Originator
-              Person: Organization for Economic Co-Operation and Development (OECD)
-              Organization: ----
-              Email: env.contact@oecd.org
-
-              Temporal extent
-              Covered time: 1980 - 2005
-              Geographic extent
-              Coverage: World
-            url: http://ede.grid.unep.ch/
-            date_accessed: 2018-02-15
-            published_by: United Nations Environment Programme
     dimensions:
       - name: year
         slug: year

--- a/etl/steps/data/garden/who/2023-06-01/cholera.meta.yml
+++ b/etl/steps/data/garden/who/2023-06-01/cholera.meta.yml
@@ -1,54 +1,22 @@
-all_sources:
-  - who_gho: &who-gho
-      name: WHO, Global Health Observatory (2022)
-      published_by: WHO, Global Health Observatory (2022)
-      description: The cholera data is sourced from here for all years up to and including 2016.
-      date_accessed: 2022-08-03
-      publication_year: 2022
-  - who_wer: &who-wer
-      name: WHO, Weekly Epidemic Reports (2023)
-      published_by: WHO, Weekly Epidemic Reports (2023)
-      description: |
-        The data is created by combining multiple WHO Weekly Epidemiological Reports for cholera reported cases, deaths and case fatality rate.
-
-        The reports for the years 2017-2021 can be found at:
-
-        2017: https://web.archive.org/web/20230328164426/https://apps.who.int/iris/bitstream/handle/10665/274655/WER9338-489-497.pdf?sequence=1&isAllowed=y
-
-        2018: https://web.archive.org/web/20230601084841/https://apps.who.int/iris/bitstream/handle/10665/330005/WER9448-561-568-eng-fre.pdf?sequence=1&isAllowed=y
-
-        2019: https://web.archive.org/web/20221007234707/http://apps.who.int/iris/bitstream/handle/10665/334242/WER9537-441-448-eng-fre.pdf?sequence=1&isAllowed=y
-
-        2020: https://web.archive.org/web/20230326231135/http://apps.who.int/iris/bitstream/handle/10665/345271/WER9637-445-454-eng-fre.pdf?sequence=1&isAllowed=y
-
-        2021: https://web.archive.org/web/20230526223955/https://apps.who.int/iris/bitstream/handle/10665/362858/WER9737-453-464-eng-fre.pdf?sequence=1&isAllowed=y
-dataset:
-  title: World Health Organization - Cholera report cases, deaths and case fatality rate
-  licenses:
-    - name: Attribution 4.0 International (CC BY 4.0)
-      url: https://cdn.who.int/media/docs/default-source/publishing-policies/data-policy/who-policy-on-use-and-sharing-of-data-collected-in-member-states-outside-phe_en.pdf?sfvrsn=713112d4_27
-  sources:
-    - *who-gho
-    - *who-wer
 tables:
   cholera:
     variables:
         cholera_case_fatality_rate:
           title: Cholera case fatality rate
-          description: WHO calculates case fatality rates based on the numbers of cases and deaths as reported by national authorities. The case fatality rate is the number of reported deaths, divided by the number of reported cases, shown as a percentage.
+          description_short: WHO calculates case fatality rates based on the numbers of cases and deaths as reported by national authorities. The case fatality rate is the number of reported deaths, divided by the number of reported cases, shown as a percentage.
           unit: "%"
           short_unit: "%"
           display:
             numDecimalPlaces: 2
         cholera_reported_cases:
           title: Reported cholera cases
-          description: Confirmed cholera cases, including those confirmed clinically, epidemiologically, or by laboratory investigation.
+          description_short: Confirmed cholera cases, including those confirmed clinically, epidemiologically, or by laboratory investigation.
           unit: reported cases
           display:
             numDecimalPlaces: 0
         cholera_deaths:
           title: Reported cholera deaths
-          description: Number of deaths from cholera reported to WHO.
+          description_short: Number of deaths from cholera reported to WHO.
           unit: reported deaths
           display:
             numDecimalPlaces: 0

--- a/etl/steps/data/garden/who/2023-06-01/cholera.py
+++ b/etl/steps/data/garden/who/2023-06-01/cholera.py
@@ -1,7 +1,7 @@
 """Load a meadow dataset and create a garden dataset."""
 
-import pandas as pd
 from owid.catalog import Dataset, Table
+from owid.catalog import processing as pr
 from structlog import get_logger
 
 from etl.data_helpers import geo
@@ -24,7 +24,7 @@ def run(dest_dir: str) -> None:
 
     # Load fast track dataset
     snap = paths.load_snapshot("cholera.csv")
-    cholera_ft = pd.read_csv(snap.path)
+    cholera_ft = snap.read_csv()
 
     # Load countries regions
     regions_dataset = paths.load_dataset("regions")
@@ -40,16 +40,17 @@ def run(dest_dir: str) -> None:
     # Add global aggregate
     cholera_bp = add_global_total(cholera_bp, regions)
     # Combine datasets
-    cholera_combined = pd.concat([cholera_bp, cholera_ft])
+    cholera_combined = pr.concat([cholera_bp, cholera_ft])
 
     cholera_combined = add_regions(cholera_combined, regions)
 
-    tb_garden = Table(cholera_combined.set_index(["country", "year"], verify_integrity=True), short_name="cholera")
+    tb_garden = cholera_combined.set_index(["country", "year"], verify_integrity=True)
+    tb_garden.metadata.short_name = "cholera"
 
     # Save outputs.
     #
-    # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb_garden])
+    # Create a new garden dataset, inheriting metadata (title etc.) from the WER snapshot's origin.
+    ds_garden = create_dataset(dest_dir, tables=[tb_garden], default_metadata=snap.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()
@@ -90,7 +91,7 @@ def process_gho_cholera(who_gh_dataset: Dataset) -> Table:
     return tb
 
 
-def add_global_total(df: pd.DataFrame, regions: Table) -> pd.DataFrame:
+def add_global_total(tb: Table, regions: Table) -> Table:
     """
     Calculate global total of cholera cases and add it to the existing dataset
     """
@@ -98,29 +99,28 @@ def add_global_total(df: pd.DataFrame, regions: Table) -> pd.DataFrame:
     countries = regions[regions["region_type"] == "country"]["name"].to_list()
     manual_countries_to_allow = ["Serbia and Montenegro (former)"]
     countries = countries + manual_countries_to_allow
-    assert all(df["country"].isin(countries)), (
-        f"{df['country'][~df['country'].isin(countries)].drop_duplicates()}, is not a country"
+    assert all(tb["country"].isin(countries)), (
+        f"{tb['country'][~tb['country'].isin(countries)].drop_duplicates()}, is not a country"
     )
-    df_glob = df.groupby(["year"]).agg({"cholera_reported_cases": "sum", "cholera_deaths": "sum"}).reset_index()
-    df_glob["country"] = "World"
-    df_glob["cholera_case_fatality_rate"] = cholera_case_fatality_rate(df_glob)
-    df = pd.concat([df, df_glob])
+    tb_glob = tb.groupby(["year"]).agg({"cholera_reported_cases": "sum", "cholera_deaths": "sum"}).reset_index()
+    tb_glob["country"] = "World"
+    tb_glob["cholera_case_fatality_rate"] = cholera_case_fatality_rate(tb_glob)
+    tb = pr.concat([tb, tb_glob])
 
-    return df
+    return tb
 
 
-def add_regions(df: pd.DataFrame, regions: Table) -> pd.DataFrame:
+def add_regions(tb: Table, regions: Table) -> Table:
     continents = regions[regions["region_type"] == "continent"]["name"].to_list()
 
     countries_in_regions = {
-        region: sorted(set(geo.list_countries_in_region(region)) & set(df["country"])) for region in continents
+        region: sorted(set(geo.list_countries_in_region(region)) & set(tb["country"])) for region in continents
     }
-    df_cont = df
-    df_out = pd.DataFrame()
+    tb_out = None
     for continent in continents:
         if continent == "Europe":
-            df_cont = geo.add_region_aggregates(
-                df=df[["year", "country", "cholera_reported_cases", "cholera_deaths"]],
+            tb_cont = geo.add_region_aggregates(
+                df=tb[["year", "country", "cholera_reported_cases", "cholera_deaths"]],
                 region=continent,
                 countries_in_region=countries_in_regions[continent] + ["Serbia and Montenegro (former)"],
                 countries_that_must_have_data=[],
@@ -128,8 +128,8 @@ def add_regions(df: pd.DataFrame, regions: Table) -> pd.DataFrame:
                 frac_allowed_nans_per_year=0.2,
             )
         else:
-            df_cont = geo.add_region_aggregates(
-                df=df[["year", "country", "cholera_reported_cases", "cholera_deaths"]],
+            tb_cont = geo.add_region_aggregates(
+                df=tb[["year", "country", "cholera_reported_cases", "cholera_deaths"]],
                 region=continent,
                 countries_in_region=countries_in_regions[continent],
                 countries_that_must_have_data=[],
@@ -138,14 +138,14 @@ def add_regions(df: pd.DataFrame, regions: Table) -> pd.DataFrame:
                 year_col="year",
                 frac_allowed_nans_per_year=1,
             )
-        df_cont = df_cont[df_cont["country"].isin(continents)]
-        df_out = pd.concat([df_out, df_cont])
-    df_out["cholera_case_fatality_rate"] = cholera_case_fatality_rate(df_out)
+        tb_cont = tb_cont[tb_cont["country"].isin(continents)]
+        tb_out = tb_cont if tb_out is None else pr.concat([tb_out, tb_cont])
+    tb_out["cholera_case_fatality_rate"] = cholera_case_fatality_rate(tb_out)
 
-    df = pd.concat([df, df_out])
+    tb = pr.concat([tb, tb_out])
 
-    return df
+    return tb
 
 
-def cholera_case_fatality_rate(df: pd.DataFrame) -> pd.Series:
-    return (df["cholera_deaths"] / df["cholera_reported_cases"]) * 100
+def cholera_case_fatality_rate(tb: Table) -> Table:
+    return (tb["cholera_deaths"] / tb["cholera_reported_cases"]) * 100

--- a/etl/steps/data/garden/who/2023-06-29/guinea_worm_certification.meta.yml
+++ b/etl/steps/data/garden/who/2023-06-29/guinea_worm_certification.meta.yml
@@ -1,59 +1,3 @@
-descriptions:
-  certification: &certification_description |
-    The current and historical values for the status of Guinea worm disease (Dracunculiasis) as certified by the WHO. To be certified as free of guinea worm disease, a country must have reported zero indigenous cases through active surveillance for at least three consecutive years.
-
-    Data regarding certification status is taken from:
-
-    https://web.archive.org/web/20211024081702/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_t0.html
-
-    This is supplmented with more recent changes to Guinea worm disease certification:
-
-    - Angola has had endemic status since 2020:  https://www.who.int/news/item/23-09-2020-eradicating-dracunculiasis-human-cases-and-animal-infections-decline-as-angola-becomes-endemic
-    - Kenya was certified guinea worm free in 2018: https://www.who.int/news/item/21-03-2018-dracunculiasis-eradication-south-sudan-claims-interruption-of-transmission-in-humans
-    - DRC was certified guinea worm free in 2022: https://www.who.int/news/item/15-12-2022-the-democratic-republic-of-the-congo-certified-free-of-dracunculiasis-transmission-by-who
-
-  reported_cases: &reported_cases_description |
-    Reported cases of guinea worm disease (Dracunculiasis) as recorded by WHO.
-
-    For Cameroon, Central African Republic, Cote d'Ivoire, Mauritania, Senegal and Yemen data is gathered from:
-
-    1986-2017: https://web.archive.org/web/20220208133814/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_i2.html
-    2018: Table 1a: https://web.archive.org/web/20230629130727/https://apps.who.int/iris/bitstream/handle/10665/324786/WER9420-233-251.pdf?sequence=1&isAllowed=y
-    2019: Table 1a: https://web.archive.org/web/20230629130619/https://apps.who.int/iris/bitstream/handle/10665/332086/WER9520-209-227-eng-fre.pdf?sequence=1&isAllowed=y
-    2020: Table 1a: https://web.archive.org/web/20230226162934/https://apps.who.int/iris/bitstream/handle/10665/341529/WER9621-173-194-eng-fre.pdf?sequence=1&isAllowed=y
-    2021: Table 1a: https://web.archive.org/web/20230226163027/https://apps.who.int/iris/bitstream/handle/10665/354576/WER9721-22-225-247-eng-fre.pdf?sequence=1&isAllowed=y
-    2022: Table 1a: https://web.archive.org/web/20230629124651/https://apps.who.int/iris/bitstream/handle/10665/367924/WER9820-205-224.pdf?sequence=1&isAllowed=y
-
-    For all other countries data is gathered from the following sources:
-
-    1980-2020: https://www.who.int/teams/control-of-neglected-tropical-diseases/dracunculiasis/dracunculiasis-eradication-portal
-    2021: Table 1a: https://web.archive.org/web/20230226163027/https://apps.who.int/iris/bitstream/handle/10665/354576/WER9721-22-225-247-eng-fre.pdf?sequence=1&isAllowed=y
-    2022: Table 1a: https://web.archive.org/web/20230629124651/https://apps.who.int/iris/bitstream/handle/10665/367924/WER9820-205-224.pdf?sequence=1&isAllowed=y
-
-    Global totals are calculated yearly as the sum of the number of reported cases in each country.
-all_sources:
-  - source_certification: &source_certification
-      name: World Health Organization
-      published_by: World Health Organization
-      url: https://web.archive.org/web/20211024081702/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_t0.html
-      date_accessed: '2023-06-29'
-      publication_year: 2018
-  - source_reported_cases: &source_reported_cases
-      name: World Health Organization
-      published_by: Dracunculiasis Eradication Portal, World Health Organization
-      date_accessed: '2023-06-28'
-      url: https://www.who.int/teams/control-of-neglected-tropical-diseases/dracunculiasis/dracunculiasis-eradication-portal
-
-
-
-dataset:
-  title: Guinea worm reported cases and certification (WHO)
-  licenses:
-  - name: CC BY-NC-SA 3.0 IGO
-    url: https://www.who.int/about/policies/publishing/copyright
-  sources:
-  - *source_certification
-  - *source_reported_cases
 tables:
   guinea_worm_certification:
     variables:
@@ -62,10 +6,30 @@ tables:
         unit: ''
         display:
           numDecimalPlaces: 0
-        description:
-          *certification_description
+        description_short: |
+          The current and historical values for the status of Guinea worm disease (Dracunculiasis) as certified by the WHO. To be certified as free of guinea worm disease, a country must have reported zero indigenous cases through active surveillance for at least three consecutive years.
+
+          Data regarding certification status is taken from:
+
+          https://web.archive.org/web/20211024081702/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_t0.html
+
+          This is supplmented with more recent changes to Guinea worm disease certification:
+
+          - Angola has had endemic status since 2020:  https://www.who.int/news/item/23-09-2020-eradicating-dracunculiasis-human-cases-and-animal-infections-decline-as-angola-becomes-endemic
+          - Kenya was certified guinea worm free in 2018: https://www.who.int/news/item/21-03-2018-dracunculiasis-eradication-south-sudan-claims-interruption-of-transmission-in-humans
+          - DRC was certified guinea worm free in 2022: https://www.who.int/news/item/15-12-2022-the-democratic-republic-of-the-congo-certified-free-of-dracunculiasis-transmission-by-who
       certification_status:
         title: Certification status over time
         unit: ''
-        description:
-          *certification_description
+        description_short: |
+          The current and historical values for the status of Guinea worm disease (Dracunculiasis) as certified by the WHO. To be certified as free of guinea worm disease, a country must have reported zero indigenous cases through active surveillance for at least three consecutive years.
+
+          Data regarding certification status is taken from:
+
+          https://web.archive.org/web/20211024081702/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_t0.html
+
+          This is supplmented with more recent changes to Guinea worm disease certification:
+
+          - Angola has had endemic status since 2020:  https://www.who.int/news/item/23-09-2020-eradicating-dracunculiasis-human-cases-and-animal-infections-decline-as-angola-becomes-endemic
+          - Kenya was certified guinea worm free in 2018: https://www.who.int/news/item/21-03-2018-dracunculiasis-eradication-south-sudan-claims-interruption-of-transmission-in-humans
+          - DRC was certified guinea worm free in 2022: https://www.who.int/news/item/15-12-2022-the-democratic-republic-of-the-congo-certified-free-of-dracunculiasis-transmission-by-who

--- a/etl/steps/data/garden/who/2023-07-13/autopsy.meta.yml
+++ b/etl/steps/data/garden/who/2023-07-13/autopsy.meta.yml
@@ -1,26 +1,3 @@
-dataset:
-  title: WHO European Health Information Gateway (WHO, 2022)
-  description: &dataset-description >-
-    Since the mid-1980s, Member States of the WHO European Region have been reporting essential health-related statistics
-    to the Health for All (HFA) family of databases, making it one of WHO’s oldest sources of data. As it is based on reported
-    data, rather than estimates, the HFA family of databases is also particularly valuable.
-
-
-    HFA databases bring together the indicators that are part of major monitoring frameworks relevant to the Region, such
-    as Health 2020 and the Sustainable Development Goals. The indicators cover basic demographics, health status, health determinants
-    and risk factors, as well as health care resources, expenditures and more.
-  licenses:
-  - name: CC BY-NC-SA 3.0 IGO
-    url: https://www.who.int/about/policies/publishing/copyright
-  sources:
-  - name: WHO (2022)
-    description: *dataset-description
-    url: https://gateway.euro.who.int/en/indicators/hfa_545-6410-autopsy-rate-for-all-deaths/
-    date_accessed: '2023-07-13'
-    publication_date: '2022-09-01'
-    publication_year: 2022
-    published_by: WHO Regional Office for Europe. European Health for All database (HFA-DB). Published 2022-09-01. Accessed
-      2023-07-13. https://gateway.euro.who.int
 tables:
   autopsy:
     variables:

--- a/etl/steps/data/garden/who/2023-07-13/autopsy.py
+++ b/etl/steps/data/garden/who/2023-07-13/autopsy.py
@@ -1,38 +1,24 @@
 """Load a meadow dataset and create a garden dataset."""
 
-from typing import cast
-
-from owid.catalog import Dataset, Table
-
 from etl.data_helpers import geo
 from etl.helpers import PathFinder, create_dataset
 
-# Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
-    #
-    # Load inputs.
-    #
-    # Load WHO Europe meadow dataset.
-    ds_meadow = cast(Dataset, paths.load_dependency("autopsy"))
-    # Read table from meadow dataset.
-    tb = ds_meadow["autopsy"]
+    # load meadow
+    ds_meadow = paths.load_dataset("autopsy")
+    tb = ds_meadow["autopsy"].reset_index()
 
-    #
-    # Process data.
-    #
-    tb: Table = geo.harmonize_countries(
-        df=tb, countries_file=paths.country_mapping_path, excluded_countries_file=paths.excluded_countries_path
+    # harmonize country names
+    tb = geo.harmonize_countries(
+        df=tb,
+        countries_file=paths.country_mapping_path,
+        excluded_countries_file=paths.excluded_countries_path,
     )
-    tb = tb.set_index(["country", "sex", "year"], verify_integrity=True).sort_index().sort_index(axis=1)
+    tb = tb.format(["country", "sex", "year"])
 
-    #
-    # Save outputs.
-    #
-    # Create a new garden dataset with the same metadata as the meadow dataset.
+    # save dataset
     ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
-
-    # Save changes in the new garden dataset.
     ds_garden.save()

--- a/etl/steps/data/garden/worldbank_wdi/2017-11-14/world_bank_se4all_database__energy_efficiency.meta.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2017-11-14/world_bank_se4all_database__energy_efficiency.meta.yml
@@ -1,174 +1,92 @@
-dataset:
-  title: World Bank SE4ALL database - Energy efficiency
 tables:
   world_bank_se4all_database__energy_efficiency:
     variables:
       divisia_decomposition_analysis__activity_component_index:
         title: Divisia Decomposition Analysis - Activity component Index
         unit: ''
-        description: |-
+        description_short: |-
           Divisia Decomposition Analysis - Activity component Index: This Index is created from the activity component that results from the Decomposition Analysis with the DIVISIA LMDI I method.
-        sources:
-          - name: 'World Bank SE4ALL database: Divisia Decomposition Analysis - Activity component Index'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       divisia_decomposition_analysis__energy_intensity_component_index:
         title: Divisia Decomposition Analysis - Energy Intensity component Index
         unit: ''
-        description: |-
+        description_short: |-
           Divisia Decomposition Analysis - Energy Intensity component Index: This Index is created from the energy Intensity component that results from the Decomposition Analysis with the DIVISIA LMDI I method.
-        sources:
-          - name: 'World Bank SE4ALL database: Divisia Decomposition Analysis - Energy Intensity component Index'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       energy_intensity_level_of_final_energy__mj_2011_usd_ppp:
         title: Energy intensity level of final energy (MJ/2011 USD PPP)
         unit: MJ/2011 USD PPP
-        description: |-
+        description_short: |-
           Energy intensity level of final energy (MJ/2011 USD PPP): A ratio between final energy consumption and gross domestic product measured at purchasing power parity. Energy intensity is an indication of how much energy is used to produce one unit of economic output. Lower ratio indicates that less energy is used to produce one unit of output.
-        sources:
-          - name: 'World Bank SE4ALL database: Energy intensity level of final energy (MJ/2011 USD PPP)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       energy_intensity_level_of_primary_energy__mj_2011_usd_ppp:
         title: Energy intensity level of primary energy (MJ/2011 USD PPP)
         unit: MJ/2011 USD PPP
-        description: |-
+        description_short: |-
           Energy intensity level of primary energy (MJ/2011 USD PPP): A ratio between energy supply and gross domestic product measured at purchasing power parity. Energy intensity is an indication of how much energy is used to produce one unit of economic output. A lower ratio indicates that less energy is used to produce one unit of output.
-        sources:
-          - name: 'World Bank SE4ALL database: Energy intensity level of primary energy (MJ/2011 USD PPP)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       energy_intensity_of_agricultural_sector__mj_2011_usd_ppp:
         title: Energy intensity of agricultural sector (MJ/2011 USD PPP)
         unit: MJ/2011 USD PPP
-        description: |-
+        description_short: |-
           Energy intensity of agricultural sector (MJ/2011 USD PPP):  A ratio between energy consumption in the agricultural sector (including forestry and fishing) and agricultural sector value added measured at purchasing power parity. Energy intensity is an indication of how much energy is used to produce one unit of economic output. A lower ratio indicates that less energy is used to produce one unit of output.
-        sources:
-          - name: 'World Bank SE4ALL database: Energy intensity of agricultural sector (MJ/2011 USD PPP)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       energy_intensity_of_industrial_sector__mj_2011_usd_ppp:
         title: Energy intensity of industrial sector (MJ/2011 USD PPP)
         unit: MJ/2011 USD PPP
-        description: |-
+        description_short: |-
           Energy intensity of industrial sector (MJ/2011 USD PPP):  A ratio between energy consumption in industry (including energy industry own use) and industry sector value added measured at purchasing power parity. Energy intensity is an indication of how much energy is used to produce one unit of economic output. A lower ratio indicates that less energy is used to produce one unit of output.
-        sources:
-          - name: 'World Bank SE4ALL database: Energy intensity of industrial sector (MJ/2011 USD PPP)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       energy_intensity_of_residential_sector__gj_household:
         title: Energy intensity of residential sector (GJ/household)
         unit: GJ/household
-        description: |-
+        description_short: |-
           Energy intensity of residential sector (GJ/household): A ratio between energy consumption in the residential sector and the number of households.
-        sources:
-          - name: 'World Bank SE4ALL database: Energy intensity of residential sector (GJ/household)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       energy_intensity_of_service_sector__mj_2011_usd_ppp:
         title: Energy intensity of service sector (MJ/2011 USD PPP)
         unit: MJ/2011 USD PPP
-        description: |-
+        description_short: |-
           Energy intensity of service sector (MJ/2011 USD PPP): A ratio between energy consumption in the service sector (including commercial and public services) and service sector value added (VA) measured at purchasing power parity. Energy intensity is an indication of how much energy is used to produce one unit of economic output. A lower ratio indicates that less energy is used to produce one unit of output.
-        sources:
-          - name: 'World Bank SE4ALL database: Energy intensity of service sector (MJ/2011 USD PPP)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       energy_intensity_of_transportation_sector__mj_2011_usd_ppp:
         title: Energy intensity of transportation sector (MJ/2011 USD PPP)
         unit: MJ/2011 USD PPP
-        description: |-
+        description_short: |-
           Energy intensity of transportation sector (MJ/2011 USD PPP): A ratio between energy consumption in the transportation sector and transportation sector value added measured at purchasing power parity  Energy intensity is an indication of how much energy is used to produce one unit of economic output. A lower ratio indicates that less energy is used to produce one unit of output.
-        sources:
-          - name: 'World Bank SE4ALL database: Energy intensity of transportation sector (MJ/2011 USD PPP)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       energy_savings_of_primary_energy__tj:
         title: Energy savings of primary energy (TJ)
         unit: TJ
         short_unit: TJ
-        description: |-
+        description_short: |-
           Energy savings of primary energy (TJ): Energy savings due to realized energy intensity improvements. Country level savings represent the difference between a hypothetical energy consumption that would have been should the energy intensity remained at its 1990 level and actual consumption. Global, regional and income group savings represent the sum of country by country savings and not calculated separately.
-        sources:
-          - name: 'World Bank SE4ALL database: Energy savings of primary energy (TJ)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       final_to_primary_energy_ratio__pct:
         title: Final to primary energy ratio (%)
         unit: '%'
         short_unit: '%'
-        description: |-
+        description_short: |-
           Final to primary energy ratio (%): A high-level indicator that captures the overall energy efficiency in the supply sector obtained by dividing end-use final energy over primary energy.  High ratio indicates better supply sector efficiency.
-        sources:
-          - name: 'World Bank SE4ALL database: Final to primary energy ratio (%)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       gdp__2011_usd_ppp:
         title: GDP (2011 USD PPP)
         unit: 2011 USD PPP
-        description: |-
+        description_short: |-
           GDP (2011 USD PPP): Gross domestic product, measured at purchasing power parity in constant 2011 US dollars. The data is obtained from the World Development Indicators (WDI) database, refer to the WDI for further details on the indicator
-        sources:
-          - name: 'World Bank SE4ALL database: GDP (2011 USD PPP)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       thermal_efficiency_in_power_supply__pct:
         title: Thermal efficiency in power supply (%)
         unit: '%'
         short_unit: '%'
-        description: |-
+        description_short: |-
           Thermal efficiency in power supply (%):  This supply-side energy efficiency indicator measures the efficiency of thermal plants in converting primary energy sources—such as coal, gas, and oil—into electricity. It is calculated by dividing gross electricity production from electricity and cogeneration plants by total inputs of fuels into those plants. Whether market-based or privately owned, self-generating plants that do not export their power are included in the index assessment. In the case of cogeneration plants, fuel inputs are allocated between electricity and heat production in proportion to their shares of the annual output.
-        sources:
-          - name: 'World Bank SE4ALL database: Thermal efficiency in power supply (%)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       total_final_consumption__tj:
         title: Total final consumption (TJ)
         unit: TJ
         short_unit: TJ
-        description: |-
+        description_short: |-
           Total final consumption (TJ): As defined by the IEA, total final consumption represents the sum of consumption in the end-use sectors and excludes energy used for transformation processes and energy used of the energy producing industries
-        sources:
-          - name: 'World Bank SE4ALL database: Total final consumption (TJ)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       total_primary_energy_supply__tj:
         title: Total primary energy supply (TJ)
         unit: TJ
         short_unit: TJ
-        description: |-
+        description_short: |-
           Total primary energy supply (TJ): As defined by the IEA, total primary energy supply is made up of production+net imports-international marine and aviation bunkers+-stock changes.
-        sources:
-          - name: 'World Bank SE4ALL database: Total primary energy supply (TJ)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
       transmission_and_distribution_losses__pct:
         title: Transmission and distribution losses (%)
         unit: '%'
         short_unit: '%'
-        description: |-
+        description_short: |-
           Transmission and distribution losses (%): Transmission and distribution (T&D) losses measure power lost in the transmission of (high-voltage) electricity from power generators to distributors and in the distribution of (medium- and low-voltage) electricity from distributors to end-users. T&D losses are represented as a percentage of gross electricity production. They include both technical and nontechnical (or commercial) losses. Included in the latter are unmetered, unbilled, and unpaid electricity, including theft, which could be significant in developing countries. Aggregate T&D system indicators may be dominated by factors other than losses. The location of primary energy resources (such as hydro lakes and coal seams) and large loads (cities and industries) may be more significant factors in T&D efficiency indicators than the losses or efficiency of the transmission system itself. Properly separating true losses (and hence the efficiency potential of transmission systems) from exogenous location and scale factors and non-technical losses would require detailed studies of system-dynamic interactions and real operating requirements that are not practical for global tracking purposes.
-        sources:
-          - name: 'World Bank SE4ALL database: Transmission and distribution losses (%)'
-            url: https://data.worldbank.org/data-catalog/sustainable-energy-for-all
-            date_accessed: 2017-11-14
-            published_by: World Bank SE4ALL database, IEA
     dimensions:
       - name: year
         slug: year

--- a/etl/steps/data/garden/wvs/2023-06-25/longitudinal_wvs.meta.yml
+++ b/etl/steps/data/garden/wvs/2023-06-25/longitudinal_wvs.meta.yml
@@ -1,61 +1,30 @@
-dataset:
-  title: World Values Survey time-series data (1981-2022)
-  description: >
-    The WVS comprises survey data conducted across 64 countries and societies around the world and more than 80,000 respondents.This dataset includes survey responses comprises integrated survey responses for the 1981-2022 period to the following questions:
-
-
-    'Worries: a terrorist attack' corresponding to column 'H006_04'
-
-
-    'Effects of immigrants on the development of [your country]: Increase the risks of terrorism' corresponding to column 'G057'
-
-
-    'Justifiable: Terrorism as a political, ideological or religious mean' corresponding to column 'F114E'.
-
-  licenses:
-  - name: 'These data files are available without restrictions, provided: a) that
-      they are used for non-profit purposes; b) correct citations are provided and
-      sent to the World Values Survey Association for each publication of results
-      based in part or entirely on these data files; c) the data files themselves
-      are not redistributed; d) proper citation to the WVS data is included into the
-      references list of the publication (citation format available for downloading
-      in the Documentation section).'
-  sources:
-  - name: World Values Survey (1981-2022)
-    url: https://www.worldvaluessurvey.org/WVSDocumentationWVL.jsp
-    date_accessed: '2023-06-25'
-    publication_year: 2022
-    published_by: 'Inglehart, R., C. Haerpfer, A. Moreno, C. Welzel, K. Kizilova,
-      J. Diez-Medrano, M. Lagos, P. Norris, E. Ponarin & B. Puranen (eds.). 2022.
-      World Values Survey: All Rounds - Country-Pooled Datafile. Madrid, Spain & Vienna,
-      Austria: JD Systems Institute & WVSA Secretariat. Dataset Version 3.0.0. doi:10.14281/18241.17'
 tables:
   longitudinal_wvs:
     variables:
       great_deal_or_very_much_not_at_all_or_not_much_ratio:
         title:  Great deal or Very much/ Not much or Not at all
-        description: To what degree are you worried about a terrorist attack?
+        description_short: To what degree are you worried about a terrorist attack?
         unit: ''
         display:
           numDecimalPlaces: 1
 
       agree_disagree:
         title: Agree/Disagree
-        description: "Effects of immigrants on the development of [your country]: Increase the risks of terrorism"
+        description_short: "Effects of immigrants on the development of [your country]: Increase the risks of terrorism"
         unit: ''
         display:
           numDecimalPlaces: 1
 
       average_from_never_1_always_10:
         title: Average (1 - never justifiable; 10 - always justifiable)
-        description: "Terrorism as a political, ideological or religious mean. Options range from 1 (never justifiable) to 10 (always justifiable)"
+        description_short: "Terrorism as a political, ideological or religious mean. Options range from 1 (never justifiable) to 10 (always justifiable)"
         unit: ''
         display:
           numDecimalPlaces: 1
 
       agree:
         title: Agree (worries about terrorism)
-        description: "Effects of immigrants on the development of [your country]: Increase the risks of terrorism"
+        description_short: "Effects of immigrants on the development of [your country]: Increase the risks of terrorism"
         unit: "%"
         short_unit: "%"
         display:
@@ -63,7 +32,7 @@ tables:
 
       disagree:
         title: Disagree (worries about terrorism)
-        description: "Effects of immigrants on the development of [your country]: Increase the risks of terrorism"
+        description_short: "Effects of immigrants on the development of [your country]: Increase the risks of terrorism"
         unit: "%"
         short_unit: "%"
         display:
@@ -71,7 +40,7 @@ tables:
 
       great_deal_or_very_much:
         title:  Great deal or Very much
-        description: To what degree are you worried about a terrorist attack?
+        description_short: To what degree are you worried about a terrorist attack?
         unit: "%"
         short_unit: "%"
         display:
@@ -80,11 +49,8 @@ tables:
 
       not_at_all_or_not_much:
         title:  Not much or Not at all
-        description: To what degree are you worried about a terrorist attack?
+        description_short: To what degree are you worried about a terrorist attack?
         unit: "%"
         short_unit: "%"
         display:
           numDecimalPlaces: 0
-
-
-

--- a/etl/steps/data/garden/wvs/2023-06-25/longitudinal_wvs.py
+++ b/etl/steps/data/garden/wvs/2023-06-25/longitudinal_wvs.py
@@ -2,7 +2,7 @@
 
 from typing import cast
 
-import pandas as pd
+import owid.catalog.processing as pr
 from owid.catalog import Dataset, Table
 from structlog import get_logger
 
@@ -30,7 +30,7 @@ def run(dest_dir: str) -> None:
     # Process data.
     #
     log.info("longitudinal_wvs.harmonize_countries")
-    tb: Table = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
+    tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
 
     cols = [c for c in tb.columns if c not in ["country", "year"]]
     tb[cols] = tb[cols].astype(float)
@@ -42,18 +42,19 @@ def run(dest_dir: str) -> None:
     # Compute the average response to the question on justifiability of terrorism as a political, ideological, or religious mean.
     q3 = question_3(tb)
 
-    merge_q1_q2 = pd.merge(q1, q2, on=["country", "year"], how="outer")
+    merge_q1_q2 = pr.merge(q1, q2, on=["country", "year"], how="outer")
     # Merge all 3 questions
-    merge_q1_q2_q3 = pd.merge(merge_q1_q2, q3, on=["country", "year"], how="outer")
-    tb = Table(merge_q1_q2_q3, short_name=paths.short_name, underscore=True)
-    tb.set_index(["country", "year"], inplace=True)
-    tb = tb.dropna(how="all")
+    tb_out = pr.merge(merge_q1_q2, q3, on=["country", "year"], how="outer")
+    tb_out.metadata.short_name = paths.short_name
+    tb_out = tb_out.underscore()
+    tb_out = tb_out.set_index(["country", "year"])
+    tb_out = tb_out.dropna(how="all")
 
     #
     # Save outputs.
     #
     # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden = create_dataset(dest_dir, tables=[tb_out], default_metadata=ds_meadow.metadata)
 
     # Save changes in the new garden dataset.
     ds_garden.save()
@@ -61,24 +62,24 @@ def run(dest_dir: str) -> None:
     log.info("longitudinal_wvs.end")
 
 
-def calculate_percentage(df, column, valid_responses_dict):
+def calculate_percentage(tb: Table, column: str, valid_responses_dict: dict) -> Table:
     """
-    Calculates the percentage of valid responses for a given column in a DataFrame.
+    Calculates the percentage of valid responses for a given column in a Table.
 
     Args:
-        df (DataFrame): The input DataFrame.
+        tb (Table): The input Table.
         column (str): The column name.
         valid_responses_dict (dict): A dictionary mapping valid response codes to their corresponding labels.
 
     Returns:
-        DataFrame: A DataFrame with columns: "country", "year", "column", "count", and "percentage".
+        Table: A Table with columns: "country", "year", "column", "count", and "percentage".
     """
     # Filter out invalid responses
-    valid_responses = df[column].isin(valid_responses_dict.keys())
-    df_filtered = df[["country", "year", column]][valid_responses].reset_index(drop=True)
+    valid_responses = tb[column].isin(valid_responses_dict.keys())
+    tb_filtered = tb[["country", "year", column]][valid_responses].reset_index(drop=True)
 
     # Group by country and year
-    grouped = df_filtered.groupby(["country", "year"])
+    grouped = tb_filtered.groupby(["country", "year"])
 
     # Count valid responses
     counts = grouped[column].value_counts().reset_index(name="count")
@@ -95,38 +96,38 @@ def calculate_percentage(df, column, valid_responses_dict):
     return counts
 
 
-def question_1(df):
+def question_1(tb: Table) -> Table:
     """
     Computes the ratio of responses indicating a great deal or very much worry about terrorist attacks
     to responses indicating not at all or not much worry.
 
     Args:
-        df (DataFrame): The input DataFrame.
+        tb (Table): The input Table.
 
     Returns:
-        DataFrame: A DataFrame with columns: "country", "year", and "great_deal_or_very_much_not_at_all_or_not_much_ratio".
+        Table: A Table with columns: "country", "year", and "great_deal_or_very_much_not_at_all_or_not_much_ratio".
     """
     dict_q1 = {1: "Very much", 2: "A great deal", 3: "Not much", 4: "Not at all", -1: "Don't know", -2: "No answer"}
 
     # Calculate percentage for worries about a terrorist attack
-    counts_q1 = calculate_percentage(df, "worries__a_terrorist_attack", dict_q1)
+    counts_q1 = calculate_percentage(tb, "worries__a_terrorist_attack", dict_q1)
 
     # Select relevant columns
-    select_df = counts_q1[["country", "year", "percentage", "worries__a_terrorist_attack"]]
-    # Pivot the DataFrame
-    pivoted_df = pd.pivot(
-        select_df, index=["country", "year"], columns="worries__a_terrorist_attack", values="percentage"
+    select_tb = counts_q1[["country", "year", "percentage", "worries__a_terrorist_attack"]]
+    # Pivot the Table
+    pivoted_tb = pr.pivot(
+        select_tb, index=["country", "year"], columns="worries__a_terrorist_attack", values="percentage"
     )
-    pivoted_df.reset_index(inplace=True)
-    pivoted_df.columns.name = None
+    pivoted_tb = pivoted_tb.reset_index()
+    pivoted_tb.columns.name = None
 
     # Compute the ratio of great deal or very much to not at all or not much
-    pivoted_df["great_deal_or_very_much"] = pivoted_df["A great deal"] + pivoted_df["Very much"]
-    pivoted_df["not_at_all_or_not_much"] = pivoted_df["Not at all"] + pivoted_df["Not much"]
-    pivoted_df["great_deal_or_very_much_not_at_all_or_not_much_ratio"] = (
-        pivoted_df["great_deal_or_very_much"] / pivoted_df["not_at_all_or_not_much"]
+    pivoted_tb["great_deal_or_very_much"] = pivoted_tb["A great deal"] + pivoted_tb["Very much"]
+    pivoted_tb["not_at_all_or_not_much"] = pivoted_tb["Not at all"] + pivoted_tb["Not much"]
+    pivoted_tb["great_deal_or_very_much_not_at_all_or_not_much_ratio"] = (
+        pivoted_tb["great_deal_or_very_much"] / pivoted_tb["not_at_all_or_not_much"]
     )
-    pivoted_df = pivoted_df[
+    pivoted_tb = pivoted_tb[
         [
             "country",
             "year",
@@ -136,28 +137,28 @@ def question_1(df):
         ]
     ]
 
-    return pivoted_df
+    return pivoted_tb
 
 
-def question_2(df):
+def question_2(tb: Table) -> Table:
     """
     Computes the ratio of agree to disagree responses regarding the effects of immigrants on the risks of terrorism.
 
     Args:
-        df (DataFrame): The input DataFrame.
+        tb (Table): The input Table.
 
     Returns:
-        DataFrame: A DataFrame with columns: "country", "year", and "agree_disagree".
+        Table: A Table with columns: "country", "year", and "agree_disagree".
     """
     dict_q2 = {0: "Disagree", 1: "Hard to say", 2: "Agree", -1: "Don't know", -2: "No answer"}
 
     # Calculate percentage for effects of immigrants on the risks of terrorism
     counts_q2 = calculate_percentage(
-        df, "effects_of_immigrants_on_the_development_of__your_country__increase_the_risks_of_terrorism", dict_q2
+        tb, "effects_of_immigrants_on_the_development_of__your_country__increase_the_risks_of_terrorism", dict_q2
     )
 
     # Select relevant columns
-    select_df = counts_q2[
+    select_tb = counts_q2[
         [
             "country",
             "year",
@@ -166,45 +167,45 @@ def question_2(df):
         ]
     ]
 
-    # Pivot the DataFrame
-    pivoted_df = pd.pivot(
-        select_df,
+    # Pivot the Table
+    pivoted_tb = pr.pivot(
+        select_tb,
         index=["country", "year"],
         columns="effects_of_immigrants_on_the_development_of__your_country__increase_the_risks_of_terrorism",
         values="percentage",
     )
-    pivoted_df.reset_index(inplace=True)
-    pivoted_df.columns.name = None
+    pivoted_tb = pivoted_tb.reset_index()
+    pivoted_tb.columns.name = None
 
     # Compute the ratio of agree to disagree
-    pivoted_df["agree_disagree"] = pivoted_df["Agree"] / pivoted_df["Disagree"]
+    pivoted_tb["agree_disagree"] = pivoted_tb["Agree"] / pivoted_tb["Disagree"]
 
-    return pivoted_df[["country", "year", "Agree", "Disagree", "agree_disagree"]]
+    return pivoted_tb[["country", "year", "Agree", "Disagree", "agree_disagree"]]
 
 
-def question_3(df):
+def question_3(tb: Table) -> Table:
     """
     Computes the average response to the question on justifiability of terrorism as a political, ideological,
     or religious mean.
 
     Args:
-        df (DataFrame): The input DataFrame.
+        tb (Table): The input Table.
 
     Returns:
-        DataFrame: A DataFrame with columns: "country", "year", and "average_from_never_1_always_10".
+        Table: A Table with columns: "country", "year", and "average_from_never_1_always_10".
     """
     valid_resp_q3 = list(range(11))
 
     # Filter out invalid responses
-    valid_responses_q3 = df["justifiable__terrorism_as_a_political__ideological_or_religious_mean"].isin(valid_resp_q3)
-    df_q3 = df[valid_responses_q3]
+    valid_responses_q3 = tb["justifiable__terrorism_as_a_political__ideological_or_religious_mean"].isin(valid_resp_q3)
+    tb_q3 = tb[valid_responses_q3]
 
     # Group by country and year, and calculate the average response
-    grouped_q3 = df_q3.groupby(["country", "year"])
-    df_q3 = (
+    grouped_q3 = tb_q3.groupby(["country", "year"])
+    tb_q3 = (
         grouped_q3["justifiable__terrorism_as_a_political__ideological_or_religious_mean"]
         .mean()
         .reset_index(name="average_from_never_1_always_10")
     )
 
-    return df_q3
+    return tb_q3

--- a/etl/steps/data/grapher/biodiversity/2022/living_planet_index.meta.yml
+++ b/etl/steps/data/grapher/biodiversity/2022/living_planet_index.meta.yml
@@ -1,9 +1,7 @@
 dataset:
   update_period_days: 730
-  sources: []
 definitions:
   common:
-    sources: []
     origins:
       - producer: World Wildlife Fund (WWF) and Zoological Society of London
         title: Zoological Society of London

--- a/etl/steps/data/grapher/fasttrack/2022-11-29/ai_index.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/2022-11-29/ai_index.meta.yml
@@ -1,27 +1,14 @@
 dataset:
-  namespace: fasttrack
-  version: '2022-11-29'
-  short_name: ai_index
   title: DRAFT AI Index
-  description: ''
-  sources:
-  - name: AI Index report
-    published_by: Stanford University
 tables:
   ai_index:
     variables:
       share_companies_using_ai:
         title: Share of companies using AI
         unit: '%'
-        sources:
-        - name: AI Index report
-          published_by: Stanford University
       number_ai_bills_cumulative:
         title: Number of AI bills cumulative
         unit: ''
-        sources:
-        - name: AI Index report
-          published_by: Stanford University
       growth_ai_hiring:
         title: growth_ai_hiring
         unit: ''

--- a/etl/steps/data/grapher/fasttrack/2022-11-29/ai_index.py
+++ b/etl/steps/data/grapher/fasttrack/2022-11-29/ai_index.py
@@ -1,24 +1,14 @@
-import pandas as pd
-from owid import catalog
-
-from etl.helpers import PathFinder
+from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-N = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/2022-11-29/ai_index.csv").path)
+    snap = Snapshot("fasttrack/2022-11-29/ai_index.csv")
+    tb = snap.read_csv()
 
-    # create empty dataframe and table
-    ds = catalog.Dataset.create_empty(dest_dir)
-    tb = catalog.Table(data)
-
-    # update metadata from *.meta.yml
-    ds.metadata.update_from_yaml(N.metadata_path)
-    tb.update_metadata_from_yaml(N.metadata_path, N.short_name)
-
-    # add table to dataset and save
-    ds.add(tb)
+    # add table, update metadata from *.meta.yml and save
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/biosafety_level_4_facilities.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/biosafety_level_4_facilities.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: biosafety_level_4_facilities
   title: DRAFT Biosafety level 4 facilities
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-03-01
 tables:
   biosafety_level_4_facilities:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/biosafety_level_4_facilities.py
+++ b/etl/steps/data/grapher/fasttrack/latest/biosafety_level_4_facilities.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/biosafety_level_4_facilities.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/biosafety_level_4_facilities.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp
   title: DRAFT Compare WID and PIP CHANGE in inequality 1993 vs 2015 (Joe temp)
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-04-19
 tables:
   compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp.py
+++ b/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp.py
@@ -1,21 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(
-        Snapshot("fasttrack/latest/compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp.csv").path
-    )
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp
   title: DRAFT Compare WID and PIP inequality data 1980 vs 2018 (Joe temp)
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-04-18
 tables:
   compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp.py
+++ b/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp
   title: DRAFT Compare WID and PIP inequality data 1993 vs 2015 (Joe temp)
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-04-18
 tables:
   compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp.py
+++ b/etl/steps/data/grapher/fasttrack/latest/compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/evs_per_charger.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/evs_per_charger.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: evs_per_charger
   title: DRAFT EVs per charger
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-03-31
 tables:
   evs_per_charger:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/evs_per_charger.py
+++ b/etl/steps/data/grapher/fasttrack/latest/evs_per_charger.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/evs_per_charger.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/evs_per_charger.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/owid_upload_gini_compare_1980.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/owid_upload_gini_compare_1980.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: owid_upload_gini_compare_1980
   title: DRAFT owid_upload_gini_compare_1980
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-05-09
 tables:
   owid_upload_gini_compare_1980:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/owid_upload_gini_compare_1980.py
+++ b/etl/steps/data/grapher/fasttrack/latest/owid_upload_gini_compare_1980.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/owid_upload_gini_compare_1980.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/owid_upload_gini_compare_1980.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/owid_upload_gini_compare_1993.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/owid_upload_gini_compare_1993.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: owid_upload_gini_compare_1993
   title: DRAFT owid_upload_gini_compare_1993
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-05-09
 tables:
   owid_upload_gini_compare_1993:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/owid_upload_gini_compare_1993.py
+++ b/etl/steps/data/grapher/fasttrack/latest/owid_upload_gini_compare_1993.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/owid_upload_gini_compare_1993.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/owid_upload_gini_compare_1993.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/owid_upload_top1_percent_compare_1980.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/owid_upload_top1_percent_compare_1980.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: owid_upload_top1_percent_compare_1980
   title: DRAFT owid_upload_top1_percent_compare_1980
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-05-09
 tables:
   owid_upload_top1_percent_compare_1980:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/owid_upload_top1_percent_compare_1980.py
+++ b/etl/steps/data/grapher/fasttrack/latest/owid_upload_top1_percent_compare_1980.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/owid_upload_top1_percent_compare_1980.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/owid_upload_top1_percent_compare_1980.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/owid_upload_top1_percent_compare_1993.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/owid_upload_top1_percent_compare_1993.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: owid_upload_top1_percent_compare_1993
   title: DRAFT owid_upload_top1_percent_compare_1993
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-05-09
 tables:
   owid_upload_top1_percent_compare_1993:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/owid_upload_top1_percent_compare_1993.py
+++ b/etl/steps/data/grapher/fasttrack/latest/owid_upload_top1_percent_compare_1993.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/owid_upload_top1_percent_compare_1993.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/owid_upload_top1_percent_compare_1993.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015
   title: 'DRAFT PIP: Gini vs WID: Top 1pc share – pretax – 1993 to 2015'
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-04-18
 tables:
   pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015.py
+++ b/etl/steps/data/grapher/fasttrack/latest/pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/quantum_processors_over_time.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/quantum_processors_over_time.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: quantum_processors_over_time
   title: DRAFT Quantum processors over time
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-05-03
 tables:
   quantum_processors_over_time:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/quantum_processors_over_time.py
+++ b/etl/steps/data/grapher/fasttrack/latest/quantum_processors_over_time.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/quantum_processors_over_time.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/quantum_processors_over_time.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/fasttrack/latest/who_standard_pop.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/who_standard_pop.meta.yml
@@ -1,14 +1,5 @@
 dataset:
-  namespace: fasttrack
-  version: latest
-  short_name: who_standard_pop
   title: DRAFT who_standard_pop
-  description: ''
-  sources:
-  - name: Unknown
-    published_by: Unknown
-    publication_year: 2023
-    date_accessed: 2023-04-04
 tables:
   who_standard_pop:
     variables:

--- a/etl/steps/data/grapher/fasttrack/latest/who_standard_pop.py
+++ b/etl/steps/data/grapher/fasttrack/latest/who_standard_pop.py
@@ -1,19 +1,14 @@
-import pandas as pd
-from owid import catalog
-
 from etl.helpers import PathFinder, create_dataset
 from etl.snapshot import Snapshot
 
-P = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
     # load snapshot
-    data = pd.read_csv(Snapshot("fasttrack/latest/who_standard_pop.csv").path)
-
-    # create empty dataframe and table
-    tb = catalog.Table(data, short_name=P.short_name)
+    snap = Snapshot("fasttrack/latest/who_standard_pop.csv")
+    tb = snap.read_csv()
 
     # add table, update metadata from *.meta.yml and save
-    ds = create_dataset(dest_dir, tables=[tb])
+    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
     ds.save()

--- a/etl/steps/data/grapher/gapminder/2019-05-25/fertility_rate.meta.yml
+++ b/etl/steps/data/grapher/gapminder/2019-05-25/fertility_rate.meta.yml
@@ -7,7 +7,6 @@ definitions:
 
 dataset:
   update_period_days: 0
-  sources: []
 
 tables:
   fertility_rate:
@@ -17,8 +16,7 @@ tables:
         unit: children per woman
         display:
           name: Fertility rate
-        description_short: |-
-          The number of children that would be born to a woman if she were to live to the end of her child-bearing years and give birth to children at the current age-specific fertility rates.
+        description_short: Total fertility rate represents the number of children that would be born to a woman if she were to live to the end of her childbearing years and bear children in accordance with age-specific fertility rates of the specified year.
         presentation:
           title_public: "Fertility rate: children per woman"
           attribution_short: Gapminder

--- a/etl/steps/data/grapher/iucn/2022-12-08/threatened_and_evaluated_species.meta.yml
+++ b/etl/steps/data/grapher/iucn/2022-12-08/threatened_and_evaluated_species.meta.yml
@@ -4,32 +4,8 @@ definitions:
     presentation:
       topic_tags:
         - Biodiversity
-    sources: []
-    origins:
-      - producer: International Union for Conservation of Nature (IUCN) Red List
-        title: Threatened and evaluated species (IUCN Red List)
-        description: >-
-          The IUCN Red List has assessed only a small share of the total known species in the world. This means the number
-          of species threatened with extinction is likely to be a significant underestimate of the total number of species
-          at risk.
-
-
-          This is particularly true for understudied groups such as insects, plants and fungi.
-
-
-          The share of known species threatened with extinction is only available for a few taxonomic groups where more than
-          80% of species have been assessed.
-
-
-          'Threatened' species are those that are categorized as 'Critically endangered', 'Endangered' or 'Vulnerable' on
-          the IUCN Red List.
-        citation_full: IUCN. 2023. The IUCN Red List of Threatened Species. https://www.iucnredlist.org.
-        url_main: https://www.iucnredlist.org/resources/summary-statistics
-        date_accessed: "2022-12-08"
-        date_published: "2022-12-08"
 dataset:
   update_period_days: 365
-  sources: []
 tables:
   threatened_and_evaluated_species:
     variables:
@@ -39,7 +15,7 @@ tables:
         display:
           name: Estimated number of described species
           numDecimalPlaces: 0
-        description_short: The number of formally identified, described and named species in each [taxonomic group](#dod:taxonomic_group).
+        description_short: The total number of known/described species. This does not mean these species have been assessed for their extinction risk level.
         description_key:
           - Since many species have not yet been described, this is a large underestimate of the total number of species in the world.
           - For a species to be formally described, it's description must be published in a scientific journal or book.

--- a/etl/steps/data/grapher/postnatal_care/2022-09-19/postnatal_care.meta.yml
+++ b/etl/steps/data/grapher/postnatal_care/2022-09-19/postnatal_care.meta.yml
@@ -1,29 +1,8 @@
-dataset:
-  namespace: postnatal_care
-  short_name: postnatal_care
-  title: Postnatal care coverage (% mothers) - Health Nutrition and Population Statistics
-    (2022)
-  description: Percentage of women with a postnatal checkup in the first two days
-    after birth.
-  licenses:
-  - name: Creative Commons BY 4.0
-    url: https://www.worldbank.org/en/about/legal/terms-of-use-for-datasets
-  version: '2022-09-19'
-  sources:
-  - name: World Bank (2022)
-    published_by: Health Nutrition and Population Statistics - World Bank (2022)
-    url: https://databank.worldbank.org/source/health-nutrition-and-population-statistics/Series/SH.STA.PNVC.ZS#
-    date_accessed: '2022-10-31'
-    publication_date: '2022-09-19'
-    publication_year: 2022
 tables:
   postnatal_care:
-    title: Postnatal care coverage (% mothers) - Health Nutrition and Population Statistics
-      (2022)
-    description: Percentage of women with a postnatal checkup in the first two days
-      after birth.
     variables:
       postnatal_care_coverage:
         title: postnatal_care_coverage
+        description_short: Percentage of women with a postnatal checkup in the first two days after birth.
         short_unit: '%'
         unit: '%'

--- a/etl/steps/data/grapher/postnatal_care/2022-09-19/postnatal_care.py
+++ b/etl/steps/data/grapher/postnatal_care/2022-09-19/postnatal_care.py
@@ -1,19 +1,15 @@
-from owid import catalog
+"""Load garden dataset and create grapher dataset."""
 
 from etl.helpers import PathFinder
 
-N = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
-    dataset = catalog.Dataset.create_empty(dest_dir, N.garden_dataset.metadata)
+def run() -> None:
+    # Load garden dataset and table.
+    ds_garden = paths.load_dataset("postnatal_care")
+    tb = ds_garden["postnatal_care"]
 
-    table = N.garden_dataset["postnatal_care"]
-    table = table.drop("index", axis=1)
-    # optionally set additional dimensions
-    # table = table.set_index(["sex", "income_group"], append=True)
-
-    # if your data is in long format, check gh.long_to_wide_tables
-    dataset.add(table)
-
-    dataset.save()
+    # Save grapher dataset.
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/grapher/who/2023-07-13/autopsy.meta.yml
+++ b/etl/steps/data/grapher/who/2023-07-13/autopsy.meta.yml
@@ -1,47 +1,6 @@
-descriptions:
-  who: &who-description >-
-
-
-    The data for the following countries is taken from the WHO European Health Information Gateway:
-
-
-    • Armenia, Austria, Azerbaijan, Belarus, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia, Finland, Georgia, Hungary, Iceland, Israel, Kazakhstan, Kyrgyzstan, Latvia, Lithuania, Luxembourg, Malta, Moldova, Netherlands, North Macedonia, Norway, Portugal, Romania, Russia, San Marino, Serbia, Slovakia, Sweden, Switzerland, Tajikistan, Turkey, Turkmenistan, Ukraine, United Kingdom and Uzbekistan.
-
-
-    The WHO European Health Information Gateway aggregates data from national statistics offices. Countries have data across multiple years.
-
-  paratz: &paratz-description >-
-
-
-    The data for the following countries is taken from Paratz et al., (2023):
-
-
-    • Australia, Belgium, Bhutan, Brazil, Canada, Chine, Cote d'Ivoire, Cuba, France, Jamaica, Japan, Kuwait, New Zealand, Qatar, Saudi Arabia, South Africa, South Korea, Spain and United States.
-
-
-    Paratz et al., (2023) collates data from a number of published papers and databases, including journal articles, publicly available governmental datasets, press releases, newspaper articles, and annual reports. The year shown reflects the date given in the database or the year of the publication. For Spain and Australia the data is only representative of a region of each country, Catalonia and Victoria, respectively.
-
-all_sources:
-  - who_2022: &source-who_2022
-      name: WHO (2022)
-      published_by: WHO European Health Information Gateway
-      url: https://gateway.euro.who.int/en/indicators/hfa_545-6410-autopsy-rate-for-all-deaths/
-      date_accessed: '2023-07-13'
-      publication_date: '2022-09-01'
-      description: *who-description
-  - paratz_2023: &source-paratz_2023
-      name: Paratz et al., (2023)
-      published_by: "Paratz et al., (2023) A systematic review of global autopsy rates in all-cause mortality and young sudden death. Heart Rhythm. doi: 10.1016/j.hrthm.2023.01.008."
-      url: https://www.heartrhythmjournal.com/article/S1547-5271(23)00027-9/fulltext
-      date_accessed: '2023-07-13'
-      publication_year: 2023
-      description: *paratz-description
 dataset:
   title: "Autopsy rate (WHO, 2022; Paratz et al., 2023)"
-  description: A combination of two sources of data on autopsy rates, 1) WHO European Health Information Gateway, 2) Paratz et al., (2023).
-  sources:
-    - *source-who_2022
-    - *source-paratz_2023
+
 tables:
   autopsy:
     variables:

--- a/etl/steps/data/grapher/who/2023-07-13/autopsy.py
+++ b/etl/steps/data/grapher/who/2023-07-13/autopsy.py
@@ -1,50 +1,31 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from typing import cast
-
-import pandas as pd
-from owid.catalog import Dataset, Table
+from owid.catalog import processing as pr
 
 from etl.helpers import PathFinder, create_dataset, grapher_checks
-from etl.snapshot import Snapshot
 
-# Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
-    #
-    # Load inputs.
-    #
-    # Load garden dataset.
-    ds_garden = cast(Dataset, paths.load_dependency("autopsy"))
-    # Load Paratz paper dataset
-    snap = cast(Snapshot, paths.load_dependency("paratz.csv"))
-    paratz_df = pd.read_csv(snap.path)
-    tb_paratz = Table(paratz_df, short_name="paratz")
-
-    # Read table from garden dataset.
+    # load garden WHO data
+    ds_garden = paths.load_dataset("autopsy")
     tb_who = ds_garden["autopsy"].reset_index()
     assert all(tb_who["sex"].drop_duplicates() == "ALL")
-    tb_who = tb_who.drop(columns="sex")
-    tb_who = tb_who.rename(columns={"value": "autopsy_rate"})
-    # Removing overlapping countries from Paratz as we prefer WHO as a source.
+    tb_who = tb_who.drop(columns="sex").rename(columns={"value": "autopsy_rate"})
+
+    # load Paratz paper snapshot
+    snap_paratz = paths.load_snapshot("paratz.csv")
+    tb_paratz = snap_paratz.read_csv()
+
+    # drop Paratz rows whose countries are already covered by WHO
     tb_paratz = tb_paratz[~tb_paratz["country"].isin(tb_who["country"])]
-    tb = Table(pd.concat([tb_paratz, tb_who]), short_name=paths.short_name)
 
-    tb = tb.set_index(["country", "year"], verify_integrity=True).sort_index().sort_index(axis=1)
+    # combine
+    tb = pr.concat([tb_paratz, tb_who]).format(["country", "year"], short_name=paths.short_name)
 
-    #
-    # Save outputs.
-    #
-    # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb])
-
+    # save grapher dataset (inherit metadata from upstream WHO garden dataset)
+    ds_grapher = create_dataset(dest_dir, tables=[tb], default_metadata=ds_garden.metadata)
     ds_grapher.update_metadata(paths.metadata_path)
-    #
-    # Checks.
-    #
     grapher_checks(ds_grapher)
-
-    # Save changes in the new grapher dataset.
     ds_grapher.save()

--- a/etl/steps/data/meadow/education/2023-08-09/clio_infra_education.py
+++ b/etl/steps/data/meadow/education/2023-08-09/clio_infra_education.py
@@ -1,12 +1,8 @@
 """Load a snapshot and create a meadow dataset."""
 
-from typing import cast
-
-import pandas as pd
-from owid.catalog import Table
+from owid.catalog import processing as pr
 
 from etl.helpers import PathFinder, create_dataset
-from etl.snapshot import Snapshot
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
@@ -17,15 +13,15 @@ def run(dest_dir: str) -> None:
     # Load inputs.
     #
     # Retrieve snapshot.
-    snap_years_education = cast(Snapshot, paths.load_dependency("years_of_education.xlsx"))
-    snap_years_education_gini = cast(Snapshot, paths.load_dependency("years_of_education_gini.xlsx"))
-    snap_years_education_gender = cast(Snapshot, paths.load_dependency("years_of_education_gender.xlsx"))
-    snap_numeracy = cast(Snapshot, paths.load_dependency("numeracy.xlsx"))
-    snap_numeracy_gender = cast(Snapshot, paths.load_dependency("numeracy_gender.xlsx"))
+    snap_years_education = paths.load_snapshot("years_of_education.xlsx")
+    snap_years_education_gini = paths.load_snapshot("years_of_education_gini.xlsx")
+    snap_years_education_gender = paths.load_snapshot("years_of_education_gender.xlsx")
+    snap_numeracy = paths.load_snapshot("numeracy.xlsx")
+    snap_numeracy_gender = paths.load_snapshot("numeracy_gender.xlsx")
     #
     # Process data.
     #
-    dfs = []
+    tbs = []
 
     for snap in [
         snap_years_education,
@@ -34,26 +30,26 @@ def run(dest_dir: str) -> None:
         snap_numeracy,
         snap_numeracy_gender,
     ]:
-        df = pd.read_excel(snap.path)
-        # Melting the DataFrame
+        tb = snap.read_excel()
+        # Melting the table.
         year_cols = [str(year) for year in range(1500, 2051)]
-        df_melted = pd.melt(
-            df,
+        tb_melted = tb.melt(
             id_vars=["country name"],
             value_vars=year_cols,
             var_name="year",
             value_name=snap.metadata.short_name,
         )
-        dfs.append(df_melted)
+        tbs.append(tb_melted)
 
-    merged_df = dfs[0]
-    # Iterate through the remaining DataFrames and merge them
-    for df in dfs[1:]:
-        merged_df = pd.merge(merged_df, df, on=["country name", "year"], how="outer")
-    merged_df.rename(columns={"country name": "country"}, inplace=True)
+    merged_tb = tbs[0]
+    # Iterate through the remaining tables and merge them.
+    for tb in tbs[1:]:
+        merged_tb = pr.merge(merged_tb, tb, on=["country name", "year"], how="outer")
+    merged_tb = merged_tb.rename(columns={"country name": "country"})
 
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(merged_df, short_name=paths.short_name, underscore=True)
+    # Ensure all columns are snake-case.
+    tb = merged_tb.underscore()
+    tb.metadata.short_name = paths.short_name
     tb = tb.set_index(["country", "year"], verify_integrity=True)
     tb = tb.dropna(how="all")
 

--- a/etl/steps/data/meadow/postnatal_care/2022-09-19/postnatal_care.meta.yml
+++ b/etl/steps/data/meadow/postnatal_care/2022-09-19/postnatal_care.meta.yml
@@ -1,27 +1,5 @@
-dataset:
-  namespace: postnatal_care
-  short_name: postnatal_care
-  title: Postnatal care coverage (% mothers) - Health Nutrition and Population Statistics
-    (2022)
-  description: 'Percentage of women with a postnatal checkup in the first two days
-    after birth.'
-  licenses:
-  - name: Creative Commons BY 4.0
-    url: https://www.worldbank.org/en/about/legal/terms-of-use-for-datasets
-  version: '2022-09-19'
-  sources:
-  - name: World Bank (2022)
-    published_by: Health Nutrition and Population Statistics - World Bank (2022)
-    url: https://databank.worldbank.org/source/health-nutrition-and-population-statistics/Series/SH.STA.PNVC.ZS#
-    date_accessed: '2022-10-31'
-    publication_date: '2022-09-19'
-    publication_year: 2022
 tables:
   postnatal_care:
-    title: Postnatal care coverage (% mothers) - Health Nutrition and Population Statistics
-      (2022)
-    description: 'Percentage of women with a postnatal checkup in the first two days
-      after birth.'
     variables:
       postnatal_care_coverage:
         title: postnatal_care_coverage

--- a/etl/steps/data/meadow/postnatal_care/2022-09-19/postnatal_care.py
+++ b/etl/steps/data/meadow/postnatal_care/2022-09-19/postnatal_care.py
@@ -1,43 +1,32 @@
+"""Load a snapshot and create a meadow dataset."""
+
 import numpy as np
-import pandas as pd
-from structlog import get_logger
 
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
-log = get_logger()
-
-# naming conventions
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
-    log.info("postnatal_care.start")
-
-    # retrieve raw data
+def run() -> None:
+    # Retrieve raw data from snapshot.
     snap = paths.load_snapshot("postnatal_care.csv")
     tb = snap.read()
 
+    # Drop rows with no Series Code (footer / blank rows in the source CSV).
     tb = tb[tb["Series Code"].notna()]
 
-    # clean and transform data
+    # Clean and transform data.
     tb = clean_data(tb)
 
-    # underscore all table columns
-    tb = tb.underscore()
+    # Improve table format.
+    tb = tb.underscore().format(["country", "year"], short_name=paths.short_name)
 
-    #
     # Save outputs.
-    #
-    # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
-
-    # finally save the dataset
-    ds.save()
-
-    log.info("postnatal_care.end")
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
+    ds_meadow.save()
 
 
-def clean_data(tb: pd.DataFrame) -> pd.DataFrame:
+def clean_data(tb):
     tb = tb.drop(columns=["Country Code", "Series Name", "Series Code"])
 
     cols = tb.columns[1:].str[:4].tolist()
@@ -45,4 +34,5 @@ def clean_data(tb: pd.DataFrame) -> pd.DataFrame:
     tb = tb.replace("..", np.nan)
     tb = tb.melt(id_vars="country", value_vars=cols)
     tb = tb.rename(columns={"variable": "year", "value": "postnatal_care_coverage"})
+    tb["year"] = tb["year"].astype(int)
     return tb

--- a/etl/steps/data/meadow/unep/2023-03-17/consumption_controlled_substances.py
+++ b/etl/steps/data/meadow/unep/2023-03-17/consumption_controlled_substances.py
@@ -1,7 +1,7 @@
-"""Load a snapshot and create a meadow dataset."""
+"""Load snapshots and create a meadow dataset."""
 
-import pandas as pd
 from owid.catalog import Table
+from owid.catalog import processing as pr
 from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
@@ -32,28 +32,31 @@ def run(dest_dir: str) -> None:
     #
     # Load inputs.
     #
-    dfs = []
+    tables = []
+    last_snap: Snapshot | None = None
     for name, name_pretty in CHEMICAL_NAMES.items():
         log.info(f"consumption_controlled_substances: loading snapshot `{name}`.")
         # Retrieve snapshot.
         snap: Snapshot = paths.load_dependency(f"consumption_controlled_substances_{name}.xlsx")
-        # Load data from snapshot.
-        df = format_frame(pd.read_excel(snap.path, skiprows=1), name=name_pretty)
-        # Append to list of dataframes
-        dfs.append(df)
-    log.info("consumption_controlled_substances: concatenating dataframes.")
-    df = pd.concat(dfs, ignore_index=True)
+        last_snap = snap
+        # Load data from snapshot and format it.
+        tb = format_frame(snap.read_excel(skiprows=1), name=name_pretty)
+        tables.append(tb)
+    log.info("consumption_controlled_substances: concatenating tables.")
+    tb = pr.concat(tables, ignore_index=True, short_name=paths.short_name)
+
     #
     # Process data.
     #
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(df, short_name=paths.short_name, underscore=True)
+    # Ensure all columns are snake-case.
+    tb = tb.underscore()
 
     #
     # Save outputs.
     #
     # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)  # ty: ignore
+    assert last_snap is not None
+    ds_meadow = create_dataset(dest_dir, tables=[tb], default_metadata=last_snap.metadata)
 
     # Save changes in the new garden dataset.
     ds_meadow.save()
@@ -61,21 +64,21 @@ def run(dest_dir: str) -> None:
     log.info("consumption_controlled_substances.end")
 
 
-def format_frame(df: pd.DataFrame, name: str) -> pd.DataFrame:
+def format_frame(tb: Table, name: str) -> Table:
     # Ensure no unexpected columns appear. We expect "Country", "Baseline", and year columns.
     YEAR_MIN = 1986
     YEAR_MAX = 2022
     COLUMN_NAMES_ACCEPTED = {"Country", "Baseline"} | set(range(YEAR_MIN, YEAR_MAX + 1))
-    assert not (columns_new := set(df.columns).difference(COLUMN_NAMES_ACCEPTED)), f"Unexpected columns {columns_new}"
+    assert not (columns_new := set(tb.columns).difference(COLUMN_NAMES_ACCEPTED)), f"Unexpected columns {columns_new}"
     # Ensure country column is there
-    assert "Country" in df.columns, "Missing country column!"
+    assert "Country" in tb.columns, "Missing country column!"
     # Remove 'Baseline' column if exists
-    if "Baseline" in df.columns:
-        df = df.drop(columns=["Baseline"])
-    # Format df (unpivot)
-    df = (
-        df.melt(id_vars="Country", var_name="year", value_name="consumption")
+    if "Baseline" in tb.columns:
+        tb = tb.drop(columns=["Baseline"])
+    # Format tb (unpivot)
+    tb = (
+        tb.melt(id_vars="Country", var_name="year", value_name="consumption")
         .astype({"year": int})
         .assign(chemical=name)
     )
-    return df
+    return tb

--- a/etl/steps/data/meadow/unicef/2023-06-16/diarrhea.meta.yml
+++ b/etl/steps/data/meadow/unicef/2023-06-16/diarrhea.meta.yml
@@ -1,18 +1,3 @@
-dataset:
-  title: Diarrhea treatment (UNICEF, 2022)
-  description: ''
-  licenses:
-  - name: Creative Commons Attribution-NonCommercial 3.0 IGO license
-    url: https://data.unicef.org/about-us/
-  sources:
-  - name: UNICEF (2022)
-    url: https://data.unicef.org/resources/dataset/diarrhoea/
-    source_data_url: https://data.unicef.org/wp-content/uploads/2018/06/Child-Health-Coverage-Database-May-2022.xlsx
-    date_accessed: '2023-06-16'
-    publication_date: '2022-05-01'
-    publication_year: 2022
-    published_by: Several health and multiple indicator cluster surveys compiled by
-      UNICEF
 tables:
   diarrhea:
     variables:

--- a/etl/steps/data/meadow/unicef/2023-06-16/diarrhea.py
+++ b/etl/steps/data/meadow/unicef/2023-06-16/diarrhea.py
@@ -1,13 +1,9 @@
 """Load a snapshot and create a meadow dataset."""
 
-from typing import cast
-
-import pandas as pd
-from owid.catalog import Table
+import owid.catalog.processing as pr
 from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
-from etl.snapshot import Snapshot
 
 # Initialize logger.
 log = get_logger()
@@ -23,24 +19,25 @@ def run(dest_dir: str) -> None:
     # Load inputs.
     #
     # Retrieve snapshot.
-    snap = cast(Snapshot, paths.load_dependency("diarrhea.xlsx"))
+    snap = paths.load_snapshot("diarrhea.xlsx")
 
     sheets = ["DIARCARE", "ORS", "ORTCF", "ORSZINC", "ZINC"]
-    # Load data from snapshot.
-    all_sheets_df = pd.DataFrame()
+    # Load data from snapshot, one Table per sheet, then concatenate.
+    tables = []
     for sheet in sheets:
-        df = pd.read_excel(snap.path, sheet_name=sheet)
-        df["indicator"] = sheet
-        all_sheets_df = pd.concat([all_sheets_df, df])
+        tb_sheet = snap.read_excel(sheet_name=sheet)
+        tb_sheet["indicator"] = sheet
+        tables.append(tb_sheet)
+    tb = pr.concat(tables, ignore_index=True)
 
-    all_sheets_df = all_sheets_df[["Countries and areas", "Year", "National", "indicator"]].reset_index(drop=True)
-    all_sheets_df = all_sheets_df.rename(
-        columns={"Countries and areas": "country", "Year": "year", "National": "value"}
-    )
+    tb = tb[["Countries and areas", "Year", "National", "indicator"]]
+    tb = tb.rename(columns={"Countries and areas": "country", "Year": "year", "National": "value"})
+
     # Process data.
     #
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(all_sheets_df, short_name=paths.short_name, underscore=True)
+    # Ensure all columns are snake-case and set short_name.
+    tb = tb.underscore()
+    tb.metadata.short_name = paths.short_name
 
     #
     # Save outputs.

--- a/etl/steps/data/meadow/war/2023-01-10/shared.py
+++ b/etl/steps/data/meadow/war/2023-01-10/shared.py
@@ -1,4 +1,3 @@
-import pandas as pd
 from owid.catalog import Dataset, Table
 from structlog import get_logger
 
@@ -53,13 +52,13 @@ COLUMNS_REQUIRED = [
 ]
 
 
-def clean_data(df: pd.DataFrame, column_rename: dict[str, str] | None) -> pd.DataFrame:
+def clean_data(tb: Table, column_rename: dict[str, str] | None) -> Table:
     if not column_rename:
         column_rename = COLUMN_RENAME
 
     # sanity checks
     columns_expected = set(column_rename)
-    columns_given = set(df.columns)
+    columns_given = set(tb.columns)
     # check if all columns are expected
     columns_unexpected = columns_given.difference(columns_expected)
     if columns_unexpected:
@@ -70,31 +69,32 @@ def clean_data(df: pd.DataFrame, column_rename: dict[str, str] | None) -> pd.Dat
         raise ValueError(f"There are missing columns! {columns_missing}")
 
     # rename columns
-    df = df.rename(columns=column_rename, errors="raise")
+    tb = tb.rename(columns=column_rename, errors="raise")
 
     # table might contain some columns with only NaNs. These should be dropped, as they don't contain any data.
     # Note that *not* all should be dropped, some are required for correct functioning!
-    df = df.dropna(how="all", axis=1)
+    tb = tb.dropna(how="all", axis=1)
     for col in COLUMNS_REQUIRED:
-        if col not in df.columns:
+        if col not in tb.columns:
             raise ValueError(f"Missing required column{col}")
-    return df
+    return tb
 
 
 def run_pipeline(dest_dir: str, paths: PathFinder, column_rename: dict[str, str] | None = None):
     log.info(f"{paths.short_name}.start")
-    # read snapshot dataset
+    # read snapshot dataset (preserves column-level origin metadata)
     snap = paths.load_dependency(paths.short_name + ".csv")
-    df = pd.read_csv(snap.path, header=4)
+    tb = snap.read_csv(header=4)
     # clean and transform data
-    df = clean_data(df, column_rename)
+    tb = clean_data(tb, column_rename)
 
     # create new dataset and reuse snapshot metadata
     ds = Dataset.create_empty(dest_dir, metadata=convert_snapshot_metadata(snap.metadata))
     ds.metadata.version = paths.version
 
-    # # create table with metadata from dataframe and underscore all columns
-    tb = Table(df, short_name=snap.metadata.short_name, underscore=True)
+    # set short name and underscore columns; preserves origin from snap.read_csv
+    tb.metadata.short_name = snap.metadata.short_name
+    tb = tb.underscore()
 
     # add table to a dataset
     ds.add(tb)

--- a/etl/steps/data/meadow/who/2023-06-29/guinea_worm_certification.py
+++ b/etl/steps/data/meadow/who/2023-06-29/guinea_worm_certification.py
@@ -1,13 +1,9 @@
 """Load a snapshot and create a meadow dataset."""
 
-from typing import cast
-
-import pandas as pd
 from owid.catalog import Table
 from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
-from etl.snapshot import Snapshot
 
 # Initialize logger.
 log = get_logger()
@@ -23,16 +19,17 @@ def run(dest_dir: str) -> None:
     # Load inputs.
     #
     # Retrieve snapshot.
-    snap = cast(Snapshot, paths.load_dependency("guinea_worm.csv"))
+    snap = paths.load_snapshot("guinea_worm.csv")
 
     # Load data from snapshot.
-    df = pd.read_csv(snap.path, skiprows=2)
-    df = clean_certification_table(df).reset_index(drop=True)
+    tb = snap.read_csv(skiprows=2)
+    tb = clean_certification_table(tb).reset_index(drop=True)
     #
     # Process data.
     #
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(df, short_name=paths.short_name, underscore=True)
+    # Ensure all columns are snake-case.
+    tb = tb.underscore()
+    tb.metadata.short_name = paths.short_name
 
     #
     # Save outputs.
@@ -46,12 +43,11 @@ def run(dest_dir: str) -> None:
     log.info("guinea_worm.end")
 
 
-def clean_certification_table(df: pd.DataFrame) -> pd.DataFrame:
-    df.columns.values[0] = "country"
-    df.columns.values[24] = "year_certified"
-    df.year_certified = df.year_certified.str.replace(r"Countries certified in", "", regex=True)
+def clean_certification_table(tb: Table) -> Table:
+    tb = tb.rename(columns={tb.columns[0]: "country", tb.columns[24]: "year_certified"})
+    tb["year_certified"] = tb["year_certified"].str.replace(r"Countries certified in", "", regex=True)
 
-    df = df.replace(
+    tb = tb.replace(
         {
             "year_certified": {
                 "Countries at precertification stage": "Pre-certification",
@@ -61,4 +57,4 @@ def clean_certification_table(df: pd.DataFrame) -> pd.DataFrame:
         }
     )
 
-    return df
+    return tb

--- a/etl/steps/data/meadow/who/2023-07-13/autopsy.py
+++ b/etl/steps/data/meadow/who/2023-07-13/autopsy.py
@@ -1,36 +1,21 @@
 """Load a snapshot and create a meadow dataset."""
 
-from owid.catalog import Table
-
 from etl.helpers import PathFinder, create_dataset
 
-# Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
 def run(dest_dir: str) -> None:
-    #
-    # Load inputs.
-    #
-    # Retrieve snapshot.
+    # load snapshot
     snap = paths.load_snapshot("autopsy.csv")
+    tb = snap.read_csv()
 
-    # Load data from snapshot.
-    df = snap.read_csv()
-    df = df.dropna(subset="VALUE")
-    df["COUNTRY"] = df["COUNTRY"].fillna(df["COUNTRY_GRP"])
-    df = df.drop(columns="COUNTRY_GRP")
-    #
-    # Process data.
-    #
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(df, short_name=paths.short_name, underscore=True)
+    # clean data
+    tb = tb.dropna(subset="VALUE")
+    tb["COUNTRY"] = tb["COUNTRY"].fillna(tb["COUNTRY_GRP"])
+    tb = tb.drop(columns="COUNTRY_GRP")
+    tb = tb.underscore().format(["country", "sex", "year"], short_name=paths.short_name)
 
-    #
-    # Save outputs.
-    #
-    # Create a new meadow dataset with the same metadata as the snapshot.
+    # save dataset
     ds_meadow = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
-
-    # Save changes in the new garden dataset.
     ds_meadow.save()

--- a/etl/steps/data/meadow/world_risk_poll/2023-06-26/wrp_2021.py
+++ b/etl/steps/data/meadow/world_risk_poll/2023-06-26/wrp_2021.py
@@ -1,12 +1,8 @@
 """Load a snapshot and create a meadow dataset."""
 
-import os
-import zipfile
 from typing import cast
 
 import numpy as np
-import pandas as pd
-from owid.catalog import Table
 from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
@@ -26,24 +22,22 @@ def run(dest_dir: str) -> None:
     #
     # Retrieve snapshot.
     snap = cast(Snapshot, paths.load_dependency("wrp_2021.zip"))
-    dest_dir_zip = os.path.dirname(snap.path)
 
-    with zipfile.ZipFile(snap.path, "r") as zip_file:
-        # Extract the desired file
-        zip_file.extract("lrf_wrp_2021_full_data.csv", dest_dir_zip)
+    # Read CSV from inside the zip archive (preserves origins on columns).
+    with snap.extracted() as archive:
+        tb = archive.read("lrf_wrp_2021_full_data.csv", low_memory=False)
 
-    # Load data from snapshot.
-    df = pd.read_csv(dest_dir_zip + "/" + "lrf_wrp_2021_full_data.csv", low_memory=False)
-    countries_both_years = df["country.in.both.waves"] == 1
-    df.replace(" ", np.nan, inplace=True)
-    df = df[countries_both_years]
-    df.reset_index(drop=True, inplace=True)
+    # Filter to countries present in both waves.
+    countries_both_years = tb["country.in.both.waves"] == 1
+    tb = tb.replace(" ", np.nan)
+    tb = tb[countries_both_years].reset_index(drop=True)
 
     #
     # Process data.
     #
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(df, short_name=paths.short_name, underscore=True)
+    # Ensure all columns are snake-case.
+    tb = tb.underscore()
+    tb.metadata.short_name = paths.short_name
 
     #
     # Save outputs.

--- a/etl/steps/data/meadow/wvs/2023-06-25/longitudinal_wvs.py
+++ b/etl/steps/data/meadow/wvs/2023-06-25/longitudinal_wvs.py
@@ -3,12 +3,10 @@
 from typing import cast
 
 import numpy as np
-import pandas as pd
-from owid.catalog import Dataset, Table
+from owid.catalog import Dataset
 from structlog import get_logger
 
 from etl.helpers import PathFinder, create_dataset
-from etl.snapshot import Snapshot
 
 # Initialize logger.
 log = get_logger()
@@ -24,19 +22,20 @@ def run(dest_dir: str) -> None:
     # Load inputs.
     #
     # Retrieve snapshot.
-    snap = cast(Snapshot, paths.load_dependency("longitudinal_wvs.csv"))
+    snap = paths.load_snapshot("longitudinal_wvs.csv")
 
     # Load data from snapshot.
-    df = pd.read_csv(snap.path)
+    tb = snap.read_csv()
     #
     # Process data.
     #
     terrorism_columns = ["COUNTRY_ALPHA", "S020", "H006_04", "G057", "F114E"]
-    df = df[terrorism_columns]
+    tb = tb[terrorism_columns]
     # Replace keys where question was not asked with nan
     cols_to_update = ["H006_04", "G057", "F114E"]
     valid_resp = list(range(11)) + [-1, -2]
-    df[cols_to_update] = df[cols_to_update].applymap(lambda x: x if x in valid_resp else np.nan)
+    for col in cols_to_update:
+        tb[col] = tb[col].where(tb[col].isin(valid_resp), np.nan)
     # Rename columns to more informative names
     dictionary_keys = {
         "COUNTRY_ALPHA": "code",
@@ -45,17 +44,18 @@ def run(dest_dir: str) -> None:
         "G057": "Effects of immigrants on the development of [your country]: Increase the risks of terrorism",
         "F114E": "Justifiable: Terrorism as a political, ideological or religious mean",
     }
-    df.rename(columns=dictionary_keys, inplace=True)
-    # Load the countries and ISO 3166-1 alpha-3 codes dataset to get the country names based on the  ISO 3166-1 alpha-3 codes in the datagrame
+    tb = tb.rename(columns=dictionary_keys)
+    # Load the countries and ISO 3166-1 alpha-3 codes dataset to get the country names based on the ISO 3166-1 alpha-3 codes in the dataframe
     countries_regions = cast(Dataset, paths.load_dependency("regions"))["regions"]
     iso_match = countries_regions.reset_index()[["code", "name"]]
-    match_code_df = pd.merge(iso_match, df, on="code", how="right")
+    tb = iso_match.merge(tb, on="code", how="right")
     # Drop the country column code and rename the country 'name' column to 'country' column
-    match_code_df.drop("code", axis=1, inplace=True)
-    match_code_df.rename(columns={"name": "country"}, inplace=True)
+    tb = tb.drop(columns="code")
+    tb = tb.rename(columns={"name": "country"})
 
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(match_code_df, short_name=paths.short_name, underscore=True)
+    # Ensure all columns are snake-case.
+    tb = tb.underscore()
+    tb.metadata.short_name = paths.short_name
 
     #
     # Save outputs.

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -516,7 +516,7 @@
         "title": "URL to download the producer's data",
         "type": "string",
         "description": "Producer's URL that directly downloads their data as a single file.",
-        "pattern": "/(https:\/\/www\\.|http:\/\/www\\.|https:\/\/|http:\/\/)?[a-zA-Z]{2,}(\\.[a-zA-Z]{2,})(\\.[a-zA-Z]{2,})?\/[a-zA-Z0-9]{2,}|((https:\/\/www\\.|http:\/\/www\\.|https:\/\/|http:\/\/)?[a-zA-Z]{2,}(\\.[a-zA-Z]{2,})(\\.[a-zA-Z]{2,})?)|(https:\/\/www\\.|http:\/\/www\\.|https:\/\/|http:\/\/)?[a-zA-Z0-9]{2,}\\.[a-zA-Z0-9]{2,}\\.[a-zA-Z0-9]{2,}(\\.[a-zA-Z0-9]{2,})?/g;",
+        "pattern": "/gAAAA[A-Za-z0-9_=-]{20,}|(https:\/\/www\\.|http:\/\/www\\.|https:\/\/|http:\/\/)?[a-zA-Z]{2,}(\\.[a-zA-Z]{2,})(\\.[a-zA-Z]{2,})?\/[a-zA-Z0-9]{2,}|((https:\/\/www\\.|http:\/\/www\\.|https:\/\/|http:\/\/)?[a-zA-Z]{2,}(\\.[a-zA-Z]{2,})(\\.[a-zA-Z]{2,})?)|(https:\/\/www\\.|http:\/\/www\\.|https:\/\/|http:\/\/)?[a-zA-Z0-9]{2,}\\.[a-zA-Z0-9]{2,}\\.[a-zA-Z0-9]{2,}(\\.[a-zA-Z0-9]{2,})?/g;",
         "errorMessage": "'url_download' must be a valid URL",
         "requirement_level": "required (if existing)",
         "guidelines": [

--- a/snapshots/andrew/2019-12-03/co2_mitigation_curves_1p5celsius.csv.dvc
+++ b/snapshots/andrew/2019-12-03/co2_mitigation_curves_1p5celsius.csv.dvc
@@ -1,12 +1,23 @@
 meta:
-  name: CO2 mitigation curves for 1.5 Celsius (Andrew & GCP, 2019)
-  source_name: Robbie Andrew
-  publication_year: 2019
-  publication_date: 2019-12-03
-  url: https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml
-  source_data_url: https://folk.uio.no/roberan/t/data/mitigation_curves_1.5C_191203_data.csv
-  license_url: https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml
-  license_name: CC BY
+  origin:
+    producer: Robbie Andrew
+    title: CO2 mitigation curves for 1.5°C
+    description: |-
+      The range of CO2 mitigation curves for a range of "start year scenarios": scenarios are based on the annual emission reductions necessary to keep global temperature rise below 1.5°C if emissions mitigation was to start in a given year.
+
+      For example, "Start in 2010" marks the necessary future emissions pathway to have a >66% chance of keeping global average temperatures below 1.5°C warming if global CO2 emissions mitigation had started in 2010, very quickly peaking then falling.
+
+      Historical emissions to 2017 are sourced from CDIAC/Global Carbon Project, projection to 2018 from Global Carbon Project (Le Quéré et al. 2018).
+
+      Global cumulative CO2 emissions budgets are from the IPCC Special Report on 1.5°C (Rogelj et al. 2018): 420 GtCO2 for a 66% chance of 1.5°C and 1170 GtCO2 for a 66% chance of 2°C. Mitigation curves describe approximately exponential decay pathways such that the quota is never exceeded (see Raupach et al., 2014).
+    citation_full: Andrew, R. M. (2019). Global CO2 mitigation curves. https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml.
+    url_main: https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml
+    url_download: https://folk.uio.no/roberan/t/data/mitigation_curves_1.5C_191203_data.csv
+    date_accessed: '2022-09-28'
+    date_published: '2019-12-03'
+    license:
+      name: CC BY
+      url: https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml
 outs:
   - md5: 7809417c7064d0ecde67590ec52d2de1
     size: 55133

--- a/snapshots/andrew/2019-12-03/co2_mitigation_curves_2celsius.csv.dvc
+++ b/snapshots/andrew/2019-12-03/co2_mitigation_curves_2celsius.csv.dvc
@@ -1,12 +1,23 @@
 meta:
-  name: CO2 mitigation curves for 2 Celsius (Andrew & GCP, 2019)
-  source_name: Robbie Andrew
-  publication_year: 2019
-  publication_date: 2019-12-03
-  url: https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml
-  source_data_url: https://folk.uio.no/roberan/t/data/mitigation_curves_2.0C_191203_data.csv
-  license_url: https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml
-  license_name: CC BY
+  origin:
+    producer: Robbie Andrew
+    title: CO2 mitigation curves for 2°C
+    description: |-
+      The range of CO2 mitigation curves for a range of "start year scenarios": scenarios are based on the annual emission reductions necessary to keep global temperature rise below 2°C if emissions mitigation was to start in a given year.
+
+      For example, "Start in 2010" marks the necessary future emissions pathway to have a >66% chance of keeping global average temperatures below 2°C warming if global CO2 emissions mitigation had started in 2010, very quickly peaking then falling.
+
+      Historical emissions to 2017 are sourced from CDIAC/Global Carbon Project, projection to 2018 from Global Carbon Project (Le Quéré et al. 2018).
+
+      Global cumulative CO2 emissions budgets are from the IPCC Special Report on 1.5°C (Rogelj et al. 2018): 420 GtCO2 for a 66% chance of 1.5°C and 1170 GtCO2 for a 66% chance of 2°C. Mitigation curves describe approximately exponential decay pathways such that the quota is never exceeded (see Raupach et al., 2014).
+    citation_full: Andrew, R. M. (2019). Global CO2 mitigation curves. https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml.
+    url_main: https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml
+    url_download: https://folk.uio.no/roberan/t/data/mitigation_curves_2.0C_191203_data.csv
+    date_accessed: '2022-09-28'
+    date_published: '2019-12-03'
+    license:
+      name: CC BY
+      url: https://folk.universitetetioslo.no/roberan/t/global_mitigation_curves.shtml
 outs:
   - md5: cb695aa35203bcd8b55a10d59413d6eb
     size: 61194

--- a/snapshots/biodiversity/2022/living_planet_index.feather.dvc
+++ b/snapshots/biodiversity/2022/living_planet_index.feather.dvc
@@ -8,6 +8,12 @@ meta:
       The index value is measured relative to species' populations in 1970 (i.e. 1970 = 1).
 
       To calculate an LPI, a generalised additive modelling framework is used to determine the underlying trend in each population time-series. Average rates of change are then calculated and aggregated to the species level. For the global LPI, the method of aggregation has recently been revised to include a weighting system which gives trends from more species-rich systems, realms and groups more weight in the final index.
+
+      The Living Planet Database contains tens of thousands of vertebrate population time-series from around the world. It is the largest collection of its kind, and is publicly available, making it an invaluable tool for both research and conservation.
+
+      This dataset contains time-series of population abundance data for vertebrate species spanning years between 1970 and 2021. This is the public version of the database as confidential records that cannot be shared have been removed. The open-source code used to calculate the Living Planet Index using this data set can be found here: [https://github.com/Zoological-Society-of-London/rlpi](https://github.com/Zoological-Society-of-London/rlpi).
+
+      [Text from [Living Planet Index website](https://www.livingplanetindex.org/data_portal)]
     citation_full: World Wildlife Fund (WWF) and Zoological Society of London (2022). Living Planet Report 2022 – Building a nature-positive society. Almond, R.E.A., Grooten, M., Juffe Bignoli, D. and Petersen, T. (Eds). WWF, Gland, Switzerland.
     attribution_short: WWF and ZSL
     url_main: http://stats.livingplanetindex.org/

--- a/snapshots/clio_infra/2017-09-09/clio_infra__biological_standards_of_living__baten_and_blum__2015.feather.dvc
+++ b/snapshots/clio_infra/2017-09-09/clio_infra__biological_standards_of_living__baten_and_blum__2015.feather.dvc
@@ -1,13 +1,32 @@
 meta:
   origin:
-    producer: Baten and Blum
-    title: Height Gini
+    producer: Various sources
+    title: Clio-Infra - Biological Standards of Living
     description: |-
+      Clio-Infra is a collaborative project that provides historical data on global economic development. The Biological Standards of Living theme brings together datasets on human heights and anthropometric inequality, reconstructed by birth decade and country from a variety of historical and scholarly sources.
+
+      This snapshot is an Our World in Data compilation of two Clio-Infra datasets curated by Baten and Blum (2015) on biological standards of living:
+
+      - Height (Baten and Blum 2015) — https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/IAEKLA
+      - Height Gini (Baten and Blum 2015) — https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/HKZPR9
+
+      Additional information: Methodologies used for data collection and processing. Reconstruction of heights by birth decade using a variety of different sources. Please see link for the complete list.
+
       Additional information: Methodologies used for data collection and processing. Reconstruction of height ginis by birth decade using a variety of different sources. The height gini is a transformation of the coefficient of height inequality, based on Moradi and Baten's formula: g htgini=-33.5 + 20.5*cv.
 
-      Data quality: As good as possible, but counter-checking and improvement welcome. Interpretations on individual country level should be done with careful checking.  An important caveat is many individual countries cannot be measured without a substantial amount of measurement error. The tendencies of anthropometric inequality by world region (in which country-specific measurement error tends to average out) is probably informative.
-    citation_full: Jörg Baten and Matthias Blum, "Anthropometric within-country Inequality and the Estimation of Skill Premia with Anthropometric Indicators", Review of Economics -- Jahrbuch fuer Wirtschaftswissenschaften (2011).
-    url_main: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/HKZPR9
+      Data quality: As good as possible, but counter-checking and improvement welcome. Interpretations on individual country level should be done with careful checking. An important caveat is many individual countries cannot be measured without a substantial amount of measurement error. The tendencies of anthropometric inequality by world region (in which country-specific measurement error tends to average out) is probably informative.
+
+      Publisher source: Data collated from a host of academic papers. Please refer to the link for the complete list.
+    citation_full: |-
+      Clio-Infra. (2015). Biological Standards of Living datasets curated by Baten and Blum (2015). International Institute of Social History. Underlying publications:
+
+      For the post-1800 period: Baten, Joerg and Matthias Blum, "Growing Taller, but Unequal: Biological Well-Being in World Regions and Its Determinants, 1810-1989." Economic History of Developing Regions (2012).
+
+      For the pre-1800 period: Koepke, Nikola and Baten, Joerg "The Biological Standard of Living in Europe During the Last Two Millennia," in European Review of Economic History 9-1 (2005).
+
+      Jörg Baten and Matthias Blum, "Anthropometric within-country Inequality and the Estimation of Skill Premia with Anthropometric Indicators", Review of Economics -- Jahrbuch fuer Wirtschaftswissenschaften (2011).
+    attribution_short: Clio-Infra
+    url_main: https://clio-infra.eu/
     date_accessed: '2017-09-09'
     date_published: '2015'
 outs:

--- a/snapshots/clio_infra/2017-09-09/clio_infra__human_capital.feather.dvc
+++ b/snapshots/clio_infra/2017-09-09/clio_infra__human_capital.feather.dvc
@@ -1,13 +1,32 @@
 meta:
   origin:
-    producer: Foldvari
-    title: Universities founded
+    producer: Various sources
+    title: Clio-Infra - Human Capital
     description: |-
-      Additional information: Author's note: The quantity and quality of available information on universities vary by period and geographical area. Even the definition of university is not universal: in some countries even colleges offering undergradute programmes can be named universities (Latin America, Japan, Near East). Please see source for further information.
-    citation_full: Foldvari, P. (2015). Universities founded. Clio-Infra.
-    url_main: https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/KVRJPW
+      Clio-Infra is a collaborative project that provides historical data on global economic development. The Human Capital theme brings together datasets covering education, numeracy, and the founding of universities, compiled by individual researchers from central statistical agencies, historical reconstructions, and scholarly research.
+
+      This snapshot is an Our World in Data compilation of six Clio-Infra datasets on human capital:
+
+      - Average years of education (van Leeuwen, van Leeuwen-Li 2015) — https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/KCBMKI
+      - Book titles per capita (Fink-Jensen 2015) — https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/AOQMAZ
+      - Composite wellbeing index (Rijpma 2017) — https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/QIPFQF
+      - Educational inequality gini coefficient (van Leeuwen and van Leeuwen-Li 2015) — https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/KORKQW
+      - Numeracy (total) (Baten 2015) — https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/GEQKCG
+      - Universities founded (Foldvari 2015) — https://datasets.socialhistory.org/dataset.xhtml?persistentId=hdl:10622/KVRJPW
+
+      Per-component notes:
+
+      - Average years of education (van Leeuwen, van Leeuwen-Li 2015): Publisher source: Central statistical agencies, historical reconstructions.
+      - Book titles per capita (Fink-Jensen 2015): Publisher source: Combination of datasets and publications that contain data on book production for different regions and periods. Includes CLIO Infra data.
+      - Composite wellbeing index (Rijpma 2017): Publisher source: Composite measure constructed from 9 variables from the CLIO-Infra project.
+      - Educational inequality gini coefficient (van Leeuwen and van Leeuwen-Li 2015): Publisher source: Central statistical agencies, historical reconstructions.
+      - Numeracy (total) (Baten 2015): Publisher source: Reconstruction of data using a variety of sources, incl. scholarly research.
+      - Universities founded (Foldvari 2015): Additional information: Author's note: The quantity and quality of available information on universities vary by period and geographical area. Even the definition of university is not universal: in some countries even colleges offering undergradute programmes can be named universities (Latin America, Japan, Near East). Please see source for further information. Publisher source: Central statistical agencies, historical reconstructions.
+    citation_full: 'Clio-Infra. (2015–2017). Human Capital datasets: van Leeuwen and van Leeuwen-Li (2015), Fink-Jensen (2015), Rijpma (2017), Baten (2015), and Foldvari (2015). International Institute of Social History.'
+    attribution_short: Clio-Infra
+    url_main: https://clio-infra.eu/
     date_accessed: '2017-09-09'
-    date_published: '2015'
+    date_published: '2017'
 outs:
   - md5: c163e93ca9f1cfd5046e9c10ee4bcebd
     size: 262122

--- a/snapshots/demography/2018-11-19/infant_mortality_rates_in_uk__ons__2018.feather.dvc
+++ b/snapshots/demography/2018-11-19/infant_mortality_rates_in_uk__ons__2018.feather.dvc
@@ -1,6 +1,7 @@
 meta:
-  source:
-    name: Infant Mortality Rates in UK (ONS, 2018)
+  origin:
+    producer: UK Office for National Statistics
+    title: Infant mortality rates in the UK
     description: |-
       Infant mortality rates as reported by the UK Office for National Statistics (ONS). Infant mortality rates have be subdivided into categories depending on the age of the infant as follows:
 
@@ -10,12 +11,11 @@ meta:
       - Infant – deaths of those aged under 1 year.
 
       Neonatal and postneonatal are reported as the number of deaths per 1,000 live births. Perinatal and infant mortality is reported as the number of deaths per 1,000 total births (the sum of stillbirths and live births). Note that stillbirths are only recorded for births with 24 weeks of gestation or more (i.e. stillbirths less than 24 weeks gestation are not recorded).
-    url: |-
-      https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/childhoodinfantandperinatalmortalityinenglandandwales/2016
-    date_accessed: 2018-11-19
-    published_by: UK Office for National Statistics (ONS)
-  name: Infant Mortality Rates in UK (ONS, 2018)
-  description: ''
+    citation_full: UK Office for National Statistics (ONS). Childhood, infant and perinatal mortality in England and Wales (2018).
+    attribution_short: ONS
+    url_main: https://www.ons.gov.uk/peoplepopulationandcommunity/birthsdeathsandmarriages/deaths/bulletins/childhoodinfantandperinatalmortalityinenglandandwales/2016
+    date_accessed: '2018-11-19'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 868b408885aaa22f164fe870a94253ee

--- a/snapshots/education/2023-08-09/numeracy.xlsx.dvc
+++ b/snapshots/education/2023-08-09/numeracy.xlsx.dvc
@@ -1,27 +1,22 @@
 meta:
-  name: Historical numeracy estimates (Clio Infra, 1500-1970)
-  publication_year: 2013
-  publication_date: '2013-12-26'
-  source_name: Clio Infra
-  source_published_by: Baten, Joerg, University of Tuebingen.; with the help of several
-    coauthors, without implying any responsibility to them for potential mistakes
-    (Valeria Prayon, Dorothee Crayen, Dácil Juif, Ralph Hippe, Christina Mumme and
-    many others)
-  url: https://clio-infra.eu/Indicators/NumeracyTotal.html
-  source_data_url: https://clio-infra.eu/data/Numeracy(Total)_Compact.xlsx
-  license_url: https://clio-infra.eu/index.html#about
-  license_name: ''
-  date_accessed: 2023-08-09
-  is_public: true
-  description: |
-    Age heaping refers to the tendency for age data collected in surveys or censuses to be disproportionately reported at certain "attractive" or "round" numbers. This phenomenon often manifests itself in ages being reported at numbers that end in 0 or 5.
+  origin:
+    producer: Baten et al.
+    title: Numeracy (Total)
+    description: |-
+      Age heaping refers to the tendency for age data collected in surveys or censuses to be disproportionately reported at certain "attractive" or "round" numbers. This phenomenon often manifests itself in ages being reported at numbers that end in 0 or 5.
 
-    For example, when people are asked their age, they might be more likely to report it as 30, 35, 40, etc., rather than the exact age of 31, 36, or 39.
+      For example, when people are asked their age, they might be more likely to report it as 30, 35, 40, etc., rather than the exact age of 31, 36, or 39.
 
-    The authors of this dataset use this “age heaping” to measure cognitive ability in quantitative reasoning, or “numeracy” and construct a database of age heaping-based estimates of basic numeracy with broad geographic and temporal coverage.
-
-wdir: ../../../data/snapshots/education/2023-08-09
+      The authors of this dataset use this "age heaping" to measure cognitive ability in quantitative reasoning, or "numeracy" and construct a database of age heaping-based estimates of basic numeracy with broad geographic and temporal coverage.
+    citation_full: Baten, Joerg, University of Tuebingen; with the help of several coauthors, without implying any responsibility to them for potential mistakes (Valeria Prayon, Dorothee Crayen, Dácil Juif, Ralph Hippe, Christina Mumme and many others) (2013). Numeracy (Total) via Clio Infra.
+    attribution_short: Clio Infra
+    url_main: https://clio-infra.eu/Indicators/NumeracyTotal.html
+    url_download: https://clio-infra.eu/data/Numeracy(Total)_Compact.xlsx
+    date_accessed: '2023-08-09'
+    date_published: '2013-12-26'
+    license:
+      url: https://clio-infra.eu/index.html#about
 outs:
-- md5: 7b01bc2416fc72ec6103e58201fa737d
-  size: 217881
-  path: numeracy.xlsx
+  - md5: 7b01bc2416fc72ec6103e58201fa737d
+    size: 217881
+    path: numeracy.xlsx

--- a/snapshots/education/2023-08-09/numeracy_gender.xlsx.dvc
+++ b/snapshots/education/2023-08-09/numeracy_gender.xlsx.dvc
@@ -1,26 +1,24 @@
 meta:
-  name: Historical gender inequality numeracy estimates, 1810 - 1960 (Clio Infra)
-  publication_year: 2013
-  publication_date: '2013-12-26'
-  source_name: Baten, J. via Clio Infra
-  source_published_by: Baten, J. Gender Equality of Numeracy (2013) via Clio Infra
-  url: https://clio-infra.eu/Indicators/GenderEqualityofNumeracy.html
-  source_data_url: https://clio-infra.eu/data/GenderEqualityofNumeracy_Compact.xlsx
-  license_url: https://clio-infra.eu/index.html#about
-  license_name: ''
-  date_accessed: 2023-08-09
-  is_public: true
-  description: |
-    Age heaping refers to the tendency for age data collected in surveys or censuses to be disproportionately reported at certain "attractive" or "round" numbers. This phenomenon often manifests itself in ages being reported at numbers that end in 0 or 5.
+  origin:
+    producer: Baten
+    title: Gender Equality of Numeracy
+    description: |-
+      Age heaping refers to the tendency for age data collected in surveys or censuses to be disproportionately reported at certain "attractive" or "round" numbers. This phenomenon often manifests itself in ages being reported at numbers that end in 0 or 5.
 
-    For example, when people are asked their age, they might be more likely to report it as 30, 35, 40, etc., rather than the exact age of 31, 36, or 39.
+      For example, when people are asked their age, they might be more likely to report it as 30, 35, 40, etc., rather than the exact age of 31, 36, or 39.
 
-    The authors of this dataset use this “age heaping” to measure gender inequality in cognitive ability in quantitative reasoning, or “numeracy” and construct a database of age heaping-based estimates of basic numeracy with broad geographic and temporal coverage.
+      The authors of this dataset use this "age heaping" to measure gender inequality in cognitive ability in quantitative reasoning, or "numeracy" and construct a database of age heaping-based estimates of basic numeracy with broad geographic and temporal coverage.
 
-    The higher the measure of gender equality, the lower the share of women rounding up or down their age in comparison to men rounding up or down in a certain country. A positive (negative) gender equality index implies a female (male) numeracy advantage.
-
-wdir: ../../../data/snapshots/education/2023-08-09
+      The higher the measure of gender equality, the lower the share of women rounding up or down their age in comparison to men rounding up or down in a certain country. A positive (negative) gender equality index implies a female (male) numeracy advantage.
+    citation_full: Baten, J. (2013). Gender Equality of Numeracy via Clio Infra.
+    attribution_short: Clio Infra
+    url_main: https://clio-infra.eu/Indicators/GenderEqualityofNumeracy.html
+    url_download: https://clio-infra.eu/data/GenderEqualityofNumeracy_Compact.xlsx
+    date_accessed: '2023-08-09'
+    date_published: '2013-12-26'
+    license:
+      url: https://clio-infra.eu/index.html#about
 outs:
-- md5: ca448ee954bbd4566b4bacf788aca500
-  size: 200705
-  path: numeracy_gender.xlsx
+  - md5: ca448ee954bbd4566b4bacf788aca500
+    size: 200705
+    path: numeracy_gender.xlsx

--- a/snapshots/education/2023-08-09/years_of_education.xlsx.dvc
+++ b/snapshots/education/2023-08-09/years_of_education.xlsx.dvc
@@ -1,20 +1,22 @@
 meta:
-  name: Historical estimates of average years of education, 1870-2010 (OECD, 2013)
-  publication_year: 2013
-  publication_date: '2013-03-15'
-  source_name: van Zanden, J., et al. (2014) via OECD
-  source_published_by: 'van Zanden, J., et al. (eds.) (2014), How Was Life?: Global
-    Well-being since 1820, OECD Publishing, Paris, https://doi.org/10.1787/9789264214262-en.'
-  url: https://clio-infra.eu/Indicators/AverageYearsofEducation.html#
-  source_data_url: https://clio-infra.eu/data/AverageYearsofEducation_Compact.xlsx
-  license_url: https://www.oecd.org/termsandconditions/
-  license_name: 'Public access'
-  date_accessed: 2023-08-09
-  is_public: true
-  description: |
-    The average years of education in the total population aged 15 years and older is given for the period 1870-2010.
-wdir: ../../../data/snapshots/education/2023-08-09
+  origin:
+    producer: van Zanden et al.
+    title: Average years of education
+    description: |-
+      The average years of education in the total population aged 15 years and older is given for the period 1870-2010.
+    citation_full: |-
+      van Zanden, J., et al. (eds.) (2014), How Was Life?: Global Well-being since 1820, OECD Publishing, Paris, https://doi.org/10.1787/9789264214262-en.
+
+      van Leeuwen, Bas; van Leeuwen-Li, Jieli (2015). "Average Years of Education", https://hdl.handle.net/10622/KCBMKI, IISH Data Collection, V1.
+    attribution_short: Clio Infra
+    url_main: https://clio-infra.eu/Indicators/AverageYearsofEducation.html#
+    url_download: https://clio-infra.eu/data/AverageYearsofEducation_Compact.xlsx
+    date_accessed: '2023-08-09'
+    date_published: '2013-03-15'
+    license:
+      name: Public access
+      url: https://www.oecd.org/termsandconditions/
 outs:
-- md5: 435ef211f3dcd437702b8036407cc9cf
-  size: 219444
-  path: years_of_education.xlsx
+  - md5: 435ef211f3dcd437702b8036407cc9cf
+    size: 219444
+    path: years_of_education.xlsx

--- a/snapshots/education/2023-08-09/years_of_education_gender.xlsx.dvc
+++ b/snapshots/education/2023-08-09/years_of_education_gender.xlsx.dvc
@@ -1,20 +1,18 @@
 meta:
-  name: Historical estimates of gender equality of numeracy, 1850 -2000. (OECD, 2013)
-  publication_year: 2013
-  publication_date: '2013-03-18'
-  source_name: Clio Infra
-  source_published_by: van Leeuwen, B. and van Leeuwen-Li, J. (2013). Educational
-    Inequality Gini Coefficient via Clio Infra
-  url: https://clio-infra.eu/Indicators/EducationalInequalityGiniCoefficient.html
-  source_data_url: https://clio-infra.eu/data/GenderEqualityYearsofEducation_Compact.xlsx
-  license_url: https://www.oecd.org/termsandconditions/
-  license_name: ''
-  date_accessed: 2023-08-09
-  is_public: true
-  description: |
-    The Gini of the spread of education in the total population aged 15 years and older is given annually for the period 1850-2010 (the time period varies by country)
-wdir: ../../../data/snapshots/education/2023-08-09
+  origin:
+    producer: Carmichael et al.
+    title: Gender Equality Years of Education
+    description: |-
+      The Gini of the spread of education in the total population aged 15 years and older is given annually for the period 1850-2010 (the time period varies by country).
+    citation_full: 'Carmichael, Sarah; Dilli, Selin; Rijpma, Auke (2015). "Gender Equality Years of Education", https://hdl.handle.net/10622/OTHFUK, IISH Data Collection, V1.'
+    attribution_short: Clio Infra
+    url_main: https://clio-infra.eu/Indicators/EducationalInequalityGiniCoefficient.html
+    url_download: https://clio-infra.eu/data/GenderEqualityYearsofEducation_Compact.xlsx
+    date_accessed: '2023-08-09'
+    date_published: '2013-03-18'
+    license:
+      url: https://www.oecd.org/termsandconditions/
 outs:
-- md5: 1d06074c16e19058bf8fbfde21479a41
-  size: 39934
-  path: years_of_education_gender.xlsx
+  - md5: 1d06074c16e19058bf8fbfde21479a41
+    size: 39934
+    path: years_of_education_gender.xlsx

--- a/snapshots/education/2023-08-09/years_of_education_gini.xlsx.dvc
+++ b/snapshots/education/2023-08-09/years_of_education_gini.xlsx.dvc
@@ -1,21 +1,21 @@
 meta:
-  name: Historical estimates of Gini average years of education, 1870-2010
-  publication_year: 2013
-  publication_date: '2013-03-18'
-  source_name: van Leeuwen B., et al. (2013) via Clio Infra
-  source_published_by: van Leeuwen B., van Leeuwen-Li J., and Foldvari P. (2013) Educational
-    Inequality Gini Coefficient.
-  url: https://clio-infra.eu/Indicators/EducationalInequalityGiniCoefficient.html
-  source_data_url: https://clio-infra.eu/data/EducationalInequalityGiniCoefficient_Compact.xlsx
-  license_url: https://www.oecd.org/termsandconditions/
-  license_name: ''
-  date_accessed: 2023-08-09
-  is_public: true
-  description: |
-    The Gini of the spread of education in the total population aged 15 years and older is given annually for the period 1850-2010 (the time period varies by country).
+  origin:
+    producer: van Leeuwen et al.
+    title: Educational Inequality Gini Coefficient
+    description: |-
+      The Gini of the spread of education in the total population aged 15 years and older is given annually for the period 1850-2010 (the time period varies by country).
+    citation_full: |-
+      van Leeuwen, B., van Leeuwen-Li, J., and Foldvari, P. (2013). Educational Inequality Gini Coefficient.
 
-wdir: ../../../data/snapshots/education/2023-08-09
+      van Leeuwen, Bas; van Leeuwen-Li, Jieli (2015). "Educational Inequality Gini Coefficient", https://hdl.handle.net/10622/KORKQW, IISH Data Collection, V1.
+    attribution_short: Clio Infra
+    url_main: https://clio-infra.eu/Indicators/EducationalInequalityGiniCoefficient.html
+    url_download: https://clio-infra.eu/data/EducationalInequalityGiniCoefficient_Compact.xlsx
+    date_accessed: '2023-08-09'
+    date_published: '2013-03-18'
+    license:
+      url: https://www.oecd.org/termsandconditions/
 outs:
-- md5: b436fa558e084174f49316e8fa548e6e
-  size: 581921
-  path: years_of_education_gini.xlsx
+  - md5: b436fa558e084174f49316e8fa548e6e
+    size: 581921
+    path: years_of_education_gini.xlsx

--- a/snapshots/fasttrack/2022-11-01/lighting_efficiency_uk.csv.dvc
+++ b/snapshots/fasttrack/2022-11-01/lighting_efficiency_uk.csv.dvc
@@ -1,16 +1,13 @@
 meta:
-  source:
-    name: |-
-      Fouquet & Pearson (2006). Seven centuries of energy services: The price and use of light in the United Kingdom (1300-2000).
-    url: https://www.jstor.org/stable/23296980
-    source_data_url: |-
+  origin:
+    producer: Fouquet and Pearson
+    title: 'Seven centuries of energy services: The price and use of light in the United Kingdom (1300-2000)'
+    citation_full: 'Fouquet, R., & Pearson, P. J. (2006). Seven centuries of energy services: The price and use of light in the United Kingdom (1300-2000). The Energy Journal, 27(1).'
+    url_main: https://www.jstor.org/stable/23296980
+    url_download: |-
       gAAAAABnRYZlXxepMAB9sIKn_qv_qmZn_zxaLMC7r6W0Pm4yDGaffkjMBQa1ovpzqTVnmQFcclmueGVS_TPk9_ethfFaKeAVFo7yRlvM-T5Vn56IJP1ZDGZzGF1pZQtvwvsWCYq7O_ZzRq9mGI439QHZ5s-0oewSvJFcpvI_Nc1EqVdsO-Hyb3hKhvCdXuR5Sg_E0gtagMAeh0KT8kAYTIxfAVtj29fY5yVUXXQU76CEkSRtenAVfSYjMD7hwik8ZFaG-fS-XRrP
     date_accessed: '2024-11-26'
-    published_by: |-
-      Fouquet, R., & Pearson, P. J. (2006). Seven centuries of energy services: The price and use of light in the United Kingdom (1300-2000). The energy journal, 27(1).
-  name: Lighting efficiency and shares in the UK
-  description: ''
-  license: {}
+    date_published: '2006'
   is_public: false
 outs:
   - md5: 8de6c6871078ece444a6c927db29ad48

--- a/snapshots/fasttrack/2022-11-29/ai_index.csv.dvc
+++ b/snapshots/fasttrack/2022-11-29/ai_index.csv.dvc
@@ -1,17 +1,14 @@
 meta:
-  namespace: fasttrack
-  short_name: ai_index
-  name: DRAFT AI Index
-  description: ''
-  source_name: Google Sheet
-  url: ''
-  file_extension: csv
-  date_accessed: 2023-01-03
-  source_data_url: gAAAAABjtCoJsvAcFP0HlzzttugJ22k9uQxG_zI1RI2xwVQh0c5vMHtMqsOGl4K6uOZ_QCCXpzMOVGqBB-LWO1MggkfHb5gNl-CGzfe_SEK9Vt_qcAoGmQR4CVPG-7UUwQh04c_OHt9dIXZAePjkhnh39sF89K-1ugUX39JcKEWfOpf1sCEeCeHylAna-OYnbri77pNLSjiQKM2wSHWRrPbDXXYJhZCPGoLqEmuQcaHTX8ydP5EE3ou6hugAN7a845ixWU_U9DqM
+  origin:
+    producer: AI Index
+    title: AI Index report
+    citation_full: 'AI Index (2022). AI Index report. Stanford University.'
+    url_main: https://aiindex.stanford.edu/
+    url_download: gAAAAABjtCoJsvAcFP0HlzzttugJ22k9uQxG_zI1RI2xwVQh0c5vMHtMqsOGl4K6uOZ_QCCXpzMOVGqBB-LWO1MggkfHb5gNl-CGzfe_SEK9Vt_qcAoGmQR4CVPG-7UUwQh04c_OHt9dIXZAePjkhnh39sF89K-1ugUX39JcKEWfOpf1sCEeCeHylAna-OYnbri77pNLSjiQKM2wSHWRrPbDXXYJhZCPGoLqEmuQcaHTX8ydP5EE3ou6hugAN7a845ixWU_U9DqM
+    date_accessed: '2023-01-03'
+    date_published: '2022-11-29'
   is_public: false
-  version: '2022-11-29'
-wdir: ../../../data/snapshots/fasttrack/2022-11-29
 outs:
-- md5: f9eec66a29f9c4d60a34d520e04acba0
-  size: 199651
-  path: ai_index.csv
+  - md5: f9eec66a29f9c4d60a34d520e04acba0
+    size: 199651
+    path: ai_index.csv

--- a/snapshots/fasttrack/2023-01-03/long_term_homicide_rates_in_europe.csv.dvc
+++ b/snapshots/fasttrack/2023-01-03/long_term_homicide_rates_in_europe.csv.dvc
@@ -1,21 +1,19 @@
 meta:
-  source:
-    name: Eisner (2014)
-    url: https://www.hoplofobia.info/wp-content/uploads/2015/08/From-Swords-to-Words_Eisner2014.pdf
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vSqMi2AJyqA9BgjU-t149eZSOp6MIqN77JZOB2HRK_oQiqgLR7hfpk-gWx9YerWcYLTGww7DmqRU_Ho/pub?output=csv
+  origin:
+    producer: Eisner
+    title: 'From swords to words: Does macro-level change in self-control predict long-term variation in levels of homicide?'
+    description: |-
+      The homicide rate data shown here is taken from Table 4 on pages 80-81 in Eisner (2015). In the table homicide rate estimates are given for a range of years, we present data for the mid-point year here. For example, if data is given for 1200-1299 we show this as 1250.
+
+      Dataset notes:
+
+      - For 1775 and 1862 the data for Switzerland are for the canton of Zurich only.
+      - From 1825 onwards the estimates for Corsica and Sardinia are for Sardinia only.
+    citation_full: 'Eisner, M. (2014). From swords to words: Does macro-level change in self-control predict long-term variation in levels of homicide? In M. Tonry (Ed.), Why crime rates fall and why they don''t (Vol. 43, Crime and Justice: A review of research). Chicago: University of Chicago Press.'
+    url_main: https://www.hoplofobia.info/wp-content/uploads/2015/08/From-Swords-to-Words_Eisner2014.pdf
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vSqMi2AJyqA9BgjU-t149eZSOp6MIqN77JZOB2HRK_oQiqgLR7hfpk-gWx9YerWcYLTGww7DmqRU_Ho/pub?output=csv
     date_accessed: '2025-01-06'
-    published_by: |-
-      Eisner, M. 2014. “From Swords to Words: Does Macro-Level Change in Self-Control Predict Long-Term Variation in Levels of Homicide?” In Why Crime Rates Fall and Why They Don’t, edited by Michael Tonry. Vol. 43 of Crime and Justice: A Review of Research, edited by Michael Tonry. Chicago: University of Chicago Press.
-  name: Long-term homicide rates in Europe - Eisner (2014)
-  description: |-
-    The homicide rate data shown here is taken from Table 4 on pages 80-81 in Eisner (2015). In the table homicide rate estimates are given for a range of years, we present data for the mid-point year here. For example, if data is given for 1200-1299 we show this as 1250.
-
-    Dataset notes:
-
-    * For 1775 and 1862 the data for Switzerland are for the canton of Zurich only.
-    * From 1825 onwards the estimates for Corsica and Sardinia are for Sardinia only.
-  license: {}
+    date_published: '2014'
 outs:
   - md5: 878c6031c03234033459e3b11dc18658
     size: 3225

--- a/snapshots/fasttrack/2023-04-30/paratz.csv.dvc
+++ b/snapshots/fasttrack/2023-04-30/paratz.csv.dvc
@@ -1,18 +1,20 @@
 meta:
-  source:
-    name: Paratz et al., (2023)
-    url: https://www.heartrhythmjournal.com/article/S1547-5271(23)00027-9/fulltext
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vROXfyuCq1_aNHxIkLGOhbi9xZmVHFvPltm44VU__skPYh4Gn9ES8oLcgI8okIF7D4Sts_gjD9568_O/pub?output=csv
-    date_accessed: '2024-11-26'
-    publication_year: 2023
-    published_by: Heart Rhythm Journal
-  name: A systematic review of global autopsy rates in all-cause mortality and young sudden death, Paratz et al (2023)
-  description: |-
-    The data for this indicator is taken from: Paratz ED, Rowe SJ, Stub D, Pflaumer A, La Gerche A. A systematic review of global autopsy rates in all-cause mortality and young sudden death. Heart Rhythm. 2023 Apr;20(4):607-613. doi: 10.1016/j.hrthm.2023.01.008.
+  origin:
+    producer: Paratz et al.
+    title: A systematic review of global autopsy rates in all-cause mortality and young sudden death
+    description: |-
+      The data for this indicator is taken from: Paratz ED, Rowe SJ, Stub D, Pflaumer A, La Gerche A. A systematic review of global autopsy rates in all-cause mortality and young sudden death. Heart Rhythm. 2023 Apr;20(4):607-613. doi: 10.1016/j.hrthm.2023.01.008.
 
-    The data is collated from a number of published papers and databases. The year shown reflects the date given in the database or the year of the publication. For Spain and Australia the data is only representative of a region of each country, Catalonia and Victoria, respectively.
-  license: {}
+      Paratz et al., (2023) collates data from a number of published papers and databases, including journal articles, publicly available governmental datasets, press releases, newspaper articles, and annual reports. The year shown reflects the date given in the database or the year of the publication. For Spain and Australia the data is only representative of a region of each country, Catalonia and Victoria, respectively.
+    description_snapshot: |-
+      The data for the following countries is taken from Paratz et al., (2023):
+
+      Australia, Belgium, Bhutan, Brazil, Canada, China, Cote d'Ivoire, Cuba, France, Jamaica, Japan, Kuwait, New Zealand, Qatar, Saudi Arabia, South Africa, South Korea, Spain and United States.
+    citation_full: 'Paratz, E. D., Rowe, S. J., Stub, D., Pflaumer, A., & La Gerche, A. (2023). A systematic review of global autopsy rates in all-cause mortality and young sudden death. Heart Rhythm, 20(4), 607-613.'
+    url_main: https://www.heartrhythmjournal.com/article/S1547-5271(23)00027-9/fulltext
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vROXfyuCq1_aNHxIkLGOhbi9xZmVHFvPltm44VU__skPYh4Gn9ES8oLcgI8okIF7D4Sts_gjD9568_O/pub?output=csv
+    date_accessed: '2024-11-26'
+    date_published: '2023'
 outs:
   - md5: 14f4576ea63fda9388db9f2c3f596990
     size: 1110

--- a/snapshots/fasttrack/2023-05-03/apms_2014.csv.dvc
+++ b/snapshots/fasttrack/2023-05-03/apms_2014.csv.dvc
@@ -1,19 +1,18 @@
 meta:
-  source:
-    name: Adult Psychiatric Morbidity Survey 2014, England (2016)
-    url: https://www.gov.uk/government/statistics/adult-psychiatric-morbidity-survey-mental-health-and-wellbeing-england-2014
-    source_data_url: |-
+  origin:
+    producer: NHS Digital
+    title: 'Mental health and wellbeing in England: Adult Psychiatric Morbidity Survey 2014'
+    description: |-
+      This is a dataset of the prevalence of current depression in the general population in England, living in private households. Households were sampled randomly and individuals were interviewed using the revised Clinical Interview Schedule (CIS-R), which is a diagnostic structured interview format to determine whether people had common mental disorders in the past week. In this dataset, presence of a current episode of major depression was determined.
+    citation_full: 'McManus S, Bebbington P, Jenkins R, Brugha T. (eds.) (2016). Mental health and wellbeing in England: Adult Psychiatric Morbidity Survey 2014. Leeds: NHS Digital.'
+    url_main: https://www.gov.uk/government/statistics/adult-psychiatric-morbidity-survey-mental-health-and-wellbeing-england-2014
+    url_download: |-
       gAAAAABnRYjm-BZi3Nqs7In2gpZhuG03kWo5SiR_xJvXwncMzCmm--o4Z8FRFP55gIjTYun0AkKER23bHIUepBVraLszkW61lTi6JF3H7H0letw5MoLXJDe4S8UEwvkcq5h37pnxrcSJnzImSFrTQOuHF8l2kjJAF1QscQkYd_LGafvd9rWKkokdPPVLBf7iopl1gdm1gu7njbwKkauTdZyUbskGamH5fblFVs2LZv_GOGMQTv9yc4C-7dcXaRivHu-c-oU0j61D
     date_accessed: '2024-11-26'
-    publication_year: 2016
-    published_by: |-
-      "McManus S, Bebbington P, Jenkins R, Brugha T. (eds.) (2016) Mental health and wellbeing in England: Adult Psychiatric Morbidity Survey 2014. Leeds: NHS Digital"
-  name: Current depression in England by age and gender (APMS, 2014)
-  description: |-
-    This is a dataset of the prevalence of current depression in the general population in England, living in private households. Households were sampled randomly and individuals were interviewed using the revised Clinical Interview Schedule (CIS-R), which is a diagnostic structured interview format to determine whether people had common mental disorders in the past week. In this dataset, presence of a current episode of major depression was determined.
-  license:
-    name: Open Government Licence v3.0
-    url: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
+    date_published: '2016'
+    license:
+      name: Open Government Licence v3.0
+      url: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
   is_public: false
 outs:
   - md5: 7a42c7cee959d16ae9d981f4b8b7ade1

--- a/snapshots/fasttrack/2023-05-31/cholera.csv.dvc
+++ b/snapshots/fasttrack/2023-05-31/cholera.csv.dvc
@@ -1,27 +1,32 @@
 meta:
-  source:
-    name: World Health Organization (2023)
-    url: nan
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vSlmIK_QFOjnb3DSPq6AoEeVFCPhsvKBE4yiUKrOogGhyu98SqoJutDR_3CEI43nvslvYIcJjICn-qI/pub?output=csv
+  origin:
+    producer: World Health Organization
+    title: Cholera reported cases, deaths and case fatality rate
+    description: |-
+      The data is created by combining multiple WHO Weekly Epidemiological Reports for cholera reported cases, deaths and case fatality rate.
+
+      The reports for the years 2017-2021 can be found at:
+
+      2017: https://web.archive.org/web/20230328164426/https://apps.who.int/iris/bitstream/handle/10665/274655/WER9338-489-497.pdf?sequence=1&isAllowed=y
+
+      2018: https://web.archive.org/web/20230601084841/https://apps.who.int/iris/bitstream/handle/10665/330005/WER9448-561-568-eng-fre.pdf?sequence=1&isAllowed=y
+
+      2019: https://web.archive.org/web/20221007234707/http://apps.who.int/iris/bitstream/handle/10665/334242/WER9537-441-448-eng-fre.pdf?sequence=1&isAllowed=y
+
+      2020: https://web.archive.org/web/20230326231135/http://apps.who.int/iris/bitstream/handle/10665/345271/WER9637-445-454-eng-fre.pdf?sequence=1&isAllowed=y
+
+      2021: https://web.archive.org/web/20230526223955/https://apps.who.int/iris/bitstream/handle/10665/362858/WER9737-453-464-eng-fre.pdf?sequence=1&isAllowed=y
+    description_snapshot: |-
+      Our World in Data combines this dataset with the WHO Global Health Observatory cholera series. The Global Health Observatory cholera data is sourced from there for all years up to and including 2016.
+    citation_full: World Health Organization (2023). Cholera reported cases, deaths and case fatality rate. WHO Weekly Epidemiological Reports.
+    attribution_short: WHO
+    url_main: https://www.who.int/publications/journals/weekly-epidemiological-record
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vSlmIK_QFOjnb3DSPq6AoEeVFCPhsvKBE4yiUKrOogGhyu98SqoJutDR_3CEI43nvslvYIcJjICn-qI/pub?output=csv
     date_accessed: '2024-11-26'
-    published_by: World Health Organization
-  name: Cholera reported cases, deaths and case fatality rate (WHO, 2023)
-  description: |-
-    The data is created by combining multiple WHO Weekly Epidemiological Reports for cholera reported cases, deaths and case fatality rate.
-
-    The reports for the years 2017-2021 can be found at:
-
-    2017: https://web.archive.org/web/20230328164426/https://apps.who.int/iris/bitstream/handle/10665/274655/WER9338-489-497.pdf?sequence=1&isAllowed=y
-
-    2018: https://web.archive.org/web/20230601084841/https://apps.who.int/iris/bitstream/handle/10665/330005/WER9448-561-568-eng-fre.pdf?sequence=1&isAllowed=y
-
-    2019: https://web.archive.org/web/20221007234707/http://apps.who.int/iris/bitstream/handle/10665/334242/WER9537-441-448-eng-fre.pdf?sequence=1&isAllowed=y
-
-    2020: https://web.archive.org/web/20230326231135/http://apps.who.int/iris/bitstream/handle/10665/345271/WER9637-445-454-eng-fre.pdf?sequence=1&isAllowed=y
-
-    2021: https://web.archive.org/web/20230526223955/https://apps.who.int/iris/bitstream/handle/10665/362858/WER9737-453-464-eng-fre.pdf?sequence=1&isAllowed=y
-  license: {}
+    date_published: '2023'
+    license:
+      name: Attribution 4.0 International (CC BY 4.0)
+      url: https://cdn.who.int/media/docs/default-source/publishing-policies/data-policy/who-policy-on-use-and-sharing-of-data-collected-in-member-states-outside-phe_en.pdf?sfvrsn=713112d4_27
 outs:
   - md5: 39d2f683da32e151413ab8d2dbfc7582
     size: 4141

--- a/snapshots/fasttrack/2023-06-19/world_population_comparison.csv.dvc
+++ b/snapshots/fasttrack/2023-06-19/world_population_comparison.csv.dvc
@@ -1,30 +1,32 @@
 meta:
-  source:
-    name: Multiple sources compiled by Our World in Data (2019)
-    url: nan
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vQjyo0SCpkP7gW490fsxx2x0nkCPqW3elr5LfI-zbFWkb1rzOAumgJrEDO0eFpoEtPsZyHjIM58iXDe/pub?output=csv
+  origin:
+    producer: Various sources
+    title: Historical world population comparison
+    description: |-
+      Among others these are the original source:
+
+      McEvedy, Colin and Richard Jones, 1978, "Atlas of World Population History," Facts on File, New York, pp. 342-351.
+
+      Biraben, Jean-Noel, 1980, An Essay Concerning Mankind's Evolution, Population, Selected Papers, December, table 2.
+
+      Durand, John D., 1974, "Historical Estimates of World Population: An Evaluation," University of Pennsylvania, Population Center, Analytical and Technical Reports, Number 10, table 2.
+
+      Haub, Carl, 1995, "How Many People Have Ever Lived on Earth?" Population Today, February, p. 5.
+
+      Thomlinson, Ralph, 1975, "Demographic Problems, Controversy Over Population Control," Second Edition, Table 1.
+
+      United Nations, 1999, The World at Six Billion, Table 1, "World Population From" Year 0 to Stabilization, p. 5,
+      U.S. Census Bureau (USCB), 2012, Total Midyear Population for the World: 1950-2050.
+
+      Michael Kremer (1993) "Population Growth and Technological Change: One Million B.C. to 1990", Quarterly Journal of Economics., August 1993, pp.681-716.
+
+      Klein Goldewijk K, Beusen A, Janssen P (2010) "Long term dynamic modeling of global population and built-up area in a spatially explicit way: HYDE 3.1". The Holocene 20:565-573.
+    citation_full: Multiple sources compiled by Our World in Data (2019). Historical world population comparison.
+    attribution: Multiple sources compiled by Our World in Data (2019)
+    url_main: https://docs.google.com/spreadsheets/d/e/2PACX-1vQjyo0SCpkP7gW490fsxx2x0nkCPqW3elr5LfI-zbFWkb1rzOAumgJrEDO0eFpoEtPsZyHjIM58iXDe/pub
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vQjyo0SCpkP7gW490fsxx2x0nkCPqW3elr5LfI-zbFWkb1rzOAumgJrEDO0eFpoEtPsZyHjIM58iXDe/pub?output=csv
     date_accessed: '2024-12-02'
-    published_by: Multiple sources compiled by Our World in Data (2019)
-  name: Historical world population comparison (various sources)
-  description: |-
-    Among others these are the original source:
-
-    McEvedy, Colin and Richard Jones, 1978, “Atlas of World Population History,” Facts on File, New York, pp. 342-351.
-
-    Biraben, Jean-Noel, 1980, An Essay Concerning Mankind’s Evolution, Population, Selected Papers, December, table 2.
-
-    Durand, John D., 1974, “Historical Estimates of World Population: An Evaluation,” University of Pennsylvania, Population Center, Analytical and Technical Reports, Number 10, table 2.
-
-    Haub, Carl, 1995, “How Many People Have Ever Lived on Earth?” Population Today, February, p. 5.
-
-    Thomlinson, Ralph, 1975, “Demographic Problems, Controversy Over Population Control,” Second Edition, Table 1.
-
-    United Nations, 1999, The World at Six Billion, Table 1, “World Population From” Year 0 to Stabilization, p. 5,
-    U.S. Census Bureau (USCB), 2012, Total Midyear Population for the World: 1950-2050.
-
-    Michael Kremer (1993) “Population Growth and Technological Change: One Million B.C. to 1990”, Quarterly Journal of Economics., August 1993, pp.681-716.
-  license: {}
+    date_published: '2019'
 outs:
   - md5: f7ff2acb39ad85d3a9b2599a63175abc
     size: 13424

--- a/snapshots/fasttrack/2023-08-07/pain_hours_days_hen_systems.csv.dvc
+++ b/snapshots/fasttrack/2023-08-07/pain_hours_days_hen_systems.csv.dvc
@@ -1,15 +1,12 @@
 meta:
-  source:
-    name: Welfare Footprint based on Schuck-Paim and Alonso (2021)
-    url: https://welfarefootprint.org/research-projects/laying-hens/
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vRioMTHFwUUiCe2JWDOAZD7BDur4MSx3o576xfvTROzUY75sxIYqOZuIWQw_lopGkrLQ_lgXxMRgAk2/pub?output=csv
+  origin:
+    producer: Welfare Footprint
+    title: Pain hours and days of hen systems
+    citation_full: Welfare Footprint based on Schuck-Paim, C. and Alonso, W. J. (2021). Quantifying Pain in Laying Hens.
+    url_main: https://welfarefootprint.org/research-projects/laying-hens/
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vRioMTHFwUUiCe2JWDOAZD7BDur4MSx3o576xfvTROzUY75sxIYqOZuIWQw_lopGkrLQ_lgXxMRgAk2/pub?output=csv
     date_accessed: '2024-11-26'
-    publication_year: 2021
-    published_by: Welfare Footprint
-  name: Pain hours and days of hen systems (Welfare Footprint)
-  description: ''
-  license: {}
+    date_published: '2021'
 outs:
   - md5: 2053ef477157266c201a9c39c46a8df8
     size: 459

--- a/snapshots/fasttrack/2023-10-05/great_pacific_garbage_lebreton.csv.dvc
+++ b/snapshots/fasttrack/2023-10-05/great_pacific_garbage_lebreton.csv.dvc
@@ -1,16 +1,12 @@
 meta:
-  source:
-    name: Plastics in Great Pacific Garbage Patch (Lebreton et al. 2022)
-    url: https://www.nature.com/articles/s41598-022-16529-0
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vShK8-lh5FUIl954ziCnKzkt9N3B5IdxAxk9mh-QhufRD-SuovXXLKjbQtq8g40yzUbHIPWRVLuVzKZ/pub?output=csv
+  origin:
+    producer: Lebreton et al.
+    title: Industrialised fishing nations largely contribute to floating plastic pollution in the North Pacific subtropical gyre
+    citation_full: Lebreton et al. (2022). Industrialised fishing nations largely contribute to floating plastic pollution in the North Pacific subtropical gyre. Nature Scientific Reports.
+    url_main: https://www.nature.com/articles/s41598-022-16529-0
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vShK8-lh5FUIl954ziCnKzkt9N3B5IdxAxk9mh-QhufRD-SuovXXLKjbQtq8g40yzUbHIPWRVLuVzKZ/pub?output=csv
     date_accessed: '2024-11-26'
-    publication_year: 2022
-    published_by: |-
-      Lebreton et al. (2022). Industrialised fishing nations largely contribute to floating plastic pollution in the North Pacific subtropical gyre. Nature Scientific Reports.
-  name: Plastics in Great Pacific Garbage Patch (Lebreton)
-  description: ''
-  license: {}
+    date_published: '2022'
 outs:
   - md5: 96e4d3017bd50b72a8bd267198ab1971
     size: 338

--- a/snapshots/fasttrack/2024-06-17/guinea_worm.csv.dvc
+++ b/snapshots/fasttrack/2024-06-17/guinea_worm.csv.dvc
@@ -1,38 +1,36 @@
 meta:
-  source:
-    name: World Health Organization
-    url: https://www.who.int/teams/control-of-neglected-tropical-diseases/dracunculiasis/dracunculiasis-eradication-portal
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vQxUg_FPFYvf4Uzc1rH6k_T6JaP2pmlVkBNpPnDiWpMaCTdqT_wkiaQ1rOgUIntSMx5VpILVn5hZ98D/pub?output=csv
+  origin:
+    producer: World Health Organization
+    title: Guinea worm cases
+    description: |-
+      Reported cases of guinea worm disease (dracunculiasis) as recorded by WHO.
+
+      For Cameroon, Central African Republic, Cote d'Ivoire, Mauritania, Senegal and Yemen data is gathered from:
+
+      1986-2017: https://web.archive.org/web/20220208133814/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_i2.html
+      2018: Table 1a: https://web.archive.org/web/20230629130727/https://apps.who.int/iris/bitstream/handle/10665/324786/WER9420-233-251.pdf?sequence=1&isAllowed=y
+      2019: Table 1a: https://web.archive.org/web/20230629130619/https://apps.who.int/iris/bitstream/handle/10665/332086/WER9520-209-227-eng-fre.pdf?sequence=1&isAllowed=y
+      2020: Table 1a: https://web.archive.org/web/20230226162934/https://apps.who.int/iris/bitstream/handle/10665/341529/WER9621-173-194-eng-fre.pdf?sequence=1&isAllowed=y
+      2021: Table 1a: https://web.archive.org/web/20230226163027/https://apps.who.int/iris/bitstream/handle/10665/354576/WER9721-22-225-247-eng-fre.pdf?sequence=1&isAllowed=y
+      2022: Table 1a: https://web.archive.org/web/20230629124651/https://apps.who.int/iris/bitstream/handle/10665/367924/WER9820-205-224.pdf?sequence=1&isAllowed=y
+
+      For all other countries data is gathered from the following sources:
+
+      1980-2020: https://www.who.int/teams/control-of-neglected-tropical-diseases/dracunculiasis/dracunculiasis-eradication-portal
+      2021: Table 1a: https://web.archive.org/web/20230226163027/https://apps.who.int/iris/bitstream/handle/10665/354576/WER9721-22-225-247-eng-fre.pdf?sequence=1&isAllowed=y
+      2022: Table 1a: https://web.archive.org/web/20230629124651/https://apps.who.int/iris/bitstream/handle/10665/367924/WER9820-205-224.pdf?sequence=1&isAllowed=y
+      2023: Table 1a: https://iris.who.int/bitstream/handle/10665/376790/WER9920-249-269.pdf?sequence=1
+
+      Global totals are calculated yearly as the sum of the number of reported cases in each country.
+    citation_full: World Health Organization (2024). Dracunculiasis Eradication Portal.
+    attribution_short: WHO
+    url_main: https://www.who.int/teams/control-of-neglected-tropical-diseases/dracunculiasis/dracunculiasis-eradication-portal
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vQxUg_FPFYvf4Uzc1rH6k_T6JaP2pmlVkBNpPnDiWpMaCTdqT_wkiaQ1rOgUIntSMx5VpILVn5hZ98D/pub?output=csv
     date_accessed: '2024-06-17'
-    published_by: Dracunculiasis Eradication Portal
-  name: Guinea worm cases (WHO, 2024)
-  description: |-
-    Reported cases of guinea worm disease (dracunculiasis) as recorded by WHO.
-
-    For Cameroon, Central African Republic, Cote d'Ivoire, Mauritania, Senegal and Yemen data is gathered from:
-
-    1986-2017: https://web.archive.org/web/20220208133814/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_i2.html
-    2018: Table 1a: https://web.archive.org/web/20230629130727/https://apps.who.int/iris/bitstream/handle/10665/324786/WER9420-233-251.pdf?sequence=1&isAllowed=y
-    2019: Table 1a: https://web.archive.org/web/20230629130619/https://apps.who.int/iris/bitstream/handle/10665/332086/WER9520-209-227-eng-fre.pdf?sequence=1&isAllowed=y
-    2020: Table 1a: https://web.archive.org/web/20230226162934/https://apps.who.int/iris/bitstream/handle/10665/341529/WER9621-173-194-eng-fre.pdf?sequence=1&isAllowed=y
-    2021: Table 1a: https://web.archive.org/web/20230226163027/https://apps.who.int/iris/bitstream/handle/10665/354576/WER9721-22-225-247-eng-fre.pdf?sequence=1&isAllowed=y
-    2022: Table 1a: https://web.archive.org/web/20230629124651/https://apps.who.int/iris/bitstream/handle/10665/367924/WER9820-205-224.pdf?sequence=1&isAllowed=y
-
-    For all other countries data is gathered from the following sources:
-
-    1980-2020: https://www.who.int/teams/control-of-neglected-tropical-diseases/dracunculiasis/dracunculiasis-eradication-portal
-    2021: Table 1a: https://web.archive.org/web/20230226163027/https://apps.who.int/iris/bitstream/handle/10665/354576/WER9721-22-225-247-eng-fre.pdf?sequence=1&isAllowed=y
-    2022: Table 1a: https://web.archive.org/web/20230629124651/https://apps.who.int/iris/bitstream/handle/10665/367924/WER9820-205-224.pdf?sequence=1&isAllowed=y
-    2023: Table 1a: https://iris.who.int/bitstream/handle/10665/376790/WER9920-249-269.pdf?sequence=1
-
-    Global totals are calculated yearly as the sum of the number of reported cases in each country.
-  license:
-    name: CC BY-NC-SA 3.0 IGO
-    url: https://www.who.int/about/policies/publishing/copyright
-
-
-
+    date_published: '2024'
+    license:
+      name: CC BY-NC-SA 3.0 IGO
+      url: https://www.who.int/about/policies/publishing/copyright
 outs:
   - md5: ad470e933652da5616882e1e9140665d
     size: 13383

--- a/snapshots/fasttrack/latest/baxter_2013_gbd_adult_coverage.csv.dvc
+++ b/snapshots/fasttrack/latest/baxter_2013_gbd_adult_coverage.csv.dvc
@@ -1,22 +1,19 @@
 meta:
-  source:
-    name: Baxter et al. (2013)
-    url: https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0065514
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vTc9pnvq5Q4ztKjTXZEH0l0DeExyf3u074L7z4DLZF-X8mK1aV439ejXQl-Ji85mjhCCc0F82TI8aNj/pub?output=csv
+  origin:
+    producer: Baxter et al.
+    title: 'Global epidemiology of mental disorders: what are we missing?'
+    description: |-
+      This dataset shows the coverage of each country for which mental health data has been collected, by age and sex, between 1980 and 2008 using DSM or ICD diagnostic criteria. For example, if mental health data has been collected for men and women across all adult age groups from a country, then its coverage would be given as 100%. Mental health data was defined as any studies on disease epidemiology in the general population. For schizophrenia, bipolar disorder and eating disorder, this also included remission and mortality studies based on clinical samples with naturalistic follow-up, due to a lack of community studies on the topic. For studies with subnational data, coverage was considered as the population coverage of that subnational region, then the population of that subnational region relative to the country. These were calculated for GBD world regions.
+    citation_full: 'Baxter, A. J., Patton, G., Scott, K. M., Degenhardt, L., & Whiteford, H. A. (2013). Global Epidemiology of Mental Disorders: What Are We Missing? PLoS ONE, 8(6), e65514.'
+    url_main: https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0065514
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vTc9pnvq5Q4ztKjTXZEH0l0DeExyf3u074L7z4DLZF-X8mK1aV439ejXQl-Ji85mjhCCc0F82TI8aNj/pub?output=csv
     date_accessed: '2024-02-14'
-    publication_year: '2013'
-    published_by: |-
-      Baxter, A. J., Patton, G., Scott, K. M., Degenhardt, L., & Whiteford, H. A. (2013). Global Epidemiology of Mental Disorders: What Are We Missing? PLoS ONE, 8(6), e65514
-  name: Adult coverage in prevalence studies of mental disorders in GBD 2010 (Baxter
-    et al., 2013)
-  description: |-
-    This dataset shows the coverage of each country for which mental health data has been collected, by age and sex, between 1980 and 2008 using DSM or ICD diagnostic criteria. For example, if mental health data has been collected for men and women across all adult age groups from a country, then its coverage would be given as 100%. Mental health data was defined as any studies on disease epidemiology in the general population. For schizophrenia, bipolar disorder and eating disorder, this also included remission and mortality studies based on clinical samples with naturalistic follow-up, due to a lack of community studies on the topic. For studies with subnational data, coverage was considered as the population coverage of that subnational region, then the population of that subnational region relative to the country. These were calculated for GBD world regions.
-  license:
-    name: Open access
-    url: https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0065514
+    date_published: '2013'
+    license:
+      name: Open access
+      url: https://journals.plos.org/plosone/article?id=10.1371/journal.pone.0065514
 wdir: ../../../data/snapshots/fasttrack/latest
 outs:
-- md5: ee8edcf104c5049e9d10f7316c577a2d
-  size: 1165
-  path: baxter_2013_gbd_adult_coverage.csv
+  - md5: ee8edcf104c5049e9d10f7316c577a2d
+    size: 1165
+    path: baxter_2013_gbd_adult_coverage.csv

--- a/snapshots/fasttrack/latest/biosafety_level_4_facilities.csv.dvc
+++ b/snapshots/fasttrack/latest/biosafety_level_4_facilities.csv.dvc
@@ -1,18 +1,15 @@
 meta:
-  namespace: fasttrack
-  short_name: biosafety_level_4_facilities
-  file_extension: csv
-  date_accessed: 2023-03-01
+  origin:
+    producer: Unknown
+    title: Unknown
+    version_producer: Local CSV
+    url_download: gAAAAABj_xXoidWko-sw03skrCdO_qB6qpDQ-JfjIDpmcbo5ueW9rJdxYg8_SzGIzYgiC5P8UW7pEj5TEStcSCHxq_qlQQH3yQ==
+    date_accessed: '2023-03-01'
+    date_published: '2023'
   name: DRAFT Biosafety level 4 facilities
   description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABj_xXoidWko-sw03skrCdO_qB6qpDQ-JfjIDpmcbo5ueW9rJdxYg8_SzGIzYgiC5P8UW7pEj5TEStcSCHxq_qlQQH3yQ==
   is_public: false
-  version: latest
-wdir: ../../../data/snapshots/fasttrack/latest
 outs:
-- md5: 01bf4be498a35d1b9a50d8e9ba517e6f
-  size: 410
-  path: biosafety_level_4_facilities.csv
+  - md5: 01bf4be498a35d1b9a50d8e9ba517e6f
+    size: 410
+    path: biosafety_level_4_facilities.csv

--- a/snapshots/fasttrack/latest/compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp.csv.dvc
+++ b/snapshots/fasttrack/latest/compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp.csv.dvc
@@ -1,16 +1,13 @@
 meta:
-  namespace: fasttrack
-  short_name: compare_wid_and_pip_change_in_inequality_1993_vs_2015__joe_temp
-  file_extension: csv
-  date_accessed: 2023-04-19
-  name: DRAFT Compare WID and PIP CHANGE in inequality 1993 vs 2015 (Joe temp)
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABkQGjg8pZBg8WMNZUv2EasjfCdgUz5BsZx3qHgkWANzLpoAI75wEHzixo6ZJI28uSItJ4E3OYryQBFdXDUohCjH9yhTQ==
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: Unknown.
+    version_producer: Local CSV
+    url_download: gAAAAABkQGjg8pZBg8WMNZUv2EasjfCdgUz5BsZx3qHgkWANzLpoAI75wEHzixo6ZJI28uSItJ4E3OYryQBFdXDUohCjH9yhTQ==
+    date_accessed: '2023-04-19'
+    date_published: '2023'
   is_public: false
-  version: latest
 wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: 82da9221c1216a5531ebc6f4b1957d55

--- a/snapshots/fasttrack/latest/compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp.csv.dvc
+++ b/snapshots/fasttrack/latest/compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp.csv.dvc
@@ -1,16 +1,13 @@
 meta:
-  namespace: fasttrack
-  short_name: compare_wid_and_pip_inequality_data_1980_vs_2018__joe_temp
-  file_extension: csv
-  date_accessed: 2023-04-18
-  name: DRAFT Compare WID and PIP inequality data 1980 vs 2018 (Joe temp)
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABkPnvjWjkvLdUrfVlCfL7LlME4D9o29z3V_9ugnqMLIGzV_z-9UedVSfUjHrVKypEPt7Lj4u8Y3KMqG1lAQBfhpkYbVg==
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: Unknown.
+    version_producer: Local CSV
+    url_download: gAAAAABkPnvjWjkvLdUrfVlCfL7LlME4D9o29z3V_9ugnqMLIGzV_z-9UedVSfUjHrVKypEPt7Lj4u8Y3KMqG1lAQBfhpkYbVg==
+    date_accessed: '2023-04-18'
+    date_published: '2023'
   is_public: false
-  version: latest
 wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: ff3a6e764ec49942e727fe73e207d705

--- a/snapshots/fasttrack/latest/compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp.csv.dvc
+++ b/snapshots/fasttrack/latest/compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp.csv.dvc
@@ -1,16 +1,13 @@
 meta:
-  namespace: fasttrack
-  short_name: compare_wid_and_pip_inequality_data_1993_vs_2015__joe_temp
-  file_extension: csv
-  date_accessed: 2023-04-18
-  name: DRAFT Compare WID and PIP inequality data 1993 vs 2015 (Joe temp)
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABkPnwc8rglwdJVaxQSw95w4M6T348j4H0wGDjvVfpZZ8BYK_uOztpuHa_k2PTszwKQpZm0B4fXtUmLlokW7K73lNod4g==
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: Unknown.
+    version_producer: Local CSV
+    url_download: gAAAAABkPnwc8rglwdJVaxQSw95w4M6T348j4H0wGDjvVfpZZ8BYK_uOztpuHa_k2PTszwKQpZm0B4fXtUmLlokW7K73lNod4g==
+    date_accessed: '2023-04-18'
+    date_published: '2023'
   is_public: false
-  version: latest
 wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: 7681d711badc9b36d770f850a8cb2103

--- a/snapshots/fasttrack/latest/democracy_freedom_house.csv.dvc
+++ b/snapshots/fasttrack/latest/democracy_freedom_house.csv.dvc
@@ -1,19 +1,18 @@
 meta:
-  source:
-    name: Freedom House (2023)
-    url: https://freedomhouse.org/report/freedom-world
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vRXOAxs_t6f-Y3kMGmKc0trQiH2PMWjOxxlHZ1uKd88g_sFMq1zvgaeGO3G15lJdSixh9dCIIqUcBHI/pub?output=csv
+  origin:
+    producer: Freedom House
+    title: Freedom in the World
+    description: |-
+      This dataset provides information on political regimes, using data from Freedom House's Freedom in the World (2023).
+
+      You can read a description of the data in this post: https://ourworldindata.org/democracies-measurement
+
+      You can download the code and complete dataset, including supplementary variables, from GitHub: https://github.com/owid/notebooks/tree/main/BastianHerre/democracy
+    citation_full: Freedom House (2023). Freedom in the World.
+    url_main: https://freedomhouse.org/report/freedom-world
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vRXOAxs_t6f-Y3kMGmKc0trQiH2PMWjOxxlHZ1uKd88g_sFMq1zvgaeGO3G15lJdSixh9dCIIqUcBHI/pub?output=csv
     date_accessed: '2024-11-26'
-    published_by: Freedom House (2023). Freedom in the World.
-  name: Democracy - Freedom House (2023)
-  description: |-
-    This dataset provides information on political regimes, using data from Freedom House's Freedom in the World (2023).
-
-    You can read a description of the data in this post: https://ourworldindata.org/democracies-measurement
-
-    You can download the code and complete dataset, including supplementary variables, from GitHub: https://github.com/owid/notebooks/tree/main/BastianHerre/democracy
-  license: {}
+    date_published: '2023'
 outs:
   - md5: 8c5d63ec87bb5475b75de261d7e32a73
     size: 629913

--- a/snapshots/fasttrack/latest/evs_per_charger.csv.dvc
+++ b/snapshots/fasttrack/latest/evs_per_charger.csv.dvc
@@ -1,17 +1,14 @@
 meta:
-  namespace: fasttrack
-  short_name: evs_per_charger
-  file_extension: csv
-  date_accessed: 2023-03-31
-  name: DRAFT EVs per charger
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABkJl_u4p5nY0tJr6_X8fck-rhJ8ZNF4kIgerQ-h5cqf218uYplccqfBPndCtxv01c8o2qCgTKL3iMfgFOnot_WtsvZ6g==
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: DRAFT EVs per charger.
+    attribution_short: DRAFT EVs per charger
+    version_producer: Local CSV
+    url_download: gAAAAABkJl_u4p5nY0tJr6_X8fck-rhJ8ZNF4kIgerQ-h5cqf218uYplccqfBPndCtxv01c8o2qCgTKL3iMfgFOnot_WtsvZ6g==
+    date_accessed: '2023-03-31'
+    date_published: '2023'
   is_public: false
-  version: latest
-wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: 9dd92eeb66256559bdb6f11257080847
   size: 31298

--- a/snapshots/fasttrack/latest/gbd_2019_mental_health_country_coverage.csv.dvc
+++ b/snapshots/fasttrack/latest/gbd_2019_mental_health_country_coverage.csv.dvc
@@ -1,20 +1,21 @@
 meta:
-  source:
-    name: IHME GBD (2019)
-    url: https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(20)30925-9/fulltext
-    source_data_url: |-
-      gAAAAABnRYlazzL_oEfuzBXSmjRVB2Y_aOmXSCAXVYIW_72BvzIYsW9GUt8OjdfLueLZUKFP-ZGq7e8B19xEzO3nPErc9S9x8w5MaFQeUEEwgZHOHjHGCjfOxrcUDXEQ-RyBwZuKmo7Ngy5dTDkh_sza4x9FOhmx5yUB25NI0TKhPhkPxrC_AIads-3sWMviypayPf_OebJnlMZUgRBEnRYqUH5sGcQTZvpi2ixly61NvwF_oU1_8FZL8iyj9mDiUvBP-kpERU3L
-    date_accessed: '2024-11-26'
-    publication_year: 2020
-    published_by: |-
-      Vos, T., Lim, S. S., Abbafati, C., Abbas, K. M., Abbasi, M., Abbasifard, M., Abbasi-Kangevari, M., Abbastabar, H., Abd-Allah, F., Abdelalim, A., Abdollahi, M., Abdollahpour, I., Abolhassani, H., Aboyans, V., Abrams, E. M., Abreu, L. G., Abrigo, M. R. M., Abu-Raddad, L. J., Abushouk, A. I., … Murray, C. J. L. (2020). Global burden of 369 diseases and injuries in 204 countries and territories, 1990–2019: A systematic analysis for the Global Burden of Disease Study 2019. The Lancet, 396(10258), 1204–1222.
-  name: Countries with mental health data in GBD 2019
-  description: |-
-    Dataset showing the number of countries with primary data on the prevalence of mental illnesses. These were found after a systematic review, grey literature search and expert consultation, to identify studies with data on the prevalence of each mental illness.
+  origin:
+    producer: IHME, Global Burden of Disease
+    title: Global Burden of Disease Study
+    description: |-
+      Dataset showing the number of countries with primary data on the prevalence of mental illnesses. These were found after a systematic review, grey literature search and expert consultation, to identify studies with data on the prevalence of each mental illness.
 
-    'The GBD inclusion criteria stipulated that: (1) the diagnostic criteria must be from 1980 onward; (2) “caseness” must be based on clinical threshold as established by the DSM, ICD, Chinese Classification of Mental Disorders (CCMD), or diagnosed by a clinician using established tools; (3) sufficient information must be provided on study method and sample characteristics to assess the quality of the study; and (4) study samples must be representative of the general population (i.e., case studies, veterans, or refugee samples were excluded). No limitation was set on the language of publication.'
-  license:
-    url: https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(20)30925-9/fulltext
+      'The GBD inclusion criteria stipulated that: (1) the diagnostic criteria must be from 1980 onward; (2) "caseness" must be based on clinical threshold as established by the DSM, ICD, Chinese Classification of Mental Disorders (CCMD), or diagnosed by a clinician using established tools; (3) sufficient information must be provided on study method and sample characteristics to assess the quality of the study; and (4) study samples must be representative of the general population (i.e., case studies, veterans, or refugee samples were excluded). No limitation was set on the language of publication.'
+    title_snapshot: Global Burden of Disease Study - Countries with mental health data in GBD 2019
+    citation_full: 'Vos, T., Lim, S. S., Abbafati, C., Abbas, K. M., Abbasi, M., Abbasifard, M., Abbasi-Kangevari, M., Abbastabar, H., Abd-Allah, F., Abdelalim, A., Abdollahi, M., Abdollahpour, I., Abolhassani, H., Aboyans, V., Abrams, E. M., Abreu, L. G., Abrigo, M. R. M., Abu-Raddad, L. J., Abushouk, A. I., … Murray, C. J. L. (2020). Global burden of 369 diseases and injuries in 204 countries and territories, 1990–2019: A systematic analysis for the Global Burden of Disease Study 2019. The Lancet, 396(10258), 1204–1222.'
+    attribution_short: IHME GBD
+    version_producer: GBD 2019
+    url_main: https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(20)30925-9/fulltext
+    url_download: gAAAAABnRYlazzL_oEfuzBXSmjRVB2Y_aOmXSCAXVYIW_72BvzIYsW9GUt8OjdfLueLZUKFP-ZGq7e8B19xEzO3nPErc9S9x8w5MaFQeUEEwgZHOHjHGCjfOxrcUDXEQ-RyBwZuKmo7Ngy5dTDkh_sza4x9FOhmx5yUB25NI0TKhPhkPxrC_AIads-3sWMviypayPf_OebJnlMZUgRBEnRYqUH5sGcQTZvpi2ixly61NvwF_oU1_8FZL8iyj9mDiUvBP-kpERU3L
+    date_accessed: '2024-11-26'
+    date_published: '2020'
+    license:
+      url: https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(20)30925-9/fulltext
   is_public: false
 outs:
   - md5: f972f0ff8f16acaf3af8c63d4e880e96

--- a/snapshots/fasttrack/latest/global_maternal_offspring_loss.csv.dvc
+++ b/snapshots/fasttrack/latest/global_maternal_offspring_loss.csv.dvc
@@ -1,17 +1,14 @@
 meta:
-  source:
-    name: Smith-Greenaway et al. (2021)
-    url: https://gh.bmj.com/content/6/4/e004837.abstract
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vSiCgGTJ8kXoVPpaaskyRz79os2jbWtLbcqk18ybEXI_tsE6WPJy6DH-lXggK_VbHir456mI3D98Jbd/pub?output=csv
+  origin:
+    producer: Smith-Greenaway et al.
+    title: 'Global burden of maternal bereavement: indicators of the cumulative prevalence of child loss'
+    description: |-
+      This dataset shows survey data and estimates of maternal offspring loss across countries. This includes mothers who have lost an infant, child under 5 years old, or offspring. These are given as a rate per 1000 women in the age group. Underlying data comes from large-scale surveys (such as the Demographic and Health Surveys and Multiple Indicator Cluster Surveys) conducted in many low- and middle-income countries. For countries lacking data, these are estimated using an indirect approach that combines formal kinship models and life-table methods in an additional 81 countries. Citation: Smith-Greenaway, E., Alburez-Gutierrez, D., Trinitapoli, J., & Zagheni, E. (2021). Global burden of maternal bereavement: Indicators of the cumulative prevalence of child loss. BMJ Global Health, 6(4), e004837. https://doi.org/10.1136/bmjgh-2020-004837
+    citation_full: 'Smith-Greenaway, E., Alburez-Gutierrez, D., Trinitapoli, J., & Zagheni, E. (2021). Global burden of maternal bereavement: Indicators of the cumulative prevalence of child loss. BMJ Global Health, 6(4), e004837.'
+    url_main: https://gh.bmj.com/content/6/4/e004837.abstract
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vSiCgGTJ8kXoVPpaaskyRz79os2jbWtLbcqk18ybEXI_tsE6WPJy6DH-lXggK_VbHir456mI3D98Jbd/pub?output=csv
     date_accessed: '2024-11-26'
-    publication_year: 2021
-    published_by: |-
-      Global burden of maternal bereavement: indicators of the cumulative prevalence of child loss. (2021) Emily Smith-Greenaway, Diego Alburez-Gutierrez, Jenny Trinitapoli, Emilio Zagheni.
-  name: Global maternal offspring loss - Smith-Greenaway et al. 2021
-  description: |-
-    This dataset shows survey data and estimates of maternal offspring loss across countries. This includes mothers who have lost an infant, child under 5 years old, or offspring. These are given as a rate per 1000 women in the age group. Underlying data comes from large-scale surveys (such as the Demographic and Health Surveys and Multiple Indicator Cluster Surveys) conducted in many low- and middle-income countries. For countries lacking data, these are estimated using an indirect approach that combines formal kinship models and life-table methods in an additional 81 countries. Citation: Smith-Greenaway, E., Alburez-Gutierrez, D., Trinitapoli, J., & Zagheni, E. (2021). Global burden of maternal bereavement: Indicators of the cumulative prevalence of child loss. BMJ Global Health, 6(4), e004837. https://doi.org/10.1136/bmjgh-2020-004837
-  license: {}
+    date_published: '2021'
 outs:
   - md5: 7ce7e9d8a371afa038a470f8977d160d
     size: 8075

--- a/snapshots/fasttrack/latest/historical_france_mortality_cause.csv.dvc
+++ b/snapshots/fasttrack/latest/historical_france_mortality_cause.csv.dvc
@@ -1,34 +1,32 @@
 meta:
-  source:
-    name: Institut National d'Études Démographiques
-    url: https://www.demographic-research.org/Volumes/Vol36/21/
-    source_data_url: |-
-      gAAAAABnRYkUiIe1Lp-eC1kj1PYYYQ25kHCvpjl7pYYYL4eO5R8EtQ_r17u121vjvLUCpJ3X0LDrvoZ7IGgLK52Of2eKqxKBxWh30Ud4jSt_oSgpu6iL2FdM4M5nJbVStK7IBlb2SregUwmWCdJDn8xUpzz__p-Ly3mpfWJfa1i11msoZyXQVbTlcGbq5Rz9GEYok3B9elGj9tKPOFgqprbt4_UgHuYSUGPyn9fXCX9DBkRhC52YfXIpd_G625e2UxdS1-TK06j4
+  origin:
+    producer: Vallin and Meslé
+    title: Database on causes of death in France from 1925 to 1999
+    description: |-
+      Dataset on mortality rates from each cause of death category in France between 1925 and 1999. The underlying data for this chart comes from the Institut National d'Études Démographiques, published by Jacques Vallin and France Meslé, and covers causes of deaths nationally in France between 1925 and 1999. Causes of death were categorized into categories according to the 9th edition of the International Classification of Diseases (ICD-9) manual. Mortality rates are given for five-year age bands, as an annual rate out of 100,000 people in that age group. Below are the ICD codes used for each cause category: All causes = 000*-999*,
+      Infectious and parasitic diseases = 001*-139*,
+      Neoplasms = 140*-239*,
+      Endocrine nutritional and metabolic diseases and immunity disorders = 240*-279*,
+      Diseases of the blood and blood-forming organs = 280*-289*,
+      Mental disorders = 290*-319*,
+      Diseases of the nervous system = 320*-359*,
+      Diseases of the sense organs = 360*-389*,
+      Diseases of the circulatory system = 390*-459*,
+      Diseases of the respiratory system = 460*-519*,
+      Diseases of the digestive system = 520*-579*,
+      Diseases of the genitourinary system = 580*-629*,
+      Complications of pregnancy childbirth and the puerperium = 630*-679*,
+      Diseases of the skin and subcutaneous tissue = 680*-709*,
+      Diseases of the musculoskeletal system and connective tissue = 710*-739*,
+      Congenital anomalies = 740*-759*,
+      Certain conditions originating in the perinatal period = 760*-779*,
+      Symptoms signs and ill-defined conditions = 780*-799*,
+      External causes (injury and poisoning) = 800*-999*
+    citation_full: Jacques Vallin and France Meslé (2014). Database on causes of death in France from 1925 to 1999. Institut National d'Études Démographiques.
+    url_main: https://www.demographic-research.org/Volumes/Vol36/21/
+    url_download: gAAAAABnRYkUiIe1Lp-eC1kj1PYYYQ25kHCvpjl7pYYYL4eO5R8EtQ_r17u121vjvLUCpJ3X0LDrvoZ7IGgLK52Of2eKqxKBxWh30Ud4jSt_oSgpu6iL2FdM4M5nJbVStK7IBlb2SregUwmWCdJDn8xUpzz__p-Ly3mpfWJfa1i11msoZyXQVbTlcGbq5Rz9GEYok3B9elGj9tKPOFgqprbt4_UgHuYSUGPyn9fXCX9DBkRhC52YfXIpd_G625e2UxdS1-TK06j4
     date_accessed: '2024-11-26'
-    publication_year: 2014
-    published_by: Jacques Vallin and France Meslé
-  name: Database on causes of death in France from 1925 to 1999
-  description: |-
-    Dataset on mortality rates from each cause of death category in France between 1925 and 1999. The underlying data for this chart comes from the Institut National d'Études Démographiques, published by Jacques Vallin and France Meslé, and covers causes of deaths nationally in France between 1925 and 1999. Causes of death were categorized into categories according to the 9th edition of the International Classification of Diseases (ICD-9) manual. Mortality rates are given for five-year age bands, as an annual rate out of 100,000 people in that age group. Below are the ICD codes used for each cause category: All causes = 000*-999*,
-    Infectious and parasitic diseases = 001*-139*,
-    Neoplasms = 140*-239*,
-    Endocrine nutritional and metabolic diseases and immunity disorders = 240*-279*,
-    Diseases of the blood and blood-forming organs = 280*-289*,
-    Mental disorders = 290*-319*,
-    Diseases of the nervous system = 320*-359*,
-    Diseases of the sense organs = 360*-389*,
-    Diseases of the circulatory system = 390*-459*,
-    Diseases of the respiratory system = 460*-519*,
-    Diseases of the digestive system = 520*-579*,
-    Diseases of the genitourinary system = 580*-629*,
-    Complications of pregnancy childbirth and the puerperium = 630*-679*,
-    Diseases of the skin and subcutaneous tissue = 680*-709*,
-    Diseases of the musculoskeletal system and connective tissue = 710*-739*,
-    Congenital anomalies = 740*-759*,
-    Certain conditions originating in the perinatal period = 760*-779*,
-    Symptoms signs and ill-defined conditions = 780*-799*,
-    External causes (injury and poisoning) = 800*-999*
-  license: {}
+    date_published: '2014'
   is_public: false
 outs:
   - md5: 856b79cf2b8b9e0ba868c7d4084c7c4a

--- a/snapshots/fasttrack/latest/lead_paint_regulation_who.csv.dvc
+++ b/snapshots/fasttrack/latest/lead_paint_regulation_who.csv.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Lead paint regulations (WHO, 2023)
-    url: https://www.who.int/data/gho/data/themes/topics/indicator-groups/legally-binding-controls-on-lead-paint
-    source_data_url: |-
+  origin:
+    producer: WHO
+    title: Legally-binding controls on lead paint
+    description: |-
+      The WHO collects data on which countries have legally-binding controls on lead paint. It sources this data from surveys conducted by WHO and UNEP of national authorities. The World Health Organization (WHO) tracks the introduction of legally-binding controls on lead concentrations in paint. Paint is a main contributor to harmful lead exposure.
+
+      The stringency of controls on lead paint can vary by country. Maximum concentrations of lead can differ, and may only apply to particular types of paint (for example, products used in households).
+    citation_full: World Health Organization (WHO) (2023). Legally-binding controls on lead paint. Global Health Observatory.
+    url_main: https://www.who.int/data/gho/data/themes/topics/indicator-groups/legally-binding-controls-on-lead-paint
+    url_download: |-
       gAAAAABnRY1UxjQRqqtwi3k4YRi5i2a_AmviR0K1Yq7lWpp5mQ8zmhp0sOt2x_D-aN8W2WkMf8tCvbcZ2Bi41ergSpO1KCkDtsaTcT24IcGVC16eX9TpV0AkYs4TAXg4LbY31u0XeecK9mQ7uw7nzqkQLsEbEDXTz7izPL1kz58WSwNQE8WCvzhV2kv3mddI_ycEwFGUFSypG0QXyYHreQLjP3n5CsnC2vGymzKGwdQUmiK0r2nipPcCj4vh3O6qbvSj0W_hcA5j
     date_accessed: '2024-11-26'
-    publication_year: 2023
-    published_by: World Health Organization (WHO)
-  name: Lead paint regulations (WHO, 2023)
-  description: |-
-    The WHO collects data on which countries have legally-binding controls on lead paint. It sources this data from surveys conducted by WHO and UNEP of national authorities. The World Health Organization (WHO) tracks the introduction of legally-binding controls on lead concentrations in paint. Paint is a main contributor to harmful lead exposure.
-
-    The stringency of controls on lead paint can vary by country. Maximum concentrations of lead can differ, and may only apply to particular types of paint (for example, products used in households).
-  license: {}
+    date_published: '2023'
   is_public: false
 outs:
   - md5: 1699f03673a329af3bf555a0b4e6e8a0

--- a/snapshots/fasttrack/latest/owid_upload_gini_compare_1980.csv.dvc
+++ b/snapshots/fasttrack/latest/owid_upload_gini_compare_1980.csv.dvc
@@ -1,16 +1,13 @@
 meta:
-  namespace: fasttrack
-  short_name: owid_upload_gini_compare_1980
-  file_extension: csv
-  date_accessed: 2023-05-09
-  name: DRAFT owid_upload_gini_compare_1980
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABkWr_NpiIDERhzQi1aYMvZaHOcThH8h_RvJ98xluTgV-uN3dBWkJIFE5CspcyU7QuUOK5lkxnSlqCSdBqXiAlq8aHZjw==
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: Unknown.
+    version_producer: Local CSV
+    url_download: gAAAAABkWr_NpiIDERhzQi1aYMvZaHOcThH8h_RvJ98xluTgV-uN3dBWkJIFE5CspcyU7QuUOK5lkxnSlqCSdBqXiAlq8aHZjw==
+    date_accessed: '2023-05-09'
+    date_published: '2023'
   is_public: false
-  version: latest
 wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: 65d0c91e1014e983da658a46c5d51318

--- a/snapshots/fasttrack/latest/owid_upload_gini_compare_1993.csv.dvc
+++ b/snapshots/fasttrack/latest/owid_upload_gini_compare_1993.csv.dvc
@@ -1,16 +1,13 @@
 meta:
-  namespace: fasttrack
-  short_name: owid_upload_gini_compare_1993
-  file_extension: csv
-  date_accessed: 2023-05-09
-  name: DRAFT owid_upload_gini_compare_1993
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABkWrEYse8SRzl9C_CF8Md7IleZMleUQHpKweR-R0FLnBMXB73R_TR8R4apbld3SFjOWcMEZc5MWqmGpmusI8HQLRa-5A==
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: Unknown.
+    version_producer: Local CSV
+    url_download: gAAAAABkWrEYse8SRzl9C_CF8Md7IleZMleUQHpKweR-R0FLnBMXB73R_TR8R4apbld3SFjOWcMEZc5MWqmGpmusI8HQLRa-5A==
+    date_accessed: '2023-05-09'
+    date_published: '2023'
   is_public: false
-  version: latest
 wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: 2bdd8abe9ce6b079b2f234537f64279f

--- a/snapshots/fasttrack/latest/owid_upload_top1_percent_compare_1980.csv.dvc
+++ b/snapshots/fasttrack/latest/owid_upload_top1_percent_compare_1980.csv.dvc
@@ -1,16 +1,13 @@
 meta:
-  namespace: fasttrack
-  short_name: owid_upload_top1_percent_compare_1980
-  file_extension: csv
-  date_accessed: 2023-05-09
-  name: DRAFT owid_upload_top1_percent_compare_1980
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABkWsFSIIN-EgbQN4cULmWnbIWlxMQhMg-1xt1meoIo6FtsqFaWJd8F4NO1llZAUQTiA7kH-xGq4qA25fbHHTxgvARBvw==
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: Unknown.
+    version_producer: Local CSV
+    url_download: gAAAAABkWsFSIIN-EgbQN4cULmWnbIWlxMQhMg-1xt1meoIo6FtsqFaWJd8F4NO1llZAUQTiA7kH-xGq4qA25fbHHTxgvARBvw==
+    date_accessed: '2023-05-09'
+    date_published: '2023'
   is_public: false
-  version: latest
 wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: 33fb0ebbca08babec0b87601fdd5ad82

--- a/snapshots/fasttrack/latest/owid_upload_top1_percent_compare_1993.csv.dvc
+++ b/snapshots/fasttrack/latest/owid_upload_top1_percent_compare_1993.csv.dvc
@@ -1,16 +1,13 @@
 meta:
-  namespace: fasttrack
-  short_name: owid_upload_top1_percent_compare_1993
-  file_extension: csv
-  date_accessed: 2023-05-09
-  name: DRAFT owid_upload_top1_percent_compare_1993
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABkWrkoabDCuM3fmJK4apCZ1dmVdNB4PvCji3Kgp8NIa0Eumb3txcp5idd-pJxJAlmyUVcaVPr6qXXr5hakEcHcxjn-tA==
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: Unknown.
+    version_producer: Local CSV
+    url_download: gAAAAABkWrkoabDCuM3fmJK4apCZ1dmVdNB4PvCji3Kgp8NIa0Eumb3txcp5idd-pJxJAlmyUVcaVPr6qXXr5hakEcHcxjn-tA==
+    date_accessed: '2023-05-09'
+    date_published: '2023'
   is_public: false
-  version: latest
 wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: 3852a3844536dda9cc88f788fa9c7a7d

--- a/snapshots/fasttrack/latest/pain_hours_hen_systems.csv.dvc
+++ b/snapshots/fasttrack/latest/pain_hours_hen_systems.csv.dvc
@@ -1,15 +1,13 @@
 meta:
-  source:
-    name: Welfare Footprint based on Schuck-Paim and Alonso (2021)
-    url: https://welfarefootprint.org/research-projects/laying-hens/
-    source_data_url: |-
+  origin:
+    producer: Welfare Footprint
+    title: Quantifying pain in laying hens
+    citation_full: 'Schuck-Paim, C., and Alonso, W. J. (2021). Quantifying pain in laying hens: A blueprint for the comparative analysis of welfare in animals. Welfare Footprint Project.'
+    url_main: https://welfarefootprint.org/research-projects/laying-hens/
+    url_download: |-
       gAAAAABnRY4A9xP89q46o72YIhvw5MBBfzt_84o2BNljMcBv29JHUFXvVtuYbTDPVsVbX-hfm9rZ8DJ-rW8qWqW0lWbhRDNvNd_ncCTITnovArjMEeLU41PNBF1vXiAz3Exdbb4orqamK0KosiZFwIKGtyvRFrF7XOH32d6O3z8ybbYchAUPJ8fqDyHP87olHyJt21OraPoNDQZ-MmNI5oSAHeMlz6zqyaEtO6mfd1g98R0B5QG6wf4zx7ogpunekE2MdQl1bOkQ
     date_accessed: '2024-11-26'
-    publication_year: 2021
-    published_by: Welfare Footprint
-  name: Pain hours of hen systems (Welfare Footprint)
-  description: ''
-  license: {}
+    date_published: '2021'
   is_public: false
 outs:
   - md5: daf4b07b53f3eb73c1725266e6e7b83c

--- a/snapshots/fasttrack/latest/pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015.csv.dvc
+++ b/snapshots/fasttrack/latest/pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015.csv.dvc
@@ -1,16 +1,13 @@
 meta:
-  namespace: fasttrack
-  short_name: pip__gini_vs_wid__top_1pc_share__pretax__1993_to_2015
-  file_extension: csv
-  date_accessed: 2023-04-18
-  name: 'DRAFT PIP: Gini vs WID: Top 1pc share – pretax – 1993 to 2015'
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABkPlOSr7r68fRmFhQUvAmGt3ic6GMZV6Xyub1XFwWU_Ct4RENLfR6J4yKaU9E4ZsN67q7XMGnN0k1PQgJPY2OLJ9aCcQ==
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: Unknown.
+    version_producer: Local CSV
+    url_download: gAAAAABkPlOSr7r68fRmFhQUvAmGt3ic6GMZV6Xyub1XFwWU_Ct4RENLfR6J4yKaU9E4ZsN67q7XMGnN0k1PQgJPY2OLJ9aCcQ==
+    date_accessed: '2023-04-18'
+    date_published: '2023'
   is_public: false
-  version: latest
 wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: 7681d711badc9b36d770f850a8cb2103

--- a/snapshots/fasttrack/latest/quantum_processors_over_time.csv.dvc
+++ b/snapshots/fasttrack/latest/quantum_processors_over_time.csv.dvc
@@ -1,17 +1,13 @@
 meta:
-  namespace: fasttrack
-  short_name: quantum_processors_over_time
-  file_extension: csv
-  date_accessed: 2023-05-03
-  name: DRAFT Quantum processors over time
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: local_csv
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: DRAFT Quantum processors over time.
+    attribution_short: DRAFT Quantum processors over time
+    version_producer: Local CSV
+    date_accessed: '2023-05-03'
+    date_published: '2023'
   is_public: false
-  version: latest
-wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: 98bc4786b97bbd9641e4193482760e42
   size: 134

--- a/snapshots/fasttrack/latest/treatment_gap_anxiety_disorders_world_mental_health_surveys.csv.dvc
+++ b/snapshots/fasttrack/latest/treatment_gap_anxiety_disorders_world_mental_health_surveys.csv.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Treatment gap for anxiety disorders - World Mental Health Surveys - Alonso et al. 2017
-    url: https://pubmed.ncbi.nlm.nih.gov/29356216/
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vQtKZYhI1TbqVZILdDFZuSYJcew8xyYKc9Euyzfzwz6g8O28Qfapc-QJfVetZqJF2N8mNLItaErz63_/pub?output=csv
+  origin:
+    producer: Alonso et al.
+    title: 'Treatment gap for anxiety disorders is global: Results of the World Mental Health Surveys in 21 countries'
+    description: |-
+      This dataset comes from the World Mental Health surveys, which conducted national studies in 21 countries, using validated structured interviews to survey members of the general population about symptoms of mental illnesses they had in the past 12 months and their lifetime so far. The source describes the dataset: "Data came from 24 community epidemiological surveys administered in 21 countries as part of the WMH surveys (Kessler & Ustun, 2004). These included 12 surveys carried out in high-income countries, 6 surveys in upper-middle-income countries and 6 in low or lower-middle income countries (see table 1). The majority of surveys were based on nationally representative household samples. Three were representative of urban areas in their countries (Colombia, Mexico, and Peru). Three were representative of selected regions in their countries (Japan, Nigeria, and Murcia, Spain). Four were representative of selected Metropolitan Areas (Sao Paulo, Brazil; Medellin, Colombia; and Beijing-Shanghai and Shenzhen in the People's Republic of China (PRC)). Trained lay interviewers conducted face-to-face interviews with respondents, aged 18 years and over. The interviews took place within the households of the respondents. To reduce respondent burden, the interview was divided into two parts. Part I assessed core mental disorders and was administered to all respondents. Part II, which assessed additional disorders and correlates, was administered to all Part I respondents who met lifetime criteria for any disorder plus a probability subsample of other Part I respondents. Part II data, the focus of this report, were weighted by the inverse of their probabilities of selection into Part II and additionally weighted to adjust samples to match population distributions on the cross-classification of key socio-demographic and geographic variables. Further details about WMH sampling and weighting are available elsewhere(Heeringa et al., 2008). Response rates ranged between 45.9% and 97.2% and had a weighted average of 70.1% across all surveys."
+    citation_full: 'Alonso, J., Liu, Z., Evans-Lacko, S., Sadikova, E., Sampson, N., Chatterji, S., Abdulmalik, J., Aguilar-Gaxiola, S., Al-Hamzawi, A., Andrade, L. H., Bruffaerts, R., Cardoso, G., Cia, A., Florescu, S., de Girolamo, G., Gureje, O., Haro, J. M., He, Y., de Jonge, P., … Thornicroft, G. (2018). Treatment gap for anxiety disorders is global: Results of the World Mental Health Surveys in 21 countries. Depression and Anxiety, 35(3), 195–208.'
+    url_main: https://pubmed.ncbi.nlm.nih.gov/29356216/
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vQtKZYhI1TbqVZILdDFZuSYJcew8xyYKc9Euyzfzwz6g8O28Qfapc-QJfVetZqJF2N8mNLItaErz63_/pub?output=csv
     date_accessed: '2024-11-26'
-    publication_year: 2017
-    published_by: Alonso et al. (2017)
-  name: Treatment gap for anxiety disorders - World Mental Health Surveys - Alonso et al. 2017
-  description: |-
-    This dataset comes from the World Mental Health surveys, which conducted national studies in 21 countries, using validated structured interviews to survey members of the general population about symptoms of mental illnesses they had in the past 12 months and their lifetime so far. The source describes the dataset: "Data came from 24 community epidemiological surveys administered in 21 countries as part of the WMH surveys (Kessler & Ustun, 2004). These included 12 surveys carried out in high-income countries, 6 surveys in upper-middle-income countries and 6 in low or lower-middle income countries (see table 1). The majority of surveys were based on nationally representative household samples. Three were representative of urban areas in their countries (Colombia, Mexico, and Peru). Three were representative of selected regions in their countries (Japan, Nigeria, and Murcia, Spain). Four were representative of selected Metropolitan Areas (Sao Paulo, Brazil; Medellin, Colombia; and Beijing-Shanghai and Shenzhen in the People’s Republic of China (PRC)). Trained lay interviewers conducted face-to-face interviews with respondents, aged 18 years and over. The interviews took place within the households of the respondents. To reduce respondent burden, the interview was divided into two parts. Part I assessed core mental disorders and was administered to all respondents. Part II, which assessed additional disorders and correlates, was administered to all Part I respondents who met lifetime criteria for any disorder plus a probability subsample of other Part I respondents. Part II data, the focus of this report, were weighted by the inverse of their probabilities of selection into Part II and additionally weighted to adjust samples to match population distributions on the cross-classification of key socio-demographic and geographic variables. Further details about WMH sampling and weighting are available elsewhere(Heeringa et al., 2008). Response rates ranged between 45.9% and 97.2% and had a weighted average of 70.1% across all surveys."
-  license:
-    name: Made freely available by authors
-    url: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6008788/
+    date_published: '2017'
+    license:
+      name: Made freely available by authors
+      url: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6008788/
 outs:
   - md5: 24b2bc09a23fe8ed5ab7e8a37df42c4d
     size: 1297

--- a/snapshots/fasttrack/latest/under_five_mortality_lmics.csv.dvc
+++ b/snapshots/fasttrack/latest/under_five_mortality_lmics.csv.dvc
@@ -1,23 +1,14 @@
 meta:
-  source:
-    name: Smith-Greenaway et al. (2023)
-    url: https://osf.io/preprints/socarxiv/xvbkj/
-    source_data_url: 
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vTSjhkmuM72U-5tPH-ZskJYrdf6HHXWl9qm1aHAM7yoMygj0YVGGlxEvRW3_Xw7w4ynF-1lKJQkB-5V/pub?output=csv
+  origin:
+    producer: Smith-Greenaway et al.
+    title: 'Under-five mortality exposure in low- and middle-income countries: A multi-generation and cohort perspective of sibling and offspring loss'
+    description: |-
+      This dataset shows estimated share of mothers who have lost a child under 5 years old, based on large-scale surveys including the Demographic and Health Surveys (DHS) and Multiple Indicator Cluster Surveys (MICS).
+    citation_full: 'Smith-Greenaway, E., Weitzman, A., Lin, Y., & Huss, K. (2023, January 1). Under-five mortality exposure in low- and middle-income countries: A multi-generation and cohort perspective of sibling and offspring loss. https://doi.org/10.31235/osf.io/xvbkj'
+    url_main: https://osf.io/preprints/socarxiv/xvbkj/
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vTSjhkmuM72U-5tPH-ZskJYrdf6HHXWl9qm1aHAM7yoMygj0YVGGlxEvRW3_Xw7w4ynF-1lKJQkB-5V/pub?output=csv
     date_accessed: '2023-10-20'
-    publication_year: '2023'
-    published_by: 'Under-five mortality exposure in low- and middle-income countries:
-      A multi-generation and cohort perspective of sibling and offspring loss. Emily
-      Smith-Greenaway, Abigail Weitzman, Yingyi Lin, Katarina Huss.'
-  name: 'Greenaway - Under-five mortality exposure in low- and middle-income countries:
-    A multi-generation and cohort perspective of sibling and offspring loss'
-  description: 'This dataset shows estimated share of mothers who have lost a child
-    under 5 years old, based on large-scale surveys including the Demographic and
-    Health Surveys (DHS) and Multiple Indicator Cluster Surveys (MICS). Citation:
-    Smith-Greenaway, E., Weitzman, A., Lin, Y., & Huss, K. (2023, January 1). Under-five
-    mortality exposure in low- and middle-income countries: A multi-generation and
-    cohort perspective of sibling and offspring loss. https://doi.org/10.31235/osf.io/xvbkj'
-  license: {}
+    date_published: '2023'
 wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: 0c480c8bd17bc1bc25091862be75471e

--- a/snapshots/fasttrack/latest/whm_treatment_gap_anxiety_disorders.csv.dvc
+++ b/snapshots/fasttrack/latest/whm_treatment_gap_anxiety_disorders.csv.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Treatment gap for anxiety disorders - World Mental Health Surveys - Alonso et al. 2017
-    url: https://pubmed.ncbi.nlm.nih.gov/29356216/
-    source_data_url: |-
-      https://docs.google.com/spreadsheets/d/e/2PACX-1vTQERY6SffT6Lc4ogBdVxjBlPFiOOluxEd3h9oAbrRtSy5YXQ0BTYqZFhrF1wl5N9j6Ko-Mm2XwHZtZ/pub?output=csv
+  origin:
+    producer: Alonso et al.
+    title: 'Treatment gap for anxiety disorders is global: Results of the World Mental Health Surveys in 21 countries'
+    description: |-
+      This dataset comes from the World Mental Health surveys, which conducted national studies in 21 countries, using validated structured interviews to survey members of the general population about symptoms of mental illnesses they had in the past 12 months and their lifetime so far. The source describes the dataset: "Data came from 24 community epidemiological surveys administered in 21 countries as part of the WMH surveys (Kessler & Ustun, 2004). These included 12 surveys carried out in high-income countries, 6 surveys in upper-middle-income countries and 6 in low or lower-middle income countries (see table 1). The majority of surveys were based on nationally representative household samples. Three were representative of urban areas in their countries (Colombia, Mexico, and Peru). Three were representative of selected regions in their countries (Japan, Nigeria, and Murcia, Spain). Four were representative of selected Metropolitan Areas (Sao Paulo, Brazil; Medellin, Colombia; and Beijing-Shanghai and Shenzhen in the People's Republic of China (PRC)). Trained lay interviewers conducted face-to-face interviews with respondents, aged 18 years and over. The interviews took place within the households of the respondents. To reduce respondent burden, the interview was divided into two parts. Part I assessed core mental disorders and was administered to all respondents. Part II, which assessed additional disorders and correlates, was administered to all Part I respondents who met lifetime criteria for any disorder plus a probability subsample of other Part I respondents. Part II data, the focus of this report, were weighted by the inverse of their probabilities of selection into Part II and additionally weighted to adjust samples to match population distributions on the cross-classification of key socio-demographic and geographic variables. Further details about WMH sampling and weighting are available elsewhere(Heeringa et al., 2008). Response rates ranged between 45.9% and 97.2% and had a weighted average of 70.1% across all surveys."
+    citation_full: 'Alonso, J., Liu, Z., Evans-Lacko, S., Sadikova, E., Sampson, N., Chatterji, S., Abdulmalik, J., Aguilar-Gaxiola, S., Al-Hamzawi, A., Andrade, L. H., Bruffaerts, R., Cardoso, G., Cia, A., Florescu, S., de Girolamo, G., Gureje, O., Haro, J. M., He, Y., de Jonge, P., … Thornicroft, G. (2018). Treatment gap for anxiety disorders is global: Results of the World Mental Health Surveys in 21 countries. Depression and Anxiety, 35(3), 195–208.'
+    url_main: https://pubmed.ncbi.nlm.nih.gov/29356216/
+    url_download: https://docs.google.com/spreadsheets/d/e/2PACX-1vTQERY6SffT6Lc4ogBdVxjBlPFiOOluxEd3h9oAbrRtSy5YXQ0BTYqZFhrF1wl5N9j6Ko-Mm2XwHZtZ/pub?output=csv
     date_accessed: '2024-11-26'
-    publication_year: 2017
-    published_by: Alonso et al. (2017)
-  name: Treatment gap for anxiety disorders (WMH, 2017)
-  description: |-
-    This dataset comes from the World Mental Health surveys, which conducted national studies in 21 countries, using validated structured interviews to survey members of the general population about symptoms of mental illnesses they had in the past 12 months and their lifetime so far. The source describes the dataset: "Data came from 24 community epidemiological surveys administered in 21 countries as part of the WMH surveys (Kessler & Ustun, 2004). These included 12 surveys carried out in high-income countries, 6 surveys in upper-middle-income countries and 6 in low or lower-middle income countries (see table 1). The majority of surveys were based on nationally representative household samples. Three were representative of urban areas in their countries (Colombia, Mexico, and Peru). Three were representative of selected regions in their countries (Japan, Nigeria, and Murcia, Spain). Four were representative of selected Metropolitan Areas (Sao Paulo, Brazil; Medellin, Colombia; and Beijing-Shanghai and Shenzhen in the People’s Republic of China (PRC)). Trained lay interviewers conducted face-to-face interviews with respondents, aged 18 years and over. The interviews took place within the households of the respondents. To reduce respondent burden, the interview was divided into two parts. Part I assessed core mental disorders and was administered to all respondents. Part II, which assessed additional disorders and correlates, was administered to all Part I respondents who met lifetime criteria for any disorder plus a probability subsample of other Part I respondents. Part II data, the focus of this report, were weighted by the inverse of their probabilities of selection into Part II and additionally weighted to adjust samples to match population distributions on the cross-classification of key socio-demographic and geographic variables. Further details about WMH sampling and weighting are available elsewhere(Heeringa et al., 2008). Response rates ranged between 45.9% and 97.2% and had a weighted average of 70.1% across all surveys."
-  license:
-    name: Made freely available by authors
-    url: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6008788/
+    date_published: '2017'
+    license:
+      name: Made freely available by authors
+      url: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6008788/
 outs:
   - md5: 2ef040684f17d2121ded34c460efa4aa
     size: 2000

--- a/snapshots/fasttrack/latest/who_standard_pop.csv.dvc
+++ b/snapshots/fasttrack/latest/who_standard_pop.csv.dvc
@@ -1,17 +1,14 @@
 meta:
-  namespace: fasttrack
-  short_name: who_standard_pop
-  file_extension: csv
-  date_accessed: 2023-04-04
-  name: DRAFT who_standard_pop
-  description: ''
-  source_name: Local CSV
-  url: ''
-  source_published_by: Local CSV
-  source_data_url: gAAAAABkK_Ivu_Je_oySMG3rgLckjjugFOOG9jhgajTBIwUJ87fOQX3EcGZdjwRpsHoFeZBCGlbef41qF0k0cvf-8OSrcTED0w==
+  origin:
+    producer: Unknown
+    title: Unknown
+    citation_full: DRAFT who_standard_pop.
+    attribution_short: DRAFT who_standard_pop
+    version_producer: Local CSV
+    url_download: gAAAAABkK_Ivu_Je_oySMG3rgLckjjugFOOG9jhgajTBIwUJ87fOQX3EcGZdjwRpsHoFeZBCGlbef41qF0k0cvf-8OSrcTED0w==
+    date_accessed: '2023-04-04'
+    date_published: '2023'
   is_public: false
-  version: latest
-wdir: ../../../data/snapshots/fasttrack/latest
 outs:
 - md5: cc14c66a73f7db992f0b39fe1d0db45e
   size: 611

--- a/snapshots/gapminder/2019-05-25/fertility_rate.feather.dvc
+++ b/snapshots/gapminder/2019-05-25/fertility_rate.feather.dvc
@@ -1,41 +1,31 @@
 meta:
   origin:
-    # Data product / Snapshot
-    title: Fertility Rate
+    producer: Gapminder
+    title: Fertility rate
     description: |-
       Data is that of version 12 of Gapminder, the latest version as of 2019. This is the full fertility rate dataset published by Gapminder.
 
-      Gapminder's sources and methodology if well-documented in its dataset at: https://www.gapminder.org/data/
+      Gapminder's sources and methodology are well-documented in its dataset at: https://www.gapminder.org/data/
 
       It notes its data sources during three key periods of time:
 
-      * 1800 to 1950 (and in some cases also years after 1950): Gapminder v6 which were compiled and documented by Mattias Lindgren.
-      * 1950 to 2014: In most cases we use the latest UN estimates from World Population Prospects 2017 published in the file with Annually interpolated demographic indicators, called WPP2017_INT_F01_ANNUAL_DEMOGRAPHIC_INDICATORS.xlsx, accessed on September 2, 2017.
-      * 2015 – 2099: We use the UN forecast of future fertility rate in all countries, called median fertility variant.
+      - 1800 to 1950 (and in some cases also years after 1950): Gapminder v6 which were compiled and documented by Mattias Lindgren.
+      - 1950 to 2014: In most cases we use the latest UN estimates from World Population Prospects 2017 published in the file with Annually interpolated demographic indicators, called WPP2017_INT_F01_ANNUAL_DEMOGRAPHIC_INDICATORS.xlsx, accessed on September 2, 2017.
+      - 2015–2099: We use the UN forecast of future fertility rate in all countries, called median fertility variant.
 
       Version 12 of the dataset extends back to the year 1800. Version 6 of Gapminder's fertility series includes data for a few countries further than 1800. We have included more historic data from Version 6 for Finland, the United Kingdom and Sweden. All data from 1800 onwards is from Version 12; data from pre-1800 is from Version 6.
 
       There are significant uncertainties in data for many countries pre-1950. To develop full series back to 1800 for all countries, Gapminder combines published estimates within the academic literature and national statistics, with their own guesstimates and extrapolations for countries without published estimates. This series presents the selective Gapminder dataset: we have removed data points which were estimated by Gapminder with high uncertainty and instead only include those from published sources or the United Nations dataset.
 
       We also publish the full dataset from Gapminder for users looking for a complete series. However, we should highlight that some of these estimates have a high degree of uncertainty. This dataset can be accessed here: https://ourworldindata.org/grapher/fertility-rate-complete-gapminder
-    date_published: 2017-12-12
-
-    # Citation
-    producer: Gapminder
-    citation_full: |-
-      Free data from www.gapminder.org
-
-    # Files
+    citation_full: Gapminder (2017). Fertility rate, version 12. Free data from www.gapminder.org.
     url_main: https://drive.google.com/drive/folders/1i30LyIcvbLa800Q1ZFrPGlNHIw9ymYGm
-    date_accessed: 2019-05-25
-
-    # License
+    date_accessed: '2019-05-25'
+    date_published: '2017-12-12'
     license:
       name: CC BY 4.0
-      url: www.gapm.io/data_license
-
-wdir: ../../../data/snapshots/gapminder/2019-05-25
+      url: https://www.gapm.io/data_license
 outs:
-- md5: 07302fc652ae3018457e339e7fde539a
-  size: 135234
-  path: fertility_rate.feather
+  - md5: 07302fc652ae3018457e339e7fde539a
+    size: 135234
+    path: fertility_rate.feather

--- a/snapshots/iucn/2022-12-08/threatened_and_evaluated_species.feather.dvc
+++ b/snapshots/iucn/2022-12-08/threatened_and_evaluated_species.feather.dvc
@@ -1,26 +1,28 @@
 meta:
   origin:
     producer: IUCN
-    title: IUCN Red List
+    title: The IUCN Red List of Threatened Species
     description: |-
+      The IUCN Red List of Threatened Species is the world's most comprehensive inventory of the global conservation status of biological species. It uses a set of quantitative criteria to evaluate the extinction risk of thousands of species, classifying them into categories from "Least Concern" to "Extinct".
+
       The IUCN Red List has assessed only a small share of the total known species in the world. This means the number of species threatened with extinction is likely to be a significant underestimate of the total number of species at risk.
 
       This is particularly true for understudied groups such as insects, plants and fungi.
 
       The share of known species threatened with extinction is only available for a few taxonomic groups where more than 80% of species have been assessed.
 
-      'Threatened' species are those that are categorized as 'Critically endangered', 'Endangered' or 'Vulnerable' on the IUCN Red List.
+      "Threatened" species are those that are categorized as "Critically endangered", "Endangered" or "Vulnerable" on the IUCN Red List.
 
-      This dataset should be next updated by the source in December 2022. We will update it on Our World in Data soon after the new version is published. At the link above you can directly access the source page and see the latest available data.
-
-      The 'mushrooms' taxonomic group includes brackets, rusts, smuts and, jelly fungi.
-    citation_full: IUCN (2022). The IUCN Red List of Threatened Species.
-    attribution_short: IUCN Red List
+      The "mushrooms" taxonomic group includes brackets, rusts, smuts and jelly fungi.
+    title_snapshot: The IUCN Red List of Threatened Species - Summary statistics
+    description_snapshot: |-
+      This snapshot provides summary statistics on the number of described, evaluated and threatened species in each taxonomic group, as published in Table 1a of the IUCN Red List summary statistics.
+    citation_full: IUCN (2022). The IUCN Red List of Threatened Species. https://www.iucnredlist.org.
     url_main: https://www.iucnredlist.org/resources/summary-statistics
     url_download: https://nc.iucnredlist.org/redlist/content/attachment_files/2022-1_RL_Stats_Table_1a.pdf
     date_accessed: '2022-12-08'
-    date_published: '2022'
+    date_published: '2022-12-08'
 outs:
-- md5: 0172e60a8ed2a8d4f814c74b08a417c5
-  size: 7250
-  path: threatened_and_evaluated_species.feather
+  - md5: 0172e60a8ed2a8d4f814c74b08a417c5
+    size: 7250
+    path: threatened_and_evaluated_species.feather

--- a/snapshots/postnatal_care/2022-09-19/postnatal_care.csv.dvc
+++ b/snapshots/postnatal_care/2022-09-19/postnatal_care.csv.dvc
@@ -1,14 +1,19 @@
 meta:
-  name: Postnatal care coverage (% mothers) - Health Nutrition and Population Statistics (2022)
-  source_name: Health Nutrition and Population Statistics - World Bank (2022)
-  publication_year: 2022
-  publication_date: 2022-09-19
-  url: https://databank.worldbank.org/source/health-nutrition-and-population-statistics/Series/SH.STA.PNVC.ZS#
-  source_data_url: https://walden.owid.io/postnatal_care/2022-09-19/postnatal_care.csv
-  license_url: https://www.worldbank.org/en/about/legal/terms-of-use-for-datasets
-  license_name: Creative Commons BY 4.0
-  description: |
-    Percentage of women with a postnatal checkup in the first two days after birth.
+  origin:
+    producer: World Bank
+    title: Health Nutrition and Population Statistics
+    description: |-
+      The World Bank's Health Nutrition and Population Statistics database brings together key health, nutrition, and population indicators compiled from a range of national and international sources, including demographic and health surveys, multiple indicator cluster surveys, and country statistical agencies.
+    title_snapshot: Health Nutrition and Population Statistics - Postnatal care coverage (% of mothers)
+    description_snapshot: |-
+      Percentage of women with a postnatal checkup in the first two days after birth.
+    citation_full: World Bank (2022). Health Nutrition and Population Statistics - Postnatal care coverage (% of mothers) [SH.STA.PNVC.ZS].
+    url_main: https://databank.worldbank.org/source/health-nutrition-and-population-statistics/Series/SH.STA.PNVC.ZS#
+    date_accessed: '2022-10-31'
+    date_published: '2022-09-19'
+    license:
+      name: Creative Commons BY 4.0
+      url: https://www.worldbank.org/en/about/legal/terms-of-use-for-datasets
 outs:
   - md5: dbea3cf2b1d0075680f305d532df9c9a
     size: 28675

--- a/snapshots/unep/2023-03-17/consumption_controlled_substances_bromochloromethane.xlsx.dvc
+++ b/snapshots/unep/2023-03-17/consumption_controlled_substances_bromochloromethane.xlsx.dvc
@@ -1,18 +1,19 @@
 meta:
-  name: Consumption of controlled substances (UNEP, 2023)
-  publication_year: 2023
-  publication_date: 2023-03-16
-  source_name: UN Environment Programme (2023)
-  source_published_by: UN Environment Programme
-  url: https://ozone.unep.org/countries/data-table
-  source_data_url:
-  license_url:
-  license_name:
-  date_accessed: 2023-03-17
-  is_public: true
-  description: |
-    Period: 1986-2022
-wdir: ../../../data/snapshots/unep/2023-03-17
+  origin:
+    producer: UN Environment Programme
+    title: Consumption of controlled substances
+    description: |-
+      Data reported by Parties to the Montreal Protocol on the consumption of controlled substances, compiled by the UN Environment Programme Ozone Secretariat.
+
+      Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
+    title_snapshot: Consumption of controlled substances - Bromochloromethane (BCM)
+    description_snapshot: |-
+      Consumption of bromochloromethane (BCM), reported by country and year over the period 1986-2022.
+    citation_full: UN Environment Programme Ozone Secretariat (2023). Data on consumption of controlled substances. https://ozone.unep.org/countries/data-table.
+    attribution_short: UNEP
+    url_main: https://ozone.unep.org/countries/data-table
+    date_accessed: '2023-03-17'
+    date_published: '2023-03-16'
 outs:
   - md5: 05aa062cc4a2daff0aac73b751fbb29b
     size: 20314

--- a/snapshots/unep/2023-03-17/consumption_controlled_substances_carbon_tetrachloride.xlsx.dvc
+++ b/snapshots/unep/2023-03-17/consumption_controlled_substances_carbon_tetrachloride.xlsx.dvc
@@ -1,18 +1,19 @@
 meta:
-  name: Consumption of controlled substances (UNEP, 2023)
-  publication_year: 2023
-  publication_date: 2023-03-16
-  source_name: UN Environment Programme (2023)
-  source_published_by: UN Environment Programme
-  url: https://ozone.unep.org/countries/data-table
-  source_data_url:
-  license_url:
-  license_name:
-  date_accessed: 2023-03-17
-  is_public: true
-  description: |
-    Period: 1986-2022
-wdir: ../../../data/snapshots/unep/2023-03-17
+  origin:
+    producer: UN Environment Programme
+    title: Consumption of controlled substances
+    description: |-
+      Data reported by Parties to the Montreal Protocol on the consumption of controlled substances, compiled by the UN Environment Programme Ozone Secretariat.
+
+      Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
+    title_snapshot: Consumption of controlled substances - Carbon Tetrachloride (CTC)
+    description_snapshot: |-
+      Consumption of carbon tetrachloride (CTC), reported by country and year over the period 1986-2022.
+    citation_full: UN Environment Programme Ozone Secretariat (2023). Data on consumption of controlled substances. https://ozone.unep.org/countries/data-table.
+    attribution_short: UNEP
+    url_main: https://ozone.unep.org/countries/data-table
+    date_accessed: '2023-03-17'
+    date_published: '2023-03-16'
 outs:
   - md5: ecfccd28c87882149b5462e18cf28764
     size: 137775

--- a/snapshots/unep/2023-03-17/consumption_controlled_substances_chlorofluorocarbons.xlsx.dvc
+++ b/snapshots/unep/2023-03-17/consumption_controlled_substances_chlorofluorocarbons.xlsx.dvc
@@ -1,18 +1,19 @@
 meta:
-  name: Consumption of controlled substances (UNEP, 2023)
-  publication_year: 2023
-  publication_date: 2023-03-16
-  source_name: UN Environment Programme (2023)
-  source_published_by: UN Environment Programme
-  url: https://ozone.unep.org/countries/data-table
-  source_data_url:
-  license_url:
-  license_name:
-  date_accessed: 2023-03-17
-  is_public: true
-  description: |
-    Period: 1986-2022
-wdir: ../../../data/snapshots/unep/2023-03-17
+  origin:
+    producer: UN Environment Programme
+    title: Consumption of controlled substances
+    description: |-
+      Data reported by Parties to the Montreal Protocol on the consumption of controlled substances, compiled by the UN Environment Programme Ozone Secretariat.
+
+      Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
+    title_snapshot: Consumption of controlled substances - Chlorofluorocarbons (CFCs)
+    description_snapshot: |-
+      Consumption of chlorofluorocarbons (CFCs), reported by country and year over the period 1986-2022.
+    citation_full: UN Environment Programme Ozone Secretariat (2023). Data on consumption of controlled substances. https://ozone.unep.org/countries/data-table.
+    attribution_short: UNEP
+    url_main: https://ozone.unep.org/countries/data-table
+    date_accessed: '2023-03-17'
+    date_published: '2023-03-16'
 outs:
   - md5: a313469300309a8ee1ca095090e62217
     size: 218230

--- a/snapshots/unep/2023-03-17/consumption_controlled_substances_halons.xlsx.dvc
+++ b/snapshots/unep/2023-03-17/consumption_controlled_substances_halons.xlsx.dvc
@@ -1,18 +1,19 @@
 meta:
-  name: Consumption of controlled substances (UNEP, 2023)
-  publication_year: 2023
-  publication_date: 2023-03-16
-  source_name: UN Environment Programme (2023)
-  source_published_by: UN Environment Programme
-  url: https://ozone.unep.org/countries/data-table
-  source_data_url:
-  license_url:
-  license_name:
-  date_accessed: 2023-03-17
-  is_public: true
-  description: |
-    Period: 1986-2022
-wdir: ../../../data/snapshots/unep/2023-03-17
+  origin:
+    producer: UN Environment Programme
+    title: Consumption of controlled substances
+    description: |-
+      Data reported by Parties to the Montreal Protocol on the consumption of controlled substances, compiled by the UN Environment Programme Ozone Secretariat.
+
+      Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
+    title_snapshot: Consumption of controlled substances - Halons
+    description_snapshot: |-
+      Consumption of halons, reported by country and year over the period 1986-2022.
+    citation_full: UN Environment Programme Ozone Secretariat (2023). Data on consumption of controlled substances. https://ozone.unep.org/countries/data-table.
+    attribution_short: UNEP
+    url_main: https://ozone.unep.org/countries/data-table
+    date_accessed: '2023-03-17'
+    date_published: '2023-03-16'
 outs:
   - md5: 0377c4a5f86c4eaba4674cf351e2b992
     size: 165036

--- a/snapshots/unep/2023-03-17/consumption_controlled_substances_hydrobromofluorocarbons.xlsx.dvc
+++ b/snapshots/unep/2023-03-17/consumption_controlled_substances_hydrobromofluorocarbons.xlsx.dvc
@@ -1,18 +1,19 @@
 meta:
-  name: Consumption of controlled substances (UNEP, 2023)
-  publication_year: 2023
-  publication_date: 2023-03-16
-  source_name: UN Environment Programme (2023)
-  source_published_by: UN Environment Programme
-  url: https://ozone.unep.org/countries/data-table
-  source_data_url:
-  license_url:
-  license_name:
-  date_accessed: 2023-03-17
-  is_public: true
-  description: |
-    Period: 1986-2022
-wdir: ../../../data/snapshots/unep/2023-03-17
+  origin:
+    producer: UN Environment Programme
+    title: Consumption of controlled substances
+    description: |-
+      Data reported by Parties to the Montreal Protocol on the consumption of controlled substances, compiled by the UN Environment Programme Ozone Secretariat.
+
+      Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
+    title_snapshot: Consumption of controlled substances - Hydrobromofluorocarbons (HBFCs)
+    description_snapshot: |-
+      Consumption of hydrobromofluorocarbons (HBFCs), reported by country and year over the period 1986-2022.
+    citation_full: UN Environment Programme Ozone Secretariat (2023). Data on consumption of controlled substances. https://ozone.unep.org/countries/data-table.
+    attribution_short: UNEP
+    url_main: https://ozone.unep.org/countries/data-table
+    date_accessed: '2023-03-17'
+    date_published: '2023-03-16'
 outs:
   - md5: 2f28b25aed78d84476123d3b6b86ab69
     size: 23233

--- a/snapshots/unep/2023-03-17/consumption_controlled_substances_hydrochlorofluorocarbons.xlsx.dvc
+++ b/snapshots/unep/2023-03-17/consumption_controlled_substances_hydrochlorofluorocarbons.xlsx.dvc
@@ -1,18 +1,19 @@
 meta:
-  name: Consumption of controlled substances (UNEP, 2023)
-  publication_year: 2023
-  publication_date: 2023-03-16
-  source_name: UN Environment Programme (2023)
-  source_published_by: UN Environment Programme
-  url: https://ozone.unep.org/countries/data-table
-  source_data_url:
-  license_url:
-  license_name:
-  date_accessed: 2023-03-17
-  is_public: true
-  description: |
-    Period: 1986-2022
-wdir: ../../../data/snapshots/unep/2023-03-17
+  origin:
+    producer: UN Environment Programme
+    title: Consumption of controlled substances
+    description: |-
+      Data reported by Parties to the Montreal Protocol on the consumption of controlled substances, compiled by the UN Environment Programme Ozone Secretariat.
+
+      Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
+    title_snapshot: Consumption of controlled substances - Hydrochlorofluorocarbons (HCFCs)
+    description_snapshot: |-
+      Consumption of hydrochlorofluorocarbons (HCFCs), reported by country and year over the period 1986-2022.
+    citation_full: UN Environment Programme Ozone Secretariat (2023). Data on consumption of controlled substances. https://ozone.unep.org/countries/data-table.
+    attribution_short: UNEP
+    url_main: https://ozone.unep.org/countries/data-table
+    date_accessed: '2023-03-17'
+    date_published: '2023-03-16'
 outs:
   - md5: c37b5dce2d945f478830e1d891942ef5
     size: 212762

--- a/snapshots/unep/2023-03-17/consumption_controlled_substances_hydrofluorocarbons.xlsx.dvc
+++ b/snapshots/unep/2023-03-17/consumption_controlled_substances_hydrofluorocarbons.xlsx.dvc
@@ -1,18 +1,19 @@
 meta:
-  name: Consumption of controlled substances (UNEP, 2023)
-  publication_year: 2023
-  publication_date: 2023-03-16
-  source_name: UN Environment Programme (2023)
-  source_published_by: UN Environment Programme
-  url: https://ozone.unep.org/countries/data-table
-  source_data_url:
-  license_url:
-  license_name:
-  date_accessed: 2023-03-17
-  is_public: true
-  description: |
-    Period: 1986-2022
-wdir: ../../../data/snapshots/unep/2023-03-17
+  origin:
+    producer: UN Environment Programme
+    title: Consumption of controlled substances
+    description: |-
+      Data reported by Parties to the Montreal Protocol on the consumption of controlled substances, compiled by the UN Environment Programme Ozone Secretariat.
+
+      Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
+    title_snapshot: Consumption of controlled substances - Hydrofluorocarbons (HFCs)
+    description_snapshot: |-
+      Consumption of hydrofluorocarbons (HFCs), reported by country and year over the period 1986-2022.
+    citation_full: UN Environment Programme Ozone Secretariat (2023). Data on consumption of controlled substances. https://ozone.unep.org/countries/data-table.
+    attribution_short: UNEP
+    url_main: https://ozone.unep.org/countries/data-table
+    date_accessed: '2023-03-17'
+    date_published: '2023-03-16'
 outs:
   - md5: baf2fb2afc2f7dc31fee79d69de0a9a7
     size: 42274

--- a/snapshots/unep/2023-03-17/consumption_controlled_substances_methyl_bromide.xlsx.dvc
+++ b/snapshots/unep/2023-03-17/consumption_controlled_substances_methyl_bromide.xlsx.dvc
@@ -1,18 +1,19 @@
 meta:
-  name: Consumption of controlled substances (UNEP, 2023)
-  publication_year: 2023
-  publication_date: 2023-03-16
-  source_name: UN Environment Programme (2023)
-  source_published_by: UN Environment Programme
-  url: https://ozone.unep.org/countries/data-table
-  source_data_url:
-  license_url:
-  license_name:
-  date_accessed: 2023-03-17
-  is_public: true
-  description: |
-    Period: 1986-2022
-wdir: ../../../data/snapshots/unep/2023-03-17
+  origin:
+    producer: UN Environment Programme
+    title: Consumption of controlled substances
+    description: |-
+      Data reported by Parties to the Montreal Protocol on the consumption of controlled substances, compiled by the UN Environment Programme Ozone Secretariat.
+
+      Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
+    title_snapshot: Consumption of controlled substances - Methyl Bromide (MB)
+    description_snapshot: |-
+      Consumption of methyl bromide (MB), reported by country and year over the period 1986-2022.
+    citation_full: UN Environment Programme Ozone Secretariat (2023). Data on consumption of controlled substances. https://ozone.unep.org/countries/data-table.
+    attribution_short: UNEP
+    url_main: https://ozone.unep.org/countries/data-table
+    date_accessed: '2023-03-17'
+    date_published: '2023-03-16'
 outs:
   - md5: cdcb0c7dd3481c7d8237939d52436d5e
     size: 141099

--- a/snapshots/unep/2023-03-17/consumption_controlled_substances_methyl_chloroform.xlsx.dvc
+++ b/snapshots/unep/2023-03-17/consumption_controlled_substances_methyl_chloroform.xlsx.dvc
@@ -1,18 +1,19 @@
 meta:
-  name: Consumption of controlled substances (UNEP, 2023)
-  publication_year: 2023
-  publication_date: 2023-03-16
-  source_name: UN Environment Programme (2023)
-  source_published_by: UN Environment Programme
-  url: https://ozone.unep.org/countries/data-table
-  source_data_url:
-  license_url:
-  license_name:
-  date_accessed: 2023-03-17
-  is_public: true
-  description: |
-    Period: 1986-2022
-wdir: ../../../data/snapshots/unep/2023-03-17
+  origin:
+    producer: UN Environment Programme
+    title: Consumption of controlled substances
+    description: |-
+      Data reported by Parties to the Montreal Protocol on the consumption of controlled substances, compiled by the UN Environment Programme Ozone Secretariat.
+
+      Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
+    title_snapshot: Consumption of controlled substances - Methyl Chloroform (TCA)
+    description_snapshot: |-
+      Consumption of methyl chloroform (TCA), reported by country and year over the period 1986-2022.
+    citation_full: UN Environment Programme Ozone Secretariat (2023). Data on consumption of controlled substances. https://ozone.unep.org/countries/data-table.
+    attribution_short: UNEP
+    url_main: https://ozone.unep.org/countries/data-table
+    date_accessed: '2023-03-17'
+    date_published: '2023-03-16'
 outs:
   - md5: 7c1ae2679918a97f6a75ad889e34dbb7
     size: 117419

--- a/snapshots/unep/2023-03-17/consumption_controlled_substances_other_fully_halogenated.xlsx.dvc
+++ b/snapshots/unep/2023-03-17/consumption_controlled_substances_other_fully_halogenated.xlsx.dvc
@@ -1,18 +1,19 @@
 meta:
-  name: Consumption of controlled substances (UNEP, 2023)
-  publication_year: 2023
-  publication_date: 2023-03-16
-  source_name: UN Environment Programme (2023)
-  source_published_by: UN Environment Programme
-  url: https://ozone.unep.org/countries/data-table
-  source_data_url:
-  license_url:
-  license_name:
-  date_accessed: 2023-03-17
-  is_public: true
-  description: |
-    Period: 1986-2022
-wdir: ../../../data/snapshots/unep/2023-03-17
+  origin:
+    producer: UN Environment Programme
+    title: Consumption of controlled substances
+    description: |-
+      Data reported by Parties to the Montreal Protocol on the consumption of controlled substances, compiled by the UN Environment Programme Ozone Secretariat.
+
+      Negative values for a given year imply that quantities destroyed or quantities exported for the year exceeded the sum of production and imports, implying that the destroyed or exported quantities came from stockpiles.
+    title_snapshot: Consumption of controlled substances - Other Fully Halogenated CFCs
+    description_snapshot: |-
+      Consumption of other fully halogenated CFCs, reported by country and year over the period 1986-2022.
+    citation_full: UN Environment Programme Ozone Secretariat (2023). Data on consumption of controlled substances. https://ozone.unep.org/countries/data-table.
+    attribution_short: UNEP
+    url_main: https://ozone.unep.org/countries/data-table
+    date_accessed: '2023-03-17'
+    date_published: '2023-03-16'
 outs:
   - md5: 87c6df5654e6d35f3d70c04b4df9605a
     size: 72535

--- a/snapshots/unicef/2023-06-16/diarrhea.xlsx.dvc
+++ b/snapshots/unicef/2023-06-16/diarrhea.xlsx.dvc
@@ -1,25 +1,20 @@
 meta:
-  namespace: unicef
-  short_name: diarrhea
-  name: Diarrhea treatment (UNICEF, 2022)
-  version: '2023-06-16'
-  publication_year: 2022
-
-  publication_date: '2022-05-01'
-  source_name: UNICEF (2022)
-  source_published_by: Diarrhea treatment (UNICEF, 2022)
-  url: https://data.unicef.org/resources/dataset/diarrhoea/
-  source_data_url:
-    https://data.unicef.org/wp-content/uploads/2018/06/Child-Health-Coverage-Database-May-2022.xlsx
-  file_extension: xlsx
-  license_url: https://data.unicef.org/about-us/
-  license_name: Creative Commons Attribution-NonCommercial 3.0 IGO license
-  date_accessed: 2023-06-16
-  is_public: true
-  description: |
-
-wdir: ../../../data/snapshots/unicef/2023-06-16
+  origin:
+    producer: UNICEF
+    title: Child Health Coverage Database
+    title_snapshot: Child Health Coverage Database - Diarrhea treatment
+    description_snapshot: |-
+      This snapshot contains the diarrhea-related indicators from UNICEF's Child Health Coverage Database, compiled from several health and multiple indicator cluster surveys: careseeking for diarrhea (DIARCARE), oral rehydration salts (ORS), ORS and zinc (ORSZINC), oral rehydration therapy and continued feeding (ORTCF), and zinc (ZINC).
+    citation_full: |-
+      UNICEF (2022). Child Health Coverage Database. Several health and multiple indicator cluster surveys compiled by UNICEF.
+    url_main: https://data.unicef.org/resources/dataset/diarrhoea/
+    url_download: https://data.unicef.org/wp-content/uploads/2018/06/Child-Health-Coverage-Database-May-2022.xlsx
+    date_accessed: '2023-06-16'
+    date_published: '2022-05-01'
+    license:
+      name: Creative Commons Attribution-NonCommercial 3.0 IGO license
+      url: https://data.unicef.org/about-us/
 outs:
-- md5: 9710d68b6b8575c51217e8e1ad25d77a
-  size: 2067580
-  path: diarrhea.xlsx
+  - md5: 9710d68b6b8575c51217e8e1ad25d77a
+    size: 2067580
+    path: diarrhea.xlsx

--- a/snapshots/war/2023-01-09/bouthoul_carrere_1978.csv.dvc
+++ b/snapshots/war/2023-01-09/bouthoul_carrere_1978.csv.dvc
@@ -1,69 +1,45 @@
 meta:
-  namespace: war
-  short_name: bouthoul_carrere_1978
-  name: A list of the 366 major armed conflicts of the period 1740 - 1974
-  source_name: Bouthoul and Carrere (1978)
-  publication_year: 1978
-  publication_date: 1978-07-01
-  url: https://www.jstor.org/stable/23609587
-  source_data_url: https://docs.google.com/spreadsheets/d/1JXkz05kb_gkGXuvdnI21B6lhHIVZJD5BaiEOZi8mqRk/edit?usp=sharing
-  file_extension: csv
-  license_url: https://about.jstor.org/terms/
-  license_name: JSTOR
-  date_accessed: 2023-01-09
-  is_public: true
-  description: >-
-    What years and countries are covered? 1740–1974, worldwide
+  origin:
+    producer: Bouthoul et al.
+    title: 'A list of the 366 major armed conflicts of the period 1740–1974'
+    description: |-
+      This dataset provides information on direct and indirect military and civilian deaths from major armed conflicts, drawn from the article by Bouthoul and Carrère (1978).
 
-      - "List of all major armed conflicts – domestic and international – for the
-    period 1740 - 1974" (Bouthoul et al. 1978: 83)
+      What years and countries are covered? 1740–1974, worldwide
 
+      - "List of all major armed conflicts – domestic and international – for the period 1740 - 1974" (Bouthoul et al. 1978: 83)
 
-    Which conflicts are covered?
+      Which conflicts are covered?
 
       - Major armed conflicts, domestic and international.
 
-      - "Only those conflicts were included which satisfied at least one of the following
-    six quantitative criteria and could
-      therefore be considered as 'major armed conflicts', wars and revolutions being
-    the most representative ones." (Bouthoul et al. 1978: 83).
+      - "Only those conflicts were included which satisfied at least one of the following six quantitative criteria and could therefore be considered as 'major armed conflicts', wars and revolutions being the most representative ones." (Bouthoul et al. 1978: 83).
 
-      - 'Major': more than one state, affected a large area, lasted longer than one
-    year, killed more than 1,000, or had important results,
-      such as regime change or independence; "Those six criteria were: a. undertaken
-    by more than one state, b. Affected a space larger
-      than one province or a capital, c. lasted longer than one year, d. Was of great
-    intensity (more than 1,000 killed)[...], e. Had important
-      internal results (secession or regime change), f. Had important international
-    results (annexation or independence, emergence or
-      disappearance of a state" (Bouthoul et al. 1978: 83).
+      - 'Major': more than one state, affected a large area, lasted longer than one year, killed more than 1,000, or had important results, such as regime change or independence; "Those six criteria were: a. undertaken by more than one state, b. Affected a space larger than one province or a capital, c. lasted longer than one year, d. Was of great intensity (more than 1,000 killed)[...], e. Had important internal results (secession or regime change), f. Had important international results (annexation or independence, emergence or disappearance of a state" (Bouthoul et al. 1978: 83).
 
-      - "The list thus includes the following types of conflicts: foreign and civil
-    wars, occupations by force (e.g. Austria, 1938),
-      military penetrations, revolutions, uprisings and insurrections, massacres and
-    genocide, and other violent troubles with important
-      consequences." (Bouthoul et al. 1978: 83-84).
+      - "The list thus includes the following types of conflicts: foreign and civil wars, occupations by force (e.g. Austria, 1938), military penetrations, revolutions, uprisings and insurrections, massacres and genocide, and other violent troubles with important consequences." (Bouthoul et al. 1978: 83-84).
 
-      - "Conflicts preceded by an asterisk are classified as "inter-state" conflicts
-    in the authors' investigation." (Bouthoul et al. 1978: 84).
+      - "Conflicts preceded by an asterisk are classified as "inter-state" conflicts in the authors' investigation." (Bouthoul et al. 1978: 84).
 
-
-    Which deaths and casualties are covered?
+      Which deaths and casualties are covered?
 
       - Deaths; military and civilian combined; direct and indirect combined
 
-      - "Number of killed, military and civilian, on account of the conflict (operations,
-    massacres, epidemies and famines directly linked to the
-      conflict) (order of magnitude, e.g. 60,000). In view of the difficulty of obtaining
-    precise figures, the ones given indicate orders of magnitude"
-      (Bouthoul et al. 1978: 84).
+      - "Number of killed, military and civilian, on account of the conflict (operations, massacres, epidemies and famines directly linked to the conflict) (order of magnitude, e.g. 60,000). In view of the difficulty of obtaining precise figures, the ones given indicate orders of magnitude" (Bouthoul et al. 1978: 84).
 
-    How did we construct our source spreadsheet?
+      How did we construct our source spreadsheet?
 
       - We identified conflicts as well as deaths from the list in their article.
 
       - We excluded conflicts without deaths.
-wdir: ../../../data/snapshots/war/2023-01-09
+    citation_full: 'Bouthoul, Gaston, René Carrère, and Gernot Köhler. 1978. A list of the 366 Major Armed Conflicts of the Period 1740-1974. Peace Research 10(3): 83-108.'
+    url_main: https://www.jstor.org/stable/23609587
+    url_download: https://docs.google.com/spreadsheets/d/1JXkz05kb_gkGXuvdnI21B6lhHIVZJD5BaiEOZi8mqRk/edit?usp=sharing
+    date_accessed: '2023-01-09'
+    date_published: '1978-07-01'
+    license:
+      name: JSTOR
+      url: https://about.jstor.org/terms/
 outs:
   - md5: 4a417e2fb2e8563a715a7bb61104bc7a
     size: 46668

--- a/snapshots/war/2023-01-09/clodfelter_2017.csv.dvc
+++ b/snapshots/war/2023-01-09/clodfelter_2017.csv.dvc
@@ -1,175 +1,73 @@
 meta:
-  namespace: war
-  short_name: clodfelter_2017
-  name: 'Warfare and Armed Conflicts: A Statistical Encyclopedia of Casualty and Other Figures, 1492-2015, 4th ed.'
-  source_name: Clodfelter (2017)
-  publication_year: 2017
-  publication_date: 2017-04-24
-  url: https://books.google.es/books/about/Warfare_and_Armed_Conflicts.html?id=kNzCDgAAQBAJ&redir_esc=y
-  source_data_url: https://docs.google.com/spreadsheets/d/1Evc5VP2Ra3Lb2_GoV8LjMaJcFoCzlUwslY-TFtC_fB4/edit?usp=sharing
-  file_extension: csv
-  license_url: https://mcfarlandbooks.com/product/warfare-and-armed-conflicts/
-  license_name: McFarland, 2017
-  date_accessed: 2023-01-09
-  is_public: true
-  description: >-
-    What years and countries are covered? 1492 – 2015
+  origin:
+    producer: Clodfelter
+    title: 'Warfare and Armed Conflicts: A Statistical Encyclopedia of Casualty and Other Figures, 1492-2015'
+    description: |-
+      This dataset provides information on direct and indirect military and civilian deaths and casualties from wars, drawn from the book by Clodfelter (2017).
 
+      What years and countries are covered? 1492 – 2015.
 
-    Which conflicts are covered? Wars, domestic and international
+      Which conflicts are covered? Wars, domestic and international.
 
-      - 1492 chosen because data before even more flawed: "Because of the paucity
-    of even remotely reliable statistics before the Renaissance,
-      this volume employs as its starting point the epical year of 1492" (Clodfelter
-    2017: 1).
+      - 1492 chosen because data before even more flawed: "Because of the paucity of even remotely reliable statistics before the Renaissance, this volume employs as its starting point the epical year of 1492" (Clodfelter 2017: 1).
 
-      - "I have attempted to include every war, major or minor, for which there exist
-    statistics—international wars and civil wars,
-      internationalized civil wars, limited wars and unlimited wars, border wars and
-    miniwars—as well as those less organized and
-      less sustained, or wholly one-sided outbreaks of mass human violence—riots,
-    revolutions, massacres, bloodbaths, and pogroms,
-      (or those conflicts, such as the U.S. Civil Rights Movement, in which only one
-    side was armed and violent and the other
-      determinedly non-violent)" (Clodfelter 2017: 1-2).
+      - "I have attempted to include every war, major or minor, for which there exist statistics—international wars and civil wars, internationalized civil wars, limited wars and unlimited wars, border wars and miniwars—as well as those less organized and less sustained, or wholly one-sided outbreaks of mass human violence—riots, revolutions, massacres, bloodbaths, and pogroms, (or those conflicts, such as the U.S. Civil Rights Movement, in which only one side was armed and violent and the other determinedly non-violent)" (Clodfelter 2017: 1-2).
 
+      Which deaths and casualties are covered?
 
-    Which deaths and casualties are covered?
+      - Deaths and casualties; military and civilian combined; direct and indirect combined.
 
-      - Deaths and casualties; military and civilian combined; direct and indirect
-    combined.
+      - Deaths and casualties from battle: "KIA for killed-in-action; DOW for died of wounds; WIA for wounded-in-action; MIA for missing-in-action; POW for prisoner of war. In many instances, because of a lack of accurate information about the number who died of wounds subsequent to the battle or who died from fratricide or other causes directly or indirectly attributable to hostile fire, KIA is employed as a catch-all designation for lack of more precise data. Where more appropriate, the term "battle deaths" is used" (Clodfelter 2017: xix-xx).
 
-      - Deaths and casualties from battle: "KIA for killed-in-action; DOW for died
-    of wounds; WIA for wounded-in-action; MIA for missing-in-action;
-      POW for prisoner of war. In many instances, because of a lack of accurate information
-    about the number who died of wounds subsequent to the
-      battle or who died from fratricide or other causes directly or indirectly attributable
-    to hostile fire, KIA is employed as a catch-all
-      designation for lack of more precise data. Where more appropriate, the term
-    "battle deaths" is used" (Clodfelter 2017: xix-xx).
+      - Deaths from disease included: "Of course, a very large proportion of the dead shown in these sets of figures were not killed in battle but died as a result of infections arising from wounds or disease. Until the great medical advances of the late nineteenth century and of the twentieth century, nearly as many men did after the guns had fallen silent as had been killed in the heat and smoke of battle" (Clodfelter 2017: 6).
 
-      - Deaths from disease included: "Of course, a very large proportion of the dead
-    shown in these sets of figures were not killed in battle but
-      died as a result of infections arising from wounds or disease. Until the great
-    medical advances of the late nineteenth century and of the
-      twentieth century, nearly as many men did after the guns had fallen silent as
-    had been killed in the heat and smoke of battle"
-      (Clodfelter 2017: 6).
+      - "Until the twentieth century a soldier marching off to war had a far greater chance of dying for his cause or country because of disease than through enemy fire. The proportion of disease deaths to combat deaths (including those who died of wounds) was almost always at least 3:1, even in the healthiest of climates" (Clodfelter 2017: 6).
 
-      - "Until the twentieth century a soldier marching off to war had a far greater
-    chance of dying for his cause or country because of disease than
-      through enemy fire. The proportion of disease deaths to combat deaths (including
-    those who died of wounds) was almost always at least 3:1, even
-      in the healthiest of climates" (Clodfelter 2017: 6).
+      - No deaths or casualties threshold: "It is, of course, beyond the scope of a work such as this to include the losses of every single battle for which someone has bothered to take and record a count of casualties. [...] It is obvious that I must establish some kind of minimum cut-off figure for the toll of the battles of, say, World War I's Western Front or World War II's Russian Front, while setting a different criterion when recording the losses suffered in the actions of a great many lesser wars. If I were to arbitrarily conform to a figure of 50,000 or even 25,000 total casualties incurred, below which I would not bother to include a battle in this survey, this work would ignore a great many of the important battles of history" (Clodfelter 2017: 2).
 
-      - No deaths or casualties threshold: "It is, of course, beyond the scope of
-    a work such as this to include the losses of every single battle
-      for which someone has bothered to take and record a count of casualties. [...]
-    It is obvious that I must establish some kind of minimum
-      cut-off figure for the toll of the battles of, say, World War I's Western Front
-    or World War II's Russian Front, while setting a different
-      criterion when recording the losses suffered in the actions of a great many
-    lesser wars. If I were to arbitrarily conform to a figure of
-      50,000 or even 25,000 total casualties incurred, below which I would not bother
-    to include a battle in this survey, this work would
-      ignore a great many of the important battles of history" (Clodfelter 2017: 2).
+      - One-sided violence included: "I have attempted to include every war, major or minor, for which there exist statistics [...] as well as those less organized and less sustained, or wholly one-sided outbreaks of mass human violence—riots, revolutions, massacres, bloodbaths, and pogroms, (or those conflicts, such as the U.S. Civil Rights Movement, in which only one side was armed and violent and the other determinedly non-violent)" (Clodfelter 2017: 1-2).
 
-      - One-sided violence included: "I have attempted to include every war, major
-    or minor, for which there exist statistics [...] as well as those
-      less organized and less sustained, or wholly one-sided outbreaks of mass human
-    violence—riots, revolutions, massacres, bloodbaths, and pogroms,
-      (or those conflicts, such as the U.S. Civil Rights Movement, in which only one
-    side was armed and violent and the other determinedly
-      non-violent)" (Clodfelter 2017: 1-2).
+      - Numbers do not necessarily add up across categories: "Figures in tables organized by year or unit do not always conform strictly to other cumulative counts or estimates due to variables in the methodology and dating of the counts" (Clodfelter 2017: xx).
 
-      - Numbers do not necessarily add up across categories: "Figures in tables organized
-    by year or unit do not always conform strictly to other
-      cumulative counts or estimates due to variables in the methodology and dating
-    of the counts" (Clodfelter 2017: xx).
+      - Data quality low because lives lost were not valued: "Body counts were not important in earlier centuries, particularly the seventeenth and eighteenth, the era of siege warfare. In those centuries the magnitude of victory was often calculated as much on fortresses or cities captured and war materiel seized as on casualties inflicted" (Clodfelter 2017: 4).
 
-      - Data quality low because lives lost were not valued: "Body counts were not
-    important in earlier centuries, particularly the seventeenth and
-      eighteenth, the era of siege warfare. In those centuries the magnitude of victory
-    was often calculated as much on fortresses or cities
-      captured and war materiel seized as on casualties inflicted" (Clodfelter 2017:
-    4).
+      - "The ratio of killed to wounded also remained fairly constant up to World War I. For every 10 men killed usually another 35 were wounded" (Clodfelter 2017: 4).
 
-      - "The ratio of killed to wounded also remained fairly constant up to World
-    War I. For every 10 men killed usually another 35 were wounded"
-      (Clodfelter 2017: 4).
+      - Sometimes several estimates are given: "Usually a single set of figures is presented in this work, but in some cases, for the sake of comparison, conflicting counts are given. The abbreviation "n.a." (not available) is used when no reliable data were found." (Clodfelter 2017: xix).
 
-      - Sometimes several estimates are given: "Usually a single set of figures is
-    presented in this work, but in some cases, for the sake of
-      comparison, conflicting counts are given. The abbreviation "n.a." (not available)
-    is used when no reliable data were found." (Clodfelter 2017: xix).
+      How did he construct the data?
 
+      - Data quality as good as can be, but flawed: "I have employed official and supposedly authoritative sources wherever available, have sought statistics from both sides in each war to evaluate the inevitably conflicting claims, and have tried to verify the numbers reported on the battlefield with the records of the various medical corps and military surgeon-general reports. But for all my efforts at cutting through the exaggeration, propaganda, and outright mendacity with which the statistics of warfare are weighted, it must still be admitted that every quantity in this work may legitimately be questioned" (Clodfelter 2017: xix).
 
-    How did he construct the data?
+      - Data quality lower for earlier years and for countries outside Europe: "Usually the longer the battle and the larger the battlefield, the more uncertain the numbers involved. Generally also, the reliability of battlefield figures decreases the further back one goes in history and the further one travels from the Western industrial world. Numerical precision in warfare, even in the West, was rare prior to the Age of the Enlightenment. Every battlefield statistic can be no more than an educated guess" (Clodfelter 2017: xix).
 
-      - Data quality as good as can be, but flawed: "I have employed official and
-    supposedly authoritative sources wherever available, have sought
-      statistics from both sides in each war to evaluate the inevitably conflicting
-    claims, and have tried to verify the numbers reported on
-      the battlefield with the records of the various medical corps and military surgeon-general
-    reports. But for all my efforts at cutting
-      through the exaggeration, propaganda, and outright mendacity with which the
-    statistics of warfare are weighted, it must still be admitted
-      that every quantity in this work may legitimately be questioned" (Clodfelter
-    2017: xix).
+      - Data is still informative: "But there are precise numbers in the documentation of warfare—tens of thousands of them. It is unnecessary to reject them all because a few seem unlikely or even impossible, and round off all battlefield numbers" (Clodfelter 2017: xix).
 
-      - Data quality lower for earlier years and for countries outside Europe: "Usually
-    the longer the battle and the larger the battlefield,
-      the more uncertain the numbers involved. Generally also, the reliability of
-    battlefield figures decreases the further back one goes in
-      history and the further one travels from the Western industrial world. Numerical
-    precision in warfare, even in the West, was rare prior
-      to the Age of the Enlightenment. Every battlefield statistic can be no more
-    than an educated guess" (Clodfelter 2017: xix).
+      - Data quality for European countries is better (but a troubling way of expressing that): "In some cases, exact numbers are stated for one side in a conflict while estimated figures are given for the opposing side. This is due to the progression in statistical accuracy of the one side and lack of such for the other. This is particularly characteristic of the colonial conflicts of the late eighteenth through the early twentieth centuries, when the more technologically advanced Western armies battled the forces of Africa and Asia whose cultures cared little for statistical precision" (Clodfelter 2017: xix).
 
-      - Data is still informative: "But there are precise numbers in the documentation
-    of warfare—tens of thousands of them. It is unnecessary
-      to reject them all because a few seem unlikely or even impossible, and round
-    off all battlefield numbers" (Clodfelter 2017: xix).
+      - Data quality is better if war was relatively small, brief, and clear geography and timeline: "The dependability of statistical accuracy rises with battles of relatively small scope, brief duration, and distinct boundaries in geography and chronology" (Clodfelter 2017: xix).
 
-      - Data quality for European countries is better (but a troubling way of expressing
-    that): "In some cases, exact numbers are stated for one
-      side in a conflict while estimated figures are given for the opposing side.
-    This is due to the progression in statistical accuracy of the
-      one side and lack of such for the other. This is particularly characteristic
-    of the colonial conflicts of the late eighteenth through the
-      early twentieth centuries, when the more technologically advanced Western armies
-    battled the forces of Africa and Asia whose cultures cared
-      little for statistical precision" (Clodfelter 2017: xix).
+      - Worked to reconcile differing sources: "Where generally reliable, but conflicting, sources exist for the same battle or war, the origin of each source has been investigated to determine the more accurate of the two" (Clodfelter 2017: xix).
 
-      - Data quality is better if war was relatively small, brief, and clear geography
-    and timeline: "The dependability of statistical accuracy
-      rises with battles of relatively small scope, brief duration, and distinct boundaries
-    in geography and chronology" (Clodfelter 2017: xix).
+      How did we construct our source spreadsheet?
 
-      - Worked to reconcile differing sources: "Where generally reliable, but conflicting,
-    sources exist for the same battle or war, the origin
-      of each source has been investigated to determine the more accurate of the two"
-    (Clodfelter 2017: xix).
+      - We identified conflicts as well as deaths and casualties based on the conflict narratives in his book.
 
+      - We seem to have almost exclusively coded conflicts until the early 19th century; among the coded conflicts, the latest start date is 1831.
 
-    How did we construct our source spreadsheet?
+      - We erred on the side of caution, such as by excluding estimates referring to 'dead, wounded, or missing in action'.
 
-      - We identified conflicts as well as deaths and casualties based on the conflict
-    narratives in his book.
+      - In some cases, we used overall estimates of deaths instead of adding up more specific death types.
 
-      - We seem to have almost exclusively coded conflicts until the early 19th century;
-    among the coded conflicts, the latest start date is 1831.
-
-      - We erred on the side of caution, such as by excluding estimates referring
-    to 'dead, wounded, or missing in action'.
-
-      - In some cases, we used overall estimates of deaths instead of adding up more
-    specific death types.
-
-      - We have two source spreadsheets: they include the same information, but whereas
-    one provides more information in the 'notes' column, the
-      other follows the structure common for the other datasets of one conflict per
-    row.
+      - We have two source spreadsheets: they include the same information, but whereas one provides more information in the 'notes' column, the other follows the structure common for the other datasets of one conflict per row.
+    citation_full: 'Clodfelter, M. (2017). Warfare and Armed Conflicts: A Statistical Encyclopedia of Casualty and Other Figures, 1492-2015. Fourth edition. McFarland & Company.'
+    url_main: https://books.google.es/books/about/Warfare_and_Armed_Conflicts.html?id=kNzCDgAAQBAJ&redir_esc=y
+    url_download: https://docs.google.com/spreadsheets/d/1Evc5VP2Ra3Lb2_GoV8LjMaJcFoCzlUwslY-TFtC_fB4/edit?usp=sharing
+    date_accessed: '2023-01-09'
+    date_published: '2017-04-24'
+    license:
+      name: McFarland, 2017
+      url: https://mcfarlandbooks.com/product/warfare-and-armed-conflicts/
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
   - md5: abb021bfa5cd726d64aa03c30a9d7af4

--- a/snapshots/war/2023-01-09/dunnigan_martel_1987.csv.dvc
+++ b/snapshots/war/2023-01-09/dunnigan_martel_1987.csv.dvc
@@ -1,118 +1,66 @@
 meta:
-  namespace: war
-  short_name: dunnigan_martel_1987
-  name: How to stop a war (1987)
-  source_name: Dunnigan and Martel (1987)
-  publication_year: 1987
-  publication_date: 1987-10-01
-  url: https://books.google.es/books/about/How_to_Stop_a_War.html?id=lg7cAAAAMAAJ
-  source_data_url: https://docs.google.com/spreadsheets/d/13XJbTXryll5VqhtmbutMLCbb3pgjEtofk3o2dJG29Aw/edit?usp=sharing
-  file_extension: csv
-  license_url:
-  license_name: Doubleday (1987)
-  date_accessed: 2023-01-09
-  is_public: true
-  description: >-
-    What years and countries are covered?
+  origin:
+    producer: Dunnigan and Martel
+    title: How to Stop a War
+    description: |-
+      What years and countries are covered?
 
-      - "Wars that occurred during the last two hundred years" (Dunnigan and Martel
-    1987: 6).
+      - "Wars that occurred during the last two hundred years" (Dunnigan and Martel 1987: 6).
 
-      - 1786-1987  (Dunnigan and Martel 1987: 207, 250)
+      - 1786–1987 (Dunnigan and Martel 1987: 207, 250)
 
+      Which conflicts are covered?
 
-    Which conflicts are covered?
+      - "War is organized violence caused by national governments" (Dunnigan and Martel 1987: 11).
 
-      - "War is organized violence caused by national governments" (Dunnigan and Martel
-    1987: 11).
+      - "Traditional Wars. [...] Two nations gather up their armed forces and go after each other" (Dunnigan and Martel 1987: 11).
 
-      - "Traditional Wars. [...] Two nations gather up their armed forces and go after
-    each other" (Dunnigan and Martel 1987: 11).
+      - "Colonial Wars. A broad category of conflicts best described as a major power going to war with a significantly weaker power on the defender's own territory. This does not always involve actual colonies, just big guys beating up on little guys. [The major distinguishing characteristic is the great disparity in military power between the two combatants. [...] What is most important about this type of war is that only one side, the major power, can escalate the war to include nuclear weapons or other combat between superpowers" (Dunnigan and Martel 1987: 11).
 
-      - "Colonial Wars. A broad category of conflicts best described as a major power
-    going to war with a significantly weaker power on the
-      defender's own territory. This does not always involve actual colonies, just
-    big guys beating up on little guys.
-      [The major distinguishing characteristic is the great disparity in military
-    power between the two combatants. [...] What is most important
-      about this type of war is that only one side, the major power, can escalate
-    the war to include nuclear weapons or other combat between
-      superpowers" (Dunnigan and Martel 1987: 11).
+      - "Civil Wars. A nation at war with itself, with both sides deploying armed forces. This category includes insurrections, separatist movements, persistent terrorism and rebellions in general" (Dunnigan and Martel 1987: 11-12).
 
-      - "Civil Wars. A nation at war with itself, with both sides deploying armed
-    forces. This category includes insurrections, separatist movements,
-      persistent terrorism and rebellions in general" (Dunnigan and Martel 1987: 11-12).
+      - "Civil Terrors. A nation goes to war against its own people. Many of these wars are very similar to civil wars, except that the "rebels" are not organized well, if at all. [...] The most prominent examples are the Stalinist Terror in Russia during the 1930s, the Communist Terror in China during the 1950s [...]" (Dunnigan and Martel 1987: 12).
 
-      - "Civil Terrors. A nation goes to war against its own people. Many of these
-    wars are very similar to civil wars, except that the "rebels" are
-      not organized well, if at all. [...] The most prominent examples are the Stalinist
-    Terror in Russia during the 1930s, the Communist Terror in
-      China during the 1950s [...]" (Dunnigan and Martel 1987: 12).
+      - "Began: Year in which the war began. Sometimes it differs from the official starting date. We used the date at which hostilities or large-scale unrest began" (Dunnigan and Martel 1987: 180).
 
-      - "Began: Year in which the war began. Sometimes it differs from the official
-    starting date. We used the date at which hostilities or
-      large-scale unrest began" (Dunnigan and Martel 1987: 180).
+      - "We categorized wars into the following groups: C— Civil terror[;] R—Social revolution[;] S—Secessionist movement[;] T—Territorial conflict" (Dunnigan and Martel 1987: 184).
 
-      - "We categorized wars into the following groups: C— Civil terror[;] R—Social
-    revolution[;] S—Secessionist movement[;] T—Territorial conflict"
-      (Dunnigan and Martel 1987: 184).
-
-
-    Which deaths and casualties are covered?
+      Which deaths and casualties are covered?
 
       - Probably deaths; military and civilian combined; direct and indirect combined.
 
       - "Losses: Military and civilian" (Dunnigan and Martel 1987: 185).
 
-      - "Keep in mind that it is often difficult to separate them. A further complication
-    is that civilian losses are often not noted in histories"
-      (Dunnigan and Martel 1987: 185).
+      - "Keep in mind that it is often difficult to separate them. A further complication is that civilian losses are often not noted in histories" (Dunnigan and Martel 1987: 185).
 
-      - 'Losses' used, which probably means deaths: "nearly half the deaths in all
-    wars" made up by the Napoleonic Wars, the Taiping Rebellion, and
-      the World Wars — which is half of all the losses of the 163 million they list.
+      - 'Losses' used, which probably means deaths: "nearly half the deaths in all wars" made up by the Napoleonic Wars, the Taiping Rebellion, and the World Wars — which is half of all the losses of the 163 million they list.
 
+      How did they construct the data?
 
-    How did they construct the data?
+      - "our information was collected for each participant of the war" (Dunnigan and Martel 1987: 6).
 
-      - "our information was collected for each participant of the war" (Dunnigan
-    and Martel 1987: 6).
+      - "One source that was quite useful is The Encyclopedia of Military History (New York: Harper & Row, 1977) by R. E. Dupuy and T. N. Dupuy. The detailed accounts of wars provided a starting point for identifying wars" (Dunnigan and Martel 1987: 275).
 
-      - "One source that was quite useful is The Encyclopedia of Military History
-    (New York: Harper & Row, 1977) by R. E. Dupuy and T. N. Dupuy.
-      The detailed accounts of wars provided a starting point for identifying wars"
-    (Dunnigan and Martel 1987: 275).
+      - "An important reference was The Wages of War, 1819-1965 (New York: John Wiley & Sons, 1972) by J. David Singer and Melvin Small. [...] It is also a good source of data on the size of the combat forces for each nation, and estimates of the casualties. Singer and Small, however, tend to generate statistics of dubious value, such as battle deaths per month of the war" (Dunnigan and Martel 1987: 275).
 
-      - "An important reference was The Wages of War, 1819-1965 (New York: John Wiley
-    & Sons, 1972) by J. David Singer and Melvin Small. [...] It
-      is also a good source of data on the size of the combat forces for each nation,
-    and estimates of the casualties. Singer and Small, however,
-      tend to generate statistics of dubious value, such as battle deaths per month
-    of the war" (Dunnigan and Martel 1987: 275).
+      - "There is considerable uncertainty about the number of people who are killed in a given war, especially as one proceeds further into the past" (Dunnigan and Martel 1987: 275).
 
-      - "There is considerable uncertainty about the number of people who are killed
-    in a given war, especially as one proceeds further into the past"
-      (Dunnigan and Martel 1987: 275).
+      - "Some other sources for data on combat casualties are Statistics of Deadly Quarrels (Pittsburgh: Boxwood Press, 1960) by Lewis Frye Richardson; Social and Cultural Dynamics (New York: American Book, 1937) by Pitirim A. Sorokin; Losses of Life in Modern Wars (London: Oxford University, 1916) by Gaston Bodart; Losses of Life Caused by War (London: Oxford University, 1920) by Vedel and Petersen. Military Balance (Letchford, England: The Garden City Press Ltd., 1985), which is published annually by the International Institute for Strategic Studies, is a good source for the size of armed forces in the contemporary period" (Dunnigan and Martel 1987: 276).
 
-      - "Some other sources for data on combat casualties are Statistics of Deadly
-    Quarrels (Pittsburgh: Boxwood Press, 1960) by Lewis Frye Richardson;
-      Social and Cultural Dynamics (New York: American Book, 1937) by Pitirim A. Sorokin;
-    Losses of Life in Modern Wars (London: Oxford University,
-      1916) by Gaston Bodart; Losses of Life Caused by War (London: Oxford University,
-    1920) by Vedel and Petersen. Military Balance (Letchford,
-      England: The Garden City Press Ltd., 1985), which is published annually by the
-    International Institute for Strategic Studies, is a good source
-      for the size of armed forces in the contemporary period" (Dunnigan and Martel
-    1987: 276).
+      How did we construct it?
 
-    How did we construct it?
+      - We used to access the book here; the access since seems to have become restricted, we have purchased a used copy; the quotes above are from that copy.
 
-      - We used to access the book here; the access since seems to have become restricted,
-    we have purchased a used copy; the quotes above are from
-      that copy.
+      - We extracted conflicts as well as deaths and casualties from the list in their book, starting at page 207.
 
-      - We extracted conflicts as well as deaths and casualties from the list in their
-    book, starting at page 207.
+      This dataset provides information on military and civilian deaths from wars, drawn from the book by Dunnigan and Martel (1987).
+    citation_full: 'Dunnigan, James, and William Martel. 1987. How to Stop a War. Doubleday.'
+    url_main: https://books.google.es/books/about/How_to_Stop_a_War.html?id=lg7cAAAAMAAJ
+    url_download: https://docs.google.com/spreadsheets/d/13XJbTXryll5VqhtmbutMLCbb3pgjEtofk3o2dJG29Aw/edit?usp=sharing
+    date_accessed: '2023-01-09'
+    date_published: '1987-10-01'
+    license:
+      name: Doubleday (1987)
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
   - md5: f197fb1e4ea3807a186e7dfffa93d1ed

--- a/snapshots/war/2023-01-09/eckhardt_1991.csv.dvc
+++ b/snapshots/war/2023-01-09/eckhardt_1991.csv.dvc
@@ -1,61 +1,43 @@
 meta:
-  namespace: war
-  short_name: eckhardt_1991
-  name: Wars and War-Related Deaths, 1500-1990 - Eckhardt (1991)
-  source_name: Eckhardt (1991)
-  publication_year: 1991
-  publication_date: 1991-01-01
-  url: https://ruthsivard.com/wmse91.html
-  source_data_url: https://docs.google.com/spreadsheets/d/1vI5zTU5r7LNjG8AcH0ZIoCNEjMIo68Rn6pqwarVAQ-Q/edit?usp=sharing
-  file_extension: csv
-  license_url:
-  license_name: World Priorities
-  date_accessed: 2023-01-09
-  is_public: true
-  description: >-
-    What years and countries are covered? 1500 – 1990.
+  origin:
+    producer: Eckhardt
+    title: Wars and War-Related Deaths, 1500-1990
+    description: |-
+      This dataset provides information on military and civilian deaths from wars, drawn from the chapter by Eckhardt (1991).
 
+      What years and countries are covered? 1500 – 1990.
 
-    Which conflicts are covered? War, domestic or international, involving at least
-    one state.
+      Which conflicts are covered? War, domestic or international, involving at least one state.
 
-      - Threshold for a war: "War—any armed conflict involving one or more governments
-    and causing the death of 1,000 or more people per year"
-      (Eckhardt 1991: 25).
+      - Threshold for a war: "War—any armed conflict involving one or more governments and causing the death of 1,000 or more people per year" (Eckhardt 1991: 25).
 
-      - "Location refer to country which was principal battleground, except for two
-    World Wars for which location refers to participating country"
-      (Eckhardt 1991: 25).
+      - "Location refer to country which was principal battleground, except for two World Wars for which location refers to participating country" (Eckhardt 1991: 25).
 
-      - Also included: "Intervention—overt military action by foreign forces, at the
-    invitation of the government in power" (Eckhardt 1991: 25).
+      - Also included: "Intervention—overt military action by foreign forces, at the invitation of the government in power" (Eckhardt 1991: 25).
 
-      - Also included: "Invasion—armed attack by foreign country, including air attack
-    without land invasion" (Eckhardt 1991: 25).
+      - Also included: "Invasion—armed attack by foreign country, including air attack without land invasion" (Eckhardt 1991: 25).
 
-
-    Which deaths and casualties are covered? Deaths; total, military, or civilian;
-
+      Which deaths and casualties are covered? Deaths; total, military, or civilian.
 
       - "War-Related Deaths" (Eckhardt 1991: 22).
 
       - "Civilian [—] Military [—] Total" (Eckhardt 1991: 22).
 
-      - "Incomplete; breakdown of civilian and military deaths not available in all
-    cases" (Eckhardt 1991: 25).
+      - "Incomplete; breakdown of civilian and military deaths not available in all cases" (Eckhardt 1991: 25).
 
-      - "World War area-wide deaths are in addition to those which could be located
-    by country, and are shown under the country of origin"
-      (Eckhardt 1991: 25).
+      - "World War area-wide deaths are in addition to those which could be located by country, and are shown under the country of origin" (Eckhardt 1991: 25).
 
+      How did we construct it?
 
-    How did we construct it?
-
-      - We extracted conflicts as well as deaths and casualties from the list in this
-    book.
-      - There seems to be an affordable used edition available in the UK that we could
-    buy if we wanted more information; alternatively,
-      this book by Eckhardt may have more details in chapter 9.
+      - We extracted conflicts as well as deaths and casualties from the list in this book.
+      - There seems to be an affordable used edition available in the UK that we could buy if we wanted more information; alternatively, this book by Eckhardt may have more details in chapter 9.
+    citation_full: 'Eckhardt, W. (1991). Wars and War-Related Deaths, 1500-1990. In: Ruth Sivard, World Military and Social Expenditures. World Priorities.'
+    url_main: https://ruthsivard.com/wmse91.html
+    url_download: https://docs.google.com/spreadsheets/d/1vI5zTU5r7LNjG8AcH0ZIoCNEjMIo68Rn6pqwarVAQ-Q/edit?usp=sharing
+    date_accessed: '2023-01-09'
+    date_published: '1991-01-01'
+    license:
+      name: World Priorities
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
   - md5: 8714107efdc4a5d6a7bf1e7ac0531382

--- a/snapshots/war/2023-01-09/kaye_1985.csv.dvc
+++ b/snapshots/war/2023-01-09/kaye_1985.csv.dvc
@@ -1,144 +1,74 @@
 meta:
-  namespace: war
-  short_name: kaye_1985
-  name: ORAE Report 95 - National Defence of Canada (1985)
-  source_name: Kaye et al. (1985)
-  publication_year: 1985
-  publication_date: 1985-11-01
-  url: https://books.google.es/books/about/Major_Armed_Conflict.html?id=Xce_PwAACAAJ&redir_esc=y
-  source_data_url: https://docs.google.com/spreadsheets/d/1GIB-8ZPNXqTATwHU4ZDavKz0iJoiOg2UROfoRz43kQY/edit#gid=1251805698
-  file_extension: csv
-  license_url:
-  license_name: Department of National Defence, Canada, Operational Research and Analysis Establishment, 1985
-  date_accessed: 2023-01-09
-  is_public: true
-  description: >-
-    What years and countries are covered? 1720–1985, worldwide.
+  origin:
+    producer: Kaye et al.
+    title: 'Major Armed Conflict: A Compendium of Interstate and Intrastate Conflict, 1720 to 1985'
+    description: |-
+      This dataset provides information on direct and indirect military and civilian deaths from major armed conflicts, drawn from the report by Kaye et al. (1985).
+
+      What years and countries are covered? 1720–1985, worldwide.
 
       - "190 nations for the years 1720 to 1985" (ORAE 1985: 12).
 
-      - "The nation list is so large because it includes nations that have ceased
-    to exist today" (ORAE 1985: 12).
+      - "The nation list is so large because it includes nations that have ceased to exist today" (ORAE 1985: 12).
 
-      - "all identifiable wars and conflicts that have taken place since 1720" (ORAE
-    1985: i).
+      - "all identifiable wars and conflicts that have taken place since 1720" (ORAE 1985: i).
 
-      - Coverage start was chosen because modern age begins then: "The 260-year time
-    period was chosen because it covers the development of
-      modern war and conflict" (ORAE 1985: 12-13).
+      - Coverage start was chosen because modern age begins then: "The 260-year time period was chosen because it covers the development of modern war and conflict" (ORAE 1985: 12-13).
 
-
-    Which conflicts are covered?
+      Which conflicts are covered?
 
       - Major armed conflicts involving at least one state, domestic and international.
 
-      - Definition of major armed conflict: "It was originally defined as "An event
-    where one or more nations or actors used armed force against
-      another nation or actor. The violent actions must result in significant casualties""
-    (ORAE 1985: 13).
+      - Definition of major armed conflict: "It was originally defined as "An event where one or more nations or actors used armed force against another nation or actor. The violent actions must result in significant casualties"" (ORAE 1985: 13).
 
-      - One state has to be involved: "there are certain types of conflict which the
-    definition should exclude, for example, isolated terrorist acts,
-      gang warfare not involving a national government, changes of government by bloodless
-    coup, riots controlled by police without military support,
-      etc. Most of these can be excluded by setting the requirement that in a conflict
-    at least one nation must be involved; the other participants may
-      be actors" (ORAE 1985: 14).
+      - One state has to be involved: "there are certain types of conflict which the definition should exclude, for example, isolated terrorist acts, gang warfare not involving a national government, changes of government by bloodless coup, riots controlled by police without military support, etc. Most of these can be excluded by setting the requirement that in a conflict at least one nation must be involved; the other participants may be actors" (ORAE 1985: 14).
 
-      - Different types of conflict: "Major armed conflicts may include: international
-    wars, civil wars, guerrilla wars, limited wars, nuclear wars,
-      colonial wars, revolutions, occupation by force, massacres (if committed for
-    or against a government), violent civil disorders with military
-      involvement, coups d'état (where armed resistance or attack is involved), military
-    revolts, wars for independence, etc. Specifically, the
-      following typology of conflict modes has been utilized in the Compendium: 1.
-    Conventional Interstate 2. Unconventional Interstate 3. Internal
-      with Significant External Involvement 4. Primarily Internal 5. Colonial 6. Imperial
-    7. Cold War Crisis[.] The definitions, criteria and
-      assumptions of these modes are discussed in Annex A: Guide to the Variable list"
-    (ORAE 1985: 14).
+      - Different types of conflict: "Major armed conflicts may include: international wars, civil wars, guerrilla wars, limited wars, nuclear wars, colonial wars, revolutions, occupation by force, massacres (if committed for or against a government), violent civil disorders with military involvement, coups d'état (where armed resistance or attack is involved), military revolts, wars for independence, etc. Specifically, the following typology of conflict modes has been utilized in the Compendium: 1. Conventional Interstate 2. Unconventional Interstate 3. Internal with Significant External Involvement 4. Primarily Internal 5. Colonial 6. Imperial 7. Cold War Crisis[.] The definitions, criteria and assumptions of these modes are discussed in Annex A: Guide to the Variable list" (ORAE 1985: 14).
 
-      - "Seven modes of conflict have been identified [...] The most important are
-    "Primarily Internal" Conflict – 230 cases, and "Conventional
-      Interstate Conflict" – 164 cases" (ORAE 1985: 1).
+      - "Seven modes of conflict have been identified [...] The most important are "Primarily Internal" Conflict – 230 cases, and "Conventional Interstate Conflict" – 164 cases" (ORAE 1985: 1).
 
-      - "However, since the appearance of mode 7, Cold War Crisis, may be unexpected,
-    it should be explained that a cold war crisis is really a
-      substitute for a major armed conflict, or a major armed conflict that doesn't
-    happen. It is a new development in the nature of conflict and
-      seems best regarded as a major conflict that is resolved peaceably. Such cases
-    are, therefore, included whether or not there were many
-      casualties or even any at all. They do not occur before 1945" (ORAE 1985: 14-15).
+      - "However, since the appearance of mode 7, Cold War Crisis, may be unexpected, it should be explained that a cold war crisis is really a substitute for a major armed conflict, or a major armed conflict that doesn't happen. It is a new development in the nature of conflict and seems best regarded as a major conflict that is resolved peaceably. Such cases are, therefore, included whether or not there were many casualties or even any at all. They do not occur before 1945" (ORAE 1985: 14-15).
 
-      - Casualty numbers unnecessary to be included: "Moreover, in a large number
-    of cases there is no reliable record of the number of casualties'
-      these cases have not been excluded if they appeared to meet the other requirements
-    for a major conflict" (ORAE 1985: 14).
+      - Casualty numbers unnecessary to be included: "Moreover, in a large number of cases there is no reliable record of the number of casualties' these cases have not been excluded if they appeared to meet the other requirements for a major conflict" (ORAE 1985: 14).
 
-      - "a total of 654 conflicts [...] deaths are recorded for only 504 of the cases"
-    (ORAE 1985: 1).
+      - "a total of 654 conflicts [...] deaths are recorded for only 504 of the cases" (ORAE 1985: 1).
 
-    Which deaths and casualties are covered? Deaths; military and civilian combined
+      Which deaths and casualties are covered? Deaths; military and civilian combined
 
-      - "This report has attempted to identify the total casualties (deaths) associated
-    with each conflict, both military and civilian, but it
-      should be noted that there are inconsistencies and inaccuracies in the data"
-    (ORAE 1985: 18).
+      - "This report has attempted to identify the total casualties (deaths) associated with each conflict, both military and civilian, but it should be noted that there are inconsistencies and inaccuracies in the data" (ORAE 1985: 18).
 
-      - "DEATHS - the sum of the deaths in all the nations actively involved in each
-    conflict which can be related to that conflict.
-      There is some inconsistency in the data because Singer and Small include only
-    battle deaths while Bouthoul and Carrière [sic] include
-      both military and civilian deaths. An effort has been made to include the casualties
-    for both civilians and military that were a result
-      of the armed conflict. When there is no figure available, the deaths are listed
-    as ‘0'" (ORAE 1985: A7).
+      - "DEATHS - the sum of the deaths in all the nations actively involved in each conflict which can be related to that conflict. There is some inconsistency in the data because Singer and Small include only battle deaths while Bouthoul and Carrière [sic] include both military and civilian deaths. An effort has been made to include the casualties for both civilians and military that were a result of the armed conflict. When there is no figure available, the deaths are listed as '0'" (ORAE 1985: A7).
 
-      - Direct and indirect deaths combined because one source is Singer and Small
-    (i.e. early Correlates of War)
+      - Direct and indirect deaths combined because one source is Singer and Small (i.e. early Correlates of War)
 
+      How did they construct the data?
 
-    How did they construct the data?
+      - "This research project is based upon an approach to the study of war and conflict largely begun by Quincy Wright in A Study of War (1942) and Lewis F. Richardson in Statistics of Deadly Quarrels (1960)" (ORAE 1985: 10).
 
-      - "This research project is based upon an approach to the study of war and conflict
-    largely begun by Quincy Wright in A Study of War (1942)
-      and Lewis F. Richardson in Statistics of Deadly Quarrels (1960)" (ORAE 1985:
-    10).
+      - The data of Bouthoul and Carrère (1976) served as an important secondary source" (ORAE 1985: 12).
 
-      - The data of Bouthoul and Carrère (1976) served as an important secondary source"
-    (ORAE 1985: 12).
+      - Singer and Small (i.e. early Correlates of War) used as one source: "There is some inconsistency in the data because Singer and Small include only battle deaths" (ORAE 1985: A7).
 
-      - Singer and Small (i.e. early Correlates of War) used as one source: "There
-    is some inconsistency in the data because Singer and Small
-      include only battle deaths" (ORAE 1985: A7).
+      - "In this Annex [B] each conflict is listed in order of starting date and a number of basic facts describing the conflicts are given. [...] They relate to the when, where, why of the conflict and who is involved" (ORAE 1985: 4).
 
-      - "In this Annex [B] each conflict is listed in order of starting date and a
-    number of basic facts describing the conflicts are given.
-      [...] They relate to the when, where, why of the conflict and who is involved"
-    (ORAE 1985: 4).
+      - "each conflict case has been subjected to the same formally-defined and operationalized variables. These include: date, region, participants (i.e. nations and actors), committer, location, intervenor, magnitude, combatants, deaths (both military and civilian), type of force employed, issues and outcomes" (ORAE 1985: 15).
 
-      - "each conflict case has been subjected to the same formally-defined and operationalized
-    variables. These include: date, region, participants
-      (i.e. nations and actors), committer, location, intervenor, magnitude, combatants,
-    deaths (both military and civilian), type of force employed,
-       issues and outcomes" (ORAE 1985: 15).
+      - War duration precise to the month: "the duration statistics are not refined to days and the shortest war is, therefore, one month" (ORAE 1985: 33).
 
-      - War duration precise to the month: "the duration statistics are not refined
-    to days and the shortest war is, therefore, one month"
-      (ORAE 1985: 33).
+      - War within one year assumed to have lasted six months: "When a conflict was identified by only the year during which it occurred, the assumption was made that the conflict began mid-year and lasted six months" (ORAE 1985: A1).
 
-      - War within one year assumed to have lasted six months: "When a conflict was
-    identified by only the year during which it occurred, the
-      assumption was made that the conflict began mid-year and lasted six months"
-    (ORAE 1985: A1).
+      How did we construct our source spreadsheet?
 
-
-    How did we construct our source spreadsheet?
-
-      - We identified conflicts as well as deaths and casualties from appendix B1
-    in their report.
+      - We identified conflicts as well as deaths and casualties from appendix B1 in their report.
 
       - We excluded conflicts with 0 deaths.
+    citation_full: 'Kaye, G.D., D.A. Grant, and E.J. Emond. 1985. Major Armed Conflict: A Compendium of Interstate and Intrastate Conflict, 1720 to 1985. Operational Research and Analysis Establishment Report No. R 95, Department of National Defence Canada.'
+    url_main: https://books.google.es/books/about/Major_Armed_Conflict.html?id=Xce_PwAACAAJ&redir_esc=y
+    url_download: https://docs.google.com/spreadsheets/d/1GIB-8ZPNXqTATwHU4ZDavKz0iJoiOg2UROfoRz43kQY/edit#gid=1251805698
+    date_accessed: '2023-01-09'
+    date_published: '1985-11-01'
+    license:
+      name: Department of National Defence, Canada, Operational Research and Analysis Establishment, 1985
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
   - md5: 3d199e72dd14724172c093594f1225ec

--- a/snapshots/war/2023-01-09/sorokin_1937.csv.dvc
+++ b/snapshots/war/2023-01-09/sorokin_1937.csv.dvc
@@ -1,87 +1,51 @@
 meta:
-  namespace: war
-  short_name: sorokin_1937
-  name: 'Social and cultural dynamics. Volume III: Fluctuation of Social Relationships, War, and Revolution (1937)'
-  source_name: Sorokin (1937)
-  publication_year: 1937
-  publication_date: 1937-12-01
-  url: https://doi.org/10.2307/2143975
-  source_data_url: https://docs.google.com/spreadsheets/d/1Xo5e8aiFJnmv_aasFXU8MtzizSU0LxiysoUuErEJx3Q/edit?usp=sharing
-  file_extension: csv
-  license_url: https://about.jstor.org/terms/
-  license_name: JSTOR
-  date_accessed: 2023-01-09
-  is_public: true
-  description: >-
-    What years and countries are covered? 12th-20th century, 11 European countries
+  origin:
+    producer: Sorokin
+    title: 'Social and cultural dynamics. Volume III: Fluctuation of Social Relationships, War, and Revolution'
+    description: |-
+      What years and countries are covered? 12th–20th century, 11 European countries
 
-      - "We have taken almost all the known wars of Greece, Rome, Austria, Germany,
-    England, France, the Netherlands, Spain, Italy, Russia, and
-      Poland and Lithuania from the periods indicated in the subsequent tables (Chapter
-    Ten and Eleven) to the present time, or, in the case of
-      Greece and Rome, to the loss of Greek independence and to the so-called "end
-    of the Western Roman Empire," respectively" (Sorokin 1937: 283).
+      - "We have taken almost all the known wars of Greece, Rome, Austria, Germany, England, France, the Netherlands, Spain, Italy, Russia, and Poland and Lithuania from the periods indicated in the subsequent tables (Chapter Ten and Eleven) to the present time, or, in the case of Greece and Rome, to the loss of Greek independence and to the so-called "end of the Western Roman Empire," respectively" (Sorokin 1937: 283).
 
-      - "for Greece, for Rome, and for nine other European countries" (Sorokin 1937:
-    286).
+      - "for Greece, for Rome, and for nine other European countries" (Sorokin 1937: 286).
 
       - "From the twelfth to the twentieth century" (Sorokin 1937: 286).
 
       - 976 for France to 1925 (Sorokin 1937: 306-307).
 
+      Which conflicts are covered? Wars
 
-    Which conflicts are covered? Wars
+      Which deaths and casualties are covered? Direct military casualties
 
+      - Casualties, military, direct: "This study deals precisely with these three quantitative elements of war: the strength of the army, the number of casualties (killed and wounded), and the duration of each of the wars studied. No other aspect of the war phenomena is studied, not the economic losses, nor the morbidity and mortality of the civilian population, nor anything else" (Sorokin 1937: 282).
 
-    Which deaths and casualties are covered? Direct military casualties
+      - "general losses up to 47,000 [...] but mainly from sickness, therefore not included" (Sorokin 1937: 552).
 
-      - Casualties, military, direct: "This study deals precisely with these three
-    quantitative elements of war: the strength of the army,
-      the number of casualties (killed and wounded), and the duration of each of the
-    wars studied. No other aspect of the war phenomena is
-      studied, not the economic losses, nor the morbidity and mortality of the civilian
-    population, nor anything else" (Sorokin 1937: 282).
+      - Casualties are sometimes estimated based on army sizes and war duration: "Likewise, the total number of the casualties in a given war means the typical per cent of the casualties in regard to the strength of the army multiplied by the number of years during which the war lasted" (Sorokin 1937: 284).
 
-      - "general losses up to 47,000 [...] but mainly from sickness, therefore not
-    included" (Sorokin 1937: 552).
+      - War casualties sometimes estimated using annual casualties: "the total number of the casualties for each given war is obtained, either by multiplication of the typical per cent of the casualties by the number of years, or by putting down the actual data which exist in regard to this item for a given war as a whole" (Sorokin 1937: 284).
 
-      - Casualties are sometimes estimated based on army sizes and war duration: "Likewise,
-    the total number of the casualties in a given war means
-      the typical per cent of the casualties in regard to the strength of the army
-    multiplied by the number of years during which the war lasted"
-      (Sorokin 1937: 284).
+      - Data quality is rough: "This means that the figures given for each period are aimed not so much to lay down the actual number of the mobilized or killed and wounded as to obtain a rough measuring device to see the comparative increase or de- crease of war from period to period" (Sorokin 1937: 285).
 
-      - War casualties sometimes estimated using annual casualties: "the total number
-    of the casualties for each given war is obtained, either by
-      multiplication of the typical per cent of the casualties by the number of years,
-    or by putting down the actual data which exist in regard
-      to this item for a given war as a whole" (Sorokin 1937: 284).
+      How did he construct the data?
 
-      - Data quality is rough: "This means that the figures given for each period
-    are aimed not so much to lay down the actual number of the
-      mobilized or killed and wounded as to obtain a rough measuring device to see
-    the comparative increase or de- crease of war from period
-      to period" (Sorokin 1937: 285).
+      - "The actual data are taken from authoritative historical sources, often ably summarized and elaborated by various special historical works like the often-quoted works of Delbruck, Bodart, and various encyclopedias of war and military science" (Sorokin 1937: 285).
 
+      How did we construct our spreadsheet?
 
-    How did he construct the data?
+      - We accessed the book, the relevant methodological section starts on page 282, the detailed descriptions of wars and deaths starts on page 543.
 
-      - "The actual data are taken from authoritative historical sources, often ably
-    summarized and elaborated by various special historical
-      works like the often-quoted works of Delbruck, Bodart, and various encyclopedias
-    of war and military science" (Sorokin 1937: 285).
+      - We extracted deaths and casualties from Sorokin's numbers on which participant suffered which losses during any given conflict; Sorokin often does not provide estimates for all participants of a given conflict.
 
-
-    How did we construct our spreadsheet?
-
-      - We accessed the book, the relevant methodological section starts on page
-    282, the detailed descriptions of wars and deaths starts on
-      page 543.
-
-      - We extracted deaths and casualties from Sorokin's numbers on which participant
-    suffered which losses during any given conflict; Sorokin
-      often does not provide estimates for all participants of a given conflict.
-
+      This dataset provides information on direct military casualties from wars, drawn from the book by Sorokin (1937).
+    citation_full: 'Sorokin, Pitirim. 1937. Social and cultural dynamics. Volume Three: Fluctuation of Social Relationships, Wars, and Revolution. American Book Company.'
+    url_main: https://doi.org/10.2307/2143975
+    url_download: https://docs.google.com/spreadsheets/d/1Xo5e8aiFJnmv_aasFXU8MtzizSU0LxiysoUuErEJx3Q/edit?usp=sharing
+    date_accessed: '2023-01-09'
+    date_published: '1937-12-01'
+    license:
+      name: JSTOR
+      url: https://about.jstor.org/terms/
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
   - md5: b3f14480bf4936bccc548afa77d237b6

--- a/snapshots/war/2023-01-09/sutton_1971.csv.dvc
+++ b/snapshots/war/2023-01-09/sutton_1971.csv.dvc
@@ -1,58 +1,43 @@
 meta:
-  namespace: war
-  short_name: sutton_1971
-  name: Wars and revolutions - Hoover Institution (1971)
-  source_name: Sutton, Hoover Institution (1971)
-  publication_year: 1971
-  publication_date:
-  url: https://searchworks.stanford.edu/view/3023823
-  source_data_url: https://docs.google.com/spreadsheets/d/1egViYkL0TXcGVCm_MFdJ98nYmQpOO54vdlUxG-4bwBM/edit?usp=sharing
-  file_extension: csv
-  license_url:
-  license_name: Unknown
-  date_accessed: 2023-01-09
-  is_public: true
-  description: |
-    What years and countries are covered? 1820-1970, worldwide
+  origin:
+    producer: Sutton
+    title: Wars and Revolutions in the Nineteenth Century
+    description: |-
+      This dataset provides information on deaths from wars and revolutions, using data from Sutton (1972).
 
-      - "All conflict resulting in more than 20 killed where certain basic facts can be determined is listed; the first volume includes the period
-      1820 to 1900, and the second volume the period 1900 to 1970" (Sutton 1972: 9).
+      What years and countries are covered? 1820-1970, worldwide
 
-      - "It does provide for the first time a complete empirical base for conflict in the nineteenth century; this was my primary objective"
-      (Sutton 1972: 7).
+      - "All conflict resulting in more than 20 killed where certain basic facts can be determined is listed; the first volume includes the period 1820 to 1900, and the second volume the period 1900 to 1970" (Sutton 1972: 9).
+
+      - "It does provide for the first time a complete empirical base for conflict in the nineteenth century; this was my primary objective" (Sutton 1972: 7).
 
       - The list of wars and revolution starts with the year 1800 and lists eight conflicts before 1820 (Sutton 1972: 269)
 
-
-    Which conflicts are covered? Conflicts with more than 20 deaths, domestic and international
+      Which conflicts are covered? Conflicts with more than 20 deaths, domestic and international
 
       - "All conflict resulting in more than 20 killed where certain basic facts can be determined is listed" (Sutton 1972: 9)
 
+      Which deaths and casualties are covered? Deaths
 
-    Which deaths and casualties are covered? Deaths
+      - "The "Killed" column has three subdivisions: the "number killed for…" columns refers to the number killed from the participant country. This is followed by a "total for the incidents" figure i.e. number killed for participants combined. In a civil war these two columns are the same. In an "external" war the figures are different (except when one participant has no casualties)" (Sutton 1972: 15).
 
-      - "The "Killed" column has three subdivisions: the "number killed for…" columns refers to the number killed from the participant country.
-      This is followed by a "total for the incidents" figure i.e. number killed for participants combined. In a civil war these two columns are
-      the same. In an "external" war the figures are different (except when one participant has no casualties)" (Sutton 1972: 15).
+      How did he construct the data?
+      - "The sources used and cited under each country listing are incomplete. It would require, in many cases, a bibliography longer than the tabulated data. Only more significant sources are cited. Further, the following standard works were consulted for all countries and citations are not repeated below the country listings: [Richardson 1960; Sorokin nd; Wright 1965]" (Sutton 1972: 10).
 
-
-    How did he construct the data?
-      - "The sources used and cited under each country listing are incomplete. It would require, in many cases, a bibliography longer than the
-      tabulated data. Only more significant sources are cited. Further, the following standard works were consulted for all countries and
-      citations are not repeated below the country listings: [Richardson 1960; Sorokin nd; Wright 1965]" (Sutton 1972: 10).
-
-
-    How did we construct our spreadsheet?
+      How did we construct our spreadsheet?
 
       - We only coded the conflicts for Sutton's manuscript on the 19th century, not for his manuscript on the years 1900–1972
 
-      - We identified conflicts with the tables by region and country (pages 16-268) and the list of wars and revolutions in Appendix Three
-      (pages 269-301).
+      - We identified conflicts with the tables by region and country (pages 16-268) and the list of wars and revolutions in Appendix Three (pages 269-301).
 
-      - We identified deaths with the "Killed — Total for the incident" column in the tables by country; if the value was missing, but there was
-      an estimate for the main participant, we added a note.
+      - We identified deaths with the "Killed — Total for the incident" column in the tables by country; if the value was missing, but there was an estimate for the main participant, we added a note.
 
       - We also copied any of his notes that numbers were 'estimated' or 'suspect'
+    citation_full: Sutton, Antony. 1972. Wars and Revolutions in the Nineteenth Century. Hoover Institution Archives.
+    url_main: https://searchworks.stanford.edu/view/3023823
+    url_download: https://docs.google.com/spreadsheets/d/1egViYkL0TXcGVCm_MFdJ98nYmQpOO54vdlUxG-4bwBM/edit?usp=sharing
+    date_accessed: '2023-01-09'
+    date_published: '1972'
 wdir: ../../../data/snapshots/war/2023-01-09
 outs:
   - md5: 8205dd3c7b31f5c94eea6b3fbf75afdd

--- a/snapshots/waste/2018-02-15/waste_production_and_management.feather.dvc
+++ b/snapshots/waste/2018-02-15/waste_production_and_management.feather.dvc
@@ -1,33 +1,54 @@
 meta:
   origin:
-    producer: UNEP
-    title: Participation in Treaties - Rotterdam Convention
+    producer: United Nations Environment Programme
+    title: Environmental Data Explorer
     description: |-
-      Publication year: 2013-12-01
+      The UNEP Environmental Data Explorer is the authoritative source for data sets used by the United Nations Environment Programme and its partners in the Global Environment Outlook (GEO) report and other integrated environment assessments. Its online database holds national, sub-regional, regional and global statistics and geospatial data sets, covering themes like freshwater, population, forests, emissions, climate, disasters, health and GDP.
+    title_snapshot: Environmental Data Explorer - Waste production and management
+    description_snapshot: |-
+      This snapshot bundles six waste-related indicators from UNEP's Environmental Data Explorer. Each indicator is described below, preserving the originator, abstract, and temporal/geographic extent recorded in the source.
 
-      Unit: Number of Parties Subscribing each Year
+      Amounts of Municipal Waste - Total
 
-      Abstract
+      Publication year: 2007. Unit: Thousand Tons. Originator: Organization for Economic Co-Operation and Development (OECD), env.contact@oecd.org. Temporal extent: 1980-2005. Geographic extent: World.
+
+      Waste collected and treated by or for municipalities. It covers waste from households, including bulky waste, similar waste from commerce and trade, office buildings, institutions and small businesses, yard and garden waste, street sweepings, the contents of litter containers, and market cleansing waste. The definition excludes waste from municipal sewage networks and treatment, as well as municipal construction and demolition waste.
+
+      Municipal Waste Collection
+
+      Publication year: 2009-08-01. Unit: Thousand Tons. Originator: United Nations Statistics Division (UNSD), statistics@un.org. Temporal extent: 1990-2007. Geographic extent: World.
+
+      Municipal waste includes waste originating from: households, commerce and trade, small businesses, office buildings and institutions (schools, hospitals, government buildings). It also includes bulky waste (e.g. white goods, old furniture, mattresses) and waste from selected municipal services, e.g. waste from park and garden maintenance, waste from street cleaning services (street sweepings, the content of litter containers, market cleansing waste), if managed as waste. The definition excludes waste from municipal sewage network and treatment, municipal construction and demolition waste.
+
+      Municipal waste collected refers to waste collected by or on behalf of municipalities, as well as municipal waste collected by the private sector. It includes mixed waste, and fractions collected separately for recovery operations (through door-to-door collection and/or through voluntary deposits). Percentage of total population served by municipal waste collection refers to the percentage proportion of the total population covered by regular municipal waste removal service in relation to the total population of the country.
+
+      Participation in Treaties - Basel Convention
+
+      Publication year: 2013-12-01. Unit: Number of Parties Subscribing each Year. Originator: United Nations Office of Legal Affairs (OLA). Temporal extent: 1989 to 2013-12-01. Geographic extent: World.
+
+      The Basel Convention on the Control of Transboundary Movements of Hazardous Wastes and their Disposal was adopted in 1989 and entered into force on 5 May 1992.
+
+      Participation in Treaties - Rotterdam Convention
+
+      Publication year: 2013-12-01. Unit: Number of Parties Subscribing each Year. Originator: United Nations Office of Legal Affairs (OLA). Temporal extent: 1999 to 2013-12-01. Geographic extent: World.
 
       The Convention establishes the principle that export of a chemical covered by the Convention can only take place with the prior informed consent of the importing party. The Convention establishes a "Prior Informed Consent procedure," a means for formally obtaining and disseminating the decisions of importing countries as to whether they wish to receive future shipments of specified chemicals and for ensuring compliance with these decisions by exporting countries.
 
       The Convention initially covers 22 pesticides (including five severely hazardous pesticide formulations) and 5 industrial chemicals, but many more are expected to be added in the future. The Conference of the Parties will decide on the inclusion of chemicals.
 
-      Point of contact
+      Waste Recycling Rates - Glass
 
-      Role: Originator
-      Person: United Nations Office of Legal Affairs (OLA)
-      Organization: ----
-      Email: ----
+      Publication year: 2007. Unit: Percent of Apparent Consumption. Originator: Organization for Economic Co-Operation and Development (OECD), env.contact@oecd.org. Temporal extent: 1980-2005. Geographic extent: World.
 
-      Temporal extent
+      Recycling is defined as reuse of material in a production process that diverts it from the waste stream, except for recycling within industrial plants and the reuse of material as fuel. "Recycling rates" are the ratios of the quantity collected for recycling to the apparent consumption (economic notion of domestic production of the respective material + imports - exports). It should, however, be noted that definitions may vary from one country to another. In particular, total amounts of waste produced, rather than apparent consumption, may be used in some areas to derive recycling rates.
 
-      Covered time: 1999 - 2013-12-01
+      Waste Recycling Rates - Paper and Cardboard
 
-      Geographic extent
+      Publication year: 2007. Unit: Percent of Apparent Consumption. Originator: Organization for Economic Co-Operation and Development (OECD), env.contact@oecd.org. Temporal extent: 1980-2005. Geographic extent: World.
 
-      Coverage: World
-    citation_full: United Nations Environment Programme (2013). Participation in Treaties - Rotterdam Convention.
+      Recycling is defined as reuse of material in a production process that diverts it from the waste stream, except for recycling within industrial plants and the reuse of material as fuel. "Recycling rates" are the ratios of the quantity collected for recycling to the apparent consumption (economic notion of domestic production of the respective material + imports - exports). It should, however, be noted that definitions may vary from one country to another. In particular, total amounts of waste produced, rather than apparent consumption, may be used in some areas to derive recycling rates.
+    citation_full: United Nations Environment Programme (2013). Environmental Data Explorer - Waste production and management.
+    attribution_short: UNEP
     url_main: http://ede.grid.unep.ch/
     date_accessed: '2018-02-15'
     date_published: '2013-12-01'

--- a/snapshots/who/2022-09-01/autopsy.csv.dvc
+++ b/snapshots/who/2022-09-01/autopsy.csv.dvc
@@ -1,26 +1,27 @@
 meta:
-  name: European Health Information Gateway (WHO, 2022)
-  publication_year: 2022
+  origin:
+    producer: World Health Organization
+    title: European Health for All database
+    description: |-
+      Since the mid-1980s, Member States of the WHO European Region have been reporting essential health-related statistics to the Health for All (HFA) family of databases, making it one of WHO's oldest sources of data. As it is based on reported data, rather than estimates, the HFA family of databases is also particularly valuable.
 
-  publication_date: '2022-09-01'
-  source_name: WHO (2022)
-  source_published_by: WHO Regional Office for Europe. European Health for All database
-    (HFA-DB). Published 2022-09-01. Accessed 2023-07-13. https://gateway.euro.who.int
-  url: 
-    https://gateway.euro.who.int/en/indicators/hfa_545-6410-autopsy-rate-for-all-deaths/
-  source_data_url:
-  license_url: https://www.who.int/about/policies/publishing/copyright
-  license_name: CC BY-NC-SA 3.0 IGO
-  date_accessed: 2023-07-13
-  file_extension: csv
-  is_public: true
-  description: |
-    Since the mid-1980s, Member States of the WHO European Region have been reporting essential health-related statistics to the Health for All (HFA) family of databases, making it one of WHO’s oldest sources of data. As it is based on reported data, rather than estimates, the HFA family of databases is also particularly valuable.
+      HFA databases bring together the indicators that are part of major monitoring frameworks relevant to the Region, such as Health 2020 and the Sustainable Development Goals. The indicators cover basic demographics, health status, health determinants and risk factors, as well as health care resources, expenditures and more.
+    title_snapshot: European Health for All database - Autopsy rate for all deaths
+    description_snapshot: |-
+      The data for the following countries is taken from the WHO European Health Information Gateway:
 
-    HFA databases bring together the indicators that are part of major monitoring frameworks relevant to the Region, such as Health 2020 and the Sustainable Development Goals. The indicators cover basic demographics, health status, health determinants and risk factors, as well as health care resources, expenditures and more.
+      Armenia, Austria, Azerbaijan, Belarus, Bulgaria, Croatia, Cyprus, Czechia, Denmark, Estonia, Finland, Georgia, Hungary, Iceland, Israel, Kazakhstan, Kyrgyzstan, Latvia, Lithuania, Luxembourg, Malta, Moldova, Netherlands, North Macedonia, Norway, Portugal, Romania, Russia, San Marino, Serbia, Slovakia, Sweden, Switzerland, Tajikistan, Turkey, Turkmenistan, Ukraine, United Kingdom and Uzbekistan.
 
-wdir: ../../../data/snapshots/who/2022-09-01
+      The WHO European Health Information Gateway aggregates data from national statistics offices. Countries have data across multiple years.
+    citation_full: WHO Regional Office for Europe. European Health for All database (HFA-DB). Published 2022-09-01. https://gateway.euro.who.int.
+    attribution_short: WHO
+    url_main: https://gateway.euro.who.int/en/indicators/hfa_545-6410-autopsy-rate-for-all-deaths/
+    date_accessed: '2023-07-13'
+    date_published: '2022-09-01'
+    license:
+      name: CC BY-NC-SA 3.0 IGO
+      url: https://www.who.int/about/policies/publishing/copyright
 outs:
-- md5: 5b7d5a6cdbe8de8af1c4e2eb0a8cd9c3
-  size: 30011
-  path: autopsy.csv
+  - md5: 5b7d5a6cdbe8de8af1c4e2eb0a8cd9c3
+    size: 30011
+    path: autopsy.csv

--- a/snapshots/who/2023-06-29/guinea_worm.csv.dvc
+++ b/snapshots/who/2023-06-29/guinea_worm.csv.dvc
@@ -1,19 +1,27 @@
 meta:
-  name: Certification status of dracunculiasis eradication (WHO, 2018)
-  publication_year: 2018
-  source_name: WHO (2018)
-  source_published_by: 'Certification status of dracunculiasis eradication: World
-    Health Organization; 2018. Licence: CC BY-NC-SA 3.0 IGO'
-  url: 
-    https://web.archive.org/web/20211024081702/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_t0.html
-  source_data_url:
-  license_url: https://www.who.int/about/policies/publishing/copyright
-  license_name: CC BY-NC-SA 3.0 IGO
-  date_accessed: 2023-06-29
-  file_extension: csv
-  is_public: true
-  description: |
+  origin:
+    producer: World Health Organization
+    title: Certification status of dracunculiasis eradication
+    description: |-
+      The current and historical values for the status of Guinea worm disease (dracunculiasis) as certified by the WHO. To be certified as free of Guinea worm disease, a country must have reported zero indigenous cases through active surveillance for at least three consecutive years.
+    description_snapshot: |-
+      Data regarding certification status is taken from:
 
+      https://web.archive.org/web/20211024081702/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_t0.html
+
+      This is supplemented with more recent changes to Guinea worm disease certification:
+
+      - Angola has had endemic status since 2020: https://www.who.int/news/item/23-09-2020-eradicating-dracunculiasis-human-cases-and-animal-infections-decline-as-angola-becomes-endemic
+      - Kenya was certified Guinea worm free in 2018: https://www.who.int/news/item/21-03-2018-dracunculiasis-eradication-south-sudan-claims-interruption-of-transmission-in-humans
+      - DRC was certified Guinea worm free in 2022: https://www.who.int/news/item/15-12-2022-the-democratic-republic-of-the-congo-certified-free-of-dracunculiasis-transmission-by-who
+    citation_full: 'Certification status of dracunculiasis eradication. World Health Organization; 2018. Licence: CC BY-NC-SA 3.0 IGO.'
+    attribution_short: WHO
+    url_main: https://web.archive.org/web/20211024081702/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_t0.html
+    date_accessed: '2023-06-29'
+    date_published: '2018'
+    license:
+      name: CC BY-NC-SA 3.0 IGO
+      url: https://www.who.int/about/policies/publishing/copyright
 wdir: ../../../data/snapshots/who/2023-06-29
 outs:
 - md5: 00fe995cf57cead2f8f435f9bab29501

--- a/snapshots/world_risk_poll/2023-06-26/wrp_2021.zip.dvc
+++ b/snapshots/world_risk_poll/2023-06-26/wrp_2021.zip.dvc
@@ -1,24 +1,33 @@
 meta:
-  name: World Risk Poll (2021)
-  publication_year: 2022
-  source_name: Lloyd’s Register Foundation (2022)
-  source_published_by: 'World Risk Poll 2021, Lloyd’s Register Foundation (2022) '
-  url: https://wrp.lrfoundation.org.uk/data-resources/
-  source_data_url:
-    https://wrp.lrfoundation.org.uk/wp-content/uploads/2023/05/lrf_wrp_2021_full_data.zip
-  license_url: https://wrp.lrfoundation.org.uk/terms-of-use/
-  license_name: ' Lloyd’s Register Foundation 2018'
-  date_accessed: 2023-06-26
-  is_public: true
-  description: |
-    Spread across four themed reports, the 2021 World Risk Poll covers the biggest risks facing people and communities globally, ranging from road crashes, severe weather, climate change and disaster resilience, to work-related harm, violence and harassment at work, and use of personal data.
+  origin:
+    producer: Lloyd's Register Foundation
+    title: World Risk Poll
+    description: |-
+      The World Risk Poll covers the biggest risks facing people and communities globally, ranging from road crashes, severe weather, climate change and disaster resilience, to work-related harm, violence and harassment at work, and use of personal data.
 
-    The 2021 World Risk Poll builds on the results from the inaugural Poll in 2019 and explores how the relationship between perception and experience of risk may have shifted over time, including differences before and after the start of the Covid-19 pandemic. The Poll also allows us to understand how demographic factors contribute to different groups of people worrying about, and experiencing risks, in different ways.
+      The Poll is repeated periodically to explore how the relationship between perception and experience of risk may have shifted over time, and to understand how demographic factors contribute to different groups of people worrying about, and experiencing, risks in different ways.
+    title_snapshot: World Risk Poll - 2021
+    description_snapshot: |-
+      Spread across four themed reports, the 2021 World Risk Poll covers the biggest risks facing people and communities globally, ranging from road crashes, severe weather, climate change and disaster resilience, to work-related harm, violence and harassment at work, and use of personal data.
 
-    It will be repeated at least two more times, in 2023 and 2025.
+      The 2021 World Risk Poll builds on the results from the inaugural Poll in 2019 and explores how the relationship between perception and experience of risk may have shifted over time, including differences before and after the start of the Covid-19 pandemic. The Poll also allows us to understand how demographic factors contribute to different groups of people worrying about, and experiencing risks, in different ways.
 
-wdir: ../../../data/snapshots/world_risk_poll/2023-06-26
+      It will be repeated at least two more times, in 2023 and 2025.
+
+      Our World in Data extracts aggregates of survey responses to the following two artificial intelligence questions:
+
+      1) Will artificial intelligence help or harm people in the next 20 years?
+
+      2) Would you feel safe in a car driven by computer without a human driver?
+    citation_full: 'World Risk Poll 2021, Lloyd''s Register Foundation (2022).'
+    url_main: https://wrp.lrfoundation.org.uk/data-resources/
+    url_download: https://wrp.lrfoundation.org.uk/wp-content/uploads/2023/05/lrf_wrp_2021_full_data.zip
+    date_accessed: '2023-06-26'
+    date_published: '2022'
+    license:
+      name: Lloyd's Register Foundation 2018
+      url: https://wrp.lrfoundation.org.uk/terms-of-use/
 outs:
-- md5: 2fba71249275d42350426aa8f447eb98
-  size: 36621707
-  path: wrp_2021.zip
+  - md5: 2fba71249275d42350426aa8f447eb98
+    size: 36621707
+    path: wrp_2021.zip

--- a/snapshots/wvs/2023-06-25/longitudinal_wvs.csv.dvc
+++ b/snapshots/wvs/2023-06-25/longitudinal_wvs.csv.dvc
@@ -1,17 +1,26 @@
 meta:
-  name: World Values Survey time-series data (1981-2022)
-  publication_year: 2022
-  source_name: World Values Survey (2022)
-  source_published_by: 'Inglehart, R., C. Haerpfer, A. Moreno, C. Welzel, K. Kizilova, J. Diez-Medrano, M. Lagos, P. Norris, E. Ponarin & B. Puranen (eds.). 2022. World Values Survey: All Rounds - Country-Pooled Datafile. Madrid, Spain & Vienna, Austria: JD Systems Institute & WVSA Secretariat. Dataset Version 3.0.0. doi:10.14281/18241.17'
-  url: https://www.worldvaluessurvey.org/WVSDocumentationWVL.jsp
-  source_data_url:
-  license_url:
-  license_name: ' These data files are available without restrictions, provided: a) that they are used for non-profit purposes; b) correct citations are provided and sent to the World Values Survey Association for each publication of results based in part or entirely on these data files; c) the data files themselves are not redistributed; d) proper citation to the WVS data is included into the references list of the publication (citation format available for downloading in the Documentation section).'
-  date_accessed: 2023-06-25
-  is_public: true
-  description: |-
-    The WVS comprises survey data conducted across 64 countries and societies around the world and more than 80,000 respondents. This dataset comprises integrated files for the 1981-2022 period for all survey questions.
+  origin:
+    producer: World Values Survey Association
+    title: 'World Values Survey: All Rounds - Country-Pooled Datafile'
+    description: |-
+      The World Values Survey (WVS) comprises survey data conducted across 64 countries and societies around the world and more than 80,000 respondents. This dataset comprises integrated files for the 1981-2022 period for all survey questions.
+    title_snapshot: 'World Values Survey: All Rounds - Country-Pooled Datafile - Terrorism-related questions'
+    description_snapshot: |-
+      Our World in Data extracted three terrorism-related questions from the integrated 1981-2022 World Values Survey datafile:
 
+      - "Worries: a terrorist attack" (column H006_04).
+
+      - "Effects of immigrants on the development of [your country]: Increase the risks of terrorism" (column G057).
+
+      - "Justifiable: Terrorism as a political, ideological or religious mean" (column F114E).
+    citation_full: 'Inglehart, R., C. Haerpfer, A. Moreno, C. Welzel, K. Kizilova, J. Diez-Medrano, M. Lagos, P. Norris, E. Ponarin and B. Puranen (eds.). 2022. World Values Survey: All Rounds - Country-Pooled Datafile. Madrid, Spain and Vienna, Austria: JD Systems Institute and WVSA Secretariat. Dataset Version 3.0.0. doi:10.14281/18241.17.'
+    attribution_short: WVS
+    version_producer: 3.0.0
+    url_main: https://www.worldvaluessurvey.org/WVSDocumentationWVL.jsp
+    date_accessed: '2023-06-25'
+    date_published: '2022'
+    license:
+      name: 'These data files are available without restrictions, provided: a) that they are used for non-profit purposes; b) correct citations are provided and sent to the World Values Survey Association for each publication of results based in part or entirely on these data files; c) the data files themselves are not redistributed; d) proper citation to the WVS data is included into the references list of the publication (citation format available for downloading in the Documentation section).'
 wdir: ../../../data/snapshots/wvs/2023-06-25
 outs:
   - md5: 7551df3ae753117e33bbbd9ddefc997c


### PR DESCRIPTION
## Summary

End-to-end source→origin migration for OWID's snapshot/meta.yml pipeline across the active DAG.

**Scope of changes:**
- **~40 snapshot DVCs** migrated from legacy `meta.source:` block or flat top-level legacy fields to modern `meta.origin:` (fasttrack chains, war papers, education, demography, health, biodiversity, etc.).
- **~30 garden/grapher/meadow `meta.yml` files** cleaned: stripped `dataset.sources:`, `dataset.licenses:`, `all_sources:`, `descriptions:`, variable-level `sources:`. Variable-level `description:` renamed to `description_short:`. Per-source notes (e.g. country lists for combined indicators) lifted into the relevant snapshot's `origin.description_snapshot` so they travel with the origin.
- **~25 `.py` steps** refactored to preserve origins through Table operations: `pd.read_csv(snap.path)` + `Table(df, ...)` → `snap.read_csv()` returning a Table; `pd.concat` / `pd.merge` → `pr.concat` / `pr.merge`; `pivot_table` → `Table.pivot`; explicit origin re-stamping where pivots/value_counts mathematically create new columns.

**Schema change:**
- `schemas/definitions.json` — `url_download` pattern relaxed to accept Fernet-encrypted blobs (`gAAAA…`) used by fasttrack private snapshots. The legacy `source.source_data_url` had no URL-pattern check; relaxing the pattern restores that behaviour for origins.

**Skill update:**
- `.claude/skills/migrate-source-to-origin/SKILL.md` rewritten to capture lessons learned during this PR:
  - Flat top-level legacy DVC shape (pre-`meta.source:`).
  - Downstream sweep step (meta.yml dedupe + `.py` refactor).
  - Audit step before declaring done.
  - `description_snapshot` for OWID-curated slice notes.
  - `date_published` precision rule.
  - `producer` + `attribution_short` pairing.
  - Fernet-encrypted `url_download`.
  - Variable `description:` → `description_short:` rule (don't lift to `origin.description`).
  - `date_accessed` plausibility rule: only 2026-03+ dates on older snapshots are migration-tool artifacts.

**Deferred:**
- `grapher/un/2023-08-16/un_sdg` — needs structural refactor (the grapher dynamically creates ~hundreds of variables from long-format data and currently reads `ds_garden.metadata.sources[0]` for a single dataset-level source; making origins flow per-column requires meadow + garden + grapher refactor and is its own PR).
- `grapher/worldbank_wdi/2024-05-20/wdi` — flagged as tough; left out of scope.
- `garden/dummy/dummy_monster` — intentional test fixture for the legacy `sources:` + `origins:` co-existence case.

## Test plan

- [x] Each migrated snapshot passes `SnapshotMeta.load_from_yaml(...)`.
- [x] Each migrated chain re-run end-to-end (snapshot → meadow → garden → grapher) on the staging server with `--grapher`.
- [x] `pd.concat` ban + `Table(df, …)` rewrap ban added to project `CLAUDE.md`.
- [ ] Spot-check a few charts on the staging server to confirm the data-sources pane renders the new origins correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)