### PR TITLE
📊 Skip PRs with lost MySQL connection in scan-chart-diff

### DIFF
--- a/apps/utils/scan_chart_diff.py
+++ b/apps/utils/scan_chart_diff.py
@@ -64,5 +64,9 @@ def cli(dry_run: bool) -> None:
             if "Can't connect to MySQL server" in str(e):
                 log.warning("scan-chart-diff.cant-connect", pr=pr)
                 continue
+            # Server reset the connection mid-query (being refreshed/restarted)
+            if "Lost connection to MySQL server" in str(e):
+                log.warning("scan-chart-diff.lost-connection", pr=pr)
+                continue
             else:
                 raise e


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## What

Skip a PR (instead of aborting the whole scan) when its staging-site MySQL drops the connection mid-query in `scan-chart-diff`.

Fixes [ETL-8Y](https://our-world-in-data.sentry.io/issues/ETL-8Y) — `OperationalError (2013, 'Lost connection to MySQL server during query (Connection reset by peer)')`, 217 occurrences over the last month.

## Why

`etl d scan-chart-diff` (cron on `etl-prod-2`) loops over every open PR and runs chart-diff against each one's staging server. The handler already tolerates a family of transient per-PR staging conditions and `continue`s past them — `Unknown MySQL server host`, `Unknown database`, `Unknown column`, `Can't connect to MySQL server`.

Error 2013 ("Lost connection during query" — the staging MySQL being refreshed/restarted/OOM-killed) was **not** in that list, so it fell through to `raise e` and killed the scan for **every remaining PR** in that run. The ~daily occurrence rate matches the cron cadence.

## Change

Adds one more branch in the `OperationalError` handler in `apps/utils/scan_chart_diff.py`, matching on the message string like the existing cases:

```python
# Server reset the connection mid-query (being refreshed/restarted)
if "Lost connection to MySQL server" in str(e):
    log.warning("scan-chart-diff.lost-connection", pr=pr)
    continue
```

A single PR's unhealthy staging server no longer aborts the rest of the scan; it logs a warning and moves on.
