### PR TITLE
🐛 fix Taiwan unit mismatch in UNWTO domestic accommodation guests

### DIFF
--- a/etl/steps/data/garden/tourism/2026-01-21/unwto.py
+++ b/etl/steps/data/garden/tourism/2026-01-21/unwto.py
@@ -280,7 +280,11 @@ def sanity_check_population_ratios(tb: Table) -> None:
       genuinely receive >100× their population in visitors.
     """
     # Columns that represent counts of people (guests, arrivals, departures, trips).
-    PERSON_COUNT_COLUMNS = [col for col in tb.columns if any(k in col for k in ["guest", "arrival", "departure", "trip", "vis_tourist", "vis_excur"])]
+    PERSON_COUNT_COLUMNS = [
+        col
+        for col in tb.columns
+        if any(k in col for k in ["guest", "arrival", "departure", "trip", "vis_tourist", "vis_excur"])
+    ]
 
     for col in PERSON_COUNT_COLUMNS:
         data = tb[["country", "year", "population", col]].dropna(subset=[col, "population"])

--- a/etl/steps/data/garden/tourism/2026-01-21/unwto.py
+++ b/etl/steps/data/garden/tourism/2026-01-21/unwto.py
@@ -44,6 +44,21 @@ ABBREVIATIONS = {
     "occupancy": "occ",
 }
 
+# Source-side unit corrections: (country, meadow_column, divisor).
+# UNWTO occasionally reports a country-indicator in units while the rest are in thousands.
+# Each entry divides the raw value by `divisor` before the blanket ×1000 conversion.
+# If the source fixes the inconsistency, the population sanity check will still pass and
+# the correction becomes a harmless no-op (dividing an already-correct value makes it too small,
+# which the check would also catch on the next update — remove the entry then).
+UNIT_CORRECTIONS = [
+    # Taiwan reports domestic hotel guests in units, not thousands (as of 2026-01-21 snapshot).
+    (
+        "Taiwan",
+        "domestic_tourism_accommodation_domestic__accommodation__short_term_accommodation__hotels_and_similar__isic_5510__guests",
+        1000,
+    ),
+]
+
 # Columns to keep after shortening column names
 COLUMNS_TO_KEEP = [
     "dom_tour_trips_total_overnight_vis_tourists",
@@ -91,6 +106,26 @@ def run() -> None:
     tb = paths.regions.harmonize_names(tb)
     # Drop columns with all NaN values
     tb = tb.dropna(axis=1, how="all")
+
+    # Corrections for source-side unit inconsistencies.
+    # The sanity_check_population_ratios() below will catch any *new* mismatches — when it
+    # fails, investigate the source and add a correction here.
+    # If the source fixes the inconsistency, the correction becomes wrong (makes values too
+    # small). To guard against that, we verify the correction is still needed: the raw value
+    # must be >100× the median of other countries. If not, the source was fixed — remove the entry.
+    for country, col, divisor in UNIT_CORRECTIONS:
+        if col in tb.columns:
+            mask = tb["country"] == country
+            country_vals = tb.loc[mask, col].dropna()
+            others_median = tb.loc[~mask, col].dropna().median()
+            if len(country_vals) > 0 and others_median > 0:
+                ratio = country_vals.median() / others_median
+                assert ratio > 100, (
+                    f"Unit correction for {country}/{col} may no longer be needed: "
+                    f"ratio to others' median is only {ratio:.1f}x (expected >100x). "
+                    f"The source may have fixed the inconsistency — verify and remove the entry from UNIT_CORRECTIONS."
+                )
+            tb.loc[mask, col] = tb.loc[mask, col] / divisor
 
     # Find columns that start with the specified prefixes - units are not thousands
     matching_columns = [col for col in tb.columns if any(col.startswith(prefix) for prefix in PREFIXES_NOT_THOUSANDS)]
@@ -152,6 +187,10 @@ def run() -> None:
         tb["dom_tour_trips_total_overnight_vis_tourists_per_person"] = (
             tb["dom_tour_trips_total_overnight_vis_tourists"] / tb["population"]
         )
+
+    # Sanity check: no person-count indicator should exceed 50× the country's population.
+    # Catches unit mismatches at the source (e.g. values in units instead of thousands).
+    sanity_check_population_ratios(tb)
 
     tb = tb.drop(columns=["population"])
 
@@ -224,6 +263,44 @@ def run() -> None:
 
     # Save changes in the new garden dataset.
     ds_garden.save()
+
+
+def sanity_check_population_ratios(tb: Table) -> None:
+    """Check that person-count indicators don't exceed a plausible multiple of the country's population.
+
+    After unit conversion (×1000), indicators like guests, arrivals, trips, and departures should
+    not exceed a threshold × population. A value that does almost certainly has the wrong units in
+    the source (e.g. reported in units instead of thousands). This check is immune to what other
+    countries report — it only depends on the country's own population, which is a hard physical bound.
+
+    Thresholds differ by indicator type:
+    - Domestic indicators (dom_*): max 50× population. A country's own residents can't generate
+      more than ~50 hotel stays per person per year.
+    - Inbound indicators (in_*): max 200× population. Micro-states like Andorra and Macao
+      genuinely receive >100× their population in visitors.
+    """
+    # Columns that represent counts of people (guests, arrivals, departures, trips).
+    PERSON_COUNT_COLUMNS = [col for col in tb.columns if any(k in col for k in ["guest", "arrival", "departure", "trip", "vis_tourist", "vis_excur"])]
+
+    for col in PERSON_COUNT_COLUMNS:
+        data = tb[["country", "year", "population", col]].dropna(subset=[col, "population"])
+        if data.empty:
+            continue
+        data = data[data["population"] > 0]
+
+        # Domestic indicators have a tighter bound — residents can't exceed their own population by much.
+        max_ratio = 50 if col.startswith("dom_") else 200
+
+        ratio = data[col] / data["population"]
+        violations = data[ratio > max_ratio]
+        if not violations.empty:
+            for _, row in violations.iterrows():
+                r = row[col] / row["population"]
+                raise AssertionError(
+                    f"'{col}': {row['country']} ({int(row['year'])}) has {row[col]:,.0f} "
+                    f"which is {r:,.0f}x its population ({row['population']:,.0f}). "
+                    f"The source likely reports this indicator in a different unit (e.g. units instead of thousands)."
+                )
 
 
 def shorten_column_names(columns):


### PR DESCRIPTION
## Fix Taiwan unit mismatch in UNWTO domestic accommodation guests

### Problem

Taiwan's `dom_tour_accom_short_term_hotels_and_similar_isic_5510_guests` was **~1000× too large**. The UNWTO source reports Taiwan's domestic hotel guests in **units** while all other 98 countries report in **thousands**. After the garden step's blanket ×1000 conversion, Taiwan showed ~60 billion guests instead of ~60 million.

### Fix

- **`UNIT_CORRECTIONS`**: Divides Taiwan's raw value by 1000 before the ×1000 conversion. The correction is **self-validating** — it asserts that the raw value is still >100× the median of other countries. If the source fixes the inconsistency in a future release, this assert fails with a clear message telling the developer to remove the entry.

### Sanity checks

- **`sanity_check_population_ratios()`**: After unit conversion, checks that no person-count indicator (guests, arrivals, departures, trips) exceeds a plausible multiple of the country's population. Uses domain-appropriate thresholds:
  - **Domestic** (`dom_*`): max **50×** population
  - **Inbound** (`in_*`): max **200×** population (micro-states like Andorra genuinely reach ~122×)

This catches any **new** unit mismatches automatically, without depending on what other countries report — it's anchored to population, a hard physical bound.

### Future scenarios

| Scenario | What happens |
|---|---|
| Source fixes Taiwan | The `ratio > 100` pre-check fails → tells you to remove the `UNIT_CORRECTIONS` entry |
| New country has same bug | Population check catches it with a clear error |
| Source changes units globally | Population check catches all affected countries |