### PR TITLE
📊 Migrate active snapshots from meta.source to meta.origin

### DIFF
--- a/snapshots/agriculture/2014-01-01/nitrogen_efficiency__lassaletta_et_al__2014.feather.dvc
+++ b/snapshots/agriculture/2014-01-01/nitrogen_efficiency__lassaletta_et_al__2014.feather.dvc
@@ -1,7 +1,7 @@
 meta:
-  source:
-    name: |-
-      Lassaletta, Billen, Grizzetti, Anglade & Garnier (2014). 50 year trends in nitrogen use efficiency of world cropping systems: the relationship between yield and nitrogen input to cropland. Environmental Research Letters.
+  origin:
+    producer: Lassaletta et al.
+    title: '50 year trends in nitrogen use efficiency of world cropping systems: the relationship between yield and nitrogen input to cropland'
     description: |-
       This dataset measures the nitrogen balance of agricultural inputs and outputs.
 
@@ -10,12 +10,10 @@ meta:
       Nitrogen output is measured as the nitrogen produced in the form of crops.
 
       Nitrogen use efficiency (NUE) is the ratio between nitrogen inputs and output. A NUE of 40% means that only 40% of nitrogen inputs are converted into nitrogen in the form of crops. The remaining 60% is lost to the environment as a pollutant.
-    url: https://iopscience.iop.org/article/10.1088/1748-9326/9/10/105011/meta
+    citation_full: 'Lassaletta, L., Billen, G., Grizzetti, B., Anglade, J., & Garnier, J. (2014). 50 year trends in nitrogen use efficiency of world cropping systems: the relationship between yield and nitrogen input to cropland. Environmental Research Letters, 9(10), 105011.'
+    url_main: https://iopscience.iop.org/article/10.1088/1748-9326/9/10/105011/meta
     date_accessed: '2014-01-01'
-    published_by: |-
-      Lassaletta, L., Billen, G., Grizzetti, B., Anglade, J., & Garnier, J. (2014). 50 year trends in nitrogen use efficiency of world cropping systems: the relationship between yield and nitrogen input to cropland. Environmental Research Letters, 9(10), 105011.
-  name: Nitrogen efficiency (Lassaletta et al. 2014)
-  description: ''
+    date_published: '2014'
   is_public: false
 outs:
   - md5: 54ec611d5c8ec338623b3d397202951e

--- a/snapshots/agriculture/2014/excess_fertilizers__west_et_al__2014.feather.dvc
+++ b/snapshots/agriculture/2014/excess_fertilizers__west_et_al__2014.feather.dvc
@@ -1,17 +1,15 @@
 meta:
-  source:
-    name: |-
-      West, Gerber, Engstrom, Mueller, Brauman, Carlson, Cassidy, Johnston, MacDonald, Ray & Siebert (2014). Leverage points for improving global food security and the environment. Science.
+  origin:
+    producer: West et al.
+    title: Leverage points for improving global food security and the environment
     description: |-
-      This data reprersents the nutrient balance of global croplands for nitrogen and phosphorous. It quantifies nutrient inputs to the crops across multiple sources – synthetic fertilizers, organic fertilizers such as manures, and nutrient fixation from legume crops.
+      This data represents the nutrient balance of global croplands for nitrogen and phosphorous. It quantifies nutrient inputs to the crops across multiple sources – synthetic fertilizers, organic fertilizers such as manures, and nutrient fixation from legume crops.
 
       Nutrient removal at harvest was estimated using nutrient density data for the dry fraction of harvested material. "Excess nutrients" is the difference between nutrient inputs and the amount harvested in crop material. This represents nutrients that are lost to the environment and can create ecological imbalances on ecosystems and in water bodies.
-    url: https://science.sciencemag.org/content/345/6194/325
+    citation_full: West, P. C., Gerber, J. S., Engstrom, P. M., Mueller, N. D., Brauman, K. A., Carlson, K. M., Cassidy, E. S., Johnston, M., MacDonald, G. K., Ray, D. K., and Siebert, S. (2014). Leverage points for improving global food security and the environment. Science, 345(6194), 325-328.
+    url_main: https://science.sciencemag.org/content/345/6194/325
     date_accessed: '2014-01-01'
-    published_by: |-
-      West, P. C., Gerber, J. S., Engstrom, P. M., Mueller, N. D., Brauman, K. A., Carlson, K. M., ... & Siebert, S. (2014). Leverage points for improving global food security and the environment. Science, 345(6194), 325-328.
-  name: Excess fertilizers (West et al. 2014)
-  description: ''
+    date_published: '2014'
   is_public: false
 outs:
   - md5: a22c146ed933a829cb009b2d913e9026

--- a/snapshots/agriculture/2016-01-01/average_farm_size__lowder_et_al__2016.feather.dvc
+++ b/snapshots/agriculture/2016-01-01/average_farm_size__lowder_et_al__2016.feather.dvc
@@ -1,17 +1,15 @@
 meta:
-  source:
-    name: |-
-      Lowder et al. (2016). The number, size, and distribution of farms, smallholder farms, and family farms worldwide. World Development.
+  origin:
+    producer: Lowder et al.
+    title: The number, size, and distribution of farms, smallholder farms, and family farms worldwide
     description: |-
       This study uses agricultural census data to estimate the number and size distribution of farm holdings by country.
 
       This article relies on data from numerous agricultural censuses, which are representative of all farms or farm households in a country. The Food and Agriculture Organization of the United Nations (FAO) has promoted the Programme for the World Census of Agriculture (WCA) since 1950 by providing governments with guidance on standard methodology and contents for their agricultural census.
-    url: https://www.sciencedirect.com/science/article/pii/S0305750X15002703
+    citation_full: 'Lowder, S. K., Skoet, J., and Raney, T. (2016). The number, size, and distribution of farms, smallholder farms, and family farms worldwide. World Development, 87, 16-29.'
+    url_main: https://www.sciencedirect.com/science/article/pii/S0305750X15002703
     date_accessed: '2016-01-01'
-    published_by: |-
-      Lowder, S. K., Skoet, J., & Raney, T. (2016). The number, size, and distribution of farms, smallholder farms, and family farms worldwide. World Development, 87, 16-29.
-  name: Average farm size (Lowder et al. 2016)
-  description: ''
+    date_published: '2016'
   is_public: false
 outs:
   - md5: 6991abcc5a5b0bfd697d3dcbd7a3a80a

--- a/snapshots/agriculture/2016-01-01/farm_size_distribution__lowder_et_al__2016.feather.dvc
+++ b/snapshots/agriculture/2016-01-01/farm_size_distribution__lowder_et_al__2016.feather.dvc
@@ -1,17 +1,15 @@
 meta:
-  source:
-    name: |-
-      Lowder et al. (2016). The number, size, and distribution of farms, smallholder farms, and family farms worldwide. World Development.
+  origin:
+    producer: Lowder et al.
+    title: The number, size, and distribution of farms, smallholder farms, and family farms worldwide
     description: |-
       This study uses agricultural census data to estimate the number and size distribution of farm holdings by country.
 
       This article relies on data from numerous agricultural censuses, which are representative of all farms or farm households in a country. The Food and Agriculture Organization of the United Nations (FAO) has promoted the Programme for the World Census of Agriculture (WCA) since 1950 by providing governments with guidance on standard methodology and contents for their agricultural census.
-    url: https://www.sciencedirect.com/science/article/pii/S0305750X15002703
+    citation_full: 'Lowder, S. K., Skoet, J., & Raney, T. (2016). The number, size, and distribution of farms, smallholder farms, and family farms worldwide. World Development, 87, 16-29.'
+    url_main: https://www.sciencedirect.com/science/article/pii/S0305750X15002703
     date_accessed: '2016-01-01'
-    published_by: |-
-      Lowder, S. K., Skoet, J., & Raney, T. (2016). The number, size, and distribution of farms, smallholder farms, and family farms worldwide. World Development, 87, 16-29.
-  name: Farm size distribution (Lowder et al. 2016)
-  description: ''
+    date_published: '2016'
   is_public: false
 outs:
   - md5: 80a28f704b06b25841bd3e5c9f8e1466

--- a/snapshots/agriculture/2021-01-11/soil_lifespans__evans_et_al__2020.feather.dvc
+++ b/snapshots/agriculture/2021-01-11/soil_lifespans__evans_et_al__2020.feather.dvc
@@ -1,13 +1,11 @@
 meta:
-  source:
-    name: |-
-      Evans, D. L., Quinton, J. N., Davies, J. A. C., Zhao, J., & Govers, G. (2020). Soil lifespans and how they can be extended by land use and management change.
-    url: https://iopscience.iop.org/article/10.1088/1748-9326/aba2fd
-    date_accessed: 2021-01-11
-    published_by: |-
-      Evans, D. L., Quinton, J. N., Davies, J. A. C., Zhao, J., & Govers, G. (2020). Soil lifespans and how they can be extended by land use and management change. Environmental Research Letters, 15(9), 0940b2.
-  name: Soil Lifespans (Evans et al. 2020)
-  description: ''
+  origin:
+    producer: Evans et al.
+    title: Soil lifespans and how they can be extended by land use and management change
+    citation_full: 'Evans, D. L., Quinton, J. N., Davies, J. A. C., Zhao, J., and Govers, G. (2020). Soil lifespans and how they can be extended by land use and management change. Environmental Research Letters, 15(9), 0940b2.'
+    url_main: https://iopscience.iop.org/article/10.1088/1748-9326/aba2fd
+    date_accessed: '2021-01-11'
+    date_published: '2020'
   is_public: false
 outs:
   - md5: 8e458329d5d97d0d89e517319d285a37

--- a/snapshots/agriculture/2021-06-01/global_agricultural_production_by_farm_size__riccardi_et_al__2018.feather.dvc
+++ b/snapshots/agriculture/2021-06-01/global_agricultural_production_by_farm_size__riccardi_et_al__2018.feather.dvc
@@ -1,12 +1,11 @@
 meta:
-  source:
-    name: Ricciardi et al. (2018), How much of the world's food do smallholders produce?. Global Food Security.
-    url: https://www.sciencedirect.com/science/article/pii/S2211912417301293
+  origin:
+    producer: Ricciardi et al.
+    title: How much of the world's food do smallholders produce?
+    citation_full: 'Ricciardi, V., Ramankutty, N., Mehrabi, Z., Jarvis, L., & Chookolingo, B. (2018). How much of the world''s food do smallholders produce? Global Food Security, 17, 64-72.'
+    url_main: https://www.sciencedirect.com/science/article/pii/S2211912417301293
     date_accessed: '2021-06-01'
-    published_by: |-
-      Ricciardi, V., Ramankutty, N., Mehrabi, Z., Jarvis, L., & Chookolingo, B. (2018). How much of the world's food do smallholders produce?. Global Food Security, 17, 64-72.
-  name: Global agricultural production by farm size (Riccardi et al. 2018)
-  description: ''
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 6ae068aecdb77e9ba004084822301b1b

--- a/snapshots/agriculture/2021-06-01/global_agricultural_productivity.feather.dvc
+++ b/snapshots/agriculture/2021-06-01/global_agricultural_productivity.feather.dvc
@@ -1,10 +1,10 @@
 meta:
-  source:
-    name: global_agricultural_productivity
+  origin:
+    producer: Global agricultural productivity
+    title: Global agricultural productivity
+    citation_full: Global agricultural productivity (2021).
     date_accessed: '2021-06-01'
-    published_by: global_agricultural_productivity
-  name: global_agricultural_productivity
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 311121625d946923291b3059d70631a5

--- a/snapshots/agriculture/2021/long_term_land_use__taylor_and_rising.feather.dvc
+++ b/snapshots/agriculture/2021/long_term_land_use__taylor_and_rising.feather.dvc
@@ -1,12 +1,12 @@
 meta:
-  source:
-    name: Taylor & Rising (2021); UN World Population Prospects (2021)
-    url: https://iopscience.iop.org/article/10.1088/1748-9326/ac3c6d
+  origin:
+    producer: Taylor and Rising, and United Nations
+    title: Tipping point dynamics in global land use
+    attribution_short: Taylor and Rising
+    citation_full: 'Taylor, C. A., and Rising, J. (2021). Tipping point dynamics in global land use. Environmental Research Letters, 16(12), 125012. Population data from United Nations, World Population Prospects (2021).'
+    url_main: https://iopscience.iop.org/article/10.1088/1748-9326/ac3c6d
     date_accessed: '2021-01-01'
-    published_by: |-
-      Taylor, C. A., & Rising, J. (2021). Tipping point dynamics in global land use. Environmental Research Letters, 16(12), 125012.
-  name: Long-term land use (Taylor and Rising)
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 3ffa48edc9a26e356ae268940e21bda7

--- a/snapshots/artificial_intelligence/2022-12-01/ai_index_report__2022.feather.dvc
+++ b/snapshots/artificial_intelligence/2022-12-01/ai_index_report__2022.feather.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: AI Index Report (2022)
+  origin:
+    producer: AI Index
+    title: AI Index Report
     description: |-
       The AI Index is an independent initiative at the Stanford University Institute for Human-Centered Artificial Intelligence.
 
-      The mission of the AI Index is “to provide unbiased, rigorously vetted, and globally sourced data for policymakers, researchers, executives, journalists, and the general public to develop intuitions about the complex field of AI.”
+      The mission of the AI Index is "to provide unbiased, rigorously vetted, and globally sourced data for policymakers, researchers, executives, journalists, and the general public to develop intuitions about the complex field of AI."
 
       Their flagship output is the annual AI Index Report, which has been published since 2017.
-    url: https://aiindex.stanford.edu/report/
-    date_accessed: 2022-01-12
-    published_by: |-
-      Daniel Zhang, Nestor Maslej, Erik Brynjolfsson, John Etchemendy, Terah Lyons, James Manyika, Helen Ngo, Juan Carlos Niebles, Michael Sellitto, Ellie Sakhaee, Yoav Shoham, Jack Clark, and Raymond Perrault, “The AI Index 2022 Annual Report,” AI Index Steering Committee, Stanford Institute for Human-Centered AI, Stanford University, March 2022.
-  name: AI Index Report (2022)
-  description: ''
+    citation_full: 'Daniel Zhang, Nestor Maslej, Erik Brynjolfsson, John Etchemendy, Terah Lyons, James Manyika, Helen Ngo, Juan Carlos Niebles, Michael Sellitto, Ellie Sakhaee, Yoav Shoham, Jack Clark, and Raymond Perrault, "The AI Index 2022 Annual Report," AI Index Steering Committee, Stanford Institute for Human-Centered AI, Stanford University, March 2022.'
+    url_main: https://aiindex.stanford.edu/report/
+    date_accessed: '2022-12-01'
+    date_published: '2022'
   is_public: false
 outs:
   - md5: 277d7fb310567bc801b51d6cc58b3483

--- a/snapshots/bank_of_england/2020-01-21/a_millennium_of_macroeconomic_data__bank_of_england__2016.feather.dvc
+++ b/snapshots/bank_of_england/2020-01-21/a_millennium_of_macroeconomic_data__bank_of_england__2016.feather.dvc
@@ -1,13 +1,14 @@
 meta:
-  source:
-    name: A Millennium of Macroeconomic Data - Bank of England
-    description: |-
-      This dataset consists of all the variables from the Headline Annual Composite Series and real GDP per capita taken from the 'Summary of Population and GDP per capita 1086-2016' worksheet available from the Bank of England's 'A Millennium of Macroeconomic Data'.
-    url: https://www.bankofengland.co.uk/statistics/research-datasets
-    date_accessed: 2020-01-21
-    published_by: Bank of England
-  name: A Millennium of Macroeconomic Data - Bank of England (2016)
-  description: ''
+  origin:
+    producer: Bank of England
+    title: A Millennium of Macroeconomic Data
+    title_snapshot: A Millennium of Macroeconomic Data - Headline annual composite series and real GDP per capita
+    description_snapshot: |-
+      This dataset consists of all the variables from the Headline Annual Composite Series and real GDP per capita taken from the "Summary of Population and GDP per capita 1086-2016" worksheet available from the Bank of England's "A Millennium of Macroeconomic Data".
+    citation_full: Bank of England (2016). A Millennium of Macroeconomic Data.
+    url_main: https://www.bankofengland.co.uk/statistics/research-datasets
+    date_accessed: '2020-01-21'
+    date_published: '2016'
   is_public: false
 outs:
   - md5: aa73791de6df2d1b8d7831b1e077344a

--- a/snapshots/biodiversity/2018/global_bleaching_events__hughes_et_al__2018.feather.dvc
+++ b/snapshots/biodiversity/2018/global_bleaching_events__hughes_et_al__2018.feather.dvc
@@ -1,14 +1,13 @@
 meta:
-  source:
-    name: Hughes, T. P., et al. (2018). Spatial and temporal patterns of mass bleaching of corals in the Anthropocene. Science.
+  origin:
+    producer: Hughes et al.
+    title: 'Spatial and temporal patterns of mass bleaching of corals in the Anthropocene'
     description: |-
       The number of moderate bleaching events (up to 30% of corals) and severe bleaching events (more than 30% corals) measured at 100 fixed global locations.
-    url: https://science.sciencemag.org/content/359/6371/80
-    date_accessed: 2021-04-06
-    published_by: |-
-      Hughes, T. P., Anderson, K. D., Connolly, S. R., Heron, S. F., Kerry, J. T., Lough, J. M., ... & Wilson, S. K. (2018). Spatial and temporal patterns of mass bleaching of corals in the Anthropocene. Science, 359(6371), 80-83.
-  name: Global bleaching events (Hughes et al. 2018)
-  description: ''
+    citation_full: 'Hughes, T. P., Anderson, K. D., Connolly, S. R., Heron, S. F., Kerry, J. T., Lough, J. M., ... & Wilson, S. K. (2018). Spatial and temporal patterns of mass bleaching of corals in the Anthropocene. Science, 359(6371), 80-83.'
+    url_main: https://science.sciencemag.org/content/359/6371/80
+    date_accessed: '2021-04-06'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 459bd4ed0947ecf57dde06c0be25cbd0

--- a/snapshots/biodiversity/2020-12-01/change_in_marine_mammal_populations__duarte_et_al__2020.feather.dvc
+++ b/snapshots/biodiversity/2020-12-01/change_in_marine_mammal_populations__duarte_et_al__2020.feather.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Duarte et al. (2020). Rebuilding marine life. Nature.
+  origin:
+    producer: Duarte et al.
+    title: Rebuilding marine life
     description: |-
       Duarte et al. (2020) compiled the share of marine mammal populations increasing, decreasing or showing no change across the world's oceans based on original studies from Lortze et al. (2017); and Magera et al. (2013).
 
       Lotze, H. K., Mills Flemming, J., Magera, A. Critical factors to marine mammal recovery. Conservation Biology 31, 1301-1311 (2017).
 
       Magera, A. M. et al. Recovery trends in marine mammal populations. PLoS ONE 8(10): e77908 (2013).
-    url: https://www.nature.com/articles/s41586-020-2146-7
+    citation_full: Duarte, C. M., Agusti, S., Barbier, E., Britten, G. L., Castilla, J. C., Gattuso, J. P., ... & Worm, B. (2020). Rebuilding marine life. Nature, 580(7801), 39-51.
+    url_main: https://www.nature.com/articles/s41586-020-2146-7
     date_accessed: '2020-12-01'
-    published_by: |-
-      Duarte, C. M., Agusti, S., Barbier, E., Britten, G. L., Castilla, J. C., Gattuso, J. P., ... & Worm, B. (2020). Rebuilding marine life. Nature, 580(7801), 39-51.
-  name: Change in marine mammal populations (Duarte et al. 2020)
-  description: ''
+    date_published: '2020'
   is_public: false
 outs:
   - md5: a00393e3bc008353da0f0891f040a6be

--- a/snapshots/biodiversity/2021-01-01/habitat_loss.feather.dvc
+++ b/snapshots/biodiversity/2021-01-01/habitat_loss.feather.dvc
@@ -1,7 +1,7 @@
 meta:
-  source:
-    name: |-
-      Williams, Clark, Buchanan, Ficetola, Rondinini, & Tilman (2021). Proactive conservation to prevent habitat losses to agricultural expansion. Nature Sustainability.
+  origin:
+    producer: Williams et al.
+    title: Proactive conservation to prevent habitat losses to agricultural expansion
     description: |-
       Projected species' habitat loss is projected to 2050 under a business-as-usual, plus five intervention scenarios with changes to diets or agricultural production.
 
@@ -16,12 +16,10 @@ meta:
       Optimize trade: agricultural production and trade is optimized to produce food in the locations with the least risk of habitat loss. Agricultural production shifts from the 25 countries projected to have the greatest mean losses of suitable habitat across all species to countries where less than 10% of species are threatened with extinction.
 
       Combined: all four interventions are combined.
-    url: https://www.nature.com/articles/s41893-020-00656-5
-    date_accessed: 2025-04-10
-    published_by: |-
-      Williams, D. R., Clark, M., Buchanan, G. M., Ficetola, G. F., Rondinini, C., & Tilman, D. (2021). Proactive conservation to prevent habitat losses to agricultural expansion. Nature Sustainability, 4(4), 314-322.
-  name: Biodiversity habitat loss (Williams et al. 2021)
-  description: ''
+    citation_full: 'Williams, D. R., Clark, M., Buchanan, G. M., Ficetola, G. F., Rondinini, C., & Tilman, D. (2021). Proactive conservation to prevent habitat losses to agricultural expansion. Nature Sustainability, 4(4), 314-322.'
+    url_main: https://www.nature.com/articles/s41893-020-00656-5
+    date_accessed: '2025-04-10'
+    date_published: '2021'
 outs:
   - md5: 76f76eaa98796b44f2f3ab0342acfbea
     size: 104690

--- a/snapshots/biodiversity/2021-02-26/global_wildlife_trade__harfoot_et_al__2018.feather.dvc
+++ b/snapshots/biodiversity/2021-02-26/global_wildlife_trade__harfoot_et_al__2018.feather.dvc
@@ -1,17 +1,16 @@
 meta:
-  source:
-    name: Harfoot et al. (2018). Unveiling the patterns and trends in 40 years of global trade in CITES-listed wildlife.
+  origin:
+    producer: Harfoot et al.
+    title: 'Unveiling the patterns and trends in 40 years of global trade in CITES-listed wildlife'
     description: |-
       To quantify wildlife trade across different species and over time, the authors calculate wildlife trade in 'whole organism equivalents (WOE).
 
       As they define:
       "To summarise and make the data equivalent across the heterogeneous types of products, we transformed products reported in trade to whole organism equivalents (WOEs), where possible. For example, five skulls represent five WOEs, whereas we assume that four ears are sourced from two animals and so represent two WOEs."
-    url: https://www.sciencedirect.com/science/article/pii/S0006320717312478#!
-    date_accessed: 2021-02-26
-    published_by: |-
-      Harfoot, M., Glaser, S. A., Tittensor, D. P., Britten, G. L., McLardy, C., Malsch, K., & Burgess, N. D. (2018). Unveiling the patterns and trends in 40 years of global trade in CITES-listed wildlife. Biological Conservation, 223, 47-57.
-  name: Global wildlife trade (Harfoot et al. 2018)
-  description: ''
+    citation_full: 'Harfoot, M., Glaser, S. A., Tittensor, D. P., Britten, G. L., McLardy, C., Malsch, K., & Burgess, N. D. (2018). Unveiling the patterns and trends in 40 years of global trade in CITES-listed wildlife. Biological Conservation, 223, 47-57.'
+    url_main: https://www.sciencedirect.com/science/article/pii/S0006320717312478#!
+    date_accessed: '2021-02-26'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: c9e4d3c5cca6554f3883c14d787c9a6b

--- a/snapshots/biodiversity/2021-03-23/wildlife_trade__scheffers_et_al__2019.feather.dvc
+++ b/snapshots/biodiversity/2021-03-23/wildlife_trade__scheffers_et_al__2019.feather.dvc
@@ -1,17 +1,15 @@
 meta:
-  source:
-    name: |-
-      Scheffers, B. R., Oliveira, B. F., Lamb, I., & Edwards, D. P. (2019). Global wildlife trade across the tree of life. Science.
+  origin:
+    producer: Scheffers et al.
+    title: Global wildlife trade across the tree of life
     description: |-
       Scheffers et al. (2019) quantify the number and share of vertebrate species that are traded, either locally, nationally or internationally.
 
       This data is also available, broken down by the share of traded species that are used as pets or as products (such as for meat, medicines, body parts, trophy hunts etc.). Note these shares may sum to more than 100% since many species are traded as both pets and for their products.
-    url: https://science.sciencemag.org/content/366/6461/71
-    date_accessed: 2021-03-23
-    published_by: |-
-      Scheffers, B. R., Oliveira, B. F., Lamb, I., & Edwards, D. P. (2019). Global wildlife trade across the tree of life. Science, 366(6461), 71-76.
-  name: Wildlife trade (Scheffers et al. 2019)
-  description: ''
+    citation_full: 'Scheffers, B. R., Oliveira, B. F., Lamb, I., and Edwards, D. P. (2019). Global wildlife trade across the tree of life. Science, 366(6461), 71-76.'
+    url_main: https://science.sciencemag.org/content/366/6461/71
+    date_accessed: '2021-03-23'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: a6a1cbae55fd0a97ee79b1b2f6f45bec

--- a/snapshots/biodiversity/2021-04-23/caribbean_reefs_with_acropora_corals_present__cramer_et_al__2020.feather.dvc
+++ b/snapshots/biodiversity/2021-04-23/caribbean_reefs_with_acropora_corals_present__cramer_et_al__2020.feather.dvc
@@ -1,19 +1,17 @@
 meta:
-  source:
-    name: |-
-      Cramer et al. (2020). Widespread loss of Caribbean acroporid corals was underway before coral bleaching and disease outbreaks. Science Advances.
+  origin:
+    producer: Cramer et al.
+    title: Widespread loss of Caribbean acroporid corals was underway before coral bleaching and disease outbreaks
     description: |-
       This study reconstructs historical trends in reef cover of the coral species Acropora in the Caribbean. It is measured by two variables:
       – the percentage of sites where Acropora was dominant
       – the percentage of sites where Acropora was present
 
-      To present this data as a time-series: where timings are given as a range, we have simplified the values into the mid-point year: e.g. 1960-1969 is given as the year 1965.
-    url: https://advances.sciencemag.org/content/6/17/eaax9395
-    date_accessed: 2021-04-23
-    published_by: |-
-      Cramer, K. L., Jackson, J. B., Donovan, M. K., Greenstein, B. J., Korpanty, C. A., Cook, G. M., & Pandolfi, J. M. (2020). Widespread loss of Caribbean acroporid corals was underway before coral bleaching and disease outbreaks. Science Advances, 6(17), eaax9395.
-  name: Caribbean reefs with acropora corals present (Cramer et al. 2020)
-  description: ''
+      To present this data as a time-series: where timings are given as a range, we have simplified the values into the mid-point year: e.g. 1960–1969 is given as the year 1965.
+    citation_full: 'Cramer, K. L., Jackson, J. B., Donovan, M. K., Greenstein, B. J., Korpanty, C. A., Cook, G. M., and Pandolfi, J. M. (2020). Widespread loss of Caribbean acroporid corals was underway before coral bleaching and disease outbreaks. Science Advances, 6(17), eaax9395.'
+    url_main: https://advances.sciencemag.org/content/6/17/eaax9395
+    date_accessed: '2021-04-23'
+    date_published: '2020'
   is_public: false
 outs:
   - md5: 5ebcd190c33d5ca4654c056a6b9bd842

--- a/snapshots/biodiversity/2021-06-01/fish_discards__un_fao.feather.dvc
+++ b/snapshots/biodiversity/2021-06-01/fish_discards__un_fao.feather.dvc
@@ -1,16 +1,16 @@
 meta:
-  source:
-    name: Pérez Roda, M.A. et al. (2019).  A third assessment of global marine fisheries discards. FAO Fisheries and Aquaculture.
+  origin:
+    producer: Pérez Roda et al.
+    title: A third assessment of global marine fisheries discards
     description: |-
       Discards are animals thrown back (alive or dead) into the sea after being caught during fishing activities.
 
-      This is one subset of 'bycatch': animals that are not the target species but are caught during fishing activities. Some bycatch is still used as human food, or animal feed. The proportion that is not used, and is instead, thrown back into the sea is called 'discards'.
-    url: http://www.fao.org/3/CA2905EN/ca2905en.pdf
+      This is one subset of "bycatch": animals that are not the target species but are caught during fishing activities. Some bycatch is still used as human food, or animal feed. The proportion that is not used, and is instead, thrown back into the sea is called "discards".
+    citation_full: 'Pérez Roda, M.A. (ed.), Gilman, E., Huntington, T., Kennelly, S.J., Suuronen, P., Chaloupka, M. and Medley, P. (2019). A third assessment of global marine fisheries discards. FAO Fisheries and Aquaculture Technical Paper No. 633. Rome, FAO. 78 pp.'
+    attribution_short: FAO
+    url_main: http://www.fao.org/3/CA2905EN/ca2905en.pdf
     date_accessed: '2021-06-01'
-    published_by: |-
-      Pérez Roda, M.A. (ed.), Gilman, E., Huntington, T., Kennelly, S.J., Suuronen, P., Chaloupka, M. and Medley, P. 2019. A third assessment of global marine fisheries discards. FAO Fisheries and Aquaculture Technical Paper No. 633. Rome, FAO. 78 pp.
-  name: Fish discards (UN FAO)
-  description: ''
+    date_published: '2019'
   is_public: false
 outs:
   - md5: 47818ed174936d2ac9cfdb89ed82eb42

--- a/snapshots/biodiversity/2021-06-01/north_atlantic_cod_catch__schijns_et_al__2021.feather.dvc
+++ b/snapshots/biodiversity/2021-06-01/north_atlantic_cod_catch__schijns_et_al__2021.feather.dvc
@@ -1,14 +1,13 @@
 meta:
-  source:
-    name: Schjins et al. (2021). Five centuries of cod catches in Eastern Canada.
+  origin:
+    producer: Schijns et al.
+    title: Five centuries of cod catches in Eastern Canada
     description: |-
       This measures estimates of North Atlantic cod (Gadus morhua) catch off Newfoundland and Labrador, Eastern Canada. The stock defined by this assessment includes all cod caught within NAFO-delineated Divisions 2J3KL.
-    url: https://academic.oup.com/icesjms/advance-article/doi/10.1093/icesjms/fsab153/6359257
+    citation_full: Schijns, R., Froese, R., Hutchings, J. A., Pauly, D., and Raicevich, S. (2021). Five centuries of cod catches in Eastern Canada. ICES Journal of Marine Science.
+    url_main: https://academic.oup.com/icesjms/advance-article/doi/10.1093/icesjms/fsab153/6359257
     date_accessed: '2021-06-01'
-    published_by: |-
-      Schijns, R., Froese, R., Hutchings, J. A., Pauly, D., & Raicevich, S. (2021). Five centuries of cod catches in Eastern Canada. ICES Journal of Marine Science.
-  name: North Atlantic cod catch (Schijns et al. 2021)
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 69e977e8c2f4a919bbc00912f8c83553

--- a/snapshots/biodiversity/2021-09-29/marine_protected_areas__wdpa.feather.dvc
+++ b/snapshots/biodiversity/2021-09-29/marine_protected_areas__wdpa.feather.dvc
@@ -1,12 +1,13 @@
 meta:
-  source:
-    name: 'UNEP-WCMC and IUCN (2021). Protected Planet: The World Database on Protected Areas (WDPA).'
-    url: https://www.protectedplanet.net/
-    date_accessed: 2021-09-29
-    published_by: |-
-      UNEP-WCMC and IUCN (2021). Protected Planet: The World Database on Protected Areas (WDPA) and World Database on Other Effective Area-based Conservation Measures (WD-OECM) [Online], September 2021, Cambridge, UK: UNEP-WCMC and IUCN.
-  name: Marine protected areas (WDPA)
-  description: ''
+  origin:
+    producer: UNEP-WCMC and IUCN
+    title: World Database on Protected Areas
+    title_snapshot: World Database on Protected Areas - Marine protected areas
+    citation_full: 'UNEP-WCMC and IUCN (2021). Protected Planet: The World Database on Protected Areas (WDPA) and World Database on Other Effective Area-based Conservation Measures (WD-OECM) [Online], September 2021, Cambridge, UK: UNEP-WCMC and IUCN.'
+    attribution_short: WDPA
+    url_main: https://www.protectedplanet.net/
+    date_accessed: '2021-09-29'
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 2a9595fcc376e63bc6b0b1dbc17b2c0d

--- a/snapshots/biodiversity/2022-12-07/eu_wild_bird_populations__eurostat__2022.feather.dvc
+++ b/snapshots/biodiversity/2022-12-07/eu_wild_bird_populations__eurostat__2022.feather.dvc
@@ -1,19 +1,19 @@
 meta:
-  source:
-    name: European Bird Census Council; National BirdLife organisations; RSPB; Czech Society for Ornithology (CSO)) via Eurostat
+  origin:
+    producer: Eurostat
+    title: EU wild bird populations
     description: |-
-      Bird monitoring in the EU is conducted under the umbrella of the PanEuropean Common Bird Monitoring Scheme. The scheme helps standardize data collection and data analysis practices across countries and produces three indices of the populations of common birds – index for all common birds (including 168 species), index for common farmland birds (39 species) and index for common forest birds (34 species).
+      Bird monitoring in the EU is conducted under the umbrella of the Pan-European Common Bird Monitoring Scheme. The scheme helps standardize data collection and data analysis practices across countries and produces three indices of the populations of common birds — index for all common birds (including 168 species), index for common farmland birds (39 species) and index for common forest birds (34 species).
 
       The bird population index is measured relative to population size in the year 2000 (i.e. the value in 2000 = 100).
 
       More information on this statistic is found here: https://web.archive.org/web/20221102140322/https://ec.europa.eu/eurostat/cache/metadata/EN/env_biodiv_esms.htm
 
       This dataset was last updated on the 30th November 2022 and is typically updated annually. It will therefore next be updated on Our World in Data from December 2023.
-    url: https://ec.europa.eu/eurostat/web/environment/biodiversity
-    date_accessed: 2022-12-07
-    published_by: European Bird Census Council; National BirdLife organisations; RSPB; Czech Society for Ornithology (CSO)) via Eurostat
-  name: EU Wild Bird Populations (Eurostat, 2022)
-  description: ''
+    citation_full: European Bird Census Council, National BirdLife organisations, RSPB, and Czech Society for Ornithology (CSO) via Eurostat (2022). EU wild bird populations.
+    url_main: https://ec.europa.eu/eurostat/web/environment/biodiversity
+    date_accessed: '2022-12-07'
+    date_published: '2022-11-30'
   is_public: false
 outs:
   - md5: 804a2fb97cf204afb7a6fa19d24ec52f

--- a/snapshots/biodiversity/2022-12-07/international_whaling_commission_status__iwc__2022.feather.dvc
+++ b/snapshots/biodiversity/2022-12-07/international_whaling_commission_status__iwc__2022.feather.dvc
@@ -1,11 +1,12 @@
 meta:
-  source:
-    name: International Whaling Commission (IWC; 2022)
-    url: https://iwc.int/member-map
-    date_accessed: 2022-12-07
-    published_by: International Whaling Commission (IWC)
-  name: International Whaling Commission Status (IWC, 2022)
-  description: ''
+  origin:
+    producer: International Whaling Commission
+    title: Member countries
+    citation_full: International Whaling Commission (IWC) (2022). Member countries.
+    attribution_short: IWC
+    url_main: https://iwc.int/member-map
+    date_accessed: '2022-12-07'
+    date_published: '2022'
   is_public: false
 outs:
   - md5: 703b72fa3c4831d69d2335bc958b4ac9

--- a/snapshots/biodiversity/2022-12-07/international_whaling_commissions_members_by_year__2022.feather.dvc
+++ b/snapshots/biodiversity/2022-12-07/international_whaling_commissions_members_by_year__2022.feather.dvc
@@ -1,11 +1,12 @@
 meta:
-  source:
-    name: International Whaling Commission (IWC; 2022)
-    url: https://iwc.int/member-map
-    date_accessed: 2022-12-07
-    published_by: International Whaling Commission (IWC)
-  name: International Whaling Commissions Members by Year (2022)
-  description: ''
+  origin:
+    producer: International Whaling Commission
+    title: Member countries by year
+    citation_full: International Whaling Commission (2022). Member countries by year.
+    attribution_short: IWC
+    url_main: https://iwc.int/member-map
+    date_accessed: '2022-12-07'
+    date_published: '2022'
   is_public: false
 outs:
   - md5: 8c60116603562e90a43cac5a6a60a1d0

--- a/snapshots/biodiversity/2022-12-12/drivers_of_recovery_in_european_bird_species__zsl__2022.feather.dvc
+++ b/snapshots/biodiversity/2022-12-12/drivers_of_recovery_in_european_bird_species__zsl__2022.feather.dvc
@@ -1,14 +1,13 @@
 meta:
-  source:
-    name: |-
-      Ledger, S.E.H., Rutherford, C.A., Benham, C., Burfield, I.J., Deinet, S., Eaton, M., Freeman, R., Gray, C., Herrando, S., Scott-Gatty, K., Staneva, A. and McRae, L., (2022) Wildlife Comeback in Europe: Opportunities and challenges for species recovery.
-    description: This dataset is taken from Figure 13 on page 249 of the Wildlife Comeback in Europe report (2022).
-    url: https://www.rewildingeurope.com/wp-content/uploads/publications/wildlife-comeback-in-europe-2022/index.html
-    date_accessed: 2022-12-12
-    published_by: |-
-      Ledger, S.E.H, Rutherford, C.A, Benham, C., Burfield, I.J., Deinet, S., Eaton, M., Freeman, R., Gray, C., Herrando, S., Scott-Gatty, K., Staneva, A and McRae, L., (2022) Wildlife Comeback in Europe: Opportunities and challenges for species recovery.
-  name: Drivers of recovery in European bird species (ZSL, 2022)
-  description: ''
+  origin:
+    producer: Ledger et al.
+    title: 'Wildlife comeback in Europe: Opportunities and challenges for species recovery'
+    description: |-
+      This dataset is taken from Figure 13 on page 249 of the Wildlife Comeback in Europe report (2022).
+    citation_full: 'Ledger, S.E.H., Rutherford, C.A., Benham, C., Burfield, I.J., Deinet, S., Eaton, M., Freeman, R., Gray, C., Herrando, S., Scott-Gatty, K., Staneva, A. and McRae, L. (2022). Wildlife Comeback in Europe: Opportunities and challenges for species recovery.'
+    url_main: https://www.rewildingeurope.com/wp-content/uploads/publications/wildlife-comeback-in-europe-2022/index.html
+    date_accessed: '2022-12-12'
+    date_published: '2022'
   is_public: false
 outs:
   - md5: a001a63e6ef6648a990a56f9bf6d0e67

--- a/snapshots/climate/2018-09-20/wildfire_data_in_the_us__nifc.feather.dvc
+++ b/snapshots/climate/2018-09-20/wildfire_data_in_the_us__nifc.feather.dvc
@@ -1,17 +1,18 @@
 meta:
-  source:
-    name: Wildfire data in the US (NIFC)
+  origin:
+    producer: National Interagency Fire Center
+    title: Wildfire data in the US
     description: |-
       The National Interagency Coordination Center at NIFC compiles annual wildland fire statistics for federal and state agencies. This information is provided through Situation Reports, which have been in use for several decades.
 
       **Prior to 1983, sources of these figures are not known, or cannot be confirmed, and were not derived from the current situation reporting process. As a result the figures prior to 1983 should not be compared to later data.
 
       The average acres burned per wildfire has been calculated by Our World in Data by dividing the total number of acres burned by the number of wildfires in a given year. Note this simplifies and does not account for the distribution of wildfire extents.
-    url: https://www.nifc.gov/fireInfo/fireInfo_stats_totalFires.html
-    date_accessed: 2018-09-20
-    published_by: National Interagency Coordination Center; National Interagency Fire Center
-  name: Wildfire data in the US (NIFC)
-  description: ''
+    citation_full: National Interagency Coordination Center, National Interagency Fire Center. Wildland fire statistics.
+    attribution_short: NIFC
+    url_main: https://www.nifc.gov/fireInfo/fireInfo_stats_totalFires.html
+    date_accessed: '2018-09-20'
+    date_published: latest
   is_public: false
 outs:
   - md5: f72496137036cbc6d59018f293bae34a

--- a/snapshots/climate/2021-04-13/coral_bleaching_events_by_enso_phase__hughes_et_al__2018.feather.dvc
+++ b/snapshots/climate/2021-04-13/coral_bleaching_events_by_enso_phase__hughes_et_al__2018.feather.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Hughes, T. P., et al. (2018). Spatial and temporal patterns of mass bleaching of corals in the Anthropocene. Science.
+  origin:
+    producer: Hughes et al.
+    title: 'Spatial and temporal patterns of mass bleaching of corals in the Anthropocene'
     description: |-
       Data on the frequency of coral bleaching events comes from the work of Hughes et al. (2018). This measures the number of moderate bleaching events (up to 30% of corals) and severe bleaching events (more than 30% corals) measured at 100 fixed global locations.
 
       Our World in Data have categorized these events by year based on the stage in the El Nino Southern Oscillation (ENSO) cycle. This is based on the Oceanic Nino Index (ONI) from this source: https://ggweather.com/enso/oni.htm
 
       The ENSO or ONI categorizes years based on whether they are part of the El Nino (warm phase), La Nina (cool phase) or moderate (neither) stage of the cycle.
-    url: https://science.sciencemag.org/content/359/6371/80
-    date_accessed: 2021-04-13
-    published_by: |-
-      Hughes, T. P., Anderson, K. D., Connolly, S. R., Heron, S. F., Kerry, J. T., Lough, J. M., ... & Wilson, S. K. (2018). Spatial and temporal patterns of mass bleaching of corals in the Anthropocene. Science, 359(6371), 80-83.
-  name: Coral bleaching events by ENSO phase (Hughes et al. 2018)
-  description: ''
+    citation_full: 'Hughes, T. P., Anderson, K. D., Connolly, S. R., Heron, S. F., Kerry, J. T., Lough, J. M., ... & Wilson, S. K. (2018). Spatial and temporal patterns of mass bleaching of corals in the Anthropocene. Science, 359(6371), 80-83.'
+    url_main: https://science.sciencemag.org/content/359/6371/80
+    date_accessed: '2021-04-13'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: d3afabd819f1ac7222fb479a80350d29

--- a/snapshots/climate/2022-09-10/young_people_opinions_climate_change__hickman_et_al__2021.feather.dvc
+++ b/snapshots/climate/2022-09-10/young_people_opinions_climate_change__hickman_et_al__2021.feather.dvc
@@ -1,17 +1,15 @@
 meta:
-  source:
-    name: |-
-      Hickman et al. (2021). Climate anxiety in children and young people and their beliefs about government responses to climate change: a global survey.
+  origin:
+    producer: Hickman et al.
+    title: 'Climate anxiety in children and young people and their beliefs about government responses to climate change: a global survey'
     description: |-
       Hickman et al. (2021) surveyed young people, aged 16-to-25 years old, about their attitudes to climate change.
 
       The total sample of this survey was approximately 10,000 people. This was split across 10 countries, which approximately 1,000 people in each country in the sample.
-    url: https://www.thelancet.com/journals/lanplh/article/PIIS2542-5196(21)00278-3/fulltext
+    citation_full: 'Hickman, C., Marks, E., Pihkala, P., Clayton, S., Lewandowski, R. E., Mayall, E. E., ... & van Susteren, L. (2021). Climate anxiety in children and young people and their beliefs about government responses to climate change: a global survey. The Lancet Planetary Health, 5(12), e863-e873.'
+    url_main: https://www.thelancet.com/journals/lanplh/article/PIIS2542-5196(21)00278-3/fulltext
     date_accessed: '2022-09-10'
-    published_by: |-
-      Hickman, C., Marks, E., Pihkala, P., Clayton, S., Lewandowski, R. E., Mayall, E. E., ... & van Susteren, L. (2021). Climate anxiety in children and young people and their beliefs about government responses to climate change: a global survey. The Lancet Planetary Health, 5(12), e863-e873.
-  name: Young people opinions climate change (Hickman et al. 2021)
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 77dc07ef1413a3d94846ff0d66006f98

--- a/snapshots/corruption/2016-10-13/diplomatic_parking_violations__fisman_and_miguel__2007__split.feather.dvc
+++ b/snapshots/corruption/2016-10-13/diplomatic_parking_violations__fisman_and_miguel__2007__split.feather.dvc
@@ -1,12 +1,11 @@
 meta:
-  source:
-    name: Fisman and Miguel (2007)
-    url: https://web.archive.org/web/20170705082223/http://projects.iq.harvard.edu/gov2126/files/fisman_miguel_parkingtickets.pdf
-    date_accessed: 2016-10-13
-    published_by: |-
-      Fisman, R., & Miguel, E. (2007). Corruption, norms, and legal enforcement: Evidence from diplomatic parking tickets. Journal of Political economy, 115(6), 1020-1048.
-  name: Diplomatic parking violations (Fisman and Miguel (2007)) (split)
-  description: ''
+  origin:
+    producer: Fisman and Miguel
+    title: 'Corruption, norms, and legal enforcement: Evidence from diplomatic parking tickets'
+    citation_full: 'Fisman, R., & Miguel, E. (2007). Corruption, norms, and legal enforcement: Evidence from diplomatic parking tickets. Journal of Political Economy, 115(6), 1020-1048.'
+    url_main: https://web.archive.org/web/20170705082223/http://projects.iq.harvard.edu/gov2126/files/fisman_miguel_parkingtickets.pdf
+    date_accessed: '2016-10-13'
+    date_published: '2007'
   is_public: false
 outs:
   - md5: 3611eea05aa3a4c5953573c291cec125

--- a/snapshots/demography/2020-10-01/labour_force_dependency_ratio__iiasc.feather.dvc
+++ b/snapshots/demography/2020-10-01/labour_force_dependency_ratio__iiasc.feather.dvc
@@ -1,21 +1,16 @@
 meta:
-  source:
-    name: European Commission and IIASA, 2020
+  origin:
+    producer: Marois et al.
+    title: Population aging, migration, and productivity in Europe
     description: |-
-      These population projections come from a joint project between the European Commission and the International Institute for Applied Systems Analysis (IIASA). The results, first published as the "<a href="https://ec.europa.eu/jrc/en/facts4eufuture/eu-demographic-scenarios">Demographic Scenarios for the EU</a>" flagship report, were since updated and published by the Proceedings of the National Academy of Sciences of the United States of America (PNAS). Information on the detailed methodology and updated microsimulation results can be found <a href="https://www.pnas.org/content/117/14/7690.abstract">here</a>.
+      These population projections come from a joint project between the European Commission and the International Institute for Applied Systems Analysis (IIASA). The results, first published as the [Demographic Scenarios for the EU](https://ec.europa.eu/jrc/en/facts4eufuture/eu-demographic-scenarios) flagship report, were since updated and published by the Proceedings of the National Academy of Sciences of the United States of America (PNAS). Information on the detailed methodology and updated microsimulation results can be found [here](https://www.pnas.org/content/117/14/7690.abstract).
 
-      Full reference:
-      Marois, G., Bélanger, A., & Lutz, W. (2020). Population aging, migration, and productivity in Europe. Proceedings of the National Academy of Sciences, 117(14), 7690-7695.
-
-      -------
       Background on the labour force assumptions for the 'LFDR - Constant Participation' and 'LFDR - High Participation' scenarios:
       Future labour force participation rates are calculated from statistical modelling based on the 2014 and 2015 Labour Force Survey, assuming constant entry and exit rates in the labour force by age, sex, education, and country. The 'high participation (Swedish) scenario' assumes a convergence in labour participation rates by 2050 to what was observed in Sweden during 2014-2015.
-    url: https://www.pnas.org/content/117/14/7690.abstract
+    citation_full: 'Marois, G., Bélanger, A., and Lutz, W. (2020). Population aging, migration, and productivity in Europe. Proceedings of the National Academy of Sciences, 117(14), 7690-7695.'
+    url_main: https://www.pnas.org/content/117/14/7690.abstract
     date_accessed: '2020-10-01'
-    published_by: |-
-      Marois, G., Bélanger, A., & Lutz, W. (2020). Population aging, migration, and productivity in Europe. Proceedings of the National Academy of Sciences, 117(14), 7690-7695.
-  name: Labour Force Dependency Ratio (IIASC)
-  description: ''
+    date_published: '2020'
   is_public: false
 outs:
   - md5: 59264a536aa9398ddcf6ccf44726fdcf

--- a/snapshots/demography/2021/share_of_one_person_households__owid_based_on_un_and_other_sources.feather.dvc
+++ b/snapshots/demography/2021/share_of_one_person_households__owid_based_on_un_and_other_sources.feather.dvc
@@ -1,13 +1,14 @@
 meta:
-  source:
-    name: OWID based on UN and other sources
+  origin:
+    producer: UN, national statistical agencies, OECD, and Deutschland in Daten
+    title: Share of one-person households
     description: |-
       This is an OWID constructed dataset on the share of one-person households.
 
       Estimates rely on data from multiple sources:
-      - For European countries, the data comes from the <a href="https://ec.europa.eu/eurostat/statistics-explained/index.php/People_in_the_EU_-_statistics_on_household_and_family_structures#Single-person_households">Eurostat dataset</a> using the ilc_lvph02 series.
-      - Data for <a href="http://nzdotstat.stats.govt.nz/wbos/Index.aspx">New Zealand</a>, <a href="https://www.e-stat.go.jp/en/stat-search/files?page=1&query=household&layout=dataset&toukei=00200521&tstat=000001080615&metadata=1&data=1">Japan</a>, <a href="https://www.census.gov/data/tables/time-series/demo/families/households.html">the US</a>, and <a href="https://quickstats.censusdata.abs.gov.au/census_services/getproduct/census/2001/quickstat/0?opendocument">Australia</a> were taken from the countries' national statistical agencies
-      - For all other countries the data comes from the <a href="https://population.un.org/Household/index.html#/countries/840">United Nations Database on Household Size and Composition 2018</a>.
+      - For European countries, the data comes from the [Eurostat dataset](https://ec.europa.eu/eurostat/statistics-explained/index.php/People_in_the_EU_-_statistics_on_household_and_family_structures#Single-person_households) using the ilc_lvph02 series.
+      - Data for [New Zealand](http://nzdotstat.stats.govt.nz/wbos/Index.aspx), [Japan](https://www.e-stat.go.jp/en/stat-search/files?page=1&query=household&layout=dataset&toukei=00200521&tstat=000001080615&metadata=1&data=1), [the US](https://www.census.gov/data/tables/time-series/demo/families/households.html), and [Australia](https://quickstats.censusdata.abs.gov.au/census_services/getproduct/census/2001/quickstat/0?opendocument) were taken from the countries' national statistical agencies
+      - For all other countries the data comes from the [United Nations Database on Household Size and Composition 2018](https://population.un.org/Household/index.html#/countries/840).
 
       The UN database pulls from 4 different sources:
       1) Demographic and Health Surveys (DHS);
@@ -17,11 +18,11 @@ meta:
 
       Where a country time series was composed of multiple sources, we favoured the source covering the most years. In cases where there was a tie between sources, we favoured the DYB, then IPUMS, DHS, and lastly LFS estimates. The DYB covered the largest number of countries and the LFS the least.
 
-      - Data from the <a href="http://www.oecd.org/els/family/database.htm#structure">OECD</a> was used to supplement the dataset for 2011, for countries where data from other sources were unavailable.
-      - The time series for Germany was supplemented using the <a href="https://figshare.com/articles/German_Time_Series_Dataset_1834_2012/1450809/1">Deutschland in Daten</a> dataset where West Germany refers to the German Federal Republic series and East Germany to the German Democratic Republic.
+      - Data from the [OECD](http://www.oecd.org/els/family/database.htm#structure) was used to supplement the dataset for 2011, for countries where data from other sources were unavailable.
+      - The time series for Germany was supplemented using the [Deutschland in Daten](https://figshare.com/articles/German_Time_Series_Dataset_1834_2012/1450809/1) dataset where West Germany refers to the German Federal Republic series and East Germany to the German Democratic Republic.
       See Rahlf, Thomas; Erker, Paul; Fertig, Georg; Rothenbacher, Franz; Oltmer, Jochen; Müller-Benedict, Volker; et al. (2015): German Time Series Dataset, 1834-2012. figshare. Dataset. https://doi.org/10.6084/m9.figshare.1450809.v1
 
-      (<em>NB. The source for each observation can be found in the metadata spreadsheet <a href="https://owid.cloud/app/uploads/2019/12/living-alone-metadata-final_country_stan.csv">here</a></em>)
+      (*NB. The source for each observation can be found in the metadata spreadsheet [here](https://owid.cloud/app/uploads/2019/12/living-alone-metadata-final_country_stan.csv)*)
 
       Notes:
       The UN data included two observations for Tanzania in 2004 and two for Senegal in 2013. We favoured the observation produced later in the year to avoid under- or over-estimating the share of one-person households. The figures produced later in the year are a more sensible fit for their respective country series.
@@ -33,11 +34,9 @@ meta:
       United States estimates in 1993 and 2011 are revised based on population from the most recent decennial census.
 
       The OECD-32 average excludes Israel.
-    url: See below
-    date_accessed: 2019-11-15
-    published_by: UN, national statistical agencies, OECD, Deutschland in Daten
-  name: Share of one person households - OWID based on UN and other sources
-  description: ''
+    citation_full: Our World in Data based on UN, national statistical agencies, OECD, and Deutschland in Daten (2021).
+    date_accessed: '2019-11-15'
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 2a40f540af1d083faf0092c0de3148bd

--- a/snapshots/eat_lancet/2021-06-07/eat_lancet_diet_composition__grams_per_capita_per_day.feather.dvc
+++ b/snapshots/eat_lancet/2021-06-07/eat_lancet_diet_composition__grams_per_capita_per_day.feather.dvc
@@ -1,6 +1,7 @@
 meta:
-  source:
-    name: Food and Agriculture Organization of the United Nations;  EAT-Lancet Commission
+  origin:
+    producer: Food and Agriculture Organization of the United Nations and EAT-Lancet Commission
+    title: EAT-Lancet diet composition (grams per capita per day)
     description: |-
       This dataset compares the composition of the EAT-Lancet diet with average diets across the world.
 
@@ -11,10 +12,11 @@ meta:
       The EAT-Lancet diet is a diet recommended to balance the goals of healthy nutrition and environmental sustainability for a global population.
 
       As the report states: "Although the planetary health diet, which is based on health considerations, is consistent with many traditional eating patterns, it does not imply that the global population should eat exactly the same food, nor does it prescribe an exact diet. Instead, the planetary health diet outlines empirical food groups and ranges of food intakes, which combined in a diet, would optimize human health. Local interpretation and adaptation of the universally-applicable planetary health diet is necessary and should reflect the culture, geography and demography of the population and individuals."
-    date_accessed: 2021-06-07
-    published_by: Food and Agriculture Organization of the United Nations;  EAT-Lancet Commission
-  name: eat-lancet-diet-composition (grams per capita per day)
-  description: ''
+    citation_full: 'Food and Agriculture Organization of the United Nations (FAOSTAT food supply data) and EAT-Lancet Commission (2019). EAT-Lancet Commission Summary Report.'
+    attribution_short: FAO and EAT-Lancet
+    url_main: https://eatforum.org/content/uploads/2019/07/EAT-Lancet_Commission_Summary_Report.pdf
+    date_accessed: '2021-06-07'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: 02ff3d2d34b5a970e3e4948522002956

--- a/snapshots/economics/2018-09-18/extreme_poverty_share_to_2030__crespo_cuaresma__2018.feather.dvc
+++ b/snapshots/economics/2018-09-18/extreme_poverty_share_to_2030__crespo_cuaresma__2018.feather.dvc
@@ -1,28 +1,27 @@
 meta:
-  source:
-    name: Extreme Poverty Share to 2030 - Crespo-Cuaresma (2018)
+  origin:
+    producer: Crespo-Cuaresma et al.
+    title: 'Will the Sustainable Development Goals be fulfilled? Assessing present and future global poverty'
     description: |-
       Data on extreme poverty projections by country and region are sourced from the Nature publication by Crespo-Cuaresma et al. (2018). This data is also presented visually at the World Poverty Clock: http://worldpoverty.io/index.html
 
       Extreme poverty is defined by the international poverty line, set at a threshold of $1.90 per person per day, which is adjusted for inflation (by normalising to 2011 dollars), and corrected for cross-country price differences (PPP).
 
-      The UN's Sustainable Development Goal (SDG) Target 1.1 is to end extreme poverty by 2030. 'Ending extreme poverty' is assumed when a country reaches an extreme poverty level below 3% of the total population.
+      The UN's Sustainable Development Goal (SDG) Target 1.1 is to end extreme poverty by 2030. "Ending extreme poverty" is assumed when a country reaches an extreme poverty level below 3% of the total population.
 
       Scenarios of future extreme poverty rates were assessed and modelled by Crespo-Cuaresma et al. (2018) using a combination of the IMF World Economic Outlook, and multiple Shared Socioeconomic Pathways (SSP).
 
       Data presented here is for SSP2 which is defined as the baseline (business-as-usual) projections. This represents the benchmark scenario and assumes the continuation of current global socioeconomic trends at the global level.
 
-      Allocation of 'poverty rising', 'on-track', 'off-track' and 'target reached' are used to show whether countries are on or off-track to meet the UN SDG target of ending extreme poverty by 2030. 'Ending extreme poverty' is here defined as reaching a level below 3 percent of the total population.
+      Allocation of "poverty rising", "on-track", "off-track" and "target reached" are used to show whether countries are on or off-track to meet the UN SDG target of ending extreme poverty by 2030. "Ending extreme poverty" is here defined as reaching a level below 3 percent of the total population.
 
-      The categories of 'extremely fragile', 'fragile' and 'non-fragile' have been added for reference based on the OECD (2018) States of Fragility framework. This framework measures the fragility of countries based on multiple political and socioeconomic indicators. More information on this fragility measure can be found at the OECD (2018) report.
+      The categories of "extremely fragile", "fragile" and "non-fragile" have been added for reference based on the OECD (2018) States of Fragility framework. This framework measures the fragility of countries based on multiple political and socioeconomic indicators. More information on this fragility measure can be found at the OECD (2018) report.
 
       Reference: OECD (2018), States of Fragility. OECD Publishing, Paris. Available at: https://www.oecd-ilibrary.org/development/states-of-fragility-2018_9789264302075-en
-    url: https://www.nature.com/articles/s41599-018-0083-y
-    date_accessed: 2018-09-18
-    published_by: |-
-      Cuaresma, J. C., Fengler, W., Kharas, H., Bekhtiar, K., Brottrager, M., & Hofer, M. (2018). Will the Sustainable Development Goals be fulfilled? Assessing present and future global poverty. Palgrave Communications, 4(1), 29.
-  name: Extreme Poverty Share to 2030 - Crespo-Cuaresma (2018)
-  description: ''
+    citation_full: 'Cuaresma, J. C., Fengler, W., Kharas, H., Bekhtiar, K., Brottrager, M., and Hofer, M. (2018). Will the Sustainable Development Goals be fulfilled? Assessing present and future global poverty. Palgrave Communications, 4(1), 29.'
+    url_main: https://www.nature.com/articles/s41599-018-0083-y
+    date_accessed: '2018-09-18'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 432d03205b0209b2fdc9448f37541981

--- a/snapshots/economics/2018-10-01/country_programmable_aid__cpa__from_2000_2019__oecd__2018.feather.dvc
+++ b/snapshots/economics/2018-10-01/country_programmable_aid__cpa__from_2000_2019__oecd__2018.feather.dvc
@@ -1,10 +1,10 @@
 meta:
-  source:
-    name: Country programmable aid (CPA) from 2000-2019 (OECD, 2018)
+  origin:
+    producer: OECD
+    title: Country programmable aid (CPA), 2000–2019
+    citation_full: OECD (2018). Country programmable aid (CPA), 2000–2019.
     date_accessed: '2018-10-01'
-    published_by: Country programmable aid (CPA) from 2000-2019 (OECD, 2018)
-  name: Country programmable aid (CPA) from 2000-2019 (OECD, 2018)
-  description: ''
+    date_published: '2018'
   is_public: false
 outs:
   - md5: a06b4821c1066a6ed233e1f06d41e9b1

--- a/snapshots/economics/2018-11-01/gini_index_around_2000_and_2015__povcal_2018_and_chartbook_2017.feather.dvc
+++ b/snapshots/economics/2018-11-01/gini_index_around_2000_and_2015__povcal_2018_and_chartbook_2017.feather.dvc
@@ -1,11 +1,11 @@
 meta:
-  source:
-    name: Povcal (2018), The Chartbook of Economic Inequality (2017), Kanbur et al (2017) Table 1.B
+  origin:
+    producer: PovcalNet, Atkinson et al., and Kanbur and Wang
+    title: Gini index around 2000 and 2015
+    citation_full: |-
+      PovcalNet (2018); Atkinson, A. B., Hasell, J., Morelli, S., and Roser, M. (2017). The Chartbook of Economic Inequality; Kanbur, R., and Wang, Y. (2017). The great Chinese inequality turnaround. ECINEQ Working Paper Series WP 2017 – 433.
     date_accessed: '2018-11-01'
-    published_by: |-
-      Povcal (2018); Atkinson, Hasell, Morelli, and Roser (2017), “The Chartbook of Economic Inequality”; Kanbur, R., & Wang, Y. 2017. The great Chinese inequality turnaround. ECINEQ Working Paper Series WP 2017 – 433
-  name: Gini Index around 2000 and 2015 (Povcal 2018 and Chartbook 2017)
-  description: ''
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 6a8d844b476f801b0bec5067084fc273

--- a/snapshots/economics/2018-12-03/gini_index_in_1980__1990__and__2015__gcip__2018.feather.dvc
+++ b/snapshots/economics/2018-12-03/gini_index_in_1980__1990__and__2015__gcip__2018.feather.dvc
@@ -1,12 +1,14 @@
 meta:
-  source:
-    name: Global Consumption and Income Project
-    url: gcip.info
-    date_accessed: 2018-12-03
-    published_by: Global Consumption and Income Project
-  name: Gini index in 1980, 1990 & 2015 – GCIP (2018)
-  description: ''
   is_public: false
+  origin:
+    producer: Global Consumption and Income Project
+    title: Global Consumption and Income Project
+    title_snapshot: Global Consumption and Income Project - Gini index in 1980, 1990, and 2015
+    citation_full: Global Consumption and Income Project (2018).
+    attribution_short: GCIP
+    url_main: https://gcip.info
+    date_accessed: '2018-12-03'
+    date_published: '2018'
 outs:
   - md5: 86f484af29f92e0dfcaa82dab5ba86c0
     size: 30810

--- a/snapshots/economics/2018/global_preferences_survey__gps__falk__becker__dohmen__enke__huffman__and_sunde__2018.feather.dvc
+++ b/snapshots/economics/2018/global_preferences_survey__gps__falk__becker__dohmen__enke__huffman__and_sunde__2018.feather.dvc
@@ -1,6 +1,7 @@
 meta:
-  source:
-    name: Falk, Becker, Dohmen, Enke, Huffman, and Sunde (2018) - Global Preferences Survey (GPS)
+  origin:
+    producer: Global Preferences Survey
+    title: Global Preferences Survey
     description: |-
       The Global Preferences Survey (GPS) measures preferences for nationally representative samples taken from each of the 76 countries covered. This includes 15 countries from the Americas, 25 from Europe, 22 from Asia and the Pacific, and 14 African countries - 11 of which are Sub-Saharan. In total, this covers 90% of both the world population and total income.
 
@@ -9,16 +10,14 @@ meta:
       Country level averages for each economic preference were calculated using individual-level data weighted by the sampling weights provided by the Gallup World Poll. Each preference is normalized to have mean 0 and standard deviation 1 in the individual-level data.
 
       For more information on the construction of the GPS dataset, see Section II.A of the paper by Falk et al. (2018).
+    citation_full: |-
+      Falk, A., Becker, A., Dohmen, T., Enke, B., Huffman, D., and Sunde, U. (2018). Global evidence on economic preferences. Quarterly Journal of Economics (forthcoming). Published by briq - Institute on Behavior and Inequality.
 
-      Full citation:
-      Falk, A., Becker, A., Dohmen, T., Enke, B., Huffman, D., & Sunde, U. (2018). Global evidence on economic preferences. Quarterly Journal of Economics (forthcoming).
-
-      Falk, A., Becker, A., Dohmen, T. J., Huffman, D., & Sunde, U. (2016). The preference survey module: A validated instrument for measuring risk, time, and social preferences. IZA Discussion Paper No. 9674.
-    url: https://www.briq-institute.org/global-preferences/downloads
-    date_accessed: 2018-11-06
-    published_by: briq - Institute on Behavior and Inequality
-  name: Global Preferences Survey (GPS) - Falk, Becker, Dohmen, Enke, Huffman, and Sunde (2018)
-  description: ''
+      Falk, A., Becker, A., Dohmen, T. J., Huffman, D., and Sunde, U. (2016). The preference survey module: A validated instrument for measuring risk, time, and social preferences. IZA Discussion Paper No. 9674.
+    attribution_short: GPS
+    url_main: https://www.briq-institute.org/global-preferences/downloads
+    date_accessed: '2018-11-06'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 2f4d05f8c36b890146471d3b32e4206f

--- a/snapshots/economics/2019-04-04/share_of_women_in_top_income_groups__atkinson__casarico__and__voitchovsky__2018.feather.dvc
+++ b/snapshots/economics/2019-04-04/share_of_women_in_top_income_groups__atkinson__casarico__and__voitchovsky__2018.feather.dvc
@@ -1,13 +1,13 @@
 meta:
-  source:
-    name: Atkinson, Casarico and Voitchovsky (2018)
+  origin:
+    producer: Atkinson et al.
+    title: Share of women in top income groups
     description: |-
       Share of women in pre-tax top income groups. Based on tax data. Income includes earned, self-employment and investment income. Capital gains is in general excluded, but to varying degrees between countries.
-    url: https://doi.org/10.1007/s10888-018-9384-z
-    date_accessed: 2019-04-04
-    published_by: 'Atkinson, A.B., Casarico, A. & Voitchovsky, S. J Econ Inequal (2018) 16: 225. https://doi.org/10.1007/s10888-018-9384-z'
-  name: Share of women in top income groups – Atkinson, Casarico & Voitchovsky (2018)
-  description: ''
+    citation_full: 'Atkinson, A. B., Casarico, A., and Voitchovsky, S. (2018). Top incomes and the gender divide. The Journal of Economic Inequality, 16(2), 225–256. https://doi.org/10.1007/s10888-018-9384-z.'
+    url_main: https://doi.org/10.1007/s10888-018-9384-z
+    date_accessed: '2019-04-04'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: fb2d88c10e6da54196c575d7df3dc045

--- a/snapshots/economics/2019-09-04/corporate_tax_revenue__ictd_unu_wider_grd__2019.feather.dvc
+++ b/snapshots/economics/2019-09-04/corporate_tax_revenue__ictd_unu_wider_grd__2019.feather.dvc
@@ -1,15 +1,17 @@
 meta:
-  source:
-    name: ICTD/UNU-WIDER Government Revenue Dataset, September 2019
+  origin:
+    producer: International Centre for Tax and Development and UNU-WIDER
+    title: Government Revenue Dataset
     description: |-
-      This data comes from the 'merged' dataset provided by ICTD, after excluding observations flagged as unreliable. Specifically, we excluded the observations where the ICTD indicated concerns about their quality, accuracy or comparability. Details regarding these flags, as well as the dataset more generally, are available Prichard, W. (2016). Reassessing Tax and Development Research: A New Dataset, New Findings, and Lessons for Research. World Development, 80, 48-60.
+      This data comes from the "merged" dataset provided by ICTD, after excluding observations flagged as unreliable. Specifically, we excluded the observations where the ICTD indicated concerns about their quality, accuracy or comparability. Details regarding these flags, as well as the dataset more generally, are available Prichard, W. (2016). Reassessing Tax and Development Research: A New Dataset, New Findings, and Lessons for Research. World Development, 80, 48-60.
 
-      The September 2019 release differs from the previous release with the inclusion of new data for 2017. For more details on the Government Revenue Dataset see its <a href="https://www.wider.unu.edu/about-grd">update history</a>.
-    url: https://www.wider.unu.edu/project/government-revenue-dataset
-    date_accessed: 2019-09-04
-    published_by: International Centre for Tax and Development / UNU-WIDER
-  name: Corporate tax revenue - ICTD UNU-WIDER GRD (2019)
-  description: ''
+      The September 2019 release differs from the previous release with the inclusion of new data for 2017. For more details on the Government Revenue Dataset see its [update history](https://www.wider.unu.edu/about-grd).
+    citation_full: 'International Centre for Tax and Development and UNU-WIDER (2019). Government Revenue Dataset, September 2019.'
+    attribution_short: ICTD/UNU-WIDER
+    version_producer: September 2019
+    url_main: https://www.wider.unu.edu/project/government-revenue-dataset
+    date_accessed: '2019-09-04'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: 2fb5245719bcc3f5622d5b707c419fe4

--- a/snapshots/economics/2020-10-01/historical_estimates_of_number_of_people_living_at_different_income_thresholds_globally__owid_based_on_maddison_project_database_2020__gcip_and_van_zanden_et_al__2014.feather.dvc
+++ b/snapshots/economics/2020-10-01/historical_estimates_of_number_of_people_living_at_different_income_thresholds_globally__owid_based_on_maddison_project_database_2020__gcip_and_van_zanden_et_al__2014.feather.dvc
@@ -1,12 +1,10 @@
 meta:
-  source:
-    name: OWID based on Maddison Project Database 2020, GCIP and van Zanden et al. (2014))
-    description: 'See data appendix:'
+  origin:
+    producer: Maddison Project Database, GCIP and van Zanden et al.
+    title: Historical estimates of number of people living at different income thresholds globally
+    citation_full: Our World in Data based on Maddison Project Database (2020), Global Consumption and Income Project (GCIP), and van Zanden et al. (2014).
     date_accessed: '2020-10-01'
-    published_by: OWID based on Maddison Project Database 2020, GCIP and van Zanden et al. (2014))
-  name: |-
-    Historical estimates of number of people living at different income thresholds globally (OWID based on Maddison Project Database 2020, GCIP and van Zanden et al. (2014))
-  description: ''
+    date_published: '2020'
   is_public: false
 outs:
   - md5: c89d0f847c7c46ff72b59f4ea2272723

--- a/snapshots/economics/2020-10-01/historical_poverty_rates_by_region__owid_based_on_maddison_project_database_2020__van_zanden_et_al__2014__de_la_escosura__2012.feather.dvc
+++ b/snapshots/economics/2020-10-01/historical_poverty_rates_by_region__owid_based_on_maddison_project_database_2020__van_zanden_et_al__2014__de_la_escosura__2012.feather.dvc
@@ -1,14 +1,13 @@
 meta:
-  source:
-    name: OWID based on Maddison Project Database 2020, van Zanden et al. (2014), de la Escosura (2012)
+  origin:
+    producer: Maddison Project Database, van Zanden et al. and de la Escosura
+    title: Historical poverty rates by region
     description: |-
       See the data appendix describing the source data and methods underlying these estimates: https://ourworldindata.org/history-of-poverty-data-appendix
+    citation_full: |-
+      Bolt, Jutta and Jan Luiten van Zanden (2020), "Maddison style estimates of the evolution of the world economy. A new 2020 update"; van Zanden, Jan Luiten van, Joerg Baten, Peter Foldvari, and Bas van Leeuwen (2014), "The Changing Shape of Global Inequality 1820–2000; Exploring a New Dataset," Review of Income and Wealth 60 (2): 279–97; Prados de la Escosura, Leandro (2012), "Output per head in pre-independence Africa: Quantitative conjectures," Economic History of Developing Regions 27 (2): 1–36.
     date_accessed: '2020-10-01'
-    published_by: |-
-      OWID based on Maddison Project Database, version 2020. Bolt, Jutta and Jan Luiten van Zanden (2020), “Maddison style estimates of the evolution of the world economy. A new 2020 update ”; van Zanden, Jan Luiten van, Joerg Baten, Peter Foldvari, and Bas van Leeuwen. 2014. “The Changing Shape of Global Inequality 1820–2000; Exploring a New Dataset.” Review of Income and Wealth 60 (2): 279–97; Prados de la Escosura, Leandro. 2012. “OUTPUT PER HEAD IN PRE-INDEPENDENCE AFRICA: QUANTITATIVE CONJECTURES.” Economic History of Developing Regions 27 (2): 1–36.
-  name: |-
-    Historical poverty rates by region (OWID based on Maddison Project Database 2020, van Zanden et al. (2014), de la Escosura (2012))
-  description: ''
+    date_published: '2020'
   is_public: false
 outs:
   - md5: 45c5b52113a82930491fc875704fa585

--- a/snapshots/emissions/2019/deforestation_emissions_embedded_in_trade__pendrill_et_al__2019.feather.dvc
+++ b/snapshots/emissions/2019/deforestation_emissions_embedded_in_trade__pendrill_et_al__2019.feather.dvc
@@ -1,16 +1,15 @@
 meta:
-  source:
-    name: Pendrill et al. (2019). Agricultural and forestry trade drives large share of tropical deforestation emissions.
+  origin:
+    producer: Pendrill et al.
+    title: Agricultural and forestry trade drives large share of tropical deforestation emissions
     description: |-
       Pendrill et al. (2019) developed a land-balance model which attributed detected forest loss across the world to the expansion of croplands, pasture and tree plantations. This is then linked to particular agricultural commodities based on national land use, crop and forest product statistics published in the UN Food and Agricultural Organization balance sheets.
 
       This study also maps deforestation and related CO2 emissions embedded in the international trade of these products using both a physical trade model, and a MRIO (multi-regional input-output) model. This allows for the quantification of deforestation and related emissions embedded in imported food and forestry products.
-    url: https://www.sciencedirect.com/science/article/pii/S0959378018314365
-    date_accessed: 2020-11-10
-    published_by: |-
-      Pendrill, F., Persson, U. M., Godar, J., Kastner, T., Moran, D., Schmidt, S., & Wood, R. (2019). Agricultural and forestry trade drives large share of tropical deforestation emissions. Global Environmental Change, 56, 1-10.
-  name: Deforestation emissions embedded in trade (Pendrill et al. 2019)
-  description: ''
+    citation_full: 'Pendrill, F., Persson, U. M., Godar, J., Kastner, T., Moran, D., Schmidt, S., & Wood, R. (2019). Agricultural and forestry trade drives large share of tropical deforestation emissions. Global Environmental Change, 56, 1-10.'
+    url_main: https://www.sciencedirect.com/science/article/pii/S0959378018314365
+    date_accessed: '2020-11-10'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: 316b4a642c298772f3800a4cedfb7892

--- a/snapshots/emissions/2021-01-28/carbon_opportunity_costs_by_food__searchinger_et_al__2018.feather.dvc
+++ b/snapshots/emissions/2021-01-28/carbon_opportunity_costs_by_food__searchinger_et_al__2018.feather.dvc
@@ -1,17 +1,15 @@
 meta:
-  source:
-    name: |-
-      Searchinger, T. D., Wirsenius, S., Beringer, T., & Dumas, P. (2018). Assessing the efficiency of changes in land use for mitigating climate change. Nature.
+  origin:
+    producer: Searchinger et al.
+    title: Assessing the efficiency of changes in land use for mitigating climate change
     description: |-
       The Carbon Opportunity Cost (COC) of each crop is equal to the amount of carbon lost from native vegetation and soils in order to produce a given food product. If food products were not produced on a given plot of land, this land could be used to restore native vegetation and sequester carbon.
 
-      Because carbon storage is lost quickly but crop production can continue indefinitely, any system for evaluating the carbon costs of land use must in some way address the relative costs of emissions over time. Much of the discussion focuses on the value of up-front versus later mitigation. In general, this question can be thought as a question about what is the relative value of reducing emissions sooner rather than later. Searchinger et al. (2018) apply a 4% time 'discount rate' over 100 years. The the choice of a discount rate and a carbon value trajectory is a question of policy; the authors selected a 4% discount rate as their central scenario because it is roughly consistent with U.S. bioenergy policies.
-    url: https://www.nature.com/articles/s41586-018-0757-z
-    date_accessed: 2021-01-28
-    published_by: |-
-      Searchinger, T. D., Wirsenius, S., Beringer, T., & Dumas, P. (2018). Assessing the efficiency of changes in land use for mitigating climate change. Nature, 564(7735), 249-253.
-  name: Carbon Opportunity Costs by Food (Searchinger et al. 2018)
-  description: ''
+      Because carbon storage is lost quickly but crop production can continue indefinitely, any system for evaluating the carbon costs of land use must in some way address the relative costs of emissions over time. Much of the discussion focuses on the value of up-front versus later mitigation. In general, this question can be thought as a question about what is the relative value of reducing emissions sooner rather than later. Searchinger et al. (2018) apply a 4% time "discount rate" over 100 years. The the choice of a discount rate and a carbon value trajectory is a question of policy; the authors selected a 4% discount rate as their central scenario because it is roughly consistent with US bioenergy policies.
+    citation_full: 'Searchinger, T. D., Wirsenius, S., Beringer, T., and Dumas, P. (2018). Assessing the efficiency of changes in land use for mitigating climate change. Nature, 564(7735), 249-253.'
+    url_main: https://www.nature.com/articles/s41586-018-0757-z
+    date_accessed: '2021-01-28'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 5a7293da8db162aed08b353082203528

--- a/snapshots/emissions/2021/ghg_emissions_from_food__crippa_et_al__2021.feather.dvc
+++ b/snapshots/emissions/2021/ghg_emissions_from_food__crippa_et_al__2021.feather.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Crippa et al. (2021). Food systems are responsible for a third of global anthropogenic GHG emissions. Nature Food.
+  origin:
+    producer: Crippa et al.
+    title: 'Food systems are responsible for a third of global anthropogenic GHG emissions'
     description: |-
       Crippa et al. (2021) quantify the greenhouse gas emissions of the food system from 1990 to 2015. This includes not only direct emissions from agriculture, but also land use change and supply chain emissions (transport, packaging, food processing, retail, consumer cooking, refrigeration and waste).
 
       Greenhouse gas emissions are quantified on the basis of their 100-year global warming potential (GWP100) using emission factors from the IPCC 5th Assessment Report (AR5).
 
       Emissions by country are quantified on the basis of food production, not consumption. This means they do not account for international trade.
-    url: https://www.nature.com/articles/s43016-021-00225-9
-    date_accessed: 2021-03-10
-    published_by: |-
-      Crippa, M., Solazzo, E., Guizzardi, D. et al. Food systems are responsible for a third of global anthropogenic GHG emissions. Nature Food (2021).
-  name: GHG emissions from food (Crippa et al. 2021)
-  description: ''
+    citation_full: 'Crippa, M., Solazzo, E., Guizzardi, D. et al. Food systems are responsible for a third of global anthropogenic GHG emissions. Nature Food (2021).'
+    url_main: https://www.nature.com/articles/s43016-021-00225-9
+    date_accessed: '2021-03-10'
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 2c0a945c30bcf85cc4bc5ffe24f35c9d

--- a/snapshots/emissions/2021/ghg_emissions_from_food_by_life_cycle_stage__crippa_et_al__2021.feather.dvc
+++ b/snapshots/emissions/2021/ghg_emissions_from_food_by_life_cycle_stage__crippa_et_al__2021.feather.dvc
@@ -1,16 +1,15 @@
 meta:
-  source:
-    name: Crippa et al. (2021). Food systems are responsible for a third of global anthropogenic GHG emissions. Nature Food.
+  origin:
+    producer: Crippa et al.
+    title: 'Food systems are responsible for a third of global anthropogenic GHG emissions'
     description: |-
       Crippa et al. (2021) quantify the greenhouse gas emissions of the food system from 1990 to 2015. This includes not only direct emissions from agriculture, but also land use change and supply chain emissions (transport, packaging, food processing, retail, consumer cooking, refrigeration and waste).
 
       Greenhouse gas emissions are quantified on the basis of their 100-year global warming potential (GWP100) using emission factors from the IPCC 5th Assessment Report (AR5).
-    url: https://www.nature.com/articles/s43016-021-00225-9
-    date_accessed: 2021-03-10
-    published_by: |-
-      Crippa, M., Solazzo, E., Guizzardi, D. et al. Food systems are responsible for a third of global anthropogenic GHG emissions. Nature Food (2021).
-  name: GHG emissions from food by life-cycle stage (Crippa et al. 2021)
-  description: ''
+    citation_full: 'Crippa, M., Solazzo, E., Guizzardi, D. et al. Food systems are responsible for a third of global anthropogenic GHG emissions. Nature Food (2021).'
+    url_main: https://www.nature.com/articles/s43016-021-00225-9
+    date_accessed: '2021-03-10'
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 72ea4b947689bfde7b344997bd840eb5

--- a/snapshots/energy/2017-05-01/death_rate_from_energy_production__markandya__and__wilkinson__2007.feather.dvc
+++ b/snapshots/energy/2017-05-01/death_rate_from_energy_production__markandya__and__wilkinson__2007.feather.dvc
@@ -1,15 +1,15 @@
 meta:
-  source:
-    name: Death rate from energy production - Markandya & Wilkinson (2007)
+  origin:
+    producer: Markandya and Wilkinson
+    title: Electricity generation and health
     description: |-
       Data was derived from Table 2 in Markandya, A., & Wilkinson, P. (2007). Electricity generation and health. The Lancet, 370(9591), 979-990. Available at: doi.org/10.1016/S0140-6736(07)61253-7.
 
-      This data is based on European energy production standards and practices. Data includes both acute and chronic effects (chronic effects account for between 88% and 99% of total deaths). Figures for nuclear include all cancer-related deaths. The figures for death rates per TWh for cancer-related nuclear deaths by Markandya, A., & Wilkinson, P. (2007) are calculated on a theoretical basis using a method called the ‘linear, no-threshold model’. The basis of this model assumes that the number of deaths is directly and linearly proportional to the dosage of radiation; additionally it assumes there is no lower limit or “safe” level of exposure, meaning individuals are at risk even at very low doses.
-    url: doi.org/10.1016/S0140-6736(07)61253-7
+      This data is based on European energy production standards and practices. Data includes both acute and chronic effects (chronic effects account for between 88% and 99% of total deaths). Figures for nuclear include all cancer-related deaths. The figures for death rates per TWh for cancer-related nuclear deaths by Markandya, A., & Wilkinson, P. (2007) are calculated on a theoretical basis using a method called the "linear, no-threshold model". The basis of this model assumes that the number of deaths is directly and linearly proportional to the dosage of radiation; additionally it assumes there is no lower limit or "safe" level of exposure, meaning individuals are at risk even at very low doses.
+    citation_full: Markandya, A., & Wilkinson, P. (2007). Electricity generation and health. The Lancet, 370(9591), 979-990.
+    url_main: https://doi.org/10.1016/S0140-6736(07)61253-7
     date_accessed: '2017-05-01'
-    published_by: Markandya, A., & Wilkinson, P. (2007). Electricity generation and health. The Lancet.
-  name: Death rate from energy production - Markandya & Wilkinson (2007)
-  description: ''
+    date_published: '2007'
   is_public: false
 outs:
   - md5: 821da16fbd20df4df43c96cdd0152245

--- a/snapshots/energy/2021-01-01/coal_phase_out__ppca__beyondcoal_and_other_sources.feather.dvc
+++ b/snapshots/energy/2021-01-01/coal_phase_out__ppca__beyondcoal_and_other_sources.feather.dvc
@@ -1,21 +1,25 @@
 meta:
-  source:
-    name: |-
-      Powering Past Coal Alliance; Ember Climate; Beyond Coal EU; Bloomberg Coal Countdown and other sourcesPowering Past Coal Alliance; Ember Climate; Beyond Coal EU; Bloomberg Coal Countdown and other sources
+  origin:
+    producer: Powering Past Coal Alliance, Ember, Beyond Coal EU, and Bloomberg Coal Countdown
+    title: Coal phase-out
     description: |-
       This dataset is collated by Our World in Data based on several data sources, including:
 
       Powering Past Coal Alliance (PPCA): https://www.poweringpastcoal.org/
+
       Beyond Coal EU: https://beyond-coal.eu/coal-exit-tracker/
+
       Bloomberg Global Coal Countdown: https://bloombergcoalcountdown.com/
-      EMBER Climate: https://ember-climate.org/
+
+      Ember: https://ember-climate.org/
+
       National announcements during the COP26 Climate Summit: https://ukcop26.org/global-coal-to-clean-power-transition-statement/
 
-      Where a concrete phase out date is not defined, we have allocated the final year of the target decade. For example, "Phase out in the 2040s" is given a target date of 2049.
+      Where a concrete phase-out date is not defined, we have allocated the final year of the target decade. For example, "Phase out in the 2040s" is given a target date of 2049.
+    citation_full: Powering Past Coal Alliance, Ember, Beyond Coal EU, Bloomberg Coal Countdown, and other sources (2021). Coal phase-out announcements.
+    attribution_short: PPCA and others
     date_accessed: '2021-01-01'
-    published_by: Powering Past Coal Alliance; Ember Climate; Beyond Coal EU; Bloomberg Coal Countdown and other sources
-  name: Coal Phase Out (PPCA, BeyondCoal and other sources)
-  description: ''
+    date_published: '2021-01-01'
   is_public: false
 outs:
   - md5: b35bb5d8af3e259b471c600e736758b0

--- a/snapshots/energy/2021-01-01/lead_petrol_banned.feather.dvc
+++ b/snapshots/energy/2021-01-01/lead_petrol_banned.feather.dvc
@@ -1,6 +1,7 @@
 meta:
-  source:
-    name: Collected by Our World in Data based on multiple sources
+  origin:
+    producer: Various sources
+    title: Leaded petrol bans in road vehicles
     description: |-
       This dataset reports the year for which leaded petrol (Tetraethyllead) was banned for use in road vehicles.
 
@@ -14,10 +15,9 @@ meta:
       https://www.un.org/esa/gite/cleanfuels/ifqc-globaloverview.pdf
       https://www.reglugerd.is/reglugerdir/eftir-raduneytum/umhverfisraduneyti/nr/4507
       https://timesofmalta.com/articles/view/leaded-petrol-replacement-to-go-on-sale-from-thursday.159938
+    citation_full: Our World in Data (2021). Leaded petrol bans in road vehicles, based on multiple sources.
     date_accessed: '2021-01-01'
-    published_by: Collected by Our World in Data based on multiple sources
-  name: lead_petrol_banned
-  description: ''
+    date_published: '2021-01-01'
   is_public: false
 outs:
   - md5: 264d9d044d6e7286d8109aec50462747

--- a/snapshots/energy/2021/consumption_based_energy__kulionis__2021.feather.dvc
+++ b/snapshots/energy/2021/consumption_based_energy__kulionis__2021.feather.dvc
@@ -1,6 +1,7 @@
 meta:
-  source:
-    name: Calculated by Viktoras Kulionis, based on the EXIOBASE v3.8.2 database
+  origin:
+    producer: Kulionis
+    title: Consumption-based energy
     description: |-
       Consumption-based (trade-adjusted) energy use can be calculated from data published in the EXIOBASE v3.8.2 database using a multi-regional input-output (MRIO) model.
 
@@ -8,7 +9,7 @@ meta:
 
       Consumption-based (trade-adjusted) energy use is then calculated as domestic energy use minus energy embodied in exported goods, plus imported goods.
 
-      This trade-adjusted energy use data was calculated by <a href="https://baug.ethz.ch/en/department/people/staff/personen-detail.MjY1MDUz.TGlzdC82NzksLTU1NTc1NDEwMQ==.html">Viktoras Kulionis</a> using this approach.
+      This trade-adjusted energy use data was calculated by [Viktoras Kulionis](https://baug.ethz.ch/en/department/people/staff/personen-detail.MjY1MDUz.TGlzdC82NzksLTU1NTc1NDEwMQ==.html) using this approach.
 
       The EXIOBASE v3.8.2 database is available online: https://zenodo.org/record/5589597#.YYf3EdnMK_0.
 
@@ -20,11 +21,10 @@ meta:
       Reference: Global Carbon Project. (2021). Supplemental data of Global Carbon Project 2021 (1.0) [Data set]. Global Carbon Project. https://doi.org/10.18160/gcp-2021.)
 
       The EXIOBASE database contains a data error for Australia for 2018 and 2019, which provides erroneous results. We have therefore removed these two data points for Australia only.
-    url: https://zenodo.org/record/5589597#.YYf3EdnMK_0
+    citation_full: Kulionis, V. (2021). Consumption-based energy, calculated based on the EXIOBASE v3.8.2 database.
+    url_main: https://zenodo.org/record/5589597#.YYf3EdnMK_0
     date_accessed: '2021-01-01'
-    published_by: Calculated by Viktoras Kulionis, based on the EXIOBASE v3.8.2 database
-  name: Consumption-based energy (Kulionis, 2021)
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: b031c9f7d189fbadb3731cfb56a5b39c

--- a/snapshots/fao/2021-07-30/employment_in_fisheries_and_aquaculture__un_fao__2021.feather.dvc
+++ b/snapshots/fao/2021-07-30/employment_in_fisheries_and_aquaculture__un_fao__2021.feather.dvc
@@ -1,12 +1,13 @@
 meta:
-  source:
-    name: Food and Agriculture Organization of the United Nations
-    url: http://www.fao.org/3/ca9229en/ca9229en.pdf
-    date_accessed: 2021-07-30
-    published_by: |-
-      FAO. 2020. The State of World Fisheries and Aquaculture 2020. Sustainability in action. Rome. https://doi.org/10.4060/ca9229en
-  name: Employment in fisheries and aquaculture (UN FAO, 2021)
-  description: ''
+  origin:
+    producer: Food and Agriculture Organization of the United Nations
+    title: The State of World Fisheries and Aquaculture 2020
+    title_snapshot: The State of World Fisheries and Aquaculture 2020 - Employment in fisheries and aquaculture
+    citation_full: 'FAO (2020). The State of World Fisheries and Aquaculture 2020. Sustainability in action. Rome. https://doi.org/10.4060/ca9229en'
+    attribution_short: FAO
+    url_main: http://www.fao.org/3/ca9229en/ca9229en.pdf
+    date_accessed: '2021-07-30'
+    date_published: '2020'
   is_public: false
 outs:
   - md5: 67f5f19d6fc42f5553ea94bca6abeb02

--- a/snapshots/fisheries/2021-01-01/fish_catch_in_the_uk__thurstan_et_al__2009.feather.dvc
+++ b/snapshots/fisheries/2021-01-01/fish_catch_in_the_uk__thurstan_et_al__2009.feather.dvc
@@ -1,13 +1,11 @@
 meta:
-  source:
-    name: |-
-      Ruth Thurstan et al. (2010). The effects of 118 years of industrial fishing on UK bottom trawl fisheries. Nature Communications.
-    url: https://www.nature.com/articles/ncomms1013
+  origin:
+    producer: Thurstan et al.
+    title: 'The effects of 118 years of industrial fishing on UK bottom trawl fisheries'
+    citation_full: 'Thurstan, R. H., Brockington, S., and Roberts, C. M. (2010). The effects of 118 years of industrial fishing on UK bottom trawl fisheries. Nature Communications, 1(1), 1-6.'
+    url_main: https://www.nature.com/articles/ncomms1013
     date_accessed: '2021-01-01'
-    published_by: |-
-      Thurstan, R. H., Brockington, S., & Roberts, C. M. (2010). The effects of 118 years of industrial fishing on UK bottom trawl fisheries. Nature communications, 1(1), 1-6.
-  name: Fish catch in the UK (Thurstan et al. 2009)
-  description: ''
+    date_published: '2010'
   is_public: false
 outs:
   - md5: e5bcf10f4a93209bff59356e9ad0f3db

--- a/snapshots/fisheries/2021-01-01/trawling_by_region__amoroso_et_al__2018.feather.dvc
+++ b/snapshots/fisheries/2021-01-01/trawling_by_region__amoroso_et_al__2018.feather.dvc
@@ -1,16 +1,15 @@
 meta:
-  source:
-    name: Amoroso et al. (2018). Bottom trawl fishing footprints on the world’s continental shelves. PNAS.
+  origin:
+    producer: Amoroso et al.
+    title: "Bottom trawl fishing footprints on the world's continental shelves"
     description: |-
       Amoroso et al. (2018) map the extent of bottom trawling – a method used to catch fish and crustaceans at or on the seabed across world regions.
 
       This metric measures the share of the seabed on continental shelves – to a depth of 1000m – that experienced at least one trawling pass over a 3 to 4 year period.
-    url: https://www.pnas.org/content/115/43/e10275
+    citation_full: 'Amoroso, R. O., Pitcher, C. R., Rijnsdorp, A. D., McConnaughey, R. A., Parma, A. M., Suuronen, P., ... & Jennings, S. (2018). Bottom trawl fishing footprints on the world''s continental shelves. Proceedings of the National Academy of Sciences, 115(43), E10275-E10282.'
+    url_main: https://www.pnas.org/content/115/43/e10275
     date_accessed: '2021-01-01'
-    published_by: |-
-      Amoroso, R. O., Pitcher, C. R., Rijnsdorp, A. D., McConnaughey, R. A., Parma, A. M., Suuronen, P., ... & Jennings, S. (2018). Bottom trawl fishing footprints on the world’s continental shelves. Proceedings of the National Academy of Sciences, 115(43), E10275-E10282.
-  name: Trawling by region (Amoroso et al. 2018)
-  description: ''
+    date_published: '2018'
   is_public: false
 outs:
   - md5: a3ca0fffbb088b696ed2bd05b400afeb

--- a/snapshots/food/2018/environmental_impact_of_milks__poore_and_nemecek__2018.feather.dvc
+++ b/snapshots/food/2018/environmental_impact_of_milks__poore_and_nemecek__2018.feather.dvc
@@ -1,24 +1,22 @@
 meta:
-  source:
-    name: |-
-      Poore, J., & Nemecek, T. (2018). Reducing food’s environmental impacts through producers and consumers. Science, 360(6392), 987-992.
+  origin:
+    producer: Poore and Nemecek
+    title: Reducing food's environmental impacts through producers and consumers
     description: |-
-      Data is based on the largest meta-analysis of food system impact studies to date, from Poore & Nemecek's 2018 study.
+      Data is based on the largest meta-analysis of food system impact studies to date, from Poore and Nemecek's 2018 study.
 
       The authors note the following about the scope of the studies included in this meta-analysis:
-      "We derived data from a comprehensive meta-analysis, identifying 1530 studies for potential inclusion, which were supplemented with additional data received from 139 authors. Studies were assessed against 11 criteria designed to standardize methodology, resulting in 570 suitable studies with a median reference year of 2010. The data set covers ~38,700 commercially viable farms in 119 countries and 40 products representing ~90% of global protein and calorie consumption'.
+      "We derived data from a comprehensive meta-analysis, identifying 1530 studies for potential inclusion, which were supplemented with additional data received from 139 authors. Studies were assessed against 11 criteria designed to standardize methodology, resulting in 570 suitable studies with a median reference year of 2010. The data set covers ~38,700 commercially viable farms in 119 countries and 40 products representing ~90% of global protein and calorie consumption".
 
       Environmental impacts are compared across several metrics: land use (m2), greenhouse gas emissions (tonnes of CO2-equivalents), eutrophying emissions (grams of PO4-equivalents), and freshwater withdrawals (liters).
 
       All comparisons here are based on the global mean value per food product across all studies.
 
       Comparisons can be made in functional units: here all comparisons are made as impacts per kilogram of product.
-    url: https://science.sciencemag.org/content/360/6392/987
+    citation_full: 'Poore, J., and Nemecek, T. (2018). Reducing food''s environmental impacts through producers and consumers. Science, 360(6392), 987-992.'
+    url_main: https://science.sciencemag.org/content/360/6392/987
     date_accessed: '2018-01-01'
-    published_by: |-
-      Poore, J., & Nemecek, T. (2018). Reducing food’s environmental impacts through producers and consumers. Science, 360(6392), 987-992.
-  name: Environmental impact of milks (Poore and Nemecek, 2018)
-  description: ''
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 2d30cda874c1872536741279b0a1449e

--- a/snapshots/food/2018/food_emissions_by_life_cycle_stage__poore_and_nemecek__2018.feather.dvc
+++ b/snapshots/food/2018/food_emissions_by_life_cycle_stage__poore_and_nemecek__2018.feather.dvc
@@ -1,22 +1,20 @@
 meta:
-  source:
-    name: |-
-      Poore, J., & Nemecek, T. (2018). Reducing food’s environmental impacts through producers and consumers. Science, 360(6392), 987-992.
+  origin:
+    producer: Poore and Nemecek
+    title: "Reducing food's environmental impacts through producers and consumers"
     description: |-
-      Data is based on the largest meta-analysis of food system impact studies to date, from Poore & Nemecek's 2018 study.
+      Data is based on the largest meta-analysis of food system impact studies to date, from Poore and Nemecek's 2018 study.
 
       The authors note the following about the scope of the studies included in this meta-analysis:
-      "We derived data from a comprehensive meta-analysis, identifying 1530 studies for potential inclusion, which were supplemented with additional data received from 139 authors. Studies were assessed against 11 criteria designed to standardize methodology, resulting in 570 suitable studies with a median reference year of 2010. The data set covers ~38,700 commercially viable farms in 119 countries and 40 products representing ~90% of global protein and calorie consumption'.
+      "We derived data from a comprehensive meta-analysis, identifying 1530 studies for potential inclusion, which were supplemented with additional data received from 139 authors. Studies were assessed against 11 criteria designed to standardize methodology, resulting in 570 suitable studies with a median reference year of 2010. The data set covers ~38,700 commercially viable farms in 119 countries and 40 products representing ~90% of global protein and calorie consumption."
 
       All comparisons here are based on the global mean value per food product across all studies.
 
       Comparisons can be made in functional units: here all comparisons are made as impacts per kilogram of product.
-    url: https://science.sciencemag.org/content/360/6392/987
+    citation_full: 'Poore, J., and Nemecek, T. (2018). Reducing food''s environmental impacts through producers and consumers. Science, 360(6392), 987-992.'
+    url_main: https://science.sciencemag.org/content/360/6392/987
     date_accessed: '2018-01-01'
-    published_by: |-
-      Poore, J., & Nemecek, T. (2018). Reducing food’s environmental impacts through producers and consumers. Science, 360(6392), 987-992.
-  name: Food emissions by life-cycle stage (Poore and Nemecek, 2018)
-  description: ''
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 3e07575b738695be8899de7c76cd6757

--- a/snapshots/food/2021/environmental_impacts_of_seafood__gephart_et_al__2021.feather.dvc
+++ b/snapshots/food/2021/environmental_impacts_of_seafood__gephart_et_al__2021.feather.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Gephart et al. (2021). Environmental performance of blue foods. Nature.
+  origin:
+    producer: Gephart et al.
+    title: Environmental performance of blue foods
     description: |-
       This meta-study brings together life cycle inventory data (i.e., material and energy input and farm-level performance data) from studies of the environmental footprint of wild-caught and farmed seafood products. It draws on data from over 1690 farms and 1000 unique fishery records.
 
       These impacts include those on-farm and off-farm, but stops at the farmgate (or landing of fish). This means it does not include impacts such as transport to retail, packaging, processing or cooking.
 
       Impacts are normalised by the fish or seafood's edible weight (rather than their live weight).
-    url: https://www.nature.com/articles/s41586-021-03889-2
+    citation_full: 'Gephart, J. A., Henriksson, P. J., Parker, R. W., Shepon, A., Gorospe, K. D., Bergman, K., ... and Tyedmers, P. (2021). Environmental performance of blue foods. Nature.'
+    url_main: https://www.nature.com/articles/s41586-021-03889-2
     date_accessed: '2021-01-01'
-    published_by: |-
-      Gephart, J. A., Henriksson, P. J., Parker, R. W., Shepon, A., Gorospe, K. D., Bergman, K., ... & Tyedmers, P. (2021). Environmental performance of blue foods. Nature.
-  name: Environmental impacts of seafood (Gephart et al. 2021)
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 0f5b963d4fa139f1a11fc128820a87fd

--- a/snapshots/forests/2020-12-31/indonesian_deforestation_drivers__austin_et_al__2019.feather.dvc
+++ b/snapshots/forests/2020-12-31/indonesian_deforestation_drivers__austin_et_al__2019.feather.dvc
@@ -1,12 +1,11 @@
 meta:
-  source:
-    name: Austin, K. G., Schwantes, A., Gu, Y., & Kasibhatla, P. S. (2019). What causes deforestation in Indonesia?
-    url: https://iopscience.iop.org/article/10.1088/1748-9326/aaf6db
-    date_accessed: 2020-12-31
-    published_by: |-
-      Austin, K. G., Schwantes, A., Gu, Y., & Kasibhatla, P. S. (2019). What causes deforestation in Indonesia?. Environmental Research Letters, 14(2), 024007.
-  name: Indonesian deforestation drivers (Austin et al. (2019)
-  description: ''
+  origin:
+    producer: Austin et al.
+    title: What causes deforestation in Indonesia?
+    citation_full: 'Austin, K. G., Schwantes, A., Gu, Y., & Kasibhatla, P. S. (2019). What causes deforestation in Indonesia?. Environmental Research Letters, 14(2), 024007.'
+    url_main: https://iopscience.iop.org/article/10.1088/1748-9326/aaf6db
+    date_accessed: '2020-12-31'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: b8233e2c4440b62839bd9cd2e61fe13b

--- a/snapshots/ggdc/2017-08-03/share_of_industry_in_gdp_at_constant_2005_prices__ggdc__split.feather.dvc
+++ b/snapshots/ggdc/2017-08-03/share_of_industry_in_gdp_at_constant_2005_prices__ggdc__split.feather.dvc
@@ -1,14 +1,18 @@
 meta:
-  source:
-    name: Our World In Data based on GGDC-10 (2015)
-    description: |-
-      The only changes we applied to the GGDC 10-sector database were: (i) dropping observations for GDP shares in Peru 1950-1985 since these are reported as negative in the original; and (ii) dropping observations for GDP shares in the Netherlands 1949-1959, since these are comparable to the period after 1960, as suggested by a marked jump in levels in the original series.
-    url: http://www.rug.nl/ggdc/productivity/10-sector/
-    date_accessed: 2017-08-03
-    published_by: Our World In Data based on GGDC-10 (2015)
-  name: Share of industry in GDP at constant 2005 prices (GGDC) (split)
-  description: ''
   is_public: false
+  origin:
+    producer: Groningen Growth and Development Centre
+    title: GGDC 10-sector database
+    description: |-
+      The GGDC 10-sector database provides a long-run, internationally comparable dataset on sectoral productivity performance for 10 broad sectors of the economy, covering Asian, Latin American, and African countries as well as the US and Europe.
+    title_snapshot: GGDC 10-sector database - Share of industry in GDP at constant 2005 prices
+    description_snapshot: |-
+      The only changes we applied to the GGDC 10-sector database were: (i) dropping observations for GDP shares in Peru 1950–1985 since these are reported as negative in the original; and (ii) dropping observations for GDP shares in the Netherlands 1949–1959, since these are comparable to the period after 1960, as suggested by a marked jump in levels in the original series.
+    citation_full: Timmer, M. P., de Vries, G. J., and de Vries, K. (2015). Patterns of structural change in developing countries. In J. Weiss, & M. Tribe (Eds.), Routledge Handbook of Industry and Development (pp. 65–83). Routledge.
+    attribution_short: GGDC
+    url_main: http://www.rug.nl/ggdc/productivity/10-sector/
+    date_accessed: '2017-08-03'
+    date_published: '2015'
 outs:
   - md5: fe56480d0f33340a4683abf2e767da9f
     size: 12226

--- a/snapshots/happiness/2021-05-25/gallup_world_poll__someone_to_help_you.feather.dvc
+++ b/snapshots/happiness/2021-05-25/gallup_world_poll__someone_to_help_you.feather.dvc
@@ -1,11 +1,12 @@
 meta:
-  source:
-    name: Someone-to-help-you-Gallup-World-Poll
-    description: If you were in trouble, do you have relatives or friends you can count on to help you whenever you need them, or not?
-    date_accessed: 2021-05-25
-    published_by: Gallup World Poll
-  name: Gallup World Poll - Someone to help you
-  description: (Max, 22 Feb 2023) This cannot be shared publicly! It is not publicly licensed. But I want to keep it internally.
+  origin:
+    producer: Gallup
+    title: Gallup World Poll
+    description: |-
+      If you were in trouble, do you have relatives or friends you can count on to help you whenever you need them, or not?
+    citation_full: Gallup World Poll (2021).
+    date_accessed: '2021-05-25'
+    date_published: '2021'
   is_public: false
 outs:
   - md5: c48474b17c3e9108e75a2f3855c011f0

--- a/snapshots/health/2016-01-01/health_insurance_coverage__tanzi__and__schuknecht__2000__split.feather.dvc
+++ b/snapshots/health/2016-01-01/health_insurance_coverage__tanzi__and__schuknecht__2000__split.feather.dvc
@@ -1,11 +1,10 @@
 meta:
-  source:
-    name: Tanzi & Schuknecht (2000) (2)
+  origin:
+    producer: Tanzi and Schuknecht
+    title: 'Public spending in the 20th century: A global perspective'
+    citation_full: 'Tanzi, V., and Schuknecht, L. (2000). Public spending in the 20th century: A global perspective. Cambridge University Press. Page 38.'
     date_accessed: '2016-01-01'
-    published_by: |-
-      Tanzi, Vito, and Ludger Schuknecht. Public spending in the 20th century: A global perspective. Cambridge University Press, 2000. Page 38.
-  name: Health Insurance Coverage (Tanzi & Schuknecht (2000)) (split)
-  description: ''
+    date_published: '2000'
   is_public: false
 outs:
   - md5: 0ec444199336ba7ebbfaa5849d4af2f5

--- a/snapshots/health/2019-09-01/relative_change_in_maternal_mortality_ratio__world_bank.feather.dvc
+++ b/snapshots/health/2019-09-01/relative_change_in_maternal_mortality_ratio__world_bank.feather.dvc
@@ -1,12 +1,10 @@
 meta:
-  source:
-    name: World Bank (2020)
-    description: ''
-    url: ''
+  origin:
+    producer: World Bank
+    title: Relative change in maternal mortality ratio
+    citation_full: World Bank (2020).
     date_accessed: '2019-09-01'
-    published_by: World Bank (2020)
-  name: Relative change in maternal mortality ratio (World Bank)
-  description: ''
+    date_published: '2020'
   is_public: false
 outs:
   - md5: aa1c7343dc9532d0c9bf9c3ced6749c9

--- a/snapshots/health/2019-09-18/annual_deaths_averted_by_pcv13__chen_et_al__the_lancet_global_health__2019.feather.dvc
+++ b/snapshots/health/2019-09-18/annual_deaths_averted_by_pcv13__chen_et_al__the_lancet_global_health__2019.feather.dvc
@@ -1,12 +1,11 @@
 meta:
-  source:
-    name: Chen et al.(2019)
-    url: https://www.thelancet.com/journals/langlo/article/PIIS2214-109X(18)30422-4/fulltext
-    date_accessed: 2019-09-18
-    published_by: |-
-      Chen, C., Liceras, F. C., Flasche, S., Sidharta, S., Yoong, J., Sundaram, N., & Jit, M. (2019). Effect and cost-effectiveness of pneumococcal conjugate vaccination: a global modelling analysis. The Lancet Global Health, 7(1), e58-e67.
-  name: Annual deaths averted by PCV13- Chen et al., The Lancet Global Health (2019)
-  description: ''
+  origin:
+    producer: Chen et al.
+    title: 'Effect and cost-effectiveness of pneumococcal conjugate vaccination: a global modelling analysis'
+    citation_full: 'Chen, C., Liceras, F. C., Flasche, S., Sidharta, S., Yoong, J., Sundaram, N., & Jit, M. (2019). Effect and cost-effectiveness of pneumococcal conjugate vaccination: a global modelling analysis. The Lancet Global Health, 7(1), e58-e67.'
+    url_main: https://www.thelancet.com/journals/langlo/article/PIIS2214-109X(18)30422-4/fulltext
+    date_accessed: '2019-09-18'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: 21626e198d5ab4ac79157d296646116a

--- a/snapshots/health/2019-11-11/streptococcus_caused_deaths_in_children_under_5__wahl__2018.feather.dvc
+++ b/snapshots/health/2019-11-11/streptococcus_caused_deaths_in_children_under_5__wahl__2018.feather.dvc
@@ -1,16 +1,13 @@
 meta:
-  source:
-    name: Wahl (2018)
+  origin:
+    producer: Wahl et al.
+    title: 'Burden of Streptococcus pneumoniae and Haemophilus influenzae type b disease in children in the era of conjugate vaccines: global, regional, and national estimates for 2000–15'
     description: |-
       Deaths and mortality rates from diseases caused by Streptococcus pneumoniae bacteria in children under-5.
-
-      Wahl, B., O'Brien, K. L., Greenbaum, A., Majumder, A., Liu, L., Chu, Y., ... & Rudan, I. (2018). Burden of Streptococcus pneumoniae and Haemophilus influenzae type b disease in children in the era of conjugate vaccines: global, regional, and national estimates for 2000–15. The Lancet Global Health, 6(7), e744-e757.
-    url: https://www.thelancet.com/journals/langlo/article/PIIS2214-109X(18)30247-X
-    date_accessed: 2019-11-11
-    published_by: |-
-      Wahl, B., O'Brien, K. L., Greenbaum, A., Majumder, A., Liu, L., Chu, Y., ... & Rudan, I. (2018). Burden of Streptococcus pneumoniae and Haemophilus influenzae type b disease in children in the era of conjugate vaccines: global, regional, and national estimates for 2000–15. The Lancet Global Health, 6(7), e744-e757.
-  name: Streptococcus-caused deaths in children under-5, Wahl (2018)
-  description: ''
+    citation_full: 'Wahl, B., O''Brien, K. L., Greenbaum, A., Majumder, A., Liu, L., Chu, Y., ... & Rudan, I. (2018). Burden of Streptococcus pneumoniae and Haemophilus influenzae type b disease in children in the era of conjugate vaccines: global, regional, and national estimates for 2000–15. The Lancet Global Health, 6(7), e744-e757.'
+    url_main: https://www.thelancet.com/journals/langlo/article/PIIS2214-109X(18)30247-X
+    date_accessed: '2019-11-11'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: af9f5944171786fbecd34abd0ecb03bb

--- a/snapshots/health/2020-11-01/swedish_covid_19_deaths_comparison.feather.dvc
+++ b/snapshots/health/2020-11-01/swedish_covid_19_deaths_comparison.feather.dvc
@@ -1,10 +1,10 @@
 meta:
-  source:
-    name: Swedish COVID-19 deaths comparison
+  origin:
+    producer: Various sources
+    title: Swedish COVID-19 deaths comparison
+    citation_full: Swedish COVID-19 deaths comparison.
     date_accessed: '2020-11-01'
-    published_by: Swedish COVID-19 deaths comparison
-  name: Swedish COVID-19 deaths comparison
-  description: ''
+    date_published: '2020-11-01'
   is_public: false
 outs:
   - md5: f4b58b31fd3fc505be5d1c90667b1366

--- a/snapshots/health/2021-01-01/lead_blood_concentrations_in_lmic__ericson_et_al__2021.feather.dvc
+++ b/snapshots/health/2021-01-01/lead_blood_concentrations_in_lmic__ericson_et_al__2021.feather.dvc
@@ -1,19 +1,17 @@
 meta:
-  source:
-    name: |-
-      Ericson et al. (2021). Blood lead levels in low-income and middle-income countries: a systematic review. The Lancet Planetary Health.
+  origin:
+    producer: Ericson et al.
+    title: 'Blood lead levels in low-income and middle-income countries: a systematic review'
     description: |-
       Ericson et al. (2021) collated studies measuring lead blood concentrations in children and adults between 2010 and 2019. This analysis yielded 520 studies covering 1100 sampled populations with a total population of 1,003,455 people from 49 countries.
 
       Children are defined as those aged 0 to 14 years.
 
-      Blood level concentrations are measured in µg/dL. There is no defined 'safe' level for lead blood concentrations. The WHO adopts a threshold of 5 µg/dL as an achievable maximum level in children.
-    url: https://www.thelancet.com/journals/lanplh/article/PIIS2542-5196%2820%2930278-3/fulltext
+      Blood level concentrations are measured in µg/dL. There is no defined "safe" level for lead blood concentrations. The WHO adopts a threshold of 5 µg/dL as an achievable maximum level in children.
+    citation_full: 'Ericson, B., Hu, H., Nash, E., Ferraro, G., Sinitsky, J., & Taylor, M. P. (2021). Blood lead levels in low-income and middle-income countries: a systematic review. The Lancet Planetary Health, 5(3), e145-e153.'
+    url_main: https://www.thelancet.com/journals/lanplh/article/PIIS2542-5196%2820%2930278-3/fulltext
     date_accessed: '2021-01-01'
-    published_by: |-
-      Ericson, B., Hu, H., Nash, E., Ferraro, G., Sinitsky, J., & Taylor, M. P. (2021). Blood lead levels in low-income and middle-income countries: a systematic review. The Lancet Planetary Health, 5(3), e145-e153.
-  name: Lead blood concentrations in LMIC (Ericson et al. 2021)
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 1531bbf580133d608b3d74675fa4572e

--- a/snapshots/health/2021-09-01/lead_concentrations_in_paint__ipen__2021.feather.dvc
+++ b/snapshots/health/2021-09-01/lead_concentrations_in_paint__ipen__2021.feather.dvc
@@ -1,17 +1,18 @@
 meta:
-  source:
-    name: International Pollutants Elimination Network (IPEN)
+  origin:
+    producer: International Pollutants Elimination Network
+    title: Lead concentrations in paint
     description: |-
-      The International Pollutants Elimination Network (IPEN) have collated studies on the concentration of lead in paint sold across low and middle-income countries. More than 100 studies have been conducted across 59 countries, involving the testing of more than 4,000 solvent-based paints.
+      The International Pollutants Elimination Network (IPEN) have collated studies on the concentration of lead in paint sold across low and middle-income countries. More than 100 studies have been conducted across 59 countries, involving the testing of more than 4,000 solvent-based paints.
 
       These studies report the share of paints that have a lead concentration great than 90 parts per million (ppm); 600ppm and 10,000ppm of the dry weight of paint.
 
       Lead paint is thought to be a significant contributor to lead poisoning; many countries have therefore implemented a regulatory limit of 90ppm or 600ppm for sold paints.
-    url: http://www.ipen.org
+    citation_full: International Pollutants Elimination Network (IPEN) (2021). Lead concentrations in paint.
+    attribution_short: IPEN
+    url_main: http://www.ipen.org
     date_accessed: '2021-09-01'
-    published_by: International Pollutants Elimination Network (IPEN)
-  name: Lead concentrations in paint (IPEN, 2021)
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: d53291d7fd8da8d6b85622c859b48e48

--- a/snapshots/health/2021-11-29/clinical_trial_results_reporting_by_country__eu_ctr__dal_re_et_al__2021.feather.dvc
+++ b/snapshots/health/2021-11-29/clinical_trial_results_reporting_by_country__eu_ctr__dal_re_et_al__2021.feather.dvc
@@ -1,14 +1,13 @@
 meta:
-  source:
-    name: Dal-Ré et al. (2021)
+  origin:
+    producer: Dal-Ré et al.
+    title: European non-commercial sponsors showed substantial variation in results reporting to the EU trial registry
     description: |-
-      This is a dataset of clinical trials with results reported to the European Clinical Trials Register (EU-CTR). Under EU guidelines, all clinical trials are required to be registered in the EudraCT system and to have results submitted within 12 months of the trial's completion or 6 months for certain paediatric trials, as of December 2016. This requirement to report results was retrospectively applied to all completed trials on the registry dating to its launch in 2004. However, many clinical trials breach these requirements. This dataset shows the proportion of registered clinical trials by non-commercial sponsors in each country that reported results on the EU-CTR. Data is shown until January 2021. Data is shown until January 2021. After the UK left the European Union in January 2021, clinical trials in the UK were then no longer required to report their results to the EU-CTR.
-    url: https://www.sciencedirect.com/science/article/pii/S0895435621003577
-    date_accessed: 2021-11-29
-    published_by: |-
-      Dal-Ré, R., Goldacre, B., Mahillo-Fernández, I., & DeVito, N. J. (2021). European non-commercial sponsors showed substantial variation in results reporting to the EU trial registry. Journal of Clinical Epidemiology, S0895435621003577. https://doi.org/10.1016/j.jclinepi.2021.11.005
-  name: Clinical trial results reporting by country – EU-CTR (Dal-Ré et al., 2021)
-  description: ''
+      This is a dataset of clinical trials with results reported to the European Clinical Trials Register (EU-CTR). Under EU guidelines, all clinical trials are required to be registered in the EudraCT system and to have results submitted within 12 months of the trial's completion or 6 months for certain paediatric trials, as of December 2016. This requirement to report results was retrospectively applied to all completed trials on the registry dating to its launch in 2004. However, many clinical trials breach these requirements. This dataset shows the proportion of registered clinical trials by non-commercial sponsors in each country that reported results on the EU-CTR. Data is shown until January 2021. After the UK left the European Union in January 2021, clinical trials in the UK were then no longer required to report their results to the EU-CTR.
+    citation_full: 'Dal-Ré, R., Goldacre, B., Mahillo-Fernández, I., & DeVito, N. J. (2021). European non-commercial sponsors showed substantial variation in results reporting to the EU trial registry. Journal of Clinical Epidemiology, S0895435621003577. https://doi.org/10.1016/j.jclinepi.2021.11.005'
+    url_main: https://www.sciencedirect.com/science/article/pii/S0895435621003577
+    date_accessed: '2021-11-29'
+    date_published: '2021'
   is_public: false
 outs:
   - md5: be52b35df059d63fd58bb2e2c43652d4

--- a/snapshots/health/2021-11-29/clinical_trials_results_reporting__eu_ctr__dal_re__2021.feather.dvc
+++ b/snapshots/health/2021-11-29/clinical_trials_results_reporting__eu_ctr__dal_re__2021.feather.dvc
@@ -1,14 +1,13 @@
 meta:
-  source:
-    name: Dal-Ré et al. (2021)
+  origin:
+    producer: Dal-Ré et al.
+    title: European non-commercial sponsors showed substantial variation in results reporting to the EU trial registry
     description: |-
       This is a dataset of clinical trials with results reported to the European Clinical Trials Register (EU-CTR). Under EU guidelines, all clinical trials in the European Economic Area are required to be registered in the EudraCT system and to have results submitted within 12 months of the trial's completion or 6 months for certain paediatric trials, as of December 2016. This requirement to report results was retrospectively applied to all completed trials on the registry dating to its launch in 2004. However, many clinical trials breach these requirements. This dataset shows the proportion of all registered clinical trials by non-commercial sponsors in the European Economic Area that reported results in time on the EU-CTR.
-    url: https://www.sciencedirect.com/science/article/pii/S0895435621003577
-    date_accessed: 2021-11-29
-    published_by: |-
-      Dal-Ré, R., Goldacre, B., Mahillo-Fernández, I., & DeVito, N. J. (2021). European non-commercial sponsors showed substantial variation in results reporting to the EU trial registry. Journal of Clinical Epidemiology, S0895435621003577. https://doi.org/10.1016/j.jclinepi.2021.11.005
-  name: Clinical trials results reporting – EU-CTR (Dal-Ré, 2021)
-  description: ''
+    citation_full: 'Dal-Ré, R., Goldacre, B., Mahillo-Fernández, I., & DeVito, N. J. (2021). European non-commercial sponsors showed substantial variation in results reporting to the EU trial registry. Journal of Clinical Epidemiology, S0895435621003577. https://doi.org/10.1016/j.jclinepi.2021.11.005'
+    url_main: https://www.sciencedirect.com/science/article/pii/S0895435621003577
+    date_accessed: '2021-11-29'
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 6241411ccd09bd8a066cd66cf7fec86b

--- a/snapshots/health/2021-11-29/randomized_controlled_trials_published_in_high_impact_medical_journals.feather.dvc
+++ b/snapshots/health/2021-11-29/randomized_controlled_trials_published_in_high_impact_medical_journals.feather.dvc
@@ -1,14 +1,13 @@
 meta:
-  source:
-    name: Catalá-López et al. (2020)
+  origin:
+    producer: Catalá-López et al.
+    title: 'Global mapping of randomised trials related articles published in high-impact-factor medical journals: A cross-sectional analysis'
     description: |-
       This is a dataset of all randomized controlled trials (RCTs) published in high-impact medical journals (with an impact factor above 10 in 2017). This includes primary analyses, secondary analyses and methods papers of RCTs. The papers were extracted from PubMed and their associated raw metadata was collected from the Web of Science. Country refers to the country of the first author's affiliated institution.
-    url: https://doi.org/10.1186/s13063-019-3944-9
-    date_accessed: 2021-11-29
-    published_by: |-
-      Catalá-López, F., Aleixandre-Benavent, R., Caulley, L., Hutton, B., Tabarés-Seisdedos, R., Moher, D., & Alonso-Arroyo, A. (2020). Global mapping of randomised trials related articles published in high-impact-factor medical journals: A cross-sectional analysis. Trials, 21(1), 34. https://doi.org/10.1186/s13063-019-3944-9
-  name: Randomized controlled trials published in high-impact medical journals
-  description: ''
+    citation_full: 'Catalá-López, F., Aleixandre-Benavent, R., Caulley, L., Hutton, B., Tabarés-Seisdedos, R., Moher, D., & Alonso-Arroyo, A. (2020). Global mapping of randomised trials related articles published in high-impact-factor medical journals: A cross-sectional analysis. Trials, 21(1), 34. https://doi.org/10.1186/s13063-019-3944-9.'
+    url_main: https://doi.org/10.1186/s13063-019-3944-9
+    date_accessed: '2021-11-29'
+    date_published: '2020'
   is_public: false
 outs:
   - md5: 72d8edbb08e27a3fc1c734f12792b8ef

--- a/snapshots/health/2021/childhood_vaccination_policies__vanderslott_et_al__2021.feather.dvc
+++ b/snapshots/health/2021/childhood_vaccination_policies__vanderslott_et_al__2021.feather.dvc
@@ -1,13 +1,13 @@
 meta:
-  source:
-    name: Vanderslott & Marks (2021). Charting mandatory childhood vaccination policies worldwide. Vaccine.
+  origin:
+    producer: Vanderslott and Marks
+    title: Charting mandatory vaccination policies worldwide
     description: |-
       This is a live dataset that relies on crowdsourcing to note policy changes. If you are aware of any new policies or policy changes for any country please do get in touch at: samantha.vanderslott@paediatrics.ox.ac.uk.
-    url: https://www.sciencedirect.com/science/article/pii/S0264410X21005478
+    citation_full: 'Vanderslott, S., and Marks, T. (2021). Charting mandatory vaccination policies worldwide. Vaccine.'
+    url_main: https://www.sciencedirect.com/science/article/pii/S0264410X21005478
     date_accessed: '2021-01-01'
-    published_by: Vanderslott, S., & Marks, T. (2021). Charting mandatory vaccination policies worldwide. <i>Vaccine</i>.
-  name: Childhood vaccination policies (Vanderslott et al. 2021)
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 9675e72c3d64db8b2da2eab3c4b2891f

--- a/snapshots/health/2021/lead_blood_concentrations_in_usa__us_cdc.feather.dvc
+++ b/snapshots/health/2021/lead_blood_concentrations_in_usa__us_cdc.feather.dvc
@@ -1,19 +1,18 @@
 meta:
-  source:
-    name: |-
-      Centers for Disease Control and Prevention; National Center for Health Statistics and National Center for Environmental Health; National Health and Nutrition Examination Survey
+  origin:
+    producer: Centers for Disease Control and Prevention
+    title: Lead blood concentrations in USA
     description: |-
       This measures the median and 95th percentile of lead blood concentrations in 1-5 year olds in the United States from the 1970s onwards.
 
       - Data is obtained from an ongoing continuous survey conducted by the National Center for Health Statistics.
       - Survey data are representative of the U.S. general population.
       - Lead is measured in blood samples obtained from individual survey participants.
-    url: https://www.epa.gov/americaschildrenenvironment/ace-biomonitoring-lead
+    citation_full: 'Centers for Disease Control and Prevention, National Center for Health Statistics, and National Center for Environmental Health. National Health and Nutrition Examination Survey (2021).'
+    attribution_short: CDC
+    url_main: https://www.epa.gov/americaschildrenenvironment/ace-biomonitoring-lead
     date_accessed: '2021-01-01'
-    published_by: |-
-      Centers for Disease Control and Prevention; National Center for Health Statistics and National Center for Environmental Health; National Health and Nutrition Examination Survey
-  name: Lead blood concentrations in USA (US CDC)
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 41e5d17e91142451315f84486d6b1be0

--- a/snapshots/health/2022-02-21/estimated_malaria_deaths.feather.dvc
+++ b/snapshots/health/2022-02-21/estimated_malaria_deaths.feather.dvc
@@ -1,14 +1,19 @@
 meta:
-  source:
-    name: Global Malaria Programme, World Health Organization
+  origin:
+    producer: World Health Organization
+    title: World malaria report 2021
     description: |-
       Values for estimated malaria deaths are the point values taken from the World Malaria Report 2021. The regional values are found in the following tables: Africa (Table 3.2), South-East Asia (Table 3.3), Eastern Mediterranean (Table 3.4), Western Pacific (Table 3.5), Americas (Table 3.6) and Europe (Section 3.7).
-    url: https://apps.who.int/iris/rest/bitstreams/1398397/retrieve
-    date_accessed: 2022-02-21
-    published_by: 'World malaria report 2021. Geneva: World Health Organization; 2021. Licence: CC BY-NC-SA 3.0 IGO.'
-  name: Estimated Malaria Deaths
-  description: |-
-    There is some rounding of the figures for each of the regions, so that the sum doesn't quite add up to the values in the global estimates, which is also rounded. For example their estimate of global malaria deaths is 627000, but the regions sum to 626909.
+
+      There is some rounding of the figures for each of the regions, so that the sum doesn't quite add up to the values in the global estimates, which is also rounded. For example their estimate of global malaria deaths is 627000, but the regions sum to 626909.
+    title_snapshot: World malaria report 2021 - Estimated malaria deaths
+    citation_full: 'World malaria report 2021. Geneva: World Health Organization; 2021. Licence: CC BY-NC-SA 3.0 IGO.'
+    attribution_short: WHO
+    url_main: https://apps.who.int/iris/rest/bitstreams/1398397/retrieve
+    date_accessed: '2022-02-21'
+    date_published: '2021'
+    license:
+      name: CC BY-NC-SA 3.0 IGO
   is_public: false
 outs:
   - md5: 2c34ceb29a2a27631a573ffaee087c25

--- a/snapshots/health/2022-04-01/polio_vaccine_costs_in_low_income_countries.feather.dvc
+++ b/snapshots/health/2022-04-01/polio_vaccine_costs_in_low_income_countries.feather.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Thompson and Kalkowska (2020)
+  origin:
+    producer: Thompson and Kalkowska
+    title: Potential future use, costs, and value of poliovirus vaccines
     description: |-
       This dataset shows actual and estimated costs of polio vaccines by type, dosage, route of administration and type of vaccination schedule.
 
       Polio vaccines can be of two types: Oral Poliovirus Vaccines (OPV) or Inactivated Poliovirus Vaccines (IPV). They can be given at different doses (full or fractional). They can be administered in different ways: orally (for OPVs), by needle, device, or patch (for IPVs). They are either given during routine immunizations (RI) or during supplementary immunization activities (SIAs) where large groups tend to be vaccinated at the same time. SIAs are performed as preventative (pSIAs) or as part of an outbreak-response (oSIAs).
 
       In eligible countries, Gavi funds IPVs to make them more affordable.
-    url: https://onlinelibrary.wiley.com/doi/pdfdirect/10.1111/risa.13557
+    citation_full: 'Thompson, K. M., & Kalkowska, D. A. (2021). Potential future use, costs, and value of poliovirus vaccines. Risk Analysis, 41(2), 349-363.'
+    url_main: https://onlinelibrary.wiley.com/doi/pdfdirect/10.1111/risa.13557
     date_accessed: '2022-04-01'
-    published_by: |-
-      Thompson, K. M., & Kalkowska, D. A. (2021). Potential future use, costs, and value of poliovirus vaccines. Risk Analysis, 41(2), 349-363.
-  name: Polio vaccine costs in low-income countries
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 669127a96a3ae1ffb7ccc4e05ca89b09

--- a/snapshots/health/2022-09-26/seasonal_influenza_mortality__glamor__2019.feather.dvc
+++ b/snapshots/health/2022-09-26/seasonal_influenza_mortality__glamor__2019.feather.dvc
@@ -1,6 +1,7 @@
 meta:
-  source:
-    name: GLaMOR (2019)
+  origin:
+    producer: Paget et al.
+    title: 'Global mortality associated with seasonal influenza epidemics: New burden estimates and predictors from the GLaMOR Project'
     description: |-
       This study was part of the Global Pandemic Mortality Project II (GLaMOR) and was conducted by the Netherlands Institute for Health Service Research, in collaboration with the US National Institutes of Health and Centers for Disease Control, funded by the World Health Organization.
 
@@ -8,16 +9,15 @@ meta:
 
       These estimates focus on respiratory-associated influenza mortality. This means they aim to include respiratory deaths where other complications may have been listed as the primary cause of death, but those deaths were actually caused by influenza. However, it would exclude deaths where patients did not have respiratory disease, even if their deaths were caused by influenza (such as through only cardiovascular complications).
 
-      The global number of people who die from other complications of the flu is unclear. Paget et al. (the authors of the GLaMOR project) state in their paper that their estimate “does not cover cardiovascular deaths, something that could at least double the estimate of influenza-associated deaths.” In recent meta-analyses, Behrouzi et al. found that influenza vaccination reduces the chances of major cardiovascular events (such as heart attacks and strokes) by around 34%, in clinical trials of the elderly. This suggests the death toll from other complications could be large. However, global estimates have not been made of these types of deaths from flu.
+      The global number of people who die from other complications of the flu is unclear. Paget et al. (the authors of the GLaMOR project) state in their paper that their estimate "does not cover cardiovascular deaths, something that could at least double the estimate of influenza-associated deaths." In recent meta-analyses, Behrouzi et al. found that influenza vaccination reduces the chances of major cardiovascular events (such as heart attacks and strokes) by around 34%, in clinical trials of the elderly. This suggests the death toll from other complications could be large. However, global estimates have not been made of these types of deaths from flu.
 
       See: Paget, J., Danielle Iuliano, A., Taylor, R. J., Simonsen, L., Viboud, C., & Spreeuwenberg, P. (2022). Estimates of mortality associated with seasonal influenza for the European Union from the GLaMOR project. Vaccine, 40(9), 1361–1369. https://doi.org/10.1016/j.vaccine.2021.11.080
       Behrouzi, B., Bhatt, D. L., Cannon, C. P., Vardeny, O., Lee, D. S., Solomon, S. D., & Udell, J. A. (2022). Association of Influenza Vaccination With Cardiovascular Risk: A Meta-analysis. JAMA Network Open, 5(4), e228873. https://doi.org/10.1001/jamanetworkopen.2022.8873
-    url: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6815659/
-    date_accessed: 2022-09-26
-    published_by: |-
-      Paget J, Spreeuwenberg P, Charu V, Taylor RJ, Iuliano AD, Bresee J, Simonsen L, Viboud C; Global Seasonal Influenza-associated Mortality Collaborator Network and GLaMOR Collaborating Teams*. Global mortality associated with seasonal influenza epidemics: New burden estimates and predictors from the GLaMOR Project. J Glob Health. 2019 Dec;9(2):020421. doi: 10.7189/jogh.09.020421. PMID: 31673337; PMCID: PMC6815659.
-  name: Seasonal influenza mortality – GLaMOR (2019)
-  description: This dataset has higher estimates for seasonal influenza mortality for Eastern European countries than the CDC dataset.
+    citation_full: |-
+      Paget J, Spreeuwenberg P, Charu V, Taylor RJ, Iuliano AD, Bresee J, Simonsen L, Viboud C; Global Seasonal Influenza-associated Mortality Collaborator Network and GLaMOR Collaborating Teams. Global mortality associated with seasonal influenza epidemics: New burden estimates and predictors from the GLaMOR Project. J Glob Health. 2019 Dec;9(2):020421. doi: 10.7189/jogh.09.020421. PMID: 31673337; PMCID: PMC6815659.
+    url_main: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6815659/
+    date_accessed: '2022-09-26'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: 1db49f26fc7baee570f898be6f81a0f4

--- a/snapshots/health/2023/influenza_vaccination_rates_in_over_65s__oecd.feather.dvc
+++ b/snapshots/health/2023/influenza_vaccination_rates_in_over_65s__oecd.feather.dvc
@@ -1,15 +1,15 @@
 meta:
-  source:
-    name: OECD
+  origin:
+    producer: OECD
+    title: Influenza vaccination rates
     description: |-
       This data comes from the OECD.
 
-      'Influenza vaccination rate refers to the number of people aged 65 and older who have received an annual influenza vaccination, divided by the total number of people over 65 years of age. This indicator is measured as a percentage of the population aged 65 and older who have received an annual influenza vaccine. The data come from administrative sources or surveys, depending on the country.'
-    url: https://data.oecd.org/healthcare/influenza-vaccination-rates.htm
+      Influenza vaccination rate refers to the number of people aged 65 and older who have received an annual influenza vaccination, divided by the total number of people over 65 years of age. This indicator is measured as a percentage of the population aged 65 and older who have received an annual influenza vaccine. The data come from administrative sources or surveys, depending on the country.
+    citation_full: 'OECD (2022), Influenza vaccination rates (indicator). doi: 10.1787/e452582e-en.'
+    url_main: https://data.oecd.org/healthcare/influenza-vaccination-rates.htm
     date_accessed: '2023-01-01'
-    published_by: 'OECD (2022), Influenza vaccination rates (indicator). doi: 10.1787/e452582e-en (Accessed on 25 September 2022)'
-  name: Influenza vaccination rates in over 65s (OECD)
-  description: https://github.com/owid/notebooks/tree/main/FionaSpooner/oecd_flu_vaccination
+    date_published: '2022'
   is_public: false
 outs:
   - md5: 9cfed4cc043149c0ef73940329711ac2

--- a/snapshots/human_rights/2021-06-14/laws_on_child_marriage__gender__institutions_and_development_database__gid_db__2019.feather.dvc
+++ b/snapshots/human_rights/2021-06-14/laws_on_child_marriage__gender__institutions_and_development_database__gid_db__2019.feather.dvc
@@ -1,7 +1,9 @@
 meta:
-  source:
-    name: Gender, Institutions and Development Database (GID-DB) 2019
-    description: |-
+  origin:
+    producer: OECD
+    title: Gender, Institutions and Development Database
+    title_snapshot: Gender, Institutions and Development Database - Laws on child marriage
+    description_snapshot: |-
       The Gender, Institutions and Development Database (GID-DB) compiles data on the laws on child marriage, specifically whether women and men have the same legal minimum age of marriage. The child marriage indicator has five categories listed below:
 
       0: The law guarantees the same minimum age of marriage above 18 years to women and men, without legal exceptions regarding either consent or some groups of women. Customary, religious and traditional laws or practices do not encourage girl child marriage.
@@ -14,12 +16,12 @@ meta:
 
       1: The law allows child marriage for women but not for men.
 
-      For further information see the <a href="https://www.genderindex.org/methodology/">SIGI methodology page</a>.
-    url: https://stats.oecd.org/Index.aspx?DataSetCode=GIDDB2019#
-    date_accessed: 2021-06-14
-    published_by: OECD.Stat
-  name: Laws on child marriage - Gender, Institutions and Development Database (GID-DB, 2019)
-  description: ''
+      For further information see the [SIGI methodology page](https://www.genderindex.org/methodology/).
+    citation_full: 'OECD (2019). Gender, Institutions and Development Database (GID-DB) 2019. OECD.Stat.'
+    version_producer: '2019'
+    url_main: https://stats.oecd.org/Index.aspx?DataSetCode=GIDDB2019#
+    date_accessed: '2021-06-14'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: 1a44ec088d854fa2dde75010118aacf1

--- a/snapshots/labor/2017-08-01/female_labor_force_participation_index__owid__2017__split.feather.dvc
+++ b/snapshots/labor/2017-08-01/female_labor_force_participation_index__owid__2017__split.feather.dvc
@@ -1,16 +1,17 @@
 meta:
-  source:
-    name: OWID based on Olivetti (2013)
+  origin:
+    producer: Olivetti
+    title: Female labor force participation index
     description: |-
       The female labor force participation (FLFP) index was calculated by OWID based on FLFP data compiled from Olivetti (2013). The original data shows FLFP as percentage of the female population that is economically active. Olivetti compiled data from Mitchell (1998) and the International Labor Organization.
 
       For more detail see: http://www.nber.org/papers/w19131.pdf.
+
       The index measures FLFP as an index to 1900. This was calculated by dividing FLFP in each year by FLFP in 1900 (therefore 1900 = 100). Values less than 100 indicate a decrease in FLFP relative to 1900; values greater than 100 indicate an increase in FLFP relative to 1900.
-    url: http://www.nber.org/papers/w19131.pdf
-    date_accessed: 2017-08-01
-    published_by: OWID calculation based on original data by Olivetti (2013)
-  name: Female Labor Force Participation Index (OWID (2017)) (split)
-  description: ''
+    citation_full: 'Olivetti, C. (2013). The female labor force and long-run development: The American experience in comparative perspective. National Bureau of Economic Research.'
+    url_main: http://www.nber.org/papers/w19131.pdf
+    date_accessed: '2017-08-01'
+    date_published: '2013'
   is_public: false
 outs:
   - md5: 03db02368a6cf3374f1200c0e01eb4f4

--- a/snapshots/labor/2018/average_effective_age_of_retirement__by_gender__oecd__2018.feather.dvc
+++ b/snapshots/labor/2018/average_effective_age_of_retirement__by_gender__oecd__2018.feather.dvc
@@ -1,21 +1,21 @@
 meta:
-  source:
-    name: Average effective age of retirement, by gender (OECD, 2018)
+  origin:
+    producer: OECD
+    title: Average effective age of retirement, by gender
     description: |-
       The average effective age of retirement is calculated as a weighted average of (net) labour market withdrawals at different ages over a 5-year period for workers initially aged 40 and over.
 
       The estimate for each year corresponds to the 5 year interval leading up to that year. For example, the observation for 1970 corresponds to (1965-70), 1971 to (1966-71) etc.
 
-      Labour force withdrawals are estimated based on changes in labour force participation rates rather than labour force levels to abstract from compositional effects. Estimates include both interpolations of census data as well as labour force surveys. For a breakdown by observation, see the <a href="http://www.oecd.org/els/emp/Summary_1970%20values.xlsx">following spreadsheet</a>.
+      Labour force withdrawals are estimated based on changes in labour force participation rates rather than labour force levels to abstract from compositional effects. Estimates include both interpolations of census data as well as labour force surveys. For a breakdown by observation, see the [following spreadsheet](http://www.oecd.org/els/emp/Summary_1970%20values.xlsx).
 
       Note: The estimates for women in Turkey are based on 3-yearly moving averages of participation rates for each 5-year age group.
 
       The 'Europe average' series includes: Austria, Belgium, Bulgaria, Croatia, Cyprus, Czech Republic, Denmark, Estonia, Finland, France, Germany, Greece, Hungary, Ireland, Italy, Latvia, Lithuania, Luxembourg, Malta, Netherlands, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden, United Kingdom.
-    url: http://www.oecd.org/els/emp/average-effective-age-of-retirement.htm
-    date_accessed: 2020-11-28
-    published_by: OECD Database on Average Effective Retirement Age
-  name: Average effective age of retirement, by gender (OECD, 2018)
-  description: ''
+    citation_full: 'OECD (2018). OECD Database on Average Effective Retirement Age.'
+    url_main: http://www.oecd.org/els/emp/average-effective-age-of-retirement.htm
+    date_accessed: '2020-11-28'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 1f1877661255323acaf25ee8985470b0

--- a/snapshots/labor/2019-10-02/methods_used_by_employed_workers_to_find_their_current_jobs__pellizzari__2010.feather.dvc
+++ b/snapshots/labor/2019-10-02/methods_used_by_employed_workers_to_find_their_current_jobs__pellizzari__2010.feather.dvc
@@ -1,13 +1,13 @@
 meta:
-  source:
-    name: Methods used by employed workers to find their current jobs - Pellizzari (2010)
+  origin:
+    producer: Pellizzari
+    title: Do friends and relatives really help in getting a good job?
     description: |-
-      Employed workers in the ECHP are asked to indicate how they have found their current job. The exact phrasing of the question reads: ”By what means were you first informed about your current job?”. Six possible answers are offered, and respondents can choose only one. The sample includes individuals aged 16-64 in 14 European countries over the period 1994-1999.
-    url: http://eprints.lse.ac.uk/19980/1/Do_Friends_and_Relatives_Really_Help_in_Getting_a_Good_Job.pdf
-    date_accessed: 2019-10-02
-    published_by: Pellizzari, M. (2010). Do friends and relatives really help in getting a good job?. ILR Review, 63(3), 494-510.
-  name: Methods used by employed workers to find their current jobs - Pellizzari (2010)
-  description: ''
+      Employed workers in the ECHP are asked to indicate how they have found their current job. The exact phrasing of the question reads: "By what means were you first informed about your current job?". Six possible answers are offered, and respondents can choose only one. The sample includes individuals aged 16-64 in 14 European countries over the period 1994-1999.
+    citation_full: 'Pellizzari, M. (2010). Do friends and relatives really help in getting a good job? ILR Review, 63(3), 494-510.'
+    url_main: http://eprints.lse.ac.uk/19980/1/Do_Friends_and_Relatives_Really_Help_in_Getting_a_Good_Job.pdf
+    date_accessed: '2019-10-02'
+    date_published: '2010'
   is_public: false
 outs:
   - md5: 49b59d6c213b2a46ae101130e5d53599

--- a/snapshots/labor/2019-10-30/proportion_of_unemployed_using_specific_search_methods__bachmann_and_baumgarten__2013.feather.dvc
+++ b/snapshots/labor/2019-10-30/proportion_of_unemployed_using_specific_search_methods__bachmann_and_baumgarten__2013.feather.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Bachmann and Baumgarten (2013)
+  origin:
+    producer: Bachmann and Baumgarten
+    title: 'How do the unemployed search for a job? Evidence from the EU Labour Force Survey'
     description: |-
-      The EU-LFS survey question(s) asked to determine the job search methods used by respondents vary country to country. For exact question(s) asked by country, see the <a href="https://ec.europa.eu/eurostat/statistics-explained/index.php/EU_labour_force_survey_-_methodology#Core_questionnaires">EU-LFS core questionnaires documentation</a>.
+      The EU-LFS survey question(s) asked to determine the job search methods used by respondents vary country to country. For exact question(s) asked by country, see the [EU-LFS core questionnaires documentation](https://ec.europa.eu/eurostat/statistics-explained/index.php/EU_labour_force_survey_-_methodology#Core_questionnaires).
 
       The authors note the "annual dataset [...] consists of yearly cross-sections. This means it is not possible to follow individuals over time."
 
-      Note: The method “Test, interview, or examination” is not surveyed in the UK, therefore it is not strictly comparable across countries.
-    url: https://link.springer.com/content/pdf/10.1186%2F2193-9012-2-22.pdf (Table 5)
-    date_accessed: 2019-10-30
-    published_by: |-
-      Bachmann and Baumgarten: How do the unemployed search for a job? – Evidence from the EU Labour Force Survey. IZA Journal of European Labor Studies 2013, 2:22
-  name: Proportion of unemployed using specific search methods - Bachmann and Baumgarten (2013)
-  description: ''
+      Note: The method "Test, interview, or examination" is not surveyed in the UK, therefore it is not strictly comparable across countries.
+    citation_full: 'Bachmann, R. and Baumgarten, D. (2013). How do the unemployed search for a job? Evidence from the EU Labour Force Survey. IZA Journal of European Labor Studies, 2:22.'
+    url_download: https://link.springer.com/content/pdf/10.1186%2F2193-9012-2-22.pdf
+    date_accessed: '2019-10-30'
+    date_published: '2013'
   is_public: false
 outs:
   - md5: f8ead8109ba38548a748092560ef5e33

--- a/snapshots/labor/2024-01-03/shares_and_numbers_employed_by_sector__world_bank_and_historical_sources.feather.dvc
+++ b/snapshots/labor/2024-01-03/shares_and_numbers_employed_by_sector__world_bank_and_historical_sources.feather.dvc
@@ -1,14 +1,14 @@
 meta:
-  source:
-    name: Our World in Data based on International Labor Organization (via the World Bank) and historical sources
+  origin:
+    producer: International Labor Organization and historical sources
+    title: Shares and numbers employed by sector
     description: |-
       This dataset was constructed by Our World in Data based on the primary dataset on labor force participation, published by the International Labor Organization (via the World Bank). This publishes data on labor statistics since 1991.
 
       Data prior to 1991 has been compiled from various historical reconstructions. The sources for this dataset are described in detail here: https://ourworldindata.org/agri-employment-sources
+    citation_full: International Labor Organization (via the World Bank) and historical sources, compiled by Our World in Data (2024).
     date_accessed: '2024-01-03'
-    published_by: Our World in Data based on International Labor Organization (via the World Bank) and historical sources
-  name: Shares and numbers employed by sector (World Bank and historical sources)
-  description: ''
+    date_published: '2024'
   is_public: false
 outs:
   - md5: 23c4e09e7fecedbc052e347e97ad2dcf

--- a/snapshots/oecd/2015-08-18/transport_and_communication_costs__oecd_economic_outlook__2007.feather.dvc
+++ b/snapshots/oecd/2015-08-18/transport_and_communication_costs__oecd_economic_outlook__2007.feather.dvc
@@ -1,13 +1,14 @@
 meta:
-  source:
-    name: Transaction Costs - OECD Economic Outlook (2007)
-    description: |-
-      Sea fright corresponds to average international freight charges per tonne. Passenger air transport corresponds to average airline revenue per passenger mile until 2000 spliced to US import air passenger fares afterwards. International calls correspond to cost of a three-minute call from New York to London.
-    url: http://www.oecd-ilibrary.org/economics/economic-globalisation_9789264111905-en
-    date_accessed: 2015-08-18
-    published_by: 'OECD Insights - Economic Globalisation: Origins and Consequences'
-  name: Transport and communication costs, OECD Economic Outlook (2007)
-  description: ''
+  origin:
+    producer: OECD
+    title: 'Economic Globalisation: Origins and Consequences'
+    title_snapshot: 'Economic Globalisation: Origins and Consequences - Transport and communication costs'
+    description_snapshot: |-
+      Sea fright corresponds to average international freight charges per tonne. Passenger air transport corresponds to average airline revenue per passenger mile until 2000 spliced to US import air passenger fares afterwards. International calls correspond to cost of a three-minute call from New York to London.
+    citation_full: 'OECD (2007). Economic Globalisation: Origins and Consequences. OECD Insights.'
+    url_main: http://www.oecd-ilibrary.org/economics/economic-globalisation_9789264111905-en
+    date_accessed: '2015-08-18'
+    date_published: '2007'
   is_public: false
 outs:
   - md5: f5d01f501d84d9986b79dd4756b4b57e

--- a/snapshots/oecd/2018-01-01/developmental_food_aid__oecd__2018.feather.dvc
+++ b/snapshots/oecd/2018-01-01/developmental_food_aid__oecd__2018.feather.dvc
@@ -1,10 +1,10 @@
 meta:
-  source:
-    name: Developmental Food Aid (OECD, 2018)
+  origin:
+    producer: OECD
+    title: Developmental food aid
+    citation_full: Developmental Food Aid (2018). OECD.
     date_accessed: '2018-01-01'
-    published_by: Developmental Food Aid (OECD, 2018)
-  name: Developmental Food Aid (OECD, 2018)
-  description: ''
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 86f6425117a74bf372ed0a9c54886af9

--- a/snapshots/oecd/2018-03-11/road_deaths_and_injuries.feather.dvc
+++ b/snapshots/oecd/2018-03-11/road_deaths_and_injuries.feather.dvc
@@ -1,36 +1,27 @@
 meta:
-  source:
-    name: Road deaths and injuries - OECD
-    description: >-
+  origin:
+    producer: OECD
+    title: Road accidents
+    description: |-
       The majority of series data is sourced from the OECD Statistics.
 
-
-      For particular countries, longer series have been sourced from specific national
-      records as referenced below.
-
+      For particular countries, longer series have been sourced from specific national records as referenced below.
 
       Germany: Statistisches Bundesamt (https://www.destatis.de/EN/FactsFigures/EconomicSectors/TransportTraffic/TrafficAccidents/Tables_/RoadTrafficAccidents.html)
 
-
       New Zealand: http://www.transport.govt.nz/research/roadtoll/annualroadtollhistoricalinformation/
 
-
-      Australia: https://bitre.gov.au/publications/ongoing/road_deaths_australia_annual_summaries.aspx
-      and https://infrastructure.gov.au/roads/safety/publications/2008/pdf/Ann_Stats_2007.pdf
-
+      Australia: https://bitre.gov.au/publications/ongoing/road_deaths_australia_annual_summaries.aspx and https://infrastructure.gov.au/roads/safety/publications/2008/pdf/Ann_Stats_2007.pdf
 
       Scotland: https://www.transport.gov.scot/media/39307/sct05174402361.pdf
 
-
       Northern Ireland: https://www.psni.police.uk/inside-psni/Statistics/road-traffic-collision-statistics/
 
-
       United States: https://www.bts.gov/content/transportation-fatalities-mode
-    url: https://data.oecd.org/transport/road-accidents.htm
-    date_accessed: 2018-03-11
-    published_by: OECD (2018), Road accidents (indicator).
-  name: Road deaths and injuries - OECD
-  description: ''
+    citation_full: OECD (2018). Road accidents (indicator).
+    url_main: https://data.oecd.org/transport/road-accidents.htm
+    date_accessed: '2018-03-11'
+    date_published: '2018'
 wdir: ../../../data/snapshots/oecd/2018-03-11
 outs:
 - md5: 5efa4d8daf1c198e5bdb0e26adf5a288

--- a/snapshots/oecd/2019-05-04/corporate_income_tax__cit__corporate_tax_statistics_database__ctsd__oecd__2019.feather.dvc
+++ b/snapshots/oecd/2019-05-04/corporate_income_tax__cit__corporate_tax_statistics_database__ctsd__oecd__2019.feather.dvc
@@ -1,15 +1,16 @@
 meta:
-  source:
-    name: Corporate Tax Statistics Database (CTSD) - OECD (2019)
+  origin:
+    producer: OECD
+    title: Corporate Tax Statistics Database
     description: |-
       Data is taken from the OECD's Corporate Tax Statistics Database (CTSD). The database compiles data relating to four main categories: i) corporate tax revenues; ii) corporate effective tax rates; iii) statutory corporate income tax rates; and iv) tax incentives related to innovation.
 
-      Further information on the CTSD is available on the <a href="http://www.oecd.org/tax/tax-policy/corporate-tax-statistics-database.htm">OECD's website</a>.
-    url: https://stats.oecd.org/Index.aspx?DataSetCode=CTS_CIT
-    date_accessed: 2019-05-04
-    published_by: OECD
-  name: Corporate income tax (CIT) - Corporate Tax Statistics Database (CTSD) - OECD (2019)
-  description: ''
+      Further information on the CTSD is available on the [OECD's website](http://www.oecd.org/tax/tax-policy/corporate-tax-statistics-database.htm).
+    title_snapshot: Corporate Tax Statistics Database - Corporate income tax
+    citation_full: OECD (2019). Corporate Tax Statistics Database. Organisation for Economic Co-operation and Development.
+    url_main: https://stats.oecd.org/Index.aspx?DataSetCode=CTS_CIT
+    date_accessed: '2019-05-04'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: a2a58aa63d60a49c5468beeaaac362d2

--- a/snapshots/oecd/2020-11-05/time_use_across_activities__oecd_gender_data__2020.feather.dvc
+++ b/snapshots/oecd/2020-11-05/time_use_across_activities__oecd_gender_data__2020.feather.dvc
@@ -1,7 +1,9 @@
 meta:
-  source:
-    name: OECD Gender Data (2020)
-    description: |-
+  origin:
+    producer: OECD
+    title: OECD Gender Data
+    title_snapshot: OECD Gender Data - Time use across activities
+    description_snapshot: |-
       Australia, Belgium, Estonia, Greece, Hungary, Lithuania, Luxembourg, Mexico, Poland, Sweden, Turkey, and China time use estimates are not fully comparable, due to differences in the age of reference. The remaining countries' age of reference are between 15-64.
 
       Note: Data are normalized to 1440 minutes per day. In other words, for those countries for which the time use does not sum up to 1440 minutes, the missing minutes are equally distributed across all activities.
@@ -12,12 +14,11 @@ meta:
       Australia  (2006); Austria  (2008/09); Belgium (2013); Canada  (2015); Denmark (2001); Estonia (2009/10); Finland (2009/10); France (2009/10); Germany (2012/13); Greece (2013); Hungary (2010); Ireland (2005); Italy (2013/14); Japan (2016); Korea (2014); Latvia (2003); Lithuania (2003); Luxembourg (2013); Mexico (2014); Netherlands (2016); New Zealand (2009/10); Norway (2010/11); Poland  (2013); Portugal (1999); Slovenia (2000/01); Spain (2009/10); Sweden (2010); Turkey (2014/15); UK (2014/15); US (2018); China (2008); India (1998/99); South Africa (2010).
 
       OECD estimates based on national time use surveys. Methodological documentation on national time-use surveys used for the estimates is in Miranda V. (2011) "Cooking, Caring and Volunteering: Unpaid Work Around the World" available at: https://www.oecd-ilibrary.org/social-issues-migration-health/cooking-caring-and-volunteering-unpaid-work-around-the-world_5kghrjm8s142-en
-    url: |-
-      http://www.oecd.org/gender/data/balancingpaidworkunpaidworkandleisure.htm and excel document: http://www.oecd.org/gender/data/OECD_1564_TUSupdatePortal.xlsx
-    date_accessed: 2020-11-05
-    published_by: OECD
-  name: Time use across activities - OECD Gender data (2020)
-  description: ''
+    citation_full: 'OECD (2020). OECD Gender Data - Time use across activities.'
+    url_main: http://www.oecd.org/gender/data/balancingpaidworkunpaidworkandleisure.htm
+    url_download: http://www.oecd.org/gender/data/OECD_1564_TUSupdatePortal.xlsx
+    date_accessed: '2020-11-05'
+    date_published: '2020'
   is_public: false
 outs:
   - md5: 20b305af1bec5e4c57dc261014e7f956

--- a/snapshots/poverty_inequality/2018-09-17/extreme_poverty_2030_projections_by_ssp__crespo_et_al__2018.feather.dvc
+++ b/snapshots/poverty_inequality/2018-09-17/extreme_poverty_2030_projections_by_ssp__crespo_et_al__2018.feather.dvc
@@ -1,12 +1,13 @@
 meta:
-  source:
-    name: Extreme Poverty 2030 Projections by SSP - Crespo-Cuaresma et al. (2018)
+  origin:
+    producer: Crespo-Cuaresma et al.
+    title: 'Will the Sustainable Development Goals be fulfilled? Assessing present and future global poverty'
     description: |-
       Data on extreme poverty projections by country and region are sourced from the Nature publication by Crespo-Cuaresma et al. (2018). This data is also presented visually at the World Poverty Clock: http://worldpoverty.io/index.html
 
       Extreme poverty is defined by the international poverty line, set at a threshold of $1.90 per person per day, which is adjusted for inflation (by normalising to 2011 dollars), and corrected for cross-country price differences (PPP).
 
-      The UN's Sustainable Development Goal (SDG) Target 1.1 is to end extreme poverty by 2030. 'Ending extreme poverty' is assumed when a country reaches an extreme poverty level below 3% of the total population.
+      The UN's Sustainable Development Goal (SDG) Target 1.1 is to end extreme poverty by 2030. "Ending extreme poverty" is assumed when a country reaches an extreme poverty level below 3% of the total population.
 
       Scenarios of future extreme poverty rates were assessed and modelled by Crespo-Cuaresma et al. (2018) using a combination of the IMF World Economic Outlook, and multiple Shared Socioeconomic Pathways (SSP).
 
@@ -21,17 +22,15 @@ meta:
 
       - SSP5: presents a scenario with high economic growth (and therefore low adaptation challenges) coupled with high demand for fossil energy from developing economies, but with high global CO2 emissions.
 
-      SSP2 is defined as the baseline 'business-as-usual' scenario.
+      SSP2 is defined as the baseline "business-as-usual" scenario.
 
-      The categories of 'extremely fragile', 'fragile' and 'non-fragile' have been added for reference based on the OECD (2018) States of Fragility framework. This framework measures the fragility of countries based on multiple political and socioeconomic indicators. More information on this fragility measure can be found at the OECD (2018) report.
+      The categories of "extremely fragile", "fragile" and "non-fragile" have been added for reference based on the OECD (2018) States of Fragility framework. This framework measures the fragility of countries based on multiple political and socioeconomic indicators. More information on this fragility measure can be found at the OECD (2018) report.
 
       Reference: OECD (2018), States of Fragility. OECD Publishing, Paris. Available at: https://www.oecd-ilibrary.org/development/states-of-fragility-2018_9789264302075-en
-    url: https://www.nature.com/articles/s41599-018-0083
-    date_accessed: 2018-09-17
-    published_by: |-
-      Cuaresma, J. C., Fengler, W., Kharas, H., Bekhtiar, K., Brottrager, M., & Hofer, M. (2018). Will the Sustainable Development Goals be fulfilled? Assessing present and future global poverty. Palgrave Communications, 4(1), 29.
-  name: Extreme Poverty 2030 Projections by SSP - Crespo et al. (2018)
-  description: ''
+    citation_full: 'Cuaresma, J. C., Fengler, W., Kharas, H., Bekhtiar, K., Brottrager, M., & Hofer, M. (2018). Will the Sustainable Development Goals be fulfilled? Assessing present and future global poverty. Palgrave Communications, 4(1), 29.'
+    url_main: https://www.nature.com/articles/s41599-018-0083
+    date_accessed: '2018-09-17'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 8d875fa953864447d5819029561613c1

--- a/snapshots/poverty_inequality/2018-10-01/gini_index_around_1990_and_2015__povcal__2018__and_chartbook__2017.feather.dvc
+++ b/snapshots/poverty_inequality/2018-10-01/gini_index_around_1990_and_2015__povcal__2018__and_chartbook__2017.feather.dvc
@@ -1,12 +1,16 @@
 meta:
-  source:
-    name: Povcal (2018), The Chartbook of Economic Inequality (2017), Kanbur et al (2017) Table 1.B
-    url: http://iresearch.worldbank.org/PovcalNet/povOnDemand.aspx ; https://www.chartbookofeconomicinequality.com
-    date_accessed: 2018-10-01
-    published_by: |-
-      Povcal (2018); Atkinson, Hasell, Morelli, and Roser (2017), “The Chartbook of Economic Inequality”; Kanbur, R., & Wang, Y. 2017. The great Chinese inequality turnaround. ECINEQ Working Paper Series WP 2017 – 433
-  name: Gini Index around 1990 and 2015 – Povcal (2018) and Chartbook (2017)
-  description: ''
+  origin:
+    producer: World Bank, Atkinson et al., and Kanbur and Wang
+    title: Gini index around 1990 and 2015
+    citation_full: |-
+      World Bank (2018). PovcalNet: an online analysis tool for global poverty monitoring. http://iresearch.worldbank.org/PovcalNet/.
+
+      Atkinson, A. B., Hasell, J., Morelli, S., and Roser, M. (2017). The Chartbook of Economic Inequality.
+
+      Kanbur, R., and Wang, Y. (2017). The great Chinese inequality turnaround. ECINEQ Working Paper Series WP 2017–433.
+    url_main: http://iresearch.worldbank.org/PovcalNet/povOnDemand.aspx
+    date_accessed: '2018-10-01'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 639225fb05a38cf1b3142bc3fa77b747

--- a/snapshots/poverty_inequality/2020/reconstruction_of_historical_poverty_trends_by_country__1820_2017__owid_based_on_maddison_project_database_2020_and_van_zanden_et_al__2014.feather.dvc
+++ b/snapshots/poverty_inequality/2020/reconstruction_of_historical_poverty_trends_by_country__1820_2017__owid_based_on_maddison_project_database_2020_and_van_zanden_et_al__2014.feather.dvc
@@ -1,13 +1,12 @@
 meta:
-  source:
-    name: OWID based on Maddison Project Database 2020, GCIP, van Zanden et al. (2014), de la Escosura (2012)
-    description: '[Provide link to detailed documentation before this is circulated publicly]'
+  origin:
+    producer: Various sources
+    title: Reconstruction of historical poverty trends by country, 1820–2017
+    attribution_short: Maddison Project Database, GCIP, van Zanden et al. and de la Escosura
+    citation_full: |-
+      Maddison Project Database, version 2020. Bolt, Jutta and Jan Luiten van Zanden (2020), "Maddison style estimates of the evolution of the world economy. A new 2020 update". Global Consumption and Income Project database. van Zanden, Jan Luiten, Joerg Baten, Peter Foldvari, and Bas van Leeuwen (2014). "The Changing Shape of Global Inequality 1820–2000; Exploring a New Dataset." Review of Income and Wealth 60 (2): 279–297. Prados de la Escosura, Leandro (2012). "Output per head in pre-independence Africa: Quantitative conjectures." Economic History of Developing Regions 27 (2): 1–36.
     date_accessed: '2020-01-01'
-    published_by: |-
-      OWID based on Maddison Project Database, version 2020. Global Income and Consumption Project database.  Bolt, Jutta and Jan Luiten van Zanden (2020), “Maddison style estimates of the evolution of the world economy. A new 2020 update ”; van Zanden, Jan Luiten van, Joerg Baten, Peter Foldvari, and Bas van Leeuwen. 2014. “The Changing Shape of Global Inequality 1820–2000; Exploring a New Dataset.” Review of Income and Wealth 60 (2): 279–97; Prados de la Escosura, Leandro. 2012. “OUTPUT PER HEAD IN PRE-INDEPENDENCE AFRICA: QUANTITATIVE CONJECTURES.” Economic History of Developing Regions 27 (2): 1–36.
-  name: |-
-    Reconstruction of historical poverty trends by country, 1820-2017 (OWID based on Maddison Project Database 2020 and van Zanden et al. (2014))
-  description: ''
+    date_published: '2020'
   is_public: false
 outs:
   - md5: dea650f6613887c8ab3847002c32408b

--- a/snapshots/poverty_inequality/2021-01-27/top_marginal_income_tax_rate__world_inequality_report__2018.feather.dvc
+++ b/snapshots/poverty_inequality/2021-01-27/top_marginal_income_tax_rate__world_inequality_report__2018.feather.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Top marginal income tax rate - World Inequality Report (2018)
+  origin:
+    producer: Alvaredo et al.
+    title: World Inequality Report 2018
     description: |-
       The World Inequality Report 2018 provides a long-term series of the top marginal income tax rates in rich countries including the US, UK, France, Germany, and Japan from 1900 to 2017.
 
       The top marginal income tax rates reported include general income tax supplements (such as surtaxes applying to all incomes above a certain level) but excludes all other taxes and social contributions.
 
-      For more detailed information on the construction of the top marginal income tax rate country-by-country, see page 161 of the World Inequality Report 2018 <a href="http://wid.world/static/technical-notes-for-figures-and-tables.pdf">Technical Notes for Figures and Tables</a>.
-    url: https://wir2018.wid.world/methodology.html
-    date_accessed: 2021-01-27
-    published_by: |-
-      Alvaredo, F., Chancel, L., Piketty, T., Saez, E., & Zucman, G. (Eds.). (2018). World Inequality Report 2018. Belknap Press.
-  name: Top marginal income tax rate - World Inequality Report (2018)
-  description: ''
+      For more detailed information on the construction of the top marginal income tax rate country-by-country, see page 161 of the World Inequality Report 2018 [Technical Notes for Figures and Tables](http://wid.world/static/technical-notes-for-figures-and-tables.pdf).
+    citation_full: 'Alvaredo, F., Chancel, L., Piketty, T., Saez, E., and Zucman, G. (Eds.). (2018). World Inequality Report 2018. Belknap Press.'
+    url_main: https://wir2018.wid.world/methodology.html
+    date_accessed: '2021-01-27'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 796d8a00201cac8ca061d8ad266ca495

--- a/snapshots/poverty_inequality/2021-02-01/reconstruction_of_historical_global_extreme_poverty_rates__1820_2017__roser_and_hasell__2021__and_world_bank__2020.feather.dvc
+++ b/snapshots/poverty_inequality/2021-02-01/reconstruction_of_historical_global_extreme_poverty_rates__1820_2017__roser_and_hasell__2021__and_world_bank__2020.feather.dvc
@@ -1,12 +1,13 @@
 meta:
-  source:
-    name: Reconstruction of historical global extreme poverty rates, 1820-2017 (Roser and Hasell (2021) and World Bank(2020))
+  origin:
+    producer: Roser and Hasell, and World Bank
+    title: Reconstruction of historical global extreme poverty rates, 1820–2017
     description: |-
       See the data appendix describing the source data and methods underlying these estimates: https://ourworldindata.org/history-of-poverty-data-appendix
+    citation_full: 'Roser, M. and Hasell, J. (2021), and World Bank (2020). Reconstruction of historical global extreme poverty rates, 1820–2017.'
+    url_main: https://ourworldindata.org/history-of-poverty-data-appendix
     date_accessed: '2021-02-01'
-    published_by: Reconstruction of historical global extreme poverty rates, 1820-2017 (Roser and Hasell (2021) and World Bank(2020))
-  name: Reconstruction of historical global extreme poverty rates, 1820-2017 (Roser and Hasell (2021) and World Bank(2020))
-  description: ''
+    date_published: '2021'
   is_public: false
 outs:
   - md5: 8c5e3b85dcef5d1def9ed7a1a92c9f7c

--- a/snapshots/poverty_inequality/2022-11-01/inequality_among_world_citizens__bourguignon_and_morrisson__2002.feather.dvc
+++ b/snapshots/poverty_inequality/2022-11-01/inequality_among_world_citizens__bourguignon_and_morrisson__2002.feather.dvc
@@ -1,13 +1,13 @@
 meta:
-  source:
-    name: Inequality Among World Citizens - Bourguignon and Morrisson (2002)
+  origin:
+    producer: Bourguignon and Morrisson
+    title: Inequality among world citizens
     description: |-
       This paper investigates the distribution of well-being among world citizens during the last two centuries. The estimates show that inequality in the world distribution of income worsened from the beginning of the 19th century to World War II. After that, it seems to have stabilized or grown more slowly. In the early 19th century, most inequalities were due to differences within countries; later, it was due to differences between countries. Inequality in longevity also increased during the 19th century. Still, it then was reversed in the second half of the 20th century, perhaps mitigating the failure of income inequality to improve in the last decades. (JEL D31, F0, N0, O0)
-    url: http://dx.doi.org/10.1257/00028280260344443
+    citation_full: Bourguignon, F., and Morrisson, C. (2002). Inequality among world citizens. American Economic Review.
+    url_main: http://dx.doi.org/10.1257/00028280260344443
     date_accessed: '2022-11-01'
-    published_by: Bourguignon and Morrisson (2002)
-  name: Inequality Among World Citizens - Bourguignon and Morrisson (2002)
-  description: Backported
+    date_published: '2002'
   is_public: false
 outs:
   - md5: a94bcf54c04288466e331aae2b5a7285

--- a/snapshots/technology/2019/daily_hours_spent_with_digital_media_per_adult_user__us__bond_internet_trends__2019.feather.dvc
+++ b/snapshots/technology/2019/daily_hours_spent_with_digital_media_per_adult_user__us__bond_internet_trends__2019.feather.dvc
@@ -1,13 +1,13 @@
 meta:
-  source:
-    name: BOND Internet Trends (2019)
+  origin:
+    producer: BOND
+    title: Internet Trends 2019
     description: |-
-      Other connected devices include over-the-top (OTT) & game consoles. Mobile includes smartphone & tablet. Usage includes both home & work for consumers 18+. Non deduplicated-time is assigned to each medium individually, regardless of multitasking.
-    url: https://www.bondcap.com/report/it19/#view/41
-    date_accessed: 2019-01-08
-    published_by: BOND Internet Trends (2019)
-  name: Daily hours spent with digital media per adult user, US (BOND Internet Trends (2019))
-  description: ''
+      Other connected devices include over-the-top (OTT) and game consoles. Mobile includes smartphone and tablet. Usage includes both home and work for consumers 18+. Non deduplicated-time is assigned to each medium individually, regardless of multitasking.
+    citation_full: BOND (2019). Internet Trends 2019.
+    url_main: https://www.bondcap.com/report/it19/#view/41
+    date_accessed: '2019-01-08'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: ea39513c2f5c411ed5cbeeaf31d0025a

--- a/snapshots/trade/2014/world_trade_based_on_own_estimates__pct_of_gdp__klasing_and_milionis__2014__split.feather.dvc
+++ b/snapshots/trade/2014/world_trade_based_on_own_estimates__pct_of_gdp__klasing_and_milionis__2014__split.feather.dvc
@@ -1,14 +1,13 @@
 meta:
-  source:
-    name: Klasing and Milionis (2014)
+  origin:
+    producer: Klasing and Milionis
+    title: 'Quantifying the evolution of world trade, 1870–1949'
     description: |-
-      For consistency, the 62 countries used in Klasing and Milionis are used to calculate the world trade to GDP ratio for the period 1950-2011. The list can be found in Appendix A2 of their paper.
-    url: https://www.sciencedirect.com/science/article/pii/S0022199613001074?via%3Dihub
-    date_accessed: 2018-07-20
-    published_by: |-
-      Klasing, Mariko J. and Milionis, P. (2014). "Quantifying the Evolution of World Trade, 1870-1949". Journal of International Economics 92(1), pp. 185-197
-  name: World trade based on own estimates (% of GDP) (Klasing and Milionis (2014))  (split)
-  description: ''
+      For consistency, the 62 countries used in Klasing and Milionis are used to calculate the world trade to GDP ratio for the period 1950–2011. The list can be found in Appendix A2 of their paper.
+    citation_full: 'Klasing, M. J., and Milionis, P. (2014). Quantifying the evolution of world trade, 1870–1949. Journal of International Economics, 92(1), 185–197.'
+    url_main: https://www.sciencedirect.com/science/article/pii/S0022199613001074?via%3Dihub
+    date_accessed: '2018-07-20'
+    date_published: '2014'
   is_public: false
 outs:
   - md5: c7bc0c3115457f66634f00e605568c2c

--- a/snapshots/trade/2018-01-15/total_merchandise_trade_as_share_of_gdp__cow_v_4_0_national__2016__split.feather.dvc
+++ b/snapshots/trade/2018-01-15/total_merchandise_trade_as_share_of_gdp__cow_v_4_0_national__2016__split.feather.dvc
@@ -1,19 +1,20 @@
 meta:
-  source:
-    name: Correlates of War v4.0 - National (2016)
+  origin:
+    producer: Correlates of War Project, CEPII, and Bank of England
+    title: Total merchandise trade as share of GDP
     description: |-
       The national COW trade dataset provides estimates of total country exports (i.e. sum of exports to the rest of the world). To calculate trade as a share of GDP, we have used Fouquin and Hugot (CEPII 2016)'s long run historical GDP series (in nominal British pounds), converted to US$ using historical exchange rates from the Bank of England.
 
+      Trade data is from the [COW bilateral trade dataset](http://www.correlatesofwar.org/data-sets/bilateral-trade). Exchange rates are from the [Bank of England](http://www.bankofengland.co.uk/research/Pages/datasets/default.aspx). GDP data is from [CEPII (2016)](http://www.cepii.fr/cepii/en/bdd_modele/presentation.asp?id=32).
+
       Full reference: Barbieri, Katherine and Omar M. G. Omar Keshk. 2016. Correlates of War Project Trade Data Set Codebook, Version 4.0. Online: http://correlatesofwar.org.
 
-      Barbieri, Katherine, Omar M. G. Keshk, and Brian Pollins. 2009. “TRADING DATA: Evaluating our Assumptions and Coding Rules.” Conflict Management and Peace Science. 26(5): 471-491.
-    url: |-
-      Trade data: http://www.correlatesofwar.org/data-sets/bilateral-trade BOE Exchange Rate: http://www.bankofengland.co.uk/research/Pages/datasets/default.aspx; CEPII (2016) GDP data: http://www.cepii.fr/cepii/en/bdd_modele/presentation.asp?id=32
-    date_accessed: 2018-01-15
-    published_by: |-
-      Barbieri, Katherine and Omar M. G. Omar Keshk. 2016. Correlates of War Project Trade Data Set Codebook, Version 4.0. Online: http://correlatesofwar.org.
-  name: Total merchandise trade as share of GDP (COW v 4.0 National (2016)) (split)
-  description: ''
+      Barbieri, Katherine, Omar M. G. Keshk, and Brian Pollins. 2009. "TRADING DATA: Evaluating our Assumptions and Coding Rules." Conflict Management and Peace Science. 26(5): 471-491.
+    citation_full: 'Barbieri, Katherine and Omar M. G. Keshk. 2016. Correlates of War Project Trade Data Set Codebook, Version 4.0. Online: http://correlatesofwar.org.'
+    version_producer: v4.0
+    url_main: http://www.correlatesofwar.org/data-sets/bilateral-trade
+    date_accessed: '2018-01-15'
+    date_published: '2016'
   is_public: false
 outs:
   - md5: 05eaa415872f4c7b8a3ea7c32ed77571

--- a/snapshots/trade/2018-02-06/total_merchandise_trade_as_share_of_gdp__fouquin_and_hugot__cepii_2016__split.feather.dvc
+++ b/snapshots/trade/2018-02-06/total_merchandise_trade_as_share_of_gdp__fouquin_and_hugot__cepii_2016__split.feather.dvc
@@ -1,18 +1,17 @@
 meta:
-  source:
-    name: Fouquin and Hugot (CEPII 2016)
+  origin:
+    producer: Fouquin and Hugot
+    title: 'Two Centuries of Bilateral Trade and Gravity Data: 1827-2014'
     description: |-
       Fouquin and Hugot (CEPII 2016) have compiled aggregate country-year export trade data. A number of sources are consulted in compiling these figures; the top three sources are the IMF (2002 and 2015) (19,026 observations); Mitchell (2007a,b,c) (11,705 observations); and the World Bank (2015) (3,030 observations). For further information see Table 6, page 18 of Fouquin and Hugot (CEPII 2016)'s working paper at: http://www.cepii.fr/PDF_PUB/wp/2016/wp2016-14.pdf
 
       To calculate export trade as a share of GDP, aggregate country-year export data (in nominal British pounds) has been divided by Fouquin and Hugot (CEPII 2016) nominal GDP data, and multiplied by 100.
 
       Andorra has been dropped as it had very sparse coverage; 3 observations for the years 1993,1994,1996.
-    url: http://www.cepii.fr/cepii/en/bdd_modele/presentation.asp?id=32
-    date_accessed: 2018-02-06
-    published_by: |-
-      Michel Fouquin & Jules Hugot , 2016. "Two Centuries of Bilateral Trade and Gravity Data: 1827-2014," CEPII Working Paper 2016- 14 , May 2016 , CEPII
-  name: Total merchandise trade as share of GDP (Fouquin and Hugot (CEPII 2016)) (split)
-  description: ''
+    citation_full: 'Fouquin, M. and Hugot, J. (2016). Two Centuries of Bilateral Trade and Gravity Data: 1827-2014. CEPII Working Paper 2016-14, May 2016, CEPII.'
+    url_main: http://www.cepii.fr/cepii/en/bdd_modele/presentation.asp?id=32
+    date_accessed: '2018-02-06'
+    date_published: '2016'
   is_public: false
 outs:
   - md5: 1f056789847124a229fb1c4035c51469

--- a/snapshots/trade/2018-02-21/total_merchandise_trade_as_share_of_gdp__nber_united_nations_1962_2000__split.feather.dvc
+++ b/snapshots/trade/2018-02-21/total_merchandise_trade_as_share_of_gdp__nber_united_nations_1962_2000__split.feather.dvc
@@ -1,8 +1,9 @@
 meta:
-  source:
-    name: NBER-United Nations Dataset 1962-2000
+  origin:
+    producer: Feenstra and Lipsey, CEPII, and Bank of England
+    title: Total merchandise trade as share of GDP
     description: |-
-      To calculate merchandise trade as a share of GDP, the NBER-UN data series uses Fouquin and Hugot (CEPII 2016)'s long run GDP series, converted from nominal British pounds to US$, using historical exchange rates sourced from the Bank of England (see 'A millennium of macroeconomic data' dataset, section VII). NBER-UN has national trade statistics of country exports to the world.
+      To calculate merchandise trade as a share of GDP, the NBER-UN data series uses Fouquin and Hugot (CEPII 2016)'s long run GDP series, converted from nominal British pounds to US$, using historical exchange rates sourced from the Bank of England (see "A millennium of macroeconomic data" dataset, section VII). NBER-UN has national trade statistics of country exports to the world.
 
       The total value of exports includes only trade in goods, classified according to the 4 digit Standard International Trade Classification, Revision 2. Authors give primacy to importers' reports whenever they are available, assumed to be more accurate.
 
@@ -13,12 +14,15 @@ meta:
       Russia: the former USSR and Russia.
       France: French Guinea, Guadeloupe, Saint Pierre and Miquelon, and France.
       Yemen: the Yemen Arab Republic, the Yemen People's Republic, and Yemen.
-    url: |-
-      NBER-UN trade data: http://cid.econ.ucdavis.edu/nberus.html BOE Exchange Rate: https://www.bankofengland.co.uk/statistics/research-datasets CEPII (2016) GDP data: http://www.cepii.fr/cepii/en/bdd_modele/presentation.asp?id=32
-    date_accessed: 2018-02-21
-    published_by: Robert Feenstra and Robert Lipsey, The Center for International Development, UC Davis
-  name: Total merchandise trade as share of GDP (NBER-United Nations 1962-2000) (split)
-  description: ''
+
+      Underlying sources:
+      - NBER-UN trade data: http://cid.econ.ucdavis.edu/nberus.html
+      - Bank of England exchange rates: https://www.bankofengland.co.uk/statistics/research-datasets
+      - CEPII (2016) GDP data: http://www.cepii.fr/cepii/en/bdd_modele/presentation.asp?id=32
+    citation_full: 'Feenstra, R. and Lipsey, R. (2018). Total merchandise trade as share of GDP (NBER-United Nations 1962-2000). The Center for International Development, UC Davis.'
+    url_main: http://cid.econ.ucdavis.edu/nberus.html
+    date_accessed: '2018-02-21'
+    date_published: '2018-02-21'
   is_public: false
 outs:
   - md5: 18f330a53bd2b7ce1995c41105eb4f8d

--- a/snapshots/trade/2018-03-02/total_merchandise_trade_as_a_share_of_gdp__oecd__2016__split.feather.dvc
+++ b/snapshots/trade/2018-03-02/total_merchandise_trade_as_a_share_of_gdp__oecd__2016__split.feather.dvc
@@ -1,15 +1,16 @@
 meta:
-  source:
-    name: OECD, Balanced International Merchandise Trade Statistics (2015)
+  origin:
+    producer: Organisation for Economic Co-operation and Development
+    title: Balanced International Merchandise Trade Statistics
     description: |-
-      The Balanced International Merchandise Trade Statistics (BIMTS) database follows a four step procedure in order to reconcile bilateral trade asymmetries, i.e. so that exports from country A to country B are consistent with the imports of country B from country A. For more information on the OECD’s balancing methodology see the link provided above.
+      The Balanced International Merchandise Trade Statistics (BIMTS) database follows a four step procedure in order to reconcile bilateral trade asymmetries, i.e. so that exports from country A to country B are consistent with the imports of country B from country A. For more information on the OECD's balancing methodology see the link provided above.
 
-      To calculate the total value of exports to the world, we sum the value of all products exported, by country, to all of its trading partners. Then to express total exports as a share of GDP, the total value of exports is divided by the exporting country’s GDP. GDP data is taken from the World Bank’s WDI available at: https://data.worldbank.org/indicator/NY.GDP.MKTP.CD
-    url: https://stats.oecd.org/Index.aspx?DataSetCode=BIMTS_CPA#
-    date_accessed: 2018-03-02
-    published_by: OECD
-  name: Total merchandise trade as a share of GDP (OECD (2016)) (split)
-  description: ''
+      To calculate the total value of exports to the world, we sum the value of all products exported, by country, to all of its trading partners. Then to express total exports as a share of GDP, the total value of exports is divided by the exporting country's GDP. GDP data is taken from the World Bank's WDI available at: https://data.worldbank.org/indicator/NY.GDP.MKTP.CD
+    citation_full: OECD (2015). Balanced International Merchandise Trade Statistics (BIMTS).
+    attribution_short: OECD
+    url_main: https://stats.oecd.org/Index.aspx?DataSetCode=BIMTS_CPA#
+    date_accessed: '2018-03-02'
+    date_published: '2015'
   is_public: false
 outs:
   - md5: dea6445cc5ed6bde291419e756371080

--- a/snapshots/trade/2018-03-05/total_goods_trade_as_a_share_of_gdp__eurostat__2016__split.feather.dvc
+++ b/snapshots/trade/2018-03-05/total_goods_trade_as_a_share_of_gdp__eurostat__2016__split.feather.dvc
@@ -1,15 +1,16 @@
 meta:
-  source:
-    name: Eurostat (2016)
-    description: |-
+  origin:
+    producer: Eurostat
+    title: International trade in goods
+    title_snapshot: International trade in goods - Total goods trade as a share of GDP (split)
+    description_snapshot: |-
       Eurostat data reports goods exports in millions of euros to the rest of the world. To calculate the total value of goods exports to the world, we convert the total value of exports into USD using the average yearly USD/euro exchange rate produced by the European Central Bank available at: http://sdw.ecb.europa.eu/browseSelection.do?removeItem=&mergeFilter=&ec=&rc=&EXR_SUFFIX.18=A&oc=&df=true&DATASET=0&dc=&CURRENCY.18=USD&node=9691296&showHide=&pb=&removedItemList=&activeTab=&FREQ.18=A&legendRef=reference
 
       Then, the total export value in US$ is divided by the country's GDP to give total exports as a share of GDP. The World Bank's GDP data series (in current US$) is used.
-    url: http://ec.europa.eu/eurostat/web/international-trade-in-goods/data/database
-    date_accessed: 2018-03-05
-    published_by: Eurostat Comext
-  name: Total goods trade as a share of GDP (Eurostat (2016)) (split)
-  description: ''
+    citation_full: Eurostat Comext (2016). International trade in goods. Eurostat.
+    url_main: http://ec.europa.eu/eurostat/web/international-trade-in-goods/data/database
+    date_accessed: '2018-03-05'
+    date_published: '2016'
   is_public: false
 outs:
   - md5: ff29264d082f77844a4b989866dce38e

--- a/snapshots/trade/2018-03-14/total_merchandise_trade_as_share_of_gdp__dots__2017__split.feather.dvc
+++ b/snapshots/trade/2018-03-14/total_merchandise_trade_as_share_of_gdp__dots__2017__split.feather.dvc
@@ -1,16 +1,19 @@
 meta:
-  source:
-    name: IMF Direction of Trade Statistics (DOTS) (2017)
-    description: |-
+  origin:
+    producer: International Monetary Fund
+    title: Direction of Trade Statistics
+    title_snapshot: Direction of Trade Statistics - Total merchandise trade as share of GDP
+    description_snapshot: |-
       To calculate total merchandise exports as a share of GDP, the DOTS value of merchandise exports was divided by country GDP (in current US$), with the ratio multiplied by 100. GDP data was taken from the World Bank's WDI available at: https://data.worldbank.org/indicator/NY.GDP.MKTP.CD
 
       Russia's time series is made up of Russia and the USSR.
+
       Yemen's time series is made up of Yemen, the Yemen Arab Republic, and the Yemen People's Republic.
-    url: http://data.imf.org/?sk=9D6028D4-F14A-464C-A2F2-59B2CD424B85&sId=1390030341854
-    date_accessed: 2018-03-14
-    published_by: IMF
-  name: Total merchandise trade as share of GDP (DOTS (2017)) (split)
-  description: ''
+    citation_full: International Monetary Fund (2017). Direction of Trade Statistics (DOTS).
+    attribution_short: IMF
+    url_main: http://data.imf.org/?sk=9D6028D4-F14A-464C-A2F2-59B2CD424B85&sId=1390030341854
+    date_accessed: '2018-03-14'
+    date_published: '2017'
   is_public: false
 outs:
   - md5: 594f41766bb6f9f3c4d4af467bed3aef

--- a/snapshots/trade/2018-07-20/world_trade__upper_bound__pct_of_gdp__estevadeordal__frantz__and_taylor__2003__split.feather.dvc
+++ b/snapshots/trade/2018-07-20/world_trade__upper_bound__pct_of_gdp__estevadeordal__frantz__and_taylor__2003__split.feather.dvc
@@ -1,14 +1,13 @@
 meta:
-  source:
-    name: Estevadeordal, Frantz, and Taylor (2003)
+  origin:
+    producer: Estevadeordal et al.
+    title: The rise and fall of world trade, 1870-1939
     description: |-
-      Notes on the calculation of the lower and upper bound estimates from the authors: "1500–1800: Trade growth rates from O’Rourke and Williamson [2002, Table 1; volume estimates only]. Level index derived, and scaled by world GDP levels from Maddison [2001, Table B-18]. The “upper bound” series is then scaled to the benchmark 8 percent European trade-GDP ratio for 1780 due to O’Brien [1982], probably an overstatement of the world trade-GDP ratio. The “lower bound” series is scaled to the benchmark 2 percent world trade-GDP ratio for 1820 due to Maddison [1995, Table 2-4], possibly biased downwards relative to the long-run trend because of the blockades during the Napoleonic Wars."
-    url: https://www.jstor.org/stable/25053910?seq=1#page_scan_tab_contents
-    date_accessed: 2018-07-20
-    published_by: |-
-      Estevadeordal, A., Frantz, B., & Taylor, A. (2003). The Rise and Fall of World Trade, 1870-1939. The Quarterly Journal of Economics, 118(2), 359-407. Retrieved from http://www.jstor.org/stable/25053910
-  name: World trade - upper bound (% of GDP) (Estevadeordal, Frantz, and Taylor (2003)) (split)
-  description: ''
+      Notes on the calculation of the lower and upper bound estimates from the authors: "1500–1800: Trade growth rates from O'Rourke and Williamson [2002, Table 1; volume estimates only]. Level index derived, and scaled by world GDP levels from Maddison [2001, Table B-18]. The "upper bound" series is then scaled to the benchmark 8 percent European trade-GDP ratio for 1780 due to O'Brien [1982], probably an overstatement of the world trade-GDP ratio. The "lower bound" series is scaled to the benchmark 2 percent world trade-GDP ratio for 1820 due to Maddison [1995, Table 2-4], possibly biased downwards relative to the long-run trend because of the blockades during the Napoleonic Wars."
+    citation_full: 'Estevadeordal, A., Frantz, B., and Taylor, A. (2003). The Rise and Fall of World Trade, 1870-1939. The Quarterly Journal of Economics, 118(2), 359-407.'
+    url_main: https://www.jstor.org/stable/25053910?seq=1#page_scan_tab_contents
+    date_accessed: '2018-07-20'
+    date_published: '2003'
   is_public: false
 outs:
   - md5: dc71723ae6115551134cd48898422eb5

--- a/snapshots/usda_nass/2021-01-01/long_term_corn_production_and_yield_in_the_us__us_census_bureau__usda.feather.dvc
+++ b/snapshots/usda_nass/2021-01-01/long_term_corn_production_and_yield_in_the_us__us_census_bureau__usda.feather.dvc
@@ -1,20 +1,20 @@
 meta:
-  source:
-    name: Calculated by Our World in Data based on US Census Bureau and USDA
+  origin:
+    producer: USDA and US Census Bureau
+    title: Long-term corn production and yield in the US
     description: |-
       This dataset was built by Our World in Data based on two sources.
 
-      Corn production data was sources from the United States Department for Agriculture (USDA), available at: https://quickstats.nass.usda.gov/
+      Corn production data was sourced from the United States Department of Agriculture (USDA), available at: https://quickstats.nass.usda.gov/
 
       Corn land use data from 1926 onwards was also sourced from the USDA (https://quickstats.nass.usda.gov/). Corn land use data pre-1926 was sourced from the US Census Bureau, available at: https://www2.census.gov/prod2/statcomp/documents/HistoricalStatisticsoftheUnitedStates1789-1945.pdf
 
       Production data was converted from bushels to tonnes using a conversion factor of 0.025.
       Land use data was converted from acres to hectares using a conversion factor of 0.45.
-    url: https://quickstats.nass.usda.gov/
+    citation_full: United States Department of Agriculture (USDA) and US Census Bureau (2021). Long-term corn production and yield in the US.
+    url_main: https://quickstats.nass.usda.gov/
     date_accessed: '2021-01-01'
-    published_by: United States Department for Agriculture (USDA); and US Census Bureau
-  name: Long-term corn production and yield in the US (US Census Bureau; USDA)
-  description: ''
+    date_published: '2021-01-01'
   is_public: false
 outs:
   - md5: 36949a00bac07c5a9f2bc4aad9a7d3cb

--- a/snapshots/who/2025-08-01/guinea_worm.csv.dvc
+++ b/snapshots/who/2025-08-01/guinea_worm.csv.dvc
@@ -1,16 +1,15 @@
 meta:
-  source:
-    name: World Health Organization (2018)
-    description: ""
-    url: https://web.archive.org/web/20211024081702/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_t0.html
-    date_accessed: 2025-08-01
-    publication_year: 2018
-    published_by: "Certification status of dracunculiasis eradication: World Health Organization; 2018. Licence: CC BY-NC-SA 3.0 IGO"
-  name: Certification status of dracunculiasis eradication (WHO, 2018)
-  description: ""
-  license:
-    name: CC BY-NC-SA 3.0 IGO
-    url: https://www.who.int/about/policies/publishing/copyright
+  origin:
+    producer: World Health Organization
+    title: 'Certification status of dracunculiasis eradication'
+    citation_full: 'Certification status of dracunculiasis eradication. World Health Organization; 2018. Licence: CC BY-NC-SA 3.0 IGO.'
+    attribution_short: WHO
+    url_main: https://web.archive.org/web/20211024081702/https://apps.who.int/dracunculiasis/dradata/html/report_Countries_t0.html
+    date_accessed: '2025-08-01'
+    date_published: '2018'
+    license:
+      name: CC BY-NC-SA 3.0 IGO
+      url: https://www.who.int/about/policies/publishing/copyright
 outs:
   - md5: 00fe995cf57cead2f8f435f9bab29501
     size: 186834

--- a/snapshots/working_hours/2017-04-14/home_production_working_hours_per_week_in_the_us__by_demographic_group__ramey__2009__split.feather.dvc
+++ b/snapshots/working_hours/2017-04-14/home_production_working_hours_per_week_in_the_us__by_demographic_group__ramey__2009__split.feather.dvc
@@ -1,15 +1,15 @@
 meta:
-  source:
-    name: Ramey (2009)
+  origin:
+    producer: Ramey
+    title: 'Time spent in home production in the twentieth-century United States: new estimates from old data'
     description: |-
-      Ramey (2009), following M.T. Reid, Economics of Household Production (1934), defines 'Home Production' as "those unpaid activities which are carried on, by and for the members, which activities might be replaced by market goods, or paid services, if circumstances such as income, market conditions, and personal inclinations permit the service being delegated to someone outside the household group".
+      Ramey (2009), following M.T. Reid, Economics of Household Production (1934), defines "Home Production" as "those unpaid activities which are carried on, by and for the members, which activities might be replaced by market goods, or paid services, if circumstances such as income, market conditions, and personal inclinations permit the service being delegated to someone outside the household group".
+
       For more details on how these data are constructed see Ramey (2009), pp.3-4, and Appendix A.
-    url: http://econweb.ucsd.edu/~vramey/research/Home_Production_published.pdf
-    date_accessed: 2017-04-14
-    published_by: |-
-      Ramey, Valerie R. Time Spent in Home Production in the Twentieth-Century United States: New Estimates from Old Data. The Journal of Economic History, 2009.
-  name: Home production working hours per week in the US, by demographic group (Ramey (2009)) (split)
-  description: ''
+    citation_full: 'Ramey, V. R. (2009). Time spent in home production in the twentieth-century United States: new estimates from old data. The Journal of Economic History, 69(1).'
+    url_main: http://econweb.ucsd.edu/~vramey/research/Home_Production_published.pdf
+    date_accessed: '2017-04-14'
+    date_published: '2009'
   is_public: false
 outs:
   - md5: ce39891550a5fcbf26e4d0bfefbca328

--- a/snapshots/working_hours/2017-09-19/female_to_male_ratio_of_time_devoted_to_unpaid_care_work__oecd__2014__split.feather.dvc
+++ b/snapshots/working_hours/2017-09-19/female_to_male_ratio_of_time_devoted_to_unpaid_care_work__oecd__2014__split.feather.dvc
@@ -1,9 +1,9 @@
 meta:
-  source:
-    name: OECD Gender, Institutions and Development Database (2014)
-    description: |-
-      OECD Gender, Institutions and Development Database (2014)
-
+  origin:
+    producer: OECD
+    title: Gender, Institutions and Development Database
+    title_snapshot: Gender, Institutions and Development Database - Female to male ratio of time devoted to unpaid care work
+    description_snapshot: |-
       The source does not specify the actual measurement methodology.
 
       For most countries, estimates correspond to 15-64 year olds. Except: for Australia (15+ year olds), China and Hungary (15-74 year olds) and Sweden (25-64 year olds).
@@ -15,11 +15,10 @@ meta:
       Different sources use different reference years, as well as different definitions of unpaid care work. Because of this cross-country comparisons should be made with caution.
 
       For the OECD, you can find details regarding all activities included, and the corresponding survey years for each country, here: http://www.oecd.org/gender/data/balancingpaidworkunpaidworkandleisure.htm.
-    url: https://stats.oecd.org/Index.aspx?DataSetCode=GIDDB2014#
-    date_accessed: 2017-09-19
-    published_by: Gender, Institutions and Development Database 2014
-  name: Female to male ratio of time devoted to unpaid care work (OECD (2014)) (split)
-  description: Average number of hours spent on paid and unpaid domestic work by sex.
+    citation_full: 'OECD (2014). Gender, Institutions and Development Database 2014.'
+    url_main: https://stats.oecd.org/Index.aspx?DataSetCode=GIDDB2014#
+    date_accessed: '2017-09-19'
+    date_published: '2014'
   is_public: false
 outs:
   - md5: 090a8984fe4bb199c4ed2642ac6d29e5

--- a/snapshots/working_hours/2018-06-28/new_estimates_of_hours_of_work_per_week__1900_1957__jones__1963.feather.dvc
+++ b/snapshots/working_hours/2018-06-28/new_estimates_of_hours_of_work_per_week__1900_1957__jones__1963.feather.dvc
@@ -1,12 +1,11 @@
 meta:
-  source:
-    name: Jones (1963)
-    url: https://www.jstor.org/stable/1927922
-    date_accessed: 2018-06-28
-    published_by: |-
-      Jones, E.B., 1963. New estimates of hours of work per week and hourly earnings, 1900-1957. The Review of Economics and Statistics, pp.374-385.
-  name: New estimates of hours of work per week, 1900-1957 - Jones (1963)
-  description: ''
+  origin:
+    producer: Jones
+    title: New estimates of hours of work per week and hourly earnings, 1900-1957
+    citation_full: 'Jones, E.B., 1963. New estimates of hours of work per week and hourly earnings, 1900-1957. The Review of Economics and Statistics, pp.374-385.'
+    url_main: https://www.jstor.org/stable/1927922
+    date_accessed: '2018-06-28'
+    date_published: '1963'
   is_public: false
 outs:
   - md5: f4394d3f759af11b9bd6b03bc6b143b0

--- a/snapshots/working_hours/2018-06-28/time_spent__participation_time__and_participation_rates__eurostat.feather.dvc
+++ b/snapshots/working_hours/2018-06-28/time_spent__participation_time__and_participation_rates__eurostat.feather.dvc
@@ -1,17 +1,18 @@
 meta:
-  source:
-    name: Eurostat
-    description: |-
+  origin:
+    producer: Eurostat
+    title: Harmonised European time use surveys
+    title_snapshot: Harmonised European time use surveys - Time spent, participation time, and participation rates
+    description_snapshot: |-
       This Eurostat data set measures the time spent, participation time, and participation rate in 55 activities.
 
       For the purposes of illustrating how time use has changed over time, we have aggregated the 55 activities under six main headings provided in the original Eurostat source. The six headings are (1) Personal care; (2) Employment, related activities, and travel; (3) Study; (4) Household and family care; (5) Leisure, social, and associative life; and (6) Travel and unspecified time use. The data has been normalised to 1440 minutes per day.
 
-      The survey population includes private participants only - individuals living in institutions (nursing homes, homes for the elderly, children’s homes, rehabilitation centres and penitentiary) are excluded. For further information on the time use surveys see: http://ec.europa.eu/eurostat/cache/metadata/en/tus_esms.htm
-    url: 'http://ec.europa.eu/eurostat/data/database?node_code=tus_00npaywork# Dataset: tus_00age'
-    date_accessed: 2018-06-28
-    published_by: Eurostat
-  name: Time spent, participation time, and participation rates - Eurostat
-  description: ''
+      The survey population includes private participants only - individuals living in institutions (nursing homes, homes for the elderly, children's homes, rehabilitation centres and penitentiary) are excluded. For further information on the time use surveys see: http://ec.europa.eu/eurostat/cache/metadata/en/tus_esms.htm
+    citation_full: 'Eurostat (2018). Harmonised European time use surveys: Time spent, participation time, and participation rates (datasets tus_00npaywork and tus_00age).'
+    url_main: 'http://ec.europa.eu/eurostat/data/database?node_code=tus_00npaywork# Dataset: tus_00age'
+    date_accessed: '2018-06-28'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 78ee349900075078e02858e34408efee

--- a/snapshots/working_hours/2018-08-13/length_of_the_workday_in_1880__atack_and_bateman__1992.feather.dvc
+++ b/snapshots/working_hours/2018-08-13/length_of_the_workday_in_1880__atack_and_bateman__1992.feather.dvc
@@ -1,17 +1,15 @@
 meta:
-  source:
-    name: Atack and Bateman (1992)
+  origin:
+    producer: Atack and Bateman
+    title: 'How long was the workday in 1880?'
     description: |-
       See Table 3 and Table 4 for original data.
 
       Estimates of seasonality are derived from the six winter months (November to May) and the six summer months (May to November).
-    url: |-
-      https://www.cambridge.org/core/services/aop-cambridge-core/content/view/15F272CAB8BD86EDF27D3347284DD60A/S0022050700010299a.pdf/how_long_was_the_workday_in_1880.pdf
-    date_accessed: 2018-08-13
-    published_by: |-
-      Atack, J. and Bateman, F., (1992). How Long was the Workday in 1880?. The Journal of Economic History, 52(1), pp.129-160.
-  name: Length of the workday in 1880 - Atack and Bateman (1992)
-  description: ''
+    citation_full: 'Atack, J. and Bateman, F. (1992). How long was the workday in 1880? The Journal of Economic History, 52(1), pp. 129–160.'
+    url_main: https://www.cambridge.org/core/services/aop-cambridge-core/content/view/15F272CAB8BD86EDF27D3347284DD60A/S0022050700010299a.pdf/how_long_was_the_workday_in_1880.pdf
+    date_accessed: '2018-08-13'
+    date_published: '1992'
   is_public: false
 outs:
   - md5: f859d20559c99fe89493a54d030a4302

--- a/snapshots/working_hours/2018-08-14/length_of_the_work_day__from_1890s_to_1991__costa__2000.feather.dvc
+++ b/snapshots/working_hours/2018-08-14/length_of_the_work_day__from_1890s_to_1991__costa__2000.feather.dvc
@@ -1,16 +1,15 @@
 meta:
-  source:
-    name: Costa (2000)
+  origin:
+    producer: Costa
+    title: 'The wage and the length of the work day: from the 1890s to 1991'
     description: |-
       See Table 5 and 6 for original data.
 
       *The surveys that are used are from California in 1892; Kansas in 1895, 1896, 1897, and 1899; Main in 1890; Michigan stoneworkers in 1888; Michigan railway workers in 1893; Wisconsin in 1895; and women in Indianapolis in 1893
-    url: https://www.jstor.org/stable/pdf/10.1086/209954.pdf?refreqid=excelsior%3A8920c4a4b77c89fea2c1e2839f1471d2
-    date_accessed: 2018-08-14
-    published_by: |-
-      Costa, D. (2000). The Wage and the Length of the Work Day: From the 1890s to 1991. Journal of Labor Economics, 18(1), 156-181. doi:10.1086/209954
-  name: 'Length of the work day: from 1890s to 1991 - Costa (2000)'
-  description: ''
+    citation_full: 'Costa, D. (2000). The Wage and the Length of the Work Day: From the 1890s to 1991. Journal of Labor Economics, 18(1), 156-181. doi:10.1086/209954.'
+    url_main: https://www.jstor.org/stable/pdf/10.1086/209954.pdf?refreqid=excelsior%3A8920c4a4b77c89fea2c1e2839f1471d2
+    date_accessed: '2018-08-14'
+    date_published: '2000'
   is_public: false
 outs:
   - md5: b926d62508a8262f6553dd2ebaa52e31

--- a/snapshots/working_hours/2020-09-14/working_hours__bick_et_al__2019.feather.dvc
+++ b/snapshots/working_hours/2020-09-14/working_hours__bick_et_al__2019.feather.dvc
@@ -1,12 +1,11 @@
 meta:
-  source:
-    name: Bick et al (2019)
-    url: https://onlinelibrary.wiley.com/doi/abs/10.1111/sjoe.12344
-    date_accessed: 2020-09-14
-    published_by: |-
-      Bick, Brüggemann, & Fuchs-Schündeln (2019), "Hours Worked in Europe and the United States: New Data, New Answers." Scandinavian Journal of Economics, 121(4), 1381–1416.
-  name: Working Hours – Bick et al (2019)
-  description: ''
+  origin:
+    producer: Bick et al.
+    title: 'Hours worked in Europe and the United States: New data, new answers'
+    citation_full: 'Bick, A., Brüggemann, B., and Fuchs-Schündeln, N. (2019). Hours worked in Europe and the United States: New data, new answers. Scandinavian Journal of Economics, 121(4), 1381–1416.'
+    url_main: https://onlinelibrary.wiley.com/doi/abs/10.1111/sjoe.12344
+    date_accessed: '2020-09-14'
+    date_published: '2019'
   is_public: false
 outs:
   - md5: d6a1e4252d8f24d7d248a3ec0574e20b

--- a/snapshots/working_hours/2020-09-16/working_hours__oecd__2020.feather.dvc
+++ b/snapshots/working_hours/2020-09-16/working_hours__oecd__2020.feather.dvc
@@ -1,11 +1,12 @@
 meta:
-  source:
-    name: Organisation for Economic Co-operation and Development, Labour Force Statistics (2020)
-    url: https://stats.oecd.org/Index.aspx?DataSetCode=ANHRS#
-    date_accessed: 2020-09-16
-    published_by: Organisation for Economic Co-operation and Development (2020)
-  name: Working Hours – OECD (2020)
-  description: ''
+  origin:
+    producer: OECD
+    title: Labour Force Statistics
+    title_snapshot: Labour Force Statistics - Average annual hours actually worked per worker
+    citation_full: OECD (2020). Labour Force Statistics - Average annual hours actually worked per worker.
+    url_main: https://stats.oecd.org/Index.aspx?DataSetCode=ANHRS#
+    date_accessed: '2020-09-16'
+    date_published: '2020'
   is_public: false
 outs:
   - md5: dd5f9d1843e5f9c39ea1ee2557a95bed

--- a/snapshots/working_hours/2020-10-13/working_hours__boe__2016.feather.dvc
+++ b/snapshots/working_hours/2020-10-13/working_hours__boe__2016.feather.dvc
@@ -1,13 +1,14 @@
 meta:
-  source:
-    name: Bank of England, A Millennium of Macroeconomic Data (2016)
-    description: |-
-      The data series joins together numerous sources and is considered tentative by its authors, especially before 1770. For a detailed list of underlying sources, assumptions, and adjustments, see the worksheet titled “A54. Hours worked 1260-2016,” available from the Bank of England's “A Millennium of Macroeconomic Data.”
-    url: https://www.bankofengland.co.uk/statistics/research-datasets
-    date_accessed: 2020-10-13
-    published_by: Bank of England
-  name: Working Hours – BoE (2016)
-  description: ''
+  origin:
+    producer: Bank of England
+    title: A millennium of macroeconomic data
+    title_snapshot: A millennium of macroeconomic data - Hours worked
+    description_snapshot: |-
+      The data series joins together numerous sources and is considered tentative by its authors, especially before 1770. For a detailed list of underlying sources, assumptions, and adjustments, see the worksheet titled "A54. Hours worked 1260-2016," available from the Bank of England's "A Millennium of Macroeconomic Data."
+    citation_full: Bank of England (2016). A millennium of macroeconomic data.
+    url_main: https://www.bankofengland.co.uk/statistics/research-datasets
+    date_accessed: '2020-10-13'
+    date_published: '2016'
   is_public: false
 outs:
   - md5: 8040e167b07403ecacc8fb458e17997a

--- a/snapshots/working_hours/2020-11-12/working_hours_by_income__bick_et_al__2018.feather.dvc
+++ b/snapshots/working_hours/2020-11-12/working_hours_by_income__bick_et_al__2018.feather.dvc
@@ -1,6 +1,7 @@
 meta:
-  source:
-    name: Bick, Fuchs-Schündeln, and Lagakos (2018)
+  origin:
+    producer: Bick et al.
+    title: 'How do hours worked vary with income? Cross-country evidence and implications'
     description: |-
       Data comes from nationally representative household surveys that cover workers in all sectors, including the self-employed, which represent the majority of the workforce in low-income countries. Most of the data is from 2005 or within a few years of 2005.
 
@@ -10,14 +11,12 @@ meta:
       3. Hours worked cover the production of goods or services counted in the National Income and Product Accounts (NIPA). Thus, the working hours cover unpaid work in agricultural or nonagricultural businesses, as well as wage employment, but do not cover home-produced services, such as child care.
 
       Data not currently in the Grapher but available from the paper that might be of interest:
-      – Employment rates
-      – Average working hours by: sex, age group, educational attainment, sector (agriculture, manufacturing, services)
-    url: https://www.aeaweb.org/articles?id=10.1257/aer.20151720
-    date_accessed: 2020-11-12
-    published_by: |-
-      Bick, A., Fuchs-Schündeln, N., & Lagakos, D. (2018). How do hours worked vary with income? Cross-country evidence and implications. American Economic Review, 108(1), 170–199. https://doi.org/10.1257/aer.20151720
-  name: Working Hours by Income – Bick et al (2018)
-  description: ''
+      - Employment rates
+      - Average working hours by: sex, age group, educational attainment, sector (agriculture, manufacturing, services)
+    citation_full: 'Bick, A., Fuchs-Schündeln, N., & Lagakos, D. (2018). How do hours worked vary with income? Cross-country evidence and implications. American Economic Review, 108(1), 170–199. https://doi.org/10.1257/aer.20151720'
+    url_main: https://www.aeaweb.org/articles?id=10.1257/aer.20151720
+    date_accessed: '2020-11-12'
+    date_published: '2018'
   is_public: false
 outs:
   - md5: 6c4781b00a86d164c5d56daeb77d923f


### PR DESCRIPTION
## Summary

Migrate the legacy `meta.source:` block to modern `meta.origin:` for **all 110 unarchived snapshot DVC files** still using the legacy schema. Each file was migrated by an LLM subagent following the project's [`migrate-source-to-origin`](.claude/skills/migrate-source-to-origin/SKILL.md) skill, then validated against `SnapshotMeta.load_from_yaml`.

The migration is **restructure-not-rewrite**: every legacy fact survives into the new origin, just placed in the right field per OWID's documented Origin style.

## Scope

- **110 snapshot DVC files modified** (find them via `git diff --name-only origin/master`)
- **No downstream sweep** — only the snapshot `.dvc` files were touched. Downstream `meta.yml`, `.py` steps, and `dataset.sources:` blocks that duplicate this source info were intentionally left in place for a follow-up sweep.
- **Active DAG only** — these are the 110 snapshots referenced in `dag/*.yml`. Archived snapshots (referenced only from `dag/archive/`) were not touched.

## Per-file decisions

For each file, the subagent ran:

1. **STEP 1 (coincidence test)** — does the snapshot coincide with the producer's data product (default), or is it a producer-defined slice (rare)? This decides whether `title_snapshot` / `description_snapshot` are set.
2. **STEP 2 (field rules)** — fill `producer`, `title`, `citation_full`, `date_published`, `date_accessed`, `url_main`, `attribution_short`, `version_producer`, `license` per OWID style.
3. **Self-check** against lint rules (no `&`/`;`/year in `producer`, no trailing period in `title`, `attribution_short` ≠ `producer`, etc.).
4. **Validate** via `SnapshotMeta.load_from_yaml` — all 110 files parse cleanly.

## Common patterns

- The legacy `meta.name` is OWID's internal label — it was discarded when it embedded the producer name, year, or `(et al.)` suffix; the producer-issued title from `published_by` was used instead.
- Single journal papers → STEP 1 says they coincide → no `title_snapshot`.
- Multi-product producer databases (e.g. WDPA, GID-DB, BoE Millennium, BIMTS, DOTS, OECD Gender Data, GGDC, Eurostat Comext) → STEP 1 says they differ → `title_snapshot` is set, slice-specific prose lives in `description_snapshot`.
- OWID compilations of multiple raw sources → producers enumerated when ≤3 are named, else `Various sources`; legacy "Our World in Data based on …" prefix stripped from `producer` and preserved in `citation_full`.
- HTML in legacy descriptions (`<a href>`, `<ul>`, `<br>`) converted to Markdown — grapher renders origin descriptions through a markdown-only path.
- `is_public: false` is a `SnapshotMeta` sibling field and was preserved verbatim alongside `meta.origin`.

## Out of scope (deliberately deferred)

- **Downstream `meta.yml` sweep** — many of these snapshots have garden/grapher steps with `dataset.sources:`, `all_sources:`, or variable-level `descriptions:` blocks that duplicate the snapshot's source info. Migrating those is a separate per-chain task (workflow step 9 in the skill).
- **Variable-level `description:` → `description_short:` rename** — out of scope for the snapshot migration.

## Test plan

- [x] All 110 files parse cleanly with `SnapshotMeta.load_from_yaml`
- [x] No residual `meta:\n  source:` blocks in the modified files
- [x] All modified files contain a `meta.origin:` block
- [ ] Spot-check a few representative migrations against the legacy diff (single paper, OWID compilation, producer-defined slice)