### PR TITLE
📊 Fix spacing in UCDP chart titles (countries-in-conflict-data explorer)

### DIFF
--- a/etl/steps/data/garden/war/2025-06-13/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2025-06-13/ucdp.meta.yml
@@ -160,8 +160,10 @@ definitions:
       - "{definitions.all.conflict_type}"
 
   number_ongoing_conflicts:
+    # Outer trim markers intentionally non-stripping (<% ... %>) so a leading space
+    # in the interpolating template (e.g. "...over time. {description_short}") is preserved.
     description_short: |-
-      <%- if conflict_type == "all" -%>
+      <% if conflict_type == "all" -%>
       Included are armed conflicts that were ongoing a year.
 
       <%- elif conflict_type == "intrastate (internationalized)" -%>
@@ -182,7 +184,7 @@ definitions:
       <%- else -%>
       Included are << conflict_type >> conflicts that were ongoing a year.
 
-      <%- endif -%>
+      <%- endif %>
     description_key: &description_key_ongoing
       - "{definitions.all.conflict_type}"
       # - We count a conflict as ongoing in a region even if the conflict is also ongoing in other regions. The sum across all regions can therefore be higher than the total number of ongoing conflicts.

--- a/etl/steps/data/garden/war/2025-06-13/ucdp.meta.yml
+++ b/etl/steps/data/garden/war/2025-06-13/ucdp.meta.yml
@@ -42,23 +42,25 @@ definitions:
 
       <%- endif -%>
     # Conflict-type label used in titles/subtitles (e.g. "armed conflicts", "one-sided violence").
+    # Outer trim markers intentionally non-stripping (<% ... %>) so surrounding spaces in the
+    # interpolating template (e.g. title: "Deaths {prep} {label} based...") are preserved.
     conflict_label: |-
-      <%- if conflict_type == "all" -%>armed conflicts
+      <% if conflict_type == "all" -%>armed conflicts
       <%- elif conflict_type == "one-sided violence" -%>one-sided violence
       <%- else -%><< conflict_type >> conflicts
-      <%- endif -%>
+      <%- endif %>
     # Slug for the matching DoD ("details on demand") definition link.
     conflict_dod_slug: |-
-      <%- if conflict_type == "all" -%>armed-conflict-ucdp
+      <% if conflict_type == "all" -%>armed-conflict-ucdp
       <%- elif conflict_type == "one-sided violence" -%>onesided-ucdp
       <%- elif conflict_type == "non-state conflict" -%>nonstate-ucdp
       <%- else -%><< conflict_type >>-ucdp
-      <%- endif -%>
+      <%- endif %>
     # Preposition: "from" for one-sided violence, "in" for everything else.
     conflict_prep: |-
-      <%- if conflict_type == "one-sided violence" -%>from
+      <% if conflict_type == "one-sided violence" -%>from
       <%- else -%>in
-      <%- endif -%>
+      <%- endif %>
     location_conflicts_method: |-
       UCDP provides geographical coordinates of each conflict event. We have mapped these coordinates to countries by means of the geoBoundaries dataset.
 


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Fixes spacing in UCDP chart titles shown on the [countries-in-conflict-data](https://ourworldindata.org/explorers/countries-in-conflict-data) explorer (e.g. titles rendered as \`Deathsinarmed conflictsbased on where they occurred\`).

## Quick links
| | |
|---|---|
| Staging site | http://staging-site-data-ucdp-chart-spacing |
| Explorer (staging) | http://staging-site-data-ucdp-chart-spacing/explorers/countries-in-conflict-data |

/schedule