### PR TITLE
📊 Validate fasttrack duplicate keys

### DIFF
--- a/apps/wizard/app_pages/fasttrack/load.py
+++ b/apps/wizard/app_pages/fasttrack/load.py
@@ -273,7 +273,27 @@ def parse_data_from_sheets(data_df: pd.DataFrame) -> pd.DataFrame:
     if data_df.year.dtype not in INT_TYPES and not _is_valid_date(data_df.year):
         raise ValidationError("Column 'year' should be integer or date")
 
+    _validate_unique_keys(data_df)
+
     return data_df.set_index(["country", "year"])
+
+
+def _validate_unique_keys(data_df: pd.DataFrame) -> None:
+    key_columns = ["country", "year"] + [col for col in data_df.columns if col.startswith("dim_")]
+    duplicated_keys = data_df.loc[data_df.duplicated(subset=key_columns, keep=False), key_columns]
+
+    if duplicated_keys.empty:
+        return
+
+    sample = duplicated_keys.drop_duplicates().head(20)
+    sample_text = sample.to_string(index=False)
+    extra = (
+        "" if len(duplicated_keys) <= 20 else f"\n\nShowing the first 20 duplicated rows out of {len(duplicated_keys)}."
+    )
+    raise ValidationError(
+        "Duplicate keys found in the incoming data. Each row must have a unique "
+        f"combination of {', '.join(key_columns)}.\n\n{sample_text}{extra}"
+    )
 
 
 def _is_valid_date(series: pd.Series) -> bool:

--- a/tests/apps/wizard/app_pages/fasttrack/test_load.py
+++ b/tests/apps/wizard/app_pages/fasttrack/test_load.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import pytest
+
+from apps.wizard.app_pages.fasttrack.load import ValidationError, parse_data_from_sheets
+
+
+def test_parse_data_from_sheets_rejects_duplicate_country_year_keys():
+    data = pd.DataFrame(
+        {
+            "country": ["Taiwan", "Taiwan", "Zimbabwe"],
+            "year": [2023, 2023, 2023],
+            "value": [1, 2, 3],
+        }
+    )
+
+    with pytest.raises(ValidationError, match="Duplicate keys found"):
+        parse_data_from_sheets(data)
+
+
+def test_parse_data_from_sheets_allows_duplicate_country_year_with_different_dimensions():
+    data = pd.DataFrame(
+        {
+            "country": ["Taiwan", "Taiwan"],
+            "year": [2023, 2023],
+            "dim_scenario": ["low", "high"],
+            "value": [1, 2],
+        }
+    )
+
+    parsed = parse_data_from_sheets(data)
+
+    assert parsed.index.names == ["country", "year"]
+    assert list(parsed["dim_scenario"]) == ["low", "high"]


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Summary

- Validate Fasttrack incoming data for duplicate key rows before building the ETL dataset.
- Include `dim_*` columns in the uniqueness key, so dimensional datasets can have repeated country-year pairs across different dimensions.
- Show a validation error with a sample of duplicated keys instead of failing later during the ETL step.
- Add regression tests for duplicate and dimensioned Fasttrack inputs.

## Testing

- `.venv/bin/pytest tests/apps/wizard/app_pages/fasttrack/test_load.py`
- `make check`