### PR TITLE
:recycle: expert: query the BigQuery semantic layer (DuckDB connection retired)

### DIFF
--- a/apps/wizard/app_pages/expert_agent/agent.py
+++ b/apps/wizard/app_pages/expert_agent/agent.py
@@ -18,12 +18,7 @@ from pydantic_ai.tools import RunContext
 # from RestrictedPython import compile_restricted, safe_globals
 from apps.wizard.app_pages.expert_agent.media import save_code_file, save_plot_file
 from apps.wizard.app_pages.expert_agent.utils import CURRENT_DIR, MODEL_DEFAULT, QueryResult, log, serialize_df
-from etl.analytics.datasette import (
-    DatasetteSQLError,
-    _generate_url_to_datasette,
-    read_datasette,
-)
-from etl.analytics.metabase import _generate_question_url, create_question, get_question_info
+from etl.analytics.metabase import _generate_question_url, create_question, get_question_info, read_semantic_layer
 from etl.analytics.metabase import get_question_data as _get_question_data
 from etl.config import GOOGLE_API_KEY, OWID_MCP_SERVER_URL
 from etl.docs import (
@@ -387,42 +382,39 @@ async def get_db_table_fields(tb_names: list[str]) -> dict[str, Any]:
     return result
 
 
-# Metabase/Datasette
+# Metabase
 @agent.tool_plain(docstring_format="google")
 async def execute_query(query: str, title: str, description: str, num_rows: int = 10) -> QueryResult:
-    """Execute a query in the semantic layer and get the data results.
+    """Execute a query against the BigQuery semantic layer and get the data results.
 
-    The query is ran on Datasette, and if valid, it obtains the results from Datasette and creates a "question" in Metabase with the same query. Note that Metabase and Datasette use the same underlying database, so the query should work in both places.
+    The query runs on the semantic layer via Metabase; if valid, it returns the results and creates a "question" in Metabase with the same query.
 
     If the query is invalid, it returns an error message that can be used to improve the query until valid.
 
     Args:
-        query: Query to Datasette instance.
+        query: SQL query (BigQuery / GoogleSQL) against the semantic layer. Reference tables with their dataset, e.g. `prod_semantic.views_detailed`.
         title: Title that describes what the query does. Should be short and concise.
         description: Description of what the query does. Should be 1-3 sentence long.
         num_rows: Number of rows to return. Defaults to 10. Too many rows may increase the tokens. Be mindful when increasing this number.
     Returns:
         QueryResult: Serializable object with the following fields:
-            message (str): Message about the query execution. "SUCCCESS" if the query was valid, or an error message if not.
+            message (str): Message about the query execution. "SUCCESS" if the query was valid, or an error message if not.
             valid (bool): Whether the query was valid or not.
             result (str): The data results in markdown format (first `num_rows` rows).
             url_metabase (str): Link to the created question in Metabase, if the query was valid and the question was created successfully.
-            url_datasette (str): Link to the query in Datasette.
     """
     # tool_ui_message(
     #     message_type="markdown",
-    #     text=f"**:material/construction: Tool use**: Getting data ({num_rows} rows) from Datasette, via `execute_query`",
+    #     text=f"**:material/construction: Tool use**: Getting data ({num_rows} rows) from the semantic layer, via `execute_query`",
     # )
 
     try:
-        df = read_datasette(query, use_https=False)
-        url_datasette = _generate_url_to_datasette(query)
+        df = read_semantic_layer(query)
 
         if df.empty:
             return QueryResult(
-                message="Query returned no results. Try it on Datasette",
+                message="Query returned no results. Double-check it against the schema.",
                 valid=False,
-                url_datasette=url_datasette,
             )
 
         # Serialize dataframe
@@ -430,9 +422,8 @@ async def execute_query(query: str, title: str, description: str, num_rows: int 
 
         if data.data == []:
             return QueryResult(
-                message="Query returned no results. Try it on Datasette",
+                message="Query returned no results. Double-check it against the schema.",
                 valid=False,
-                url_datasette=url_datasette,
             )
 
         try:
@@ -452,13 +443,11 @@ async def execute_query(query: str, title: str, description: str, num_rows: int 
             valid=True,
             result=data,
             url_metabase=url_metabase,
-            url_datasette=url_datasette,
             card_id_metabase=card_id,
         )
-    except (DatasetteSQLError,) as e:
-        # Handle specific Datasette-related errors
+    except Exception as e:
         return QueryResult(
-            message=f"ERROR. Query is invalid! Check for correctness, it must be DuckDB compatible!\nError: {e}",
+            message=f"ERROR. Query is invalid! Check for correctness, it must be BigQuery (GoogleSQL) compatible!\nError: {e}",
             valid=False,
         )
 

--- a/apps/wizard/app_pages/expert_agent/context.yml
+++ b/apps/wizard/app_pages/expert_agent/context.yml
@@ -11,7 +11,7 @@ system_prompt: |-
 
   Sometimes, the intent of the question might be obvious, and you may skip the `get_context` tool:
 
-    - Learn the analytics database schema: Use `get_db_tables` and `get_db_table_fields` tools, to understand the available tables and their columns. Our analytics database is based on DuckDB.
+    - Learn the analytics database schema: Use `get_db_tables` and `get_db_table_fields` tools, to understand the available tables and their columns. Our analytics database is the `prod_semantic` dataset on our BigQuery data warehouse, queried through Metabase.
     - Run queries and get the data with `execute_query`.
     - Get API reference documentation: Use `get_api_reference_metadata` tool with the appropriate object_name to get details on metadata fields.
     - Get documentation: Use `get_docs_index` to get a list of available documentation files, and then use `get_docs_page` to read specific documentation files.
@@ -19,7 +19,7 @@ system_prompt: |-
   Remember that you may not know everything: If you are unsure about the question's intent, you can ask the user for clarification. Also, if you are unable to answer the question, let the user know that you cannot help with that specific question.
 
   Output format:
-  - Use markdown formatting for your responses. For example, when providing SQL queries, use code blocks with the SQL language (DuckDB flavour) specified (i.e. ```sql...```), and same for other languages.
+  - Use markdown formatting for your responses. For example, when providing SQL queries, use code blocks with the SQL language (BigQuery / GoogleSQL flavour) specified (i.e. ```sql...```), and same for other languages.
   - When answering with SQL queries to our DB, also provide a clickable link to the created Metabase question, formatted as "[View results in Metabase](link)".
   - Avoid suggesting following-up questions.
   - If the user asks for a plot, you should run `generate_plot` at some point to create it. Don't worry about the presentation of the plot, as the system will take care of it after you've generated it.
@@ -46,9 +46,9 @@ context:
 
     Use `get_api_reference_metadata` tool to get details on the metadata fields for Dataset, Table, Indicator, Collection (or MDIM), and Origin. This will provide you with the API reference documentation for these metadata entities. Additionally, resort to `get_docs_index` tool find out metadata-related available documentation files, and then use `get_docs_page` tool to read them.
   analytics: |-
-    We have our main user database "Semantic Layer", which is based on DuckDB. It is the result of careful curation of our other more raw databases. It is intended to be used mostly for analytics purposes. It is exposed via Metabase and Datasette, which allows users to run SQL queries against it.
+    We have our main user "Semantic Layer", the `prod_semantic` dataset on our BigQuery data warehouse. It is the result of careful curation of our other more raw datasets, and is intended mostly for analytics purposes. It is exposed via Metabase, which lets users run SQL queries against it.
 
-    Both Metabase and Datasette expose the same DuckDB database. Datasette is intended to be used to validate and run queries, and get data. Metabase is for saving the created queries, linking the users to them, etc.
+    You run queries against the semantic layer with `execute_query` (which runs them on BigQuery via Metabase and returns the data), and save useful ones as Metabase questions so users can be linked to them.
 
     Various users don't have SQL expertise, but still want to get their questions answered. You are an expert that can understand these user' questions, generate SQL queries to answer them and link them to the relevant *Metabase* results, present visualization/plots whenever you are asked for them, etc.
 
@@ -58,11 +58,11 @@ context:
     If you can't find any question in Metabase, or the user explicitly asks for a new query, you will generate a new SQL query to answer the user's question. You will use the `get_db_tables` and `get_db_table_fields` tools to understand the database schema, and then use the `execute_query` tool to run your SQL query and get the data.
 
     ### Generating SQL queries
-    Utilize the database documentation, making intelligent use of foreign key constraints to deduce relationships from natural language inquiries. You will prioritize identifying and using actual table and column names from the schema to ensure accuracy in SQL query generation. When the system infers table or column names, it may confirm with the user to ensure correctness. The SQL dialect used is SQLite.
+    Utilize the database documentation, making intelligent use of foreign key constraints to deduce relationships from natural language inquiries. You will prioritize identifying and using actual table and column names from the schema to ensure accuracy in SQL query generation. When the system infers table or column names, it may confirm with the user to ensure correctness. The SQL dialect used is BigQuery (GoogleSQL).
 
     To get details about the tables available in the database, you can use the `get_db_tables` tool. To get details about the columns of a specific table, you can use the `get_db_table_fields` tool.
 
-    Your job is to create an SQL query for the user that answers their question given the database schema. This query must be DuckDB compatible! Use the return information string to improve the SQL until valid. If you keep failing, considering zooming out, getting back to the user's question and solve it differently.
+    Your job is to create an SQL query for the user that answers their question given the database schema. This query must be BigQuery (GoogleSQL) compatible! Use the return information string to improve the SQL until valid. If you keep failing, considering zooming out, getting back to the user's question and solve it differently.
 
     ### Generate plots
     If the user asks for a plot, you will first find a relevant Metabase question that answers the user's question or, create a new one. Once the data is in Metabase, you will use the `generate_plot` tool. This tool requires a Metabase card ID as input, and natural language instructions on how to plot the data.
@@ -70,9 +70,9 @@ context:
     You will typically call `generate_plot` after running `execute_query` to create a new Metabase question, or after using `list_available_questions_metabase` / `get_question_data` to get data from an existing Metabase question.
 
     ## Important SQL Guidelines
-    - **NEVER use DATE() function**: Use `DATE '2025-01-01'` syntax instead of `DATE('2025-01-01')`
-    - Example: `DATE '2025-01-01' - INTERVAL '1 year'`
-    - Don't hardcode dates (unless explicitly asked by the user). Instead, use relative date functions like `CURRENT_DATE`.
+    - The dialect is **BigQuery (GoogleSQL)**. Reference tables with their dataset, e.g. `prod_semantic.views_detailed` — not a bare table name.
+    - For relative dates use `DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)` — BigQuery has no `date - interval` operator, and the unit is an unquoted keyword (`DAY`, `MONTH`, `YEAR`, …). Group time series with `DATE_TRUNC(day, MONTH)` (column first, then the unquoted unit). Don't hardcode dates unless the user asks.
+    - **Cost matters**: queries run on BigQuery, billed by bytes scanned. ALWAYS aggregate in SQL and filter by `day` (the big tables like `views_detailed` are date-partitioned, so a `day` filter prunes the scan). Never `SELECT *` from a large table.
 
     ## Response format
     Start with a brief comment on the user's question, but avoid being overly verbose.
@@ -81,4 +81,4 @@ context:
 
     Then, share a preview of the results, which should either come from an existing Metabase question (if you used `get_question_data` tool) or from the results of your SQL query (if you used `execute_query` tool). If the results are too large (e.g. more than 20 rows), consider summarizing them or providing a sample that is most relevant.
 
-    Finally, provide a clickable link to the Metabase question with the results. Format it as "[View results in Metabase](link)". If the metabase link is unavailable, share a Datasette link instead.
+    Finally, provide a clickable link to the Metabase question with the results. Format it as "[View results in Metabase](link)". If the Metabase link is unavailable, just present the results directly.

--- a/etl/analytics/metabase.py
+++ b/etl/analytics/metabase.py
@@ -25,7 +25,10 @@ log = get_logger()
 
 # Config
 COLLECTION_EXPERT_ID = 61  # Expert collection
-DATABASE_ID = 2  # Semantic Layer database
+# Default DB for created questions = the semantic layer (now the prod_semantic dataset on the
+# BigQuery "Data warehouse" connection; the old DuckDB connection (id 2) was retired). Single
+# source of truth with the read path.
+DATABASE_ID = METABASE_SEMANTIC_LAYER_DATABASE_ID
 
 # HTTP status codes that indicate Metabase is temporarily unavailable rather than a permanent error.
 # Metabase is restarted by the analytics pipeline whenever the DuckDB mirrors are rebuilt (daily, plus
@@ -101,7 +104,7 @@ def read_metabase(
     }
     body = {
         "query": {
-            # Database corresponding to the Semantic Layer (DuckDB).
+            # Database corresponding to the Semantic Layer (BigQuery).
             "database": database_id,
             "type": "native",
             "native": {"query": re.sub(r"\s+", " ", sql.strip())},
@@ -113,7 +116,7 @@ def read_metabase(
     # I cannot get the /api/dataset/csv endpoint to work when sending a dict (or json.dumps(dict)) to the POST body,
     # so I instead urlencode the body. The url encoding is a little awkward – we cannot simply use urllib.parse.urlencode(body)
     # b/c python dict single quotes need to be changed to double quotes. But we can't naively change all single quotes to
-    # double quotes b/c the sql query might include single quotes (and DuckDB doesn't allow double quotes). So the line below
+    # double quotes b/c the sql query might include single quotes (and double quotes mean identifiers, not strings). So the line below
     # executes the url encoding without replacing any quotes within the sql query.
     urlencoded = "&".join([f"{k}={urllib.parse.quote_plus(json.dumps(v))}" for k, v in body.items()])
 
@@ -203,10 +206,10 @@ def create_question(
 ):
     """Create a question in Metabase with the given SQL query and title.
 
-    This tool should be used once we are sure that the query is valid in Datasette.
+    This tool should be used once we are sure that the query is valid (i.e. it ran successfully against the semantic layer).
 
     Args:
-        query: Query user for Datasette/Metabase.
+        query: SQL query (BigQuery / GoogleSQL) for the Metabase question.
         title: Title that describes what the query does. Should be short, but concise.
     Returns:
         Question object from Metabase API.

--- a/etl/config.py
+++ b/etl/config.py
@@ -724,7 +724,9 @@ for env_var in env_vars:
 METABASE_API_KEY = os.environ.get("METABASE_API_KEY")
 METABASE_API_KEY_ADMIN = os.environ.get("METABASE_API_KEY_ADMIN")
 METABASE_URL = os.environ.get("METABASE_URL")
-METABASE_SEMANTIC_LAYER_DATABASE_ID = 2
+# Semantic layer = the `prod_semantic` dataset on the "Data warehouse (BigQuery)" connection (id 3).
+# The old DuckDB semantic-layer connection (id 2) was retired (owid/analytics#735).
+METABASE_SEMANTIC_LAYER_DATABASE_ID = 3
 METABASE_URL_LOCAL = os.environ.get("METABASE_URL", "http://localhost:3000")
 METABASE_URL = os.environ.get("METABASE_URL", "http://metabase.owid.io")
 


### PR DESCRIPTION
Repoints the **Expert agent** off the now-deleted Metabase DuckDB connection onto the BigQuery semantic layer. Companion to the Nao repoint; both follow owid/analytics#735 (the DuckDB→BigQuery migration).

### Why
The Metabase "Semantic layer (DuckDB)" connection (db 2) was deleted in the analytics repo. The same semantic-layer tables now live in the **`prod_semantic`** dataset on the **"Data warehouse (BigQuery)"** connection (db 3). The Expert was coupled to DuckDB in three places: it *validated/fetched* via Datasette (DuckDB), *persisted* questions to db 2, and was *prompted* to write DuckDB SQL.

### Changes
- **`etl/config.py`** — `METABASE_SEMANTIC_LAYER_DATABASE_ID` `2` → `3`.
- **`etl/analytics/metabase.py`** — `DATABASE_ID` (default DB for `create_question`) now references `METABASE_SEMANTIC_LAYER_DATABASE_ID` (one source of truth), so created questions land on the BigQuery connection. DuckDB-flavoured comments/docstrings updated.
- **`apps/wizard/app_pages/expert_agent/agent.py`** — `execute_query` runs via `read_semantic_layer` (Metabase-on-BigQuery) instead of `read_datasette` (DuckDB). Removes the Datasette imports + `url_datasette`; the invalid-query message now asks for **BigQuery (GoogleSQL)** SQL.
- **`apps/wizard/app_pages/expert_agent/context.yml`** — system prompt rewritten for GoogleSQL: dataset-qualified table names (`prod_semantic.<table>`), `DATE_SUB(CURRENT_DATE(), INTERVAL N DAY)` / `DATE_TRUNC(day, MONTH)` instead of DuckDB date syntax, and **BigQuery cost guidance** (always aggregate + filter by `day` on the partitioned tables; never `SELECT *`). Dropped the "Datasette validates / Metabase saves" framing (it's one backend now).

### Heads-up
- **Cost**: `execute_query` now runs on BigQuery (billed by bytes scanned) where it previously hit Datasette for free, and the agent retries until a query is valid. Per the analytics-side decision this is handled by **prompt guidance** (aggregate + `day`-filter) rather than a hard cost guard — worth watching, and easy to add a dry-run cost cap later if it bites.
- **Permissions**: the Expert's `METABASE_API_KEY` needs native-query permission on the BigQuery connection (db 3) for `execute_query` to run.
- The table-docs source (`read_analytics.get_metabase_db_docs()` → analytics repo `docs/db/db_docs.yml` "semantic" section) is unchanged — table names are identical on the BigQuery connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)