### PR TITLE
📊 Use AR5 GWPs for land emissions in emissions by human activity

### DIFF
--- a/dag/emissions.yml
+++ b/dag/emissions.yml
@@ -156,7 +156,7 @@ steps:
     - data://garden/emissions/2026-06-15/emissions_by_human_activity_splitting_electricity:
       - data://garden/emissions/2026-06-15/emissions_by_human_activity
       - data://garden/un/2026-02-11/energy_statistics_database
-  # As above, but "Growing food" uses gross agriculture-and-land-use emissions from Jones et al. (AR4).
+  # As above, but "Growing food" uses gross agriculture-and-land-use emissions from Jones et al. (AR5).
   data://grapher/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf:
     - data://garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf:
       - data://garden/emissions/2026-06-15/emissions_by_human_activity

--- a/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity.py
+++ b/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity.py
@@ -17,6 +17,13 @@ redistributes the Electricity activity into the activities that consume the elec
 The ideal data for these custom categories comes from the IEA, but it is under a heavy paywall, so the
 tables are built from Climate Watch as an approximation. See WRI's methodology:
 https://files.wri.org/d8/s3fs-public/2024-05/climate-watch-country-greenhouse-gas-emissions-data-methodology.pdf?VersionId=1geU96keSmqZlUjv41FNGB4CLpHQbruN
+
+Note: that PDF (dated 2024-05) states non-CO2 gases are converted to CO2 equivalents with IPCC AR4 global
+warming potentials, but it predates a methodology change. Climate Watch's data explorer now states that, as
+of 16 September 2025, it uses AR5 GWPs (see the "meta" note at
+https://www.climatewatchdata.org/data-explorer/historical-emissions?historical-emissions-data-sources=climate-watch&historical-emissions-gases=all-ghg&historical-emissions-sectors=total-including-lulucf#meta).
+Our 2026-02-10 snapshot therefore uses AR5, which is what the gross-LULUCF step matches when converting the
+Jones et al. land emissions.
 """
 
 from etl.helpers import PathFinder

--- a/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf.meta.yml
+++ b/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf.meta.yml
@@ -2,7 +2,7 @@ definitions:
   description_processing: |-
     Emissions are categorized by human activity following the approach of the "emissions by human activity" dataset, which is based on Climate Watch's emissions by sector.
 
-    The "Growing food" activity, however, is replaced with gross agriculture-and-land-use emissions from Jones et al. (national contributions). Climate Watch's land-use-change-and-forestry emissions are net, so global land-use CO₂ is close to zero, which understates the climate impact of land use. Jones et al. report the gross land component (land-use-change CO₂ plus agricultural CH₄ and N₂O), which we convert to CO₂ equivalents using IPCC AR4 100-year global warming potentials (CH₄ = 25, N₂O = 298).
+    The "Growing food" activity, however, is replaced with gross agriculture-and-land-use emissions from Jones et al. (national contributions). Climate Watch's land-use-change-and-forestry emissions are net, so global land-use CO₂ is close to zero, which understates the climate impact of land use. Jones et al. report the gross land component (land-use-change CO₂ plus agricultural CH₄ and N₂O), which we convert to CO₂ equivalents using IPCC AR5 100-year global warming potentials (CH₄ = 28, N₂O = 265), to match the convention Climate Watch uses for the other activities.
   common:
     presentation:
       topic_tags:

--- a/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf.py
+++ b/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf.py
@@ -7,8 +7,9 @@ agriculture-and-land-use emissions derived from Jones et al. (national contribut
 Climate Watch's land-use-change-and-forestry emissions are *net* (so global land-use CO2 is close to
 zero), which understates the climate impact of land use. Jones et al. report the *gross* land component
 (land-use-change CO2 plus agricultural CH4 and N2O), which is much larger. We convert Jones' per-gas land
-emissions to CO2 equivalents using IPCC AR4 100-year global warming potentials (CH4 = 25, N2O = 298),
-rather than the AR6 values used in the national_contributions garden step, and use the result as the new
+emissions to CO2 equivalents using IPCC AR5 100-year global warming potentials (CH4 = 28, N2O = 265), to
+match Climate Watch (the source for every other activity), which expresses non-CO2 gases with AR5 values.
+This differs from the AR6 values used in the national_contributions garden step. The result becomes the new
 "Growing food" activity.
 
 It produces two country-level tables (electricity is still its own activity, as in the input step):
@@ -24,9 +25,10 @@ from etl.helpers import PathFinder
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
-# IPCC AR4 100-year global warming potentials, used to convert Jones et al. land emissions to CO2 equivalents.
-CH4_TO_CO2EQ_AR4 = 25
-N2O_TO_CO2EQ_AR4 = 298
+# IPCC AR5 100-year global warming potentials, used to convert Jones et al. land emissions to CO2 equivalents.
+# Climate Watch (the source for all other activities) expresses non-CO2 gases with AR5 GWPs, so we match it.
+CH4_TO_CO2EQ_AR5 = 28
+N2O_TO_CO2EQ_AR5 = 265
 
 # Activity whose emissions we replace with Jones et al.'s gross agriculture-and-land-use figures.
 ACTIVITY_TO_REPLACE = "Growing food"
@@ -39,12 +41,17 @@ def compute_jones_land(ds_jones):
 
     # Gross land-use CO2 emissions (Jones' LULUCF CO2, which is much larger than Climate Watch's net figure).
     tb["co2_land"] = tb["annual_emissions_co2_land"]
-    # Gross agriculture-and-land-use GHG emissions, using AR4 global warming potentials.
+    # Gross agriculture-and-land-use GHG emissions, using AR5 global warming potentials.
     tb["ghg_land"] = (
         tb["annual_emissions_co2_land"]
-        + CH4_TO_CO2EQ_AR4 * tb["annual_emissions_ch4_land"]
-        + N2O_TO_CO2EQ_AR4 * tb["annual_emissions_n2o_land"]
+        + CH4_TO_CO2EQ_AR5 * tb["annual_emissions_ch4_land"]
+        + N2O_TO_CO2EQ_AR5 * tb["annual_emissions_n2o_land"]
     )
+
+    # Keep only entity-years where Jones provides the complete gross figures. A few small island states
+    # (e.g. Marshall Islands, Palau) report land-use CO2 but no agricultural CH4/N2O, leaving the GHG sum
+    # undefined; those are dropped downstream rather than backfilled with Climate Watch's net figures.
+    tb = tb.dropna(subset=["co2_land", "ghg_land"]).reset_index(drop=True)
 
     return tb[["country", "year", "co2_land", "ghg_land"]]
 
@@ -67,12 +74,13 @@ def replace_growing_food(tb, jones, ofc=None):
     # Keep every activity except the one we replace.
     tb_other = tb[tb["sector"] != ACTIVITY_TO_REPLACE].reset_index(drop=True)
 
-    # Build the new "Growing food" activity from Jones' gross land emissions.
+    # Build the new "Growing food" activity from Jones' gross land emissions, keeping only the (country, year)
+    # pairs where Jones has land data. The inner merge drops the rest, rather than falling back to Climate
+    # Watch's net figures (which would mix conventions within a single chart).
     gf = tb[tb["sector"] == ACTIVITY_TO_REPLACE].reset_index(drop=True)
-    gf = gf.merge(jones, on=["country", "year"], how="left")
-    # Use Jones' gross figures, falling back to Climate Watch where Jones has no data.
-    gf["co2_emissions"] = gf["co2_land"].fillna(gf["co2_emissions"])
-    gf["ghg_emissions"] = gf["ghg_land"].fillna(gf["ghg_emissions"])
+    gf = gf.merge(jones, on=["country", "year"], how="inner")
+    gf["co2_emissions"] = gf["co2_land"]
+    gf["ghg_emissions"] = gf["ghg_land"]
     gf = gf.drop(columns=["co2_land", "ghg_land"], errors="raise")
 
     # In the base table, "Growing food" also contains other fuel combustion, which we keep on top.
@@ -83,12 +91,16 @@ def replace_growing_food(tb, jones, ofc=None):
             gf["ghg_emissions"] = gf["ghg_emissions"] + gf["ghg_ofc"].fillna(0)
         gf = gf.drop(columns=["co2_ofc", "ghg_ofc"], errors="raise")
 
+    # Drop the other activities for any (country, year) without Jones land data, so an entity's stacked
+    # total never mixes gross land emissions (Jones) with net land emissions (Climate Watch).
+    tb_other = tb_other.merge(gf[["country", "year"]].drop_duplicates(), on=["country", "year"], how="inner")
+
     tb = pr.concat([tb_other, gf], ignore_index=True)
 
     return tb
 
 
-def sanity_check_outputs(tb_base, tb_other, jones):
+def sanity_check_outputs(tb_base, tb_other):
     # Every input activity should still be present.
     error = "Set of activities changed unexpectedly."
     assert set(tb_base["sector"]) == {
@@ -114,13 +126,6 @@ def sanity_check_outputs(tb_base, tb_other, jones):
     error = "Expected positive gross 'Growing food' emissions at World level."
     assert (world_gf["ghg_emissions"] > 0).all(), error
 
-    # Warn about entities that have a "Growing food" activity but no Jones coverage (kept as Climate Watch).
-    covered = set(zip(jones.dropna(subset=["ghg_land"])["country"], jones.dropna(subset=["ghg_land"])["year"]))
-    gf = tb_other[tb_other["sector"] == "Growing food"]
-    missing = sorted(set(gf["country"]) - {c for c, _ in covered})
-    if missing:
-        paths.log.warning(f"Entities without Jones land coverage (kept as Climate Watch): {missing}")
-
 
 def run() -> None:
     #
@@ -137,7 +142,7 @@ def run() -> None:
     #
     # Process data.
     #
-    # Gross agriculture-and-land-use emissions from Jones et al., using AR4 global warming potentials.
+    # Gross agriculture-and-land-use emissions from Jones et al., using AR5 global warming potentials.
     jones = compute_jones_land(ds_jones)
 
     # Other fuel combustion (the part of the base "Growing food" that is not agriculture or land use).
@@ -147,8 +152,14 @@ def run() -> None:
     tb_base_gross = replace_growing_food(tb_base, jones, ofc=ofc)
     tb_other_gross = replace_growing_food(tb_other, jones, ofc=None)
 
+    # Report any entities dropped for lacking Jones land data (so coverage gaps surface, rather than being
+    # silently filled with Climate Watch's net figures).
+    dropped = sorted(set(tb_base["country"]) - set(tb_base_gross["country"]))
+    if dropped:
+        paths.log.warning(f"Dropped entities without Jones land coverage: {dropped}")
+
     # Sanity checks.
-    sanity_check_outputs(tb_base=tb_base_gross, tb_other=tb_other_gross, jones=jones)
+    sanity_check_outputs(tb_base=tb_base_gross, tb_other=tb_other_gross)
 
     # Improve table format.
     tb_base_gross = tb_base_gross.format(

--- a/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf.py
+++ b/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf.py
@@ -63,7 +63,7 @@ def compute_other_fuel_combustion(tb_base, tb_other):
     gf_other = tb_other[tb_other["sector"] == ACTIVITY_TO_REPLACE][
         ["country", "year", "co2_emissions", "ghg_emissions"]
     ]
-    ofc = gf_base.merge(gf_other, on=["country", "year"], how="inner", suffixes=("_base", "_other"))
+    ofc = pr.merge(gf_base, gf_other, on=["country", "year"], how="inner", suffixes=("_base", "_other"))
     ofc["co2_ofc"] = ofc["co2_emissions_base"] - ofc["co2_emissions_other"]
     ofc["ghg_ofc"] = ofc["ghg_emissions_base"] - ofc["ghg_emissions_other"]
 
@@ -78,14 +78,14 @@ def replace_growing_food(tb, jones, ofc=None):
     # pairs where Jones has land data. The inner merge drops the rest, rather than falling back to Climate
     # Watch's net figures (which would mix conventions within a single chart).
     gf = tb[tb["sector"] == ACTIVITY_TO_REPLACE].reset_index(drop=True)
-    gf = gf.merge(jones, on=["country", "year"], how="inner")
+    gf = pr.merge(gf, jones, on=["country", "year"], how="inner")
     gf["co2_emissions"] = gf["co2_land"]
     gf["ghg_emissions"] = gf["ghg_land"]
     gf = gf.drop(columns=["co2_land", "ghg_land"], errors="raise")
 
     # In the base table, "Growing food" also contains other fuel combustion, which we keep on top.
     if ofc is not None:
-        gf = gf.merge(ofc, on=["country", "year"], how="left")
+        gf = pr.merge(gf, ofc, on=["country", "year"], how="left")
         with pr.ignore_warnings():
             gf["co2_emissions"] = gf["co2_emissions"] + gf["co2_ofc"].fillna(0)
             gf["ghg_emissions"] = gf["ghg_emissions"] + gf["ghg_ofc"].fillna(0)
@@ -93,7 +93,7 @@ def replace_growing_food(tb, jones, ofc=None):
 
     # Drop the other activities for any (country, year) without Jones land data, so an entity's stacked
     # total never mixes gross land emissions (Jones) with net land emissions (Climate Watch).
-    tb_other = tb_other.merge(gf[["country", "year"]].drop_duplicates(), on=["country", "year"], how="inner")
+    tb_other = pr.merge(tb_other, gf[["country", "year"]].drop_duplicates(), on=["country", "year"], how="inner")
 
     tb = pr.concat([tb_other, gf], ignore_index=True)
 
@@ -152,11 +152,17 @@ def run() -> None:
     tb_base_gross = replace_growing_food(tb_base, jones, ofc=ofc)
     tb_other_gross = replace_growing_food(tb_other, jones, ofc=None)
 
-    # Report any entities dropped for lacking Jones land data (so coverage gaps surface, rather than being
-    # silently filled with Climate Watch's net figures).
-    dropped = sorted(set(tb_base["country"]) - set(tb_base_gross["country"]))
+    # Report (country, year) rows dropped for lacking Jones land data, so coverage gaps surface (including
+    # entities that lose only some years) rather than being silently filled with Climate Watch's net figures.
+    before = set(map(tuple, tb_base[["country", "year"]].drop_duplicates().to_numpy()))
+    after = set(map(tuple, tb_base_gross[["country", "year"]].drop_duplicates().to_numpy()))
+    dropped = sorted(before - after)
     if dropped:
-        paths.log.warning(f"Dropped entities without Jones land coverage: {dropped}")
+        by_country = {
+            c: f"{min(y for cc, y in dropped if cc == c)}-{max(y for cc, y in dropped if cc == c)}"
+            for c in sorted({c for c, _ in dropped})
+        }
+        paths.log.warning(f"Dropped country-years without Jones land coverage: {by_country}")
 
     # Sanity checks.
     sanity_check_outputs(tb_base=tb_base_gross, tb_other=tb_other_gross)

--- a/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf_splitting_electricity.meta.yml
+++ b/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf_splitting_electricity.meta.yml
@@ -1,6 +1,6 @@
 definitions:
   description_processing_gross: |-
-    The "Growing food" activity uses gross agriculture-and-land-use emissions from Jones et al. (land-use-change CO₂ plus agricultural CH₄ and N₂O, with IPCC AR4 global warming potentials), rather than Climate Watch's net land-use figures.
+    The "Growing food" activity uses gross agriculture-and-land-use emissions from Jones et al. (land-use-change CO₂ plus agricultural CH₄ and N₂O, with IPCC AR5 global warming potentials), rather than Climate Watch's net land-use figures.
   description_processing_direct: |-
     Direct emissions are the emissions produced on-site by each activity (for example, fuel burned in vehicles or factories), taken from the step that keeps electricity as its own activity. They do not include the emissions from generating the electricity that the activity consumes.
 

--- a/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf_splitting_electricity.meta.yml
+++ b/etl/steps/data/garden/emissions/2026-06-15/emissions_by_human_activity_including_gross_lulucf_splitting_electricity.meta.yml
@@ -1,6 +1,6 @@
 definitions:
   description_processing_gross: |-
-    The "Growing food" activity uses gross agriculture-and-land-use emissions from Jones et al. (land-use-change CO₂ plus agricultural CH₄ and N₂O, with IPCC AR5 global warming potentials), rather than Climate Watch's net land-use figures.
+    The "Growing food" activity uses gross agriculture-and-land-use emissions from Jones et al. (land-use-change CO₂ plus agricultural CH₄ and N₂O, with IPCC AR5 100-year global warming potentials), rather than Climate Watch's net land-use figures.
   description_processing_direct: |-
     Direct emissions are the emissions produced on-site by each activity (for example, fuel burned in vehicles or factories), taken from the step that keeps electricity as its own activity. They do not include the emissions from generating the electricity that the activity consumes.
 


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

Follow-up to [owid-issues#2431](https://github.com/owid/owid-issues/issues/2431), on the `emissions_by_human_activity_including_gross_lulucf` step (the chart chosen for the Energy chapter of Max's book, option 2).

### What changed

**1. GWP convention: AR4 → AR5.** The step replaces "Growing food" with Jones et al. gross agriculture-and-land-use emissions, converting CH₄/N₂O to CO₂e. It was using IPCC **AR4** GWPs (25 / 298), but Climate Watch (the source for every other activity in the chart) switched to **AR5** in its September 2025 update, and our `climate_watch/2026-02-10` snapshot uses AR5. The land bar was therefore on a different basis than the rest of the chart. Now it uses AR5 (28 / 265) to match. Net effect on the World land bar is small (~1.6%), since the CH₄ and N₂O changes partly cancel.

**2. Removed the silent Climate-Watch fallback.** Where Jones lacked complete gross figures, the step backfilled Climate Watch's *net* land emissions, mixing conventions within a single stacked chart. It now drops those entity-years instead (and the matching rows of the other activities, so no stacked total mixes gross and net land). A warning logs anything dropped.

Only two tiny entities are affected: **Marshall Islands** (all years) and **Palau** (1990–2011) report land-use CO₂ but no agricultural CH₄/N₂O. Both are negligible globally and unaffected at World level.

### Verification

- Pipeline runs clean through the dependent `..._splitting_electricity` step; `make check` passes.
- World 2023: total **54.9 Gt CO₂e**; land-use CO₂ within "Growing food" ≈ **4.8 Gt**, consistent with the Global Carbon Budget figure in the chapter's opening chart. No NaN in the output.