### PR TITLE
📊 Migrate UN WPP source to origin

### DIFF
--- a/etl/steps/data/grapher/un/2022-07-11/un_wpp.py
+++ b/etl/steps/data/grapher/un/2022-07-11/un_wpp.py
@@ -9,8 +9,6 @@ NAMESPACE = "un"
 VERSION = "2022-07-11"
 FNAME = "un_wpp"
 TNAME = "un_wpp"
-SOURCE_NAME_DISPLAY = "UN, World Population Prospects (2022)"
-
 
 log = structlog.get_logger()
 
@@ -53,10 +51,8 @@ def _propagate_metadata(dataset: catalog.Dataset, table: catalog.Table) -> catal
     meta_map = {}
     for var_name, var_meta in meta["tables"][TNAME]["variables"].items():
         var_meta = catalog.VariableMeta(**var_meta)
+        var_meta.origins = table["value"].metadata.origins
         meta_map[var_name] = var_meta
-        var_meta.sources = dataset.metadata.sources
-        # Temporary
-        var_meta.sources[0].name = SOURCE_NAME_DISPLAY
 
     table["meta"] = table["variable"].astype(object).map(meta_map)
     return table

--- a/snapshots/un/2022-07-11/un_wpp.zip.dvc
+++ b/snapshots/un/2022-07-11/un_wpp.zip.dvc
@@ -1,33 +1,18 @@
 meta:
-  name: World Population Prospects - UN (2022)
-  description: World Population Prospects 2022 is the 27th edition of the official
-    estimates and projections of the global population that have been published by
-    the United Nations since 1951. The estimates are based on all available sources
-    of data on population size and levels of fertility, mortality and international
-    migration for 237 countries or areas. More details at https://population.un.org/wpp/Publications/.
-  source_name: United Nations, Department of Economic and Social Affairs, Population
-    Division (2022)
-  url: https://population.un.org/wpp/Download/
-  date_accessed: '2022-09-09'
-  license_url: http://creativecommons.org/licenses/by/3.0/igo/
-  license_name: CC BY 3.0 IGO
-  publication_year: 2022
-  publication_date: '2022-07-11'
   origin:
     producer: United Nations
     title: World Population Prospects
     description: |-
-      World Population Prospects 2022 is the 27th edition of the official estimates and projections of the global population that have been published by the United Nations since 1951. The estimates are based on all available sources of data on population size and levels of fertility, mortality and international migration for 237 countries or areas. More details at https://population.un.org/wpp/Publications/.
-    citation_full: |-
-      United Nations, Department of Economic and Social Affairs, Population Division (2022). World Population Prospects 2022, Online Edition.
+      World Population Prospects 2022 is the 27th edition of the official estimates and projections of the global population that have been published by the United Nations since 1951. The estimates are based on all available sources of data on population size and levels of fertility, mortality, and international migration for 237 countries or areas. More details at https://population.un.org/wpp/Publications/.
+    citation_full: United Nations, Department of Economic and Social Affairs, Population Division (2022). World Population Prospects 2022, Online Edition.
+    attribution_short: UN WPP
+    version_producer: '2022'
     url_main: https://population.un.org/wpp/Download/
-    attribution: "United Nations - World Population Prospects (2022)"
-    attribution_short: "UN WPP"
-    date_accessed: 2022-09-09
-    date_published: 2022-07-11
+    date_accessed: '2022-09-09'
+    date_published: '2022-07-11'
     license:
       name: CC BY 3.0 IGO
-      url: https://population.un.org/wpp/Download/Standard/MostUsed/
+      url: http://creativecommons.org/licenses/by/3.0/igo/
 wdir: ../../../data/snapshots/un/2022-07-11
 outs:
 - md5: e49634a6a64f5b290d2f3a56837b44a1


### PR DESCRIPTION
Migrates the UN WPP 2022 snapshot metadata from legacy source fields to a modern origin block.

Also removes legacy source propagation in the grapher step and attaches the table origins directly to generated variable metadata instead.