### PR TITLE
📊 Fix housekeeper chart reviews: read Slack IDs from grapher MySQL

### DIFF
--- a/apps/housekeeper/charts.py
+++ b/apps/housekeeper/charts.py
@@ -25,8 +25,9 @@ from apps.housekeeper.utils import (
     owidb_get_reviews_id,
     owidb_submit_review_id,
 )
-from etl.analytics.metabase import get_question_data, read_metabase
+from etl.analytics.metabase import get_question_data
 from etl.config import OWID_ENV, SLACK_API_TOKEN
+from etl.db import read_sql
 from etl.slack_helpers import send_slack_message
 
 log = get_logger()
@@ -361,10 +362,10 @@ def get_references(chart_id: int):
 
 
 def get_usernames():
-    df = read_metabase(
-        "select fullName, slackId from users where slackId is not null",
-        database_id=5,
-    )
+    # Read staff Slack IDs straight from grapher MySQL (the native home of these columns).
+    # Previously this went through Metabase database id 5, which was removed when we
+    # switched analytics over to BigQuery.
+    df = read_sql("SELECT fullName, slackId FROM users WHERE slackId IS NOT NULL")
     df = df[["fullName", "slackId"]].dropna()
     dix = df.set_index("fullName")["slackId"].to_dict()
     return dix


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Problem

The scheduled **Housekeeper: Charts review** job has been failing on every run ([example build](https://buildkite.com/our-world-in-data/etl-housekeeper-master/builds/739)):

```
File "apps/housekeeper/charts.py", line 364, in get_usernames
  df = read_metabase(...)
RuntimeError: Metabase API request failed with status code 500:
  Assert failed: (keyword? driver)
```

`get_usernames()` queried **Metabase database id 5** — the old grapher production MySQL connection. That connection was removed when we switched analytics over to BigQuery, so Metabase can no longer resolve a driver for it and returns a 500. It's the only `database_id=5` reference in the repo.

## Fix

Read `fullName`/`slackId` straight from grapher MySQL via `etl.db.read_sql` instead of going through Metabase. This matches how the rest of `apps/housekeeper` already sources its data (`utils.py` reads from `OWID_ENV.engine`), needs no new credentials, and avoids depending on the freshness of the BigQuery `prod_mysql` mirror — `slackId` lives natively in grapher MySQL.

## Verification

- Ran `get_usernames()` against the live grapher DB → returns 27 staff with Slack IDs (previously crashed).
- `make check` passes.
