### PR TITLE
📊 Add child labor and hazardous work multidims

### DIFF
--- a/.claude/skills/create-multidim/SKILL.md
+++ b/.claude/skills/create-multidim/SKILL.md
@@ -36,7 +36,9 @@ https://ourworldindata.org/grapher/{chart-slug}.metadata.json
 https://api.ourworldindata.org/v1/indicators/{id}.metadata.json
 ```
 
-The catalogPath format is: `grapher/{namespace}/{version}/{dataset}/{table}#{variable_name}`
+**Reference indicators by the short `{table}#{variable_name}` form** (e.g. `child_labor#share_child_labor__sex_total__age_5_17`). PathFinder resolves the namespace/version/dataset from the step's DAG dependency, so the config never hardcodes the version — when the dataset version bumps, only the DAG entry changes. See `etl/steps/export/multidim/wid/latest/wealth_wid.config.yml` for a real example.
+
+The full form `grapher/{namespace}/{version}/{dataset}/{table}#{variable_name}` is valid too, but only reach for it to disambiguate when two DAG dependencies both contain a table of the same name. Never hardcode the version just to "be explicit" — it rots on the next update.
 
 Look at the indicator shortNames to identify the dimensional structure. For example:
 - `life_expectancy__sex_female__age_0__type_period` → dimensions: sex, age
@@ -157,7 +159,7 @@ views:
       sex: female
     indicators:
       y:
-        - catalogPath: grapher/namespace/version/dataset/table#variable_female
+        - catalogPath: table#variable_female
     config:
       title: "Title for females view"
       subtitle: "Subtitle for females view"
@@ -166,7 +168,7 @@ views:
       sex: male
     indicators:
       y:
-        - catalogPath: grapher/namespace/version/dataset/table#variable_male
+        - catalogPath: table#variable_male
     config:
       title: "Title for males view"
       subtitle: "Subtitle for males view"
@@ -182,10 +184,10 @@ views:
       sex: female
     indicators:
       y:
-        - catalogPath: grapher/ns/ver/ds/tb#indicator_a
+        - catalogPath: tb#indicator_a
           display:
             name: "Label for line A"
-        - catalogPath: grapher/ns/ver/ds/tb#indicator_b
+        - catalogPath: tb#indicator_b
           display:
             name: "Label for line B"
     config:
@@ -215,6 +217,10 @@ definitions:
           colorScale:
             binningStrategy: manual
 ```
+
+## Per-view FAUST: inherit from garden, don't re-type it
+
+A view's chart config can omit `title`/`subtitle`/`note` — each view then inherits FAUST from the indicator's `presentation.grapher_config` in the **garden** `.meta.yml` (templated by dimension). Inheritance is from `grapher_config` only — there is no fallback to the indicator `title`/`description_short`/`display.name`. So to replicate an existing chart's FAUST across many views, set `grapher_config.title`/`subtitle`/`note` once in the garden metadata (e.g. age-aware via a Jinja `<% if %>` template), rebuild the grapher step, and leave the view configs thin. To verify what will actually render, read the resolved per-view config from `multi_dim_x_chart_configs` → `chart_configs` in the staging DB.
 
 ## Common Dimension Patterns
 

--- a/dag/labor.yml
+++ b/dag/labor.yml
@@ -50,6 +50,10 @@ steps:
         - snapshot://un/2026-04-08/child_labor_trends.csv
         - snapshot://un/2026-04-08/child_labor_by_region.csv
         - snapshot://un/2026-04-08/hazardous_work_by_region.csv
+  export://multidim/un/latest/child_labor:
+    - data://grapher/un/2026-04-08/child_labor_report
+  export://multidim/un/latest/hazardous_work:
+    - data://grapher/un/2026-04-08/child_labor_report
 
   #
   # Child labor in the long run (multiple sources)

--- a/etl/steps/data/garden/un/2026-04-08/child_labor_report.meta.yml
+++ b/etl/steps/data/garden/un/2026-04-08/child_labor_report.meta.yml
@@ -73,6 +73,10 @@ definitions:
   note_including_household_chores: |-
     Work here refers to economic activities (employment and production of goods). Does not include the worst forms of child labor that cannot be measured through surveys (trafficking, forced labor, etc.).
 
+  # Age clause spliced into chart titles: empty for the full 5-17 range (matching the standalone charts), " aged <<age>>" otherwise.
+  title_age_suffix: |-
+    <% if age == "5-17" %><%- else %> aged <<age>><%- endif %>
+
 
 # Learn more about the available fields:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/
@@ -98,6 +102,8 @@ tables:
           - "{definitions.description_key_modelled_data}"
         presentation:
           grapher_config:
+            title: Share of {definitions.sex}{definitions.title_age_suffix} in child labor
+            subtitle: Percentage of {definitions.sex} aged <<age>> who are either working at an age that is too young for them to be employed, or doing work that — by its nature or conditions — is likely to harm their health, safety, or morals.
             note: "{definitions.note_excluding_household_chores}"
         display:
           name: Share of {definitions.sex} in child labor (<<age>>)
@@ -117,6 +123,8 @@ tables:
           - "{definitions.description_key_modelled_data}"
         presentation:
           grapher_config:
+            title: Number of {definitions.sex}{definitions.title_age_suffix} in child labor
+            subtitle: Number of {definitions.sex} aged <<age>> who are either working at an age that is too young for them to be employed, or doing work that — by its nature or conditions — is likely to harm their health, safety, or morals.
             note: "{definitions.note_excluding_household_chores}"
         display:
           name: Number of {definitions.sex} in child labor (<<age>>)
@@ -135,6 +143,8 @@ tables:
           - "{definitions.description_key_modelled_data}"
         presentation:
           grapher_config:
+            title: Share of {definitions.sex}{definitions.title_age_suffix} in hazardous work
+            subtitle: Percentage of {definitions.sex} aged <<age>> in [child labor](#dod:child-labor) who are doing work that — by its nature or conditions — is likely to harm their health, safety, or morals.
             note: "{definitions.note_excluding_household_chores}"
         display:
           name: Share of {definitions.sex} in hazardous work (<<age>>)
@@ -153,6 +163,8 @@ tables:
           - "{definitions.description_key_modelled_data}"
         presentation:
           grapher_config:
+            title: Number of {definitions.sex}{definitions.title_age_suffix} in hazardous work
+            subtitle: Number of {definitions.sex} aged <<age>> in [child labor](#dod:child-labor) who are doing work that — by its nature or conditions — is likely to harm their health, safety, or morals.
             note: "{definitions.note_excluding_household_chores}"
         display:
           name: Number of {definitions.sex} in hazardous work (<<age>>)

--- a/etl/steps/export/multidim/un/latest/child_labor.config.yml
+++ b/etl/steps/export/multidim/un/latest/child_labor.config.yml
@@ -25,8 +25,10 @@ dimensions:
     choices:
       - slug: share
         name: Share in child labor
+        description: Percentage of all children
       - slug: number
         name: Number in child labor
+        description: Total number of children
 
 views:
   - dimensions:

--- a/etl/steps/export/multidim/un/latest/child_labor.config.yml
+++ b/etl/steps/export/multidim/un/latest/child_labor.config.yml
@@ -6,7 +6,7 @@ topic_tags:
 default_selection:
   - World
 default_dimensions:
-  metric: share
+  indicator: share
 
 definitions:
   common_views:
@@ -17,27 +17,27 @@ definitions:
         yAxis:
           min: 0
 
-# For now the only selector is the metric (share vs number); the underlying table is also
+# For now the only selector is the indicator (share vs number); the underlying table is also
 # disaggregated by sex (total/boys/girls), which could be added as a dimension in the future.
 dimensions:
-  - name: Metric
-    slug: metric
+  - name: Indicator
+    slug: indicator
     choices:
       - slug: share
-        name: Share
+        name: Share in child labor
         description: Share of children who are in child labor
       - slug: number
-        name: Number
+        name: Number in child labor
         description: Number of children who are in child labor
 
 views:
   - dimensions:
-      metric: share
+      indicator: share
     indicators:
       y:
         - catalogPath: "child_labor#share_child_labor__sex_total__age_5_17"
   - dimensions:
-      metric: number
+      indicator: number
     indicators:
       y:
         - catalogPath: "child_labor#number_child_labor__sex_total__age_5_17"

--- a/etl/steps/export/multidim/un/latest/child_labor.config.yml
+++ b/etl/steps/export/multidim/un/latest/child_labor.config.yml
@@ -1,0 +1,43 @@
+title:
+  title: Children in child labor
+  title_variant: ""
+topic_tags:
+  - Child Labor
+default_selection:
+  - World
+default_dimensions:
+  metric: share
+
+definitions:
+  common_views:
+    - config:
+        chartTypes: ["LineChart"]
+        hasMapTab: false
+        tab: chart
+        yAxis:
+          min: 0
+
+# For now the only selector is the metric (share vs number); the underlying table is also
+# disaggregated by sex (total/boys/girls), which could be added as a dimension in the future.
+dimensions:
+  - name: Metric
+    slug: metric
+    choices:
+      - slug: share
+        name: Share
+        description: Share of children who are in child labor
+      - slug: number
+        name: Number
+        description: Number of children who are in child labor
+
+views:
+  - dimensions:
+      metric: share
+    indicators:
+      y:
+        - catalogPath: "grapher/un/2026-04-08/child_labor_report/child_labor#share_child_labor__sex_total__age_5_17"
+  - dimensions:
+      metric: number
+    indicators:
+      y:
+        - catalogPath: "grapher/un/2026-04-08/child_labor_report/child_labor#number_child_labor__sex_total__age_5_17"

--- a/etl/steps/export/multidim/un/latest/child_labor.config.yml
+++ b/etl/steps/export/multidim/un/latest/child_labor.config.yml
@@ -1,6 +1,6 @@
 title:
   title: Children in child labor
-  title_variant: ""
+  title_variant: ILO and UNICEF
 topic_tags:
   - Child Labor
 default_selection:
@@ -16,9 +16,6 @@ definitions:
         tab: chart
         yAxis:
           min: 0
-      metadata:
-        presentation:
-          attribution_short: ILO and UNICEF
 
 # For now the only selector is the metric (share vs number); the underlying table is also
 # disaggregated by sex (total/boys/girls), which could be added as a dimension in the future.

--- a/etl/steps/export/multidim/un/latest/child_labor.config.yml
+++ b/etl/steps/export/multidim/un/latest/child_labor.config.yml
@@ -11,7 +11,7 @@ default_dimensions:
 definitions:
   common_views:
     - config:
-        chartTypes: ["LineChart"]
+        chartTypes: ["LineChart", "DiscreteBar"]
         hasMapTab: false
         tab: chart
         yAxis:

--- a/etl/steps/export/multidim/un/latest/child_labor.config.yml
+++ b/etl/steps/export/multidim/un/latest/child_labor.config.yml
@@ -25,10 +25,8 @@ dimensions:
     choices:
       - slug: share
         name: Share in child labor
-        description: Share of children who are in child labor
       - slug: number
         name: Number in child labor
-        description: Number of children who are in child labor
 
 views:
   - dimensions:

--- a/etl/steps/export/multidim/un/latest/child_labor.config.yml
+++ b/etl/steps/export/multidim/un/latest/child_labor.config.yml
@@ -35,9 +35,9 @@ views:
       metric: share
     indicators:
       y:
-        - catalogPath: "grapher/un/2026-04-08/child_labor_report/child_labor#share_child_labor__sex_total__age_5_17"
+        - catalogPath: "child_labor#share_child_labor__sex_total__age_5_17"
   - dimensions:
       metric: number
     indicators:
       y:
-        - catalogPath: "grapher/un/2026-04-08/child_labor_report/child_labor#number_child_labor__sex_total__age_5_17"
+        - catalogPath: "child_labor#number_child_labor__sex_total__age_5_17"

--- a/etl/steps/export/multidim/un/latest/child_labor.config.yml
+++ b/etl/steps/export/multidim/un/latest/child_labor.config.yml
@@ -25,10 +25,8 @@ dimensions:
     choices:
       - slug: share
         name: Share in child labor
-        description: Percentage of all children
       - slug: number
         name: Number in child labor
-        description: Total number of children
 
 views:
   - dimensions:

--- a/etl/steps/export/multidim/un/latest/child_labor.config.yml
+++ b/etl/steps/export/multidim/un/latest/child_labor.config.yml
@@ -16,6 +16,9 @@ definitions:
         tab: chart
         yAxis:
           min: 0
+      metadata:
+        presentation:
+          attribution_short: ILO and UNICEF
 
 # For now the only selector is the metric (share vs number); the underlying table is also
 # disaggregated by sex (total/boys/girls), which could be added as a dimension in the future.

--- a/etl/steps/export/multidim/un/latest/child_labor.config.yml
+++ b/etl/steps/export/multidim/un/latest/child_labor.config.yml
@@ -17,8 +17,6 @@ definitions:
         yAxis:
           min: 0
 
-# For now the only selector is the indicator (share vs number); the underlying table is also
-# disaggregated by sex (total/boys/girls), which could be added as a dimension in the future.
 dimensions:
   - name: Indicator
     slug: indicator

--- a/etl/steps/export/multidim/un/latest/child_labor.py
+++ b/etl/steps/export/multidim/un/latest/child_labor.py
@@ -1,0 +1,11 @@
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    c = paths.create_collection(
+        config=paths.load_collection_config(),
+        short_name="child_labor",
+    )
+    c.save()

--- a/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
@@ -6,7 +6,7 @@ topic_tags:
 default_selection:
   - World
 default_dimensions:
-  metric: share
+  indicator: share
 
 definitions:
   common_views:
@@ -17,27 +17,27 @@ definitions:
         yAxis:
           min: 0
 
-# For now the only selector is the metric (share vs number); the underlying table is also
+# For now the only selector is the indicator (share vs number); the underlying table is also
 # disaggregated by sex (total/boys/girls), which could be added as a dimension in the future.
 dimensions:
-  - name: Metric
-    slug: metric
+  - name: Indicator
+    slug: indicator
     choices:
       - slug: share
-        name: Share
+        name: Share in hazardous work
         description: Share of children who are in hazardous work
       - slug: number
-        name: Number
+        name: Number in hazardous work
         description: Number of children who are in hazardous work
 
 views:
   - dimensions:
-      metric: share
+      indicator: share
     indicators:
       y:
         - catalogPath: "child_labor#share_hazardous_work__sex_total__age_5_17"
   - dimensions:
-      metric: number
+      indicator: number
     indicators:
       y:
         - catalogPath: "child_labor#number_hazardous_work__sex_total__age_5_17"

--- a/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
@@ -1,0 +1,43 @@
+title:
+  title: Children in hazardous work
+  title_variant: ""
+topic_tags:
+  - Child Labor
+default_selection:
+  - World
+default_dimensions:
+  metric: share
+
+definitions:
+  common_views:
+    - config:
+        chartTypes: ["LineChart"]
+        hasMapTab: false
+        tab: chart
+        yAxis:
+          min: 0
+
+# For now the only selector is the metric (share vs number); the underlying table is also
+# disaggregated by sex (total/boys/girls), which could be added as a dimension in the future.
+dimensions:
+  - name: Metric
+    slug: metric
+    choices:
+      - slug: share
+        name: Share
+        description: Share of children who are in hazardous work
+      - slug: number
+        name: Number
+        description: Number of children who are in hazardous work
+
+views:
+  - dimensions:
+      metric: share
+    indicators:
+      y:
+        - catalogPath: "grapher/un/2026-04-08/child_labor_report/child_labor#share_hazardous_work__sex_total__age_5_17"
+  - dimensions:
+      metric: number
+    indicators:
+      y:
+        - catalogPath: "grapher/un/2026-04-08/child_labor_report/child_labor#number_hazardous_work__sex_total__age_5_17"

--- a/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
@@ -25,10 +25,8 @@ dimensions:
     choices:
       - slug: share
         name: Share in hazardous work
-        description: Share of children who are in hazardous work
       - slug: number
         name: Number in hazardous work
-        description: Number of children who are in hazardous work
 
 views:
   - dimensions:

--- a/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
@@ -11,7 +11,7 @@ default_dimensions:
 definitions:
   common_views:
     - config:
-        chartTypes: ["LineChart"]
+        chartTypes: ["LineChart", "DiscreteBar"]
         hasMapTab: false
         tab: chart
         yAxis:

--- a/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
@@ -35,9 +35,9 @@ views:
       metric: share
     indicators:
       y:
-        - catalogPath: "grapher/un/2026-04-08/child_labor_report/child_labor#share_hazardous_work__sex_total__age_5_17"
+        - catalogPath: "child_labor#share_hazardous_work__sex_total__age_5_17"
   - dimensions:
       metric: number
     indicators:
       y:
-        - catalogPath: "grapher/un/2026-04-08/child_labor_report/child_labor#number_hazardous_work__sex_total__age_5_17"
+        - catalogPath: "child_labor#number_hazardous_work__sex_total__age_5_17"

--- a/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
@@ -25,10 +25,8 @@ dimensions:
     choices:
       - slug: share
         name: Share in hazardous work
-        description: Percentage of all children
       - slug: number
         name: Number in hazardous work
-        description: Total number of children
 
 views:
   - dimensions:

--- a/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
@@ -16,6 +16,9 @@ definitions:
         tab: chart
         yAxis:
           min: 0
+      metadata:
+        presentation:
+          attribution_short: ILO and UNICEF
 
 # For now the only selector is the metric (share vs number); the underlying table is also
 # disaggregated by sex (total/boys/girls), which could be added as a dimension in the future.

--- a/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
@@ -17,8 +17,6 @@ definitions:
         yAxis:
           min: 0
 
-# For now the only selector is the indicator (share vs number); the underlying table is also
-# disaggregated by sex (total/boys/girls), which could be added as a dimension in the future.
 dimensions:
   - name: Indicator
     slug: indicator

--- a/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
@@ -1,6 +1,6 @@
 title:
   title: Children in hazardous work
-  title_variant: ""
+  title_variant: ILO and UNICEF
 topic_tags:
   - Child Labor
 default_selection:
@@ -16,9 +16,6 @@ definitions:
         tab: chart
         yAxis:
           min: 0
-      metadata:
-        presentation:
-          attribution_short: ILO and UNICEF
 
 # For now the only selector is the metric (share vs number); the underlying table is also
 # disaggregated by sex (total/boys/girls), which could be added as a dimension in the future.

--- a/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.config.yml
@@ -25,8 +25,10 @@ dimensions:
     choices:
       - slug: share
         name: Share in hazardous work
+        description: Percentage of all children
       - slug: number
         name: Number in hazardous work
+        description: Total number of children
 
 views:
   - dimensions:

--- a/etl/steps/export/multidim/un/latest/hazardous_work.py
+++ b/etl/steps/export/multidim/un/latest/hazardous_work.py
@@ -1,0 +1,11 @@
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    c = paths.create_collection(
+        config=paths.load_collection_config(),
+        short_name="hazardous_work",
+    )
+    c.save()


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## What

Adds two new multidims on the `un/2026-04-08/child_labor_report` dataset, each with a single **Metric** selector toggling **Share ↔ Number**:

- **Children in child labor** → `export://multidim/un/latest/child_labor`
- **Children in hazardous work** → `export://multidim/un/latest/hazardous_work`

Scope is metric-only for now (both sexes, ages 5–17); the underlying table is also disaggregated by sex (total/boys/girls) and age, which can be added as dimensions later.

## FAUST replication

The goal was for each view to reproduce the FAUST of the corresponding standalone chart. The multidim view configs are intentionally thin — they inherit Title/Subtitle/Footnote from each indicator's `presentation.grapher_config` in the garden metadata. So the work was mostly in the garden `.meta.yml`:

- **Title** — added `grapher_config.title` to `share/number_child_labor` and `share/number_hazardous_work`, age-aware via a shared `title_age_suffix` definition: empty for the full **5–17** range (so `total/5-17` renders exactly the standalone chart title, e.g. *"Share of children in child labor"*), and *"aged \<\<age\>\>"* otherwise.
- **Subtitle** — copied `description_short` into `grapher_config.subtitle` (literal duplicate, so the two can diverge in the future).
- **Footnote** — already present; unchanged.

Verified the resolved per-view configs (`multi_dim_x_chart_configs` → `chart_configs`) carry the exact Title/Subtitle/Note, `LineChart`, `hasMapTab: false`, `yAxis.min: 0` for all four views.

## Files

- `etl/steps/data/garden/un/2026-04-08/child_labor_report.meta.yml` — `title_age_suffix` definition + title/subtitle on 4 indicators
- `etl/steps/export/multidim/un/latest/{child_labor,hazardous_work}.{py,config.yml}` — new
- `dag/labor.yml` — two `export://multidim/un/latest/…` entries