### PR TITLE
🐛 Fix analytics queries broken by DuckDB to BigQuery semantic-layer migration

### DIFF
--- a/etl/analytics/config.py
+++ b/etl/analytics/config.py
@@ -15,6 +15,12 @@ ANALYTICS_JSON_URL = f"{ANALYTICS_URL}.json"
 # Maximum number of rows that a single Datasette csv call can return.
 MAX_DATASETTE_N_ROWS = 10000
 
+# Schema (BigQuery dataset) where the semantic-layer tables live, on the "Data warehouse (BigQuery)"
+# connection (METABASE_SEMANTIC_LAYER_DATABASE_ID). BigQuery requires table names to be qualified with
+# their dataset (e.g. `prod_semantic.charts`), unlike the old DuckDB semantic layer where bare names
+# resolved. See owid/analytics#735 (DuckDB → BigQuery migration).
+SEMANTIC_LAYER_SCHEMA = "prod_semantic"
+
 # Base OWID URL, used to find views in articles and topic pages.
 OWID_BASE_URL = "https://ourworldindata.org/"
 

--- a/etl/analytics/data.py
+++ b/etl/analytics/data.py
@@ -12,6 +12,7 @@ from etl.analytics.config import (
     OWID_BASE_URL,
     POST_LINK_TYPES_TO_URL,
     POST_TYPE_TO_URL,
+    SEMANTIC_LAYER_SCHEMA,
 )
 from etl.analytics.datasette import read_datasette
 from etl.analytics.metabase import read_semantic_layer
@@ -83,7 +84,7 @@ def get_number_of_days(
         )
 
     # There is always a lag in analytics, so we need to find out the maximum date informed in the analytics data.
-    query = f"SELECT MAX({day_column_name}) AS date_max FROM {table_name}"
+    query = f"SELECT MAX({day_column_name}) AS date_max FROM {SEMANTIC_LAYER_SCHEMA}.{table_name}"
     date_max_informed = read_analytics(sql=query)["date_max"].item()
     date_end = min(pd.to_datetime(date_max_informed), pd.to_datetime(date_max))
 
@@ -141,8 +142,8 @@ def get_chart_views_per_day_by_chart_id(
         c.url,
         v.day,
         SUM(v.events) AS events
-    FROM charts c
-    JOIN grapher_views_detailed v ON c.url = v.grapher
+    FROM {SEMANTIC_LAYER_SCHEMA}.charts c
+    JOIN {SEMANTIC_LAYER_SCHEMA}.grapher_views_detailed v ON c.url = v.grapher
     {where_sql}
     GROUP BY c.chart_id, c.url, v.day
     ORDER BY c.chart_id, v.day ASC;
@@ -192,8 +193,8 @@ def get_chart_views_by_chart_id(
         c.url,
         c.published_at,
         SUM(v.events) AS views
-    FROM charts c
-    JOIN grapher_views_detailed v ON c.url = v.grapher
+    FROM {SEMANTIC_LAYER_SCHEMA}.charts c
+    JOIN {SEMANTIC_LAYER_SCHEMA}.grapher_views_detailed v ON c.url = v.grapher
     {where_sql}
     GROUP BY c.chart_id, c.url, c.published_at
     ORDER BY views DESC
@@ -302,8 +303,8 @@ def get_post_views_by_url(
     SELECT
         url,
         SUM(views) AS views
-    FROM views_detailed
-    JOIN pages USING(url)
+    FROM {SEMANTIC_LAYER_SCHEMA}.views_detailed
+    JOIN {SEMANTIC_LAYER_SCHEMA}.pages USING(url)
     WHERE day >= '{date_min}'
     AND day <= '{date_max}'
     """


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## What

Qualify the four semantic-layer tables (`charts`, `grapher_views_detailed`, `views_detailed`, `pages`) with the `prod_semantic` schema in the analytics queries that go through `read_semantic_layer`.

## Why

The analytics "semantic layer" was migrated from DuckDB to the `prod_semantic` BigQuery dataset ([owid/analytics#735](https://github.com/owid/analytics), announced [in Slack](https://owid.slack.com/archives/C014N17DHEC/p1782726257395539)). Saved Metabase questions were updated as part of that migration, but the **ad-hoc SQL the ETL repo sends to Metabase** was not.

BigQuery requires table names to be qualified with their dataset. The bare table names that resolved fine under DuckDB now fail with:

```
RuntimeError: Metabase API request failed with status code 400
BigQueryException: Table "charts" must be qualified with a dataset (e.g. dataset.table).
```

This broke the `test_app_chart_diff` integration test on **every** branch (the chart-diff app calls `get_chart_views_last_n_days` on load), e.g. [build 39627](https://buildkite.com/our-world-in-data/etl-automated-staging-environment/builds/39627) — not just the branch it happened to surface on.

## Changes

- New constant `SEMANTIC_LAYER_SCHEMA = "prod_semantic"` in `etl/analytics/config.py`.
- Qualified the bare table names in the four `read_semantic_layer` queries in `etl/analytics/data.py` (`get_chart_views_per_day_by_chart_id`, `get_chart_views_by_chart_id`, `get_post_views_by_url`, and `get_number_of_days`).

Queries that go through `OWID_ENV.read_sql` (the grapher **MySQL** DB) are unaffected and left unchanged.

## Verification

Ran all three affected functions against the live BigQuery semantic layer — all return data:
- `get_chart_views_by_chart_id` → 4,420 rows
- `get_post_views_by_url` → 1,105 rows
- `get_chart_views_per_day_by_chart_id` → OK

`make check` passes.
