### PR TITLE
📜 Style guide: use curly apostrophes and quotes in prose

### DIFF
--- a/.claude/skills/check-metadata-style/STYLE_GUIDE.md
+++ b/.claude/skills/check-metadata-style/STYLE_GUIDE.md
@@ -223,8 +223,21 @@ Always use em dashes (—) for asides, and add spaces on both sides of the em da
 
 Always use double quotes for quotations and titles. Single quotes are used only for quotations within quotations.
 
-- ❌ 'Climate change is the defining issue of our time', stated the researcher.
-- ✅ "Climate change is the defining issue of our time", stated the researcher.
+- ❌ ‘Climate change is the defining issue of our time’, stated the researcher.
+- ✅ “Climate change is the defining issue of our time”, stated the researcher.
+
+### Use curly apostrophes and quotation marks
+
+Use curly (“typographic”) apostrophes and quotation marks, not straight ones. Word processors curl these automatically, but LLMs and code editors emit the straight versions — so a mix of straight and curly marks in the same text is a tell-tale sign of pasted machine output.
+
+- Apostrophe: `’` (U+2019), not `'`
+- Double quotes: `“ … ”` (U+201C/U+201D), not `" … "`
+- Single quotes, for a quote within a quote: `‘ … ’` (U+2018/U+2019), not `' … '`
+
+- ❌ The world's population didn't "peak" in 2020.
+- ✅ The world’s population didn’t “peak” in 2020.
+
+Exception: keep straight marks (or proper primes) where they are technically meaningful — units and measurements such as 5'10" or 30″ of arc, and any code, identifiers, or text quoted verbatim from a source.
 
 ### Never capitalize after colons
 

--- a/.claude/skills/owid-metadata-generation/SKILL.md
+++ b/.claude/skills/owid-metadata-generation/SKILL.md
@@ -244,4 +244,5 @@ Items that are easy to miss (obvious rules like "set title" are omitted — see 
 - [ ] `display.name` paired with `title_public` when set
 - [ ] No TODO/FIXME, no copy-paste errors, no producer names/years in titles
 - [ ] Repeated text uses anchors/aliases or `{definitions.xxx}`; Jinja for 10+ similar variables
+- [ ] Prose uses curly apostrophes/quotes (`’ “ ”`), not straight (`' "`) — straight marks are an LLM tell; see [check-metadata-style/STYLE_GUIDE.md](../check-metadata-style/STYLE_GUIDE.md)
 - [ ] Typo check passed


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Addresses Edouard's point in [#data-comms](https://owid.slack.com/archives/C0149NKLZAM/p1779794476989979?thread_ts=1779793040.802179&cid=C0149NKLZAM): LLMs emit **straight** apostrophes/quotes (`'` `"`) while OWID house style uses **curly** ones (`’` `“` `”`). A mix of the two in the same piece is a visible LLM tell, increasingly showing up in articles, DIs, topic pages, and metadata. (The grapher side is adding a preview warning in owid/owid-grapher#6541; this is the ETL-drafting side.)

| | |
|---|---|
| Rule (enforced) | `.claude/skills/check-metadata-style/STYLE_GUIDE.md` |
| Drafting pointer | `.claude/skills/owid-metadata-generation/SKILL.md` |

**Where & why:**
- **`STYLE_GUIDE.md`** (the writing/style guide `check-metadata-style` evaluates against — it only flags rules that live in this file): added a Punctuation rule *"Use curly apostrophes and quotation marks"*, with the legitimate-straight exceptions (units/primes like `5'10"`, and verbatim code/quotes). Also updated the adjacent double-quote example to curly so the section is self-consistent.
- **`owid-metadata-generation`** (the skill that drafts metadata prose): added a Quality Checklist item so generated `description_short`/`description_key`/etc. use curly marks, linking back to the style guide.

**Note:** `STYLE_GUIDE.md` is a committed mirror of the [OWID Notion style guide](https://www.notion.so/owid/Writing-and-style-guide-d51a3739ff8542ca90297fa8de40437c). Worth adding the same rule to the Notion page so the two stay in sync — happy to leave that to you.

/schedule