### PR TITLE
🐛 Gate narrative-charts block on its sidebar toggle

### DIFF
--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -593,6 +593,13 @@ class ChartDiffShow:
         if not self.diff.chart_id:
             return
 
+        # Respect the sidebar toggle. The list-side filter in app.py only runs when
+        # `show_all` is off; without this gate the block would still render here when
+        # the user toggles narrative-charts off but also has "Show all charts" enabled.
+        # Mirrors the same pattern in `_show_citations`.
+        if not st.session_state.get("show-narrative-charts", True):
+            return
+
         # Load narrative charts for this parent chart
         narrative_charts = gm.NarrativeChart.load_narrative_charts_by_parent_chart_ids(
             self.source_session, {self.diff.chart_id}


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

Visiting chart-diff with `?show_all=&show-narrative-charts=False` still rendered the "📖 Narrative Charts" block under each chart — the sidebar toggle was being ignored.

## Root cause

Two checks have to fire together to honour the toggle, and only one was wired up:

1. **List-side filter** (`apps/wizard/app_pages/chart_diff/app.py:185–205`): removes parent charts of narrative charts from the listing when the toggle is off. This filter sits inside the `else` branch of `if "show_all" in st.query_params:`, so it is **skipped entirely whenever `show_all` is on**.
2. **Per-chart UI block** (`apps/wizard/app_pages/chart_diff/chart_diff_show.py::_show_narrative_charts`): rendered unconditionally. No toggle check.

So with `show_all=&show-narrative-charts=False`, the filter never ran AND the per-chart block had no gate of its own → the narrative-charts section showed up regardless.

`_show_citations` next to it already follows the right pattern (`if not st.session_state.get("show-article-citations", True): return`), which is why article citations honour their toggle correctly.

## Fix

Bail out of `_show_narrative_charts` early when the toggle is off — mirrors the citations gate exactly. The list-side filter is still useful when `show_all` is off (it actually removes parents from the list); this PR doesn't touch it.

## Test plan

- [ ] Reload `…/chart-diff?show_all=&show-narrative-charts=False` — narrative-charts block no longer appears under any chart.
- [ ] Toggle "Show narrative charts" on → block reappears.
- [ ] Without `show_all`, with toggle off → parent charts are filtered from the list (existing behaviour, unchanged).