### PR TITLE
🐝 Add missing checks to review-data-pr skill

### DIFF
--- a/.claude/skills/review-data-pr/SKILL.md
+++ b/.claude/skills/review-data-pr/SKILL.md
@@ -110,6 +110,27 @@ When in doubt, run the `/check-outdated-practices` skill on the new files.
 - **Annotations**: scan the diff for any `# NOTE:` / `# TODO:` / `# FIXME:` / `# HACK:` / `# XXX:` that are unchanged from the old version. For each, confirm the PR body mentions whether the workaround is still needed, or that it was deleted with its code. Unresolved + undocumented = 🟡.
 - **Sanity-check log flags**: grep the diff for `SHOW_SANITY_CHECK_LOGS`, `DEBUG`, `LONG_FORMAT` set to `True`. If a debug flag was left enabled, that's a 🔴 — must be reverted.
 - **Silent deletes**: in any `sanity_checks` function, scan for `drop`, `filter`, `tb = tb[...]` — row removals that the user might miss. Make sure the PR body lists them.
+- **Findings surfaced, not just flags reverted**: if the step has any sanity-check logic (function or inline `# Sanity check` block), the PR body should carry a "Sanity-check findings" section reporting what the checks said on the new data. A green pipeline run is **not** proof the invariants held — checks that `paths.log.warning(...)`/`.critical(...)` instead of `assert`/`raise` pass silently. If the new garden chain has logging-style checks and the PR body has no findings section, re-run the garden step (`--private --force --only`) and scan stdout/stderr for `warning`, `dropped`, `outlier`, `AssertionError`. Undocumented findings = 🟡; a check that newly raises on the new data = 🔴 (must be triaged with the author per `/update-dataset` §5b).
+
+### 8c. Country harmonization audit (review side)
+
+`/update-dataset` §5c defines the full audit (validate `.countries.json` targets against the canonical regions + income-groups catalogs, audit `.excluded_countries.json`, scan the garden log for the three warnings, and confirm garden-output entities are canonical). As reviewer, verify the **outcome** — every entity reaching Grapher must be canonical, and any that isn't must be documented in the PR body.
+
+Run after the §4 pipeline build. Three checks:
+
+1. **Garden log warnings.** Re-run the garden step capturing output and scan for the three stable warning strings:
+   ```bash
+   .venv/bin/etlr data://garden/<namespace>/<new_version>/<short_name> --private --force --only \
+       > /tmp/<short_name>_harmon.log 2>&1
+   rg -n "missing values in mapping\.|unused values in mapping\.|Unknown country names in excluded countries file:" /tmp/<short_name>_harmon.log
+   ```
+   `missing values in mapping` (source countries not in `.countries.json`) is the actionable one — 🟡 unless the PR body documents the gap. `unused values in mapping` / `Unknown … excluded` are informational 🟢.
+
+2. **Garden-output entities are canonical.** This is the check that catches inline `tb["country"] = "…"` assignments and post-harmonization mutations the `.countries.json` review can't see. Build the canonical set (regions + latest income groups) and diff against the entities actually in the built garden tables — see the Python snippet in `/update-dataset` §5c (Python checks #3 + #5). Any entity in the garden output that isn't in canonical regions or income groups is 🔴 **unless** it's a legitimately custom source aggregate (e.g. `" (ILO)"`/`" (WB)"`-suffixed regions, BRICS, G7) that the PR body explicitly notes lives outside the canonical system.
+
+3. **Over-exclusion.** If `.excluded_countries.json` exists, flag any entry that *is* a canonical region/aggregate (`/update-dataset` §5c Python check #4) — dropping a real country/region silently is 🟡 unless the PR body says why (e.g. source double-counts "World").
+
+If the garden step doesn't use the harmonizer at all (no `.countries.json`; `country` assigned inline), checks #2 and #3 still apply — #2 is the only thing that catches non-canonical inline values.
 
 ### 9. Indicator metadata coverage & dataset block
 
@@ -129,6 +150,15 @@ Any `NULL` row is a 🔴.
 - **Long-format-with-dimensions Jinja coverage.** When variables are keyed by a long-column name (e.g. `proportion`) with `<% if <dim> == "X" %>...<% endif %>` blocks for `title`, `description_short`, `display.name`, verify every active `(dim1, dim2)` cell renders a non-empty value. Easiest check: read every column from the grapher dataset and assert `metadata.title` is non-empty.
 - **`paths.regions.add_population(tb)` / `paths.regions.add_aggregates(tb, regions=[...])` auto-resolve their DAG dependencies.** If the garden step loads `population` (or `income_groups`) via `paths.load_dataset(...)` but never passes the dataset to anything, that's dead code — 🟡. The DAG dependency still needs to be declared either way.
 - **WB income groups in regional aggregates.** When the dataset is suitable for cross-country aggregation, check that the four WB income groups (`High-income countries`, `Upper-middle-income countries`, `Lower-middle-income countries`, `Low-income countries`) are in the `REGIONS` list, the `income_groups` DAG dep is declared, and `description_regions_processing` references the [income groups article](https://ourworldindata.org/world-bank-income-groups-explained). 🟢 informational if absent — not all datasets need this, but it's worth surfacing.
+- **Phantom-category audit on categorical indicators.** For any categorical/ordinal indicator (one whose meta declares a `sort:` label order or a category map), compare the declared labels against the values that actually appear in the built grapher data. Labels declared in `sort:` (or in a category map) but never produced clutter chart legends with empty buckets. Load each categorical column from the grapher dataset, take its unique values, and diff against the `sort:` list:
+  ```python
+  from owid.catalog import Dataset
+  ds = Dataset("data/grapher/<ns>/<v>/<short_name>")
+  tb = ds["<table>"]
+  present = set(tb["<col>"].dropna().astype(str).unique())
+  # compare `present` against the `sort:` labels in the .meta.yml
+  ```
+  Any `sort:`/map label with no backing value is 🟡 — author should drop it from `sort:`/`description_key` (or from the map if it can never occur). Re-check on every refresh: phantoms reappear when a category drops out upstream.
 
 ### 10. Metadata quality skills
 
@@ -143,6 +173,15 @@ rg "<namespace>/<old_version>/<short_name>" dag/ -g "*.yml" | grep -v "^dag/arch
 rg "<namespace>/<old_version>/<short_name>" dag/archive/ -g "*.yml"                    # should match
 rg "<namespace>/<new_version>/<short_name>" dag/ -g "*.yml" | grep -v "^dag/archive"   # should be in old slot, not at bottom
 ```
+
+**Internal version consistency (the silent-stale-data bug).** `etl update` occasionally leaves a new step depending on an *old*-version dep (e.g. new garden still pointing at old meadow or old snapshot), which silently loads stale data. Verify every dep *inside* the new chain's block is on the new version. Read the new chain's DAG block and confirm none of its dependency lines reference `<old_version>`:
+
+```bash
+# Print the new chain's block and eyeball the dependency lines — none should contain <old_version>.
+rg -n -A8 "<namespace>/<new_version>/<short_name>" dag/ -g "*.yml" | rg "<old_version>"   # should be empty
+```
+
+Any hit here is a 🔴 — the new step is wired to a stale dependency.
 
 Visual inspection of the diff for:
 - Comment headers (`# Source — dataset name.`) preserved above both archived and new entries
@@ -190,8 +229,8 @@ Structure the review with:
 
 ## Severity rubric
 
-- 🔴 **Blocker**: missing mandatory metadata field, broken link, failing pipeline step, breaking change to chart data, missing `update_period_days`, missing `presentation.attribution_short`, outdated `__main__` block in snapshot, DAG reference to old version that should be archived
-- 🟡 **Suggestion**: brittle assertion, hardcoded year that should be dynamic, duplicated grapher meta.yml that could be removed, non-blocking style issues
+- 🔴 **Blocker**: missing mandatory metadata field, broken link, failing pipeline step, breaking change to chart data, missing `update_period_days`, missing `presentation.attribution_short`, outdated `__main__` block in snapshot, DAG reference to old version that should be archived, new step wired to a stale (old-version) DAG dependency, non-canonical garden-output entity that isn't a documented custom aggregate, sanity check that newly raises on the new data
+- 🟡 **Suggestion**: brittle assertion, hardcoded year that should be dynamic, duplicated grapher meta.yml that could be removed, non-blocking style issues, undocumented sanity-check findings, phantom `sort:` labels with no backing value, over-exclusion of a canonical region, undocumented `missing values in mapping` countries
 - 🟢 **Informational**: things to be aware of but not action items
 
 ## Notes


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

Adds four review checks to the `/review-data-pr` skill that were present in `/update-dataset` but missing on the review side.

## What's added

- **§8c — Country harmonization audit (review side).** Verifies the outcome of `/update-dataset` §5c: scans the garden log for the three harmonization warnings, confirms every garden-output entity is canonical (catches inline `tb["country"]=…` assignments the `.countries.json` check can't see), and flags over-exclusion in `.excluded_countries.json`. Non-canonical undocumented entity = 🔴.
- **§11 — DAG internal version consistency.** New `rg -A8 … | rg "<old_version>"` check for the silent-stale-data bug, where a new step still depends on an old-version dep (e.g. new garden → old meadow). Any hit = 🔴.
- **§9 — Phantom-category audit.** For categorical/ordinal indicators, diffs `sort:`/category-map labels against values actually present in the built grapher data; unbacked labels that clutter legends = 🟡.
- **§8b — Sanity-check findings, not just flags.** Verifies the PR body carries a "Sanity-check findings" section when the step has sanity logic, and notes that logging-style checks (`paths.log.warning`) pass silently — a green run isn't proof.

Severity rubric updated to list the new blockers/suggestions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)