### PR TITLE
🐛🤖 Fix Dependabot updates for compare extension

### DIFF
--- a/.claude/skills/fix-dependabot/SKILL.md
+++ b/.claude/skills/fix-dependabot/SKILL.md
@@ -28,6 +28,30 @@ Present a summary table grouped by severity (critical > high > medium > low) wit
 
 Ask the user which severities to fix (e.g. "critical and high only" or "all"). If the user already specified a filter in their request, proceed with that.
 
+## Step 1b: Audit existing Dependabot PRs
+
+Always list open Dependabot PRs, not just open alerts. Dependabot PRs can remain open after the default branch already contains the requested dependency version (especially old/conflicted PRs where automatic rebases have been disabled).
+
+```bash
+gh pr list --repo owid/etl --author app/dependabot --state open \
+  --json number,title,headRefName,mergeStateStatus,files --limit 100 \
+  --jq '.[] | {number,title,mergeStateStatus,files:[.files[].path]}'
+```
+
+For each open PR:
+
+1. Identify the manifest/lockfile and target package/version from the title and changed files.
+2. Compare against the **current default branch** (`origin/master` or `master`), not just your working branch. Check whether the dependency is already at the requested version or newer.
+   - For `uv.lock` files, inspect the relevant package entry in the affected lockfile.
+   - For npm lockfiles, parse `package-lock.json` and check all installed versions of the package in that extension.
+3. If the PR is obsolete, close it with a clear comment, for example:
+   ```bash
+   gh pr close <number> --repo owid/etl --comment \
+     "Closing as obsolete: the current default branch already has this dependency at the requested version or newer, so this stale Dependabot PR is no longer relevant."
+   ```
+4. If you create a replacement PR that batches or supersedes Dependabot PRs, close the superseded PRs and reference the replacement PR in the close comment.
+5. Re-run the PR list and confirm there are no open irrelevant Dependabot PRs before reporting completion.
+
 ## Step 2: Categorize each alert
 
 For each alert to fix, determine:

--- a/vscode_extensions/compare-previous-version/package-lock.json
+++ b/vscode_extensions/compare-previous-version/package-lock.json
@@ -2430,9 +2430,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4522,9 +4522,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Updates the `compare-previous-version` VS Code extension lockfile to resolve the two remaining open Dependabot bumps for that extension:

- `flatted` 3.3.3 → 3.4.2
- `picomatch` 2.3.1 → 2.3.2

Also updates the `fix-dependabot` skill so future runs explicitly audit and close stale Dependabot PRs whose requested updates are already present on the default branch, instead of only looking at open Dependabot alerts.

Supersedes #6126 and #6127. I also closed the other stale open Dependabot PRs that were already satisfied by `master`.

Verification:
- `npm --prefix vscode_extensions/compare-previous-version ls flatted picomatch`
- `gh pr list --repo owid/etl --author app/dependabot --state open --json number,title --limit 100` → no open Dependabot PRs
- commit hook ran install, lint/format, and type checks successfully
