### PR TITLE
📊 ai_diffusion_msft: clarify regional-average caveat

### DIFF
--- a/etl/steps/data/garden/artificial_intelligence/2026-04-07/ai_diffusion_msft.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2026-04-07/ai_diffusion_msft.meta.yml
@@ -26,8 +26,7 @@ tables:
           - This indicator counts anyone who visited one of 19 tracked AI tools during the period, from a single visit to daily use. It does not distinguish between occasional and frequent users.
           - "The 19 tracked platforms are: Alice, ChatGPT, Character.ai, Claude, CLOVA X, DeepSeek, ERNIE Bot (Yiyan.baidu), GigaChat, Google Gemini, Grok, Khanmigo.ai, Meta.ai, Microsoft Copilot, Midjourney, Mistral.ai, NanoSemantics AI Assistant, Perplexity, Tongyi Qianwen, and Xiaowei."
           - Users with less than 90 minutes of total activity observed through Microsoft telemetry per month are excluded, to reduce the influence of very infrequent users. This threshold applies to overall tracked activity, not to time spent on AI tools.
-          - Some countries do not have enough data for their own estimate and are assigned a regional average instead.
-          - The source notes that coverage is limited in some countries, especially Russia, Iran, and parts of China, so estimates for these places carry greater uncertainty.
+          - For some countries, Microsoft doesn't have enough data to estimate the AI user share directly. These countries are assigned the average value of their region instead. This affects many countries in Sub-Saharan Africa, where several appear with identical values in the data.
 
         display:
           numDecimalPlaces: 1

--- a/etl/steps/data/garden/artificial_intelligence/2026-04-07/ai_diffusion_msft.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2026-04-07/ai_diffusion_msft.meta.yml
@@ -6,7 +6,7 @@ definitions:
         - Artificial Intelligence
 
 dataset:
-  update_period_days: 183
+  update_period_days: 92
 
   owners:
     - Veronika Samborska

--- a/etl/steps/data/garden/artificial_intelligence/2026-04-07/ai_diffusion_msft.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2026-04-07/ai_diffusion_msft.meta.yml
@@ -9,7 +9,6 @@ dataset:
   update_period_days: 92
 
   owners:
-    - Veronika Samborska
     - Edouard Mathieu
 tables:
   ai_diffusion_msft:

--- a/etl/steps/data/garden/artificial_intelligence/2026-04-07/ai_diffusion_msft.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2026-04-07/ai_diffusion_msft.meta.yml
@@ -10,6 +10,7 @@ dataset:
 
   owners:
     - Veronika Samborska
+    - Edouard Mathieu
 tables:
   ai_diffusion_msft:
     variables:


### PR DESCRIPTION
> _Written by Claude Code — @edomt at the wheel._

Replaces the existing two bullets about regional averaging and country-specific uncertainty with a single, more accurate bullet.

The previous wording singled out **Russia, Iran, and parts of China** as having limited coverage. But the published methodology paper ([Misra et al., 2025](https://arxiv.org/abs/2511.02781)) does not name these countries — the only country-coverage issue it explicitly flags is low telemetry opt-in in parts of **Europe**, and the paper actually uses China as its flagship real-time-detection case (DeepSeek). All three countries appear in the Q1 2026 appendix with country-specific values, not regional blends.

The real coverage issue visible in the published data is **Sub-Saharan Africa**, where 12+ countries share an identical value (e.g. Benin, Burkina Faso, Ghana, Guinea, Guinea-Bissau, Liberia, Mali, Mauritania, Niger, Nigeria, Sierra Leone, Togo are all at 10.1% in Q1 2026 — that's a regional average, not 12 independent measurements). The new bullet calls this out plainly.

## Before

> Some countries do not have enough data for their own estimate and are assigned a regional average instead.
>
> The source notes that coverage is limited in some countries, especially Russia, Iran, and parts of China, so estimates for these places carry greater uncertainty.

## After

> For some countries, Microsoft doesn't have enough data to estimate the AI user share directly. These countries are assigned the average value of their region instead. This affects many countries in Sub-Saharan Africa, where several appear with identical values in the data.

## Test plan

- [x] Spot-check the rendered "What you should know about this indicator" section on the staging chart page.