### PR TITLE
🐛 Retry admin API on 500/503 for grapher config upserts

### DIFF
--- a/apps/chart_sync/admin_api.py
+++ b/apps/chart_sync/admin_api.py
@@ -260,7 +260,7 @@ class AdminAPI:
 
 def requests_with_retry() -> requests.Session:
     s = requests.Session()
-    retries = Retry(total=5, backoff_factor=1, status_forcelist=[502, 504])
+    retries = Retry(total=5, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
     s.mount("http://", HTTPAdapter(max_retries=retries))
     s.mount("https://", HTTPAdapter(max_retries=retries))
     return s


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Summary

Transient 500/503 responses from the prod admin API now retry instead of killing a `--grapher` upload.

We recently saw an `etlr … --grapher` (almost certainly the cron-driven automatic update on \`owid-admin-prod\`) crash with:

\`\`\`
HTTPError: 500 Server Error: Internal Server Error for url:
http://owid-admin-prod.tail6e23.ts.net/admin/api/variables/954536/grapherConfigETL
\`\`\`

That request originates from \`AdminAPI.put_grapher_config\` (\`apps/chart_sync/admin_api.py:128\`), which already goes through \`requests_with_retry()\`. The retry policy only listed 502/504, so a one-off 500 (or 503) from the admin server falls straight through to \`resp.raise_for_status()\` and aborts the whole step.

## Change

\`requests_with_retry()\` now retries on 500 and 503 in addition to 502 and 504:

\`\`\`python
retries = Retry(total=5, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
\`\`\`

\`urllib3\`'s default \`allowed_methods\` already covers PUT/DELETE/GET (idempotent), so this applies cleanly to the existing PUT call sites: \`put_grapher_config\`, \`put_mdim_config\`, \`put_explorer_config\`. POST is not retried by default, which is the right behavior for chart create.

## Test plan

- [ ] Watch the next automatic update cycle (flunet / measles / covid sequences) on prod — a transient 500 should now be absorbed by the retry instead of aborting the step.
- [ ] No behavior change expected for the happy path or for genuine 4xx errors.