### PR TITLE
🐛 Migrate outdated grapher_config schemas + fix unpicklable ValidationError

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,7 @@ Add 🤖 after emoji for AI-written code: `🔨🤖 Refactor country mapping`
 - **`paths.regions.harmonize_names(tb, country_col=..., countries_file=...)`** — current harmonization API (replaces `geo.harmonize_countries`)
 - **`Table.format()`** needs both `country` and `year`. For year-less tables: `set_index("country")` + set `tb.metadata.short_name`
 - **`*.meta.yml`**: omit `dataset:` block — inherited from origin. Only define `tables:` → `variables:`
+- **`grapher_config`: omit `$schema:`** — pinning a specific schema version ages badly. The default in `etl/config.py:DEFAULT_GRAPHER_SCHEMA` is applied automatically by `_validate_grapher_config`.
 
 ### Performance
 
@@ -190,6 +191,8 @@ Automatically connects to `staging-site-{branch}` based on current git branch.
 from etl.config import OWID_ENV
 df = OWID_ENV.read_sql("SELECT * FROM datasets LIMIT 10")
 ```
+
+**Prefer Python when the SQL contains `%` (LIKE patterns, JSON_EXTRACT paths) or single-quoted strings — `make query` re-interprets those via shell + make and breaks unpredictably.** Use `params={...}` for `%`/quoted values to dodge pymysql's own `%`-format-string parsing.
 
 ## Additional Tools
 

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -593,6 +593,13 @@ class ChartDiffShow:
         if not self.diff.chart_id:
             return
 
+        # Respect the sidebar toggle. The list-side filter in app.py only runs when
+        # `show_all` is off; without this gate the block would still render here when
+        # the user toggles narrative-charts off but also has "Show all charts" enabled.
+        # Mirrors the same pattern in `_show_citations`.
+        if not st.session_state.get("show-narrative-charts", True):
+            return
+
         # Load narrative charts for this parent chart
         narrative_charts = gm.NarrativeChart.load_narrative_charts_by_parent_chart_ids(
             self.source_session, {self.diff.chart_id}

--- a/etl/grapher/helpers.py
+++ b/etl/grapher/helpers.py
@@ -741,9 +741,16 @@ def _validate_grapher_config(tab: Table, col: str) -> None:
         # schema["required"] = [f for f in schema["required"] if f not in ("dimensions", "version", "title")]
         schema["required"] = []
 
-        from jsonschema import validate
+        from jsonschema import ValidationError, validate
 
-        validate(grapher_config, schema)
+        # Re-raise as ValueError because jsonschema.exceptions.ValidationError is not
+        # reliably picklable across multiprocessing workers (re-imported class identity
+        # mismatches break ForkingPickler), which crashes parallel `etl run` past
+        # --continue-on-failure.
+        try:
+            validate(grapher_config, schema)
+        except ValidationError as e:
+            raise ValueError(f"Invalid grapher_config for column `{col}`: {e}") from None
 
 
 def _validate_description_key(description_key: list[str], col: str) -> None:

--- a/etl/steps/data/garden/ahdi/2023-09-08/augmented_hdi.meta.yml
+++ b/etl/steps/data/garden/ahdi/2023-09-08/augmented_hdi.meta.yml
@@ -85,8 +85,6 @@ tables:
             - Western offshoots (AHDI)
             - Western Europe (AHDI)
             - Eastern Europe (AHDI)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
           topic_tags:
             - Human Development Index (HDI)
             - Life Expectancy
@@ -142,8 +140,6 @@ tables:
               - China
               - Brazil
               - Nigeria
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
       life_expectancy:
         title: Life expectancy
         unit: "years"

--- a/etl/steps/data/garden/ahdi/2023-09-08/augmented_hdi.meta.yml
+++ b/etl/steps/data/garden/ahdi/2023-09-08/augmented_hdi.meta.yml
@@ -85,7 +85,7 @@ tables:
             - Western offshoots (AHDI)
             - Western Europe (AHDI)
             - Eastern Europe (AHDI)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
           topic_tags:
             - Human Development Index (HDI)
@@ -142,7 +142,7 @@ tables:
               - China
               - Brazil
               - Nigeria
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
       life_expectancy:
         title: Life expectancy

--- a/etl/steps/data/garden/gcp/2023-12-12/global_carbon_budget.meta.yml
+++ b/etl/steps/data/garden/gcp/2023-12-12/global_carbon_budget.meta.yml
@@ -94,7 +94,7 @@ tables:
             tab: map
             originUrl: https://ourworldindata.org/co2-and-greenhouse-gas-emissions
             colorScale:
-              binningStrategy: equalInterval
+              binningStrategy: equalSizeBins-normal
             map:
               colorScale:
                 baseColorScheme: Reds

--- a/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
+++ b/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
@@ -42,7 +42,6 @@ tables:
                 colorScale:
                     baseColorScheme: GnBu
                     binningStrategy: manual
-                    binningStrategyBinCount: 9
                     customNumericValues:
                         - 0
                         - 1000
@@ -52,7 +51,6 @@ tables:
                         - 20000
                         - 50000
                         - 100000
-                variableId: 417485
             selectedEntityNames:
                 - World
                 - South and South-East Asia (MPD)
@@ -63,4 +61,4 @@ tables:
                 - Latin America (MPD)
                 - Middle East (MPD)
                 - East Asia (MPD)
-            $schema: 'https://files.ourworldindata.org/schemas/grapher-schema.003.json'
+            $schema: 'https://files.ourworldindata.org/schemas/grapher-schema.010.json'

--- a/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
+++ b/etl/steps/data/garden/ggdc/2020-10-01/ggdc_maddison.meta.yml
@@ -61,4 +61,3 @@ tables:
                 - Latin America (MPD)
                 - Middle East (MPD)
                 - East Asia (MPD)
-            $schema: 'https://files.ourworldindata.org/schemas/grapher-schema.010.json'

--- a/etl/steps/data/garden/ggdc/2024-04-26/maddison_project_database.meta.yml
+++ b/etl/steps/data/garden/ggdc/2024-04-26/maddison_project_database.meta.yml
@@ -157,7 +157,7 @@ tables:
             - fragment_id: poverty-international-dollars
               gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
           grapher_config:
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.008.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
             title: GDP per capita
             subtitle: |-
               {definitions.subtitle_gdp_per_capita} {definitions.description_key_ppp_adjustment}

--- a/etl/steps/data/garden/ggdc/2024-04-26/maddison_project_database.meta.yml
+++ b/etl/steps/data/garden/ggdc/2024-04-26/maddison_project_database.meta.yml
@@ -157,7 +157,6 @@ tables:
             - fragment_id: poverty-international-dollars
               gdoc_id: 1gGburArxglFdHXeTLotFW4TOOLoeRq5XW6UfAdKtaAw
           grapher_config:
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
             title: GDP per capita
             subtitle: |-
               {definitions.subtitle_gdp_per_capita} {definitions.description_key_ppp_adjustment}

--- a/etl/steps/data/garden/harvard/2023-09-18/colonial_dates_dataset.meta.yml
+++ b/etl/steps/data/garden/harvard/2023-09-18/colonial_dates_dataset.meta.yml
@@ -120,8 +120,6 @@ tables:
                 customCategoryLabels:
                   z. Multiple colonizers: Multiple colonizers
                   United Kingdom: United Kingdom
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
       total_colonies:
         title: Number of colonies
         unit: "countries"

--- a/etl/steps/data/garden/harvard/2023-09-18/colonial_dates_dataset.meta.yml
+++ b/etl/steps/data/garden/harvard/2023-09-18/colonial_dates_dataset.meta.yml
@@ -120,7 +120,7 @@ tables:
                 customCategoryLabels:
                   z. Multiple colonizers: Multiple colonizers
                   United Kingdom: United Kingdom
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
       total_colonies:
         title: Number of colonies

--- a/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
+++ b/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
@@ -105,7 +105,7 @@ tables:
               - Democratic Republic of Congo
               - Niger
               - Chile
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
       hdi_f:
         title: Human Development Index (female)

--- a/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
+++ b/etl/steps/data/garden/un/2024-04-09/undp_hdr.meta.yml
@@ -105,8 +105,6 @@ tables:
               - Democratic Republic of Congo
               - Niger
               - Chile
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
       hdi_f:
         title: Human Development Index (female)
         unit: ""

--- a/etl/steps/data/garden/unu_wider/2023-11-01/government_revenue_dataset.meta.yml
+++ b/etl/steps/data/garden/unu_wider/2023-11-01/government_revenue_dataset.meta.yml
@@ -254,7 +254,7 @@ tables:
               - United States
               - France
               - United Kingdom
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       tax_ex_sc:
         title: Taxes excluding social contributions (as a share of GDP)
         description_from_producer: |-

--- a/etl/steps/data/garden/unu_wider/2023-11-01/government_revenue_dataset.meta.yml
+++ b/etl/steps/data/garden/unu_wider/2023-11-01/government_revenue_dataset.meta.yml
@@ -254,7 +254,6 @@ tables:
               - United States
               - France
               - United Kingdom
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       tax_ex_sc:
         title: Taxes excluding social contributions (as a share of GDP)
         description_from_producer: |-

--- a/etl/steps/data/garden/wb/2024-01-17/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2024-01-17/world_bank_pip.meta.yml
@@ -9,7 +9,6 @@ definitions:
       attribution_short: World Bank
       grapher_config:
         originUrl: https://ourworldindata.org/poverty
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
     processing_level: major
 
 

--- a/etl/steps/data/garden/wb/2024-01-17/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2024-01-17/world_bank_pip.meta.yml
@@ -9,7 +9,7 @@ definitions:
       attribution_short: World Bank
       grapher_config:
         originUrl: https://ourworldindata.org/poverty
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
     processing_level: major
 
 

--- a/etl/steps/data/garden/wb/2024-03-27/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2024-03-27/world_bank_pip.meta.yml
@@ -9,7 +9,6 @@ definitions:
       attribution_short: World Bank
       grapher_config:
         originUrl: https://ourworldindata.org/poverty
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
     processing_level: major
 
 
@@ -404,8 +403,6 @@ tables:
               - Nigeria
               - Bangladesh
             originUrl: https://ourworldindata.org/poverty
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
       gini:
         presentation:
           title_public: Gini Coefficient

--- a/etl/steps/data/garden/wb/2024-03-27/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2024-03-27/world_bank_pip.meta.yml
@@ -9,7 +9,7 @@ definitions:
       attribution_short: World Bank
       grapher_config:
         originUrl: https://ourworldindata.org/poverty
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
     processing_level: major
 
 
@@ -404,7 +404,7 @@ tables:
               - Nigeria
               - Bangladesh
             originUrl: https://ourworldindata.org/poverty
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.005.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
       gini:
         presentation:

--- a/etl/steps/data/garden/wid/2025-03-14/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2025-03-14/world_inequality_database.meta.yml
@@ -7,7 +7,6 @@ definitions:
         - Economic Inequality
       grapher_config:
         originUrl: https://ourworldindata.org/economic-inequality
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
     processing_level: major
 
 

--- a/etl/steps/data/garden/wid/2025-03-14/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2025-03-14/world_inequality_database.meta.yml
@@ -7,7 +7,7 @@ definitions:
         - Economic Inequality
       grapher_config:
         originUrl: https://ourworldindata.org/economic-inequality
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
     processing_level: major
 
 

--- a/etl/steps/data/garden/wid/2026-01-02/world_inequality_database_legacy.meta.yml
+++ b/etl/steps/data/garden/wid/2026-01-02/world_inequality_database_legacy.meta.yml
@@ -7,7 +7,6 @@ definitions:
         - Economic Inequality
       grapher_config:
         originUrl: https://ourworldindata.org/economic-inequality
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
     processing_level: major
 
 

--- a/etl/steps/data/garden/wid/2026-01-02/world_inequality_database_legacy.meta.yml
+++ b/etl/steps/data/garden/wid/2026-01-02/world_inequality_database_legacy.meta.yml
@@ -7,7 +7,7 @@ definitions:
         - Economic Inequality
       grapher_config:
         originUrl: https://ourworldindata.org/economic-inequality
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
     processing_level: major
 
 

--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database_legacy.meta.yml
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database_legacy.meta.yml
@@ -7,7 +7,6 @@ definitions:
         - Economic Inequality
       grapher_config:
         originUrl: https://ourworldindata.org/economic-inequality
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
     processing_level: major
 
 

--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database_legacy.meta.yml
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database_legacy.meta.yml
@@ -7,7 +7,7 @@ definitions:
         - Economic Inequality
       grapher_config:
         originUrl: https://ourworldindata.org/economic-inequality
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
     processing_level: major
 
 

--- a/etl/steps/data/grapher/biodiversity/2022/living_planet_index.meta.yml
+++ b/etl/steps/data/grapher/biodiversity/2022/living_planet_index.meta.yml
@@ -90,10 +90,10 @@ tables:
               timeTolerance: 1
               colorScale:
                 baseColorScheme: BuGn
-                binningStrategy: equalInterval
+                binningStrategy: equalSizeBins-normal
                 legendDescription: ""
             selectedEntityNames:
               - World
             selectedEntityColors:
               World: "#adadad"
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/biodiversity/2022/living_planet_index.meta.yml
+++ b/etl/steps/data/grapher/biodiversity/2022/living_planet_index.meta.yml
@@ -96,4 +96,3 @@ tables:
               - World
             selectedEntityColors:
               World: "#adadad"
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/democracy/2023-03-02/vdem.meta.yml
+++ b/etl/steps/data/grapher/democracy/2023-03-02/vdem.meta.yml
@@ -3,10 +3,8 @@
 
 dataset:
   update_period_days: 365
-  sources: []
 definitions:
   common:
-    sources: []
     origins:
       - producer: V-Dem
         version_producer: "v13"
@@ -122,7 +120,7 @@ tables:
       #         - url: https://ourworldindata.org/grapher/electoral-democracy-index#faqs
       #           text: FAQs on this data
       #       selectedFacetStrategy: entity
-      #       $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+      #       $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
       # civ_libs_vdem_owid:
       #   title: civ_libs_vdem_owid
@@ -185,7 +183,7 @@ tables:
       #         - Botswana
       #         - China
       #         - World
-      #       $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+      #       $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       regime_row_owid:
         title: Political regime
         display:
@@ -333,7 +331,7 @@ tables:
               - Botswana
               - China
             note: The Chart tab uses numeric values, ranging from 0 for closed autocracies to 3 for liberal democracies.
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       # wom_emp_vdem_owid:
       #   title: Women's political empowerment index
       #   description_short: Captures the extent to which women enjoy civil liberties, can participate in civil society, and are represented in politics. It ranges from 0 to 1 (most empowered).
@@ -419,7 +417,7 @@ tables:
       #         - Australia
       #         - Botswana
       #         - China
-      #       $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+      #       $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       # terr_contr_vdem_owid:
       #   title: Percentage of territory effectively controlled by government
       #   unit: "%"
@@ -503,4 +501,4 @@ tables:
       #         - Botswana
       #         - China
       #       note: Values are missing if the country is not independent.
-      #       $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+      #       $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/democracy/2023-03-02/vdem.meta.yml
+++ b/etl/steps/data/grapher/democracy/2023-03-02/vdem.meta.yml
@@ -331,7 +331,6 @@ tables:
               - Botswana
               - China
             note: The Chart tab uses numeric values, ranging from 0 for closed autocracies to 3 for liberal democracies.
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       # wom_emp_vdem_owid:
       #   title: Women's political empowerment index
       #   description_short: Captures the extent to which women enjoy civil liberties, can participate in civil society, and are represented in politics. It ranges from 0 to 1 (most empowered).

--- a/etl/steps/data/grapher/faostat/2023-06-12/faostat_qcl.meta.yml
+++ b/etl/steps/data/grapher/faostat/2023-06-12/faostat_qcl.meta.yml
@@ -73,4 +73,3 @@ tables:
               - Northern America
               - Europe
               - South America
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/faostat/2023-06-12/faostat_qcl.meta.yml
+++ b/etl/steps/data/grapher/faostat/2023-06-12/faostat_qcl.meta.yml
@@ -1,6 +1,5 @@
 definitions:
   common:
-    sources: []
     origins:
       - producer: Food and Agriculture Organization of the United Nations
         title: 'Production: Crops and livestock products'
@@ -27,7 +26,6 @@ definitions:
 
 dataset:
   update_period_days: 365
-  sources: []
 
 tables:
   faostat_qcl_flat:
@@ -75,4 +73,4 @@ tables:
               - Northern America
               - Europe
               - South America
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/fasttrack/2023-09-29/un_space_objects.meta.override.yml
+++ b/etl/steps/data/grapher/fasttrack/2023-09-29/un_space_objects.meta.override.yml
@@ -1,10 +1,8 @@
 dataset:
   update_period_days: 365
-  sources: []
 
 definitions:
   common:
-    sources: []
     origins:
       - producer: United Nations Office for Outer Space Affairs
         title: Online Index of Objects Launched into Outer Space

--- a/etl/steps/data/grapher/ggdc/2020-10-01/ggdc_maddison.meta.yml
+++ b/etl/steps/data/grapher/ggdc/2020-10-01/ggdc_maddison.meta.yml
@@ -65,5 +65,5 @@ tables:
               - East Asia (MPD)
               - Western offshoots (MPD)
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2011 prices.
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
             hideRelativeToggle: false

--- a/etl/steps/data/grapher/ggdc/2020-10-01/ggdc_maddison.meta.yml
+++ b/etl/steps/data/grapher/ggdc/2020-10-01/ggdc_maddison.meta.yml
@@ -65,5 +65,4 @@ tables:
               - East Asia (MPD)
               - Western offshoots (MPD)
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2011 prices.
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
             hideRelativeToggle: false

--- a/etl/steps/data/grapher/ggdc/2022-11-28/penn_world_table.meta.yml
+++ b/etl/steps/data/grapher/ggdc/2022-11-28/penn_world_table.meta.yml
@@ -8,7 +8,6 @@ definitions:
       attribution_short: Penn World Table
       topic_tags:
         - Economic Growth
-    sources: []
     origins:
       - producer: Feenstra et al. (2015), Penn World Table (2021)
         attribution: Feenstra et al. (2015), Penn World Table (2021)
@@ -37,7 +36,6 @@ definitions:
 
 dataset:
   update_period_days: 550
-  sources: []
 tables:
   penn_world_table:
     variables:

--- a/etl/steps/data/grapher/happiness/2023-03-20/happiness.meta.yml
+++ b/etl/steps/data/grapher/happiness/2023-03-20/happiness.meta.yml
@@ -1,9 +1,7 @@
 dataset:
   update_period_days: 365
-  sources: []
 definitions:
   common:
-    sources: []
     origins:
       - producer: World Happiness Report
         title: World Happiness Report (2023)
@@ -148,4 +146,4 @@ tables:
               - Bhutan
               - Australia
               - Germany
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/happiness/2023-03-20/happiness.meta.yml
+++ b/etl/steps/data/grapher/happiness/2023-03-20/happiness.meta.yml
@@ -146,4 +146,3 @@ tables:
               - Bhutan
               - Australia
               - Germany
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/health/2023-08-16/deaths_karlinsky.meta.yml
+++ b/etl/steps/data/grapher/health/2023-08-16/deaths_karlinsky.meta.yml
@@ -1,9 +1,7 @@
 dataset:
   update_period_days: 365
-  sources: []
 definitions:
   common:
-    sources: []
     origins:
       - producer: Ariel Karlinksy
         title: International Completeness of Death Registration 2015-2019
@@ -88,4 +86,4 @@ tables:
               - Russia
               - Indonesia
               - Nigeria
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/health/2023-08-16/deaths_karlinsky.meta.yml
+++ b/etl/steps/data/grapher/health/2023-08-16/deaths_karlinsky.meta.yml
@@ -86,4 +86,3 @@ tables:
               - Russia
               - Indonesia
               - Nigeria
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/ihme_gbd/2019/gbd_cause.meta.yml
+++ b/etl/steps/data/grapher/ihme_gbd/2019/gbd_cause.meta.yml
@@ -69,4 +69,4 @@ tables:
               - Niger
               - Chad
             note: To allow comparisons between countries and over time this metric is [age-standardized](#dod:age_standardized).
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/ihme_gbd/2019/gbd_cause.meta.yml
+++ b/etl/steps/data/grapher/ihme_gbd/2019/gbd_cause.meta.yml
@@ -69,4 +69,3 @@ tables:
               - Niger
               - Chad
             note: To allow comparisons between countries and over time this metric is [age-standardized](#dod:age_standardized).
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/un/2022-11-29/undp_hdr.meta.yml
+++ b/etl/steps/data/grapher/un/2022-11-29/undp_hdr.meta.yml
@@ -7,7 +7,6 @@ definitions:
         - Life Expectancy
         - Global Education
         - Economic Growth
-    sources: []
     origins:
       - producer: UNDP, Human Development Report (2021-22)
         title: Human Development Report - UNDP (2021-22)
@@ -38,7 +37,6 @@ definitions:
           url: https://hdr.undp.org/copyright-and-terms-use
 dataset:
   update_period_days: 365
-  sources: []
 tables:
   undp_hdr:
     variables:
@@ -103,4 +101,4 @@ tables:
               - Democratic Republic of Congo
               - Niger
               - Chile
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/un/2022-11-29/undp_hdr.meta.yml
+++ b/etl/steps/data/grapher/un/2022-11-29/undp_hdr.meta.yml
@@ -101,4 +101,3 @@ tables:
               - Democratic Republic of Congo
               - Niger
               - Chile
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/un/2023-08-16/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2023-08-16/un_sdg.meta.yml
@@ -75,7 +75,7 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
   _6_1_1__sh_h2o_safe__all_areas:
     variables:
       _6_1_1__sh_h2o_safe__all_areas:
@@ -134,4 +134,4 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/un/2023-08-16/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2023-08-16/un_sdg.meta.yml
@@ -75,7 +75,6 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
   _6_1_1__sh_h2o_safe__all_areas:
     variables:
       _6_1_1__sh_h2o_safe__all_areas:
@@ -134,4 +133,3 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/un/2023-09-19/long_run_child_mortality.meta.yml
+++ b/etl/steps/data/grapher/un/2023-09-19/long_run_child_mortality.meta.yml
@@ -67,4 +67,3 @@ tables:
               - France
               - Brazil
               - India
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/un/2023-09-19/long_run_child_mortality.meta.yml
+++ b/etl/steps/data/grapher/un/2023-09-19/long_run_child_mortality.meta.yml
@@ -67,4 +67,4 @@ tables:
               - France
               - Brazil
               - India
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/un/2024-08-27/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2024-08-27/un_sdg.meta.yml
@@ -176,7 +176,6 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
   _6_1_1__sh_h2o_safe__all_areas:
     variables:
       _6_1_1__sh_h2o_safe__all_areas:
@@ -237,8 +236,6 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
   _16_5_1__iu_cor_brib__both_sexes:
     variables:
       _16_5_1__iu_cor_brib__both_sexes:

--- a/etl/steps/data/grapher/un/2024-08-27/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2024-08-27/un_sdg.meta.yml
@@ -176,7 +176,7 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
   _6_1_1__sh_h2o_safe__all_areas:
     variables:
       _6_1_1__sh_h2o_safe__all_areas:
@@ -237,7 +237,7 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
   _16_5_1__iu_cor_brib__both_sexes:
     variables:

--- a/etl/steps/data/grapher/un/2025-10-29/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2025-10-29/un_sdg.meta.yml
@@ -189,7 +189,7 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
   _6_1_1__sh_h2o_safe__all_areas:
     variables:
       _6_1_1__sh_h2o_safe__all_areas:
@@ -250,7 +250,7 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
   _16_5_1__iu_cor_brib__both_sexes:
     variables:

--- a/etl/steps/data/grapher/un/2025-10-29/un_sdg.meta.yml
+++ b/etl/steps/data/grapher/un/2025-10-29/un_sdg.meta.yml
@@ -189,7 +189,6 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
   _6_1_1__sh_h2o_safe__all_areas:
     variables:
       _6_1_1__sh_h2o_safe__all_areas:
@@ -250,8 +249,6 @@ tables:
               - Oceania (UN)
               - Europe and Northern America (UN)
               - Eastern and South-Eastern Asia (UN)
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
   _16_5_1__iu_cor_brib__both_sexes:
     variables:
       _16_5_1__iu_cor_brib__both_sexes:

--- a/etl/steps/data/grapher/wb/2017-04-16/world_gdp.meta.yml
+++ b/etl/steps/data/grapher/wb/2017-04-16/world_gdp.meta.yml
@@ -8,7 +8,6 @@ definitions:
 
 dataset:
   update_period_days: 0
-  sources: []
   title: World GDP (World Bank & Maddison, 2017)
 
 tables:

--- a/etl/steps/data/grapher/wb/2022-10-03/extreme_poverty_by_region.meta.yml
+++ b/etl/steps/data/grapher/wb/2022-10-03/extreme_poverty_by_region.meta.yml
@@ -23,8 +23,6 @@ definitions:
       attribution_short: World Bank
       grapher_config:
         originUrl: https://ourworldindata.org/poverty
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
   income_consumption_pc: Depending on the country and year, the data relates to income measured after taxes and benefits, or to consumption, per capita. 'Per capita' means that the incomes of each household are attributed equally to each member of the household (including children).
   non_market_income: Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account.
   processing_notes: |-
@@ -94,9 +92,3 @@ tables:
               - Middle East and North Africa
               - Europe and Central Asia
               - Sub-Saharan Africa
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
-
-
-
-

--- a/etl/steps/data/grapher/wb/2022-10-03/extreme_poverty_by_region.meta.yml
+++ b/etl/steps/data/grapher/wb/2022-10-03/extreme_poverty_by_region.meta.yml
@@ -1,10 +1,8 @@
 dataset:
   update_period_days: 365
-  sources: []
 
 definitions:
   common:
-    sources: []
     origins:
       - producer: World Bank Poverty and Inequality Platform
         title: World Bank Poverty and Inequality Platform
@@ -25,7 +23,7 @@ definitions:
       attribution_short: World Bank
       grapher_config:
         originUrl: https://ourworldindata.org/poverty
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
   income_consumption_pc: Depending on the country and year, the data relates to income measured after taxes and benefits, or to consumption, per capita. 'Per capita' means that the incomes of each household are attributed equally to each member of the household (including children).
   non_market_income: Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account.
@@ -96,7 +94,7 @@ tables:
               - Middle East and North Africa
               - Europe and Central Asia
               - Sub-Saharan Africa
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
 
 

--- a/etl/steps/data/grapher/wb/2022-10-03/world_bank_pip.meta.yml
+++ b/etl/steps/data/grapher/wb/2022-10-03/world_bank_pip.meta.yml
@@ -23,8 +23,6 @@ definitions:
       attribution_short: World Bank
       grapher_config:
         originUrl: https://ourworldindata.org/poverty
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
   income_consumption_pc: Depending on the country and year, the data relates to income measured after taxes and benefits, or to consumption, per capita. 'Per capita' means that the incomes of each household are attributed equally to each member of the household (including children).
   non_market_income: Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account.
   processing_notes: |-

--- a/etl/steps/data/grapher/wb/2022-10-03/world_bank_pip.meta.yml
+++ b/etl/steps/data/grapher/wb/2022-10-03/world_bank_pip.meta.yml
@@ -1,10 +1,8 @@
 dataset:
   update_period_days: 365
-  sources: []
 
 definitions:
   common:
-    sources: []
     origins:
       - producer: World Bank Poverty and Inequality Platform
         title: World Bank Poverty and Inequality Platform
@@ -25,7 +23,7 @@ definitions:
       attribution_short: World Bank
       grapher_config:
         originUrl: https://ourworldindata.org/poverty
-        $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+        $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
   income_consumption_pc: Depending on the country and year, the data relates to income measured after taxes and benefits, or to consumption, per capita. 'Per capita' means that the incomes of each household are attributed equally to each member of the household (including children).
   non_market_income: Non-market sources of income, including food grown by subsistence farmers for their own consumption, are taken into account.

--- a/etl/steps/data/grapher/wid/2023-08-24/world_inequality_database.meta.yml
+++ b/etl/steps/data/grapher/wid/2023-08-24/world_inequality_database.meta.yml
@@ -72,4 +72,3 @@ tables:
               - South Africa
               - China
               - France
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/wid/2023-08-24/world_inequality_database.meta.yml
+++ b/etl/steps/data/grapher/wid/2023-08-24/world_inequality_database.meta.yml
@@ -1,9 +1,7 @@
 dataset:
   update_period_days: 365
-  sources: []
 definitions:
   common:
-    sources: []
     origins:
       - producer: World Inequality Database (WID.world)
         title: World Inequality Database
@@ -74,4 +72,4 @@ tables:
               - South Africa
               - China
               - France
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json

--- a/etl/steps/data/grapher/worldbank_wdi/2023-05-29/wdi.meta.yml
+++ b/etl/steps/data/grapher/worldbank_wdi/2023-05-29/wdi.meta.yml
@@ -223,7 +223,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       ny_gdp_pcap_pp_kd:
         origins:
           - *wdi_origin
@@ -289,7 +288,6 @@ tables:
               - China
               - India
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices.
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       ny_gdp_mktp_pp_kd:
         origins:
           - *wdi_origin
@@ -354,8 +352,6 @@ tables:
               - Russia
               - France
               - Mexico
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
       eg_cft_accs_zs:
         origins:
           - *wdi_origin

--- a/etl/steps/data/grapher/worldbank_wdi/2023-05-29/wdi.meta.yml
+++ b/etl/steps/data/grapher/worldbank_wdi/2023-05-29/wdi.meta.yml
@@ -19,13 +19,11 @@ definitions:
 
 dataset:
   update_period_days: 365
-  sources: []
 
 tables:
   wdi:
     variables:
       it_net_user_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Individuals using the Internet (% of population)
@@ -136,7 +134,6 @@ tables:
               - Latin America and Caribbean (WB)
               - World
       sh_sta_stnt_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Share of children who are stunted
@@ -226,9 +223,8 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       ny_gdp_pcap_pp_kd:
-        sources: []
         origins:
           - *wdi_origin
         title: GDP per capita, PPP (constant 2017 international $)
@@ -293,9 +289,8 @@ tables:
               - China
               - India
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices.
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       ny_gdp_mktp_pp_kd:
-        sources: []
         origins:
           - *wdi_origin
         title: GDP, PPP (constant 2017 international $)
@@ -359,10 +354,9 @@ tables:
               - Russia
               - France
               - Mexico
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
       eg_cft_accs_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Access to clean fuels and technologies for cooking (% of population)
@@ -385,7 +379,6 @@ tables:
             - Energy
         processing_level: minor
       eg_elc_accs_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Access to electricity (% of population)
@@ -407,7 +400,6 @@ tables:
             - Energy
         processing_level: minor
       sn_itk_defc_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Prevalence of undernourishment (% of population)

--- a/etl/steps/data/grapher/worldbank_wdi/2024-05-20/wdi.meta.yml
+++ b/etl/steps/data/grapher/worldbank_wdi/2024-05-20/wdi.meta.yml
@@ -223,7 +223,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       sh_sta_stnt_me_zs:
         origins:
           - *wdi_origin
@@ -314,7 +313,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       ny_gdp_pcap_pp_kd:
         origins:
           - *wdi_origin
@@ -380,7 +378,6 @@ tables:
               - China
               - India
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices.
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       ny_gdp_mktp_pp_kd:
         origins:
           - *wdi_origin
@@ -445,8 +442,6 @@ tables:
               - Russia
               - France
               - Mexico
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
-
       eg_cft_accs_zs:
         origins:
           - *wdi_origin

--- a/etl/steps/data/grapher/worldbank_wdi/2024-05-20/wdi.meta.yml
+++ b/etl/steps/data/grapher/worldbank_wdi/2024-05-20/wdi.meta.yml
@@ -19,13 +19,11 @@ definitions:
 
 dataset:
   update_period_days: 365
-  sources: []
 
 tables:
   wdi:
     variables:
       it_net_user_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Individuals using the Internet (% of population)
@@ -136,7 +134,6 @@ tables:
               - Latin America and Caribbean (WB)
               - World
       sh_sta_stnt_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Share of children who are stunted
@@ -226,9 +223,8 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       sh_sta_stnt_me_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Share of children who are stunted (modeled estimates)
@@ -318,9 +314,8 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       ny_gdp_pcap_pp_kd:
-        sources: []
         origins:
           - *wdi_origin
         title: GDP per capita, PPP (constant 2017 international $)
@@ -385,9 +380,8 @@ tables:
               - China
               - India
             note: This data is expressed in [international-$](#dod:int_dollar_abbreviation) at 2017 prices.
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
       ny_gdp_mktp_pp_kd:
-        sources: []
         origins:
           - *wdi_origin
         title: GDP, PPP (constant 2017 international $)
@@ -451,10 +445,9 @@ tables:
               - Russia
               - France
               - Mexico
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
+            $schema: https://files.ourworldindata.org/schemas/grapher-schema.010.json
 
       eg_cft_accs_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Access to clean fuels and technologies for cooking (% of population)
@@ -477,7 +470,6 @@ tables:
             - Energy
         processing_level: minor
       eg_elc_accs_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Access to electricity (% of population)
@@ -499,7 +491,6 @@ tables:
             - Energy
         processing_level: minor
       sn_itk_defc_zs:
-        sources: []
         origins:
           - *wdi_origin
         title: Prevalence of undernourishment (% of population)


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

The nightly full-rebuild build #1216 crashed with `_pickle.PicklingError: Can't pickle <class 'jsonschema.exceptions.ValidationError'>`. Root cause was a chart config in `colonial_dates_dataset` that declared `$schema: grapher-schema.003.json` but used the post-003 property `chartTypes`. The validation error fired inside a parallel worker, couldn't be pickled back to the parent, and that bypassed `--continue-on-failure` — one bad config killed the whole rebuild.

## What's in this PR

**1. Crash-proof the validator** — `etl/grapher/helpers.py::_validate_grapher_config` now catches `jsonschema.ValidationError` and re-raises as a plain `ValueError`. `ValueError` pickles cleanly across `ProcessPoolExecutor`, so a single broken config no longer takes down the parallel `etl run`. Same error message, same fail-fast behaviour for the offending step — but `--continue-on-failure` actually keeps going.

**2. Remove every outdated `$schema:` pin** — `list` showed 41 active configs pinned to old versions (39× `003`, 1× `005`, 1× `008`). Instead of bumping each to `010`, just **delete the line** — `_validate_grapher_config` already does `setdefault("$schema", DEFAULT_GRAPHER_SCHEMA)`, so an absent `$schema:` falls through to the default in `etl/config.py`. Pinning `010` would age just as badly: next bump to `011` and every file is stale again. After this PR, 1589 configs flow through the default and **0** are pinned.

**3. Hand-fix the 4 content violations the cleanup surfaced**:
  - `colonial_dates_dataset`, `extreme_poverty_by_region` — used `chartTypes` (rejected by schema 003, legal in the default).
  - `ggdc_maddison` — dropped the legacy `variableId: 417485` map pin and the unsupported `binningStrategyBinCount` field.
  - `living_planet_index`, `global_carbon_budget` — `binningStrategy: equalInterval` was renamed; mapped to the closest current equivalent `equalSizeBins-normal`.

**4. Remove deprecated `sources: []` markers** — 38 instances across 13 files. Empty `sources` arrays were once used to silence inherited deprecated `sources` blocks; now they're just noise.

## Tooling that came out of this

`ai/scan_invalid_grapher_configs.py` (gitignored, kept locally) — three subcommands:
- `scan` — validate every `grapher_config` against its declared (or default) schema.
- `list` — histogram of `$schema` URLs in use, so the next migration is easy to scope.
- `upgrade --to <url> --from <versions> [--write] [--validate]` — bulk rewrite of `$schema:` lines, with optional post-rewrite validation.

## Test plan

- [ ] `.venv/bin/etlr data://grapher/harvard/2023-09-18/colonial_dates_dataset --force --only --private` passes locally (was the original crash).
- [ ] CI green on this PR.
- [ ] (Spot-check on staging) Map for `living_planet_index_average` and `global_carbon_budget.consumption_emissions_per_capita` still bins reasonably with `equalSizeBins-normal`; rollback to `auto` if it looks off.