### PR TITLE
📜 Fix escaped pipe in review-data-pr export-step lookup

### DIFF
--- a/.claude/skills/review-data-pr/SKILL.md
+++ b/.claude/skills/review-data-pr/SKILL.md
@@ -208,7 +208,7 @@ Verify the author completed each post-step item from `/update-dataset`. The proc
 | Item | Verify by |
 |---|---|
 | Indicator upgrade ran (§7) | `make query SQL="SELECT COUNT(*) FROM chart_dimensions cd JOIN variables v ON cd.variableId=v.id WHERE v.catalogPath LIKE '%<ns>/<new_v>/%'"` — non-zero |
-| Explorers / MDims re-exported (§7) | Only if the DAG has `export://explorers/...` or `export://multidim/...` steps for this dataset (`rg "export://(explorers\|multidim)/.*/<short_name>" dag/ -g "*.yml"`). The indicator-upgrader never touches these, so run the two staging queries from `/update-dataset` §7 (old-version references in `explorer_variables` / `multi_dim_x_chart_configs`) — both must return empty. A hit = 🔴, the export step wasn't re-run. |
+| Explorers / MDims re-exported (§7) | Only if the DAG has `export://explorers/...` or `export://multidim/...` steps for this dataset (`rg -e "export://explorers/.*/<short_name>" -e "export://multidim/.*/<short_name>" dag/ -g "*.yml"`). The indicator-upgrader never touches these, so run the two staging queries from `/update-dataset` §7 (old-version references in `explorer_variables` / `multi_dim_x_chart_configs`) — both must return empty. A hit = 🔴, the export step wasn't re-run. |
 | Chart-diff bot result | PR comments include `<!--chart-diff-start-->` block ✅ |
 | `@codex review` posted (§9) | `gh pr view <num> --json comments` shows the trigger comment + a Codex review |
 | Codex threads resolved (§10) | `gh api graphql -f query='{ repository(owner:"owid", name:"etl") { pullRequest(number:<num>) { reviewThreads(first:20) { nodes { isResolved } } } } }'` — all `isResolved: true` |


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## Summary

Follow-up to #6235, addressing a Codex P2 that landed after the merge ([comment](https://github.com/owid/etl/pull/6235#discussion_r3387370963)).

The export-step lookup in `/review-data-pr` §13 was written as `rg "export://(explorers\|multidim)/..."` — the pipe was escaped to keep the markdown table cell rendering, but copied verbatim into a shell, `\|` matches a literal pipe instead of alternation. The lookup would never match real DAG entries, so the explorer/MDim re-export check would silently pass and stale references could slip through review.

Fixed by using two `-e` patterns (`rg -e "export://explorers/..." -e "export://multidim/..."`), which needs no pipes at all.

The same fix is applied identically on the open LIS branch (#6213), which carries the same line — merge order doesn't matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)