### PR TITLE
📊🤖 Update NVIDIA quarterly revenue (2026-06-08)

### DIFF
--- a/dag/archive/artificial_intelligence.yml
+++ b/dag/archive/artificial_intelligence.yml
@@ -891,3 +891,9 @@ steps:
     - data://garden/regions/2023-01-01/regions
   data://grapher/artificial_intelligence/2025-11-07/energy_ai:
     - data://garden/artificial_intelligence/2025-11-07/energy_ai
+
+  # NVIDIA quarterly revenue dataset
+  data://grapher/artificial_intelligence/2026-04-02/nvidia_revenue:
+    - data://garden/artificial_intelligence/2026-04-02/nvidia_revenue:
+      - data://meadow/artificial_intelligence/2026-04-02/nvidia_revenue:
+        - snapshot://artificial_intelligence/2026-04-02/nvidia_revenue.csv

--- a/dag/artificial_intelligence.yml
+++ b/dag/artificial_intelligence.yml
@@ -170,10 +170,10 @@ steps:
         - snapshot://artificial_intelligence/2026-03-30/robotaxis.csv
 
   # NVIDIA quarterly revenue dataset
-  data://grapher/artificial_intelligence/2026-04-02/nvidia_revenue:
-    - data://garden/artificial_intelligence/2026-04-02/nvidia_revenue:
-      - data://meadow/artificial_intelligence/2026-04-02/nvidia_revenue:
-        - snapshot://artificial_intelligence/2026-04-02/nvidia_revenue.csv
+  data://grapher/artificial_intelligence/2026-06-08/nvidia_revenue:
+    - data://garden/artificial_intelligence/2026-06-08/nvidia_revenue:
+      - data://meadow/artificial_intelligence/2026-06-08/nvidia_revenue:
+        - snapshot://artificial_intelligence/2026-06-08/nvidia_revenue.csv
 
   # Microsoft AI Diffusion — Global AI adoption estimates
   data://grapher/artificial_intelligence/2026-04-07/ai_diffusion_msft:

--- a/etl/steps/data/garden/artificial_intelligence/2026-06-08/nvidia_revenue.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2026-06-08/nvidia_revenue.meta.yml
@@ -1,0 +1,40 @@
+definitions:
+  common:
+    presentation:
+      topic_tags:
+        - Artificial Intelligence
+      attribution_short: NVIDIA
+
+dataset:
+  update_period_days: 91
+  owners:
+    - Edouard Mathieu
+    - Veronika Samborska
+tables:
+  nvidia_revenue:
+    variables:
+      revenue:
+        title: NVIDIA's revenue by market segment
+        unit: "US dollars"
+        short_unit: "$"
+        description_short: NVIDIA's self-reported quarterly revenue across its main market segments, in US dollars. This data is not adjusted for inflation.
+        description_key:
+          - This indicator splits NVIDIA's quarterly revenue between its data center & AI business and everything else, which covers gaming graphics cards, professional workstations, automotive chips, and chips sold to other manufacturers.
+          - Figures are self-reported by NVIDIA in its quarterly financial disclosures, shown in US dollars, and not adjusted for inflation.
+          - In April 2026, NVIDIA changed how it groups its market segments. Until then, it reported four separate non-data-center segments ("Gaming", "Professional Visualization", "Auto", and "OEM & Other"); from then on, it reports them as a single combined segment. We use the combined version throughout, summing the four older segments for earlier quarters so the time series stays consistent.
+        description_processing: |-
+          NVIDIA publishes its quarterly revenue split by market segment. We combine all of its historical disclosures (covering fiscal years 2016 through 2027) into a single time series with two main categories — "Data centers and AI" and "Gaming, devices, automotive" — alongside the overall total.
+
+          In the first quarter of fiscal 2027 (the quarter ending April 26, 2026), NVIDIA changed the structure of these disclosures. Until Q4 FY26 (the quarter ending January 25, 2026), NVIDIA reported five market segments: "Data Center", "Gaming", "Professional Visualization", "Auto", and "OEM & Other". From Q1 FY27 onward, it reports just two segments — "Data Center" (further broken down into "Hyperscale" and "AI Clouds, Industrial & Enterprise") and "Edge Computing". Reconciling the eight quarters that appear in both presentations confirms that NVIDIA's new "Edge Computing" segment equals the sum of the previous categories labeled as "Gaming", "Professional Visualization", "Auto", and "OEM & Other".
+
+          To keep the time series consistent over the full period, we sum the four older non-data-center segments ("Gaming", "Professional Visualization", "Auto", and "OEM & Other") into a single bucket for quarters before Q1 FY27, and we use NVIDIA's combined value from Q1 FY27 onward. We label this bucket "Gaming, devices, automotive" rather than NVIDIA's own term ("Edge Computing") to more plainly describe what's in it. Data center revenue is taken as reported in both presentations.
+
+          Each data point is dated by NVIDIA's reported fiscal-quarter end — the last Sunday of April, July, October, or January (for example, Q4 FY26 is dated January 25, 2026).
+        processing_level: major
+        presentation:
+          title_public: NVIDIA's quarterly revenue by market segment
+          grapher_config:
+            note: '"Gaming, devices, automotive" combines NVIDIA''s revenue from gaming graphics cards, workstations, automotive chips, and chips sold to other manufacturers.'
+        display:
+          name: NVIDIA's quarterly revenue
+          numDecimalPlaces: 0

--- a/etl/steps/data/garden/artificial_intelligence/2026-06-08/nvidia_revenue.py
+++ b/etl/steps/data/garden/artificial_intelligence/2026-06-08/nvidia_revenue.py
@@ -1,0 +1,107 @@
+"""Garden step for NVIDIA's quarterly revenue by market segment.
+
+The snapshot is a faithful copy of NVIDIA's published "Revenue by Market" PDF
+cells — multiple PDFs, two different segment taxonomies (NVIDIA recast its
+disclosure in Q1 FY27), and the same quarter often appears in several PDFs.
+This step harmonises that input into a single tidy time series for grapher:
+
+- Segments are mapped into a unified scheme: data centers and AI vs. a single
+  "Gaming, devices, automotive" bucket (the latter combining either the four
+  old non-Data-Center segments, or NVIDIA's new "Edge Computing" line). The
+  Data Center sub-rows from the new PDF (Hyperscale, AI Clouds, Industrial &
+  Enterprise) are dropped — they're a sub-split of Data Center, not separate
+  top-level segments.
+- The quarter label (e.g. "Q4 FY26") is converted to NVIDIA's reported
+  fiscal-quarter end date (the last Sunday of Apr/Jul/Oct/Jan). For example,
+  Q4 FY26 -> 2026-01-25.
+- When a quarter appears in more than one source PDF, the most recent PDF wins.
+- Revenue is converted from millions to dollars.
+"""
+
+import calendar
+import re
+from datetime import date, timedelta
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+# Map NVIDIA's raw segment names (as printed in their PDFs) to the unified
+# two-line scheme used in the chart. Hyperscale and the "AI Clouds, Industrial,
+# & Enterprise" sub-row are intentionally absent: they're a breakdown of the
+# Data Center segment, not separate top-level segments.
+SEG_DATA_CENTER = "Data centers and AI"
+SEG_OTHER = "Gaming, devices, automotive"
+SEG_TOTAL = "Total"
+
+SEGMENT_MAP = {
+    "Data Center": SEG_DATA_CENTER,
+    "Datacenter": SEG_DATA_CENTER,
+    "Gaming": SEG_OTHER,
+    "Professional Visualization": SEG_OTHER,
+    "Auto": SEG_OTHER,
+    "Automotive": SEG_OTHER,
+    "OEM & Other": SEG_OTHER,
+    "OEM & IP": SEG_OTHER,
+    "Edge Computing": SEG_OTHER,
+    "TOTAL": SEG_TOTAL,
+    "Total": SEG_TOTAL,
+}
+
+
+def _parse_quarter(label: str) -> tuple[int, int]:
+    """Parse 'Q4 FY26' or 'Q4FY26' into (fiscal_quarter, fiscal_year_4digit)."""
+    m = re.match(r"Q(\d)\s*FY(\d{2})", label)
+    if not m:
+        raise ValueError(f"Cannot parse quarter label: {label!r}")
+    return int(m.group(1)), 2000 + int(m.group(2))
+
+
+def _fiscal_quarter_end(fiscal_year: int, fiscal_quarter: int) -> date:
+    """Last Sunday of NVIDIA's fiscal quarter end month (Apr/Jul/Oct/Jan)."""
+    quarter_end_month = {1: 4, 2: 7, 3: 10, 4: 1}
+    month = quarter_end_month[fiscal_quarter]
+    cal_year = fiscal_year if fiscal_quarter == 4 else fiscal_year - 1
+    last_day = calendar.monthrange(cal_year, month)[1]
+    d = date(cal_year, month, last_day)
+    while d.weekday() != 6:  # 6 = Sunday
+        d -= timedelta(days=1)
+    return d
+
+
+def run() -> None:
+    ds_meadow = paths.load_dataset("nvidia_revenue")
+    tb = ds_meadow.read("nvidia_revenue")
+
+    # Map each raw segment to its unified bucket; drop sub-segments not in the
+    # map (Hyperscale, "AI Clouds, Industrial, & Enterprise").
+    tb = tb[tb["segment"].isin(SEGMENT_MAP.keys())]
+    tb["segment"] = tb["segment"].replace(SEGMENT_MAP)
+
+    # Sum within (source_pdf, quarter, segment) so the four old non-Data-Center
+    # segments collapse into one row per source PDF (and "Edge Computing" in the
+    # new PDF simply passes through).
+    tb = tb.groupby(["source_pdf", "quarter", "segment"], as_index=False, observed=True)["revenue_millions"].sum()
+
+    # Deduplicate across source PDFs: same quarter often appears in many PDFs;
+    # the most recent PDF (highest fiscal_year, then fiscal_quarter) wins.
+    src_fyq = tb["source_pdf"].astype(str).apply(_parse_quarter)
+    tb["_src_rank"] = src_fyq.apply(lambda t: t[1] * 10 + t[0])
+    tb = tb.sort_values(["quarter", "segment", "_src_rank"], ascending=[True, True, False])
+    tb = tb.drop_duplicates(subset=["quarter", "segment"], keep="first")
+    tb = tb.drop(columns=["_src_rank", "source_pdf"])
+
+    # Convert quarter label to fiscal-quarter-end date.
+    qy = tb["quarter"].astype(str).apply(_parse_quarter)
+    tb["date"] = qy.apply(lambda t: _fiscal_quarter_end(t[1], t[0]))
+    tb = tb.drop(columns=["quarter"])
+
+    # Millions of USD -> USD.
+    tb["revenue_millions"] = tb["revenue_millions"] * 1_000_000
+    tb = tb.rename(columns={"revenue_millions": "revenue"})
+
+    tb = tb[["date", "segment", "revenue"]].sort_values(["date", "segment"]).reset_index(drop=True)
+    tb = tb.format(["date", "segment"])
+
+    ds_garden = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_meadow.metadata)
+    ds_garden.save()

--- a/etl/steps/data/grapher/artificial_intelligence/2026-06-08/nvidia_revenue.py
+++ b/etl/steps/data/grapher/artificial_intelligence/2026-06-08/nvidia_revenue.py
@@ -1,0 +1,27 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset("nvidia_revenue")
+
+    # Read table from garden dataset.
+    tb = ds_garden.read("nvidia_revenue", reset_index=False)
+    #
+    # Save outputs.
+    #
+    # Rename 'segment' index to 'country' to display as entity on grapher
+    tb = tb.rename_index_names({"segment": "country"})
+    # Create a new grapher dataset with the same metadata as the garden dataset.
+    ds_grapher = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=ds_garden.metadata)
+
+    # Save changes in the new grapher dataset.
+    ds_grapher.save()

--- a/etl/steps/data/meadow/artificial_intelligence/2026-06-08/nvidia_revenue.py
+++ b/etl/steps/data/meadow/artificial_intelligence/2026-06-08/nvidia_revenue.py
@@ -1,0 +1,19 @@
+"""Meadow step: light type cleanup; preserves the snapshot's row shape."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    snap = paths.load_snapshot("nvidia_revenue.csv")
+    tb = snap.read()
+
+    # Cast low-cardinality string columns to categorical for compactness.
+    for col in ["source_pdf", "quarter", "segment"]:
+        tb[col] = tb[col].astype("category")
+
+    tb = tb.format(["source_pdf", "quarter", "segment"])
+
+    ds_meadow = paths.create_dataset(tables=[tb], check_variables_metadata=True, default_metadata=snap.metadata)
+    ds_meadow.save()

--- a/snapshots/artificial_intelligence/2026-06-08/nvidia_revenue.csv.dvc
+++ b/snapshots/artificial_intelligence/2026-06-08/nvidia_revenue.csv.dvc
@@ -1,0 +1,21 @@
+meta:
+  origin:
+    producer: NVIDIA Corporation
+    title: NVIDIA Quarterly Revenue by Market Segment
+    description: |-
+      Quarterly revenue data for NVIDIA Corporation, broken down by market segment and reported in millions of US dollars per fiscal quarter.
+
+      NVIDIA's fiscal year is a 52/53-week period ending on the last Sunday in January. Each fiscal quarter is named after the fiscal year in which it ends, so fiscal year 2026 covers ~Feb 2025 to Jan 2026, and its quarters end on the last Sunday of April, July, October, and January respectively.
+    title_snapshot: NVIDIA Quarterly Revenue by Market Segment - Q1 FY2027
+    citation_full: NVIDIA Corporation - Quarterly Revenue Trends by Market Platform (2014-2026)
+    attribution_short: NVIDIA
+    url_main: https://investor.nvidia.com/financial-info/financial-reports/default.aspx
+    date_accessed: '2026-06-08'
+    date_published: '2026-05-20'
+    license:
+      name: ©2026 NVIDIA Corporation
+      url: https://www.nvidia.com/en-us/about-nvidia/terms-of-service/
+outs:
+  - md5: ef7de151621248d0c631605d277a82fa
+    size: 20239
+    path: nvidia_revenue.csv

--- a/snapshots/artificial_intelligence/2026-06-08/nvidia_revenue.py
+++ b/snapshots/artificial_intelligence/2026-06-08/nvidia_revenue.py
@@ -1,0 +1,263 @@
+"""Snapshot of NVIDIA's quarterly Revenue-by-Market PDFs.
+
+Downloads every "Revenue Trends by Market" PDF NVIDIA Investor Relations publishes,
+extracts the table on its first page, and writes one tidy CSV row per source-PDF /
+reported-quarter / segment cell. Segment names and quarter labels are preserved
+exactly as NVIDIA prints them; no aggregation or relabelling happens here. Any
+harmonisation across PDF presentations belongs in meadow/garden.
+"""
+
+import io
+import re
+from pathlib import Path
+
+import click
+import pandas as pd
+import pdfplumber
+import requests
+from structlog import get_logger
+
+from etl.snapshot import Snapshot
+
+log = get_logger()
+
+SNAPSHOT_VERSION = Path(__file__).parent.name
+
+# Source PDFs published by NVIDIA Investor Relations. Each PDF reports several
+# quarters; we keep historical PDFs for depth and the latest PDF for new data.
+PDF_URLS = {
+    "Q1FY27": "https://s201.q4cdn.com/141608511/files/doc_financials/2027/Q127/Rev_by_Mkt_Qtrly_Trend_Q127-NEW-v3.pdf",
+    "Q4FY26": "https://s201.q4cdn.com/141608511/files/doc_financials/2026/Q426/Rev_by_Mkt_Qtrly_Trend_Q426.pdf",
+    "Q3FY26": "https://s201.q4cdn.com/141608511/files/doc_financials/2026/Q326/Rev_by_Mkt_Qtrly_Trend_Q326.pdf",
+    "Q4FY25": "https://s201.q4cdn.com/141608511/files/doc_financials/2025/Q425/Rev_by_Mkt_Qtrly_Trend_Q425.pdf",
+    "Q4FY24": "https://s201.q4cdn.com/141608511/files/doc_financials/2024/Q4FY24/Rev_by_Mkt_Qtrly_Trend_Q424.pdf",
+    "Q4FY23": "https://s201.q4cdn.com/141608511/files/doc_financials/2023/Q423/Q423-Qtrly-Revenue-by-Market-slide.pdf",
+    "Q4FY22": "https://s201.q4cdn.com/141608511/files/doc_financials/2022/q4/Rev_by_Mkt_Qtrly_Trend_Q422.pdf",
+    "Q4FY21": "https://s201.q4cdn.com/141608511/files/doc_financials/annual/2021/Rev_by_Mkt_Qtrly_Trend_Q421.pdf",
+    "Q4FY20": "https://s201.q4cdn.com/141608511/files/doc_financials/quarterly_reports/2020/Q420/Rev_by_Mkt_Qtrly_Trend_Q420.pdf",
+    "Q4FY19": "https://s201.q4cdn.com/141608511/files/doc_financials/quarterly_reports/2019/Q419/Rev_by_Mkt_Qtrly_Trend_Q419.pdf",
+    "Q4FY18": "https://s201.q4cdn.com/141608511/files/doc_financials/quarterly_reports/2018/Rev_by_Mkt_Qtrly_Trend_Q418.pdf",
+    "Q4FY17": "https://s201.q4cdn.com/141608511/files/doc_financials/quarterly_reports/2017/Rev_by_Mkt_Qtrly_Trend_Q417.pdf",
+    "Q4FY16": "https://s201.q4cdn.com/141608511/files/doc_financials/quarterly_reports/2016/Rev_by_Mkt_Qtrly_Trend_Q416.FINAL.pdf",
+}
+
+# First source PDF that uses NVIDIA's recast market-platform presentation (in
+# which the four non-Data-Center segments are rolled into a single "Edge
+# Computing" line, and Data Center is sub-split into Hyperscale + ACIE).
+NEW_PRESENTATION_FROM = (2027, 1)  # (fiscal_year, fiscal_quarter)
+
+
+def _parse_source_label(label: str) -> tuple[int, int]:
+    m = re.match(r"Q(\d)FY(\d{2})", label)
+    if not m:
+        raise ValueError(f"Cannot parse PDF source label: {label!r}")
+    return int(m.group(1)), 2000 + int(m.group(2))
+
+
+def _uses_new_presentation(label: str) -> bool:
+    q, y = _parse_source_label(label)
+    return (y, q) >= NEW_PRESENTATION_FROM
+
+
+def _download_pdf(url: str) -> bytes:
+    log.info("downloading_pdf", url=url)
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return response.content
+
+
+def _clean_value(value) -> float | None:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    s = str(value).strip().replace("$", "").replace(",", "").replace(" ", "")
+    if s in {"", "-", "—"}:
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def _clean_label(name) -> str:
+    """Strip footnote markers and collapse whitespace in a row/column label."""
+    s = str(name).replace("\n", " ").strip()
+    s = re.sub(r"[\d\*†‡]+$", "", s).strip()
+    return re.sub(r"\s+", " ", s)
+
+
+def _extract_old_format(pdf_bytes: bytes, source: str) -> list[dict]:
+    """Old PDFs (Q4 FY16 .. Q4 FY26): rows = segment, columns = quarter ('Q1 FY26')."""
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+        page = pdf.pages[0]
+        tables = page.extract_tables() or []
+
+        table = None
+        for cand in tables:
+            if len(cand) > 5 and len(cand[0]) > 2:
+                header = " ".join(str(c or "") for c in cand[0])
+                if any(q in header for q in ["Q1", "Q2", "Q3", "Q4"]):
+                    table = cand
+                    break
+        if table is None and tables:
+            table = tables[0]
+        if table is None:
+            log.warning("no_table_found", source=source)
+            return []
+
+        # Some older PDFs concatenate all values for a row into a single cell.
+        if len(table) > 1 and len(table[1]) > 1:
+            none_count = sum(1 for cell in table[1][1:] if cell is None)
+            if none_count > len(table[1]) / 2:
+                fixed = [table[0]]
+                for row in table[1:]:
+                    if isinstance(row[1], str):
+                        values = row[1].replace("$", "").replace(",", "").strip().split()
+                        fixed.append([row[0]] + values)
+                    else:
+                        fixed.append(row)
+                table = fixed
+
+        df = pd.DataFrame(table[1:], columns=table[0])
+
+        # Some PDFs (Q4 FY21) lose segment names from rows whose label wraps
+        # across two lines. Reconstruct by listing the canonical segment order
+        # and filling nan rows with the ones missing from the table — skipping
+        # any segments already labelled to avoid double-assignment.
+        if df.iloc[:, 0].isna().any():
+            text = page.extract_text() or ""
+            seg_order = ["Gaming", "Professional Visualization", "Data Center", "Auto", "OEM & Other", "TOTAL"]
+            already_labelled = {str(s) for s in df.iloc[:, 0].dropna()}
+            pending = [s for s in seg_order if s not in already_labelled and s in text]
+            for nan_idx, seg in zip(df.index[df.iloc[:, 0].isna()].tolist(), pending):
+                df.iloc[nan_idx, 0] = seg
+
+    records: list[dict] = []
+    seg_col = df.columns[0]
+    for _, row in df.iterrows():
+        seg = row[seg_col]
+        if pd.isna(seg):
+            continue
+        segment = _clean_label(seg)
+        if not segment:
+            continue
+        for col in df.columns[1:]:
+            m = re.match(r"Q(\d)\s*FY(\d{2})", str(col))
+            if not m:
+                continue
+            value = _clean_value(row[col])
+            if value is None:
+                continue
+            records.append(
+                {
+                    "source_pdf": source,
+                    "quarter": f"Q{m.group(1)} FY{m.group(2)}",
+                    "segment": segment,
+                    "revenue_millions": value,
+                }
+            )
+    return records
+
+
+def _extract_new_format(pdf_bytes: bytes, source: str) -> list[dict]:
+    """New PDF (Q1 FY27+): two-row header with fiscal-year span over quarter labels."""
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+        page = pdf.pages[0]
+        tables = page.extract_tables() or []
+
+    table = None
+    for cand in tables:
+        flat = "\n".join(" ".join(str(c or "") for c in row) for row in cand)
+        if "Fiscal" in flat and "TOTAL" in flat:
+            table = cand
+            break
+    if table is None or len(table) < 3:
+        log.warning("no_table_found", source=source)
+        return []
+
+    header_fy = table[0]
+    header_q = table[1]
+    data_rows = table[2:]
+
+    col_fyq: list[tuple[int, int] | None] = []
+    current_fy: int | None = None
+    for fy_cell, q_cell in zip(header_fy[1:], header_q[1:]):
+        if fy_cell and str(fy_cell).strip():
+            m = re.search(r"\d{4}", str(fy_cell))
+            if m:
+                current_fy = int(m.group())
+        if current_fy is None:
+            col_fyq.append(None)
+            continue
+        m = re.match(r"Q(\d)", str(q_cell or "").strip())
+        if not m:
+            col_fyq.append(None)
+            continue
+        col_fyq.append((current_fy, int(m.group(1))))
+
+    records: list[dict] = []
+    for row in data_rows:
+        if not row or not row[0]:
+            continue
+        segment = _clean_label(row[0])
+        if not segment:
+            continue
+        for idx, fyq in enumerate(col_fyq):
+            if fyq is None:
+                continue
+            cell = row[idx + 1] if idx + 1 < len(row) else None
+            value = _clean_value(cell)
+            if value is None:
+                continue
+            fy, fq = fyq
+            records.append(
+                {
+                    "source_pdf": source,
+                    "quarter": f"Q{fq} FY{str(fy)[-2:]}",
+                    "segment": segment,
+                    "revenue_millions": value,
+                }
+            )
+    return records
+
+
+def extract_nvidia_revenue() -> pd.DataFrame:
+    """Download every source PDF and return a tidy long table.
+
+    Output columns: source_pdf, quarter, segment, revenue_millions. Each row is
+    one cell from a source PDF; segment names are as NVIDIA prints them.
+    Downstream (garden) is responsible for any aggregation, relabelling, and
+    deduplication across PDFs.
+    """
+    log.info("starting_extraction", total_pdfs=len(PDF_URLS))
+    rows: list[dict] = []
+    for source, url in PDF_URLS.items():
+        try:
+            pdf_bytes = _download_pdf(url)
+        except Exception as e:
+            log.error("download_failed", source=source, error=str(e))
+            continue
+        if _uses_new_presentation(source):
+            rows.extend(_extract_new_format(pdf_bytes, source))
+        else:
+            rows.extend(_extract_old_format(pdf_bytes, source))
+
+    if not rows:
+        raise ValueError("No data extracted from any PDF")
+
+    df = pd.DataFrame(rows).sort_values(["source_pdf", "quarter", "segment"]).reset_index(drop=True)
+    log.info("extraction_complete", rows=len(df), sources=df["source_pdf"].nunique(), segments=df["segment"].nunique())
+    return df
+
+
+@click.command()
+@click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
+def main(upload: bool) -> None:
+    snap = Snapshot(f"artificial_intelligence/{SNAPSHOT_VERSION}/nvidia_revenue.csv")
+    df = extract_nvidia_revenue()
+    snap.create_snapshot(upload=upload, data=df)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/artificial_intelligence/2026-06-08/nvidia_revenue.py
+++ b/snapshots/artificial_intelligence/2026-06-08/nvidia_revenue.py
@@ -233,11 +233,9 @@ def extract_nvidia_revenue() -> pd.DataFrame:
     log.info("starting_extraction", total_pdfs=len(PDF_URLS))
     rows: list[dict] = []
     for source, url in PDF_URLS.items():
-        try:
-            pdf_bytes = _download_pdf(url)
-        except Exception as e:
-            log.error("download_failed", source=source, error=str(e))
-            continue
+        # Let any download error propagate — partial-source snapshots silently
+        # publish missing data, which is worse than failing the whole update.
+        pdf_bytes = _download_pdf(url)
         if _uses_new_presentation(source):
             rows.extend(_extract_new_format(pdf_bytes, source))
         else:
@@ -247,6 +245,13 @@ def extract_nvidia_revenue() -> pd.DataFrame:
         raise ValueError("No data extracted from any PDF")
 
     df = pd.DataFrame(rows).sort_values(["source_pdf", "quarter", "segment"]).reset_index(drop=True)
+
+    # Defensive check: every PDF in PDF_URLS should contribute at least one row.
+    # Catches the case where the PDF was reachable (no download error) but the
+    # extractor silently returned no records (e.g. table layout changed).
+    missing = sorted(set(PDF_URLS) - set(df["source_pdf"].unique()))
+    if missing:
+        raise ValueError(f"Snapshot would be missing data from these source PDFs: {missing}")
     log.info("extraction_complete", rows=len(df), sources=df["source_pdf"].nunique(), segments=df["segment"].nunique())
     return df
 


### PR DESCRIPTION
> _Written by Claude Code — @edomt at the wheel._

## Summary

- Bumped `artificial_intelligence/nvidia_revenue` from `2026-04-02` to `2026-06-08`, picking up NVIDIA's Q1 FY27 release (May 20, 2026; period ending Apr 26, 2026; revenue $81.6B).
- **Adopted NVIDIA's new market-segment presentation** introduced in Q1 FY27: the four previous non-data-center segments ("Gaming", "Professional Visualization", "Auto", "OEM & Other") were rolled into a single combined bucket (NVIDIA's term: "Edge Computing"; our label: **"Gaming, devices, automotive"**).
- **Fixed the fiscal-quarter → calendar-date logic**: each data point is now dated to NVIDIA's reported fiscal-quarter end (e.g., Q4 FY26 = `2026-01-25`), replacing the previous mapping that placed each point at the start of a roughly-aligned calendar quarter (e.g., Q4 FY26 was dated `2025-10-01`).

## Data-shape diff (verified)

| | OLD (2026-04-02) | NEW (2026-06-08) |
|---|---|---|
| quarters | 48 | 49 |
| indicators | 4 (Data centers and AI, Gaming, Other, Total) | 3 (Data centers and AI, Gaming/devices/automotive, Total) |
| date range | 2014-01-01 → 2025-10-01 | 2014-04-27 → 2026-04-26 |

Numeric reconciliation across the 8 overlapping quarters (Q1 FY25 .. Q4 FY26): NVIDIA's new "Edge Computing" equals the sum of the four older non-data-center categories to the dollar; data center total unchanged; overall total unchanged.

## DAG

Old `2026-04-02` entries moved to `dag/archive/artificial_intelligence.yml`; new `2026-06-08` entries placed in the original slot under the `# NVIDIA quarterly revenue dataset` section header.