### PR TITLE
📊 Activate make check pre-commit hook by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ help:
 	@echo '  make fasttrack 	Start Fast-track on port 8082'
 	@echo '  make chart-sync 	Start Chart-sync on port 8083'
 	@echo '  make query SQL="..." Run SQL query on staging MySQL for current branch'
-	@echo '  make install-hooks	Install git hooks (runs make check before commit)'
+	@echo '  make install-hooks	Activate pre-commit hook (auto-runs with make .venv)'
 	@echo '  make test      	Run all linting and unit tests'
 	@echo '  make test-all  	Run all linting and unit tests (including for modules in lib/)'
 	@echo '  make vsce-exclude-archived  Exclude archived steps from VSCode user settings'
@@ -224,12 +224,18 @@ vsce-sync:
 		echo "⚠️ VS Code CLI (code) is not installed. Skipping extension sync."; \
 	fi
 
-# Backward-compatible alias
+# Activate the tracked pre-commit hook by pointing git at scripts/hooks/.
+# Idempotent; runs as a dependency of .venv so a fresh clone gets the hook
+# the first time anyone sets up the environment.
 install-hooks:
-	@echo '==> Installing git hooks'
-	cp scripts/hooks/pre-commit .git/hooks/pre-commit
-	chmod +x .git/hooks/pre-commit
-	@echo '==> Done. pre-commit hook will run make check before each commit.'
+	@if [ -d .git ]; then \
+		git config core.hooksPath scripts/hooks; \
+		chmod +x scripts/hooks/pre-commit; \
+		echo '==> pre-commit hook active (core.hooksPath=scripts/hooks)'; \
+	fi
+
+.venv: .venv-default install-hooks
+	@true
 
 # Backward-compatible alias
 install-vscode-extensions: vsce-sync

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,7 @@ vsce-sync:
 # Idempotent; runs as a dependency of .venv so a fresh clone gets the hook
 # the first time anyone sets up the environment.
 install-hooks:
-	@if [ -d .git ]; then \
+	@if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
 		git config core.hooksPath scripts/hooks; \
 		chmod +x scripts/hooks/pre-commit; \
 		echo '==> pre-commit hook active (core.hooksPath=scripts/hooks)'; \

--- a/docs/getting-started/working-environment.md
+++ b/docs/getting-started/working-environment.md
@@ -218,13 +218,13 @@ If `make test` succeeds, then you should be able to build any dataset you like, 
 
 ## Git hooks
 
-We recommend installing the pre-commit hook, which automatically runs `make check` (lint, format, type-check) before every `git commit`:
+The pre-commit hook is activated automatically by `make .venv` (and any target that depends on it). It runs `make check` (lint, format, type-check) before every `git commit`, which prevents accidentally pushing code that fails CI.
+
+If you need to (re)activate it manually:
 
 ```bash
 make install-hooks
 ```
-
-This prevents accidentally pushing code that fails CI.
 
 ## VSCode setup
 


### PR DESCRIPTION
## Summary

Make the `make check` pre-commit hook active by default for everyone, so it doesn't depend on a manual `make install-hooks` step (follow-up from #6059).

## Changes

- **`install-hooks` switches from copy → `core.hooksPath`.** Previously it copied `scripts/hooks/pre-commit` into `.git/hooks/pre-commit`. Now it runs `git config core.hooksPath scripts/hooks`, which is idempotent and stays in sync if the hook is ever edited (no stale copy in `.git/hooks/`).
- **`install-hooks` is a dep of `.venv`.** Anyone running `make .venv` (directly or via `make test`, `make check`, etc.) gets the hook activated on the first run.
- **Docs**: working-environment.md now says the hook is auto-activated; `make install-hooks` is kept as a manual fallback.

## Notes / tradeoffs

- `core.hooksPath` is per-clone (lives in `.git/config`), so existing checkouts pick it up the next time anyone runs `make .venv`.
- If a user has a personal hook in `.git/hooks/`, `core.hooksPath` overrides it. Unlikely here.
- Guarded with `if [ -d .git ]` so it's a no-op in environments without a `.git/` (e.g. some CI containers).

## Test plan

- [x] `make install-hooks` sets `core.hooksPath` and prints the confirmation.
- [x] `make -n .venv` shows both `.venv-default`'s `uv sync` recipe **and** the install-hooks block.
- [x] `make check` passes.
- [x] Commit on this branch was blocked by the hook (it ran `make check` automatically) before landing.