### PR TITLE
🐛 Enrich partial indicator-upgrader mapping in Anomalist

### DIFF
--- a/apps/owidbot/anomalist.py
+++ b/apps/owidbot/anomalist.py
@@ -30,9 +30,8 @@ def run(branch: str) -> None:
 
     # Append datasets with changed local files. This is done to be compatible with the Anomalist streamlit app.
     with Session(source_engine) as session:
-        datasets_new_ids = list(
-            set(datasets_new_ids) | set(get_new_grapher_datasets_and_their_previous_versions(session=session))
-        )
+        dataset_new_and_old = get_new_grapher_datasets_and_their_previous_versions(session=session)
+    datasets_new_ids = list(set(datasets_new_ids) | set(dataset_new_and_old))
 
     if not datasets_new_ids:
         log.info("No new datasets found.")
@@ -51,8 +50,10 @@ def run(branch: str) -> None:
         variable_ids = variable_ids_sorted[:MAX_VARIABLES]
         log.info(f"Limited to {MAX_VARIABLES} variables from {len(variable_ids_sorted)} total variables")
 
-    # Load variable mapping
-    variable_mapping_dict = load_variable_mapping(datasets_new_ids)
+    # Load variable mapping. Pass the new->old dataset pairs so the mapping can be inferred (or
+    # enriched) by shortName — the indicator upgrader only persists mappings for charted
+    # indicators, which on its own would restrict upgrade detectors to those indicators.
+    variable_mapping_dict = load_variable_mapping(datasets_new_ids, dataset_new_and_old)
 
     log.info("owidbot.anomalist.start", n_variables=len(variable_ids))
     t = time.time()

--- a/apps/owidbot/anomalist.py
+++ b/apps/owidbot/anomalist.py
@@ -53,7 +53,7 @@ def run(branch: str) -> None:
     # Load variable mapping. Pass the new->old dataset pairs so the mapping can be inferred (or
     # enriched) by shortName — the indicator upgrader only persists mappings for charted
     # indicators, which on its own would restrict upgrade detectors to those indicators.
-    variable_mapping_dict = load_variable_mapping(datasets_new_ids, dataset_new_and_old)
+    variable_mapping_dict = load_variable_mapping(datasets_new_ids, dataset_new_and_old, engine=source_engine)
 
     log.info("owidbot.anomalist.start", n_variables=len(variable_ids))
     t = time.time()

--- a/apps/wizard/app_pages/anomalist/utils.py
+++ b/apps/wizard/app_pages/anomalist/utils.py
@@ -89,6 +89,18 @@ def get_datasets_and_mapping_inputs() -> tuple[dict[int, str], dict[int, str], d
 def load_variable_mapping(
     datasets_new_ids: list[int], dataset_new_and_old: dict[int, int | None] | None = None
 ) -> dict[int, int]:
+    # Infer a mapping by shortName for each new dataset and its previous version (if known).
+    # This is combined with the indicator upgrader's mapping below: the upgrader only persists
+    # mappings for indicators used in charts, so on its own it can silently restrict the upgrade
+    # detectors (upgrade_missing / upgrade_change) to a fraction of the dataset's indicators.
+    inferred_mapping: dict[int, int] = dict()
+    if dataset_new_and_old:
+        for dataset_id_new, dataset_id_old in dataset_new_and_old.items():
+            if dataset_id_old is None:
+                continue
+            # Infer (assuming no names have changed).
+            inferred_mapping.update(infer_variable_mapping(dataset_id_new, dataset_id_old))
+
     mapping = WizardDB.get_variable_mapping_raw()
     if len(mapping) > 0:
         log.info("Using variable mapping created by indicator upgrader.")
@@ -101,17 +113,16 @@ def load_variable_mapping(
             log.error(
                 f"Indicator upgrader mapped indicators to new datasets ({datasets_new_mapped}) that are not among the datasets detected as new in the code ({datasets_new_expected}). Look into this."
             )
-        # Create a mapping dictionary.
-        variable_mapping = mapping.set_index("id_old")["id_new"].to_dict()
-    elif dataset_new_and_old:
+        # Create a mapping dictionary, enriched with inferred pairs for indicators the upgrader
+        # didn't map (explicit upgrader entries take precedence over inferred ones).
+        explicit_mapping = mapping.set_index("id_old")["id_new"].to_dict()
+        n_enriched = len(set(inferred_mapping) - set(explicit_mapping))
+        if n_enriched > 0:
+            log.info(f"Enriching indicator-upgrader mapping with {n_enriched} pairs inferred by shortName.")
+        variable_mapping = {**inferred_mapping, **explicit_mapping}
+    elif inferred_mapping:
         log.info("Inferring variable mapping (since no mapping was created by indicator upgrader).")
-        # Infer the mapping of the new datasets (assuming no names have changed).
-        variable_mapping = dict()
-        for dataset_id_new, dataset_id_old in dataset_new_and_old.items():
-            if dataset_id_old is None:
-                continue
-            # Infer
-            variable_mapping.update(infer_variable_mapping(dataset_id_new, dataset_id_old))
+        variable_mapping = inferred_mapping
     else:
         # No mapping available.
         variable_mapping = dict()

--- a/apps/wizard/app_pages/anomalist/utils.py
+++ b/apps/wizard/app_pages/anomalist/utils.py
@@ -6,6 +6,7 @@ from enum import Enum
 import pandas as pd
 import streamlit as st
 from sqlalchemy import select
+from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from structlog import get_logger
 
@@ -28,8 +29,8 @@ class AnomalyTypeEnum(Enum):
     # AI = "ai"  # Uncomment if needed
 
 
-def infer_variable_mapping(dataset_id_new: int, dataset_id_old: int) -> dict[int, int]:
-    engine = get_engine()
+def infer_variable_mapping(dataset_id_new: int, dataset_id_old: int, engine: Engine | None = None) -> dict[int, int]:
+    engine = engine or get_engine()
     with Session(engine) as session:
         variables_new = gm.Variable.load_variables_in_datasets(session=session, dataset_ids=[dataset_id_new])
         variables_old = gm.Variable.load_variables_in_datasets(session=session, dataset_ids=[dataset_id_old])
@@ -87,7 +88,9 @@ def get_datasets_and_mapping_inputs() -> tuple[dict[int, str], dict[int, str], d
 
 
 def load_variable_mapping(
-    datasets_new_ids: list[int], dataset_new_and_old: dict[int, int | None] | None = None
+    datasets_new_ids: list[int],
+    dataset_new_and_old: dict[int, int | None] | None = None,
+    engine: Engine | None = None,
 ) -> dict[int, int]:
     # Infer a mapping by shortName for each new dataset and its previous version (if known).
     # This is combined with the indicator upgrader's mapping below: the upgrader only persists
@@ -99,7 +102,7 @@ def load_variable_mapping(
             if dataset_id_old is None:
                 continue
             # Infer (assuming no names have changed).
-            inferred_mapping.update(infer_variable_mapping(dataset_id_new, dataset_id_old))
+            inferred_mapping.update(infer_variable_mapping(dataset_id_new, dataset_id_old, engine=engine))
 
     mapping = WizardDB.get_variable_mapping_raw()
     if len(mapping) > 0:


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## Summary

Fixes a coverage gap in Anomalist's upgrade detectors, found during the Public Finances in Modern History update (#6256).

**The bug.** Anomalist's `upgrade_missing` / `upgrade_change` detectors only compare old→new variable pairs from the wizard's variable-mapping table. The indicator upgrader persists mappings **only for charted indicators**, and `load_variable_mapping` used any non-empty table as-is — so a partial mapping silently restricted the upgrade detectors to the charted subset, while suppressing the shortName-inference fallback that an *empty* table would have triggered. A partial mapping was strictly worse than none.

**Real instance.** In #6256, the IMF dropped all USA observations before 1929 across all ten indicators, and revised ~1,600 country-year values per column. Only one indicator (expenditure) is used in charts, so only it was in the mapping — Anomalist flagged the USA data loss on expenditure alone, and the other nine indicators (including gross debt, with revisions up to 26 pp of GDP) were never scanned by either upgrade detector.

**Why full coverage matters.** A dataset update upgrades *all* of the dataset's indicators, not just the ones currently feeding standalone charts. Indicators outside the chart-derived mapping are still consumed through MDims and explorers, published in the catalog and data API, cited in articles, and may get charted later. Anomalist QA is the gate where regressions in any of them should surface; scoping it to the charted subset means, e.g., an MDim-only indicator could lose or corrupt data without any anomaly ever being raised.

**The fix.**
- `load_variable_mapping` now always infers old→new pairs by shortName for each new dataset and its previous version, and overlays the indicator upgrader's explicit entries on top (explicit wins). The empty-table and no-pairs behaviors are unchanged.
- `owidbot/anomalist.py` already computed the new→old dataset pairs but discarded them, calling `load_variable_mapping` without them — meaning the staging bot never even reached the inference fallback. It now passes them through.

## Testing

Against the #6256 staging DB (which has the real partial mapping — 2 expenditure-only entries):
- `load_variable_mapping([7987], {7987: 7049})` → 11 pairs covering all 10 indicators, with both explicit entries preserved and 9 pairs enriched by shortName (log line confirms).
- `load_variable_mapping([7987])` (no pairs, old bot call shape) → 2 pairs, unchanged behavior.
- Manually re-running the upgrade detectors with the full mapping on that staging DB made the USA flag appear on all ten indicators in `upgrade_missing` (previously: expenditure only) and grew `upgrade_change` from expenditure-only to 1,049 reduced rows.
- `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

