### PR TITLE
📊 Remove remaining active legacy source metadata

### DIFF
--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -876,8 +876,10 @@ def _local_catalog_datasets(
 def _fetch_remote_dataset(path: str, frame: pd.DataFrame) -> RemoteDataset:
     uri = f"{DEFAULT_CATALOG_URL}{path}/index.json"
     js = http_session.get(uri).json()
-    # drop origins for backward compatibility
+    # Drop deprecated provenance fields for backward compatibility with remote catalog entries
+    # that were built before the Source -> Origin migration was fully rolled out.
     js.pop("origins", None)
+    js.pop("sources", None)
     ds_meta = DatasetMeta(**js)
     # TODO: channel should be in DatasetMeta by default
     ds_meta.channel = path.split("/")[0]  # ty: ignore

--- a/etl/steps/data/garden/dummy/2023-10-12/dummy_monster.meta.yml
+++ b/etl/steps/data/garden/dummy/2023-10-12/dummy_monster.meta.yml
@@ -173,30 +173,13 @@ tables:
             producer: "Common producer for this data product"
             citation_full: *common_citation_full
 
-      # Indicator that has multiple origins and sources.
+      # Indicator that has multiple origins.
       multiple_origins_and_sources:
-        title: "Multiple origins and sources"
+        title: "Multiple origins"
         unit: ""
         origins:
           - *origin_typical
           - *origin_with_all_normal_fields
-        sources:
-          - name: "Source number one"
-            description: Description of source one. This could be a long text that describes the source. This could be a long text that describes the source. This could be a long text that describes the source.
-            published_by: Citation of the first source. This could be a long text that contains the full citation of the source. This could be a long text that contains the full citation of the source. This could be a long text that contains the full citation of the source.
-            url: https://url-for-source-one.com/
-            source_data_url: https://url-to-download-data-from-source-one.com/
-            date_accessed: "2023-01-01"
-            publication_date: "2000-01-01"
-            publication_year: 2000
-          - name: "Source number two"
-            description: Description of source two. This could be a long text that describes the source. This could be a long text that describes the source. This could be a long text that describes the source.
-            published_by: Citation of the second source. This could be a long text that contains the full citation of the source. This could be a long text that contains the full citation of the source. This could be a long text that contains the full citation of the source.
-            url: https://url-for-source-two.com/
-            source_data_url: https://url-to-download-data-from-source-two.com/
-            date_accessed: "2023-01-01"
-            publication_date: "2000-01-01"
-            publication_year: 2000
 
       # Horrible indicator with all possible metadata, and all fields unreasonably long.
       all_possible_long_metadata:

--- a/snapshots/hyde/2017/baseline.zip.dvc
+++ b/snapshots/hyde/2017/baseline.zip.dvc
@@ -1,14 +1,4 @@
 meta:
-  name: Hyde 3.2 (baseline estimates)
-  source_name: PBL Netherlands Environmental Assessment Agency
-  publication_year: 2017
-  url: https://www.pbl.nl/en/image/links/hyde
-  source_data_url: https://dataportaal.pbl.nl/downloads/HYDE/HYDE3.2/baseline.zip
-  license_url: https://dataportaal.pbl.nl/downloads/HYDE/HYDE3.2/readme_release_HYDE3.2.1.txt
-  license_name: CC BY 3.0
-  date_accessed: 2021-10-01
-  description: |
-    HYDE is an internally consistent combination of updated historical population (gridded) estimates and land use for the past 12,000 years. Categories include cropland, with a new distinction into irrigated and rain fed crops (other than rice) and irrigated and rain fed rice. Also grazing lands are provided, divided into more intensively used pasture, converted rangeland and non-converted natural (less intensively used) rangeland. Population is represented by maps of total, urban, rural population and population density as well as built-up area.
   origin:
     producer: PBL Netherlands Environmental Assessment Agency
     title: HYDE


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Removes the remaining active-DAG legacy source metadata found after the catalog `Source` removal, and keeps `etl diff REMOTE ...` compatible with older remote catalog entries that still contain legacy `sources` in their dataset metadata.

This PR cleans up two active metadata cases:
- HYDE 3.2 baseline snapshot: removes leftover flat legacy source fields from `meta`, leaving `meta.origin` as the source of truth. The CC BY 3.0 license is preserved under `origin.license` using the currently working HYDE landing page URL.
- Dummy monster metadata: removes the variable-level legacy `sources:` example now that source metadata is represented with `origins`.

It also updates `etl/datadiff.py` to drop deprecated remote `sources` metadata before constructing `DatasetMeta`, matching the existing compatibility handling for remote `origins`.

Validation:
- `SnapshotMeta.load_from_yaml('snapshots/hyde/2017/baseline.zip.dvc')`
- `PREFER_DOWNLOAD=1 .venv/bin/etlr data://garden/hyde/2017/baseline --private`
- `PREFER_DOWNLOAD=1 .venv/bin/etlr data://garden/dummy/2023-10-12/dummy_monster --private --only`
- Re-scanned active DAG snapshots/meta files for legacy `source*` / `sources:` metadata hits: none remaining.
- `_remote_catalog_datasets(channels=('garden',), include='garden', exclude='excess_mortality|covid|fluid|flunet|country_profile|garden/ihme_gbd/2019/gbd_risk')` loads 1,752 remote garden datasets without the legacy `sources` crash.
- Commit hook ran lint/import formatting/type checks successfully.
