### PR TITLE
🎉 Key ETL charts by catalogPath (parallel to mdims)

### DIFF
--- a/apps/chart_sync/admin_api.py
+++ b/apps/chart_sync/admin_api.py
@@ -156,8 +156,9 @@ class AdminAPI:
     ) -> dict:
         """Insert or update the chart's ETL-authored grapher config.
 
-        Writes to `chart_configs.etlConfig`. Admin patches are preserved; the
-        rendered `full` is recomputed as merge(variableETL, etlConfig, patch).
+        Writes the ETL config to its own `chart_configs` row, pointed to by
+        `charts.configIdETL`. Admin patches are preserved; the rendered `full`
+        is recomputed as merge(variableETL, etlConfig, patch).
         When `catalog_path` is given, it's stored on `charts.catalogPath` as the
         chart's ETL identity (mirrors `multi_dim_data_pages.catalogPath`).
         """

--- a/apps/chart_sync/admin_api.py
+++ b/apps/chart_sync/admin_api.py
@@ -147,11 +147,19 @@ class AdminAPI:
             raise AdminAPIError({"error": js["error"], "variable_id": variable_id})
         return js
 
-    def put_chart_etl_config(self, chart_id: int, grapher_config: dict[str, Any], user_id: int | None = None) -> dict:
+    def put_chart_etl_config(
+        self,
+        chart_id: int,
+        grapher_config: dict[str, Any],
+        catalog_path: str | None = None,
+        user_id: int | None = None,
+    ) -> dict:
         """Insert or update the chart's ETL-authored grapher config.
 
         Writes to `chart_configs.etlConfig`. Admin patches are preserved; the
         rendered `full` is recomputed as merge(variableETL, etlConfig, patch).
+        When `catalog_path` is given, it's stored on `charts.catalogPath` as the
+        chart's ETL identity (mirrors `multi_dim_data_pages.catalogPath`).
         """
         # Mirror put_grapher_config: default the schema if missing.
         grapher_config.setdefault("$schema", DEFAULT_GRAPHER_SCHEMA)
@@ -160,6 +168,7 @@ class AdminAPI:
         resp = requests_with_retry().put(
             self.owid_env.admin_api + f"/charts/{chart_id}/etlConfig",
             headers=self._headers(user_id),
+            params={"catalogPath": catalog_path} if catalog_path else None,
             json=grapher_config,
         )
         js = self._json_from_response(resp)

--- a/etl/collection/chart_upsert.py
+++ b/etl/collection/chart_upsert.py
@@ -51,12 +51,13 @@ def upsert_collection_as_chart(collection: "Collection", owid_env: OWIDEnv) -> i
 
     admin_api = AdminAPI(owid_env)
 
-    # Look up the chart by slug. If it already exists, we keep it; otherwise
-    # we create a new one with a minimal bootstrap config and then write the
-    # full config into chart_configs.etlConfig.
+    # Look up the chart by its ETL catalog path (the stable ETL identity, like
+    # multi_dim_data_pages.catalogPath) — not by slug, which is a mutable public
+    # URL. If it exists, we keep it; otherwise we create a new one with a minimal
+    # bootstrap config and then write the full config into chart_configs.etlConfig.
     with Session(owid_env.engine) as session:
         try:
-            existing = Chart.load_chart(session, slug=slug)
+            existing = Chart.load_chart(session, catalog_path=collection.catalog_path)
         except NoResultFound:
             existing = None
 
@@ -82,7 +83,7 @@ def upsert_collection_as_chart(collection: "Collection", owid_env: OWIDEnv) -> i
     # Write the chart's ETL-authored config. This recomputes `full` server-side
     # as merge(variableETL, etlConfig, existing patch); any admin patches
     # already in chart_configs.patch are preserved.
-    admin_api.put_chart_etl_config(chart_id=chart_id, grapher_config=chart_config)
+    admin_api.put_chart_etl_config(chart_id=chart_id, grapher_config=chart_config, catalog_path=collection.catalog_path)
 
     # Set topic tags on freshly created charts only — once a chart exists,
     # tags are admin-managed and ETL must not stomp on them.

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -435,6 +435,8 @@ class Chart(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
     configId: Mapped[bytes] = mapped_column(CHAR(36))
+    # ETL step that authored this chart (mirrors multi_dim_data_pages.catalogPath); NULL for hand-authored charts.
+    catalogPath: Mapped[str | None] = mapped_column(VARCHAR(767), init=False)
     isInheritanceEnabled: Mapped[int] = mapped_column(TINYINT(1), server_default=text("'1'"))
     forceDatapage: Mapped[int] = mapped_column(TINYINT(1), server_default=text("'0'"))
     createdAt: Mapped[datetime] = mapped_column(DateTime, server_default=text("CURRENT_TIMESTAMP"), init=False)
@@ -478,14 +480,22 @@ class Chart(Base):
         return select(ChartConfig.slug).where(ChartConfig.id == cls.configId).scalar_subquery()
 
     @classmethod
-    def load_chart(cls, session: Session, chart_id: int | None = None, slug: str | None = None) -> "Chart":
-        """Load chart with id `chart_id`."""
+    def load_chart(
+        cls,
+        session: Session,
+        chart_id: int | None = None,
+        slug: str | None = None,
+        catalog_path: str | None = None,
+    ) -> "Chart":
+        """Load a chart by `chart_id`, `slug`, or `catalog_path`."""
         if chart_id:
             cond = cls.id == chart_id
         elif slug:
             cond = cls.slug == slug
+        elif catalog_path:
+            cond = cls.catalogPath == catalog_path
         else:
-            raise ValueError("Either chart_id or slug must be provided")
+            raise ValueError("One of chart_id, slug, or catalog_path must be provided")
         charts = session.scalars(select(cls).where(cond)).all()
 
         # there can be multiple charts with the same slug, pick the published one


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

Small, isolated PR into the chart-config feature branch (`etl-chart-config`), reviewable on its own. Pairs with **owid/owid-grapher#6590** (adds the `charts.catalogPath` column).

## What & why

A single chart is a zero-dimension mdim, and mdims are already identified by **`catalogPath`** (`multi_dim_data_pages.catalogPath`, unique; slug is nullable/secondary). Single charts, however, were keyed only by **slug**. This change gives charts the same stable ETL identity, so the two are keyed identically — the groundwork for unifying charts and mdims (#6069).

`collection.catalog_path` already exists (e.g. `animal_welfare/latest/banning_of_chick_culling#banning_of_chick_culling`) — we just persist and look up by it instead of throwing it away.

## Changes

- **`Chart` model** — add the `catalogPath` column; `load_chart` gains a `catalog_path` lookup.
- **`admin_api.put_chart_etl_config`** — optional `catalog_path`, sent as `?catalogPath=` to the etlConfig endpoint (which persists it on `charts.catalogPath`).
- **`upsert_collection_as_chart`** — look up the chart by `catalog_path` (not slug), and pass it through on push.

## Behavior change to flag for review

ETL now keys on `catalogPath`, not slug. So it **no longer adopts a hand-authored chart that merely shares a slug** — an accidental slug collision surfaces at publish time instead of silently overwriting someone's chart (the concern raised earlier in the feature review). The slug stays the mutable public URL, set on the bootstrap create as before.

## Notes

- **chart-sync → prod** doesn't yet carry `catalogPath` (it writes `chart_configs.patch`, not the etlConfig endpoint) — same open question as the grapher PR; treated as a follow-up.
- Existing ETL charts backfill their `catalogPath` lazily on next push (NULL until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)