### PR TITLE
Repoint topic-tags datasette link to the public instance

### DIFF
--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -1020,7 +1020,7 @@
                       "requirement_level": "recommended (for curated indicators)",
                       "guidelines": [
                         [
-                          "Must be an existing topic tag, and be spelled correctly (see the list of topic tags in [datasette](http://analytics/private?sql=SELECT%0D%0A++DISTINCT+t.name%0D%0AFROM%0D%0A++tag_graph+tg%0D%0A++LEFT+JOIN+tags+t+ON+tg.childId+%3D+t.id%0D%0A++LEFT+JOIN+posts_gdocs+p+ON+t.slug+%3D+p.slug%0D%0A++AND+p.published+%3D+1%0D%0A++AND+p.type+IN+%28%27article%27%2C+%27topic-page%27%2C+%27linear-topic-page%27%29%0D%0AWHERE%0D%0A++p.slug+IS+NOT+NULL%0D%0AUNION%0D%0ASELECT%0D%0A++%27Uncategorized%27%0D%0AORDER+BY%0D%0A++t.name) (requires Tailscale)."
+                          "Must be an existing topic tag, and be spelled correctly (see the list of topic tags in [datasette](https://datasette-public.owid.io/owid?sql=SELECT%0D%0A++DISTINCT+t.name%0D%0AFROM%0D%0A++tag_graph+tg%0D%0A++LEFT+JOIN+tags+t+ON+tg.childId+%3D+t.id%0D%0A++LEFT+JOIN+posts_gdocs+p+ON+t.slug+%3D+p.slug%0D%0A++AND+p.published+%3D+1%0D%0A++AND+p.type+IN+%28%27article%27%2C+%27topic-page%27%2C+%27linear-topic-page%27%29%0D%0AWHERE%0D%0A++p.slug+IS+NOT+NULL%0D%0AUNION%0D%0ASELECT%0D%0A++%27Uncategorized%27%0D%0AORDER+BY%0D%0A++t.name)."
                         ],
                         [
                           "The first tag must correspond to the most relevant topic page (since that topic page will be used in citations of this indicator)."


### PR DESCRIPTION
The schema's topic-tags helper link pointed at the internal Datasette's `private` database, which no longer exists (`private.duckdb` was retired in owid/analytics#810 — the analytics pipeline now serves everything from BigQuery/`analytics.duckdb`).

The public Datasette has the same `tags`/`tag_graph`/`posts_gdocs` tables, so this repoints the link to [datasette-public.owid.io](https://datasette-public.owid.io/owid) with the identical query — verified it returns the same 127 topic tags. Bonus: no Tailscale needed anymore, so the "(requires Tailscale)" note is dropped.

One-character-class change: URL base + note text only; the SQL is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)