### PR TITLE
🐛 Fix broken features in notebook docs

### DIFF
--- a/docs/ignore/post-build/convert_notebooks.py
+++ b/docs/ignore/post-build/convert_notebooks.py
@@ -552,8 +552,14 @@ def wrap_in_full_zensical_template(
         # Remove trailing slash from relative_root for JSON
         base_path = relative_root.rstrip("/")
         template = template.replace('"base":"."', f'"base":"{base_path}"')
-        # Also fix search worker path in config
-        template = template.replace('"search":"assets/javascripts/', f'"search":"{relative_root}assets/javascripts/')
+        # Also fix search worker path in the __config JSON. Newer zensical
+        # emits `"search":"./assets/javascripts/..."` (with a leading `./`),
+        # so accept both forms.
+        template = re.sub(
+            r'"search":"(?:\./)?(assets/javascripts/[^"]+)"',
+            lambda m: f'"search":"{relative_root}{m.group(1)}"',
+            template,
+        )
 
     # Fix navigation links to be absolute from root
     # Convert relative navigation links like href="guides/" to href="../../guides/"

--- a/docs/ignore/post-build/convert_notebooks.py
+++ b/docs/ignore/post-build/convert_notebooks.py
@@ -523,12 +523,15 @@ def wrap_in_full_zensical_template(
 
         template = re.sub(toc_pattern, replace_toc, template, flags=re.DOTALL)
 
-    # Fix relative paths for assets. Match both the bare form (`href="assets/…"`)
-    # and the explicitly-CWD-prefixed form (`href="./assets/…"`) that newer
-    # zensical versions emit — without this, the `./` prefix slips through
-    # untouched and resolves relative to the notebook's own subdirectory,
-    # 404'ing every asset on every notebook page (cell-toggles, the main
-    # bundle, CSS, …).
+    # Fix relative paths for assets. Match both the bare form (`src="javascripts/…"`)
+    # and the CWD-prefixed form (`src="./javascripts/…"`) that newer zensical
+    # versions emit for the locally-hosted JS. Without the `./`-aware match,
+    # the prefix passes through untouched and resolves relative to the
+    # notebook's own subdirectory, 404-ing the main Material bundle and the
+    # extra_javascript files (cell-toggles, csv-table, katex, notebook-copy,
+    # tablesort) on every notebook page at depth ≥ 1. CSS hrefs are written by
+    # zensical with the depth-correct prefix already, so they are unaffected,
+    # but we cover them here too for completeness.
     if relative_root != "./":
 
         def _retarget(attr: str, prefix: str) -> None:

--- a/docs/ignore/post-build/convert_notebooks.py
+++ b/docs/ignore/post-build/convert_notebooks.py
@@ -523,13 +523,27 @@ def wrap_in_full_zensical_template(
 
         template = re.sub(toc_pattern, replace_toc, template, flags=re.DOTALL)
 
-    # Fix relative paths for assets
+    # Fix relative paths for assets. Match both the bare form (`href="assets/…"`)
+    # and the explicitly-CWD-prefixed form (`href="./assets/…"`) that newer
+    # zensical versions emit — without this, the `./` prefix slips through
+    # untouched and resolves relative to the notebook's own subdirectory,
+    # 404'ing every asset on every notebook page (cell-toggles, the main
+    # bundle, CSS, …).
     if relative_root != "./":
-        template = template.replace('href="assets/', f'href="{relative_root}assets/')
-        template = template.replace('src="assets/', f'src="{relative_root}assets/')
-        template = template.replace('href="css/', f'href="{relative_root}css/')
-        template = template.replace('href="javascripts/', f'href="{relative_root}javascripts/')
-        template = template.replace('src="javascripts/', f'src="{relative_root}javascripts/')
+
+        def _retarget(attr: str, prefix: str) -> None:
+            nonlocal template
+            pattern = rf'{attr}="(?:\./)?({re.escape(prefix)}[^"]+)"'
+            template = re.sub(pattern, lambda m: f'{attr}="{relative_root}{m.group(1)}"', template)
+
+        for attr, prefix in [
+            ("href", "assets/"),
+            ("src", "assets/"),
+            ("href", "css/"),
+            ("href", "javascripts/"),
+            ("src", "javascripts/"),
+        ]:
+            _retarget(attr, prefix)
 
         # Fix __config base path for JavaScript bundle
         # Remove trailing slash from relative_root for JSON


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

## Review
Hey @lucasrodes, I noticed that some of the features in notebooks of the docs are broken. You can see that, e.g. [this notebook](https://docs.owid.io/projects/etl/analyses/food_supply_of_world_regions/food_supply_of_world_regions.html) in prod doesn't have collapsable code blocks; the search bar is gone, and the TOC doesn't follow the content dynamically. This PR should fix those issues ([comparison notebook](http://staging-site-bug-fix-asset-paths/etl/docs/analyses/food_supply_of_world_regions/food_supply_of_world_regions.html#Introduction) on staging). The issue may have happened after a zensical update.

I've also just noticed that the logo was missing in prod, and I think it's related to the same problem, fixed with the current PR.
<img width="685" height="205" alt="Screenshot 2026-05-18 at 14 37 16" src="https://github.com/user-attachments/assets/13de331d-53e0-42aa-aad9-8295b496f8f2" />

## Summary

On notebook docs pages, the locally-hosted JavaScript files (main Material bundle + the `extra_javascript` entries: `cell-toggles.js`, `csv-table.js`, `katex.js`, `notebook-copy.js`, `tablesort.js`) were returning 404. Visible symptoms: collapsable code blocks no longer collapse on tagged cells, search bar does nothing, theme toggle doesn't switch, sidebar nav does full page reloads, code-copy buttons are gone. CSS still loads correctly, so the page looks styled.

## Root cause

Newer zensical versions write JS references as `src="./javascripts/..."` (with a leading `./`) where they previously wrote `src="javascripts/..."`. The post-build path rewriter in `docs/ignore/post-build/convert_notebooks.py` only matched the bare form, so the `./` slipped through unmodified and resolved relative to the notebook's directory — 404 at any depth ≥ 1. (CSS is unaffected because zensical writes it with the depth-correct prefix already.)

## Fix

Replace the five `template.replace(...)` calls with a regex that accepts both the bare and the `./`-prefixed form.

## Test plan

- [x] Notebook pages (e.g. `analyses/food_supply_of_world_regions/`) load with collapse toggles working again.
- [x] DevTools → Network → reload: no 404s on `bundle.*.min.js`, `cell-toggles.js`, `csv-table.js`, `notebook-copy.js`, `katex.js`, `tablesort.js`.
- [x] Search bar in the header returns suggestions when typing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)