### PR TITLE
📊 Add .corrections.yml mechanism for known upstream data errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,8 @@
       "**/*.meta.override.yml"
     ],
     "schemas/multidim-schema.json": "etl/steps/export/multidim/**/*.config.yml",
-    "schemas/explorer-schema.json": "etl/steps/export/explorers/**/*.config.yml"
+    "schemas/explorer-schema.json": "etl/steps/export/explorers/**/*.config.yml",
+    "schemas/corrections-schema.json": "**/*.corrections.yml"
   },
   "[python]": {
     "editor.formatOnSave": true,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,16 @@ def run() -> None:
     ds_garden.save()
 ```
 
+### Correcting known upstream data errors (`.corrections.yml`)
+
+For a *known error in the source data* that we patch locally until the provider fixes it, don't scatter inline `.loc[...]` / `.drop(...)` edits — record it declaratively in a `<short_name>.corrections.yml` next to the step and apply it in one line:
+
+```python
+tb = paths.apply_corrections(tb)   # no-op if there's no corrections file
+```
+
+Each entry carries the locator (`entity` + `years`, or `match: {value: ...}`), an `action` (`drop` / `override` / `scale` / `flag`), and bookkeeping (`reason`, `provider`, `status`, optional `reported`). Add an `expect:` guard on `override`/`scale` so the step **fails loudly if the source fixes the value** (`drop` self-validates). Garden is the default home. See `etl/data_corrections.py` for the full format, and run `etl corrections -o /tmp/c.html --charts` to inventory + visualise every correction in the repo. This is for enumerated provider point-errors — systematic recoding *rules* and aggregation stay in step code.
+
 ### Ad-hoc Data Exploration
 ```python
 from etl.snapshot import Snapshot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,13 +183,7 @@ def run() -> None:
 
 ### Correcting known upstream data errors (`.corrections.yml`)
 
-For a *known error in the source data* that we patch locally until the provider fixes it, don't scatter inline `.loc[...]` / `.drop(...)` edits — record it declaratively in a `<short_name>.corrections.yml` next to the step and apply it in one line:
-
-```python
-tb = paths.apply_corrections(tb)   # no-op if there's no corrections file
-```
-
-Each entry carries the locator (`entity` + `years`, or `match: {value: ...}`), an `action` (`drop` / `override` / `scale` / `flag`), and bookkeeping (`reason`, `provider`, `status`, optional `reported`). Add an `expect:` guard on `override`/`scale` so the step **fails loudly if the source fixes the value** (`drop` self-validates). Garden is the default home. See `etl/data_corrections.py` for the full format, and run `etl corrections -o /tmp/c.html --charts` to inventory + visualise every correction in the repo. This is for enumerated provider point-errors — systematic recoding *rules* and aggregation stay in step code.
+For a known *source* error we patch locally until the provider fixes it, don't inline `.loc[...]`/`.drop(...)` — declare it in a `<short_name>.corrections.yml` next to the step and apply with `tb = paths.apply_corrections(tb)`. See `etl/data_corrections.py` for the format; `etl corrections -o /tmp/c.html --charts` inventories and visualises them all. For enumerated provider point-errors only — systematic recoding *rules* and aggregation stay in step code.
 
 ### Ad-hoc Data Exploration
 ```python

--- a/apps/cli/__init__.py
+++ b/apps/cli/__init__.py
@@ -150,6 +150,7 @@ GROUPS = (
                 "archive-dag": "apps.archive_dag.cli.cli",
                 "pr": "apps.pr.cli.cli",
                 "pr-clean": "apps.pr.cli.clean_cli",
+                "corrections": "apps.corrections.cli.cli",
             },
         },
         {

--- a/apps/corrections/cli.py
+++ b/apps/corrections/cli.py
@@ -65,8 +65,13 @@ def collect_corrections(step_dir: Path) -> list[dict[str, Any]]:
 
 
 def _fmt(v: float | None) -> str:
-    """Compact human-readable number (e.g. -1.23, 6.4e+07)."""
-    return "—" if v is None else f"{v:.4g}"
+    """Human-readable number with thousands separators (e.g. 56,180,148 · -742,811 · 14.2)."""
+    if v is None:
+        return "—"
+    a = abs(v)
+    if a != 0 and (a < 0.01 or a >= 1e15):
+        return f"{v:.3g}"  # fall back to scientific only for extreme magnitudes
+    return f"{v:,.2f}".rstrip("0").rstrip(".") or "0"
 
 
 def _affected_table(affected: list, action: str) -> str:

--- a/apps/corrections/cli.py
+++ b/apps/corrections/cli.py
@@ -11,6 +11,7 @@ the cross-dataset view of known upstream data errors and what we've reported to 
 
 import datetime as dt
 import html
+import json
 import webbrowser
 from pathlib import Path
 from typing import Any
@@ -79,76 +80,81 @@ def _affected_table(affected: list, action: str) -> str:
     return f'<table class="affected"><thead><tr><th>Year</th><th>Before</th><th>{after_label}</th></tr></thead><tbody>{body}</tbody></table>'
 
 
-def _chart_svg(series: list, affected: list, action: str) -> str:
-    """SVG of the full *pre-correction* series, with the problematic (before) values highlighted.
+def _plotly_source() -> str:
+    """The bundled plotly.min.js shipped with the plotly Python package (inlined for a portable file)."""
+    import plotly
 
-    Uses a symlog y-axis when the values cross zero or span many orders of magnitude, so a small
-    negative dip stays visible next to values that are millions of times larger.
-    """
-    import math
+    return (Path(plotly.__file__).parent / "package_data" / "plotly.min.js").read_text()
 
-    w, h = 720, 280
-    ml, mr, mt, mb = 64, 24, 16, 34  # margins
-    pts = [(int(y), float(v)) for y, v in series]
-    after_pts = [(int(y), a) for y, _, a in affected if action != "drop" and a is not None]
-    before_pts = [(int(y), b) for y, b, _ in affected if b is not None]
-    all_vals = [v for _, v in pts] + [a for _, a in after_pts] + [b for _, b in before_pts]
-    if not pts or not all_vals:
-        return '<span class="note">No numeric data captured for this correction.</span>'
 
-    years = [y for y, _ in pts] + [y for y, _ in before_pts]
-    if len(set(years)) < 2:
-        return ""  # a single-year "series" is not a time series — the before→after table says it all
-    ymin_x, ymax_x = min(years), max(years)
-    vmin, vmax = min(all_vals), max(all_vals)
-    nonzero = [abs(v) for v in all_vals if v != 0]
-    use_symlog = (vmin < 0 < vmax) or (nonzero and max(nonzero) / min(nonzero) > 1000)
-    linthresh = min(nonzero) if nonzero else 1.0
+def _chart_traces(ent: dict[str, Any], action: str) -> tuple[list, dict]:
+    """Build Plotly traces + layout for one entity: the pre-correction series with bad/corrected points."""
+    series = ent["series"]
+    affected = ent["affected"]
+    before = [(y, b) for y, b, _ in affected if b is not None]
+    after = [(y, a) for y, _, a in affected if action != "drop" and a is not None]
 
-    def t(v: float) -> float:
-        return math.copysign(math.log10(1 + abs(v) / linthresh), v) if use_symlog else v
-
-    tmin, tmax = t(vmin), t(vmax)
-    tspan = (tmax - tmin) or 1.0
-    xspan = (ymax_x - ymin_x) or 1
-
-    def px(year: float) -> float:
-        return ml + (year - ymin_x) / xspan * (w - ml - mr)
-
-    def py(val: float) -> float:
-        return h - mb - (t(val) - tmin) / tspan * (h - mt - mb)
-
-    # Horizontal gridlines / y labels at min, max, and 0 (if the range crosses it).
-    grid_vals = sorted({vmin, vmax} | ({0.0} if vmin < 0 < vmax else set()))
-    grid = "".join(
-        f'<line x1="{ml}" y1="{py(gv):.1f}" x2="{w - mr}" y2="{py(gv):.1f}" stroke="#eee"/>'
-        f'<text x="{ml - 6}" y="{py(gv) + 3:.1f}" font-size="11" fill="#999" text-anchor="end">{_fmt(gv)}</text>'
-        for gv in grid_vals
-    )
-    line = " ".join(f"{px(y):.1f},{py(v):.1f}" for y, v in pts)
-    polyline = f'<polyline points="{line}" fill="none" stroke="#9bb" stroke-width="1.5"/>' if len(pts) > 1 else ""
-    dots = "".join(f'<circle cx="{px(y):.1f}" cy="{py(v):.1f}" r="2.5" fill="#9bb"/>' for y, v in pts)
-    # Problematic (before) values in red — these are the points the correction acts on.
-    bad = "".join(f'<circle cx="{px(y):.1f}" cy="{py(b):.1f}" r="5" fill="#d9534f"/>' for y, b in before_pts)
-    # Corrected (after) values in green (scale/override only).
-    good = "".join(f'<circle cx="{px(y):.1f}" cy="{py(a):.1f}" r="4" fill="#5cb85c"/>' for y, a in after_pts)
-
-    return (
-        f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}" xmlns="http://www.w3.org/2000/svg" class="chart">'
-        f"{grid}{polyline}{dots}{bad}{good}"
-        f'<text x="{ml}" y="{h - 8}" font-size="11" fill="#999">{ymin_x}</text>'
-        f'<text x="{w - mr}" y="{h - 8}" font-size="11" fill="#999" text-anchor="end">{ymax_x}</text>'
-        + (
-            f'<text x="{w - mr}" y="{mt + 10}" font-size="10" fill="#bbb" text-anchor="end">symlog</text>'
-            if use_symlog
-            else ""
+    traces: list[dict] = []
+    if series:
+        traces.append(
+            {
+                "x": [y for y, _ in series],
+                "y": [v for _, v in series],
+                "mode": "lines+markers",
+                "name": "series",
+                "line": {"color": "#9bb7c0"},
+                "marker": {"size": 5, "color": "#9bb7c0"},
+            }
         )
-        + "</svg>"
-    )
+    if before:
+        traces.append(
+            {
+                "x": [y for y, _ in before],
+                "y": [b for _, b in before],
+                "mode": "markers",
+                "name": "removed (bad)" if action == "drop" else "original (bad)",
+                "marker": {"size": 11, "color": "#d9534f", "symbol": "circle"},
+            }
+        )
+    if after:
+        traces.append(
+            {
+                "x": [y for y, _ in after],
+                "y": [a for _, a in after],
+                "mode": "markers",
+                "name": "corrected",
+                "marker": {"size": 9, "color": "#5cb85c", "symbol": "diamond"},
+            }
+        )
+    layout = {
+        "margin": {"t": 28, "r": 12, "b": 36, "l": 64},
+        "height": 300,
+        "hovermode": "closest",
+        "showlegend": True,
+        "legend": {"orientation": "h", "y": -0.2},
+        "xaxis": {"title": {"text": "Year"}, "tickformat": "d"},
+        "yaxis": {"title": {"text": ""}},
+        # A Linear/Log y-axis toggle (log drops non-positive points, so Linear stays the default).
+        "updatemenus": [
+            {
+                "type": "buttons",
+                "direction": "right",
+                "x": 1,
+                "xanchor": "right",
+                "y": 1.2,
+                "showactive": True,
+                "buttons": [
+                    {"label": "Linear", "method": "relayout", "args": [{"yaxis.type": "linear"}]},
+                    {"label": "Log", "method": "relayout", "args": [{"yaxis.type": "log"}]},
+                ],
+            }
+        ],
+    }
+    return traces, layout
 
 
 def _chart_cell(r: dict[str, Any]) -> str:
-    """The expandable detail for a correction: a before→after table plus a time-series chart."""
+    """The expandable detail for a correction: a before→after table plus a Plotly time-series."""
     records = read_audit(r["path"])
     if records is None:
         rel = r["path"].parent.relative_to(STEP_DIR)
@@ -165,11 +171,17 @@ def _chart_cell(r: dict[str, Any]) -> str:
     for ent in rec["entities"]:
         if not ent["affected"]:
             continue
+        traces, layout = _chart_traces(ent, action)
+        # Plotly is initialised lazily (on row expand) from these data-* attributes — the detail row is
+        # display:none until then, and Plotly can't size a hidden container.
+        traces_attr = html.escape(json.dumps(traces), quote=True)
+        layout_attr = html.escape(json.dumps(layout), quote=True)
         blocks.append(
             f'<div class="entity-block">'
             f'<div class="note"><b>{html.escape(ent["entity"])}</b> · pre-correction series · {legend}</div>'
-            f'<div class="chart-row">{_affected_table(ent["affected"], action)}{_chart_svg(ent["series"], ent["affected"], action)}</div>'
-            f"</div>"
+            f'<div class="chart-row">{_affected_table(ent["affected"], action)}'
+            f'<div class="plot" data-traces="{traces_attr}" data-layout="{layout_attr}"></div>'
+            f"</div></div>"
         )
     return "".join(blocks) or '<span class="note">No affected points captured.</span>'
 
@@ -223,6 +235,9 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str, charts: bool) ->
         if charts:
             body_rows.append(f'<tr class="detail"><td colspan="{n_cols}">{_chart_cell(r)}</td></tr>')
 
+    # Inline the Plotly bundle only when charts are requested (keeps the metadata-only report small).
+    plotly_script = f"<script>{_plotly_source()}</script>" if charts else ""
+
     return f"""<!doctype html>
 <html lang="en">
 <head>
@@ -255,9 +270,9 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str, charts: bool) ->
   tr.detail td {{ background: #fbfbfd; padding: 1rem; }}
   tr.hidden {{ display: none !important; }}
   .note {{ color: #888; font-size: .78rem; margin-bottom: .4rem; }}
-  .entity-block {{ margin-bottom: 1.25rem; }}
+  .entity-block {{ margin-bottom: 1.5rem; }}
   .chart-row {{ display: flex; gap: 1.5rem; align-items: flex-start; flex-wrap: wrap; }}
-  .chart {{ background: #fff; border: 1px solid #eee; border-radius: 6px; }}
+  .plot {{ flex: 1 1 560px; min-width: 480px; height: 300px; }}
   table.affected {{ border-collapse: collapse; font-size: .8rem; min-width: 220px; }}
   table.affected th, table.affected td {{ border: 1px solid #eee; padding: .3rem .6rem; text-align: right; }}
   table.affected th {{ background: #f7f7f7; position: static; }}
@@ -280,6 +295,7 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str, charts: bool) ->
     </tbody>
   </table>
   </div>
+{plotly_script}
 <script>
   const mainRows = Array.from(document.querySelectorAll('#t tbody tr.main'));
   // Pair each main row with its detail row once, before any DOM moves (sorting breaks sibling links).
@@ -288,13 +304,25 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str, charts: bool) ->
     return [r, (n && n.classList.contains('detail')) ? n : null];
   }}));
 
+  // Plotly can't size a hidden container, so we draw each chart the first time its row is expanded.
+  const drawn = new WeakSet();
+  function drawPlots(detailRow) {{
+    if (typeof Plotly === 'undefined') return;
+    detailRow.querySelectorAll('.plot').forEach(div => {{
+      if (drawn.has(div)) return;
+      drawn.add(div);
+      Plotly.newPlot(div, JSON.parse(div.dataset.traces), JSON.parse(div.dataset.layout),
+                     {{responsive: true, displayModeBar: false}});
+    }});
+  }}
+
   // Click an expandable row to toggle its chart detail row.
   mainRows.forEach(row => {{
     if (!row.classList.contains('expandable')) return;
     row.addEventListener('click', () => {{
       row.classList.toggle('open');
       const d = detail.get(row);
-      if (d) d.classList.toggle('show');
+      if (d) {{ d.classList.toggle('show'); if (d.classList.contains('show')) drawPlots(d); }}
     }});
   }});
 

--- a/apps/corrections/cli.py
+++ b/apps/corrections/cli.py
@@ -255,7 +255,7 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str, charts: bool) ->
   .card .label {{ font-size: .75rem; color: #777; text-transform: uppercase; letter-spacing: .04em; }}
   input[type="search"] {{ width: 100%; max-width: 420px; padding: .5rem .75rem; border: 1px solid #ccc; border-radius: 6px; margin-bottom: 1rem; font-size: .9rem; }}
   .table-wrap {{ overflow-x: auto; background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; }}
-  table {{ border-collapse: collapse; width: 100%; font-size: .82rem; }}
+  #t {{ border-collapse: collapse; width: 100%; font-size: .82rem; }}
   th, td {{ text-align: left; padding: .55rem .75rem; border-bottom: 1px solid #f0f0f0; vertical-align: top; }}
   th {{ position: sticky; top: 0; background: #f7f7f7; font-weight: 600; cursor: pointer; white-space: nowrap; }}
   code {{ font-size: .78rem; background: #f3f3f3; padding: .1rem .3rem; border-radius: 3px; word-break: break-all; }}
@@ -272,8 +272,8 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str, charts: bool) ->
   .note {{ color: #888; font-size: .78rem; margin-bottom: .4rem; }}
   .entity-block {{ margin-bottom: 1.5rem; }}
   .chart-row {{ display: flex; gap: 1.5rem; align-items: flex-start; flex-wrap: wrap; }}
-  .plot {{ flex: 1 1 560px; min-width: 480px; height: 300px; }}
-  table.affected {{ border-collapse: collapse; font-size: .8rem; min-width: 220px; }}
+  .plot {{ flex: 0 1 620px; min-width: 0; height: 320px; }}
+  table.affected {{ border-collapse: collapse; font-size: .8rem; width: auto; flex: 0 0 auto; align-self: flex-start; }}
   table.affected th, table.affected td {{ border: 1px solid #eee; padding: .3rem .6rem; text-align: right; }}
   table.affected th {{ background: #f7f7f7; position: static; }}
   table.affected td.bad {{ color: #d9534f; font-weight: 600; }}

--- a/apps/corrections/cli.py
+++ b/apps/corrections/cli.py
@@ -1,0 +1,227 @@
+"""CLI to inventory and visualise all `.corrections.yml` files in the repo.
+
+Scans every step for a `.corrections.yml` sidecar, validates the entries (so this also acts as a
+repo-wide lint), and renders a self-contained HTML dashboard grouped by provider and status. This is
+the cross-dataset view of known upstream data errors and what we've reported to whom.
+
+    etl corrections                       # write ai/corrections.html and open it
+    etl corrections -o /tmp/c.html        # custom output path
+    etl corrections --no-open             # don't open a browser
+"""
+
+import datetime as dt
+import html
+import webbrowser
+from pathlib import Path
+from typing import Any
+
+import rich_click as click
+from rich.console import Console
+from rich.table import Table as RichTable
+
+from etl.data_corrections import load_corrections
+from etl.paths import BASE_DIR, STEP_DIR
+
+console = Console()
+
+# Colours for each status, used for the HTML badges.
+STATUS_COLORS = {
+    "open": "#d9534f",  # red — unreported error we're carrying
+    "reported": "#f0ad4e",  # amber — told the provider, awaiting fix
+    "acknowledged": "#5bc0de",  # blue — provider confirmed
+    "fixed_upstream": "#5cb85c",  # green — fixed at source (correction can likely be removed)
+}
+STATUS_ORDER = ["open", "reported", "acknowledged", "fixed_upstream"]
+
+
+def _locator(correction: dict[str, Any]) -> str:
+    """A human-readable description of which rows a correction targets."""
+    if "match" in correction:
+        return "match " + ", ".join(f"{k}={v}" for k, v in correction["match"].items())
+    return f"{correction.get('entity')} · {correction.get('years')}"
+
+
+def _action_detail(correction: dict[str, Any]) -> str:
+    """The action plus its parameter (value / factor), and the expect guard if present."""
+    action = correction.get("action", "")
+    if action == "override":
+        action += f" → {correction.get('value')!r}"
+    elif action == "scale":
+        action += f" × {correction.get('factor')}"
+    if "expect" in correction:
+        action += " (guarded)"
+    return action
+
+
+def collect_corrections(step_dir: Path) -> list[dict[str, Any]]:
+    """Find, load and validate every `.corrections.yml` under `step_dir`."""
+    rows = []
+    for path in sorted(step_dir.rglob("*.corrections.yml")):
+        # load_corrections validates each entry and raises on a malformed file.
+        for correction in load_corrections(path):
+            rows.append({"path": path, "correction": correction})
+    return rows
+
+
+def _render_html(rows: list[dict[str, Any]], generated_at: str) -> str:
+    """Render the inventory as a single self-contained HTML page."""
+    # Summary counts by status.
+    by_status = {s: sum(1 for r in rows if r["correction"].get("status") == s) for s in STATUS_ORDER}
+    summary_cards = "".join(
+        f'<div class="card"><div class="count" style="color:{STATUS_COLORS[s]}">{by_status[s]}</div>'
+        f'<div class="label">{s}</div></div>'
+        for s in STATUS_ORDER
+    )
+
+    # Sort rows by provider, then status order, then dataset path.
+    rows = sorted(
+        rows,
+        key=lambda r: (
+            str(r["correction"].get("provider", "")).lower(),
+            STATUS_ORDER.index(r["correction"]["status"]) if r["correction"].get("status") in STATUS_ORDER else 99,
+            str(r["path"]),
+        ),
+    )
+
+    body_rows = []
+    for r in rows:
+        c = r["correction"]
+        step = r["path"].relative_to(BASE_DIR)
+        # The step directory (drop the .corrections.yml filename) — the clickable dataset path.
+        dataset = str(step.parent.relative_to("etl/steps")) + "/" + r["path"].name.replace(".corrections.yml", "")
+        status = c.get("status", "")
+        color = STATUS_COLORS.get(status, "#999")
+        reported = c.get("reported", "")
+        body_rows.append(
+            "<tr>"
+            f"<td>{html.escape(str(c.get('provider', '')))}</td>"
+            f"<td><code>{html.escape(dataset)}</code></td>"
+            f"<td><code>{html.escape(str(c.get('indicator', '')))}</code></td>"
+            f"<td>{html.escape(_locator(c))}</td>"
+            f"<td>{html.escape(_action_detail(c))}</td>"
+            f'<td><span class="badge" style="background:{color}">{html.escape(status)}</span></td>'
+            f"<td>{html.escape(str(reported))}</td>"
+            f'<td class="reason">{html.escape(str(c.get("reason", "")))}</td>'
+            "</tr>"
+        )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Data corrections inventory</title>
+<style>
+  :root {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }}
+  body {{ margin: 0; padding: 2rem; color: #1a1a1a; background: #fafafa; }}
+  h1 {{ font-size: 1.4rem; margin: 0 0 .25rem; }}
+  .sub {{ color: #777; font-size: .85rem; margin-bottom: 1.5rem; }}
+  .cards {{ display: flex; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap; }}
+  .card {{ background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; padding: .75rem 1.25rem; text-align: center; min-width: 90px; }}
+  .card .count {{ font-size: 1.6rem; font-weight: 700; }}
+  .card .label {{ font-size: .75rem; color: #777; text-transform: uppercase; letter-spacing: .04em; }}
+  input[type="search"] {{ width: 100%; max-width: 420px; padding: .5rem .75rem; border: 1px solid #ccc; border-radius: 6px; margin-bottom: 1rem; font-size: .9rem; }}
+  .table-wrap {{ overflow-x: auto; background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; }}
+  table {{ border-collapse: collapse; width: 100%; font-size: .82rem; }}
+  th, td {{ text-align: left; padding: .55rem .75rem; border-bottom: 1px solid #f0f0f0; vertical-align: top; }}
+  th {{ position: sticky; top: 0; background: #f7f7f7; font-weight: 600; cursor: pointer; white-space: nowrap; }}
+  code {{ font-size: .78rem; background: #f3f3f3; padding: .1rem .3rem; border-radius: 3px; word-break: break-all; }}
+  .badge {{ color: #fff; padding: .15rem .5rem; border-radius: 10px; font-size: .72rem; font-weight: 600; white-space: nowrap; }}
+  .reason {{ max-width: 380px; color: #444; }}
+  tr:hover {{ background: #fcfcff; }}
+</style>
+</head>
+<body>
+  <h1>Data corrections inventory</h1>
+  <div class="sub">{len(rows)} corrections across the repo · generated {generated_at}</div>
+  <div class="cards">{summary_cards}</div>
+  <input type="search" id="filter" placeholder="Filter (provider, dataset, country, reason…)">
+  <div class="table-wrap">
+  <table id="t">
+    <thead><tr>
+      <th>Provider</th><th>Dataset</th><th>Indicator</th><th>Locator</th>
+      <th>Action</th><th>Status</th><th>Reported</th><th>Reason</th>
+    </tr></thead>
+    <tbody>
+      {"".join(body_rows)}
+    </tbody>
+  </table>
+  </div>
+<script>
+  // Live text filter across all cells.
+  const input = document.getElementById('filter');
+  const rows = Array.from(document.querySelectorAll('#t tbody tr'));
+  input.addEventListener('input', () => {{
+    const q = input.value.toLowerCase();
+    rows.forEach(r => {{ r.style.display = r.textContent.toLowerCase().includes(q) ? '' : 'none'; }});
+  }});
+  // Click a header to sort by that column.
+  document.querySelectorAll('#t th').forEach((th, i) => {{
+    let asc = true;
+    th.addEventListener('click', () => {{
+      const body = document.querySelector('#t tbody');
+      Array.from(body.querySelectorAll('tr'))
+        .sort((a, b) => a.cells[i].textContent.localeCompare(b.cells[i].textContent) * (asc ? 1 : -1))
+        .forEach(r => body.appendChild(r));
+      asc = !asc;
+    }});
+  }});
+</script>
+</body>
+</html>
+"""
+
+
+def _print_terminal_summary(rows: list[dict[str, Any]]) -> None:
+    table = RichTable(title=f"{len(rows)} data corrections", show_lines=False)
+    table.add_column("Provider")
+    table.add_column("Dataset")
+    table.add_column("Locator")
+    table.add_column("Action")
+    table.add_column("Status")
+    for r in sorted(rows, key=lambda r: str(r["correction"].get("provider", ""))):
+        c = r["correction"]
+        dataset = str(r["path"].parent.relative_to(STEP_DIR)) + "/" + r["path"].name.replace(".corrections.yml", "")
+        table.add_row(
+            str(c.get("provider", "")),
+            dataset,
+            _locator(c),
+            _action_detail(c),
+            str(c.get("status", "")),
+        )
+    console.print(table)
+
+
+@click.command(name="corrections", cls=click.RichCommand)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=BASE_DIR / "ai" / "corrections.html",
+    help="Path to write the HTML dashboard.",
+)
+@click.option("--open/--no-open", "open_browser", default=True, help="Open the dashboard in a browser.")
+def cli(output: Path, open_browser: bool) -> None:
+    """Inventory all `.corrections.yml` files and render an HTML dashboard.
+
+    Scans every step for a `.corrections.yml` sidecar, validates each entry, and writes a
+    self-contained HTML page grouped by provider and status.
+    """
+    rows = collect_corrections(STEP_DIR)
+    if not rows:
+        console.print("[yellow]No .corrections.yml files found.[/yellow]")
+        return
+
+    _print_terminal_summary(rows)
+
+    generated_at = dt.datetime.now().strftime("%Y-%m-%d %H:%M")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(_render_html(rows, generated_at))
+    console.print(f"\n[green]Wrote[/green] {output}")
+
+    if open_browser:
+        webbrowser.open(f"file://{output.resolve()}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/apps/corrections/cli.py
+++ b/apps/corrections/cli.py
@@ -16,11 +16,10 @@ from pathlib import Path
 from typing import Any
 
 import rich_click as click
-from owid.catalog import Dataset
 from rich.console import Console
 from rich.table import Table as RichTable
 
-from etl.data_corrections import load_corrections
+from etl.data_corrections import _label, load_corrections, read_audit
 from etl.paths import BASE_DIR, STEP_DIR
 
 console = Console()
@@ -64,116 +63,115 @@ def collect_corrections(step_dir: Path) -> list[dict[str, Any]]:
     return rows
 
 
-def _dataset_dir(corrections_path: Path) -> Path:
-    """The built-dataset directory that corresponds to a `.corrections.yml` file.
+def _fmt(v: float | None) -> str:
+    """Compact human-readable number (e.g. -1.23, 6.4e+07)."""
+    return "—" if v is None else f"{v:.4g}"
 
-    `etl/steps/data/garden/gcp/.../x.corrections.yml` → `data/garden/gcp/.../x`.
+
+def _affected_table(affected: list, action: str) -> str:
+    """A small table of the affected points: year, the (problematic) before value, and the after value."""
+    after_label = "After" if action != "drop" else "Result"
+    body = "".join(
+        f'<tr><td>{int(y)}</td><td class="bad">{_fmt(before)}</td>'
+        f"<td>{'removed' if action == 'drop' else _fmt(after)}</td></tr>"
+        for y, before, after in affected
+    )
+    return f'<table class="affected"><thead><tr><th>Year</th><th>Before</th><th>{after_label}</th></tr></thead><tbody>{body}</tbody></table>'
+
+
+def _chart_svg(series: list, affected: list, action: str) -> str:
+    """SVG of the full *pre-correction* series, with the problematic (before) values highlighted.
+
+    Uses a symlog y-axis when the values cross zero or span many orders of magnitude, so a small
+    negative dip stays visible next to values that are millions of times larger.
     """
-    rel = corrections_path.relative_to(STEP_DIR)  # e.g. data/garden/.../x.corrections.yml
-    return BASE_DIR / rel.parent / rel.name.replace(".corrections.yml", "")
+    import math
 
+    w, h = 720, 280
+    ml, mr, mt, mb = 64, 24, 16, 34  # margins
+    pts = [(int(y), float(v)) for y, v in series]
+    after_pts = [(int(y), a) for y, _, a in affected if action != "drop" and a is not None]
+    before_pts = [(int(y), b) for y, b, _ in affected if b is not None]
+    all_vals = [v for _, v in pts] + [a for _, a in after_pts] + [b for _, b in before_pts]
+    if not pts or not all_vals:
+        return '<span class="note">No numeric data captured for this correction.</span>'
 
-def _load_series(corrections_path: Path, indicator: str, entity: str, country_col: str = "country") -> list[tuple]:
-    """Return the published `(year, value)` series for `entity`/`indicator` from the built dataset.
+    years = [y for y, _ in pts] + [y for y, _ in before_pts]
+    if len(set(years)) < 2:
+        return ""  # a single-year "series" is not a time series — the before→after table says it all
+    ymin_x, ymax_x = min(years), max(years)
+    vmin, vmax = min(all_vals), max(all_vals)
+    nonzero = [abs(v) for v in all_vals if v != 0]
+    use_symlog = (vmin < 0 < vmax) or (nonzero and max(nonzero) / min(nonzero) > 1000)
+    linthresh = min(nonzero) if nonzero else 1.0
 
-    Raises on any problem (dataset not built, indicator renamed/absent) — the caller turns that into a
-    "chart unavailable" note rather than failing the whole report.
-    """
-    import pandas as pd
+    def t(v: float) -> float:
+        return math.copysign(math.log10(1 + abs(v) / linthresh), v) if use_symlog else v
 
-    ds = Dataset(_dataset_dir(corrections_path))
-    for table_name in ds.table_names:
-        tb = ds[table_name].reset_index()
-        if indicator in tb.columns and country_col in tb.columns and "year" in tb.columns:
-            if not pd.api.types.is_numeric_dtype(tb[indicator]):
-                raise ValueError(f"indicator '{indicator}' is categorical — no time series")
-            sub = tb[tb[country_col] == entity][["year", indicator]].dropna()
-            series = sorted((int(y), float(v)) for y, v in zip(sub["year"], sub[indicator]))
-            if series:
-                return series
-    raise ValueError(f"indicator '{indicator}' not found for '{entity}' in the built dataset")
+    tmin, tmax = t(vmin), t(vmax)
+    tspan = (tmax - tmin) or 1.0
+    xspan = (ymax_x - ymin_x) or 1
 
-
-def _affected_years(correction: dict[str, Any], series_years: list[int]) -> set[int]:
-    """Years the correction targets, intersected with the years present on the chart's axis."""
-    years = correction.get("years")
-    axis = set(series_years)
-    if years == "all":
-        return axis
-    if years == "latest":
-        return {max(series_years)} if series_years else set()
-    if isinstance(years, list):
-        return {int(y) for y in years}
-    if isinstance(years, dict):
-        lo = max(years.get("from", years.get("after", -(10**9)) + 1), min(axis, default=-(10**9)))
-        hi = min(years.get("to", years.get("before", 10**9) - 1), max(axis, default=10**9))
-        return {y for y in range(lo, hi + 1)}
-    return set()
-
-
-def _sparkline_svg(series: list[tuple], affected: set[int], action: str) -> str:
-    """A small self-contained SVG line chart of the series, annotating the affected years."""
-    w, h, pad = 480, 140, 32
-    years = [y for y, _ in series]
-    vals = [v for _, v in series]
-    ymin, ymax = min(years), max(years)
-    vmin, vmax = min(vals), max(vals)
-    xspan = max(ymax - ymin, 1)
-    vspan = max(vmax - vmin, 1e-9)
-
-    def px(year: int) -> float:
-        return pad + (year - ymin) / xspan * (w - 2 * pad)
+    def px(year: float) -> float:
+        return ml + (year - ymin_x) / xspan * (w - ml - mr)
 
     def py(val: float) -> float:
-        return h - pad - (val - vmin) / vspan * (h - 2 * pad)
+        return h - mb - (t(val) - tmin) / tspan * (h - mt - mb)
 
-    points = " ".join(f"{px(y):.1f},{py(v):.1f}" for y, v in series)
-    dots = "".join(f'<circle cx="{px(y):.1f}" cy="{py(v):.1f}" r="2" fill="#3b6"/>' for y, v in series)
+    # Horizontal gridlines / y labels at min, max, and 0 (if the range crosses it).
+    grid_vals = sorted({vmin, vmax} | ({0.0} if vmin < 0 < vmax else set()))
+    grid = "".join(
+        f'<line x1="{ml}" y1="{py(gv):.1f}" x2="{w - mr}" y2="{py(gv):.1f}" stroke="#eee"/>'
+        f'<text x="{ml - 6}" y="{py(gv) + 3:.1f}" font-size="11" fill="#999" text-anchor="end">{_fmt(gv)}</text>'
+        for gv in grid_vals
+    )
+    line = " ".join(f"{px(y):.1f},{py(v):.1f}" for y, v in pts)
+    polyline = f'<polyline points="{line}" fill="none" stroke="#9bb" stroke-width="1.5"/>' if len(pts) > 1 else ""
+    dots = "".join(f'<circle cx="{px(y):.1f}" cy="{py(v):.1f}" r="2.5" fill="#9bb"/>' for y, v in pts)
+    # Problematic (before) values in red — these are the points the correction acts on.
+    bad = "".join(f'<circle cx="{px(y):.1f}" cy="{py(b):.1f}" r="5" fill="#d9534f"/>' for y, b in before_pts)
+    # Corrected (after) values in green (scale/override only).
+    good = "".join(f'<circle cx="{px(y):.1f}" cy="{py(a):.1f}" r="4" fill="#5cb85c"/>' for y, a in after_pts)
 
-    # Annotate the affected years.
-    marks = []
-    for ay in sorted(affected):
-        x = px(ay)
-        if action == "drop":
-            # The dropped points are gone from the series — mark the position with a red axis tick.
-            marks.append(
-                f'<line x1="{x:.1f}" y1="{h - pad:.1f}" x2="{x:.1f}" y2="{h - pad + 6:.1f}" stroke="#d9534f" stroke-width="2"/>'
-            )
-        else:
-            # scale/override keep the (corrected) point — highlight it.
-            match = [v for yy, v in series if yy == ay]
-            if match:
-                marks.append(
-                    f'<circle cx="{x:.1f}" cy="{py(match[0]):.1f}" r="4" fill="none" stroke="#d9534f" stroke-width="2"/>'
-                )
-    polyline = f'<polyline points="{points}" fill="none" stroke="#3b6" stroke-width="1.5"/>' if len(series) > 1 else ""
     return (
-        f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}" xmlns="http://www.w3.org/2000/svg">'
-        f'<line x1="{pad}" y1="{h - pad}" x2="{w - pad}" y2="{h - pad}" stroke="#ddd"/>'
-        f"{polyline}{dots}{''.join(marks)}"
-        f'<text x="{pad}" y="{h - pad + 18}" font-size="10" fill="#999">{ymin}</text>'
-        f'<text x="{w - pad}" y="{h - pad + 18}" font-size="10" fill="#999" text-anchor="end">{ymax}</text>'
-        f'<text x="{pad - 4}" y="{py(vmax):.1f}" font-size="10" fill="#999" text-anchor="end">{vmax:g}</text>'
-        f'<text x="{pad - 4}" y="{py(vmin):.1f}" font-size="10" fill="#999" text-anchor="end">{vmin:g}</text>'
-        "</svg>"
+        f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}" xmlns="http://www.w3.org/2000/svg" class="chart">'
+        f"{grid}{polyline}{dots}{bad}{good}"
+        f'<text x="{ml}" y="{h - 8}" font-size="11" fill="#999">{ymin_x}</text>'
+        f'<text x="{w - mr}" y="{h - 8}" font-size="11" fill="#999" text-anchor="end">{ymax_x}</text>'
+        + (
+            f'<text x="{w - mr}" y="{mt + 10}" font-size="10" fill="#bbb" text-anchor="end">symlog</text>'
+            if use_symlog
+            else ""
+        )
+        + "</svg>"
     )
 
 
 def _chart_cell(r: dict[str, Any]) -> str:
-    """The expandable chart HTML for a correction row, or a note explaining why it's unavailable."""
-    c = r["correction"]
-    if "match" in c or "entity" not in c:
-        return '<span class="note">Chart not supported for match-based corrections.</span>'
-    try:
-        series = _load_series(r["path"], c["indicator"], c["entity"])
-    except (FileNotFoundError, ValueError, KeyError) as e:
-        return f'<span class="note">Chart unavailable: {html.escape(str(e))}. Build the step (or the indicator was renamed after the correction).</span>'
-    affected = _affected_years(c, [y for y, _ in series])
-    legend = "red tick = removed year" if c.get("action") == "drop" else "red ring = corrected value"
-    return (
-        f'<div class="note">Published (post-correction) series for {html.escape(c["entity"])} · {legend}</div>'
-        + _sparkline_svg(series, affected, c.get("action", ""))
-    )
+    """The expandable detail for a correction: a before→after table plus a time-series chart."""
+    records = read_audit(r["path"])
+    if records is None:
+        rel = r["path"].parent.relative_to(STEP_DIR)
+        return f'<span class="note">No audit captured yet — run the step (<code>etlr {rel}</code>) to generate chart data.</span>'
+    rec = next((x for x in records if x["label"] == _label(r["correction"])), None)
+    if rec is None:
+        return '<span class="note">No audit entry for this correction (re-run the step after editing it).</span>'
+    if not rec.get("numeric"):
+        return '<span class="note">Indicator is non-numeric (categorical) — no time series.</span>'
+
+    action = rec["action"]
+    legend = "red = removed values" if action == "drop" else "red = original (bad) value · green = corrected value"
+    blocks = []
+    for ent in rec["entities"]:
+        if not ent["affected"]:
+            continue
+        blocks.append(
+            f'<div class="entity-block">'
+            f'<div class="note"><b>{html.escape(ent["entity"])}</b> · pre-correction series · {legend}</div>'
+            f'<div class="chart-row">{_affected_table(ent["affected"], action)}{_chart_svg(ent["series"], ent["affected"], action)}</div>'
+            f"</div>"
+        )
+    return "".join(blocks) or '<span class="note">No affected points captured.</span>'
 
 
 def _render_html(rows: list[dict[str, Any]], generated_at: str, charts: bool) -> str:
@@ -257,6 +255,13 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str, charts: bool) ->
   tr.detail td {{ background: #fbfbfd; padding: 1rem; }}
   tr.hidden {{ display: none !important; }}
   .note {{ color: #888; font-size: .78rem; margin-bottom: .4rem; }}
+  .entity-block {{ margin-bottom: 1.25rem; }}
+  .chart-row {{ display: flex; gap: 1.5rem; align-items: flex-start; flex-wrap: wrap; }}
+  .chart {{ background: #fff; border: 1px solid #eee; border-radius: 6px; }}
+  table.affected {{ border-collapse: collapse; font-size: .8rem; min-width: 220px; }}
+  table.affected th, table.affected td {{ border: 1px solid #eee; padding: .3rem .6rem; text-align: right; }}
+  table.affected th {{ background: #f7f7f7; position: static; }}
+  table.affected td.bad {{ color: #d9534f; font-weight: 600; }}
 </style>
 </head>
 <body>

--- a/apps/corrections/cli.py
+++ b/apps/corrections/cli.py
@@ -4,9 +4,9 @@ Scans every step for a `.corrections.yml` sidecar, validates the entries (so thi
 repo-wide lint), and renders a self-contained HTML dashboard grouped by provider and status. This is
 the cross-dataset view of known upstream data errors and what we've reported to whom.
 
-    etl corrections                       # write ai/corrections.html and open it
-    etl corrections -o /tmp/c.html        # custom output path
-    etl corrections --no-open             # don't open a browser
+    etl corrections -o /tmp/c.html            # write the dashboard and open it
+    etl corrections -o /tmp/c.html --charts   # also embed per-correction time-series charts
+    etl corrections -o /tmp/c.html --no-open  # generate only, don't open a browser
 """
 
 import datetime as dt
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import rich_click as click
+from owid.catalog import Dataset
 from rich.console import Console
 from rich.table import Table as RichTable
 
@@ -63,7 +64,119 @@ def collect_corrections(step_dir: Path) -> list[dict[str, Any]]:
     return rows
 
 
-def _render_html(rows: list[dict[str, Any]], generated_at: str) -> str:
+def _dataset_dir(corrections_path: Path) -> Path:
+    """The built-dataset directory that corresponds to a `.corrections.yml` file.
+
+    `etl/steps/data/garden/gcp/.../x.corrections.yml` → `data/garden/gcp/.../x`.
+    """
+    rel = corrections_path.relative_to(STEP_DIR)  # e.g. data/garden/.../x.corrections.yml
+    return BASE_DIR / rel.parent / rel.name.replace(".corrections.yml", "")
+
+
+def _load_series(corrections_path: Path, indicator: str, entity: str, country_col: str = "country") -> list[tuple]:
+    """Return the published `(year, value)` series for `entity`/`indicator` from the built dataset.
+
+    Raises on any problem (dataset not built, indicator renamed/absent) — the caller turns that into a
+    "chart unavailable" note rather than failing the whole report.
+    """
+    import pandas as pd
+
+    ds = Dataset(_dataset_dir(corrections_path))
+    for table_name in ds.table_names:
+        tb = ds[table_name].reset_index()
+        if indicator in tb.columns and country_col in tb.columns and "year" in tb.columns:
+            if not pd.api.types.is_numeric_dtype(tb[indicator]):
+                raise ValueError(f"indicator '{indicator}' is categorical — no time series")
+            sub = tb[tb[country_col] == entity][["year", indicator]].dropna()
+            series = sorted((int(y), float(v)) for y, v in zip(sub["year"], sub[indicator]))
+            if series:
+                return series
+    raise ValueError(f"indicator '{indicator}' not found for '{entity}' in the built dataset")
+
+
+def _affected_years(correction: dict[str, Any], series_years: list[int]) -> set[int]:
+    """Years the correction targets, intersected with the years present on the chart's axis."""
+    years = correction.get("years")
+    axis = set(series_years)
+    if years == "all":
+        return axis
+    if years == "latest":
+        return {max(series_years)} if series_years else set()
+    if isinstance(years, list):
+        return {int(y) for y in years}
+    if isinstance(years, dict):
+        lo = max(years.get("from", years.get("after", -(10**9)) + 1), min(axis, default=-(10**9)))
+        hi = min(years.get("to", years.get("before", 10**9) - 1), max(axis, default=10**9))
+        return {y for y in range(lo, hi + 1)}
+    return set()
+
+
+def _sparkline_svg(series: list[tuple], affected: set[int], action: str) -> str:
+    """A small self-contained SVG line chart of the series, annotating the affected years."""
+    w, h, pad = 480, 140, 32
+    years = [y for y, _ in series]
+    vals = [v for _, v in series]
+    ymin, ymax = min(years), max(years)
+    vmin, vmax = min(vals), max(vals)
+    xspan = max(ymax - ymin, 1)
+    vspan = max(vmax - vmin, 1e-9)
+
+    def px(year: int) -> float:
+        return pad + (year - ymin) / xspan * (w - 2 * pad)
+
+    def py(val: float) -> float:
+        return h - pad - (val - vmin) / vspan * (h - 2 * pad)
+
+    points = " ".join(f"{px(y):.1f},{py(v):.1f}" for y, v in series)
+    dots = "".join(f'<circle cx="{px(y):.1f}" cy="{py(v):.1f}" r="2" fill="#3b6"/>' for y, v in series)
+
+    # Annotate the affected years.
+    marks = []
+    for ay in sorted(affected):
+        x = px(ay)
+        if action == "drop":
+            # The dropped points are gone from the series — mark the position with a red axis tick.
+            marks.append(
+                f'<line x1="{x:.1f}" y1="{h - pad:.1f}" x2="{x:.1f}" y2="{h - pad + 6:.1f}" stroke="#d9534f" stroke-width="2"/>'
+            )
+        else:
+            # scale/override keep the (corrected) point — highlight it.
+            match = [v for yy, v in series if yy == ay]
+            if match:
+                marks.append(
+                    f'<circle cx="{x:.1f}" cy="{py(match[0]):.1f}" r="4" fill="none" stroke="#d9534f" stroke-width="2"/>'
+                )
+    polyline = f'<polyline points="{points}" fill="none" stroke="#3b6" stroke-width="1.5"/>' if len(series) > 1 else ""
+    return (
+        f'<svg width="{w}" height="{h}" viewBox="0 0 {w} {h}" xmlns="http://www.w3.org/2000/svg">'
+        f'<line x1="{pad}" y1="{h - pad}" x2="{w - pad}" y2="{h - pad}" stroke="#ddd"/>'
+        f"{polyline}{dots}{''.join(marks)}"
+        f'<text x="{pad}" y="{h - pad + 18}" font-size="10" fill="#999">{ymin}</text>'
+        f'<text x="{w - pad}" y="{h - pad + 18}" font-size="10" fill="#999" text-anchor="end">{ymax}</text>'
+        f'<text x="{pad - 4}" y="{py(vmax):.1f}" font-size="10" fill="#999" text-anchor="end">{vmax:g}</text>'
+        f'<text x="{pad - 4}" y="{py(vmin):.1f}" font-size="10" fill="#999" text-anchor="end">{vmin:g}</text>'
+        "</svg>"
+    )
+
+
+def _chart_cell(r: dict[str, Any]) -> str:
+    """The expandable chart HTML for a correction row, or a note explaining why it's unavailable."""
+    c = r["correction"]
+    if "match" in c or "entity" not in c:
+        return '<span class="note">Chart not supported for match-based corrections.</span>'
+    try:
+        series = _load_series(r["path"], c["indicator"], c["entity"])
+    except (FileNotFoundError, ValueError, KeyError) as e:
+        return f'<span class="note">Chart unavailable: {html.escape(str(e))}. Build the step (or the indicator was renamed after the correction).</span>'
+    affected = _affected_years(c, [y for y, _ in series])
+    legend = "red tick = removed year" if c.get("action") == "drop" else "red ring = corrected value"
+    return (
+        f'<div class="note">Published (post-correction) series for {html.escape(c["entity"])} · {legend}</div>'
+        + _sparkline_svg(series, affected, c.get("action", ""))
+    )
+
+
+def _render_html(rows: list[dict[str, Any]], generated_at: str, charts: bool) -> str:
     """Render the inventory as a single self-contained HTML page."""
     # Summary counts by status.
     by_status = {s: sum(1 for r in rows if r["correction"].get("status") == s) for s in STATUS_ORDER}
@@ -83,6 +196,7 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str) -> str:
         ),
     )
 
+    n_cols = 9 if charts else 8
     body_rows = []
     for r in rows:
         c = r["correction"]
@@ -92,8 +206,12 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str) -> str:
         status = c.get("status", "")
         color = STATUS_COLORS.get(status, "#999")
         reported = c.get("reported", "")
+        # With charts on, the row is expandable and a leading caret toggles a detail row below it.
+        expand_cell = '<td class="caret">▸</td>' if charts else ""
+        row_class = "main expandable" if charts else "main"
         body_rows.append(
-            "<tr>"
+            f'<tr class="{row_class}">'
+            f"{expand_cell}"
             f"<td>{html.escape(str(c.get('provider', '')))}</td>"
             f"<td><code>{html.escape(dataset)}</code></td>"
             f"<td><code>{html.escape(str(c.get('indicator', '')))}</code></td>"
@@ -104,6 +222,8 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str) -> str:
             f'<td class="reason">{html.escape(str(c.get("reason", "")))}</td>'
             "</tr>"
         )
+        if charts:
+            body_rows.append(f'<tr class="detail"><td colspan="{n_cols}">{_chart_cell(r)}</td></tr>')
 
     return f"""<!doctype html>
 <html lang="en">
@@ -128,7 +248,15 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str) -> str:
   code {{ font-size: .78rem; background: #f3f3f3; padding: .1rem .3rem; border-radius: 3px; word-break: break-all; }}
   .badge {{ color: #fff; padding: .15rem .5rem; border-radius: 10px; font-size: .72rem; font-weight: 600; white-space: nowrap; }}
   .reason {{ max-width: 380px; color: #444; }}
-  tr:hover {{ background: #fcfcff; }}
+  tr.main:hover {{ background: #fcfcff; }}
+  tr.expandable {{ cursor: pointer; }}
+  .caret {{ color: #aaa; width: 1rem; transition: transform .1s; }}
+  tr.open .caret {{ transform: rotate(90deg); }}
+  tr.detail {{ display: none; }}
+  tr.detail.show {{ display: table-row; }}
+  tr.detail td {{ background: #fbfbfd; padding: 1rem; }}
+  tr.hidden {{ display: none !important; }}
+  .note {{ color: #888; font-size: .78rem; margin-bottom: .4rem; }}
 </style>
 </head>
 <body>
@@ -139,7 +267,7 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str) -> str:
   <div class="table-wrap">
   <table id="t">
     <thead><tr>
-      <th>Provider</th><th>Dataset</th><th>Indicator</th><th>Locator</th>
+      {"<th></th>" if charts else ""}<th>Provider</th><th>Dataset</th><th>Indicator</th><th>Locator</th>
       <th>Action</th><th>Status</th><th>Reported</th><th>Reason</th>
     </tr></thead>
     <tbody>
@@ -148,21 +276,43 @@ def _render_html(rows: list[dict[str, Any]], generated_at: str) -> str:
   </table>
   </div>
 <script>
-  // Live text filter across all cells.
+  const mainRows = Array.from(document.querySelectorAll('#t tbody tr.main'));
+  // Pair each main row with its detail row once, before any DOM moves (sorting breaks sibling links).
+  const detail = new Map(mainRows.map(r => {{
+    const n = r.nextElementSibling;
+    return [r, (n && n.classList.contains('detail')) ? n : null];
+  }}));
+
+  // Click an expandable row to toggle its chart detail row.
+  mainRows.forEach(row => {{
+    if (!row.classList.contains('expandable')) return;
+    row.addEventListener('click', () => {{
+      row.classList.toggle('open');
+      const d = detail.get(row);
+      if (d) d.classList.toggle('show');
+    }});
+  }});
+
+  // Live text filter over main rows (detail rows follow their main row).
   const input = document.getElementById('filter');
-  const rows = Array.from(document.querySelectorAll('#t tbody tr'));
   input.addEventListener('input', () => {{
     const q = input.value.toLowerCase();
-    rows.forEach(r => {{ r.style.display = r.textContent.toLowerCase().includes(q) ? '' : 'none'; }});
+    mainRows.forEach(row => {{
+      const hide = !row.textContent.toLowerCase().includes(q);
+      row.classList.toggle('hidden', hide);
+      const d = detail.get(row);
+      if (d) d.classList.toggle('hidden', hide);
+    }});
   }});
-  // Click a header to sort by that column.
+
+  // Click a header to sort by that column (keeps each detail row attached to its main row).
   document.querySelectorAll('#t th').forEach((th, i) => {{
     let asc = true;
     th.addEventListener('click', () => {{
       const body = document.querySelector('#t tbody');
-      Array.from(body.querySelectorAll('tr'))
+      mainRows
         .sort((a, b) => a.cells[i].textContent.localeCompare(b.cells[i].textContent) * (asc ? 1 : -1))
-        .forEach(r => body.appendChild(r));
+        .forEach(row => {{ body.appendChild(row); const d = detail.get(row); if (d) body.appendChild(d); }});
       asc = !asc;
     }});
   }});
@@ -197,15 +347,21 @@ def _print_terminal_summary(rows: list[dict[str, Any]]) -> None:
     "-o",
     "--output",
     type=click.Path(dir_okay=False, path_type=Path),
-    default=BASE_DIR / "ai" / "corrections.html",
-    help="Path to write the HTML dashboard.",
+    required=True,
+    help="Path to write the HTML dashboard (e.g. /tmp/corrections.html).",
 )
 @click.option("--open/--no-open", "open_browser", default=True, help="Open the dashboard in a browser.")
-def cli(output: Path, open_browser: bool) -> None:
+@click.option(
+    "--charts/--no-charts",
+    default=False,
+    help="Embed an expandable post-correction time-series chart per row (loads each built dataset).",
+)
+def cli(output: Path, open_browser: bool, charts: bool) -> None:
     """Inventory all `.corrections.yml` files and render an HTML dashboard.
 
     Scans every step for a `.corrections.yml` sidecar, validates each entry, and writes a
-    self-contained HTML page grouped by provider and status.
+    self-contained HTML page grouped by provider and status. With ``--charts``, each row expands to a
+    small time-series of the affected indicator (loaded from the built dataset — run the steps first).
     """
     rows = collect_corrections(STEP_DIR)
     if not rows:
@@ -216,7 +372,7 @@ def cli(output: Path, open_browser: bool) -> None:
 
     generated_at = dt.datetime.now().strftime("%Y-%m-%d %H:%M")
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(_render_html(rows, generated_at))
+    output.write_text(_render_html(rows, generated_at, charts=charts))
     console.print(f"\n[green]Wrote[/green] {output}")
 
     if open_browser:

--- a/etl/data_corrections.py
+++ b/etl/data_corrections.py
@@ -64,6 +64,7 @@ This module is the mechanism only. The cross-dataset dashboard, per-provider rep
 auto-expiry on re-ingestion are deliberately out of scope here.
 """
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -71,6 +72,8 @@ import numpy as np
 import yaml
 from owid.catalog import Table
 from structlog import get_logger
+
+from etl.paths import DATA_DIR, STEP_DIR
 
 log = get_logger()
 
@@ -315,3 +318,108 @@ def apply_corrections(
         tb = tb.reset_index(drop=True)
 
     return tb
+
+
+# --------------------------------------------------------------------------------------------------
+# Audit: capture the before/after of each correction so `etl corrections --charts` can show the
+# *problematic* values (which are gone from the published data once the correction is applied).
+# --------------------------------------------------------------------------------------------------
+
+
+def _to_float(value: Any) -> float | None:
+    """Coerce a value to float, or None if it's missing/non-numeric (e.g. a categorical entity)."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if f != f else f  # drop NaN
+
+
+def audit_path_for(corrections_path: Path | str) -> Path:
+    """Where the audit JSON for a given `.corrections.yml` lives (under the gitignored data/ tree)."""
+    rel = Path(corrections_path).resolve().relative_to(STEP_DIR.resolve())  # data/<channel>/.../x.corrections.yml
+    parts = rel.parts[1:] if rel.parts and rel.parts[0] == "data" else rel.parts
+    name = parts[-1].replace(".corrections.yml", ".audit.json")
+    return DATA_DIR / "corrections_audit" / Path(*parts[:-1]) / name
+
+
+def build_audit(
+    tb: Table,
+    corrections: list[dict[str, Any]],
+    *,
+    country_col: str = DEFAULT_COUNTRY_COL,
+    year_col: str = DEFAULT_YEAR_COL,
+) -> list[dict[str, Any]]:
+    """Record each correction's affected entities: their full *pre-correction* series and the
+    before/after of every affected point. Computed on `tb` before any correction is applied.
+    """
+    index_names = [name for name in tb.index.names if name is not None]
+    records = []
+    for correction in corrections:
+        indicator = correction["indicator"]
+        try:
+            ind_vals = _column_values(tb, indicator, index_names)
+            entity_vals = _column_values(tb, country_col, index_names).astype(str)
+            year_vals = _column_values(tb, year_col, index_names)
+        except KeyError:
+            continue  # can't audit if the locator columns aren't present at this stage
+        mask = _row_mask(tb, correction, country_col, year_col)
+        action = correction["action"]
+        factor = correction.get("factor")
+        override_value = _to_float(correction.get("value"))
+
+        any_numeric = False
+        entities = []
+        for ent in sorted(set(entity_vals[mask].tolist())):
+            ent_mask = entity_vals == ent
+            series = sorted(
+                [int(y), fv]
+                for y, v in zip(year_vals[ent_mask].tolist(), ind_vals[ent_mask].tolist())
+                if (fv := _to_float(v)) is not None
+            )
+            any_numeric = any_numeric or bool(series)
+            affected = []
+            for y, v in sorted(zip(year_vals[(ent_mask & mask)].tolist(), ind_vals[(ent_mask & mask)].tolist())):
+                before = _to_float(v)
+                if before is None:
+                    continue  # a matched-but-empty cell carries no value to show
+                if action == "drop":
+                    after = None
+                elif action == "override":
+                    after = override_value
+                elif action == "scale":
+                    after = before * float(factor) if before is not None else None
+                else:
+                    after = before
+                affected.append([int(y), before, after])
+            entities.append({"entity": ent, "series": series, "affected": affected})
+
+        records.append(
+            {
+                "label": _label(correction),
+                "indicator": indicator,
+                "action": action,
+                "reason": correction.get("reason"),
+                "numeric": any_numeric,
+                "entities": entities,
+            }
+        )
+    return records
+
+
+def write_audit(corrections_path: Path | str, records: list[dict[str, Any]]) -> None:
+    """Write the audit JSON for a corrections file (best-effort; never raises)."""
+    try:
+        path = audit_path_for(corrections_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(records))
+    except (OSError, TypeError, ValueError) as e:
+        log.warning("data_corrections.audit_write_failed", path=str(corrections_path), error=str(e))
+
+
+def read_audit(corrections_path: Path | str) -> list[dict[str, Any]] | None:
+    """Read the audit JSON for a corrections file, or None if it hasn't been generated yet."""
+    path = audit_path_for(corrections_path)
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())

--- a/etl/data_corrections.py
+++ b/etl/data_corrections.py
@@ -1,0 +1,210 @@
+#
+#  data_corrections.py
+#  etl
+#
+"""Declarative corrections for known upstream data errors.
+
+A `.corrections.yml` file sits next to a step (exactly like `.excluded_countries.json`) and records
+known errors in the *source* data together with the local fix we apply until the provider fixes them.
+One entry per error. This replaces scattered inline `.loc[...]` / `.drop(...)` exceptions with a single
+auditable record that carries the reason, provider and reporting status.
+
+Format (a list of entries)::
+
+    - id: gcp-panama-negative-consumption      # unique, kebab-case
+      indicator: consumption_emissions          # the COLUMN to correct
+      entity: Panama                            # country/entity
+      years: [2006, 2008, 2016]                 # list | latest | {after/before/from/to: Y}
+      action: drop                              # drop | override | flag
+      reason: Negative consumption-based CO2 (physically impossible) in source data.
+      provider: Global Carbon Project
+      reported: 2024-11-13                       # optional — when we told the provider
+      status: reported                           # open | reported | acknowledged | fixed_upstream
+
+Rows can also be located by their current value instead of entity+years::
+
+    - id: gfs-drinks-typo-4p5
+      indicator: drinks
+      match: {value: 4.5}                        # match by current value of the indicator column
+      action: override
+      value: 5
+      ...
+
+Actions:
+- ``drop``     — remove the matched rows.
+- ``override`` — replace the indicator value of the matched rows with ``value``.
+- ``flag``     — no data change; logs that the (uncorrected) error is known.
+
+This module is the mechanism only. The cross-dataset dashboard, per-provider report generator and
+auto-expiry on re-ingestion are deliberately out of scope here.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+from owid.catalog import Table
+from structlog import get_logger
+
+log = get_logger()
+
+# Default names of the columns (or index levels) used to locate rows by entity and year.
+DEFAULT_COUNTRY_COL = "country"
+DEFAULT_YEAR_COL = "year"
+
+VALID_ACTIONS = {"drop", "override", "flag"}
+VALID_STATUSES = {"open", "reported", "acknowledged", "fixed_upstream"}
+
+
+def load_corrections(path: Path | str) -> list[dict[str, Any]]:
+    """Load and validate the list of corrections from a `.corrections.yml` file."""
+    with open(path) as istream:
+        corrections = yaml.safe_load(istream)
+
+    if corrections is None:
+        return []
+
+    if not isinstance(corrections, list):
+        raise ValueError(f"Corrections file {path} must contain a list of entries, got {type(corrections).__name__}.")
+
+    for correction in corrections:
+        _validate_correction(correction, path)
+
+    # Ensure ids are unique within the file.
+    ids = [c["id"] for c in corrections]
+    duplicated = sorted({i for i in ids if ids.count(i) > 1})
+    assert not duplicated, f"Duplicate correction id(s) in {path}: {duplicated}"
+
+    return corrections
+
+
+def _validate_correction(correction: Any, path: Path | str) -> None:
+    """Fail loudly if a correction entry is malformed."""
+    if not isinstance(correction, dict):
+        raise ValueError(f"Each correction in {path} must be a mapping, got {type(correction).__name__}.")
+
+    cid = correction.get("id", "<missing id>")
+
+    for field in ("id", "indicator", "action", "reason", "provider", "status"):
+        assert correction.get(field) not in (None, ""), f"Correction '{cid}' in {path} is missing required '{field}'."
+
+    action = correction["action"]
+    assert action in VALID_ACTIONS, f"Correction '{cid}': invalid action '{action}' (expected one of {VALID_ACTIONS})."
+    assert correction["status"] in VALID_STATUSES, (
+        f"Correction '{cid}': invalid status '{correction['status']}' (expected one of {VALID_STATUSES})."
+    )
+
+    has_entity_years = "entity" in correction and "years" in correction
+    has_match = "match" in correction
+    assert has_entity_years ^ has_match, f"Correction '{cid}': specify exactly one of (entity + years) or match."
+
+    if action == "override":
+        assert "value" in correction, f"Correction '{cid}': action 'override' requires a 'value'."
+
+
+def _column_values(tb: Table, col: str, index_names: list[str]) -> np.ndarray:
+    """Return the values of `col` whether it lives in the table's columns or its index."""
+    if col in tb.columns:
+        return tb[col].to_numpy()
+    if col in index_names:
+        return tb.index.get_level_values(col).to_numpy()
+    raise KeyError(f"Column '{col}' not found in table columns {list(tb.columns)} or index {index_names}.")
+
+
+def _year_mask(years: Any, year_values: np.ndarray, entity_mask: np.ndarray, cid: str) -> np.ndarray:
+    """Build a boolean mask over rows selected by the `years` grammar.
+
+    Supports: a literal list of years, the keyword `latest` (the max year present among the entity's
+    rows), and range dicts using `after` / `before` / `from` / `to`.
+    """
+    if years == "latest":
+        present = year_values[entity_mask]
+        assert len(present) > 0, f"Correction '{cid}': entity has no rows, cannot resolve 'latest' year."
+        return year_values == present.max()
+    if isinstance(years, list):
+        return np.isin(year_values, years)
+    if isinstance(years, dict):
+        mask = np.ones(len(year_values), dtype=bool)
+        unknown = set(years) - {"after", "before", "from", "to"}
+        assert not unknown, f"Correction '{cid}': unknown year-range keys {sorted(unknown)}."
+        if "after" in years:
+            mask &= year_values > years["after"]
+        if "before" in years:
+            mask &= year_values < years["before"]
+        if "from" in years:
+            mask &= year_values >= years["from"]
+        if "to" in years:
+            mask &= year_values <= years["to"]
+        return mask
+    raise ValueError(
+        f"Correction '{cid}': unsupported 'years' value {years!r} (expected list, 'latest' or a range dict)."
+    )
+
+
+def _row_mask(tb: Table, correction: dict[str, Any], country_col: str, year_col: str) -> np.ndarray:
+    """Return a positional boolean mask over `tb` selecting the rows a correction targets."""
+    index_names = [name for name in tb.index.names if name is not None]
+    cid = correction["id"]
+
+    if "match" in correction:
+        mask = np.ones(len(tb), dtype=bool)
+        for key, value in correction["match"].items():
+            # `value` is shorthand for the indicator column; any other key matches that column by name.
+            col = correction["indicator"] if key == "value" else key
+            mask &= _column_values(tb, col, index_names) == value
+        return mask
+
+    entity_mask = _column_values(tb, country_col, index_names) == correction["entity"]
+    year_values = _column_values(tb, year_col, index_names)
+    return entity_mask & _year_mask(correction["years"], year_values, entity_mask, cid)
+
+
+def apply_corrections(
+    tb: Table,
+    corrections: list[dict[str, Any]],
+    *,
+    country_col: str = DEFAULT_COUNTRY_COL,
+    year_col: str = DEFAULT_YEAR_COL,
+) -> Table:
+    """Apply a list of corrections to a table and return the corrected copy.
+
+    `country_col` / `year_col` name the entity and year fields, which may be either columns or index
+    levels of `tb`. The original table is not mutated.
+    """
+    tb = tb.copy()
+
+    # If entity/year are plain columns, the table carries an ordinary RangeIndex; after dropping rows we
+    # renumber it so the result matches the long-standing `df.drop(...).reset_index(drop=True)` idiom.
+    entity_year_in_columns = country_col in tb.columns and year_col in tb.columns
+    dropped_any = False
+
+    for correction in corrections:
+        cid = correction["id"]
+        action = correction["action"]
+        mask = _row_mask(tb, correction, country_col, year_col)
+        n_matched = int(mask.sum())
+
+        if action == "flag":
+            log.info("data_corrections.flag", id=cid, matched=n_matched, reason=correction["reason"])
+            continue
+
+        # A correction that no longer matches anything is a signal: the upstream error was likely fixed,
+        # or the source schema changed. Fail loudly rather than silently doing nothing.
+        assert n_matched > 0, (
+            f"Correction '{cid}' matched no rows. The upstream error may have been fixed — "
+            f"remove or update this correction."
+        )
+
+        if action == "drop":
+            tb = tb[~mask]
+            dropped_any = True
+        elif action == "override":
+            tb.loc[mask, correction["indicator"]] = correction["value"]
+
+        log.info("data_corrections.apply", id=cid, action=action, matched=n_matched)
+
+    if dropped_any and entity_year_in_columns:
+        tb = tb.reset_index(drop=True)
+
+    return tb

--- a/etl/data_corrections.py
+++ b/etl/data_corrections.py
@@ -11,8 +11,7 @@ auditable record that carries the reason, provider and reporting status.
 
 Format (a list of entries)::
 
-    - id: gcp-panama-negative-consumption      # unique, kebab-case
-      indicator: consumption_emissions          # the COLUMN to correct
+    - indicator: consumption_emissions          # the COLUMN to correct
       entity: Panama                            # country/entity
       years: [2006, 2008, 2016]                 # list | latest | {after/before/from/to: Y}
       action: drop                              # drop | override | flag
@@ -23,17 +22,20 @@ Format (a list of entries)::
 
 Rows can also be located by their current value instead of entity+years::
 
-    - id: gfs-drinks-typo-4p5
-      indicator: drinks
+    - indicator: drinks
       match: {value: 4.5}                        # match by current value of the indicator column
       action: override
       value: 5
       ...
 
 Actions:
-- ``drop``     — remove the matched rows.
-- ``override`` — replace the indicator value of the matched rows with ``value``.
+- ``drop``     — remove the matched rows (use for long/tidy tables, where a row *is* one data point).
+- ``override`` — replace the indicator value of the matched rows with ``value``. Set ``value: null``
+                 to blank a single bad cell in a wide table without dropping the whole row.
 - ``flag``     — no data change; logs that the (uncorrected) error is known.
+
+There is intentionally no ``id`` field — a stable identifier is derived from the entry's target
+(provider / indicator / entity+years or match) for logs and error messages.
 
 This module is the mechanism only. The cross-dataset dashboard, per-provider report generator and
 auto-expiry on re-ingestion are deliberately out of scope here.
@@ -71,12 +73,20 @@ def load_corrections(path: Path | str) -> list[dict[str, Any]]:
     for correction in corrections:
         _validate_correction(correction, path)
 
-    # Ensure ids are unique within the file.
-    ids = [c["id"] for c in corrections]
-    duplicated = sorted({i for i in ids if ids.count(i) > 1})
-    assert not duplicated, f"Duplicate correction id(s) in {path}: {duplicated}"
-
     return corrections
+
+
+def _label(correction: dict[str, Any]) -> str:
+    """A short human-readable identifier for a correction, used in logs and error messages.
+
+    There is no `id` field to invent — we derive a label from what the correction targets.
+    """
+    target = (
+        f"{correction.get('entity')} {correction.get('years')}"
+        if "entity" in correction
+        else f"match {correction.get('match')}"
+    )
+    return f"{correction.get('provider', '?')} / {correction.get('indicator', '?')} / {target}"
 
 
 def _validate_correction(correction: Any, path: Path | str) -> None:
@@ -84,23 +94,25 @@ def _validate_correction(correction: Any, path: Path | str) -> None:
     if not isinstance(correction, dict):
         raise ValueError(f"Each correction in {path} must be a mapping, got {type(correction).__name__}.")
 
-    cid = correction.get("id", "<missing id>")
+    label = _label(correction)
 
-    for field in ("id", "indicator", "action", "reason", "provider", "status"):
-        assert correction.get(field) not in (None, ""), f"Correction '{cid}' in {path} is missing required '{field}'."
+    for field in ("indicator", "action", "reason", "provider", "status"):
+        assert correction.get(field) not in (None, ""), f"Correction [{label}] in {path} is missing required '{field}'."
 
     action = correction["action"]
-    assert action in VALID_ACTIONS, f"Correction '{cid}': invalid action '{action}' (expected one of {VALID_ACTIONS})."
+    assert action in VALID_ACTIONS, (
+        f"Correction [{label}]: invalid action '{action}' (expected one of {VALID_ACTIONS})."
+    )
     assert correction["status"] in VALID_STATUSES, (
-        f"Correction '{cid}': invalid status '{correction['status']}' (expected one of {VALID_STATUSES})."
+        f"Correction [{label}]: invalid status '{correction['status']}' (expected one of {VALID_STATUSES})."
     )
 
     has_entity_years = "entity" in correction and "years" in correction
     has_match = "match" in correction
-    assert has_entity_years ^ has_match, f"Correction '{cid}': specify exactly one of (entity + years) or match."
+    assert has_entity_years ^ has_match, f"Correction [{label}]: specify exactly one of (entity + years) or match."
 
     if action == "override":
-        assert "value" in correction, f"Correction '{cid}': action 'override' requires a 'value'."
+        assert "value" in correction, f"Correction [{label}]: action 'override' requires a 'value'."
 
 
 def _column_values(tb: Table, col: str, index_names: list[str]) -> np.ndarray:
@@ -112,22 +124,21 @@ def _column_values(tb: Table, col: str, index_names: list[str]) -> np.ndarray:
     raise KeyError(f"Column '{col}' not found in table columns {list(tb.columns)} or index {index_names}.")
 
 
-def _year_mask(years: Any, year_values: np.ndarray, entity_mask: np.ndarray, cid: str) -> np.ndarray:
+def _year_mask(years: Any, year_values: np.ndarray, label: str) -> np.ndarray:
     """Build a boolean mask over rows selected by the `years` grammar.
 
-    Supports: a literal list of years, the keyword `latest` (the max year present among the entity's
-    rows), and range dicts using `after` / `before` / `from` / `to`.
+    Supports: a literal list of years, the keyword `latest` (the max year present in the table, i.e.
+    the dataset's most recent year), and range dicts using `after` / `before` / `from` / `to`.
     """
     if years == "latest":
-        present = year_values[entity_mask]
-        assert len(present) > 0, f"Correction '{cid}': entity has no rows, cannot resolve 'latest' year."
-        return year_values == present.max()
+        assert len(year_values) > 0, f"Correction [{label}]: table has no rows, cannot resolve 'latest' year."
+        return year_values == year_values.max()
     if isinstance(years, list):
         return np.isin(year_values, years)
     if isinstance(years, dict):
         mask = np.ones(len(year_values), dtype=bool)
         unknown = set(years) - {"after", "before", "from", "to"}
-        assert not unknown, f"Correction '{cid}': unknown year-range keys {sorted(unknown)}."
+        assert not unknown, f"Correction [{label}]: unknown year-range keys {sorted(unknown)}."
         if "after" in years:
             mask &= year_values > years["after"]
         if "before" in years:
@@ -138,14 +149,14 @@ def _year_mask(years: Any, year_values: np.ndarray, entity_mask: np.ndarray, cid
             mask &= year_values <= years["to"]
         return mask
     raise ValueError(
-        f"Correction '{cid}': unsupported 'years' value {years!r} (expected list, 'latest' or a range dict)."
+        f"Correction [{label}]: unsupported 'years' value {years!r} (expected list, 'latest' or a range dict)."
     )
 
 
 def _row_mask(tb: Table, correction: dict[str, Any], country_col: str, year_col: str) -> np.ndarray:
     """Return a positional boolean mask over `tb` selecting the rows a correction targets."""
     index_names = [name for name in tb.index.names if name is not None]
-    cid = correction["id"]
+    label = _label(correction)
 
     if "match" in correction:
         mask = np.ones(len(tb), dtype=bool)
@@ -157,7 +168,7 @@ def _row_mask(tb: Table, correction: dict[str, Any], country_col: str, year_col:
 
     entity_mask = _column_values(tb, country_col, index_names) == correction["entity"]
     year_values = _column_values(tb, year_col, index_names)
-    return entity_mask & _year_mask(correction["years"], year_values, entity_mask, cid)
+    return entity_mask & _year_mask(correction["years"], year_values, label)
 
 
 def apply_corrections(
@@ -180,19 +191,19 @@ def apply_corrections(
     dropped_any = False
 
     for correction in corrections:
-        cid = correction["id"]
+        label = _label(correction)
         action = correction["action"]
         mask = _row_mask(tb, correction, country_col, year_col)
         n_matched = int(mask.sum())
 
         if action == "flag":
-            log.info("data_corrections.flag", id=cid, matched=n_matched, reason=correction["reason"])
+            log.info("data_corrections.flag", correction=label, matched=n_matched, reason=correction["reason"])
             continue
 
         # A correction that no longer matches anything is a signal: the upstream error was likely fixed,
         # or the source schema changed. Fail loudly rather than silently doing nothing.
         assert n_matched > 0, (
-            f"Correction '{cid}' matched no rows. The upstream error may have been fixed — "
+            f"Correction [{label}] matched no rows. The upstream error may have been fixed — "
             f"remove or update this correction."
         )
 
@@ -202,7 +213,7 @@ def apply_corrections(
         elif action == "override":
             tb.loc[mask, correction["indicator"]] = correction["value"]
 
-        log.info("data_corrections.apply", id=cid, action=action, matched=n_matched)
+        log.info("data_corrections.apply", correction=label, action=action, matched=n_matched)
 
     if dropped_any and entity_year_in_columns:
         tb = tb.reset_index(drop=True)

--- a/etl/data_corrections.py
+++ b/etl/data_corrections.py
@@ -19,8 +19,8 @@ Format (a list of entries)::
 
     - indicator: consumption_emissions          # the COLUMN to correct
       entity: Panama                            # country/entity
-      years: [2006, 2008, 2016]                 # list | latest | {after/before/from/to: Y}
-      action: drop                              # drop | override | flag
+      years: [2006, 2008, 2016]                 # list | all | latest | {after/before/from/to: Y}
+      action: drop                              # drop | override | scale | flag
       reason: Negative consumption-based CO2 (physically impossible) in source data.
       provider: Global Carbon Project
       reported: 2024-11-13                       # optional — when we told the provider
@@ -38,7 +38,24 @@ Actions:
 - ``drop``     — remove the matched rows (use for long/tidy tables, where a row *is* one data point).
 - ``override`` — replace the indicator value of the matched rows with ``value``. Set ``value: null``
                  to blank a single bad cell in a wide table without dropping the whole row.
+- ``scale``    — multiply the indicator value of the matched rows by ``factor`` (e.g. ``factor: 0.001``
+                 to fix a value reported in units while the rest are in thousands).
 - ``flag``     — no data change; logs that the (uncorrected) error is known.
+
+Guard against silently re-applying a correction after the source fixes it (optional ``expect``)::
+
+    - indicator: ..._guests
+      entity: Taiwan
+      years: all
+      action: scale
+      factor: 0.001
+      expect: {gt: 1000000}                      # matched values must still be anomalously large
+      ...
+
+``expect`` is a mapping of comparison operator (``eq``/``ne``/``gt``/``ge``/``lt``/``le``) to a numeric
+threshold; every operator must hold for *all* matched rows or the step fails loudly. ``drop`` is already
+self-validating (the row vanishing trips the no-match assertion), but ``override``/``scale`` keep the row,
+so ``expect`` is how they detect an upstream fix. It cannot be combined with ``flag``.
 
 There is intentionally no ``id`` field — a stable identifier is derived from the entry's target
 (provider / indicator / entity+years or match) for logs and error messages.
@@ -61,8 +78,18 @@ log = get_logger()
 DEFAULT_COUNTRY_COL = "country"
 DEFAULT_YEAR_COL = "year"
 
-VALID_ACTIONS = {"drop", "override", "flag"}
+VALID_ACTIONS = {"drop", "override", "scale", "flag"}
 VALID_STATUSES = {"open", "reported", "acknowledged", "fixed_upstream"}
+
+# Comparison operators allowed in an `expect:` guard, mapping to the function applied elementwise.
+EXPECT_OPERATORS = {
+    "eq": lambda values, threshold: values == threshold,
+    "ne": lambda values, threshold: values != threshold,
+    "gt": lambda values, threshold: values > threshold,
+    "ge": lambda values, threshold: values >= threshold,
+    "lt": lambda values, threshold: values < threshold,
+    "le": lambda values, threshold: values <= threshold,
+}
 
 
 def load_corrections(path: Path | str) -> list[dict[str, Any]]:
@@ -132,6 +159,29 @@ def _validate_correction(correction: Any, path: Path | str) -> None:
     if action == "override":
         assert "value" in correction, f"Correction [{label}]: action 'override' requires a 'value'."
 
+    if action == "scale":
+        factor = correction.get("factor")
+        assert isinstance(factor, (int, float)) and not isinstance(factor, bool), (
+            f"Correction [{label}]: action 'scale' requires a numeric 'factor'."
+        )
+
+    if "expect" in correction:
+        # `expect` only guards a data-changing action — there is nothing to guard for 'flag'.
+        assert action != "flag", f"Correction [{label}]: 'expect' cannot be combined with action 'flag'."
+        expect = correction["expect"]
+        assert isinstance(expect, dict) and len(expect) > 0, (
+            f"Correction [{label}]: 'expect' must be a non-empty mapping of operator → threshold."
+        )
+        unknown_ops = set(expect) - set(EXPECT_OPERATORS)
+        assert not unknown_ops, (
+            f"Correction [{label}]: unknown 'expect' operators {sorted(unknown_ops)} "
+            f"(expected a subset of {sorted(EXPECT_OPERATORS)})."
+        )
+        for op, threshold in expect.items():
+            assert isinstance(threshold, (int, float)) and not isinstance(threshold, bool), (
+                f"Correction [{label}]: 'expect.{op}' threshold must be numeric, got {threshold!r}."
+            )
+
 
 def _column_values(tb: Table, col: str, index_names: list[str]) -> np.ndarray:
     """Return the values of `col` whether it lives in the table's columns or its index."""
@@ -145,9 +195,12 @@ def _column_values(tb: Table, col: str, index_names: list[str]) -> np.ndarray:
 def _year_mask(years: Any, year_values: np.ndarray, label: str) -> np.ndarray:
     """Build a boolean mask over rows selected by the `years` grammar.
 
-    Supports: a literal list of years, the keyword `latest` (the max year present in the table, i.e.
-    the dataset's most recent year), and range dicts using `after` / `before` / `from` / `to`.
+    Supports: a literal list of years, the keyword `all` (every year for the entity), the keyword
+    `latest` (the max year present in the table, i.e. the dataset's most recent year), and range dicts
+    using `after` / `before` / `from` / `to`.
     """
+    if years == "all":
+        return np.ones(len(year_values), dtype=bool)
     if years == "latest":
         assert len(year_values) > 0, f"Correction [{label}]: table has no rows, cannot resolve 'latest' year."
         return year_values == year_values.max()
@@ -167,7 +220,7 @@ def _year_mask(years: Any, year_values: np.ndarray, label: str) -> np.ndarray:
             mask &= year_values <= years["to"]
         return mask
     raise ValueError(
-        f"Correction [{label}]: unsupported 'years' value {years!r} (expected list, 'latest' or a range dict)."
+        f"Correction [{label}]: unsupported 'years' value {years!r} (expected list, 'all', 'latest' or a range dict)."
     )
 
 
@@ -187,6 +240,23 @@ def _row_mask(tb: Table, correction: dict[str, Any], country_col: str, year_col:
     entity_mask = _column_values(tb, country_col, index_names) == correction["entity"]
     year_values = _column_values(tb, year_col, index_names)
     return entity_mask & _year_mask(correction["years"], year_values, label)
+
+
+def _check_expectation(tb: Table, correction: dict[str, Any], mask: np.ndarray, label: str) -> None:
+    """Assert the matched rows still satisfy the `expect` predicate (i.e. the anomaly is still present).
+
+    This is the "raise if fixed upstream" guard: every operator in `expect` must hold for *all* matched
+    values of the indicator column. If any fails, the upstream error was likely corrected and the
+    correction should be removed.
+    """
+    values = tb.loc[mask, correction["indicator"]]
+    for op, threshold in correction["expect"].items():
+        satisfied = EXPECT_OPERATORS[op](values, threshold)
+        assert satisfied.all(), (
+            f"Correction [{label}]: expectation '{op} {threshold}' failed for {(~satisfied).sum()} of "
+            f"{len(values)} matched rows (values: {sorted(set(values.tolist()))[:5]}). The upstream error "
+            f"may have been fixed — remove or update this correction."
+        )
 
 
 def apply_corrections(
@@ -225,11 +295,19 @@ def apply_corrections(
             f"remove or update this correction."
         )
 
+        # `drop` is self-validating (the row vanishing trips the assert above), but `override`/`scale`
+        # keep the row, so a fixed-upstream value would be silently re-mangled. An optional `expect`
+        # guard asserts the matched rows are *still* anomalous before we touch them.
+        if "expect" in correction:
+            _check_expectation(tb, correction, mask, label)
+
         if action == "drop":
             tb = tb[~mask]
             dropped_any = True
         elif action == "override":
             tb.loc[mask, correction["indicator"]] = correction["value"]
+        elif action == "scale":
+            tb.loc[mask, correction["indicator"]] *= correction["factor"]
 
         log.info("data_corrections.apply", correction=label, action=action, matched=n_matched)
 

--- a/etl/data_corrections.py
+++ b/etl/data_corrections.py
@@ -9,6 +9,12 @@ known errors in the *source* data together with the local fix we apply until the
 One entry per error. This replaces scattered inline `.loc[...]` / `.drop(...)` exceptions with a single
 auditable record that carries the reason, provider and reporting status.
 
+The mechanism is channel-agnostic (it works wherever `PathFinder.apply_corrections` is called), but
+**garden is the default home**: a correction is a judgment about the data, its `entity`/`year` locators
+are only canonical after garden harmonization, and some corrections target derived/rescaled columns that
+don't exist upstream. Keep meadow/snapshot a faithful mirror of the provider — reserve them for raw
+transcription typos that are wrong before any OWID processing and shared across multiple consumers.
+
 Format (a list of entries)::
 
     - indicator: consumption_emissions          # the COLUMN to correct

--- a/etl/data_corrections.py
+++ b/etl/data_corrections.py
@@ -111,6 +111,18 @@ def _validate_correction(correction: Any, path: Path | str) -> None:
     has_match = "match" in correction
     assert has_entity_years ^ has_match, f"Correction [{label}]: specify exactly one of (entity + years) or match."
 
+    if has_match:
+        match = correction["match"]
+        # An empty (or non-dict) match would build an all-true mask and silently apply the correction to
+        # *every* row — wiping a table on drop, or overwriting a whole indicator on override. Reject it.
+        assert isinstance(match, dict) and len(match) > 0, (
+            f"Correction [{label}]: 'match' must be a non-empty mapping of column → value."
+        )
+        # `entity`/`years` only apply to the entity+years form; mixing them with `match` is a mistake
+        # (they would be silently ignored), so reject the combination.
+        mixed = {"entity", "years"} & set(correction)
+        assert not mixed, f"Correction [{label}]: do not combine 'match' with {sorted(mixed)}."
+
     if action == "override":
         assert "value" in correction, f"Correction [{label}]: action 'override' requires a 'value'."
 

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -30,6 +30,7 @@ from etl.collection import Collection, CollectionSet
 from etl.collection.core.create import Listable, create_collection
 from etl.collection.explorer import Explorer, ExplorerLegacy, create_explorer_legacy
 from etl.dag_helpers import load_dag
+from etl.data_corrections import apply_corrections, load_corrections
 from etl.data_helpers.geo import Regions
 from etl.grapher.helpers import grapher_checks
 from etl.snapshot import Snapshot, SnapshotMeta
@@ -319,6 +320,22 @@ class PathFinder:
     @property
     def excluded_countries_path(self) -> Path:
         return self.directory / (self.short_name + ".excluded_countries.json")
+
+    @property
+    def corrections_path(self) -> Path:
+        return self.directory / (self.short_name + ".corrections.yml")
+
+    def apply_corrections(self, tb: Table, *, country_col: str = "country", year_col: str = "year") -> Table:
+        """Apply the step's `.corrections.yml` (known upstream data errors) to a table.
+
+        Mirrors the `.excluded_countries.json` ergonomics: a sibling file next to the step, applied in
+        one line. If no corrections file exists, the table is returned unchanged. See
+        `etl.data_corrections` for the file format.
+        """
+        if not self.corrections_path.exists():
+            return tb
+        corrections = load_corrections(self.corrections_path)
+        return apply_corrections(tb, corrections, country_col=country_col, year_col=year_col)
 
     @property
     def metadata_path(self) -> Path:

--- a/etl/helpers.py
+++ b/etl/helpers.py
@@ -30,7 +30,7 @@ from etl.collection import Collection, CollectionSet
 from etl.collection.core.create import Listable, create_collection
 from etl.collection.explorer import Explorer, ExplorerLegacy, create_explorer_legacy
 from etl.dag_helpers import load_dag
-from etl.data_corrections import apply_corrections, load_corrections
+from etl.data_corrections import apply_corrections, build_audit, load_corrections, write_audit
 from etl.data_helpers.geo import Regions
 from etl.grapher.helpers import grapher_checks
 from etl.snapshot import Snapshot, SnapshotMeta
@@ -335,6 +335,9 @@ class PathFinder:
         if not self.corrections_path.exists():
             return tb
         corrections = load_corrections(self.corrections_path)
+        # Record the affected rows (before/after) so `etl corrections --charts` can visualise the
+        # problematic values, which are gone from the published data once the correction is applied.
+        write_audit(self.corrections_path, build_audit(tb, corrections, country_col=country_col, year_col=year_col))
         return apply_corrections(tb, corrections, country_col=country_col, year_col=year_col)
 
     @property

--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.corrections.yml
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.corrections.yml
@@ -1,7 +1,6 @@
 # Known upstream data errors in the Global Carbon Budget, corrected locally until fixed at the source.
 # See etl/data_corrections.py for the format.
-- id: gcp-panama-negative-consumption
-  indicator: consumption_emissions
+- indicator: consumption_emissions
   entity: Panama
   years: [2006, 2008, 2016]
   action: drop

--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.corrections.yml
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.corrections.yml
@@ -6,5 +6,5 @@
   action: drop
   reason: Negative consumption-based CO2 emissions (physically impossible) in the source data.
   provider: Global Carbon Project
-  reported: 2024-11-13
+  reported: "2024-11-13"
   status: reported

--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.corrections.yml
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.corrections.yml
@@ -1,0 +1,11 @@
+# Known upstream data errors in the Global Carbon Budget, corrected locally until fixed at the source.
+# See etl/data_corrections.py for the format.
+- id: gcp-panama-negative-consumption
+  indicator: consumption_emissions
+  entity: Panama
+  years: [2006, 2008, 2016]
+  action: drop
+  reason: Negative consumption-based CO2 emissions (physically impossible) in the source data.
+  provider: Global Carbon Project
+  reported: 2024-11-13
+  status: reported

--- a/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.py
+++ b/etl/steps/data/garden/gcp/2025-11-13/global_carbon_budget.py
@@ -23,14 +23,6 @@ log = get_logger()
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
-# Expected outliers in consumption-based emissions (with negative emissions in the original data, that will be removed).
-# NOTE: This issue has been reported to the data providers, and will hopefully be fixed in a coming version.
-OUTLIERS_IN_CONSUMPTION_DF = [
-    ("Panama", 2006),
-    ("Panama", 2008),
-    ("Panama", 2016),
-]
-
 # Regions and income groups to create by aggregating contributions from member countries.
 # In the following dictionary, if nothing is stated, the region is supposed to be a default continent/income group.
 # Otherwise, the dictionary can have "regions_included", "regions_excluded", "countries_included", and
@@ -493,20 +485,9 @@ def prepare_consumption_emissions(tb_consumption: Table) -> Table:
     for column in tb_consumption.drop(columns=["country", "year"]).columns:
         tb_consumption[column] *= MILLION_TONNES_OF_CARBON_TO_TONNES_OF_CO2
 
-    # List indexes of rows in tb_consumption corresponding to outliers (defined above in OUTLIERS_IN_tb_consumption).
-    outlier_indexes = [
-        tb_consumption[(tb_consumption["country"] == outlier[0]) & (tb_consumption["year"] == outlier[1])].index.item()
-        for outlier in OUTLIERS_IN_CONSUMPTION_DF
-    ]
-
-    error = (
-        "Outliers were expected to have negative consumption emissions. "
-        "Maybe outliers have been fixed (and should be removed from the code)."
-    )
-    assert (tb_consumption.loc[outlier_indexes]["consumption_emissions"] < 0).all(), error
-
-    # Remove outliers.
-    tb_consumption = tb_consumption.drop(outlier_indexes).reset_index(drop=True)
+    # Remove known upstream data errors (e.g. Panama's negative consumption emissions), declared in
+    # global_carbon_budget.corrections.yml.
+    tb_consumption = paths.apply_corrections(tb_consumption)
 
     return tb_consumption
 

--- a/etl/steps/data/garden/ifr/2026-01-14/robot_density.corrections.yml
+++ b/etl/steps/data/garden/ifr/2026-01-14/robot_density.corrections.yml
@@ -1,0 +1,10 @@
+# Known upstream data errors in IFR robot density, corrected locally until fixed at the source.
+# See etl/data_corrections.py for the format. Values are in robots per 10,000 employees (post the /10 rescale).
+- indicator: robot_density
+  entity: China
+  years: [2023]
+  action: override
+  value: 14.2
+  reason: Source value for China 2023 was incorrect; IFR revised it to 142 robots per 10,000 employees (forwarded to us; the image with the new data is paywalled).
+  provider: International Federation of Robotics
+  status: acknowledged

--- a/etl/steps/data/garden/ifr/2026-01-14/robot_density.py
+++ b/etl/steps/data/garden/ifr/2026-01-14/robot_density.py
@@ -24,9 +24,9 @@ def run() -> None:
 
     tb["robot_density"] = tb["robot_density"] / 10
 
-    # Fix incorrect China 2023 value (revised to 142 robots per 10,000 employees per IFR)
-    # The image with the new data is paywalled but was forwarded to us by the source
-    tb.loc[(tb["country"] == "China") & (tb["year"] == 2023), "robot_density"] = 142 / 10
+    # Fix known upstream data errors (e.g. China's incorrect 2023 value), declared in
+    # robot_density.corrections.yml.
+    tb = paths.apply_corrections(tb)
 
     # Improve table format.
     tb = tb.format(["country", "year"])

--- a/etl/steps/data/garden/literacy/2026-05-12/historic_literacy_omm.corrections.yml
+++ b/etl/steps/data/garden/literacy/2026-05-12/historic_literacy_omm.corrections.yml
@@ -1,0 +1,9 @@
+# Known upstream data errors in UNESCO literacy data, dropped locally until fixed at the source.
+# See etl/data_corrections.py for the format.
+- indicator: literacy_rate
+  entity: Cote d'Ivoire
+  years: [2019]
+  action: drop
+  reason: UNESCO's adult literacy rate for Cote d'Ivoire in 2019 is a likely error (inconsistent with the surrounding series).
+  provider: UNESCO Institute for Statistics
+  status: open

--- a/etl/steps/data/garden/literacy/2026-05-12/historic_literacy_omm.py
+++ b/etl/steps/data/garden/literacy/2026-05-12/historic_literacy_omm.py
@@ -66,8 +66,9 @@ def run() -> None:
     tb_unesco["source"] = "UNESCO Institute for Statistics"
     tb_unesco["source_url"] = "https://databrowser.uis.unesco.org/resources/bulk"
 
-    # Remove Cote d'Ivoire for 2019 due to likely error
-    tb_unesco = tb_unesco[~((tb_unesco["country"] == "Cote d'Ivoire") & (tb_unesco["year"] == 2019))]
+    # Drop known upstream data errors (e.g. Cote d'Ivoire 2019), declared in
+    # historic_literacy_omm.corrections.yml.
+    tb_unesco = paths.apply_corrections(tb_unesco)
 
     # Remove any rows with missing data to avoid duplicates
     tables = [tb_1950, tb_1900_1950, tb_1451_1800, tb_oecd, tb_unesco]

--- a/etl/steps/data/garden/tourism/2026-01-21/unwto.corrections.yml
+++ b/etl/steps/data/garden/tourism/2026-01-21/unwto.corrections.yml
@@ -1,0 +1,15 @@
+# Known upstream data errors in the UNWTO data, corrected locally until fixed at the source.
+# See etl/data_corrections.py for the format. Applied on the raw meadow values (before the garden
+# ×1000 thousands→units conversion), so `indicator` uses the long meadow column name.
+- indicator: domestic_tourism_accommodation_domestic__accommodation__short_term_accommodation__hotels_and_similar__isic_5510__guests
+  entity: Taiwan
+  years: all
+  action: scale
+  factor: 0.001
+  # Guard: Taiwan's raw value is ~46–64 million while the next-largest country is ~0.35 million.
+  # A fixed source would report ~46–64 thousand (in line with others), tripping this `gt` and
+  # telling us to remove the entry. 1,000,000 sits safely between the buggy and fixed magnitudes.
+  expect: {gt: 1000000}
+  reason: UNWTO reports Taiwan's domestic short-term hotel guests in units while every other country reports in thousands, making the value ~1000× too large after the garden ×1000 conversion.
+  provider: UNWTO
+  status: open

--- a/etl/steps/data/garden/tourism/2026-01-21/unwto.py
+++ b/etl/steps/data/garden/tourism/2026-01-21/unwto.py
@@ -44,21 +44,6 @@ ABBREVIATIONS = {
     "occupancy": "occ",
 }
 
-# Source-side unit corrections: (country, meadow_column, divisor).
-# UNWTO occasionally reports a country-indicator in units while the rest are in thousands.
-# Each entry divides the raw value by `divisor` before the blanket ×1000 conversion.
-# If the source fixes the inconsistency, the population sanity check will still pass and
-# the correction becomes a harmless no-op (dividing an already-correct value makes it too small,
-# which the check would also catch on the next update — remove the entry then).
-UNIT_CORRECTIONS = [
-    # Taiwan reports domestic hotel guests in units, not thousands (as of 2026-01-21 snapshot).
-    (
-        "Taiwan",
-        "domestic_tourism_accommodation_domestic__accommodation__short_term_accommodation__hotels_and_similar__isic_5510__guests",
-        1000,
-    ),
-]
-
 # Columns to keep after shortening column names
 COLUMNS_TO_KEEP = [
     "dom_tour_trips_total_overnight_vis_tourists",
@@ -107,25 +92,11 @@ def run() -> None:
     # Drop columns with all NaN values
     tb = tb.dropna(axis=1, how="all")
 
-    # Corrections for source-side unit inconsistencies.
-    # The sanity_check_population_ratios() below will catch any *new* mismatches — when it
-    # fails, investigate the source and add a correction here.
-    # If the source fixes the inconsistency, the correction becomes wrong (makes values too
-    # small). To guard against that, we verify the correction is still needed: the raw value
-    # must be >100× the median of other countries. If not, the source was fixed — remove the entry.
-    for country, col, divisor in UNIT_CORRECTIONS:
-        if col in tb.columns:
-            mask = tb["country"] == country
-            country_vals = tb.loc[mask, col].dropna()
-            others_median = tb.loc[~mask, col].dropna().median()
-            if len(country_vals) > 0 and others_median > 0:
-                ratio = country_vals.median() / others_median
-                assert ratio > 100, (
-                    f"Unit correction for {country}/{col} may no longer be needed: "
-                    f"ratio to others' median is only {ratio:.1f}x (expected >100x). "
-                    f"The source may have fixed the inconsistency — verify and remove the entry from UNIT_CORRECTIONS."
-                )
-            tb.loc[mask, col] = tb.loc[mask, col] / divisor
+    # Corrections for source-side unit inconsistencies (see unwto.corrections.yml). Applied on the raw
+    # meadow values, before the ×1000 conversion below. Each correction self-validates via its `expect`
+    # guard and fails loudly if the source fixes the issue. The sanity_check_population_ratios() below
+    # independently catches any *new* mismatches — when it fails, investigate and add a correction.
+    tb = paths.apply_corrections(tb)
 
     # Find columns that start with the specified prefixes - units are not thousands
     matching_columns = [col for col in tb.columns if any(col.startswith(prefix) for prefix in PREFIXES_NOT_THOUSANDS)]

--- a/etl/steps/data/garden/usgs/2025-12-15/mineral_commodity_summaries.corrections.yml
+++ b/etl/steps/data/garden/usgs/2025-12-15/mineral_commodity_summaries.corrections.yml
@@ -1,0 +1,20 @@
+# Known upstream data errors in the USGS Mineral Commodity Summaries, blanked locally until fixed at
+# the source. See etl/data_corrections.py for the format. `value: null` blanks the bad cell without
+# dropping the (country, year) row (other minerals for that row are fine).
+- indicator: reserves|Zinc|Mine|tonnes
+  entity: Australia
+  years: [2022]
+  action: override
+  value: null
+  reason: Zinc mine reserves for Australia in 2022 are unreasonably high (much larger than the world total).
+  provider: USGS
+  status: open
+
+- indicator: production|Asbestos|Mine|tonnes
+  entity: Kazakhstan
+  years: [2020]
+  action: override
+  value: null
+  reason: Asbestos mine production for Kazakhstan in 2020 is reported as 27400, but BGS reports 227400, which is consistent with prior and posterior years; the USGS value looks like a data-entry error.
+  provider: USGS
+  status: open

--- a/etl/steps/data/garden/usgs/2025-12-15/mineral_commodity_summaries.py
+++ b/etl/steps/data/garden/usgs/2025-12-15/mineral_commodity_summaries.py
@@ -1336,15 +1336,9 @@ def run() -> None:
     tb_flat = tb_flat.dropna(axis=1, how="all").reset_index(drop=True)
 
     ####################################################################################################################
-    # Corrections to USGS current data.
-    # Zinc mine reserves in Australia in 2022 is unreasonably high, much larger than the world.
-    tb_flat.loc[(tb_flat["country"] == "Australia") & (tb_flat["year"] == 2022), "reserves|Zinc|Mine|tonnes"] = None
-
-    # Asbestos mine production in Kazakhstan 2020, data says "27400", but in BGS, it is "227400", which is much more
-    # reasonable, looking at prior and posterior data. So it looks like an error in the data. Remove that point.
-    tb_flat.loc[(tb_flat["country"] == "Kazakhstan") & (tb_flat["year"] == 2020), "production|Asbestos|Mine|tonnes"] = (
-        None
-    )
+    # Corrections to USGS current data: known upstream data errors, declared in
+    # mineral_commodity_summaries.corrections.yml (Australia zinc reserves 2022, Kazakhstan asbestos 2020).
+    tb_flat = paths.apply_corrections(tb_flat)
 
     # As explained above (in the mapping) Chromium production is in gross weight, but reserves are not.
     tb_flat = tb_flat.rename(

--- a/etl/steps/data/garden/wb/2025-07-01/income_groups.corrections.yml
+++ b/etl/steps/data/garden/wb/2025-07-01/income_groups.corrections.yml
@@ -1,0 +1,9 @@
+# Known upstream data errors in the World Bank income groups, corrected locally until fixed at the
+# source. See etl/data_corrections.py for the format.
+- indicator: classification
+  entity: Ethiopia
+  years: latest
+  action: drop
+  reason: Ethiopia's latest-year classification is included in the source file but officially has a temporary status of unclassification, so we drop it.
+  provider: World Bank
+  status: open

--- a/etl/steps/data/garden/wb/2025-07-01/income_groups.py
+++ b/etl/steps/data/garden/wb/2025-07-01/income_groups.py
@@ -1,6 +1,6 @@
 """Load a meadow dataset and create a garden dataset."""
-# NOTE: We have manually modified the value for Ethiopia, because, although it is included in the file, it has officially a temporary status of unclassification.
-# NOTE: Check this back when it's fixed in the source file.
+# NOTE: Ethiopia's latest-year row is dropped via income_groups.corrections.yml, because, although it is
+# included in the file, it officially has a temporary status of unclassification.
 
 import owid.catalog.processing as pr
 import pandas as pd
@@ -20,7 +20,7 @@ EXPECTED_MISSING_COUNTRIES_IN_LATEST_RELEASE = {
     "USSR",
     "Venezuela",
     "Yugoslavia",
-    "Ethiopia",  # NOTE: This is the one we manually modified. Delete when it has a classification again.
+    "Ethiopia",  # NOTE: Dropped via income_groups.corrections.yml. Delete when it has a classification again.
 }
 
 # Define French overseas territories where we want to assign the same income group as France
@@ -53,9 +53,9 @@ def run() -> None:
     # Drop unnecessary columns.
     tb = tb.drop(columns=["country_code"], errors="raise")
 
-    # Delete the row for Ethiopia in the latest year, as it has a temporary status of unclassification.
-    # NOTE: This is a manual fix, delete the line when the source file is fixed.
-    tb = tb[~((tb["country"] == "Ethiopia") & (tb["year"] == tb["year"].max()))].reset_index(drop=True)
+    # Drop known upstream data errors (e.g. Ethiopia's unclassified latest year), declared in
+    # income_groups.corrections.yml. This is why Ethiopia appears in EXPECTED_MISSING_COUNTRIES_IN_LATEST_RELEASE.
+    tb = paths.apply_corrections(tb)
 
     # Create an additional table for the classification of the latest year available.
     tb_latest = tb.reset_index(drop=True).drop_duplicates(subset=["country"], keep="last")

--- a/schemas/corrections-schema.json
+++ b/schemas/corrections-schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ETL data corrections",
+  "description": "Declarative corrections for known upstream data errors. See etl/data_corrections.py.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["indicator", "action", "reason", "provider", "status"],
+    "properties": {
+      "indicator": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The column to correct."
+      },
+      "entity": {
+        "type": "string",
+        "description": "Country/entity to locate rows by (use together with 'years')."
+      },
+      "years": {
+        "description": "Years to locate rows by: a list, 'all', 'latest', or an after/before/from/to range.",
+        "oneOf": [
+          {
+            "type": "array",
+            "items": { "type": "integer" },
+            "minItems": 1
+          },
+          { "enum": ["all", "latest"] },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "minProperties": 1,
+            "properties": {
+              "after": { "type": "integer" },
+              "before": { "type": "integer" },
+              "from": { "type": "integer" },
+              "to": { "type": "integer" }
+            }
+          }
+        ]
+      },
+      "match": {
+        "type": "object",
+        "minProperties": 1,
+        "description": "Locate rows by their current value(s), e.g. {value: 4.5}. Mutually exclusive with entity/years."
+      },
+      "action": {
+        "enum": ["drop", "override", "scale", "flag"],
+        "description": "drop = remove rows; override = set value; scale = multiply by factor; flag = log only."
+      },
+      "value": {
+        "description": "Replacement value for action 'override' (use null to blank a single cell)."
+      },
+      "factor": {
+        "type": "number",
+        "description": "Multiplier for action 'scale' (e.g. 0.001 to fix a units/thousands mismatch)."
+      },
+      "expect": {
+        "type": "object",
+        "additionalProperties": false,
+        "minProperties": 1,
+        "description": "Guard asserted over all matched rows before applying the fix; fails loudly if the source is fixed.",
+        "properties": {
+          "eq": { "type": "number" },
+          "ne": { "type": "number" },
+          "gt": { "type": "number" },
+          "ge": { "type": "number" },
+          "lt": { "type": "number" },
+          "le": { "type": "number" }
+        }
+      },
+      "reason": {
+        "type": "string",
+        "minLength": 1,
+        "description": "Why this is a known error (human-readable)."
+      },
+      "provider": {
+        "type": "string",
+        "minLength": 1,
+        "description": "The upstream data provider."
+      },
+      "status": {
+        "enum": ["open", "reported", "acknowledged", "fixed_upstream"],
+        "description": "Reporting status with the provider."
+      },
+      "reported": {
+        "type": "string",
+        "format": "date",
+        "description": "Date we reported the error to the provider (optional)."
+      }
+    },
+    "oneOf": [
+      {
+        "required": ["entity", "years"],
+        "not": { "required": ["match"] }
+      },
+      {
+        "required": ["match"],
+        "not": { "anyOf": [{ "required": ["entity"] }, { "required": ["years"] }] }
+      }
+    ],
+    "allOf": [
+      {
+        "if": { "properties": { "action": { "const": "override" } }, "required": ["action"] },
+        "then": { "required": ["value"] }
+      },
+      {
+        "if": { "properties": { "action": { "const": "scale" } }, "required": ["action"] },
+        "then": { "required": ["factor"] }
+      },
+      {
+        "if": { "properties": { "action": { "const": "flag" } }, "required": ["action"] },
+        "then": { "not": { "required": ["expect"] } }
+      }
+    ]
+  }
+}

--- a/tests/test_data_corrections.py
+++ b/tests/test_data_corrections.py
@@ -154,6 +154,68 @@ def test_validate_rejects_match_combined_with_years():
         _validate_correction(_correction(action="drop", match={"value": 10.0}, years=[2006]), "<test>")
 
 
+def test_scale_multiplies_matched_values():
+    tb = _make_table()
+    out = apply_corrections(tb, [_correction(action="scale", factor=0.5, entity="France", years="all")])
+    # France 2006 (10.0) and 2016 (20.0) halved; Panama untouched.
+    assert sorted(out.loc[out["country"] == "France", "value"].tolist()) == [5.0, 10.0]
+    assert sorted(out.loc[out["country"] == "Panama", "value"].tolist()) == [-3.0, -2.0, -1.0]
+    # Metadata preserved through scale.
+    assert out["value"].metadata.unit == "tonnes"
+
+
+def test_scale_requires_numeric_factor():
+    from etl.data_corrections import _validate_correction
+
+    with pytest.raises(AssertionError, match="numeric 'factor'"):
+        _validate_correction(_correction(action="scale", entity="France", years="all"), "<test>")
+    # A boolean is not a valid factor (bool is an int subclass — guard against it).
+    with pytest.raises(AssertionError, match="numeric 'factor'"):
+        _validate_correction(_correction(action="scale", factor=True, entity="France", years="all"), "<test>")
+
+
+def test_years_all_selects_every_year_for_entity():
+    tb = _make_table()
+    out = apply_corrections(tb, [_correction(action="drop", entity="Panama", years="all")])
+    # All three Panama rows dropped; France untouched.
+    assert (out["country"] == "Panama").sum() == 0
+    assert (out["country"] == "France").sum() == 2
+
+
+def test_expect_passes_when_anomaly_present():
+    tb = _make_table()
+    # France values are 10 and 20, both > 5 → expectation holds, scale applies.
+    out = apply_corrections(
+        tb, [_correction(action="scale", factor=0.1, entity="France", years="all", expect={"gt": 5})]
+    )
+    assert sorted(out.loc[out["country"] == "France", "value"].tolist()) == [1.0, 2.0]
+
+
+def test_expect_raises_when_anomaly_fixed():
+    tb = _make_table()
+    # Panama values are negative; expecting them > 0 fails (simulates an upstream fix).
+    with pytest.raises(AssertionError, match="may have been fixed"):
+        apply_corrections(
+            tb, [_correction(action="override", value=0.0, entity="Panama", years="all", expect={"gt": 0})]
+        )
+
+
+def test_expect_rejected_on_flag():
+    from etl.data_corrections import _validate_correction
+
+    with pytest.raises(AssertionError, match="cannot be combined with action 'flag'"):
+        _validate_correction(_correction(action="flag", entity="Panama", years="all", expect={"gt": 0}), "<test>")
+
+
+def test_expect_rejects_unknown_operator():
+    from etl.data_corrections import _validate_correction
+
+    with pytest.raises(AssertionError, match="unknown 'expect' operators"):
+        _validate_correction(
+            _correction(action="scale", factor=0.5, entity="France", years="all", expect={"approx": 10}), "<test>"
+        )
+
+
 def test_load_corrections_rejects_both_entity_and_match(tmp_path):
     p = tmp_path / "x.corrections.yml"
     p.write_text(

--- a/tests/test_data_corrections.py
+++ b/tests/test_data_corrections.py
@@ -216,6 +216,42 @@ def test_expect_rejects_unknown_operator():
         )
 
 
+def test_build_audit_captures_drop_before_values():
+    from etl.data_corrections import build_audit
+
+    tb = _make_table()
+    records = build_audit(tb, [_correction(action="drop", entity="Panama", years=[2006, 2016])])
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["action"] == "drop" and rec["numeric"] is True
+    ent = rec["entities"][0]
+    assert ent["entity"] == "Panama"
+    # Full pre-correction series is captured (all 3 Panama years).
+    assert ent["series"] == [[2006, -1.0], [2008, -2.0], [2016, -3.0]]
+    # Affected points carry the before value and None (removed) as the after.
+    assert ent["affected"] == [[2006, -1.0, None], [2016, -3.0, None]]
+
+
+def test_build_audit_captures_scale_before_after():
+    from etl.data_corrections import build_audit
+
+    tb = _make_table()
+    records = build_audit(tb, [_correction(action="scale", factor=0.5, entity="France", years="all")])
+    ent = records[0]["entities"][0]
+    # before → before*factor for every affected point.
+    assert ent["affected"] == [[2006, 10.0, 5.0], [2016, 20.0, 10.0]]
+
+
+def test_audit_path_is_under_data_tree():
+    from etl.data_corrections import audit_path_for
+    from etl.paths import STEP_DIR
+
+    p = STEP_DIR / "data" / "garden" / "gcp" / "2025-11-13" / "global_carbon_budget.corrections.yml"
+    out = audit_path_for(p)
+    assert out.name == "global_carbon_budget.audit.json"
+    assert "corrections_audit" in out.parts and "garden" in out.parts
+
+
 def test_load_corrections_rejects_both_entity_and_match(tmp_path):
     p = tmp_path / "x.corrections.yml"
     p.write_text(

--- a/tests/test_data_corrections.py
+++ b/tests/test_data_corrections.py
@@ -1,0 +1,161 @@
+"""Tests for etl.data_corrections (the .corrections.yml mechanism)."""
+
+import pytest
+from owid.catalog import Table
+
+from etl.data_corrections import apply_corrections, load_corrections
+
+
+def _make_table() -> Table:
+    tb = Table(
+        {
+            "country": ["Panama", "Panama", "Panama", "France", "France"],
+            "year": [2006, 2008, 2016, 2006, 2016],
+            "value": [-1.0, -2.0, -3.0, 10.0, 20.0],
+        }
+    )
+    # Give the indicator column some metadata so we can check it survives.
+    tb["value"].metadata.unit = "tonnes"
+    tb["value"].metadata.title = "Some emissions"
+    return tb
+
+
+def _correction(**overrides):
+    base = {
+        "id": "test-correction",
+        "indicator": "value",
+        "action": "drop",
+        "reason": "Test reason.",
+        "provider": "Test provider.",
+        "status": "open",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_drop_by_entity_and_year_list():
+    tb = _make_table()
+    out = apply_corrections(tb, [_correction(entity="Panama", years=[2006, 2016])])
+    # Two Panama rows dropped; France untouched.
+    assert list(zip(out["country"], out["year"])) == [("Panama", 2008), ("France", 2006), ("France", 2016)]
+    # Index is renumbered (matching the df.drop(...).reset_index(drop=True) idiom).
+    assert list(out.index) == [0, 1, 2]
+    # Metadata preserved.
+    assert out["value"].metadata.unit == "tonnes"
+
+
+def test_drop_does_not_mutate_input():
+    tb = _make_table()
+    apply_corrections(tb, [_correction(entity="Panama", years=[2006])])
+    assert len(tb) == 5
+
+
+def test_years_latest_resolves_per_entity():
+    tb = _make_table()
+    out = apply_corrections(tb, [_correction(entity="Panama", years="latest")])
+    # Panama's latest year is 2016.
+    assert (out["country"] == "Panama").sum() == 2
+    assert not ((out["country"] == "Panama") & (out["year"] == 2016)).any()
+
+
+def test_years_range_from_to():
+    tb = _make_table()
+    out = apply_corrections(tb, [_correction(entity="Panama", years={"from": 2007, "to": 2016})])
+    # Drops Panama 2008 and 2016, keeps 2006.
+    assert ((out["country"] == "Panama") & (out["year"] == 2006)).any()
+    assert (out["country"] == "Panama").sum() == 1
+
+
+def test_years_range_after_before():
+    tb = _make_table()
+    out = apply_corrections(tb, [_correction(entity="France", years={"after": 2006, "before": 2017})])
+    assert (out["country"] == "France").sum() == 1  # only 2016 dropped
+
+
+def test_override_by_match_value():
+    tb = _make_table()
+    out = apply_corrections(
+        tb,
+        [_correction(id="ovr", action="override", match={"value": 10.0}, value=99.0)],
+    )
+    # France 2006 had value 10.0 → now 99.0.
+    assert out.loc[(out["country"] == "France") & (out["year"] == 2006), "value"].item() == 99.0
+    # Metadata preserved through override.
+    assert out["value"].metadata.unit == "tonnes"
+
+
+def test_override_requires_value():
+    # Validation rejects an override entry without a `value`.
+    from etl.data_corrections import _validate_correction
+
+    with pytest.raises(AssertionError):
+        _validate_correction(_correction(id="bad", action="override", match={"value": 10.0}), "<test>")
+
+
+def test_flag_is_a_noop_on_data():
+    tb = _make_table()
+    out = apply_corrections(tb, [_correction(id="flagged", action="flag", entity="Panama", years=[2006])])
+    assert len(out) == len(tb)
+
+
+def test_unmatched_drop_raises():
+    tb = _make_table()
+    with pytest.raises(AssertionError, match="matched no rows"):
+        apply_corrections(tb, [_correction(entity="Atlantis", years=[2006])])
+
+
+def test_works_with_country_year_in_index():
+    tb = _make_table().set_index(["country", "year"])
+    out = apply_corrections(tb, [_correction(entity="Panama", years=[2006])])
+    assert ("Panama", 2006) not in out.index
+    assert len(out) == 4
+
+
+def test_load_corrections_validates_and_dedupes(tmp_path):
+    p = tmp_path / "x.corrections.yml"
+    p.write_text(
+        "- id: a\n"
+        "  indicator: value\n"
+        "  entity: Panama\n"
+        "  years: [2006]\n"
+        "  action: drop\n"
+        "  reason: r\n"
+        "  provider: p\n"
+        "  status: open\n"
+    )
+    corrections = load_corrections(p)
+    assert corrections[0]["id"] == "a"
+
+
+def test_load_corrections_rejects_duplicate_ids(tmp_path):
+    p = tmp_path / "x.corrections.yml"
+    entry = (
+        "- id: dup\n"
+        "  indicator: value\n"
+        "  entity: Panama\n"
+        "  years: [2006]\n"
+        "  action: drop\n"
+        "  reason: r\n"
+        "  provider: p\n"
+        "  status: open\n"
+    )
+    p.write_text(entry + entry)
+    with pytest.raises(AssertionError, match="Duplicate correction id"):
+        load_corrections(p)
+
+
+def test_load_corrections_rejects_both_entity_and_match(tmp_path):
+    p = tmp_path / "x.corrections.yml"
+    p.write_text(
+        "- id: a\n"
+        "  indicator: value\n"
+        "  entity: Panama\n"
+        "  years: [2006]\n"
+        "  match: {value: 4.5}\n"
+        "  action: drop\n"
+        "  reason: r\n"
+        "  provider: p\n"
+        "  status: open\n"
+    )
+    with pytest.raises(AssertionError, match="exactly one of"):
+        load_corrections(p)

--- a/tests/test_data_corrections.py
+++ b/tests/test_data_corrections.py
@@ -1,9 +1,13 @@
 """Tests for etl.data_corrections (the .corrections.yml mechanism)."""
 
+import json
+
 import pytest
+import yaml
 from owid.catalog import Table
 
 from etl.data_corrections import apply_corrections, load_corrections
+from etl.paths import BASE_DIR, STEP_DIR
 
 
 def _make_table() -> Table:
@@ -214,6 +218,21 @@ def test_expect_rejects_unknown_operator():
         _validate_correction(
             _correction(action="scale", factor=0.5, entity="France", years="all", expect={"approx": 10}), "<test>"
         )
+
+
+def test_all_repo_corrections_match_schema():
+    """Every `.corrections.yml` in the repo must validate against schemas/corrections-schema.json
+    (the same schema VSCode uses), so the editor lint and CI agree."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads((BASE_DIR / "schemas" / "corrections-schema.json").read_text())
+    jsonschema.Draft7Validator.check_schema(schema)
+    validator = jsonschema.Draft7Validator(schema)
+    files = sorted(STEP_DIR.rglob("*.corrections.yml"))
+    assert files, "expected at least one .corrections.yml in the repo"
+    for path in files:
+        data = yaml.safe_load(path.read_text())
+        errors = [f"{list(e.path)}: {e.message}" for e in validator.iter_errors(data)]
+        assert not errors, f"{path} does not match the corrections schema:\n" + "\n".join(errors)
 
 
 def test_build_audit_captures_drop_before_values():

--- a/tests/test_data_corrections.py
+++ b/tests/test_data_corrections.py
@@ -137,6 +137,23 @@ def test_load_corrections_rejects_missing_required_field(tmp_path):
         load_corrections(p)
 
 
+def test_validate_rejects_empty_match():
+    # An empty match would build an all-true mask and apply the correction to every row (wiping a table
+    # on drop, or overwriting a whole indicator on override). Validation must reject it.
+    from etl.data_corrections import _validate_correction
+
+    with pytest.raises(AssertionError, match="non-empty mapping"):
+        _validate_correction(_correction(action="drop", match={}), "<test>")
+
+
+def test_validate_rejects_match_combined_with_years():
+    # `match` + `years` (without entity) passes the XOR check but `years` would be silently ignored.
+    from etl.data_corrections import _validate_correction
+
+    with pytest.raises(AssertionError, match="do not combine 'match'"):
+        _validate_correction(_correction(action="drop", match={"value": 10.0}, years=[2006]), "<test>")
+
+
 def test_load_corrections_rejects_both_entity_and_match(tmp_path):
     p = tmp_path / "x.corrections.yml"
     p.write_text(

--- a/tests/test_data_corrections.py
+++ b/tests/test_data_corrections.py
@@ -22,7 +22,6 @@ def _make_table() -> Table:
 
 def _correction(**overrides):
     base = {
-        "id": "test-correction",
         "indicator": "value",
         "action": "drop",
         "reason": "Test reason.",
@@ -50,12 +49,14 @@ def test_drop_does_not_mutate_input():
     assert len(tb) == 5
 
 
-def test_years_latest_resolves_per_entity():
+def test_years_latest_resolves_to_global_max():
     tb = _make_table()
     out = apply_corrections(tb, [_correction(entity="Panama", years="latest")])
-    # Panama's latest year is 2016.
+    # The table's latest year is 2016; only Panama's 2016 row is dropped.
     assert (out["country"] == "Panama").sum() == 2
     assert not ((out["country"] == "Panama") & (out["year"] == 2016)).any()
+    # France's 2016 row is untouched (the correction is scoped to Panama).
+    assert ((out["country"] == "France") & (out["year"] == 2016)).any()
 
 
 def test_years_range_from_to():
@@ -76,7 +77,7 @@ def test_override_by_match_value():
     tb = _make_table()
     out = apply_corrections(
         tb,
-        [_correction(id="ovr", action="override", match={"value": 10.0}, value=99.0)],
+        [_correction(action="override", match={"value": 10.0}, value=99.0)],
     )
     # France 2006 had value 10.0 → now 99.0.
     assert out.loc[(out["country"] == "France") & (out["year"] == 2006), "value"].item() == 99.0
@@ -89,12 +90,12 @@ def test_override_requires_value():
     from etl.data_corrections import _validate_correction
 
     with pytest.raises(AssertionError):
-        _validate_correction(_correction(id="bad", action="override", match={"value": 10.0}), "<test>")
+        _validate_correction(_correction(action="override", match={"value": 10.0}), "<test>")
 
 
 def test_flag_is_a_noop_on_data():
     tb = _make_table()
-    out = apply_corrections(tb, [_correction(id="flagged", action="flag", entity="Panama", years=[2006])])
+    out = apply_corrections(tb, [_correction(action="flag", entity="Panama", years=[2006])])
     assert len(out) == len(tb)
 
 
@@ -111,11 +112,10 @@ def test_works_with_country_year_in_index():
     assert len(out) == 4
 
 
-def test_load_corrections_validates_and_dedupes(tmp_path):
+def test_load_corrections_validates(tmp_path):
     p = tmp_path / "x.corrections.yml"
     p.write_text(
-        "- id: a\n"
-        "  indicator: value\n"
+        "- indicator: value\n"
         "  entity: Panama\n"
         "  years: [2006]\n"
         "  action: drop\n"
@@ -124,31 +124,23 @@ def test_load_corrections_validates_and_dedupes(tmp_path):
         "  status: open\n"
     )
     corrections = load_corrections(p)
-    assert corrections[0]["id"] == "a"
+    assert corrections[0]["entity"] == "Panama"
 
 
-def test_load_corrections_rejects_duplicate_ids(tmp_path):
+def test_load_corrections_rejects_missing_required_field(tmp_path):
     p = tmp_path / "x.corrections.yml"
-    entry = (
-        "- id: dup\n"
-        "  indicator: value\n"
-        "  entity: Panama\n"
-        "  years: [2006]\n"
-        "  action: drop\n"
-        "  reason: r\n"
-        "  provider: p\n"
-        "  status: open\n"
+    # Missing 'reason'.
+    p.write_text(
+        "- indicator: value\n  entity: Panama\n  years: [2006]\n  action: drop\n  provider: p\n  status: open\n"
     )
-    p.write_text(entry + entry)
-    with pytest.raises(AssertionError, match="Duplicate correction id"):
+    with pytest.raises(AssertionError, match="missing required 'reason'"):
         load_corrections(p)
 
 
 def test_load_corrections_rejects_both_entity_and_match(tmp_path):
     p = tmp_path / "x.corrections.yml"
     p.write_text(
-        "- id: a\n"
-        "  indicator: value\n"
+        "- indicator: value\n"
         "  entity: Panama\n"
         "  years: [2006]\n"
         "  match: {value: 4.5}\n"


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

A declarative **`.corrections.yml`** mechanism for recording known **upstream data errors** and applying the local fix, replacing scattered inline `.loc[...]` / `.drop(...)` exceptions with one auditable record per error (carrying its reason, provider, and reporting status) — plus a CLI that inventories and visualises every correction in the repo.

## 🔎 Visual review

**[Open the corrections dashboard →](https://htmlpreview.github.io/?https://gist.githubusercontent.com/Marigold/3e46907c92259d6d03caf2f4a98723c2/raw/a79cd61f093683abe73c741b5dc967575e6b5d71/corrections.html)** — every correction in the repo, grouped by provider/status. Expand a row for a before→after table and a time-series chart showing the *problematic* values (red) and the fix (green). Generated by `etl corrections -o out.html --charts`.

## What's here

- **`etl/data_corrections.py`** — loader (`load_corrections`) + `apply_corrections(tb, corrections)`, plus an audit (`build_audit` / `write_audit` / `read_audit`) that records each correction's affected points for visualisation.
- **`PathFinder.corrections_path`** + **`PathFinder.apply_corrections(tb)`** in `etl/helpers.py`, mirroring the `.excluded_countries.json` ergonomics — one line in a step. It also writes the audit on each run.
- **`etl corrections`** CLI (`apps/corrections/cli.py`) — scans all `.corrections.yml`, validates them (repo-wide lint), prints a terminal summary, and renders a self-contained HTML dashboard.
- **Six real cases migrated** from inline code, each verified **value-identical** end-to-end.
- **JSON Schema** (`schemas/corrections-schema.json`, wired in `.vscode/settings.json`) so `.corrections.yml` files are linted in the editor like `.meta.yml`; a test enforces every repo corrections file against it.
- Unit tests in `tests/test_data_corrections.py`.

## The format

A `<short_name>.corrections.yml` next to the step, a list of entries:

```yaml
- indicator: consumption_emissions          # the COLUMN to correct
  entity: Panama                            # country/entity
  years: [2006, 2008, 2016]                 # list | all | latest | {after/before/from/to: Y}
  action: drop                              # drop | override | scale | flag
  reason: Negative consumption-based CO2 emissions (physically impossible) in the source data.
  provider: Global Carbon Project
  reported: 2024-11-13                       # optional — when we told the provider
  status: reported                           # open | reported | acknowledged | fixed_upstream
```

- Rows are located by `entity` + `years`, or by their current value: `match: {value: 4.5}`.
- **Actions**: **`drop`** removes the matched rows (long/tidy tables); **`override`** replaces the indicator value with `value` (use `value: null` to blank one bad cell in a wide table without dropping the row); **`scale`** multiplies by `factor` (e.g. a unit mismatch — `factor: 0.001`); **`flag`** logs the known error without changing data.
- `years` grammar: a literal list, `all` (every year for the entity), `latest` (the table's most recent year), or `{after/before/from/to}` ranges.
- **`expect:` guard** (optional): a mapping of `eq`/`ne`/`gt`/`ge`/`lt`/`le` → threshold, asserted over all matched rows *before* the fix. `drop` is self-validating (the row vanishing trips the no-match assert), but `override`/`scale` keep the row — `expect` is how they **fail loudly when the source fixes the value**. Cannot combine with `flag`.
- **No `id` field** — a stable label is derived from `provider / indicator / target` for logs and error messages.

## Migrated cases

| Step | Correction | Action |
|---|---|---|
| `gcp/2025-11-13/global_carbon_budget` | Panama negative consumption emissions (2006/2008/2016) | `drop`, year list |
| `ifr/2026-01-14/robot_density` | China 2023 value revised by the source | `override` |
| `usgs/2025-12-15/mineral_commodity_summaries` | Australia zinc reserves 2022 + Kazakhstan asbestos 2020 | `override: value: null` (blank cell) |
| `wb/2025-07-01/income_groups` | Ethiopia's unclassified latest-year row | `drop`, `years: latest` |
| `literacy/2026-05-12/historic_literacy_omm` | Cote d'Ivoire 2019 likely-error literacy rate | `drop`, year list |
| `tourism/2026-01-21/unwto` | Taiwan domestic hotel guests reported in units, not thousands | `scale: factor: 0.001` + `expect: {gt: 1000000}` |

These exercise every action (`drop`, `override`, value-blanking, `scale`) and the `entity`+list / `entity`+`latest` / `entity`+`all` locators, plus the `expect` guard.

## Visualisation & audit

`PathFinder.apply_corrections` records, at apply time, each affected entity's full pre-correction series and the exact before/after of every affected point, under `data/corrections_audit/` (gitignored). `etl corrections --charts` reads it to render — per correction — a before→after table plus a **Plotly** time-series that highlights the problematic values in red and the fix in green (with a Linear/Log toggle). Charts are exact and immune to mid-pipeline column renames (the audit is captured where the correction runs, not re-read from the published dataset).

> Note: the audit reflects the value **at the correction's apply point**. For corrections that run before a downstream transform (e.g. UNWTO, applied before the garden ×1000), the "After" is the intermediate value, not the final published number.

## Verification

For each migrated step I built the garden output with the old inline code and with the new corrections file and asserted `assert_frame_equal(check_exact=True)` **plus** per-column metadata equality. All are value-identical — a behaviour-preserving refactor, not a data change. `make check` (ruff + ty) and the unit tests pass.

## Notes for review

- **`override` changes a published number** (IFR China 2023). The corrected value and the source's note are in the correction's `reason`/`status` — worth a glance.
- **The old "lost guard" concern is now addressed** by `expect:` — `override`/`scale` corrections can assert the rows are still anomalous before acting (e.g. UNWTO's `expect: {gt: 1000000}`), failing loudly if the source fixes the issue. Richer cross-row guards (e.g. animal-welfare's `barn == free_range`) remain inline for now.
- **WB `EXPECTED_MISSING_COUNTRIES_IN_LATEST_RELEASE`** keeps its `Ethiopia` entry on purpose — dropping Ethiopia's latest row is *why* it shows as missing, and a downstream assertion checks that. I only updated the comments to point at the corrections file.

## Surveyed but intentionally NOT migrated

I swept `garden/`, `meadow/` and `snapshots/` for inline point-corrections (multiple angles). Good candidates remain for follow-ups — deferred here with reasons, so the next pass is just picking from this list:

**Mechanism supports them, deferred for verification care:**
- **`gfs/.../gfs_wave_two` drinks 4.5→5** and **WHO typo fixes** (`avian_influenza` "225"→"2025", `vaccine_stock_out` "Inaccurtae"→"Inaccurate") — these use `.astype().replace(...)` rather than a `.loc` assignment, so a value-identical migration needs care, not a copy.
- **`animal_welfare/.../laying_hens_keeping_eu` Belgium 2025 + Greece 2013** — clean drops, but the inline code carries *cross-row* value-guards (`barn == free_range`, `total < 100k`) that the per-row `expect:` clause can't express yet.
- **`gapminder/.../maternal_mortality` year typos** (meadow) and **`health/.../polio_free_countries` Somalia 2000** — in-scope point corrections, lower priority.

**Out of scope (not provider point-errors):**
- **`democracy/.../lexical_index` `regime_lied==7 → regime_redux_lied=6`** — looks like a point fix but rewrites **4,234 rows**: a systematic scale-recoding *rule*, not a point correction. Left inline.
- **`emissions/.../gdp_and_co2_decoupling` Honduras 2008/2013** — reads more like an analytical decision (removing distorting peaks).
- **GCP Kuwait-1991 Oil Fires merge**, **`health/.../wgm_2018` answer-code merge** — aggregation / cross-wave harmonization.
- **`faostat/.../detected_anomalies`** — already a dedicated anomaly-class framework with value-based `check()`, multi-key (item/element) locators, and a replace-from-another-source fix that the current mechanism can't express; consolidation is a separate effort.
- **NOAA missing-country fix** (categorical handling), **waste-management UAE** (×100 rescale via `scale` is now possible — candidate for a follow-up).
- **BGS USSR-after-1991, Energy Institute zero-fills, agriculture spurious zeros, WB-PIP snapshot validation, `ggdc` source-flagged outliers, OECD pre-1990 marriage rates** — geopolitical/temporal/harmonization/systematic *rules*, not enumerated provider errors.

> Note: the search also turned up corrections living in **archived (superseded) step versions** — I verified active-DAG membership before touching anything and skipped archive-only files.

## Explicitly NOT in this PR (follow-ups)

Per-provider report generator, auto-expiry on re-ingestion, Anomalist-seeded patch drafting. (The cross-dataset dashboard — originally a follow-up — is now included via `etl corrections`.)
