### PR TITLE
Fix equaldex description_processing — we don't back-extend undated statuses

### DIFF
--- a/etl/steps/data/garden/lgbt_rights/2026-05-14/equaldex.meta.yml
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-14/equaldex.meta.yml
@@ -8,7 +8,7 @@ definitions:
     description_processing: |-
       - We have extracted the data from the official [Equaldex JSON API](https://equaldex.stoplight.io/docs/equaldex/d033e28a5cf0c-equaldex-json-api).
       - We combine the historical and current data extracted from the API to create a time series.
-      - Whenever policy implementation dates for a status are not provided in the data, and this status is the only available for the country, we consider that this status has not changed during the entire period of the dataset.
+      - If Equaldex doesn't record when a status began, we only include it for the most recent year — we don't extend it backward.
       - We group some of the categories the source has defined for each issue, for further clarity in our visualizations.
       - We present this data only for sovereign states, defined by [Butcher and Griffiths (2020)](https://ourworldindata.org/grapher/sovereign-state-butcher-griffiths), using the definitions of the latest year available. Greenland is the one exception: we keep it as its own country row but exclude it from regional aggregates.
     presentation:


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## Summary

Follow-up to [#6123](https://github.com/owid/etl/pull/6123). The merged Equaldex update had a stale \`description_processing\` bullet claiming:

> Whenever policy implementation dates for a status are not provided in the data, and this status is the only available for the country, we consider that this status has not changed during the entire period of the dataset.

That isn't what the code actually does. \`equaldex_extract.create_long_dataset\` stamps undated current statuses onto the snapshot year only, and historical rows with null dates are dropped earlier in the same function. Antarctica's homosexuality \`current_status\` has \`start_date_formatted = null\` → 1 row in the long-format file (\`year=2026\`), not 1950–2026.

Rewrite the bullet to match the code:

> When the producer doesn't record a start date for a country's current status on an issue, we only stamp that status onto the snapshot year — we do not back-extend it, so the row appears for a single year rather than being asserted across the whole period.

## Test plan

- [ ] Sanity-check the rewritten bullet on any chart's data page (e.g. [same-sex-sexual-acts-equaldex](https://ourworldindata.org/grapher/same-sex-sexual-acts-equaldex)).