### PR TITLE
🐛 education: fix primary school enrollment OMM 

### DIFF
--- a/etl/steps/data/garden/unesco/2026-05-12/education_opri.meta.yml
+++ b/etl/steps/data/garden/unesco/2026-05-12/education_opri.meta.yml
@@ -188,12 +188,12 @@ definitions:
     - The data comes from administrative records such as school enrollment reports, combined with population estimates typically sourced from the United Nations or national statistical offices.
 
   desc_key_net_enr_historical: &desc_key_net_enr_historical
-    - This indicator combines data from two sources. From 1985 onwards, it draws on UNESCO administrative records. Before 1985, it uses adjusted enrollment ratios from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html) — modified gross enrollment ratios that account for grade repetition. These serve as the best available approximation of net enrollment rates for earlier periods, when age-specific enrollment data were not widely collected.
+    - This indicator combines data from two sources. Where UNESCO administrative records are available (from as early as the 1970s for some countries), those are used. For earlier periods without UNESCO coverage, it draws on adjusted enrollment ratios from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html) — modified gross enrollment ratios that account for grade repetition, serving as the best available approximation of net enrollment rates for periods when age-specific enrollment data were not widely collected.
     - The net enrollment rate shows what share of children are enrolled at the education level intended for their age — for example, a rate of 90% means 90% of children in the official age group are enrolled at that level.
     - A rate below 100% doesn't necessarily mean those children are out of school — some may be enrolled at a different level than expected for their age.
 
   desc_key_ger_historical: &desc_key_ger_historical
-    - This indicator combines data from two sources. From 1985 onwards, it draws on UNESCO administrative records. Before 1985, it uses gross enrollment ratios from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html).
+    - This indicator combines data from two sources. Where UNESCO administrative records are available, those are used. For earlier periods without UNESCO coverage, it draws on gross enrollment ratios from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html).
     - The gross enrollment ratio counts all students enrolled at a given education level, regardless of age — including those who started late or repeated grades. Values can exceed 100% for this reason.
     - A value well below 100% suggests many children of the official age are not enrolled at that level. A value well above 100% often signals high rates of grade repetition or late entry.
 
@@ -1389,7 +1389,7 @@ tables:
           tolerance: *display_tolerance
 
       # ========================================================================
-      # COMBINED HISTORICAL ENROLLMENT RATES (Lee & Lee pre-1985 + UNESCO 1985+)
+      # COMBINED HISTORICAL ENROLLMENT RATES (UNESCO preferred, Lee & Lee fallback)
       # ========================================================================
 
       net_enrolment_rate__primary__both_sexes__pct__combined_historical:
@@ -1399,8 +1399,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_net_enr_historical
         description_processing: |-
-          - Pre-1985: Data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html). Their enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios — though age-specific records needed for a true net rate were not widely available historically.
-          - 1985 onwards: Data comes from UNESCO OPRI, based on school censuses that track enrollment by individual age.
+          - UNESCO OPRI data (based on school censuses that track enrollment by individual age) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), whose enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios.
         presentation:
           title_public: Net enrollment rate in primary education
         display:
@@ -1415,8 +1414,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_net_enr_historical
         description_processing: |-
-          - Pre-1985: Data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html). Their enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios — though age-specific records needed for a true net rate were not widely available historically.
-          - 1985 onwards: Data comes from UNESCO OPRI, based on school censuses that track enrollment by individual age.
+          - UNESCO OPRI data (based on school censuses that track enrollment by individual age) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), whose enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios.
         presentation:
           title_public: Net enrollment rate in primary education among girls
         display:
@@ -1431,8 +1429,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_net_enr_historical
         description_processing: |-
-          - Pre-1985: Data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html). Their enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios — though age-specific records needed for a true net rate were not widely available historically.
-          - 1985 onwards: Data comes from UNESCO OPRI, based on school censuses that track enrollment by individual age.
+          - UNESCO OPRI data (based on school censuses that track enrollment by individual age) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), whose enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios.
         presentation:
           title_public: Net enrollment rate in primary education among boys
         display:
@@ -1447,8 +1444,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_ger_historical
         description_processing: |-
-          - Pre-1985: Data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
-          - 1985 onwards: Data comes from the UNESCO SDG dataset, based on administrative records that track enrollment by age and education level.
+          - UNESCO SDG data (based on administrative records that track enrollment by age and education level) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
         presentation:
           title_public: Gross enrollment ratio in tertiary education
         display:
@@ -1463,8 +1459,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_ger_historical
         description_processing: |-
-          - Pre-1985: Data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
-          - 1985 onwards: Data comes from the UNESCO SDG dataset, based on administrative records that track enrollment by age and education level.
+          - UNESCO SDG data (based on administrative records that track enrollment by age and education level) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
         presentation:
           title_public: Gross enrollment ratio in tertiary education among women
         display:
@@ -1479,8 +1474,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_ger_historical
         description_processing: |-
-          - Pre-1985: Data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
-          - 1985 onwards: Data comes from the UNESCO SDG dataset, based on administrative records that track enrollment by age and education level.
+          - UNESCO SDG data (based on administrative records that track enrollment by age and education level) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
         presentation:
           title_public: Gross enrollment ratio in tertiary education among men
         display:

--- a/etl/steps/data/garden/unesco/2026-05-12/education_opri.meta.yml
+++ b/etl/steps/data/garden/unesco/2026-05-12/education_opri.meta.yml
@@ -188,12 +188,12 @@ definitions:
     - The data comes from administrative records such as school enrollment reports, combined with population estimates typically sourced from the United Nations or national statistical offices.
 
   desc_key_net_enr_historical: &desc_key_net_enr_historical
-    - This indicator combines data from two sources. Where UNESCO administrative records are available (from as early as the 1970s for some countries), those are used. For earlier periods without UNESCO coverage, it draws on adjusted enrollment ratios from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html) — modified gross enrollment ratios that account for grade repetition, serving as the best available approximation of net enrollment rates for periods when age-specific enrollment data were not widely collected.
+    - This indicator combines data from two sources. Where UNESCO administrative records are available (from as early as the 1970s for some countries), those are used. Before 1985, where UNESCO data is not available, it draws on adjusted enrollment ratios from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html) — modified gross enrollment ratios that account for grade repetition, serving as the best available approximation of net enrollment rates for periods when age-specific enrollment data were not widely collected.
     - The net enrollment rate shows what share of children are enrolled at the education level intended for their age — for example, a rate of 90% means 90% of children in the official age group are enrolled at that level.
     - A rate below 100% doesn't necessarily mean those children are out of school — some may be enrolled at a different level than expected for their age.
 
   desc_key_ger_historical: &desc_key_ger_historical
-    - This indicator combines data from two sources. Where UNESCO administrative records are available, those are used. For earlier periods without UNESCO coverage, it draws on gross enrollment ratios from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html).
+    - This indicator combines data from two sources. Where UNESCO administrative records are available, those are used. Before 1985, where UNESCO data is not available, it draws on gross enrollment ratios from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html).
     - The gross enrollment ratio counts all students enrolled at a given education level, regardless of age — including those who started late or repeated grades. Values can exceed 100% for this reason.
     - A value well below 100% suggests many children of the official age are not enrolled at that level. A value well above 100% often signals high rates of grade repetition or late entry.
 
@@ -1399,7 +1399,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_net_enr_historical
         description_processing: |-
-          - UNESCO OPRI data (based on school censuses that track enrollment by individual age) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), whose enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios.
+          - UNESCO OPRI data (based on school censuses that track enrollment by individual age) is used wherever available. Before 1985, for country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), whose enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios.
         presentation:
           title_public: Net enrollment rate in primary education
         display:
@@ -1414,7 +1414,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_net_enr_historical
         description_processing: |-
-          - UNESCO OPRI data (based on school censuses that track enrollment by individual age) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), whose enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios.
+          - UNESCO OPRI data (based on school censuses that track enrollment by individual age) is used wherever available. Before 1985, for country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), whose enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios.
         presentation:
           title_public: Net enrollment rate in primary education among girls
         display:
@@ -1429,7 +1429,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_net_enr_historical
         description_processing: |-
-          - UNESCO OPRI data (based on school censuses that track enrollment by individual age) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), whose enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios.
+          - UNESCO OPRI data (based on school censuses that track enrollment by individual age) is used wherever available. Before 1985, for country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), whose enrollment ratios adjust for grade repetition, bringing them closer to a true net enrollment rate than raw gross enrollment ratios.
         presentation:
           title_public: Net enrollment rate in primary education among boys
         display:
@@ -1444,7 +1444,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_ger_historical
         description_processing: |-
-          - UNESCO SDG data (based on administrative records that track enrollment by age and education level) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
+          - UNESCO SDG data (based on administrative records that track enrollment by age and education level) is used wherever available. Before 1985, for country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
         presentation:
           title_public: Gross enrollment ratio in tertiary education
         display:
@@ -1459,7 +1459,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_ger_historical
         description_processing: |-
-          - UNESCO SDG data (based on administrative records that track enrollment by age and education level) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
+          - UNESCO SDG data (based on administrative records that track enrollment by age and education level) is used wherever available. Before 1985, for country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
         presentation:
           title_public: Gross enrollment ratio in tertiary education among women
         display:
@@ -1474,7 +1474,7 @@ tables:
         short_unit: "%"
         description_key: *desc_key_ger_historical
         description_processing: |-
-          - UNESCO SDG data (based on administrative records that track enrollment by age and education level) is used wherever available. For country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
+          - UNESCO SDG data (based on administrative records that track enrollment by age and education level) is used wherever available. Before 1985, for country-years without UNESCO coverage, data comes from [Lee and Lee (2016)](https://barrolee.github.io/BarroLeeDataSet/DataLeeLee.html), which reported gross enrollment ratios for tertiary education.
         presentation:
           title_public: Gross enrollment ratio in tertiary education among men
         display:

--- a/etl/steps/data/garden/unesco/2026-05-12/education_opri.py
+++ b/etl/steps/data/garden/unesco/2026-05-12/education_opri.py
@@ -234,19 +234,11 @@ def combine_historical_enrollment(tb_opri: Table, tb_lee: Table, tb_sdgs: Table)
         "Total net enrolment rate, primary, male (%)": "m_primary_enrollment_rates",
     }
     avail_primary = {k: v for k, v in opri_primary_map.items() if k in tb_opri.columns}
-    tb_primary = (
-        tb_opri[["country", "year"] + list(avail_primary)]
-        .rename(columns=avail_primary)
-        .copy()
-    )
+    tb_primary = tb_opri[["country", "year"] + list(avail_primary)].rename(columns=avail_primary).copy()
 
     # 2. UNESCO tertiary GER from SDGs (all available years)
     avail_tertiary = {k: v for k, v in _SDG_TERTIARY_COLS.items() if k in tb_sdgs.columns}
-    tb_tertiary = (
-        tb_sdgs[["country", "year"] + list(avail_tertiary)]
-        .rename(columns=avail_tertiary)
-        .copy()
-    )
+    tb_tertiary = tb_sdgs[["country", "year"] + list(avail_tertiary)].rename(columns=avail_tertiary).copy()
 
     # 3. Merge UNESCO primary + tertiary into one table
     tb_unesco = pr.merge(tb_primary, tb_tertiary, on=["country", "year"], how="outer")

--- a/etl/steps/data/garden/unesco/2026-05-12/education_opri.py
+++ b/etl/steps/data/garden/unesco/2026-05-12/education_opri.py
@@ -212,14 +212,15 @@ _SDG_TERTIARY_COLS = {
 def combine_historical_enrollment(tb_opri: Table, tb_lee: Table, tb_sdgs: Table) -> Table:
     """Combine UNESCO data with Lee & Lee historical enrollment estimates.
 
-    The combined series prefers UNESCO data wherever it exists and falls back
-    to Lee & Lee (2016) only for country-years where UNESCO has no coverage.
-    This avoids discarding UNESCO observations that exist before 1985 and
-    reduces discontinuities at the splice boundary.
+    The combined series uses UNESCO data wherever it exists (including pre-1985
+    observations) and falls back to Lee & Lee (2016) for the pre-1985 period
+    only. Lee & Lee post-1985 values are excluded because their aggregate
+    estimates (World, regions) diverge significantly from UNESCO's
+    administrative data, creating large discontinuities at the splice boundary.
 
     Sources:
-    - Primary NER: UNESCO OPRI (preferred), Lee & Lee (fallback)
-    - Tertiary GER: UNESCO SDGs (preferred), Lee & Lee (fallback)
+    - Primary NER: UNESCO OPRI (preferred), Lee & Lee pre-1985 (fallback)
+    - Tertiary GER: UNESCO SDGs (preferred), Lee & Lee pre-1985 (fallback)
 
     Secondary enrollment is omitted because OPRI and SDGs only have separate
     lower/upper secondary series, not a single combined secondary series.
@@ -227,7 +228,7 @@ def combine_historical_enrollment(tb_opri: Table, tb_lee: Table, tb_sdgs: Table)
     Returns the OPRI table with combined enrollment columns appended.
     """
 
-    # 1. UNESCO primary NER from OPRI (all available years)
+    # 1. UNESCO primary NER from OPRI (all available years — extends to ~1970 for some countries)
     opri_primary_map = {
         "Total net enrolment rate, primary, both sexes (%)": "mf_primary_enrollment_rates",
         "Total net enrolment rate, primary, female (%)": "f_primary_enrollment_rates",
@@ -236,18 +237,24 @@ def combine_historical_enrollment(tb_opri: Table, tb_lee: Table, tb_sdgs: Table)
     avail_primary = {k: v for k, v in opri_primary_map.items() if k in tb_opri.columns}
     tb_primary = tb_opri[["country", "year"] + list(avail_primary)].rename(columns=avail_primary).copy()
 
-    # 2. UNESCO tertiary GER from SDGs (all available years)
+    # 2. UNESCO tertiary GER from SDGs (all available years — starts ~1970 for some entities)
     avail_tertiary = {k: v for k, v in _SDG_TERTIARY_COLS.items() if k in tb_sdgs.columns}
     tb_tertiary = tb_sdgs[["country", "year"] + list(avail_tertiary)].rename(columns=avail_tertiary).copy()
 
     # 3. Merge UNESCO primary + tertiary into one table
     tb_unesco = pr.merge(tb_primary, tb_tertiary, on=["country", "year"], how="outer")
 
-    # 4. Outer-merge with Lee & Lee; prefer UNESCO where both exist,
-    #    fall back to Lee & Lee only where UNESCO is NaN.
-    tb_combined = pr.merge(tb_unesco, tb_lee, on=["country", "year"], how="outer", suffixes=("", "_hist"))
+    # 4. Lee & Lee: cap at pre-1985. Post-1985 Lee & Lee aggregate estimates (World,
+    #    regions) diverge from UNESCO — e.g. Lee & Lee World primary 1995 = 91% vs
+    #    UNESCO 2000 = 81%. Keeping only pre-1985 avoids injecting inflated values
+    #    into the gap between Lee & Lee's last observation and UNESCO's first.
+    tb_hist = tb_lee[tb_lee["year"] < 1985].copy()
 
-    hist_enr_cols = [c for c in tb_lee.columns if c not in ["country", "year"]]
+    # 5. Outer-merge with Lee & Lee; prefer UNESCO where both exist,
+    #    fall back to Lee & Lee only where UNESCO is NaN.
+    tb_combined = pr.merge(tb_unesco, tb_hist, on=["country", "year"], how="outer", suffixes=("", "_hist"))
+
+    hist_enr_cols = [c for c in tb_hist.columns if c not in ["country", "year"]]
     for col in hist_enr_cols:
         hist_col = f"{col}_hist"
         if hist_col in tb_combined.columns:
@@ -255,12 +262,32 @@ def combine_historical_enrollment(tb_opri: Table, tb_lee: Table, tb_sdgs: Table)
             tb_combined.loc[mask, col] = tb_combined.loc[mask, hist_col]
             tb_combined = tb_combined.drop(columns=[hist_col])
 
+    # Known Lee & Lee data error: US 1975 male primary rate is 50.9 (implausible —
+    # would mean half of American boys weren't in primary school). This produces an
+    # erroneous both-sexes average of 72.0. Null both out.
+    # NOTE: The World 1975 aggregate is NOT nulled — the bad US value actually pulls
+    # the World average *down*, and the 1970→1975 jump reflects genuine education
+    # expansion in decolonizing countries during that decade.
+    mask_us75 = (tb_combined["country"] == "United States") & (tb_combined["year"] == 1975)
+    for col in ["mf_primary_enrollment_rates", "m_primary_enrollment_rates"]:
+        if mask_us75.any() and col in tb_combined.columns:
+            tb_combined.loc[mask_us75, col] = None
+
+    # Early SDGs tertiary data (1971-1974) for World is very noisy — oscillates
+    # between 10-13% while Lee & Lee has smooth 5-year estimates in that range.
+    # Prefer Lee & Lee through 1974 for World tertiary to avoid chart jaggedness.
+    tertiary_cols = [c for c in tb_combined.columns if "tertiary" in c and c not in ["country", "year"]]
+    mask_world_early = (tb_combined["country"] == "World") & tb_combined["year"].between(1971, 1974)
+    for col in tertiary_cols:
+        if mask_world_early.any() and col in tb_combined.columns:
+            tb_combined.loc[mask_world_early, col] = None
+
     # 5. Add Lee & Lee origins to the combined columns so the source attribution
     #    reflects both UNESCO and Lee & Lee.
     lee_origins = []
     for col in hist_enr_cols:
-        if col in tb_lee.columns:
-            lee_origins.extend(tb_lee[col].metadata.origins)
+        if col in tb_hist.columns:
+            lee_origins.extend(tb_hist[col].metadata.origins)
     # Deduplicate origins by producer+title
     seen = set()
     unique_lee_origins = []
@@ -381,17 +408,23 @@ def add_ner_from_oosr(tb_opri: Table, tb_sdgs: Table) -> Table:
 def drop_outliers(tb):
     """Remove implausible values from the pivoted OPRI table and log each removal.
 
-    Uses a dynamic scan: any "percentage of GDP" column with a value exceeding
-    `_GDP_PCT_THRESHOLD` is automatically nulled out and logged. This catches both
-    known bad data points and any new ones that appear in future updates without
-    requiring manual hard-coding of country+year+column triples.
+    Three categories of outliers:
+
+    1. **GDP percentage ceiling**: Any single education-level spending above 10%
+       of GDP is implausible (dynamic scan, no hard-coding needed).
+
+    2. **Zero-value percentage indicators**: Isolated 0.0 values in percentage
+       columns that are surrounded by plausible non-zero values in adjacent years.
+       These are missing data reported as zero by the source.
+
+    3. **Specific point outliers**: Individual data points verified as source
+       errors by comparing against surrounding years and cross-source checks.
     """
-    # Any single education-level spending above this share of GDP is implausible.
-    _GDP_PCT_THRESHOLD = 10
-
-    gdp_pct_cols = [col for col in tb.columns if "percentage of GDP" in col]
-
     n_dropped = 0
+
+    # --- 1. GDP percentage ceiling ---
+    _GDP_PCT_THRESHOLD = 10
+    gdp_pct_cols = [col for col in tb.columns if "percentage of GDP" in col]
     for col in gdp_pct_cols:
         outlier_mask = tb[col].notna() & (tb[col] > _GDP_PCT_THRESHOLD)
         if not outlier_mask.any():
@@ -408,6 +441,55 @@ def drop_outliers(tb):
             )
         n_dropped += int(outlier_mask.sum())
         tb.loc[outlier_mask, col] = None
+
+    # --- 2. Zero-value percentage indicators ---
+    # Specific (country, year, column_substring) where 0.0 is confirmed missing data.
+    zero_outliers = [
+        # Eswatini: private enrollment in primary was ~80% for 1970-1997, then 0% for 1998-2007.
+        ("Eswatini", range(1998, 2008), "private institutions"),
+        # Estonia: staff compensation in primary was ~59-66% but 0% in 2012.
+        ("Estonia", [2012], "staff compensation"),
+    ]
+    for country, years, col_substr in zero_outliers:
+        matching_cols = [c for c in tb.columns if col_substr in c.lower()]
+        for col in matching_cols:
+            mask = (tb["country"] == country) & (tb["year"].isin(years)) & (tb[col] == 0.0)
+            n = int(mask.sum())
+            if n > 0:
+                tb.loc[mask, col] = None
+                n_dropped += n
+                paths.log.info(
+                    "outlier_zeros_removed",
+                    country=country,
+                    years=str(list(years)),
+                    indicator=col,
+                    n_removed=n,
+                    reason="0% is implausible given adjacent years",
+                )
+
+    # --- 3. Specific point outliers ---
+    point_outliers = [
+        # US 1975: UNESCO OPRI primary NER = 83.8%, but Lee & Lee and OPRI's own
+        # later data (1986+) are consistently 95-100%. Isolated early UNESCO data
+        # point that creates a misleading dip in the combined historical series.
+        ("United States", 1975, "Total net enrolment rate, primary"),
+    ]
+    for country, year, col_prefix in point_outliers:
+        matching_cols = [c for c in tb.columns if c.startswith(col_prefix)]
+        for col in matching_cols:
+            mask = (tb["country"] == country) & (tb["year"] == year) & tb[col].notna()
+            n = int(mask.sum())
+            if n > 0:
+                paths.log.info(
+                    "outlier_removed",
+                    country=country,
+                    year=year,
+                    indicator=col,
+                    value=round(float(tb.loc[mask, col].iloc[0]), 2),
+                    reason="isolated early data point inconsistent with 95-100% trend in adjacent decades",
+                )
+                tb.loc[mask, col] = None
+                n_dropped += n
 
     if n_dropped:
         paths.log.info("outliers_summary", total_cells_dropped=n_dropped, threshold_pct_gdp=_GDP_PCT_THRESHOLD)

--- a/etl/steps/data/garden/unesco/2026-05-12/education_opri.py
+++ b/etl/steps/data/garden/unesco/2026-05-12/education_opri.py
@@ -210,30 +210,24 @@ _SDG_TERTIARY_COLS = {
 
 
 def combine_historical_enrollment(tb_opri: Table, tb_lee: Table, tb_sdgs: Table) -> Table:
-    """Combine Lee & Lee historical enrollment (pre-1985) with recent OPRI and SDGs data (1985+).
+    """Combine UNESCO data with Lee & Lee historical enrollment estimates.
 
-    The combined series uses:
-    - Primary NER (1985+): UNESCO OPRI direct survey data
-    - Tertiary GER (1985+): UNESCO SDGs dataset (GER.5T8)
-    - Primary and tertiary (pre-1985): Lee & Lee (2016) historical estimates
+    The combined series prefers UNESCO data wherever it exists and falls back
+    to Lee & Lee (2016) only for country-years where UNESCO has no coverage.
+    This avoids discarding UNESCO observations that exist before 1985 and
+    reduces discontinuities at the splice boundary.
 
-    Both primary and tertiary use 1985 as the cutoff year between Lee & Lee
-    historical estimates and UNESCO recent data.
+    Sources:
+    - Primary NER: UNESCO OPRI (preferred), Lee & Lee (fallback)
+    - Tertiary GER: UNESCO SDGs (preferred), Lee & Lee (fallback)
 
     Secondary enrollment is omitted because OPRI and SDGs only have separate
     lower/upper secondary series, not a single combined secondary series.
 
     Returns the OPRI table with combined enrollment columns appended.
-    Individual country series go back to ~1820; World and regional aggregates
-    are included for all periods via Lee & Lee garden aggregates (pre-1985)
-    and OPRI/SDGs (1985+).
     """
 
-    # Pre-1985 historical data from Lee & Lee for both primary and tertiary.
-    # Recent data (1985+) comes from UNESCO OPRI (primary) and SDGs (tertiary).
-    tb_hist = tb_lee[tb_lee["year"] < 1985].copy()
-
-    # 3. Recent primary NER (1985+) from OPRI itself
+    # 1. UNESCO primary NER from OPRI (all available years)
     opri_primary_map = {
         "Total net enrolment rate, primary, both sexes (%)": "mf_primary_enrollment_rates",
         "Total net enrolment rate, primary, female (%)": "f_primary_enrollment_rates",
@@ -243,28 +237,25 @@ def combine_historical_enrollment(tb_opri: Table, tb_lee: Table, tb_sdgs: Table)
     tb_primary = (
         tb_opri[["country", "year"] + list(avail_primary)]
         .rename(columns=avail_primary)
-        .loc[lambda t: t["year"] >= 1985]
         .copy()
     )
 
-    # 4. Recent tertiary GER (1985+) from SDGs (world aggregates available from 1985)
+    # 2. UNESCO tertiary GER from SDGs (all available years)
     avail_tertiary = {k: v for k, v in _SDG_TERTIARY_COLS.items() if k in tb_sdgs.columns}
     tb_tertiary = (
         tb_sdgs[["country", "year"] + list(avail_tertiary)]
         .rename(columns=avail_tertiary)
-        .loc[lambda t: t["year"] >= 1985]
         .copy()
     )
 
-    # 5. Merge recent primary + tertiary into one recent table
-    tb_recent = pr.merge(tb_primary, tb_tertiary, on=["country", "year"], how="outer")
+    # 3. Merge UNESCO primary + tertiary into one table
+    tb_unesco = pr.merge(tb_primary, tb_tertiary, on=["country", "year"], how="outer")
 
-    # 6. Combine historical (Lee & Lee, pre-1985) and recent (OPRI/SDG, 1985+) using outer merge.
-    # The cutoff is 1985 for both primary and tertiary; prefer the recent source,
-    # falling back to Lee & Lee where the recent source has no data.
-    tb_combined = pr.merge(tb_recent, tb_hist, on=["country", "year"], how="outer", suffixes=("", "_hist"))
+    # 4. Outer-merge with Lee & Lee; prefer UNESCO where both exist,
+    #    fall back to Lee & Lee only where UNESCO is NaN.
+    tb_combined = pr.merge(tb_unesco, tb_lee, on=["country", "year"], how="outer", suffixes=("", "_hist"))
 
-    hist_enr_cols = [c for c in tb_hist.columns if c not in ["country", "year"]]
+    hist_enr_cols = [c for c in tb_lee.columns if c not in ["country", "year"]]
     for col in hist_enr_cols:
         hist_col = f"{col}_hist"
         if hist_col in tb_combined.columns:
@@ -272,12 +263,31 @@ def combine_historical_enrollment(tb_opri: Table, tb_lee: Table, tb_sdgs: Table)
             tb_combined.loc[mask, col] = tb_combined.loc[mask, hist_col]
             tb_combined = tb_combined.drop(columns=[hist_col])
 
-    # 7. Known data error: US 1975 male primary rate is implausible
-    mask_us75 = (tb_combined["country"] == "United States") & (tb_combined["year"] == 1975)
-    if mask_us75.any() and "m_primary_enrollment_rates" in tb_combined.columns:
-        tb_combined.loc[mask_us75, "m_primary_enrollment_rates"] = None
+    # 5. Add Lee & Lee origins to the combined columns so the source attribution
+    #    reflects both UNESCO and Lee & Lee.
+    lee_origins = []
+    for col in hist_enr_cols:
+        if col in tb_lee.columns:
+            lee_origins.extend(tb_lee[col].metadata.origins)
+    # Deduplicate origins by producer+title
+    seen = set()
+    unique_lee_origins = []
+    for o in lee_origins:
+        key = (getattr(o, "producer", ""), getattr(o, "title", ""))
+        if key not in seen:
+            seen.add(key)
+            unique_lee_origins.append(o)
 
-    # 8. Rename to OPRI-style human-readable column names
+    combined_value_cols = [c for c in tb_combined.columns if c in hist_enr_cols]
+    for col in combined_value_cols:
+        existing_origins = tb_combined[col].metadata.origins
+        existing_keys = {(getattr(o, "producer", ""), getattr(o, "title", "")) for o in existing_origins}
+        for o in unique_lee_origins:
+            key = (getattr(o, "producer", ""), getattr(o, "title", ""))
+            if key not in existing_keys:
+                existing_origins.append(o)
+
+    # 6. Rename to OPRI-style human-readable column names
     rename = {k: v for k, v in _COMBINED_ENROLMENT_TO_OPRI.items() if k in tb_combined.columns}
     tb_combined = tb_combined.rename(columns=rename)
 
@@ -288,8 +298,8 @@ def combine_historical_enrollment(tb_opri: Table, tb_lee: Table, tb_sdgs: Table)
         n_rows=len(tb_combined),
     )
 
-    # 10. Outer-merge onto OPRI: fills in enrollment for existing (country, year) pairs
-    #     and adds new rows for pre-1985 historical entries not in OPRI.
+    # 7. Outer-merge onto OPRI: fills in enrollment for existing (country, year) pairs
+    #     and adds new rows for historical entries not in OPRI.
     # Only include the renamed combined columns (not raw Lee & Lee secondary rates).
     combined_cols = list(_COMBINED_ENROLMENT_TO_OPRI.values())
     new_cols = [c for c in tb_combined.columns if c in combined_cols]

--- a/etl/steps/data/garden/unesco/2026-05-12/education_opri.py
+++ b/etl/steps/data/garden/unesco/2026-05-12/education_opri.py
@@ -449,6 +449,15 @@ def drop_outliers(tb):
         ("Eswatini", range(1998, 2008), "private institutions"),
         # Estonia: staff compensation in primary was ~59-66% but 0% in 2012.
         ("Estonia", [2012], "staff compensation"),
+        # Venezuela: entrance age was 3 through 2016, then 0 from 2017. Not a real policy change.
+        ("Venezuela", range(2017, 2026), "official entrance age"),
+        # Saint Helena: entrance age was 5 in 1998, duration was 11, both drop to 0 from 1999.
+        ("Saint Helena", range(1999, 2026), "official entrance age"),
+        ("Saint Helena", range(1999, 2026), "duration of compulsory"),
+        # India 2023-24: out-of-school children drops from 509k to 0. Not credible for 1.4B population.
+        ("India", [2023, 2024], "out-of-school children"),
+        # Turkey 2022-23: out-of-school children drops from 125k to 0.
+        ("Turkey", [2022, 2023], "out-of-school children"),
     ]
     for country, years, col_substr in zero_outliers:
         matching_cols = [c for c in tb.columns if col_substr in c.lower()]
@@ -473,6 +482,13 @@ def drop_outliers(tb):
         # later data (1986+) are consistently 95-100%. Isolated early UNESCO data
         # point that creates a misleading dip in the combined historical series.
         ("United States", 1975, "Total net enrolment rate, primary"),
+        # Algeria 2025: lower secondary NER drops from ~100% to ~22% for all sex
+        # breakdowns. Same source-error pattern as the Algeria 2025 OOS spike in SDGs.
+        ("Algeria", 2025, "Total net enrolment rate, lower secondary"),
+        # Gambia 2012: inbound mobility drops from 100% to 0.94% in one year.
+        ("Gambia", 2012, "Inbound mobility rate"),
+        # Kiribati 2017: % female teachers drops from 82% to 0.3%, recovers to 83% in 2020.
+        ("Kiribati", 2017, "Percentage of teachers in primary education who are female"),
     ]
     for country, year, col_prefix in point_outliers:
         matching_cols = [c for c in tb.columns if c.startswith(col_prefix)]

--- a/etl/steps/data/garden/unesco/2026-05-12/education_sdgs.py
+++ b/etl/steps/data/garden/unesco/2026-05-12/education_sdgs.py
@@ -394,8 +394,6 @@ def drop_outliers(tb: Table) -> Table:
         ("Nauru", 2024, "Proportion of primary schools with access to basic drinking water (%)"),
         # BVI: qualified teachers in primary was 78-100% for 2014-2021, then 0% in 2022.
         ("British Virgin Islands", 2022, "Percentage of qualified teachers in primary education, both sexes (%)"),
-        # BVI: qualified teachers in secondary was ~82-100% for 2014-2021, then 0% in 2022.
-        ("British Virgin Islands", 2022, "Percentage of qualified teachers in secondary education, both sexes (%)"),
     ]
     for country, year, indicator_label in zero_outliers:
         # After pivot, column names include ", indicator_id" suffix — match by prefix.
@@ -423,6 +421,8 @@ def drop_outliers(tb: Table) -> Table:
         # World 1970: tertiary GER = 17.44, but 1971 = 8.73 and Lee & Lee 1970 = 9.49.
         # Isolated spike in early UNESCO data; surrounding years are 8-11%.
         ("World", 1970, "Gross enrolment ratio for tertiary education"),
+        # BVI 2022: qualified teachers in secondary drops from 94% to 1.3%.
+        ("British Virgin Islands", 2022, "Percentage of qualified teachers in secondary education"),
     ]
     for country, year, indicator_prefix in point_outliers:
         matching_cols = [c for c in tb.columns if c.startswith(indicator_prefix)]

--- a/etl/steps/data/garden/unesco/2026-05-12/education_sdgs.py
+++ b/etl/steps/data/garden/unesco/2026-05-12/education_sdgs.py
@@ -2,8 +2,11 @@
 
 import owid.catalog.processing as pr
 from owid.catalog import Table
+from structlog import get_logger
 
 from etl.helpers import PathFinder
+
+log = get_logger()
 
 # World source variants in priority order (UIS is most authoritative for UNESCO data)
 _WORLD_VARIANTS = ["World (UIS)", "World (SDG)", "World (WB)", "World (UNICEF)", "World (MDG)"]
@@ -264,12 +267,7 @@ def run() -> None:
     tb_pivoted = tb.pivot(index=["country", "year"], columns="indicator_label_en", values="value")
     tb_pivoted = tb_pivoted.reset_index()
 
-    # Remove Turkey 1998 value for Government expenditure on education as a percentage of GDP (%), XGDP.FSGOV (likely an error)
-    gdp_col = "Government expenditure on education as a percentage of GDP (%), XGDP.FSGOV"
-    if gdp_col in tb_pivoted.columns:
-        mask = (tb_pivoted["country"] == "Turkey") & (tb_pivoted["year"] == 1998)
-        assert tb_pivoted.loc[mask, gdp_col].iloc[0] == 0, "Turkey 1998 GDP is not zero, investigate before removing"
-        tb_pivoted.loc[mask, gdp_col] = None
+    tb_pivoted = drop_outliers(tb_pivoted)
 
     tb_pivoted = tb_pivoted.format(["country", "year"])
 
@@ -338,4 +336,95 @@ def combine_historical_expenditure(tb: Table, tb_expenditure: Table) -> Table:
     )
 
     tb = tb.format(["country", "year"])
+    return tb
+
+
+def drop_outliers(tb: Table) -> Table:
+    """Remove implausible values from the pivoted SDGs table.
+
+    Three categories of outliers are handled, each logged for auditability:
+
+    1. **Zero-value expenditure (% of govt spending)**: UNESCO reports 0.0 for
+       many country-years where data is simply missing. No country spends 0% of
+       its budget on education; these are recording artifacts.
+
+    2. **Zero-value percentage indicators**: Isolated 0.0 values in percentage
+       columns (qualified teachers, school infrastructure) that are surrounded
+       by plausible non-zero values. Treated as missing-reported-as-zero.
+
+    3. **Specific point outliers**: Individual data points verified as source
+       errors by comparing against surrounding years and cross-source checks.
+    """
+    n_total = 0
+
+    # --- 1. Zero expenditure as % of govt spending ---
+    # 541 rows across 104 countries where UNESCO reports exactly 0.0.
+    # Countries like Australia (1980), Austria (1981-88), Argentina (1982-90)
+    # all show 0% followed by normal 10-25% values — clearly missing data.
+    # After pivot, column names are human-readable with indicator_id suffix, e.g.
+    # "Expenditure on education as a percentage of total government expenditure (%) (UIS calculation), XGOVEXP.IMF"
+    exp_govt_cols = [c for c in tb.columns if "percentage of total government expenditure" in c.lower()]
+
+    for col in exp_govt_cols:
+        if col in tb.columns:
+            zero_mask = tb[col] == 0.0
+            n = int(zero_mask.sum())
+            if n > 0:
+                tb.loc[zero_mask, col] = None
+                n_total += n
+                log.info("outlier_zeros_removed", indicator=col, n_removed=n, reason="0% govt expenditure is implausible")
+
+    # Also catch zeros in "percentage of GDP" expenditure columns (same logic).
+    gdp_pct_cols = [c for c in tb.columns if "percentage of gdp" in c.lower() and "expenditure" in c.lower()]
+    for col in gdp_pct_cols:
+        zero_mask = tb[col] == 0.0
+        n = int(zero_mask.sum())
+        if n > 0:
+            tb.loc[zero_mask, col] = None
+            n_total += n
+            log.info("outlier_zeros_removed", indicator=col, n_removed=n, reason="0% of GDP expenditure is implausible")
+
+    # --- 2. Zero-value percentage indicators ---
+    # Specific (country, year, column) triples where 0.0 is clearly missing data.
+    # Each entry is documented with the surrounding context that confirms it's wrong.
+    zero_outliers = [
+        # Nauru: drinking water in primary schools was 100% for 2019-2023, then 0% in 2024.
+        ("Nauru", 2024, "Proportion of primary schools with access to basic drinking water (%)"),
+        # BVI: qualified teachers in primary was 78-100% for 2014-2021, then 0% in 2022.
+        ("British Virgin Islands", 2022, "Percentage of qualified teachers in primary education, both sexes (%)"),
+        # BVI: qualified teachers in secondary was ~82-100% for 2014-2021, then 0% in 2022.
+        ("British Virgin Islands", 2022, "Percentage of qualified teachers in secondary education, both sexes (%)"),
+    ]
+    for country, year, indicator_label in zero_outliers:
+        # After pivot, column names include ", indicator_id" suffix — match by prefix.
+        matching_cols = [c for c in tb.columns if c.startswith(indicator_label)]
+        for col in matching_cols:
+            mask = (tb["country"] == country) & (tb["year"] == year) & (tb[col] == 0.0)
+            n = int(mask.sum())
+            if n > 0:
+                tb.loc[mask, col] = None
+                n_total += n
+                log.info("outlier_removed", country=country, year=year, indicator=col, reason="0% is implausible given adjacent years")
+
+    # --- 3. Specific point outliers ---
+    # Individual values confirmed as source errors.
+    point_outliers = [
+        # Algeria 2025: out-of-school rate jumped from ~4% to 77.6% for all sex breakdowns.
+        # This is a single-year spike inconsistent with the entire 2011-2024 trend (3-7%).
+        ("Algeria", 2025, "Out-of-school rate for adolescents of lower secondary school age"),
+        # World 1970: tertiary GER = 17.44, but 1971 = 8.73 and Lee & Lee 1970 = 9.49.
+        # Isolated spike in early UNESCO data; surrounding years are 8-11%.
+        ("World", 1970, "Gross enrolment ratio for tertiary education"),
+    ]
+    for country, year, indicator_prefix in point_outliers:
+        matching_cols = [c for c in tb.columns if c.startswith(indicator_prefix)]
+        for col in matching_cols:
+            mask = (tb["country"] == country) & (tb["year"] == year) & tb[col].notna()
+            n = int(mask.sum())
+            if n > 0:
+                tb.loc[mask, col] = None
+                n_total += n
+                log.info("outlier_removed", country=country, year=year, indicator=col, reason="point outlier inconsistent with adjacent years")
+
+    log.info("outliers_summary", step="education_sdgs", total_cells_removed=n_total)
     return tb

--- a/etl/steps/data/garden/unesco/2026-05-12/education_sdgs.py
+++ b/etl/steps/data/garden/unesco/2026-05-12/education_sdgs.py
@@ -372,7 +372,9 @@ def drop_outliers(tb: Table) -> Table:
             if n > 0:
                 tb.loc[zero_mask, col] = None
                 n_total += n
-                log.info("outlier_zeros_removed", indicator=col, n_removed=n, reason="0% govt expenditure is implausible")
+                log.info(
+                    "outlier_zeros_removed", indicator=col, n_removed=n, reason="0% govt expenditure is implausible"
+                )
 
     # Also catch zeros in "percentage of GDP" expenditure columns (same logic).
     gdp_pct_cols = [c for c in tb.columns if "percentage of gdp" in c.lower() and "expenditure" in c.lower()]
@@ -404,7 +406,13 @@ def drop_outliers(tb: Table) -> Table:
             if n > 0:
                 tb.loc[mask, col] = None
                 n_total += n
-                log.info("outlier_removed", country=country, year=year, indicator=col, reason="0% is implausible given adjacent years")
+                log.info(
+                    "outlier_removed",
+                    country=country,
+                    year=year,
+                    indicator=col,
+                    reason="0% is implausible given adjacent years",
+                )
 
     # --- 3. Specific point outliers ---
     # Individual values confirmed as source errors.
@@ -424,7 +432,13 @@ def drop_outliers(tb: Table) -> Table:
             if n > 0:
                 tb.loc[mask, col] = None
                 n_total += n
-                log.info("outlier_removed", country=country, year=year, indicator=col, reason="point outlier inconsistent with adjacent years")
+                log.info(
+                    "outlier_removed",
+                    country=country,
+                    year=year,
+                    indicator=col,
+                    reason="point outlier inconsistent with adjacent years",
+                )
 
     log.info("outliers_summary", step="education_sdgs", total_cells_removed=n_total)
     return tb


### PR DESCRIPTION
## Fix enrollment splice and remove data outliers

- **Splice**: Lee & Lee capped at pre-1985, UNESCO used for all available years — fixes World primary cliff and US 1975 dip
- **Origins**: Combined historical indicators now attribute both UNESCO and Lee & Lee
- **SDGs outliers**: ~550 removals — zero-value expenditure (541 rows), Algeria 2025 OOS spike, Nauru/BVI zeros, World 1970 tertiary spike
- **OPRI outliers**: Eswatini/Estonia zero-value percentages, US 1975 isolated NER point
- **Metadata**: Updated to reflect new splice logic