### PR TITLE
🔨 climate: Restructure pipeline DAG and stop wildfires autoupdate

### DIFF
--- a/.claude/skills/climate-update/SKILL.md
+++ b/.claude/skills/climate-update/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: climate-update
+description: Run OWID's monthly climate data update. Bumps all updateable climate-namespace datasets to one common version in a single PR with one announcement, skipping the frozen sources. Also supports a wildfires-only subset for fire season. Use when the user wants to update climate data, run the monthly climate update, or refresh wildfires mid-season.
+metadata:
+  internal: true
+---
+
+# Climate update (monthly umbrella update)
+
+All OWID climate data is updated once a month as a single batch: every updateable
+climate-namespace dataset is bumped to one common version date, in one PR, with one
+Slack announcement. This skill owns *which* datasets, *in what order*, and the
+single-PR / single-announcement discipline. It delegates the per-dataset mechanics
+(snapshot → meadow → garden → grapher, diffs, metadata checks, chart upgrade) to
+[`/update-dataset`](../update-dataset/SKILL.md) — run each chain through that flow on
+the same branch.
+
+The matching reminder lives in `owid-issues/.github/workflows/update-climate.yml`
+(one monthly issue on the 10th). There are no per-dataset climate reminders.
+
+## Modes
+
+- **Full monthly update** (default): bump every updateable dataset below to a common
+  new version date.
+- **Wildfires-only subset**: bump just `weekly_wildfires` (and optionally
+  `yearly_burned_area`) to a new version. Use during peak fire season when wildfire
+  charts need fresher data than the monthly cadence. Same mechanics, narrower scope.
+
+## Updateable datasets (climate.yml "UPDATEABLE" section)
+
+Grouped by source. Bump all of these to the **same** new version date.
+
+| Source | Garden dataset(s) | Snapshot(s) | Cadence |
+|---|---|---|---|
+| Copernicus ERA5 | `surface_temperature` | `surface_temperature.zip` | monthly |
+| Copernicus ERA5 | `total_precipitation` | `total_precipitation.zip` | **yearly** |
+| GWIS | `weekly_wildfires` | `weekly_wildfires.csv` | continuous (fire season) |
+| GWIS | `yearly_burned_area` | `yearly_burned_area.csv` | **yearly** |
+| NOAA (Equatorial Pacific) | `sst` | `sst.csv` | monthly |
+| NOAA GML | `ghg_concentration` | `co2/ch4/n2o_concentration_monthly.csv` | monthly |
+| NSIDC | `sea_ice_index` | `sea_ice_index.xlsx` | monthly |
+| NASA Ozone Watch | `nasa_ozone_hole` | `nasa_ozone_hole_p1/p2.txt` | **yearly** |
+| Rutgers Global Snow Lab | `snow_cover_extent` | `snow_cover_extent_*.csv` | monthly |
+| Hawaii Ocean Time-series | `ocean_ph_levels` | `hawaii_ocean_time_series.csv` | monthly |
+| Met Office Hadley Centre | `sea_surface_temperature` | `sea_surface_temperature_*.csv` | monthly |
+| Met Office Hadley Centre | `near_surface_temperature` | `near_surface_temperature_*.csv` | **yearly** |
+| NOAA NCEI | `ocean_heat_content` | `ocean_heat_content_*.csv` | monthly |
+
+Plus two derived/aggregate datasets with no snapshot of their own:
+- `long_run_ghg_concentration` (combines NOAA `ghg_concentration` with the frozen EPA series)
+- `climate_change_impacts` (the aggregate; pulls most of the rows above)
+
+The **yearly** sources usually show no change in a given month — that is expected, not a bug.
+
+## Frozen — NEVER bump these (climate.yml "NOT UPDATEABLE" section)
+
+Skip entirely. They receive no new data and several feed `climate_change_impacts`:
+
+- EPA 2024-04-17: `ghg_concentration`, `ocean_heat_content`, `ice_sheet_mass_balance`, `mass_balance_us_glaciers`
+- `global_sea_level` (2024-01-28, NOAA Climate.gov)
+- `ipcc_scenarios`
+- The 12 migrated legacy chains (one-off papers / historical sources, dates 2017-2022)
+
+If a frozen source's producer ever republishes, that is a separate, deliberate version
+bump — not part of the monthly run.
+
+## Dependency order
+
+1. Bump and run the leaf source chains (snapshot → meadow → garden) for every updateable
+   dataset above. `climate_change_impacts`'s frozen deps (EPA, global_sea_level) stay on
+   their old versions — reference them unchanged.
+2. Bump and run `long_run_ghg_concentration`, then the `climate_change_impacts` aggregate.
+3. Run all grapher steps and the `climate_change` explorer (the explorer stays `latest`).
+
+The grapher families to rebuild: the 7 `surface_*` graphers, `total_precipitation_annual`,
+the 4 wildfire graphers, `sst`/`sst_by_month`, `nasa_ozone_hole`, the 3 `sea_ice_*`
+graphers, `climate_change_impacts_annual`/`_monthly`, and `yearly_burned_area`.
+
+## Procedure
+
+1. Create the branch + draft PR with `etl pr "📊 Update climate data" data`. **One** branch
+   and **one** PR for the whole batch.
+2. Run each updateable chain through the `/update-dataset` flow on that branch, all targeting
+   today's date as `<new_version>` so they land on a common version. Bump the aggregate
+   (`climate_change_impacts`) only after its sources are done, so it picks up the new versions
+   once rather than repeatedly.
+3. Chart remap on staging via the Indicator Upgrader. Variables remap by catalogPath, so most
+   charts follow automatically. **Watch the once-off cases**: any dataset moving from `latest`
+   or changing namespace needs its remap reviewed explicitly (see below).
+4. Verify on staging: Anomalist + Chart Diff (enable "Show all charts").
+5. **One** announcement: run [`/data-updates-comms`](../data-updates-comms/SKILL.md) for the
+   combined batch, post to #data-updates-comms, and draft the single `/latest` post. Do not
+   produce per-dataset announcements.
+
+## One-off migrations (only on the first run after the refactor)
+
+These are structural moves that happen once, then the dataset behaves like any other updateable one:
+
+- **`weekly_wildfires`: `latest` → versioned.** Its grapher variables get new IDs, so the wildfire
+  charts (and any wildfires explorer) need a ghost-variable remap — see
+  [`/remapping-ghost-variables`](../remapping-ghost-variables/SKILL.md).
+- **`ipcc_scenarios`: namespace `emissions` → `climate`**, and **EPA 2024-04-17: namespace `epa` → `climate`**
+  (retires the `epa` namespace). ipcc also moves its standalone explorer. EPA has no charts of its own
+  (it only feeds `climate_change_impacts`), so its move is chart-free; ipcc's needs an explorer/chart remap.
+
+After these land, update this skill's inventory if any short_names or namespaces changed.

--- a/dag/climate.yml
+++ b/dag/climate.yml
@@ -1,4 +1,80 @@
 steps:
+  # ===========================================================================
+  # NOT UPDATEABLE
+  # These steps receive no new data; skip them in the monthly climate update.
+  # ===========================================================================
+  #
+  # Migrated legacy datasets (frozen one-off papers and historical sources).
+  #
+  data://grapher/climate/2017-04-22/weather_fatality_rates_in_the_us__owid_based_on_noaa_and_lopez_holle_and_population_data:
+    - data://garden/climate/2017-04-22/weather_fatality_rates_in_the_us__owid_based_on_noaa_and_lopez_holle_and_population_data:
+      - snapshot://climate/2017-04-22/weather_fatality_rates_in_the_us__owid_based_on_noaa_and_lopez_holle_and_population_data.feather
+  data://grapher/climate/2017-12-04/ozone_concentration_stateofglobalair:
+    - data://garden/climate/2017-12-04/ozone_concentration_stateofglobalair:
+      - snapshot://climate/2017-12-04/ozone_concentration_stateofglobalair.feather
+  data://grapher/climate/2018-01-01/economic_impacts_of_2c__pretis_et_al__2018:
+    - data://garden/climate/2018-01-01/economic_impacts_of_2c__pretis_et_al__2018:
+      - snapshot://climate/2018-01-01/economic_impacts_of_2c__pretis_et_al__2018.feather
+  data://grapher/climate/2018-01-01/ozone_depleting_emissions_since_1960__scientific_assessment__2014:
+    - data://garden/climate/2018-01-01/ozone_depleting_emissions_since_1960__scientific_assessment__2014:
+      - snapshot://climate/2018-01-01/ozone_depleting_emissions_since_1960__scientific_assessment__2014.feather
+  data://grapher/climate/2018-03-21/economic_impacts_of_1_5c__pretis_et_al:
+    - data://garden/climate/2018-03-21/economic_impacts_of_1_5c__pretis_et_al:
+      - snapshot://climate/2018-03-21/economic_impacts_of_1_5c__pretis_et_al.feather
+  data://grapher/climate/2018-04-05/parties_to_montreal_protocol__unep__2023:
+    - data://garden/climate/2018-04-05/parties_to_montreal_protocol__unep__2023:
+      - snapshot://climate/2018-04-05/parties_to_montreal_protocol__unep__2023.feather
+  data://grapher/climate/2018-04-06/ozone_depletion_impacts_on_skin_cancer_incidence__slaper_et_al__1996:
+    - data://garden/climate/2018-04-06/ozone_depletion_impacts_on_skin_cancer_incidence__slaper_et_al__1996:
+      - snapshot://climate/2018-04-06/ozone_depletion_impacts_on_skin_cancer_incidence__slaper_et_al__1996.feather
+  data://grapher/climate/2018-07-01/ozone_and_chlorine_projections_to_2100__scientific_assessment__2014:
+    - data://garden/climate/2018-07-01/ozone_and_chlorine_projections_to_2100__scientific_assessment__2014:
+      - snapshot://climate/2018-07-01/ozone_and_chlorine_projections_to_2100__scientific_assessment__2014.feather
+  data://grapher/climate/2018-11-07/economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018:
+    - data://garden/climate/2018-11-07/economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018:
+      - snapshot://climate/2018-11-07/economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018.feather
+  data-private://grapher/climate/2018-09-20/wildfire_data_in_the_us__nifc:
+    - data-private://garden/climate/2018-09-20/wildfire_data_in_the_us__nifc:
+      - snapshot-private://climate/2018-09-20/wildfire_data_in_the_us__nifc.feather
+  data-private://grapher/climate/2021-04-13/coral_bleaching_events_by_enso_phase__hughes_et_al__2018:
+    - data-private://garden/climate/2021-04-13/coral_bleaching_events_by_enso_phase__hughes_et_al__2018:
+      - snapshot-private://climate/2021-04-13/coral_bleaching_events_by_enso_phase__hughes_et_al__2018.feather
+  data-private://grapher/climate/2022-09-10/young_people_opinions_climate_change__hickman_et_al__2021:
+    - data-private://garden/climate/2022-09-10/young_people_opinions_climate_change__hickman_et_al__2021:
+      - snapshot-private://climate/2022-09-10/young_people_opinions_climate_change__hickman_et_al__2021.feather
+  #
+  # IPCC scenarios (frozen; namespace migration emissions -> climate pending).
+  #
+  export://explorers/emissions/latest/ipcc_scenarios:
+    - data://grapher/emissions/2022-08-30/ipcc_scenarios:
+      - snapshot://emissions/2022-08-30/ipcc_scenarios.zip
+  #
+  # EPA - Climate change indicators (frozen). Consumed by climate_change_impacts below.
+  #
+  data://garden/epa/2024-04-17/ghg_concentration:
+    - data://meadow/epa/2024-04-17/ghg_concentration:
+      - snapshot://epa/2024-04-17/co2_concentration.csv
+      - snapshot://epa/2024-04-17/ch4_concentration.csv
+      - snapshot://epa/2024-04-17/n2o_concentration.csv
+  data://garden/epa/2024-04-17/ocean_heat_content:
+    - data://meadow/epa/2024-04-17/ocean_heat_content:
+      - snapshot://epa/2024-04-17/ocean_heat_content_annual_world_700m.csv
+      - snapshot://epa/2024-04-17/ocean_heat_content_annual_world_2000m.csv
+  data://garden/epa/2024-04-17/ice_sheet_mass_balance:
+    - data://meadow/epa/2024-04-17/ice_sheet_mass_balance:
+      - snapshot://epa/2024-04-17/ice_sheet_mass_balance.csv
+  data://garden/epa/2024-04-17/mass_balance_us_glaciers:
+    - data://meadow/epa/2024-04-17/mass_balance_us_glaciers:
+      - snapshot://epa/2024-04-17/mass_balance_us_glaciers.csv
+  #
+  # NOAA Climate.gov - Global sea level (frozen). Consumed by climate_change_impacts below.
+  #
+  data://garden/climate/2024-01-28/global_sea_level:
+    - data://meadow/climate/2024-01-28/global_sea_level:
+      - snapshot://climate/2024-01-28/global_sea_level.csv
+  # ===========================================================================
+  # UPDATEABLE
+  # ===========================================================================
   #
   # Copernicus Climate Change Service - Surface temperature.
   #
@@ -62,7 +138,6 @@ steps:
     # Various sources - Climate change impacts (monthly).
     - data://grapher/climate/2026-05-13/climate_change_impacts_monthly:
       - data://garden/climate/2026-05-13/climate_change_impacts
-
   #
   # NASA Ozone Watch - Ozone hole area and concentration.
   #
@@ -71,12 +146,6 @@ steps:
       - data://meadow/climate/2026-03-02/nasa_ozone_hole:
         - snapshot://climate/2026-03-02/nasa_ozone_hole_p2.txt
         - snapshot://climate/2026-03-02/nasa_ozone_hole_p1.txt
-  #
-  # IPCC scenarios
-  #
-  export://explorers/emissions/latest/ipcc_scenarios:
-    - data://grapher/emissions/2022-08-30/ipcc_scenarios:
-      - snapshot://emissions/2022-08-30/ipcc_scenarios.zip
   #
   # NSIDC - Arctic sea ice extent.
   #
@@ -113,17 +182,10 @@ steps:
     # Various sources - Long-run greenhouse gas concentration.
     - data://garden/climate/2026-05-13/long_run_ghg_concentration:
       - data://garden/climate/2026-05-13/ghg_concentration
-      # EPA - Climate change indicators (possibly not updateable).
-      - data://garden/epa/2024-04-17/ghg_concentration:
-        - data://meadow/epa/2024-04-17/ghg_concentration:
-          - snapshot://epa/2024-04-17/co2_concentration.csv
-          - snapshot://epa/2024-04-17/ch4_concentration.csv
-          - snapshot://epa/2024-04-17/n2o_concentration.csv
-    # NOAA National Centers for Environmental Information - Ocean Heat Content.
-    - data://garden/epa/2024-04-17/ocean_heat_content:
-      - data://meadow/epa/2024-04-17/ocean_heat_content:
-        - snapshot://epa/2024-04-17/ocean_heat_content_annual_world_700m.csv
-        - snapshot://epa/2024-04-17/ocean_heat_content_annual_world_2000m.csv
+      # EPA - GHG concentration (frozen; defined in NOT UPDATEABLE section above).
+      - data://garden/epa/2024-04-17/ghg_concentration
+    # EPA - Ocean heat content (frozen; defined in NOT UPDATEABLE section above).
+    - data://garden/epa/2024-04-17/ocean_heat_content
     # Rutgers University Global Snow Lab - Snow Cover Extent.
     - data://garden/climate/2026-05-13/snow_cover_extent:
       - data://meadow/climate/2026-05-13/snow_cover_extent:
@@ -133,17 +195,11 @@ steps:
     - data://garden/climate/2026-05-13/ocean_ph_levels:
       - data://meadow/climate/2026-05-13/hawaii_ocean_time_series:
         - snapshot://climate/2026-05-13/hawaii_ocean_time_series.csv
-    # NOAA Climate.gov - Global sea level (possibly not updateable).
-    - data://garden/climate/2024-01-28/global_sea_level:
-      - data://meadow/climate/2024-01-28/global_sea_level:
-        - snapshot://climate/2024-01-28/global_sea_level.csv
-    # EPA - Climate change indicators (possibly not updateable).
-    - data://garden/epa/2024-04-17/ice_sheet_mass_balance:
-      - data://meadow/epa/2024-04-17/ice_sheet_mass_balance:
-        - snapshot://epa/2024-04-17/ice_sheet_mass_balance.csv
-    - data://garden/epa/2024-04-17/mass_balance_us_glaciers:
-      - data://meadow/epa/2024-04-17/mass_balance_us_glaciers:
-        - snapshot://epa/2024-04-17/mass_balance_us_glaciers.csv
+    # NOAA Climate.gov - Global sea level (frozen; defined in NOT UPDATEABLE section above).
+    - data://garden/climate/2024-01-28/global_sea_level
+    # EPA - Ice sheet mass balance and US glaciers (frozen; defined in NOT UPDATEABLE section above).
+    - data://garden/epa/2024-04-17/ice_sheet_mass_balance
+    - data://garden/epa/2024-04-17/mass_balance_us_glaciers
     # Met Office Hadley Centre - Sea surface temperature.
     - data://garden/climate/2026-05-13/sea_surface_temperature:
       - data://meadow/climate/2026-05-13/sea_surface_temperature:

--- a/dag/migrated.yml
+++ b/dag/migrated.yml
@@ -259,9 +259,6 @@ steps:
   data://grapher/oecd/2023-03-01/oecd__trust_in_government:
     - data://garden/oecd/2023-03-01/oecd__trust_in_government:
       - snapshot://oecd/2023-03-01/oecd__trust_in_government.feather
-  data://grapher/climate/2017-12-04/ozone_concentration_stateofglobalair:
-    - data://garden/climate/2017-12-04/ozone_concentration_stateofglobalair:
-      - snapshot://climate/2017-12-04/ozone_concentration_stateofglobalair.feather
   data://grapher/demography/2017-06-01/crude_birth_and_death_rates__per_1_000__england_and_wales_1541_2015__wrigley_and_schofield__mitchell__uk_ons:
     - data://garden/demography/2017-06-01/crude_birth_and_death_rates__per_1_000__england_and_wales_1541_2015__wrigley_and_schofield__mitchell__uk_ons:
       - snapshot://demography/2017-06-01/crude_birth_and_death_rates__per_1_000__england_and_wales_1541_2015__wrigley_and_schofield__mitchell__uk_ons.feather
@@ -319,9 +316,6 @@ steps:
   data-private://grapher/ggdc/2017-08-03/share_of_industry_in_gdp_at_constant_2005_prices__ggdc__split:
     - data-private://garden/ggdc/2017-08-03/share_of_industry_in_gdp_at_constant_2005_prices__ggdc__split:
       - snapshot-private://ggdc/2017-08-03/share_of_industry_in_gdp_at_constant_2005_prices__ggdc__split.feather
-  data-private://grapher/climate/2018-09-20/wildfire_data_in_the_us__nifc:
-    - data-private://garden/climate/2018-09-20/wildfire_data_in_the_us__nifc:
-      - snapshot-private://climate/2018-09-20/wildfire_data_in_the_us__nifc.feather
   data-private://grapher/working_hours/2017-09-19/female_to_male_ratio_of_time_devoted_to_unpaid_care_work__oecd__2014__split:
     - data-private://garden/working_hours/2017-09-19/female_to_male_ratio_of_time_devoted_to_unpaid_care_work__oecd__2014__split:
       - snapshot-private://working_hours/2017-09-19/female_to_male_ratio_of_time_devoted_to_unpaid_care_work__oecd__2014__split.feather
@@ -388,9 +382,6 @@ steps:
   data://grapher/economics/2016-09-20/tax_revenue__piketty__2014:
     - data://garden/economics/2016-09-20/tax_revenue__piketty__2014:
       - snapshot://economics/2016-09-20/tax_revenue__piketty__2014.feather
-  data://grapher/climate/2017-04-22/weather_fatality_rates_in_the_us__owid_based_on_noaa_and_lopez_holle_and_population_data:
-    - data://garden/climate/2017-04-22/weather_fatality_rates_in_the_us__owid_based_on_noaa_and_lopez_holle_and_population_data:
-      - snapshot://climate/2017-04-22/weather_fatality_rates_in_the_us__owid_based_on_noaa_and_lopez_holle_and_population_data.feather
   data://grapher/economics/2017-05-12/swedish_historical_national_accounts__schon_and_krantz__2007__2012__2015:
     - data://garden/economics/2017-05-12/swedish_historical_national_accounts__schon_and_krantz__2007__2012__2015:
       - snapshot://economics/2017-05-12/swedish_historical_national_accounts__schon_and_krantz__2007__2012__2015.feather
@@ -412,21 +403,12 @@ steps:
   data://grapher/demography/2018-03-21/historical_gender_equality_index__how_was_life__2014:
     - data://garden/demography/2018-03-21/historical_gender_equality_index__how_was_life__2014:
       - snapshot://demography/2018-03-21/historical_gender_equality_index__how_was_life__2014.feather
-  data://grapher/climate/2018-03-21/economic_impacts_of_1_5c__pretis_et_al:
-    - data://garden/climate/2018-03-21/economic_impacts_of_1_5c__pretis_et_al:
-      - snapshot://climate/2018-03-21/economic_impacts_of_1_5c__pretis_et_al.feather
   data://grapher/economics/2018-03-22/womens_economic_opportunity_2012__economist_intelligence_unit__2012:
     - data://garden/economics/2018-03-22/womens_economic_opportunity_2012__economist_intelligence_unit__2012:
       - snapshot://economics/2018-03-22/womens_economic_opportunity_2012__economist_intelligence_unit__2012.feather
   data://grapher/demography/2018-01-31/number_of_deaths_in_england_and_wales_by_age__ons:
     - data://garden/demography/2018-01-31/number_of_deaths_in_england_and_wales_by_age__ons:
       - snapshot://demography/2018-01-31/number_of_deaths_in_england_and_wales_by_age__ons.feather
-  data://grapher/climate/2018-04-05/parties_to_montreal_protocol__unep__2023:
-    - data://garden/climate/2018-04-05/parties_to_montreal_protocol__unep__2023:
-      - snapshot://climate/2018-04-05/parties_to_montreal_protocol__unep__2023.feather
-  data://grapher/climate/2018-04-06/ozone_depletion_impacts_on_skin_cancer_incidence__slaper_et_al__1996:
-    - data://garden/climate/2018-04-06/ozone_depletion_impacts_on_skin_cancer_incidence__slaper_et_al__1996:
-      - snapshot://climate/2018-04-06/ozone_depletion_impacts_on_skin_cancer_incidence__slaper_et_al__1996.feather
   data://grapher/plastic_waste/2018-08-01/plastic_discarded__recycled__incinerated__geyer_et_al__2017:
     - data://garden/plastic_waste/2018-08-01/plastic_discarded__recycled__incinerated__geyer_et_al__2017:
       - snapshot://plastic_waste/2018-08-01/plastic_discarded__recycled__incinerated__geyer_et_al__2017.feather
@@ -460,15 +442,9 @@ steps:
   data://grapher/health/2018-03-24/drinking_habits_in_great_britain__uk_ons:
     - data://garden/health/2018-03-24/drinking_habits_in_great_britain__uk_ons:
       - snapshot://health/2018-03-24/drinking_habits_in_great_britain__uk_ons.feather
-  data://grapher/climate/2018-07-01/ozone_and_chlorine_projections_to_2100__scientific_assessment__2014:
-    - data://garden/climate/2018-07-01/ozone_and_chlorine_projections_to_2100__scientific_assessment__2014:
-      - snapshot://climate/2018-07-01/ozone_and_chlorine_projections_to_2100__scientific_assessment__2014.feather
   data://grapher/trade/2018-03-19/share_of_world_merchandise_trade_by_type_of_trade__fouquin_and_hugot__cepii_2016__dyadic_data:
     - data://garden/trade/2018-03-19/share_of_world_merchandise_trade_by_type_of_trade__fouquin_and_hugot__cepii_2016__dyadic_data:
       - snapshot://trade/2018-03-19/share_of_world_merchandise_trade_by_type_of_trade__fouquin_and_hugot__cepii_2016__dyadic_data.feather
-  data://grapher/climate/2018-11-07/economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018:
-    - data://garden/climate/2018-11-07/economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018:
-      - snapshot://climate/2018-11-07/economic_losses_from_disasters_as_a_share_of_gdp__pielke__2018.feather
   data-private://grapher/forests/2020-12-31/indonesian_deforestation_drivers__austin_et_al__2019:
     - data-private://garden/forests/2020-12-31/indonesian_deforestation_drivers__austin_et_al__2019:
       - snapshot-private://forests/2020-12-31/indonesian_deforestation_drivers__austin_et_al__2019.feather
@@ -562,9 +538,6 @@ steps:
   data-private://grapher/poverty_inequality/2022-11-01/inequality_among_world_citizens__bourguignon_and_morrisson__2002:
     - data-private://garden/poverty_inequality/2022-11-01/inequality_among_world_citizens__bourguignon_and_morrisson__2002:
       - snapshot-private://poverty_inequality/2022-11-01/inequality_among_world_citizens__bourguignon_and_morrisson__2002.feather
-  data-private://grapher/climate/2022-09-10/young_people_opinions_climate_change__hickman_et_al__2021:
-    - data-private://garden/climate/2022-09-10/young_people_opinions_climate_change__hickman_et_al__2021:
-      - snapshot-private://climate/2022-09-10/young_people_opinions_climate_change__hickman_et_al__2021.feather
   data://grapher/economics/2017-10-01/relative_wages_of_craftsmen_to_labourers__1200_2000__clark__2005:
     - data://garden/economics/2017-10-01/relative_wages_of_craftsmen_to_labourers__1200_2000__clark__2005:
       - snapshot://economics/2017-10-01/relative_wages_of_craftsmen_to_labourers__1200_2000__clark__2005.feather
@@ -841,18 +814,12 @@ steps:
   data://grapher/fisheries/2018-03-08/fishery_catch_breakdown__pauly_and_zeller__2016:
     - data://garden/fisheries/2018-03-08/fishery_catch_breakdown__pauly_and_zeller__2016:
       - snapshot://fisheries/2018-03-08/fishery_catch_breakdown__pauly_and_zeller__2016.feather
-  data://grapher/climate/2018-01-01/economic_impacts_of_2c__pretis_et_al__2018:
-    - data://garden/climate/2018-01-01/economic_impacts_of_2c__pretis_et_al__2018:
-      - snapshot://climate/2018-01-01/economic_impacts_of_2c__pretis_et_al__2018.feather
   data-private://grapher/oecd/2020-11-05/time_use_across_activities__oecd_gender_data__2020:
     - data-private://garden/oecd/2020-11-05/time_use_across_activities__oecd_gender_data__2020:
       - snapshot-private://oecd/2020-11-05/time_use_across_activities__oecd_gender_data__2020.feather
   data://grapher/health/2018-04-19/mental_health_as_risk_factor_for_substance_use__swendsen_et_al__2010:
     - data://garden/health/2018-04-19/mental_health_as_risk_factor_for_substance_use__swendsen_et_al__2010:
       - snapshot://health/2018-04-19/mental_health_as_risk_factor_for_substance_use__swendsen_et_al__2010.feather
-  data://grapher/climate/2018-01-01/ozone_depleting_emissions_since_1960__scientific_assessment__2014:
-    - data://garden/climate/2018-01-01/ozone_depleting_emissions_since_1960__scientific_assessment__2014:
-      - snapshot://climate/2018-01-01/ozone_depleting_emissions_since_1960__scientific_assessment__2014.feather
   data-private://grapher/oecd/2015-08-18/transport_and_communication_costs__oecd_economic_outlook__2007:
     - data-private://garden/oecd/2015-08-18/transport_and_communication_costs__oecd_economic_outlook__2007:
       - snapshot-private://oecd/2015-08-18/transport_and_communication_costs__oecd_economic_outlook__2007.feather
@@ -874,9 +841,6 @@ steps:
   data-private://grapher/agriculture/2021-01-11/soil_lifespans__evans_et_al__2020:
     - data-private://garden/agriculture/2021-01-11/soil_lifespans__evans_et_al__2020:
       - snapshot-private://agriculture/2021-01-11/soil_lifespans__evans_et_al__2020.feather
-  data-private://grapher/climate/2021-04-13/coral_bleaching_events_by_enso_phase__hughes_et_al__2018:
-    - data-private://garden/climate/2021-04-13/coral_bleaching_events_by_enso_phase__hughes_et_al__2018:
-      - snapshot-private://climate/2021-04-13/coral_bleaching_events_by_enso_phase__hughes_et_al__2018.feather
   data://grapher/biodiversity/2022-12-12/uk_butterfly_populations__uk_ons:
     - data://garden/biodiversity/2022-12-12/uk_butterfly_populations__uk_ons:
       - snapshot://biodiversity/2022-12-12/uk_butterfly_populations__uk_ons.feather

--- a/snapshots/climate/latest/weekly_wildfires.csv.dvc
+++ b/snapshots/climate/latest/weekly_wildfires.csv.dvc
@@ -1,5 +1,3 @@
-autoupdate:
-  name: Wildfires
 meta:
   origin:
     producer: Global Wildfire Information System


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

Structural refactor of the climate pipeline, with **no data or chart changes**. This is the first of a small series; the actual data update lands in a later PR.

## What changed

- **Stop the wildfires autoupdate.** Removed the `autoupdate:` block from `snapshots/climate/latest/weekly_wildfires.csv.dvc`, so the daily `etl autoupdate` job no longer opens weekly wildfire PRs. Wildfires will be refreshed as part of the monthly climate update instead.
- **Consolidate the DAG.** Moved the 12 frozen legacy climate chains out of `dag/migrated.yml` into `dag/climate.yml`, so every climate-namespace step now lives in one file.
- **Reorganize `climate.yml`.** Split into a `NOT UPDATEABLE` block at the top (migrated legacy datasets, IPCC scenarios, the EPA 2024-04-17 chains, and global sea level, all marked frozen) and an `UPDATEABLE` block below. Frozen dependencies of `climate_change_impacts` are now defined at the top and referenced by path.
- **New `climate-update` skill** documenting the monthly batch: dataset inventory, frozen skiplist, dependency order, single-PR / single-announcement discipline, and a wildfires-only subset for fire season.

## Verification

- Resolved DAG is byte-identical to before the reorg (no checksums change, nothing re-runs).
- `etl autoupdate --dry-run` no longer picks up wildfires.
- All climate-namespace steps now live in `climate.yml`; both YAML files parse; `make check` passes.

## Not in this PR (follow-ups)

- **owid-issues**: replace the 8 per-dataset climate reminders with one monthly `update-climate.yml`.
- **Data update**: bump all updateable climate datasets to a common version, de-`latest` wildfires, and migrate `ipcc_scenarios` and the EPA chains into the `climate` namespace (with chart / explorer remaps).