### PR TITLE
🐝 Discontinue monkeypox update — Global.health mpox-2024 source dead

### DIFF
--- a/scripts/update-monkeypox.sh
+++ b/scripts/update-monkeypox.sh
@@ -1,24 +1,34 @@
 #!/bin/bash
 
-set -e
+# This update has been discontinued.
+# Global.health discontinued the mpox-2024 line list (last report 2024-12-20) and its download
+# endpoint (https://mpox-2024.s3.eu-central-1.amazonaws.com/latest.csv) now returns 403 Access Denied.
+# There is no replacement endpoint, so we no longer refresh this snapshot — the frozen historical data
+# (supplementary suspected_cases_cumulative) stays cached in R2 and downstream steps keep using it.
+# The whole monkeypox update is disabled below; re-enable if a maintained source becomes available.
 
-start_time=$(date +%s)
+echo '--- Monkeypox update is DISCONTINUED: Global.health mpox-2024 source returns 403 (no replacement). Skipping.'
+exit 0
 
-echo '--- Update Monkeypox'
-cd /home/owid/etl
-uv run etls who/latest/monkeypox
-uv run etls health/latest/global_health_mpox
+# set -e
 
-# commit to master will trigger ETL which is gonna run the step
-echo '--- Commit and push changes'
+# start_time=$(date +%s)
 
-git add .
-git commit -m ":robot: update: monkeypox" || true
-git push origin master -q || true
+# echo '--- Update Monkeypox'
+# cd /home/owid/etl
+# uv run etls who/latest/monkeypox
+# uv run etls health/latest/global_health_mpox
 
-echo '--- Commit dataset to https://github.com/owid/monkeypox'
-MONKEYPOX_COMMIT=1 uv run etlr github/who/latest/monkeypox --export --private
+# # commit to master will trigger ETL which is gonna run the step
+# echo '--- Commit and push changes'
 
-end_time=$(date +%s)
+# git add .
+# git commit -m ":robot: update: monkeypox" || true
+# git push origin master -q || true
 
-echo "--- Done! ($(($end_time - $start_time))s)"
+# echo '--- Commit dataset to https://github.com/owid/monkeypox'
+# MONKEYPOX_COMMIT=1 uv run etlr github/who/latest/monkeypox --export --private
+
+# end_time=$(date +%s)
+
+# echo "--- Done! ($(($end_time - $start_time))s)"

--- a/snapshots/health/latest/global_health_mpox.csv.dvc
+++ b/snapshots/health/latest/global_health_mpox.csv.dvc
@@ -1,9 +1,14 @@
+# NOTE: Global.health discontinued the mpox-2024 line list (last report 2024-12-20) and the
+# url_download below now returns "403 Access Denied". There is no replacement endpoint. This
+# snapshot is frozen historical data and is no longer refreshable from source; the monkeypox update
+# (scripts/update-monkeypox.sh) has been disabled. The data remains available from our catalog/R2.
 meta:
   origin:
     producer: Global.health
     title: Mpox - 2024
     citation_full: Global.health Mpox (accessed on 2024-09-02)
     url_main: https://global.health/
+    # url_download no longer accessible (403 Access Denied as of 2026-06-01); source discontinued.
     url_download: https://mpox-2024.s3.eu-central-1.amazonaws.com/latest.csv
     date_accessed: '2024-09-02'
     date_published: '2024-09-02'


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## What

Disables the automated monkeypox update because the **Global.health mpox-2024 line list has been discontinued**.

## Why

- Global.health's last mpox-2024 report is dated **2024-12-20**, and its download endpoint (`https://mpox-2024.s3.eu-central-1.amazonaws.com/latest.csv`) now returns **`403 Access Denied`**.
- There is **no replacement endpoint** — the official mpox-2024 report still points at the same (now-dead) URL, and the data portal/API gateway alternatives don't serve the same country×date series.
- The Global.health data was only ever the supplementary `suspected_cases_cumulative` column and was already **frozen** (nothing past 2023-12-01). It remains available from our catalog/R2, so downstream steps are unaffected.
- The WHO source (the primary one) is still live, but the update was failing in `scripts/update-monkeypox.sh` on the Global.health snapshot step, blocking the whole run.

## Changes

- **`scripts/update-monkeypox.sh`** — disabled. It now logs an informative line and `exit 0`s cleanly so the scheduler sees a clear reason; the original commands are kept commented out for reference/re-enabling.
- **`snapshots/health/latest/global_health_mpox.csv.dvc`** — added a note that the source is discontinued and `url_download` returns 403; data stays available from R2.

The snapshot script and downstream ETL steps are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)