### PR TITLE
Skip remote data diff when feather ETag matches local MD5

### DIFF
--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -301,6 +301,45 @@ class RemoteDataset:
         return tb
 
 
+def _data_files_match(ds_local: Dataset, ds_remote: "RemoteDataset") -> bool:
+    """Return True if every local table's feather file is byte-identical to its remote counterpart.
+
+    Compares the local MD5 to the remote object's S3/R2 ETag (which is the file's MD5 for
+    OWID's non-multipart uploads). Used to skip data diffs when ``source_checksum`` cascades
+    from an upstream metadata-only change but the actual feather bytes are unchanged.
+    """
+    from owid.catalog.core.datasets import checksum_file
+
+    if set(ds_local.table_names) != set(ds_remote.table_names):
+        return False
+
+    local_md5: dict[str, str] = {}
+    for t in ds_local.table_names:
+        path = Path(ds_local.path) / f"{t}.feather"
+        if not path.exists():
+            return False
+        local_md5[t] = checksum_file(path.as_posix()).hexdigest()
+
+    base = (
+        f"{DEFAULT_CATALOG_URL}{ds_remote.metadata.channel}/{ds_remote.metadata.namespace}/"
+        f"{ds_remote.metadata.version}/{ds_remote.metadata.short_name}"
+    )
+
+    def _remote_md5(table_name: str) -> str | None:
+        try:
+            r = http_session.head(f"{base}/{table_name}.feather", timeout=10)
+        except Exception:
+            return None
+        if r.status_code != 200:
+            return None
+        return r.headers.get("ETag", "").strip('"').lower() or None
+
+    with ThreadPoolExecutor(max_workers=min(8, max(1, len(local_md5)))) as executor:
+        remote_md5 = dict(zip(local_md5.keys(), executor.map(_remote_md5, local_md5.keys())))
+
+    return all(local_md5[t] == remote_md5.get(t) for t in local_md5)
+
+
 @click.command(name="diff", help=__doc__)
 @click.argument(
     "path-a",
@@ -453,6 +492,7 @@ def cli(
     any_error = False
 
     matched_datasets = []
+    skipped_identical_data = 0
     for path in sorted(set(path_to_ds_a.keys()) | set(path_to_ds_b.keys())):
         ds_a = _match_dataset(path_to_ds_a, path)
         ds_b = _match_dataset(path_to_ds_b, path)
@@ -462,7 +502,20 @@ def cli(
             # to improve performance. Source checksum should be enough
             continue
 
+        # Fast-path: source_checksum differs (typical when an upstream metadata change cascades)
+        # but the feather files are byte-identical. Compare local MD5 to remote S3/R2 ETag and
+        # skip the full data download/diff when they match.
+        if ds_a and ds_b:
+            local_ds = ds_b if isinstance(ds_a, RemoteDataset) else ds_a
+            remote_ds = ds_a if isinstance(ds_a, RemoteDataset) else (ds_b if isinstance(ds_b, RemoteDataset) else None)
+            if remote_ds is not None and isinstance(local_ds, Dataset) and _data_files_match(local_ds, remote_ds):
+                skipped_identical_data += 1
+                continue
+
         matched_datasets.append((ds_a, ds_b))
+
+    if skipped_identical_data:
+        log.info("Skipped datasets with identical data (source_checksum cascade)", count=skipped_identical_data)
 
     if workers > 1:
         futures = []


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

`etl owidbot` on [#6147 (data-remove-remaining-active)](https://github.com/owid/etl/pull/6147) spent ~14m32s inside the data-diff service — long enough that I initially blamed the analytics step. Root cause: the PR edits `snapshots/hyde/2017/baseline.zip.dvc` (legacy Source removal), and HYDE has **89 downstream garden datasets**. `source_checksum` cascades to every one, so `etl diff` can't short-circuit at `etl/datadiff.py:460` and instead downloads each remote feather and runs `series_equals` column-by-column — even though the actual data is byte-identical.

## What

Add a HEAD-request fast-path right after the existing `source_checksum` check:

- For each table, compare the local feather's MD5 to the remote object's `ETag` header
- R2/S3 ETags are the MD5 for non-multipart uploads — which is what `etl publish` does (one PUT per file, MD5 also stored in `x-amz-meta-md5`)
- If every table matches → skip the dataset (consistent with the existing source_checksum skip — no `= Dataset X` line printed either)
- Any 404 / network error / missing local feather → returns `False`, falls through to the existing diff logic. Strictly an optimization

No schema change, no remote catalog reindex needed — the ETags are already there.

## Benchmark

Against the actual 71 garden datasets that would be checked on this branch (after the owidbot `--exclude` filter, totalling 2,744 feather files):

| Path | Time |
|---|---|
| Baseline (full download + column compare, `--workers 3`) | ~14m32s |
| Fast-path (HEAD requests, 20 workers — matches existing default in `_remote_catalog_datasets`) | ~10s |
| Fast-path (50 workers) | ~4s |

Local MD5 add ~0.2s for a 6-table dataset on cached disk, scaling linearly.

## Correctness

Verified on a real local dataset (`garden/demography/2024-07-15/population`):

| Case | Returned |
|---|---|
| Identical local & remote | `True` (would skip) |
| Local has tables remote doesn't | `False` (falls through) |
| Remote URL returns 404 | `False` (falls through) |

ETag = MD5 confirmed by downloading `food_expenditure.feather` and re-hashing — exact match.

## Caveats

- Only helps when the dataset is actually built locally (always the case on the staging server)
- If we ever switch to multipart uploads for large feather files, ETag becomes `md5-of-md5s-N` and won't match local MD5 → falls through cleanly, no incorrect skips