### PR TITLE
🎉 Add map-explorer-to-mdim skill

### DIFF
--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -32,15 +32,40 @@ to write, seeded with auto-suggested matches.
   e.g. `natural_disasters/latest/deaths#deaths`. The MDIMs must be **published in the
   DB you connect to** (their fully-expanded views are read from `multi_dim_data_pages.config`).
 
-## DB access
+## DB access (confirm this *before* running)
 
-Both the explorer and the MDIMs are read from the grapher DB via `OWID_ENV`. Run either:
+Both the explorer and the MDIMs are read from the grapher DB via `OWID_ENV`, so the
+scripts only work where that DB actually contains both the explorer and the published
+MDIMs. There are three ways to point `OWID_ENV` at such a DB — **figure out which one
+applies before running, and don't assume `.env.prod` exists:**
 
-- from a **staging branch** (the usual case — `OWID_ENV` points at `staging-site-<branch>`, a prod clone), or
-- against **production** (read-only) by prefixing commands with `ENV_FILE=.env.prod DATA_API_ENV=production`.
+1. **Staging branch** (often easiest): if you're on a `staging-site-<branch>` branch,
+   `OWID_ENV` already points at that prod-clone DB — run the commands as-is, no prefix.
+2. **Production, read-only, via `.env.prod`**: prefix commands with
+   `ENV_FILE=.env.prod DATA_API_ENV=production`. **Only if `.env.prod` is present.**
+3. **Some other credentials file**: the user may keep prod (or other) DB creds in a
+   different env file — run with `ENV_FILE=<their file> [DATA_API_ENV=production]`.
 
-If a query returns nothing, the scripts stop with a clear message (explorer slug not
-found, or MDIM not published in this DB).
+**Preflight — check, then ask if needed:**
+
+```bash
+# Is .env.prod available?
+ls -la .env.prod 2>/dev/null && echo "found .env.prod" || echo "NO .env.prod"
+
+# Connectivity test (swap the ENV_FILE prefix for whatever applies; drop it on a staging branch):
+ENV_FILE=.env.prod DATA_API_ENV=production .venv/bin/python -c \
+  "from etl.config import OWID_ENV; print('DB OK:', OWID_ENV.read_sql('SELECT 1 AS x').iloc[0,0])"
+```
+
+If `.env.prod` is missing **and** you're not on a staging branch with the data, **stop
+and ask the user which credentials / env file to use** (e.g. "I don't see `.env.prod` —
+which env file holds DB credentials that can reach the explorer + MDIMs? Or should I run
+this from a staging branch?"). Then use that file as the `ENV_FILE=` prefix for both
+script invocations below. Don't hardcode credentials.
+
+If the connection works but a query returns nothing, the scripts stop with a clear
+message (explorer slug not found, or MDIM not published in this DB) — that means the DB
+you reached doesn't have it, so re-check which DB you're pointed at.
 
 ## Workflow
 

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: map-explorer-to-mdim
+description: >-
+  Suggest a redirect mapping from a (soon-to-sunset) OWID explorer's views to the
+  views of one or more replacement MDIMs. Pulls explorer views and MDIM views from
+  the grapher DB, writes a CSV per source/target plus a wide joint proposal that
+  routes each explorer view to a target MDIM view, and flags when several explorer
+  views land on the same MDIM view. Trigger when the user says "map explorer <slug>
+  to mdim(s) <...>", "suggest explorer->MDIM redirects", "we're sunsetting the
+  <slug> explorer, map its views to the new multidims", or similar.
+metadata:
+  internal: true
+---
+
+# Map an explorer's views to MDIM views (redirect proposal)
+
+When an explorer is being retired in favour of one or more MDIMs, every explorer
+view needs a redirect to the equivalent MDIM view. This skill produces the input
+for that: a CSV of explorer views, a CSV per target MDIM, and a **joint proposal**
+mapping each explorer view to a target MDIM view (the suggestion is for human review).
+
+The mapping itself is **explorer-specific** (how the explorer's dimensions translate
+to MDIM dimension slugs, and — when there are multiple MDIMs — which MDIM each view
+routes to). The skill automates everything mechanical (pulling views, the join, the
+shared-target accounting, validation) and leaves only the per-explorer rules for you
+to write, seeded with auto-suggested matches.
+
+## Inputs
+
+- **Explorer slug** — matches `explorers.slug` in the grapher DB (e.g. `natural-disasters`).
+- **One or more MDIM catalogPaths** — as stored in `multi_dim_data_pages.catalogPath`,
+  e.g. `natural_disasters/latest/deaths#deaths`. The MDIMs must be **published in the
+  DB you connect to** (their fully-expanded views are read from `multi_dim_data_pages.config`).
+
+## DB access
+
+Both the explorer and the MDIMs are read from the grapher DB via `OWID_ENV`. Run either:
+
+- from a **staging branch** (the usual case — `OWID_ENV` points at `staging-site-<branch>`, a prod clone), or
+- against **production** (read-only) by prefixing commands with `ENV_FILE=.env.prod DATA_API_ENV=production`.
+
+If a query returns nothing, the scripts stop with a clear message (explorer slug not
+found, or MDIM not published in this DB).
+
+## Workflow
+
+### 1. Extract views + scaffold
+
+```bash
+.venv/bin/python .claude/skills/map-explorer-to-mdim/scripts/extract_views.py \
+  --explorer <slug> \
+  --mdim <ns/v/short#short> [--mdim <ns/v/short#short> ...] \
+  --out ai/<slug>-mdim-mapping
+```
+
+Writes into the out folder:
+
+- `explorer_views.csv` — `id` (1..N) + `dimension_1..M` (explorer **display** values).
+- `multidim_<short>_views.csv` — one per MDIM; `id` is letter-prefixed by `--mdim` order
+  (`A1…`, `B1…`, `C1…`) so ids are unique across MDIMs; columns are the MDIM dimension **slugs**.
+- `_scaffold.md` — the explorer dimension legend (which `dimension_i` is which name),
+  the distinct values per dimension, each MDIM's dims/choices, auto-suggested value
+  matches (where a slugified explorer value equals a real MDIM choice slug), and a
+  ready-to-edit `mapping_rules.py` template.
+
+### 2. Write `mapping_rules.py`
+
+Open `_scaffold.md`, then write `ai/<slug>-mdim-mapping/mapping_rules.py` defining:
+
+- `EXPLORER_DIMENSIONS` — list naming `dimension_1..N` (copy from the scaffold; keep order).
+- `MDIMS` — MDIM short names in the same order as `--mdim` (= prefixes `A`, `B`, `C`, …).
+- `route(dims) -> str` — given a view's `{dimension name: value}`, return the target MDIM
+  short name. For a single MDIM this is just `return "<short>"`. For several, it's a
+  decision on some explorer dimension (e.g. natural-disasters routes on `Impact`:
+  `Deaths`→deaths, `Economic damages (% GDP)`→economic_damages, the rest→affected).
+- `translate(dims, mdim) -> dict` — return `{mdim_dim_slug: choice_slug}` for the target
+  MDIM view, built from the `*_MAP` dicts. Only include slugs the MDIM actually has
+  (e.g. economic_damages has no `metric` — single-choice dims are pruned from MDIM views).
+
+The scaffold seeds the `*_MAP` dicts with `slugify(value)` guesses. **Verify every entry** —
+slugify won't catch label↔slug differences like `Decadal average`→`decadal`, `Injuries`→`injured`,
+`Volcanoes`→`volcanic_activity`, or aggregate collapses like `All disasters`/`All disasters (by type)`→`all_stacked`.
+
+### 3. Build the proposal
+
+```bash
+.venv/bin/python .claude/skills/map-explorer-to-mdim/scripts/build_mapping.py --out ai/<slug>-mdim-mapping
+```
+
+Writes `mapping_proposal.csv`, one row per explorer view:
+
+| columns | meaning |
+|---|---|
+| `id`, `dimension_1..N` | the explorer view (same as `explorer_views.csv`) |
+| `target_mdim`, `target_view_id` | the resolved target (`target_view_id` is the `A*`/`B*`/`C*` id) |
+| `<mdim>_<dimslug>` … | wide block; only the **target** MDIM's columns are filled with the translated slugs |
+| `shared_target_explorer_ids` | when >1 explorer view lands on the same MDIM view, the comma-joined list of all those explorer ids (e.g. `1,12`); empty when the target is unique |
+
+The script prints a validation report: how many explorer views resolved, distinct MDIM
+views hit per MDIM, how many rows share a target, and **FLAGS** for any explorer view that
+didn't resolve to a real MDIM view (fix the rules and re-run until there are no flags).
+
+### 4. Review
+
+Sanity-check the flagged rows and the judgment calls (approximate type matches, aggregate
+collapses, MDIM choices with no explorer source). The CSVs are typically pasted into a
+spreadsheet for a human reviewer / topic owner to confirm before redirects are created.
+
+## Notes & gotchas
+
+- **MDIM views come from `multi_dim_data_pages.config`** (published, fully expanded). This
+  already reflects code-generated views (`group_views` aggregates) and **pruned single-choice
+  dimensions** — so e.g. a `metric` that has only one active choice won't appear as a column.
+- **Many explorer views can redirect to one MDIM view** — that's expected (the explorer often
+  splits a concept the MDIM merges, e.g. a single-line "All disasters" total and a
+  stacked-by-type view both mapping to the `all_stacked` MDIM view). `shared_target_explorer_ids`
+  surfaces these so the reviewer sees the collisions.
+- **An MDIM may have choices with no explorer source** (e.g. an `…_excluding_extreme_temperature`
+  aggregate). Nothing redirects to those — fine, just confirm.
+- Explorer dimension columns stay `dimension_1..N` (compact, and joinable to the explorer CSV);
+  the name legend lives in `_scaffold.md` and in `EXPLORER_DIMENSIONS`.
+- Re-running `extract_views.py` overwrites the CSVs but **not** your `mapping_rules.py`.

--- a/.claude/skills/map-explorer-to-mdim/scripts/build_mapping.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/build_mapping.py
@@ -1,0 +1,163 @@
+"""Join explorer views to MDIM views into a wide mapping proposal.
+
+Reads, from ``--out``:
+- ``explorer_views.csv``        (from extract_views.py)
+- ``multidim_<short>_views.csv`` (one per MDIM, from extract_views.py)
+- ``mapping_rules.py``          (written by you, per explorer — see _scaffold.md)
+
+``mapping_rules.py`` must define:
+- ``EXPLORER_DIMENSIONS``: list[str] naming dimension_1..N (the explorer column order)
+- ``MDIMS``: list[str] of MDIM short names, in the prefix order A, B, C, ...
+- ``route(dims) -> str``: explorer-view dims dict -> target MDIM short name
+- ``translate(dims, mdim) -> dict``: -> {mdim_dim_slug: choice_slug} for that MDIM
+
+Writes ``mapping_proposal.csv`` (one row per explorer view):
+    id, dimension_1..N,
+    target_mdim, target_view_id,
+    <mdim>_<dimslug> ... (wide; only the target MDIM's columns are filled),
+    shared_target_explorer_ids  (when >1 explorer view hits the same MDIM view,
+                                 the comma-joined list of all those explorer ids)
+
+Usage:
+    .venv/bin/python .claude/skills/map-explorer-to-mdim/scripts/build_mapping.py --out ai/<folder>
+"""
+
+import argparse
+import csv
+import importlib.util
+from collections import defaultdict
+from pathlib import Path
+
+
+def load_rules(out: Path):
+    spec = importlib.util.spec_from_file_location("mapping_rules", out / "mapping_rules.py")
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"Could not load {out / 'mapping_rules.py'}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    for attr in ("EXPLORER_DIMENSIONS", "MDIMS", "route", "translate"):
+        if not hasattr(mod, attr):
+            raise SystemExit(f"mapping_rules.py is missing `{attr}`")
+    return mod
+
+
+def read_csv(path: Path):
+    with open(path) as f:
+        r = csv.reader(f)
+        header = next(r)
+        return header, list(r)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Build the explorer->MDIM mapping proposal.")
+    ap.add_argument(
+        "--out", required=True, help="Folder with explorer_views.csv, multidim_*_views.csv, mapping_rules.py"
+    )
+    args = ap.parse_args()
+    out = Path(args.out)
+
+    rules = load_rules(out)
+
+    # Explorer views
+    exp_header, exp_rows = read_csv(out / "explorer_views.csv")
+    n_dims = len(exp_header) - 1  # minus id
+    if len(rules.EXPLORER_DIMENSIONS) != n_dims:
+        raise SystemExit(
+            f"EXPLORER_DIMENSIONS has {len(rules.EXPLORER_DIMENSIONS)} names but "
+            f"explorer_views.csv has {n_dims} dimension columns."
+        )
+
+    # MDIM views: short -> (dim_slugs, {tuple(values): view_id})
+    mdim_dims = {}
+    mdim_lut = {}
+    for short in rules.MDIMS:
+        header, rows = read_csv(out / f"multidim_{short}_views.csv")
+        dim_slugs = header[1:]  # minus id
+        mdim_dims[short] = dim_slugs
+        lut = {}
+        for row in rows:
+            lut[tuple(row[1:])] = row[0]
+        mdim_lut[short] = lut
+
+    # Wide MDIM dimension columns, in MDIMS order.
+    mdim_cols = []  # list of (short, dim_slug, column_name)
+    for short in rules.MDIMS:
+        for dslug in mdim_dims[short]:
+            mdim_cols.append((short, dslug, f"{short}_{dslug}"))
+
+    header = (
+        ["id"]
+        + [f"dimension_{i + 1}" for i in range(n_dims)]
+        + ["target_mdim", "target_view_id"]
+        + [c for _, _, c in mdim_cols]
+        + ["shared_target_explorer_ids"]
+    )
+
+    out_rows = []
+    flags = []
+    ids_by_target = defaultdict(list)  # (mdim, view_id) -> [explorer ids]
+
+    for er in exp_rows:
+        eid, evals = er[0], er[1:]
+        dims = dict(zip(rules.EXPLORER_DIMENSIONS, evals))
+
+        mdim = rules.route(dims)
+        if mdim not in rules.MDIMS:
+            raise SystemExit(f"route() returned unknown MDIM {mdim!r} (not in MDIMS)")
+        target = rules.translate(dims, mdim)
+
+        key = tuple(target.get(s, "") for s in mdim_dims[mdim])
+        view_id = mdim_lut[mdim].get(key, "")
+
+        row = {c: "" for c in header}
+        row["id"] = eid
+        for i, v in enumerate(evals):
+            row[f"dimension_{i + 1}"] = v
+        row["target_mdim"] = mdim
+        row["target_view_id"] = view_id
+        for s, dslug, col in mdim_cols:
+            if s == mdim and dslug in target:
+                row[col] = target[dslug]
+
+        if view_id:
+            ids_by_target[(mdim, view_id)].append(eid)
+        else:
+            flags.append(f"id={eid}: no {mdim} view for {target} (from {dims})")
+        out_rows.append((row, mdim, view_id))
+
+    # shared_target_explorer_ids: fill when >1 explorer view shares a target MDIM view.
+    for row, mdim, view_id in out_rows:
+        if view_id:
+            sharers = ids_by_target[(mdim, view_id)]
+            if len(sharers) > 1:
+                row["shared_target_explorer_ids"] = ",".join(sharers)
+
+    path = out / "mapping_proposal.csv"
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=header)
+        w.writeheader()
+        w.writerows(r for r, _, _ in out_rows)
+
+    # Report
+    resolved = sum(1 for _, _, v in out_rows if v)
+    print(f"-> {path}")
+    print(f"explorer views: {len(out_rows)}  |  resolved: {resolved}  |  unresolved: {len(out_rows) - resolved}")
+    per_mdim = defaultdict(lambda: [0, set()])
+    for _, mdim, v in out_rows:
+        per_mdim[mdim][0] += 1
+        if v:
+            per_mdim[mdim][1].add(v)
+    for mdim, (n, vids) in per_mdim.items():
+        print(f"  {mdim}: {n} explorer views -> {len(vids)} distinct MDIM views")
+    shared = sum(1 for r, _, _ in out_rows if r["shared_target_explorer_ids"])
+    print(f"rows pointing at a shared MDIM view: {shared}")
+    if flags:
+        print("\nFLAGS (unresolved):")
+        for fl in flags:
+            print("  -", fl)
+    else:
+        print("\nNo flags: every explorer view resolved to exactly one MDIM view.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
@@ -1,0 +1,239 @@
+"""Extract explorer views and MDIM views into CSVs, plus a mapping scaffold.
+
+Reads from the grapher DB via ``OWID_ENV`` (run on a staging branch, or against
+production with ``ENV_FILE=.env.prod DATA_API_ENV=production``):
+
+- Explorer views come from the ``tsv`` column of the ``explorers`` table — the
+  ``graphers`` block, one row per view; dimension columns are those whose header
+  ends in " Dropdown" / " Radio" / " Checkbox".
+- MDIM views come from ``multi_dim_data_pages.config`` (the published, fully
+  expanded ``views[].dimensions``, slug -> slug).
+
+Outputs into ``--out``:
+- ``explorer_views.csv``        — id (1..N) + dimension_1..M (explorer display values)
+- ``multidim_<short>_views.csv`` — id (A1.., B1.., ...) + one column per MDIM dim slug
+- ``_scaffold.md``              — dimension legend, distinct values, auto-suggested
+                                  value matches, and a ``mapping_rules.py`` template
+
+Usage:
+    .venv/bin/python .claude/skills/map-explorer-to-mdim/scripts/extract_views.py \
+        --explorer natural-disasters \
+        --mdim natural_disasters/latest/deaths#deaths \
+        --mdim natural_disasters/latest/economic_damages#economic_damages \
+        --mdim natural_disasters/latest/affected#affected \
+        --out ai/natural-disasters-mdim-mapping
+"""
+
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+
+from sqlalchemy import text
+
+from etl.config import OWID_ENV
+
+WIDGET_SUFFIXES = ("Dropdown", "Radio", "Checkbox")
+
+
+def slugify(value: str) -> str:
+    """Lowercase + underscores; only used to *suggest* value->slug matches."""
+    return re.sub(r"_+", "_", re.sub(r"[^a-z0-9]+", "_", value.strip().lower())).strip("_")
+
+
+def dim_name(col: str) -> str:
+    """'Disaster Type Dropdown' -> 'Disaster Type'."""
+    parts = col.split(" ")
+    return " ".join(parts[:-1]) if parts and parts[-1] in WIDGET_SUFFIXES else col
+
+
+# ----- Explorer -----------------------------------------------------------------
+
+
+def parse_explorer_views(tsv: str):
+    """Return (dim_names, rows) from the graphers block of an explorer TSV."""
+    lines = tsv.split("\n")
+    try:
+        gi = next(i for i, ln in enumerate(lines) if ln.rstrip("\r") == "graphers")
+    except StopIteration:
+        raise SystemExit("No 'graphers' block found in explorer TSV.")
+
+    header = lines[gi + 1].split("\t")
+    dim_cols = [(j, dim_name(name)) for j, name in enumerate(header) if name.split(" ")[-1] in WIDGET_SUFFIXES]
+    dim_names = [name for _, name in dim_cols]
+
+    rows = []
+    for ln in lines[gi + 2 :]:
+        if not ln.startswith("\t"):  # blank line or next top-level key ends the block
+            break
+        fields = ln.split("\t")
+        rows.append([fields[j] if j < len(fields) else "" for j, _ in dim_cols])
+    return dim_names, rows
+
+
+def write_explorer_csv(out: Path, dim_names, rows) -> Path:
+    path = out / "explorer_views.csv"
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["id"] + [f"dimension_{i + 1}" for i in range(len(dim_names))])
+        for n, r in enumerate(rows, start=1):
+            w.writerow([n] + r)
+    return path
+
+
+# ----- MDIM ---------------------------------------------------------------------
+
+
+def short_name_of(catalog_path: str) -> str:
+    """'ns/v/deaths#deaths' -> 'deaths'."""
+    return catalog_path.split("#", 1)[1] if "#" in catalog_path else catalog_path.rstrip("/").split("/")[-1]
+
+
+def get_mdim_views(catalog_path: str):
+    """Return (dim_slugs, rows) for a published MDIM from multi_dim_data_pages.config."""
+    df = OWID_ENV.read_sql(
+        text("SELECT config FROM multi_dim_data_pages WHERE catalogPath = :cp"),
+        params={"cp": catalog_path},
+    )
+    if df.empty:
+        raise SystemExit(
+            f"MDIM not found in multi_dim_data_pages: {catalog_path!r}. Is it published in the DB you're connected to?"
+        )
+    cfg = df["config"].iloc[0]
+    cfg = json.loads(cfg) if isinstance(cfg, str) else cfg
+    views = cfg.get("views", [])
+    order = [d["slug"] for d in cfg.get("dimensions", [])]
+    used = set().union(*(v["dimensions"].keys() for v in views)) if views else set()
+    dim_slugs = [s for s in order if s in used]  # config order, only dims that vary in views
+    rows = [[v["dimensions"].get(s, "") for s in dim_slugs] for v in views]
+    return dim_slugs, rows
+
+
+def write_mdim_csv(out: Path, short: str, prefix: str, dim_slugs, rows) -> Path:
+    path = out / f"multidim_{short}_views.csv"
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["id"] + dim_slugs)
+        for n, r in enumerate(rows, start=1):
+            w.writerow([f"{prefix}{n}"] + r)
+    return path
+
+
+# ----- Scaffold -----------------------------------------------------------------
+
+
+def distinct_by_col(rows, ncols):
+    return [sorted({r[j] for r in rows}) for j in range(ncols)]
+
+
+def build_scaffold(out: Path, explorer_slug, dim_names, exp_rows, mdims) -> Path:
+    """mdims: list of dicts {short, prefix, catalog_path, dim_slugs, rows}."""
+    exp_distinct = distinct_by_col(exp_rows, len(dim_names))
+
+    # Index every MDIM choice slug for auto-suggesting explorer-value -> slug matches.
+    slug_index = {}  # choice_slug -> list of "short.dim_slug"
+    for m in mdims:
+        m_distinct = distinct_by_col(m["rows"], len(m["dim_slugs"]))
+        for dslug, vals in zip(m["dim_slugs"], m_distinct):
+            for v in vals:
+                slug_index.setdefault(v, []).append(f"{m['short']}.{dslug}")
+
+    lines = [f"# Mapping scaffold — explorer `{explorer_slug}`", ""]
+    lines.append(f"Explorer views: **{len(exp_rows)}**\n")
+
+    lines.append("## Explorer dimensions (column legend)\n")
+    for i, (name, vals) in enumerate(zip(dim_names, exp_distinct), start=1):
+        lines.append(f"- `dimension_{i}` = **{name}** ({len(vals)} values)")
+        for v in vals:
+            hits = slug_index.get(slugify(v), [])
+            hint = f"  → auto-match: {', '.join(hits)}" if hits else ""
+            lines.append(f"    - `{v}`{hint}")
+    lines.append("")
+
+    lines.append("## MDIMs\n")
+    for m in mdims:
+        m_distinct = distinct_by_col(m["rows"], len(m["dim_slugs"]))
+        lines.append(f"### `{m['prefix']}` — {m['short']}  ({len(m['rows'])} views)")
+        lines.append(f"`{m['catalog_path']}`\n")
+        for dslug, vals in zip(m["dim_slugs"], m_distinct):
+            lines.append(f"- **{dslug}**: {', '.join(f'`{v}`' for v in vals)}")
+        lines.append("")
+
+    lines.append("## Next step\n")
+    lines.append(
+        "Write `mapping_rules.py` in this folder (template below), then run `build_mapping.py --out <this folder>`.\n"
+    )
+    lines.append("```python")
+    lines.append("# mapping_rules.py — fill in routing + value translation for this explorer.")
+    lines.append("")
+    lines.append(f"EXPLORER_DIMENSIONS = {dim_names!r}  # order of dimension_1..N (do not change)")
+    lines.append(f"MDIMS = {[m['short'] for m in mdims]!r}  # order = prefixes {[m['prefix'] for m in mdims]!r}")
+    lines.append("")
+    lines.append("# Per-explorer-dimension value -> mdim choice slug. Seeded from auto-matches above;")
+    lines.append("# verify and complete every value.")
+    for i, (name, vals) in enumerate(zip(dim_names, exp_distinct), start=1):
+        var = slugify(name).upper() + "_MAP"
+        lines.append(f"{var} = {{")
+        for v in vals:
+            # slugify(v) is the best guess for the choice slug; when it matches a real
+            # MDIM choice the auto-match comment above confirms which dim it lands in.
+            lines.append(f"    {v!r}: {slugify(v)!r},")
+        lines.append("}")
+    lines.append("")
+    lines.append("def route(dims):")
+    lines.append('    """dims: {explorer dimension name -> value}. Return target MDIM short name."""')
+    if len(mdims) == 1:
+        lines.append(f"    return {mdims[0]['short']!r}")
+    else:
+        shorts = [m["short"] for m in mdims]
+        lines.append(f"    # EDIT: pick the target MDIM ({', '.join(shorts)}) from the explorer's dimensions.")
+        lines.append("    raise NotImplementedError")
+    lines.append("")
+    lines.append("def translate(dims, mdim):")
+    lines.append('    """Return {mdim_dim_slug: choice_slug} for the target MDIM view."""')
+    lines.append("    # EDIT: build the target dimension dict per MDIM, using the *_MAP dicts above.")
+    lines.append("    raise NotImplementedError")
+    lines.append("```")
+
+    path = out / "_scaffold.md"
+    path.write_text("\n".join(lines))
+    return path
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Extract explorer + MDIM views into CSVs for redirect mapping.")
+    ap.add_argument("--explorer", required=True, help="Explorer slug (explorers.slug)")
+    ap.add_argument(
+        "--mdim", required=True, action="append", help="MDIM catalogPath (repeatable), e.g. ns/v/short#short"
+    )
+    ap.add_argument("--out", required=True, help="Output folder")
+    args = ap.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # Explorer
+    df = OWID_ENV.read_sql(text("SELECT tsv FROM explorers WHERE slug = :slug"), params={"slug": args.explorer})
+    if df.empty:
+        raise SystemExit(f"Explorer not found: {args.explorer!r}")
+    dim_names, exp_rows = parse_explorer_views(df["tsv"].iloc[0])
+    p = write_explorer_csv(out, dim_names, exp_rows)
+    print(f"explorer: {len(exp_rows)} views, dims={dim_names} -> {p.name}")
+
+    # MDIMs
+    mdims = []
+    for i, cp in enumerate(args.mdim):
+        prefix = chr(ord("A") + i)
+        short = short_name_of(cp)
+        dim_slugs, rows = get_mdim_views(cp)
+        p = write_mdim_csv(out, short, prefix, dim_slugs, rows)
+        print(f"{prefix} {short}: {len(rows)} views, dims={dim_slugs} -> {p.name}")
+        mdims.append({"short": short, "prefix": prefix, "catalog_path": cp, "dim_slugs": dim_slugs, "rows": rows})
+
+    p = build_scaffold(out, args.explorer, dim_names, exp_rows, mdims)
+    print(f"scaffold -> {p.name}  (write mapping_rules.py, then run build_mapping.py)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
@@ -201,6 +201,23 @@ def build_scaffold(out: Path, explorer_slug, dim_names, exp_rows, mdims) -> Path
     return path
 
 
+def check_db_connection():
+    """Fail fast with actionable guidance if the grapher DB isn't reachable."""
+    try:
+        OWID_ENV.read_sql(text("SELECT 1"))
+    except Exception as e:  # noqa: BLE001 - connectivity preflight, surface a friendly hint
+        raise SystemExit(
+            "Cannot reach the grapher DB via OWID_ENV:\n"
+            f"  {type(e).__name__}: {str(e).splitlines()[0]}\n\n"
+            "This skill reads the explorer + MDIMs from the grapher DB. Point OWID_ENV at a DB\n"
+            "that has both, by one of:\n"
+            "  - running on a `staging-site-<branch>` branch (no prefix needed), or\n"
+            "  - `ENV_FILE=.env.prod DATA_API_ENV=production` (only if .env.prod exists), or\n"
+            "  - `ENV_FILE=<your creds file> [DATA_API_ENV=production]`.\n"
+            "If you don't have a credentials file, ask which one to use — don't hardcode secrets."
+        )
+
+
 def main():
     ap = argparse.ArgumentParser(description="Extract explorer + MDIM views into CSVs for redirect mapping.")
     ap.add_argument("--explorer", required=True, help="Explorer slug (explorers.slug)")
@@ -212,6 +229,8 @@ def main():
 
     out = Path(args.out)
     out.mkdir(parents=True, exist_ok=True)
+
+    check_db_connection()
 
     # Explorer
     df = OWID_ENV.read_sql(text("SELECT tsv FROM explorers WHERE slug = :slug"), params={"slug": args.explorer})


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

New skill **`map-explorer-to-mdim`**: suggests a redirect mapping from a soon-to-sunset explorer's views to the views of one or more replacement MDIMs. Built out of the manual natural-disasters mapping (#6167).

| | |
|---|---|
| Skill | `.claude/skills/map-explorer-to-mdim/` |
| Related issue | #6167 |

**Inputs:** explorer slug + one or more MDIM catalogPaths (e.g. `natural_disasters/latest/deaths#deaths`).

**Outputs** (into `ai/<slug>-mdim-mapping/`):
- `explorer_views.csv` — `id` + `dimension_1..N`
- `multidim_<short>_views.csv` — one per MDIM, ids letter-prefixed by arg order (`A1…`, `B1…`, `C1…`)
- `_scaffold.md` — dimension legend + per-MDIM choices + a pre-seeded `mapping_rules.py` template
- `mapping_proposal.csv` — wide joint table; includes `shared_target_explorer_ids` (when several explorer views hit the same MDIM view, lists them e.g. `1,12`)

**How it works:** both explorer views (`explorers.tsv` graphers block) and MDIM views (`multi_dim_data_pages.config`, published & fully expanded) are read straight from the grapher DB — no TSV-file parsing or running ETL steps. Only the explorer-specific routing + value→slug translation is left to fill in `mapping_rules.py` (seeded with auto-matches); `build_mapping.py` validates every row resolves to a real MDIM view and flags any that don't.

Validated against natural-disasters: 204/204 explorer views resolved, 0 flags, matching the hand-built mapping exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


/schedule