### PR TITLE
📊 Archive worldbank_wdi/2024-05-20/wdi

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,9 @@ Key flags: `--grapher/-g` (upload), `--dry-run` (preview), `--force/-f` (re-run)
 ```
 
 **Important:**
-- **Avoid `--force`** — `etlr` has built-in change detection and only re-runs steps whose code or data changed. Use `--force` only when you need to re-run a step despite no code changes (e.g., after fixing external data). Never use `--force` alone — always pair with `--only`.
+- **Avoid `--force`** — `etlr` has built-in change detection and re-runs steps whose **code, dag entries, or data** changed. Editing a step's `.py`/`.yml` or its dag dependency line is enough to trigger a rebuild — don't add `--force`. Reserve `--force --only` for the narrow case where nothing in the repo changed but you still need to re-run (e.g., upstream data was patched out-of-band). Never use `--force` alone.
+- **`--only` requires deps on disk.** It skips dep resolution and won't download missing deps — even with `PREFER_DOWNLOAD=1`. If you hit a `FileNotFoundError` on a dep's `index.json`, drop `--only` and let etlr resolve the chain.
+- **`PREFER_DOWNLOAD=1`** — Download already-built datasets from the OWID catalog instead of recomputing locally. Useful when verifying a downstream step still works after a dag edit (the upstream deps get fetched, not rebuilt). Doesn't help if you've edited the dataset's own code.
 - For `grapher://` steps, always add `--grapher` flag
 - Some steps support **`SUBSET`** env var for fast dev iterations: `SUBSET='France,Germany' .venv/bin/etlr namespace/version/dataset --private`
 

--- a/dag/archive/main.yml
+++ b/dag/archive/main.yml
@@ -747,6 +747,20 @@ steps:
     - data://meadow/aviation/2025-04-01/air_traffic
   data://grapher/aviation/2025-04-01/air_traffic:
     - data://garden/aviation/2025-04-01/air_traffic
+  # World Development Indicators - WDI
+  data://meadow/worldbank_wdi/2024-05-20/wdi:
+    - snapshot://worldbank_wdi/2024-05-20/wdi.zip
+
+  data://garden/worldbank_wdi/2024-05-20/wdi:
+    - data://garden/wb/2025-07-01/income_groups
+    - data://meadow/worldbank_wdi/2024-05-20/wdi
+    - data://garden/regions/2023-01-01/regions
+    - snapshot://worldbank_wdi/2024-05-20/wdi.zip
+    - data://garden/demography/2024-07-15/population
+
+  data://grapher/worldbank_wdi/2024-05-20/wdi:
+    - data://garden/worldbank_wdi/2024-05-20/wdi
+
 include:
   # Include all active steps plus all archive steps.
   - dag/main.yml

--- a/dag/covid.yml
+++ b/dag/covid.yml
@@ -36,7 +36,7 @@ steps:
     - data://garden/wash/2025-12-08/household
     - data://garden/who/2024-07-30/ghe
     # WDI
-    - data://garden/worldbank_wdi/2024-05-20/wdi
+    - data://garden/worldbank_wdi/2026-02-27/wdi
 
   # Sequencing (variants)
   data-private://meadow/covid/latest/sequence:

--- a/dag/education.yml
+++ b/dag/education.yml
@@ -19,7 +19,7 @@ steps:
     - data://meadow/education/2023-07-17/education_lee_lee
     - data://garden/regions/2023-01-01/regions
     - data://garden/demography/2023-03-31/population
-    - data://garden/worldbank_wdi/2024-05-20/wdi
+    - data://garden/worldbank_wdi/2026-02-27/wdi
     - data://garden/unesco/2025-05-01/education_opri
   data://grapher/education/2023-07-17/education_lee_lee:
     - data://garden/education/2023-07-17/education_lee_lee

--- a/dag/health.yml
+++ b/dag/health.yml
@@ -295,7 +295,7 @@ steps:
     - snapshot://health/2024-04-22/gpei_funding.xlsx
   data://garden/health/2024-04-22/gpei_funding:
     - data://meadow/health/2024-04-22/gpei_funding
-    - data://garden/worldbank_wdi/2024-05-20/wdi
+    - data://garden/worldbank_wdi/2026-02-27/wdi
   data://grapher/health/2024-04-22/gpei_funding:
     - data://garden/health/2024-04-22/gpei_funding
 

--- a/dag/main.yml
+++ b/dag/main.yml
@@ -34,7 +34,7 @@ steps:
   data://grapher/malnutrition/2024-12-16/malnutrition:
     - data://garden/malnutrition/2024-12-16/malnutrition
   data://garden/malnutrition/2024-12-16/malnutrition:
-    - data://garden/worldbank_wdi/2024-05-20/wdi
+    - data://garden/worldbank_wdi/2026-02-27/wdi
     - data://garden/un/2024-07-12/un_wpp
 
   #
@@ -51,7 +51,7 @@ steps:
 
   # Internet
   data://garden/technology/2024-12-23/internet:
-    - data://garden/worldbank_wdi/2024-05-20/wdi
+    - data://garden/worldbank_wdi/2026-02-27/wdi
     - data://garden/demography/2024-07-15/population
     - data://garden/regions/2023-01-01/regions
     - data://garden/wb/2025-07-01/income_groups
@@ -300,22 +300,6 @@ steps:
     - data://meadow/news/2024-05-23/gdelt_v2
   data://grapher/news/2024-05-23/gdelt_v2:
     - data://garden/news/2024-05-23/gdelt_v2
-
-  # World Development Indicators - WDI
-  # TO BE ARCHIVED
-  data://meadow/worldbank_wdi/2024-05-20/wdi:
-    - snapshot://worldbank_wdi/2024-05-20/wdi.zip
-
-  data://garden/worldbank_wdi/2024-05-20/wdi:
-    - snapshot://worldbank_wdi/2024-05-20/wdi.zip
-    - data://meadow/worldbank_wdi/2024-05-20/wdi
-    - data://garden/demography/2024-07-15/population
-    - data://garden/regions/2023-01-01/regions
-    - data://garden/wb/2025-07-01/income_groups
-
-  data://grapher/worldbank_wdi/2024-05-20/wdi:
-    - data://garden/worldbank_wdi/2024-05-20/wdi
-
   # World Development Indicators - WDI
   data://meadow/worldbank_wdi/2025-01-24/wdi:
     - snapshot://worldbank_wdi/2025-01-24/wdi.zip
@@ -339,7 +323,7 @@ steps:
     - snapshot://aviation_safety_network/2024-06-05/aviation_statistics_by_nature.csv
   data://garden/aviation_safety_network/2024-06-05/aviation_statistics:
     - data://meadow/aviation_safety_network/2024-06-05/aviation_statistics
-    - data://garden/worldbank_wdi/2024-05-20/wdi
+    - data://garden/worldbank_wdi/2026-02-27/wdi
   data://grapher/aviation_safety_network/2024-06-05/aviation_statistics:
     - data://garden/aviation_safety_network/2024-06-05/aviation_statistics
 


### PR DESCRIPTION
## Summary

- Bump downstream dependents from `worldbank_wdi/2024-05-20` to `worldbank_wdi/2026-02-27`:
  - `data://garden/malnutrition/2024-12-16/malnutrition`
  - `data://garden/technology/2024-12-23/internet`
  - `data://garden/aviation_safety_network/2024-06-05/aviation_statistics`
  - `data://garden/education/2023-07-17/education_lee_lee`
  - `data://garden/health/2024-04-22/gpei_funding`
  - `data://garden/covid/latest/compact`
- Run `etl archive worldbank_wdi/2024-05-20/wdi` — moves meadow/garden/grapher entries to `dag/archive/main.yml`.
- Drop the stale `# TO BE ARCHIVED` comment.

Also includes an unrelated commit to `CLAUDE.md` documenting `PREFER_DOWNLOAD=1` and clarifying the `--force` / `--only` rules for `etlr`.

## Test plan

- [x] `etlr` each migrated downstream step with `PREFER_DOWNLOAD=1` — all succeeded
- [x] `make check` passes
- [x] No active dag references to `worldbank_wdi/2024-05-20/wdi` remain