### PR TITLE
Reword land-use subtitle to clarify m²·year unit

### DIFF
--- a/etl/steps/data/garden/food/2019-10-08/environmental_impacts_of_food__poore__and__nemecek__2018.meta.yml
+++ b/etl/steps/data/garden/food/2019-10-08/environmental_impacts_of_food__poore__and__nemecek__2018.meta.yml
@@ -159,7 +159,7 @@ tables:
         presentation:
           grapher_config:
             title: "{definitions.title_land_use} of foods per {definitions.noun_per_1000kcal}"
-            subtitle: "Land use is measured in meters squared (m²) for 1 year to produce {definitions.noun_per_1000kcal_long_2}."
+            subtitle: "Land use is measured in meters squared (m²) for one year to produce {definitions.noun_per_1000kcal_long_2}."
             note: "The median year of the studies involved in this research was 2010."
 
       land_use_per_100g_protein__poore__and__nemecek__2018:
@@ -174,7 +174,7 @@ tables:
         presentation:
           grapher_config:
             title: "{definitions.title_land_use} per {definitions.noun_per_100g_protein}"
-            subtitle: "Land use is measured in meters squared (m²) for 1 year to produce {definitions.noun_per_100g_protein} across various food products."
+            subtitle: "Land use is measured in meters squared (m²) for one year to produce {definitions.noun_per_100g_protein} across various food products."
 
       land_use_per_kilogram__poore__and__nemecek__2018:
         title: Land use per kilogram (Poore & Nemecek, 2018)
@@ -188,7 +188,7 @@ tables:
         presentation:
           grapher_config:
             title: "{definitions.title_land_use} per {definitions.noun_per_kg}"
-            subtitle: "Land use is measured in meters squared (m²) for 1 year to produce one kilogram of a given food product."
+            subtitle: "Land use is measured in meters squared (m²) for one year to produce one kilogram of a given food product."
 
       scarcity_weighted_water_use_per_1000kcal__poore__and__nemecek__2018:
         title: Scarcity-weighted water use per 1000kcal (Poore & Nemecek, 2018)

--- a/etl/steps/data/garden/food/2019-10-08/environmental_impacts_of_food__poore__and__nemecek__2018.meta.yml
+++ b/etl/steps/data/garden/food/2019-10-08/environmental_impacts_of_food__poore__and__nemecek__2018.meta.yml
@@ -159,7 +159,7 @@ tables:
         presentation:
           grapher_config:
             title: "{definitions.title_land_use} of foods per {definitions.noun_per_1000kcal}"
-            subtitle: "Land use is measured in meters squared (m²) of land used for 1 year to produce {definitions.noun_per_1000kcal_long_2}."
+            subtitle: "Land use is measured in meters squared (m²) for 1 year to produce {definitions.noun_per_1000kcal_long_2}."
             note: "The median year of the studies involved in this research was 2010."
 
       land_use_per_100g_protein__poore__and__nemecek__2018:
@@ -174,7 +174,7 @@ tables:
         presentation:
           grapher_config:
             title: "{definitions.title_land_use} per {definitions.noun_per_100g_protein}"
-            subtitle: "Land use is measured in meters squared (m²) of land used for 1 year to produce {definitions.noun_per_100g_protein} across various food products."
+            subtitle: "Land use is measured in meters squared (m²) for 1 year to produce {definitions.noun_per_100g_protein} across various food products."
 
       land_use_per_kilogram__poore__and__nemecek__2018:
         title: Land use per kilogram (Poore & Nemecek, 2018)
@@ -188,7 +188,7 @@ tables:
         presentation:
           grapher_config:
             title: "{definitions.title_land_use} per {definitions.noun_per_kg}"
-            subtitle: "Land use is measured in meters squared (m²) of land used for 1 year to produce one kilogram of a given food product."
+            subtitle: "Land use is measured in meters squared (m²) for 1 year to produce one kilogram of a given food product."
 
       scarcity_weighted_water_use_per_1000kcal__poore__and__nemecek__2018:
         title: Scarcity-weighted water use per 1000kcal (Poore & Nemecek, 2018)

--- a/etl/steps/data/garden/food/2019-10-08/environmental_impacts_of_food__poore__and__nemecek__2018.meta.yml
+++ b/etl/steps/data/garden/food/2019-10-08/environmental_impacts_of_food__poore__and__nemecek__2018.meta.yml
@@ -159,7 +159,7 @@ tables:
         presentation:
           grapher_config:
             title: "{definitions.title_land_use} of foods per {definitions.noun_per_1000kcal}"
-            subtitle: "Land use is measured in meters squared (m²) per year to produce {definitions.noun_per_1000kcal_long_2}."
+            subtitle: "Land use is measured in meters squared (m²) of land used for 1 year to produce {definitions.noun_per_1000kcal_long_2}."
             note: "The median year of the studies involved in this research was 2010."
 
       land_use_per_100g_protein__poore__and__nemecek__2018:
@@ -174,7 +174,7 @@ tables:
         presentation:
           grapher_config:
             title: "{definitions.title_land_use} per {definitions.noun_per_100g_protein}"
-            subtitle: "Land use is measured in meters squared (m²) per year to produce {definitions.noun_per_100g_protein} across various food products."
+            subtitle: "Land use is measured in meters squared (m²) of land used for 1 year to produce {definitions.noun_per_100g_protein} across various food products."
 
       land_use_per_kilogram__poore__and__nemecek__2018:
         title: Land use per kilogram (Poore & Nemecek, 2018)
@@ -188,7 +188,7 @@ tables:
         presentation:
           grapher_config:
             title: "{definitions.title_land_use} per {definitions.noun_per_kg}"
-            subtitle: "Land use is measured in meters squared (m²) per year to produce one kilogram of a given food product."
+            subtitle: "Land use is measured in meters squared (m²) of land used for 1 year to produce one kilogram of a given food product."
 
       scarcity_weighted_water_use_per_1000kcal__poore__and__nemecek__2018:
         title: Scarcity-weighted water use per 1000kcal (Poore & Nemecek, 2018)

--- a/etl/steps/export/explorers/food/latest/food_footprints.py
+++ b/etl/steps/export/explorers/food/latest/food_footprints.py
@@ -171,7 +171,7 @@ def _subtitle(view) -> str | None:
         return None
     noun = UNIT_NOUN[unit]
     if impact == "land_use":
-        return f"Land use is measured in meters squared (m²) of land used for 1 year, per {noun}."
+        return f"Land use is measured in meters squared (m²) for 1 year, per {noun}."
     if impact == "water":
         return f"Freshwater withdrawals are measured in liters per {noun}."
     if impact == "water_scarcity":

--- a/etl/steps/export/explorers/food/latest/food_footprints.py
+++ b/etl/steps/export/explorers/food/latest/food_footprints.py
@@ -171,7 +171,7 @@ def _subtitle(view) -> str | None:
         return None
     noun = UNIT_NOUN[unit]
     if impact == "land_use":
-        return f"Land use is measured in meters squared (m²) per year, per {noun}."
+        return f"Land use is measured in meters squared (m²) of land used for 1 year, per {noun}."
     if impact == "water":
         return f"Freshwater withdrawals are measured in liters per {noun}."
     if impact == "water_scarcity":

--- a/etl/steps/export/explorers/food/latest/food_footprints.py
+++ b/etl/steps/export/explorers/food/latest/food_footprints.py
@@ -171,7 +171,7 @@ def _subtitle(view) -> str | None:
         return None
     noun = UNIT_NOUN[unit]
     if impact == "land_use":
-        return f"Land use is measured in meters squared (m²) for 1 year, per {noun}."
+        return f"Land use is measured in meters squared (m²) for one year, per {noun}."
     if impact == "water":
         return f"Freshwater withdrawals are measured in liters per {noun}."
     if impact == "water_scarcity":


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

## Summary

A reader pointed out that the subtitle on the "Land use per kilogram of food product" chart (in the [food-footprints explorer](https://ourworldindata.org/explorers/food-footprints)) currently reads:

> Land use is measured in meters squared (m²) per year to produce one kilogram of a given food product.

"per year" reads as a rate (m²/year), but the underlying quantity from Poore & Nemecek (2018) is m²·year — area × time, i.e. how much land is occupied **for** how long to produce 1 kg. So saying "for 1 year" is more accurate than "per year".

This PR reuses the existing sentence structure and just swaps the offending fragment: `per year` → `of land used for 1 year`. Affects:

- `etl/steps/data/garden/food/2019-10-08/environmental_impacts_of_food__poore__and__nemecek__2018.meta.yml` — 3 subtitles (per kg, per 100g protein, per 1000kcal) inherited by single-y charts including the explorer's commodity-side views.
- `etl/steps/export/explorers/food/latest/food_footprints.py` — the equivalent subtitle for the specific-food-product views generated by the explorer.

## Test plan

- [ ] Spot-check the affected chart on staging: [Land use per kg of food](https://ourworldindata.org/explorers/food-footprints?country=~Maize&Commodity+or+Specific+Food+Product=Commodity&Environmental+Impact=Land+use&Kilogram+%2F+Protein+%2F+Calories=Per+kilogram&By+stage+of+supply+chain=false).
- [ ] Check the per-100g-protein and per-1000kcal variants in the same explorer.
- [ ] Check the specific-food-product views (e.g. land use of beef).