### PR TITLE
📊 Support nesting-aware DAG updates

### DIFF
--- a/etl/dag_helpers.py
+++ b/etl/dag_helpers.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
 from structlog import get_logger
 
 from etl import paths
@@ -285,13 +287,12 @@ def write_to_dag_file(
         for step, dependencies in (dag_yml.get("steps") or {}).items()
         if _dependencies_contain_nested_step(dependencies)
     }
-    steps_that_would_flatten = set(dag_part) & (nested_only_steps | nested_top_level_steps)
-    if steps_that_would_flatten:
-        steps = ", ".join(sorted(steps_that_would_flatten))
-        raise ValueError(
-            "Cannot update steps declared with nested DAG syntax without flattening the file. "
-            f"Affected steps: {steps}. Please flatten the file manually or use a nesting-aware writer."
-        )
+    steps_that_need_nested_writer = set(dag_part) & (nested_only_steps | nested_top_level_steps)
+    has_nested_steps = bool(nested_only_steps or nested_top_level_steps)
+    has_new_step = any(step not in existing_steps for step in dag_part)
+    if steps_that_need_nested_writer or (has_nested_steps and has_new_step):
+        _write_to_nested_dag_file(dag_file=dag_file, dag_part=dag_part, comments=comments)
+        return
 
     # Read the lines in the original dag file.
     with open(dag_file) as file:
@@ -398,6 +399,106 @@ def _dependencies_contain_nested_step(dependencies: Any) -> bool:
     if not isinstance(dependencies, list):
         return False
     return any(isinstance(dependency, dict) for dependency in dependencies)
+
+
+def _write_to_nested_dag_file(dag_file: Path, dag_part: dict[str, Any], comments: dict[str, str]) -> None:
+    """Update a DAG file that already uses compact nested syntax.
+
+    The historical writer is line-based and can only update top-level step
+    declarations. For nested declarations, use ruamel's round-trip loader so
+    existing structure and comments are preserved while replacing dependency
+    lists structurally.
+    """
+    yaml_rt = YAML(typ="rt")
+    yaml_rt.preserve_quotes = True
+    yaml_rt.indent(mapping=2, sequence=2, offset=2)
+    yaml_rt.width = 4096
+    yaml_rt.emitter.MAX_SIMPLE_KEY_LENGTH = 4096
+
+    with open(dag_file) as istream:
+        doc = yaml_rt.load(istream)
+
+    steps = doc.setdefault("steps", CommentedMap())
+    original_steps = set(_parse_dag_yaml(doc))
+    declared_steps = set(original_steps)
+
+    for step, dependencies in dag_part.items():
+        node = _find_step_mapping(steps, step)
+        if node is None:
+            continue
+        mapping, key = node
+        mapping[key] = _build_dependency_sequence(dependencies, dag_part, declared_steps, {step})
+        declared_steps.update(_collect_declared_steps(mapping[key]))
+
+    dag_part_dependencies = {dependency for dependencies in dag_part.values() for dependency in dependencies}
+    new_roots = [step for step in dag_part if step not in original_steps and step not in dag_part_dependencies]
+    for step in new_roots:
+        steps[step] = _build_dependency_sequence(dag_part[step], dag_part, declared_steps, {step})
+        if comments.get(step):
+            steps.yaml_set_comment_before_after_key(step, before=_normalise_ruamel_comment(comments[step]), indent=2)
+        declared_steps.add(step)
+        declared_steps.update(_collect_declared_steps(steps[step]))
+
+    with open(dag_file, "w") as ostream:
+        yaml_rt.dump(doc, ostream)
+
+
+def _normalise_ruamel_comment(comment: str) -> str:
+    """Convert a literal YAML comment block to ruamel's comment text format."""
+    lines = []
+    for line in comment.rstrip("\n").split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            stripped = stripped[1:].lstrip()
+        lines.append(stripped)
+    return "\n".join(lines)
+
+
+def _find_step_mapping(node: Any, step: str) -> tuple[Any, str] | None:
+    """Find the mapping object and key where ``step`` is declared."""
+    if isinstance(node, dict):
+        if step in node:
+            return node, step
+        for value in node.values():
+            result = _find_step_mapping(value, step)
+            if result is not None:
+                return result
+    elif isinstance(node, list):
+        for item in node:
+            result = _find_step_mapping(item, step)
+            if result is not None:
+                return result
+    return None
+
+
+def _build_dependency_sequence(
+    dependencies: Any, dag_part: dict[str, Any], declared_steps: set[str], ancestors: set[str]
+) -> CommentedSeq:
+    sequence = CommentedSeq()
+    for dependency in dependencies or []:
+        if dependency in dag_part and dependency not in declared_steps and dependency not in ancestors:
+            nested = CommentedMap()
+            nested[dependency] = _build_dependency_sequence(
+                dag_part[dependency], dag_part, declared_steps, ancestors | {dependency}
+            )
+            sequence.append(nested)
+            declared_steps.add(dependency)
+            declared_steps.update(_collect_declared_steps(nested[dependency]))
+        else:
+            sequence.append(dependency)
+    return sequence
+
+
+def _collect_declared_steps(node: Any) -> set[str]:
+    declared_steps: set[str] = set()
+    if isinstance(node, dict):
+        for step, dependencies in node.items():
+            declared_steps.add(step)
+            declared_steps.update(_collect_declared_steps(dependencies))
+    elif isinstance(node, list):
+        for item in node:
+            declared_steps.update(_collect_declared_steps(item))
+    return declared_steps
 
 
 def _remove_step_from_dag_file(dag_file: Path, step: str) -> None:

--- a/tests/test_dag_utils.py
+++ b/tests/test_dag_utils.py
@@ -1147,12 +1147,15 @@ steps:
     - data://garden/existing/2024/bar:
       - data://meadow/existing/2024/bar
 """
-    expected_content = old_content + """\
+    expected_content = (
+        old_content
+        + """\
   data://grapher/foo/2025/bar:
     - data://garden/foo/2025/bar:
       - data://meadow/foo/2025/bar:
         - snapshot://foo/2025/bar.csv
 """
+    )
     with tempfile.TemporaryDirectory() as d:
         p = Path(d) / "dag.yml"
         p.write_text(old_content)

--- a/tests/test_dag_utils.py
+++ b/tests/test_dag_utils.py
@@ -1079,10 +1079,12 @@ steps:
         assert load_dag(p)["data://garden/un/2022-07-11/un_wpp"] == {"data://meadow/un/2022-07-11/un_wpp"}
 
 
-def test_write_to_dag_file_nested_input_refuses_to_update_nested_steps():
+def test_write_to_dag_file_nested_input_updates_nested_steps_in_place():
     old_content = """\
 steps:
+  # UN WPP (2022)
   data://grapher/un/2022-07-11/un_wpp:
+    # In-block comment.
     - data://garden/un/2022-07-11/un_wpp:
       - data://meadow/un/2022-07-11/un_wpp:
         - snapshot://un/2022-07-11/un_wpp.zip
@@ -1090,17 +1092,80 @@ steps:
     with tempfile.TemporaryDirectory() as d:
         p = Path(d) / "dag.yml"
         p.write_text(old_content)
-        with pytest.raises(ValueError, match="nested DAG syntax"):
-            write_to_dag_file(
-                p,
-                dag_part={
-                    "data://garden/un/2022-07-11/un_wpp": [
-                        "data://meadow/un/2022-07-11/un_wpp",
-                        "data://garden/regions/latest",
-                    ]
-                },
-            )
-        assert p.read_text() == old_content
+        write_to_dag_file(
+            p,
+            dag_part={
+                "data://garden/un/2022-07-11/un_wpp": [
+                    "data://meadow/un/2022-07-11/un_wpp",
+                    "data://garden/regions/latest",
+                ]
+            },
+        )
+        after = p.read_text()
+        assert "# UN WPP (2022)" in after
+        assert "# In-block comment." in after
+        assert "data://grapher/un/2022-07-11/un_wpp:\n    # In-block comment.\n    - data://garden" in after
+        assert "      - data://garden/regions/latest\n" in after
+        assert load_dag(p)["data://garden/un/2022-07-11/un_wpp"] == {
+            "data://meadow/un/2022-07-11/un_wpp",
+            "data://garden/regions/latest",
+        }
+
+
+def test_write_to_dag_file_nested_input_inserts_new_step_under_natural_parent():
+    old_content = """\
+steps:
+  data://grapher/foo/2024/bar:
+    - data://garden/foo/2024/bar:
+      - data://meadow/foo/2024/bar
+"""
+    expected_content = """\
+steps:
+  data://grapher/foo/2024/bar:
+    - data://garden/foo/2024/bar:
+      - data://meadow/foo/2024/bar:
+        - snapshot://foo/2024/bar.csv
+"""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "dag.yml"
+        p.write_text(old_content)
+        write_to_dag_file(
+            p,
+            dag_part={
+                "data://garden/foo/2024/bar": ["data://meadow/foo/2024/bar"],
+                "data://meadow/foo/2024/bar": ["snapshot://foo/2024/bar.csv"],
+            },
+        )
+        assert p.read_text() == expected_content
+        assert load_dag(p)["data://meadow/foo/2024/bar"] == {"snapshot://foo/2024/bar.csv"}
+
+
+def test_write_to_dag_file_nested_input_adds_brand_new_chain_nested():
+    old_content = """\
+steps:
+  data://grapher/existing/2024/bar:
+    - data://garden/existing/2024/bar:
+      - data://meadow/existing/2024/bar
+"""
+    expected_content = old_content + """\
+  data://grapher/foo/2025/bar:
+    - data://garden/foo/2025/bar:
+      - data://meadow/foo/2025/bar:
+        - snapshot://foo/2025/bar.csv
+"""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "dag.yml"
+        p.write_text(old_content)
+        write_to_dag_file(
+            p,
+            dag_part={
+                "data://grapher/foo/2025/bar": ["data://garden/foo/2025/bar"],
+                "data://garden/foo/2025/bar": ["data://meadow/foo/2025/bar"],
+                "data://meadow/foo/2025/bar": ["snapshot://foo/2025/bar.csv"],
+            },
+        )
+        assert p.read_text() == expected_content
+        assert load_dag(p)["data://grapher/foo/2025/bar"] == {"data://garden/foo/2025/bar"}
 
 
 def test_remove_steps_from_dag_file_handles_nested_input():


### PR DESCRIPTION
## Summary

Follow-up to #6120 / phase 2 for #6117.

This adds a nesting-aware path to `write_to_dag_file` for DAG files that already use compact nested syntax. When an update touches nested declarations, the writer now uses ruamel round-tripping to preserve the nested structure and comments while updating dependencies in place. New multi-step chains are emitted in compact nested form under their root step when they are passed together to the writer.

Flat DAG files continue to use the existing line-based writer to minimize churn.

## Testing

- `.venv/bin/pytest tests/test_dag_utils.py -k "write_to_dag_file or nested"`
- `.venv/bin/pytest tests/test_dag_utils.py`
- Manual check: ran `etl update data://garden/climate/2026-05-13/climate_change_impacts --step-version-new 2026-05-14 --non-interactive`; confirmed `dag/climate.yml` was not flattened and generated changes were reverted afterwards.
- Manual nuclear-weapons check: ran `etl update` commands against the 2025-05-15 nuclear weapons steps in `dag/war.yml`; confirmed the patch only appended the new 2026-05-13 entries and did not flatten/reformat the existing nested `dag/war.yml` blocks. Generated changes were reverted afterwards.

Note: commit hooks also ran lint/format/type checks.