### PR TITLE
📜 Test: faster ETL staging-server bake (ops#525)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,3 +10,6 @@ This documentation explains our data workflow and tooling — both to help OWID 
 [:material-format-list-bulleted-triangle: Internal guides](guides/){ .md-button }
 
 [:material-book-open-variant: Technical publications](analyses/){ .md-button }
+
+<!-- Test PR to exercise the faster ETL staging-server bake (ops#525): the staging
+     site should come up without the ~17 min full grapher chart bake. No-op doc change. -->


### PR DESCRIPTION
Throwaway PR to validate [ops#525](https://github.com/owid/ops/pull/525) on a real ETL staging server.

**What to watch in the `etl-automated-staging-environment` build:**
- The **Grapher bake** step should run only the fast partial bake (`--steps assets dods redirects gdocPosts explorers`, ~2 min) and **not** the ~17 min "Baking all changed grapher pages and deleting removed graphers" step.
- The staging site should still serve grapher pages (seeded from the `staging-site-master` snapshot, host-rewritten in `grapher-build.sh`).

Diff is a no-op doc comment. Safe to close/delete after verifying. Add the `staging-bake` label to this PR to confirm the full-bake path still works on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)