### PR TITLE
🐛 Warn on unmapped narrative charts in indicator upgrade

### DIFF
--- a/apps/indicator_upgrade/upgrade.py
+++ b/apps/indicator_upgrade/upgrade.py
@@ -154,20 +154,24 @@ def push_new_narrative_charts_cli(
             # Update variable IDs in the full config
             config_new = update_narrative_chart_config(full_config, indicator_mapping)
 
+            # Check on every chart, not only unchanged ones: a config can mix a mappable indicator
+            # with a stale pin from an even older dataset version, so a partial remap would
+            # otherwise PUT the stale ID back silently.
+            stale = _find_stale_lineage_variables(
+                collect_variable_ids_from_narrative_config(full_config), indicator_mapping
+            )
+            if stale:
+                log.warning(
+                    f"Narrative chart {nc.id} ({nc.name}) pins indicators from a version of the upgraded "
+                    f"dataset that the mapping does not cover: {stale}. These were likely left behind by a "
+                    "previous upgrade cycle — remap them with an explicit mapping "
+                    "(WizardDB.add_variable_mapping + push_new_narrative_charts_cli)."
+                )
+
             if config_new == full_config:
                 # Nothing in this config matched the mapping. PUTting an identical config would only
                 # bump updatedAt and make the log claim a remap that never happened.
-                stale = _find_stale_lineage_variables(
-                    collect_variable_ids_from_narrative_config(full_config), indicator_mapping
-                )
-                if stale:
-                    log.warning(
-                        f"Narrative chart {nc.id} ({nc.name}) was NOT remapped: it pins indicators from a "
-                        f"version of the upgraded dataset that the mapping does not cover: {stale}. These were "
-                        "likely left behind by a previous upgrade cycle — remap them with an explicit mapping "
-                        "(WizardDB.add_variable_mapping + push_new_narrative_charts_cli)."
-                    )
-                else:
+                if not stale:
                     log.info(f"Narrative chart {nc.id} ({nc.name}) references no mapped indicators — left unchanged.")
                 skipped += 1
                 continue

--- a/apps/indicator_upgrade/upgrade.py
+++ b/apps/indicator_upgrade/upgrade.py
@@ -75,14 +75,17 @@ def get_affected_narrative_charts_cli(charts: list[gm.Chart]) -> list[gm.Narrati
     return narrative_charts
 
 
-# User-facing text fields (FAUST: Footnote, Axis titles, Units, Subtitle, Title) checked for stale
-# overrides in narrative charts, as config paths.
+# User-facing text fields (FAUST) checked for stale overrides in narrative charts, as config paths.
 FAUST_FIELDS = {
     "title": ("title",),
     "subtitle": ("subtitle",),
     "note": ("note",),
-    "y-axis label": ("yAxis", "label"),
-    "x-axis label": ("xAxis", "label"),
+}
+# Per-dimension display fields checked for stale overrides (under dimensions[].display).
+FAUST_DISPLAY_TEXT_FIELDS = {
+    "display.name": "name",
+    "unit": "unit",
+    "short unit": "shortUnit",
 }
 # Similarity (difflib ratio) above which a differing override is treated as a stale copy of the
 # parent's text rather than an intentional rewrite.
@@ -106,7 +109,20 @@ def _normalize_chart_text(text: str) -> str:
     return " ".join(text.split())
 
 
-def _find_stale_faust_overrides(patch_config: dict, parent_config: dict) -> list[tuple[str, str, str]]:
+def _texts_look_stale(narrative_value: str, parent_value: str) -> bool:
+    """True when two differing texts are similar enough that the narrative one looks like a stale
+    copy of the parent's (rather than an intentional rewrite)."""
+    narrative_norm = _normalize_chart_text(narrative_value)
+    parent_norm = _normalize_chart_text(parent_value)
+    return (
+        narrative_norm == parent_norm
+        or difflib.SequenceMatcher(None, narrative_norm, parent_norm).ratio() >= FAUST_STALE_SIMILARITY
+    )
+
+
+def _find_stale_faust_overrides(
+    patch_config: dict, parent_config: dict, indicator_mapping: dict[int, int] | None = None
+) -> list[tuple[str, str, str]]:
     """Find user-facing text overrides in a narrative chart that look like stale copies of the parent.
 
     A narrative chart pins in its patch any field it overrides. Overriding the title or subtitle is
@@ -114,25 +130,47 @@ def _find_stale_faust_overrides(patch_config: dict, parent_config: dict) -> list
     *nearly identical* to the parent's current text is the signature of a stale copy: the narrative
     chart froze the parent's text at creation time and the parent has since evolved (e.g. gained
     detail-on-demand links in its note). Texts are compared after stripping markdown link syntax;
-    equal-after-normalization or highly similar values are reported as stale. Returns
-    (field_label, narrative_value, parent_value) for each such field; identical raw values and
-    substantially different overrides are not reported.
+    equal-after-normalization or highly similar values are reported as stale. Checked fields:
+    title, subtitle, note, and — per dimension, matched to the parent by (mapped) variable id —
+    display.name, unit, shortUnit, and tolerance (numeric: any pinned difference is reported).
+    Returns (field_label, narrative_value, parent_value) for each such field; identical raw values
+    and substantially different text overrides are not reported.
     """
     stale = []
+
+    # Top-level text fields.
     for label, path in FAUST_FIELDS.items():
         narrative_value = _get_nested(patch_config, path)
         parent_value = _get_nested(parent_config, path)
         if not isinstance(narrative_value, str) or not isinstance(parent_value, str):
             continue
-        if narrative_value == parent_value:
-            continue
-        narrative_norm = _normalize_chart_text(narrative_value)
-        parent_norm = _normalize_chart_text(parent_value)
-        if (
-            narrative_norm == parent_norm
-            or difflib.SequenceMatcher(None, narrative_norm, parent_norm).ratio() >= FAUST_STALE_SIMILARITY
-        ):
+        if narrative_value != parent_value and _texts_look_stale(narrative_value, parent_value):
             stale.append((label, narrative_value, parent_value))
+
+    # Per-dimension display fields, matched to the parent dimension by variable id (translating
+    # the narrative chart's pinned id through the mapping, since the patch may predate the remap).
+    parent_displays = {dim.get("variableId"): dim.get("display") or {} for dim in parent_config.get("dimensions", [])}
+    for dim in patch_config.get("dimensions", []):
+        variable_id = dim.get("variableId")
+        if indicator_mapping and variable_id in indicator_mapping:
+            variable_id = indicator_mapping[variable_id]
+        parent_display = parent_displays.get(variable_id)
+        if parent_display is None:
+            continue
+        display = dim.get("display") or {}
+        for label, key in FAUST_DISPLAY_TEXT_FIELDS.items():
+            narrative_value = display.get(key)
+            parent_value = parent_display.get(key)
+            if not isinstance(narrative_value, str) or not isinstance(parent_value, str):
+                continue
+            if narrative_value != parent_value and _texts_look_stale(narrative_value, parent_value):
+                stale.append((f"{label} (indicator {variable_id})", narrative_value, parent_value))
+        # Tolerance is numeric — no similarity notion; any pinned difference is worth review.
+        narrative_tolerance = display.get("tolerance")
+        parent_tolerance = parent_display.get("tolerance")
+        if narrative_tolerance is not None and parent_tolerance is not None and narrative_tolerance != parent_tolerance:
+            stale.append((f"tolerance (indicator {variable_id})", str(narrative_tolerance), str(parent_tolerance)))
+
     return stale
 
 
@@ -249,7 +287,9 @@ def push_new_narrative_charts_cli(
         try:
             # Warn when the narrative chart pins user-facing text that is nearly identical to the
             # parent's current text — likely frozen at creation time and stale since.
-            stale_faust = _find_stale_faust_overrides(patches.get(nc.id, {}), parent_configs.get(nc.parentChartId, {}))
+            stale_faust = _find_stale_faust_overrides(
+                patches.get(nc.id, {}), parent_configs.get(nc.parentChartId, {}), indicator_mapping
+            )
             if stale_faust:
                 details = "; ".join(
                     f"{field}: narrative={narrative_value!r} vs parent={parent_value!r}"

--- a/apps/indicator_upgrade/upgrade.py
+++ b/apps/indicator_upgrade/upgrade.py
@@ -87,6 +87,12 @@ FAUST_DISPLAY_TEXT_FIELDS = {
     "unit": "unit",
     "short unit": "shortUnit",
 }
+# Numeric display fields — no similarity notion; any pinned difference is reported.
+FAUST_DISPLAY_NUMERIC_FIELDS = {
+    "tolerance": "tolerance",
+    "decimal places": "numDecimalPlaces",
+    "significant figures": "numSignificantFigures",
+}
 # Similarity (difflib ratio) above which a differing override is treated as a stale copy of the
 # parent's text rather than an intentional rewrite.
 FAUST_STALE_SIMILARITY = 0.8
@@ -132,7 +138,8 @@ def _find_stale_faust_overrides(
     detail-on-demand links in its note). Texts are compared after stripping markdown link syntax;
     equal-after-normalization or highly similar values are reported as stale. Checked fields:
     title, subtitle, note, and — per dimension, matched to the parent by (mapped) variable id —
-    display.name, unit, shortUnit, and tolerance (numeric: any pinned difference is reported).
+    display.name, unit, shortUnit, and the numeric fields tolerance, numDecimalPlaces, and
+    numSignificantFigures (numeric: any pinned difference is reported).
     Returns (field_label, narrative_value, parent_value) for each such field; identical raw values
     and substantially different text overrides are not reported.
     """
@@ -165,11 +172,13 @@ def _find_stale_faust_overrides(
                 continue
             if narrative_value != parent_value and _texts_look_stale(narrative_value, parent_value):
                 stale.append((f"{label} (indicator {variable_id})", narrative_value, parent_value))
-        # Tolerance is numeric — no similarity notion; any pinned difference is worth review.
-        narrative_tolerance = display.get("tolerance")
-        parent_tolerance = parent_display.get("tolerance")
-        if narrative_tolerance is not None and parent_tolerance is not None and narrative_tolerance != parent_tolerance:
-            stale.append((f"tolerance (indicator {variable_id})", str(narrative_tolerance), str(parent_tolerance)))
+        # Numeric fields (tolerance, decimal places, significant figures) — no similarity notion;
+        # any pinned difference is worth review.
+        for label, key in FAUST_DISPLAY_NUMERIC_FIELDS.items():
+            narrative_value = display.get(key)
+            parent_value = parent_display.get(key)
+            if narrative_value is not None and parent_value is not None and narrative_value != parent_value:
+                stale.append((f"{label} (indicator {variable_id})", str(narrative_value), str(parent_value)))
 
     return stale
 

--- a/apps/indicator_upgrade/upgrade.py
+++ b/apps/indicator_upgrade/upgrade.py
@@ -1,5 +1,8 @@
 """CLI functions for upgrading indicators and charts."""
 
+import difflib
+import json
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import click
@@ -72,6 +75,100 @@ def get_affected_narrative_charts_cli(charts: list[gm.Chart]) -> list[gm.Narrati
     return narrative_charts
 
 
+# User-facing text fields (FAUST: Footnote, Axis titles, Units, Subtitle, Title) checked for stale
+# overrides in narrative charts, as config paths.
+FAUST_FIELDS = {
+    "title": ("title",),
+    "subtitle": ("subtitle",),
+    "note": ("note",),
+    "y-axis label": ("yAxis", "label"),
+    "x-axis label": ("xAxis", "label"),
+}
+# Similarity (difflib ratio) above which a differing override is treated as a stale copy of the
+# parent's text rather than an intentional rewrite.
+FAUST_STALE_SIMILARITY = 0.8
+
+
+def _get_nested(config: dict, path: tuple[str, ...]):
+    value = config
+    for key in path:
+        if not isinstance(value, dict):
+            return None
+        value = value.get(key)
+    return value
+
+
+def _normalize_chart_text(text: str) -> str:
+    """Normalize chart text for staleness comparison: strip markdown links (keep anchor text) and
+    collapse whitespace, so e.g. a parent note that gained detail-on-demand links still matches a
+    narrative override that froze the older, link-less wording."""
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)
+    return " ".join(text.split())
+
+
+def _find_stale_faust_overrides(patch_config: dict, parent_config: dict) -> list[tuple[str, str, str]]:
+    """Find user-facing text overrides in a narrative chart that look like stale copies of the parent.
+
+    A narrative chart pins in its patch any field it overrides. Overriding the title or subtitle is
+    usually an intentional rewrite (that's what narrative charts are for), but an override that is
+    *nearly identical* to the parent's current text is the signature of a stale copy: the narrative
+    chart froze the parent's text at creation time and the parent has since evolved (e.g. gained
+    detail-on-demand links in its note). Texts are compared after stripping markdown link syntax;
+    equal-after-normalization or highly similar values are reported as stale. Returns
+    (field_label, narrative_value, parent_value) for each such field; identical raw values and
+    substantially different overrides are not reported.
+    """
+    stale = []
+    for label, path in FAUST_FIELDS.items():
+        narrative_value = _get_nested(patch_config, path)
+        parent_value = _get_nested(parent_config, path)
+        if not isinstance(narrative_value, str) or not isinstance(parent_value, str):
+            continue
+        if narrative_value == parent_value:
+            continue
+        narrative_norm = _normalize_chart_text(narrative_value)
+        parent_norm = _normalize_chart_text(parent_value)
+        if (
+            narrative_norm == parent_norm
+            or difflib.SequenceMatcher(None, narrative_norm, parent_norm).ratio() >= FAUST_STALE_SIMILARITY
+        ):
+            stale.append((label, narrative_value, parent_value))
+    return stale
+
+
+def _load_patches_and_parent_configs(
+    narrative_charts: list[gm.NarrativeChart],
+) -> tuple[dict[int, dict], dict[int, dict]]:
+    """Load each narrative chart's config patch and each parent chart's full config."""
+
+    def to_dict(value) -> dict:
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, (str, bytes)):
+            return json.loads(value)
+        return {}
+
+    nc_ids = sorted({nc.id for nc in narrative_charts if nc.id})
+    parent_ids = sorted({nc.parentChartId for nc in narrative_charts if nc.parentChartId})
+    patches: dict[int, dict] = {}
+    parent_configs: dict[int, dict] = {}
+    if nc_ids:
+        df = read_sql(
+            "SELECT nc.id, cc.patch FROM narrative_charts nc JOIN chart_configs cc ON cc.id = nc.chartConfigId "
+            f"WHERE nc.id IN ({','.join(str(int(i)) for i in nc_ids)})",
+            engine=get_engine(),
+        )
+        patches = {int(row["id"]): to_dict(row["patch"]) for _, row in df.iterrows()}
+    if parent_ids:
+        df = read_sql(
+            "SELECT c.id, cc.full FROM charts c JOIN chart_configs cc ON cc.id = c.configId "
+            f"WHERE c.id IN ({','.join(str(int(i)) for i in parent_ids)})",
+            engine=get_engine(),
+        )
+        parent_configs = {int(row["id"]): to_dict(row["full"]) for _, row in df.iterrows()}
+    return patches, parent_configs
+
+
 def _find_stale_lineage_variables(referenced_ids: set[int], indicator_mapping: dict[int, int]) -> dict[int, str]:
     """Find referenced indicators that belong to a different version of an upgraded dataset.
 
@@ -140,6 +237,9 @@ def push_new_narrative_charts_cli(
     # API to interact with the admin tool
     api = AdminAPI(OWID_ENV)
 
+    # Load patches and parent configs to check for stale user-facing text overrides (FAUST).
+    patches, parent_configs = _load_patches_and_parent_configs(narrative_charts)
+
     # Update narrative charts sequentially
     successful_updates = 0
     skipped = 0
@@ -147,6 +247,21 @@ def push_new_narrative_charts_cli(
 
     for nc in narrative_charts:
         try:
+            # Warn when the narrative chart pins user-facing text that is nearly identical to the
+            # parent's current text — likely frozen at creation time and stale since.
+            stale_faust = _find_stale_faust_overrides(patches.get(nc.id, {}), parent_configs.get(nc.parentChartId, {}))
+            if stale_faust:
+                details = "; ".join(
+                    f"{field}: narrative={narrative_value!r} vs parent={parent_value!r}"
+                    for field, narrative_value, parent_value in stale_faust
+                )
+                log.warning(
+                    f"Narrative chart {nc.id} ({nc.name}) overrides user-facing text that is nearly "
+                    f"identical to its parent chart {nc.parentChartId} — likely a stale copy of older "
+                    f"parent text rather than an intentional rewrite: {details}. Setting the field to "
+                    "the parent's exact text restores inheritance (identical values drop out of the patch)."
+                )
+
             # Get full config via API (full config = parent + patch merged)
             response = api.get_narrative_chart(nc.id)
             full_config = response["configFull"]

--- a/apps/indicator_upgrade/upgrade.py
+++ b/apps/indicator_upgrade/upgrade.py
@@ -12,9 +12,10 @@ from apps.chart_sync.admin_api import AdminAPI, AdminAPIError
 from apps.wizard.utils.cached import get_grapher_user
 from apps.wizard.utils.db import WizardDB
 from etl.config import OWID_ENV
-from etl.db import get_engine
+from etl.db import get_engine, read_sql
 from etl.files import get_schema_from_url
 from etl.indicator_upgrade.indicator_update import (
+    collect_variable_ids_from_narrative_config,
     find_charts_from_variable_ids,
     update_chart_config,
     update_narrative_chart_config,
@@ -71,6 +72,41 @@ def get_affected_narrative_charts_cli(charts: list[gm.Chart]) -> list[gm.Narrati
     return narrative_charts
 
 
+def _find_stale_lineage_variables(referenced_ids: set[int], indicator_mapping: dict[int, int]) -> dict[int, str]:
+    """Find referenced indicators that belong to a different version of an upgraded dataset.
+
+    `update_narrative_chart_config` only rewrites IDs present in `indicator_mapping`
+    (old_version -> new_version). A narrative chart can still pin an ID from an even older
+    version of the same dataset — left behind by a previous upgrade cycle — which the mapping
+    cannot cover. Returns {variable_id: catalogPath} for such IDs so the caller can warn.
+    """
+    candidate_ids = referenced_ids - set(indicator_mapping) - set(indicator_mapping.values())
+    if not candidate_ids:
+        return {}
+
+    def lineage(catalog_path: str) -> tuple[str, str] | None:
+        # catalogPath format: grapher/<namespace>/<version>/<dataset>/<table>#<column>
+        parts = catalog_path.split("/")
+        if len(parts) < 4:
+            return None
+        return parts[1], parts[3]
+
+    all_ids = candidate_ids | set(indicator_mapping.values())
+    df = read_sql(
+        f"SELECT id, catalogPath FROM variables WHERE id IN ({','.join(str(int(i)) for i in sorted(all_ids))})",
+        engine=get_engine(),
+    ).dropna(subset=["catalogPath"])
+    paths = dict(zip(df["id"], df["catalogPath"]))
+
+    upgraded_lineages = {lineage(paths[new_id]) for new_id in indicator_mapping.values() if new_id in paths} - {None}
+
+    return {
+        var_id: paths[var_id]
+        for var_id in sorted(candidate_ids)
+        if var_id in paths and lineage(paths[var_id]) in upgraded_lineages
+    }
+
+
 def push_new_narrative_charts_cli(
     narrative_charts: list[gm.NarrativeChart],
     indicator_mapping: dict[int, int],
@@ -106,6 +142,7 @@ def push_new_narrative_charts_cli(
 
     # Update narrative charts sequentially
     successful_updates = 0
+    skipped = 0
     errors: list[dict] = []
 
     for nc in narrative_charts:
@@ -116,6 +153,24 @@ def push_new_narrative_charts_cli(
 
             # Update variable IDs in the full config
             config_new = update_narrative_chart_config(full_config, indicator_mapping)
+
+            if config_new == full_config:
+                # Nothing in this config matched the mapping. PUTting an identical config would only
+                # bump updatedAt and make the log claim a remap that never happened.
+                stale = _find_stale_lineage_variables(
+                    collect_variable_ids_from_narrative_config(full_config), indicator_mapping
+                )
+                if stale:
+                    log.warning(
+                        f"Narrative chart {nc.id} ({nc.name}) was NOT remapped: it pins indicators from a "
+                        f"version of the upgraded dataset that the mapping does not cover: {stale}. These were "
+                        "likely left behind by a previous upgrade cycle — remap them with an explicit mapping "
+                        "(WizardDB.add_variable_mapping + push_new_narrative_charts_cli)."
+                    )
+                else:
+                    log.info(f"Narrative chart {nc.id} ({nc.name}) references no mapped indicators — left unchanged.")
+                skipped += 1
+                continue
 
             # PUT the updated full config - backend will recalculate the patch
             api.update_narrative_chart(narrative_chart_id=nc.id, config=config_new, user_id=user_id)
@@ -131,12 +186,14 @@ def push_new_narrative_charts_cli(
                 }
             )
 
+    unchanged_note = f" ({skipped} left unchanged)" if skipped else ""
     if errors:
         log.warning(
             f"Updated {successful_updates}/{len(narrative_charts)} narrative charts with {len(errors)} failures"
+            + unchanged_note
         )
     else:
-        log.info(f"Successfully updated all {len(narrative_charts)} narrative charts")
+        log.info(f"Updated {successful_updates}/{len(narrative_charts)} narrative charts{unchanged_note}")
 
     return errors
 

--- a/etl/indicator_upgrade/indicator_update.py
+++ b/etl/indicator_upgrade/indicator_update.py
@@ -85,6 +85,34 @@ def update_narrative_chart_config(
     return config_new
 
 
+def collect_variable_ids_from_narrative_config(config: dict[str, Any]) -> set[int]:
+    """Collect the indicator IDs referenced by a narrative chart config.
+
+    Reads the same fields that `update_narrative_chart_config` rewrites (dimensions,
+    map.columnSlug, sortColumnSlug), so callers can tell which referenced indicators a given
+    mapping did *not* cover.
+    """
+    variable_ids: set[int] = set()
+
+    for dimension in config.get("dimensions", []):
+        if isinstance(dimension.get("variableId"), int):
+            variable_ids.add(dimension["variableId"])
+
+    if "map" in config and "columnSlug" in config["map"]:
+        try:
+            variable_ids.add(int(config["map"]["columnSlug"]))
+        except (ValueError, TypeError):
+            pass  # columnSlug might not be a numeric variable ID
+
+    if config.get("sortBy") == "column" and "sortColumnSlug" in config:
+        try:
+            variable_ids.add(int(config["sortColumnSlug"]))
+        except (ValueError, TypeError):
+            pass
+
+    return variable_ids
+
+
 def update_chart_config(
     config: dict[str, Any],
     indicator_mapping: dict[int, int],


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## Summary

Fixes a silent failure mode in the indicator upgrade's narrative-chart pass, found during the Public Finances in Modern History update (#6256).

**The bug.** `push_new_narrative_charts_cli` PUTs every affected narrative chart's config and logs "Successfully updated narrative chart N" — even when `update_narrative_chart_config` matched nothing and the config is byte-identical. That hides the one case that matters: a narrative chart pinning an indicator id from a version **older** than the one being upgraded (left behind by a previous upgrade cycle). The mapping only covers `old_version → new_version` ids, and narrative-chart pins live in `chart_configs` (not `chart_dimensions`), so neither the chart finder nor the post-upgrade verification query can see them.

**Real instance.** Narrative chart 83 (`government-spending-as-a-share-of-gdp`) pinned the *2024-06-12* expenditure variable through both subsequent updates; the upgrader reported success twice while leaving it on data two versions stale. (Fixed manually on the #6256 staging branch with an explicit mapping.)

**The fix.**
- When the remapped config is identical to the original, **skip the PUT** (no spurious `updatedAt` / `lastEditedByUser` bump) and count it as "left unchanged" in the summary line.
- New helper `collect_variable_ids_from_narrative_config` gathers the ids a narrative config references (same fields `update_narrative_chart_config` rewrites: dimensions, `map.columnSlug`, `sortColumnSlug`).
- New helper `_find_stale_lineage_variables` checks whether those unmapped ids belong to another version of an upgraded dataset's lineage (`<namespace>/<short_name>` from `catalogPath`). If so, the log now **warns** with the exact ids and catalog paths and points to the explicit-mapping remedy; otherwise an info line notes the chart was left unchanged.

Deliberately **not** auto-remapping across older versions: a pin to an older version could be intentional, so surfacing it for a human decision is the safer behavior.

The wizard path (`apps/wizard/app_pages/indicator_upgrade/charts_update.py`) calls the same function, so it gets the fix for free.

**Also added: stale-FAUST warning.** Narrative charts pin in their patch any user-facing text they override (FAUST: footnote, axis titles, units, subtitle, title). An override that is *nearly identical* to the parent's current text is usually not an intentional rewrite but text frozen at creation time that the parent has since outgrown — e.g. in #6256, a narrative chart's note had lost the detail-on-demand links its parent gained later, and its title differed from the parent's by one article ("as a share" vs "as share"). The narrative-chart pass now compares each pinned FAUST field against the parent (after stripping markdown links, so dod-link additions don't mask equality) and warns when they're equal-after-normalization or highly similar; intentional rewrites (substantially different text) stay quiet. Checked fields: `title`, `subtitle`, `note`, plus per-dimension `display.name`, `unit`, `shortUnit` (matched to the parent dimension by variable id, translated through the indicator mapping) and the numeric fields `tolerance`, `numDecimalPlaces`, and `numSignificantFigures` (any pinned difference is reported).

## Testing

On the #6256 staging DB:
- `_find_stale_lineage_variables({935576}, {1025229: 1270200})` reproduces the narrative-chart-83 case and returns the stale id with its 2024-06-12 catalog path; ids already on the new dataset and ids from unrelated datasets return empty.
- End-to-end: `push_new_narrative_charts_cli` on a narrative chart whose config needs no change logs "references no mapped indicators — left unchanged", performs no PUT (`updatedAt` verified unchanged), and reports "Updated 0/1 narrative charts (1 left unchanged)".
- `_find_stale_faust_overrides` verified on the real #6256 cases: the link-less stale note is flagged (equal after normalization), the custom narrative title ("Canada is the only G7 country…") is not, minor copyedits are flagged via the similarity branch, and the live scan on staging surfaced a genuine stale title pin on narrative chart 83.
- `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



