### PR TITLE
📊 Fix tempcompare duplicate index diff

### DIFF
--- a/etl/tempcompare.py
+++ b/etl/tempcompare.py
@@ -269,10 +269,18 @@ class HighLevelDiff:
             self.df2[self.df2.index.duplicated()].index.values
         )
 
+        duplicate_index_values_in_either_df = self.df1.index[self.df1.index.duplicated(keep=False)].union(
+            self.df2.index[self.df2.index.duplicated(keep=False)]
+        )
+        comparable_index_values = self.index_values_shared.difference(duplicate_index_values_in_either_df)
+
         # Now we calculate the value differences in the intersection of the two dataframes.
-        if self.columns_shared and not self.index_values_shared.empty:
-            df1_intersected = self.df1.loc[self.index_values_shared, list(self.columns_shared)]
-            df2_intersected = self.df2.loc[self.index_values_shared, list(self.columns_shared)]
+        # If an index value is duplicated in either dataframe, `.loc` would expand it to a different number of rows on
+        # each side. Those duplicate rows are already reported as structural differences, so compare values only for
+        # shared index values that are unique in both dataframes.
+        if self.columns_shared and not comparable_index_values.empty:
+            df1_intersected = self.df1.loc[comparable_index_values, list(self.columns_shared)]
+            df2_intersected = self.df2.loc[comparable_index_values, list(self.columns_shared)]
 
             diffs = df_equals(
                 df1_intersected,

--- a/tests/test_tempcompare.py
+++ b/tests/test_tempcompare.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from etl.tempcompare import df_equals, series_equals
+from etl.tempcompare import HighLevelDiff, df_equals, series_equals
 
 
 def test_df_equals():
@@ -66,6 +66,30 @@ def test_df_equals_exceptions():
     df2 = pd.DataFrame({"col1": [1, 2, 3]}, index=[4, 5, 6])
     with pytest.raises(AssertionError):
         df_equals(df1, df2)
+
+
+def test_high_level_diff_with_duplicate_index_values_does_not_crash():
+    df1 = pd.DataFrame({"col1": [1, 2]}, index=pd.Index([1, 1], name="year"))
+    df2 = pd.DataFrame({"col1": [1]}, index=pd.Index([1], name="year"))
+
+    diff = HighLevelDiff(df1, df2)
+
+    assert not diff.are_structurally_equal
+    assert list(diff.duplicate_index_values_in_df1) == [1]
+    assert diff.value_differences is None
+
+
+def test_high_level_diff_compares_unique_shared_rows_when_other_rows_have_duplicate_index_values():
+    df1 = pd.DataFrame({"col1": [1, 2, 3]}, index=pd.Index([1, 2, 2], name="year"))
+    df2 = pd.DataFrame({"col1": [1, 20, 4]}, index=pd.Index([1, 2, 3], name="year"))
+
+    diff = HighLevelDiff(df1, df2)
+
+    assert not diff.are_structurally_equal
+    assert diff.value_differences is None
+    assert list(diff.duplicate_index_values_in_df1) == [2]
+    assert list(diff.index_values_missing_in_df2) == []
+    assert list(diff.index_values_missing_in_df1) == [3]
 
 
 def test_series_equals_nans():


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Summary

- Avoid crashing data diffs when shared index values are duplicated in either dataframe.
- Continue reporting duplicated index values as structural differences.
- Add regression tests for duplicate-index comparisons in `HighLevelDiff`.

## Testing

- `.venv/bin/pytest tests/test_tempcompare.py`
- `make check`