### PR TITLE
📊 Cover wealth properly in WID metadata

### DIFF
--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
@@ -80,10 +80,13 @@ definitions:
     with extrapolations
     <%- endif %>
 
+  # NOTE: Wealth is a stock, so it has no period dimension in the text. Both snippets render empty
+  # for wealth; per_period carries its own leading space so usage sites glue it directly after a word.
   per_period: |-
-    <% if period in ["day", "month", "year"] %>
-    per <<period>>
-    <%- endif %>
+    <% if welfare_type != "wealth" and period in ["day", "month", "year"] %> per <<period>><% endif %>
+
+  title_period_part: |-
+    <% if welfare_type != "wealth" and period in ["day", "month", "year"] %>per <<period>>, <% endif %>
 
   verb_welfare_type: |-
     <% if welfare_type != "wealth" %>
@@ -125,7 +128,7 @@ definitions:
     <%- elif welfare_type == "after tax disposable" %>
     Income is measured after taxes have been paid and most government benefits have been received. It does not include public services like health and education, or collective spending such as defense and infrastructure, so it does not add up to national income.
     <%- elif welfare_type == "wealth" %>
-    This measure is related to net national wealth, which is the total value of non-financial (housing, land) and financial assets (deposits, bonds, equities) held by households, minus their debts.
+    This measure is related to household net wealth, which is the total value of non-financial (housing, land) and financial assets (deposits, bonds, equities) held by households, minus their debts.
     <%- endif %>
 
   description_key_ppp: |-
@@ -153,23 +156,26 @@ definitions:
   description_key_relative_poverty: |-
     This is a measure of _relative_ poverty — it captures the share of people whose {definitions.concept_welfare_type} is low by the standards typical in their own country.
 
+  intro_unequal_distribution: |-
+    <% if welfare_type != "wealth" %>Incomes are<%- else %>Wealth is<%- endif %> distributed very unequally, both between countries and within them.
+
   description_key_top_incomes: |-
-    Incomes are distributed very unequally, both between countries and within them. A large share of total income is concentrated among the very richest, making the top of the distribution important to understand. Read more in our topic page on [economic inequality](https://ourworldindata.org/economic-inequality).
+    {definitions.intro_unequal_distribution} A large share of total {definitions.concept_welfare_type} is concentrated among the very richest, making the top of the distribution important to understand. Read more in our topic page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_gini: |-
-    Incomes are distributed very unequally, both between countries and within them. The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality. We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss income inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
+    {definitions.intro_unequal_distribution} The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality.<% if welfare_type == "wealth" %> Because some people have negative net wealth — their debts are larger than their assets — the Gini coefficient for wealth can be higher than 1.<%- endif %> We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss {definitions.concept_welfare_type} inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_palma_ratio: |-
-    Incomes are distributed very unequally, both between countries and within them. The Palma ratio captures this by comparing the income share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% receive twice as much as the poorest 40%. We discuss income inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
+    {definitions.intro_unequal_distribution} The Palma ratio captures this by comparing the {definitions.concept_welfare_type} share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% <% if welfare_type != "wealth" %>receive<%- else %>own<%- endif %> twice as much as the poorest 40%. We discuss {definitions.concept_welfare_type} inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_share: |-
-    This data shows the share of total income that goes to specific groups of the population. For example, if the richest decile receives 40% of total income, it means the richest 10% of people share 40% of all income between them.
+    This data shows the share of total {definitions.concept_welfare_type} <% if welfare_type != "wealth" %>that goes to<%- else %>owned by<%- endif %> specific groups of the population. For example, if the richest decile <% if welfare_type != "wealth" %>receives<%- else %>owns<%- endif %> 40% of total {definitions.concept_welfare_type}, it means the richest 10% of people share 40% of all {definitions.concept_welfare_type} between them.
 
   description_key_avg: |-
-    This data shows the mean (average) income per person within specific groups of the population, ranked by income. For example, the poorest decile is the poorest 10% of people in a country.
+    This data shows the mean (average) {definitions.concept_welfare_type} per person within specific groups of the population, ranked by {definitions.concept_welfare_type}. For example, the poorest decile is the poorest 10% of people in a country.
 
   description_key_thr: |-
-    This data shows the income threshold for a specific group of the population. The "poorest decile" threshold, for example, is the income level below which the poorest 10% of people in a country fall.
+    This data shows the {definitions.concept_welfare_type} threshold for a specific group of the population. The "poorest decile" threshold, for example, is the {definitions.concept_welfare_type} level below which the poorest 10% of people in a country fall.
 
   description_processing_general: |-
     We extract estimations of Gini, mean, percentile thresholds, averages, and shares via the [`wid` Stata command](https://github.com/thomasblanchet/wid-stata-tool). We calculate threshold and share ratios by dividing different thresholds and shares, respectively.
@@ -194,9 +200,9 @@ definitions:
   title_threshold: |-
     {macros}
     <% if quantile == "p50p60" %>
-    Median {definitions.concept_welfare_type} {definitions.per_period}{definitions.concept_welfare_type_for_title}
+    Median {definitions.concept_welfare_type}{definitions.per_period}{definitions.concept_welfare_type_for_title}
     <%- else %>
-    Threshold {definitions.concept_welfare_type} {definitions.per_period} marking the <<quantiles_thr(quantile) | lower>>{definitions.concept_welfare_type_for_title}
+    Threshold {definitions.concept_welfare_type}{definitions.per_period} marking the <<quantiles_thr(quantile) | lower>>{definitions.concept_welfare_type_for_title}
     <%- endif %>
 
   subtitle_welfare_type: |-
@@ -633,10 +639,10 @@ tables:
   incomes:
     variables:
       mean:
-        title: Mean ({definitions.per_period}, <<welfare_type>>){definitions.title_extrapolated}
+        title: Mean ({definitions.title_period_part}<<welfare_type>>){definitions.title_extrapolated}
         unit: "international-$ in {definitions.ppp_year} prices"
         short_unit: "$"
-        description_short: Average {definitions.concept_welfare_type} {definitions.per_period}. {definitions.subtitle_welfare_type}
+        description_short: Average {definitions.concept_welfare_type}{definitions.per_period}. {definitions.subtitle_welfare_type}
         description_key:
           - "{definitions.description_key_ppp}"
           - "{definitions.description_key_welfare_type}"
@@ -649,7 +655,7 @@ tables:
           <<: *common_display
         presentation:
           grapher_config:
-            title: "Mean {definitions.concept_welfare_type} {definitions.per_period}{definitions.concept_welfare_type_for_title}"
+            title: "Mean {definitions.concept_welfare_type}{definitions.per_period}{definitions.concept_welfare_type_for_title}"
             subtitle: |-
               {definitions.subtitle_ppp} {definitions.subtitle_welfare_type}
             note: "{definitions.note_ppp_before_tax}"
@@ -665,10 +671,10 @@ tables:
             selectedEntityNames: *entity_names_inequality
 
       median:
-        title: Median ({definitions.per_period}, <<welfare_type>>){definitions.title_extrapolated}
+        title: Median ({definitions.title_period_part}<<welfare_type>>){definitions.title_extrapolated}
         unit: "international-$ in {definitions.ppp_year} prices"
         short_unit: "$"
-        description_short: Value of {definitions.concept_welfare_type} {definitions.per_period} below which 50% of the population live. {definitions.subtitle_welfare_type}
+        description_short: Value of {definitions.concept_welfare_type}{definitions.per_period} below which 50% of the population live. {definitions.subtitle_welfare_type}
         description_key:
           - "{definitions.description_key_ppp}"
           - "{definitions.description_key_welfare_type}"
@@ -681,7 +687,7 @@ tables:
           <<: *common_display
         presentation:
           grapher_config:
-            title: "Median {definitions.concept_welfare_type} {definitions.per_period}{definitions.concept_welfare_type_for_title}"
+            title: "Median {definitions.concept_welfare_type}{definitions.per_period}{definitions.concept_welfare_type_for_title}"
             subtitle: |-
               {definitions.subtitle_ppp} {definitions.subtitle_welfare_type}
             note: "{definitions.note_ppp_before_tax}"
@@ -699,12 +705,12 @@ tables:
       avg:
         title: |-
           {macros}
-          Average ({definitions.per_period}, <<quantiles_avg_share(quantile) | lower>>, <<welfare_type>>){definitions.title_extrapolated}
+          Average ({definitions.title_period_part}<<quantiles_avg_share(quantile) | lower>>, <<welfare_type>>){definitions.title_extrapolated}
         unit: "international-$ in {definitions.ppp_year} prices"
         short_unit: "$"
         description_short: |-
           {macros}
-          The mean {definitions.concept_welfare_type} {definitions.per_period} within the <<quantiles_avg_share(quantile) | lower>><<quantiles_avg_share_tenth_population(quantile)>>. {definitions.subtitle_welfare_type}
+          The mean {definitions.concept_welfare_type}{definitions.per_period} within the <<quantiles_avg_share(quantile) | lower>><<quantiles_avg_share_tenth_population(quantile)>>. {definitions.subtitle_welfare_type}
         description_key:
           - "{definitions.description_key_avg}"
           - "{definitions.description_key_ppp}"
@@ -722,10 +728,10 @@ tables:
           grapher_config:
             title: |-
               {macros}
-              Mean {definitions.concept_welfare_type} {definitions.per_period} within the <<quantiles_avg_share(quantile) | lower>>{definitions.concept_welfare_type_for_title}
+              Mean {definitions.concept_welfare_type}{definitions.per_period} within the <<quantiles_avg_share(quantile) | lower>>{definitions.concept_welfare_type_for_title}
             subtitle: |-
               {macros}
-              The mean {definitions.concept_welfare_type} {definitions.per_period} within the <<quantiles_avg_share(quantile) | lower>><<quantiles_avg_share_tenth_population(quantile)>>. {definitions.subtitle_ppp} {definitions.subtitle_welfare_type}
+              The mean {definitions.concept_welfare_type}{definitions.per_period} within the <<quantiles_avg_share(quantile) | lower>><<quantiles_avg_share_tenth_population(quantile)>>. {definitions.subtitle_ppp} {definitions.subtitle_welfare_type}
             note: "{definitions.note_ppp_before_tax}"
             hasMapTab: true
             tab: map
@@ -783,12 +789,12 @@ tables:
       thr:
         title: |-
           {macros}
-          Threshold ({definitions.per_period}, <<quantiles_thr(quantile) | lower>>, <<welfare_type>>){definitions.title_extrapolated}
+          Threshold ({definitions.title_period_part}<<quantiles_thr(quantile) | lower>>, <<welfare_type>>){definitions.title_extrapolated}
         unit: "international-$ in {definitions.ppp_year} prices"
         short_unit: "$"
         description_short: |-
           {macros}
-          The level of {definitions.concept_welfare_type} {definitions.per_period} below which <<quantiles_thr_percentage(quantile)>>% of the population falls. {definitions.subtitle_welfare_type}
+          The level of {definitions.concept_welfare_type}{definitions.per_period} below which <<quantiles_thr_percentage(quantile)>>% of the population falls. {definitions.subtitle_welfare_type}
         description_key:
           - "{definitions.description_key_thr}"
           - "{definitions.description_key_ppp}"
@@ -808,7 +814,7 @@ tables:
               {definitions.title_threshold}
             subtitle: |-
               {macros}
-              The level of {definitions.concept_welfare_type} {definitions.per_period} below which <<quantiles_thr_percentage(quantile)>>% of the population falls. {definitions.subtitle_ppp} {definitions.subtitle_welfare_type}
+              The level of {definitions.concept_welfare_type}{definitions.per_period} below which <<quantiles_thr_percentage(quantile)>>% of the population falls. {definitions.subtitle_ppp} {definitions.subtitle_welfare_type}
             note: "{definitions.note_ppp_before_tax}"
             hasMapTab: true
             tab: map

--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
@@ -116,13 +116,6 @@ definitions:
     owned by
     <%- endif %>
 
-  concept_welfare_type_subject: |-
-    <% if welfare_type != "wealth" %>
-    Incomes are
-    <%- else %>
-    Wealth is
-    <%- endif %>
-
   concept_welfare_type: |-
     <% if welfare_type != "wealth" %>
     income
@@ -185,7 +178,11 @@ definitions:
     This is a measure of _relative_ poverty — it captures the share of people whose {definitions.concept_welfare_type} is low by the standards typical in their own country.
 
   intro_unequal_distribution: |-
-    {definitions.concept_welfare_type_subject} distributed very unequally, both between countries and within them.
+    <% if welfare_type != "wealth" %>
+    Incomes are distributed very unequally, both between countries and within them.
+    <%- else %>
+    Wealth is distributed very unequally, both between countries and within them — typically even more unequally than income.
+    <%- endif %>
 
   description_key_gini_wealth_note: |-
     <% if welfare_type == "wealth" %>

--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
@@ -187,15 +187,16 @@ definitions:
   intro_unequal_distribution: |-
     {definitions.concept_welfare_type_subject} distributed very unequally, both between countries and within them.
 
-  # NOTE: Renders empty for income, so it carries its own leading space — glue it directly after a word.
   description_key_gini_wealth_note: |-
-    <% if welfare_type == "wealth" %> Because some people have negative net wealth — their debts are larger than their assets — the Gini coefficient for wealth can be higher than 1.<% endif %>
+    <% if welfare_type == "wealth" %>
+    Because some people have negative net wealth — their debts are larger than their assets — the Gini coefficient for wealth can be higher than 1.
+    <%- endif %>
 
   description_key_top_incomes: |-
     {definitions.intro_unequal_distribution} A large share of total {definitions.concept_welfare_type} is concentrated among the very richest, making the top of the distribution important to understand. Read more in our topic page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_gini: |-
-    {definitions.intro_unequal_distribution} The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality.{definitions.description_key_gini_wealth_note} We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss {definitions.concept_welfare_type} inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
+    {definitions.intro_unequal_distribution} The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality. We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss {definitions.concept_welfare_type} inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_palma_ratio: |-
     {definitions.intro_unequal_distribution} The Palma ratio captures this by comparing the {definitions.concept_welfare_type} share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% {definitions.verb_welfare_type_present_plural} twice as much as the poorest 40%. We discuss {definitions.concept_welfare_type} inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
@@ -321,6 +322,7 @@ tables:
         description_short: The [Gini coefficient](#dod:gini) measures inequality on a scale from 0 to 1. Higher values indicate higher inequality. {definitions.description_short_welfare_type_inequality}
         description_key:
           - "{definitions.description_key_gini}"
+          - "{definitions.description_key_gini_wealth_note}"
           - "{definitions.description_key_welfare_type}"
           - "{definitions.description_key_methodology_1}"
           - "{definitions.description_key_methodology_2}"

--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.meta.yml
@@ -95,6 +95,34 @@ definitions:
     owned
     <%- endif %>
 
+  verb_welfare_type_present: |-
+    <% if welfare_type != "wealth" %>
+    receives
+    <%- else %>
+    owns
+    <%- endif %>
+
+  verb_welfare_type_present_plural: |-
+    <% if welfare_type != "wealth" %>
+    receive
+    <%- else %>
+    own
+    <%- endif %>
+
+  verb_welfare_type_goes_to: |-
+    <% if welfare_type != "wealth" %>
+    that goes to
+    <%- else %>
+    owned by
+    <%- endif %>
+
+  concept_welfare_type_subject: |-
+    <% if welfare_type != "wealth" %>
+    Incomes are
+    <%- else %>
+    Wealth is
+    <%- endif %>
+
   concept_welfare_type: |-
     <% if welfare_type != "wealth" %>
     income
@@ -157,19 +185,23 @@ definitions:
     This is a measure of _relative_ poverty — it captures the share of people whose {definitions.concept_welfare_type} is low by the standards typical in their own country.
 
   intro_unequal_distribution: |-
-    <% if welfare_type != "wealth" %>Incomes are<%- else %>Wealth is<%- endif %> distributed very unequally, both between countries and within them.
+    {definitions.concept_welfare_type_subject} distributed very unequally, both between countries and within them.
+
+  # NOTE: Renders empty for income, so it carries its own leading space — glue it directly after a word.
+  description_key_gini_wealth_note: |-
+    <% if welfare_type == "wealth" %> Because some people have negative net wealth — their debts are larger than their assets — the Gini coefficient for wealth can be higher than 1.<% endif %>
 
   description_key_top_incomes: |-
     {definitions.intro_unequal_distribution} A large share of total {definitions.concept_welfare_type} is concentrated among the very richest, making the top of the distribution important to understand. Read more in our topic page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_gini: |-
-    {definitions.intro_unequal_distribution} The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality.<% if welfare_type == "wealth" %> Because some people have negative net wealth — their debts are larger than their assets — the Gini coefficient for wealth can be higher than 1.<%- endif %> We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss {definitions.concept_welfare_type} inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
+    {definitions.intro_unequal_distribution} The Gini coefficient is a common measure of inequality, which summarizes the distribution and expresses it in terms of a number from 0 to 1. Higher values indicate higher inequality.{definitions.description_key_gini_wealth_note} We explain how it works in our article [Measuring inequality: what is the Gini coefficient?](https://ourworldindata.org/what-is-the-gini-coefficient), and discuss {definitions.concept_welfare_type} inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_palma_ratio: |-
-    {definitions.intro_unequal_distribution} The Palma ratio captures this by comparing the {definitions.concept_welfare_type} share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% <% if welfare_type != "wealth" %>receive<%- else %>own<%- endif %> twice as much as the poorest 40%. We discuss {definitions.concept_welfare_type} inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
+    {definitions.intro_unequal_distribution} The Palma ratio captures this by comparing the {definitions.concept_welfare_type} share of the richest 10% to that of the poorest 40%. For example, a value of 2 means the richest 10% {definitions.verb_welfare_type_present_plural} twice as much as the poorest 40%. We discuss {definitions.concept_welfare_type} inequality more broadly on our page on [economic inequality](https://ourworldindata.org/economic-inequality).
 
   description_key_share: |-
-    This data shows the share of total {definitions.concept_welfare_type} <% if welfare_type != "wealth" %>that goes to<%- else %>owned by<%- endif %> specific groups of the population. For example, if the richest decile <% if welfare_type != "wealth" %>receives<%- else %>owns<%- endif %> 40% of total {definitions.concept_welfare_type}, it means the richest 10% of people share 40% of all {definitions.concept_welfare_type} between them.
+    This data shows the share of total {definitions.concept_welfare_type} {definitions.verb_welfare_type_goes_to} specific groups of the population. For example, if the richest decile {definitions.verb_welfare_type_present} 40% of total {definitions.concept_welfare_type}, it means the richest 10% of people share 40% of all {definitions.concept_welfare_type} between them.
 
   description_key_avg: |-
     This data shows the mean (average) {definitions.concept_welfare_type} per person within specific groups of the population, ranked by {definitions.concept_welfare_type}. For example, the poorest decile is the poorest 10% of people in a country.

--- a/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.py
+++ b/etl/steps/data/garden/wid/2026-02-10/world_inequality_database.py
@@ -131,6 +131,14 @@ def run() -> None:
     # Add period dimension to incomes table
     tb_incomes = add_period_dimension(tb=tb_incomes)
 
+    # Wealth is a stock: it must not have day/month variants, nor relative poverty estimations.
+    assert not ((tb_incomes["welfare_type"] == "wealth") & tb_incomes["period"].isin(["day", "month"])).any(), (
+        "Wealth rows must not have day/month period variants."
+    )
+    assert not (tb_relative_poverty["welfare_type"] == "wealth").any(), (
+        "Wealth must not be included in relative poverty estimations."
+    )
+
     # Sanity checks
     sanity_checks(
         tb_inequality=tb_inequality,
@@ -297,8 +305,10 @@ def add_period_dimension(tb: Table) -> Table:
     tb_non_period = tb[["country", "year", "welfare_type", "quantile", "extrapolated", "share"]].copy()
 
     # Create two copies of tb_period, one for "day" and another for "month"
-    tb_day = tb_period.copy()
-    tb_month = tb_period.copy()
+    # NOTE: Wealth is a stock, not a flow — per-day/per-month values are not meaningful for it,
+    # so only income welfare types get day/month variants. Wealth keeps a single "year" period.
+    tb_day = tb_period[tb_period["welfare_type"] != "wealth"].copy()
+    tb_month = tb_period[tb_period["welfare_type"] != "wealth"].copy()
 
     for col in ["mean", "median", "avg", "thr"]:
         tb_day[col] = tb_day[col] / 365
@@ -344,6 +354,10 @@ def add_relative_poverty(tb_inequality: Table, tb_incomes: Table, tb_distributio
     tb_incomes = tb_incomes.copy()
     tb_distribution = tb_distribution.copy()
     tb_inequality = tb_inequality.copy()
+
+    # NOTE: Relative poverty is an income concept (the poverty line is a share of the median income),
+    # so wealth is excluded from these estimations.
+    tb_distribution = tb_distribution[tb_distribution["welfare_type"] != "wealth"].reset_index(drop=True)
 
     # Filter tb_incomes to only include median values
     tb_median = tb_incomes[tb_incomes["quantile"].isnull()][

--- a/snapshots/wid/2026-02-10/wid_indices.do
+++ b/snapshots/wid/2026-02-10/wid_indices.do
@@ -5,7 +5,7 @@ This program extracts inequality data from LIS for three types of income and one
 	- Pretax national income, income before the payment and receipt of taxes and benefits, but after payment of public and private pensions.
 	- Post-tax disposable income, income that includes all cash redistribution through the tax and transfer system, but does not include in-kind benefits and therefore does not add up to national income.
 	- Post-tax national income, income that includes all cash redistribution through the tax and transfer system and also in-kind transfers (i.e., government consumption expenditures) to individuals.
-	- Net national wealth, the total value of non-financial and financial assets (housing, land, deposits, bonds, equities, etc.) held by households, minus their debts.
+	- Household net wealth, the total value of non-financial and financial assets (housing, land, deposits, bonds, equities, etc.) held by households, minus their debts.
 
 The inequality variables extracted from here include Gini coefficients, averages, thresholds and shares per decile, statistics for the top 1, 0.1, 0.01 and 0.001% percentile and share ratios.
 When needed, values are converted to PPP (2011 vintage) adjusted to prices of the most recent year available.


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## Summary

The WID dataset has a `welfare_type` dimension that includes **wealth**, but several `description_key` definitions and templates hardcoded income wording — so wealth indicators showed bullets like "Incomes are distributed very unequally…" and "the share of total **income** that goes to…". This PR makes all user-facing text welfare-aware and removes two data-side artifacts that treated wealth (a stock) like an income flow.

## Text fixes (`world_inequality_database.meta.yml`)

All done by splicing named dynamic-YAML snippets into the **existing** sentences — no inline conditionals in the prose; the welfare-dependent words live in standalone definitions (`verb_welfare_type_present`, `verb_welfare_type_goes_to`, etc.), and conditional sentences follow the `description_key_posttax` pattern (own bullet, renders empty when not applicable). Income renders are **byte-identical** to before — verified by diffing rendered metadata for `before tax` / `after tax` / per-day variants against a pre-change baseline.

| Definition | Income render (unchanged) | Wealth render (new) |
|---|---|---|
| `intro_unequal_distribution` (bullet 1 of share/gini/palma) | "Incomes are distributed very unequally, both between countries and within them." | "**Wealth is** distributed very unequally, both between countries and within them — **typically even more unequally than income**." |
| `description_key_top_incomes` (share bullet 1) | "…A large share of total income is concentrated…" | "…A large share of total **wealth** is concentrated…" |
| `description_key_share` (share bullet 2) | "…total income that goes to… receives 40% of total income…" | "…total **wealth owned by**… **owns** 40% of total **wealth**…" |
| `description_key_gini` + new `description_key_gini_wealth_note` | unchanged (4 bullets) | "…discuss **wealth** inequality…" + standalone bullet: *negative net wealth means the wealth Gini can exceed 1* (the data contains South Africa values up to 1.06) |
| `description_key_palma_ratio` | unchanged | "…comparing the **wealth** share… the richest 10% **own** twice as much…" |
| `description_key_avg` / `description_key_thr` | unchanged | "mean **wealth** per person… ranked by **wealth**" / "**wealth** threshold… **wealth** level" |
| `description_key_welfare_type` | — | "net national wealth" → "**household net wealth**" (the data uses WID's `hweal` codes = household wealth, not `nweal`) |

## Data fixes (`world_inequality_database.py`)

- **Dropped per-day/per-month wealth variants** (`add_period_dimension`): they were just the yearly stock ÷ 365/30, which is meaningless for a stock. Wealth keeps a single `year` period, and titles no longer say "per year" for wealth (e.g. "Mean (wealth)", "Mean wealth within the richest decile").
- **Dropped wealth from relative poverty** (`add_relative_poverty`): relative poverty is an income concept (line = % of median income).
- Added hard asserts for both invariants in `run()`.
- **0 charts** used any of the 122 removed variables (checked `chart_dimensions` on the grapher DB), so no chart remapping is needed.

Also fixed the "Net national wealth" label in the `wid_indices.do` extraction-script comment (doc-only).

## MDims

No changes needed in `incomes_wid` / `gini_wid` / `palma_ratio_wid`: they expose no wealth views, reference none of the dropped variables, and all their verbatim-text drift asserts pass (income bullets are unchanged). All three rebuilt and validated cleanly against staging.

## Verification

- Rendered-metadata diff against baseline: income variants byte-identical, wealth variants as intended (re-checked after each refactor).
- FAUST audits before/after (`ai/wid_faust_before.md` / `ai/wid_faust_after.md`, local): income sections identical except auto-slug renumbering; wealth sections show exactly the intended changes.
- Spacing scan over all 822 rendered grapher columns: no double spaces / stray whitespace.
- Rebuilt garden + grapher locally; new sanity asserts pass; income row counts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)