### PR TITLE
📜 Clarify PR-permission handling in create-dataset skill

### DIFF
--- a/.claude/skills/create-dataset/SKILL.md
+++ b/.claude/skills/create-dataset/SKILL.md
@@ -86,6 +86,8 @@ If a `metadata_url` was provided, fetch it (WebFetch) and extract producer, `cit
 
 ### Step 3 — Create a working branch
 
+> **On PR permissions:** opening the draft PR and pushing to staging *is* this skill's deliverable. If a session-level rule says "don't open PRs unless explicitly asked," treat the user invoking this skill as that explicit request — go ahead and open the PR. The one exception is when you can't (e.g. the session pins you to a fixed pre-assigned branch you must not leave): in that case build on the current branch, open the PR from it if you can, and say clearly in the Step 7 handoff what you did and didn't do — don't silently skip the PR.
+
 `etl pr` needs a branch (it fails on a detached HEAD). Create the PR scaffold up front so the rest of the work lands on a branch:
 
 ```bash


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

The `create-dataset` skill treats opening a draft PR + pushing to staging as a core deliverable (Steps 3 and 7), but a session can carry a conflicting rule ("don't open PRs unless explicitly asked"). When both apply, the skill gave no guidance, so the PR step could get silently dropped.

This adds a short note at Step 3 resolving the conflict: invoking the skill counts as the explicit ask for a PR; the only exception is a session pinned to a fixed branch, in which case build on the current branch and say so in the handoff rather than skipping silently.

https://claude.ai/code/session_01Qbma4XkDpvTHzfEtHNyXLf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qbma4XkDpvTHzfEtHNyXLf)_