### PR TITLE
✨ Add min_frac_population option to region aggregates

### DIFF
--- a/etl/data_helpers/geo.py
+++ b/etl/data_helpers/geo.py
@@ -1995,6 +1995,8 @@ class Regions:
         countries_that_must_have_data: dict[str, list[str]] | None = None,
         min_num_countries_informed: int | None = None,
         min_frac_countries_informed: float | None = None,
+        min_frac_population: float | dict[str, float] | None = None,
+        warn_on_missing_population: bool = True,
     ) -> Table:
         """Add region aggregates to a table.
 
@@ -2070,9 +2072,25 @@ class Regions:
             Regions not in the dict will not have this constraint applied.
             * If None, an aggregate is constructed regardless of the fraction of countries informed.
             * This condition is applied after the aggregation, and works together with min_num_countries_informed (both must be met).
+            * NOTE ON THE "_informed" SUFFIX: the denominator is the set of countries that have *ever* reported the
+            variable, not the region's full member list. See min_frac_population (no suffix) for the all-members analog.
             Example: If 30 unique countries in Europe have ever reported data for a given indicator (across all years),
             and min_frac_countries_informed=0.5, then at least 15 countries must have data in any given year, otherwise
             the aggregate for indicator and that year is nan.
+        min_frac_population : Optional[float | dict[str, float]], default: None
+            * Minimum fraction of the region's total population that must live in countries with data, for a particular
+            variable, region and year, otherwise the aggregate is set to nan.
+            * The denominator is the region's total population, read straight from the population dataset (e.g. the
+            population of "Africa"); it is not reconstructed by summing members, so a region the population dataset does
+            not know is left ungated. Countries that never appear in the data still count against coverage.
+            * Country populations come from population_col when present, otherwise from the population dataset.
+            * A float applies the same threshold to all regions; a dict maps regions to fractions; None disables it.
+            * Composes with the other coverage conditions (all must be met).
+            Example: if the countries reporting an indicator for Africa in a given year are home to 40% of Africa's
+            population, then min_frac_population=0.5 sets that year's aggregate to nan.
+        warn_on_missing_population : bool, default: True
+            * Only relevant when min_frac_population is set. If True, warn about countries or regions that have no
+            population in the population dataset (their absence affects the coverage check). Set to False to silence it.
 
         Returns
         -------
@@ -2100,6 +2118,8 @@ class Regions:
             countries_that_must_have_data=countries_that_must_have_data,
             min_num_countries_informed=min_num_countries_informed,
             min_frac_countries_informed=min_frac_countries_informed,
+            min_frac_population=min_frac_population,
+            warn_on_missing_population=warn_on_missing_population,
         )
 
     def add_per_capita(
@@ -2718,6 +2738,91 @@ class RegionAggregator:
                     original_indices_to_nan = df_region_subset[mask_to_nan]["original_index"].values
                     df_only_regions.loc[original_indices_to_nan, column] = np.nan
 
+    def _impose_population_condition(
+        self, df_only_regions, tb, columns, min_frac_population, warn_on_missing_population
+    ):
+        """Set region aggregates to NaN when too little of the region's population is covered by data.
+
+        For each variable, region and year, divides the population of the member countries that have (not-nan) data
+        by the region's total population, and sets the aggregate to NaN when that fraction is below the threshold.
+        Country populations are taken from population_col when the table already provides it, otherwise read from the
+        population dataset; the region total is always read from the population dataset (taken directly, not summed
+        from members). Missing population is reported by add_population_to_table via warn_on_missing_population.
+        Modifies df_only_regions in place.
+        """
+        if min_frac_population is None:
+            return
+
+        # A float applies the same threshold to all regions; a dict restricts it to the regions it lists.
+        if isinstance(min_frac_population, float):
+            min_frac_population = {region: min_frac_population for region in self.regions}
+        regions_to_check = [region for region in self.regions if region in min_frac_population]
+        if not regions_to_check:
+            return
+
+        other_index_columns = [column for column in self.index_columns if column != self.country_col]
+        coverage_columns = [column for column in columns if column in self.tb_coverage.columns]  # ty: ignore
+
+        # Reuse the existing coverage table (1 where the original cell had data, 0 otherwise) as a plain DataFrame.
+        cov = pd.DataFrame(self.tb_coverage)
+
+        # Population per (entity, year). Country populations are reused from population_col when the table already has
+        # it; the region totals (and country populations when there is no such column) are read from the population
+        # dataset in a single call, whose warn_on_missing_countries surfaces any entity without population.
+        df_pop_parts = []
+        entities_to_fetch = [pd.DataFrame(df_only_regions[[self.country_col, self.year_col]])]
+        if self.population_col in tb.columns:
+            df_pop_parts.append(
+                pd.DataFrame(tb[[self.country_col, self.year_col, self.population_col]]).rename(
+                    columns={self.population_col: "__population"}
+                )
+            )
+        else:
+            entities_to_fetch.append(pd.DataFrame(cov[[self.country_col, self.year_col]]))
+        df_pop_parts.append(
+            pd.DataFrame(
+                add_population_to_table(
+                    tb=Table(pd.concat(entities_to_fetch, ignore_index=True).drop_duplicates()),
+                    ds_population=self.ds_population,  # ty: ignore
+                    country_col=self.country_col,
+                    year_col=self.year_col,
+                    population_col="__population",
+                    warn_on_missing_countries=warn_on_missing_population,
+                )
+            )
+        )
+        # One population per (entity, year) so the lookups below stay one-to-one.
+        df_pop = pd.concat(df_pop_parts, ignore_index=True).drop_duplicates(subset=[self.country_col, self.year_col])
+        cov = cov.merge(df_pop, on=[self.country_col, self.year_col], how="left")
+
+        for region in regions_to_check:
+            region_mask = df_only_regions[self.country_col] == region
+            if not region_mask.any():
+                continue
+            threshold = min_frac_population[region]
+
+            # Coverage rows for the members of this region.
+            region_cov = cov[cov[self.country_col].isin(self.regions_members[region])]
+            if region_cov.empty:
+                continue
+
+            # Region rows and their total population, computed once (the total does not depend on the column).
+            # Plain DataFrame so the merges do not dispatch to Table.merge (which needs Tables on both sides).
+            region_rows = pd.DataFrame(df_only_regions[region_mask]).reset_index().rename(columns={"index": "__row"})
+            total_pop = region_rows.merge(df_pop, on=[self.country_col, self.year_col], how="left")["__population"]
+
+            for column in coverage_columns:
+                # Covered population per series-year (members with not-nan data for this column).
+                covered = (
+                    region_cov[region_cov[column]]
+                    .groupby(other_index_columns, as_index=False)["__population"]
+                    .sum()
+                    .rename(columns={"__population": "__covered"})
+                )
+                covered_pop = region_rows.merge(covered, on=other_index_columns, how="left")["__covered"].fillna(0)
+                mask_to_nan = (total_pop > 0) & (covered_pop / total_pop < threshold)
+                df_only_regions.loc[region_rows.loc[mask_to_nan, "__row"].to_numpy(), column] = np.nan
+
     def add_aggregates(
         self,
         tb: Table,
@@ -2726,6 +2831,8 @@ class RegionAggregator:
         min_num_values_per_year: int | None = None,
         min_num_countries_informed: int | dict[str, int] | None = None,
         min_frac_countries_informed: float | dict[str, float] | None = None,
+        min_frac_population: float | dict[str, float] | None = None,
+        warn_on_missing_population: bool = True,
         check_for_region_overlaps: bool = True,
         accepted_overlaps: list[dict[int, set[str]]] | None = None,
         ignore_overlaps_of_zeros: bool = False,
@@ -2799,9 +2906,31 @@ class RegionAggregator:
             Regions not in the dict will not have this constraint applied.
             * If None, an aggregate is constructed regardless of the fraction of countries informed.
             * This condition is applied after the aggregation, and works together with min_num_countries_informed (both must be met).
+            * NOTE ON THE "_informed" SUFFIX: the denominator is the set of countries that have *ever* reported the
+            variable, not the region's full member list. See min_frac_population (no suffix) for the all-members analog.
             Example: If 30 unique countries in Europe have ever reported data for a given indicator (across all years),
             and min_frac_countries_informed=0.5, then at least 15 countries must have data in any given year, otherwise
             the aggregate for indicator and that year is nan.
+        min_frac_population : Optional[float | dict[str, float]], default: None
+            * If a float is passed (between 0 and 1), this is the minimum fraction of the region's total population that
+            must live in countries with data, for a particular variable, region and year. If that fraction is not reached,
+            the aggregate will be nan.
+            * If a dict is passed, it maps region names to minimum fractions (e.g., {"Europe": 0.9, "Africa": 0.5}).
+            Regions not in the dict will not have this constraint applied.
+            * If None, an aggregate is constructed regardless of the population covered.
+            * The numerator is the population of the member countries that have (not-nan) data for that variable and year.
+            Country populations come from population_col when the table already has it, otherwise from the population
+            dataset. The denominator is the region's total population, read straight from the population dataset (e.g. the
+            population of "Africa"); it is NOT reconstructed by summing members. A region the population dataset does not
+            know is left ungated. Because the region total includes countries that never appear in the data, those count
+            against coverage.
+            * This condition is applied after the aggregation, and composes with the other coverage conditions (all must be met).
+            Example: if the countries reporting an indicator for Africa in a given year are home to 40% of Africa's
+            population, then min_frac_population=0.5 sets that year's aggregate to nan.
+        warn_on_missing_population : bool, default: True
+            * Only relevant when min_frac_population is set. If True, warn (via add_population_to_table) about countries
+            or regions that have no population in the population dataset, since their absence affects the coverage check.
+            * Set to False to silence that warning (e.g. when some entities are knowingly without population).
 
         Returns
         -------
@@ -2834,7 +2963,9 @@ class RegionAggregator:
                 if weight_col in tb.columns:
                     weight_columns.add(weight_col)
 
-        needed_columns = self.index_columns + columns + list(weight_columns)
+        # Deduplicate while preserving order: a weight column may already be an index or aggregated column,
+        # and selecting it twice would create a duplicate column that breaks downstream operations.
+        needed_columns = list(dict.fromkeys(self.index_columns + columns + list(weight_columns)))
         tb_fast = tb[needed_columns]
         other_columns = [col for col in tb.columns if col not in needed_columns]
 
@@ -2857,20 +2988,38 @@ class RegionAggregator:
             min_num_values_per_year=min_num_values_per_year,
         )
 
+        # Build the coverage table if any country- or population-based condition is specified.
+        if (
+            countries_that_must_have_data is not None
+            or min_num_countries_informed is not None
+            or min_frac_countries_informed is not None
+            or min_frac_population is not None
+        ):
+            if self.tb_coverage is None:
+                self._create_coverage_table(tb=tb_fast)
+
         # Apply country-based conditions if any are specified.
         if (
             countries_that_must_have_data is not None
             or min_num_countries_informed is not None
             or min_frac_countries_informed is not None
         ):
-            if self.tb_coverage is None:
-                self._create_coverage_table(tb=tb_fast)
             self._impose_country_conditions(
                 df_only_regions=df_only_regions,
                 columns=columns,
                 countries_that_must_have_data=countries_that_must_have_data,
                 min_num_countries_informed=min_num_countries_informed,
                 min_frac_countries_informed=min_frac_countries_informed,
+            )
+
+        # Apply the population-coverage condition if specified.
+        if min_frac_population is not None:
+            self._impose_population_condition(
+                df_only_regions=df_only_regions,
+                tb=tb,
+                columns=columns,
+                min_frac_population=min_frac_population,
+                warn_on_missing_population=warn_on_missing_population,
             )
 
         # Create a mask that selects rows of regions in the original data, if any.

--- a/tests/data_helpers/test_geo.py
+++ b/tests/data_helpers/test_geo.py
@@ -916,6 +916,26 @@ class MockPopulationDataset:
             raise KeyError(f"Table {name} not found.")
 
 
+class MockPopulationDatasetEurope:
+    """Mock population dataset covering the mock Europe members across several years (for coverage tests)."""
+
+    def __init__(self):
+        self.table_names = ["population"]
+
+    def __getitem__(self, name: str) -> Table:
+        return self.read(name)
+
+    def read(self, name: str, safe_types: bool = True) -> Table:
+        if name != "population":
+            raise KeyError(f"Table {name} not found.")
+        # Constant population per country across years, in arbitrary units. "Europe" is the region total
+        # (sum of the five members, 329), read directly as the denominator for min_frac_population.
+        populations = {"France": 67, "Italy": 60, "Spain": 47, "Russia": 146, "Belarus": 9, "Europe": 329}
+        years = [2020, 2021, 2022, 2023]
+        rows = [(country, year, pop) for country, pop in populations.items() for year in years]
+        return Table(pd.DataFrame(rows, columns=["country", "year", "population"]))
+
+
 class TestAddRegionsToTable(unittest.TestCase):
     def test_overlaps_without_income_groups(self):
         tb_in = Table.from_records(
@@ -3893,6 +3913,131 @@ class TestRegionAggregator(unittest.TestCase):
 
         # 2023 should have value
         self.assertEqual(europe_lenient[europe_lenient["year"] == 2023]["value"].iloc[0], 380)
+
+    def test_min_frac_population_basic(self):
+        """Test min_frac_population gates region-years by the population covered by countries with data."""
+        # Europe members and (mock) populations: France 67, Italy 60, Spain 47, Russia 146, Belarus 9 -> total 329.
+        # Coverage per year:
+        #   2020: all five report     -> 329/329 = 1.000
+        #   2021: France+Italy+Spain   -> 174/329 = 0.529
+        #   2022: France+Russia        -> 213/329 = 0.647
+        #   2023: France only          -> 67/329  = 0.204
+        tb_test = Table(
+            {
+                "country": [
+                    "France",
+                    "Italy",
+                    "Spain",
+                    "Russia",
+                    "Belarus",
+                    "France",
+                    "Italy",
+                    "Spain",
+                    "France",
+                    "Russia",
+                    "France",
+                ],
+                "year": [2020, 2020, 2020, 2020, 2020, 2021, 2021, 2021, 2022, 2022, 2023],
+                "value": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+            }
+        )
+
+        aggregator = geo.RegionAggregator(
+            ds_regions=self.ds_regions,
+            regions_all=self.regions_all,
+            regions=["Europe"],
+            aggregations={"value": "sum"},
+            ds_income_groups=self.ds_income_groups,
+            ds_population=cast(Dataset, MockPopulationDatasetEurope()),
+        )
+
+        # With a 0.6 threshold, only 2020 (1.000) and 2022 (0.647) survive.
+        result = aggregator.add_aggregates(tb_test, min_frac_population=0.6, check_for_region_overlaps=False)
+        europe = result[result["country"] == "Europe"].set_index("year")["value"]
+
+        self.assertFalse(pd.isna(europe.loc[2020]))
+        self.assertTrue(pd.isna(europe.loc[2021]))
+        self.assertFalse(pd.isna(europe.loc[2022]))
+        self.assertTrue(pd.isna(europe.loc[2023]))
+
+    def test_min_frac_population_counts_countries_without_data(self):
+        """A member country with population but no data counts against coverage (it is in the denominator).
+
+        Belarus (population 9) never reports. In 2020 the other four members (France+Italy+Spain+Russia = 320)
+        report, while the region total is 329, so coverage is 320/329 = 0.973. A 0.99 threshold drops the
+        aggregate; a 0.95 threshold keeps it.
+        """
+        tb_test = Table(
+            {
+                "country": ["France", "Italy", "Spain", "Russia"],
+                "year": [2020, 2020, 2020, 2020],
+                "value": [1, 1, 1, 1],
+            }
+        )
+
+        def _europe_value(threshold):
+            aggregator = geo.RegionAggregator(
+                ds_regions=self.ds_regions,
+                regions_all=self.regions_all,
+                regions=["Europe"],
+                aggregations={"value": "sum"},
+                ds_income_groups=self.ds_income_groups,
+                ds_population=cast(Dataset, MockPopulationDatasetEurope()),
+            )
+            result = aggregator.add_aggregates(tb_test, min_frac_population=threshold, check_for_region_overlaps=False)
+            return result[result["country"] == "Europe"].set_index("year")["value"].loc[2020]
+
+        # Coverage 0.973 < 0.99 -> dropped.
+        self.assertTrue(pd.isna(_europe_value(0.99)))
+        # Coverage 0.973 >= 0.95 -> kept.
+        self.assertFalse(pd.isna(_europe_value(0.95)))
+
+    def test_min_frac_population_warns_on_missing_population(self):
+        """Missing population is surfaced via add_population_to_table and silenced by warn_on_missing_population=False."""
+
+        class _PopWithoutBelarus:
+            def __getitem__(self, name):
+                return self.read(name)
+
+            def read(self, name, safe_types=True):
+                # Belarus is a member of (mock) Europe but is deliberately absent from the population dataset.
+                populations = {"France": 67, "Italy": 60, "Spain": 47, "Russia": 146, "Europe": 329}
+                rows = [(country, 2020, pop) for country, pop in populations.items()]
+                return Table(pd.DataFrame(rows, columns=["country", "year", "population"]))
+
+        tb_test = Table(
+            {
+                "country": ["France", "Italy", "Spain", "Russia", "Belarus"],
+                "year": [2020] * 5,
+                "value": [1, 1, 1, 1, 1],
+            }
+        )
+
+        def _run(warn):
+            aggregator = geo.RegionAggregator(
+                ds_regions=self.ds_regions,
+                regions_all=self.regions_all,
+                regions=["Europe"],
+                aggregations={"value": "sum"},
+                ds_income_groups=self.ds_income_groups,
+                ds_population=cast(Dataset, _PopWithoutBelarus()),
+            )
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                result = aggregator.add_aggregates(
+                    tb_test, min_frac_population=0.5, warn_on_missing_population=warn, check_for_region_overlaps=False
+                )
+            return result, [str(w.message) for w in caught]
+
+        # By default the missing-population entity (Belarus) is surfaced.
+        result, messages = _run(True)
+        assert any("Belarus" in message for message in messages), "Expected a warning naming the missing entity."
+        # Belarus is counted as zero population; the other four cover 320/329 = 0.973 >= 0.5, so 2020 is kept.
+        self.assertFalse(pd.isna(result[result["country"] == "Europe"].set_index("year")["value"].loc[2020]))
+
+        # With the flag off, the warning is silenced.
+        _, messages_off = _run(False)
+        assert not any("Belarus" in message for message in messages_off), "Warning should be silenced."
 
     def test_min_num_and_frac_countries_informed_combined(self):
         """Test both min_num_countries_informed and min_frac_countries_informed together."""


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

Adds a `min_frac_population` option to `paths.regions.add_aggregates`: a region-year aggregate is set to NaN when the countries with data cover less than the given fraction of the region's **total population** (read straight from the population dataset, not reconstructed by summing members). A companion `warn_on_missing_population` flag (default on) surfaces countries or regions that have no population in the dataset, since their absence affects the coverage check. Tests included.

It also fixes a small latent bug in `add_aggregates`: when a column was used both as the weight (`mean_weighted_by_population`) and as an aggregated or index column, it was selected twice in the internal column subset, producing a duplicate column that crashed the aggregation. It's now deduplicated while preserving order.