### PR TITLE
📊 Add Ebola outbreak datasets (2026 tracker + historical)

### DIFF
--- a/dag/health.yml
+++ b/dag/health.yml
@@ -4,6 +4,22 @@ steps:
   data://garden/owid/latest/covid:
     - etag://raw.githubusercontent.com/owid/covid-19-data/master/public/data/owid-covid-data.csv
 
+  # 2026 Bundibugyo Ebola outbreak (DRC + Uganda), via Kraemer Lab / INSP SitReps
+  data://meadow/ebola/2026-06-15/ebola_drc_2026:
+    - snapshot://ebola/2026-06-15/ebola_drc_2026.csv
+  data://garden/ebola/2026-06-15/ebola_drc_2026:
+    - data://meadow/ebola/2026-06-15/ebola_drc_2026
+  data://grapher/ebola/2026-06-15/ebola_drc_2026:
+    - data://garden/ebola/2026-06-15/ebola_drc_2026
+
+  # Historical Ebola outbreak chronology (CDC), 1976-present
+  data://meadow/ebola/2026-06-15/ebola_outbreaks:
+    - snapshot://ebola/2026-06-15/ebola_outbreaks.html
+  data://garden/ebola/2026-06-15/ebola_outbreaks:
+    - data://meadow/ebola/2026-06-15/ebola_outbreaks
+  data://grapher/ebola/2026-06-15/ebola_outbreaks:
+    - data://garden/ebola/2026-06-15/ebola_outbreaks
+
   # Death completion (Karlinsky, 2024)
   data://grapher/health/2025-04-18/deaths_karlinsky:
     - data://garden/health/2025-04-18/deaths_karlinsky:

--- a/etl/steps/data/garden/ebola/2026-06-15/ebola_drc_2026.countries.json
+++ b/etl/steps/data/garden/ebola/2026-06-15/ebola_drc_2026.countries.json
@@ -1,0 +1,3 @@
+{
+  "DRC": "Democratic Republic of Congo"
+}

--- a/etl/steps/data/garden/ebola/2026-06-15/ebola_drc_2026.meta.yml
+++ b/etl/steps/data/garden/ebola/2026-06-15/ebola_drc_2026.meta.yml
@@ -1,0 +1,73 @@
+# NOTE: dataset block omitted — inherited from the snapshot origin.
+definitions:
+  common:
+    presentation:
+      topic_tags:
+        - Pandemics
+    processing_level: minor
+    description_processing: |-
+      The source publishes one CSV file per indicator, with values labelled by health zone (and aggregated to the national level). We stack these per-indicator files into a single table, parse the source's "ND" ("no data") and "NA" markers to missing values, and convert the source's daily labels into dates. National figures are attributed to the Democratic Republic of Congo; health-zone figures are kept at their original subnational resolution.
+
+tables:
+  ebola_drc_2026:
+    title: 2026 Bundibugyo Ebola outbreak — national indicators (DRC)
+    variables:
+      cumulative_confirmed_cases:
+        title: Cumulative confirmed Ebola cases
+        unit: cases
+        short_unit: ""
+        description_short: Total number of laboratory-confirmed cases of Ebola disease (Bundibugyo virus) reported in the Democratic Republic of the Congo since the start of the 2026 outbreak.
+      cumulative_confirmed_deaths:
+        title: Cumulative confirmed Ebola deaths
+        unit: deaths
+        short_unit: ""
+        description_short: Total number of deaths among laboratory-confirmed Ebola cases (Bundibugyo virus) reported in the Democratic Republic of the Congo since the start of the 2026 outbreak.
+      cumulative_suspected_cases:
+        title: Cumulative suspected Ebola cases
+        unit: cases
+        short_unit: ""
+        description_short: Total number of suspected cases of Ebola disease (Bundibugyo virus) reported in the Democratic Republic of the Congo since the start of the 2026 outbreak.
+      cumulative_suspected_deaths:
+        title: Cumulative suspected Ebola deaths
+        unit: deaths
+        short_unit: ""
+        description_short: Total number of deaths among suspected Ebola cases (Bundibugyo virus) reported in the Democratic Republic of the Congo since the start of the 2026 outbreak.
+
+  ebola_drc_2026_by_health_zone:
+    title: 2026 Bundibugyo Ebola outbreak — indicators by health zone
+    variables:
+      cumulative_confirmed_cases:
+        title: Cumulative confirmed Ebola cases, by health zone
+        unit: cases
+        short_unit: ""
+        description_short: Total laboratory-confirmed cases of Ebola disease (Bundibugyo virus) reported in each health zone since the start of the 2026 outbreak.
+      cumulative_confirmed_deaths:
+        title: Cumulative confirmed Ebola deaths, by health zone
+        unit: deaths
+        short_unit: ""
+        description_short: Total deaths among laboratory-confirmed Ebola cases (Bundibugyo virus) reported in each health zone since the start of the 2026 outbreak.
+      cumulative_suspected_cases:
+        title: Cumulative suspected Ebola cases, by health zone
+        unit: cases
+        short_unit: ""
+        description_short: Total suspected cases of Ebola disease (Bundibugyo virus) reported in each health zone since the start of the 2026 outbreak.
+      cumulative_suspected_deaths:
+        title: Cumulative suspected Ebola deaths, by health zone
+        unit: deaths
+        short_unit: ""
+        description_short: Total deaths among suspected Ebola cases (Bundibugyo virus) reported in each health zone since the start of the 2026 outbreak.
+      new_confirmed_cases:
+        title: New confirmed Ebola cases, by health zone
+        unit: cases
+        short_unit: ""
+        description_short: Newly reported laboratory-confirmed cases of Ebola disease (Bundibugyo virus) in each health zone.
+      new_suspected_cases:
+        title: New suspected Ebola cases, by health zone
+        unit: cases
+        short_unit: ""
+        description_short: Newly reported suspected cases of Ebola disease (Bundibugyo virus) in each health zone.
+      new_suspected_deaths:
+        title: New suspected Ebola deaths, by health zone
+        unit: deaths
+        short_unit: ""
+        description_short: Newly reported deaths among suspected Ebola cases (Bundibugyo virus) in each health zone.

--- a/etl/steps/data/garden/ebola/2026-06-15/ebola_drc_2026.py
+++ b/etl/steps/data/garden/ebola/2026-06-15/ebola_drc_2026.py
@@ -1,0 +1,107 @@
+"""Garden step for the 2026 Bundibugyo Ebola outbreak (DRC + Uganda).
+
+Produces two tables:
+  - ``ebola_drc_2026``: national (DRC) time series, country-harmonized.
+  - ``ebola_drc_2026_by_health_zone``: per-health-zone time series (subnational entities,
+    not country-harmonized — the zone names are kept verbatim as grapher entities).
+"""
+
+import owid.catalog.processing as pr
+from owid.catalog import Table
+from structlog import get_logger
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+log = get_logger()
+
+# Metrics expected from the snapshot (see snapshot script FILES mapping).
+EXPECTED_METRICS = {
+    "cumulative_confirmed_cases",
+    "cumulative_confirmed_deaths",
+    "cumulative_suspected_cases",
+    "cumulative_suspected_deaths",
+    "new_confirmed_cases",
+    "new_suspected_cases",
+    "new_suspected_deaths",
+}
+
+
+def sanity_check_inputs(tb: Table) -> None:
+    assert set(tb["level"].unique()) <= {"national", "health_zone"}, "Unexpected level in source data."
+    assert set(tb["metric"].unique()) <= EXPECTED_METRICS, "Unexpected metric in source data."
+    assert not tb.duplicated(subset=["level", "metric", "location", "date"]).any(), (
+        "Duplicate (level, metric, location, date) rows."
+    )
+    # National rows must all be DRC; anything else means the source changed its national label.
+    nat_locations = set(tb.loc[tb["level"] == "national", "location"].unique())
+    assert nat_locations <= {"DRC"}, f"Unexpected national location label(s): {nat_locations}"
+
+
+def sanity_check_outputs(tb_nat: Table, tb_hz: Table) -> None:
+    # No negative cases/deaths anywhere.
+    for tb, name in [(tb_nat, "national"), (tb_hz, "health_zone")]:
+        value_cols = [c for c in tb.columns if c not in ["country", "date"]]
+        assert (tb[value_cols].min(numeric_only=True) >= 0).all(), f"Negative case/death count in {name} table."
+
+    # National confirmed cases must be present and non-decreasing (cumulative).
+    assert "cumulative_confirmed_cases" in tb_nat.columns, "National table is missing cumulative confirmed cases."
+    nat = tb_nat.sort_values("date")
+    cc = nat["cumulative_confirmed_cases"].dropna()
+    if not cc.is_monotonic_increasing:
+        # Soft signal: the source occasionally revises figures downward.
+        log.warning("National cumulative confirmed cases are not monotonically increasing — possible source revision.")
+
+    # Confirmed deaths should never exceed confirmed cases at the national level.
+    overlap = nat.dropna(subset=["cumulative_confirmed_cases", "cumulative_confirmed_deaths"])
+    assert (overlap["cumulative_confirmed_deaths"] <= overlap["cumulative_confirmed_cases"]).all(), (
+        "National confirmed deaths exceed confirmed cases."
+    )
+
+
+def _pivot(tb: Table, short_name: str) -> Table:
+    """Pivot long [location, date, metric, value] into wide [country, date, <metrics...>]."""
+    tb = tb.pivot(index=["location", "date"], columns="metric", values="value", join_column_levels_with="_").rename(
+        columns={"location": "country"}
+    )
+    # Drop columns that are entirely empty (e.g. confirmed deaths by zone are all "ND" early on).
+    all_nan = [c for c in tb.columns if c not in ["country", "date"] and tb[c].isna().all()]
+    if all_nan:
+        log.info(f"Dropping fully-empty columns from {short_name}: {all_nan}")
+        tb = tb.drop(columns=all_nan)
+    return tb
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_meadow = paths.load_dataset("ebola_drc_2026")
+    tb = ds_meadow["ebola_drc_2026"].reset_index()
+
+    sanity_check_inputs(tb)
+
+    #
+    # Process data.
+    #
+    # Parse the raw source strings: "ND"/"NA" -> NaN; dates -> datetime.
+    tb["value"] = pr.to_numeric(tb["value"], errors="coerce")
+    tb["date"] = pr.to_datetime(tb["date"], format="%Y-%m-%d")
+
+    tb_nat = _pivot(tb[tb["level"] == "national"].copy(), "ebola_drc_2026")
+    tb_hz = _pivot(tb[tb["level"] == "health_zone"].copy(), "ebola_drc_2026_by_health_zone")
+
+    # Harmonize only the national table ("DRC" -> "Democratic Republic of Congo"). Health-zone
+    # names are subnational and kept verbatim as grapher entities.
+    tb_nat = paths.regions.harmonize_names(tb_nat, country_col="country", countries_file=paths.country_mapping_path)
+
+    sanity_check_outputs(tb_nat, tb_hz)
+
+    tb_nat = tb_nat.format(["country", "date"], short_name="ebola_drc_2026")
+    tb_hz = tb_hz.format(["country", "date"], short_name="ebola_drc_2026_by_health_zone")
+
+    #
+    # Save outputs.
+    #
+    ds_garden = paths.create_dataset(tables=[tb_nat, tb_hz], default_metadata=ds_meadow.metadata)
+    ds_garden.save()

--- a/etl/steps/data/garden/ebola/2026-06-15/ebola_outbreaks.countries.json
+++ b/etl/steps/data/garden/ebola/2026-06-15/ebola_outbreaks.countries.json
@@ -1,0 +1,23 @@
+{
+  "Cote d’Ivoire": "Cote d'Ivoire",
+  "Democratic Republic of the Congo": "Democratic Republic of Congo",
+  "Democratic Republic of the Congo (DRC)": "Democratic Republic of Congo",
+  "Democratic Republic of the Congo (DRC) and Uganda": "Democratic Republic of Congo and Uganda (2026 outbreak)",
+  "Gabon": "Gabon",
+  "Guinea": "Guinea",
+  "Guinea, Liberia, Sierra Leone (West African Epidemic)": "West Africa (2014-2016 epidemic)",
+  "Italy": "Italy",
+  "Mali": "Mali",
+  "Nigeria": "Nigeria",
+  "Russia": "Russia",
+  "Senegal": "Senegal",
+  "South Africa": "South Africa",
+  "Spain": "Spain",
+  "Sudan": "Sudan",
+  "The Democratic Republic of the Congo": "Democratic Republic of Congo",
+  "The Philippines": "Philippines",
+  "The Republic of the Congo": "Congo",
+  "Uganda": "Uganda",
+  "United Kingdom": "United Kingdom",
+  "United States": "United States"
+}

--- a/etl/steps/data/garden/ebola/2026-06-15/ebola_outbreaks.meta.yml
+++ b/etl/steps/data/garden/ebola/2026-06-15/ebola_outbreaks.meta.yml
@@ -1,0 +1,39 @@
+# NOTE: dataset block omitted — inherited from the snapshot origin.
+definitions:
+  common:
+    presentation:
+      topic_tags:
+        - Pandemics
+    processing_level: major
+    description_processing: |-
+      We extracted one record per outbreak from the CDC's outbreak chronology. A small number of country-years contain two separate outbreaks; for those we summed the reported cases and deaths and recomputed the case fatality rate from the totals. Country names were harmonized; the 2014–2016 West African epidemic (Guinea, Liberia and Sierra Leone) and the ongoing 2026 outbreak (DRC and Uganda) are reported by the CDC as multi-country outbreaks and are kept as combined entities.
+
+tables:
+  ebola_outbreaks:
+    title: History of Ebola disease outbreaks
+    variables:
+      cases:
+        title: Reported Ebola cases
+        unit: cases
+        short_unit: ""
+        description_short: Reported number of cases of Ebola disease in each outbreak, as totalled when the outbreak was declared over.
+      deaths:
+        title: Reported Ebola deaths
+        unit: deaths
+        short_unit: ""
+        description_short: Reported number of deaths from Ebola disease in each outbreak, as totalled when the outbreak was declared over.
+      case_fatality_rate:
+        title: Ebola case fatality rate
+        unit: "%"
+        short_unit: "%"
+        description_short: Share of reported Ebola cases that resulted in death, computed from the reported cases and deaths.
+      outbreaks:
+        title: Number of reported Ebola outbreaks
+        unit: outbreaks
+        short_unit: ""
+        description_short: Number of distinct Ebola outbreaks reported by the CDC for the country and year.
+      species:
+        title: Ebola virus species
+        unit: ""
+        short_unit: ""
+        description_short: The Ebola virus species responsible for the outbreak(s) reported for the country and year.

--- a/etl/steps/data/garden/ebola/2026-06-15/ebola_outbreaks.py
+++ b/etl/steps/data/garden/ebola/2026-06-15/ebola_outbreaks.py
@@ -1,0 +1,76 @@
+"""Garden step for the historical Ebola outbreak chronology (CDC).
+
+Harmonizes country names and aggregates to one row per country and year (a handful of country-years
+had two separate outbreaks in the meadow table; here their cases and deaths are summed and the case
+fatality rate is recomputed from the totals).
+"""
+
+from owid.catalog import Table
+from structlog import get_logger
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+log = get_logger()
+
+
+def sanity_check_inputs(tb: Table) -> None:
+    assert tb["species"].str.startswith("Orthoebolavirus").all(), "Unexpected Ebola species in input."
+    both = tb.dropna(subset=["cases", "deaths"])
+    assert (both["deaths"] <= both["cases"]).all(), "Deaths exceed cases in an input outbreak."
+
+
+def sanity_check_outputs(tb: Table) -> None:
+    assert not tb.duplicated(subset=["country", "year"]).any(), "Country-year is not unique after aggregation."
+    assert (tb["deaths"].dropna() <= tb["cases"].dropna()).all(), "Aggregated deaths exceed cases."
+    cfr = tb["case_fatality_rate"].dropna()
+    assert ((cfr >= 0) & (cfr <= 100)).all(), "Case fatality rate outside [0, 100]."
+    # The CDC chronology should always reach back to the first known outbreaks in 1976.
+    assert tb["year"].min() == 1976, f"Earliest outbreak year is {tb['year'].min()}, expected 1976."
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_meadow = paths.load_dataset("ebola_outbreaks")
+    tb = ds_meadow["ebola_outbreaks"].reset_index()
+
+    sanity_check_inputs(tb)
+
+    #
+    # Process data.
+    #
+    tb = paths.regions.harmonize_names(tb, country_col="country", countries_file=paths.country_mapping_path)
+
+    # Capture the source origin to reattach after groupby (aggregation drops column metadata).
+    origins = tb["cases"].metadata.origins
+
+    # Collapse the few country-years with multiple outbreaks into a single total per country-year.
+    species = (
+        tb.groupby(["country", "year"], observed=True)["species"].agg(lambda s: ", ".join(sorted(set(s)))).reset_index()
+    )
+    tb = tb.groupby(["country", "year"], observed=True).agg(
+        cases=("cases", "sum"),
+        deaths=("deaths", "sum"),
+        outbreaks=("outbreak_index", "size"),
+    )
+    tb = tb.reset_index().merge(species, on=["country", "year"])
+
+    # Recompute the case fatality rate from the totals (the source's per-outbreak percentages
+    # can't simply be added when two outbreaks share a country-year).
+    tb["case_fatality_rate"] = (tb["deaths"] / tb["cases"]) * 100
+
+    # Reattach the source origin to every indicator (groupby/derivation dropped it).
+    for col in ["cases", "deaths", "outbreaks", "species", "case_fatality_rate"]:
+        tb[col].metadata.origins = origins
+
+    sanity_check_outputs(tb)
+
+    tb = tb.format(["country", "year"], short_name="ebola_outbreaks")
+
+    #
+    # Save outputs.
+    #
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden.save()

--- a/etl/steps/data/grapher/ebola/2026-06-15/ebola_drc_2026.py
+++ b/etl/steps/data/grapher/ebola/2026-06-15/ebola_drc_2026.py
@@ -1,0 +1,42 @@
+"""Grapher step for the 2026 Bundibugyo Ebola outbreak.
+
+Both tables are date-based. Grapher stores daily series as "days since a zero day", so we convert
+the ``date`` column to an integer day offset and flag it with the ``zeroDay`` / ``yearIsDay`` display
+options (the same convention used by other daily OWID datasets).
+"""
+
+import pandas as pd
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+ZERO_DAY = "2000-01-01"
+TABLES = ["ebola_drc_2026", "ebola_drc_2026_by_health_zone"]
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_garden = paths.load_dataset("ebola_drc_2026")
+
+    #
+    # Process data.
+    #
+    tables = []
+    for table_name in TABLES:
+        tb = ds_garden[table_name].reset_index()
+        # The date index level comes back as a categorical; coerce to datetime before differencing.
+        tb["year"] = (pd.to_datetime(tb["date"].astype(str)) - pd.Timestamp(ZERO_DAY)).dt.days
+        tb = tb.drop(columns=["date"])
+        tb = tb.format(["country", "year"], short_name=table_name)
+        for column in tb.columns:
+            tb[column].metadata.display = {"zeroDay": ZERO_DAY, "yearIsDay": True}
+        tables.append(tb)
+
+    #
+    # Save outputs.
+    #
+    ds_grapher = paths.create_dataset(tables=tables, default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/grapher/ebola/2026-06-15/ebola_outbreaks.py
+++ b/etl/steps/data/grapher/ebola/2026-06-15/ebola_outbreaks.py
@@ -1,0 +1,19 @@
+"""Grapher step for the historical Ebola outbreak chronology (annual, by country)."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_garden = paths.load_dataset("ebola_outbreaks")
+    tb = ds_garden["ebola_outbreaks"]
+
+    #
+    # Save outputs.
+    #
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/ebola/2026-06-15/ebola_drc_2026.py
+++ b/etl/steps/data/meadow/ebola/2026-06-15/ebola_drc_2026.py
@@ -1,0 +1,29 @@
+"""Load the 2026 Ebola outbreak snapshot and create a meadow dataset."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    snap = paths.load_snapshot("ebola_drc_2026.csv")
+    # Keep values as raw strings; the "ND"/"NA" sentinels are parsed to NaN in garden.
+    tb = snap.read_csv(dtype=str)
+
+    #
+    # Process data.
+    #
+    # Low-cardinality string columns -> categoricals (smaller feather, faster reads).
+    for col in ["level", "metric", "location"]:
+        tb[col] = tb[col].astype("category")
+
+    tb = tb.format(["level", "metric", "location", "date"], short_name="ebola_drc_2026")
+
+    #
+    # Save outputs.
+    #
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
+    ds_meadow.save()

--- a/etl/steps/data/meadow/ebola/2026-06-15/ebola_outbreaks.py
+++ b/etl/steps/data/meadow/ebola/2026-06-15/ebola_outbreaks.py
@@ -1,0 +1,116 @@
+"""Parse the CDC Ebola outbreak chronology (HTML) into one row per outbreak.
+
+The CDC page is an HTML accordion: one ``h3`` per year, and within each year one ``h4`` per
+country/outbreak followed by ``li`` items labelled "Species:", "Reported number of cases:" and
+"Reported number of deaths and percentage of fatal cases:". We walk the elements in document
+order, starting a new outbreak at each ``h4`` and attaching the labelled values that follow.
+
+This step does the scraping, so the integrity checks that guard against silent parser drift
+(page restructured, labels renamed) live here.
+"""
+
+import re
+
+import pandas as pd
+from bs4 import BeautifulSoup
+from owid.catalog import Table
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def _to_int(text: str) -> int | None:
+    """First integer in a string.
+
+    Collapses separators that sit *between* digits — thousands commas and the stray spaces the page
+    sometimes leaves where a footnote superscript split a number (e.g. '3,470*' -> 3470,
+    '1 2 confirmed' -> 12) — then reads the first integer.
+    """
+    cleaned = re.sub(r"(?<=\d)[\s,](?=\d)", "", text)
+    match = re.search(r"\d+", cleaned)
+    return int(match.group()) if match else None
+
+
+def _parse(html: str) -> pd.DataFrame:
+    soup = BeautifulSoup(html, "html.parser")
+    rows: list[dict] = []
+    for accordion in soup.select("h3.accordion-header"):
+        year_match = re.search(r"(?:19|20)\d{2}", accordion.get_text(" ", strip=True))
+        if not year_match:
+            continue
+        year = int(year_match.group())
+        item = accordion.find_parent(class_="accordion-item")
+        if item is None:
+            continue
+
+        current: dict | None = None
+        for el in item.find_all(["h4", "li"]):
+            if el.name == "h4":
+                if current is not None:
+                    rows.append(current)
+                current = {
+                    "year": year,
+                    "country": el.get_text(" ", strip=True),
+                    "species": None,
+                    "cases": None,
+                    "deaths": None,
+                    "cfr_reported": None,
+                }
+            elif current is not None:
+                text = el.get_text(" ", strip=True)
+                low = text.lower()
+                value = text.split(":", 1)[1].strip() if ":" in text else text
+                if low.startswith("species"):
+                    current["species"] = value
+                elif "death" in low:
+                    current["deaths"] = _to_int(value)
+                    pct = re.search(r"\((\d+)\s*%\)", value)
+                    current["cfr_reported"] = int(pct.group(1)) if pct else None
+                elif "case" in low:
+                    current["cases"] = _to_int(value)
+        if current is not None:
+            rows.append(current)
+
+    return pd.DataFrame(rows)
+
+
+def _sanity_check(df: pd.DataFrame) -> None:
+    assert len(df) >= 50, f"Parsed only {len(df)} outbreaks; the CDC page structure may have changed."
+    assert df["species"].notna().all(), "Some outbreaks have no species — the 'Species:' label may have changed."
+    assert df["country"].notna().all() and (df["country"].str.len() > 0).all(), "Empty country name parsed."
+    assert df["year"].between(1976, 2100).all(), "Outbreak year outside the plausible range."
+    # All known Ebola species are 'Orthoebolavirus ...'; flags relabelling/leakage from narrative text.
+    assert df["species"].str.startswith("Orthoebolavirus").all(), f"Unexpected species value(s): {set(df['species'])}"
+    # Deaths cannot exceed cases for any outbreak where both are reported.
+    both = df.dropna(subset=["cases", "deaths"])
+    assert (both["deaths"] <= both["cases"]).all(), "An outbreak reports more deaths than cases — parser misalignment."
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    snap = paths.load_snapshot("ebola_outbreaks.html")
+    with open(snap.path, encoding="utf-8") as f:
+        df = _parse(f.read())
+
+    _sanity_check(df)
+
+    #
+    # Process data.
+    #
+    # A few country-years contain two distinct outbreaks; index them so the meadow key is unique.
+    df["outbreak_index"] = df.groupby(["country", "year"]).cumcount()
+
+    tb = Table(df, short_name="ebola_outbreaks")
+    # Built from a fresh DataFrame, so columns carry no origin — attach the snapshot's.
+    for col in tb.columns:
+        tb[col].metadata.origins = [snap.metadata.origin]
+    tb = tb.format(["country", "year", "outbreak_index"], short_name="ebola_outbreaks")
+
+    #
+    # Save outputs.
+    #
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
+    ds_meadow.save()

--- a/snapshots/ebola/2026-06-15/ebola_drc_2026.csv.dvc
+++ b/snapshots/ebola/2026-06-15/ebola_drc_2026.csv.dvc
@@ -1,0 +1,26 @@
+meta:
+  origin:
+    producer: Institut National de Santé Publique (Democratic Republic of the Congo)
+    title: 2026 Bundibugyo Ebola outbreak in the Democratic Republic of the Congo and Uganda
+    description: |-
+      Epidemiological surveillance data for the 2026 outbreak of Ebola disease caused by Bundibugyo virus (Orthoebolavirus bundibugyoense) in the Democratic Republic of the Congo and Uganda. The outbreak was confirmed in May 2026 and declared a Public Health Emergency of International Concern by the World Health Organization on 17 May 2026.
+
+      The DRC Institut National de Santé Publique (INSP) publishes daily Situation Reports (SitRep MVE series) as PDFs. These report confirmed and suspected cases and deaths, contacts traced, hospitalisations and point-of-entry screening, broken down by health zone and aggregated to the national level.
+
+      This snapshot covers the core epidemiological indicators only — confirmed and suspected cases and deaths (cumulative and newly reported) — at the national (DRC) and health-zone levels.
+    title_snapshot: 2026 Bundibugyo Ebola outbreak — core case and death indicators
+    description_snapshot: |-
+      Compiled from the INSP SitRep MVE series by the Kraemer Lab (University of Oxford), which transcribes the source PDFs into tidy per-metric CSV files. We download only the core case/death layer and stack the individual metric files into a single long-format table; mobility, conflict and demographic layers in the upstream repository are excluded.
+    citation_full: |-
+      Institut National de Santé Publique (INSP), Democratic Republic of the Congo. Situation Reports on the 2026 Bundibugyo Ebola outbreak (SitRep MVE series). Compiled and transcribed by the Kraemer Lab, University of Oxford (INRB-UMIE/Ebola_DRC_2026, https://github.com/INRB-UMIE/Ebola_DRC_2026).
+    attribution_short: INSP (via Kraemer Lab)
+    url_main: https://github.com/INRB-UMIE/Ebola_DRC_2026
+    date_accessed: "2026-06-15"
+    date_published: "2026-06-14"
+    license:
+      name: INSP SitReps; reuse with attribution
+      url: https://github.com/INRB-UMIE/Ebola_DRC_2026/blob/main/LICENSE.md
+outs:
+  - md5: 6a7d96319b43747a6b2cbd3d943eb2b0
+    size: 116157
+    path: ebola_drc_2026.csv

--- a/snapshots/ebola/2026-06-15/ebola_drc_2026.py
+++ b/snapshots/ebola/2026-06-15/ebola_drc_2026.py
@@ -1,0 +1,74 @@
+"""Snapshot of the 2026 Bundibugyo Ebola outbreak (DRC + Uganda) — core epidemiological indicators.
+
+Source: INRB-UMIE/Ebola_DRC_2026 (Kraemer Lab, University of Oxford), which transcribes the
+DRC Institut National de Santé Publique (INSP) SitRep MVE series PDFs into tidy per-metric CSVs
+under ``build/long/``. Each file is headerless ``[location, date, value]`` where ``location`` is
+either ``DRC`` (national files) or a health-zone name, ``date`` is ISO-8601, and ``value`` may carry
+the source sentinel ``ND`` ("no data") which we keep verbatim — parsing happens in garden.
+
+We download only the core case/death layer and stack the per-metric files into one long-format CSV
+with explicit ``level`` and ``metric`` columns. The repository's mobility / conflict / demographic
+layers (ACLED, IOM, Flowminder, WorldPop, …) are deliberately excluded: several carry restrictive
+licenses and none are needed for a cases/deaths tracker.
+
+GitHub is a third-party host, so this uses plain ``requests`` (default User-Agent), not the OWID session.
+"""
+
+from io import StringIO
+
+import click
+import pandas as pd
+import requests
+from owid.datautils.io import df_to_file
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+BASE_URL = "https://raw.githubusercontent.com/INRB-UMIE/Ebola_DRC_2026/main/build/long/"
+
+# Upstream file stem -> (level, metric). Every file is headerless [location, date, value].
+FILES = {
+    # National level (location == "DRC")
+    "insp_sitrep__national_cumulative_confirmed_cases": ("national", "cumulative_confirmed_cases"),
+    "insp_sitrep__national_cumulative_confirmed_deaths": ("national", "cumulative_confirmed_deaths"),
+    "insp_sitrep__national_cumulative_suspected_cases": ("national", "cumulative_suspected_cases"),
+    "insp_sitrep__national_cumulative_suspected_deaths": ("national", "cumulative_suspected_deaths"),
+    # Health-zone level (location == health zone name)
+    "insp_sitrep__cumulative_confirmed_cases": ("health_zone", "cumulative_confirmed_cases"),
+    "insp_sitrep__cumulative_confirmed_deaths": ("health_zone", "cumulative_confirmed_deaths"),
+    "insp_sitrep__cumulative_suspected_cases": ("health_zone", "cumulative_suspected_cases"),
+    "insp_sitrep__cumulative_suspected_deaths": ("health_zone", "cumulative_suspected_deaths"),
+    "insp_sitrep__new_confirmed_cases": ("health_zone", "new_confirmed_cases"),
+    "insp_sitrep__new_suspected_cases": ("health_zone", "new_suspected_cases"),
+    "insp_sitrep__new_suspected_deaths": ("health_zone", "new_suspected_deaths"),
+}
+
+
+@click.command()
+@click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
+def main(upload: bool) -> None:
+    snap = paths.init_snapshot()
+
+    frames = []
+    for stem, (level, metric) in FILES.items():
+        resp = requests.get(f"{BASE_URL}{stem}.csv", timeout=60)
+        resp.raise_for_status()
+        # Keep values as strings so source sentinels ("ND"/"NA") survive into garden untouched.
+        df = pd.read_csv(StringIO(resp.text), header=None, names=["location", "date", "value"], dtype=str)
+        df["level"] = level
+        df["metric"] = metric
+        frames.append(df)
+
+    combined = pd.concat(frames, ignore_index=True)[["level", "metric", "location", "date", "value"]]
+
+    if combined.empty:
+        raise ValueError("No data downloaded from the upstream Ebola repository.")
+
+    df_to_file(combined, file_path=snap.path)  # ty: ignore[invalid-argument-type]
+
+    snap.dvc_add(upload=upload)
+
+
+if __name__ == "__main__":
+    main()

--- a/snapshots/ebola/2026-06-15/ebola_outbreaks.html.dvc
+++ b/snapshots/ebola/2026-06-15/ebola_outbreaks.html.dvc
@@ -1,0 +1,25 @@
+meta:
+  origin:
+    producer: U.S. Centers for Disease Control and Prevention
+    title: History of Ebola disease outbreaks
+    description: |-
+      A chronology, maintained by the U.S. Centers for Disease Control and Prevention (CDC), of known Ebola disease outbreaks since the virus was first identified in 1976. For each outbreak the CDC reports the year, the country (or countries) affected, the Ebola virus species, the reported number of cases, and the reported number of deaths with the corresponding case fatality rate.
+
+      Figures are compiled by the CDC from its own field investigations, the World Health Organization, and national government reports, and reflect the totals reported at the time each outbreak was declared over.
+    title_snapshot: History of Ebola disease outbreaks — outbreak chronology page
+    description_snapshot: |-
+      The CDC publishes this chronology as an HTML page with one expandable section per year, each listing one or more outbreaks. We archive the page and extract the per-outbreak figures from it.
+    citation_full: |-
+      U.S. Centers for Disease Control and Prevention (CDC). History of Ebola Disease Outbreaks. https://www.cdc.gov/ebola/outbreaks/index.html
+    attribution_short: CDC
+    url_main: https://www.cdc.gov/ebola/outbreaks/index.html
+    url_download: https://www.cdc.gov/ebola/outbreaks/index.html
+    date_accessed: "2026-06-15"
+    date_published: "2025-12-18"
+    license:
+      name: Public domain (U.S. Government work)
+      url: https://www.cdc.gov/other/agencymaterials.html
+outs:
+  - md5: f628993adf1d9c72c17b79cd463de9e0
+    size: 124986
+    path: ebola_outbreaks.html


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

> **Status (not merging for now).** After review with @edomt, we're not pursuing Ebola charts at this point: the data isn't well-suited to charting, modeled GBD estimates are unreliable at the scale of small regional outbreaks, and covering an active outbreak is a high-commitment, one-way decision (and not reproducible in Grapher — no DRC health-zone shapefile). This PR is parked as a working reference: the historical CDC table is *reported* (non-modeled) per-outbreak counts that could serve as a factual backbone **if** we ever write about Ebola. Likely to be closed.

Adds two new datasets under a new `ebola` namespace, both built end-to-end (snapshot → meadow → garden → grapher) and wired into `dag/health.yml`.

## ⚠️ Licensing — read before publishing

Neither dataset is cleared for republication yet:

- **2026 tracker** is built on the DRC **Institut National de Santé Publique (INSP)** SitRep series, compiled by the Kraemer Lab (Oxford). The upstream metadata flags: *"reuse with attribution to INSP and citation of the specific report number and date; confirm distribution terms with INSP before external republication."* The `.dvc` records this.
- **Historical** data is from the **CDC** chronology (US Government work, public domain) — lower risk, but worth a confirm.

**We should reach out to INSP / the Kraemer Lab directly before making any of the 2026 charts public.** Until then this is a build only — no charts created. (Snapshots are uploaded to R2 so the pipeline builds on staging; that's internal storage, not reader-facing republication.)

## A. Live 2026 outbreak tracker — `ebola/2026-06-15/ebola_drc_2026`

The 2026 Bundibugyo Ebola outbreak (DRC + Uganda), declared a PHEIC by WHO on 17 May 2026.

- **Source:** [`INRB-UMIE/Ebola_DRC_2026`](https://github.com/INRB-UMIE/Ebola_DRC_2026) (Kraemer Lab), which transcribes the INSP SitRep PDFs into tidy per-metric CSVs.
- **Snapshot** stacks the 11 core case/death CSVs into one long table, keeping the source `ND`/`NA` sentinels verbatim. Mobility/conflict/demographic layers in the upstream repo are deliberately excluded (restrictive third-party licenses; not needed for a cases/deaths tracker).
- **Garden** produces two tables: **national** (cumulative confirmed/suspected cases & deaths) and **by health zone** (38 zones; cumulative + newly reported). Health-zone names are kept as subnational entities (not country-harmonized).
- **Cross-check:** the 38 health zones sum to 782 confirmed cases on 13 June — exactly the national figure (and 676 on 10 June matches WHO/press reports).

## B. Historical outbreak chronology — `ebola/2026-06-15/ebola_outbreaks`

Every known Ebola outbreak since 1976.

- **Source:** [CDC Ebola outbreak history](https://www.cdc.gov/ebola/outbreaks/index.html). The snapshot archives the raw HTML; the **meadow** step parses the year/country accordion structure into one row per outbreak, with integrity checks that fail loudly if the page is restructured.
- **Garden** harmonizes 21 country labels (the 2014–2016 West African epidemic and the 2026 DRC+Uganda outbreak are kept as combined entities), aggregates the 5 country-years that had two distinct outbreaks, and recomputes the case fatality rate from the totals.
- **Result:** 49 country-years, 1976–2026, totalling 34,982 cases / 15,443 deaths — consistent with the published ~34,936 / 15,409 for 1976–2022 plus recent years.

## Notes for reviewers

- **Snapshots are uploaded to R2** (public-domain CDC HTML + the INSP-derived CSV), so the pipeline builds on staging. This is internal data storage; reader-facing publication (charts) stays gated on the licensing question above.
- **Provincial level** is omitted from the tracker for v1 (the source's provincial linelist uses a different date format and an onset basis); national + health-zone only.
- The tracker covers an **active outbreak** — the upstream schema may shift as it evolves, and it needs a refresh cadence once we decide to maintain it.
