### PR TITLE
🔨 Read WDI rich metadata from WDISeries.csv instead of DDH

### DIFF
--- a/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.py
+++ b/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.py
@@ -645,36 +645,47 @@ def load_clean_source_mapping() -> dict[str, dict[str, str]]:
     return source_mapping
 
 
+# Sections appended to description_from_producer, in display order. Each entry maps a
+# column from the meadow `wdi_metadata` table to the markdown section header rendered
+# in the producer description. The order follows the WB databank metadata glossary
+# layout. `source_meta`/`topic_meta` come from DDH (legacy `source` and `topic` are
+# kept separately for the wdi.sources.json join).
+_PRODUCER_DESCRIPTION_SECTIONS: list[tuple[str, str]] = [
+    # Source: redundant with `origin.producer` / `origin.citation_full`, which are
+    # already surfaced to the reader. Keeping the column in meadow in case it's needed.
+    # ("source_meta", "Source"),
+    # Topic: WB's internal taxonomy (e.g. "Financial Sector: Exchange rates & prices");
+    # the chart's existing topic context covers this for readers.
+    # ("topic_meta", "Topic"),
+    ("periodicity", "Periodicity"),
+    ("base_period", "Base period"),
+    ("aggregation_method", "Aggregation method"),
+    ("statistical_concept_and_methodology", "Statistical concept and methodology"),
+    ("development_relevance", "Development relevance"),
+    ("limitations_and_exceptions", "Limitations and exceptions"),
+    ("general_comments", "General comments"),
+    ("notes_from_original_source", "Notes from original source"),
+    ("other_notes", "Other notes"),
+    ("related_source_links", "Related source links"),
+    ("other_web_links", "Other web links"),
+    ("related_indicators", "Related indicators"),
+    # License type: ~93% of indicators are "CC BY-4.0"; license is already expressed
+    # at the dataset/origin level, so per-indicator repetition is noise.
+    # ("license_type", "License type"),
+]
+
+
 def create_description_from_producer(var: dict[str, Any]) -> str | None:
     desc = ""
-    if pd.notnull(var["long_definition"]) and len(var["long_definition"].strip()) > 0:
+    if pd.notnull(var.get("long_definition")) and len(var["long_definition"].strip()) > 0:
         desc += var["long_definition"]
-    elif pd.notnull(var["short_definition"]) and len(var["short_definition"].strip()) > 0:
+    elif pd.notnull(var.get("short_definition")) and len(var["short_definition"].strip()) > 0:
         desc += var["short_definition"]
 
-    if pd.notnull(var["limitations_and_exceptions"]) and len(var["limitations_and_exceptions"].strip()) > 0:
-        desc += f"\n\n### Limitations and exceptions:\n{var['limitations_and_exceptions']}"
-
-    if (
-        pd.notnull(var["statistical_concept_and_methodology"])
-        and len(var["statistical_concept_and_methodology"].strip()) > 0
-    ):
-        desc += f"\n\n### Statistical concept and methodology:\n{var['statistical_concept_and_methodology']}"
-
-    ####################################################################################################################
-    # I think that the development relevance could also be an interesting field to add to the description_from_producer.
-    # For now, I'll include it in this specific indicator (access to electricity), but in the future we can consider adding this field for all indicators.
-    if (
-        (var["indicator_code_original"] in ["EG.ELC.ACCS.ZS"])
-        and pd.notnull(var["development_relevance"])
-        and len(var["development_relevance"].strip()) > 0
-    ):
-        desc += f"\n\n### Development relevance:\n{var['development_relevance']}"
-    ####################################################################################################################
-
-    # retrieves additional source info, if it exists.
-    if pd.notnull(var["notes_from_original_source"]) and len(var["notes_from_original_source"].strip()) > 0:
-        desc += f"\n\n### Notes from original source:\n{var['notes_from_original_source']}"
+    for column, header in _PRODUCER_DESCRIPTION_SECTIONS:
+        value = var.get(column)
+        if pd.notnull(value) and len(value.strip()) > 0:
+            desc += f"\n\n### {header}:\n{value}"
 
     desc = re.sub(r" *(\n+) *", r"\1", re.sub(r"[ \t]+", " ", desc)).strip()
 

--- a/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.py
+++ b/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.py
@@ -685,6 +685,11 @@ def create_description_from_producer(var: dict[str, Any]) -> str | None:
     for column, header in _PRODUCER_DESCRIPTION_SECTIONS:
         value = var.get(column)
         if pd.notnull(value) and len(value.strip()) > 0:
+            # ~90% of WDI indicators are "Annual", which adds noise next to a yearly
+            # time series — only surface periodicity when it deviates (Triennial,
+            # Biennial, Every two years, Quarterly-represented-as-Annual).
+            if column == "periodicity" and value.strip() == "Annual":
+                continue
             desc += f"\n\n### {header}:\n{value}"
 
     desc = re.sub(r" *(\n+) *", r"\1", re.sub(r"[ \t]+", " ", desc)).strip()

--- a/etl/steps/data/meadow/worldbank_wdi/2026-02-27/wdi.py
+++ b/etl/steps/data/meadow/worldbank_wdi/2026-02-27/wdi.py
@@ -22,9 +22,15 @@ def create_metadata_table(legacy_json: dict, new_json: dict) -> Table:
     Legacy JSON (from api.worldbank.org/v2) provides core fields:
     - indicator_code, indicator_name, unit, source, topic
 
-    New JSON (from ddh-openapi.worldbank.org) provides rich descriptions:
-    - long_definition, short_definition, limitations_and_exceptions,
-      statistical_concept_and_methodology, development_relevance, notes_from_original_source
+    New JSON (from ddh-openapi.worldbank.org) provides every metadata-glossary
+    field WB exposes per indicator (long_definition, aggregation_method,
+    periodicity, license_type, statistical_concept_and_methodology,
+    development_relevance, etc.).
+
+    DDH fields whose snake_cased name would collide with a legacy column are
+    stored under a `_meta` suffix (e.g. `Source` -> `source_meta`) so the
+    legacy values stay authoritative — the garden step uses legacy `source`
+    as a join key into wdi.sources.json.
     """
     # Parse legacy metadata (core fields)
     df_legacy = pd.DataFrame(legacy_json["data"])
@@ -55,6 +61,33 @@ def create_metadata_table(legacy_json: dict, new_json: dict) -> Table:
                 indicator_info["development_relevance"] = field_description
             elif field_name == "Notes from original source":
                 indicator_info["notes_from_original_source"] = field_description
+            elif field_name == "Aggregation method":
+                indicator_info["aggregation_method"] = field_description
+            elif field_name == "Periodicity":
+                indicator_info["periodicity"] = field_description
+            elif field_name == "Base Period":
+                indicator_info["base_period"] = field_description
+            elif field_name == "License Type":
+                indicator_info["license_type"] = field_description
+            elif field_name == "General comments":
+                indicator_info["general_comments"] = field_description
+            elif field_name == "Other notes":
+                indicator_info["other_notes"] = field_description
+            elif field_name == "Related source links":
+                indicator_info["related_source_links"] = field_description
+            elif field_name == "Other web links":
+                indicator_info["other_web_links"] = field_description
+            elif field_name == "Related indicators":
+                indicator_info["related_indicators"] = field_description
+            # `Source` and `Topic` collide with legacy columns, so store them under `_meta`.
+            elif field_name == "Source":
+                indicator_info["source_meta"] = field_description
+            elif field_name == "Topic":
+                indicator_info["topic_meta"] = field_description
+            # Skipped: Indicator Name (legacy has it), and the taxonomy fields
+            # (Description, First level, Second level, Unit of measure) which only
+            # appear on the ~130 indicators where a classification entry survived
+            # snapshot dedup instead of the rich-metadata entry.
 
         if indicator_info["series_code"]:
             indicators_data.append(indicator_info)

--- a/etl/steps/data/meadow/worldbank_wdi/2026-02-27/wdi.py
+++ b/etl/steps/data/meadow/worldbank_wdi/2026-02-27/wdi.py
@@ -15,95 +15,54 @@ log = get_logger()
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
+# Rich-metadata columns we pull out of WDISeries.csv (left = CSV header, right = column
+# the garden step expects). WDISeries.csv is the per-field metadata table the WB
+# ships inside the WDI zip; it tracks the data portal's rich glossary fields and
+# is generally fresher than the DDH API for the same fields.
+WDI_SERIES_RICH_COLUMNS: dict[str, str] = {
+    "Long definition": "long_definition",
+    "Short definition": "short_definition",
+    "Aggregation method": "aggregation_method",
+    "Periodicity": "periodicity",
+    "Base Period": "base_period",
+    "Limitations and exceptions": "limitations_and_exceptions",
+    "Statistical concept and methodology": "statistical_concept_and_methodology",
+    "Development relevance": "development_relevance",
+    "Notes from original source": "notes_from_original_source",
+    "Other notes": "other_notes",
+    "Related source links": "related_source_links",
+    "Other web links": "other_web_links",
+    "Related indicators": "related_indicators",
+    "General comments": "general_comments",
+    "License Type": "license_type",
+}
 
-def create_metadata_table(legacy_json: dict, new_json: dict) -> Table:
-    """Create metadata table by merging legacy and new API metadata.
 
-    Legacy JSON (from api.worldbank.org/v2) provides core fields:
-    - indicator_code, indicator_name, unit, source, topic
+def create_metadata_table(legacy_json: dict, series_csv) -> Table:
+    """Build the wdi_metadata table from two complementary WB sources.
 
-    New JSON (from ddh-openapi.worldbank.org) provides every metadata-glossary
-    field WB exposes per indicator (long_definition, aggregation_method,
-    periodicity, license_type, statistical_concept_and_methodology,
-    development_relevance, etc.).
+    - Legacy v2 JSON (api.worldbank.org/v2): core fields used as join keys
+      downstream — `indicator_code`, `indicator_name`, `unit`, `source`, `topic`.
+      `source` is the `rawName` the garden step matches against `wdi.sources.json`,
+      so we keep legacy as the authoritative source for these four fields. CSV's
+      `Source` agrees with legacy on 1499 of 1516 indicators, but the 17 mismatches
+      are CSV-NaN cases where legacy still has a value (Enterprise Surveys group).
 
-    DDH fields whose snake_cased name would collide with a legacy column are
-    stored under a `_meta` suffix (e.g. `Source` -> `source_meta`) so the
-    legacy values stay authoritative — the garden step uses legacy `source`
-    as a join key into wdi.sources.json.
+    - WDISeries.csv (inside the WDI zip): per-field rich metadata. WB keeps this
+      in sync with their data portal display, while the DDH API lags. CSV `Source`
+      and `Topic` are intentionally omitted here — legacy v2 wins for those.
     """
-    # Parse legacy metadata (core fields)
+    # Legacy JSON → core join-key columns.
     df_legacy = pd.DataFrame(legacy_json["data"])
     df_legacy.rename(columns={"indicator_code": "series_code"}, inplace=True)
 
-    # Parse new metadata (rich descriptions)
-    indicators_data = []
-    for indicator in new_json["data"]:
-        fields = indicator.get("fields", [])
-        indicator_info = {"series_code": None}
+    # WDISeries.csv → rich glossary fields, snake_cased to the garden-expected names.
+    df_csv = pd.read_csv(series_csv, usecols=["Series Code", *WDI_SERIES_RICH_COLUMNS.keys()])
+    df_csv = df_csv.rename(columns={"Series Code": "series_code", **WDI_SERIES_RICH_COLUMNS})
 
-        for field in fields:
-            field_name = field.get("name", "")
-            field_description = field.get("description", "")
-            if field_name == "Series Code":
-                indicator_info["series_code"] = field_description
-            elif field_name == "Code" and not indicator_info["series_code"]:
-                indicator_info["series_code"] = field_description
-            elif field_name == "Long definition":
-                indicator_info["long_definition"] = field_description
-            elif field_name == "Short definition":
-                indicator_info["short_definition"] = field_description
-            elif field_name == "Limitations and exceptions":
-                indicator_info["limitations_and_exceptions"] = field_description
-            elif field_name == "Statistical concept and methodology":
-                indicator_info["statistical_concept_and_methodology"] = field_description
-            elif field_name == "Development relevance":
-                indicator_info["development_relevance"] = field_description
-            elif field_name == "Notes from original source":
-                indicator_info["notes_from_original_source"] = field_description
-            elif field_name == "Aggregation method":
-                indicator_info["aggregation_method"] = field_description
-            elif field_name == "Periodicity":
-                indicator_info["periodicity"] = field_description
-            elif field_name == "Base Period":
-                indicator_info["base_period"] = field_description
-            elif field_name == "License Type":
-                indicator_info["license_type"] = field_description
-            elif field_name == "General comments":
-                indicator_info["general_comments"] = field_description
-            elif field_name == "Other notes":
-                indicator_info["other_notes"] = field_description
-            elif field_name == "Related source links":
-                indicator_info["related_source_links"] = field_description
-            elif field_name == "Other web links":
-                indicator_info["other_web_links"] = field_description
-            elif field_name == "Related indicators":
-                indicator_info["related_indicators"] = field_description
-            # `Source` and `Topic` collide with legacy columns, so store them under `_meta`.
-            elif field_name == "Source":
-                indicator_info["source_meta"] = field_description
-            elif field_name == "Topic":
-                indicator_info["topic_meta"] = field_description
-            # Skipped: Indicator Name (legacy has it), and the taxonomy fields
-            # (Description, First level, Second level, Unit of measure) which only
-            # appear on the ~130 indicators where a classification entry survived
-            # snapshot dedup instead of the rich-metadata entry.
+    df_meta = df_legacy.merge(df_csv, on="series_code", how="left")
 
-        if indicator_info["series_code"]:
-            indicators_data.append(indicator_info)
-
-    df_new = pd.DataFrame(indicators_data)
-
-    # Drop duplicates from new metadata (keep first occurrence)
-    df_new = df_new.drop_duplicates(subset=["series_code"], keep="first")
-
-    # Merge: legacy as base, add rich descriptions from new
-    df_meta = df_legacy.merge(df_new, on="series_code", how="left")
-
-    # Create Table with proper naming
-    tb_meta = Table(df_meta, short_name="wdi_metadata", underscore=True)
-
-    return tb_meta
+    return Table(df_meta, short_name="wdi_metadata", underscore=True)
 
 
 def run() -> None:
@@ -175,11 +134,9 @@ def run() -> None:
         # Add original code as titles
         tb[col].m.title = indicator_code_map[col]
 
-    # Load metadata from both JSON files in snapshot
-    # Legacy JSON provides core fields (indicator_name, source), new JSON provides rich descriptions
+    # Load metadata: legacy JSON for core join keys, WDISeries.csv for rich glossary fields.
     legacy_json = json.load(zf.open("WDIMetadataLegacy.json"))
-    new_json = json.load(zf.open("WDIMetadata.json"))
-    tb_meta = create_metadata_table(legacy_json, new_json)
+    tb_meta = create_metadata_table(legacy_json, zf.open("WDISeries.csv"))
 
     #
     # Save outputs.

--- a/snapshots/worldbank_wdi/2026-02-27/wdi.py
+++ b/snapshots/worldbank_wdi/2026-02-27/wdi.py
@@ -56,8 +56,6 @@ It's easier to do it in two steps:
 - Write a script to auto-approve charts with no changes.
 - ✅ Replaced update_metadata.ipynb with CLI tool (update_wdi_metadata.py) - see above for usage
 - "dataPublisherSource" is no longer returned by WDI. Remove it if that's the case.
-- Indicator metadata from downloaded ZIP file is outdated and we have to fetch metadata from API. Have they solved
-    this problem? If yes, we can go back to ZIP file only.
 - Check old WDI version and try to switch their charts to new indicators and archive them.
 
 """
@@ -83,9 +81,6 @@ SNAPSHOT_VERSION = Path(__file__).parent.name
 
 # URL to the World Bank metadata API.
 URL_METADATA = "https://ddh-openapi.worldbank.org/dataset/download?dataset_unique_id=0037712"
-
-API_BASE_URL = "https://ddh-openapi.worldbank.org/indicators"
-DATASET_ID = "0037712"
 
 # Legacy API for individual indicator metadata (used by garden step)
 LEGACY_API_BASE_URL = "https://api.worldbank.org/v2/indicator"
@@ -115,79 +110,12 @@ def main(upload: bool) -> None:
     # Download the ~270MB zip data file.
     snap.download_from_source()
 
-    # Add JSON metadata from API to the zip file
-    # NOTE: Ideally, we'd get all metadata from wdi.zip, but it contains outdated metadata.
-    add_json_metadata_to_zip(snap.path)
-
     # Add legacy metadata from individual indicator API calls
     # This provides the exact format needed by the garden step (indicator_name, source, unit, topic)
     add_legacy_metadata_to_zip(snap.path)
 
     # Create the snapshot and upload the data.
     snap.dvc_add(upload=upload)
-
-
-def add_json_metadata_to_zip(zip_path: Path) -> None:
-    """Fetch JSON metadata from API and add it to the existing zip file."""
-    all_indicators = []
-    skip = 0
-    batch_size = 1000
-
-    # Fetch all indicators using pagination
-    while True:
-        url = f"{API_BASE_URL}?dataset_unique_id={DATASET_ID}&top={batch_size}&skip={skip}"
-        response = requests.get(url)
-        response.raise_for_status()
-        batch_data = response.json()
-
-        # Check if we got any data
-        if not batch_data.get("data") or len(batch_data["data"]) == 0:
-            break
-
-        all_indicators.extend(batch_data["data"])
-
-        # If we got less than the batch size, we're done
-        if len(batch_data["data"]) < batch_size:
-            break
-
-        skip += batch_size
-
-    # Deduplicate by series code - keep the last occurrence (likely most recent)
-    unique_indicators = {}
-    for indicator in all_indicators:
-        # Find the series code in fields
-        series_code = None
-        for field in indicator.get("fields", []):
-            if field.get("name") == "Series Code":
-                series_code = field.get("description")
-                break
-            elif field.get("name") == "Code":
-                series_code = field.get("description")
-                break
-
-        if series_code:
-            unique_indicators[series_code] = indicator
-
-    deduped_indicators = list(unique_indicators.values())
-    print(
-        f"After deduplication: {len(deduped_indicators)} unique indicators (removed {len(all_indicators) - len(deduped_indicators)} duplicates)"
-    )
-
-    # Create the complete metadata JSON with deduplicated indicators
-    metadata_json = {"data": deduped_indicators, "count": len(deduped_indicators)}
-
-    # Create a temporary file for the JSON metadata
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as temp_file:
-        json.dump(metadata_json, temp_file, indent=2)
-        temp_json_path = temp_file.name
-
-    try:
-        # Add the JSON file to the existing zip
-        with zipfile.ZipFile(zip_path, "a") as zf:
-            zf.write(temp_json_path, "WDIMetadata.json")
-    finally:
-        # Clean up temporary file
-        Path(temp_json_path).unlink()
 
 
 @memory.cache


### PR DESCRIPTION
## Why

In review of #6034, @paarriagadap flagged that the WDI metadata we display is stale: GDP per capita PPP's `description_from_producer` still reads "Data are in constant 2017 international dollars" while the [WB data portal](https://data.worldbank.org/indicator/NY.GDP.PCAP.PP.KD) shows the indicator was rebased to 2021. He pointed to `WDISeries.csv` (inside the WDI zip) as a fresher source.

This PR is that swap. It supersedes #6034: instead of trying to dedupe DDH's stale revisions, we stop consulting DDH for per-indicator metadata and read directly from `WDISeries.csv`, which WB keeps in sync with their data portal display.

## Three parallel WB sources for indicator metadata

| Source | What it ships | Status |
|---|---|---|
| [`data.worldbank.org`](https://data.worldbank.org/indicator/NY.GDP.PCAP.PP.KD) | Single prose blob (`sourceNote`) — rendered from legacy v2 API | Fresh |
| [`ddh-openapi.worldbank.org`](https://ddh-openapi.worldbank.org/indicators?dataset_unique_id=0037712) | Per-field JSON metadata glossary | **Stale** — lags WB's own portal |
| `WDISeries.csv` inside the WDI zip | Per-field rich metadata, 20 columns | Fresh, in sync with the portal |

Before #5378 we read rich metadata from `WDISeries.csv`. #5378 swapped to DDH "for rich descriptions" — turns out CSV had those descriptions all along and they're fresher. This PR reverts that aspect of #5378 and goes back to CSV.

## Empirical field coverage (2026-02-27 zip)

Per-field non-null counts:

| Field | `WDISeries.csv` (out of 1516) | DDH deduped (out of 1665) |
|---|---|---|
| Long definition | 1499 | 1570 |
| Aggregation method | 1093 | 1079 |
| Periodicity | 1483 | 1503 |
| Statistical concept and methodology | **1499** | 1009 |
| Development relevance | **1313** | 843 |
| Limitations and exceptions | 907 | 899 |
| Other notes | **386** | 107 |
| Short definition | 0 | 202 |
| **Base Period** | **0** | 81 |
| **Notes from original source** | **0** | 111 |
| General comments | 5 | 371 |

CSV wins on freshness *and* coverage for the fields that actually drive `description_from_producer`. CSV is empty for `Base Period`, `Notes from original source`, and effectively empty for `Short definition` / `General comments` — but for the PPP-class indicators where Base Period matters most, the long definition itself already says "constant 2021 international $", so dropping the `### Base period:` section is cosmetic.

## What changes

- **`etl/steps/data/meadow/worldbank_wdi/2026-02-27/wdi.py`** — `create_metadata_table` now reads rich fields from `WDISeries.csv` (15 columns). Legacy v2 JSON still supplies `indicator_name`, `unit`, `source`, `topic` because `source` is the join key against `wdi.sources.json`. CSV's `Source` agrees with legacy on 1499/1516 indicators; the 17 mismatches are Enterprise Surveys group where CSV is NaN and legacy has the value — keeping legacy avoids breaking the mapping.
- **`snapshots/worldbank_wdi/2026-02-27/wdi.py`** — drop `add_json_metadata_to_zip`; meadow no longer reads `WDIMetadata.json` so there's no reason to fetch it.
- Garden enrichment + Periodicity: Annual suppression carried over from #6034 (commits intact).

## Verification

`description_from_producer` for the four indicators Pablo flagged:

| Indicator | Before (master) | After this PR |
|---|---|---|
| `ny_gdp_pcap_pp_kd` | constant 2017 international dollars | "expressed in constant international dollars, converted by purchasing power parities (PPPs)" (CSV-fresh) |
| `eg_gdp_puse_ko_pp_kd` | 2017 PPPs | "2021 constant international dollars" |
| `ny_gnp_pcap_pp_kd` | 2017 | "constant international dollars, converted by purchasing power parities" |
| `fp_cpi_totl_zg` | terse generic definition | "...percentage change over each previous year of the constant price (base year 2015) series..." |

`make check` passes locally.

## Relationship to #6034

This PR supersedes #6034. The dedupe heuristic in #6034 fixes only the 9 indicators where DDH ships PPP-2017 + PPP-2021 duplicates — it doesn't help `FP.CPI.TOTL.ZG` (DDH only has one stale entry there) and it requires keeping a custom-compressed zip on R2 (different md5 from WB's original) because the dedupe runs at snapshot-creation time. This PR sidesteps both issues by sourcing rich metadata from a path that doesn't need WB or us to touch the zip.

Recommend closing #6034 in favour of this PR.