### PR TITLE
🐛 Make --modified select affected export (multidim/explorer) steps

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -329,20 +329,26 @@ def _modified_steps(includes: list[str], exact_match: bool = False) -> list[str]
     Reuses the same machinery as chart-diff (`get_changed_files` + `get_all_changed_catalog_paths`),
     so the selection matches what chart-diff considers affected. If `includes` is non-empty, the
     result is narrowed to changed paths that also match one of those patterns.
+
+    Export steps (e.g. `export://multidim/...`) are included too, so `--modified` can pick the
+    multidims/explorers a branch affects via their upstream data steps. Data steps are returned
+    URI-less (e.g. "garden/foo/bar"); export steps keep their full URI so `export://...` patterns
+    match them.
     """
     from etl.git_helpers import get_changed_files
     from etl.io import get_all_changed_catalog_paths
 
     # We only need file names/statuses to pick steps, not the (slow) per-file diff contents.
-    changed_paths = get_all_changed_catalog_paths(get_changed_files(include_diff=False))
+    changed_paths = get_all_changed_catalog_paths(get_changed_files(include_diff=False), include_export=True)
 
     # Narrow to those also matching the explicit STEPS arguments.
     if includes:
         if exact_match:
-            # changed_paths are URI-less catalog paths (e.g. "garden/foo/bar"), while exact-match
-            # includes are full step URIs (e.g. "data://garden/foo/bar"); compare on the path part.
+            # changed_paths are URI-less for data steps (e.g. "garden/foo/bar") but full URIs for
+            # export steps; exact-match includes are full step URIs (e.g. "data://garden/foo/bar").
+            # Compare on the scheme-less path part of both sides.
             wanted = {i.split("://", 1)[-1] for i in includes}
-            changed_paths = [p for p in changed_paths if p in wanted]
+            changed_paths = [p for p in changed_paths if p.split("://", 1)[-1] in wanted]
         else:
             patterns = [re.compile(p) for p in includes]
             changed_paths = [p for p in changed_paths if any(pat.search(p) for pat in patterns)]

--- a/etl/io.py
+++ b/etl/io.py
@@ -40,6 +40,10 @@ def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]], incl
         excluded by default (chart-diff/datadiff only care about data steps).
     """
     dataset_catalog_paths = []
+    # Directly-changed export steps (e.g. a modified multidim/explorer recipe). These live under
+    # etl/steps/export/, not etl/steps/data/, so they aren't data catalog paths; we keep their full
+    # export:// URI and add them to the result when include_export is set.
+    changed_export_uris = []
 
     # Get catalog paths of all datasets with changed files.
     for step_path in get_changed_steps(files_changed):
@@ -52,10 +56,18 @@ def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]], incl
                 ds_path = abs_step_path.relative_to(STEP_DIR / "data").with_suffix("").with_suffix("").as_posix()
             dataset_catalog_paths.append(ds_path)
         except ValueError:
-            continue
+            # Not a data/snapshot step. It might be an export step (etl/steps/export/...); if so,
+            # record its export:// URI so a branch that only edits an export recipe still selects it.
+            try:
+                export_path = abs_step_path.relative_to(STEP_DIR / "export").with_suffix("").with_suffix("").as_posix()
+            except ValueError:
+                continue
+            changed_export_uris.append(f"export://{export_path}")
 
     if not dataset_catalog_paths:
-        return []
+        # No data steps changed. We can still have directly-changed export steps; return those when
+        # requested (their downstream subgraph is computed from data steps, of which there are none).
+        return changed_export_uris if include_export else []
 
     # NOTE:
     # This is OK, as it filters down the DAG a little bit. But using VersionTracker.steps_df would be much more precise. You could do:
@@ -71,9 +83,16 @@ def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]], incl
     # TODO: use StepPath from https://github.com/owid/etl/pull/3165 to refactor this
     catalog_paths = [step.split("://")[1] for step in dag_steps if step.startswith("data://")]
 
-    # Optionally also return downstream export steps, keeping their full URI so callers can match
-    # them with `export://...` include patterns (export steps have no data:// catalogPath).
+    # Optionally also return export steps, keeping their full URI so callers can match them with
+    # `export://...` include patterns (export steps have no data:// catalogPath). This covers both
+    # downstream exports (reached via changed data steps) and directly-changed export recipes.
     if include_export:
-        catalog_paths += [step for step in dag_steps if step.startswith("export://")]
+        downstream_export_uris = [step for step in dag_steps if step.startswith("export://")]
+        # Dedupe while preserving order (a directly-changed export can also be a downstream one).
+        seen = set(catalog_paths)
+        for uri in downstream_export_uris + changed_export_uris:
+            if uri not in seen:
+                seen.add(uri)
+                catalog_paths.append(uri)
 
     return catalog_paths

--- a/etl/io.py
+++ b/etl/io.py
@@ -32,8 +32,13 @@ def get_changed_steps(files_changed: dict[str, dict[str, str]]) -> list[str]:
     return changed_steps
 
 
-def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]]) -> list[str]:
-    """Get all changed steps and their downstream dependencies."""
+def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]], include_export: bool = False) -> list[str]:
+    """Get all changed steps and their downstream dependencies.
+
+    :param include_export: If True, also return downstream export steps (e.g. multidim/explorer
+        exports) with their full ``export://`` URI. These have no data:// catalogPath, so they're
+        excluded by default (chart-diff/datadiff only care about data steps).
+    """
     dataset_catalog_paths = []
 
     # Get catalog paths of all datasets with changed files.
@@ -65,5 +70,10 @@ def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]]) -> l
     # From data://... extract catalogPath
     # TODO: use StepPath from https://github.com/owid/etl/pull/3165 to refactor this
     catalog_paths = [step.split("://")[1] for step in dag_steps if step.startswith("data://")]
+
+    # Optionally also return downstream export steps, keeping their full URI so callers can match
+    # them with `export://...` include patterns (export steps have no data:// catalogPath).
+    if include_export:
+        catalog_paths += [step for step in dag_steps if step.startswith("export://")]
 
     return catalog_paths

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+from etl.io import get_all_changed_catalog_paths
+
+
+@patch("etl.io.load_dag")
+def test_get_all_changed_catalog_paths_directly_changed_export_step(mock_load_dag):
+    """A branch that only edits an export recipe should still select that export step.
+
+    Such files live under etl/steps/export/, so they are neither data nor snapshot catalog
+    paths. Without include_export they're dropped; with include_export their export:// URI is
+    returned even though no data step changed (so dataset_catalog_paths is empty and the DAG
+    subgraph is never consulted).
+    """
+    files_changed = {"etl/steps/export/multidim/un/latest/un_wpp.py": "M"}
+
+    # Default: export steps are excluded, so an export-only change selects nothing.
+    assert get_all_changed_catalog_paths(files_changed) == []
+
+    # With include_export, the directly-changed export step is returned by its full URI.
+    # load_dag is not even reached here (no data steps), but patch it to keep the test hermetic.
+    mock_load_dag.return_value = {}
+    assert get_all_changed_catalog_paths(files_changed, include_export=True) == ["export://multidim/un/latest/un_wpp"]
+
+
+@patch("etl.io.filter_to_subgraph")
+@patch("etl.io.load_dag")
+def test_get_all_changed_catalog_paths_downstream_and_direct_export_deduped(mock_load_dag, mock_filter_to_subgraph):
+    """Downstream and directly-changed export steps are merged and deduped under include_export."""
+    files_changed = {
+        # A changed data step whose downstream subgraph includes an export step.
+        "etl/steps/data/garden/un/latest/un_wpp.py": "M",
+        # A directly-changed export step that also appears downstream (should not be duplicated).
+        "etl/steps/export/multidim/un/latest/un_wpp.py": "M",
+    }
+    mock_load_dag.return_value = {}
+    # Pretend the downstream subgraph contains the data step plus two export steps.
+    mock_filter_to_subgraph.return_value = {
+        "data://garden/un/latest/un_wpp": set(),
+        "export://multidim/un/latest/un_wpp": set(),
+        "export://explorers/un/latest/un_wpp": set(),
+    }
+
+    result = get_all_changed_catalog_paths(files_changed, include_export=True)
+
+    # Data step returned URI-less; both export steps present exactly once.
+    assert result.count("export://multidim/un/latest/un_wpp") == 1
+    assert set(result) == {
+        "garden/un/latest/un_wpp",
+        "export://multidim/un/latest/un_wpp",
+        "export://explorers/un/latest/un_wpp",
+    }
+
+    # Without include_export, only the data catalog path is returned.
+    result_no_export = get_all_changed_catalog_paths(files_changed)
+    assert result_no_export == ["garden/un/latest/un_wpp"]


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Problem

On staging we run two ETL invocations (ops `etl-build.sh`):

1. `etl run garden grapher explorers --modified …` — the grapher push, correctly filtered to the branch's changes.
2. `etl run export://explorers export://multidim …` — the mdim/explorer build, **without** `--modified`, so it rebuilds every mdim/explorer (and pulls their upstream).

The obvious fix — add `--modified` to (2) — doesn't work as-is: `get_all_changed_catalog_paths` only ever returns `data://` steps (it drops every `export://` step), so `_modified_steps(includes=["export://multidim", "export://explorers"])` returns `[]` and the build would skip **all** mdims. That's a regression: a branch that edits a grapher dataset feeding a multidim wouldn't get that multidim refreshed for chart-diff.

## Fix

`filter_to_subgraph(downstream=True)` already includes the affected export steps — they were just being filtered out at the end. So:

- `get_all_changed_catalog_paths` gains an opt-in `include_export` flag. Default `False`, so chart-diff and datadiff (the other two callers) are unchanged. When `True`, downstream `export://…` steps are returned with their full URI (they have no `data://` catalogPath).
- `_modified_steps` passes `include_export=True`, and its exact-match branch now compares on the scheme-less path on both sides so export URIs match too.

Net effect once the companion ops change lands: the mdim/explorer build only rebuilds the multidims/explorers a branch actually affects (via their upstream), instead of all of them.

## Verification

Simulated a change to `grapher/energy/2025-02-03/energy_prices` (feeds `export://multidim/energy/latest/energy_prices`):

- `_modified_steps(["export://explorers", "export://multidim"])` → `['export://multidim/energy/latest/energy_prices']` ✅ (was `[]`)
- `_modified_steps(["garden", "grapher", "explorers"])` (grapher push) → unchanged, still selects the data steps ✅
- A self-contained leaf dataset with no mdim downstream selects no export steps → mdim build early-exits ✅

`tests/test_command.py` passes; pre-commit lint + types clean.

## Companion change

Needs **owid/ops#528**, which adds the feature-detected `--modified` flag to `build_mdims` in `etl-build.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)