### PR TITLE
📊 Remove EIU sub-indices from democracy explorer (license compliance)

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -253,6 +253,14 @@ def main_cli(
             if not steps:
                 click.echo("No steps modified relative to origin/master.")
                 return
+            # `--modified` surfaces modified export steps (multidim/explorer recipes) by design, but
+            # they're only buildable in export mode. When a branch edits only such a recipe (e.g. a
+            # single `<explorer>.<key>.config.yml`), the modified set is export-only; without this we
+            # would exclude it downstream and crash with "No steps matched". Enable export (which also
+            # un-excludes the grapher deps the export step needs) so the explorer actually rebuilds.
+            if not export and any(s.startswith("export://") for s in steps):
+                export = True
+                click.echo("Detected modified export step(s); enabling --export for this run.")
             click.echo(f"Restricting to {len(steps)} step(s) modified vs origin/master.")
             # We matched modified catalog paths as substrings, so disable exact matching downstream.
             exact_match = False

--- a/etl/io.py
+++ b/etl/io.py
@@ -59,9 +59,18 @@ def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]], incl
             # Not a data/snapshot step. It might be an export step (etl/steps/export/...); if so,
             # record its export:// URI so a branch that only edits an export recipe still selects it.
             try:
-                export_path = abs_step_path.relative_to(STEP_DIR / "export").with_suffix("").with_suffix("").as_posix()
+                rel_export = abs_step_path.relative_to(STEP_DIR / "export")
             except ValueError:
                 continue
+            # A collection recipe can be split across companion config files named
+            # `<short>.<key>.config.yml` (e.g. democracy.eiu.config.yml) that all feed the single
+            # `<short>.py` step. Blindly stripping suffixes would invent a nonexistent
+            # `<short>.<key>` step, so resolve to the sibling `<short>.py` recipe when it exists.
+            short = abs_step_path.name.split(".", 1)[0]
+            if (abs_step_path.parent / f"{short}.py").exists():
+                export_path = (rel_export.parent / short).as_posix()
+            else:
+                export_path = rel_export.with_suffix("").with_suffix("").as_posix()
             changed_export_uris.append(f"export://{export_path}")
 
     if not dataset_catalog_paths:

--- a/etl/steps/export/explorers/democracy/latest/democracy.eiu.config.yml
+++ b/etl/steps/export/explorers/democracy/latest/democracy.eiu.config.yml
@@ -46,16 +46,6 @@ dimensions:
         name: "Main index"
       - slug: political_regime
         name: "Political regime"
-      - slug: electoral_pluralism_index
-        name: "Electoral pluralism index"
-      - slug: functioning_government_index
-        name: "Functioning government index"
-      - slug: political_participation_index
-        name: "\xadPolitical participation index"
-      - slug: democratic_culture_index
-        name: "Democratic culture index"
-      - slug: civil_liberties_index
-        name: "\xadCivil liberties index"
       - slug: number_and_share_of_democracies
         name: "\xad\xad\xadNumber and share of democracies"
       - slug: people_living_in_democracies
@@ -76,36 +66,6 @@ views:
         - catalogPath: eiu#regime_eiu
     config:
       colorVariableId: eiu#regime_eiu
-  - dimensions:
-      metric: democracy
-      sub_metric: electoral_pluralism_index
-    indicators:
-      y:
-        - catalogPath: eiu#elect_freefair_eiu
-  - dimensions:
-      metric: democracy
-      sub_metric: functioning_government_index
-    indicators:
-      y:
-        - catalogPath: eiu#funct_gov_eiu
-  - dimensions:
-      metric: democracy
-      sub_metric: political_participation_index
-    indicators:
-      y:
-        - catalogPath: eiu#pol_part_eiu
-  - dimensions:
-      metric: democracy
-      sub_metric: democratic_culture_index
-    indicators:
-      y:
-        - catalogPath: eiu#dem_culture_eiu
-  - dimensions:
-      metric: democracy
-      sub_metric: civil_liberties_index
-    indicators:
-      y:
-        - catalogPath: eiu#civlib_eiu
   - dimensions:
       metric: democracy
       sub_metric: number_and_share_of_democracies

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -23,6 +23,23 @@ def test_get_all_changed_catalog_paths_directly_changed_export_step(mock_load_da
     assert get_all_changed_catalog_paths(files_changed, include_export=True) == ["export://multidim/un/latest/un_wpp"]
 
 
+@patch("etl.io.load_dag")
+def test_get_all_changed_catalog_paths_collection_subconfig(mock_load_dag):
+    """A collection sub-config maps to its parent `<short>` export step, not a phantom step.
+
+    The democracy explorer is built by `democracy.py` from companion configs like
+    `democracy.eiu.config.yml`. Editing only a sub-config must select the real
+    `export://explorers/democracy/latest/democracy` step; naive suffix-stripping would invent a
+    nonexistent `...democracy.eiu` step and make the staging deploy fail with "No steps matched".
+    Resolution relies on the sibling `democracy.py` recipe existing on disk.
+    """
+    mock_load_dag.return_value = {}
+    files_changed = {"etl/steps/export/explorers/democracy/latest/democracy.eiu.config.yml": "M"}
+    assert get_all_changed_catalog_paths(files_changed, include_export=True) == [
+        "export://explorers/democracy/latest/democracy"
+    ]
+
+
 @patch("etl.io.filter_to_subgraph")
 @patch("etl.io.load_dag")
 def test_get_all_changed_catalog_paths_downstream_and_direct_export_deduped(mock_load_dag, mock_filter_to_subgraph):


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

EIU license compliance — see [owid-issues#2287 (comment)](https://github.com/owid/owid-issues/issues/2287#issuecomment-4832685860).

**1. Explorer (the actual ask)** — removes the five EIU sub-index views + `sub_metric` choices from the democracy explorer (electoral pluralism, functioning government, political participation, democratic culture, civil liberties). `political_participation_index` is also defined by the BTI config, so BTI's view is unaffected.

**2 & 3. Staging change-detection fixes** (this is the first config-only edit to a multi-config explorer, which exposed two pre-existing gaps):
- `get_all_changed_catalog_paths` derived a phantom `…/democracy.eiu` step from `democracy.eiu.config.yml` (naive suffix-stripping). Now resolves collection sub-configs to their parent `<short>.py` step. Test added in `tests/test_io.py`.
- `--modified` surfaces modified export steps but they were excluded without `--export`, crashing the staging build with "No steps matched". Now enables export for the run when a modified export step is present, so the explorer actually rebuilds.

> ℹ️ **Separate follow-up (not in this PR):** data downloads for the remaining EIU charts are not fully off in prod. The dataset is `non_redistributable: true` in the DB, but only `democracy_eiu`'s published API metadata was ever re-synced — the other EIU variables still serve `nonRedistributable: false`. Fixing needs a forced re-sync of `grapher://grapher/democracy/2025-03-05/eiu` against prod.

| Link | |
|---|---|
| Issue | [owid-issues#2287](https://github.com/owid/owid-issues/issues/2287) |
| Staging explorer | http://staging-site-data-remove-eiu-subindices/explorers/democracy?Dataset=Economist+Intelligence+Unit |
