### PR TITLE
🐛 Drop $schema: 003 pins from active *.meta.override.yml files

### DIFF
--- a/etl/steps/data/garden/worldbank_wdi/2025-01-24/wdi.meta.override.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2025-01-24/wdi.meta.override.yml
@@ -617,7 +617,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
       sh_sta_stnt_me_zs:
         title: Share of children who are stunted (modeled estimates)
         unit: '% of children under 5'
@@ -706,7 +705,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
 
       eg_cft_accs_zs:
         title: Access to clean fuels and technologies for cooking (% of population)

--- a/etl/steps/data/garden/worldbank_wdi/2025-09-08/wdi.meta.override.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2025-09-08/wdi.meta.override.yml
@@ -718,7 +718,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
       sh_sta_stnt_me_zs:
         title: Share of children who are stunted (modeled estimates)
         unit: '% of children under 5'
@@ -807,7 +806,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
 
       eg_cft_accs_zs:
         title: Access to clean fuels and technologies for cooking (% of population)

--- a/etl/steps/data/garden/worldbank_wdi/2026-01-29/wdi.meta.override.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2026-01-29/wdi.meta.override.yml
@@ -717,7 +717,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
       sh_sta_stnt_me_zs:
         title: Share of children who are stunted (modeled estimates)
         unit: '% of children under 5'
@@ -806,7 +805,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
 
       eg_cft_accs_zs:
         title: Access to clean fuels and technologies for cooking (% of population)

--- a/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.meta.override.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.meta.override.yml
@@ -719,7 +719,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
       sh_sta_stnt_me_zs:
         title: Share of children who are stunted (modeled estimates)
         unit: '% of children under 5'
@@ -808,7 +807,6 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json
 
       eg_cft_accs_zs:
         title: Access to clean fuels and technologies for cooking (% of population)

--- a/etl/steps/data/grapher/who/2024-01-03/gho.meta.override.yml
+++ b/etl/steps/data/grapher/who/2024-01-03/gho.meta.override.yml
@@ -104,4 +104,3 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json

--- a/etl/steps/data/grapher/who/2025-05-19/gho.meta.override.yml
+++ b/etl/steps/data/grapher/who/2025-05-19/gho.meta.override.yml
@@ -104,4 +104,3 @@ tables:
               - url: >-
                   https://ourworldindata.org/grapher/share-of-children-younger-than-5-who-suffer-from-stunting#faqs
                 text: FAQs on this data
-            $schema: https://files.ourworldindata.org/schemas/grapher-schema.003.json


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

Follow-up to #6134. That PR removed `$schema:` pins from every `*.meta.yml` so configs inherit `DEFAULT_GRAPHER_SCHEMA` from `etl/config.py`. The scanner I used globbed `*.meta.yml` only, which doesn't match the `*.meta.override.yml` naming pattern — so 8 lines still pinned `grapher-schema.003.json` across 6 active override files survived the cleanup.

Why it matters now (and not just for tidiness): after #6135, `metadataChecksum` hashes `variable_meta.to_dict()`, which includes `grapher_config.$schema` inline. So a branch where the value differs from prod produces a real per-variable checksum mismatch — chart-diff flags METADATA CHANGE, but the modal can't show what changed because `grapher_config` gets popped out of `variable_meta` and shipped to the admin API separately (so it never reaches the S3 metadata JSON the modal diffs). Net effect: confusing UI flags driven by a difference that's invisible in the modal.

## What this PR does

Strip the surviving `$schema: ...grapher-schema.003.json` lines from these 6 active overrides — same fix as #6134, just applied to the files my glob missed:

- `etl/steps/data/grapher/who/2024-01-03/gho.meta.override.yml`
- `etl/steps/data/grapher/who/2025-05-19/gho.meta.override.yml`
- `etl/steps/data/garden/worldbank_wdi/2025-01-24/wdi.meta.override.yml`
- `etl/steps/data/garden/worldbank_wdi/2025-09-08/wdi.meta.override.yml`
- `etl/steps/data/garden/worldbank_wdi/2026-01-29/wdi.meta.override.yml`
- `etl/steps/data/garden/worldbank_wdi/2026-02-27/wdi.meta.override.yml`

`fasttrack/2023-09-29/un_space_objects.meta.override.yml` is not referenced in any active DAG file, so it's left alone per the active-DAG-only rule. The 4 commented-out `$schema` references inside `vdem.meta.yml` block comments are also unchanged.

## Verification

`ai/scan_invalid_grapher_configs.py` was patched locally to glob `*.meta.override.yml` too; `list` now reports 1735 grapher_configs on the default and only the one inactive `un_space_objects` line still pinned.

## Test plan

- [x] `make check` clean.
- [ ] CI green.
- [ ] On staging: the next chart-diff against prod for charts tied to these datasets (gho / WDI) should stop showing the schema-only drift once both sides re-upsert.