### PR TITLE
📊 Silence transient Metabase retry warnings in Sentry

### DIFF
--- a/etl/analytics/metabase.py
+++ b/etl/analytics/metabase.py
@@ -138,7 +138,10 @@ def read_metabase(
         return response
 
     def _log_retry(retry_state) -> None:
-        log.warning(
+        # Logged at debug level on purpose: a transient 502/503/504 mid-restart is expected and
+        # resolves on retry, so it shouldn't surface in Sentry. If all attempts are exhausted,
+        # reraise=True propagates the exception, which is a genuine failure worth alerting on.
+        log.debug(
             "metabase.request_retry",
             attempt=retry_state.attempt_number,
             error=str(retry_state.outcome.exception()),


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## What

Transient Metabase `502`/`503`/`504` responses (the front-end briefly returning errors while the JVM reboots after a DuckDB mirror rebuild) were surfacing in Sentry and triggering notifications, even though the request succeeds on retry.

## Why this happens

`read_metabase` already retries these transient failures with exponential backoff via tenacity. The retry mechanism works correctly — but each retry attempt logged at `warning` level in the `before_sleep` callback, and that warning was what leaked to Sentry. The raised `MetabaseTransientError` itself never propagates when a later attempt succeeds (it's caught internally by the `Retrying` loop), so the raise is **not** the source of the noise and must stay — tenacity relies on it to know the call is retryable.

## Change

Downgrade the retry log line from `log.warning` → `log.debug`. Expected transient retries no longer surface in Sentry, while genuine failures still do: if all 5 attempts are exhausted, `reraise=True` propagates `MetabaseTransientError` to the caller as before.