### PR TITLE
📊 Add freedom of choice and control indicator to Integrated Values Surveys

### DIFF
--- a/etl/steps/data/garden/ivs/2025-06-27/integrated_values_surveys.meta.yml
+++ b/etl/steps/data/garden/ivs/2025-06-27/integrated_values_surveys.meta.yml
@@ -8294,3 +8294,54 @@ tables:
           <<: *common-display
         unit: ""
         short_unit: ""
+      little_freedom_of_choice:
+        title: "Freedom of choice and control: Little freedom of choice and control"
+        description_short: '% of respondents replying in a scale from 1 to 4 when asked "Some people feel they have completely free choice and control over their lives, while other people feel that what they do has no real effect on what happens to them. Please use this scale where 1 means "no choice at all" and 10 means "a great deal of choice" to indicate how much freedom of choice and control you feel you have over the way your life turns out".'
+        display:
+          name: "Little freedom of choice and control"
+          <<: *common-display
+        presentation:
+          topic_tags: *topic_tags_human_rights
+      neutral_freedom_of_choice:
+        title: "Freedom of choice and control: Neutral"
+        description_short: '% of respondents replying 5 or 6 when asked "Some people feel they have completely free choice and control over their lives, while other people feel that what they do has no real effect on what happens to them. Please use this scale where 1 means "no choice at all" and 10 means "a great deal of choice" to indicate how much freedom of choice and control you feel you have over the way your life turns out".'
+        display:
+          name: "Neutral"
+          <<: *common-display
+        presentation:
+          topic_tags: *topic_tags_human_rights
+      great_freedom_of_choice:
+        title: "Freedom of choice and control: A great deal of freedom of choice and control"
+        description_short: '% of respondents replying in a scale from 7 to 10 when asked "Some people feel they have completely free choice and control over their lives, while other people feel that what they do has no real effect on what happens to them. Please use this scale where 1 means "no choice at all" and 10 means "a great deal of choice" to indicate how much freedom of choice and control you feel you have over the way your life turns out".'
+        display:
+          name: "A great deal of freedom of choice and control"
+          <<: *common-display
+        presentation:
+          topic_tags: *topic_tags_human_rights
+      dont_know_freedom_of_choice:
+        title: "Freedom of choice and control: Don't know"
+        description_short: '% of respondents replying "don''t know" when asked "Some people feel they have completely free choice and control over their lives, while other people feel that what they do has no real effect on what happens to them. Please use this scale where 1 means "no choice at all" and 10 means "a great deal of choice" to indicate how much freedom of choice and control you feel you have over the way your life turns out".'
+        display:
+          name: "Don't know"
+          <<: *common-display
+        presentation:
+          topic_tags: *topic_tags_human_rights
+      no_answer_freedom_of_choice:
+        title: "Freedom of choice and control: No answer"
+        description_short: '% of answers classified as "No answer" for the question "Some people feel they have completely free choice and control over their lives, while other people feel that what they do has no real effect on what happens to them. Please use this scale where 1 means "no choice at all" and 10 means "a great deal of choice" to indicate how much freedom of choice and control you feel you have over the way your life turns out".'
+        display:
+          name: "No answer"
+          <<: *common-display
+        presentation:
+          topic_tags: *topic_tags_human_rights
+      avg_score_freedom_of_choice:
+        title: "Freedom of choice and control: Average score"
+        description_short: 'Average score of respondents when asked "Some people feel they have completely free choice and control over their lives, while other people feel that what they do has no real effect on what happens to them. Please use this scale where 1 means "no choice at all" and 10 means "a great deal of choice" to indicate how much freedom of choice and control you feel you have over the way your life turns out", on a scale from 1 (no choice at all) to 10 (a great deal of choice).'
+        display:
+          name: "Average score"
+          numDecimalPlaces: 2
+          <<: *common-display
+        unit: ""
+        short_unit: ""
+        presentation:
+          topic_tags: *topic_tags_human_rights

--- a/etl/steps/data/garden/ivs/2025-06-27/integrated_values_surveys.py
+++ b/etl/steps/data/garden/ivs/2025-06-27/integrated_values_surveys.py
@@ -38,6 +38,8 @@ ENVIRONMENT_VS_ECONOMY_QUESTIONS = ["env_ec"]
 
 INCOME_EQUALITY_QUESTIONS = ["eq_ineq"]
 
+FREEDOM_OF_CHOICE_QUESTIONS = ["freedom_of_choice"]
+
 SCHWARTZ_QUESTIONS = [
     "new_ideas",
     "rich",
@@ -319,6 +321,11 @@ def drop_indicators_and_replace_nans(tb: Table) -> Table:
     # For income equality question
     tb = replace_dont_know_by_null(
         tb=tb, questions=INCOME_EQUALITY_QUESTIONS, answers=["equality", "neutral", "inequality"]
+    )
+
+    # For freedom of choice and control question
+    tb = replace_dont_know_by_null(
+        tb=tb, questions=FREEDOM_OF_CHOICE_QUESTIONS, answers=["little", "neutral", "great"]
     )
 
     # For "Schwartz" questions
@@ -666,6 +673,14 @@ def sanity_checks(tb: Table) -> Table:
         tb=tb,
         questions=INCOME_EQUALITY_QUESTIONS,
         answers=["equality", "neutral", "inequality", "dont_know", "no_answer"],
+        margin=MARGIN,
+    )
+
+    # For freedom of choice and control question
+    tb = check_sum_100(
+        tb=tb,
+        questions=FREEDOM_OF_CHOICE_QUESTIONS,
+        answers=["little", "neutral", "great", "dont_know", "no_answer"],
         margin=MARGIN,
     )
 

--- a/etl/steps/data/garden/ivs/2025-06-27/integrated_values_surveys.py
+++ b/etl/steps/data/garden/ivs/2025-06-27/integrated_values_surveys.py
@@ -324,9 +324,7 @@ def drop_indicators_and_replace_nans(tb: Table) -> Table:
     )
 
     # For freedom of choice and control question
-    tb = replace_dont_know_by_null(
-        tb=tb, questions=FREEDOM_OF_CHOICE_QUESTIONS, answers=["little", "neutral", "great"]
-    )
+    tb = replace_dont_know_by_null(tb=tb, questions=FREEDOM_OF_CHOICE_QUESTIONS, answers=["little", "neutral", "great"])
 
     # For "Schwartz" questions
     tb = replace_dont_know_by_null(

--- a/snapshots/ivs/2025-06-27/ivs_create_file.do
+++ b/snapshots/ivs/2025-06-27/ivs_create_file.do
@@ -66,6 +66,9 @@ global environment_vs_econ_questions B008
 * income equality
 global income_equality_questions E035
 
+* freedom of choice and control over one's life
+global freedom_of_choice_question A173
+
 * Schwartz questions
 global schwartz_questions A189 A190 A191 A192 A193 A194 A195 A196 A197 A198
 
@@ -146,7 +149,7 @@ global humankind_concern_question E158
 
 * List of questions to work with
 * NOTE: A168 is not available in IVS
-global questions A165 A168 G007_33_B G007_34_B $additional_questions $important_in_life_questions $politics_questions $environment_vs_econ_questions $income_equality_questions $schwartz_questions $work_leisure_questions $work_questions $most_serious_problem_questions $justifiable_questions $worries_questions $happiness_questions $neighbors_questions $homosexuals_parents_questions $democracy_satisfied $democracy_very_good_very_bad $democracy_essential_char $democracy_importance $democracy_democraticness $democracy_elections_makes_diff $religion_how_often $religion_god_important $religion_how_often_services $religion_how_often_pray $jobs_scarce_questions $gender_roles_questions $neighborhood_frequency_questions $security_actions_questions $neighborhood_security_question $human_rights_respect_question $felt_unsafe_question $welzel_equality_question $media_questions $closeness_questions $tech_questions $science_world_question $aims_country_questions $aims_respondent_questions $most_important_questions $humankind_concern_question
+global questions A165 A168 G007_33_B G007_34_B $additional_questions $important_in_life_questions $politics_questions $environment_vs_econ_questions $income_equality_questions $freedom_of_choice_question $schwartz_questions $work_leisure_questions $work_questions $most_serious_problem_questions $justifiable_questions $worries_questions $happiness_questions $neighbors_questions $homosexuals_parents_questions $democracy_satisfied $democracy_very_good_very_bad $democracy_essential_char $democracy_importance $democracy_democraticness $democracy_elections_makes_diff $religion_how_often $religion_god_important $religion_how_often_services $religion_how_often_pray $jobs_scarce_questions $gender_roles_questions $neighborhood_frequency_questions $security_actions_questions $neighborhood_security_question $human_rights_respect_question $felt_unsafe_question $welzel_equality_question $media_questions $closeness_questions $tech_questions $science_world_question $aims_country_questions $aims_respondent_questions $most_important_questions $humankind_concern_question
 
  * Keep wave ID, country, weight and the list of questions
 keep S002VS S002EVS S003 S017 $questions
@@ -561,6 +564,58 @@ gen avg_score_eq_ineq = E035
 collapse (mean) equality_eq_ineq neutral_eq_ineq inequality_eq_ineq dont_know_eq_ineq no_answer_eq_ineq avg_score_eq_ineq [w=S017], by (year country)
 tempfile income_equality_file
 save "`income_equality_file'"
+
+restore
+preserve
+
+* Processing freedom of choice and control question
+/*
+           1 None at all
+           2 2
+           3 3
+           4 4
+           5 5
+           6 6
+           7 7
+           8 8
+           9 9
+          10 A great deal
+          .a Don't know
+          .b No answer
+          .c Not applicable
+          .d Not asked in survey
+          .e Missing: other
+
+*/
+
+* Keep only answers
+keep if A173 >= 1
+keep if A173 != .c
+keep if A173 != .d
+keep if A173 != .e
+
+*Generate variables
+gen little_freedom_of_choice = 0
+replace little_freedom_of_choice = 1 if A173 <= 4
+
+gen neutral_freedom_of_choice = 0
+replace neutral_freedom_of_choice = 1 if A173 == 5 | A173 == 6
+
+gen great_freedom_of_choice = 0
+replace great_freedom_of_choice = 1 if A173 >= 7 & A173 <= 10
+
+gen dont_know_freedom_of_choice = 0
+replace dont_know_freedom_of_choice = 1 if A173 == .a
+
+gen no_answer_freedom_of_choice = 0
+replace no_answer_freedom_of_choice = 1 if A173 == .b
+
+gen avg_score_freedom_of_choice = A173
+
+* Make dataset of the weighted shares by wave and country
+collapse (mean) little_freedom_of_choice neutral_freedom_of_choice great_freedom_of_choice dont_know_freedom_of_choice no_answer_freedom_of_choice avg_score_freedom_of_choice [w=S017], by (year country)
+tempfile freedom_of_choice_file
+save "`freedom_of_choice_file'"
 
 restore
 preserve
@@ -2349,6 +2404,8 @@ foreach var in $rest_politics_questions {
 qui merge 1:1 year country using "`environment_vs_econ_file'", nogenerate // keep(master match)
 
 qui merge 1:1 year country using "`income_equality_file'", nogenerate // keep(master match)
+
+qui merge 1:1 year country using "`freedom_of_choice_file'", nogenerate // keep(master match)
 
 foreach var in $schwartz_questions {
 	qui merge 1:1 year country using "`schwartz_`var'_file'", nogenerate // keep(master match)


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

Adds **A173 "How much freedom of choice and control"** (WVS-7 Q48) to the existing `integrated_values_surveys` pipeline — no version bump.

A173 is a 10-point self-placement scale (`1 = No choice at all … 10 = A great deal`, verified against the `.dta` value labels). It's processed exactly like the existing income-equality (E035) 10-point block: three aggregate bands + Don't know / No answer + a native-scale average.

### Indicators (6 new columns)

| Column | Meaning |
|---|---|
| `little_freedom_of_choice` | % replying 1–4 |
| `neutral_freedom_of_choice` | % replying 5–6 |
| `great_freedom_of_choice` | % replying 7–10 |
| `dont_know_freedom_of_choice` | % "Don't know" |
| `no_answer_freedom_of_choice` | % "No answer" |
| `avg_score_freedom_of_choice` | weighted mean, native 1–10 scale |

The three bands + DK + NA partition to 100% (`check_sum_100` gate); `avg_score` is an extra on the 1–10 scale.

### Changes

- **`ivs_create_file.do`** — new `global freedom_of_choice_question A173`, added to the master `keep`, a custom recode block (cloned from the income-equality block), and the `merge`.
- **meadow** — no change needed (custom block emits final column names directly, no `VARS_DICT` entry).
- **garden** — `FREEDOM_OF_CHOICE_QUESTIONS` constant + `replace_dont_know_by_null` + `check_sum_100`.
- **garden `.meta.yml`** — 6 variable entries (titles, `description_short` quoting the verbatim Q48 stem, `display.name`), tagged **Human Rights**.

### Topic tag

Tagged **Human Rights** (per maintainer's call). The dictionary files it under "Perceptions of life" alongside life-satisfaction, but freedom/control over one's life is treated here as a rights concept.

### Still pending (data not yet regenerated)

This PR currently contains **code only**. The `.do` must be run in Stata to regenerate `ivs.csv` (Claude can't run Stata), after which:

- [ ] Run `ivs_create_file.do` in Stata → regenerate `ivs.csv`
- [ ] Re-snapshot (same version) → updates `.dvc` md5/size
- [ ] `etlr integrated_values_surveys` (meadow → garden → grapher) + `--grapher` upload
- [ ] Verify ranges + flip Notion `Available` flag for A173

Sanity anchor (global, S017-weighted, valid 1–10): bands ≈ 14.2% / 24.9% / 60.9%, weighted avg ≈ 6.89.
