### PR TITLE
📜 Keep update-dataset and review-data-pr skills in sync

### DIFF
--- a/.claude/skills/review-data-pr/SKILL.md
+++ b/.claude/skills/review-data-pr/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 End-to-end review of a dataset-update PR. Goes deeper than `/review`: actually runs the steps, compares to the previous version, audits metadata coverage against a fixed checklist, and reports on `/update-dataset` workflow status (Slack draft, Codex review, indicator upgrade, downstream deps).
 
+> **Paired skill — keep in sync.** [`/update-dataset`](../update-dataset/SKILL.md) is the author-side counterpart of this skill: the steps it defines are the outcomes verified here. Whenever you add, remove, or change a check in this file, check whether `update-dataset/SKILL.md` needs a matching author-side step (and add it in the same commit if so). The reverse also holds — see the mirror note there.
+
 ## Inputs
 
 - Optional PR number. If omitted, derive it from the current branch via `gh pr list --head <branch>`.
@@ -22,6 +24,8 @@ gh pr view <num> --json title,body,isDraft,mergeable,statusCheckRollup,comments,
 ```
 
 Flag if **PR description is empty** (per user's standing rule: keep PR body in sync with substantial changes).
+
+Flag 🟡 if the Summary doesn't open with a **tracking-issue link** (`Tracks: owid/owid-issues#NNNN`) — `/update-dataset` requires it as the first line; most data updates have a corresponding `owid-issues` ticket.
 
 ### 2. Diff and changed files
 
@@ -76,13 +80,14 @@ Read both `.dvc` files (old and new) and produce a side-by-side table for these 
 | `date_published` | **Must differ from `date_accessed`** — source from `url_main` or the file. If unsure, ask. |
 | `date_accessed` | Updated to today (or run-date) |
 | `producer` / `attribution_short` | Same source, same values (unless changed deliberately) |
+| `citation_full` / `attribution` | **Year bumped to the new release year** — `etl update` copies both verbatim from the old `.dvc`, so a stale year ships silently. 🔴 if still the old version's year. |
 | `url_main` | Status check — see step 6 |
 | `url_download` | Status check; OK to remove if data is now fetched via API |
 | `license.url` | Status check |
 
 ### 6. Verify all links
 
-Run the HEAD-check loop from `/update-dataset` § 6c on every URL in the new `.dvc` and `.meta.yml` files. Anything non-2xx is a 🔴 blocker.
+Run the HEAD-check loop from `/update-dataset` § 6c on every URL in the new `.dvc` and `.meta.yml` files. A curl non-2xx is a *signal*, not proof — Cloudflare-fronted hosts return false 404s to curl. Apply the same escalation as `/update-dataset` § 6c: re-check with `WebFetch`, then the Wayback Machine. Only a URL that fails **all three** is a 🔴 blocker; a curl-only failure that WebFetch resolves is 🟢 informational.
 
 ### 7. Code clarity & docs
 
@@ -141,6 +146,7 @@ Any `NULL` row is a 🔴.
 
 **Additional reviewer-side metadata checks:**
 
+- **`dataset.owners` includes the PR author.** `/update-dataset` step 1a-bis requires the author to append their canonical OWID name (an entry in the `schemas/dataset-schema.json` enum) to the garden `.meta.yml` `owners:` list, preserving the existing order and any `# review` / `# backport` / `# fasttrack` markers. Author missing from the list = 🟡; existing owners reordered or dropped = 🔴.
 - **`processing_level: major` must come with `description_processing`.** Grep the new garden meta.yml for `processing_level: major`. Each occurrence (whether on `definitions.common` or per-indicator) requires a `description_processing` field on that same scope. 🟡 mismatch.
 - **Per-indicator `description_processing` should describe the indicator's own derivation, not just point at a shared generic note.** When every aggregate indicator's `description_processing` is the exact same string (e.g. all four region indicators just reference `{definitions.description_regions_processing}` with no per-indicator detail), 🟡 flag — author should compose per-indicator sentences.
 - **Long-format-with-dimensions Jinja coverage.** When variables are keyed by a long-column name (e.g. `proportion`) with `<% if <dim> == "X" %>...<% endif %>` blocks for `title`, `description_short`, `display.name`, verify every active `(dim1, dim2)` cell renders a non-empty value. Easiest check: read every column from the grapher dataset and assert `metadata.title` is non-empty.
@@ -202,6 +208,7 @@ Verify the author completed each post-step item from `/update-dataset`. The proc
 | Item | Verify by |
 |---|---|
 | Indicator upgrade ran (§7) | `make query SQL="SELECT COUNT(*) FROM chart_dimensions cd JOIN variables v ON cd.variableId=v.id WHERE v.catalogPath LIKE '%<ns>/<new_v>/%'"` — non-zero |
+| Explorers / MDims re-exported (§7) | Only if the DAG has `export://explorers/...` or `export://multidim/...` steps for this dataset (`rg "export://(explorers\|multidim)/.*/<short_name>" dag/ -g "*.yml"`). The indicator-upgrader never touches these, so run the two staging queries from `/update-dataset` §7 (old-version references in `explorer_variables` / `multi_dim_x_chart_configs`) — both must return empty. A hit = 🔴, the export step wasn't re-run. |
 | Chart-diff bot result | PR comments include `<!--chart-diff-start-->` block ✅ |
 | `@codex review` posted (§9) | `gh pr view <num> --json comments` shows the trigger comment + a Codex review |
 | Codex threads resolved (§10) | `gh api graphql -f query='{ repository(owner:"owid", name:"etl") { pullRequest(number:<num>) { reviewThreads(first:20) { nodes { isResolved } } } } }'` — all `isResolved: true` |
@@ -225,8 +232,8 @@ Structure the review with:
 
 ## Severity rubric
 
-- 🔴 **Blocker**: missing mandatory metadata field, broken link, failing pipeline step, breaking change to chart data, missing `update_period_days`, missing `presentation.attribution_short`, outdated `__main__` block in snapshot, DAG reference to old version that should be archived, new step wired to a stale (old-version) DAG dependency, non-canonical garden-output entity that isn't a documented custom aggregate, sanity check that newly raises on the new data
-- 🟡 **Suggestion**: brittle assertion, hardcoded year that should be dynamic, duplicated grapher meta.yml that could be removed, non-blocking style issues, undocumented sanity-check findings, phantom `sort:` labels with no backing value, over-exclusion of a canonical region, undocumented `missing values in mapping` countries
+- 🔴 **Blocker**: missing mandatory metadata field, genuinely broken link (fails curl + WebFetch + Wayback), failing pipeline step, breaking change to chart data, missing `update_period_days`, missing `presentation.attribution_short`, stale year in `citation_full`/`attribution`, outdated `__main__` block in snapshot, DAG reference to old version that should be archived, new step wired to a stale (old-version) DAG dependency, explorer/MDim still referencing old-version variables on staging, non-canonical garden-output entity that isn't a documented custom aggregate, sanity check that newly raises on the new data
+- 🟡 **Suggestion**: brittle assertion, hardcoded year that should be dynamic, duplicated grapher meta.yml that could be removed, non-blocking style issues, undocumented sanity-check findings, phantom `sort:` labels with no backing value, over-exclusion of a canonical region, undocumented `missing values in mapping` countries, PR author missing from `dataset.owners`, missing tracking-issue link in the PR body
 - 🟢 **Informational**: things to be aware of but not action items
 
 ## Notes

--- a/.claude/skills/update-dataset/SKILL.md
+++ b/.claude/skills/update-dataset/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 Use this skill to run a complete dataset update with Claude Code subagents, keep a live progress checklist, and pause for user approval only when something needs attention.
 
+> **Paired skill — keep in sync.** [`/review-data-pr`](../review-data-pr/SKILL.md) is the reviewer-side counterpart of this skill: it verifies the *outcomes* of the author-side steps defined here. Whenever you add, remove, or change a workflow step in this file, check whether `review-data-pr/SKILL.md` needs a matching reviewer-side check (and add it in the same commit if so). The reverse also holds — see the mirror note there.
+
 ## Inputs
 
 - `<namespace>/<old_version>/<name>`
@@ -96,6 +98,7 @@ For the **long-format with dimensions** sub-case specifically (e.g. one row per 
 - Aggregations: `paths.regions.add_aggregates(tb, index_columns=[...full key...], regions=REGIONS, aggregations={...})`.
 - Grapher: pass long tables through unchanged; the framework auto-expands them into per-cell variables.
 - Metadata: variables are keyed by the long-column name, with `<% if <dim> == "X" and <dim2> == "Y" %>...<% endif %>` Jinja blocks inside `title`, `description_short`, `display.name`. Grep this repo for `tb.format(["country", "year"` with more than two index entries to find current reference examples.
+- Jinja coverage: after building the grapher dataset, verify every active `(dim1, dim2)` cell renders a non-empty value — read every column from the built grapher dataset and assert `metadata.title` is non-empty. A dimension combination with no matching `<% if %>` branch ships an untitled indicator.
 
 ## Workflow orchestration
 
@@ -634,6 +637,7 @@ These pages need a fresh staging build, so they're only meaningful after the PR'
 - **WB income-group aggregates**: add the four classification names (`High-income countries`, `Upper-middle-income countries`, `Lower-middle-income countries`, `Low-income countries`) to your `REGIONS` list and add `data://garden/wb/<latest>/income_groups` to the DAG. `paths.regions.add_aggregates(...)` auto-resolves the classification.
 - **Detect structural placeholders dynamically**: when a source ships "balanced panel" rows that are zero everywhere by design (status combos that exist only for completeness), detect them at runtime (`groupby(...).max() == 0`) and assert the count matches the codebook. A coding change in the source then surfaces as a test failure instead of silently shipping noise.
 - **Codebook-vs-data inconsistencies**: when the codebook documents one thing but the actual CSV shows another (placeholder claimed but non-zero rows present, etc.), preserve the data as-shipped and flag it in the PR description for the producer to confirm. Don't silently force the data to match the codebook.
+- **Grapher `.meta.yml` only when it adds something**: the grapher step inherits everything via `default_metadata=ds_garden.metadata`, so drop the grapher `.meta.yml` if it only duplicates the garden values. Keep it only for genuine grapher-side overrides.
 - **`processing_level: major` requires `description_processing`**: keep `processing_level: minor` as the common default and override to `major` only on indicators that have a `description_processing` field. Don't blanket-set `major` on the common block and then leave country-level proportions without their own processing note.
 - **Per-indicator description_processing reads better than a generic shared note**: when an indicator is derived (combined-categorical buckets, regional aggregates, computed counts), spell out *that indicator's* derivation. Reusing named definitions for shared boilerplate is fine; just compose them into per-indicator sentences rather than dropping a single generic note across all indicators.
 - **`description_key` in `definitions.common` propagates only to indicators without their own list**: if you want a bullet to appear on every indicator, either keep it on `common.description_key` and don't define per-indicator lists (it inherits), or prepend it explicitly to each per-indicator list (treats it as a "first bullet" pattern).


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## Summary

`/update-dataset` (author side) and `/review-data-pr` (reviewer side) are a pair: the second verifies the outcomes of the steps defined in the first. They had drifted apart. This PR:

1. **Adds a mutual "Paired skill — keep in sync" note** at the top of both skills, instructing whoever adds/changes a step in one to add the matching check/step to the other in the same commit.
2. **Fills the gaps found in a full cross-check** of the two skills in their current state.

## Reviewer-side gaps fixed in `/review-data-pr`

- **`citation_full` / `attribution` year** — `/update-dataset` §6c warns that `etl update` copies these verbatim and the year must be bumped, but the snapshot comparison table (§5) only checked `date_published`. Added a row; stale year = 🔴.
- **Link-check inconsistency** — §6 said "anything non-2xx is a 🔴 blocker", contradicting `/update-dataset` §6c's curl-false-positive escalation (Cloudflare-fronted hosts return false 404s to curl). Now aligned: re-check with WebFetch, then Wayback; 🔴 only when all three fail.
- **`dataset.owners`** — author step 1a-bis (add yourself to `owners:`) had no reviewer counterpart. Added to §9: author missing = 🟡, existing owners reordered/dropped = 🔴.
- **Explorer/MDim re-export** — the indicator-upgrader never touches `export://explorers/...` / `export://multidim/...` steps; `/update-dataset` §7 covers re-running them, but reviewer §13 only verified the chart upgrade. Added a table row with the staging queries; an old-version reference = 🔴.
- **Tracking-issue link** — `/update-dataset` requires `Tracks: owid/owid-issues#NNNN` as the first PR-body line; reviewer §1 only flagged an empty body. Added a 🟡 check.
- Severity rubric updated to match the new checks.

## Author-side gaps fixed in `/update-dataset`

- **Grapher `.meta.yml` duplication** — reviewer §7 flags grapher meta files that only duplicate garden values, but the author skill never said to avoid them. Added a guardrail.
- **Jinja coverage for long-format dimensions** — reviewer §9 asserts every dimension cell renders a non-empty `metadata.title`; added the matching verification line to the author-side long-format pattern.

## Relationship to #6213

This commit is also cherry-picked onto the LIS branch (#6213), so both PRs carry identical content for these hunks — merge order doesn't matter. #6213 additionally replicates its own new `/update-dataset` functionality (explorer/MDim re-export and announcement counting, Codex clean-review shape) into `/review-data-pr` and `/data-updates-comms`, per the new keep-in-sync rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
