### PR TITLE
📊 Fix maternal mortality origins after Source removal

### DIFF
--- a/etl/steps/data/garden/maternal_mortality/2024-07-08/maternal_mortality.py
+++ b/etl/steps/data/garden/maternal_mortality/2024-07-08/maternal_mortality.py
@@ -1,7 +1,7 @@
 """Load a meadow dataset and create a garden dataset."""
 
 import pandas as pd
-from owid.catalog import Dataset, Origin, Table
+from owid.catalog import Dataset, Table
 from owid.catalog import processing as pr
 from owid.datautils.dataframes import combine_two_overlapping_dataframes
 
@@ -88,13 +88,11 @@ def run(dest_dir: str) -> None:
     ds_wpp = paths.load_dataset("un_wpp")
     ds_pop = paths.load_dataset("population")
 
-    # save origins for later:
-    who_origins = sources_to_origins_who(ds_who_mortality)
-
-    # Read table from meadow dataset.
-    tb_gm = ds_gm["maternal_mortality"].reset_index()
-    tb_un = ds_un["maternal_mortality"].reset_index()
-    tb_who_mortality = ds_who_mortality["mortality_database"].reset_index()
+    # Read tables from input datasets, preserving their metadata and origins from snapshots.
+    # Use safe_types=False to match the previous ds[...].reset_index() behavior.
+    tb_gm = ds_gm.read("maternal_mortality", safe_types=False)
+    tb_un = ds_un.read("maternal_mortality", safe_types=False)
+    tb_who_mortality = ds_who_mortality.read("mortality_database", safe_types=False)
     # Filtering out the data we need from WHO mortality database
     tb_who_mortality = tb_who_mortality[
         (tb_who_mortality["cause"] == "Maternal conditions")
@@ -102,8 +100,8 @@ def run(dest_dir: str) -> None:
         & (tb_who_mortality["sex"] == "Both sexes")
     ]
     assert tb_who_mortality.shape[0] > 0
-    tb_wpp_pop = ds_wpp["population"].reset_index()
-    tb_wpp_births = ds_wpp["births"].reset_index()
+    tb_wpp_pop = ds_wpp.read("population", safe_types=False)
+    tb_wpp_births = ds_wpp.read("births", safe_types=False)
 
     # calculate maternal mortality ratio/ rate out of WHO mortality database and UN WPP
     tb_who_mortality = tb_who_mortality.rename(columns={"number": "maternal_deaths"})[
@@ -205,10 +203,7 @@ def run(dest_dir: str) -> None:
     tb["mm_rate"] = pd.to_numeric(tb["mm_rate"], errors="coerce").copy_metadata(tb["mm_rate"])
 
     # index and format columns
-    tb = tb.format(["country", "year"])
-
-    # add who origins to the table
-    tb = add_origins(tb, who_origins, ["maternal_deaths", "mmr", "mm_rate"])
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
 
     #
     # Save outputs.
@@ -247,32 +242,4 @@ def check_region_share_population(tb: Table, regions: list, ds_population: Datas
 
     tb_region = tb_region.drop(columns=["total_population", "share_population"])
     tb = pr.concat([tb_region, tb_no_regions])
-    return tb
-
-
-def sources_to_origins_who(ds: Dataset) -> list[Origin]:
-    """Create an origin from the sources of the who dataset."""
-    origins = []
-    for source in ds.metadata.sources:
-        origin_ds = Origin(
-            producer="WHO Mortality Database",
-            description=source.description,
-            attribution_short="WHO",
-            title=source.name,
-            date_published=source.publication_date,
-            url_main=source.url,
-            citation_full="World Health Organization. 'WHO Mortality Database.' 2022, https://www.who.int/data/data-collection-tools/who-mortality-database.",
-            license=ds.licenses[0],
-            date_accessed=source.date_accessed,
-        )
-        origins.append(origin_ds)
-    return origins
-
-
-def add_origins(tb: Table, origins: list[Origin], cols=None):
-    if cols is None:
-        cols = tb.columns
-    for origin in origins:
-        for col in cols:
-            tb[col].metadata.origins = tb[col].metadata.origins + [origin]
     return tb


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Fixes the nightly private rebuild failure in the 2024 maternal mortality garden step after the legacy `DatasetMeta.sources` attribute was removed.

The step was still doing a custom `Source` → `Origin` conversion for the WHO Mortality Database input. That is no longer needed: the WHO snapshot already carries origins, and downstream steps should preserve them via catalog Tables rather than recreating them manually.

This PR:
- reads Gapminder, UN MMEIG, WHO mortality, and WPP input tables via `Dataset.read(..., safe_types=False)`, preserving full table/variable metadata and origins while matching the previous `ds[...].reset_index()` data-loading behavior
- removes the legacy `sources_to_origins_who()` conversion helper
- removes the manual `add_origins()` restamping of WHO origins onto output indicators
- sets the formatted table short name explicitly, which the updated read path requires here

Validation:
- `PREFER_DOWNLOAD=1 .venv/bin/etlr data://garden/maternal_mortality/2024-07-08/maternal_mortality --private --only`
- Spot-checked the rebuilt output keeps `update_period_days`, table description, `description_from_producer`, topic tags, and propagated origins.
- Compared the rebuilt values against the previous `ds[...].reset_index()` loading behavior: `maternal_deaths`, `mmr`, `live_births`, and `mm_rate` are identical across all 9,264 rows.
- Commit hook ran lint/import formatting/type checks successfully.
