### PR TITLE
🐛 Fix row-shift bug in NVIDIA revenue snapshot

### DIFF
--- a/snapshots/artificial_intelligence/2026-06-08/nvidia_revenue.csv.dvc
+++ b/snapshots/artificial_intelligence/2026-06-08/nvidia_revenue.csv.dvc
@@ -16,6 +16,6 @@ meta:
       name: ©2026 NVIDIA Corporation
       url: https://www.nvidia.com/en-us/about-nvidia/terms-of-service/
 outs:
-  - md5: ef7de151621248d0c631605d277a82fa
-    size: 20239
+  - md5: c109a9519747ae14568973299cd04962
+    size: 20631
     path: nvidia_revenue.csv

--- a/snapshots/artificial_intelligence/2026-06-08/nvidia_revenue.py
+++ b/snapshots/artificial_intelligence/2026-06-08/nvidia_revenue.py
@@ -124,12 +124,16 @@ def _extract_old_format(pdf_bytes: bytes, source: str) -> list[dict]:
         # Some PDFs (Q4 FY21) lose segment names from rows whose label wraps
         # across two lines. Reconstruct by listing the canonical segment order
         # and filling nan rows with the ones missing from the table — skipping
-        # any segments already labelled to avoid double-assignment.
+        # any segments already labelled to avoid double-assignment. A segment
+        # is considered present if every word of its label appears anywhere on
+        # the page text (this handles wrapped labels like
+        # "Professional\n<values>\nVisualization" where the words aren't
+        # adjacent in the rendered text).
         if df.iloc[:, 0].isna().any():
             text = page.extract_text() or ""
             seg_order = ["Gaming", "Professional Visualization", "Data Center", "Auto", "OEM & Other", "TOTAL"]
             already_labelled = {str(s) for s in df.iloc[:, 0].dropna()}
-            pending = [s for s in seg_order if s not in already_labelled and s in text]
+            pending = [s for s in seg_order if s not in already_labelled and all(w in text for w in s.split())]
             for nan_idx, seg in zip(df.index[df.iloc[:, 0].isna()].tolist(), pending):
                 df.iloc[nan_idx, 0] = seg
 
@@ -252,6 +256,32 @@ def extract_nvidia_revenue() -> pd.DataFrame:
     missing = sorted(set(PDF_URLS) - set(df["source_pdf"].unique()))
     if missing:
         raise ValueError(f"Snapshot would be missing data from these source PDFs: {missing}")
+
+    # Sanity check: for each (source_pdf, quarter) two invariants must hold:
+    #   1. Sum of top-level segments equals NVIDIA's published TOTAL.
+    #   2. In the new presentation, Hyperscale + ACIE equals Data Center.
+    # These catch row-shift extraction bugs that mislabel segments without
+    # changing the row count — they would otherwise propagate silently.
+    DC_SUB_ROWS = {"Hyperscale", "AI Clouds, Industrial, & Enterprise"}
+    bad: list[str] = []
+    for (src, q), g in df.groupby(["source_pdf", "quarter"]):
+        seg_values = g.set_index("segment")["revenue_millions"]
+        total_keys = [k for k in ("TOTAL", "Total") if k in seg_values.index]
+        if not total_keys:
+            bad.append(f"{src}/{q}: no TOTAL row")
+            continue
+        reported_total = seg_values[total_keys[0]]
+        summed = seg_values.drop(total_keys + [s for s in DC_SUB_ROWS if s in seg_values.index]).sum()
+        if abs(summed - reported_total) > 0.5:
+            bad.append(f"{src}/{q}: sum of segments = {summed:.0f}, but TOTAL row = {reported_total:.0f}")
+        if DC_SUB_ROWS.issubset(seg_values.index):
+            dc_sub_sum = seg_values[list(DC_SUB_ROWS)].sum()
+            dc_total = seg_values.get("Data Center", float("nan"))
+            if pd.isna(dc_total) or abs(dc_sub_sum - dc_total) > 0.5:
+                bad.append(f"{src}/{q}: Hyperscale + ACIE = {dc_sub_sum:.0f}, but Data Center = {dc_total:.0f}")
+    if bad:
+        raise ValueError("PDF extraction integrity check failed:\n  " + "\n  ".join(bad))
+
     log.info("extraction_complete", rows=len(df), sources=df["source_pdf"].nunique(), segments=df["segment"].nunique())
     return df
 


### PR DESCRIPTION
> _Written by Claude Code — @edomt at the wheel._

## Summary

Follow-up bugfix on [#6223](https://github.com/owid/etl/pull/6223). Esteban (with Claude) spotted that the four FY2020 quarters (Apr 2019 → Jan 2020) had corrupted segment values in the just-merged dataset.

The "Data centers and AI" line was understated by ~2× for those four bars, but the values were small enough relative to the recent post-2022 boom that the visual anomaly didn't jump out either.

## What was wrong

The Q4 FY21 PDF prints "Professional Visualization" with the row label wrapping across two lines (the row's *values* sit between the words). My fallback for unlabelled rows did a substring check (`"Professional Visualization" in text`), which fails on wrapped labels. So Professional Visualization was silently dropped from the canonical-segment assignment list, and every row beneath it shifted up by one label.

Concretely, for Q1 FY20:

| Row in PDF | Real value | Label the buggy extractor gave it |
|---|---|---|
| Gaming | $1,055M | Gaming ✓ |
| Professional Visualization | $266M | Data Center ❌ |
| Data Center | $634M | Auto ❌ |
| Auto | $166M | OEM & Other ❌ |
| OEM & Other | $99M | **TOTAL** ❌ |
| TOTAL | **$2,220M** | (unlabelled → dropped) ❌ |

Why FY20 only: the Q4 FY21 PDF is the most-recent source for FY20 in the dedup step. Older PDFs win for older quarters; newer PDFs win for newer quarters.

## Fix

1. Match each word of the segment label separately, so a wrapped label is recognised when "Professional" *and* "Visualization" both appear somewhere in the page text.
2. Add two snapshot-time integrity checks that would have caught this:
   1. Sum of top-level segments must equal the published TOTAL for every `(source_pdf, quarter)`.
   2. Hyperscale + ACIE must equal Data Center in the new (Q1 FY27+) presentation.

Both invariants pass on the corrected snapshot.

## Verified

- All 13 source PDFs spot-checked one random `(quarter, segment)` cell each against the rendered PDF in Firefox; all match.
- FY20 quarters now report correct values (e.g. Q1 FY20 Total = $2,220M, Data Center = $634M).