### PR TITLE
📊 Silence pytest warnings

### DIFF
--- a/etl/data_helpers/misc.py
+++ b/etl/data_helpers/misc.py
@@ -231,14 +231,25 @@ def expand_time_column(
     if method == "full_range_entity":
 
         def _reindex_dates(group):
+            name = group.name
             complete_date_range = _get_complete_date_range(group[time_col])
             group = (
                 group.set_index(time_col).reindex(complete_date_range).reset_index().rename(columns={"index": time_col})
             )
-            group[dimension_col] = group[dimension_col].ffill().bfill()  # Fill NaNs in 'country'
+            # Fill the dimension column(s) with the group key (avoiding the previous ffill/bfill hack).
+            if SINGLE_DIMENSION:
+                group[dimension_col] = name
+            else:
+                for col, val in zip(dimension_col, name):
+                    group[col] = val
             return group
 
-        df = df.groupby(dimension_col).apply(_reindex_dates).reset_index(drop=True).set_index(index)  # ty: ignore
+        df = (  # ty: ignore[invalid-assignment]
+            df.groupby(dimension_col, group_keys=False)
+            .apply(_reindex_dates, include_groups=False)
+            .reset_index(drop=True)
+            .set_index(index)
+        )
         df = cast(TableOrDataFrame, df.reset_index())
     # Either full range or all observations.
     elif method in {"full_range", "observed"}:

--- a/tests/collections/test_collections_utils.py
+++ b/tests/collections/test_collections_utils.py
@@ -129,7 +129,8 @@ def test_group_views_legacy():
         {"dimensions": {"country": "a"}, "indicators": {"y": "ind2"}},
         {"dimensions": {"country": "b"}, "indicators": {"y": "ind3"}},
     ]
-    grouped = group_views_legacy(views, by=["country"])
+    with pytest.warns(DeprecationWarning, match="group_views_legacy"):
+        grouped = group_views_legacy(views, by=["country"])
     assert grouped == [
         {
             "dimensions": {"country": "a"},
@@ -142,7 +143,7 @@ def test_group_views_legacy():
     ]
 
     err_view = {"dimensions": {"country": "c"}, "indicators": {"y": ["a", "b"]}}
-    with pytest.raises(NotImplementedError):
+    with pytest.warns(DeprecationWarning, match="group_views_legacy"), pytest.raises(NotImplementedError):
         group_views_legacy([err_view], by=["country"])
 
 

--- a/tests/data_helpers/test_geo.py
+++ b/tests/data_helpers/test_geo.py
@@ -287,6 +287,7 @@ class TestHarmonizeCountries:
             excluded_countries_file="MOCK_EXCLUDED_COUNTRIES_FILE",
             warn_on_unused_countries=False,
             warn_on_missing_countries=False,
+            warn_on_unknown_excluded_countries=False,
         ).equals(df_out)
 
     def test_one_country_left_equal_one_harmonized_and_one_excluded(self):
@@ -298,6 +299,7 @@ class TestHarmonizeCountries:
             excluded_countries_file="MOCK_EXCLUDED_COUNTRIES_FILE",
             warn_on_unused_countries=False,
             warn_on_missing_countries=False,
+            warn_on_unknown_excluded_countries=False,
         ).equals(df_out)
 
     def test_warn_on_unknown_excluded_countries(self):
@@ -813,8 +815,8 @@ class MockRegionsDataset:
     def __getitem__(self, name: str) -> Table:
         mock_tb_regions = Table(
             {
-                "code": ["OWID_EUR", "BLR", "FRA", "ITA", "RUS", "ESP", "OWID_USS"],
-                "name": ["Europe", "Belarus", "France", "Italy", "Russia", "Spain", "USSR"],
+                "code": ["OWID_EUR", "BLR", "FRA", "ITA", "RUS", "ESP", "OWID_USS", "GUF"],
+                "name": ["Europe", "Belarus", "France", "Italy", "Russia", "Spain", "USSR", "French Guiana"],
                 "region_type": [
                     "continent",
                     "country",
@@ -823,11 +825,21 @@ class MockRegionsDataset:
                     "country",
                     "country",
                     "country",
+                    "country",
                 ],
-                "is_historical": [False, False, False, False, False, False, True],
-                "members": ['["BLR", "FRA", "ITA", "RUS", "ESP", "OWID_USS"]', "[]", "[]", "[]", "[]", "[]", "[]"],
-                "successors": ["[]", "[]", "[]", "[]", "[]", "[]", '["BLR", "RUS"]'],
-                "related": ["[]", '["GUF"]', "[]", "[]", "[]", "[]", "[]"],
+                "is_historical": [False, False, False, False, False, False, True, False],
+                "members": [
+                    '["BLR", "FRA", "ITA", "RUS", "ESP", "OWID_USS"]',
+                    "[]",
+                    "[]",
+                    "[]",
+                    "[]",
+                    "[]",
+                    "[]",
+                    "[]",
+                ],
+                "successors": ["[]", "[]", "[]", "[]", "[]", "[]", '["BLR", "RUS"]', "[]"],
+                "related": ["[]", '["GUF"]', "[]", "[]", "[]", "[]", "[]", "[]"],
             }
         ).set_index("code")
         return mock_tb_regions

--- a/tests/data_helpers/test_misc.py
+++ b/tests/data_helpers/test_misc.py
@@ -304,8 +304,8 @@ def test_expand_time_column_fillna_basic():
         )
 
         # Tag those filled
-        df_tag = df[index_col]
-        df_tag.loc[:, "expand"] = False
+        df_tag = df[index_col].copy()
+        df_tag["expand"] = False
 
         dfx = dfx.merge(df_tag, on=index_col, how="left")
         dfx["expand"] = dfx["expand"].fillna(True).astype(bool)
@@ -328,8 +328,8 @@ def test_expand_time_column_fillna_basic():
 
 def test_expand_time_column_fillna_zero():
     def _add_expand_tag(dfx, df):
-        df_tag = df[index_col]
-        df_tag.loc[:, "expand"] = False
+        df_tag = df[index_col].copy()
+        df_tag["expand"] = False
 
         dfx = dfx.merge(df_tag, on=index_col, how="left")
         dfx["expand"] = dfx["expand"].fillna(True).astype(bool)
@@ -363,8 +363,8 @@ def test_expand_time_column_fillna_zero():
 
 def test_expand_time_column_fillna_ffill():
     def _add_expand_tag(dfx, df):
-        df_tag = df[index_col]
-        df_tag.loc[:, "expand"] = False
+        df_tag = df[index_col].copy()
+        df_tag["expand"] = False
 
         dfx = dfx.merge(df_tag, on=index_col, how="left")
         dfx["expand"] = dfx["expand"].fillna(True).astype(bool)
@@ -442,8 +442,8 @@ def test_expand_time_column_fillna_ffill():
 
 def test_expand_time_column_fillna_bfill():
     def _add_expand_tag(dfx, df):
-        df_tag = df[index_col]
-        df_tag.loc[:, "expand"] = False
+        df_tag = df[index_col].copy()
+        df_tag["expand"] = False
 
         dfx = dfx.merge(df_tag, on=index_col, how="left")
         dfx["expand"] = dfx["expand"].fillna(True).astype(bool)
@@ -521,8 +521,8 @@ def test_expand_time_column_fillna_bfill():
 
 def test_expand_time_column_fillna_interpolate():
     def _add_expand_tag(dfx, df):
-        df_tag = df[index_col]
-        df_tag.loc[:, "expand"] = False
+        df_tag = df[index_col].copy()
+        df_tag["expand"] = False
 
         dfx = dfx.merge(df_tag, on=index_col, how="left")
         dfx["expand"] = dfx["expand"].fillna(True).astype(bool)
@@ -600,8 +600,8 @@ def test_expand_time_column_fillna_interpolate():
 
 def test_expand_time_column_fillna_interpolate_and_zero():
     def _add_expand_tag(dfx, df):
-        df_tag = df[index_col]
-        df_tag.loc[:, "expand"] = False
+        df_tag = df[index_col].copy()
+        df_tag["expand"] = False
 
         dfx = dfx.merge(df_tag, on=index_col, how="left")
         dfx["expand"] = dfx["expand"].fillna(True).astype(bool)
@@ -679,8 +679,8 @@ def test_expand_time_column_fillna_interpolate_and_zero():
 
 def test_expand_time_column_and_extra_years():
     def _add_expand_tag(dfx, df):
-        df_tag = df[index_col]
-        df_tag.loc[:, "expand"] = False
+        df_tag = df[index_col].copy()
+        df_tag["expand"] = False
 
         dfx = dfx.merge(df_tag, on=index_col, how="left")
         dfx["expand"] = dfx["expand"].fillna(True).astype(bool)
@@ -722,8 +722,8 @@ def test_expand_time_complex():
     """
 
     def _add_expand_tag(dfx, df):
-        df_tag = df[index_col]
-        df_tag.loc[:, "expand"] = False
+        df_tag = df[index_col].copy()
+        df_tag["expand"] = False
 
         dfx = dfx.merge(df_tag, on=index_col, how="left")
         dfx["expand"] = dfx["expand"].fillna(True).astype(bool)

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch
 
 import pandas as pd
+import pytest
 from owid.catalog import Dataset, DatasetMeta, Table
 
 from etl.datadiff import DatasetDiff
@@ -22,6 +23,7 @@ def _create_datasets(tmp_path):
     return ds_a, ds_b
 
 
+@pytest.mark.filterwarnings("ignore:Table `tab` does not have a primary_key")
 @patch.dict(os.environ, {"OWID_STRICT": ""})
 def test_DatasetDiff_summary(tmp_path):
     ds_a, ds_b = _create_datasets(tmp_path)
@@ -47,6 +49,7 @@ def test_DatasetDiff_summary(tmp_path):
     ]
 
 
+@pytest.mark.filterwarnings("ignore:Table `tab` does not have a primary_key")
 @patch.dict(os.environ, {"OWID_STRICT": ""})
 def test_new_data(tmp_path):
     ds_a, ds_b = _create_datasets(tmp_path)

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -46,6 +46,7 @@ from owid.catalog import Dataset
 def run(dest_dir):
     ds = Dataset.create_empty(dest_dir)
     ds.metadata.short_name = "test"
+    ds.metadata.namespace = "test_ns"
     ds.save()
             """,
             file=ostream,
@@ -326,6 +327,7 @@ tables:
             # Create initial dataset
             ds = Dataset.create_empty(dataset_dir.as_posix())
             ds.metadata.short_name = "test_dataset"
+            ds.metadata.namespace = "test_ns"
 
             # Create a table with one indicator
             tb = Table(pd.DataFrame({"value": [1, 2, 3]}, index=pd.Index([2020, 2021, 2022], name="year")))


### PR DESCRIPTION
## Summary

`make test` was emitting 32 pytest warnings, polluting CI output. This PR cleans all of them up so the warnings summary stays empty.

### Source fix
- `etl/data_helpers/misc.py` — `expand_time_column(method="full_range_entity")` was using `groupby().apply()` in a way that triggers a pandas 2.2 `DeprecationWarning` (grouping columns being passed to the apply func). Refactored `_reindex_dates` to use `include_groups=False` and fill the dimension column(s) from `group.name`, instead of the post-reindex `ffill().bfill()` hack. Handles both single- and multi-dimension cases.

### Test-only fixes
- `tests/data_helpers/test_misc.py` — 8× `df_tag = df[index_col]` → `df_tag = df[index_col].copy()` (`SettingWithCopyWarning`).
- `tests/data_helpers/test_geo.py` — added `warn_on_unknown_excluded_countries=False` to the two `harmonize_countries` tests that weren't testing that warning; added `GUF` / `French Guiana` to `MockRegionsDataset` so the `related` mapping resolves cleanly (`1 missing values in mapping`).
- `tests/collections/test_collections_utils.py` — wrapped the two `group_views_legacy` calls in `pytest.warns(DeprecationWarning, ...)` (this test exists specifically to cover the deprecated function).
- `tests/test_steps.py` — added `ds.metadata.namespace = "test_ns"` to the mock step + `test_instant_metadata_with_override_file` (`Dataset … is missing namespace`).
- `tests/test_datadiff.py` — added `@pytest.mark.filterwarnings("ignore:Table \`tab\` does not have a primary_key")` on the two summary tests. Using a real primary key here would have moved 'a' into the index and changed the asserted diff output.

## Test plan
- [x] `make test` runs clean (452 passed, 0 warnings)