### PR TITLE
Verify Tailscale after waking a staging server

### DIFF
--- a/apps/wizard/app_pages/servers_dashboard/app.py
+++ b/apps/wizard/app_pages/servers_dashboard/app.py
@@ -128,6 +128,16 @@ with st.container(horizontal=True, vertical_alignment="bottom", horizontal_align
         **Branch Names**: The 'staging-site-' prefix is automatically removed for cleaner display.
         """)
 
+# Show the outcome of the last server action (carried across the post-action rerun, so it's
+# displayed alongside the freshly-refreshed server list).
+_action_result = st.session_state.pop("servers_action_result", None)
+if _action_result is not None:
+    _ok, _label, _msg = _action_result
+    if _ok:
+        st.success(f"✅ {_label}: {_msg}")
+    else:
+        st.error(f"❌ {_label} failed: {_msg}")
+
 # Fetch server data and host memory stats
 with st.spinner("Fetching staging server data...", show_time=True):
     servers_df, error = fetch_lxc_servers_data()
@@ -240,12 +250,13 @@ def _run_action(label: str, action_fn, server_name: str, spinner_msg: str) -> No
     """Run a (non-destructive) server action with a spinner, then refresh the dashboard."""
     with st.spinner(spinner_msg, show_time=True):
         success, message = action_fn(server_name)
-    if success:
-        st.toast(f"✅ {message}", icon="✅")
-        st.cache_data.clear()
-        st.rerun()
-    else:
-        st.error(f"❌ {label} failed: {message}")
+    # Always refresh the cached server list and rerun — even on failure the container's state may
+    # have changed (e.g. a wake that started the container but couldn't reach Tailscale), and a
+    # stale Idle row + Wake button would mislead. Carry the outcome across the rerun so it's still
+    # shown once the fresh state is loaded.
+    st.session_state["servers_action_result"] = (success, label, message)
+    st.cache_data.clear()
+    st.rerun()
 
 
 def _confirm_destructive_action(

--- a/apps/wizard/app_pages/servers_dashboard/utils.py
+++ b/apps/wizard/app_pages/servers_dashboard/utils.py
@@ -2,6 +2,7 @@
 
 import json
 import subprocess
+import time
 from datetime import datetime, timezone
 from typing import Any
 
@@ -481,7 +482,48 @@ def start_server(server_name: str) -> tuple[bool, str]:
     """
     cmd = f"LXC_HOST={LXC_HOST} owid-lxc start {server_name}"
     # Starting also runs a tailscale login and a short readiness delay, so allow time.
-    return _run_lxc_command(cmd, server_name, action="start", timeout=180)
+    ok, msg = _run_lxc_command(cmd, server_name, action="start", timeout=180)
+    if not ok:
+        return ok, msg
+
+    # `owid-lxc start` re-authenticates the container to Tailscale, but that step can fail
+    # silently (it's only a warning in owid-lxc). When it does, the container is Running but
+    # logged out of Tailscale, so its hostname doesn't resolve and admin/SSH are unreachable —
+    # the wake looks successful but the server is effectively dead. Verify it actually rejoined
+    # the tailnet and report honestly instead of a misleading success.
+    if _is_on_tailnet(server_name):
+        return True, f"Server {server_name} is awake and on the tailnet."
+    return False, (
+        f"Server {server_name} started, but it is NOT on the Tailscale network, so it's "
+        "unreachable by hostname (admin/SSH won't work). Tailscale failed to re-authenticate on "
+        "wake. Try waking it again; if it keeps failing, Tailscale must be re-authenticated on the host."
+    )
+
+
+def _is_on_tailnet(server_name: str, attempts: int = 3, delay: int = 5) -> bool:
+    """
+    Return True if the container is logged into Tailscale (has a 100.x tailnet IP).
+
+    Uses ``owid-lxc exec`` (host-level ``lxc exec``, which works even when Tailscale is down), so
+    it can distinguish a container that's running-and-on-the-tailnet from one that started but
+    failed its Tailscale login. Retries briefly to absorb the race right after start.
+    """
+    for attempt in range(attempts):
+        try:
+            result = subprocess.run(
+                f"LXC_HOST={LXC_HOST} owid-lxc exec {server_name} -- tailscale ip -4",
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode == 0 and result.stdout.strip().startswith("100."):
+                return True
+        except subprocess.TimeoutExpired:
+            log.warning("Tailscale check timed out", server=server_name, attempt=attempt)
+        if attempt < attempts - 1:
+            time.sleep(delay)
+    return False
 
 
 def stop_server(server_name: str) -> tuple[bool, str]:


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Problem

A colleague pressed **Wake up** on a staging server ([#6054](https://github.com/owid/etl/pull/6054)) and got a success toast, but `http://staging-site-…/admin` stayed unreachable.

Diagnosis: `owid-lxc start` (what Wake runs) does two things — start the container **and** re-authenticate it to Tailscale. The container started fine, but the **Tailscale login failed silently** (it's only a warning inside `owid-lxc`, which still exits 0). The result: the container is `Running` but `Logged out` of Tailscale, so its hostname doesn't resolve via MagicDNS and admin/SSH are unreachable — while the dashboard happily reported success.

## Fix

After `owid-lxc start`, confirm the container actually rejoined the tailnet by checking it has a `100.x` Tailscale IP (`owid-lxc exec … tailscale ip -4`, which works even when Tailscale is down). If it didn't, return a clear, actionable error instead of a misleading success:

> Server … started, but it is NOT on the Tailscale network, so it's unreachable by hostname (admin/SSH won't work). Tailscale failed to re-authenticate on wake. Try waking it again; …

`restart_server` inherits the check (it calls `start_server`).

## Testing

Exercised against live containers:
- Waking a real idle container → `ok=True`, *"is awake and on the tailnet"* (only after Tailscale genuinely reconnected).
- The check returns `False` for a container that's stopped / not on the tailnet, so the failure path reports honestly.

## Follow-up (not in this PR)

This makes the failure **visible**; it doesn't change *why* Tailscale sometimes fails to re-auth on wake (likely the host running `owid-lxc` can't read the Tailscale auth key from the vault). Worth confirming the prod-wizard host has vault access so wakes reliably rejoin the tailnet. Could also make `owid-lxc start` itself exit non-zero on Tailscale-login failure, but that's left alone to avoid affecting the deploy pipeline that tolerates Tailscale warnings.