### PR TITLE
📊 Retry transient Metabase 502s in read_metabase

### DIFF
--- a/etl/analytics/metabase.py
+++ b/etl/analytics/metabase.py
@@ -9,6 +9,8 @@ from io import BytesIO
 import pandas as pd
 import requests
 from metabase_api import Metabase_API
+from structlog import get_logger
+from tenacity import Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from etl.config import (
     METABASE_API_KEY,
@@ -19,9 +21,21 @@ from etl.config import (
     OWID_ENV,
 )
 
+log = get_logger()
+
 # Config
 COLLECTION_EXPERT_ID = 61  # Expert collection
 DATABASE_ID = 2  # Semantic Layer database
+
+# HTTP status codes that indicate Metabase is temporarily unavailable rather than a permanent error.
+# Metabase is restarted by the analytics pipeline whenever the DuckDB mirrors are rebuilt (daily, plus
+# on every push to the analytics / owid-grapher main branches), so its nginx front-end briefly returns
+# 502/503/504 while the JVM reboots. These are worth retrying; a 4xx is not.
+RETRYABLE_STATUS_CODES = frozenset({502, 503, 504})
+
+
+class MetabaseTransientError(RuntimeError):
+    """Metabase upstream was temporarily unavailable (e.g. mid-restart). Safe to retry."""
 
 
 def mb_cli(domain: str | None = None, key: str | None = None):
@@ -106,14 +120,41 @@ def read_metabase(
     # Send request.
     if mb_url is None:
         mb_url = METABASE_URL
-    response = requests.post(
-        f"{mb_url}/api/dataset/csv",
-        headers=headers,
-        data=urlencoded,
-        timeout=30,
-    )
-    if not response.ok:
-        raise RuntimeError(f"Metabase API request failed with status code {response.status_code}: {response.text}")
+    url = f"{mb_url}/api/dataset/csv"
+
+    # Retry transient failures with exponential backoff. Metabase is restarted regularly by the
+    # analytics pipeline (see RETRYABLE_STATUS_CODES), which can otherwise hard-fail an entire owidbot
+    # run on a single 502 that resolves within a minute. Connection/timeout errors are retried too;
+    # a permanent error (4xx, parse failure) is reraised immediately without retrying.
+    def _request() -> requests.Response:
+        response = requests.post(url, headers=headers, data=urlencoded, timeout=30)
+        if response.status_code in RETRYABLE_STATUS_CODES:
+            raise MetabaseTransientError(
+                f"Metabase API temporarily unavailable (status code {response.status_code}). "
+                "It is likely being restarted; retrying."
+            )
+        if not response.ok:
+            raise RuntimeError(f"Metabase API request failed with status code {response.status_code}: {response.text}")
+        return response
+
+    def _log_retry(retry_state) -> None:
+        log.warning(
+            "metabase.request_retry",
+            attempt=retry_state.attempt_number,
+            error=str(retry_state.outcome.exception()),
+        )
+
+    for attempt in Retrying(
+        retry=retry_if_exception_type(
+            (MetabaseTransientError, requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+        ),
+        stop=stop_after_attempt(5),
+        wait=wait_exponential(multiplier=2, min=2, max=60),
+        before_sleep=_log_retry,
+        reraise=True,
+    ):
+        with attempt:
+            response = _request()
 
     # Create a dataframe with the returned data.
     df = pd.read_csv(BytesIO(response.content))


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Problem

owidbot chart-diff runs (and any other caller of the analytics → Metabase path) intermittently hard-fail with:

```
RuntimeError: Metabase API request failed with status code 502: <html>
... nginx/1.24.0 (Ubuntu) ...
```

The 502 page is generated by **nginx**, not Metabase — the upstream Metabase JVM is briefly unreachable. This is expected and benign: the analytics pipeline restarts Metabase every time it rebuilds the DuckDB mirrors so it picks up the fresh files (`ops/.buildkite/analytics/shared_duckdb_steps.yml` → `make metabase.restart` + `pm2 restart metabase`). That happens **daily**, plus on every push to the `analytics` / `owid-grapher` main branches, so the restart window is hit fairly often. Metabase reads the semantic layer straight from on-disk DuckDB files, whose inode is rewritten on rebuild (documented at `analytics/Makefile`), which is why a restart is needed in the first place.

The bug on our side: `read_metabase` fired a single request with **no retry**, so a few-second restart window failed the entire run.

## Fix

Wrap the request in a `tenacity.Retrying` loop (same pattern already used in `etl/snapshot.py` / `etl/grapher/io.py`; `tenacity` is already a dependency):

- **5 attempts, exponential backoff 2→60s** — covers a normal JVM reboot window (~30s of total wait across the gaps).
- **Retried:** HTTP 502/503/504 (`RETRYABLE_STATUS_CODES`) plus `ConnectionError` / `Timeout`.
- **Not retried:** 4xx and CSV parse failures reraise immediately (`reraise=True` preserves the original exception type rather than wrapping in `RetryError`).
- Each retry logs a `metabase.request_retry` warning with the attempt number, so restarts stay visible rather than silently swallowed.

## Testing

Verified with mocked responses: transient 502s retry and recover, a 400 fails fast with no retry, and a persistent 502 exhausts all attempts then reraises `MetabaseTransientError`. `make check` passes.
