### PR TITLE
Unarchive ihme_gbd/2020-12-19 child_mortality and migrate sources to origins

### DIFF
--- a/dag/archive/health.yml
+++ b/dag/archive/health.yml
@@ -66,14 +66,6 @@ steps:
   data://grapher/ihme_gbd/2023-06-14/prevalence_dalys_world:
     - data://garden/ihme_gbd/2023-06-14/prevalence_dalys_world
 
-  # IHME Global Burden of Disease - Child mortality long run
-  data://meadow/ihme_gbd/2020-12-19/child_mortality:
-    - walden://ihme_gbd/2020-12-19/child_mortality
-  data://garden/ihme_gbd/2020-12-19/child_mortality:
-    - data://meadow/ihme_gbd/2020-12-19/child_mortality
-  data://grapher/ihme_gbd/2020-12-19/child_mortality:
-    - data://garden/ihme_gbd/2020-12-19/child_mortality
-
   # IHME Global Burden of Disease - Deaths and DALYs
   data://meadow/ihme_gbd/2019/gbd_cause:
     - walden://ihme_gbd/2019/gbd_cause

--- a/dag/health.yml
+++ b/dag/health.yml
@@ -342,6 +342,14 @@ steps:
   data-private://grapher/ihme_gbd/2026-02-11/gbd_child_mortality_leading_causes:
     - data-private://garden/ihme_gbd/2026-02-11/gbd_child_mortality_leading_causes
 
+  # IHME Global Burden of Disease - Child mortality long run (frozen 2020-12-19 vintage, still used by the Global Health explorer)
+  data://meadow/ihme_gbd/2020-12-19/child_mortality:
+    - snapshot://ihme_gbd/2020-12-19/child_mortality.feather
+  data://garden/ihme_gbd/2020-12-19/child_mortality:
+    - data://meadow/ihme_gbd/2020-12-19/child_mortality
+  data://grapher/ihme_gbd/2020-12-19/child_mortality:
+    - data://garden/ihme_gbd/2020-12-19/child_mortality
+
   # GBD 2023 - GBD Health-adjusted Life Expectancy and Life Expectancy
   data-private://meadow/ihme_gbd/2026-02-07/gbd_life_expectancy:
     - snapshot-private://ihme_gbd/2026-02-07/gbd_life_expectancy.zip

--- a/etl/steps/data/garden/ihme_gbd/2020-12-19/child_mortality.meta.yml
+++ b/etl/steps/data/garden/ihme_gbd/2020-12-19/child_mortality.meta.yml
@@ -1,80 +1,75 @@
-dataset:
-  sources:
-    -
-      name: IHME, Global Burden of Disease (2019)
-      published_by: Institute of Health Metrics and Evaluation
 tables:
   child_mortality:
     variables:
       deaths_under_5:
         title: Deaths in under-fives
-        description: Deaths in children aged under-five
-        unit: deaths   
+        description_short: Deaths in children aged under-five
+        unit: deaths
       deaths_early_neonatal:
         title: Early neonatal deaths
-        description: Deaths in children aged 0-6 days
+        description_short: Deaths in children aged 0-6 days
         unit: deaths
       deaths_late_neonatal:
         title: Late neonatal deaths
-        description: Deaths in children aged 7-27 days
+        description_short: Deaths in children aged 7-27 days
         unit: deaths
       deaths_2_to_4:
         title: Deaths 2-4 years
-        description: Deaths in children aged 2-4 years
+        description_short: Deaths in children aged 2-4 years
         unit: deaths
       deaths_neonatal:
         title: Neonatal deaths
-        description: Deaths in children aged 0-27 days
+        description_short: Deaths in children aged 0-27 days
         unit: deaths
       deaths_12_to_23_months:
         title: Deaths 12-23 months
-        description: Deaths in children aged 12-23 months
+        description_short: Deaths in children aged 12-23 months
         unit: deaths
       deaths_1_5_months:
         title: Deaths 1-5 months
-        description: Deaths in children aged 1-5 months
+        description_short: Deaths in children aged 1-5 months
         unit: deaths
       deaths_6_11_months:
         title: Deaths 6-11 months
-        description: Deaths in children aged 6-11 months
+        description_short: Deaths in children aged 6-11 months
         unit: deaths
-      probability_of_death_under_5: 
+      probability_of_death_under_5:
         title: Under-five probability of death
-        description: Probability of death before the age of five
+        description_short: Probability of death before the age of five
         unit: '%'
         short_unit: '%'
       probability_of_death_early_neonatal:
         title: 0-6 days probability of death
-        description: Probability of death before reaching one-week of age
+        description_short: Probability of death before reaching one week of age
         unit: '%'
         short_unit: '%'
       probability_of_death_late_neonatal:
         title: 7-27 days probability of death
-        description: Probability of death between 7-27 days
+        description_short: Probability of death between 7 and 27 days
         unit: '%'
         short_unit: '%'
       probability_of_death_2_to_4:
         title: 2-4 years probability of death
-        description: Probability of death between 2-4 years
+        description_short: Probability of death between ages 2 and 4
         unit: '%'
         short_unit: '%'
       probability_of_death_neonatal:
         title: 0-27 days probability of death
-        description: Probability of death between 0-27 days
+        description_short: Probability of death between 0 and 27 days
         unit: '%'
         short_unit: '%'
       probability_of_death_12_to_23_months:
         title: 12-23 months probability of death
-        description: Probability of death between 12-23 months
+        description_short: Probability of death between 12 and 23 months
         unit: '%'
         short_unit: '%'
       probability_of_death_1_5_months:
-        title: 1-5 months probabiltiy of death
-        description: Probability of death between 1-5 months
+        title: 1-5 months probability of death
+        description_short: Probability of death between 1 and 5 months
         unit: '%'
         short_unit: '%'
       probability_of_death_6_11_months:
-        title: 6-11 months probabiltiy of death
-        description: Probability of death between 6-11 months
+        title: 6-11 months probability of death
+        description_short: Probability of death between 6 and 11 months
         unit: '%'
         short_unit: '%'

--- a/etl/steps/data/garden/ihme_gbd/2020-12-19/child_mortality.py
+++ b/etl/steps/data/garden/ihme_gbd/2020-12-19/child_mortality.py
@@ -1,89 +1,48 @@
+"""Garden step for IHME GBD 2020-12-19 child mortality (frozen vintage)."""
+
 import json
-from typing import cast
 
-import pandas as pd
-from owid.catalog import Dataset, Table
-from owid.catalog.utils import underscore_table
-from structlog import get_logger
+from owid.catalog import Table
 
-from etl.data_helpers import geo
 from etl.helpers import PathFinder
-from etl.paths import DATA_DIR
 
-log = get_logger()
-
-# naming conventions
-N = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
-    log.info("child_mortality.start")
+def run() -> None:
+    ds_meadow = paths.load_dataset("child_mortality")
+    tb = ds_meadow["child_mortality"].reset_index()
 
-    # read dataset from meadow
-    ds_meadow = Dataset(DATA_DIR / "meadow/ihme_gbd/2020-12-19/child_mortality")
-    tb_meadow = ds_meadow["child_mortality"]
+    tb = exclude_countries(tb)
+    tb = paths.regions.harmonize_names(
+        tb,
+        country_col="country",
+        countries_file=paths.country_mapping_path,
+    )
 
-    df = pd.DataFrame(tb_meadow)
-    df = df.drop(columns="index")
-    log.info("child_mortality.exclude_countries")
-    df = exclude_countries(df)
+    # Keep only Both-sex rows. Rate metric is dropped — its definition is ambiguous in the raw export.
+    tb = tb[(tb["sex"] == "Both") & (tb["metric_name"] != "Rate")]
 
-    log.info("child_mortality.harmonize_countries")
-    df = harmonize_countries(df)
+    tb_p = tb.pivot(
+        index=["country", "year"],
+        columns=["measure_name", "age_group_name"],
+        values="value",
+    )
+    tb_p.columns = ["_".join(col).strip() for col in tb_p.columns.values]
+    tb_p = tb_p.reset_index()
 
-    # Selecting only Both sex values for now as need this data quite quickly - Also dropping Rate metrics as it is not clear what this means.
-    df = df[(df["sex"] == "Both") & (df["metric_name"] != "Rate")]
+    num_cols = [c for c in tb_p.columns if "Deaths" in c]
+    prob_cols = [c for c in tb_p.columns if "Probability of death" in c]
+    tb_p[num_cols] = tb_p[num_cols].round(0).astype(int)
+    tb_p[prob_cols] = (100 * tb_p[prob_cols]).round(2)
 
-    df_p = df.pivot(index=["country", "year"], columns=["measure_name", "age_group_name"], values="value")
+    tb_p = tb_p.format(["country", "year"], short_name="child_mortality")
 
-    df_p.columns = ["_".join(col).strip() for col in df_p.columns.values]
-    df_p = df_p.reset_index()
-
-    # Ensuring there is appropriate rounding for the different metrics
-    num_cols = [col for col in df_p.columns if "Deaths" in col]
-    prob_cols = [col for col in df_p.columns if "Probability of death" in col]
-    df_p[num_cols] = df_p[num_cols].round(0).astype(int)
-    df_p[prob_cols] = 100 * df_p[prob_cols]
-    df_p[prob_cols] = df_p[prob_cols].round(2)
-
-    ds_garden = Dataset.create_empty(dest_dir)
-    ds_garden.metadata = ds_meadow.metadata
-
-    tb_garden = underscore_table(Table(df_p))
-    tb_garden.metadata = tb_meadow.metadata
-
-    ds_garden.metadata.update_from_yaml(N.metadata_path)
-    tb_garden.update_metadata_from_yaml(N.metadata_path, "child_mortality")
-
-    ds_garden.add(tb_garden)
+    ds_garden = paths.create_dataset(tables=[tb_p], default_metadata=ds_meadow.metadata)
     ds_garden.save()
 
-    log.info("child_mortality.end")
 
-
-def load_excluded_countries() -> list[str]:
-    with open(N.excluded_countries_path) as f:
-        data = json.load(f)
-        assert isinstance(data, list)
-    return data
-
-
-def exclude_countries(df: pd.DataFrame) -> pd.DataFrame:
-    excluded_countries = load_excluded_countries()
-    return cast(pd.DataFrame, df.loc[~df.country.isin(excluded_countries)])
-
-
-def harmonize_countries(df: pd.DataFrame) -> pd.DataFrame:
-    unharmonized_countries = df["country"]
-    df = geo.harmonize_countries(df=df, countries_file=str(N.country_mapping_path))
-
-    missing_countries = set(unharmonized_countries[df.country.isnull()])
-    if any(missing_countries):
-        raise RuntimeError(
-            "The following raw country names have not been harmonized. "
-            f"Please: (a) edit {N.country_mapping_path} to include these country "
-            f"names; or (b) add them to {N.excluded_countries_path}."
-            f"Raw country names: {missing_countries}"
-        )
-
-    return df
+def exclude_countries(tb: Table) -> Table:
+    with open(paths.excluded_countries_path) as f:
+        excluded = json.load(f)
+    return tb.loc[~tb["country"].isin(excluded)]

--- a/etl/steps/data/grapher/ihme_gbd/2020-12-19/child_mortality.py
+++ b/etl/steps/data/grapher/ihme_gbd/2020-12-19/child_mortality.py
@@ -1,19 +1,11 @@
-from owid import catalog
-
 from etl.helpers import PathFinder
 
-N = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
-    dataset = catalog.Dataset.create_empty(dest_dir, N.garden_dataset.metadata)
+def run() -> None:
+    ds_garden = paths.load_dataset("child_mortality")
+    tb = ds_garden["child_mortality"]
 
-    table = N.garden_dataset["child_mortality"]
-
-    # optionally set additional dimensions
-    # table = table.set_index(["sex", "income_group"], append=True)
-
-    # if your data is in long format, check gh.long_to_wide_tables
-    dataset.add(table)
-
-    dataset.save()
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/ihme_gbd/2020-12-19/child_mortality.meta.yml
+++ b/etl/steps/data/meadow/ihme_gbd/2020-12-19/child_mortality.meta.yml
@@ -1,25 +1,5 @@
-dataset:
-  sources:
-    -
-      name: IHME, Global Burden of Disease (2019)
-      published_by: Institute of Health Metrics and Evaluation
-
 tables:
   child_mortality:
     variables:
-      country:
-        title: Country
-        description: Country 
-      sex:
-        title: Sex
-        description: Sex
-      age_group_name:
-        title: Age group
-        description: Age group 
-      measure_name:
-        title: Measure
-        description: Unit of the values
-      metric_name:
-        description: Unit
       value:
         title: Value

--- a/etl/steps/data/meadow/ihme_gbd/2020-12-19/child_mortality.py
+++ b/etl/steps/data/meadow/ihme_gbd/2020-12-19/child_mortality.py
@@ -1,66 +1,24 @@
-import pandas as pd
-from owid.catalog import Dataset, Table, TableMeta
-from owid.catalog.utils import underscore_table
-from owid.walden import Catalog as WaldenCatalog
-from structlog import get_logger
+"""Load a snapshot and create a meadow dataset."""
 
 from etl.helpers import PathFinder
-from etl.steps.data.converters import convert_walden_metadata
 
-log = get_logger()
-
-# naming conventions
-N = PathFinder(__file__)
+paths = PathFinder(__file__)
 
 
-def run(dest_dir: str) -> None:
-    log.info("child_mortality.start")
+def run() -> None:
+    snap = paths.load_snapshot("child_mortality.feather")
+    tb = snap.read_feather()
 
-    # retrieve raw data from walden
-    walden_ds = WaldenCatalog().find_one(namespace="ihme_gbd", short_name="child_mortality", version="2020-12-19")
-    local_file = walden_ds.ensure_downloaded()
-
-    df = pd.read_feather(local_file)
-    df = df.drop(columns="index")
-
-    # clean and transform data
-    df = clean_data(df)
-
-    # create new dataset and reuse walden metadata
-    ds = Dataset.create_empty(dest_dir)
-    ds.metadata = convert_walden_metadata(walden_ds)
-
-    # create table with metadata from dataframe
-    table_metadata = TableMeta(
-        short_name=walden_ds.short_name,
-        title=walden_ds.name,
-        description=walden_ds.description,
+    tb = tb.drop(
+        columns=["index", "location_id", "sex_id", "age_group_id", "measure_id", "metric_id", "upper", "lower"]
     )
-    tb = Table(df, metadata=table_metadata)
+    tb = tb.rename(columns={"location_name": "country", "year_id": "year", "val": "value"})
+    tb = tb.drop_duplicates()
 
-    # underscore all table columns
-    tb = underscore_table(tb)
-
-    tb.update_metadata_from_yaml(N.metadata_path, "child_mortality")
-    tb = tb.reset_index()
-    # add table to a dataset
-    ds.add(tb)
-
-    # finally save the dataset
-    ds.save()
-
-    log.info("child_mortality.end")
-
-
-def clean_data(df: pd.DataFrame) -> pd.DataFrame:
-    return (
-        df.rename(
-            columns={
-                "location_name": "country",
-                "year_id": "year",
-                "val": "value",
-            }
-        )
-        .drop(columns=["location_id", "sex_id", "age_group_id", "measure_id", "metric_id", "upper", "lower"])
-        .drop_duplicates()
+    tb = tb.format(
+        ["country", "year", "sex", "age_group_name", "measure_name", "metric_name"],
+        short_name="child_mortality",
     )
+
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
+    ds_meadow.save()

--- a/snapshots/ihme_gbd/2020-12-19/child_mortality.feather.dvc
+++ b/snapshots/ihme_gbd/2020-12-19/child_mortality.feather.dvc
@@ -1,0 +1,18 @@
+meta:
+  origin:
+    producer: IHME, Global Burden of Disease
+    title: Global Burden of Disease Study 2019 (GBD 2019) Under-5 Mortality by Detailed Age Groups 1950-2019
+    description: |-
+      This dataset provides annual estimates for 1950–2019 for numbers of deaths, mortality rate, and probability of death by sex for 6 age groups under 5 years: 0–6 days (early neonatal), 7–27 days (late neonatal), 1–5 months, 6–11 months, 12–23 months, and 2–4 years. There were 7,417 sources used to produce these estimates. These included 28,016 location-years of vital registration data, 481 surveys with complete birth histories, and 1,081 sources on summary birth histories.
+    citation_full: 'Global Burden of Disease Collaborative Network. Global Burden of Disease Study 2019 (GBD 2019) Under-5 Mortality by Detailed Age Groups 1950-2019. Seattle, United States: Institute for Health Metrics and Evaluation (IHME), 2020.'
+    attribution_short: IHME-GBD
+    url_main: https://ghdx.healthdata.org/record/ihme-data/global-burden-disease-study-2019-gbd-2019-under-5-mortality-detailed-age-groups-1950-2019
+    date_accessed: '2022-10-13'
+    date_published: '2020-12-19'
+    license:
+      name: Free-of-Charge Non-commercial User Agreement
+      url: https://www.healthdata.org/Data-tools-practices/data-practices/ihme-free-charge-non-commercial-user-agreement
+outs:
+  - md5: 9cb4502a78e86bd26d576616dbc3230b
+    size: 17156050
+    path: child_mortality.feather

--- a/snapshots/ihme_gbd/2020-12-19/child_mortality.py
+++ b/snapshots/ihme_gbd/2020-12-19/child_mortality.py
@@ -1,0 +1,28 @@
+"""Script to create a snapshot of dataset.
+
+The original 2020-12-19 vintage was previously hosted via walden. This script preserves
+the same feather file by downloading it directly from the walden bucket.
+"""
+
+from pathlib import Path
+
+import click
+import requests
+
+from etl.snapshot import Snapshot
+
+SNAPSHOT_VERSION = Path(__file__).parent.name
+WALDEN_URL = "https://walden.owid.io/ihme_gbd/2020-12-19/child_mortality.feather"
+
+
+@click.command()
+@click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
+def run(upload: bool) -> None:
+    snap = Snapshot(f"ihme_gbd/{SNAPSHOT_VERSION}/child_mortality.feather")
+    snap.path.parent.mkdir(exist_ok=True, parents=True)
+
+    response = requests.get(WALDEN_URL)
+    response.raise_for_status()
+    snap.path.write_bytes(response.content)
+
+    snap.create_snapshot(upload=upload, filename=snap.path)


### PR DESCRIPTION
## Summary

Four published charts and the Global Health explorer still depend on the frozen `ihme_gbd/2020-12-19/child_mortality` vintage, so it shouldn't have been archived. This PR unarchives the chain and migrates its metadata from the legacy `sources` system to modern `origins`.

- **Unarchive:** moved the 3 DAG entries from `dag/archive/health.yml` to `dag/health.yml`.
- **Replace walden:// with a real snapshot:** created `snapshots/ihme_gbd/2020-12-19/child_mortality.{feather.dvc,py}`. The DVC carries an `origin:` block (built from the legacy walden index — producer IHME-GBD, date_published 2020-12-19, license, citation). The Python script pulls the feather file directly from the walden bucket, preserving the original md5 byte-for-byte.
- **Modernize meadow / garden / grapher steps:** switched to `paths.load_snapshot` / `paths.regions.harmonize_names` / `paths.create_dataset`, dropped the `dataset.sources:` blocks, and trimmed dead code.

## Effect on charts

The 4 affected charts (and the indicators they reference) keep their variable IDs via catalogPath upsert, so chart references continue working with no remap needed. The legacy `sourceId` becomes `NULL` on all 16 indicators and one `origin` row gets attached instead.

| Chart ID | Slug |
|---|---|
| 677 | child-mortality-rate-ihme |
| 3445 | child-mortality-ihme-vs-un-igme |
| 3485 | neonatal-mortality-ihme |
| 3799 | number-of-neonatal-deaths-ihme |

## Test plan

- [x] `.venv/bin/etls ihme_gbd/2020-12-19/child_mortality` — md5 matches existing R2 object
- [x] `.venv/bin/etlr ihme_gbd/2020-12-19/child_mortality --grapher` — full chain succeeds, "Deleted 2 ghost sources" log line confirms source removal
- [x] Local DB check: all 16 variables have `sourceId IS NULL` and 1 attached origin
- [x] `make check` passes
- [ ] Verify on staging-site-chore-remap-ihme-child that the 4 charts above no longer appear in the "charts using sources only" query