### PR TITLE
📊 emissions: Fix units of carbon intensity of energy

### DIFF
--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
@@ -450,6 +450,7 @@ tables:
         description_short: "Annual carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours). [Land-use change emissions](#dod:land-use-change-emissions) are included."
         display:
           shortUnit: g
+          numDecimalPlaces: 0
       emissions_total_per_gdp:
         title: "Annual CO₂ emissions per GDP (kg per international-$)"
         unit: "kilograms per international-$"
@@ -462,6 +463,7 @@ tables:
         description_short: "Annual carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours). [Land-use change emissions](#dod:land-use-change-emissions) are excluded."
         display:
           shortUnit: g
+          numDecimalPlaces: 0
       gdp:
         title: "GDP"
         unit: "2011 international-$"

--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
@@ -445,19 +445,19 @@ tables:
         description_short: "Annual total emissions of carbon dioxide (CO₂), including land-use change, measured in kilograms per dollar of GDP (2011 international-$)."
       emissions_total_including_land_use_change_per_unit_energy:
         title: "Annual CO₂ emissions including land-use change per unit energy"
-        unit: "kilograms per kilowatt-hour"
-        short_unit: "kg/kWh"
-        description_short: "Annual total emissions of carbon dioxide (CO₂), including land-use change, measured in kilograms per kilowatt-hour of primary energy consumption."
+        unit: "grams per kilowatt-hour"
+        short_unit: "g/kWh"
+        description_short: "Annual total emissions of carbon dioxide (CO₂), including land-use change, measured in grams per kilowatt-hour of primary energy consumption."
       emissions_total_per_gdp:
         title: "Annual CO₂ emissions per GDP (kg per international-$)"
         unit: "kilograms per international-$"
         short_unit: "kg/$"
         description_short: "Annual total emissions of carbon dioxide (CO₂), excluding land-use change, measured in kilograms per dollar of GDP (2011 international-$)."
       emissions_total_per_unit_energy:
-        title: "Annual CO₂ emissions per unit energy (kg per kilowatt-hour)"
-        unit: "kilograms per kilowatt-hour"
-        short_unit: "kg/kWh"
-        description_short: "Annual total emissions of carbon dioxide (CO₂), excluding land-use change, measured in kilograms per kilowatt-hour of primary energy consumption."
+        title: "Annual CO₂ emissions per unit energy (grams per kilowatt-hour)"
+        unit: "grams per kilowatt-hour"
+        short_unit: "g/kWh"
+        description_short: "Annual total emissions of carbon dioxide (CO₂), excluding land-use change, measured in grams per kilowatt-hour of primary energy consumption."
       gdp:
         title: "GDP"
         unit: "2011 international-$"

--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
@@ -444,10 +444,10 @@ tables:
         short_unit: "kg/$"
         description_short: "Annual total emissions of carbon dioxide (CO₂), including land-use change, measured in kilograms per dollar of GDP (2011 international-$)."
       emissions_total_including_land_use_change_per_unit_energy:
-        title: "Annual CO₂ emissions including land-use change per unit energy"
+        title: "CO₂ emissions including land-use change per unit energy"
         unit: "grams per kilowatt-hour"
         short_unit: "g/kWh"
-        description_short: "Annual carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours). [Land-use change emissions](#dod:land-use-change-emissions) are included."
+        description_short: "Carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours). [Land-use change emissions](#dod:land-use-change-emissions) are included."
         display:
           shortUnit: g
           numDecimalPlaces: 0
@@ -457,10 +457,13 @@ tables:
         short_unit: "kg/$"
         description_short: "Annual total emissions of carbon dioxide (CO₂), excluding land-use change, measured in kilograms per dollar of GDP (2011 international-$)."
       emissions_total_per_unit_energy:
-        title: "Annual CO₂ emissions per unit energy (grams per kilowatt-hour)"
+        title: "CO₂ emissions per unit energy"
         unit: "grams per kilowatt-hour"
         short_unit: "g/kWh"
-        description_short: "Annual carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours)."
+        description_short: "Carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours)."
+        description_key:
+          - Average amount of CO₂ emitted for each unit of energy a country uses. It is calculated by dividing emissions from [fossil fuels and industry](#dod:fossilemissions) by [primary energy consumption](#dod:primaryenergy).
+          - It reflects how carbon-intensive a country's energy is. Lower values indicate a larger role for low-carbon sources such as nuclear and renewables."
         display:
           shortUnit: g
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
@@ -460,7 +460,7 @@ tables:
         title: "Annual CO₂ emissions per unit energy (grams per kilowatt-hour)"
         unit: "grams per kilowatt-hour"
         short_unit: "g/kWh"
-        description_short: "Annual carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours). [Land-use change emissions](#dod:land-use-change-emissions) are excluded."
+        description_short: "Annual carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours)."
         display:
           shortUnit: g
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
@@ -447,7 +447,9 @@ tables:
         title: "Annual CO₂ emissions including land-use change per unit energy"
         unit: "grams per kilowatt-hour"
         short_unit: "g/kWh"
-        description_short: "Annual total emissions of carbon dioxide (CO₂), including land-use change, measured in grams per kilowatt-hour of primary energy consumption."
+        description_short: "Annual carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours). [Land-use change emissions](#dod:land-use-change-emissions) are included."
+        display:
+          shortUnit: g
       emissions_total_per_gdp:
         title: "Annual CO₂ emissions per GDP (kg per international-$)"
         unit: "kilograms per international-$"
@@ -457,7 +459,9 @@ tables:
         title: "Annual CO₂ emissions per unit energy (grams per kilowatt-hour)"
         unit: "grams per kilowatt-hour"
         short_unit: "g/kWh"
-        description_short: "Annual total emissions of carbon dioxide (CO₂), excluding land-use change, measured in grams per kilowatt-hour of primary energy consumption."
+        description_short: "Annual carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours). [Land-use change emissions](#dod:land-use-change-emissions) are excluded."
+        display:
+          shortUnit: g
       gdp:
         title: "GDP"
         unit: "2011 international-$"

--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.meta.yml
@@ -463,7 +463,7 @@ tables:
         description_short: "Carbon dioxide (CO₂) emitted per unit of [primary energy consumption](#dod:primaryenergy), measured in grams of CO₂ per [kilowatt-hour](#dod:watt-hours)."
         description_key:
           - Average amount of CO₂ emitted for each unit of energy a country uses. It is calculated by dividing emissions from [fossil fuels and industry](#dod:fossilemissions) by [primary energy consumption](#dod:primaryenergy).
-          - It reflects how carbon-intensive a country's energy is. Lower values indicate a larger role for low-carbon sources such as nuclear and renewables."
+          - It reflects how carbon-intensive a country's energy is. Lower values indicate a larger role for low-carbon sources such as nuclear and renewables.
         display:
           shortUnit: g
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.py
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.py
@@ -123,8 +123,11 @@ MILLION_TONNES_OF_CARBON_TO_TONNES_OF_CO2 = 3.664 * 1e6
 # Conversion from million tonnes of CO2 to tonnes of CO2.
 MILLION_TONNES_OF_CO2_TO_TONNES_OF_CO2 = 1e6
 
-# Conversion from tonnes of CO2 to kg of CO2 (used for emissions per GDP and per unit energy).
+# Conversion from tonnes of CO2 to kg of CO2 (used for emissions per GDP).
 TONNES_OF_CO2_TO_KG_OF_CO2 = 1000
+
+# Conversion from tonnes of CO2 to grams of CO2 (used for emissions per unit energy).
+TONNES_OF_CO2_TO_G_OF_CO2 = 1e6
 
 # In order to remove uninformative columns, keep only rows where at least one of the following columns has data.
 # All other columns are either derived variables, or global variables, or auxiliary variables from other datasets.
@@ -866,16 +869,16 @@ def combine_data_and_add_variables(
             100 * tb_co2_with_regions[f"cumulative_{column}"] / tb_co2_with_regions[f"global_cumulative_{column}"]
         )
 
-    # Add total emissions per unit energy (in kg of emissions per kWh).
+    # Add total emissions per unit energy (in grams of emissions per kWh).
     tb_co2_with_regions["emissions_total_per_unit_energy"] = (
-        TONNES_OF_CO2_TO_KG_OF_CO2
+        TONNES_OF_CO2_TO_G_OF_CO2
         * tb_co2_with_regions["emissions_total"]
         / (tb_co2_with_regions["primary_energy_consumption"] * TWH_TO_KWH)
     )
 
-    # Add total emissions (including land-use change) per unit energy (in kg of emissions per kWh).
+    # Add total emissions (including land-use change) per unit energy (in grams of emissions per kWh).
     tb_co2_with_regions["emissions_total_including_land_use_change_per_unit_energy"] = (
-        TONNES_OF_CO2_TO_KG_OF_CO2
+        TONNES_OF_CO2_TO_G_OF_CO2
         * tb_co2_with_regions["emissions_total_including_land_use_change"]
         / (tb_co2_with_regions["primary_energy_consumption"] * TWH_TO_KWH)
     )

--- a/etl/steps/export/github/co2_data/latest/owid_co2.py
+++ b/etl/steps/export/github/co2_data/latest/owid_co2.py
@@ -126,7 +126,8 @@ Additionally, to construct indicators per capita, per GDP, and per unit energy, 
 ## Changelog
 
 - 2026-06-01:
-  - Changed the units of `co2_per_unit_energy` from kilograms to grams of CO₂ per kilowatt-hour.
+  - Update dataset to use the latest EIA's International Energy Data.
+  - Changed the units of the carbon intensity of energy indicators from kilograms to grams of CO₂ per kilowatt-hour.
 - 2025-12-04:
   - Update greenhouse gases using the latest data from Jones et al. (2025).
 - 2025-11-13:

--- a/etl/steps/export/github/co2_data/latest/owid_co2.py
+++ b/etl/steps/export/github/co2_data/latest/owid_co2.py
@@ -125,6 +125,8 @@ Additionally, to construct indicators per capita, per GDP, and per unit energy, 
 
 ## Changelog
 
+- 2026-06-01:
+  - Changed the units of `co2_per_unit_energy` from kilograms to grams of CO₂ per kilowatt-hour.
 - 2025-12-04:
   - Update greenhouse gases using the latest data from Jones et al. (2025).
 - 2025-11-13:


### PR DESCRIPTION
Change units of carbon intensity of energy, and improve metadata.
Update CO2 dataset accordingly after these changes.
