### PR TITLE
✨ Make staging servers dashboard lifecycle honest

### DIFF
--- a/apps/wizard/app_pages/servers_dashboard/app.py
+++ b/apps/wizard/app_pages/servers_dashboard/app.py
@@ -111,13 +111,17 @@ with st.container(horizontal=True, vertical_alignment="bottom", horizontal_align
 
         **Status Indicators**:
         - 🟢 **Running**: Container is active and operational
-        - ⏸️ **Idle**: Container is stopped to save resources, but its **data is preserved**. Wake it instantly with the **Wake** button (no commit needed) — staging servers are stopped automatically after 14 days without a commit.
+        - ⏸️ **Idle**: Container is stopped to save resources, but its **data is preserved**. Wake it instantly with the **Wake** button (no commit needed).
 
-        **Commit Status**:
-        - ✅ **Today/Recent**: Commits within the last week
-        - ⚠️ **Warning**: Commits older than 7 days
-        - ❌ **Old**: Commits much older or containers not accessible
-        - ❓ **Unknown**: Unable to determine commit status
+        **Last commit**: age of the newest ETL/Grapher commit. This is reference info only — it does **not** by itself decide when a server is stopped.
+
+        **Auto-stop** — when (and why) the reaper will stop a server:
+        - A running server is auto-stopped once **max(last commit, last _start_) is older than 14 days**. Stopping just idles it (data preserved); it's not destroyed.
+        - Because *last start* counts, **waking or restarting a server resets the clock** — so a server with an old commit can still be far from being stopped. The column shows the reason (e.g. *restarted Jun 19* vs *commit Jun 19*).
+        - 🟢 healthy · 🟡 stops within a few days · 🔴 stops on the next nightly run · ⏸️ already idle · ♾️ persistent (`master`, never auto-stopped) · ❓ can't be judged (commit unreadable).
+        - ⚠️ A **host restart bumps every container's last-start at once**, resetting the timer fleet-wide — so right after a `gaia-1` reboot most servers will read the same countdown regardless of commit age.
+
+        **Destroy** (frees the disk) only happens after the **PR is merged/closed** (~3 days later) — auto-stop never destroys.
 
         **Memory Usage**:
         - Only running containers show memory usage
@@ -410,7 +414,8 @@ else:
             "Branch": filtered_df["branch"],
             "Memory": filtered_df["memory_used_gb"].fillna(0).round(2),
             "Age (days)": filtered_df["days_old"],
-            "Last Commit": filtered_df["unified_commit"],
+            "Last commit": filtered_df["last_commit_display"],
+            "Auto-stop": filtered_df["auto_stop"],
         }
     )
 
@@ -435,8 +440,19 @@ else:
             "Age (days)": st.column_config.NumberColumn(
                 "Age (days)", help="Days since container was created", format="%d days", width="small"
             ),
-            "Last Commit": st.column_config.TextColumn(
-                "Last Commit", help="Most recent relevant commit based on server origin", width="medium"
+            "Last commit": st.column_config.TextColumn(
+                "Last commit",
+                help="Age of the newest ETL/Grapher commit. Informational only — it does not by "
+                "itself decide when a server is stopped (see Auto-stop).",
+                width="small",
+            ),
+            "Auto-stop": st.column_config.TextColumn(
+                "Auto-stop",
+                help="When the reaper will stop this server, and why it's still alive. A server is "
+                "auto-stopped once max(last commit, last start) exceeds 14 days — so a recent "
+                "restart keeps an old-commit server running. 🟢 healthy · 🟡 stops soon · "
+                "🔴 stops tonight · ⏸️ already idle · ♾️ persistent.",
+                width="medium",
             ),
         },
         hide_index=True,

--- a/apps/wizard/app_pages/servers_dashboard/utils.py
+++ b/apps/wizard/app_pages/servers_dashboard/utils.py
@@ -20,6 +20,18 @@ log = get_logger()
 # target this host (matching ops/templates/lxc-manager/*), so keep it in one place.
 LXC_HOST = "gaia-1"
 
+# Auto-stop lifecycle, mirrored from the ops reaper cron
+# (ops/templates/lxc-manager/stop_staging_containers.py). A running container is stopped (idled,
+# data preserved) once its most recent sign of activity — max(latest commit, last *start*) — is
+# older than STOP_AFTER_DAYS. We recompute that here so the dashboard's "Auto-stop" column agrees
+# with what the cron will actually do. Keep these in sync with that script.
+STOP_AFTER_DAYS = 14
+# Container the reaper skips explicitly — never auto-stopped.
+PERSISTENT_CONTAINERS = {"staging-site-master"}
+# Sentinel the LXC `info` command returns when a repo's commit can't be read transiently. The cron
+# refuses to stop on this (the other repo might have recent work it couldn't see), so neither do we.
+COMMIT_LOOKUP_FAILED = "Unable to retrieve"
+
 
 @st.cache_data(ttl=300, show_spinner=False)  # Cache for 5 minutes to avoid hammering the server
 def fetch_host_memory_stats(host: str = "gaia-1") -> tuple[dict | None, str | None]:
@@ -179,6 +191,14 @@ def _process_server_data(df: pd.DataFrame) -> pd.DataFrame:
     df["etl_commit_parsed"] = pd.to_datetime(df["etl_last_commit"], errors="coerce")
     df["grapher_commit_parsed"] = pd.to_datetime(df["grapher_last_commit"], errors="coerce")
 
+    # Last *start* time (bumped by LXC only on container start, not exec/ssh). This is what the
+    # reaper counts alongside commits, so a freshly-woken server isn't stopped the same night.
+    if "last_used_at" not in df.columns:
+        df["last_used_at"] = None
+    # format="ISO8601" handles LXC's variable fractional-second precision (and None) without the
+    # per-element dateutil fallback that pandas warns about.
+    df["last_used_parsed"] = pd.to_datetime(df["last_used_at"], errors="coerce", format="ISO8601")
+
     # Calculate days since last commit
     df["etl_days_old"] = _calculate_days_since_commit(df["etl_commit_parsed"])
     df["grapher_days_old"] = _calculate_days_since_commit(df["grapher_commit_parsed"])
@@ -200,6 +220,14 @@ def _process_server_data(df: pd.DataFrame) -> pd.DataFrame:
 
     # Build a single "last commit" column based on origin (used in the server list)
     df["unified_commit"] = df.apply(_get_unified_commit_info, axis=1)
+
+    # Neutral, alarm-free relative time of the latest commit (informational only — the lifecycle
+    # signal lives in the auto_stop column below, not here).
+    df["last_commit_display"] = df.apply(_format_last_commit_neutral, axis=1)
+
+    # Honest lifecycle column: when (and why) the reaper will stop this server.
+    now = datetime.now(timezone.utc)
+    df["auto_stop"] = df.apply(lambda row: _compute_auto_stop(row, now), axis=1)
 
     # Sort by status (running first) then by creation date (newest first)
     df = df.sort_values(
@@ -344,6 +372,81 @@ def _get_unified_commit_info(row: pd.Series) -> str:
             return format_commit_info(row["etl_last_commit"], row["etl_days_old"])
         else:
             return format_commit_info(row["grapher_last_commit"], row["grapher_days_old"])
+
+
+def _as_utc(ts) -> pd.Timestamp:
+    """Normalize a parsed timestamp to tz-aware UTC so commit and start times are comparable.
+
+    LXC emits trailing-Z timestamps; pandas parses some as tz-aware and (when the column is mixed)
+    others as naive. Localize naive values to UTC rather than guessing the host's offset.
+    """
+    ts = pd.Timestamp(ts)
+    return ts.tz_localize("UTC") if ts.tzinfo is None else ts.tz_convert("UTC")
+
+
+def _latest_commit_date(row: pd.Series) -> pd.Timestamp | None:
+    """Newest of the ETL / Grapher commit timestamps (None if neither is a real date)."""
+    dates = [_as_utc(d) for d in (row["etl_commit_parsed"], row["grapher_commit_parsed"]) if pd.notna(d)]
+    return max(dates) if dates else None
+
+
+def _commit_lookup_failed(row: pd.Series) -> bool:
+    """True if either repo's commit came back as a transient failure (vs. a legitimate absence)."""
+    return COMMIT_LOOKUP_FAILED in (row.get("etl_last_commit"), row.get("grapher_last_commit"))
+
+
+def _format_last_commit_neutral(row: pd.Series) -> str:
+    """Relative age of the latest commit, with no ✅/⚠️/❌ alarm — this column is reference info,
+    not a lifecycle signal (that's `auto_stop`)."""
+    latest = _latest_commit_date(row)
+    if pd.isna(latest):
+        return "unknown" if _commit_lookup_failed(row) else "no commits"
+    days = max(0, (datetime.now(timezone.utc) - latest).days)
+    if days == 0:
+        return "today"
+    if days == 1:
+        return "1 day ago"
+    return f"{days} days ago"
+
+
+def _compute_auto_stop(row: pd.Series, now: datetime) -> str:
+    """When (and why) the reaper will stop this server, mirroring stop_staging_containers.py.
+
+    The cron stops a running container once max(latest commit, last start) is older than
+    STOP_AFTER_DAYS. We surface the countdown plus the reason it's still alive, so an old commit
+    next to a recent restart no longer reads as "should be dead".
+    """
+    # Idle servers are already stopped — the action is Wake, not a countdown.
+    if row["status"] != "Running":
+        return "⏸️ idle · wake anytime"
+    # Persistent container is never auto-stopped.
+    if row["name"] in PERSISTENT_CONTAINERS:
+        return "♾️ persistent"
+    # The cron skips on a transient commit-lookup failure; don't imply imminent death.
+    if _commit_lookup_failed(row):
+        return "❓ won't auto-stop (commit unreadable)"
+
+    commit_date = _latest_commit_date(row)
+    last_used = _as_utc(row["last_used_parsed"]) if pd.notna(row["last_used_parsed"]) else pd.NaT
+    candidates = [d for d in (commit_date, last_used) if pd.notna(d)]
+    # No commit date at all → cron can't judge and skips it; mirror that rather than guess.
+    if pd.isna(commit_date) or not candidates:
+        return "❓ won't auto-stop (no commit date)"
+
+    last_activity = max(candidates)
+    days_left = STOP_AFTER_DAYS - (now - last_activity).days
+
+    # Which signal is keeping it alive — a recent restart or a recent commit?
+    if pd.notna(last_used) and last_used >= commit_date:
+        reason = f"restarted {last_used.strftime('%b %-d')}"
+    else:
+        reason = f"commit {commit_date.strftime('%b %-d')}"
+
+    if days_left <= 0:
+        return f"🔴 stops tonight · {reason}"
+    if days_left <= 4:
+        return f"🟡 in {days_left}d · {reason}"
+    return f"🟢 in {days_left}d · {reason}"
 
 
 def reset_mysql_database(server_name: str) -> tuple[bool, str]:


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

On the Servers dashboard, the **Last Commit** column colored each row by **git-commit age** (✅ ≤1d, ⚠️ 2–7d, ❌ >7d). But whether a server is stopped is decided by the ops reaper (`stop_staging_containers.py`) as:

```
stop when  max(last commit, last start) > 14 days
```

The two signals are unrelated, so the icons actively misled:

- `⚠️ 2 days ago` read as a warning on a perfectly healthy server ~12 days from any action.
- `❌ 47 days ago` read as dead on a server that was **restarted 3 days ago** and won't be touched for 11 more days.
- None of the icon thresholds (2d / 7d) matched the one that matters (14d), and **last-start — the field that actually keeps old-commit servers alive — wasn't shown at all.**

This came up when several servers (e.g. `refactor-migrate-energy`, `data-add-catalog-dataset`) showed `❌ 39–47 days` but were still running: a `gaia-1` restart on Jun 19 bumped every container's last-start at once, resetting the 14-day timer fleet-wide.

## What changed

- **`Last commit` is now neutral** — a plain relative time (`47 days ago`), no ✅/⚠️/❌. It's reference info, not an alarm.
- **New `Auto-stop` column** recomputes the reaper's own rule client-side and shows the countdown **plus the reason** the server is still alive:
  - `🟢 in 11d · restarted Jun 19` / `🟢 in 11d · commit Jun 19`
  - `🟡 in 2d · …` (stops soon) · `🔴 stops tonight · …`
  - `⏸️ idle · wake anytime` · `♾️ persistent` (`master`) · `❓ won't auto-stop (commit unreadable)`
  - Mirrors the cron's edge cases exactly (skip `master`, skip on transient commit-lookup failure).
- **About popover rewritten** to state the real rule, that waking/restarting resets the clock, and that a host restart resets it fleet-wide.

No new data fetch — `last_used_at` and both commit dates are already in the `owid-lxc info --json` output, so this is pure presentation logic.

## Verification

Run against the live `gaia-1` fleet:

```
                  branch status_label  last commit                   auto_stop
     data-population-omm      Running  11 days ago  🟢 in 11d · restarted Jun 19
 refactor-migrate-energy      Running  39 days ago  🟢 in 11d · restarted Jun 19
data-add-catalog-dataset      Running  47 days ago  🟢 in 11d · restarted Jun 19
                  master      Running   5 days ago  ♾️ persistent
```

68 servers processed, zero NaNs; `make check` passes.

## Note for reviewers

The reaper formula now exists in two places — here and in the ops repo (`ops/templates/lxc-manager/stop_staging_containers.py`). I left a `keep in sync` comment rather than importing across repos. A cleaner long-term option is to have `owid-lxc info` expose the computed status so the dashboard just displays it, but that's a larger ops change — happy to do that instead if preferred.
