### PR TITLE
📊 Repoint poverty and inequality steps to new PIP and WID datasets

### DIFF
--- a/dag/covid.yml
+++ b/dag/covid.yml
@@ -47,7 +47,7 @@ steps:
       - data://garden/un/2024-07-12/un_wpp
     - data://garden/un/2024-07-12/un_wpp
     # Econ
-    - data://garden/wb/2026-03-24/world_bank_pip_legacy
+    - data://garden/wb/2026-03-24/world_bank_pip
     - data://garden/un/2025-05-07/undp_hdr
     # Health
     - data://garden/wash/2025-12-08/household

--- a/dag/poverty_inequality.yml
+++ b/dag/poverty_inequality.yml
@@ -95,7 +95,6 @@ steps:
       - data://garden/poverty_inequality/2025-01-22/poverty_inequality_file:
         - data://garden/wb/2026-03-24/world_bank_pip
         - data://garden/wid/2026-02-10/world_inequality_database
-        - data://garden/worldbank_wdi/2026-02-27/wdi
       - data://garden/demography/2024-07-15/population
       - data://garden/regions/2023-01-01/regions
       - data://garden/wb/2026-03-24/world_bank_pip

--- a/dag/poverty_inequality.yml
+++ b/dag/poverty_inequality.yml
@@ -93,13 +93,13 @@ steps:
     - data://garden/poverty_inequality/2025-01-22/inequality_comparison:
       # Poverty and inequality file for inequality comparisons at OWID
       - data://garden/poverty_inequality/2025-01-22/poverty_inequality_file:
-        - data://garden/wb/2026-03-24/world_bank_pip_legacy
-        - data://garden/wid/2026-02-10/world_inequality_database_legacy
+        - data://garden/wb/2026-03-24/world_bank_pip
+        - data://garden/wid/2026-02-10/world_inequality_database
         - data://garden/worldbank_wdi/2026-02-27/wdi
       - data://garden/demography/2024-07-15/population
       - data://garden/regions/2023-01-01/regions
-      - data://garden/wb/2026-03-24/world_bank_pip_legacy
-      - data://garden/wid/2026-02-10/world_inequality_database_legacy
+      - data://garden/wb/2026-03-24/world_bank_pip
+      - data://garden/wid/2026-02-10/world_inequality_database
 
     # Global Multidimensional Poverty Index
   data://grapher/ophi/2025-12-23/multidimensional_poverty_index:

--- a/etl/steps/data/garden/covid/latest/compact.py
+++ b/etl/steps/data/garden/covid/latest/compact.py
@@ -201,7 +201,7 @@ def run() -> None:
     ds_regions = paths.load_dataset("regions")
     ds_wdi = paths.load_dataset("wdi")
     ds_hdr = paths.load_dataset("undp_hdr")
-    ds_pip = paths.load_dataset("world_bank_pip_legacy")
+    ds_pip = paths.load_dataset("world_bank_pip")
     ds_who = paths.load_dataset("household")
     ds_ghe = paths.load_dataset("ghe")
 
@@ -377,9 +377,17 @@ def add_external_indicators(
     tb_hdr = tb_hdr.loc[(tb_hdr["year"] == 2022) & (tb_hdr["year"] == "total"), ["country", "hdi"]]
     tb_hdr = tb_hdr.rename(columns={"hdi": "human_development_index"})
 
-    # PIP
-    tb_pip = ds_pip.read("income_consumption_2021")
-    tb_pip = tb_pip.loc[tb_pip["year"] > 2010, ["country", "year", "headcount_ratio_300"]]
+    # PIP — reconstruct the legacy income_consumption_2021 headcount_ratio_300 column from the
+    # dimensional poverty table (consolidated income-or-consumption series at the $3/day line).
+    tb_pip = ds_pip.read("poverty")
+    tb_pip = tb_pip.loc[
+        (tb_pip["ppp_version"] == 2021)
+        & (tb_pip["welfare_type"] == "income or consumption")
+        & (tb_pip["poverty_line"] == "300")
+        & (tb_pip["table"] == "Income or consumption consolidated")
+        & (tb_pip["year"] > 2010),
+        ["country", "year", "headcount_ratio"],
+    ].rename(columns={"headcount_ratio": "headcount_ratio_300"})
     ## get most recent data
     cols = ["headcount_ratio_300"]
     tb_pip = _ffill_and_keep_latest(tb_pip, cols)

--- a/etl/steps/data/garden/poverty_inequality/2025-01-22/inequality_comparison.meta.yml
+++ b/etl/steps/data/garden/poverty_inequality/2025-01-22/inequality_comparison.meta.yml
@@ -39,36 +39,50 @@ tables:
     variables:
       gini_pip_disposable_percapita:
         title: Gini coefficient (World Bank PIP) for the year <<ref_year>> (<<reference_years>> comparison) - <<only_all_series>>
+        unit: ""
+        short_unit: ""
         display:
           name: Gini coefficient around <<ref_year>>
 
       gini_wid_pretaxnational_peradult:
         title: Gini coefficient (WID) for the year <<ref_year>> (<<reference_years>> comparison) - <<only_all_series>> (pre-tax)
+        unit: ""
+        short_unit: ""
         display:
           name: Gini coefficient around <<ref_year>>
 
       p90p100share_pip_disposable_percapita:
         title: Income share of the richest 10% (World Bank PIP) for the year <<ref_year>> (<<reference_years>> comparison) - <<only_all_series>>
+        unit: "%"
+        short_unit: "%"
         display:
           name: Income share of the richest 10% around <<ref_year>>
 
       palmaratio_pip_disposable_percapita:
         title: Palma ratio (World Bank PIP) for the year <<ref_year>> (<<reference_years>> comparison) - <<only_all_series>>
+        unit: ""
+        short_unit: ""
         display:
           name: Palma ratio around <<ref_year>>
 
       p90p100share_wid_pretaxnational_peradult:
         title: Income share of the richest 10% (WID) for the year <<ref_year>> (<<reference_years>> comparison) - <<only_all_series>> (pre-tax)
+        unit: "%"
+        short_unit: "%"
         display:
           name: Income share of the richest 10% around <<ref_year>>
 
       p99p100share_wid_pretaxnational_peradult:
         title: Income share of the richest 1% (WID) for the year <<ref_year>> (<<reference_years>> comparison) - <<only_all_series>> (pre-tax)
+        unit: "%"
+        short_unit: "%"
         display:
           name: Income share of the richest 1% around <<ref_year>>
 
       palmaratio_wid_pretaxnational_peradult:
         title: Palma ratio (WID) for the year <<ref_year>> (<<reference_years>> comparison) - <<only_all_series>> (pre-tax)
+        unit: ""
+        short_unit: ""
         display:
           name: Palma ratio around <<ref_year>>
 

--- a/etl/steps/data/garden/poverty_inequality/2025-01-22/inequality_comparison.py
+++ b/etl/steps/data/garden/poverty_inequality/2025-01-22/inequality_comparison.py
@@ -15,6 +15,7 @@ We want to process this data inside the ETL now.
 import owid.catalog.processing as pr
 import pandas as pd
 from owid.catalog import Dataset, Table
+from shared import build_pip_unsmoothed, build_wid_main
 from structlog import get_logger
 
 from etl.data_helpers import geo
@@ -22,11 +23,6 @@ from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
-
-# Define PPP year for PIP
-# NOTE: Change this in case of new PPP versions in the future
-# TODO: Change to 2021 prices
-PPP_YEAR_PIP = 2021
 
 # Initialize logger
 log = get_logger()
@@ -70,14 +66,14 @@ def run() -> None:
     # NOTE: For now I am keeping the population and regions datasets commented out, because I might use them in the future
     # ds_population = paths.load_dataset("population")
     # ds_regions = paths.load_dataset("regions")
-    ds_pip = paths.load_dataset("world_bank_pip_legacy")
-    ds_wid = paths.load_dataset("world_inequality_database_legacy")
+    ds_pip = paths.load_dataset("world_bank_pip")
+    ds_wid = paths.load_dataset("world_inequality_database")
 
     tb = ds_pov_ineq.read("keyvars")
 
-    # Load tables from PIP, WID, and LIS datasets (for metadata)
-    tb_pip = ds_pip.read(f"income_consumption_{PPP_YEAR_PIP}_unsmoothed")
-    tb_wid = ds_wid.read("world_inequality_database")
+    # Reconstruct the legacy-shaped PIP and WID tables (for indicator metadata only — see shared.py).
+    tb_pip = build_pip_unsmoothed(ds_pip)
+    tb_wid = build_wid_main(ds_wid)
 
     # Change types of some columns to avoid issues with filtering and missing values on merge
     tb = tb.astype({"pipreportinglevel": "object", "pipwelfare": "object", "series_code": "object"})

--- a/etl/steps/data/garden/poverty_inequality/2025-01-22/inequality_comparison.py
+++ b/etl/steps/data/garden/poverty_inequality/2025-01-22/inequality_comparison.py
@@ -449,19 +449,23 @@ def add_metadata_from_original_tables(
     tb_wid: Table,
 ) -> Table:
     """
-    Add the original metadata we have in the garden steps of the main metadata.
-    This way we can add origins and indicator-based metadata
+    Copy provenance (origins) and units from the dimensional source columns.
+
+    We deliberately do NOT copy the source title/description: the dimensional PIP/WID tables template
+    those with Jinja over dimensions (welfare_type, extrapolated, ...) that don't exist in this
+    dataset, so copying them would fail Jinja rendering in the grapher step. The user-facing
+    title/display come from the .meta.yml instead.
     """
 
     for col, match in indicator_match.items():
-        # If col contains "pip"
         if "pip" in col:
-            # Get the metadata from the PIP table
-            tb[col] = tb[col].copy_metadata(tb_pip[match])
-        # If col contains "wid"
+            source = tb_pip[match]
         elif "wid" in col:
-            # Get the metadata from the WID table
-            tb[col] = tb[col].copy_metadata(tb_wid[match])
+            source = tb_wid[match]
+        else:
+            continue
+        # Only origins are taken from the source; units and titles are defined in the .meta.yml.
+        tb[col].metadata.origins = source.metadata.origins
 
     return tb
 

--- a/etl/steps/data/garden/poverty_inequality/2025-01-22/poverty_inequality_file.py
+++ b/etl/steps/data/garden/poverty_inequality/2025-01-22/poverty_inequality_file.py
@@ -2,6 +2,7 @@
 
 import owid.catalog.processing as pr
 from owid.catalog.core import Table, warnings
+from shared import build_pip_percentiles, build_pip_unsmoothed, build_wid_distribution, build_wid_main
 
 from etl.helpers import PathFinder
 
@@ -20,17 +21,18 @@ def run() -> None:
     #
     # Load inputs.
     #
-    # Load garden datasets
-    ds_pip = paths.load_dataset("world_bank_pip_legacy")
-    ds_wid = paths.load_dataset("world_inequality_database_legacy")
+    # Load garden datasets (dimensional PIP and WID; the legacy datasets are kept only for the
+    # CSV explorers — see shared.py for how the legacy-shaped tables are reconstructed here).
+    ds_pip = paths.load_dataset("world_bank_pip")
+    ds_wid = paths.load_dataset("world_inequality_database")
     ds_wdi = paths.load_dataset("wdi")
 
-    # Read tables from garden datasets.
-    tb_pip = ds_pip[f"income_consumption_{PPP_YEAR_PIP}_unsmoothed"].reset_index()
-    tb_wid = ds_wid["world_inequality_database"].reset_index()
+    # Reconstruct the legacy-shaped tables this step expects from the dimensional datasets.
+    tb_pip = build_pip_unsmoothed(ds_pip)
+    tb_wid = build_wid_main(ds_wid)
 
-    tb_pip_percentiles = ds_pip[f"percentiles_income_consumption_{PPP_YEAR_PIP}"].reset_index()
-    tb_wid_percentiles = ds_wid["world_inequality_database_distribution"].reset_index()
+    tb_pip_percentiles = build_pip_percentiles(ds_pip)
+    tb_wid_percentiles = build_wid_distribution(ds_wid)
     tb_wdi = ds_wdi["wdi"].reset_index()
 
     #

--- a/etl/steps/data/garden/poverty_inequality/2025-01-22/poverty_inequality_file.py
+++ b/etl/steps/data/garden/poverty_inequality/2025-01-22/poverty_inequality_file.py
@@ -1,19 +1,18 @@
-"""Load a garden dataset and create an explorers dataset."""
+"""Build the combined PIP + WID key-indicators (keyvars) file used by inequality_comparison."""
 
 import owid.catalog.processing as pr
 from owid.catalog.core import Table, warnings
-from shared import build_pip_percentiles, build_pip_unsmoothed, build_wid_distribution, build_wid_main
+from shared import build_pip_unsmoothed, build_wid_main
 
 from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
-# Define PPP year for PIP, LIS and WID
+# Define PPP year for PIP and WID
 # NOTE: Change this in case of new PPP versions in the future
 # TODO: Change to 2021 prices
 PPP_YEAR_PIP = 2021
-PPP_YEAR_LIS = 2021
 PPP_YEAR_WID = 2023
 
 
@@ -21,19 +20,14 @@ def run() -> None:
     #
     # Load inputs.
     #
-    # Load garden datasets (dimensional PIP and WID; the legacy datasets are kept only for the
-    # CSV explorers — see shared.py for how the legacy-shaped tables are reconstructed here).
+    # Load dimensional PIP and WID datasets (the legacy datasets are kept only for the CSV
+    # explorers — see shared.py for how the legacy-shaped key-indicator tables are reconstructed).
     ds_pip = paths.load_dataset("world_bank_pip")
     ds_wid = paths.load_dataset("world_inequality_database")
-    ds_wdi = paths.load_dataset("wdi")
 
-    # Reconstruct the legacy-shaped tables this step expects from the dimensional datasets.
+    # Reconstruct the legacy-shaped key-indicator tables from the dimensional datasets.
     tb_pip = build_pip_unsmoothed(ds_pip)
     tb_wid = build_wid_main(ds_wid)
-
-    tb_pip_percentiles = build_pip_percentiles(ds_pip)
-    tb_wid_percentiles = build_wid_distribution(ds_wid)
-    tb_wdi = ds_wdi["wdi"].reset_index()
 
     #
     # Process data.
@@ -42,53 +36,24 @@ def run() -> None:
     tb_wid_keyvars = create_keyvars_file_wid(tb_wid, extrapolated=False)
     tb_wid_keyvars_extrapolated = create_keyvars_file_wid(tb_wid, extrapolated=True)
 
-    tb_pip_percentiles = create_percentiles_file_pip(tb_pip_percentiles)
-    tb_wid_percentiles, tb_wid_percentiles_extrapolated = create_percentiles_file_wid(tb_wid_percentiles)
-
-    tb_wdi = extract_gdp_from_wdi(tb_wdi)
-
-    # Concatenate all the tables
+    # Concatenate the key-indicator tables.
     tb = pr.concat(
         [tb_pip_keyvars, tb_wid_keyvars, tb_wid_keyvars_extrapolated],
         ignore_index=True,
         short_name="keyvars",
     )
 
-    tb_percentiles = pr.concat(
-        [
-            tb_pip_percentiles,
-            tb_wid_percentiles,
-            tb_wid_percentiles_extrapolated,
-        ],
-        ignore_index=True,
-        short_name="percentiles",
-    )
-
     # Drop rows with null values in value column
     tb = tb.dropna(subset=["value"])
-
-    # When all the values in the column value for country, year, series_code are null, drop
-    tb_percentiles = tb_percentiles.groupby(["country", "year", "series_code"]).filter(
-        lambda x: x["value"].notnull().any()
-    )
-
-    # If only one value is not null for country, year, series_code, drop
-    tb_percentiles = tb_percentiles.groupby(["country", "year", "series_code"]).filter(
-        lambda x: x["value"].notnull().count() > 1
-    )
 
     # Define region "suffixes" in the country column
     region_suffixes_list = ["\\(PIP\\)", "\\(LIS\\)", "\\(WID\\)"]
 
     # Remove countries that include the text in region_suffixes_list in the country column
     tb = tb[~tb["country"].str.contains("|".join(region_suffixes_list))].reset_index(drop=True)
-    tb_percentiles = tb_percentiles[
-        ~tb_percentiles["country"].str.contains("|".join(region_suffixes_list), regex=False)
-    ].reset_index(drop=True)
 
     # Remove "World" from country column
     tb = tb[tb["country"] != "World"].reset_index(drop=True)
-    tb_percentiles = tb_percentiles[tb_percentiles["country"] != "World"].reset_index(drop=True)
 
     # Remove urban and rural entities from country column (only WID)
     tb = tb[~tb["country"].isin(["China (urban)", "China (rural)"])].reset_index(drop=True)
@@ -114,36 +79,16 @@ def run() -> None:
         verify_integrity=True,
     )
 
-    tb_percentiles = tb_percentiles.set_index(
-        [
-            "country",
-            "year",
-            "series_code",
-            "percentile",
-            "indicator_name",
-            "source",
-            "welfare",
-            "resource_sharing",
-            "pipreportinglevel",
-            "pipwelfare",
-            "prices",
-            "unit",
-        ],
-        verify_integrity=True,
-    )
-
-    tb_wdi = tb_wdi.set_index(["country", "year"], verify_integrity=True)
-
     #
     # Save outputs.
     #
-    # Create explorer dataset
-    ds_explorer = paths.create_dataset(
-        tables=[tb, tb_percentiles, tb_wdi],
+    # Create a new garden dataset.
+    ds_garden = paths.create_dataset(
+        tables=[tb],
         default_metadata=ds_pip.metadata,
         repack=False,
     )
-    ds_explorer.save()
+    ds_garden.save()
 
 
 def create_keyvars_file_pip(tb: Table) -> Table:
@@ -230,130 +175,6 @@ def create_keyvars_file_pip(tb: Table) -> Table:
     )
     tb["unit"] = tb["unit"].where(tb["indicator_name"] != "p90p100Share", "%")
     tb["unit"] = tb["unit"].astype(str)
-
-    return tb
-
-
-def create_keyvars_file_lis(tb: Table, adults: bool) -> Table:
-    """
-    Process the main table from LIS, to adapt it to a concatenated file with WID and PIP
-    """
-
-    # Define different names for per capita notation, depending on whether the table is for adults or not
-    if adults:
-        pc_notation = "perAdult"
-        pc_notation_human_readable = "Per adult"
-    else:
-        pc_notation = "perCapita"
-        pc_notation_human_readable = "Per capita"
-
-    tb = tb.copy()
-
-    # Set the list of indicators to use
-    # TODO: Add averages and shares at the top of the distribution
-    indicators_list = [
-        "gini_dhi_eq",
-        "gini_dhi_pc",
-        "gini_mi_eq",
-        "gini_mi_pc",
-        "mean_dhi_eq",
-        "mean_dhi_pc",
-        "mean_mi_eq",
-        "mean_mi_pc",
-        "median_dhi_eq",
-        "median_dhi_pc",
-        "median_mi_eq",
-        "median_mi_pc",
-        "share_p100_dhi_eq",
-        "share_p100_dhi_pc",
-        "share_p100_mi_eq",
-        "share_p100_mi_pc",
-        "palma_ratio_dhi_eq",
-        "palma_ratio_dhi_pc",
-        "palma_ratio_mi_eq",
-        "palma_ratio_mi_pc",
-        "headcount_ratio_50_median_dhi_eq",
-        "headcount_ratio_50_median_dhi_pc",
-        "headcount_ratio_50_median_mi_eq",
-        "headcount_ratio_50_median_mi_pc",
-    ]
-
-    # Select the columns to keep
-    tb = tb[["country", "year"] + indicators_list]
-
-    with warnings.ignore_warnings([warnings.DifferentValuesWarning]):
-        # Make lis table longer
-        tb = tb.melt(id_vars=["country", "year"], var_name="indicator_welfare_equivalization", value_name="value")
-
-    # Split indicator_welfare_equivalization column into three columns, using the last two "_" as separators
-    tb[["indicator_name", "welfare", "equivalization"]] = tb["indicator_welfare_equivalization"].str.rsplit(
-        "_", n=2, expand=True
-    )
-
-    # Drop indicator_welfare_equivalization column
-    tb = tb.drop(columns=["indicator_welfare_equivalization"])
-
-    # Rename welfare and equivalization columns
-    tb["welfare"] = tb["welfare"].replace({"mi": "market", "dhi": "disposable"})
-    tb["equivalization"] = tb["equivalization"].replace({"eq": "equivalized", "pc": pc_notation})
-    tb["indicator_name"] = tb["indicator_name"].replace(
-        {
-            "palma_ratio": "palmaRatio",
-            "headcount_ratio_50_median": "headcountRatio50Median",
-            "share_p100": "p90p100Share",
-        }
-    )
-
-    # Add descriptive columns
-    tb["source"] = "lis"
-    tb["prices"] = ""
-    tb["prices"] = tb["prices"].where(
-        (tb["indicator_name"] != "mean") & (tb["indicator_name"] != "median"),
-        f"{PPP_YEAR_LIS}ppp{PPP_YEAR_LIS}",
-    )
-    tb["prices"] = tb["prices"].astype(str)
-
-    # Add the column series_code, which is the concatenation of welfare, equivalization and indicator_name
-    tb["series_code"] = (
-        tb["indicator_name"].astype(str)
-        + "_"
-        + tb["source"].astype(str)
-        + "_"
-        + tb["welfare"].astype(str)
-        + "_"
-        + tb["equivalization"].astype(str)
-        + "_"
-        + tb["prices"].astype(str)
-    )
-
-    # Remove trailing "_" from series_code
-    tb["series_code"] = tb["series_code"].str.rstrip("_")
-
-    # Replace names for descriptive columns
-    tb["source"] = tb["source"].replace({"lis": "LIS"})
-    tb["prices"] = tb["prices"].replace(
-        {f"{PPP_YEAR_LIS}ppp{PPP_YEAR_LIS}": f"{PPP_YEAR_LIS} PPPs, at {PPP_YEAR_LIS} prices"}
-    )
-    tb["welfare"] = tb["welfare"].replace({"market": "Market income", "disposable": "Disposable income"})
-    tb["equivalization"] = tb["equivalization"].replace(
-        {"equivalized": "Equivalized", "perCapita": pc_notation_human_readable}
-    )
-
-    # Add unit column
-    tb["unit"] = ""
-    tb["unit"] = tb["unit"].where(
-        (tb["indicator_name"] != "mean") & (tb["indicator_name"] != "median"),
-        "dollars",
-    )
-    tb["unit"] = tb["unit"].where(tb["indicator_name"] != "p90p100Share", "%")
-    tb["unit"] = tb["unit"].astype(str)
-
-    # Rename column equivalization to resource_sharing
-    tb = tb.rename(columns={"equivalization": "resource_sharing"})
-
-    # Remove equivalized data for adults
-    if adults:
-        tb = tb[tb["resource_sharing"] != "Equivalized"].reset_index(drop=True)
 
     return tb
 
@@ -472,300 +293,5 @@ def create_keyvars_file_wid(tb: Table, extrapolated: bool) -> Table:
     tb["unit"] = tb["unit"].where(tb["indicator_name"] != "p99p100Share", "%")
     tb["unit"] = tb["unit"].where(tb["indicator_name"] != "p90p100Share", "%")
     tb["unit"] = tb["unit"].astype(str)
-
-    return tb
-
-
-def create_percentiles_file_pip(tb: Table) -> Table:
-    """
-    Process the percentiles table from PIP, to adapt it to a concatenated file with LIS and WID
-    """
-
-    with warnings.ignore_warnings([warnings.DifferentValuesWarning]):
-        # Make pip table longer
-        tb = tb.melt(
-            id_vars=["country", "year", "reporting_level", "welfare_type", "percentile"],
-            value_vars=["thr", "avg", "share"],
-            var_name="indicator_name",
-            value_name="value",
-        )
-
-    # Reduce percentile column by 1 when variable is share or average (when it's different from thr)
-    tb["percentile"] = tb["percentile"].where(tb["indicator_name"] == "thr", tb["percentile"] - 1)
-
-    # Replace percentile 100 with 0 (it's always null and only for thr)
-    tb["percentile"] = tb["percentile"].replace(100, 0)
-
-    # Sort by country, year, reporting_level, welfare_type, percentile and variable
-    tb = tb.sort_values(["country", "year", "reporting_level", "welfare_type", "indicator_name", "percentile"])
-
-    # Create WID nomenclature for percentiles
-    tb["percentile"] = "p" + tb["percentile"].astype(str) + "p" + (tb["percentile"] + 1).astype(str)
-
-    # Rename welfare_type and reporting_level columns
-    tb = tb.rename(columns={"welfare_type": "pipwelfare", "reporting_level": "pipreportinglevel"})
-
-    # Rename indicator_name column
-    tb["indicator_name"] = tb["indicator_name"].replace({"thr": "threshold", "avg": "average"})
-
-    # Add column prices, and assign it the value {PPP_YEAR_PIP} PPPs, at {PPP_YEAR_PIP} prices only for indicator names different from share
-    tb["prices"] = ""
-    tb["prices"] = tb["prices"].where(tb["indicator_name"] == "share", f"{PPP_YEAR_PIP}ppp{PPP_YEAR_PIP}")
-    tb["prices"] = tb["prices"].astype(str)
-
-    # Add descriptive columns
-    tb["source"] = "pip"
-    tb["welfare"] = "disposable"
-    tb["resource_sharing"] = "perCapita"
-
-    # Add the column series_code, which is the concatenation of welfare, equivalization and indicator_name
-    tb["series_code"] = (
-        tb["indicator_name"].astype(str)
-        + "_"
-        + tb["source"].astype(str)
-        + "_"
-        + tb["welfare"].astype(str)
-        + "_"
-        + tb["resource_sharing"].astype(str)
-        + "_"
-        + tb["prices"].astype(str)
-    )
-
-    # Remove trailing "_" from series_code
-    tb["series_code"] = tb["series_code"].str.rstrip("_")
-
-    # Replace names for descriptive columns
-    tb["source"] = tb["source"].replace({"pip": "PIP"})
-    tb["prices"] = tb["prices"].replace(
-        {f"{PPP_YEAR_PIP}ppp{PPP_YEAR_PIP}": f"{PPP_YEAR_PIP} PPPs, at {PPP_YEAR_PIP} prices"}
-    )
-    tb["welfare"] = tb["welfare"].replace({"disposable": "Disposable income or consumption"})
-    tb["resource_sharing"] = tb["resource_sharing"].replace({"perCapita": "Per capita"})
-
-    # Add unit column
-    tb["unit"] = ""
-    tb["unit"] = tb["unit"].where(tb["indicator_name"] != "share", "%")
-    tb["unit"] = tb["unit"].where(
-        (tb["indicator_name"] != "average") & (tb["indicator_name"] != "threshold"),
-        "dollars",
-    )
-    tb["unit"] = tb["unit"].astype(str)
-
-    return tb
-
-
-def create_percentiles_file_lis(tb: Table, adults: bool) -> Table:
-    """
-    Process the percentiles table from LIS, to adapt it to a concatenated file with WID and PIP
-    """
-    # Define different names for per capita notation, depending on whether the table is for adults or not
-    if adults:
-        pc_notation = "perAdult"
-        pc_notation_human_readable = "Per adult"
-    else:
-        pc_notation = "perCapita"
-        pc_notation_human_readable = "Per capita"
-
-    with warnings.ignore_warnings([warnings.DifferentValuesWarning]):
-        # Make lis table longer
-        tb = tb.melt(
-            id_vars=["country", "year", "welfare", "equivalization", "percentile"],
-            value_vars=["thr", "avg", "share"],
-            var_name="indicator_name",
-            value_name="value",
-        )
-
-    # Reduce percentile column by 1 when variable is share or average (when it's different from thr)
-    tb["percentile"] = tb["percentile"].where(tb["indicator_name"] == "thr", tb["percentile"] - 1)
-
-    # Replace percentile 100 with 0 (it's always null and only for thr)
-    tb["percentile"] = tb["percentile"].replace(100, 0)
-
-    # Sort by country, year, welfare, equivalization, percentile and variable
-    tb = tb.sort_values(["country", "year", "welfare", "equivalization", "indicator_name", "percentile"])
-
-    # Create WID nomenclature for percentiles
-    tb["percentile"] = "p" + tb["percentile"].astype(str) + "p" + (tb["percentile"] + 1).astype(str)
-
-    # Filter out welfare dhci
-    tb = tb[tb["welfare"] != "dhci"].reset_index(drop=True)
-
-    # Rename welfare, equivalization and indicator_name columns
-    tb["welfare"] = tb["welfare"].cat.rename_categories({"mi": "market", "dhi": "disposable"})
-    tb["equivalization"] = tb["equivalization"].cat.rename_categories({"eq": "equivalized", "pc": pc_notation})
-    tb["indicator_name"] = tb["indicator_name"].replace({"thr": "threshold", "avg": "average"})
-
-    # Add column prices, and assign it the value {PPP_YEAR_LIS} PPPs, at {PPP_YEAR_LIS} prices only for indicator names different from share
-    tb["prices"] = ""
-    tb["prices"] = tb["prices"].where(tb["indicator_name"] == "share", f"{PPP_YEAR_LIS}ppp{PPP_YEAR_LIS}")
-    tb["prices"] = tb["prices"].astype(str)
-
-    # Add descriptive columns
-    tb["source"] = "lis"
-
-    # Add the column series_code, which is the concatenation of welfare, equivalization and indicator_name
-    tb["series_code"] = (
-        tb["indicator_name"].astype(str)
-        + "_"
-        + tb["source"].astype(str)
-        + "_"
-        + tb["welfare"].astype(str)
-        + "_"
-        + tb["equivalization"].astype(str)
-        + "_"
-        + tb["prices"].astype(str)
-    )
-
-    # Remove trailing "_" from series_code
-    tb["series_code"] = tb["series_code"].str.rstrip("_")
-
-    # Replace names for descriptive columns
-    tb["source"] = tb["source"].replace({"lis": "LIS"})
-
-    tb["prices"] = tb["prices"].replace(
-        {f"{PPP_YEAR_LIS}ppp{PPP_YEAR_LIS}": f"{PPP_YEAR_LIS} PPPs, at {PPP_YEAR_LIS} prices"}
-    )
-
-    tb["welfare"] = tb["welfare"].cat.rename_categories({"market": "Market income", "disposable": "Disposable income"})
-    tb["equivalization"] = tb["equivalization"].cat.rename_categories(
-        {"equivalized": "Equivalized", "perCapita": pc_notation_human_readable}
-    )
-
-    # Rename column equivalization to resource_sharing
-    tb = tb.rename(columns={"equivalization": "resource_sharing"})
-
-    # Add unit column
-    tb["unit"] = ""
-    tb["unit"] = tb["unit"].where(tb["indicator_name"] != "share", "%")
-    tb["unit"] = tb["unit"].where(
-        (tb["indicator_name"] != "average") & (tb["indicator_name"] != "threshold"),
-        "dollars",
-    )
-    tb["unit"] = tb["unit"].astype(str)
-
-    # Remove equivalized data for adults
-    if adults:
-        tb = tb[tb["resource_sharing"] != "Equivalized"].reset_index(drop=True)
-
-    return tb
-
-
-def create_percentiles_file_wid(tb) -> Table:
-    """
-    Process the percentiles table from WID, to adapt it to a concatenated file with LIS and PIP. It generates two tables, one with extrapolated datapoints and one without them
-    """
-    # WID PERCENTILES
-
-    with warnings.ignore_warnings([warnings.DifferentValuesWarning]):
-        # Make wid table longer
-        tb = tb.melt(
-            id_vars=["country", "year", "welfare", "p", "percentile"],
-            value_vars=["thr", "avg", "share", "thr_extrapolated", "avg_extrapolated", "share_extrapolated"],
-            var_name="indicator_name",
-            value_name="value",
-        )
-
-    # Sort by country, year, welfare, equivalization, percentile and variable
-    tb = tb.sort_values(["country", "year", "welfare", "indicator_name", "p"])
-
-    # Select only welfare types needed
-    tb = tb[tb["welfare"].isin(["pretax", "posttax_nat"])].reset_index(drop=True)
-
-    # Rename welfare and indicator_name columns
-    tb["welfare"] = tb["welfare"].cat.rename_categories({"pretax": "pretaxNational", "posttax_nat": "posttaxNational"})
-
-    # In indicator_name, replace values that contain avg with average and thr with threshold
-    tb["indicator_name"] = tb["indicator_name"].replace(
-        {
-            "avg": "average",
-            "thr": "threshold",
-            "avg_extrapolated": "average_extrapolated",
-            "thr_extrapolated": "threshold_extrapolated",
-        }
-    )
-
-    # Drop percentile values containing "."
-    tb = tb[~tb["percentile"].str.contains("\\.")].reset_index(drop=True)
-
-    # Add descriptive columns
-    tb["source"] = "wid"
-
-    # If indicator_name contains extrapolated, add the word extrapolated to the source column
-    tb["source"] = tb["source"].where(
-        ~tb["indicator_name"].str.contains("extrapolated"),
-        tb["source"] + "Extrapolated",
-    )
-
-    # Remove substring _extrapolated from indicator_name
-    tb["indicator_name"] = tb["indicator_name"].str.replace("_extrapolated", "")
-
-    # Define id columns
-    tb["resource_sharing"] = "perAdult"
-    tb["prices"] = ""
-    tb["prices"] = tb["prices"].where(tb["indicator_name"] == "share", f"2011ppp{PPP_YEAR_WID}")
-    tb["prices"] = tb["prices"].astype(str)
-
-    # Add the column series_code, which is the concatenation of welfare, equivalization and indicator_name
-    tb["series_code"] = (
-        tb["indicator_name"].astype(str)
-        + "_"
-        + tb["source"].astype(str)
-        + "_"
-        + tb["welfare"].astype(str)
-        + "_"
-        + tb["resource_sharing"].astype(str)
-        + "_"
-        + tb["prices"].astype(str)
-    )
-
-    # Remove trailing "_" from series_code
-    tb["series_code"] = tb["series_code"].str.rstrip("_")
-
-    # Replace names for descriptive columns
-
-    tb["prices"] = tb["prices"].replace({f"2011ppp{PPP_YEAR_WID}": f"2011 PPPs, at {PPP_YEAR_WID} prices"})
-    tb["welfare"] = tb["welfare"].cat.rename_categories(
-        {"pretaxNational": "Pretax national income", "posttax_nat": "Post-tax national income"}
-    )
-    tb["resource_sharing"] = tb["resource_sharing"].replace({"perAdult": "Per adult"})
-
-    # Add unit column
-    tb["unit"] = ""
-    tb["unit"] = tb["unit"].where(tb["indicator_name"] != "share", "%")
-    tb["unit"] = tb["unit"].where(
-        (tb["indicator_name"] != "average") & (tb["indicator_name"] != "threshold"),
-        "dollars",
-    )
-    tb["unit"] = tb["unit"].astype(str)
-
-    # Remove columns welfare and percentile
-    tb = tb.drop(columns=["p"])
-
-    # Create two different tables, one for extrapolated
-    tb_extrapolated = tb[tb["source"] == "widExtrapolated"].reset_index(drop=True)
-    tb = tb[tb["source"] == "wid"].reset_index(drop=True)
-
-    # Replace source for a more descriptive name
-    tb["source"] = tb["source"].replace({"wid": "WID"})
-    tb_extrapolated["source"] = tb_extrapolated["source"].replace(
-        {"widExtrapolated": "WID (including extrapolated datapoints)"}
-    )
-
-    return tb, tb_extrapolated
-
-
-def extract_gdp_from_wdi(tb: Table) -> Table:
-    """
-    Load the table from WDI, to extract different GDP indicators
-    """
-
-    # Define list of GDP indicators
-    gdp_list = [
-        "ny_gdp_mktp_pp_kd",  # constant international $
-        "ny_gdp_mktp_kd",  # constant US$
-    ]
-
-    # Select the columns to keep
-    tb = tb[["country", "year"] + gdp_list]
 
     return tb

--- a/etl/steps/data/garden/poverty_inequality/2025-01-22/shared.py
+++ b/etl/steps/data/garden/poverty_inequality/2025-01-22/shared.py
@@ -1,0 +1,244 @@
+"""Adapters that rebuild the legacy-shaped PIP and WID tables from the new *dimensional*
+garden datasets (`world_bank_pip`, `world_inequality_database`).
+
+`poverty_inequality_file` and `inequality_comparison` used to read the wide-flat
+`world_bank_pip_legacy` / `world_inequality_database_legacy` datasets. Those legacy datasets
+are now kept only for the CSV-based explorers, so the steps here read the dimensional datasets
+instead and reshape the few tables/columns their downstream transforms need back into the
+legacy layout. The downstream functions (`create_keyvars_file_*`, `create_percentiles_file_*`)
+are left untouched — these adapters reproduce their expected inputs value-for-value.
+"""
+
+import owid.catalog.processing as pr
+import pandas as pd
+from owid.catalog import Dataset, Table
+
+# PPP version used across the poverty/inequality file.
+PPP_YEAR_PIP = 2021
+
+# WB regional aggregates. In the legacy PIP table these rows carry a missing welfare_type and a
+# literal "<NA>" reporting_level; in the dimensional dataset they live under the combined
+# "income or consumption" welfare type (and only from 1990 onwards — see note in build_pip_unsmoothed).
+PIP_REGIONS = [
+    "East Asia and Pacific (WB)",
+    "Eastern and Southern Africa (WB)",
+    "Europe and Central Asia (WB)",
+    "Latin America and Caribbean (WB)",
+    "Middle East, North Africa, Afghanistan and Pakistan (WB)",
+    "North America (WB)",
+    "South Asia (WB)",
+    "Sub-Saharan Africa (WB)",
+    "Western and Central Africa (WB)",
+    "World",
+    "World (excluding China)",
+    "World (excluding India)",
+]
+
+# Dimensional welfare_type -> legacy welfare code. Only pretax and posttax_nat are consumed by the
+# keyvars file, but the full map is used for the distribution table.
+WID_WELFARE_TO_CODE = {
+    "before tax": "pretax",
+    "after tax": "posttax_nat",
+}
+WID_DISTRIBUTION_WELFARE_TO_CODE = {
+    "before tax": "pretax",
+    "after tax": "posttax_nat",
+    "after tax disposable": "posttax_dis",
+    "wealth": "wealth",
+}
+# Legacy distribution `welfare` categorical order (so the untouched create_percentiles_file_wid,
+# which calls `.cat.rename_categories`, behaves identically).
+WID_DISTRIBUTION_WELFARE_CATEGORIES = ["posttax_dis", "posttax_nat", "pretax", "wealth"]
+
+
+def _mask(condition: pd.Series) -> pd.Series:
+    """Coerce a (possibly nullable/arrow) boolean Series to a plain bool Series (NA -> False).
+
+    The dimensional tables use nullable dtypes, so comparisons yield nullable booleans that raise
+    "boolean value of NA is ambiguous" when combined with `&` or used to index. This normalises them.
+    """
+    return condition.fillna(False).astype(bool)
+
+
+def build_pip_unsmoothed(ds_pip: Dataset) -> Table:
+    """Rebuild `income_consumption_2021_unsmoothed` (the columns create_keyvars_file_pip reads)
+    from the dimensional `complete_series` table.
+
+    Each indicator lives on a different row-subset of complete_series:
+      - gini / palma_ratio: the dimension-less inequality rows (no PPP, so ppp_version is NaN)
+      - mean / median:      2021-PPP country-year summary rows (no decile, no poverty line)
+      - decile10_share:     2021-PPP, decile "10", no poverty line -> `share`
+      - headcount_ratio_50_median: 2021-PPP relative-poverty rows -> `headcount_ratio`
+
+    Country rows keep welfare_type income/consumption; WB regions live under the combined
+    "income or consumption" welfare type and are relabelled to match the legacy table (which marks
+    them with a missing welfare_type and a "<NA>" reporting_level). NOTE: the dimensional dataset
+    only carries regional aggregates from 1990 onwards, so pre-1990 region rows that existed in the
+    legacy table are absent here — they fall outside the inequality_comparison matching windows.
+    """
+    cs = ds_pip.read("complete_series")
+    keys = ["country", "year", "welfare_type"]
+
+    ppp_current = _mask(cs["ppp_version"] == PPP_YEAR_PIP)
+    ppp_missing = _mask(cs["ppp_version"].isna())
+    decile_missing = _mask(cs["decile"].isna())
+    decile_top = _mask(cs["decile"] == "10")
+    povline_missing = _mask(cs["poverty_line"].isna())
+    povline_rel50 = _mask(cs["poverty_line"] == "50% of the median")
+    summary = decile_missing & povline_missing
+
+    tb_ineq = cs[ppp_missing & summary][keys + ["gini", "palma_ratio"]]
+    tb_mean_median = cs[ppp_current & summary][keys + ["mean", "median"]]
+    tb_decile10 = cs[ppp_current & decile_top & povline_missing][keys + ["share"]].rename(
+        columns={"share": "decile10_share"}
+    )
+    tb_rel_poverty = cs[ppp_current & decile_missing & povline_rel50][keys + ["headcount_ratio"]].rename(
+        columns={"headcount_ratio": "headcount_ratio_50_median"}
+    )
+
+    tb = tb_ineq
+    for piece in [tb_mean_median, tb_decile10, tb_rel_poverty]:
+        tb = pr.merge(tb, piece, on=keys, how="outer")
+
+    # Keep income/consumption for countries, and the combined series only for regions.
+    is_region = tb["country"].isin(PIP_REGIONS)
+    keep = _mask(tb["welfare_type"].isin(["income", "consumption"])) | (
+        is_region & _mask(tb["welfare_type"] == "income or consumption")
+    )
+    tb = tb[keep].reset_index(drop=True)
+
+    # reporting_level from the country-name suffix; regions get "<NA>" / missing welfare like the legacy table.
+    country_str = tb["country"].astype(str)
+    tb["reporting_level"] = "national"
+    tb.loc[country_str.str.endswith("(urban)"), "reporting_level"] = "urban"
+    tb.loc[country_str.str.endswith("(rural)"), "reporting_level"] = "rural"
+    region_mask = tb["country"].isin(PIP_REGIONS)
+    tb.loc[region_mask, "reporting_level"] = "<NA>"
+    tb["welfare_type"] = tb["welfare_type"].astype(object)
+    tb.loc[region_mask, "welfare_type"] = None
+
+    sanity_check_pip_unsmoothed(tb)
+    return tb
+
+
+def build_pip_percentiles(ds_pip: Dataset) -> Table:
+    """Rebuild `percentiles_income_consumption_2021` from the dimensional `percentiles` table.
+
+    The dimensional percentiles table already carries reporting_level, welfare_type
+    (income/consumption), the 1..100 percentile and a *100 share, so this is just a PPP filter.
+    """
+    tb = ds_pip.read("percentiles")
+    tb = tb[_mask(tb["ppp_version"] == PPP_YEAR_PIP)].reset_index(drop=True)
+
+    assert not tb.empty, "PIP percentiles reconstruction is empty."
+    assert set(tb["welfare_type"].dropna().unique()) <= {"income", "consumption"}, (
+        "Unexpected welfare_type in PIP percentiles."
+    )
+    return tb
+
+
+def build_wid_main(ds_wid: Dataset) -> Table:
+    """Rebuild the wide `world_inequality_database` table (the columns create_keyvars_file_wid reads)
+    from the dimensional inequality / incomes / relative_poverty tables.
+
+    For welfare ∈ {pretax, posttax_nat} and both extrapolation states, build:
+      p0p100_gini ← inequality.gini            palma_ratio ← inequality.palma_ratio
+      p99p100_share ← inequality.share_top_1   p90p100_share ← inequality.share_top_10
+      p0p100_avg ← incomes.mean (year)         median ← incomes.median (year)
+      p99p100_avg ← incomes.avg (Richest 1%, year)
+      headcount_ratio_50_median ← relative_poverty.headcount_ratio (50% of the median)
+    """
+    tb_ineq = ds_wid.read("inequality")
+    tb_inc = ds_wid.read("incomes")
+    tb_rp = ds_wid.read("relative_poverty")
+
+    all_rows = _mask(tb_ineq["country"].notna())
+    summary_income = _mask(tb_inc["quantile"].isna()) & _mask(tb_inc["period"] == "year")
+    top1_income = _mask(tb_inc["quantile"] == "Richest 1%") & _mask(tb_inc["period"] == "year")
+    rel_pov_50 = _mask(tb_rp["poverty_line"] == "50% of the median")
+
+    specs = [
+        (tb_ineq, all_rows, "gini", "p0p100_gini"),
+        (tb_ineq, all_rows, "palma_ratio", "palma_ratio"),
+        (tb_ineq, all_rows, "share_top_1", "p99p100_share"),
+        (tb_ineq, all_rows, "share_top_10", "p90p100_share"),
+        (tb_inc, summary_income, "mean", "p0p100_avg"),
+        (tb_inc, summary_income, "median", "median"),
+        (tb_inc, top1_income, "avg", "p99p100_avg"),
+        (tb_rp, rel_pov_50, "headcount_ratio", "headcount_ratio_50_median"),
+    ]
+
+    tb = None
+    for source, mask, src_col, target_base in specs:
+        piece = _wid_wide(source[mask], src_col, target_base)
+        tb = piece if tb is None else pr.merge(tb, piece, on=["country", "year"], how="outer")
+
+    sanity_check_wid_main(tb)
+    return tb
+
+
+def build_wid_distribution(ds_wid: Dataset) -> Table:
+    """Rebuild `world_inequality_database_distribution` from the dimensional `distribution` table by
+    pivoting the `extrapolated` dimension into `_extrapolated` suffix columns and mapping the
+    human-readable welfare names back to the legacy welfare codes (as an ordered categorical)."""
+    tb = ds_wid.read("distribution")
+    tb["welfare"] = (
+        tb["welfare_type"]
+        .map(WID_DISTRIBUTION_WELFARE_TO_CODE)
+        .astype("category")
+        .cat.set_categories(WID_DISTRIBUTION_WELFARE_CATEGORIES)
+    )
+
+    index_cols = ["country", "year", "welfare", "p", "percentile"]
+    value_cols = ["thr", "avg", "share"]
+    tb_no = tb[_mask(tb["extrapolated"] == "no")][index_cols + value_cols]
+    tb_yes = tb[_mask(tb["extrapolated"] == "yes")][index_cols + value_cols].rename(
+        columns={c: f"{c}_extrapolated" for c in value_cols}
+    )
+    tb = pr.merge(tb_no, tb_yes, on=index_cols, how="outer")
+
+    assert not tb.empty, "WID distribution reconstruction is empty."
+    return tb
+
+
+def _wid_wide(tb: Table, src_col: str, target_base: str) -> Table:
+    """Pivot a long dimensional WID slice into wide `{target_base}_{welfare}{_extrapolated}` columns
+    for welfare ∈ {pretax, posttax_nat}, preserving each column's origins."""
+    tb = tb[_mask(tb["welfare_type"].isin(WID_WELFARE_TO_CODE))]
+    out = None
+    for welfare_type, code in WID_WELFARE_TO_CODE.items():
+        for extrapolated, suffix in [("no", ""), ("yes", "_extrapolated")]:
+            piece = tb[_mask(tb["welfare_type"] == welfare_type) & _mask(tb["extrapolated"] == extrapolated)][
+                ["country", "year", src_col]
+            ].rename(columns={src_col: f"{target_base}_{code}{suffix}"})
+            out = piece if out is None else pr.merge(out, piece, on=["country", "year"], how="outer")
+    return out
+
+
+def sanity_check_pip_unsmoothed(tb: Table) -> None:
+    assert not tb.empty, "PIP unsmoothed reconstruction is empty."
+    assert not tb.duplicated(subset=["country", "year", "reporting_level", "welfare_type"]).any(), (
+        "Duplicate (country, year, reporting_level, welfare_type) in PIP unsmoothed reconstruction."
+    )
+    assert set(tb["reporting_level"].unique()) <= {"national", "urban", "rural", "<NA>"}, (
+        "Unexpected reporting_level value in PIP unsmoothed reconstruction."
+    )
+    for col in ["gini", "mean", "median", "decile10_share", "palma_ratio", "headcount_ratio_50_median"]:
+        assert col in tb.columns, f"Missing expected PIP column {col}."
+
+
+def sanity_check_wid_main(tb: Table) -> None:
+    assert not tb.empty, "WID main reconstruction is empty."
+    assert not tb.duplicated(subset=["country", "year"]).any(), "Duplicate (country, year) in WID main reconstruction."
+    for base in [
+        "p0p100_gini",
+        "p0p100_avg",
+        "median",
+        "p99p100_share",
+        "p99p100_avg",
+        "p90p100_share",
+        "palma_ratio",
+        "headcount_ratio_50_median",
+    ]:
+        for welfare in ["pretax", "posttax_nat"]:
+            assert f"{base}_{welfare}" in tb.columns, f"Missing expected WID column {base}_{welfare}."

--- a/etl/steps/data/garden/poverty_inequality/2025-01-22/shared.py
+++ b/etl/steps/data/garden/poverty_inequality/2025-01-22/shared.py
@@ -1,16 +1,15 @@
-"""Adapters that rebuild the legacy-shaped PIP and WID tables from the new *dimensional*
-garden datasets (`world_bank_pip`, `world_inequality_database`).
+"""Adapters that rebuild the legacy-shaped PIP and WID key-indicator tables from the new
+*dimensional* garden datasets (`world_bank_pip`, `world_inequality_database`).
 
 `poverty_inequality_file` and `inequality_comparison` used to read the wide-flat
 `world_bank_pip_legacy` / `world_inequality_database_legacy` datasets. Those legacy datasets
 are now kept only for the CSV-based explorers, so the steps here read the dimensional datasets
-instead and reshape the few tables/columns their downstream transforms need back into the
-legacy layout. The downstream functions (`create_keyvars_file_*`, `create_percentiles_file_*`)
-are left untouched — these adapters reproduce their expected inputs value-for-value.
+instead and reshape the few columns their downstream key-indicator transforms need back into the
+legacy layout. The downstream `create_keyvars_file_*` functions are left untouched — these
+adapters reproduce their expected inputs value-for-value.
 """
 
 import owid.catalog.processing as pr
-import pandas as pd
 from owid.catalog import Dataset, Table
 
 # PPP version used across the poverty/inequality file.
@@ -34,24 +33,14 @@ PIP_REGIONS = [
     "World (excluding India)",
 ]
 
-# Dimensional welfare_type -> legacy welfare code. Only pretax and posttax_nat are consumed by the
-# keyvars file, but the full map is used for the distribution table.
+# Dimensional welfare_type -> legacy welfare code (only pretax and posttax_nat are consumed).
 WID_WELFARE_TO_CODE = {
     "before tax": "pretax",
     "after tax": "posttax_nat",
 }
-WID_DISTRIBUTION_WELFARE_TO_CODE = {
-    "before tax": "pretax",
-    "after tax": "posttax_nat",
-    "after tax disposable": "posttax_dis",
-    "wealth": "wealth",
-}
-# Legacy distribution `welfare` categorical order (so the untouched create_percentiles_file_wid,
-# which calls `.cat.rename_categories`, behaves identically).
-WID_DISTRIBUTION_WELFARE_CATEGORIES = ["posttax_dis", "posttax_nat", "pretax", "wealth"]
 
 
-def _mask(condition: pd.Series) -> pd.Series:
+def _mask(condition):
     """Coerce a (possibly nullable/arrow) boolean Series to a plain bool Series (NA -> False).
 
     The dimensional tables use nullable dtypes, so comparisons yield nullable booleans that raise
@@ -121,22 +110,6 @@ def build_pip_unsmoothed(ds_pip: Dataset) -> Table:
     return tb
 
 
-def build_pip_percentiles(ds_pip: Dataset) -> Table:
-    """Rebuild `percentiles_income_consumption_2021` from the dimensional `percentiles` table.
-
-    The dimensional percentiles table already carries reporting_level, welfare_type
-    (income/consumption), the 1..100 percentile and a *100 share, so this is just a PPP filter.
-    """
-    tb = ds_pip.read("percentiles")
-    tb = tb[_mask(tb["ppp_version"] == PPP_YEAR_PIP)].reset_index(drop=True)
-
-    assert not tb.empty, "PIP percentiles reconstruction is empty."
-    assert set(tb["welfare_type"].dropna().unique()) <= {"income", "consumption"}, (
-        "Unexpected welfare_type in PIP percentiles."
-    )
-    return tb
-
-
 def build_wid_main(ds_wid: Dataset) -> Table:
     """Rebuild the wide `world_inequality_database` table (the columns create_keyvars_file_wid reads)
     from the dimensional inequality / incomes / relative_poverty tables.
@@ -174,30 +147,6 @@ def build_wid_main(ds_wid: Dataset) -> Table:
         tb = piece if tb is None else pr.merge(tb, piece, on=["country", "year"], how="outer")
 
     sanity_check_wid_main(tb)
-    return tb
-
-
-def build_wid_distribution(ds_wid: Dataset) -> Table:
-    """Rebuild `world_inequality_database_distribution` from the dimensional `distribution` table by
-    pivoting the `extrapolated` dimension into `_extrapolated` suffix columns and mapping the
-    human-readable welfare names back to the legacy welfare codes (as an ordered categorical)."""
-    tb = ds_wid.read("distribution")
-    tb["welfare"] = (
-        tb["welfare_type"]
-        .map(WID_DISTRIBUTION_WELFARE_TO_CODE)
-        .astype("category")
-        .cat.set_categories(WID_DISTRIBUTION_WELFARE_CATEGORIES)
-    )
-
-    index_cols = ["country", "year", "welfare", "p", "percentile"]
-    value_cols = ["thr", "avg", "share"]
-    tb_no = tb[_mask(tb["extrapolated"] == "no")][index_cols + value_cols]
-    tb_yes = tb[_mask(tb["extrapolated"] == "yes")][index_cols + value_cols].rename(
-        columns={c: f"{c}_extrapolated" for c in value_cols}
-    )
-    tb = pr.merge(tb_no, tb_yes, on=index_cols, how="outer")
-
-    assert not tb.empty, "WID distribution reconstruction is empty."
     return tb
 
 


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## What this does

Repoints the poverty/inequality steps off the wide-flat **legacy** datasets onto the new **dimensional** ones:

- `data://garden/poverty_inequality/2025-01-22/poverty_inequality_file`
- `data://garden/poverty_inequality/2025-01-22/inequality_comparison`
- `data://garden/covid/latest/compact`

all now read `wb/2026-03-24/world_bank_pip` and `wid/2026-02-10/world_inequality_database` instead of `*_legacy`.

## Why

`world_bank_pip_legacy` and `world_inequality_database_legacy` are kept only to feed the CSV-based explorers we plan to deprecate. These three steps were the remaining non-explorer consumers blocking that. After this PR the legacy datasets are used **only** by the two CSV explorers (`explorers/wb/latest/world_bank_pip`, `explorers/wid/latest/world_inequality_database`), so they can be removed cleanly once the explorers are sunset.

## How

A new `shared.py` rebuilds, from the dimensional long-form tables, exactly the key-indicator columns the `keyvars` transforms need:

| Adapter | Source | Notes |
|---|---|---|
| `build_pip_unsmoothed` | `world_bank_pip/complete_series` | all 6 indicators; `gini`/`palma_ratio` sit on the PPP-less inequality rows; `reporting_level` from the country-name suffix |
| `build_wid_main` | `world_inequality_database` `inequality`/`incomes`/`relative_poverty` | welfare→code map, `extrapolated` dim → `_extrapolated` suffix |

`inequality_comparison` reads only `keyvars` (plus the same adapters for indicator metadata). COVID's `extreme_poverty` is rebuilt from the dimensional `poverty` table (consolidated income-or-consumption series at the $3/day line).

No version bump — variable IDs are preserved, so existing charts are unaffected.

### Simplification: keyvars-only output

`poverty_inequality_file` historically also emitted `percentiles` and `wdi` tables, but nothing consumes them (only `keyvars` feeds `inequality_comparison`). They're dropped, which also removes the legacy long→wide→long roundtrip in the percentiles path. The step now reads the dimensional tables directly and emits a single `keyvars` table.

**Build time: ~167s → ~3s**, and the `wdi` dependency is removed from the DAG.

## Parity review (value-preserving)

Feeding the unchanged `keyvars` transforms with the **current** legacy table vs. the dimensional reconstruction yields identical values (max abs diff = float32 rounding ≈ 1e-6 for PIP; WID large-magnitude values match to 1e-4 relative):

| Output | Result |
|---|---|
| PIP keyvars | ✅ 0 value mismatches |
| WID keyvars (both extrapolation states) | ✅ 0 value mismatches |
| COVID `extreme_poverty` input | ✅ 1272 = 1272 rows, 0 mismatches |
| `inequality_comparison` (grapher output) | ✅ unchanged — reads the byte-identical `keyvars` |

One documented, harmless difference: the dimensional PIP dataset restricts regional aggregates to ≥1990 upstream (`regional_data_from_1990`), so the keyvars `keyvars` loses 243 pre-1990 WB-region values (9 regions × 1981–1989 × mean/median/relative-poverty). Those years are outside `inequality_comparison`'s 1993/2019 matching windows, so the chart output is unaffected.

Verified with `ai/parity_check_pip_wid_migration.py`. `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
