### PR TITLE
📊 Update NCD-RisC human height source metadata

### DIFF
--- a/snapshots/health/2019-05-14/human_height__ncd_risc__2017.feather.dvc
+++ b/snapshots/health/2019-05-14/human_height__ncd_risc__2017.feather.dvc
@@ -4,11 +4,11 @@ meta:
     title: Human height
     description: |-
       Mean heights of men and women aged 18 or older by birth year, extending from 1896 to 1996.
-    citation_full: NCD Risk Factor Collaboration (NCD-RisC) (2017). Human height data.
+    citation_full: 'NCD Risk Factor Collaboration (NCD-RisC) (2016) A century of trends in adult human height. eLife 5:e13410. https://doi.org/10.7554/eLife.13410'
     attribution_short: NCD-RisC
-    url_main: http://www.ncdrisc.org/data-downloads-height.html
+    url_main: https://www.ncdrisc.org/archives.html
     date_accessed: '2019-05-14'
-    date_published: '2017'
+    date_published: '2016'
 outs:
   - md5: 5d88b0e9b0fb3bdc7db1e395bab9464a
     size: 812530


### PR DESCRIPTION
> _Written by Claude Code — @edomt at the wheel._

## Summary
- Update the NCD-RisC human height snapshot metadata to point to the canonical eLife paper.
- New `citation_full`: `NCD Risk Factor Collaboration (NCD-RisC) (2016) A century of trends in adult human height. eLife 5:e13410. https://doi.org/10.7554/eLife.13410`
- New `url_main`: https://www.ncdrisc.org/archives.html (the old `data-downloads-height.html` page is no longer canonical).
- `date_published` corrected to `2016`.

Data file is unchanged — metadata-only edit.

## Test plan
- [ ] Staging chart-diff shows updated source line / "data published in" year on charts using these indicators.