### PR TITLE
📊 Improve inequality MDims: P10/median/P90 default views, WID default countries

### DIFF
--- a/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
@@ -62,6 +62,8 @@ dimensions:
         name: All deciles
       - slug: "10_40_50"
         name: Poorest 50%, middle 40% and richest 10%
+      - slug: p10_p50_p90
+        name: "Poorest 10%, median, richest 10%"
       - slug: nan
         name: ""
 

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.config.yml
@@ -14,7 +14,7 @@ default_selection:
 
 default_dimensions:
   indicator: thr
-  decile: all
+  decile: p10_p50_p90
   welfare_type: dhi
   period: month
 

--- a/etl/steps/export/multidim/lis/latest/incomes_lis.py
+++ b/etl/steps/export/multidim/lis/latest/incomes_lis.py
@@ -105,6 +105,35 @@ def run() -> None:
         },
     )
 
+    # Group deciles 1, 5, 9 as P10/P50/P90 — only used for thr indicator
+    c.group_views(
+        groups=[
+            {
+                "dimension": "decile",
+                "choices": ["1", "5", "9"],
+                "choice_new_slug": "p10_p50_p90",
+                "view_config": {
+                    "hideRelativeToggle": False,
+                    "selectedFacetStrategy": "entity",
+                    "hasMapTab": False,
+                    "tab": "chart",
+                    "chartTypes": ["LineChart", "DiscreteBar"],
+                    "hideTotalValueLabel": True,
+                    "baseColorScheme": "OwidCategoricalE",
+                    "title": "{title}",
+                    "subtitle": "{subtitle}",
+                },
+                "view_metadata": {
+                    "description_short": "{subtitle}",
+                },
+            },
+        ],
+        params={
+            "title": _get_p10_p50_p90_title,
+            "subtitle": _get_p10_p50_p90_subtitle,
+        },
+    )
+
     # Filter decile views: keep only relevant deciles per indicator
     non_share = [i for i in c.dimension_choices["indicator"] if i != "share"]
     non_thr = [i for i in c.dimension_choices["indicator"] if i != "thr"]
@@ -113,6 +142,7 @@ def run() -> None:
             {"decile": ["2", "3", "4", "6", "7", "8"]},
             {"decile": ["10_40_50"], "indicator": non_share},
             {"decile": ["5", "9"], "indicator": non_thr},
+            {"decile": ["p10_p50_p90"], "indicator": non_thr},
         ]
     )
 
@@ -121,7 +151,7 @@ def run() -> None:
 
     # Customize grouped decile views: sort indicators and set display names
     for view in c.views:
-        if view.matches(decile="all") and view.indicators.y:
+        if view.matches(decile=["all", "p10_p50_p90"]) and view.indicators.y:
             # Sort indicators by decile number
             reverse_order = view.matches(indicator="share")
             view.indicators.y = sorted(view.indicators.y, key=_get_decile_number, reverse=reverse_order)
@@ -189,7 +219,7 @@ def run() -> None:
         [
             {
                 "welfare_type": ["before_vs_after"],
-                "decile": ["all", "10_40_50"],
+                "decile": ["all", "10_40_50", "p10_p50_p90"],
             }
         ]
     )
@@ -228,6 +258,23 @@ def _get_grouped_decile_subtitle(view):
         "share": f"The share of income received by each decile (tenth of the population). Income here is measured {wt_label}es and benefits.",
     }
     return subtitles.get(view.dimensions.get("indicator"), "")
+
+
+def _get_p10_p50_p90_title(view):
+    """Return title for the P10/P50/P90 grouped threshold view."""
+    period = view.dimensions.get("period")
+    wt_label = "after tax" if view.dimensions.get("welfare_type") == "dhi" else "before tax"
+    return f"Threshold income per {period} marking the poorest decile, the median, and the richest decile ({wt_label})"
+
+
+def _get_p10_p50_p90_subtitle(view):
+    """Return subtitle for the P10/P50/P90 grouped threshold view."""
+    period = view.dimensions.get("period")
+    wt_label = "after tax" if view.dimensions.get("welfare_type") == "dhi" else "before tax"
+    return (
+        f"The level of income per person per {period} below which 10%, 50% and 90% of the population falls. "
+        f"Income here is measured {wt_label}es and benefits. {PPP_ADJUSTMENT_SUBTITLE}"
+    )
 
 
 def _after_tax_catalog_path(view):

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.config.yml
@@ -14,7 +14,7 @@ default_selection:
 
 default_dimensions:
   indicator: thr
-  decile: all
+  decile: p10_p50_p90
   period: month
   survey_comparability: No spells
 

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.py
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.py
@@ -174,6 +174,7 @@ def run() -> None:
                     "chartTypes": ["LineChart", "DiscreteBar"],
                     "hideTotalValueLabel": True,
                     "baseColorScheme": "OwidCategoricalE",
+                    "yAxis": {"facetDomain": "independent"},
                     "title": "{title}",
                     "subtitle": "{subtitle}",
                 },

--- a/etl/steps/export/multidim/wid/latest/gini_wid.config.yml
+++ b/etl/steps/export/multidim/wid/latest/gini_wid.config.yml
@@ -5,7 +5,7 @@ topic_tags:
   - Economic Inequality
 
 default_selection:
-  - Chile
+  - Netherlands
   - Brazil
   - South Africa
   - United States

--- a/etl/steps/export/multidim/wid/latest/gini_wid.config.yml
+++ b/etl/steps/export/multidim/wid/latest/gini_wid.config.yml
@@ -5,12 +5,12 @@ topic_tags:
   - Economic Inequality
 
 default_selection:
-  - Netherlands
   - Brazil
   - South Africa
   - United States
   - France
   - China
+  - Netherlands
 
 default_dimensions:
   welfare_type: before tax

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.config.yml
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.config.yml
@@ -5,7 +5,7 @@ topic_tags:
   - Economic Inequality
 
 default_selection:
-  - Chile
+  - Netherlands
   - Brazil
   - South Africa
   - United States

--- a/etl/steps/export/multidim/wid/latest/incomes_wid.config.yml
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.config.yml
@@ -5,12 +5,12 @@ topic_tags:
   - Economic Inequality
 
 default_selection:
-  - Netherlands
   - Brazil
   - South Africa
   - United States
   - France
   - China
+  - Netherlands
 
 default_dimensions:
   quantile: Richest 1%

--- a/etl/steps/export/multidim/wid/latest/palma_ratio_wid.config.yml
+++ b/etl/steps/export/multidim/wid/latest/palma_ratio_wid.config.yml
@@ -5,7 +5,7 @@ topic_tags:
   - Economic Inequality
 
 default_selection:
-  - Chile
+  - Netherlands
   - Brazil
   - South Africa
   - United States

--- a/etl/steps/export/multidim/wid/latest/palma_ratio_wid.config.yml
+++ b/etl/steps/export/multidim/wid/latest/palma_ratio_wid.config.yml
@@ -5,12 +5,12 @@ topic_tags:
   - Economic Inequality
 
 default_selection:
-  - Netherlands
   - Brazil
   - South Africa
   - United States
   - France
   - China
+  - Netherlands
 
 default_dimensions:
   welfare_type: before tax


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## Summary

1. Adds a **"Poorest 10%, median, richest 10%"** decile choice to the `incomes_lis` MDim, replicating the `p10_p50_p90` grouped views that already exist in `incomes_pip`.
2. Makes this view the **default** in both `incomes_lis` and `incomes_pip` (previously both defaulted to `thr` + all deciles, per month).
3. Unchecks **"Align axis scales"** (`yAxis.facetDomain: independent`) on the PIP P10/P50/P90 views, so each country facet scales to its own data.
4. Replaces **Chile with Netherlands** in the default country selection of all three WID MDims (`incomes_wid`, `gini_wid`, `palma_ratio_wid`).

## Changes

### New LIS views
- **`incomes_lis.py`**: mirrors the PIP logic, adapted for the LIS `welfare_type` dimension:
  - New `group_views` call grouping deciles 1, 5, 9 into `p10_p50_p90` (LineChart + DiscreteBar, entity faceting, `OwidCategoricalE`).
  - Kept only for the **threshold** indicator, same as PIP (dropped for mean/median/avg/share).
  - Reuses the existing grouped-decile customization: indicators sorted poorest → richest, entities sorted by the poorest-decile column, display names from garden metadata ("Poorest decile", "5th decile (median)", "Richest decile" — identical to PIP).
  - Excluded from the `before_vs_after` welfare-type grouping (would stack 6 indicators in one chart), so the view exists separately for before/after taxes and benefits.
  - Title/subtitle helpers follow PIP's wording with the LIS welfare-type suffix, e.g. *"Threshold income per month marking the poorest decile, the median, and the richest decile (after tax)"*.
- **`incomes_lis.config.yml`**: registers the `p10_p50_p90` decile choice, placed as in the PIP config.

This yields **6 new views** (3 periods × 2 welfare types).

### Default view change
- **`incomes_lis.config.yml`** / **`incomes_pip.config.yml`**: `default_dimensions.decile` switched from `all` to `p10_p50_p90`, so both MDims open on the monthly P10/median/P90 threshold view (after tax for LIS; no spells for PIP). Verified the default resolves to an existing view in both exported configs, and visually checked both previews on staging.

### PIP facet axes
- **`incomes_pip.py`**: the P10/P50/P90 grouped views set `yAxis.facetDomain: independent`, so the "Align axis scales" toggle is off by default and each country facet uses its own y-range.

### WID default selection
- **`incomes_wid.config.yml`** / **`gini_wid.config.yml`** / **`palma_ratio_wid.config.yml`**: Chile → Netherlands in `default_selection`.

## Notes

- The build emits "missing description_key" warnings for the new grouped views — this matches the pre-existing behavior of both the LIS `all`-decile views and PIP's own `p10_p50_p90` views. The data page falls back to the first y indicator's (poorest decile) key bullets, which read fine for the grouped view — discussed and accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)