### PR TITLE
📊 natural_disasters: Homogenize natural disasters legends and dropdowns

### DIFF
--- a/etl/steps/data/grapher/emdat/2026-04-30/natural_disasters.py
+++ b/etl/steps/data/grapher/emdat/2026-04-30/natural_disasters.py
@@ -51,24 +51,25 @@ TITLE_PUBLIC_END = {
     "extreme_temperature": "extreme temperatures",
     "all_disasters_excluding_extreme_temperature": "all disasters excluding extreme temperatures",
 }
-# Map disaster type to their name in the title (singular).
+# Map disaster type to their name shown in chart legends and the catalog title (plural,
+# to stay consistent with the multidim dropdowns and the public titles in TITLE_PUBLIC_END).
 TITLE_DISASTER = {
-    "earthquake": "Earthquake",
+    "earthquake": "Earthquakes",
     "extreme_weather": "Storms",
     "volcanic_activity": "Volcanoes",
-    "flood": "Flood",
+    "flood": "Floods",
     "all_disasters": "All disasters",
     # "glacial_lake_outburst_flood": ...,  # Folded into "Flood" — see EXPECTED_DISASTER_TYPES.
     "all_disasters_excluding_earthquakes": "All disasters excluding earthquakes",
-    "wildfire": "Wildfire",
-    "landslide": "Landslide",
+    "wildfire": "Wildfires",
+    "landslide": "Landslides",
     # Wet/dry mass movements are folded into "Landslide" — see EXPECTED_DISASTER_TYPES in the garden step.
-    # "wet_mass_movement": "Wet mass movement",
-    # "dry_mass_movement": "Dry mass movement",
+    # "wet_mass_movement": "Wet mass movements",
+    # "dry_mass_movement": "Dry mass movements",
     # "fog": "Fog",  # Excluded — see EXPECTED_DISASTER_TYPES in the garden step.
-    "drought": "Drought",
-    "extreme_temperature": "Extreme temperature",
-    "all_disasters_excluding_extreme_temperature": "All disasters excluding extreme temperature",
+    "drought": "Droughts",
+    "extreme_temperature": "Extreme temperatures",
+    "all_disasters_excluding_extreme_temperature": "All disasters excluding extreme temperatures",
 }
 
 

--- a/etl/steps/export/multidim/natural_disasters/latest/affected.config.yml
+++ b/etl/steps/export/multidim/natural_disasters/latest/affected.config.yml
@@ -39,7 +39,7 @@ dimensions:
         description: People affected by flooding
         group: Individual disaster types
       - slug: landslide
-        name: Landslide
+        name: Landslides
         description: People affected by landslides, rockfalls, mudflows, and similar events
         group: Individual disaster types
       # Disabled in shared.py — kept here so the choice is ready if re-enabled.

--- a/etl/steps/export/multidim/natural_disasters/latest/deaths.config.yml
+++ b/etl/steps/export/multidim/natural_disasters/latest/deaths.config.yml
@@ -38,7 +38,7 @@ dimensions:
         description: Deaths caused by flooding
         group: Individual disaster types
       - slug: landslide
-        name: Landslide
+        name: Landslides
         description: Deaths caused by landslides, rockfalls, mudflows, and similar events
         group: Individual disaster types
       # Disabled in shared.py — kept here so the choice is ready if re-enabled.

--- a/etl/steps/export/multidim/natural_disasters/latest/economic_damages.config.yml
+++ b/etl/steps/export/multidim/natural_disasters/latest/economic_damages.config.yml
@@ -41,7 +41,7 @@ dimensions:
         description: Damages caused by flooding
         group: Individual disaster types
       - slug: landslide
-        name: Landslide
+        name: Landslides
         description: Damages caused by landslides, rockfalls, mudflows, and similar events
         group: Individual disaster types
       # Disabled in shared.py — kept here so the choice is ready if re-enabled.

--- a/etl/steps/export/multidim/natural_disasters/latest/shared.py
+++ b/etl/steps/export/multidim/natural_disasters/latest/shared.py
@@ -74,7 +74,7 @@ DISASTER_DESCRIPTIONS = {
         "(when water held back by a glacier or moraine is suddenly released)."
     ),
     "landslide": (
-        "A landslide is a sudden movement of material down a slope. This includes wet mass movements "
+        "Landslides are sudden movements of material down a slope, including wet mass movements "
         "(such as mudflows triggered by heavy rain or melting snow) and dry mass movements (such as rockfalls)."
     ),
     "extreme_weather": (
@@ -83,11 +83,11 @@ DISASTER_DESCRIPTIONS = {
 }
 
 ALL_DISASTERS_SUBTITLE = (
-    "Disasters include events such as earthquakes, volcanoes, drought, wildfires, storms, and flooding."
+    "Disasters include events such as earthquakes, volcanoes, droughts, wildfires, storms, and floods."
 )
 
 ALL_DISASTERS_EXCL_EXTREME_TEMP_SUBTITLE = (
-    "Disasters include events such as earthquakes, volcanoes, drought, wildfires, storms, and flooding."
+    "Disasters include events such as earthquakes, volcanoes, droughts, wildfires, storms, and floods. "
     "Extreme temperatures are not included here because their geographical and time coverage is poor, "
     "making consistent comparisons difficult."
 )


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

Homogenizes disaster-type naming across the three natural-disasters multidims (deaths, affected, economic damages) so dropdowns and chart legends are consistently **plural**.

### Changes
- **Legends** (`grapher/emdat/2026-04-30/natural_disasters.py`): `TITLE_DISASTER` → plural, so series labels read `Earthquakes`, `Floods`, `Wildfires`, `Landslides`, `Droughts`, `Extreme temperatures` instead of a singular/plural mix.
- **Dropdowns** (3× `*.config.yml`): `Landslide` → `Landslides` (the lone singular among the type choices).
- **Subtitles** (`shared.py`): fixed a missing space (`…and flooding.Extreme temperatures…` → `…and floods. Extreme temperatures…`), pluralized the event list (`drought`/`flooding` → `droughts`/`floods`), and rewrote the landslide description to a plural subject to match the other types.

### Notes
- Metadata-only change (no `shortName`/`catalogPath` changes), so no ghost variables — existing charts keep working and their legends flip to plural.
- The missing-space subtitle bug was surfaced by a FAUST audit across all views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)