### PR TITLE
📊 Update gho dependency to 2026-05-22

### DIFF
--- a/.claude/skills/remapping-ghost-variables/SKILL.md
+++ b/.claude/skills/remapping-ghost-variables/SKILL.md
@@ -79,9 +79,26 @@ Compare old vs new shortNames to confirm the mapping. Common rename patterns:
 - Prefix/suffix changes
 - Restructured naming conventions
 
-### Step 5: Remap the chart via Admin API
+### Step 5: Remap via the indicator upgrader (preferred)
 
-Use the `AdminAPI` to update the chart config on staging:
+Insert the mappings, then run the upgrader — it updates dimensions, map configs, sortBy, and narrative charts, and records the mapping in `wiz__variable_mapping` so chart diff picks it up:
+
+```bash
+STAGING=<branch> .venv/bin/python -c "
+from apps.wizard.utils.db import WizardDB
+WizardDB.add_variable_mapping(
+    mapping={<old_id>: <new_id>},
+    dataset_id_old=<old_ds_id>, dataset_id_new=<new_ds_id>,
+    comments='<why>')"
+STAGING=<branch> .venv/bin/python -m apps.indicator_upgrade.cli upgrade --dry-run
+STAGING=<branch> .venv/bin/python -m apps.indicator_upgrade.cli upgrade
+```
+
+**Check `WizardDB.get_variable_mapping_raw()` first** — `upgrade` applies *all* stored mappings, not just yours.
+
+### Step 5 (fallback): Remap the chart via Admin API
+
+If the indicator upgrader can't be used, update the chart config manually on staging with `AdminAPI`:
 
 ```python
 from apps.chart_sync.admin_api import AdminAPI

--- a/dag/archive/health.yml
+++ b/dag/archive/health.yml
@@ -732,3 +732,11 @@ steps:
     - data://meadow/cancer/2024-09-13/diagnosis_routes_by_stage
   data://grapher/cancer/2024-09-13/diagnosis_routes_by_stage:
     - data://garden/cancer/2024-09-13/diagnosis_routes_by_stage
+  # Global Health Observatory (GHO) from WHO
+  data://garden/who/2025-05-19/gho:
+    - data://garden/regions/2023-01-01/regions
+    - data://meadow/who/2025-05-19/gho:
+      - snapshot://who/2025-05-19/gho.zip
+    - data://garden/demography/2024-07-15/population
+  data://grapher/who/2025-05-19/gho:
+    - data://garden/who/2025-05-19/gho

--- a/dag/health.yml
+++ b/dag/health.yml
@@ -805,13 +805,6 @@ steps:
         - snapshot://cdc/2025-05-19/tuberculosis.csv
 
   # Global Health Observatory (GHO) from WHO
-  data://garden/who/2025-05-19/gho:
-    - data://garden/regions/2023-01-01/regions
-    - data://meadow/who/2025-05-19/gho:
-      - snapshot://who/2025-05-19/gho.zip
-    - data://garden/demography/2024-07-15/population
-  data://grapher/who/2025-05-19/gho:
-    - data://garden/who/2025-05-19/gho
   data://garden/who/2026-05-22/gho:
     - data://garden/regions/2023-01-01/regions
     - data://meadow/who/2026-05-22/gho:

--- a/dag/health.yml
+++ b/dag/health.yml
@@ -80,7 +80,7 @@ steps:
   # Cholera
   data://grapher/who/2023-06-01/cholera:
     - data://garden/who/2023-06-01/cholera:
-      - data://garden/who/2025-05-19/gho
+      - data://garden/who/2026-05-22/gho
       - snapshot://fasttrack/2023-05-31/cholera.csv
       - data://garden/regions/2023-01-01/regions
       - data://garden/wb/2021-07-01/wb_income
@@ -783,11 +783,7 @@ steps:
   data://grapher/who/2025-04-07/gho_smoking:
     - data://garden/who/2025-04-07/gho_smoking:
       # Global Health Observatory (GHO) from WHO
-      - data://garden/who/2024-01-03/gho:
-        - data://meadow/who/2024-01-03/gho:
-          - snapshot://who/2024-01-03/gho.zip
-        - data://garden/demography/2023-03-31/population
-        - data://garden/regions/2023-01-01/regions
+      - data://garden/who/2026-05-22/gho
       - data://garden/regions/2023-01-01/regions
       - data://garden/wb/2025-07-01/income_groups
       - data://garden/un/2024-07-12/un_wpp

--- a/etl/steps/data/garden/who/2025-04-07/gho_smoking.py
+++ b/etl/steps/data/garden/who/2025-04-07/gho_smoking.py
@@ -1,6 +1,7 @@
 """Loads relevant smoking indicators from the GHO database and harmonizes them.
 This step includes both smoking prevalence estimates and the MPOWER indicators on tobacco control policies."""
 
+from owid.catalog import Dataset, Table
 from owid.catalog import processing as pr
 
 from etl.data_helpers import geo
@@ -14,11 +15,17 @@ REGIONS = [r for r in geo.REGIONS.keys() if r != "European Union (27)"] + ["Worl
 LAST_YEAR = 2022
 
 # short table names
-afford_gdp = "affordability_of_cigarettes__percentage_of_gdp_per_capita_required_to_purchase_2000_cigarettes_of_the_most_sold_brand"
+afford_gdp = "affordability__percentage_of_gdp_per_capita_required_to_purchase_2000_cigarettes_of_the_most_sold_brand"
 taxes = "taxes_as_a_pct_of_price__total_tax"
-ad_bans = "enforce_bans_on_tobacco_advertising"
-help_quit = "offer_help_to_quit_tobacco_use"
-smoke_free = "number_of_places_smoke_free__national_legislation"
+ad_bans = "enforcing_bans_on_tobacco_advertising__promotion_and_sponsorship"
+help_quit = "offering_help_to_quit_tobacco_use"
+smoke_free = "national_smoking_ban__number_of_places_smoke_free"
+
+
+def read_indicator(ds_meadow: Dataset, short_name: str) -> Table:
+    """Read an indicator table and drop the low/high confidence bounds and comments columns."""
+    tb = ds_meadow.read(short_name)
+    return tb.drop(columns=[f"{short_name}_low", f"{short_name}_high", "comments"], errors="raise")
 
 
 def run() -> None:
@@ -36,22 +43,20 @@ def run() -> None:
         c for c in ds_meadow.table_names if (("smok" in c.lower()) or ("tobac" in c.lower()) or "tax" in c.lower())
     ]
 
-    smoking_estimates = [ind for ind in all_rel_indicators if "estimate" in ind.lower()]
+    # prevalence estimates only (exclude `number_of_current_*__estimate` tables)
+    smoking_estimates = [ind for ind in all_rel_indicators if ind.startswith("estimate_of_current")]
 
     # read tables for policy indicators
-    tb_taxes = ds_meadow.read(taxes)
-    tb_ads = ds_meadow.read(ad_bans)
-    tb_quit = ds_meadow.read(help_quit)
-    tb_afford = ds_meadow.read(afford_gdp)
-    tb_smoke_free = ds_meadow.read(smoke_free)
+    tb_taxes = read_indicator(ds_meadow, taxes)
+    tb_ads = read_indicator(ds_meadow, ad_bans)
+    tb_quit = read_indicator(ds_meadow, help_quit)
+    tb_afford = read_indicator(ds_meadow, afford_gdp)
+    tb_smoke_free = read_indicator(ds_meadow, smoke_free)
 
     ### clean up policy indicators
     # taxes
     tb_taxes = tb_taxes[tb_taxes["tobacco_and_nicotine_product"] == "Most sold brand of cigarettes (20 sticks)"]
-    tb_taxes = tb_taxes.drop(columns=["tobacco_and_nicotine_product", "comments"], errors="raise")
-
-    # smoke free
-    tb_smoke_free = tb_smoke_free.drop(columns=["comments"], errors="raise")
+    tb_taxes = tb_taxes.drop(columns=["tobacco_and_nicotine_product"], errors="raise")
 
     # support to quit
     # 1 means no data available, so should be dropped
@@ -79,9 +84,7 @@ def run() -> None:
     # Load all smoking estimates
 
     for tb_name in smoking_estimates:
-        tb = ds_meadow.read(tb_name)
-
-        tb = tb.drop(columns=["comments"], errors="raise")
+        tb = read_indicator(ds_meadow, tb_name)
 
         # Add to list of tables.
         tbs.append(tb)
@@ -93,11 +96,11 @@ def run() -> None:
     tb = tb.rename(
         columns={
             "estimate_of_current_cigarette_smoking_prevalence__pct": "cig_smoking_pct",
-            "estimate_of_current_cigarette_smoking_prevalence__pct__age_standardized_rate": "cig_smoking_pct_age_std",
+            "estimate_of_current_cigarette_smoking_prevalence__pct__age_standardized": "cig_smoking_pct_age_std",
             "estimate_of_current_tobacco_smoking_prevalence__pct": "tobacco_smoking_pct",
-            "estimate_of_current_tobacco_smoking_prevalence__pct__age_standardized_rate": "tobacco_smoking_pct_age_std",
+            "estimate_of_current_tobacco_smoking_prevalence__pct__age_standardized": "tobacco_smoking_pct_age_std",
             "estimate_of_current_tobacco_use_prevalence__pct": "tobacco_use_pct",
-            "estimate_of_current_tobacco_use_prevalence__pct__age_standardized_rate": "tobacco_use_pct_age_std",
+            "estimate_of_current_tobacco_use_prevalence__pct__age_standardized": "tobacco_use_pct_age_std",
         },
         errors="raise",
     )


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Bump the `gho` dependency to the latest version `2026-05-22` in the remaining consumer steps:

- `garden/who/2023-06-01/cholera`: `2025-05-19/gho` → `2026-05-22/gho` (verified locally, passes)
- `garden/who/2025-04-07/gho_smoking`: `2024-01-03/gho` → `2026-05-22/gho` (replaced the inlined old chain with a reference to the existing `2026-05-22` definition)

## gho_smoking adapted to renamed tables

WHO renamed several MPOWER indicators between GHO releases, so `gho_smoking.py` was updated to match `2026-05-22/gho`:

| old table | new table |
|---|---|
| `enforce_bans_on_tobacco_advertising` | `enforcing_bans_on_tobacco_advertising__promotion_and_sponsorship` |
| `offer_help_to_quit_tobacco_use` | `offering_help_to_quit_tobacco_use` |
| `affordability_of_cigarettes__percentage_of_gdp_per_capita_required_to_purchase_2000_cigarettes_of_the_most_sold_brand` | `affordability__percentage_of_gdp_per_capita_required_to_purchase_2000_cigarettes_of_the_most_sold_brand` |
| `number_of_places_smoke_free__national_legislation` | `national_smoking_ban__number_of_places_smoke_free` |
| `estimate_of_current_*__age_standardized_rate` | `estimate_of_current_*__age_standardized` |

The new tables also carry `_low`/`_high` confidence-bound columns, which are now dropped explicitly (output tables keep the same variables as before).

## Chart remap (indicator upgrader)

4 charts were still on `2025-05-19/gho` because WHO also renamed the adult overweight indicator (`prevalence_of_overweight_among_adults__bmi__gt__25...` → `overweight_among_adults__bmi__gt__25_kg_m2...`). Remapped on staging via the indicator upgrader (data now extends to 2024):

| chart | slug | old → new variable |
|---|---|---|
| 2624 | share-of-adults-who-are-overweight | 1056900 → 1249068 |
| 2628 | share-of-females-defined-as-overweight | 1056901 → 1249069 |
| 2630 | share-of-men-defined-as-overweight | 1056902 → 1249070 |
| 3584 | share-of-overweight-men-vs-women | 1056901/1056902 → 1249069/1249070 |

No charts remain on the old gho version. The old `who/2025-05-19/gho` garden/grapher steps were moved to the archive DAG; the grapher dataset (id 7113) can be archived in the admin after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
