### PR TITLE
✨ Copy workbench and ai folders from removed worktree in etl pr-clean

### DIFF
--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -867,17 +867,19 @@ def copy_sessions(worktree_path: Path, main_project_dir: Path) -> int:
 def copy_dir_namespaced(src: Path, dst_parent: Path, branch: str) -> Path | None:
     """Copy a worktree's `src` dir into `dst_parent/<branch>`, suffixing -1, -2... on collision.
 
-    Returns the destination path, or None if `src` is missing or empty. Unlike Claude sessions
-    (UUID-named, collision-free), these dirs use task/human names, so the whole tree lands under a
-    branch-named (and, on collision, suffixed) folder. Nothing already in `dst_parent` is overwritten.
+    Returns the destination path, or None if `src` is missing, not a directory, or empty. Unlike
+    Claude sessions (UUID-named, collision-free), these dirs use task/human names, so the whole tree
+    lands under a branch-named (and, on collision, suffixed) folder. Slashes in the branch name are
+    flattened to '-' so the result stays a single folder. Nothing already in `dst_parent` is overwritten.
     """
-    if not src.exists() or not any(p.name != ".DS_Store" for p in src.iterdir()):
+    if not src.is_dir() or not any(p.name != ".DS_Store" for p in src.iterdir()):
         return None
 
-    dest = dst_parent / branch
+    safe_branch = branch.replace("/", "-")
+    dest = dst_parent / safe_branch
     i = 1
     while dest.exists():
-        dest = dst_parent / f"{branch}-{i}"
+        dest = dst_parent / f"{safe_branch}-{i}"
         i += 1
 
     dest.parent.mkdir(parents=True, exist_ok=True)

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -666,8 +666,11 @@ are flagged with `<- worktree`. Pick a single branch, or `all`, and the tool wil
 1. (Worktree branches only) Copy that worktree's Claude sessions — the `<uuid>.jsonl` transcripts and
    their `<uuid>/` subfolders under `~/.claude/projects/<encoded-worktree-path>/` — into the main
    repo's project dir, so they stay resumable with `claude --resume` after the worktree is gone.
-2. Remove the git worktree (skipped with a warning if it has uncommitted changes).
-3. Delete the local branch.
+2. (Worktree branches only) Copy the worktree's gitignored `workbench/` and `ai/` scratch dirs into
+   `workbench/<branch>/` and `ai/<branch>/` in the main repo (suffixed `-1`, `-2`... on the rare name
+   clash), so the working notes/outputs survive the worktree removal without overwriting anything.
+3. Remove the git worktree (skipped with a warning if it has uncommitted changes).
+4. Delete the local branch.
 
 Each branch is tagged `[merged]` or `[closed]` so you can see its PR outcome before selecting.
 
@@ -861,6 +864,28 @@ def copy_sessions(worktree_path: Path, main_project_dir: Path) -> int:
     return copied
 
 
+def copy_dir_namespaced(src: Path, dst_parent: Path, branch: str) -> Path | None:
+    """Copy a worktree's `src` dir into `dst_parent/<branch>`, suffixing -1, -2... on collision.
+
+    Returns the destination path, or None if `src` is missing or empty. Unlike Claude sessions
+    (UUID-named, collision-free), these dirs use task/human names, so the whole tree lands under a
+    branch-named (and, on collision, suffixed) folder. Nothing already in `dst_parent` is overwritten.
+    """
+    if not src.exists() or not any(p.name != ".DS_Store" for p in src.iterdir()):
+        return None
+
+    dest = dst_parent / branch
+    i = 1
+    while dest.exists():
+        dest = dst_parent / f"{branch}-{i}"
+        i += 1
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(src, dest, ignore=shutil.ignore_patterns(".DS_Store"))
+    log.info(f"Copied '{src}' to '{dest}'.")
+    return dest
+
+
 def clean_branch(
     repo,
     branch: str,
@@ -877,9 +902,12 @@ def clean_branch(
         return
 
     if worktree_path is not None:
-        # Copy sessions first, then drop the worktree. The session dir lives outside the worktree,
-        # so removing the worktree never touches it — but copy first on principle.
+        # Salvage anything the worktree holds but that's gitignored (so `git worktree remove` would
+        # destroy it for good): the Claude sessions, plus the workbench/ and ai/ scratch dirs.
+        # The session dir lives outside the worktree, but copy everything before removal on principle.
         copy_sessions(worktree_path, main_project_dir)
+        for name in ("workbench", "ai"):
+            copy_dir_namespaced(worktree_path / name, main_worktree_path / name, branch)
         try:
             repo.git.worktree("remove", str(worktree_path))
             log.info(f"Removed worktree '{worktree_path}'.")


### PR DESCRIPTION
> _Written by Claude Code, @pabloarosado at the wheel._

## What

`etl pr-clean` already salvages a removed worktree's Claude sessions before running `git worktree remove`. This extends the same idea to the worktree's gitignored `workbench/` and `ai/` scratch dirs, which otherwise vanish for good when the worktree is removed (they live nowhere but the working tree).

## How

A new helper `copy_dir_namespaced(src, dst_parent, branch)` copies the worktree's `workbench/`/`ai/` into `workbench/<branch>/` and `ai/<branch>/` in the main repo. Because the whole tree lands under a branch-named folder, nothing already in the main repo's `workbench/`/`ai/` is touched. On the rare name clash (e.g. running `pr-clean` twice for a recreated branch), the destination is suffixed `-1`, `-2`, and so on. Missing or empty source dirs are skipped, and `.DS_Store` is ignored.

It runs right before the worktree removal in `clean_branch`, next to the existing session copy.

## Why namespacing rather than a file-level merge

Sessions are UUID-named, so they can be copied blind. `workbench/`/`ai/` use task and human names that can genuinely collide with the main repo's own contents, so wrapping each recovered tree under a branch-named (and, on collision, suffixed) folder is what makes "never overwrite" structural rather than best-effort. As a side benefit, recovered content is easy to tell apart from native content at a glance.

`data/` is deliberately left untouched: under `--share-data` it is a symlink into the main repo's `data/`, and copying it would make no sense anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
