### PR TITLE
🐛 Hash canonical JSON for metadataChecksum to stop false-positive chart-diff

### DIFF
--- a/etl/grapher/to_db.py
+++ b/etl/grapher/to_db.py
@@ -326,6 +326,13 @@ def calculate_checksum_metadata(variable_meta: VariableMeta, df: pd.DataFrame) -
     # UI diff. `to_dict()` goes through `@pruned_json`, which drops None/empty
     # values the same way `_omit_nullable_values` does before upload to S3 — so
     # the checksum now matches what the comparator actually sees.
+    #
+    # Performance: `to_dict()` (via DataClassJsonMixin) is ~130µs/call on a
+    # realistic VariableMeta — ~3× slower than hashing the raw dataclass. Per
+    # upsert this is drowned out by the S3+MySQL roundtrips (100s of ms each).
+    # If this ever shows up in a profile, replace with a custom field walker
+    # that prunes inline, same trick `dataclass_from_dict` uses in core/utils.py.
+    #
     # entities and years are also part of the metadata checksum.
     return str(
         hash_any(

--- a/etl/grapher/to_db.py
+++ b/etl/grapher/to_db.py
@@ -319,13 +319,20 @@ def upsert_metadata(
 
 
 def calculate_checksum_metadata(variable_meta: VariableMeta, df: pd.DataFrame) -> str:
-    # entities and years are also part of the metadata checksum
+    # Hash the canonical (pruned) dict representation, not the dataclass itself.
+    # Dataclass-shape changes (a field renamed, added, or removed — even when the
+    # default is None / [] and the JSON output is unchanged) used to spuriously
+    # flip the checksum and lit up chart-diff as METADATA CHANGE with an empty
+    # UI diff. `to_dict()` goes through `@pruned_json`, which drops None/empty
+    # values the same way `_omit_nullable_values` does before upload to S3 — so
+    # the checksum now matches what the comparator actually sees.
+    # entities and years are also part of the metadata checksum.
     return str(
         hash_any(
             (
                 hash_any(sorted(df.entityId.unique())),
                 hash_any(sorted(df.year.unique())),
-                hash_any(variable_meta),
+                hash_any(variable_meta.to_dict()),
             )
         )
     )

--- a/tests/test_grapher_import.py
+++ b/tests/test_grapher_import.py
@@ -38,3 +38,26 @@ def test_calculate_checksum_metadata():
         presentation=VariablePresentationMeta(title_public="Title public"),
     )
     assert checksum != db.calculate_checksum_metadata(meta2, df)
+
+
+def test_calculate_checksum_metadata_invariant_to_empty_field_shapes():
+    """Empty list / None / missing-from-dict should all hash the same.
+
+    Regression: removing or flipping the default of a `VariableMeta` field (e.g. the
+    `sources` field dropped in #6081) used to silently flip every metadataChecksum,
+    making chart-diff flag every chart as METADATA CHANGE despite no observable
+    difference in the JSON. The checksum now hashes the pruned dict, so these
+    invisible shape flips collapse.
+    """
+    df = _get_data()
+
+    meta_with_empties = VariableMeta(
+        origins=[Origin(title="T", producer="P")],
+        description_key=[],
+        licenses=[],
+        sort=[],
+    )
+    meta_without_empties = VariableMeta(origins=[Origin(title="T", producer="P")])
+    assert db.calculate_checksum_metadata(meta_with_empties, df) == db.calculate_checksum_metadata(
+        meta_without_empties, df
+    )


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

Chart-diff was flagging charts as **METADATA CHANGE** with an empty "Metadata differences" modal — a confusing false positive that grew loud after #6081 (Remove Source metadata object) landed on May 15. Concrete example I debugged: chart `486` reported a metadata change on this branch's staging, but for its underlying variable `1119914` (`gcp/.../emissions_total_per_capita`):

- `dataChecksum` was identical between source and target.
- All MySQL columns on `variables`, all `origins_variables` joins, all `tags_variables_topic_tags` rows were byte-identical.
- The filtered S3 metadata JSON the modal renders was byte-identical too.
- Only `metadataChecksum` differed: `1931368509910834886` (source) vs `4709097733513263809` (target).

## Root cause

`calculate_checksum_metadata` (in `etl/grapher/to_db.py`) hashed the live `VariableMeta` *dataclass* via `hash_any`, which walks `dataclasses.fields(...)`. That walk is sensitive to dataclass shape:

- **Pre-#6081**: `VariableMeta` had `sources: list[Source] = field(default_factory=list)`. Each upsert produced a hash that included `("sources", hash([]))`.
- **Post-#6081**: the field is gone. The same logical metadata now produces a hash without that pair.

But `_omit_nullable_values` (the helper that builds the S3 JSON) strips `None`, `[]`, `{}`, `""` before upload — so the on-disk representation never noticed the change. Any dataset re-upserted on a post-#6081 staging while master's row still carried the pre-#6081 checksum lit up as METADATA CHANGE in chart-diff, even though nothing the comparator could see was different.

Same failure mode is waiting for the next time anyone adds, renames, or drops a `VariableMeta` field with a None/empty default.

## The fix

Hash `variable_meta.to_dict()` instead of the raw dataclass. `VariableMeta` is decorated with `@pruned_json`, which drops `None`/empty values the same way `_omit_nullable_values` does. The checksum now matches what the comparator actually sees, and is invariant to invisible dataclass-shape changes.

```diff
-                hash_any(variable_meta),
+                hash_any(variable_meta.to_dict()),
```

`hash_any` on a dict already sorts items by key, so iteration order is stable.

## What it does NOT fix on its own

Every existing `metadataChecksum` in MySQL was computed under the old scheme and is now stale. Until each variable gets re-upserted, chart-diff will flag every chart as METADATA CHANGE once. Plan agreed with @Marigold: re-upsert the whole grapher DB after this merges; one round of noise, then clean.

## Test plan

- [x] `tests/test_grapher_import.py::test_calculate_checksum_metadata_invariant_to_empty_field_shapes` — regression coverage for the empty-field-shape invariance that previously broke.
- [x] `tests/test_grapher_import.py::test_calculate_checksum_metadata` still passes (different metadata → different checksums).
- [x] `make check` clean.
- [ ] After merge: run the full grapher re-upsert, then spot-check that chart-diff no longer flags untouched charts as METADATA CHANGE.