### PR TITLE
🐝 Add related-charts refresh script for Buildkite cron

### DIFF
--- a/scripts/related-charts.sh
+++ b/scripts/related-charts.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+#  related-charts.sh
+#
+#  Refresh "related charts" recommendations from coviews
+#
+
+set -e
+
+# For logging
+start_time=$(date +%s)
+
+# Go to relevant folder
+cd /home/owid/etl
+
+echo "--- Refreshing related charts recommendations..."
+uv run etl related-charts
+
+end_time=$(date +%s)
+
+echo "--- Done! ($(($end_time - $start_time))s)"


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Adds `scripts/related-charts.sh`, a thin wrapper (following the `housekeeper.sh` pattern) that runs `etl related-charts` (#6199) on the prod ETL server. It will be invoked daily by the new Buildkite pipeline [ETL - related charts (master)](https://buildkite.com/our-world-in-data/etl-related-charts-master), whose step definition lives in `ops/.buildkite/etl/related_charts.yml`.

Before the first scheduled run can succeed:
- this PR must be merged and deployed to `/home/owid/etl`
- the ops PR adding `related_charts.yml` must be merged
- the `related_charts` table migration (owid/owid-grapher#6582) must be live in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)