### PR TITLE
Harden GitHub Actions security with Zizmor

### DIFF
--- a/.github/workflows/buildkite.yml
+++ b/.github/workflows/buildkite.yml
@@ -5,12 +5,17 @@ on:
         types:
             - closed
 
+permissions:
+    contents: read
+
 jobs:
     destroy_staging:
         runs-on: ubuntu-latest
         steps:
             - name: Check out repository
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+              with:
+                  persist-credentials: false
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/deploy-docs-cf.yml
+++ b/.github/workflows/deploy-docs-cf.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -26,7 +28,9 @@ jobs:
 
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
-          enable-cache: true
+          # Caching is disabled in this deploy workflow to avoid cache-poisoning
+          # of the published docs artifact (zizmor cache-poisoning audit).
+          enable-cache: false
 
       - name: Install dependencies
         run: uv sync --all-extras

--- a/.github/workflows/merge-schedule.yml
+++ b/.github/workflows/merge-schedule.yml
@@ -10,6 +10,13 @@ on:
     # https://crontab.guru/every-hour
     - cron: '0 * * * *'
 
+permissions:
+  contents: write
+  pull-requests: write
+  # Required for issues.addLabels, used to apply automerge_fail_label on a
+  # failed scheduled merge — pull-requests: write alone silently no-ops.
+  issues: write
+
 jobs:
   merge_schedule:
     runs-on: ubuntu-latest

--- a/.github/workflows/project-automations.yml
+++ b/.github/workflows/project-automations.yml
@@ -13,6 +13,8 @@ on:
             - review_requested
             - closed
 
+permissions: {}
+
 jobs:
     prio:
         name: Sync issue priority to project board
@@ -32,6 +34,8 @@ jobs:
         name: Add "needs triage" label
         runs-on: ubuntu-latest
         if: github.event_name == 'issues' && github.event.action == 'opened'
+        permissions:
+            issues: write
         steps:
             - name: Label issue
               uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # 1.0.4

--- a/.github/workflows/publish-owid-packages.yml
+++ b/.github/workflows/publish-owid-packages.yml
@@ -28,15 +28,18 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       with:
         fetch-depth: 2
+        persist-credentials: false
 
     - name: Detect which packages changed
       id: filter
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        PACKAGE: ${{ github.event.inputs.package }}
       run: |
         catalog=false
         datautils=false
         repack=false
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          PACKAGE="${{ github.event.inputs.package }}"
+        if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
           if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "catalog" ]; then catalog=true; fi
           if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "datautils" ]; then datautils=true; fi
           if [ "$PACKAGE" = "all" ] || [ "$PACKAGE" = "repack" ]; then repack=true; fi
@@ -82,6 +85,7 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       with:
         fetch-depth: 2
+        persist-credentials: false
 
     - name: Check if version needs publishing
       run: |
@@ -106,6 +110,10 @@ jobs:
 
     - name: Set up uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+      with:
+        # Caching is disabled in this release pipeline to avoid cache-poisoning
+        # of the published package artifact (zizmor cache-poisoning audit).
+        enable-cache: false
 
     - name: Build ${{ matrix.name }}
       run: |

--- a/.github/workflows/sync-grapher-schema.yml
+++ b/.github/workflows/sync-grapher-schema.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Check upstream for changes
         id: check

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,25 @@
+name: Zizmor
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # Advanced Security mode is a bit too complicated for our use case, but
+          # we might want to switch to it in the future.
+          advanced-security: false

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,10 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Our own actions (https://github.com/owid/actions) are referenced by
+        # branch (@main) rather than a tag/SHA, since they're internal and
+        # unversioned. Allow a branch/tag ref instead of requiring a hash.
+        owid/actions/*: ref-pin
+        # Everything else must be pinned to an immutable commit SHA.
+        "*": hash-pin

--- a/lib/catalog/.github/workflows/project-automations.yml
+++ b/lib/catalog/.github/workflows/project-automations.yml
@@ -13,6 +13,8 @@ on:
             - review_requested
             - closed
 
+permissions: {}
+
 jobs:
     prio:
         name: Sync issue priority to project board

--- a/lib/catalog/.github/workflows/python-package.yml
+++ b/lib/catalog/.github/workflows/python-package.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -17,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/lib/datautils/.github/workflows/python-package.yml
+++ b/lib/datautils/.github/workflows/python-package.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -17,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/lib/repack/.github/workflows/project-automations.yml
+++ b/lib/repack/.github/workflows/project-automations.yml
@@ -13,6 +13,8 @@ on:
             - review_requested
             - closed
 
+permissions: {}
+
 jobs:
     prio:
         name: Sync issue priority to project board

--- a/lib/repack/.github/workflows/python-package.yml
+++ b/lib/repack/.github/workflows/python-package.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:
@@ -17,6 +20,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
- Add new GitHub Workflow to run Zizmor on PRs and pushes on master
- Fix all existing Zizmor findings

Related to https://github.com/owid/owid-grapher/pull/6615