### PR TITLE
🐝 Switch PyPI publish workflow to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-owid-packages.yml
+++ b/.github/workflows/publish-owid-packages.yml
@@ -15,82 +15,80 @@ on:
         required: true
         default: 'all'
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      catalog: ${{ steps.filter.outputs.catalog }}
-      datautils: ${{ steps.filter.outputs.datautils }}
-      repack: ${{ steps.filter.outputs.repack }}
+      packages: ${{ steps.filter.outputs.packages }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 2
 
     - name: Detect which packages changed
       id: filter
       run: |
+        catalog=false
+        datautils=false
+        repack=false
         if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
           PACKAGE="${{ github.event.inputs.package }}"
-          if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "catalog" ]; then
-            echo "catalog=true" >> $GITHUB_OUTPUT
-          fi
-          if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "datautils" ]; then
-            echo "datautils=true" >> $GITHUB_OUTPUT
-          fi
-          if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "repack" ]; then
-            echo "repack=true" >> $GITHUB_OUTPUT
-          fi
+          if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "catalog" ]; then catalog=true; fi
+          if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "datautils" ]; then datautils=true; fi
+          if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "repack" ]; then repack=true; fi
         else
-          git diff --name-only HEAD~1 HEAD | grep -q 'lib/catalog/pyproject.toml' && echo "catalog=true" >> $GITHUB_OUTPUT || echo "catalog=false" >> $GITHUB_OUTPUT
-          git diff --name-only HEAD~1 HEAD | grep -q 'lib/datautils/pyproject.toml' && echo "datautils=true" >> $GITHUB_OUTPUT || echo "datautils=false" >> $GITHUB_OUTPUT
-          git diff --name-only HEAD~1 HEAD | grep -q 'lib/repack/pyproject.toml' && echo "repack=true" >> $GITHUB_OUTPUT || echo "repack=false" >> $GITHUB_OUTPUT
+          CHANGED=$(git diff --name-only HEAD~1 HEAD)
+          if echo "$CHANGED" | grep -q 'lib/catalog/pyproject.toml'; then catalog=true; fi
+          if echo "$CHANGED" | grep -q 'lib/datautils/pyproject.toml'; then datautils=true; fi
+          if echo "$CHANGED" | grep -q 'lib/repack/pyproject.toml'; then repack=true; fi
         fi
+
+        items=()
+        if [ "$catalog" = "true" ]; then
+          items+=('{"package":"catalog","name":"owid-catalog","path":"lib/catalog"}')
+        fi
+        if [ "$datautils" = "true" ]; then
+          items+=('{"package":"datautils","name":"owid-datautils","path":"lib/datautils"}')
+        fi
+        if [ "$repack" = "true" ]; then
+          items+=('{"package":"repack","name":"owid-repack","path":"lib/repack"}')
+        fi
+
+        IFS=,
+        json="[${items[*]}]"
+        echo "Will publish: $json"
+        echo "packages=$json" >> $GITHUB_OUTPUT
 
   publish:
     needs: detect-changes
+    if: needs.detect-changes.outputs.packages != '[]'
     runs-on: ubuntu-latest
-    if: needs.detect-changes.outputs.catalog == 'true' || needs.detect-changes.outputs.datautils == 'true' || needs.detect-changes.outputs.repack == 'true'
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
 
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - package: catalog
-            name: owid-catalog
-            path: lib/catalog
-            should_run: ${{ needs.detect-changes.outputs.catalog }}
-          - package: datautils
-            name: owid-datautils
-            path: lib/datautils
-            should_run: ${{ needs.detect-changes.outputs.datautils }}
-          - package: repack
-            name: owid-repack
-            path: lib/repack
-            should_run: ${{ needs.detect-changes.outputs.repack }}
+        include: ${{ fromJSON(needs.detect-changes.outputs.packages) }}
 
     steps:
-    - name: Skip if not needed
-      if: matrix.should_run != 'true'
-      run: |
-        echo "Skipping ${{ matrix.name }} - no changes detected"
-        exit 0
-
     - name: Checkout code
-      if: matrix.should_run == 'true'
-      uses: actions/checkout@v2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         fetch-depth: 2
 
     - name: Check if version needs publishing
-      if: matrix.should_run == 'true'
       run: |
-        # Extract current version from pyproject.toml
         CURRENT_VERSION=$(grep '^version = ' ${{ matrix.path }}/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
 
         echo "Current version in pyproject.toml: $CURRENT_VERSION"
 
-        # Check if this version already exists on PyPI
         PYPI_RESPONSE=$(curl -s "https://pypi.org/pypi/${{ matrix.name }}/${CURRENT_VERSION}/json" -w "%{http_code}" -o /tmp/pypi_response.json)
 
         if [ "$PYPI_RESPONSE" = "200" ]; then
@@ -102,22 +100,20 @@ jobs:
         echo "✅ Version $CURRENT_VERSION not found on PyPI, proceeding with publish"
 
     - name: Set up Python
-      if: matrix.should_run == 'true'
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: '3.x'
 
-    - name: Install UV
-      if: matrix.should_run == 'true'
-      run: curl -LsSf https://astral.sh/uv/install.sh | sh
+    - name: Set up uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
-    - name: Publish ${{ matrix.name }}
-      if: matrix.should_run == 'true'
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
+    - name: Build ${{ matrix.name }}
       run: |
         cd ${{ matrix.path }}
         rm -rf dist
         uv build
-        uvx twine upload dist/*
+
+    - name: Publish ${{ matrix.name }} to PyPI
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
+      with:
+        packages-dir: ${{ matrix.path }}/dist

--- a/lib/repack/pyproject.toml
+++ b/lib/repack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-repack"
-version = "0.1.8"
+version = "0.1.9"
 description = "Pack Pandas data frames into smaller, more memory-efficient data types."
 authors = [
     {name = "Our World in Data", email = "tech@ourworldindata.org"},

--- a/lib/repack/uv.lock
+++ b/lib/repack/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-10T08:03:28.314889Z"
+exclude-newer = "2026-05-10T08:44:47.163088Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -344,7 +344,7 @@ wheels = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Replace the long-lived `POETRY_PYPI_TOKEN_PYPI` secret in `publish-owid-packages.yml` with PyPI [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC). The publish job mints a short-lived OIDC token per run — there is no long-lived secret to steal.

Tracked in [owid/ops#472](https://github.com/owid/ops/issues/472). Recent PyPI supply-chain attacks (PyTorch Lightning Apr 2026, LiteLLM Mar 2026, Telnyx) all pivot through stolen long-lived PyPI tokens. Our `owid-*` packages are installed by our own ETL pipeline and external users; eliminating the token closes that vector permanently.

## What changes in the workflow

- Top-level `permissions: contents: read` baseline.
- `publish` job: `environment: pypi` + `permissions: id-token: write` so OIDC can mint a token for the trusted publisher configured on PyPI for each of `owid-catalog` / `owid-datautils` / `owid-repack`.
- Replace `uvx twine upload` with [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish) (pinned to commit SHA). PEP 740 attestations are emitted automatically.
- Build via `astral-sh/setup-uv` + `uv build` (replaces the unpinned `curl … | sh` uv installer).
- Bump and pin to commit SHAs: `actions/checkout` v6.0.2, `actions/setup-python` v6.2.0, `astral-sh/setup-uv` v8.1.0, `pypa/gh-action-pypi-publish` v1.14.0.
- `detect-changes` now emits a JSON array of packages to publish; `publish` matrices over it. Unchanged packages don't spin up jobs (and don't trigger the environment approval).
- `fail-fast: false` so one package failing doesn't cancel the others.

## Already done out-of-band

- PyPI: trusted publishers configured for all three projects, scoped to `owid/etl` + workflow `publish-owid-packages.yml` + environment `pypi`.
- GitHub: `pypi` environment created on this repo.

## Post-merge cleanup

After the first successful publish on this workflow:

1. Delete the `POETRY_PYPI_TOKEN_PYPI` secret from repo settings.
2. Revoke the matching API token on PyPI.

## Test plan

- [ ] Workflow file parses (no lint errors in the diff).
- [ ] After merge, bump one package's version (e.g. `lib/repack/pyproject.toml` patch bump) and confirm:
  - [ ] OIDC token mint succeeds in the Actions log.
  - [ ] `pypa/gh-action-pypi-publish` reports successful upload + PEP 740 attestation.
  - [ ] The new release appears on PyPI with the "Trusted publisher" badge.
  - [ ] `uv pip install --upgrade owid-repack` (or whichever package was bumped) works.
- [ ] Run cleanup; do a second no-op version bump to confirm publishing still works *without* the legacy secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)