### PR TITLE
📊 Avoid flattening nested DAGs on update

### DIFF
--- a/etl/dag_helpers.py
+++ b/etl/dag_helpers.py
@@ -276,10 +276,22 @@ def write_to_dag_file(
             # Ensure all comments end in a line break, otherwise add it.
             comments[step] = comments[step] + "\n"
 
-    # The line-based logic below assumes every step is declared at the top level.
-    # If ``dag_file`` uses the compact nested syntax, flatten it first so that
-    # the update touches the right entries.
-    flatten_dag_file(dag_file)
+    dag_yml = _load_dag_yaml(str(dag_file))
+    existing_steps = _parse_dag_yaml(dag_yml)
+    top_level_steps = set((dag_yml.get("steps") or {}).keys())
+    nested_only_steps = set(existing_steps) - top_level_steps
+    nested_top_level_steps = {
+        step
+        for step, dependencies in (dag_yml.get("steps") or {}).items()
+        if _dependencies_contain_nested_step(dependencies)
+    }
+    steps_that_would_flatten = set(dag_part) & (nested_only_steps | nested_top_level_steps)
+    if steps_that_would_flatten:
+        steps = ", ".join(sorted(steps_that_would_flatten))
+        raise ValueError(
+            "Cannot update steps declared with nested DAG syntax without flattening the file. "
+            f"Affected steps: {steps}. Please flatten the file manually or use a nesting-aware writer."
+        )
 
     # Read the lines in the original dag file.
     with open(dag_file) as file:
@@ -379,6 +391,13 @@ def write_to_dag_file(
     # Write the updated content back to the dag file.
     with open(dag_file, "w") as file:
         file.writelines(updated_lines)
+
+
+def _dependencies_contain_nested_step(dependencies: Any) -> bool:
+    """Return true if a dependency list declares nested DAG steps."""
+    if not isinstance(dependencies, list):
+        return False
+    return any(isinstance(dependency, dict) for dependency in dependencies)
 
 
 def _remove_step_from_dag_file(dag_file: Path, step: str) -> None:

--- a/tests/test_dag_utils.py
+++ b/tests/test_dag_utils.py
@@ -1036,10 +1036,50 @@ steps:
         assert flatten_dag_file(p) is False
 
 
-def test_write_to_dag_file_handles_nested_input():
-    # Writers operate on a flat file; if the target file has nested entries,
-    # they should be flattened first so that the line-based logic finds the
-    # step it is meant to update.
+def test_write_to_dag_file_nested_noop_preserves_structure_and_comments():
+    old_content = """\
+steps:
+  # UN WPP (2022)
+  data://grapher/un/2022-07-11/un_wpp:
+    # In-block comment.
+    - data://garden/un/2022-07-11/un_wpp:
+      - data://meadow/un/2022-07-11/un_wpp:
+        - snapshot://un/2022-07-11/un_wpp.zip
+"""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "dag.yml"
+        p.write_text(old_content)
+        write_to_dag_file(p, dag_part={})
+        assert p.read_text() == old_content
+
+
+def test_write_to_dag_file_nested_input_appends_new_steps_flat_without_flattening_existing_steps():
+    old_content = """\
+steps:
+  data://grapher/un/2022-07-11/un_wpp:
+    - data://garden/un/2022-07-11/un_wpp:
+      - data://meadow/un/2022-07-11/un_wpp:
+        - snapshot://un/2022-07-11/un_wpp.zip
+"""
+    expected_content = (
+        old_content
+        + """\
+  data://meadow/foo/2024/bar:
+    - snapshot://foo/2024/bar.csv
+"""
+    )
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "dag.yml"
+        p.write_text(old_content)
+        write_to_dag_file(
+            p,
+            dag_part={"data://meadow/foo/2024/bar": ["snapshot://foo/2024/bar.csv"]},
+        )
+        assert p.read_text() == expected_content
+        assert load_dag(p)["data://garden/un/2022-07-11/un_wpp"] == {"data://meadow/un/2022-07-11/un_wpp"}
+
+
+def test_write_to_dag_file_nested_input_refuses_to_update_nested_steps():
     old_content = """\
 steps:
   data://grapher/un/2022-07-11/un_wpp:
@@ -1050,24 +1090,17 @@ steps:
     with tempfile.TemporaryDirectory() as d:
         p = Path(d) / "dag.yml"
         p.write_text(old_content)
-        # Update the garden step to add a new dep — this must apply whether
-        # the file is stored flat or nested.
-        write_to_dag_file(
-            p,
-            dag_part={
-                "data://garden/un/2022-07-11/un_wpp": [
-                    "data://meadow/un/2022-07-11/un_wpp",
-                    "data://garden/regions/latest",
-                ]
-            },
-        )
-        after = p.read_text()
-        assert "    - data://garden/regions/latest" in after
-        # The update must not silently reintroduce the old single-dep form.
-        assert load_dag(p)["data://garden/un/2022-07-11/un_wpp"] == {
-            "data://meadow/un/2022-07-11/un_wpp",
-            "data://garden/regions/latest",
-        }
+        with pytest.raises(ValueError, match="nested DAG syntax"):
+            write_to_dag_file(
+                p,
+                dag_part={
+                    "data://garden/un/2022-07-11/un_wpp": [
+                        "data://meadow/un/2022-07-11/un_wpp",
+                        "data://garden/regions/latest",
+                    ]
+                },
+            )
+        assert p.read_text() == old_content
 
 
 def test_remove_steps_from_dag_file_handles_nested_input():


### PR DESCRIPTION
## Summary

Fixes #6117 (phase 1).

This avoids the surprising formatting loss from `etl update` by removing the automatic `flatten_dag_file()` call from `write_to_dag_file`. Existing nested DAG blocks are now preserved when unrelated new steps are appended. If an update targets a step declared in nested DAG syntax, the writer now fails clearly instead of flattening the file.

This is intentionally conservative: new steps are still appended in flat syntax, and a future phase can add a fully nesting-aware ruamel writer.

## Testing

- `.venv/bin/pytest tests/test_dag_utils.py -k "write_to_dag_file or nested"`
- `.venv/bin/pytest tests/test_dag_utils.py`
- Manual check: ran `etl update data://garden/climate/2026-05-13/climate_change_impacts --step-version-new 2026-05-14 --non-interactive` and confirmed `dag/climate.yml` was not flattened; reverted generated files afterwards.