### PR TITLE
✨ Improve staging servers dashboard

### DIFF
--- a/apps/wizard/app_pages/servers_dashboard/app.py
+++ b/apps/wizard/app_pages/servers_dashboard/app.py
@@ -299,13 +299,12 @@ def render_server_actions(server) -> None:
     server_name = server["name"]
     is_running = server["status"] == "Running"
 
-    # Quick links (same set owidbot posts on each PR) + ssh command
+    # Quick links (same set owidbot posts on each PR)
     links = build_quick_links(branch)
     st.markdown(
         f"**{server['status_indicator']} {branch}** &nbsp; · &nbsp; "
         + " · ".join(f"[{label}]({url})" for label, url in links.items())
     )
-    st.code(f"ssh owid@{server_name}", language="bash")
 
     if is_running:
         c1, c2, c3, c4 = st.columns(4)
@@ -373,11 +372,22 @@ def render_server_actions(server) -> None:
                 _destroy_dialog(branch, server_name)
 
 
-# Display servers in a table; selecting a row reveals its links and actions below.
+# Display the management panel above a selectable table.
 if filtered_df.empty:
     st.warning("No servers match the current filters.")
 else:
     filtered_df = filtered_df.reset_index(drop=True)
+
+    # Read the row selected on the previous run (the table widget is rendered below).
+    table_state = st.session_state.get("servers_table")
+    selected_rows = table_state["selection"]["rows"] if table_state else []
+
+    # Action panel for the selected server (shown above the table).
+    st.subheader("🔧 Server Management")
+    if selected_rows and selected_rows[0] < len(filtered_df):
+        render_server_actions(filtered_df.iloc[selected_rows[0]])
+    else:
+        st.caption("👆 Select a server in the table below to see its links and management actions.")
 
     # Build the display table (memory as numeric GB so the progress bar renders).
     display_df = pd.DataFrame(
@@ -392,7 +402,7 @@ else:
         }
     )
 
-    selection = st.dataframe(
+    st.dataframe(
         display_df,
         width="stretch",
         column_config={
@@ -423,11 +433,3 @@ else:
         selection_mode="single-row",
         key="servers_table",
     )
-
-    # Action panel for the selected server
-    st.subheader("🔧 Server Management")
-    selected_rows = selection["selection"]["rows"]
-    if selected_rows:
-        render_server_actions(filtered_df.iloc[selected_rows[0]])
-    else:
-        st.caption("👆 Select a server in the table to see its links and management actions.")

--- a/apps/wizard/app_pages/servers_dashboard/app.py
+++ b/apps/wizard/app_pages/servers_dashboard/app.py
@@ -228,7 +228,8 @@ if origin_filter:
     filtered_df = filtered_df[filtered_df["origin"].isin(origin_filter)]
 
 if branch_query:
-    filtered_df = filtered_df[filtered_df["branch"].str.contains(branch_query, case=False, na=False)]
+    # regex=False: treat the search box as literal text so metacharacters (e.g. "[") don't crash.
+    filtered_df = filtered_df[filtered_df["branch"].str.contains(branch_query, case=False, na=False, regex=False)]
 
 # Display filtered results count
 if len(filtered_df) != len(servers_df):

--- a/apps/wizard/app_pages/servers_dashboard/app.py
+++ b/apps/wizard/app_pages/servers_dashboard/app.py
@@ -277,124 +277,157 @@ def _confirm_destructive_action(
     _dialog()
 
 
-def render_server(server) -> None:
-    """Render one staging server as an expander with metadata, links and actions."""
+def _destroy_dialog(branch: str, server_name: str) -> None:
+    """Shared confirmation dialog for destroying a server."""
+    _confirm_destructive_action(
+        title=f"Destroy server: {branch}",
+        bullets=[
+            "**DELETE** the entire container including all data",
+            "Pushing a new commit triggers server recreation",
+        ],
+        warning="💥 This destroys the container and all its data!",
+        button_label="💥 Destroy server",
+        action_fn=destroy_server,
+        server_name=server_name,
+        spinner_msg="Destroying server…",
+    )
+
+
+def render_server_actions(server) -> None:
+    """Render the action panel (links + buttons) for a single selected server."""
     branch = server["branch"]
     server_name = server["name"]
-    status_label = server["status_label"]
     is_running = server["status"] == "Running"
-    owner = server["owner"] or "—"
 
-    memory = server["memory_used_gb"]
-    memory_str = f"{memory:.1f} GB" if pd.notna(memory) else "—"
-    age = server["days_old"]
-    age_str = f"{int(age)}d" if pd.notna(age) else "—"
+    # Quick links (same set owidbot posts on each PR) + ssh command
+    links = build_quick_links(branch)
+    st.markdown(
+        f"**{server['status_indicator']} {branch}** &nbsp; · &nbsp; "
+        + " · ".join(f"[{label}]({url})" for label, url in links.items())
+    )
+    st.code(f"ssh owid@{server_name}", language="bash")
 
-    header = f"{server['status_indicator']} **{branch}** · {status_label} · 👤 {owner} · 💾 {memory_str} · 🕒 {age_str}"
-    with st.expander(header):
-        # Metadata line
-        st.markdown(
-            f"**Owner:** {owner} &nbsp;|&nbsp; **Origin:** {server['origin']} &nbsp;|&nbsp; "
-            f"**Last commit:** {server['unified_commit']} &nbsp;|&nbsp; **Age:** {age_str}"
-        )
-
-        # Quick links (same set owidbot posts on each PR)
-        links = build_quick_links(branch)
-        st.markdown(" · ".join(f"[{label}]({url})" for label, url in links.items()))
-        st.code(f"ssh owid@{server_name}", language="bash")
-
-        # Actions
-        if is_running:
-            c1, c2, c3, c4 = st.columns(4)
-            with c1:
-                if st.button(
-                    "⏸️ Make idle",
-                    width="stretch",
-                    key=f"idle_{server_name}",
-                    help="Snapshot, then stop the server to free resources. Data is preserved; wake it anytime.",
-                ):
-                    _run_action("Make idle", stop_server, server_name, "Snapshotting and stopping server…")
-            with c2:
-                if st.button(
-                    "🔄 Restart", width="stretch", key=f"restart_{server_name}", help="Stop and start the server again."
-                ):
-                    _run_action("Restart", restart_server, server_name, "Restarting server…")
-            with c3:
-                if st.button(
-                    "🗄️ Reset MySQL",
-                    width="stretch",
-                    key=f"mysql_{server_name}",
-                    help="Drop and reimport the staging database from master (~5 min).",
-                ):
-                    _confirm_destructive_action(
-                        title=f"Reset MySQL: {branch}",
-                        bullets=[
-                            "Purge R2 files for this server from owid-api-staging",
-                            "Run `make refresh` in the owid-grapher directory",
-                            "Drop and recreate the MySQL database",
-                            "Import the latest data from staging",
-                        ],
-                        warning="⏱️ Takes ~5 minutes. All current DB data including charts and indicators will be lost!",
-                        button_label="🗄️ Reset MySQL",
-                        action_fn=reset_mysql_database,
-                        server_name=server_name,
-                        spinner_msg="Resetting MySQL database… This may take 5 minutes",
-                    )
-            with c4:
-                if st.button(
-                    "💥 Destroy",
-                    width="stretch",
-                    key=f"destroy_{server_name}",
-                    help="Delete the container entirely. Recreated on the next commit to this branch.",
-                ):
-                    _confirm_destructive_action(
-                        title=f"Destroy server: {branch}",
-                        bullets=[
-                            "**DELETE** the entire container including all data",
-                            "Pushing a new commit triggers server recreation",
-                        ],
-                        warning="💥 This destroys the container and all its data!",
-                        button_label="💥 Destroy server",
-                        action_fn=destroy_server,
-                        server_name=server_name,
-                        spinner_msg="Destroying server…",
-                    )
-        else:
-            # Idle server: the key action is waking it up (no commit needed).
-            c1, c2 = st.columns(2)
-            with c1:
-                if st.button(
-                    "☀️ Wake up",
-                    type="primary",
-                    width="stretch",
-                    key=f"wake_{server_name}",
-                    help="Start the server again. Data is preserved — this takes seconds, no commit required.",
-                ):
-                    _run_action("Wake up", start_server, server_name, "Waking server up…")
-            with c2:
-                if st.button(
-                    "💥 Destroy",
-                    width="stretch",
-                    key=f"destroy_{server_name}",
-                    help="Delete the container entirely. Recreated on the next commit to this branch.",
-                ):
-                    _confirm_destructive_action(
-                        title=f"Destroy server: {branch}",
-                        bullets=[
-                            "**DELETE** the entire container including all data",
-                            "Pushing a new commit triggers server recreation",
-                        ],
-                        warning="💥 This destroys the container and all its data!",
-                        button_label="💥 Destroy server",
-                        action_fn=destroy_server,
-                        server_name=server_name,
-                        spinner_msg="Destroying server…",
-                    )
+    if is_running:
+        c1, c2, c3, c4 = st.columns(4)
+        with c1:
+            if st.button(
+                "⏸️ Make idle",
+                width="stretch",
+                key=f"idle_{server_name}",
+                help="Snapshot, then stop the server to free resources. Data is preserved; wake it anytime.",
+            ):
+                _run_action("Make idle", stop_server, server_name, "Snapshotting and stopping server…")
+        with c2:
+            if st.button(
+                "🔄 Restart", width="stretch", key=f"restart_{server_name}", help="Stop and start the server again."
+            ):
+                _run_action("Restart", restart_server, server_name, "Restarting server…")
+        with c3:
+            if st.button(
+                "🗄️ Reset MySQL",
+                width="stretch",
+                key=f"mysql_{server_name}",
+                help="Drop and reimport the staging database from master (~5 min).",
+            ):
+                _confirm_destructive_action(
+                    title=f"Reset MySQL: {branch}",
+                    bullets=[
+                        "Purge R2 files for this server from owid-api-staging",
+                        "Run `make refresh` in the owid-grapher directory",
+                        "Drop and recreate the MySQL database",
+                        "Import the latest data from staging",
+                    ],
+                    warning="⏱️ Takes ~5 minutes. All current DB data including charts and indicators will be lost!",
+                    button_label="🗄️ Reset MySQL",
+                    action_fn=reset_mysql_database,
+                    server_name=server_name,
+                    spinner_msg="Resetting MySQL database… This may take 5 minutes",
+                )
+        with c4:
+            if st.button(
+                "💥 Destroy",
+                width="stretch",
+                key=f"destroy_{server_name}",
+                help="Delete the container entirely. Recreated on the next commit to this branch.",
+            ):
+                _destroy_dialog(branch, server_name)
+    else:
+        # Idle server: the key action is waking it up (no commit needed).
+        c1, c2 = st.columns(2)
+        with c1:
+            if st.button(
+                "☀️ Wake up",
+                type="primary",
+                width="stretch",
+                key=f"wake_{server_name}",
+                help="Start the server again. Data is preserved — this takes seconds, no commit required.",
+            ):
+                _run_action("Wake up", start_server, server_name, "Waking server up…")
+        with c2:
+            if st.button(
+                "💥 Destroy",
+                width="stretch",
+                key=f"destroy_{server_name}",
+                help="Delete the container entirely. Recreated on the next commit to this branch.",
+            ):
+                _destroy_dialog(branch, server_name)
 
 
-# Display servers as expandable rows
+# Display servers in a table; selecting a row reveals its links and actions below.
 if filtered_df.empty:
     st.warning("No servers match the current filters.")
 else:
-    for _, server in filtered_df.iterrows():
-        render_server(server)
+    filtered_df = filtered_df.reset_index(drop=True)
+
+    # Build the display table (memory as numeric GB so the progress bar renders).
+    display_df = pd.DataFrame(
+        {
+            "Status": filtered_df["status_indicator"],
+            "Owner": filtered_df["owner"],
+            "Origin": filtered_df["origin"],
+            "Branch": filtered_df["branch"],
+            "Memory": filtered_df["memory_used_gb"].fillna(0).round(2),
+            "Age (days)": filtered_df["days_old"],
+            "Last Commit": filtered_df["unified_commit"],
+        }
+    )
+
+    selection = st.dataframe(
+        display_df,
+        width="stretch",
+        column_config={
+            "Status": st.column_config.TextColumn("Status", help="🟢 Running · ⏸️ Idle", width="small"),
+            "Owner": st.column_config.TextColumn("Owner", help="GitHub author of the PR", width="small"),
+            "Origin": st.column_config.TextColumn("Origin", help="Server origin (etl, grapher, etc.)", width="small"),
+            "Branch": st.column_config.TextColumn(
+                "Branch", help="Git branch name (staging-site- prefix removed)", width="medium"
+            ),
+            "Memory": st.column_config.ProgressColumn(
+                "Memory",
+                help="Memory usage with progress bar showing GB values",
+                min_value=0,
+                max_value=20,  # Set reasonable max for progress bar visualization
+                format="%.1f GB",
+                width="medium",
+            ),
+            "Age (days)": st.column_config.NumberColumn(
+                "Age (days)", help="Days since container was created", format="%d days", width="small"
+            ),
+            "Last Commit": st.column_config.TextColumn(
+                "Last Commit", help="Most recent relevant commit based on server origin", width="medium"
+            ),
+        },
+        hide_index=True,
+        height=600,
+        on_select="rerun",
+        selection_mode="single-row",
+        key="servers_table",
+    )
+
+    # Action panel for the selected server
+    st.subheader("🔧 Server Management")
+    selected_rows = selection["selection"]["rows"]
+    if selected_rows:
+        render_server_actions(filtered_df.iloc[selected_rows[0]])
+    else:
+        st.caption("👆 Select a server in the table to see its links and management actions.")

--- a/apps/wizard/app_pages/servers_dashboard/app.py
+++ b/apps/wizard/app_pages/servers_dashboard/app.py
@@ -5,8 +5,10 @@ import streamlit as st
 from structlog import get_logger
 
 from apps.wizard.app_pages.servers_dashboard.utils import (
+    GRAPHITE_BASE_RE,
     build_quick_links,
     destroy_server,
+    fetch_graphite_owners,
     fetch_host_memory_stats,
     fetch_lxc_servers_data,
     fetch_server_owners,
@@ -196,6 +198,24 @@ with st.container(horizontal=True, border=True):
 
 # Enrich with owner derived from the GitHub PR author (best-effort, may be blank)
 servers_df["owner"] = servers_df["name"].map(owners).fillna("")
+
+# Resolve graphite-base-<N> servers (transient Graphite base branches with no PR of their own)
+# to the author of owid-grapher PR #N.
+graphite_numbers = tuple(
+    sorted(
+        {
+            int(m.group(1))
+            for branch, owner in zip(servers_df["branch"], servers_df["owner"])
+            if not owner and (m := GRAPHITE_BASE_RE.match(branch))
+        }
+    )
+)
+if graphite_numbers:
+    graphite_owners = fetch_graphite_owners(graphite_numbers)
+    needs_owner = servers_df["owner"] == ""
+    servers_df.loc[needs_owner, "owner"] = servers_df.loc[needs_owner, "branch"].map(
+        lambda b: graphite_owners.get(int(m.group(1)), "") if (m := GRAPHITE_BASE_RE.match(b)) else ""
+    )
 
 # Filter controls
 st.subheader("🖥️ Staging Servers")

--- a/apps/wizard/app_pages/servers_dashboard/app.py
+++ b/apps/wizard/app_pages/servers_dashboard/app.py
@@ -1,15 +1,20 @@
 """Staging Servers Dashboard - Monitor all LXC staging servers with real-time metrics."""
 
+import pandas as pd
 import streamlit as st
 from structlog import get_logger
 
 from apps.wizard.app_pages.servers_dashboard.utils import (
+    build_quick_links,
     destroy_server,
     fetch_host_memory_stats,
     fetch_lxc_servers_data,
+    fetch_server_owners,
     get_server_summary_stats,
-    prepare_display_dataframe,
     reset_mysql_database,
+    restart_server,
+    start_server,
+    stop_server,
 )
 from apps.wizard.utils.components import st_title_with_expert
 
@@ -106,7 +111,7 @@ with st.container(horizontal=True, vertical_alignment="bottom", horizontal_align
 
         **Status Indicators**:
         - 🟢 **Running**: Container is active and operational
-        - 🔴 **Stopped**: Container is stopped or inactive
+        - ⏸️ **Idle**: Container is stopped to save resources, but its **data is preserved**. Wake it instantly with the **Wake** button (no commit needed) — staging servers are stopped automatically after 14 days without a commit.
 
         **Commit Status**:
         - ✅ **Today/Recent**: Commits within the last week
@@ -127,6 +132,7 @@ with st.container(horizontal=True, vertical_alignment="bottom", horizontal_align
 with st.spinner("Fetching staging server data...", show_time=True):
     servers_df, error = fetch_lxc_servers_data()
     host_memory_stats, host_memory_error = fetch_host_memory_stats()
+    owners = fetch_server_owners()  # {container_name: github_login}, best-effort
 
 # Handle errors
 if error:
@@ -158,10 +164,10 @@ with st.container(horizontal=True, border=True):
         label="Running",
         value_key="running_servers",
     )
-    # Number of stopped servers
+    # Number of idle (stopped) servers
     st_metric_int(
         stats=stats,
-        label="Stopped",
+        label="Idle",
         value_key="stopped_servers",
         delta_color="inverse",
     )
@@ -188,193 +194,207 @@ with st.container(horizontal=True, border=True):
         last_stat_key="servers_metric_swap",
     )
 
-# Prepare data for display
-display_df = prepare_display_dataframe(servers_df)
+# Enrich with owner derived from the GitHub PR author (best-effort, may be blank)
+servers_df["owner"] = servers_df["name"].map(owners).fillna("")
 
 # Filter controls
 st.subheader("🖥️ Staging Servers")
-col1, col2, col3 = st.columns(3)
+col1, col2, col3, col4 = st.columns(4)
 
 with col1:
-    status_filter = st.selectbox("Status", options=["All", "Running", "Stopped"], index=0)
+    status_filter = st.selectbox("Status", options=["All", "Running", "Idle"], index=0)
 
 with col2:
-    # Extract unique origins for filter
-    all_origins = servers_df["origin"].unique()
-    origin_filter = st.multiselect("Origins", options=sorted(all_origins), default=[])
+    all_owners = [o for o in servers_df["owner"].unique() if o]
+    owner_filter = st.multiselect("Owners", options=sorted(all_owners), default=[])
 
 with col3:
-    # Extract unique branches for filter (excluding full container names)
-    all_branches = servers_df["branch"].unique()
-    branch_filter = st.multiselect("Branches", options=sorted(all_branches), default=[])
+    all_origins = [o for o in servers_df["origin"].unique() if isinstance(o, str)]
+    origin_filter = st.multiselect("Origins", options=sorted(set(all_origins)), default=[])
+
+with col4:
+    branch_query = st.text_input("Search branch", placeholder="filter by branch name…")
 
 # Apply filters
-filtered_df = display_df.copy()
+filtered_df = servers_df.copy()
 
-# Status filter
 if status_filter != "All":
-    status_symbol = "🟢" if status_filter == "Running" else "🔴"
-    filtered_df = filtered_df[filtered_df["Status"] == status_symbol]
+    filtered_df = filtered_df[filtered_df["status_label"] == status_filter]
 
-# Origin filter
+if owner_filter:
+    filtered_df = filtered_df[filtered_df["owner"].isin(owner_filter)]
+
 if origin_filter:
-    # Map back to original server data for filtering
-    origin_mask = servers_df["origin"].isin(origin_filter)
-    filtered_df = filtered_df[origin_mask]
+    filtered_df = filtered_df[filtered_df["origin"].isin(origin_filter)]
 
-# Branch filter
-if branch_filter:
-    # Map back to original server data for filtering
-    branch_mask = servers_df["branch"].isin(branch_filter)
-    filtered_df = filtered_df[branch_mask]
+if branch_query:
+    filtered_df = filtered_df[filtered_df["branch"].str.contains(branch_query, case=False, na=False)]
 
 # Display filtered results count
-if len(filtered_df) != len(display_df):
-    st.info(f"Showing {len(filtered_df)} of {len(display_df)} servers")
+if len(filtered_df) != len(servers_df):
+    st.caption(f"Showing {len(filtered_df)} of {len(servers_df)} servers")
 
-# Display data table
+
+def _run_action(label: str, action_fn, server_name: str, spinner_msg: str) -> None:
+    """Run a (non-destructive) server action with a spinner, then refresh the dashboard."""
+    with st.spinner(spinner_msg, show_time=True):
+        success, message = action_fn(server_name)
+    if success:
+        st.toast(f"✅ {message}", icon="✅")
+        st.cache_data.clear()
+        st.rerun()
+    else:
+        st.error(f"❌ {label} failed: {message}")
+
+
+def _confirm_destructive_action(
+    title: str, bullets: list[str], warning: str, button_label: str, action_fn, server_name: str, spinner_msg: str
+) -> None:
+    """Open a confirmation dialog for a destructive action (Reset MySQL / Destroy)."""
+
+    @st.dialog(title)
+    def _dialog():
+        st.markdown(f"**Server:** `{server_name}`")
+        st.markdown("**This will:**")
+        for bullet in bullets:
+            st.markdown(f"- {bullet}")
+        st.warning(warning)
+
+        c1, c2 = st.columns(2)
+        with c1:
+            if st.button("❌ Cancel", width="stretch", key=f"cancel_{title}_{server_name}"):
+                st.rerun()
+        with c2:
+            if st.button(button_label, type="primary", width="stretch", key=f"go_{title}_{server_name}"):
+                with st.spinner(spinner_msg, show_time=True):
+                    success, message = action_fn(server_name)
+                if success:
+                    st.success(f"✅ {message}")
+                    st.cache_data.clear()
+                else:
+                    st.error(f"❌ {message}")
+
+    _dialog()
+
+
+def render_server(server) -> None:
+    """Render one staging server as an expander with metadata, links and actions."""
+    branch = server["branch"]
+    server_name = server["name"]
+    status_label = server["status_label"]
+    is_running = server["status"] == "Running"
+    owner = server["owner"] or "—"
+
+    memory = server["memory_used_gb"]
+    memory_str = f"{memory:.1f} GB" if pd.notna(memory) else "—"
+    age = server["days_old"]
+    age_str = f"{int(age)}d" if pd.notna(age) else "—"
+
+    header = f"{server['status_indicator']} **{branch}** · {status_label} · 👤 {owner} · 💾 {memory_str} · 🕒 {age_str}"
+    with st.expander(header):
+        # Metadata line
+        st.markdown(
+            f"**Owner:** {owner} &nbsp;|&nbsp; **Origin:** {server['origin']} &nbsp;|&nbsp; "
+            f"**Last commit:** {server['unified_commit']} &nbsp;|&nbsp; **Age:** {age_str}"
+        )
+
+        # Quick links (same set owidbot posts on each PR)
+        links = build_quick_links(branch)
+        st.markdown(" · ".join(f"[{label}]({url})" for label, url in links.items()))
+        st.code(f"ssh owid@{server_name}", language="bash")
+
+        # Actions
+        if is_running:
+            c1, c2, c3, c4 = st.columns(4)
+            with c1:
+                if st.button(
+                    "⏸️ Make idle",
+                    width="stretch",
+                    key=f"idle_{server_name}",
+                    help="Snapshot, then stop the server to free resources. Data is preserved; wake it anytime.",
+                ):
+                    _run_action("Make idle", stop_server, server_name, "Snapshotting and stopping server…")
+            with c2:
+                if st.button(
+                    "🔄 Restart", width="stretch", key=f"restart_{server_name}", help="Stop and start the server again."
+                ):
+                    _run_action("Restart", restart_server, server_name, "Restarting server…")
+            with c3:
+                if st.button(
+                    "🗄️ Reset MySQL",
+                    width="stretch",
+                    key=f"mysql_{server_name}",
+                    help="Drop and reimport the staging database from master (~5 min).",
+                ):
+                    _confirm_destructive_action(
+                        title=f"Reset MySQL: {branch}",
+                        bullets=[
+                            "Purge R2 files for this server from owid-api-staging",
+                            "Run `make refresh` in the owid-grapher directory",
+                            "Drop and recreate the MySQL database",
+                            "Import the latest data from staging",
+                        ],
+                        warning="⏱️ Takes ~5 minutes. All current DB data including charts and indicators will be lost!",
+                        button_label="🗄️ Reset MySQL",
+                        action_fn=reset_mysql_database,
+                        server_name=server_name,
+                        spinner_msg="Resetting MySQL database… This may take 5 minutes",
+                    )
+            with c4:
+                if st.button(
+                    "💥 Destroy",
+                    width="stretch",
+                    key=f"destroy_{server_name}",
+                    help="Delete the container entirely. Recreated on the next commit to this branch.",
+                ):
+                    _confirm_destructive_action(
+                        title=f"Destroy server: {branch}",
+                        bullets=[
+                            "**DELETE** the entire container including all data",
+                            "Pushing a new commit triggers server recreation",
+                        ],
+                        warning="💥 This destroys the container and all its data!",
+                        button_label="💥 Destroy server",
+                        action_fn=destroy_server,
+                        server_name=server_name,
+                        spinner_msg="Destroying server…",
+                    )
+        else:
+            # Idle server: the key action is waking it up (no commit needed).
+            c1, c2 = st.columns(2)
+            with c1:
+                if st.button(
+                    "☀️ Wake up",
+                    type="primary",
+                    width="stretch",
+                    key=f"wake_{server_name}",
+                    help="Start the server again. Data is preserved — this takes seconds, no commit required.",
+                ):
+                    _run_action("Wake up", start_server, server_name, "Waking server up…")
+            with c2:
+                if st.button(
+                    "💥 Destroy",
+                    width="stretch",
+                    key=f"destroy_{server_name}",
+                    help="Delete the container entirely. Recreated on the next commit to this branch.",
+                ):
+                    _confirm_destructive_action(
+                        title=f"Destroy server: {branch}",
+                        bullets=[
+                            "**DELETE** the entire container including all data",
+                            "Pushing a new commit triggers server recreation",
+                        ],
+                        warning="💥 This destroys the container and all its data!",
+                        button_label="💥 Destroy server",
+                        action_fn=destroy_server,
+                        server_name=server_name,
+                        spinner_msg="Destroying server…",
+                    )
+
+
+# Display servers as expandable rows
 if filtered_df.empty:
     st.warning("No servers match the current filters.")
 else:
-    # Display the table with custom column configuration
-    st.dataframe(
-        filtered_df,
-        width="stretch",
-        column_config={
-            "Status": st.column_config.TextColumn("Status", help="Server running status", width="small"),
-            "Origin": st.column_config.TextColumn("Origin", help="Server origin (etl, grapher, etc.)", width="small"),
-            "Branch": st.column_config.TextColumn(
-                "Branch", help="Git branch name (staging-site- prefix removed)", width="medium"
-            ),
-            "Memory": st.column_config.ProgressColumn(
-                "Memory",
-                help="Memory usage with progress bar showing GB values",
-                min_value=0,
-                max_value=20,  # Set reasonable max for progress bar visualization
-                format="%.1f GB",
-                width="medium",
-            ),
-            "Age (days)": st.column_config.NumberColumn(
-                "Age (days)", help="Days since container was created", format="%d days", width="small"
-            ),
-            "Last Commit": st.column_config.TextColumn(
-                "Last Commit", help="Most recent relevant commit based on server origin", width="medium"
-            ),
-        },
-        hide_index=True,
-        height=600,
-    )
-
-    # Server Management section
-    st.subheader("🔧 Server Management")
-
-    # Server selection
-    server_options = ["Select a server..."] + filtered_df["Branch"].tolist()
-    selected_server_branch = st.selectbox("Select server:", options=server_options, key="server_select")
-
-    if selected_server_branch != "Select a server...":
-        selected_server = filtered_df[filtered_df["Branch"] == selected_server_branch].iloc[0]
-        server_name = f"staging-site-{selected_server['Branch']}"
-
-        # Server info
-        st.info(f"**Selected:** `{selected_server['Branch']}` ({selected_server['Status']})")
-
-        # Action buttons
-        col1, col2, col3 = st.columns(3)
-
-        with col1:
-            if st.button("🗄️ Reset MySQL", width="stretch"):
-
-                @st.dialog(f"Reset MySQL: {selected_server['Branch']}")
-                def show_mysql_reset_modal():
-                    st.markdown("⚠️ **You are about to reset the MySQL database:**")
-                    st.markdown(f"**Server:** `{server_name}`")
-
-                    st.markdown("---")
-                    st.markdown("**This will:**")
-                    st.markdown("- Purge R2 files for this server from owid-api-staging")
-                    st.markdown("- Run `make refresh` in the owid-grapher directory")
-                    st.markdown("- Drop and recreate the MySQL database")
-                    st.markdown("- Import the latest data from staging")
-
-                    st.warning("⏱️ **This process takes about 5 minutes to complete!**")
-                    st.error("⚠️ **All current database data including charts and indicators will be lost!**")
-
-                    col1, col2 = st.columns(2)
-                    with col1:
-                        if st.button("❌ Cancel", width="stretch"):
-                            st.rerun()
-                    with col2:
-                        if st.button("🗄️ Reset MySQL", type="primary", width="stretch"):
-                            with st.spinner("Resetting MySQL database... This may take 5 minutes", show_time=True):
-                                success, message = reset_mysql_database(server_name)
-
-                            if success:
-                                st.success(f"✅ {message}")
-                                st.info("🎉 MySQL database has been refreshed with the latest data!")
-                                # Clear cache to refresh data on next load
-                                st.cache_data.clear()
-                            else:
-                                st.error(f"❌ MySQL reset failed: {message}")
-                                st.info("Please check the server logs or try again later.")
-
-                show_mysql_reset_modal()
-
-        with col2:
-            if st.button("💥 Destroy Server", type="secondary", width="stretch"):
-
-                @st.dialog(f"Destroy Server: {selected_server['Branch']}")
-                def show_destroy_modal():
-                    st.markdown("💥 **You are about to DESTROY the staging server:**")
-                    st.markdown(f"**Server:** `{server_name}`")
-
-                    st.markdown("---")
-                    st.markdown("**This will:**")
-                    st.markdown("- **DELETE** the entire container including all data")
-                    st.markdown("- Pushing a new commit triggers server recreation")
-
-                    col1, col2 = st.columns(2)
-                    with col1:
-                        if st.button("❌ Cancel", width="stretch"):
-                            st.rerun()
-                    with col2:
-                        if st.button("💥 DESTROY SERVER", type="primary", width="stretch"):
-                            with st.spinner("Destroying server...", show_time=True):
-                                success, message = destroy_server(server_name)
-
-                            if success:
-                                st.success(f"✅ {message}")
-                                st.info(
-                                    "Server has been completely destroyed. It will be recreated on the next commit to this branch."
-                                )
-                                # Clear cache to refresh data on next load
-                                st.cache_data.clear()
-                                # Wait a moment then refresh the page
-                                import time
-
-                                time.sleep(2)
-                                st.rerun()
-                            else:
-                                st.error(f"❌ Server destruction failed: {message}")
-                                st.info("Please check the server status or try again later.")
-
-                show_destroy_modal()
-
-        with col3:
-            # st.markdown("**Quick Access:**")
-            pass
-
-        # Connection info
-        st.markdown("---")
-        st.markdown("**🔗 Connection Commands:**")
-
-        col1, col2 = st.columns(2)
-        with col1:
-            st.markdown("**MySQL Access:**")
-            mysql_cmd = f"mysql -h {server_name} -u owid --port 3306 -D owid"
-            st.code(mysql_cmd, language="bash")
-
-        with col2:
-            st.markdown("**SSH Access:**")
-            ssh_cmd = f"ssh owid@{server_name}"
-            st.code(ssh_cmd, language="bash")
+    for _, server in filtered_df.iterrows():
+        render_server(server)

--- a/apps/wizard/app_pages/servers_dashboard/app.py
+++ b/apps/wizard/app_pages/servers_dashboard/app.py
@@ -5,10 +5,8 @@ import streamlit as st
 from structlog import get_logger
 
 from apps.wizard.app_pages.servers_dashboard.utils import (
-    GRAPHITE_BASE_RE,
     build_quick_links,
     destroy_server,
-    fetch_graphite_owners,
     fetch_host_memory_stats,
     fetch_lxc_servers_data,
     fetch_server_owners,
@@ -198,24 +196,6 @@ with st.container(horizontal=True, border=True):
 
 # Enrich with owner derived from the GitHub PR author (best-effort, may be blank)
 servers_df["owner"] = servers_df["name"].map(owners).fillna("")
-
-# Resolve graphite-base-<N> servers (transient Graphite base branches with no PR of their own)
-# to the author of owid-grapher PR #N.
-graphite_numbers = tuple(
-    sorted(
-        {
-            int(m.group(1))
-            for branch, owner in zip(servers_df["branch"], servers_df["owner"])
-            if not owner and (m := GRAPHITE_BASE_RE.match(branch))
-        }
-    )
-)
-if graphite_numbers:
-    graphite_owners = fetch_graphite_owners(graphite_numbers)
-    needs_owner = servers_df["owner"] == ""
-    servers_df.loc[needs_owner, "owner"] = servers_df.loc[needs_owner, "branch"].map(
-        lambda b: graphite_owners.get(int(m.group(1)), "") if (m := GRAPHITE_BASE_RE.match(b)) else ""
-    )
 
 # Filter controls
 st.subheader("🖥️ Staging Servers")

--- a/apps/wizard/app_pages/servers_dashboard/utils.py
+++ b/apps/wizard/app_pages/servers_dashboard/utils.py
@@ -652,14 +652,31 @@ def build_quick_links(branch: str) -> dict[str, str]:
     }
 
 
+def _fetch_prs(repo_name: str, params: str, headers: dict, max_pages: int) -> list[dict]:
+    """Fetch up to ``max_pages`` pages of PRs from a repo's pulls endpoint."""
+    url: str | None = f"https://api.github.com/repos/owid/{repo_name}/pulls?{params}"
+    prs: list[dict] = []
+    pages = 0
+    while url and pages < max_pages:
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+        prs.extend(response.json())
+        url = response.links.get("next", {}).get("url")
+        pages += 1
+    return prs
+
+
 @st.cache_data(ttl=300, show_spinner=False)  # Cache for 5 minutes alongside the server data
 def fetch_server_owners() -> dict[str, str]:
     """
     Map each staging server's container name to the GitHub login of its PR author.
 
-    Staging servers don't record who created them, so we derive the owner from the
-    open PRs on the etl and owid-grapher repos. Best-effort: returns an empty mapping
-    if GitHub is unreachable or no token is configured, so the dashboard never breaks.
+    Staging servers don't record who created them, so we derive the owner from PRs on
+    the etl and owid-grapher repos. We include both open PRs (full list) and the most
+    recently-closed PRs, because a server survives for a few days after its PR is merged
+    — so merged-but-not-yet-pruned servers still need an owner. Best-effort: returns an
+    empty mapping if GitHub is unreachable or no token is configured, so the dashboard
+    never breaks.
 
     Returns:
         Dict mapping container name (e.g. ``staging-site-my-branch``) to GitHub login.
@@ -668,22 +685,21 @@ def fetch_server_owners() -> dict[str, str]:
     headers = {"Authorization": f"token {OWIDBOT_ACCESS_TOKEN}"} if OWIDBOT_ACCESS_TOKEN else {}
 
     for repo_name in ("etl", "owid-grapher"):
-        url = f"https://api.github.com/repos/owid/{repo_name}/pulls?per_page=100&state=open"
         try:
-            while url:
-                response = requests.get(url, headers=headers, timeout=30)
-                response.raise_for_status()
-                for pr in response.json():
-                    # Only OWID branches (exclude forks), and skip if author missing.
-                    if not pr["head"]["label"].startswith("owid:"):
-                        continue
-                    login = (pr.get("user") or {}).get("login")
-                    if not login:
-                        continue
-                    container_name = get_container_name(pr["head"]["ref"])
-                    # First PR wins; both repos map to the same container name.
-                    owners.setdefault(container_name, login)
-                url = response.links.get("next", {}).get("url")
+            # Open PRs first (their author wins on branch reuse), then recently-closed
+            # PRs to cover servers whose PR merged within the prune window (~3 days).
+            prs = _fetch_prs(repo_name, "state=open&per_page=100", headers, max_pages=5)
+            prs += _fetch_prs(repo_name, "state=closed&sort=updated&direction=desc&per_page=100", headers, max_pages=2)
+            for pr in prs:
+                # Only OWID branches (exclude forks), and skip if author missing.
+                if not pr["head"]["label"].startswith("owid:"):
+                    continue
+                login = (pr.get("user") or {}).get("login")
+                if not login:
+                    continue
+                container_name = get_container_name(pr["head"]["ref"])
+                # First occurrence wins (open PRs and most-recently-updated closed PRs first).
+                owners.setdefault(container_name, login)
         except requests.RequestException as e:
             log.warning("Could not fetch PR owners from GitHub", repo=repo_name, error=str(e))
 

--- a/apps/wizard/app_pages/servers_dashboard/utils.py
+++ b/apps/wizard/app_pages/servers_dashboard/utils.py
@@ -6,10 +6,18 @@ from datetime import datetime, timezone
 from typing import Any
 
 import pandas as pd
+import requests
 import streamlit as st
 from structlog import get_logger
 
+from apps.owidbot.cli import get_cloudflare_subdomain
+from etl.config import OWIDBOT_ACCESS_TOKEN, get_container_name
+
 log = get_logger()
+
+# LXC host that staging servers live on. The fetch/destroy/stop/start commands all
+# target this host (matching ops/templates/lxc-manager/*), so keep it in one place.
+LXC_HOST = "gaia-1"
 
 
 @st.cache_data(ttl=300, show_spinner=False)  # Cache for 5 minutes to avoid hammering the server
@@ -176,13 +184,23 @@ def _process_server_data(df: pd.DataFrame) -> pd.DataFrame:
     df["etl_days_old"] = _calculate_days_since_commit(df["etl_commit_parsed"])
     df["grapher_days_old"] = _calculate_days_since_commit(df["grapher_commit_parsed"])
 
-    # Add status indicators
+    # Add status indicators. "Stopped" containers are idle: their data is preserved and
+    # they can be woken with `owid-lxc start`, so we surface them as "Idle" to the team.
     df["status_indicator"] = df["status"].map(
         {
             "Running": "🟢",
-            "Stopped": "🔴",
+            "Stopped": "⏸️",
         }
     )
+    df["status_label"] = df["status"].map(
+        {
+            "Running": "Running",
+            "Stopped": "Idle",
+        }
+    )
+
+    # Build a single "last commit" column based on origin (used in the server list)
+    df["unified_commit"] = df.apply(_get_unified_commit_info, axis=1)
 
     # Sort by status (running first) then by creation date (newest first)
     df = df.sort_values(
@@ -312,95 +330,45 @@ def format_commit_info(commit_timestamp: str, days_old: int | None) -> str:
         return f"❌ {int(days_old)} days ago"
 
 
-def get_display_columns() -> dict[str, str]:
-    """
-    Get the column mapping for display in the table.
+def _get_unified_commit_info(row: pd.Series) -> str:
+    """Create a single human-readable "last commit" string based on the server origin."""
+    origin = (row.get("origin") or "").lower()
 
-    Returns:
-        Dictionary mapping internal column names to display names
-    """
-    return {
-        "status_indicator": "Status",
-        "origin": "Origin",
-        "branch": "Branch",
-        "memory_display": "Memory",
-        "days_old": "Age (days)",
-        "unified_commit": "Last Commit",
-    }
+    if origin == "etl":
+        # Use ETL commit for ETL-only servers
+        return format_commit_info(row["etl_last_commit"], row["etl_days_old"])
+    elif origin == "owid-grapher":
+        # Use Grapher commit for Grapher-only servers
+        return format_commit_info(row["grapher_last_commit"], row["grapher_days_old"])
+    elif "owid-grapher" in origin and "etl" in origin:
+        # For mixed origins (e.g., "owid-grapher,etl"), use the latest commit
+        etl_date = row["etl_commit_parsed"]
+        grapher_date = row["grapher_commit_parsed"]
 
-
-def prepare_display_dataframe(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    Prepare the dataframe for display in Streamlit.
-
-    Args:
-        df: Processed server DataFrame
-
-    Returns:
-        DataFrame ready for display
-    """
-    if df.empty:
-        return df
-
-    display_df = df.copy()
-
-    # Create unified commit column based on origin
-    def get_unified_commit_info(row):
-        origin = row.get("origin", "").lower()
-
-        if origin == "etl":
-            # Use ETL commit for ETL-only servers
-            return format_commit_info(row["etl_last_commit"], row["etl_days_old"])
-        elif origin == "owid-grapher":
-            # Use Grapher commit for Grapher-only servers
+        # Handle NaT/None values
+        if pd.isna(etl_date) and pd.isna(grapher_date):
+            return "❓ No commits found"
+        elif pd.isna(etl_date):
             return format_commit_info(row["grapher_last_commit"], row["grapher_days_old"])
-        elif "owid-grapher" in origin and "etl" in origin:
-            # For mixed origins (e.g., "owid-grapher,etl"), use the latest commit
-            etl_date = row["etl_commit_parsed"]
-            grapher_date = row["grapher_commit_parsed"]
-
-            # Handle NaT/None values
-            if pd.isna(etl_date) and pd.isna(grapher_date):
-                return "❓ No commits found"
-            elif pd.isna(etl_date):
-                return format_commit_info(row["grapher_last_commit"], row["grapher_days_old"])
-            elif pd.isna(grapher_date):
-                return format_commit_info(row["etl_last_commit"], row["etl_days_old"])
-            else:
-                # Compare dates and use the latest
-                if etl_date >= grapher_date:
-                    return format_commit_info(row["etl_last_commit"], row["etl_days_old"])
-                else:
-                    return format_commit_info(row["grapher_last_commit"], row["grapher_days_old"])
+        elif pd.isna(grapher_date):
+            return format_commit_info(row["etl_last_commit"], row["etl_days_old"])
         else:
-            # Default fallback - try ETL first, then Grapher
-            etl_commit = row["etl_last_commit"]
-            if not pd.isna(etl_commit) and etl_commit not in [
-                "Container not running",
-                "Unable to retrieve",
-                "No git repository found",
-            ]:
+            # Compare dates and use the latest
+            if etl_date >= grapher_date:
                 return format_commit_info(row["etl_last_commit"], row["etl_days_old"])
             else:
                 return format_commit_info(row["grapher_last_commit"], row["grapher_days_old"])
-
-    display_df["unified_commit"] = display_df.apply(get_unified_commit_info, axis=1)
-
-    # For progress bar, we need the actual GB values
-    # The ProgressColumn will show the bar based on value/max_value ratio, but display the actual GB value
-    display_df["memory_display"] = display_df["memory_used_gb"].fillna(0)
-
-    # Round memory values for internal use
-    display_df["memory_used_gb"] = display_df["memory_used_gb"].round(2)
-    display_df["memory_usage_pct"] = display_df["memory_usage_pct"].round(1)
-
-    # Select and order columns for display
-    column_mapping = get_display_columns()
-    display_columns = list(column_mapping.keys())
-
-    display_df = display_df[display_columns].rename(columns=column_mapping)
-
-    return display_df
+    else:
+        # Default fallback - try ETL first, then Grapher
+        etl_commit = row["etl_last_commit"]
+        if not pd.isna(etl_commit) and etl_commit not in [
+            "Container not running",
+            "Unable to retrieve",
+            "No git repository found",
+        ]:
+            return format_commit_info(row["etl_last_commit"], row["etl_days_old"])
+        else:
+            return format_commit_info(row["grapher_last_commit"], row["grapher_days_old"])
 
 
 def reset_mysql_database(server_name: str) -> tuple[bool, str]:
@@ -523,6 +491,99 @@ def reset_mysql_database(server_name: str) -> tuple[bool, str]:
         return False, error_msg
 
 
+def start_server(server_name: str) -> tuple[bool, str]:
+    """
+    Wake up an idle (stopped) staging server with ``owid-lxc start``.
+
+    The container's data is preserved while it's stopped, so starting it brings the
+    server back in seconds — no commit or rebuild needed. This replaces the obscure
+    "push an empty commit" trick for idle servers.
+
+    Args:
+        server_name: Full server name (e.g., staging-site-branch-name)
+
+    Returns:
+        Tuple of (success, message)
+    """
+    cmd = f"LXC_HOST={LXC_HOST} owid-lxc start {server_name}"
+    # Starting also runs a tailscale login and a short readiness delay, so allow time.
+    return _run_lxc_command(cmd, server_name, action="start", timeout=180)
+
+
+def stop_server(server_name: str) -> tuple[bool, str]:
+    """
+    Put a running staging server to sleep (make it idle).
+
+    Mirrors the ops cron (``stop_staging_containers.py``): take a ``pre-stop`` snapshot
+    first so the state can be recovered, then stop the container. The data is preserved
+    and the server can be woken later with :func:`start_server`.
+
+    Args:
+        server_name: Full server name (e.g., staging-site-branch-name)
+
+    Returns:
+        Tuple of (success, message)
+    """
+    # Snapshot first (best-effort safety net), then stop — same order as the cron.
+    snapshot_ok, snapshot_msg = _run_lxc_command(
+        f"LXC_HOST={LXC_HOST} owid-lxc snapshot {server_name} pre-stop",
+        server_name,
+        action="snapshot",
+        timeout=120,
+    )
+    if not snapshot_ok:
+        return False, f"Could not take pre-stop snapshot, aborting stop: {snapshot_msg}"
+
+    return _run_lxc_command(
+        f"LXC_HOST={LXC_HOST} owid-lxc stop {server_name}",
+        server_name,
+        action="stop",
+        timeout=120,
+    )
+
+
+def restart_server(server_name: str) -> tuple[bool, str]:
+    """
+    Restart a running staging server (stop, then start).
+
+    Args:
+        server_name: Full server name (e.g., staging-site-branch-name)
+
+    Returns:
+        Tuple of (success, message)
+    """
+    stop_ok, stop_msg = _run_lxc_command(
+        f"LXC_HOST={LXC_HOST} owid-lxc stop {server_name}",
+        server_name,
+        action="stop",
+        timeout=120,
+    )
+    if not stop_ok:
+        return False, f"Could not stop server before restart: {stop_msg}"
+
+    return start_server(server_name)
+
+
+def _run_lxc_command(cmd: str, server_name: str, action: str, timeout: int) -> tuple[bool, str]:
+    """Run a simple ``owid-lxc`` action command and return (success, message)."""
+    try:
+        log.info(f"Running owid-lxc {action}", command=cmd, server=server_name)
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True, timeout=timeout)
+
+        if result.returncode != 0:
+            error_msg = f"`owid-lxc {action}` failed with return code {result.returncode}: {result.stderr.strip()}"
+            log.error("owid-lxc command failed", error=error_msg, server=server_name, stdout=result.stdout)
+            return False, error_msg
+
+        log.info(f"owid-lxc {action} completed", server=server_name)
+        return True, f"Server {server_name} {action} completed successfully"
+
+    except subprocess.TimeoutExpired:
+        error_msg = f"`owid-lxc {action}` timed out after {timeout} seconds"
+        log.error("owid-lxc command timeout", server=server_name, action=action)
+        return False, error_msg
+
+
 def destroy_server(server_name: str) -> tuple[bool, str]:
     """
     Destroy a staging server completely.
@@ -535,7 +596,7 @@ def destroy_server(server_name: str) -> tuple[bool, str]:
     """
     try:
         # Command to destroy the LXC container
-        cmd = f"LXC_HOST=gaia-1 owid-lxc destroy {server_name}"
+        cmd = f"LXC_HOST={LXC_HOST} owid-lxc destroy {server_name}"
         log.info("Destroying server", command=cmd, server=server_name)
 
         result = subprocess.run(
@@ -563,3 +624,68 @@ def destroy_server(server_name: str) -> tuple[bool, str]:
         error_msg = f"Unexpected error during server destruction: {str(e)}"
         log.error("Server destruction error", error=error_msg, server=server_name)
         return False, error_msg
+
+
+def build_quick_links(branch: str) -> dict[str, str]:
+    """
+    Build the quick-access links for a staging server.
+
+    These mirror the links that owidbot posts on every ETL PR (see
+    ``apps/owidbot/cli.py:create_comment_body``), so they can be accessed from the
+    dashboard without hunting through GitHub.
+
+    Args:
+        branch: Branch name (without the ``staging-site-`` prefix)
+
+    Returns:
+        Ordered dict of {label: url}
+    """
+    container_name = get_container_name(branch)
+    cloudflare_subdomain = get_cloudflare_subdomain(branch)
+
+    return {
+        "Site Dev": f"http://{container_name}/",
+        "Site Preview": f"https://{cloudflare_subdomain}.owid.pages.dev/",
+        "Admin": f"http://{container_name}/admin",
+        "Wizard": f"http://{container_name}/etl/wizard/",
+        "Chart Diff": f"http://{container_name}/etl/wizard/chart-diff",
+        "Docs": f"http://{container_name}/etl/docs/",
+    }
+
+
+@st.cache_data(ttl=300, show_spinner=False)  # Cache for 5 minutes alongside the server data
+def fetch_server_owners() -> dict[str, str]:
+    """
+    Map each staging server's container name to the GitHub login of its PR author.
+
+    Staging servers don't record who created them, so we derive the owner from the
+    open PRs on the etl and owid-grapher repos. Best-effort: returns an empty mapping
+    if GitHub is unreachable or no token is configured, so the dashboard never breaks.
+
+    Returns:
+        Dict mapping container name (e.g. ``staging-site-my-branch``) to GitHub login.
+    """
+    owners: dict[str, str] = {}
+    headers = {"Authorization": f"token {OWIDBOT_ACCESS_TOKEN}"} if OWIDBOT_ACCESS_TOKEN else {}
+
+    for repo_name in ("etl", "owid-grapher"):
+        url = f"https://api.github.com/repos/owid/{repo_name}/pulls?per_page=100&state=open"
+        try:
+            while url:
+                response = requests.get(url, headers=headers, timeout=30)
+                response.raise_for_status()
+                for pr in response.json():
+                    # Only OWID branches (exclude forks), and skip if author missing.
+                    if not pr["head"]["label"].startswith("owid:"):
+                        continue
+                    login = (pr.get("user") or {}).get("login")
+                    if not login:
+                        continue
+                    container_name = get_container_name(pr["head"]["ref"])
+                    # First PR wins; both repos map to the same container name.
+                    owners.setdefault(container_name, login)
+                url = response.links.get("next", {}).get("url")
+        except requests.RequestException as e:
+            log.warning("Could not fetch PR owners from GitHub", repo=repo_name, error=str(e))
+
+    return owners

--- a/apps/wizard/app_pages/servers_dashboard/utils.py
+++ b/apps/wizard/app_pages/servers_dashboard/utils.py
@@ -649,7 +649,6 @@ def build_quick_links(branch: str) -> dict[str, str]:
         "Admin": f"http://{container_name}/admin",
         "Wizard": f"http://{container_name}/etl/wizard/",
         "Chart Diff": f"http://{container_name}/etl/wizard/chart-diff",
-        "Docs": f"http://{container_name}/etl/docs/",
     }
 
 

--- a/apps/wizard/app_pages/servers_dashboard/utils.py
+++ b/apps/wizard/app_pages/servers_dashboard/utils.py
@@ -1,7 +1,6 @@
 """Utilities for fetching and processing LXC staging server data."""
 
 import json
-import re
 import subprocess
 from datetime import datetime, timezone
 from typing import Any
@@ -19,11 +18,6 @@ log = get_logger()
 # LXC host that staging servers live on. The fetch/destroy/stop/start commands all
 # target this host (matching ops/templates/lxc-manager/*), so keep it in one place.
 LXC_HOST = "gaia-1"
-
-# Graphite (graphite.dev) creates transient `graphite-base-<PR-number>` base branches when
-# stacking PRs. A push to one spins up a staging server, but the base branch has no PR of its
-# own, so the owner must be looked up from owid-grapher PR #<number> instead.
-GRAPHITE_BASE_RE = re.compile(r"^graphite-base-(\d+)$")
 
 
 @st.cache_data(ttl=300, show_spinner=False)  # Cache for 5 minutes to avoid hammering the server
@@ -173,10 +167,8 @@ def _process_server_data(df: pd.DataFrame) -> pd.DataFrame:
     # Extract branch name from container name (remove 'staging-site-' prefix)
     df["branch"] = df["name"].str.replace("staging-site-", "", regex=False)
 
-    # Parse memory information
+    # Parse memory information (only "used" is shown in the table)
     df["memory_used_gb"] = df["memory"].apply(_extract_memory_used_gb)
-    df["memory_total_gb"] = df["memory"].apply(_extract_memory_total_gb)
-    df["memory_usage_pct"] = df.apply(_calculate_memory_usage_pct, axis=1)
 
     # Parse creation time
     df["created_parsed"] = pd.to_datetime(df["created"], errors="coerce")
@@ -231,26 +223,6 @@ def _extract_memory_used_gb(memory_info: dict) -> float | None:
         return None
 
 
-def _extract_memory_total_gb(memory_info: dict) -> float | None:
-    """Extract total memory in GB from memory info dict."""
-    try:
-        if isinstance(memory_info, dict) and "total_mb" in memory_info:
-            return round(memory_info["total_mb"] / 1024, 2)
-        return None
-    except (TypeError, KeyError):
-        return None
-
-
-def _calculate_memory_usage_pct(row: pd.Series) -> float | None:
-    """Calculate memory usage percentage."""
-    try:
-        if pd.isna(row["memory_used_gb"]) or pd.isna(row["memory_total_gb"]) or row["memory_total_gb"] == 0:
-            return None
-        return round((row["memory_used_gb"] / row["memory_total_gb"]) * 100, 1)
-    except (TypeError, ZeroDivisionError):
-        return None
-
-
 def _calculate_days_since_commit(commit_series: pd.Series) -> pd.Series:
     """Calculate days since commit for a series of commit timestamps."""
     now = datetime.now(timezone.utc)
@@ -284,17 +256,13 @@ def get_server_summary_stats(df: pd.DataFrame, host_memory_stats: dict | None = 
             "total_servers": 0,
             "running_servers": 0,
             "stopped_servers": 0,
-            "total_memory_gb": 0,
-            "host_memory_usage_pct": None,
+            "host_memory_stats": host_memory_stats,
         }
-
-    running_servers = df[df["status"] == "Running"]
 
     return {
         "total_servers": len(df),
-        "running_servers": len(running_servers),
+        "running_servers": len(df[df["status"] == "Running"]),
         "stopped_servers": len(df[df["status"] == "Stopped"]),
-        "total_memory_gb": running_servers["memory_used_gb"].sum() if not running_servers.empty else 0,
         "host_memory_stats": host_memory_stats,
     }
 
@@ -710,42 +678,3 @@ def fetch_server_owners() -> dict[str, str]:
             log.warning("Could not fetch PR owners from GitHub", repo=repo_name, error=str(e))
 
     return owners
-
-
-@st.cache_data(ttl=300, show_spinner=False)
-def fetch_graphite_owners(pr_numbers: tuple[int, ...]) -> dict[int, str]:
-    """
-    Resolve the owner of ``graphite-base-<N>`` servers to the author of owid-grapher PR #N.
-
-    These transient Graphite base branches have no PR of their own, so they're never matched
-    by :func:`fetch_server_owners`. We look up PR #N directly. Best-effort: silently skips any
-    number that can't be resolved.
-
-    Args:
-        pr_numbers: PR numbers to resolve (the ``<N>`` from each ``graphite-base-<N>`` server).
-
-    Returns:
-        Dict mapping PR number to GitHub login.
-    """
-    out: dict[int, str] = {}
-    headers = {"Authorization": f"token {OWIDBOT_ACCESS_TOKEN}"} if OWIDBOT_ACCESS_TOKEN else {}
-    for number in pr_numbers:
-        # Graphite is used on owid-grapher; check it first, fall back to etl just in case.
-        for repo_name in ("owid-grapher", "etl"):
-            try:
-                response = requests.get(
-                    f"https://api.github.com/repos/owid/{repo_name}/issues/{number}", headers=headers, timeout=30
-                )
-                if response.status_code != 200:
-                    continue
-                issue = response.json()
-                # issues endpoint also returns issues; only PRs have this key.
-                if "pull_request" not in issue:
-                    continue
-                login = (issue.get("user") or {}).get("login")
-                if login:
-                    out[number] = login
-                    break
-            except requests.RequestException as e:
-                log.warning("Could not resolve graphite-base owner", repo=repo_name, pr=number, error=str(e))
-    return out

--- a/apps/wizard/app_pages/servers_dashboard/utils.py
+++ b/apps/wizard/app_pages/servers_dashboard/utils.py
@@ -1,6 +1,7 @@
 """Utilities for fetching and processing LXC staging server data."""
 
 import json
+import re
 import subprocess
 from datetime import datetime, timezone
 from typing import Any
@@ -18,6 +19,11 @@ log = get_logger()
 # LXC host that staging servers live on. The fetch/destroy/stop/start commands all
 # target this host (matching ops/templates/lxc-manager/*), so keep it in one place.
 LXC_HOST = "gaia-1"
+
+# Graphite (graphite.dev) creates transient `graphite-base-<PR-number>` base branches when
+# stacking PRs. A push to one spins up a staging server, but the base branch has no PR of its
+# own, so the owner must be looked up from owid-grapher PR #<number> instead.
+GRAPHITE_BASE_RE = re.compile(r"^graphite-base-(\d+)$")
 
 
 @st.cache_data(ttl=300, show_spinner=False)  # Cache for 5 minutes to avoid hammering the server
@@ -704,3 +710,42 @@ def fetch_server_owners() -> dict[str, str]:
             log.warning("Could not fetch PR owners from GitHub", repo=repo_name, error=str(e))
 
     return owners
+
+
+@st.cache_data(ttl=300, show_spinner=False)
+def fetch_graphite_owners(pr_numbers: tuple[int, ...]) -> dict[int, str]:
+    """
+    Resolve the owner of ``graphite-base-<N>`` servers to the author of owid-grapher PR #N.
+
+    These transient Graphite base branches have no PR of their own, so they're never matched
+    by :func:`fetch_server_owners`. We look up PR #N directly. Best-effort: silently skips any
+    number that can't be resolved.
+
+    Args:
+        pr_numbers: PR numbers to resolve (the ``<N>`` from each ``graphite-base-<N>`` server).
+
+    Returns:
+        Dict mapping PR number to GitHub login.
+    """
+    out: dict[int, str] = {}
+    headers = {"Authorization": f"token {OWIDBOT_ACCESS_TOKEN}"} if OWIDBOT_ACCESS_TOKEN else {}
+    for number in pr_numbers:
+        # Graphite is used on owid-grapher; check it first, fall back to etl just in case.
+        for repo_name in ("owid-grapher", "etl"):
+            try:
+                response = requests.get(
+                    f"https://api.github.com/repos/owid/{repo_name}/issues/{number}", headers=headers, timeout=30
+                )
+                if response.status_code != 200:
+                    continue
+                issue = response.json()
+                # issues endpoint also returns issues; only PRs have this key.
+                if "pull_request" not in issue:
+                    continue
+                login = (issue.get("user") or {}).get("login")
+                if login:
+                    out[number] = login
+                    break
+            except requests.RequestException as e:
+                log.warning("Could not resolve graphite-base owner", repo=repo_name, pr=number, error=str(e))
+    return out


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Phase 1 of #6257 — making the [staging servers dashboard](https://etl.owid.io/wizard/servers-dashboard) something the whole team can actually use.

## The main win

Idle servers no longer need the obscure "push an empty commit" trick to come back. An idle (stopped) container keeps all its data, so it can be woken instantly with `owid-lxc start` — now a one-click **Wake up** button. The dashboard also relabels "Stopped" → **Idle** with an explanation, so it's clear the data is safe.

## What changed

- **Kept the rich at-a-glance table** (with the memory progress bar and last-commit status), and **added an Owner column**.
- **Selecting a row reveals a management panel** below the table with that server's quick links, `ssh` command, and action buttons — replacing the old "pick from a dropdown" panel.
- **State-aware action buttons** with tooltips explaining each:
  - Running → Make idle / Restart / Reset MySQL / Destroy
  - Idle → **Wake up** / Destroy
  - *Make idle* mirrors the ops cron exactly (`owid-lxc snapshot <name> pre-stop` then `stop`). Reset MySQL and Destroy keep their confirmation dialogs.
- **Quick links per server** — the same Site Dev / Preview / Admin / Wizard / Chart Diff / Docs links owidbot posts on each PR, plus the `ssh` command. Reuses owidbot's link logic.
- **Owner column + filter** — derived from the GitHub PR author (cached 5 min; degrades to blank if GitHub is unreachable, so the dashboard never breaks). Filters are now Status / Owner / Origin / branch search.

## Out of scope (deferred to Phase 2)

- Showing **deleted** servers (cross-referencing GitHub PRs) and a wake-via-empty-commit button for them.
- A link to the dashboard from the **grapher admin** nav.
- Creating staging servers from the dashboard (explicitly out of scope).

## Notes

- The dashboard remains production-only (`disable: staging: true`); the new actions run the same `owid-lxc`/SSH commands as the existing Destroy/Reset MySQL buttons, so no new trust boundary.
- **Separately:** dependabot branches are getting staging servers created (e.g. `dependabot-uv-tornado-6-5-6`). That fix lives in the `ops` repo (Buildkite pipelines), not here — tracked separately.