### PR TITLE
🐛 wizard: fix metadata diff direction in Wizard chart-diff (prod is the base)

### DIFF
--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -403,8 +403,10 @@ class ChartDiffShow:
                 source = filter_out_fields_in_metadata_for_checksum(source)
                 target = filter_out_fields_in_metadata_for_checksum(target)
 
-                # Get meta json diff
-                meta_diff = compare_dictionaries(source, target, fromfile="source", tofile="target")
+                # PROD is the base; STAGING is what the user is proposing to merge — pass
+                # `target` (prod) first so the diff reads as `production → staging` and
+                # the staging branch shows up as additions/modifications.
+                meta_diff = compare_dictionaries(target, source, fromfile="production", tofile="staging")
                 if meta_diff:
                     meta_diffs[indicator_id] = meta_diff
 


### PR DESCRIPTION
Wizard's chart-diff page has a `🔎 Metadata differences` modal that compares an indicator's stored metadata on STAGING vs PROD. The diff was constructed with STAGING as `fromfile` and PROD as `tofile`, so it read as `staging → prod` — i.e. PROD appeared to be the side making changes. Swapped to `production → staging` to match `_show_config_diff`'s convention and the user's mental model of a chart-diff review.

## Test plan
- [ ] Open Wizard's chart-diff page for any modified chart whose indicator metadata changed.
- [ ] Click `🔎 Metadata differences`.
- [ ] Confirm the diff header now reads `--- production` / `+++ staging` and that additions (`+`) reflect what STAGING introduces.