### PR TITLE
📊 Migrate wgm_mental_health to origins

### DIFF
--- a/etl/steps/data/garden/health/2023-04-18/wgm_mental_health.py
+++ b/etl/steps/data/garden/health/2023-04-18/wgm_mental_health.py
@@ -1,9 +1,7 @@
 """Load a meadow dataset and create a garden dataset."""
 
-from typing import cast
-
-import pandas as pd
-from owid.catalog import Dataset, Table
+from owid.catalog import Table
+from owid.catalog import processing as pr
 from shared import (
     MAPPING_AGE_VALUES,
     MAPPING_COLUMN_NAMES,
@@ -13,318 +11,219 @@ from shared import (
 from structlog import get_logger
 
 from etl.data_helpers import geo
-from etl.helpers import PathFinder, create_dataset
+from etl.helpers import PathFinder
 
 log = get_logger()
 
-# Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 # Minimum number of participants answering a question. Questions for demographic groups with fewer answers are filtered out.
 # This mostly affects very granular breakdowns (e.g. by age and gender)
 THRESHOLD_ANSWERS = 100
 
 
-def run(dest_dir: str) -> None:
-    log.info("wgm_mental_health: start")
+def run() -> None:
+    ds_meadow = paths.load_dataset("wgm_mental_health")
+    tb = ds_meadow.read("wgm_mental_health")
 
-    #
-    # Load inputs.
-    #
-    # Load meadow dataset.
-    ds_meadow = cast(Dataset, paths.load_dependency("wgm_mental_health"))
+    # Keep relevant columns, unpivot, harmonize country names.
+    tb = clean_table(tb)
+    # Remove empty answers.
+    tb = tb[tb["answer"] != " "]
+    # Build table with shares of answers to each question across geographies and demographics.
+    tb = make_share_answers(tb)
+    # Map IDs to labels (question, age and gender groups, answers).
+    tb = map_ids_to_labels(tb)
+    # Filter out questions with low participation.
+    tb = filter_rows_with_low_participation(tb)
+    # Set the final dimension index.
+    tb = final_formatting(tb)
 
-    # Read table from meadow dataset.
-    tb_meadow = ds_meadow["wgm_mental_health"]
-
-    # Create a dataframe with data from the table.
-    df = pd.DataFrame(tb_meadow)
-
-    #
-    # Process data.
-    #
-    # Keep relevant columns, unpivot dataframe, harmonize country names.
-    df = clean_df(df)
-    # Remove empty answers
-    df = df[df["answer"] != " "]
-    # Build dataframe with shares of answers to each questions.
-    df = make_df_with_share_answers(df)
-    # Map IDs to labels (question, age and gender groups, answers)
-    df = map_ids_to_labels(df)
-    # Filter out questions with low participation
-    df = filter_rows_with_low_participation(df)
-    # Format dataframe with appropriate columns, indexes
-    df = final_formatting(df)
-    # Create a new table based on the dataframe `df`
-    tb_garden = Table(df, short_name=paths.short_name, underscore=True)
-
-    #
-    # Save outputs.
-    #
-    # Create a new garden dataset with the same metadata as the meadow dataset.
-    ds_garden = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_meadow.metadata)
-
-    # Add explanation to dataset description
-    ds_garden.metadata.sources[0].description += (
-        "\n\nNote 1: Data for answers where the demographic group had less than 100 participants are filtered out."
-        "\n\nNote 2: Empty answers have been filtered out. Empty answers may appear because the question was not applicable to the respondent or the respondent did not answer the question."
-    )
-
-    # Save changes in the new garden dataset.
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
     ds_garden.save()
 
-    log.info("wgm_mental_health: end")
 
-
-def clean_df(df: pd.DataFrame) -> pd.DataFrame:
-    """Keep relevant columns, unpivot dataframe, harmonise country names."""
-    log.info("wgm_mental_health: cleaning dataframe")
-    # Relevant columns
+def clean_table(tb: Table) -> Table:
+    """Keep relevant columns, unpivot, harmonize country names."""
     columns_rel = list(MAPPING_COLUMN_NAMES.keys()) + list(MAPPING_QUESTION_VALUES.keys())
-    df = df[columns_rel]
-    # Rename columns
-    df = df.rename(columns=MAPPING_COLUMN_NAMES)
-    # Unpivot
-    log.info("wgm_mental_health: unpivotting dataframe")
-    df = df.melt(
+    tb = tb[columns_rel]
+    tb = tb.rename(columns=MAPPING_COLUMN_NAMES)
+
+    tb = tb.melt(
         id_vars=list(MAPPING_COLUMN_NAMES.values()),
         value_vars=list(MAPPING_QUESTION_VALUES.keys()),
         var_name="question",
         value_name="answer",
     )
-    # Set dtypes of all question columns to strings
-    df = df.astype({"question": str, "answer": str})
-    # Harmonise country names
-    log.info("wgm_mental_health: harmonize_countries")
-    df = geo.harmonize_countries(df=df, countries_file=paths.country_mapping_path)
-    return df
+    tb = tb.astype({"question": str, "answer": str})
+    tb = paths.regions.harmonize_names(tb=tb, country_col="country", countries_file=paths.country_mapping_path)
+    return tb
 
 
-def make_df_with_share_answers(df: pd.DataFrame) -> pd.DataFrame:
-    """Build dataframe with shares of answers to each questions.
+def make_share_answers(tb: Table) -> Table:
+    """Build a table with shares of answers, computed for countries, World, continents and income groups."""
+    tb_countries = _share_answers_for_geographies(tb)
 
-    Obtains values for all countries, continents and income groups. Also for various demographic groups (age, gender)
-    """
-    # Obtain dataframe for countries
-    log.info("wgm_mental_health: building dataframe for countries")
-    df_countries = _make_df_with_share_answers(df)
-    # Obtain dataframe for World
-    log.info("wgm_mental_health: building dataframe for World")
-    df_world = df.assign(country="World")
-    df_world = _make_df_with_share_answers(df_world, "weight_inter_country")
-    # Obtain dataframe for continents
-    log.info("wgm_mental_health: building dataframe for continents")
-    df_continents = _build_df_with_continents(df)
-    df_continents = _make_df_with_share_answers(df_continents, "weight_inter_country")
-    # Obtain dataframe for income groups
-    log.info("wgm_mental_health: building dataframe for income groups")
-    df_incomes = _build_df_with_incomes(df)
-    df_incomes = _make_df_with_share_answers(df_incomes, "weight_inter_country")
-    # Merge
-    df = pd.concat([df_countries, df_world, df_continents, df_incomes], ignore_index=True)
-    return df
+    tb_world = tb.assign(country="World")
+    tb_world = _share_answers_for_geographies(tb_world, "weight_inter_country")
+
+    tb_continents = _reassign_to_continents(tb)
+    tb_continents = _share_answers_for_geographies(tb_continents, "weight_inter_country")
+
+    tb_incomes = _reassign_to_incomes(tb)
+    tb_incomes = _share_answers_for_geographies(tb_incomes, "weight_inter_country")
+
+    return pr.concat([tb_countries, tb_world, tb_continents, tb_incomes], ignore_index=True)
 
 
-def _build_df_with_continents(df: pd.DataFrame) -> pd.DataFrame:
-    # Obtain dataframe for continents
-    df_continents = df.copy()
+def _reassign_to_continents(tb: Table) -> Table:
+    tb = tb.copy()
     continents = ["Africa", "Asia", "Europe", "North America", "Oceania", "South America"]
-    df_continents["country"] = df_continents["country"].cat.add_categories(continents)
     for continent in continents:
         countries = geo.list_countries_in_region(continent)
-        msk = df_continents["country"].isin(countries)
-        df_continents.loc[msk, "country"] = continent
+        mask = tb["country"].isin(countries)
+        tb.loc[mask, "country"] = continent
 
-    # Sanity check
-    unc_countries = set(df_continents.country).difference(continents)
+    unc_countries = set(tb["country"]).difference(continents)
     assert not unc_countries, f"Some countries do not belong to any continent: {unc_countries}!"
-    return df_continents
+    return tb
 
 
-def _build_df_with_incomes(df: pd.DataFrame) -> pd.DataFrame:
-    # Obtain dataframe for income groups
-    df_income = df.copy()
+def _reassign_to_incomes(tb: Table) -> Table:
+    tb = tb.copy()
     incomes = [
         "High-income countries",
         "Upper-middle-income countries",
         "Lower-middle-income countries",
         "Low-income countries",
     ]
-    df_income["country"] = df_income["country"].cat.add_categories(incomes)
     for income in incomes:
         countries = geo.list_countries_in_region(income)
-        msk = df_income["country"].isin(countries)
-        df_income.loc[msk, "country"] = income
+        mask = tb["country"].isin(countries)
+        tb.loc[mask, "country"] = income
 
-    # Sanity check
-    unc_countries_expected = {"Venezuela"}  # WB unclassified Venezuela in 2021, bc of lacking data
-    unc_countries = set(df_income.country).difference(incomes)
+    # WB left Venezuela unclassified in 2021 due to lacking data.
+    unc_countries_expected = {"Venezuela"}
+    unc_countries = set(tb["country"]).difference(incomes)
     assert unc_countries == unc_countries_expected, (
         f"Only Venezuela is expected to be unclassified, but found {unc_countries} to be unclassified!"
     )
-    # Remove Venezuela
-    df_income = df_income[~df_income["country"].isin(unc_countries_expected)]
-    return df_income
+    tb = tb[~tb["country"].isin(unc_countries_expected)]
+    return tb
 
 
-def _make_df_with_share_answers(df: pd.DataFrame, weight_column: str = "weight_intra_country") -> pd.DataFrame:
-    # 1. broken down by gender and age group
-    df_gender_age = _make_individual_df_with_share_answers(
-        df, dimensions=["gender", "age_group"], weight_column=weight_column
-    )
-    # 2. broken down by gender
-    df_gender = _make_individual_df_with_share_answers(df, dimensions=["gender"], weight_column=weight_column)
-    # 3. broken down by age_group
-    df_age = _make_individual_df_with_share_answers(df, dimensions=["age_group"], weight_column=weight_column)
-    # 4. no breakdown
-    df_nb = _make_individual_df_with_share_answers(df, weight_column=weight_column)
-    # Combine dataframes
-    log.info("wgm_mental_health: combining dataframes into combined one")
-    df_combined = pd.concat([df_nb, df_gender, df_age, df_gender_age], ignore_index=True)
-    # Sanity check
-    x = df_combined.groupby(["country", "year", "question", "gender", "age_group"], observed=True)[["share"]].sum()
-    assert x[abs(x.share - 100) > 0.1].empty, (
+def _share_answers_for_geographies(tb: Table, weight_column: str = "weight_intra_country") -> Table:
+    tb_gender_age = _share_answers(tb, dimensions=["gender", "age_group"], weight_column=weight_column)
+    tb_gender = _share_answers(tb, dimensions=["gender"], weight_column=weight_column)
+    tb_age = _share_answers(tb, dimensions=["age_group"], weight_column=weight_column)
+    tb_nb = _share_answers(tb, weight_column=weight_column)
+
+    tb_combined = pr.concat([tb_nb, tb_gender, tb_age, tb_gender_age], ignore_index=True)
+
+    sums = tb_combined.groupby(["country", "year", "question", "gender", "age_group"], observed=True)[["share"]].sum()
+    assert sums[abs(sums.share - 100) > 0.1].empty, (
         "The share was not correctly estimated! Sum of shares does not sum up to 100% (we allow for 0.1% error)"
     )
-    return df_combined
+    return tb_combined
 
 
-def _make_individual_df_with_share_answers(
-    df: pd.DataFrame, weight_column: str, dimensions: list[str] = []
-) -> pd.DataFrame:
-    """Obtain table with answer percentages and counts to each question for all demographic groups and countries.
-
-    For each question, obtain the number of each registered answer. Also, obtain the "weighted number", which is given
-    by weighting each answer according to the `weight_column` column. This is later used to obtain the share.
-
-    The `weight_column` has either the value of "weight_intra_country" (used to standardise different demographics within a country) or
-    "weight_inter_country" (to standardise a variable across different countries)
-    """
-
-    log.info(f"wgm_mental_health: building dataframe with share of answers for dimensions {dimensions}")
-    operations = ["sum", "count"]
+def _share_answers(tb: Table, weight_column: str, dimensions: list[str] = []) -> Table:
+    """Return per-question/answer share + count for the given demographic dimensions."""
     columns_index_base = ["country", "year", "question", "answer"]
     columns_index = columns_index_base + dimensions
-    df_ = df.groupby(columns_index, observed=True).agg({weight_column: operations})
-    df_.columns = operations
-    df_ = df_.reset_index()
-    # For each question, now obtain the percentage of each of its answers (weighted).
-    columns_normalise = [col for col in columns_index if col not in ["answer"]]
-    df_["sum_denominator"] = df_.groupby(columns_normalise, observed=True)["sum"].transform("sum")
-    df_["share"] = 100 * df_["sum"] / df_["sum_denominator"]
-    # Add missing dimensions
+
+    # Named aggregation keeps columns flat and preserves origins from `weight_column`.
+    tb_ = tb.groupby(columns_index, observed=True).agg(
+        sum=(weight_column, "sum"),
+        count=(weight_column, "count"),
+    ).reset_index()
+
+    columns_normalise = [col for col in columns_index if col != "answer"]
+    tb_["sum_denominator"] = tb_.groupby(columns_normalise, observed=True)["sum"].transform("sum")
+    tb_["share"] = 100 * tb_["sum"] / tb_["sum_denominator"]
+
     dimensions_all = ["gender", "age_group"]
     for dim in dimensions_all:
         if dim not in dimensions:
-            df_[dim] = "all"
-    # Format df
-    df_ = df_[
-        columns_index_base + dimensions_all + ["share", "count"]
-    ]  # DEBUG: return columns "sum", "sum_denominator", too
-    return df_
+            tb_[dim] = "all"
+
+    return tb_[columns_index_base + dimensions_all + ["share", "count"]]
 
 
-def map_ids_to_labels(df: pd.DataFrame) -> pd.DataFrame:
-    """Instead of having IDs we use labels.
-
-    The source uses IDs for gender and age groups, answers and questions.
-    """
-    # Answer ID to Answer label mapping
-    # Create unique identifier for answer id. Note that answer ids mean different things depending on the question!
-    # Therefore, we build a mapping `questionId__answerId -> answerLabel`
+def map_ids_to_labels(tb: Table) -> Table:
+    """Replace numeric IDs in question/answer/gender/age_group with human-readable labels."""
+    # The same answer ID means different things depending on the question, so build a `question__answer -> label` map.
     question_answer_id_to_label = {}
     for q_id, q_props in MAPPING_QUESTION_VALUES.items():
         for a_id, a_label in q_props["answers"].items():
             question_answer_id_to_label[f"{q_id}__{a_id}"] = a_label
-    df["question__answer"] = df["question"] + "__" + df["answer"]
+    tb["question__answer"] = tb["question"] + "__" + tb["answer"]
 
-    log.info("wgm_mental_health: sanity checking IDs (question, answer, gender, age_group)}")
-    # Sanity checks (Question)
-    _sanity_check_question(df)
-    # Drop question mh7b (it is too granular)
-    df = df[df["question"] != "mh7b"]
+    _sanity_check_question(tb)
+    # Drop question mh7b — too granular for the dataset.
+    tb = tb[tb["question"] != "mh7b"]
+    _sanity_check_answer(tb)
+    _sanity_check_gender(tb)
+    _sanity_check_age_ids(tb)
 
-    # Sanity checks for (question, answer) pairs
-    _sanity_check_answer(df)
-    # Sanity check gender IDs
-    _sanity_check_gender(df)
-    # Sanity checkk age_group IDs
-    _sanity_check_age_ids(df)
-
-    # Question ID to Question label mapping
     question_id_to_label = {k: f"{k} - {v['title']}" for k, v in MAPPING_QUESTION_VALUES.items()}
-
-    # Map IDs to Labels (Question, Answer, Gender, Age group)
-    log.info("wgm_mental_health: mapping ids to labels}")
-    df["question"] = df["question"].replace(question_id_to_label)
-    df["answer"] = df["question__answer"].map(question_answer_id_to_label).fillna("Unknown")
-    df["gender"] = df["gender"].replace(MAPPING_GENDER_VALUES)
-    df["age_group"] = df["age_group"].replace(MAPPING_AGE_VALUES)
-
-    return df
+    tb["question"] = tb["question"].replace(question_id_to_label)
+    tb["answer"] = tb["question__answer"].map(question_answer_id_to_label).fillna("Unknown")
+    tb["gender"] = tb["gender"].replace(MAPPING_GENDER_VALUES)
+    tb["age_group"] = tb["age_group"].replace(MAPPING_AGE_VALUES)
+    return tb
 
 
-def _sanity_check_question(df: pd.DataFrame):
-    q_map = {k: v["title"] for k, v in MAPPING_QUESTION_VALUES.items()}
-    questions = set(df["question"])
+def _sanity_check_question(tb: Table) -> None:
+    questions = set(tb["question"])
     questions_unexpected = questions.difference(set(MAPPING_QUESTION_VALUES))
     assert not questions_unexpected, f"Unexpected question ID {questions_unexpected}"
-    questions_missing = set(q_map).difference(questions)
-    assert not questions_unexpected, f"Missing question ID {questions_missing}"
 
 
-def _sanity_check_answer(df: pd.DataFrame):
+def _sanity_check_answer(tb: Table) -> None:
     q_a_map = {k: set(v["answers"]) for k, v in MAPPING_QUESTION_VALUES.items()}
-    dfg = df.groupby("question")["answer"].apply(set).to_dict()
-    for k, v in dfg.items():
+    tb_q_to_a = tb.groupby("question")["answer"].apply(set).to_dict()
+    for k, v in tb_q_to_a.items():
         answers_unexpected = v.difference(q_a_map[k])
         answers_missing = q_a_map[k].difference(v)
         if answers_unexpected:
-            print(k, "unexpected", answers_unexpected)
-            # if answers_unexpected != {" "}:
-            raise ValueError("Would expect nothing or whitespace, this is new!")
+            raise ValueError(f"{k}: unexpected answers {answers_unexpected}")
         if answers_missing:
-            print(k, "missing", answers_missing)
-            # if answers_missing != {" "}:
-            raise ValueError("Would expect nothing or whitespace, this is new!")
+            raise ValueError(f"{k}: missing answers {answers_missing}")
 
 
-def _sanity_check_gender(df: pd.DataFrame):
-    gender_unexpected = set(df["gender"]).difference(set(MAPPING_GENDER_VALUES) | {"all"})
-    gender_missing = set(set(MAPPING_GENDER_VALUES) | {"all"}).difference(df["gender"])
+def _sanity_check_gender(tb: Table) -> None:
+    expected = set(MAPPING_GENDER_VALUES) | {"all"}
+    gender_unexpected = set(tb["gender"]).difference(expected)
+    gender_missing = expected.difference(tb["gender"])
     if gender_unexpected:
         raise ValueError(f"Unexpected gender ID {gender_unexpected}")
     if gender_missing:
         raise ValueError(f"Missing gender ID {gender_missing}")
 
 
-def _sanity_check_age_ids(df: pd.DataFrame):
-    age_unexpected = set(df["age_group"]).difference(set(MAPPING_AGE_VALUES) | {"all"})
-    age_missing = set(set(MAPPING_AGE_VALUES) | {"all"}).difference(df["age_group"])
+def _sanity_check_age_ids(tb: Table) -> None:
+    expected = set(MAPPING_AGE_VALUES) | {"all"}
+    age_unexpected = set(tb["age_group"]).difference(expected)
+    age_missing = expected.difference(tb["age_group"])
     if age_unexpected:
         raise ValueError(f"Unexpected age group ID {age_unexpected}")
     if age_missing:
         raise ValueError(f"Missing age group ID {age_missing}")
 
 
-def filter_rows_with_low_participation(df: pd.DataFrame) -> pd.DataFrame:
-    """Filter rows where the number of answers for a question from a demographic group was very low"""
-    log.info("wgm_mental_health: Filtering entries with few participants.")
-    num_samples_initially = len(df)
+def filter_rows_with_low_participation(tb: Table) -> Table:
+    """Drop rows where the demographic group answered too few times to be representative."""
+    num_samples_initially = len(tb)
     col_idx = ["country", "year", "question", "gender", "age_group"]
-    df["count_total"] = df.groupby(col_idx, observed=True)["count"].transform("sum")
-    df = df[df["count_total"] > THRESHOLD_ANSWERS]
-    # Alternative would be to just remove share values and keep absolute counts
-    # df.loc[df["count_total"] > THRESHOLD_ANSWERS, "Share"] = None
-    # Log
-    percentage_kept = round(100 * len(df) / num_samples_initially, 2)
-    log.info(f"wgm_mental_health: Keeping {percentage_kept}% of all the rows.")
-    return df
+    tb["count_total"] = tb.groupby(col_idx, observed=True)["count"].transform("sum")
+    tb = tb[tb["count_total"] > THRESHOLD_ANSWERS]
+    percentage_kept = round(100 * len(tb) / num_samples_initially, 2)
+    log.info(f"wgm_mental_health: keeping {percentage_kept}% of rows after low-participation filter")
+    return tb
 
 
-def final_formatting(df: pd.DataFrame) -> pd.DataFrame:
-    """Keep relevant rows and set index."""
-    log.info("wgm_mental_health: final formatting}")
-    df = df[["country", "year", "question", "answer", "gender", "age_group", "share", "count"]].set_index(
+def final_formatting(tb: Table) -> Table:
+    """Keep relevant columns and set the dimension index."""
+    return tb[["country", "year", "question", "answer", "gender", "age_group", "share", "count"]].set_index(
         ["country", "year", "question", "answer", "gender", "age_group"], verify_integrity=True
     )
-    return df

--- a/etl/steps/data/garden/health/2023-04-18/wgm_mental_health.py
+++ b/etl/steps/data/garden/health/2023-04-18/wgm_mental_health.py
@@ -132,10 +132,14 @@ def _share_answers(tb: Table, weight_column: str, dimensions: list[str] = []) ->
     columns_index = columns_index_base + dimensions
 
     # Named aggregation keeps columns flat and preserves origins from `weight_column`.
-    tb_ = tb.groupby(columns_index, observed=True).agg(
-        sum=(weight_column, "sum"),
-        count=(weight_column, "count"),
-    ).reset_index()
+    tb_ = (
+        tb.groupby(columns_index, observed=True)
+        .agg(
+            sum=(weight_column, "sum"),
+            count=(weight_column, "count"),
+        )
+        .reset_index()
+    )
 
     columns_normalise = [col for col in columns_index if col != "answer"]
     tb_["sum_denominator"] = tb_.groupby(columns_normalise, observed=True)["sum"].transform("sum")

--- a/etl/steps/data/grapher/health/2023-04-19/wgm_mental_health.py
+++ b/etl/steps/data/grapher/health/2023-04-19/wgm_mental_health.py
@@ -1,37 +1,13 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from owid.catalog import Dataset
+from etl.helpers import PathFinder
 
-from etl.helpers import PathFinder, create_dataset, grapher_checks
-
-# Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
-    #
-    # Load inputs.
-    #
-    # Load garden dataset.
-    ds_garden: Dataset = paths.load_dependency("wgm_mental_health")
+def run() -> None:
+    ds_garden = paths.load_dataset("wgm_mental_health")
+    tb = ds_garden.read("wgm_mental_health", reset_index=False)
 
-    # Read table from garden dataset.
-    tb_garden = ds_garden["wgm_mental_health"]
-
-    #
-    # Process data.
-    #
-
-    #
-    # Save outputs.
-    #
-    # Create a new grapher dataset with the same metadata as the garden dataset.
-    ds_grapher = create_dataset(dest_dir, tables=[tb_garden], default_metadata=ds_garden.metadata)
-
-    #
-    # Checks.
-    #
-    grapher_checks(ds_grapher)
-
-    # Save changes in the new grapher dataset.
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
     ds_grapher.save()

--- a/etl/steps/data/meadow/health/2023-04-18/wgm_mental_health.py
+++ b/etl/steps/data/meadow/health/2023-04-18/wgm_mental_health.py
@@ -1,45 +1,18 @@
 """Load a snapshot and create a meadow dataset."""
 
-import pandas as pd
-from owid.catalog import Table
-from structlog import get_logger
+from etl.helpers import PathFinder
 
-from etl.helpers import PathFinder, create_dataset
-from etl.snapshot import Snapshot
-
-# Initialize logger.
-log = get_logger()
-
-# Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
-    log.info("wgm_mental_health.start")
+def run() -> None:
+    snap = paths.load_snapshot("wgm_mental_health.zip")
 
-    #
-    # Load inputs.
-    #
-    # Retrieve snapshot.
-    snap: Snapshot = paths.load_dependency("wgm_mental_health.zip")
+    # Read CSV from inside the zip; snap.read_csv returns a Table with origins on every column.
+    tb = snap.read_csv(compression="zip", underscore=True)
 
-    # Load data from snapshot.
-    df = pd.read_csv(snap.path, compression="zip")
-    # Set dtype for all questions to str
-    df = df.astype({column: str for column in df.columns if column not in ["WGT", "PROJWT"]})
-    #
-    # Process data.
-    #
-    # Create a new table and ensure all columns are snake-case.
-    tb = Table(df, short_name=paths.short_name, underscore=True)
+    # Cast all non-weight columns to string (questions are categorical IDs).
+    tb = tb.astype({col: str for col in tb.columns if col not in ["wgt", "projwt"]})
 
-    #
-    # Save outputs.
-    #
-    # Create a new meadow dataset with the same metadata as the snapshot.
-    ds_meadow = create_dataset(dest_dir, tables=[tb], default_metadata=snap.metadata)
-
-    # Save changes in the new garden dataset.
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
     ds_meadow.save()
-
-    log.info("wgm_mental_health.end")

--- a/snapshots/health/2023-04-18/wgm_mental_health.zip.dvc
+++ b/snapshots/health/2023-04-18/wgm_mental_health.zip.dvc
@@ -1,34 +1,31 @@
 meta:
-  namespace: health
-  short_name: wgm_mental_health
-  name: Wellcome Global Monitor 2020 - Mental health (Gallup and Wellcome, 2021)
-  version: 2023-04-18
-  publication_year: 2021
-  publication_date: 2021-10-21
-  source_name: Wellcome Global Monitor (2021)
-  source_published_by: "Wellcome, The Gallup Organization Ltd. (2021). Wellcome Global Monitor, 2020."
-  url: https://wellcome.org/reports/wellcome-global-monitor-mental-health/2020
-  source_data_url: https://cms.wellcome.org/sites/default/files/2021-11/wgm_full_wave2_public_file.zip
-  file_extension: zip
-  license_url:
-  license_name: Copyright Wellcome
-  date_accessed: 2023-04-18
+  origin:
+    producer: Wellcome and Gallup
+    title: Wellcome Global Monitor 2020 - Mental health
+    description: |-
+      Wellcome conducted the first Global Monitor – the largest-ever study of public attitudes to science and health – in 2018. The first wave covered topics such as whether people trust science, scientists and information about health, and attitudes towards the safety and efficacy of vaccines – a focus which has since proved incredibly forward-thinking.
+
+      In 2020, the Global Monitor's central focus was science's role in mental health.
+
+      The datasets and crosstabs cover the mental health sections of the WGM Survey 2020 conducted in 113 countries and territories worldwide on mental health views and experiences. The rest of the survey data will be published in subsequent data releases.
+
+      Relevant links:
+
+      - Wellcome Global Monitor 2020 full report: https://cms.wellcome.org/sites/default/files/2021-10/wellcome-global-monitor-mental-health.pdf
+      - Methodology: https://cms.wellcome.org/sites/default/files/2021-10/wgm2020-methodology.pdf
+      - Questionnaire details: https://cms.wellcome.org/sites/default/files/2021-10/wgm2020-questionnaire.pdf
+      - Full questionnaire: https://cms.wellcome.org/sites/default/files/2021-11/WGM_Full_Questionnaire.pdf
+
+      Note 1: Data for answers where the demographic group had less than 100 participants are filtered out.
+
+      Note 2: Empty answers have been filtered out. Empty answers may appear because the question was not applicable to the respondent or the respondent did not answer the question.
+    citation_full: 'Wellcome, The Gallup Organization Ltd. (2021). Wellcome Global Monitor 2020 - Mental health.'
+    attribution_short: WGM
+    url_main: https://wellcome.org/reports/wellcome-global-monitor-mental-health/2020
+    url_download: https://cms.wellcome.org/sites/default/files/2021-11/wgm_full_wave2_public_file.zip
+    date_accessed: '2023-04-18'
+    date_published: '2021-10-21'
   is_public: true
-  description: |
-    Wellcome conducted the first Global Monitor – the largest-ever study of public attitudes to science and health – in 2018. The first wave covered topics such as whether people trust science, scientists and information about health, and attitudes towards the safety and efficacy of vaccines – a focus which has since proved incredibly forward-thinking.
-
-    In 2020, the Global Monitor's central focus was science's role in mental health.
-
-    The datasets and crosstabs cover the mental health sections of the WGM Survey 2020 conducted in 113 countries and territories worldwide on mental health views and experiences. The rest of the survey data will be published in subsequent data releases.
-
-
-    Relevant links:
-
-    • You can find the Wellcome Global Monitor 2020 full report at https://cms.wellcome.org/sites/default/files/2021-10/wellcome-global-monitor-mental-health.pdf
-    • Details on the methodology: https://cms.wellcome.org/sites/default/files/2021-10/wgm2020-methodology.pdf
-    • Details about the questionnaire: https://cms.wellcome.org/sites/default/files/2021-10/wgm2020-questionnaire.pdf
-    • Full questionnaire: https://cms.wellcome.org/sites/default/files/2021-11/WGM_Full_Questionnaire.pdf
-wdir: ../../../data/snapshots/health/2023-04-18
 outs:
 - md5: 386bae8712f9e9f2be45d7be2aae3942
   size: 5850179


### PR DESCRIPTION
## Summary

Migrate the WGM 2020 mental-health dataset (`health/2023-04-19/wgm_mental_health`) end-to-end from legacy `sources` to modern `origins`. **19 published charts** move off the sources-only list as a result.

## Changes

**Snapshot** (`snapshots/health/2023-04-18/wgm_mental_health.zip.dvc`)
- Replace the legacy flat-field `meta.*` block with a clean `meta.origin:`.
- Producer: `Wellcome and Gallup` (`attribution_short: WGM`).
- Lift the OWID-specific filter notes (low-participation / empty-answer drops) into `origin.description` — they used to live as a runtime append on `ds_garden.metadata.sources[0].description`, which can't survive an origin migration.

**Meadow** (`etl/steps/data/meadow/health/2023-04-18/wgm_mental_health.py`)
- Use `snap.read_csv(compression="zip", underscore=True)` so the returned `Table` carries origins on every column from the start. The old `pd.read_csv(snap.path) → Table(df, ...)` chain stripped column metadata.
- Switch to `paths.create_dataset(...)` (no `dest_dir`).

**Garden** (`etl/steps/data/garden/health/2023-04-18/wgm_mental_health.py`)
- Rewrite every helper (`clean_df`/`make_df_with_share_answers`/…) to take and return `Table` instead of `pd.DataFrame`. Origins propagate naturally through `Table` operations.
- Replace `pd.concat` with `pr.concat`.
- Use named `groupby().agg(sum=..., count=...)` so `share`/`count` inherit origins from the underlying weight columns (the old `.agg({col: ["sum","count"]})` + `tb.columns = [...]` pattern dropped origins).
- Drop the `ds_garden.metadata.sources[0].description += ...` runtime hack — those notes now live in `origin.description`.
- Use `paths.regions.harmonize_names(tb, ...)` instead of `geo.harmonize_countries(df=df, ...)`.
- Modernize: `paths.load_dataset` / `paths.create_dataset` / no `dest_dir`.

**Grapher** (`etl/steps/data/grapher/health/2023-04-19/wgm_mental_health.py`)
- Trim to the modern `paths.*` API.

## Verification on staging

```sql
-- Dataset 5978 on staging-site-data-migrate-wgmmentalhealth
SELECT COUNT(DISTINCT v.id) AS n_vars,
       COUNT(DISTINCT ov.originId) AS n_origins_attached,
       COUNT(DISTINCT v.sourceId) AS n_sources_attached
FROM variables v
LEFT JOIN origins_variables ov ON ov.variableId = v.id
WHERE v.datasetId = 5978;
-- → 9610 vars, 1 origin attached, 0 sources attached ✅
```

Sources-only published chart count on staging: **148 → 129** (the 19 WGM charts cleared).

## Test plan

- [x] `etlr health/2023-04-19/wgm_mental_health --grapher` succeeds end-to-end
- [x] Variables on staging have `origins_variables` rows and no `sourceId`
- [x] All 19 WGM-backed charts no longer appear in the sources-only chart query
- [ ] Spot-check at least one chart on staging (e.g. `friends-family-anxious-depressed`) to confirm the data page still renders correctly with the new origin