### PR TITLE
🐛 Require pr-clean to run from the main repo

### DIFF
--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -81,7 +81,7 @@ from typing import cast
 import click
 import questionary
 import requests
-from git import GitCommandError, Repo
+from git import GitCommandError, InvalidGitRepositoryError, Repo
 from rich_click.rich_command import RichCommand
 from structlog import get_logger
 
@@ -680,7 +680,16 @@ def clean_cli() -> None:
     repo = Repo(BASE_DIR)
     main_worktree_path = get_main_worktree_path(repo)
     worktrees = list_worktrees(repo)  # branch name -> worktree path
-    current_worktree_path = Path(repo.working_tree_dir).resolve()  # ty: ignore
+
+    # Resolve the worktree the user is actually standing in from cwd, not from Repo(BASE_DIR).
+    # BASE_DIR is the package location, so when etl runs from the main repo's venv while the shell
+    # is inside a secondary worktree (that worktree's venv not activated), Repo(BASE_DIR) still
+    # points at the main repo — comparing its working_tree_dir would wrongly pass the guard below.
+    try:
+        cwd_repo = Repo(Path.cwd(), search_parent_directories=True)
+        current_worktree_path = Path(cwd_repo.working_tree_dir).resolve()  # ty: ignore
+    except InvalidGitRepositoryError:
+        current_worktree_path = Path(repo.working_tree_dir).resolve()  # ty: ignore
 
     # pr-clean must run from the main repo, never from a secondary worktree. From a worktree it
     # could try to remove the working tree you're standing in, or — if that worktree was switched

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -689,7 +689,9 @@ def clean_cli() -> None:
         cwd_repo = Repo(Path.cwd(), search_parent_directories=True)
         current_worktree_path = Path(cwd_repo.working_tree_dir).resolve()  # ty: ignore
     except InvalidGitRepositoryError:
-        current_worktree_path = Path(repo.working_tree_dir).resolve()  # ty: ignore
+        # cwd isn't inside any git repo — keep the raw cwd so the guard still errors out (it can't
+        # equal the main worktree), rather than falling back to BASE_DIR's repo and passing.
+        current_worktree_path = Path.cwd().resolve()
 
     # pr-clean must run from the main repo, never from a secondary worktree. From a worktree it
     # could try to remove the working tree you're standing in, or — if that worktree was switched

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -660,6 +660,9 @@ are flagged with `<- worktree`. Pick a single branch, or `all`, and the tool wil
 
 Each branch is tagged `[merged]` or `[closed]` so you can see its PR outcome before selecting.
 
+Must be run from the main repo, not from a secondary worktree (it errors out otherwise). The main
+repo can clean every worktree anyway, so just `cd` there first.
+
 ```shell
 etl pr-clean
 ```
@@ -678,6 +681,17 @@ def clean_cli() -> None:
     main_worktree_path = get_main_worktree_path(repo)
     worktrees = list_worktrees(repo)  # branch name -> worktree path
     current_worktree_path = Path(repo.working_tree_dir).resolve()  # ty: ignore
+
+    # pr-clean must run from the main repo, never from a secondary worktree. From a worktree it
+    # could try to remove the working tree you're standing in, or — if that worktree was switched
+    # off its branch (e.g. to master) — delete the branch while leaving the now-unlinked worktree
+    # orphaned. The main repo can clean every worktree anyway, so just bail and point there.
+    if current_worktree_path != main_worktree_path:
+        raise click.ClickException(
+            "pr-clean must be run from the main repo, not a worktree.\n"
+            f"  You're in:     {current_worktree_path}\n"
+            f"  cd to main and re-run:\n    cd {main_worktree_path}"
+        )
 
     # Candidate branches: every local branch except master.
     candidate_branches = [b.name for b in repo.branches if b.name != "master"]
@@ -722,7 +736,6 @@ def clean_cli() -> None:
             worktree_path=worktrees.get(branch),
             main_project_dir=main_project_dir,
             main_worktree_path=main_worktree_path,
-            current_worktree_path=current_worktree_path,
         )
 
 
@@ -832,13 +845,9 @@ def clean_branch(
     worktree_path: Path | None,
     main_project_dir: Path,
     main_worktree_path: Path,
-    current_worktree_path: Path,
 ) -> None:
     """Copy sessions (if a worktree), remove the worktree, and delete the local branch."""
-    # A branch checked out in the current or the main worktree can't be cleaned from here.
-    if worktree_path is not None and worktree_path == current_worktree_path:
-        log.warning(f"Skipping '{branch}': it's the worktree you're currently in. cd to the main repo and re-run.")
-        return
+    # The branch checked out in the main repo (where pr-clean runs) can't be cleaned from here.
     if worktree_path is not None and worktree_path == main_worktree_path:
         log.warning(
             f"Skipping '{branch}': it's checked out in the main repo. Switch the main repo to another branch first."


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

## What

Make `etl pr-clean` refuse to run from a secondary worktree. It now errors out unless invoked from the main repo, pointing you to `cd` there.

## Why

While working inside a worktree, I switched it to `master` and ran `etl pr-clean`. It deleted the branch but left the worktree behind — and a second run couldn't see the orphan either.

Root cause: `list_worktrees()` maps **currently-checked-out branch → path**. Once the worktree was switched off its branch, that branch had no worktree in the map, so `worktrees.get(branch)` returned `None`. In `clean_branch()` the worktree guards and the session-copy + `worktree remove` block are all gated on `worktree_path is not None`, so they were skipped and the code went straight to `git branch -D` — deleting the branch and orphaning the worktree. The orphan (now on `master`) is invisible to pr-clean because pr-clean only iterates over branches.

## Fix

A blanket "must run from the main repo" guard is simpler and more robust than trying to repair the branch↔worktree linkage:

- It can't pull the rug out from under you regardless of what branch any worktree is currently on.
- No path-matching or broken-link edge cases.
- The only thing it blocks is cleaning from inside worktree A instead of main — and the workaround is a single `cd` to main, which can clean *every* worktree anyway.

Changes:
- Add a global guard at the top of `clean_cli()` that bails when the current working tree isn't the main repo.
- Collapse the now-redundant per-branch current-worktree guard in `clean_branch()` (with the global guard, current always equals main).
- Note the requirement in the `pr-clean` help text.

## Test plan

- `make check` passes (lint, format, types).
- Manual: running `etl pr-clean` from a worktree now raises a clear `ClickException`; from the main repo it behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)