### PR TITLE
related_charts: read coviews from prod_exports

### DIFF
--- a/apps/related_charts/cli.py
+++ b/apps/related_charts/cli.py
@@ -1,7 +1,7 @@
 """Generate "related charts" recommendations from chart coviews.
 
 Coviews (two charts viewed in the same browsing session, from BigQuery
-`prod_google_analytics4.coviews_by_day_page`) turned out to be a simple and
+`prod_exports.coviews_by_day_page`) turned out to be a simple and
 effective signal for related content. This CLI computes the top related charts
 for every chart (or a single one) and writes them to the `related_charts`
 MySQL table with `reviewer='production'`, where they are consumed by the

--- a/apps/wizard/app_pages/related_charts/data.py
+++ b/apps/wizard/app_pages/related_charts/data.py
@@ -94,7 +94,7 @@ def get_coviews_sessions(after_date: str, min_sessions: int = 5) -> pd.Series:
             REGEXP_EXTRACT(url1, r'grapher/([^/]+)') AS slug1,
             REGEXP_EXTRACT(url2, r'grapher/([^/]+)') AS slug2,
             SUM(sessions_coviewed) AS total_sessions
-        FROM prod_google_analytics4.coviews_by_day_page
+        FROM prod_exports.coviews_by_day_page
         WHERE day >= '{after_date}'
             AND url1 LIKE 'https://ourworldindata.org/grapher%'
             AND url2 LIKE 'https://ourworldindata.org/grapher%'


### PR DESCRIPTION
OWID's analytics repo is relocating `coviews_by_day_page` out of `prod_google_analytics4` into a new **`prod_exports`** BigQuery dataset (for tables consumed *outside* the analytics warehouse — this `related_charts` wizard is its main external consumer). See owid/analytics#857.

Repoints the query + docstring:
- `apps/wizard/app_pages/related_charts/data.py` — `FROM prod_google_analytics4.coviews_by_day_page` → `prod_exports.coviews_by_day_page`
- `apps/related_charts/cli.py` — docstring reference

**Coordination:** `prod_exports.coviews_by_day_page` is already **seeded** (a `bq cp` of the current table), so this is safe to merge any time — no breakage. Merging *after* analytics#857 lands + a nightly run keeps the data fresh (until then the seeded copy is static). Once both are in, the old `prod_google_analytics4.coviews_by_day_page` gets dropped on the analytics side.

lint + format + ty pass locally.