### PR TITLE
📜 Explain shares above 100% in food trade notebook

### DIFF
--- a/docs/analyses/food_trade/food_trade.ipynb
+++ b/docs/analyses/food_trade/food_trade.ipynb
@@ -8,7 +8,7 @@
     "# Global food trade data\n",
     "\n",
     "!!! info \"\"\n",
-    "    :octicons-person-16: **[Pablo Rosado](https://ourworldindata.org/team/pablo-rosado)** • :octicons-calendar-16: June 24, 2026 *(last edit)* • [**:octicons-mail-16: Feedback**](mailto:info@ourworldindata.org?subject=Feedback%20on%20technical%20publication%20-%20Analysing%20global%20food%20trade%20data)"
+    "    :octicons-person-16: **[Pablo Rosado](https://ourworldindata.org/team/pablo-rosado)** • :octicons-calendar-16: June 29, 2026 *(last edit)* • [**:octicons-mail-16: Feedback**](mailto:info@ourworldindata.org?subject=Feedback%20on%20technical%20publication%20-%20Global%20food%20trade%20data)"
    ]
   },
   {

--- a/docs/analyses/food_trade/food_trade.ipynb
+++ b/docs/analyses/food_trade/food_trade.ipynb
@@ -2002,7 +2002,7 @@
     "For some items, exports can exceed 100% of production, and imports can exceed 100% of domestic supply.\n",
     "This is expected, and there are two possible reasons.\n",
     "\n",
-    "On the one hand, this could simply be an artefact caused by mismatches between the TM and SCL datasets.\n",
+    "On the one hand, this could simply be an artifact caused by mismatches between the TM and SCL datasets.\n",
     "In [a previous section](#Consistency-between-TM-and-SCL-trade-reports) we attempted to quantify and tackle some of these cases, but some discrepancies still remain.\n",
     "\n",
     "On the other hand, this can also be a real effect: some countries export more than they produce, by re-exporting imported goods.\n",

--- a/docs/analyses/food_trade/food_trade.ipynb
+++ b/docs/analyses/food_trade/food_trade.ipynb
@@ -1994,6 +1994,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "shares-above-100-md",
+   "metadata": {},
+   "source": [
+    "### Shares above 100%\n",
+    "\n",
+    "For some items, exports can exceed 100% of production, and imports can exceed 100% of domestic supply.\n",
+    "This is expected, and there are two possible reasons.\n",
+    "\n",
+    "On the one hand, this could simply be an artefact caused by mismatches between the TM and SCL datasets.\n",
+    "In [a previous section](#Consistency-between-TM-and-SCL-trade-reports) we attempted to quantify and tackle some of these cases, but some discrepancies still remain.\n",
+    "\n",
+    "On the other hand, this can also be a real effect: some countries export more than they produce, by re-exporting imported goods.\n",
+    "When this happens, exports as a share of production exceed 100%.\n",
+    "\n",
+    "Since domestic supply is defined as `Supply = Production + Imports − Exports − Stock variation`,\n",
+    "when `Exports > Production`, this mathematically implies that `Imports > Supply + Stock variation`.\n",
+    "So, assuming small stock variations, imports are larger than supply, and hence imports as a share of domestic supply also exceed 100%."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "meatcut-intro",
    "metadata": {},
    "source": [


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

## What

Adds a short **"Shares above 100%"** subsection to the food-trade technical companion notebook ([docs/analyses/food_trade/food_trade.ipynb](https://github.com/owid/etl/blob/master/docs/analyses/food_trade/food_trade.ipynb)), explaining why a country can show exports above 100% of its production, or imports above 100% of its domestic supply.

## Why

The notebook already documents the TM/SCL consistency checks and the import-coverage gate, but never explains the >100% shares a reader will actually see in the visualization (e.g. roasted coffee for Brazil). This closes that gap.

## What it says

Two causes:

- **Measurement artefact** — trade comes from TM while production and supply come from SCL, and where the two datasets disagree a share can exceed 100% on its own (links back to the *Consistency between TM and SCL trade reports* section).
- **Real effect** — some countries export more than they produce by re-exporting imported goods. Since `domestic supply = Production + Imports − Exports − Stock variation`, when `Exports > Production` it follows that `Imports > Supply + Stock variation`, so (for small stock variations) both shares exceed 100% together.

## Notes

- Only the canonical, git-tracked `docs/` notebook is touched; the untracked `site/` copy is a build artefact.
- The in-page link uses the case-preserved anchor that `docs/ignore/post-build/convert_notebooks.py` generates, so it resolves on the rendered docs site.
- The full notebook was not re-executed: the additions render text / are a collapsed silent-assert cell, so a full run would only churn every chart output. The assertion logic was validated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)