### PR TITLE
📊 Bump lib package versions after dependabot fixes

### DIFF
--- a/.claude/skills/fix-dependabot/SKILL.md
+++ b/.claude/skills/fix-dependabot/SKILL.md
@@ -107,9 +107,15 @@ For each vulnerable npm package:
 
 ## Step 5: Verify changes
 
-Run `make check` to ensure nothing is broken. This runs linting, formatting, and type checking.
+Run `make check-all` (lint + format + typecheck across the root and every `lib/`). The plain `make check` only covers the top-level codebase, so breaking changes from upgrades to packages used by `lib/` (e.g. gdown's `fuzzy=` removal in `lib/datautils/`) would slip through.
 
-If `make check` fails, fix the issues (commonly: removed imports that type checkers flag). Then re-run until it passes.
+If it fails, fix the issues (commonly: removed/renamed kwargs that type checkers flag) and re-run until it passes.
+
+## Step 5b: Bump lib/ package versions
+
+If you modified any `lib/{catalog,datautils,repack}/pyproject.toml`, also bump that file's `version = "x.y.z"` (patch bump). The `publish-owid-packages.yml` workflow republishes these packages to PyPI on master push and rejects the publish if the version already exists.
+
+After bumping, re-run `uv lock` (top-level and inside each modified `lib/<name>/`) so the lockfiles pick up the new version.
 
 ## Step 6: Create PR
 

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ help:
 	@echo '  make install-hooks	Activate pre-commit hook (auto-runs with make .venv)'
 	@echo '  make test      	Run all linting and unit tests'
 	@echo '  make test-all  	Run all linting and unit tests (including for modules in lib/)'
+	@echo '  make check-all 	Format, lint, and typecheck (including for modules in lib/)'
 	@echo '  make vsce-exclude-archived  Exclude archived steps from VSCode user settings'
 	@echo '  make vsce-sync 	Sync VS Code extensions (install missing, upgrade outdated)'
 # 	@echo '  make vsce-compile EXT=name [BUMP=patch|minor|major] [INSTALL=1]  Compile and package VS Code extension'
@@ -83,6 +84,14 @@ test-all:
 	@for lib in $(LIBS); do \
 		echo "================ $$lib ================="; \
 		(cd $$lib && make test); \
+	done
+
+check-all:
+	@echo '================ etl ================='
+	@make check
+	@for lib in $(LIBS); do \
+		echo "================ $$lib ================="; \
+		(cd $$lib && make check); \
 	done
 
 format-all:

--- a/lib/catalog/pyproject.toml
+++ b/lib/catalog/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-catalog"
-version = "1.1.0"
+version = "1.1.1"
 description = "Core data types used by OWID for managing data."
 readme = "README.md"
 authors = [{ name = "Our World in Data", email = "tech@ourworldindata.org" }]

--- a/lib/catalog/uv.lock
+++ b/lib/catalog/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-10T07:08:20.126358Z"
+exclude-newer = "2026-05-10T08:03:27.847958Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -1524,7 +1524,7 @@ wheels = [
 
 [[package]]
 name = "owid-catalog"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },
@@ -1610,7 +1610,7 @@ dev = [
 
 [[package]]
 name = "owid-datautils"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "../datautils" }
 dependencies = [
     { name = "boto3" },
@@ -1676,7 +1676,7 @@ dev = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "../repack" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/lib/datautils/pyproject.toml
+++ b/lib/datautils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-datautils"
-version = "0.6.2"
+version = "0.6.3"
 description = "Data utils library by the Data Team at Our World in Data"
 authors = [
     {name = "Our World in Data", email = "tech@ourworldindata.org"},

--- a/lib/datautils/uv.lock
+++ b/lib/datautils/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-10T07:08:31.290795Z"
+exclude-newer = "2026-05-10T08:03:28.029919Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -1654,7 +1654,7 @@ wheels = [
 
 [[package]]
 name = "owid-datautils"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/lib/repack/pyproject.toml
+++ b/lib/repack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-repack"
-version = "0.1.7"
+version = "0.1.8"
 description = "Pack Pandas data frames into smaller, more memory-efficient data types."
 authors = [
     {name = "Our World in Data", email = "tech@ourworldindata.org"},

--- a/lib/repack/uv.lock
+++ b/lib/repack/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-10T07:08:34.755287Z"
+exclude-newer = "2026-05-10T08:03:28.314889Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -344,7 +344,7 @@ wheels = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-10T07:08:16.138056Z"
+exclude-newer = "2026-05-10T08:03:27.01869Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -4991,7 +4991,7 @@ wheels = [
 
 [[package]]
 name = "owid-catalog"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "lib/catalog" }
 dependencies = [
     { name = "brotli" },
@@ -5065,7 +5065,7 @@ dev = [
 
 [[package]]
 name = "owid-datautils"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "lib/datautils" }
 dependencies = [
     { name = "boto3" },
@@ -5131,7 +5131,7 @@ dev = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "lib/repack" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

#6104 modified `lib/{catalog,datautils,repack}/pyproject.toml` without bumping their `version =` lines, so the `publish-owid-packages` workflow rejected the publish step ("Version X already exists on PyPI"). This PR bumps the patch versions so the next master push can republish.

| Package | From | To |
|---|---|---|
| owid-catalog | 1.1.0 | 1.1.1 |
| owid-datautils | 0.6.2 | 0.6.3 |
| owid-repack | 0.1.7 | 0.1.8 |

## Test plan

- [x] `make check` passes
- [ ] Publish workflow succeeds after merge