### PR TITLE
📊 Lexical Index: three-tier voting rights in practice

### DIFF
--- a/etl/steps/data/garden/democracy/2026-04-02/lexical_index.meta.yml
+++ b/etl/steps/data/garden/democracy/2026-04-02/lexical_index.meta.yml
@@ -309,7 +309,7 @@ tables:
           It combines the indicators `male_suffrage` and `female_suffrage` in Skaaning et al. (2015).
 
       suffrage_in_practice_lied:
-        title: Universal right to vote in practice
+        title: Universal right to vote in practice (binary)
         unit: ""
         description_short: |-
           Indicates whether virtually all adult citizens have the right to vote and elections for both the chief executive and the legislature are held.
@@ -317,7 +317,7 @@ tables:
           Takes on the value of 1 if both men and women have the right to vote (universal suffrage) and there are elections for both the chief executive and the legislature (`exe_leg_elec_lied` = 1); 0 otherwise. It differs from the "universal suffrage" indicator in that it also considers whether elections for the chief executive and the legislature are actually held.
 
       suffrage_in_practice_trich_lied:
-        title: Voting rights in practice
+        title: Universal right to vote in practice
         unit: ""
         description_short: |-
           Indicates whether virtually all adult citizens have the right to vote in practice (score 2), only men have broad voting rights in practice (score 1), or there are no broad voting rights in practice (score 0).
@@ -711,11 +711,11 @@ tables:
       num_suffrage_in_practice_lied:
         title: |-
           <%- if category == '-1' -%>
-          Number of countries with unknown universal voting rights in practice
+          Number of countries with unknown universal voting rights in practice (binary)
           <%- elif category == 'no' -%>
-          Number of countries that don't have universal voting rights in practice
+          Number of countries that don't have universal voting rights in practice (binary)
           <%- else -%>
-          Number of countries with universal voting rights in practice
+          Number of countries with universal voting rights in practice (binary)
           <%- endif -%>
         unit: "countries"
 
@@ -728,7 +728,7 @@ tables:
           <%- elif category == 'broad male voting rights' -%>
           Number of countries with broad voting rights for men in practice
           <%- else -%>
-          Number of countries with universal voting rights in practice (three categories)
+          Number of countries with universal voting rights in practice
           <%- endif -%>
         unit: "countries"
 
@@ -910,11 +910,11 @@ tables:
       pop_suffrage_in_practice_lied:
         title: |-
           <%- if category == '-1' -%>
-          People living in countries with unknown universal voting rights in practice
+          People living in countries with unknown universal voting rights in practice (binary)
           <%- elif category == 'no' -%>
-          People living in countries that don't have universal voting rights in practice
+          People living in countries that don't have universal voting rights in practice (binary)
           <%- else -%>
-          People living in countries with universal voting rights in practice
+          People living in countries with universal voting rights in practice (binary)
           <%- endif -%>
         unit: "people"
 
@@ -927,7 +927,7 @@ tables:
           <%- elif category == 'broad male voting rights' -%>
           People living in countries with broad voting rights for men in practice
           <%- else -%>
-          People living in countries with universal voting rights in practice (three categories)
+          People living in countries with universal voting rights in practice
           <%- endif -%>
         unit: "people"
 

--- a/etl/steps/data/garden/democracy/2026-04-02/lexical_index.meta.yml
+++ b/etl/steps/data/garden/democracy/2026-04-02/lexical_index.meta.yml
@@ -316,6 +316,52 @@ tables:
         description_processing: |-
           Takes on the value of 1 if both men and women have the right to vote (universal suffrage) and there are elections for both the chief executive and the legislature (`exe_leg_elec_lied` = 1); 0 otherwise. It differs from the "universal suffrage" indicator in that it also considers whether elections for the chief executive and the legislature are actually held.
 
+      suffrage_in_practice_trich_lied:
+        title: Voting rights in practice
+        unit: ""
+        description_short: |-
+          Indicates whether virtually all adult citizens have the right to vote in practice (score 2), only men have broad voting rights in practice (score 1), or there are no broad voting rights in practice (score 0).
+        description_key:
+          - Countries with universal voting rights in practice (score 2) have universal suffrage for both men and women, and hold elections for both the chief executive and the legislature.
+          - Countries with broad voting rights for men in practice (score 1) have universal suffrage for men but not women, and hold elections for both the chief executive and the legislature.
+          - Countries with no broad voting rights in practice (score 0) do not hold elections for the chief executive or the legislature, or do not have universal suffrage for men.
+          - The indicator neither considers informal restrictions nor legal restrictions based on age, criminal conviction, disability, and local residency.
+        description_processing: |-
+          Takes on the value of 2 if both men and women have the right to vote (universal suffrage) and there are elections for both the chief executive and the legislature; the value of 1 if men (but not women) have the right to vote and there are elections for both the chief executive and the legislature; and the value of 0 otherwise. It differs from the "universal suffrage" indicator in that it also considers whether elections for the chief executive and the legislature are actually held.
+        presentation:
+          grapher_config:
+            title: Voting rights in practice
+            subtitle: Data by the [Lexical Index of Electoral Democracy](#dod:regimes-lexical-index). Voting rights only count as "in practice" if elections for both the chief executive and the legislature are held.
+            hasMapTab: true
+            tab: map
+            chartTypes:
+              - LineChart
+            yAxis:
+              max: 2
+              min: 0
+            selectedFacetStrategy: entity
+            colorScale: &color_suffrage_practice
+              binningStrategy: manual
+              customNumericColors:
+                - "#ef8a62"
+                - "#67a9cf"
+                - "#2c7bb6"
+              customNumericLabels:
+                - "No broad voting rights"
+                - "Broad voting rights for men"
+                - "Universal voting rights"
+              customNumericValues:
+                - 0
+                - 0
+                - 1
+                - 2
+              customNumericColorsActive: true
+            map:
+              colorScale: *color_suffrage_practice
+              tooltipUseCustomLabels: true
+        display:
+          numDecimalPlaces: 0
+
       democracy_lied:
         title: "Electoral democracy"
         unit: ""
@@ -673,6 +719,19 @@ tables:
           <%- endif -%>
         unit: "countries"
 
+      num_suffrage_in_practice_trich_lied:
+        title: |-
+          <%- if category == '-1' -%>
+          Number of countries with unknown voting rights in practice
+          <%- elif category == 'no broad voting rights' -%>
+          Number of countries with no broad voting rights in practice
+          <%- elif category == 'broad male voting rights' -%>
+          Number of countries with broad voting rights for men in practice
+          <%- else -%>
+          Number of countries with universal voting rights in practice (three categories)
+          <%- endif -%>
+        unit: "countries"
+
       num_turnover_event:
         title: |-
           <%- if category == '-1' -%>
@@ -856,6 +915,19 @@ tables:
           People living in countries that don't have universal voting rights in practice
           <%- else -%>
           People living in countries with universal voting rights in practice
+          <%- endif -%>
+        unit: "people"
+
+      pop_suffrage_in_practice_trich_lied:
+        title: |-
+          <%- if category == '-1' -%>
+          People living in countries with unknown voting rights in practice
+          <%- elif category == 'no broad voting rights' -%>
+          People living in countries with no broad voting rights in practice
+          <%- elif category == 'broad male voting rights' -%>
+          People living in countries with broad voting rights for men in practice
+          <%- else -%>
+          People living in countries with universal voting rights in practice (three categories)
           <%- endif -%>
         unit: "people"
 

--- a/etl/steps/data/garden/democracy/2026-04-02/lexical_index.py
+++ b/etl/steps/data/garden/democracy/2026-04-02/lexical_index.py
@@ -128,6 +128,9 @@ def run() -> None:
     # Add "Universal right to vote in practice"
     tb = add_suffrage_in_practice(tb)
 
+    # Add "Voting rights in practice" (three categories)
+    tb = add_suffrage_in_practice_trich(tb)
+
     # Add "Recent electoral turnover"
     tb = add_recent_turnover(tb)
 
@@ -385,6 +388,30 @@ def add_suffrage_in_practice(tb: Table) -> Table:
     return tb
 
 
+def add_suffrage_in_practice_trich(tb: Table) -> Table:
+    """Add three-tier classification of voting rights in practice.
+
+    - 2: universal voting rights in practice (universal suffrage for men and women, and elections for both the chief
+      executive and the legislature).
+    - 1: broad voting rights for men in practice (universal suffrage for men but not women, and elections for both the
+      chief executive and the legislature).
+    - 0: no broad voting rights in practice (no elections for the chief executive or the legislature, or no universal
+      suffrage for men).
+    """
+    tb["suffrage_in_practice_trich_lied"] = 0
+    tb.loc[(tb["suffrage_lied"] == 1) & (tb["exe_leg_elec_lied"] == 1), "suffrage_in_practice_trich_lied"] = 1
+    tb.loc[(tb["suffrage_lied"] == 2) & (tb["exe_leg_elec_lied"] == 1), "suffrage_in_practice_trich_lied"] = 2
+    tb["suffrage_in_practice_trich_lied"] = tb["suffrage_in_practice_trich_lied"].astype("Int64")
+    tb["suffrage_in_practice_trich_lied"].metadata = tb["suffrage_lied"].metadata
+
+    # Sanity check: top tier must coincide with the binary "universal right to vote in practice" indicator.
+    assert ((tb["suffrage_in_practice_trich_lied"] == 2) == (tb["suffrage_in_practice_lied"] == 1)).all(), (
+        "Mismatch between `suffrage_in_practice_trich_lied` (== 2) and `suffrage_in_practice_lied` (== 1)!"
+    )
+
+    return tb
+
+
 def add_recent_turnover(tb: Table) -> Table:
     """Add recent electoral turnover indicator.
 
@@ -486,6 +513,15 @@ def get_region_aggregates(
             "values_expected": {
                 "0": "no",
                 "1": "yes",
+            },
+            "has_na": False,
+        },
+        {
+            "name": "suffrage_in_practice_trich_lied",
+            "values_expected": {
+                "0": "no broad voting rights",
+                "1": "broad male voting rights",
+                "2": "universal voting rights",
             },
             "has_na": False,
         },

--- a/snapshots/democracy/2026-04-02/lexical_index.xlsx.dvc
+++ b/snapshots/democracy/2026-04-02/lexical_index.xlsx.dvc
@@ -1,6 +1,6 @@
 meta:
   origin:
-    producer: Skaaning et al.
+    producer: Lexical Index
     title: Lexical Index of Electoral Democracy (LIED)
     description: |-
       LIED is the most comprehensive dataset on democracy in terms of country-years. It covers all independent countries and most semi-sovereign polities and overseas colonies, protectorates, etc. within the 1789 to 2020 timespan. Scores have also been assigned to the units in the case of short- term foreign occupation. Scores for each indicator reflect the status of a country on the last day of the calendar year (31 December) and are not intended to reflect the mean value of an indicator across the previous 364 days. Coding decisions are based on country-specific sources. All original coding has been done by Svend-Erik Skaaning (skaaning@ps.au.dk).
@@ -10,8 +10,8 @@ meta:
       Skaaning, Svend-Erik, 2021, "Lexical Index of Electoral Democracy (LIED) dataset v6.0", https://doi.org/10.7910/DVN/WPKNIT, Harvard Dataverse, V5
     version_producer: v6.9
     url_main: https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/WPKNIT
-    date_accessed: '2026-04-02'
-    date_published: '2026-04-01'
+    date_accessed: "2026-04-02"
+    date_published: "2026-04-01"
     license:
       name: CC0
       url: https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Derive a three-tier "voting rights in practice" indicator (0 = no broad voting rights, 1 = broad voting rights for men, 2 = universal voting rights) plus counts by year and region, and set the source attribution to "Lexical Index (2026)".

ref https://github.com/owid/owid-issues/issues/2301 (last two comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)