### PR TITLE
Update and pin GitHub Actions and Workflows

### DIFF
--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -1,0 +1,20 @@
+---
+applyTo: ".github/workflows/**,.github/actions/**"
+---
+
+# GitHub Actions version pinning
+
+We use [pinact](https://github.com/suzuki-shunsuke/pinact) to manage GitHub Actions
+and workflow versions. Action references in `.github/workflows/*` and
+`.github/actions/*` must be pinned to immutable commit SHAs with version comments:
+
+```yaml
+# Good — pinned to a SHA with a version comment
+- uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+# Bad — mutable tag, not pinned
+- uses: actions/checkout@v5
+```
+
+When adding or bumping an action, run `pinact run` to pin every reference and
+refresh the version comments.

--- a/.github/workflows/buildkite.yml
+++ b/.github/workflows/buildkite.yml
@@ -10,10 +10,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
             - name: Set up Python
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
               with:
                   python-version: 3.x
 

--- a/.github/workflows/deploy-docs-cf.yml
+++ b/.github/workflows/deploy-docs-cf.yml
@@ -18,13 +18,13 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
 
@@ -46,7 +46,7 @@ jobs:
           cp -a site/. staging/projects/etl/
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -14,7 +14,7 @@ jobs:
   merge_schedule:
     runs-on: ubuntu-latest
     steps:
-      - uses: gr2m/merge-schedule-action@v2
+      - uses: gr2m/merge-schedule-action@a9b6ddcf1282dfd66907bda8e7941dff59f03bad # v2.7.0
         with:
           # Merge method to use. Possible values are merge, squash or
           # rebase. Default is merge.

--- a/.github/workflows/project-automations.yml
+++ b/.github/workflows/project-automations.yml
@@ -34,7 +34,7 @@ jobs:
         if: github.event_name == 'issues' && github.event.action == 'opened'
         steps:
             - name: Label issue
-              uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+              uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4
               with:
                   add-labels: "needs triage"
                   repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-owid-packages.yml
+++ b/.github/workflows/publish-owid-packages.yml
@@ -25,7 +25,7 @@ jobs:
       packages: ${{ steps.filter.outputs.packages }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       with:
         fetch-depth: 2
 
@@ -79,7 +79,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       with:
         fetch-depth: 2
 
@@ -105,7 +105,7 @@ jobs:
         python-version: '3.x'
 
     - name: Set up uv
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
 
     - name: Build ${{ matrix.name }}
       run: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,7 +17,7 @@ jobs:
             pull-requests: write
 
         steps:
-            - uses: actions/stale@v9
+            - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   stale-issue-message: "This issue has had no activity within 90 days. It is considered stale and will be closed in 7 days unless it is worked on or tagged as pinned."

--- a/.github/workflows/sync-grapher-schema.yml
+++ b/.github/workflows/sync-grapher-schema.yml
@@ -24,7 +24,7 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Check upstream for changes
         id: check
@@ -65,12 +65,12 @@ jobs:
             echo "Issue #$EXISTING already open, skipping."
           fi
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         if: steps.check.outputs.changed == 'true'
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         if: steps.check.outputs.changed == 'true'
         with:
           enable-cache: true
@@ -85,7 +85,7 @@ jobs:
 
       - name: Create pull request
         if: steps.check.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: auto-sync-grapher-schema
           draft: true

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -6,8 +6,12 @@ version: 3
 files:
   - pattern: .github/workflows/*.yml
   - pattern: .github/workflows/*.yaml
+  - pattern: .github/actions/*/action.yml
+  - pattern: .github/actions/*/action.yaml
   - pattern: lib/*/.github/workflows/*.yml
   - pattern: lib/*/.github/workflows/*.yaml
+  - pattern: lib/*/.github/actions/*/action.yml
+  - pattern: lib/*/.github/actions/*/action.yaml
 
 # Our own actions (https://github.com/owid/actions) are referenced by branch and
 # are intentionally left unpinned.

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,16 @@
+version: 3
+
+# Setting `files` replaces pinact's defaults, so the root patterns are listed
+# explicitly alongside the nested ones. Globs use explicit depth (no `**`), so
+# each subpackage level is matched with `*`.
+files:
+  - pattern: .github/workflows/*.yml
+  - pattern: .github/workflows/*.yaml
+  - pattern: lib/*/.github/workflows/*.yml
+  - pattern: lib/*/.github/workflows/*.yaml
+
+# Our own actions (https://github.com/owid/actions) are referenced by branch and
+# are intentionally left unpinned.
+ignore_actions:
+  - name: owid/actions/.*
+    ref: .*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,7 +308,7 @@ Then tell the user to reload: `Cmd+Shift+P` → "Developer: Reload Window".
 
 ## GitHub Actions
 
-When editing anything under `.github/workflows/**` or `.github/actions/**`, follow the SHA-pinning convention below (also enforced for GitHub Copilot via `.github/instructions/github-actions.instructions.md`, which Claude Code does *not* auto-load — hence the import here):
+When editing `.github/workflows/**` or `.github/actions/**`, follow the SHA-pinning rule imported below:
 
 @.github/instructions/github-actions.instructions.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,12 @@ code --install-extension install/<name>-<version>.vsix --force
 
 Then tell the user to reload: `Cmd+Shift+P` → "Developer: Reload Window".
 
+## GitHub Actions
+
+When editing anything under `.github/workflows/**` or `.github/actions/**`, follow the SHA-pinning convention below (also enforced for GitHub Copilot via `.github/instructions/github-actions.instructions.md`, which Claude Code does *not* auto-load — hence the import here):
+
+@.github/instructions/github-actions.instructions.md
+
 ## Extended Documentation
 
 See `.claude/docs/` for:

--- a/docs/getting-started/working-environment.md
+++ b/docs/getting-started/working-environment.md
@@ -226,6 +226,17 @@ If you need to (re)activate it manually:
 make install-hooks
 ```
 
+## GitHub Actions
+
+We use [:octicons-link-external-16: pinact](https://github.com/suzuki-shunsuke/pinact)
+to manage GitHub Actions and workflow versions. Action references in
+`.github/workflows/*` and `.github/actions/*` should be pinned to immutable commit SHAs
+with a version comment, rather than to a mutable tag like `@v5`. Pinning to a SHA means a
+compromised or retagged action can't silently change what runs in our CI, while the
+trailing comment keeps the human-readable version visible.
+
+Run `pinact run -update` to update and pin every action and workflow in the repository.
+
 ## VSCode setup
 
 ### Recommended extensions

--- a/lib/catalog/.github/workflows/python-package.yml
+++ b/lib/catalog/.github/workflows/python-package.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/lib/datautils/.github/workflows/python-package.yml
+++ b/lib/datautils/.github/workflows/python-package.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -44,7 +44,7 @@ jobs:
         make report-coverage
 
     - name: "Coverage: Upload to codecov.io"
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         fail_ci_if_error: true
         verbose: true

--- a/lib/repack/.github/workflows/python-package.yml
+++ b/lib/repack/.github/workflows/python-package.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Pin all actions except [our internal ones](https://github.com/owid/actions). See [this post](https://astral.sh/blog/open-source-security-at-astral) for rationale. None of the updated actions should require any changes from us to keep the working as before.

Related to https://github.com/owid/owid-grapher/pull/6612

Adding all data engineers as reviewers for visibility.