### PR TITLE
📊 Add poverty/inequality external steps and region columns

### DIFF
--- a/dag/poverty_inequality.yml
+++ b/dag/poverty_inequality.yml
@@ -15,6 +15,8 @@ steps:
     - data://meadow/wb/2026-03-24/world_bank_pip
   data://grapher/wb/2026-03-24/world_bank_pip:
     - data://garden/wb/2026-03-24/world_bank_pip
+  data://external/poverty_inequality/latest/world_bank_pip:
+    - data://garden/wb/2026-03-24/world_bank_pip
   export://multidim/wb/latest/poverty_pip:
     - data://grapher/wb/2026-03-24/world_bank_pip
   export://multidim/wb/latest/incomes_pip:
@@ -143,6 +145,8 @@ steps:
       - data://garden/demography/2024-07-15/population
       - data://garden/demography/2025-12-10/population_ireland
       - data://garden/regions/2023-01-01/regions
+  data://external/poverty_inequality/latest/historical_poverty:
+    - data://garden/poverty_inequality/2025-10-23/historical_poverty
 
   # Socio-Economic Database for Latin America and the Caribbean (SEDLAC)
   data://garden/cedlas/2025-04-01/sedlac:

--- a/etl/steps/data/external/poverty_inequality/latest/historical_poverty.py
+++ b/etl/steps/data/external/poverty_inequality/latest/historical_poverty.py
@@ -1,0 +1,23 @@
+"""Historical thousand-bin distributions (1820–present), hybrid and all-lognormal variants."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    # Load garden dataset.
+    ds_garden = paths.load_dataset("historical_poverty")
+
+    # Read the two thousand-bin tables from garden dataset.
+    tables = [
+        ds_garden.read("thousand_bins_interpolated_ginis", reset_index=False),
+        ds_garden.read("thousand_bins_interpolated_ginis_all_lognormal", reset_index=False),
+    ]
+
+    # Initialize a new external dataset.
+    # Garden tables are already repacked, so skip it here to avoid the cost.
+    ds = paths.create_dataset(tables=tables, repack=False)
+
+    # Save external dataset.
+    ds.save()

--- a/etl/steps/data/external/poverty_inequality/latest/thousand_bins_distribution.py
+++ b/etl/steps/data/external/poverty_inequality/latest/thousand_bins_distribution.py
@@ -1,6 +1,5 @@
-"""Thousand-bins global income distribution from World Bank PIP.
-
-Published as CSV and JSON for use by Grapher interactive charts and static charts.
+"""
+Thousand-bins global income distribution from World Bank PIP.
 """
 
 from etl.helpers import PathFinder

--- a/etl/steps/data/external/poverty_inequality/latest/world_bank_pip.py
+++ b/etl/steps/data/external/poverty_inequality/latest/world_bank_pip.py
@@ -1,0 +1,32 @@
+"""World Bank PIP (Poverty and Inequality Platform) — external catalog mirror."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    # Load garden dataset.
+    ds_garden = paths.load_dataset("world_bank_pip")
+
+    # Read all tables from garden dataset.
+    tables = [
+        ds_garden.read(name, reset_index=False)
+        for name in [
+            "poverty",
+            "incomes",
+            "inequality",
+            "cpi",
+            "other_indicators",
+            "survey_count",
+            "percentiles",
+            "complete_series",
+        ]
+    ]
+
+    # Initialize a new external dataset.
+    # Garden tables are already repacked, so skip it here to avoid the cost.
+    ds = paths.create_dataset(tables=tables, repack=False)
+
+    # Save external dataset.
+    ds.save()

--- a/etl/steps/data/garden/poverty_inequality/2025-10-23/historical_poverty.py
+++ b/etl/steps/data/garden/poverty_inequality/2025-10-23/historical_poverty.py
@@ -224,6 +224,33 @@ def run() -> None:
     # Prepare GDP data
     tb_gdp = prepare_gdp_data(tb_maddison)
 
+    # Build country → OWID continent and country → MPD region maps. Reused below to label
+    # the thousand_bins tables alongside the existing PIP `region` / `region_old` columns.
+    owid_members = paths.regions.get_regions(
+        names=["Africa", "Asia", "Europe", "North America", "Oceania", "South America"],
+        only_subregions=True,
+    )
+    country_to_owid_region = {c: r for r, members in owid_members.items() for c in members}
+    # Channel Islands isn't a member of any OWID continent in the regions dataset.
+    country_to_owid_region.setdefault("Channel Islands", "Europe")
+
+    country_to_mpd_region = (
+        tb_maddison[["country", "region"]]
+        .drop_duplicates()
+        .assign(country=lambda d: d["country"].str.replace(" (Maddison)", "", regex=False))
+        .groupby("country")["region"]
+        .first()
+        .to_dict()
+    )
+    # PIP countries not available in MPD — use the manual mapping already maintained at the top of this file.
+    country_to_mpd_region.update(MISSING_COUNTRIES_AND_REGIONS)
+    # Successor states of historical MPD entities (inherit the historical entity's region).
+    for entity_name in ["USSR", "Yugoslavia", "Czechoslovakia", "Sudan (former)"]:
+        entity_region = country_to_mpd_region.get(entity_name)
+        if entity_region is not None:
+            for successor in paths.regions.get_region(entity_name)["successors"]:
+                country_to_mpd_region.setdefault(successor, entity_region)
+
     # Extract years where World has data in Maddison for benchmark columns (only before LATEST_YEAR_PIP_FILLED)
     maddison_world_years = set(
         tb_maddison[
@@ -458,11 +485,18 @@ def run() -> None:
                 subset=["country", "year", "region", "region_old", "quantile"]
             )
         )
+    tb_thousand_bins_interpolated_ginis = attach_extra_region_columns(
+        tb_thousand_bins_interpolated_ginis, country_to_owid_region, country_to_mpd_region
+    )
     tb_thousand_bins_interpolated_ginis = tb_thousand_bins_interpolated_ginis.format(
-        ["country", "year", "region", "region_old", "quantile"], short_name="thousand_bins_interpolated_ginis"
+        ["country", "year", "region", "region_old", "owid_region", "mpd_region", "quantile"],
+        short_name="thousand_bins_interpolated_ginis",
+    )
+    tb_thousand_bins_interpolated_ginis_all_lognormal = attach_extra_region_columns(
+        tb_thousand_bins_interpolated_ginis_all_lognormal, country_to_owid_region, country_to_mpd_region
     )
     tb_thousand_bins_interpolated_ginis_all_lognormal = tb_thousand_bins_interpolated_ginis_all_lognormal.format(
-        ["country", "year", "region", "region_old", "quantile"],
+        ["country", "year", "region", "region_old", "owid_region", "mpd_region", "quantile"],
         short_name="thousand_bins_interpolated_ginis_all_lognormal",
     )
 
@@ -501,6 +535,34 @@ def run() -> None:
 
     # Save dataset
     ds_garden.save()
+
+
+def attach_extra_region_columns(
+    tb: Table,
+    country_to_owid_region: dict,
+    country_to_mpd_region: dict,
+) -> Table:
+    """Attach OWID continent and Maddison Project Database region columns to a thousand_bins table.
+
+    Memory-light: maps via categorical codes (one int per row) instead of expanding full-length
+    string arrays — important because these tables are tens of millions of rows. Metadata is
+    inherited from the existing PIP `region` column so origins propagate to the output.
+    """
+    country = tb["country"]
+    if not isinstance(country.dtype, pd.CategoricalDtype):
+        country = country.astype("category")
+
+    categories = country.cat.categories
+    codes = country.cat.codes.to_numpy()
+
+    owid_per_cat = pd.Categorical([country_to_owid_region.get(c) for c in categories])
+    mpd_per_cat = pd.Categorical([country_to_mpd_region.get(c) for c in categories])
+
+    tb["owid_region"] = pd.Categorical.from_codes(owid_per_cat.codes[codes], categories=owid_per_cat.categories)
+    tb["mpd_region"] = pd.Categorical.from_codes(mpd_per_cat.codes[codes], categories=mpd_per_cat.categories)
+    tb["owid_region"] = tb["owid_region"].copy_metadata(tb["region"])
+    tb["mpd_region"] = tb["mpd_region"].copy_metadata(tb["region"])
+    return tb
 
 
 def prepare_gdp_data(tb_maddison: Table) -> Table:


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## Summary

Two related changes to the poverty/inequality pipeline:

### 1. New external-catalog steps (`data://external/...`)

Mirror existing garden datasets to the public catalog so they can be pulled without going through Grapher/Datasette. Same shim pattern as the existing `external/poverty_inequality/latest/thousand_bins_distribution` step.

- **`data://external/poverty_inequality/latest/world_bank_pip`** — exposes the 8 garden tables of [`wb/2026-03-24/world_bank_pip`](etl/steps/data/garden/wb/2026-03-24/world_bank_pip.py): `poverty`, `incomes`, `inequality`, `cpi`, `other_indicators`, `survey_count`, `percentiles`, `complete_series`.
- **`data://external/poverty_inequality/latest/historical_poverty`** — exposes the two thousand-bin reconstructions from [`poverty_inequality/2025-10-23/historical_poverty`](etl/steps/data/garden/poverty_inequality/2025-10-23/historical_poverty.py): `thousand_bins_interpolated_ginis` (hybrid: empirical PIP bins for 1981+, lognormal pre-1981) and `thousand_bins_interpolated_ginis_all_lognormal` (fully lognormal 1820 → present).
- Both use `repack=False` because the garden tables are already optimally packed (cut historical_poverty's external step from ~200s to ~22s).
- DAG: two new entries in `dag/poverty_inequality.yml`.
- Drive-by: minor docstring cleanup on `thousand_bins_distribution.py`.

### 2. New region columns on the two saved thousand_bins tables in `historical_poverty`

Add `owid_region` (6 OWID continents) and `mpd_region` (8 Maddison Project Database regions) alongside the existing PIP `region` / `region_old`. Both are in the `.format()` index.

- Memory-light helper that maps via categorical codes — important because the two tables are 36.6M and 34.8M rows. Avoids full-length string allocations.
- OWID continents fetched via `paths.regions.get_regions(only_subregions=True)`; Channel Islands → Europe filled in manually.
- MPD regions sourced from Maddison, with the existing `MISSING_COUNTRIES_AND_REGIONS` dict as fallback for PIP-only countries, and dynamic successor-state inheritance for Kosovo (Yugoslavia → Eastern Europe), Sudan / South Sudan (Sudan (former) → Sub Saharan Africa).
- Verified: 0 nulls across both tables; categories exactly the 6 OWID continents and 8 MPD regions.

## Test plan

- [x] `.venv/bin/etlr garden/poverty_inequality/2025-10-23/historical_poverty --private` runs cleanly.
- [x] `.venv/bin/etlr external/poverty_inequality/latest/world_bank_pip --private` writes 8 tables.
- [x] `.venv/bin/etlr external/poverty_inequality/latest/historical_poverty --private` writes 2 tables with the new region columns.
- [x] Spot-check: 0 nulls in `owid_region` / `mpd_region`; correct category sets.
- [x] `make check` passes.
- [ ] Sanity-check the published catalog entries once this lands on master.