### PR TITLE
📊 Add dumbbell plots to inequality MDims

### DIFF
--- a/.claude/skills/faust-metadata-audit/SKILL.md
+++ b/.claude/skills/faust-metadata-audit/SKILL.md
@@ -186,6 +186,24 @@ Then audit:
    - rarely, the indicator's `presentation.grapher_config` block (when the issue is title/subtitle/note rather than description_key)
 8. **After every fix push**, re-run garden + grapher + MDim export and re-verify against the report.
 
+## Regression diff: prove a refactor didn't change user-facing text
+
+When you change an MDim `.py` (reorder indicators, flip a `before_vs_after` choice order, change which y-indicator is primary, rename a helper) and need to prove the rendered FAUST is **unchanged except for the intended diff**, diff two auto-generated reports instead of eyeballing one. This is the right check whenever a change shifts the **primary y-indicator** (`y[0]`), because that's what drives inheritance — the script resolves every `[inherited]` field from `y[0]`, so identical reports prove the inherited text doesn't depend on which variant is primary (e.g. flipping LIS `welfare_type` from `dhi`-first to `mi`-first leaves all six fields byte-identical because `mi`/`dhi` share every inheritable field and the overrides resolve the same).
+
+`config_path` accepts **any** JSON path, not just the live `export/multidim/.../<name>.config.json` — so point two runs at two config snapshots:
+
+1. Build the baseline config (e.g. `git checkout origin/master -- <step>.py && etlr <mdim> --export --grapher`) and copy its `<name>.config.json` to `/tmp/cfg_before/`. Restore your branch (`git checkout HEAD -- <step>.py`), rebuild, copy to `/tmp/cfg_after/`. (Note: `git checkout … -- a.py b.py` won't word-split an unquoted `$files` var in zsh — pass the paths literally or use an array.)
+2. Run the report against each snapshot:
+   ```
+   echo '[{"name":"gini_lis_BEFORE","config_path":"/tmp/cfg_before/gini_lis.json","collapse_dims":[]}]' > /tmp/fb.json
+   echo '[{"name":"gini_lis_AFTER","config_path":"/tmp/cfg_after/gini_lis.json","collapse_dims":[]}]'  > /tmp/fa.json
+   .venv/bin/python .claude/skills/faust-metadata-audit/scripts/generate_mdim_text_report.py --config /tmp/fb.json
+   .venv/bin/python .claude/skills/faust-metadata-audit/scripts/generate_mdim_text_report.py --config /tmp/fa.json
+   ```
+3. Diff, stripping the BEFORE/AFTER name token: `diff <(sed 's/BEFORE//g' ai/gini_lis_BEFORE.md) <(sed 's/AFTER//g' ai/gini_lis_AFTER.md)`. Byte-identical = Title/Subtitle/Footnote/description_short/description_key all render the same.
+
+The FAUST diff only covers user-facing **text**. It will NOT catch indicator-order-only changes (e.g. a Dumbbell arrow direction or a LineChart series-color swap that follows column order) — pair it with a structural diff of the two `.config.json` files when order matters.
+
 ## Things to avoid
 
 - Do NOT fall back to `title` / `title_public` / `display.name` / `description_short` when resolving chart Title / Subtitle / Footnote. Use `grapher_config` only (see inheritance rules above).

--- a/etl/steps/export/multidim/lis/latest/gini_lis.py
+++ b/etl/steps/export/multidim/lis/latest/gini_lis.py
@@ -45,7 +45,7 @@ def run() -> None:
         groups=[
             {
                 "dimension": "welfare_type",
-                "choices": ["dhi", "mi"],
+                "choices": ["mi", "dhi"],
                 "choice_new_slug": "before_vs_after",
                 "view_config": {
                     "hideRelativeToggle": True,
@@ -72,8 +72,6 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
-            # Order before -> after so the dumbbell arrow points from before to after taxes
-            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "_mi_" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "_dhi_" in ind.catalogPath:
                     ind.display = {"name": "After taxes and benefits"}
@@ -88,7 +86,9 @@ def _get_before_vs_after_metadata(tb, view):
     if not view.indicators.y:
         return {"title": "", "subtitle": "", "description_key": []}
 
-    first_ind = view.indicators.y[0]
+    # Build the combined title/subtitle from the before-tax (mi) indicator, so it doesn't
+    # depend on the order of indicators in the view (mirrors the WID before_vs_after logic).
+    first_ind = next((i for i in view.indicators.y if "_mi_" in i.catalogPath), view.indicators.y[0])
     col_name = first_ind.catalogPath.split("#")[-1] if "#" in first_ind.catalogPath else None
 
     if col_name and col_name in tb.columns:
@@ -97,14 +97,14 @@ def _get_before_vs_after_metadata(tb, view):
 
         title = _assert_and_replace(
             grapher_config.get("title", "Gini coefficient"),
-            "after tax",
+            "before tax",
             "before vs. after tax",
             "grapher_config.title",
             col_name,
         )
         subtitle = _assert_and_replace(
             grapher_config.get("subtitle", ""),
-            " Inequality is measured here in terms of income after taxes and benefits.",
+            " Inequality is measured here in terms of income before taxes and benefits.",
             "",
             "grapher_config.subtitle",
             col_name,

--- a/etl/steps/export/multidim/lis/latest/gini_lis.py
+++ b/etl/steps/export/multidim/lis/latest/gini_lis.py
@@ -26,6 +26,11 @@ OLD_DESCRIPTION_KEY_WELFARE_TYPE_MI = (
 NEW_DESCRIPTION_KEY_BEFORE_VS_AFTER = "This data is based on income measured both before and after taxes and benefits, which are shown separately. In most countries, inequality is lower after taxes and benefits than before, but the extent varies widely."
 
 
+def _after_tax_catalog_path(view):
+    """Return the after-tax (dhi) indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None)
+
+
 def run() -> None:
     config = paths.load_collection_config()
 
@@ -56,9 +61,7 @@ def run() -> None:
                     "missingDataStrategy": "hide",
                     # Sort the dumbbell (and table) entities by the after-tax value, highest first
                     "sortBy": "column",
-                    "sortColumnSlug": lambda view: next(
-                        (i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None
-                    ),
+                    "sortColumnSlug": _after_tax_catalog_path,
                     "sortOrder": "desc",
                     "title": "{title}",
                     "subtitle": "{subtitle}",

--- a/etl/steps/export/multidim/lis/latest/gini_lis.py
+++ b/etl/steps/export/multidim/lis/latest/gini_lis.py
@@ -52,7 +52,7 @@ def run() -> None:
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
-                    "chartTypes": ["LineChart"],
+                    "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
                     "title": "{title}",
                     "subtitle": "{subtitle}",

--- a/etl/steps/export/multidim/lis/latest/gini_lis.py
+++ b/etl/steps/export/multidim/lis/latest/gini_lis.py
@@ -26,11 +26,6 @@ OLD_DESCRIPTION_KEY_WELFARE_TYPE_MI = (
 NEW_DESCRIPTION_KEY_BEFORE_VS_AFTER = "This data is based on income measured both before and after taxes and benefits, which are shown separately. In most countries, inequality is lower after taxes and benefits than before, but the extent varies widely."
 
 
-def _after_tax_catalog_path(view):
-    """Return the after-tax (dhi) indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
-    return next((i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None)
-
-
 def run() -> None:
     config = paths.load_collection_config()
 
@@ -88,6 +83,11 @@ def run() -> None:
                     ind.display = {"name": "Before taxes and benefits"}
 
     c.save()
+
+
+def _after_tax_catalog_path(view):
+    """Return the after-tax (dhi) indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None)
 
 
 def _get_before_vs_after_metadata(tb, view):

--- a/etl/steps/export/multidim/lis/latest/gini_lis.py
+++ b/etl/steps/export/multidim/lis/latest/gini_lis.py
@@ -72,6 +72,8 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
+            # Order before -> after so the dumbbell arrow points from before to after taxes
+            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "_mi_" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "_dhi_" in ind.catalogPath:
                     ind.display = {"name": "After taxes and benefits"}

--- a/etl/steps/export/multidim/lis/latest/gini_lis.py
+++ b/etl/steps/export/multidim/lis/latest/gini_lis.py
@@ -54,10 +54,10 @@ def run() -> None:
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
-                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    # Sort the dumbbell (and table) entities by the after-tax value, lowest first
                     "sortBy": "column",
                     "sortColumnSlug": _after_tax_catalog_path,
-                    "sortOrder": "desc",
+                    "sortOrder": "asc",
                     "title": "{title}",
                     "subtitle": "{subtitle}",
                 },

--- a/etl/steps/export/multidim/lis/latest/gini_lis.py
+++ b/etl/steps/export/multidim/lis/latest/gini_lis.py
@@ -54,6 +54,12 @@ def run() -> None:
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
+                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    "sortBy": "column",
+                    "sortColumnSlug": lambda view: next(
+                        (i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None
+                    ),
+                    "sortOrder": "desc",
                     "title": "{title}",
                     "subtitle": "{subtitle}",
                 },

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.py
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.py
@@ -36,11 +36,6 @@ OLD_DESCRIPTION_KEY_THR = 'This data shows the income threshold for a given deci
 NEW_DESCRIPTION_KEY_THR_ALL = 'This data shows the income threshold for each decile of the population. The "poorest decile" threshold, for example, is the income level below which the poorest 10% of people in a country fall.'
 
 
-def _after_tax_catalog_path(view):
-    """Return the after-tax (dhi) indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
-    return next((i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None)
-
-
 def run() -> None:
     config = paths.load_collection_config()
 
@@ -233,6 +228,11 @@ def _get_grouped_decile_subtitle(view):
         "share": f"The share of income received by each decile (tenth of the population). Income here is measured {wt_label}es and benefits.",
     }
     return subtitles.get(view.dimensions.get("indicator"), "")
+
+
+def _after_tax_catalog_path(view):
+    """Return the after-tax (dhi) indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None)
 
 
 def _get_before_vs_after_metadata(tb, view):

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.py
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.py
@@ -164,6 +164,12 @@ def run() -> None:
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
+                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    "sortBy": "column",
+                    "sortColumnSlug": lambda view: next(
+                        (i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None
+                    ),
+                    "sortOrder": "desc",
                     "title": "{title}",
                     "subtitle": "{subtitle}",
                     "note": "",

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.py
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.py
@@ -193,6 +193,8 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
+            # Order before -> after so the dumbbell arrow points from before to after taxes
+            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "_mi_" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "_dhi_" in ind.catalogPath:
                     ind.display = {"name": "After taxes and benefits"}

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.py
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.py
@@ -162,7 +162,7 @@ def run() -> None:
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
-                    "chartTypes": ["LineChart"],
+                    "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
                     "title": "{title}",
                     "subtitle": "{subtitle}",

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.py
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.py
@@ -155,7 +155,7 @@ def run() -> None:
         groups=[
             {
                 "dimension": "welfare_type",
-                "choices": ["dhi", "mi"],
+                "choices": ["mi", "dhi"],
                 "choice_new_slug": "before_vs_after",
                 "view_config": {
                     "hideRelativeToggle": True,
@@ -193,8 +193,6 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
-            # Order before -> after so the dumbbell arrow points from before to after taxes
-            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "_mi_" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "_dhi_" in ind.catalogPath:
                     ind.display = {"name": "After taxes and benefits"}
@@ -236,7 +234,9 @@ def _get_before_vs_after_metadata(tb, view):
     if not view.indicators.y:
         return {"title": "", "subtitle": "", "description_key": []}
 
-    first_ind = view.indicators.y[0]
+    # Build the combined title/subtitle from the before-tax (mi) indicator, so it doesn't
+    # depend on the order of indicators in the view (mirrors the WID before_vs_after logic).
+    first_ind = next((i for i in view.indicators.y if "_mi_" in i.catalogPath), view.indicators.y[0])
     col_name = first_ind.catalogPath.split("#")[-1] if "#" in first_ind.catalogPath else None
 
     if col_name and col_name in tb.columns:
@@ -244,11 +244,11 @@ def _get_before_vs_after_metadata(tb, view):
         grapher_config = meta.presentation.grapher_config if meta.presentation else {}
 
         title = _assert_and_replace(
-            grapher_config.get("title", ""), "after tax", "before vs. after tax", "grapher_config.title", col_name
+            grapher_config.get("title", ""), "before tax", "before vs. after tax", "grapher_config.title", col_name
         )
         subtitle = _assert_and_replace(
             grapher_config.get("subtitle", ""),
-            " Income here is measured after taxes and benefits.",
+            " Income here is measured before taxes and benefits.",
             "",
             "grapher_config.subtitle",
             col_name,

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.py
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.py
@@ -164,10 +164,10 @@ def run() -> None:
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
-                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    # Sort the dumbbell (and table) entities by the after-tax value, lowest first
                     "sortBy": "column",
                     "sortColumnSlug": _after_tax_catalog_path,
-                    "sortOrder": "desc",
+                    "sortOrder": "asc",
                     "title": "{title}",
                     "subtitle": "{subtitle}",
                     "note": "",

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.py
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.py
@@ -36,6 +36,11 @@ OLD_DESCRIPTION_KEY_THR = 'This data shows the income threshold for a given deci
 NEW_DESCRIPTION_KEY_THR_ALL = 'This data shows the income threshold for each decile of the population. The "poorest decile" threshold, for example, is the income level below which the poorest 10% of people in a country fall.'
 
 
+def _after_tax_catalog_path(view):
+    """Return the after-tax (dhi) indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None)
+
+
 def run() -> None:
     config = paths.load_collection_config()
 
@@ -166,9 +171,7 @@ def run() -> None:
                     "missingDataStrategy": "hide",
                     # Sort the dumbbell (and table) entities by the after-tax value, highest first
                     "sortBy": "column",
-                    "sortColumnSlug": lambda view: next(
-                        (i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None
-                    ),
+                    "sortColumnSlug": _after_tax_catalog_path,
                     "sortOrder": "desc",
                     "title": "{title}",
                     "subtitle": "{subtitle}",

--- a/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
+++ b/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
@@ -57,10 +57,10 @@ def run() -> None:
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
-                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    # Sort the dumbbell (and table) entities by the after-tax value, lowest first
                     "sortBy": "column",
                     "sortColumnSlug": _after_tax_catalog_path,
-                    "sortOrder": "desc",
+                    "sortOrder": "asc",
                 },
                 "view_metadata": {
                     "description_short": "{subtitle}",

--- a/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
+++ b/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
@@ -57,6 +57,12 @@ def run() -> None:
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
+                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    "sortBy": "column",
+                    "sortColumnSlug": lambda view: next(
+                        (i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None
+                    ),
+                    "sortOrder": "desc",
                 },
                 "view_metadata": {
                     "description_short": "{subtitle}",

--- a/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
+++ b/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
@@ -27,6 +27,11 @@ OLD_DESCRIPTION_KEY_WELFARE_TYPE_MI = (
 NEW_DESCRIPTION_KEY_BEFORE_VS_AFTER = "This data is based on income measured both before and after taxes and benefits, which are shown separately. In most countries, relative poverty is lower after taxes and benefits than before, but the extent varies widely."
 
 
+def _after_tax_catalog_path(view):
+    """Return the after-tax (dhi) indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None)
+
+
 def run() -> None:
     config = paths.load_collection_config()
 
@@ -59,9 +64,7 @@ def run() -> None:
                     "missingDataStrategy": "hide",
                     # Sort the dumbbell (and table) entities by the after-tax value, highest first
                     "sortBy": "column",
-                    "sortColumnSlug": lambda view: next(
-                        (i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None
-                    ),
+                    "sortColumnSlug": _after_tax_catalog_path,
                     "sortOrder": "desc",
                 },
                 "view_metadata": {

--- a/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
+++ b/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
@@ -27,11 +27,6 @@ OLD_DESCRIPTION_KEY_WELFARE_TYPE_MI = (
 NEW_DESCRIPTION_KEY_BEFORE_VS_AFTER = "This data is based on income measured both before and after taxes and benefits, which are shown separately. In most countries, relative poverty is lower after taxes and benefits than before, but the extent varies widely."
 
 
-def _after_tax_catalog_path(view):
-    """Return the after-tax (dhi) indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
-    return next((i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None)
-
-
 def run() -> None:
     config = paths.load_collection_config()
 
@@ -89,6 +84,11 @@ def run() -> None:
                     ind.display = {"name": "Before taxes and benefits"}
 
     c.save()
+
+
+def _after_tax_catalog_path(view):
+    """Return the after-tax (dhi) indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "_dhi_" in i.catalogPath), None)
 
 
 def _get_before_vs_after_metadata(tb, view):

--- a/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
+++ b/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
@@ -73,6 +73,8 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
+            # Order before -> after so the dumbbell arrow points from before to after taxes
+            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "_mi_" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "_dhi_" in ind.catalogPath:
                     ind.display = {"name": "After taxes and benefits"}

--- a/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
+++ b/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
@@ -55,7 +55,7 @@ def run() -> None:
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
-                    "chartTypes": ["LineChart"],
+                    "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
                 },
                 "view_metadata": {

--- a/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
+++ b/etl/steps/export/multidim/lis/latest/relative_poverty_lis.py
@@ -46,7 +46,7 @@ def run() -> None:
         groups=[
             {
                 "dimension": "welfare_type",
-                "choices": ["dhi", "mi"],
+                "choices": ["mi", "dhi"],
                 "choice_new_slug": "before_vs_after",
                 "view_config": {
                     "title": "{title}",
@@ -73,8 +73,6 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
-            # Order before -> after so the dumbbell arrow points from before to after taxes
-            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "_mi_" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "_dhi_" in ind.catalogPath:
                     ind.display = {"name": "After taxes and benefits"}
@@ -89,7 +87,9 @@ def _get_before_vs_after_metadata(tb, view):
     if not view.indicators.y:
         return {"title": "", "subtitle": "", "description_key": []}
 
-    first_ind = view.indicators.y[0]
+    # Build the combined title/subtitle from the before-tax (mi) indicator, so it doesn't
+    # depend on the order of indicators in the view (mirrors the WID before_vs_after logic).
+    first_ind = next((i for i in view.indicators.y if "_mi_" in i.catalogPath), view.indicators.y[0])
     col_name = first_ind.catalogPath.split("#")[-1] if "#" in first_ind.catalogPath else None
 
     if col_name and col_name in tb.columns:
@@ -97,11 +97,11 @@ def _get_before_vs_after_metadata(tb, view):
         grapher_config = meta.presentation.grapher_config if meta.presentation else {}
 
         title = _assert_and_replace(
-            grapher_config.get("title", ""), "after tax", "before vs. after tax", "grapher_config.title", col_name
+            grapher_config.get("title", ""), "before tax", "before vs. after tax", "grapher_config.title", col_name
         )
         subtitle = _assert_and_replace(
             grapher_config.get("subtitle", ""),
-            " Income here is measured after taxes and benefits.",
+            " Income here is measured before taxes and benefits.",
             "",
             "grapher_config.subtitle",
             col_name,

--- a/etl/steps/export/multidim/wid/latest/gini_wid.py
+++ b/etl/steps/export/multidim/wid/latest/gini_wid.py
@@ -57,10 +57,10 @@ def run() -> None:
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
-                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    # Sort the dumbbell (and table) entities by the after-tax value, lowest first
                     "sortBy": "column",
                     "sortColumnSlug": _after_tax_catalog_path,
-                    "sortOrder": "desc",
+                    "sortOrder": "asc",
                 },
                 "view_metadata": {
                     "description_short": "{subtitle}",

--- a/etl/steps/export/multidim/wid/latest/gini_wid.py
+++ b/etl/steps/export/multidim/wid/latest/gini_wid.py
@@ -55,7 +55,7 @@ def run() -> None:
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
-                    "chartTypes": ["LineChart"],
+                    "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
                 },
                 "view_metadata": {

--- a/etl/steps/export/multidim/wid/latest/gini_wid.py
+++ b/etl/steps/export/multidim/wid/latest/gini_wid.py
@@ -57,6 +57,12 @@ def run() -> None:
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
+                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    "sortBy": "column",
+                    "sortColumnSlug": lambda view: next(
+                        (i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None
+                    ),
+                    "sortOrder": "desc",
                 },
                 "view_metadata": {
                     "description_short": "{subtitle}",

--- a/etl/steps/export/multidim/wid/latest/gini_wid.py
+++ b/etl/steps/export/multidim/wid/latest/gini_wid.py
@@ -73,6 +73,8 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
+            # Order before -> after so the dumbbell arrow points from before to after taxes
+            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "before_tax" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "before_tax" in ind.catalogPath:
                     ind.display = {"name": "Before taxes and benefits"}

--- a/etl/steps/export/multidim/wid/latest/gini_wid.py
+++ b/etl/steps/export/multidim/wid/latest/gini_wid.py
@@ -26,6 +26,11 @@ NEW_DESCRIPTION_KEY_BEFORE_VS_AFTER = "This data is based on income measured bot
 DESCRIPTION_KEY_AFTER_TAX_AVAILABILITY = "Data on income after tax and benefits is less widely available than that before tax. Where it is missing, distributions are constructed from the more widely available pre-tax data, combined with data on tax revenue and government expenditure. This method is described in more detail in this [technical note](https://wid.world/document/preliminary-estimates-of-global-posttax-income-distributions-world-inequality-lab-technical-note-2023-02/)."
 
 
+def _after_tax_catalog_path(view):
+    """Return the after-tax indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None)
+
+
 def run() -> None:
     config = paths.load_collection_config()
 
@@ -59,9 +64,7 @@ def run() -> None:
                     "missingDataStrategy": "hide",
                     # Sort the dumbbell (and table) entities by the after-tax value, highest first
                     "sortBy": "column",
-                    "sortColumnSlug": lambda view: next(
-                        (i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None
-                    ),
+                    "sortColumnSlug": _after_tax_catalog_path,
                     "sortOrder": "desc",
                 },
                 "view_metadata": {

--- a/etl/steps/export/multidim/wid/latest/gini_wid.py
+++ b/etl/steps/export/multidim/wid/latest/gini_wid.py
@@ -73,8 +73,6 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
-            # Order before -> after so the dumbbell arrow points from before to after taxes
-            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "before_tax" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "before_tax" in ind.catalogPath:
                     ind.display = {"name": "Before taxes and benefits"}

--- a/etl/steps/export/multidim/wid/latest/gini_wid.py
+++ b/etl/steps/export/multidim/wid/latest/gini_wid.py
@@ -26,11 +26,6 @@ NEW_DESCRIPTION_KEY_BEFORE_VS_AFTER = "This data is based on income measured bot
 DESCRIPTION_KEY_AFTER_TAX_AVAILABILITY = "Data on income after tax and benefits is less widely available than that before tax. Where it is missing, distributions are constructed from the more widely available pre-tax data, combined with data on tax revenue and government expenditure. This method is described in more detail in this [technical note](https://wid.world/document/preliminary-estimates-of-global-posttax-income-distributions-world-inequality-lab-technical-note-2023-02/)."
 
 
-def _after_tax_catalog_path(view):
-    """Return the after-tax indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
-    return next((i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None)
-
-
 def run() -> None:
     config = paths.load_collection_config()
 
@@ -89,6 +84,11 @@ def run() -> None:
                     ind.display = {"name": "After taxes and benefits"}
 
     c.save()
+
+
+def _after_tax_catalog_path(view):
+    """Return the after-tax indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None)
 
 
 def _get_before_vs_after_metadata(tb, view):

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.py
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.py
@@ -166,8 +166,6 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
-            # Order before -> after so the dumbbell arrow points from before to after taxes
-            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "before_tax" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "before_tax" in ind.catalogPath:
                     ind.display = {"name": "Before taxes and benefits"}

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.py
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.py
@@ -32,6 +32,11 @@ NEW_DESCRIPTION_KEY_BEFORE_VS_AFTER = "This data is based on income measured bot
 DESCRIPTION_KEY_AFTER_TAX_AVAILABILITY = "Data on income after tax and benefits is less widely available than that before tax. Where it is missing, distributions are constructed from the more widely available pre-tax data, combined with data on tax revenue and government expenditure. This method is described in more detail in this [technical note](https://wid.world/document/preliminary-estimates-of-global-posttax-income-distributions-world-inequality-lab-technical-note-2023-02/)."
 
 
+def _after_tax_catalog_path(view):
+    """Return the after-tax indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None)
+
+
 def run() -> None:
     #
     # Load inputs.
@@ -144,9 +149,7 @@ def run() -> None:
                     "chartTypes": ["LineChart", "Dumbbell"],
                     # Sort the dumbbell (and table) entities by the after-tax value, highest first
                     "sortBy": "column",
-                    "sortColumnSlug": lambda view: next(
-                        (i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None
-                    ),
+                    "sortColumnSlug": _after_tax_catalog_path,
                     "sortOrder": "desc",
                 },
                 "view_metadata": {

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.py
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.py
@@ -142,10 +142,10 @@ def run() -> None:
                     "hasMapTab": False,
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
-                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    # Sort the dumbbell (and table) entities by the after-tax value, lowest first
                     "sortBy": "column",
                     "sortColumnSlug": _after_tax_catalog_path,
-                    "sortOrder": "desc",
+                    "sortOrder": "asc",
                 },
                 "view_metadata": {
                     "description_short": lambda view: _get_before_vs_after_metadata(tb, view)["description_short"],

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.py
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.py
@@ -32,11 +32,6 @@ NEW_DESCRIPTION_KEY_BEFORE_VS_AFTER = "This data is based on income measured bot
 DESCRIPTION_KEY_AFTER_TAX_AVAILABILITY = "Data on income after tax and benefits is less widely available than that before tax. Where it is missing, distributions are constructed from the more widely available pre-tax data, combined with data on tax revenue and government expenditure. This method is described in more detail in this [technical note](https://wid.world/document/preliminary-estimates-of-global-posttax-income-distributions-world-inequality-lab-technical-note-2023-02/)."
 
 
-def _after_tax_catalog_path(view):
-    """Return the after-tax indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
-    return next((i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None)
-
-
 def run() -> None:
     #
     # Load inputs.
@@ -197,6 +192,11 @@ def _get_grouped_quantile_subtitle(view):
     """Return subtitle for grouped quantile views."""
     welfare_type = view.dimensions.get("welfare_type")
     return f"The share of income received by each decile (tenth of the population). Income here is measured {welfare_type}es and benefits."
+
+
+def _after_tax_catalog_path(view):
+    """Return the after-tax indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None)
 
 
 def _get_before_vs_after_metadata(tb, view):

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.py
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.py
@@ -141,7 +141,7 @@ def run() -> None:
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
-                    "chartTypes": ["LineChart"],
+                    "chartTypes": ["LineChart", "Dumbbell"],
                 },
                 "view_metadata": {
                     "description_short": lambda view: _get_before_vs_after_metadata(tb, view)["description_short"],

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.py
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.py
@@ -166,6 +166,8 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
+            # Order before -> after so the dumbbell arrow points from before to after taxes
+            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "before_tax" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "before_tax" in ind.catalogPath:
                     ind.display = {"name": "Before taxes and benefits"}

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.py
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.py
@@ -142,6 +142,12 @@ def run() -> None:
                     "hasMapTab": False,
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
+                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    "sortBy": "column",
+                    "sortColumnSlug": lambda view: next(
+                        (i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None
+                    ),
+                    "sortOrder": "desc",
                 },
                 "view_metadata": {
                     "description_short": lambda view: _get_before_vs_after_metadata(tb, view)["description_short"],

--- a/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
+++ b/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
@@ -57,10 +57,10 @@ def run() -> None:
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
-                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    # Sort the dumbbell (and table) entities by the after-tax value, lowest first
                     "sortBy": "column",
                     "sortColumnSlug": _after_tax_catalog_path,
-                    "sortOrder": "desc",
+                    "sortOrder": "asc",
                 },
                 "view_metadata": {
                     "description_short": "{subtitle}",

--- a/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
+++ b/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
@@ -55,7 +55,7 @@ def run() -> None:
                     "selectedFacetStrategy": "entity",
                     "hasMapTab": False,
                     "tab": "chart",
-                    "chartTypes": ["LineChart"],
+                    "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
                 },
                 "view_metadata": {

--- a/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
+++ b/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
@@ -57,6 +57,12 @@ def run() -> None:
                     "tab": "chart",
                     "chartTypes": ["LineChart", "Dumbbell"],
                     "missingDataStrategy": "hide",
+                    # Sort the dumbbell (and table) entities by the after-tax value, highest first
+                    "sortBy": "column",
+                    "sortColumnSlug": lambda view: next(
+                        (i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None
+                    ),
+                    "sortOrder": "desc",
                 },
                 "view_metadata": {
                     "description_short": "{subtitle}",

--- a/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
+++ b/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
@@ -73,6 +73,8 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
+            # Order before -> after so the dumbbell arrow points from before to after taxes
+            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "before_tax" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "before_tax" in ind.catalogPath:
                     ind.display = {"name": "Before taxes and benefits"}

--- a/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
+++ b/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
@@ -26,6 +26,11 @@ NEW_DESCRIPTION_KEY_BEFORE_VS_AFTER = "This data is based on income measured bot
 DESCRIPTION_KEY_AFTER_TAX_AVAILABILITY = "Data on income after tax and benefits is less widely available than that before tax. Where it is missing, distributions are constructed from the more widely available pre-tax data, combined with data on tax revenue and government expenditure. This method is described in more detail in this [technical note](https://wid.world/document/preliminary-estimates-of-global-posttax-income-distributions-world-inequality-lab-technical-note-2023-02/)."
 
 
+def _after_tax_catalog_path(view):
+    """Return the after-tax indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None)
+
+
 def run() -> None:
     config = paths.load_collection_config()
 
@@ -59,9 +64,7 @@ def run() -> None:
                     "missingDataStrategy": "hide",
                     # Sort the dumbbell (and table) entities by the after-tax value, highest first
                     "sortBy": "column",
-                    "sortColumnSlug": lambda view: next(
-                        (i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None
-                    ),
+                    "sortColumnSlug": _after_tax_catalog_path,
                     "sortOrder": "desc",
                 },
                 "view_metadata": {

--- a/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
+++ b/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
@@ -73,8 +73,6 @@ def run() -> None:
     # Set display names for before_vs_after views
     for view in c.views:
         if view.dimensions.get("welfare_type") == "before_vs_after" and view.indicators.y:
-            # Order before -> after so the dumbbell arrow points from before to after taxes
-            view.indicators.y = sorted(view.indicators.y, key=lambda ind: 0 if "before_tax" in ind.catalogPath else 1)
             for ind in view.indicators.y:
                 if "before_tax" in ind.catalogPath:
                     ind.display = {"name": "Before taxes and benefits"}

--- a/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
+++ b/etl/steps/export/multidim/wid/latest/palma_ratio_wid.py
@@ -26,11 +26,6 @@ NEW_DESCRIPTION_KEY_BEFORE_VS_AFTER = "This data is based on income measured bot
 DESCRIPTION_KEY_AFTER_TAX_AVAILABILITY = "Data on income after tax and benefits is less widely available than that before tax. Where it is missing, distributions are constructed from the more widely available pre-tax data, combined with data on tax revenue and government expenditure. This method is described in more detail in this [technical note](https://wid.world/document/preliminary-estimates-of-global-posttax-income-distributions-world-inequality-lab-technical-note-2023-02/)."
 
 
-def _after_tax_catalog_path(view):
-    """Return the after-tax indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
-    return next((i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None)
-
-
 def run() -> None:
     config = paths.load_collection_config()
 
@@ -89,6 +84,11 @@ def run() -> None:
                     ind.display = {"name": "After taxes and benefits"}
 
     c.save()
+
+
+def _after_tax_catalog_path(view):
+    """Return the after-tax indicator's catalogPath for a before_vs_after view (used to sort entities by it)."""
+    return next((i.catalogPath for i in view.indicators.y if "after_tax" in i.catalogPath), None)
 
 
 def _get_before_vs_after_metadata(tb, view):

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -1643,9 +1643,52 @@
                               "SlopeChart",
                               "StackedBar",
                               "WorldMap",
-                              "Marimekko"
+                              "Marimekko",
+                              "Dumbbell"
                             ]
                           }
+                        },
+                        "dumbbell": {
+                          "type": "object",
+                          "description": "Configuration of the dumbbell chart",
+                          "properties": {
+                            "connectorStyle": {
+                              "type": "string",
+                              "default": "arrow",
+                              "description": "How the connector between dumbbell heads is drawn.\n- arrow: draw an arrow pointing from start to end\n- line: draw a simple line (only respected when two indicators are plotted)\n",
+                              "enum": [
+                                "arrow",
+                                "line"
+                              ]
+                            },
+                            "valueLabelMode": {
+                              "type": "string",
+                              "default": "absolute",
+                              "description": "What to display as value labels next to each dumbbell.\n- absolute: show the raw values at the start and end\n- change: show the absolute change (e.g. +50)\n- percentChange: show the percentage change (e.g. +33%)\n- none: hide value labels\n",
+                              "enum": [
+                                "absolute",
+                                "change",
+                                "percentChange",
+                                "none"
+                              ]
+                            },
+                            "trendColorMap": {
+                              "type": "object",
+                              "description": "Custom colors for the time-range encoding",
+                              "properties": {
+                                "increase": {
+                                  "type": "string",
+                                  "description": "Color for dumbbells whose value increased over time"
+                                },
+                                "decrease": {
+                                  "type": "string",
+                                  "description": "Color for dumbbells whose value decreased over time"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
                         },
                         "hasMapTab": {
                           "oneOf": [


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

Adds a **Dumbbell** chart tab to the "Before vs. after taxes and benefits" view of the LIS and WID inequality MDims, so users can see each country's before- and after-tax value side by side (two dots connected by an arrow) alongside the existing line chart.

## MDims affected

| Source | MDims |
|---|---|
| **LIS** | `gini_lis`, `incomes_lis`, `relative_poverty_lis` |
| **WID** | `gini_wid`, `incomes_wid`, `palma_ratio_wid` |

WB PIP is **excluded** — its welfare types are income vs. consumption, not before/after tax, so a before-vs-after dumbbell doesn't apply there.

## What changed

- **Dumbbell tab.** `"Dumbbell"` added to `chartTypes` on each `before_vs_after` view (kept as a secondary tab; the line chart stays the default). With two y-indicators, Grapher's dumbbell renders in TwoColumn mode at the latest year — exactly the before/after-tax comparison.
- **Arrow direction (before → after).** The arrow points from `yColumns[0]` → `yColumns[1]`, i.e. the indicator order. `group_views` orders indicators by choice order, so the LIS choices were flipped to `["mi", "dhi"]` (before-tax first); WID was already before-first. The LIS metadata helpers now key off the before-tax indicator explicitly so the combined title/subtitle/description_key are unaffected by the reorder.
- **Entity sort.** Each view sets `sortBy: column` / `sortColumnSlug: <after-tax indicator>` / `sortOrder: asc` so the dumbbells (and table) order entities by after-tax value, lowest first. (Dumbbell's TwoColumn mode excludes the `startValue`/`endValue` sort keys, so sorting by the after-tax *column* is the way to do this.)
- **Schema sync.** `schemas/dataset-schema.json` gains the upstream `dumbbell` grapher_config object and the `Dumbbell` chartTypes enum value, so `test_grapher_config_schema_sync` passes.
- **Skill doc.** Documents a before/after FAUST regression-diff workflow in the `faust-metadata-audit` skill (used to verify this PR — see below).

## Verification

Diffed the generated MDim configs (pre-PR master vs. branch): the only changes are the intended ones (Dumbbell tab + LIS indicator reorder). FAUST reports (Title/Subtitle/Footnote/description_short/description_key) are **byte-identical** before/after for all three LIS MDims, confirming the dhi→mi inheritance-base shift changes no user-facing text. One accepted side effect: the LIS line chart's two series swap their auto-assigned colors (no explicit colors pre-PR, so palette follows series order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)