### PR TITLE
📊 Center the rolling-average smoothing in historical_poverty

### DIFF
--- a/etl/steps/data/garden/poverty_inequality/2025-10-23/historical_poverty.py
+++ b/etl/steps/data/garden/poverty_inequality/2025-10-23/historical_poverty.py
@@ -1068,8 +1068,11 @@ def select_growth_factor(tb: Table) -> Table:
 
 def smooth_estimates(tb: Table) -> Table:
     """
-    Create smoothed estimates using 10-year rolling averages for headcount and headcount_ratio.
+    Create smoothed estimates using 11-year centered rolling averages for headcount and headcount_ratio.
     This addresses uncertainty in historical estimates.
+    A centered window is used (rather than a trailing one) so the smoothed value at year Y averages
+    [Y-5, Y+5]. A trailing window biases each decadal point upward, because the monotonically declining
+    poverty series leans on the higher-poverty preceding decade.
     Only keeps decadal years, EARLIEST_YEAR, and LATEST_YEAR_PIP_FILLED - 1 (plus all years from LATEST_YEAR_PIP_FILLED onwards).
     """
 
@@ -1091,20 +1094,21 @@ def smooth_estimates(tb: Table) -> Table:
     # Sort by country, year, and poverty line
     tb_avg = tb_avg.sort_values(["country", "year", "poverty_line"]).reset_index(drop=True)
 
-    # Calculate 10-year rolling averages per country and poverty line for headcount_ratio
+    # Calculate 11-year centered rolling averages per country and poverty line for headcount_ratio
     tb_avg["headcount_ratio_avg"] = tb_avg.groupby(["country", "poverty_line"])["headcount_ratio"].transform(
-        lambda x: x.rolling(window=10, min_periods=1).mean()
+        lambda x: x.rolling(window=11, min_periods=1, center=True).mean()
     )
 
-    # Calculate 10-year rolling averages per country and poverty line for headcount
+    # Calculate 11-year centered rolling averages per country and poverty line for headcount
     tb_avg["headcount_avg"] = tb_avg.groupby(["country", "poverty_line"])["headcount"].transform(
-        lambda x: x.rolling(window=10, min_periods=1).mean()
+        lambda x: x.rolling(window=11, min_periods=1, center=True).mean()
     )
 
-    # Replace values at LATEST_YEAR_PIP_FILLED - 1 with original values (to ensure continuity with PIP data)
-    mask_last_year = tb_avg["year"] == (LATEST_YEAR_PIP_FILLED - 1)
-    tb_avg.loc[mask_last_year, "headcount_ratio_avg"] = tb_avg.loc[mask_last_year, "headcount_ratio"]
-    tb_avg.loc[mask_last_year, "headcount_avg"] = tb_avg.loc[mask_last_year, "headcount"]
+    # Anchor the endpoints to the original values: EARLIEST_YEAR (no left-side data to smooth) and
+    # LATEST_YEAR_PIP_FILLED - 1 (to ensure continuity with PIP data).
+    mask_anchor = tb_avg["year"].isin([EARLIEST_YEAR, LATEST_YEAR_PIP_FILLED - 1])
+    tb_avg.loc[mask_anchor, "headcount_ratio_avg"] = tb_avg.loc[mask_anchor, "headcount_ratio"]
+    tb_avg.loc[mask_anchor, "headcount_avg"] = tb_avg.loc[mask_anchor, "headcount"]
 
     # Keep only decadal years, EARLIEST_YEAR, and LATEST_YEAR_PIP_FILLED - 1
     tb_avg = tb_avg[


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## What

`smooth_estimates` in `historical_poverty` produced smoothed (`*_rolling_avg`) series that sat **systematically above** both the original values and the benchmark years. This switches the smoothing from a **trailing** 10-year window to an **11-year centered** window, and anchors both endpoints to the original values.

## Why

The old code used pandas' default right-aligned window:

```python
x.rolling(window=10, min_periods=1).mean()
```

A trailing window reports, at year `Y`, the mean of `[Y-9, Y]` — effectively ~4.5 years stale. Because the historical poverty series declines almost monotonically, the preceding decade always had higher poverty, so every decadal point was biased **upward**.

## Fix

```python
x.rolling(window=11, min_periods=1, center=True).mean()
```

- Centered window → year `Y` averages `[Y-5, Y+5]`, removing the directional bias.
- Both endpoints (`EARLIEST_YEAR` = 1820 and `LATEST_YEAR_PIP_FILLED - 1` = 1980) are anchored exactly to the original values.
- The change lives in the shared `smooth_estimates`, so `constant_inequality`, `interpolated_quantiles`, `interpolated_ginis`, and `randomized_ginis` are all corrected together.

## Verification (interpolated Ginis, World)

Mean / max absolute deviation of `headcount_ratio_rolling_avg` from the original, at decadal years:

| poverty line | before (mean → max) | after (mean → max) |
|---|---|---|
| $3 | 1.19 → 2.18 pp | **0.29 → 1.28 pp** |
| $10 | 0.77 → 2.52 pp | **0.15 → 0.51 pp** |
| $30 | 0.26 → 1.75 pp | **0.04 → 0.15 pp** |

Residuals after the fix are small and symmetric (both signs) — genuine smoothing, not a one-directional lag. The largest remaining deviation (1920, $3) is a real local spike in the original series that smoothing correctly dampens. 1820 and 1980 now match the original exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)