### PR TITLE
✨ sync dataset schema with upstream dumbbell chart type

### DIFF
--- a/etl/collection/model/schema_types.py
+++ b/etl/collection/model/schema_types.py
@@ -70,6 +70,23 @@ class ComparisonLinesConfig(TypedDict, total=False):
     yEquals: str
 
 
+class DumbbellConfig(TypedDict, total=False):
+    """Nested configuration for DumbbellConfig."""
+
+    # How the connector between dumbbell heads is drawn.
+    # - arrow: draw an arrow pointing from start to end
+    # - line: draw a simple line (only respected when two indicators are plotted)
+    connectorStyle: Literal["arrow", "line"]
+    # Custom colors for the time-range encoding, with keys "increase" and "decrease"
+    trendColorMap: dict[str, str]
+    # What to display as value labels next to each dumbbell.
+    # - absolute: show the raw values at the start and end
+    # - change: show the absolute change (e.g. +50)
+    # - percentChange: show the percentage change (e.g. +33%)
+    # - none: hide value labels
+    valueLabelMode: Literal["absolute", "change", "percentChange", "none"]
+
+
 class HideAnnotationFieldsInTitleConfig(TypedDict, total=False):
     """Nested configuration for HideAnnotationFieldsInTitleConfig."""
 
@@ -255,11 +272,13 @@ class _ViewConfigBase(TypedDict, total=False):
             "SlopeChart",
             "StackedBar",
             "Marimekko",
+            "Dumbbell",
         ]
     ]
     colorScale: dict[str, Any]
     compareEndPointsOnly: bool
     comparisonLines: list[ComparisonLinesConfig]
+    dumbbell: DumbbellConfig
     entityType: str
     entityTypePlural: str
     excludedEntityNames: list[str]


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Follow-up to #6192, where @pabloarosado already synced `schemas/dataset-schema.json` with the upstream dumbbell chart type (`dumbbell` config object + `Dumbbell` in the `chartTypes` enum). This PR adds the missing counterpart in the typed view config:

- `etl/collection/model/schema_types.py`: add `Dumbbell` to the `chartTypes` Literal and a `DumbbellConfig` TypedDict (`connectorStyle`, `trendColorMap`, `valueLabelMode`) mirroring the schema block.

Upstream context: dumbbell chart type landed in grapher via owid/owid-grapher#6254, custom colors in owid/owid-grapher#6565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
