### PR TITLE
🐛 Skip pre-commit hooks on etl pr empty seeding commit

### DIFF
--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -515,7 +515,12 @@ def create_pr(repo, work_branch, base_branch, pr_title):
     pr_title_str = str(pr_title)
 
     log.info("Creating an empty commit.")
-    repo.git.commit("--allow-empty", "-m", pr_title_str or f"Start a new staging server for branch '{work_branch}'")
+    # Skip pre-commit hooks on this seeding commit: it's empty (nothing to check), and the
+    # hooks run `make check` which needs an installed `.venv`. In a fresh worktree the venv
+    # isn't set up yet (install_worktree_venv runs later), so the hooks would fail here.
+    repo.git.commit(
+        "--allow-empty", "--no-verify", "-m", pr_title_str or f"Start a new staging server for branch '{work_branch}'"
+    )
 
     log.info("Pushing the new branch to remote.")
     repo.git.push("origin", work_branch)

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -516,7 +516,7 @@ def create_pr(repo, work_branch, base_branch, pr_title):
 
     log.info("Creating an empty commit.")
     # Skip pre-commit hooks on this seeding commit: it's empty (nothing to check), and the
-    # hooks run `make check` which needs an installed `.venv`. In a fresh worktree the venv
+    # format/lint/check-typing hooks need an installed `.venv`. In a fresh worktree the venv
     # isn't set up yet (install_worktree_venv runs later), so the hooks would fail here.
     repo.git.commit(
         "--allow-empty", "--no-verify", "-m", pr_title_str or f"Start a new staging server for branch '{work_branch}'"


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

## Problem

`etl pr "…" --worktree` aborts during branch creation with a `ty` type-check error that **isn't a real code error** (`make check-typing` passes cleanly on `master`):

```
error[unresolved-import]: Cannot resolve imported module `.schemas`
  --> api_search/v1/__init__.py:12:7
error[unresolved-import]: Cannot resolve imported module `.`
  --> etl/grapher/to_db.py:37:1
```

### Root cause

1. `branch_out_worktree` creates the worktree with **no `.venv`** (it's deliberately not copied — see the comment at line 420; `install_worktree_venv` runs *after* this step).
2. `create_pr` makes a `git commit --allow-empty` to seed the branch.
3. The repo's `.pre-commit-config.yaml` has `language: system` hooks (`format`, `lint`, **`check-typing`**) that shell out to `make`. The empty commit fires them.
4. `make check-typing` depends on `.venv`, so it bootstraps a throwaway venv in the worktree via `uv sync` (~400 packages), then runs `ty check … --python .venv`.
5. `ty` ends up with **two first-party roots** — the worktree *and* the main repo, which leaks in via the still-set `VIRTUAL_ENV` pointing at the main `.venv` (whose `_editable_impl_etl.pth` hardcodes the main repo path):
   ```
   1. /…/etl                       (extra search path)
   2. /…/etl-<branch>-worktree     (first-party code)
   ```
   With `api_search` / `etl` reachable from both roots at different depths, ty's relative-import resolution breaks.
6. `ty` exits non-zero → the commit fails → `etl pr` aborts and rolls back the worktree and branch.

## Fix

Pass `--no-verify` to the empty seeding commit. The commit has no content, so there is genuinely nothing for the hooks to check — running `make check` against a not-yet-installed worktree venv is both pointless and broken. Real commits made later (once `install_worktree_venv` has set up the worktree's venv) still run the hooks normally.

```python
repo.git.commit(
    "--allow-empty", "--no-verify", "-m", pr_title_str or f"Start a new staging server for branch '{work_branch}'"
)
```

## Testing

- `make check` passes.
- `etl pr "…" bug` (this PR, non-worktree path) created its own seeding commit fine with the fix in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)