### PR TITLE
📊 Fix Velasco marriage & gender-affirming-care categories, add category guards

### DIFF
--- a/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.meta.yml
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.meta.yml
@@ -878,8 +878,8 @@ tables:
           - Neither covered nor restricted
           - Restricted for adults only
           - Restricted for minors only
-          - Restricted for both
           - Varies by region or other
+          - Restricted for both
 
       # ── Gender marker change with legal-pathway requirements ─────
         processing_level: major

--- a/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.meta.yml
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.meta.yml
@@ -42,7 +42,7 @@ definitions:
   description_key_so_gi_partial_note: |-
     "Varies by region" also covers asymmetric cases where one dimension is fully unprotected and the other is partially protected across subnational jurisdictions — e.g. a federal country where some states have hate-crime protections for sexual orientation but none for gender identity.
   derivation_gac: |-
-    From the original dataset's four indicators for gender-affirming care (adults covered, adults restricted, minors covered, minors restricted), we combined them into a single categorical indicator capturing whether care is publicly funded or legally restricted for adults and for minors. The most common patterns get a dedicated category (e.g. covered for both, adults covered with minors restricted); rarer combinations are grouped as "Varies by region or other".
+    From the original dataset's four indicators for gender-affirming care (adults covered, adults restricted, minors covered, minors restricted), we combined them into a single categorical indicator capturing whether care is publicly funded or legally restricted for adults and for minors. Each single, definite national policy combination gets a dedicated category (covered or restricted, for adults and/or minors); only country-years with subnational variation or contradictory same-year coding are grouped as "Varies by region or other".
   derivation_gmc: |-
     From the original dataset, we combined the gender-marker-change proportion (the legal direction) with the recorded legal-pathway requirement to produce a single categorical indicator. When legal change of the gender marker is fully in effect, we classify countries by their procedural requirement ("Self-declaration is enough", "Diagnosis required", "Surgery required", "Surgery and sterilization required", or "Legally possible, requirement unknown" when the requirement is not recorded). Otherwise the country is classified as "Varies by region" (legal change is only partially in effect across subnational jurisdictions) or "Not legally possible" (no legal procedure exists).
 
@@ -863,7 +863,7 @@ tables:
           Interventions that help transgender and non-binary people align their bodies with their gender identity — such as hormone replacement therapy or surgery for adults, and puberty blockers, cross-sex hormones, or surgery for minors.
         description_key:
           - '{definitions.description_key_dataset}'
-          - 'The indicator is coded as follows: **_Covered for adults and minors_** (gender-affirming healthcare is publicly funded for both adults and minors), **_Covered for adults only_** (gender-affirming healthcare is publicly funded for adults but not for minors), **_Adults covered, minors restricted_** (gender-affirming healthcare is publicly funded for adults but explicitly restricted or banned for minors), **_Neither covered nor restricted_** (no national policy explicitly funds or restricts gender-affirming healthcare for either group), **_Varies by region or other_** (rules differ between subnational jurisdictions, or both coverage and restriction are recorded in the same year because of a mid-year policy change) and **_Restricted for both_** (gender-affirming healthcare is explicitly restricted or banned for both adults and minors).'
+          - 'The indicator is coded as follows: **_Covered for adults and minors_** (gender-affirming healthcare is publicly funded for both adults and minors), **_Covered for adults only_** (gender-affirming healthcare is publicly funded for adults but not for minors), **_Covered for minors only_** (gender-affirming healthcare is publicly funded for minors but not for adults), **_Adults covered, minors restricted_** (gender-affirming healthcare is publicly funded for adults but explicitly restricted or banned for minors), **_Neither covered nor restricted_** (no national policy explicitly funds or restricts gender-affirming healthcare for either group), **_Restricted for adults only_** (gender-affirming healthcare is explicitly restricted or banned for adults but no policy applies to minors), **_Restricted for minors only_** (gender-affirming healthcare is explicitly restricted or banned for minors but no policy applies to adults), **_Restricted for both_** (gender-affirming healthcare is explicitly restricted or banned for both adults and minors) and **_Varies by region or other_** (rules differ between subnational jurisdictions, or both coverage and restriction are recorded in the same year because of a mid-year policy change).'
         unit: ""
         short_unit: ""
         display:
@@ -873,10 +873,13 @@ tables:
         sort:
           - Covered for adults and minors
           - Covered for adults only
+          - Covered for minors only
           - Adults covered, minors restricted
           - Neither covered nor restricted
-          - Varies by region or other
+          - Restricted for adults only
+          - Restricted for minors only
           - Restricted for both
+          - Varies by region or other
 
       # ── Gender marker change with legal-pathway requirements ─────
         processing_level: major
@@ -3173,6 +3176,72 @@ tables:
         short_unit: ""
         display:
           name: Restricted for both
+          numDecimalPlaces: 0
+
+      gender_affirming_care_covered_for_minors_only_count:
+        title: Gender-affirming care (adults and minors) — Covered for minors only (number of countries)
+        description_short: The number of countries classified as "Covered for minors only" on the indicator on gender-affirming care for adults and minors.
+        processing_level: major
+        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Covered for minors only" within each region. {definitions.description_regions_processing}'
+        unit: countries
+        short_unit: ""
+        display:
+          name: Covered for minors only
+          numDecimalPlaces: 0
+
+      gender_affirming_care_covered_for_minors_only_pop:
+        title: Gender-affirming care (adults and minors) — Covered for minors only (population)
+        description_short: The total population of countries classified as "Covered for minors only" on the indicator on gender-affirming care for adults and minors.
+        processing_level: major
+        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Covered for minors only" within each region. {definitions.description_regions_processing}'
+        unit: people
+        short_unit: ""
+        display:
+          name: Covered for minors only
+          numDecimalPlaces: 0
+
+      gender_affirming_care_restricted_for_minors_only_count:
+        title: Gender-affirming care (adults and minors) — Restricted for minors only (number of countries)
+        description_short: The number of countries classified as "Restricted for minors only" on the indicator on gender-affirming care for adults and minors.
+        processing_level: major
+        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Restricted for minors only" within each region. {definitions.description_regions_processing}'
+        unit: countries
+        short_unit: ""
+        display:
+          name: Restricted for minors only
+          numDecimalPlaces: 0
+
+      gender_affirming_care_restricted_for_minors_only_pop:
+        title: Gender-affirming care (adults and minors) — Restricted for minors only (population)
+        description_short: The total population of countries classified as "Restricted for minors only" on the indicator on gender-affirming care for adults and minors.
+        processing_level: major
+        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Restricted for minors only" within each region. {definitions.description_regions_processing}'
+        unit: people
+        short_unit: ""
+        display:
+          name: Restricted for minors only
+          numDecimalPlaces: 0
+
+      gender_affirming_care_restricted_for_adults_only_count:
+        title: Gender-affirming care (adults and minors) — Restricted for adults only (number of countries)
+        description_short: The number of countries classified as "Restricted for adults only" on the indicator on gender-affirming care for adults and minors.
+        processing_level: major
+        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Restricted for adults only" within each region. {definitions.description_regions_processing}'
+        unit: countries
+        short_unit: ""
+        display:
+          name: Restricted for adults only
+          numDecimalPlaces: 0
+
+      gender_affirming_care_restricted_for_adults_only_pop:
+        title: Gender-affirming care (adults and minors) — Restricted for adults only (population)
+        description_short: The total population of countries classified as "Restricted for adults only" on the indicator on gender-affirming care for adults and minors.
+        processing_level: major
+        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Restricted for adults only" within each region. {definitions.description_regions_processing}'
+        unit: people
+        short_unit: ""
+        display:
+          name: Restricted for adults only
           numDecimalPlaces: 0
 
       gender_affirming_care_varies_by_region_or_other_count:

--- a/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.meta.yml
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.meta.yml
@@ -42,7 +42,7 @@ definitions:
   description_key_so_gi_partial_note: |-
     "Varies by region" also covers asymmetric cases where one dimension is fully unprotected and the other is partially protected across subnational jurisdictions — e.g. a federal country where some states have hate-crime protections for sexual orientation but none for gender identity.
   derivation_gac: |-
-    From the original dataset's four indicators for gender-affirming care (adults covered, adults restricted, minors covered, minors restricted), we combined them into a single categorical indicator capturing whether care is publicly funded or legally restricted for adults and for minors. Each single, definite national policy combination gets a dedicated category (covered or restricted, for adults and/or minors); only country-years with subnational variation or contradictory same-year coding are grouped as "Varies by region or other".
+    From the original dataset's four indicators for gender-affirming care (adults covered, adults restricted, minors covered, minors restricted), we combined them into a single categorical indicator capturing whether care is publicly funded or legally restricted for adults and for minors. The salient national policy states keep their own category, while the rarer one-group-only states are merged into "Covered for adults or minors only" and "Restricted for adults or minors only"; only country-years with subnational variation or contradictory same-year coding are grouped as "Varies by region or other".
   derivation_gmc: |-
     From the original dataset, we combined the gender-marker-change proportion (the legal direction) with the recorded legal-pathway requirement to produce a single categorical indicator. When legal change of the gender marker is fully in effect, we classify countries by their procedural requirement ("Self-declaration is enough", "Diagnosis required", "Surgery required", "Surgery and sterilization required", or "Legally possible, requirement unknown" when the requirement is not recorded). Otherwise the country is classified as "Varies by region" (legal change is only partially in effect across subnational jurisdictions) or "Not legally possible" (no legal procedure exists).
 
@@ -863,7 +863,7 @@ tables:
           Interventions that help transgender and non-binary people align their bodies with their gender identity — such as hormone replacement therapy or surgery for adults, and puberty blockers, cross-sex hormones, or surgery for minors.
         description_key:
           - '{definitions.description_key_dataset}'
-          - 'The indicator is coded as follows: **_Covered for adults and minors_** (gender-affirming healthcare is publicly funded for both adults and minors), **_Covered for adults only_** (gender-affirming healthcare is publicly funded for adults but not for minors), **_Covered for minors only_** (gender-affirming healthcare is publicly funded for minors but not for adults), **_Adults covered, minors restricted_** (gender-affirming healthcare is publicly funded for adults but explicitly restricted or banned for minors), **_Neither covered nor restricted_** (no national policy explicitly funds or restricts gender-affirming healthcare for either group), **_Restricted for adults only_** (gender-affirming healthcare is explicitly restricted or banned for adults but no policy applies to minors), **_Restricted for minors only_** (gender-affirming healthcare is explicitly restricted or banned for minors but no policy applies to adults), **_Restricted for both_** (gender-affirming healthcare is explicitly restricted or banned for both adults and minors) and **_Varies by region or other_** (rules differ between subnational jurisdictions, or both coverage and restriction are recorded in the same year because of a mid-year policy change).'
+          - 'The indicator is coded as follows: **_Covered for adults and minors_** (gender-affirming healthcare is publicly funded for both adults and minors), **_Covered for adults or minors only_** (gender-affirming healthcare is publicly funded for one of the two groups, with no national policy for the other), **_Adults covered, minors restricted_** (gender-affirming healthcare is publicly funded for adults but explicitly restricted or banned for minors), **_Neither covered nor restricted_** (no national policy explicitly funds or restricts gender-affirming healthcare for either group), **_Varies by region or other_** (rules differ between subnational jurisdictions, or both coverage and restriction are recorded in the same year because of a mid-year policy change), **_Restricted for adults or minors only_** (gender-affirming healthcare is explicitly restricted or banned for one of the two groups, with no national policy for the other) and **_Restricted for both_** (gender-affirming healthcare is explicitly restricted or banned for both adults and minors).'
         unit: ""
         short_unit: ""
         display:
@@ -872,13 +872,11 @@ tables:
         type: ordinal
         sort:
           - Covered for adults and minors
-          - Covered for adults only
-          - Covered for minors only
+          - Covered for adults or minors only
           - Adults covered, minors restricted
           - Neither covered nor restricted
-          - Restricted for adults only
-          - Restricted for minors only
           - Varies by region or other
+          - Restricted for adults or minors only
           - Restricted for both
 
       # ── Gender marker change with legal-pathway requirements ─────
@@ -3112,26 +3110,26 @@ tables:
           name: Covered for adults and minors
           numDecimalPlaces: 0
 
-      gender_affirming_care_covered_for_adults_only_count:
-        title: Gender-affirming care (adults and minors) — Covered for adults only (number of countries)
-        description_short: The number of countries classified as "Covered for adults only" on the indicator on gender-affirming care for adults and minors.
+      gender_affirming_care_covered_for_adults_or_minors_only_count:
+        title: Gender-affirming care (adults and minors) — Covered for adults or minors only (number of countries)
+        description_short: The number of countries classified as "Covered for adults or minors only" on the indicator on gender-affirming care for adults and minors.
         processing_level: major
-        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Covered for adults only" within each region. {definitions.description_regions_processing}'
+        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Covered for adults or minors only" within each region. {definitions.description_regions_processing}'
         unit: countries
         short_unit: ""
         display:
-          name: Covered for adults only
+          name: Covered for adults or minors only
           numDecimalPlaces: 0
 
-      gender_affirming_care_covered_for_adults_only_pop:
-        title: Gender-affirming care (adults and minors) — Covered for adults only (population)
-        description_short: The total population of countries classified as "Covered for adults only" on the indicator on gender-affirming care for adults and minors.
+      gender_affirming_care_covered_for_adults_or_minors_only_pop:
+        title: Gender-affirming care (adults and minors) — Covered for adults or minors only (population)
+        description_short: The total population of countries classified as "Covered for adults or minors only" on the indicator on gender-affirming care for adults and minors.
         processing_level: major
-        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Covered for adults only" within each region. {definitions.description_regions_processing}'
+        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Covered for adults or minors only" within each region. {definitions.description_regions_processing}'
         unit: people
         short_unit: ""
         display:
-          name: Covered for adults only
+          name: Covered for adults or minors only
           numDecimalPlaces: 0
 
       gender_affirming_care_adults_covered__minors_restricted_count:
@@ -3156,92 +3154,26 @@ tables:
           name: Adults covered, minors restricted
           numDecimalPlaces: 0
 
-      gender_affirming_care_restricted_for_both_count:
-        title: Gender-affirming care (adults and minors) — Restricted for both (number of countries)
-        description_short: The number of countries classified as "Restricted for both" on the indicator on gender-affirming care for adults and minors.
+      gender_affirming_care_neither_covered_nor_restricted_count:
+        title: Gender-affirming care (adults and minors) — Neither covered nor restricted (number of countries)
+        description_short: The number of countries classified as "Neither covered nor restricted" on the indicator on gender-affirming care for adults and minors.
         processing_level: major
-        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Restricted for both" within each region. {definitions.description_regions_processing}'
+        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Neither covered nor restricted" within each region. {definitions.description_regions_processing}'
         unit: countries
         short_unit: ""
         display:
-          name: Restricted for both
+          name: Neither covered nor restricted
           numDecimalPlaces: 0
 
-      gender_affirming_care_restricted_for_both_pop:
-        title: Gender-affirming care (adults and minors) — Restricted for both (population)
-        description_short: The total population of countries classified as "Restricted for both" on the indicator on gender-affirming care for adults and minors.
+      gender_affirming_care_neither_covered_nor_restricted_pop:
+        title: Gender-affirming care (adults and minors) — Neither covered nor restricted (population)
+        description_short: The total population of countries classified as "Neither covered nor restricted" on the indicator on gender-affirming care for adults and minors.
         processing_level: major
-        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Restricted for both" within each region. {definitions.description_regions_processing}'
+        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Neither covered nor restricted" within each region. {definitions.description_regions_processing}'
         unit: people
         short_unit: ""
         display:
-          name: Restricted for both
-          numDecimalPlaces: 0
-
-      gender_affirming_care_covered_for_minors_only_count:
-        title: Gender-affirming care (adults and minors) — Covered for minors only (number of countries)
-        description_short: The number of countries classified as "Covered for minors only" on the indicator on gender-affirming care for adults and minors.
-        processing_level: major
-        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Covered for minors only" within each region. {definitions.description_regions_processing}'
-        unit: countries
-        short_unit: ""
-        display:
-          name: Covered for minors only
-          numDecimalPlaces: 0
-
-      gender_affirming_care_covered_for_minors_only_pop:
-        title: Gender-affirming care (adults and minors) — Covered for minors only (population)
-        description_short: The total population of countries classified as "Covered for minors only" on the indicator on gender-affirming care for adults and minors.
-        processing_level: major
-        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Covered for minors only" within each region. {definitions.description_regions_processing}'
-        unit: people
-        short_unit: ""
-        display:
-          name: Covered for minors only
-          numDecimalPlaces: 0
-
-      gender_affirming_care_restricted_for_minors_only_count:
-        title: Gender-affirming care (adults and minors) — Restricted for minors only (number of countries)
-        description_short: The number of countries classified as "Restricted for minors only" on the indicator on gender-affirming care for adults and minors.
-        processing_level: major
-        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Restricted for minors only" within each region. {definitions.description_regions_processing}'
-        unit: countries
-        short_unit: ""
-        display:
-          name: Restricted for minors only
-          numDecimalPlaces: 0
-
-      gender_affirming_care_restricted_for_minors_only_pop:
-        title: Gender-affirming care (adults and minors) — Restricted for minors only (population)
-        description_short: The total population of countries classified as "Restricted for minors only" on the indicator on gender-affirming care for adults and minors.
-        processing_level: major
-        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Restricted for minors only" within each region. {definitions.description_regions_processing}'
-        unit: people
-        short_unit: ""
-        display:
-          name: Restricted for minors only
-          numDecimalPlaces: 0
-
-      gender_affirming_care_restricted_for_adults_only_count:
-        title: Gender-affirming care (adults and minors) — Restricted for adults only (number of countries)
-        description_short: The number of countries classified as "Restricted for adults only" on the indicator on gender-affirming care for adults and minors.
-        processing_level: major
-        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Restricted for adults only" within each region. {definitions.description_regions_processing}'
-        unit: countries
-        short_unit: ""
-        display:
-          name: Restricted for adults only
-          numDecimalPlaces: 0
-
-      gender_affirming_care_restricted_for_adults_only_pop:
-        title: Gender-affirming care (adults and minors) — Restricted for adults only (population)
-        description_short: The total population of countries classified as "Restricted for adults only" on the indicator on gender-affirming care for adults and minors.
-        processing_level: major
-        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Restricted for adults only" within each region. {definitions.description_regions_processing}'
-        unit: people
-        short_unit: ""
-        display:
-          name: Restricted for adults only
+          name: Neither covered nor restricted
           numDecimalPlaces: 0
 
       gender_affirming_care_varies_by_region_or_other_count:
@@ -3266,27 +3198,50 @@ tables:
           name: Varies by region or other
           numDecimalPlaces: 0
 
-      gender_affirming_care_neither_covered_nor_restricted_count:
-        title: Gender-affirming care (adults and minors) — Neither covered nor restricted (number of countries)
-        description_short: The number of countries classified as "Neither covered nor restricted" on the indicator on gender-affirming care for adults and minors.
+      gender_affirming_care_restricted_for_adults_or_minors_only_count:
+        title: Gender-affirming care (adults and minors) — Restricted for adults or minors only (number of countries)
+        description_short: The number of countries classified as "Restricted for adults or minors only" on the indicator on gender-affirming care for adults and minors.
         processing_level: major
-        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Neither covered nor restricted" within each region. {definitions.description_regions_processing}'
+        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Restricted for adults or minors only" within each region. {definitions.description_regions_processing}'
         unit: countries
         short_unit: ""
         display:
-          name: Neither covered nor restricted
+          name: Restricted for adults or minors only
           numDecimalPlaces: 0
 
-      gender_affirming_care_neither_covered_nor_restricted_pop:
-        title: Gender-affirming care (adults and minors) — Neither covered nor restricted (population)
-        description_short: The total population of countries classified as "Neither covered nor restricted" on the indicator on gender-affirming care for adults and minors.
+      gender_affirming_care_restricted_for_adults_or_minors_only_pop:
+        title: Gender-affirming care (adults and minors) — Restricted for adults or minors only (population)
+        description_short: The total population of countries classified as "Restricted for adults or minors only" on the indicator on gender-affirming care for adults and minors.
         processing_level: major
-        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Neither covered nor restricted" within each region. {definitions.description_regions_processing}'
+        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Restricted for adults or minors only" within each region. {definitions.description_regions_processing}'
         unit: people
         short_unit: ""
         display:
-          name: Neither covered nor restricted
+          name: Restricted for adults or minors only
           numDecimalPlaces: 0
+
+      gender_affirming_care_restricted_for_both_count:
+        title: Gender-affirming care (adults and minors) — Restricted for both (number of countries)
+        description_short: The number of countries classified as "Restricted for both" on the indicator on gender-affirming care for adults and minors.
+        processing_level: major
+        description_processing: '{definitions.derivation_gac} We then counted the countries classified as "Restricted for both" within each region. {definitions.description_regions_processing}'
+        unit: countries
+        short_unit: ""
+        display:
+          name: Restricted for both
+          numDecimalPlaces: 0
+
+      gender_affirming_care_restricted_for_both_pop:
+        title: Gender-affirming care (adults and minors) — Restricted for both (population)
+        description_short: The total population of countries classified as "Restricted for both" on the indicator on gender-affirming care for adults and minors.
+        processing_level: major
+        description_processing: '{definitions.derivation_gac} We then summed the populations of countries classified as "Restricted for both" within each region. {definitions.description_regions_processing}'
+        unit: people
+        short_unit: ""
+        display:
+          name: Restricted for both
+          numDecimalPlaces: 0
+
 
       # ── Gender marker change regional aggregates ─────────────────────────────────
       gender_marker_change_legally_possible__requirement_unknown_count:

--- a/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
@@ -67,7 +67,11 @@ MARRIAGE_MAP = {
     "equality: 0.5 ban: 1 civil_unions: 0.5": "Varies by region",
     "equality: 0.5 ban: 1 civil_unions: 1": "Varies by region",  # Canada 2003–2004
     "equality: 0 ban: 0.5 civil_unions: 0": "Varies by region",
-    "equality: 0 ban: 1 civil_unions: 1": "Varies by region",
+    # Same-sex marriage banned nationally but civil unions recognized nationally: a national
+    # "civil unions only" regime, not a federal mismatch. The source codes these country-years
+    # with Sub_National_Variation=0 and no fractional proportions (e.g. Bolivia, Croatia,
+    # Hungary, Montenegro, Estonia, Latvia, Ecuador) — so "Varies by region" was wrong.
+    "equality: 0 ban: 1 civil_unions: 1": "Civil unions only",
     "equality: 0 ban: 1 civil_unions: 0.5": "Varies by region",
     "equality: 0 ban: 1 civil_unions: 0": "Banned",
 }

--- a/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
@@ -98,6 +98,13 @@ def _binary_map(*, prog_key, reg_key, prog_label, reg_label, neither_label, mixe
     GAC 2025), and the v2.0+ subnational coverage means most countries with both
     directions populated are real subnational mixes. For both interpretations,
     "Varies by region" is a safer default than picking one direction arbitrarily.
+
+    NOTE (future updates): as of v2.0 the `both = 1` branch fires on ZERO country-years for
+    every binary-mapped law (same_sex_acts, blood_donations, transgender_military) — so
+    no row is currently labelled "Varies by region" without partial data. If a future
+    source version reintroduces `legal: 1 illegal: 1` rows, re-check each one by hand:
+    confirm it is a genuine transition-year artefact (and "Varies by region" is right)
+    rather than a stable regime that should map to a decided category.
     """
     m = {
         f"{prog_key}: 0 {reg_key}: 0": neither_label,
@@ -108,7 +115,8 @@ def _binary_map(*, prog_key, reg_key, prog_label, reg_label, neither_label, mixe
         f"{prog_key}: 0.5 {reg_key}: 0.5": mixed_label,
         f"{prog_key}: 1 {reg_key}: 0.5": mixed_label,
         f"{prog_key}: 0.5 {reg_key}: 1": mixed_label,
-        f"{prog_key}: 1 {reg_key}: 1": mixed_label,  # was prog_label — see docstring
+        # NOTE: transition-year artefact; 0 rows in v2.0 — re-check each occurrence on future updates (see docstring).
+        f"{prog_key}: 1 {reg_key}: 1": mixed_label,
     }
     return m
 

--- a/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
@@ -639,6 +639,11 @@ def run() -> None:
     mask = tb.set_index(["law", "status"]).index.isin(placeholders)
     tb = tb.loc[~mask].reset_index(drop=True)
 
+    # Guard the `both = 1` transition-year branch of _binary_map (see its docstring): such
+    # rows fold into "Varies by region" with no partial data. Zero exist in v2.0; fail loudly
+    # if a future source version reintroduces them so each is re-checked by hand.
+    _assert_no_unhandled_transition_years(tb)
+
     # Country-level table — drop the requirement and enforcement columns here; they're
     # only used to build combined indicators and aren't published as per-row long-table
     # indicators.
@@ -698,6 +703,30 @@ def _detect_structural_placeholders(tb):
         f"Expected 18 placeholder (law, status) combos per codebook v2.0 §1.1; found {len(placeholders)}."
     )
     return placeholders
+
+
+# Two-direction laws whose combined indicator is built via _binary_map (legal vs illegal).
+_BINARY_LAWS = ["same_sex_acts", "marriage_equality", "transgender_military", "blood_donations"]
+
+
+def _assert_no_unhandled_transition_years(tb):
+    """Fail if any binary-mapped law has a country-year with legal=1 AND illegal=1.
+
+    Such "transition-year artefact" rows fold into "Varies by region" via _binary_map (or go
+    unmapped for marriage) despite carrying no partial/subnational data. As of v2.0 none exist;
+    if a future source version reintroduces them, re-check each occurrence by hand rather than
+    letting it silently inherit the "Varies by region" default. See _binary_map's docstring.
+    """
+    wide = tb.pivot_table(index=["country", "year", "law"], columns="status", values="proportion", aggfunc="first")
+    if "legal" not in wide or "illegal" not in wide:
+        return
+    both = wide[(wide["legal"] == 1) & (wide["illegal"] == 1)]
+    both = both[both.index.get_level_values("law").isin(_BINARY_LAWS)]
+    assert both.empty, (
+        f"Found {len(both)} (country, year, law) rows with legal=1 AND illegal=1 — a transition-year "
+        f"artefact that maps to 'Varies by region' with no partial data. Re-check each before trusting "
+        f"that mapping (see _binary_map docstring):\n{both.index.tolist()}"
+    )
 
 
 def _build_regional_aggregates(tb):

--- a/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
@@ -518,16 +518,16 @@ COMBINED_CONFIGS = [
     },
     # ── Gender-affirming care: adults + minors combined ──────────────
     # 4 source columns (adults covered / restricted, minors covered / restricted) →
-    # one categorical indicator. Of 81 possible 4-tuple patterns, only 12 occur in the
-    # v2 data; we map the 5 most common ones and route everything else to the
-    # "Varies by region or other" default.
+    # one categorical indicator over the adults×minors ∈ {covered, restricted, neither}
+    # grid. We map the 8 single-policy national states that occur in the data; only
+    # adults-restricted/minors-covered is unobserved and left to the default.
     #
-    # NOTE: as of v2.0 the only country-year reaching the "or other" part of the
-    # default bucket is Brazil 2025 (a transition-year artefact with both covered=1
-    # and restricted=1 for adults). On each new data release, re-check whether more
-    # transition-year cases appear here and across the two-direction policies — if
-    # the count grows materially, revisit whether to surface them as their own
-    # category or apply the codebook's end-of-year recoding rule.
+    # NOTE: with the 8 states mapped, the "Varies by region or other" default now holds
+    # only (a) genuinely partial/subnational country-years (e.g. Canada, United States)
+    # and (b) the lone Brazil 2025 transition-year artefact (adults covered=1 AND
+    # restricted=1). On each new data release, re-check what reaches the default: route
+    # any new stable single-policy state to its own category, and treat covered+restricted
+    # (or legal+illegal) contradictions via the codebook's end-of-year recoding rule.
     {
         "short_name": "gender_affirming_care",
         "sources": [
@@ -542,6 +542,11 @@ COMBINED_CONFIGS = [
             "ac: 1 ar: 0 mc: 0 mr: 1": "Adults covered, minors restricted",
             "ac: 0 ar: 1 mc: 0 mr: 1": "Restricted for both",
             "ac: 0 ar: 0 mc: 0 mr: 0": "Neither covered nor restricted",
+            # Single-policy national states previously dumped into the catch-all despite
+            # being definite (not regional): minors-only and adults-restricted-only.
+            "ac: 0 ar: 0 mc: 1 mr: 0": "Covered for minors only",
+            "ac: 0 ar: 0 mc: 0 mr: 1": "Restricted for minors only",
+            "ac: 0 ar: 1 mc: 0 mr: 0": "Restricted for adults only",
         },
         "default_category": "Varies by region or other",
     },

--- a/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
@@ -14,10 +14,12 @@ The source is long format: one row per (country, year, law, status). We:
 
 from owid.catalog.utils import underscore
 from owid.datautils.dataframes import map_series
+from structlog import get_logger
 
 from etl.helpers import PathFinder
 
 paths = PathFinder(__file__)
+log = get_logger()
 
 # OWID regions to aggregate over: the 6 continents + World, plus the 4 World Bank income groups.
 REGIONS = [
@@ -99,12 +101,12 @@ def _binary_map(*, prog_key, reg_key, prog_label, reg_label, neither_label, mixe
     directions populated are real subnational mixes. For both interpretations,
     "Varies by region" is a safer default than picking one direction arbitrarily.
 
-    NOTE (future updates): as of v2.0 the `both = 1` branch fires on ZERO country-years for
-    every binary-mapped law (same_sex_acts, blood_donations, transgender_military) — so
-    no row is currently labelled "Varies by region" without partial data. If a future
-    source version reintroduces `legal: 1 illegal: 1` rows, re-check each one by hand:
-    confirm it is a genuine transition-year artefact (and "Varies by region" is right)
-    rather than a stable regime that should map to a decided category.
+    NOTE (future updates): as of v2.0 the `both = 1` branch fires on ZERO country-years, so no row
+    is currently labelled "Varies by region" without partial data. `_warn_on_simultaneous_legal_illegal`
+    logs a warning (generically, for any law) if a future source version reintroduces `legal: 1
+    illegal: 1` rows, so each can be re-checked by hand: confirm it is a genuine transition-year
+    artefact (and "Varies by region" is right) rather than a stable regime that should map to a
+    decided category.
     """
     m = {
         f"{prog_key}: 0 {reg_key}: 0": neither_label,
@@ -639,10 +641,8 @@ def run() -> None:
     mask = tb.set_index(["law", "status"]).index.isin(placeholders)
     tb = tb.loc[~mask].reset_index(drop=True)
 
-    # Guard the `both = 1` transition-year branch of _binary_map (see its docstring): such
-    # rows fold into "Varies by region" with no partial data. Zero exist in v2.0; fail loudly
-    # if a future source version reintroduces them so each is re-checked by hand.
-    _assert_no_unhandled_transition_years(tb)
+    # Warn on country-years coded fully legal AND fully illegal at once (see _binary_map docstring).
+    _warn_on_simultaneous_legal_illegal(tb)
 
     # Country-level table — drop the requirement and enforcement columns here; they're
     # only used to build combined indicators and aren't published as per-row long-table
@@ -705,28 +705,27 @@ def _detect_structural_placeholders(tb):
     return placeholders
 
 
-# Two-direction laws whose combined indicator is built via _binary_map (legal vs illegal).
-_BINARY_LAWS = ["same_sex_acts", "marriage_equality", "transgender_military", "blood_donations"]
+def _warn_on_simultaneous_legal_illegal(tb):
+    """Warn for any (country, year, law) coded fully legal AND fully illegal in the same year.
 
-
-def _assert_no_unhandled_transition_years(tb):
-    """Fail if any binary-mapped law has a country-year with legal=1 AND illegal=1.
-
-    Such "transition-year artefact" rows fold into "Varies by region" via _binary_map (or go
-    unmapped for marriage) despite carrying no partial/subnational data. As of v2.0 none exist;
-    if a future source version reintroduces them, re-check each occurrence by hand rather than
-    letting it silently inherit the "Varies by region" default. See _binary_map's docstring.
+    For two-direction laws this is a contradiction — the codebook's "transition-year artefact"
+    (a mid-year change logged in both directions). It carries no partial/subnational signal yet
+    feeds the combined indicators (folding into "Varies by region" or an unmapped bucket), so it
+    should be re-checked by hand. Generic across every law — no hard-coded list — so future source
+    versions that introduce such rows in any law surface automatically. As of v2.0 there are none.
     """
     wide = tb.pivot_table(index=["country", "year", "law"], columns="status", values="proportion", aggfunc="first")
-    if "legal" not in wide or "illegal" not in wide:
+    if "legal" not in wide.columns or "illegal" not in wide.columns:
         return
     both = wide[(wide["legal"] == 1) & (wide["illegal"] == 1)]
-    both = both[both.index.get_level_values("law").isin(_BINARY_LAWS)]
-    assert both.empty, (
-        f"Found {len(both)} (country, year, law) rows with legal=1 AND illegal=1 — a transition-year "
-        f"artefact that maps to 'Varies by region' with no partial data. Re-check each before trusting "
-        f"that mapping (see _binary_map docstring):\n{both.index.tolist()}"
-    )
+    if not both.empty:
+        log.warning(
+            "lgbti_national_policy_dataset.simultaneous_legal_illegal",
+            n=int(len(both)),
+            cases=both.index.tolist(),
+            hint="Coded fully legal AND illegal in the same year; re-check the classification "
+            "(transition-year artefact — see _binary_map docstring).",
+        )
 
 
 def _build_regional_aggregates(tb):

--- a/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
@@ -616,7 +616,32 @@ def _build_one_combined(wide, config):
         eoe = wide[f"{law}__{status}__eoe"]
         unenforced_mask = (result == refinement["from_label"]) & (eoe == 0)
         result = result.where(~unenforced_mask, refinement["to_label"])
+
+    _warn_on_unmapped_bucket_patterns(config, keys)
     return result.copy_metadata(wide["country"])
+
+
+def _warn_on_unmapped_bucket_patterns(config, keys):
+    """Warn when an all-integer bucket combination is not explicitly mapped to a category.
+
+    For multi-input indicators (e.g. gender_affirming_care, which crosses adults × minors ×
+    {covered, restricted, neither}) an all-integer combination is a *definite* national state. If
+    it isn't in `category_map` it gets swept into the `default_category` catch-all (or, for configs
+    without one, leaks as a raw bucket string) — the gap that hid "Covered for minors only" etc.
+    Surface these so a reviewer can decide whether each deserves its own category. Partial (0.5)
+    combinations are excluded: those legitimately route to "Varies by region".
+    """
+    explicit = set(config["category_map"])
+    unmapped = keys.notna() & ~keys.isin(explicit) & ~keys.fillna("").str.contains("0.5")
+    if unmapped.any():
+        log.warning(
+            "lgbti_national_policy_dataset.unmapped_bucket_pattern",
+            indicator=config["short_name"],
+            patterns=keys[unmapped].value_counts().to_dict(),
+            hint="All-integer (non-partial) bucket combinations with no explicit category — each is a "
+            "definite state routed to the catch-all. Consider giving it its own category, or fix a "
+            "contradictory same-year coding (see gender_affirming_care).",
+        )
 
 
 def run() -> None:

--- a/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
+++ b/etl/steps/data/garden/lgbt_rights/2026-05-11/lgbti_national_policy_dataset.py
@@ -519,15 +519,20 @@ COMBINED_CONFIGS = [
     # ── Gender-affirming care: adults + minors combined ──────────────
     # 4 source columns (adults covered / restricted, minors covered / restricted) →
     # one categorical indicator over the adults×minors ∈ {covered, restricted, neither}
-    # grid. We map the 8 single-policy national states that occur in the data; only
-    # adults-restricted/minors-covered is unobserved and left to the default.
+    # grid. To keep the legend legible we consolidate the 8 single-policy states that occur
+    # in the data into 6 categories: the salient cases keep their own label (covered for
+    # both, adults-covered/minors-restricted, restricted for both), while the rarer
+    # one-group-only states are merged symmetrically into "Covered for adults or minors only"
+    # and "Restricted for adults or minors only". All states are still mapped explicitly (so
+    # _warn_on_unmapped_bucket_patterns keeps flagging anything new); nothing is silently
+    # swept into the catch-all.
     #
-    # NOTE: with the 8 states mapped, the "Varies by region or other" default now holds
-    # only (a) genuinely partial/subnational country-years (e.g. Canada, United States)
-    # and (b) the lone Brazil 2025 transition-year artefact (adults covered=1 AND
-    # restricted=1). On each new data release, re-check what reaches the default: route
-    # any new stable single-policy state to its own category, and treat covered+restricted
-    # (or legal+illegal) contradictions via the codebook's end-of-year recoding rule.
+    # NOTE: the "Varies by region or other" default holds only (a) genuinely partial/
+    # subnational country-years (e.g. Canada, United States) and (b) the lone Brazil 2025
+    # transition-year artefact (adults covered=1 AND restricted=1). On each new data release,
+    # re-check what reaches the default and what the unmapped-bucket warning surfaces: give a
+    # new stable state its own category, and treat covered+restricted (or legal+illegal)
+    # contradictions via the codebook's end-of-year recoding rule.
     {
         "short_name": "gender_affirming_care",
         "sources": [
@@ -538,15 +543,13 @@ COMBINED_CONFIGS = [
         ],
         "category_map": {
             "ac: 1 ar: 0 mc: 1 mr: 0": "Covered for adults and minors",
-            "ac: 1 ar: 0 mc: 0 mr: 0": "Covered for adults only",
+            "ac: 1 ar: 0 mc: 0 mr: 0": "Covered for adults or minors only",
+            "ac: 0 ar: 0 mc: 1 mr: 0": "Covered for adults or minors only",
             "ac: 1 ar: 0 mc: 0 mr: 1": "Adults covered, minors restricted",
             "ac: 0 ar: 1 mc: 0 mr: 1": "Restricted for both",
+            "ac: 0 ar: 1 mc: 0 mr: 0": "Restricted for adults or minors only",
+            "ac: 0 ar: 0 mc: 0 mr: 1": "Restricted for adults or minors only",
             "ac: 0 ar: 0 mc: 0 mr: 0": "Neither covered nor restricted",
-            # Single-policy national states previously dumped into the catch-all despite
-            # being definite (not regional): minors-only and adults-restricted-only.
-            "ac: 0 ar: 0 mc: 1 mr: 0": "Covered for minors only",
-            "ac: 0 ar: 0 mc: 0 mr: 1": "Restricted for minors only",
-            "ac: 0 ar: 1 mc: 0 mr: 0": "Restricted for adults only",
         },
         "default_category": "Varies by region or other",
     },


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

Fixes two classification bugs in the Velasco **LGBTI National Policy Dataset** (v2.0) combined categorical indicators, refines the gender-affirming-care category scheme, and adds two generic data-quality guards. Found while auditing the dataset against Equaldex and TRIP after external feedback on the gender-marker-change map.

**Scope note:** this PR only touches OWID-side processing. The gender-marker-change criticism itself is a *source* issue (Velasco under-codes legal gender recognition vs. both Equaldex and TRIP) to raise with the producer separately — it is **not** changed here.

## 1. Marriage — "Civil unions only", not "Varies by region" 🐛

`MARRIAGE_MAP` mapped `equality: 0 ban: 1 civil_unions: 1` (same-sex marriage **banned** nationally, civil unions **recognized** nationally) to **"Varies by region"**. There's no subnational dimension to it — the source codes these country-years with `Sub_National_Variation = 0` and no fractional proportions. It's the ban=1 sibling of the already-correct `equality: 0 ban: 0 civil_unions: 1 → "Civil unions only"`.

Reclassified to **"Civil unions only"**, affecting **8 countries / 59 country-years**: Bolivia, Latvia, Croatia, Hungary, Montenegro, Estonia, Ecuador, Canada (1999–2002). All are "marriage banned + national civil unions" regimes, none with subnational variation.

## 2. Gender-affirming care — surface buried states, then consolidate ✨

GAC crosses adults × minors ∈ {covered, restricted, neither}. Three **definite national states** (minors-covered-only, minors-restricted-only, adults-restricted-only — Spain, Hungary, New Zealand) were being swept into the **"Varies by region or other"** catch-all, wrongly implying regional variation (the same failure mode as the marriage bug).

Reworked the category scheme to **7 categories**, mapping every state explicitly and merging only the rare one-group-only states symmetrically:

- Covered for adults and minors
- Covered for adults or minors only *(merges covered-adults-only + covered-minors-only)*
- Adults covered, minors restricted
- Neither covered nor restricted
- Varies by region or other
- Restricted for adults or minors only *(merges restricted-adults-only + restricted-minors-only)*
- Restricted for both

The catch-all drops from **23 → 8 country-years** — now only genuine subnational variation (Canada, US) plus the lone Brazil 2025 covered-and-restricted contradiction. Updates `description_key`, `sort`, the derivation note, and regenerates the regional count/population aggregates to match.

## 3. Guard: warn on simultaneous legal + illegal coding ✨

`_warn_on_simultaneous_legal_illegal` scans **every** law (no hard-coded list) for country-years coded fully legal **and** fully illegal in the same year — the codebook's "transition-year artefact". Logs them for a manual re-check. Zero occur in v2.0; future source versions that introduce them in any law surface automatically.

## 4. Guard: warn on unmapped all-integer bucket combinations ✨

`_warn_on_unmapped_bucket_patterns` runs for **every** combined indicator and warns when an all-integer (non-partial) bucket combination has no explicit category — i.e. a definite state routed to a catch-all or left unmapped. This is the standing check that would have caught the buried GAC states. Partial (0.5) combos are excluded (they legitimately route to "Varies by region"). On v2.0 it flags only the Brazil 2025 contradiction.

## Verification

- Garden re-runs clean; metadata validates against columns; `make check` passes.
- Confirmed across **all** combined indicators: every published "Varies by region" country-year is backed by genuine partial (0<p<1) source data (0 violations).
- Same-sex acts / marriage / adoption checked against Equaldex and TRIP — no false negatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
