### PR TITLE
🎉🤖 (etl) Add timeInterval display field alongside deprecated yearIsDay

### DIFF
--- a/.claude/skills/create-etl-steps/SKILL.md
+++ b/.claude/skills/create-etl-steps/SKILL.md
@@ -187,7 +187,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data. Sub-yearly data is encoded as days-since-zeroDay integers.
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/apps/wizard/app_pages/indicator_upgrade/indicator_mapping.py
+++ b/apps/wizard/app_pages/indicator_upgrade/indicator_mapping.py
@@ -518,10 +518,14 @@ def get_indicator_data_cached(indicator_ids: list[int]):
 
 
 def convert_year_to_date(df: pd.DataFrame, indicator_ids: list[int]) -> pd.DataFrame:
-    """Convert year to date if zeroDay is True. Keep the column named 'year'."""
+    """Convert the day-encoded 'year' column back to real dates for sub-yearly indicators.
+
+    Keep the column named 'year'.
+    """
     q = """
     select
         id as variableId,
+        display->>'$.timeInterval' as timeInterval,
         display->>'$.yearIsDay' as yearIsDay,
         display->>'$.zeroDay' as zeroDay
     from variables where id in %(indicator_ids)s;
@@ -529,14 +533,16 @@ def convert_year_to_date(df: pd.DataFrame, indicator_ids: list[int]) -> pd.DataF
     mf = read_sql(q, get_engine(), params={"indicator_ids": tuple(indicator_ids)})
     df = df.merge(mf, on="variableId")
 
-    ix = df.yearIsDay == "true"
+    # Sub-yearly data is encoded as days-since-zeroDay integers, tagged via timeInterval
+    # (or the deprecated yearIsDay flag, kept as a fallback for un-migrated DB rows).
+    ix = df.timeInterval.isin(["day", "week", "month", "quarter"]) | (df.yearIsDay == "true")
     if ix.any():
         df.year = df.year.astype(object)  # ty: ignore[unresolved-attribute]
         df.loc[ix, "year"] = pd.to_datetime(df.loc[ix, "zeroDay"]).dt.date + np.array(
             [pd.Timedelta(days=y) for y in df.loc[ix, "year"]]
         )
 
-    return df.drop(columns=["yearIsDay", "zeroDay"])
+    return df.drop(columns=["timeInterval", "yearIsDay", "zeroDay"])
 
 
 def reset_indicator_form() -> None:

--- a/apps/wizard/etl_steps/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
+++ b/apps/wizard/etl_steps/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
@@ -60,7 +60,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data. Sub-yearly data is encoded as days-since-zeroDay integers.
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/docs/architecture/design/phases.md
+++ b/docs/architecture/design/phases.md
@@ -104,7 +104,7 @@ They present a [:octicons-link-external-16: long format](https://towardsdatascie
 
 !!! info "Using date instead of year"
 
-    It's possible to use `date` column instead of `year` if you work with daily data. Grapher step will automatically convert it to `yearIsDay` under the hood. Explicitly defining `yearIsDay` in metadata and converting `date` to `year` has been deprecated.
+    It's possible to use a `date` column instead of `year` if you work with sub-yearly data (daily, weekly, monthly, ...). The grapher step automatically converts it under the hood, encoding dates as days-since-`zeroDay` integers and setting `display.timeInterval`. Manually converting `date` to `year` and setting the interval in metadata yourself has been deprecated.
 
 
 However, datasets in the ETL are often in a very different shape instead. For example, they may have data broken down by gender, disease type, fish stock, or some other dimension. Therefore, we need a step that adapts the ETL dataset format into a Grapher friendly format: **The grapher step**.

--- a/etl/grapher/helpers.py
+++ b/etl/grapher/helpers.py
@@ -612,17 +612,25 @@ def add_columns_for_multiindicator_chart(
     return table
 
 
+TimeInterval = Literal["day", "week", "month", "quarter", "year", "decade"]
+
+
 def adapt_table_with_dates_to_grapher(
     tb: catalog.Table,
     columns: list[str] | None = None,
     date_column: str = "date",
     country_column: str = "country",
     drop_date_column: bool = True,
+    time_interval: TimeInterval = "day",
 ) -> catalog.Table:
     """Adapt a table that has a date column to grapher requirements.
 
     This function adapts a table with, e.g. monthly data, so that it can be properly interpreted by grapher, and plotted
     with dates in the horizontal axis instead of years.
+
+    All sub-yearly data is encoded as days-since-`zeroDay` integers (the same encoding daily data
+    uses); `time_interval` tells grapher how to interpret and format those integers. Pass
+    ``time_interval="month"``/``"week"``/etc. for data whose points represent months/weeks/etc.
 
     Parameters
     ----------
@@ -634,6 +642,9 @@ def adapt_table_with_dates_to_grapher(
         Name of column with dates, by default "date".
     country_column : str, optional
         Name of country column, by default "country".
+    time_interval : TimeInterval, optional
+        Interval each date represents ("day", "week", "month", "quarter", "year", "decade"),
+        written to ``display.timeInterval``. By default "day".
 
     Returns
     -------
@@ -661,8 +672,9 @@ def adapt_table_with_dates_to_grapher(
         if tb[column].metadata.display is None:
             tb[column].metadata.display = {}
 
-        # Set the yearIsDay metadata field, so that grapher can read years as dates.
-        tb[column].metadata.display["yearIsDay"] = True
+        # Set the timeInterval metadata field, so that grapher knows how to interpret and format the
+        # days-since-zeroDay integers (e.g. "month" -> "Jan 2023")
+        tb[column].metadata.display["timeInterval"] = time_interval
 
         # Set zeroDay, which grapher will interpret as the earliest day from which to start counting dates.
         tb[column].metadata.display["zeroDay"] = zero_day.strftime("%Y-%m-%d")
@@ -708,6 +720,7 @@ def grapher_checks(ds: catalog.Dataset, warn_title_public: bool = True) -> None:
             _validate_description_key(tab[col].m.description_key, col)
             _validate_ordinal_variables(tab, col)
             _validate_grapher_config(tab, col)
+            _validate_time_interval(tab, col)
 
             # Data Page title uses the following fallback
             # [title_public > grapher_config.title > display.name > title] - [attribution_short] - [title_variant]
@@ -728,6 +741,19 @@ def grapher_checks(ds: catalog.Dataset, warn_title_public: bool = True) -> None:
                 f"{len(cols_missing_title_public)} column(s) use display.name but no presentation.title_public (e.g. {', '.join(cols_missing_title_public[:3])}). Ensure the latter is also defined, otherwise display.name will be used as the indicator's title.",
                 warnings.DisplayNameWarning,
             )
+
+
+TIME_INTERVALS = {"day", "week", "month", "quarter", "year", "decade"}
+
+
+def _validate_time_interval(tab: Table, col: str) -> None:
+    """Validate the display.timeInterval field, if set."""
+    display = tab[col].m.display or {}
+    time_interval = display.get("timeInterval")
+    if time_interval is not None:
+        assert time_interval in TIME_INTERVALS, (
+            f"Column `{col}` has display.timeInterval='{time_interval}', which is not one of {sorted(TIME_INTERVALS)}."
+        )
 
 
 def _validate_grapher_config(tab: Table, col: str) -> None:

--- a/etl/grapher/to_db.py
+++ b/etl/grapher/to_db.py
@@ -534,8 +534,9 @@ def _raise_error_for_deleted_variables(rows: pd.DataFrame) -> bool:
 
 
 def _get_timespan(table: pd.DataFrame, variable_meta: VariableMeta) -> str:
-    # Timespan does not work for yearIsDay variables
-    if (variable_meta.display or {}).get("yearIsDay"):
+    display = variable_meta.display or {}
+    # Timespan does not work for sub-yearly data
+    if display.get("yearIsDay") or display.get("timeInterval") in {"day", "week", "month", "quarter"}:
         return ""
     else:
         years = table.year.unique()

--- a/lib/catalog/owid/catalog/core/meta.py
+++ b/lib/catalog/owid/catalog/core/meta.py
@@ -408,7 +408,8 @@ class VariableMeta(MetaBase):
     """Allowed fields for `display` attribute used for grapher:
         name
         zeroDay
-        yearIsDay
+        yearIsDay  # deprecated, use timeInterval instead
+        timeInterval  # one of: day, week, month, quarter, year, decade
         includeInTable
         numDecimalPlaces
         conversionFactor

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -717,7 +717,19 @@
       "yearIsDay": {
         "type": "boolean",
         "default": false,
-        "description": "Switch to indicate if the number in the year column represents a day (since zeroDay) or a year."
+        "description": "Deprecated: use `timeInterval` instead. Switch to indicate if the number in the year column represents a day (since zeroDay) or a year."
+      },
+      "timeInterval": {
+        "type": "string",
+        "description": "Interval that each value in the year/time column represents. Sub-yearly intervals (day, week, month, quarter) are encoded as days-since-`zeroDay` integers.",
+        "enum": [
+          "day",
+          "week",
+          "month",
+          "quarter",
+          "year",
+          "decade"
+        ]
       },
       "color": {
         "type": "string",


### PR DESCRIPTION
> _Written by Claude Code — @sophiamersmann at the wheel._

Base of the stack. Introduces `display.timeInterval` (`day` | `week` | `month` | `quarter` | `year` | `decade`) to replace the deprecated `display.yearIsDay` boolean. Pure plumbing — no dataset changes.

- `definitions.json`: add the `timeInterval` enum; mark `yearIsDay` deprecated.
- `adapt_table_with_dates_to_grapher()`: new `time_interval="day"` param that writes `timeInterval`.
- `grapher_checks` validates `timeInterval`; `to_db` handles timespan for sub-yearly intervals.
- Wizard `indicator_mapping.py`: reads `timeInterval` (with a `yearIsDay` fallback for un-migrated DB rows).
- Docs/templates teach `timeInterval`.

Sub-yearly data stays encoded as days-since-`zeroDay` integers; `timeInterval` just tells Grapher how to format them. The vendored grapher chart-config schema is untouched — adding `timeInterval` there and the v11 bump happen later via `/sync-grapher-schema`, once the web team ships it upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)