### PR TITLE
🔨🤖 (etl) Migrate all datasets from yearIsDay to timeInterval: day

### DIFF
--- a/.claude/skills/create-etl-steps/SKILL.md
+++ b/.claude/skills/create-etl-steps/SKILL.md
@@ -187,7 +187,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data. Sub-yearly data is encoded as days-since-zeroDay integers.
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/apps/wizard/app_pages/indicator_upgrade/indicator_mapping.py
+++ b/apps/wizard/app_pages/indicator_upgrade/indicator_mapping.py
@@ -518,10 +518,14 @@ def get_indicator_data_cached(indicator_ids: list[int]):
 
 
 def convert_year_to_date(df: pd.DataFrame, indicator_ids: list[int]) -> pd.DataFrame:
-    """Convert year to date if zeroDay is True. Keep the column named 'year'."""
+    """Convert the day-encoded 'year' column back to real dates for sub-yearly indicators.
+
+    Keep the column named 'year'.
+    """
     q = """
     select
         id as variableId,
+        display->>'$.timeInterval' as timeInterval,
         display->>'$.yearIsDay' as yearIsDay,
         display->>'$.zeroDay' as zeroDay
     from variables where id in %(indicator_ids)s;
@@ -529,14 +533,16 @@ def convert_year_to_date(df: pd.DataFrame, indicator_ids: list[int]) -> pd.DataF
     mf = read_sql(q, get_engine(), params={"indicator_ids": tuple(indicator_ids)})
     df = df.merge(mf, on="variableId")
 
-    ix = df.yearIsDay == "true"
+    # Sub-yearly data is encoded as days-since-zeroDay integers, tagged via timeInterval
+    # (or the deprecated yearIsDay flag, kept as a fallback for un-migrated DB rows).
+    ix = df.timeInterval.isin(["day", "week", "month", "quarter"]) | (df.yearIsDay == "true")
     if ix.any():
         df.year = df.year.astype(object)  # ty: ignore[unresolved-attribute]
         df.loc[ix, "year"] = pd.to_datetime(df.loc[ix, "zeroDay"]).dt.date + np.array(
             [pd.Timedelta(days=y) for y in df.loc[ix, "year"]]
         )
 
-    return df.drop(columns=["yearIsDay", "zeroDay"])
+    return df.drop(columns=["timeInterval", "yearIsDay", "zeroDay"])
 
 
 def reset_indicator_form() -> None:

--- a/apps/wizard/etl_steps/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
+++ b/apps/wizard/etl_steps/cookiecutter/garden/{{cookiecutter.namespace}}/{{cookiecutter.version}}/{{cookiecutter.short_name}}.meta.yml
@@ -60,7 +60,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data. Sub-yearly data is encoded as days-since-zeroDay integers.
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/docs/architecture/design/phases.md
+++ b/docs/architecture/design/phases.md
@@ -104,7 +104,7 @@ They present a [:octicons-link-external-16: long format](https://towardsdatascie
 
 !!! info "Using date instead of year"
 
-    It's possible to use `date` column instead of `year` if you work with daily data. Grapher step will automatically convert it to `yearIsDay` under the hood. Explicitly defining `yearIsDay` in metadata and converting `date` to `year` has been deprecated.
+    It's possible to use a `date` column instead of `year` if you work with sub-yearly data (daily, weekly, monthly, ...). The grapher step automatically converts it under the hood, encoding dates as days-since-`zeroDay` integers and setting `display.timeInterval`. Manually converting `date` to `year` and setting the interval in metadata yourself has been deprecated.
 
 
 However, datasets in the ETL are often in a very different shape instead. For example, they may have data broken down by gender, disease type, fish stock, or some other dimension. Therefore, we need a step that adapts the ETL dataset format into a Grapher friendly format: **The grapher step**.

--- a/etl/grapher/helpers.py
+++ b/etl/grapher/helpers.py
@@ -612,17 +612,25 @@ def add_columns_for_multiindicator_chart(
     return table
 
 
+TimeInterval = Literal["day", "week", "month", "quarter", "year", "decade"]
+
+
 def adapt_table_with_dates_to_grapher(
     tb: catalog.Table,
     columns: list[str] | None = None,
     date_column: str = "date",
     country_column: str = "country",
     drop_date_column: bool = True,
+    time_interval: TimeInterval = "day",
 ) -> catalog.Table:
     """Adapt a table that has a date column to grapher requirements.
 
     This function adapts a table with, e.g. monthly data, so that it can be properly interpreted by grapher, and plotted
     with dates in the horizontal axis instead of years.
+
+    All sub-yearly data is encoded as days-since-`zeroDay` integers (the same encoding daily data
+    uses); `time_interval` tells grapher how to interpret and format those integers. Pass
+    ``time_interval="month"``/``"week"``/etc. for data whose points represent months/weeks/etc.
 
     Parameters
     ----------
@@ -634,6 +642,9 @@ def adapt_table_with_dates_to_grapher(
         Name of column with dates, by default "date".
     country_column : str, optional
         Name of country column, by default "country".
+    time_interval : TimeInterval, optional
+        Interval each date represents ("day", "week", "month", "quarter", "year", "decade"),
+        written to ``display.timeInterval``. By default "day".
 
     Returns
     -------
@@ -661,8 +672,9 @@ def adapt_table_with_dates_to_grapher(
         if tb[column].metadata.display is None:
             tb[column].metadata.display = {}
 
-        # Set the yearIsDay metadata field, so that grapher can read years as dates.
-        tb[column].metadata.display["yearIsDay"] = True
+        # Set the timeInterval metadata field, so that grapher knows how to interpret and format the
+        # days-since-zeroDay integers (e.g. "month" -> "Jan 2023")
+        tb[column].metadata.display["timeInterval"] = time_interval
 
         # Set zeroDay, which grapher will interpret as the earliest day from which to start counting dates.
         tb[column].metadata.display["zeroDay"] = zero_day.strftime("%Y-%m-%d")
@@ -708,6 +720,7 @@ def grapher_checks(ds: catalog.Dataset, warn_title_public: bool = True) -> None:
             _validate_description_key(tab[col].m.description_key, col)
             _validate_ordinal_variables(tab, col)
             _validate_grapher_config(tab, col)
+            _validate_time_interval(tab, col)
 
             # Data Page title uses the following fallback
             # [title_public > grapher_config.title > display.name > title] - [attribution_short] - [title_variant]
@@ -728,6 +741,19 @@ def grapher_checks(ds: catalog.Dataset, warn_title_public: bool = True) -> None:
                 f"{len(cols_missing_title_public)} column(s) use display.name but no presentation.title_public (e.g. {', '.join(cols_missing_title_public[:3])}). Ensure the latter is also defined, otherwise display.name will be used as the indicator's title.",
                 warnings.DisplayNameWarning,
             )
+
+
+TIME_INTERVALS = {"day", "week", "month", "quarter", "year", "decade"}
+
+
+def _validate_time_interval(tab: Table, col: str) -> None:
+    """Validate the display.timeInterval field, if set."""
+    display = tab[col].m.display or {}
+    time_interval = display.get("timeInterval")
+    if time_interval is not None:
+        assert time_interval in TIME_INTERVALS, (
+            f"Column `{col}` has display.timeInterval='{time_interval}', which is not one of {sorted(TIME_INTERVALS)}."
+        )
 
 
 def _validate_grapher_config(tab: Table, col: str) -> None:

--- a/etl/grapher/to_db.py
+++ b/etl/grapher/to_db.py
@@ -534,8 +534,9 @@ def _raise_error_for_deleted_variables(rows: pd.DataFrame) -> bool:
 
 
 def _get_timespan(table: pd.DataFrame, variable_meta: VariableMeta) -> str:
-    # Timespan does not work for yearIsDay variables
-    if (variable_meta.display or {}).get("yearIsDay"):
+    display = variable_meta.display or {}
+    # Timespan does not work for sub-yearly data
+    if display.get("yearIsDay") or display.get("timeInterval") in {"day", "week", "month", "quarter"}:
         return ""
     else:
         years = table.year.unique()

--- a/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch.meta.yml
@@ -27,7 +27,7 @@ tables:
           In cases where multiple domains were associated with a model, we consolidated these entries under the label "Multiple domains". We also identified domains associated with fewer than 20 notable systems and grouped these under the category 'Other'.
         display:
           zeroDay: '1949-01-01'
-          yearIsDay: true
+          timeInterval: day
 
       organization_categorization:
         title: Researcher affiliation
@@ -49,7 +49,7 @@ tables:
         display:
           numDecimalPlaces: 0
           zeroDay: '1949-01-01'
-          yearIsDay: true
+          timeInterval: day
 
       training_dataset_size__total:
         title: Training dataset size
@@ -63,7 +63,7 @@ tables:
         display:
           numDecimalPlaces: 0
           zeroDay: '1949-01-01'
-          yearIsDay: true
+          timeInterval: day
 
       training_computation_petaflop:
         title: Training computation (petaFLOP)
@@ -77,7 +77,7 @@ tables:
         display:
           numDecimalPlaces: 0
           zeroDay: '1949-01-01'
-          yearIsDay: true
+          timeInterval: day
         presentation:
           grapher_config:
             title: Training computation

--- a/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_compute_intensive.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2025-03-12/epoch_compute_intensive.meta.yml
@@ -26,7 +26,7 @@ tables:
         description_short: Refers to the specific area, application, or field in which an AI model is designed to operate.
         display:
           zeroDay: '1949-01-01'
-          yearIsDay: true
+          timeInterval: day
 
 
       parameters:
@@ -45,7 +45,7 @@ tables:
         display:
           numDecimalPlaces: 0
           zeroDay: '1949-01-01'
-          yearIsDay: true
+          timeInterval: day
 
       training_computation_petaflop:
         title: Training computation (petaFLOP)
@@ -62,7 +62,7 @@ tables:
         display:
           numDecimalPlaces: 0
           zeroDay: '1949-01-01'
-          yearIsDay: true
+          timeInterval: day
         presentation:
           grapher_config:
             title: Training computation

--- a/etl/steps/data/garden/covid/latest/cases_and_deaths_who.meta.yml
+++ b/etl/steps/data/garden/covid/latest/cases_and_deaths_who.meta.yml
@@ -28,7 +28,7 @@ tables:
         unit: '%'
         display:
           name: Biweekly growth in cases
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
         short_unit: '%'
       biweekly_cases:
@@ -37,20 +37,20 @@ tables:
         display:
           name: Biweekly cases
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       biweekly_cases_per_million_people:
         title: Biweekly cases per million people
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       biweekly_death_growth__pct:
         title: Biweekly death growth (%)
         unit: '%'
         display:
           name: Biweekly death growth
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
         short_unit: '%'
       biweekly_deaths:
@@ -59,33 +59,33 @@ tables:
         display:
           name: Biweekly deaths
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       biweekly_deaths_per_million_people:
         title: Biweekly deaths per million people
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       case_fatality_rate_of_covid_19__pct:
         title: Case fatality rate of COVID-19 (%)
         unit: '%'
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       case_fatality_rate_of_covid_19__pct__only_observations_with__gte_100_cases:
         title: Case fatality rate of COVID-19 (%) (Only observations with ≥100 cases)
         unit: '%'
         display:
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
         short_unit: '%'
       daily_new_confirmed_cases_due_to_covid_19__rolling_7_day_average__right_aligned:
         title: Daily new confirmed cases due to COVID-19 (rolling 7-day average, right-aligned)
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_cases_of_covid_19:
         title: Daily new confirmed cases of COVID-19
@@ -93,19 +93,19 @@ tables:
         display:
           name: Daily confirmed cases
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_cases_of_covid_19_per_million_people:
         title: Daily new confirmed cases of COVID-19 per million people
         unit: cases
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_cases_of_covid_19_per_million_people__rolling_7_day_average__right_aligned:
         title: Daily new confirmed cases of COVID-19 per million people (rolling 7-day average, right-aligned)
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_deaths_due_to_covid_19:
         title: Daily new confirmed deaths due to COVID-19
@@ -113,25 +113,25 @@ tables:
         display:
           name: Daily confirmed deaths
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_deaths_due_to_covid_19__rolling_7_day_average__right_aligned:
         title: Daily new confirmed deaths due to COVID-19 (rolling 7-day average, right-aligned)
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_deaths_due_to_covid_19_per_million_people:
         title: Daily new confirmed deaths due to COVID-19 per million people
         unit: deaths per million
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_deaths_due_to_covid_19_per_million_people__rolling_7_day_average__right_aligned:
         title: Daily new confirmed deaths due to COVID-19 per million people (rolling 7-day average, right-aligned)
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_the_total_confirmed_cases_of_covid_19_per_million_people_reached_1:
         title: Days since the total confirmed cases of COVID-19 per million people reached 1
@@ -139,103 +139,103 @@ tables:
         display:
           includeInTable: false
           name: Days since the total confirmed cases per million people reached 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_the_total_confirmed_cases_of_covid_19_reached_100:
         title: Days since the total confirmed cases of COVID-19 reached 100
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_the_total_confirmed_cases_of_covid_19_reached_100__with_population__gte__5m:
         title: Days since the total confirmed cases of COVID-19 reached 100 (with population ≥ 5M)
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_the_total_confirmed_deaths_of_covid_19_per_million_people_reached_0_1:
         title: Days since the total confirmed deaths of COVID-19 per million people reached 0.1
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_the_total_confirmed_deaths_of_covid_19_reached_5:
         title: Days since the total confirmed deaths of COVID-19 reached 5
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       has_population__gte__5m_and_had__gte_100_cases__gte_21_days_ago_and_has_testing_data:
         title: Has population ≥ 5M AND had ≥100 cases ≥21 days ago AND has testing data
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_confirmed_cases_of_covid_19:
         title: Total confirmed cases of COVID-19
         unit: cases
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_confirmed_cases_of_covid_19_per_million_people:
         title: Total confirmed cases of COVID-19 per million people
         unit: cases per million
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_confirmed_deaths_due_to_covid_19:
         title: Total confirmed deaths due to COVID-19
         unit: deaths
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_confirmed_deaths_due_to_covid_19_per_million_people:
         title: Total confirmed deaths due to COVID-19 per million people
         unit: deaths per million
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_case_growth__pct:
         title: Weekly case growth (%)
         unit: '%'
         display:
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
         short_unit: '%'
       weekly_cases:
         title: Weekly cases
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_cases_per_million_people:
         title: Weekly cases per million people
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_death_growth__pct:
         title: Weekly death growth (%)
         unit: '%'
         display:
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
         short_unit: '%'
       weekly_deaths:
         title: Weekly deaths
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_deaths_per_million_people:
         title: Weekly deaths per million people
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'

--- a/etl/steps/data/garden/covid/latest/cases_deaths.meta.yml
+++ b/etl/steps/data/garden/covid/latest/cases_deaths.meta.yml
@@ -32,7 +32,7 @@ definitions:
     Due to varying protocols and challenges in the attribution of the cause of death, the number of confirmed deaths may not accurately represent the true number of deaths caused by COVID-19.
   common_display: &common_display
     zeroDay: "2020-01-21"
-    yearIsDay: true
+    timeInterval: day
   daily_population: &daily_population |-
     This indicator is estimated by normalizing by population. We have used daily population estimates, which leads to changes in the denominator between datapoints from different days. For instance, the denominator for January 1st will be different to the one on January 2nd.
   common:

--- a/etl/steps/data/garden/covid/latest/combined.meta.yml
+++ b/etl/steps/data/garden/covid/latest/combined.meta.yml
@@ -1,6 +1,6 @@
 definitions:
   zero_day: &zero_day
-    yearIsDay: true
+    timeInterval: day
     zeroDay: "2020-01-01"
   common:
     display:

--- a/etl/steps/data/garden/covid/latest/compact.meta.yml
+++ b/etl/steps/data/garden/covid/latest/compact.meta.yml
@@ -51,7 +51,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/etl/steps/data/garden/covid/latest/decoupling.meta.yml
+++ b/etl/steps/data/garden/covid/latest/decoupling.meta.yml
@@ -7,7 +7,7 @@ definitions:
     display:
       numDecimalPlaces: 1
       zeroDay: "2020-01-01"
-      yearIsDay: true
+      timeInterval: day
     processing_level: major
 
 

--- a/etl/steps/data/garden/covid/latest/decoupling_metrics.meta.yml
+++ b/etl/steps/data/garden/covid/latest/decoupling_metrics.meta.yml
@@ -39,7 +39,7 @@ tables:
         unit: '%'
         display:
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'
       confirmed_deaths:
@@ -47,7 +47,7 @@ tables:
         unit: '%'
         display:
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'
       hospital_flow:
@@ -55,7 +55,7 @@ tables:
         unit: '%'
         display:
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'
       hospital_stock:
@@ -63,7 +63,7 @@ tables:
         unit: '%'
         display:
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'
       icu_flow:
@@ -71,7 +71,7 @@ tables:
         unit: '%'
         display:
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'
       icu_stock:
@@ -79,6 +79,6 @@ tables:
         unit: '%'
         display:
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'

--- a/etl/steps/data/garden/covid/latest/ecdc.meta.yml
+++ b/etl/steps/data/garden/covid/latest/ecdc.meta.yml
@@ -25,7 +25,7 @@ tables:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
           name: Biweekly growth in cases
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
         short_unit: '%'
       biweekly_cases:
@@ -36,7 +36,7 @@ tables:
           includeInTable: true
           name: Biweekly cases
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       biweekly_cases_per_million_people:
         title: Biweekly cases per million people
@@ -44,7 +44,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
       biweekly_death_growth__pct:
         title: Biweekly death growth (%)
         unit: '%'
@@ -54,7 +54,7 @@ tables:
             Spain: Nov 4: earlier deaths added
           includeInTable: true
           name: Biweekly growth in deaths
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
         short_unit: '%'
       biweekly_deaths:
@@ -67,7 +67,7 @@ tables:
           includeInTable: true
           name: Biweekly deaths
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       biweekly_deaths_per_million_people:
         title: Biweekly deaths per million people
@@ -77,7 +77,7 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
       case_fatality_rate_of_covid_19__pct:
         title: Case fatality rate of COVID-19 (%)
         unit: '%'
@@ -88,7 +88,7 @@ tables:
           includeInTable: true
           name: Case fatality rate
           tolerance: 2
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       case_fatality_rate_of_covid_19__pct__only_observations_with__gte_100_cases:
         title: "Case fatality rate of COVID-19 (%) (Only observations with ≥100 cases)"
@@ -99,7 +99,7 @@ tables:
             Spain: Nov 4: earlier deaths added
           includeInTable: true
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
         short_unit: '%'
       case_fatality_rate_of_covid_19__pct__short_term:
@@ -110,7 +110,7 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_cases_due_to_covid_19__rolling_7_day_average__right_aligned:
         title: Daily new confirmed cases due to COVID-19 (rolling 7-day average, right-aligned)
@@ -118,7 +118,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_cases_of_covid_19:
         title: Daily new confirmed cases of COVID-19
@@ -128,7 +128,7 @@ tables:
           includeInTable: true
           name: Daily confirmed cases
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_cases_of_covid_19__rolling_3_day_average__right_aligned:
         title: Daily new confirmed cases of COVID-19 (rolling 3-day average, right-aligned)
@@ -136,7 +136,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_cases_of_covid_19_per_million_people:
         title: Daily new confirmed cases of COVID-19 per million people
@@ -144,7 +144,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_cases_of_covid_19_per_million_people__rolling_3_day_average__right_aligned:
         title: Daily new confirmed cases of COVID-19 per million people (rolling 3-day average, right-aligned)
@@ -152,7 +152,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_cases_of_covid_19_per_million_people__rolling_7_day_average__right_aligned:
         title: Daily new confirmed cases of COVID-19 per million people (rolling 7-day average, right-aligned)
@@ -160,7 +160,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_deaths_due_to_covid_19:
         title: Daily new confirmed deaths due to COVID-19
@@ -172,7 +172,7 @@ tables:
           includeInTable: true
           name: Daily confirmed deaths
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_deaths_due_to_covid_19__rolling_3_day_average__right_aligned:
         title: Daily new confirmed deaths due to COVID-19 (rolling 3-day average, right-aligned)
@@ -182,7 +182,7 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_deaths_due_to_covid_19__rolling_7_day_average__right_aligned:
         title: Daily new confirmed deaths due to COVID-19 (rolling 7-day average, right-aligned)
@@ -192,7 +192,7 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_deaths_due_to_covid_19_per_million_people:
         title: Daily new confirmed deaths due to COVID-19 per million people
@@ -202,7 +202,7 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_deaths_due_to_covid_19_per_million_people__rolling_3_day_average__right_aligned:
         title: Daily new confirmed deaths due to COVID-19 per million people (rolling 3-day average, right-aligned)
@@ -212,7 +212,7 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_new_confirmed_deaths_due_to_covid_19_per_million_people__rolling_7_day_average__right_aligned:
         title: Daily new confirmed deaths due to COVID-19 per million people (rolling 7-day average, right-aligned)
@@ -222,49 +222,49 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_10_daily_new_confirmed_deaths_recorded:
         title: Days since 10 daily new confirmed deaths recorded
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_3_daily_new_confirmed_deaths_recorded:
         title: Days since 3 daily new confirmed deaths recorded
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_30_daily_new_confirmed_cases_recorded:
         title: Days since 30 daily new confirmed cases recorded
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_5_daily_new_confirmed_deaths_recorded:
         title: Days since 5 daily new confirmed deaths recorded
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_50_daily_new_confirmed_cases_recorded:
         title: Days since 50 daily new confirmed cases recorded
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_daily_new_confirmed_cases_of_covid_19__rolling_7_day_average__right_aligned__reached_30:
         title: Days since daily new confirmed cases of COVID-19 (rolling 7-day average, right-aligned) reached 30
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_daily_new_confirmed_cases_of_covid_19_per_million_people__rolling_7_day_average__right_aligned__reached_1:
         title: Days since daily new confirmed cases of COVID-19 per million people (rolling 7-day average, right-aligned)
@@ -272,14 +272,14 @@ tables:
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_daily_new_confirmed_deaths_due_to_covid_19__rolling_7_day_average__right_aligned__reached_5:
         title: Days since daily new confirmed deaths due to COVID-19 (rolling 7-day average, right-aligned) reached 5
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       ? days_since_daily_new_confirmed_deaths_due_to_covid_19_per_million_people__rolling_7_day_average__right_aligned__reached_0_01
       : title: Days since daily new confirmed deaths due to COVID-19 per million people (rolling 7-day average, right-aligned)
@@ -287,7 +287,7 @@ tables:
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       ? days_since_daily_new_confirmed_deaths_due_to_covid_19_per_million_people__rolling_7_day_average__right_aligned__reached_0_1
       : title: Days since daily new confirmed deaths due to COVID-19 per million people (rolling 7-day average, right-aligned)
@@ -295,7 +295,7 @@ tables:
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_the_total_confirmed_cases_of_covid_19_per_million_people_reached_1:
         title: Days since the total confirmed cases of COVID-19 per million people reached 1
@@ -303,35 +303,35 @@ tables:
         display:
           includeInTable: false
           name: Days since the total confirmed cases per million people reached 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_the_total_confirmed_cases_of_covid_19_reached_100:
         title: Days since the total confirmed cases of COVID-19 reached 100
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_the_total_confirmed_cases_of_covid_19_reached_100__with_population__gte__5m:
         title: "Days since the total confirmed cases of COVID-19 reached 100 (with population ≥ 5M)"
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_the_total_confirmed_deaths_of_covid_19_per_million_people_reached_0_1:
         title: Days since the total confirmed deaths of COVID-19 per million people reached 0.1
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       days_since_the_total_confirmed_deaths_of_covid_19_reached_5:
         title: Days since the total confirmed deaths of COVID-19 reached 5
         unit: ''
         display:
           includeInTable: false
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       doubling_days_of_total_confirmed_cases__3_day_period:
         title: Doubling days of total confirmed cases (3 day period)
@@ -339,7 +339,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       doubling_days_of_total_confirmed_cases__7_day_period:
         title: Doubling days of total confirmed cases (7 day period)
@@ -347,7 +347,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       doubling_days_of_total_confirmed_deaths__3_day_period:
         title: Doubling days of total confirmed deaths (3 day period)
@@ -357,7 +357,7 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       doubling_days_of_total_confirmed_deaths__7_day_period:
         title: Doubling days of total confirmed deaths (7 day period)
@@ -367,13 +367,13 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       has_population__gte__5m_and_had__gte_100_cases__gte_21_days_ago_and_has_testing_data:
         title: "Has population ≥ 5M AND had ≥100 cases ≥21 days ago AND has testing data"
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_confirmed_cases_of_covid_19:
         title: Total confirmed cases of COVID-19
@@ -381,7 +381,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_confirmed_cases_of_covid_19_per_million_people:
         title: Total confirmed cases of COVID-19 per million people
@@ -389,7 +389,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_confirmed_deaths_due_to_covid_19:
         title: Total confirmed deaths due to COVID-19
@@ -399,7 +399,7 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_confirmed_deaths_due_to_covid_19_per_million_people:
         title: Total confirmed deaths due to COVID-19 per million people
@@ -409,7 +409,7 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_case_growth__pct:
         title: Weekly case growth (%)
@@ -418,7 +418,7 @@ tables:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
         short_unit: '%'
       weekly_cases:
@@ -427,7 +427,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_cases_per_million_people:
         title: Weekly cases per million people
@@ -435,7 +435,7 @@ tables:
         display:
           entityAnnotationsMap: 'Mexico: Oct 9: probable/earlier cases added'
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
       weekly_death_growth__pct:
         title: Weekly death growth (%)
         unit: '%'
@@ -445,7 +445,7 @@ tables:
             Spain: Nov 4: earlier deaths added
           includeInTable: true
           numDecimalPlaces: 1
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
         short_unit: '%'
       weekly_deaths:
@@ -456,7 +456,7 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_deaths_per_million_people:
         title: Weekly deaths per million people
@@ -466,4 +466,4 @@ tables:
             Sweden: recent days may undercount deaths
             Spain: Nov 4: earlier deaths added
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day

--- a/etl/steps/data/garden/covid/latest/google_mobility.meta.yml
+++ b/etl/steps/data/garden/covid/latest/google_mobility.meta.yml
@@ -6,7 +6,7 @@ definitions:
         - COVID-19
     display:
       numDecimalPlaces: 2
-      yearIsDay: true
+      timeInterval: day
       zeroDay: "2020-01-01"
     processing_level: minor
     description_processing: This indicator has been smoothed by averaging its values with a centered 7-day rolling window.

--- a/etl/steps/data/garden/covid/latest/google_mobility_trends.meta.yml
+++ b/etl/steps/data/garden/covid/latest/google_mobility_trends.meta.yml
@@ -40,7 +40,7 @@ tables:
         display:
           includeInTable: true
           name: Retail & Recreation
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       grocery_and_pharmacy:
         title: grocery_and_pharmacy
@@ -53,7 +53,7 @@ tables:
         display:
           includeInTable: true
           name: Grocery & Pharmacy Stores
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       parks:
         title: parks
@@ -66,7 +66,7 @@ tables:
         display:
           includeInTable: true
           name: Parks
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       transit_stations:
         title: transit_stations
@@ -79,7 +79,7 @@ tables:
         display:
           includeInTable: true
           name: Transit Stations
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       workplaces:
         title: workplaces
@@ -92,7 +92,7 @@ tables:
         display:
           includeInTable: true
           name: Workplaces
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       residential:
         title: residential
@@ -106,5 +106,5 @@ tables:
         display:
           includeInTable: true
           name: Residential
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'

--- a/etl/steps/data/garden/covid/latest/government_response_oxbsg.meta.yml
+++ b/etl/steps/data/garden/covid/latest/government_response_oxbsg.meta.yml
@@ -223,28 +223,28 @@ tables:
         unit: ''
         display:
           name: Cancel public events (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       close_public_transport:
         title: close_public_transport
         unit: ''
         display:
           name: Close public transport (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       contact_tracing:
         title: contact_tracing
         unit: ''
         display:
           name: Contact tracing (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       containment_index:
         title: containment_index
         unit: (0 to 100, 100 = strictest)
         display:
           name: COVID-19 Containment and Health Index
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       debt_relief:
         title: debt_relief
@@ -261,28 +261,28 @@ tables:
         unit: ''
         display:
           name: Debt or contract relief
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       emergency_investment_healthcare:
         title: emergency_investment_healthcare
         unit: ''
         display:
           name: Emergency investment in health care (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       facial_coverings:
         title: facial_coverings
         unit: ''
         display:
           name: Facial coverings (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       fiscal_measures:
         title: fiscal_measures
         unit: ''
         display:
           name: Fiscal measures (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       income_support:
         title: income_support
@@ -300,119 +300,119 @@ tables:
         unit: ''
         display:
           name: Income support
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       international_support:
         title: international_support
         unit: ''
         display:
           name: International support (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       international_travel_controls:
         title: international_travel_controls
         unit: ''
         display:
           name: International travel controls (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       investment_vaccines:
         title: investment_vaccines
         unit: $
         display:
           name: Investment in COVID-19 vaccines
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: $
       pregnant_vaccine_eligibility:
         title: pregnant_vaccine_eligibility
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       public_information_campaigns:
         title: public_information_campaigns
         unit: ''
         display:
           name: Public information campaigns (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       restriction_gatherings:
         title: restriction_gatherings
         unit: ''
         display:
           name: Restrictions on gatherings (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       restrictions_internal_movements:
         title: restrictions_internal_movements
         unit: ''
         display:
           name: Restrictions on internal movement (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       school_closures:
         title: school_closures
         unit: ''
         display:
           name: School closures
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       stay_home_requirements:
         title: stay_home_requirements
         unit: ''
         display:
           name: Stay at home requirements (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       stringency_index:
         title: stringency_index
         unit: (0 to 100, 100 = strictest)
         display:
           name: Government Response Stringency Index
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       testing_policy:
         title: testing_policy
         unit: ''
         display:
           name: Testing policy (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       vaccination_policy:
         title: vaccination_policy
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       vaccine_availability:
         title: vaccine_availability
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       vaccine_eligibility:
         title: vaccine_eligibility
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       vaccine_eligibility_age:
         title: vaccine_eligibility_age
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       vaccine_eligibility_age_at_risk:
         title: vaccine_eligibility_age_at_risk
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       workplace_closures:
         title: workplace_closures
         unit: ''
         display:
           name: Workplace Closures (OxBSG)
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'

--- a/etl/steps/data/garden/covid/latest/hospital.meta.yml
+++ b/etl/steps/data/garden/covid/latest/hospital.meta.yml
@@ -12,7 +12,7 @@ definitions:
   others:
     zero_day: &zero_day
       zeroDay: 2020-01-21
-      yearIsDay: true
+      timeInterval: day
 
   common:
     presentation:

--- a/etl/steps/data/garden/covid/latest/hospital_and_icu.meta.yml
+++ b/etl/steps/data/garden/covid/latest/hospital_and_icu.meta.yml
@@ -25,7 +25,7 @@ tables:
           entityAnnotationsMap: 'Hungary: patients on ventilator'
           name: Current number of COVID-19 patients in ICU
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_icu_occupancy_per_million:
         title: Daily ICU occupancy per million
@@ -34,7 +34,7 @@ tables:
           entityAnnotationsMap: 'Hungary: patients on ventilator'
           name: Number of COVID-19 patients in ICU per million
           numDecimalPlaces: 2
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_hospital_occupancy:
         title: Daily hospital occupancy
@@ -43,7 +43,7 @@ tables:
         display:
           name: Number of COVID-19 patients in hospital
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       daily_hospital_occupancy_per_million:
         title: Daily hospital occupancy per million
@@ -52,7 +52,7 @@ tables:
         display:
           name: Number of COVID-19 patients in hospital per million
           numDecimalPlaces: 2
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_new_icu_admissions:
         title: Weekly new ICU admissions
@@ -61,7 +61,7 @@ tables:
           entityAnnotationsMap: 'Hungary: patients on ventilator'
           name: Weekly new ICU admissions for COVID-19
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_new_icu_admissions_per_million:
         title: Weekly new ICU admissions per million
@@ -69,7 +69,7 @@ tables:
         display:
           name: Weekly new ICU admissions for COVID-19 per million
           numDecimalPlaces: 2
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_new_hospital_admissions:
         title: Weekly new hospital admissions
@@ -77,7 +77,7 @@ tables:
         display:
           name: Weekly new hospital admissions for COVID-19
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       weekly_new_hospital_admissions_per_million:
         title: Weekly new hospital admissions per million
@@ -85,5 +85,5 @@ tables:
         display:
           name: Weekly new hospital admissions for COVID-19 per million
           numDecimalPlaces: 2
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'

--- a/etl/steps/data/garden/covid/latest/john_hopkins_university.meta.yml
+++ b/etl/steps/data/garden/covid/latest/john_hopkins_university.meta.yml
@@ -2,7 +2,7 @@ definitions:
   common:
     display:
       includeInTable: true
-      yearIsDay: true
+      timeInterval: day
       zeroDay: '2020-01-21'
     presentation:
       topic_tags:

--- a/etl/steps/data/garden/covid/latest/oxcgrt_policy.meta.yml
+++ b/etl/steps/data/garden/covid/latest/oxcgrt_policy.meta.yml
@@ -1,7 +1,7 @@
 # NOTE: To learn more about the fields, hover over their names.
 definitions:
   year_is_day: &year_is_day
-    yearIsDay: true
+    timeInterval: day
     zeroDay: "2020-01-01"
   restriction_text_short: |-
     <% if restriction_name == 'c4m_restrictions_on_gatherings' %>

--- a/etl/steps/data/garden/covid/latest/sequencing.meta.yml
+++ b/etl/steps/data/garden/covid/latest/sequencing.meta.yml
@@ -35,30 +35,30 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       num_sequences_cumulative:
         title: num_sequences_cumulative
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       num_sequences_cumulative_per_1m:
         title: num_sequences_cumulative_per_1M
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       num_sequences_per_1m:
         title: num_sequences_per_1M
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       variant_dominant:
         title: variant_dominant
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'

--- a/etl/steps/data/garden/covid/latest/sweden.meta.yml
+++ b/etl/steps/data/garden/covid/latest/sweden.meta.yml
@@ -17,11 +17,11 @@ tables:
         title: Deaths
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       incomplete_deaths:
         title: Incomplete deaths
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'

--- a/etl/steps/data/garden/covid/latest/sweden_covid.meta.yml
+++ b/etl/steps/data/garden/covid/latest/sweden_covid.meta.yml
@@ -6,7 +6,7 @@ definitions:
         - COVID-19
     display:
       zeroDay: "2020-01-01"
-      yearIsDay: true
+      timeInterval: day
 
 
 # Learn more about the available fields:

--- a/etl/steps/data/garden/covid/latest/testing.meta.yml
+++ b/etl/steps/data/garden/covid/latest/testing.meta.yml
@@ -149,7 +149,7 @@ definitions:
     Zimbabwe: tests performed
   display_common: &display_common
     zeroDay: "2020-01-21"
-    yearIsDay: true
+    timeInterval: day
     entityAnnotationsMap: *annotations
 
   common:

--- a/etl/steps/data/garden/covid/latest/testing_time_series.meta.yml
+++ b/etl/steps/data/garden/covid/latest/testing_time_series.meta.yml
@@ -28,7 +28,7 @@ tables:
           conversionFactor: 100
           includeInTable: true
           name: Cumulative positivity rate
-          yearIsDay: true
+          timeInterval: day
         short_unit: '%'
       cumulative_tests_per_case:
         title: cumulative_tests_per_case
@@ -39,7 +39,7 @@ tables:
         display:
           includeInTable: true
           name: Tests per confirmed case – total
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       new_tests:
         title: new_tests
@@ -196,7 +196,7 @@ tables:
             Zimbabwe: tests performed
           includeInTable: true
           name: New tests
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       new_tests_7day_smoothed:
         title: new_tests_7day_smoothed
@@ -363,7 +363,7 @@ tables:
             Zimbabwe: tests performed
           includeInTable: true
           name: Daily tests (7-day smoothed)
-          yearIsDay: true
+          timeInterval: day
       new_tests_per_thousand:
         title: new_tests_per_thousand
         unit: ''
@@ -519,7 +519,7 @@ tables:
             Zimbabwe: tests performed
           includeInTable: true
           name: New tests per thousand
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       new_tests_per_thousand_7day_smoothed:
         title: new_tests_per_thousand_7day_smoothed
@@ -687,7 +687,7 @@ tables:
             Zimbabwe: tests performed
           includeInTable: true
           name: Daily tests per thousand people (7-day smoothed)
-          yearIsDay: true
+          timeInterval: day
       short_term_positivity_rate:
         title: short_term_positivity_rate
         unit: '%'
@@ -695,7 +695,7 @@ tables:
           conversionFactor: 100
           includeInTable: true
           name: Short-term positivity rate
-          yearIsDay: true
+          timeInterval: day
         short_unit: '%'
       short_term_tests_per_case:
         title: short_term_tests_per_case
@@ -712,14 +712,14 @@ tables:
         display:
           includeInTable: true
           name: Tests per confirmed case – daily
-          yearIsDay: true
+          timeInterval: day
       testing_observations:
         title: testing_observations
         description: Countries for which we attempted to find data are not included.
         unit: ''
         display:
           name: Number of testing observations
-          yearIsDay: true
+          timeInterval: day
       total_tests:
         title: total_tests
         unit: ''
@@ -876,7 +876,7 @@ tables:
           includeInTable: true
           name: Total tests
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_tests_per_thousand:
         title: total_tests_per_thousand
@@ -1033,5 +1033,5 @@ tables:
             Zimbabwe: tests performed
           includeInTable: true
           name: Total tests per thousand
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'

--- a/etl/steps/data/garden/covid/latest/tracking_r.meta.yml
+++ b/etl/steps/data/garden/covid/latest/tracking_r.meta.yml
@@ -2,7 +2,7 @@
 definitions:
   others:
     zero_day: &zero_day
-      yearIsDay: true
+      timeInterval: day
       zeroDay: 2020-01-01
 
   common:

--- a/etl/steps/data/garden/covid/latest/uk_covid.meta.yml
+++ b/etl/steps/data/garden/covid/latest/uk_covid.meta.yml
@@ -2,7 +2,7 @@
 definitions:
   zero_day: &zero_day
     zeroDay: "2020-01-01"
-    yearIsDay: true
+    timeInterval: day
   common:
     presentation:
       topic_tags:

--- a/etl/steps/data/garden/covid/latest/uk_covid_data.meta.yml
+++ b/etl/steps/data/garden/covid/latest/uk_covid_data.meta.yml
@@ -13,7 +13,7 @@ tables:
         display:
           name: Cumulative confirmed COVID-19 cases
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       cumulative_cases_rate:
         title: cumulative_cases_rate
@@ -21,7 +21,7 @@ tables:
         display:
           name: Cumulative confirmed COVID-19 deaths per 100,000
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       cumulative_deaths:
         title: cumulative_deaths
@@ -29,14 +29,14 @@ tables:
         display:
           name: Cumulative confirmed COVID-19 deaths
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       cumulative_deaths_rate:
         title: cumulative_deaths_rate
         unit: deaths per 100,000
         display:
           name: Cumulative confirmed COVID-19 deaths per 100,000
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       daily_cases:
         title: daily_cases
@@ -44,20 +44,20 @@ tables:
         display:
           name: Daily new confirmed COVID-19 cases
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       daily_cases_rate_rolling_average:
         title: daily_cases_rate_rolling_average
         unit: ''
         display:
           name: Daily new confirmed COVID-19 cases, 7-day rolling average
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       daily_cases_rolling_average:
         title: daily_cases_rolling_average
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       daily_deaths:
         title: daily_deaths
@@ -65,7 +65,7 @@ tables:
         display:
           name: Daily new confirmed COVID-19 deaths
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       daily_deaths_rate_rolling_average:
         title: daily_deaths_rate_rolling_average
@@ -77,7 +77,7 @@ tables:
         unit: ''
         display:
           name: Daily new confirmed COVID-19 deaths
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       new_hospital_admissions:
         title: new_hospital_admissions
@@ -85,7 +85,7 @@ tables:
         display:
           name: 'UK: Daily new hospital admissions for COVID-19'
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       people_in_hospital:
         title: people_in_hospital
@@ -93,13 +93,13 @@ tables:
         display:
           name: 'UK: Number of COVID-19 patients in hospital'
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       people_in_hospital_normalized:
         title: people_in_hospital_normalized
         unit: '%'
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'
       people_ventilated:
@@ -109,7 +109,7 @@ tables:
         title: people_ventilated_normalized
         unit: '%'
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'
       test_positivity_rate:
@@ -117,7 +117,7 @@ tables:
         unit: '%'
         display:
           name: Share of COVID-19 tests that are positive
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'
       weekly_cases_rate:
@@ -125,20 +125,20 @@ tables:
         unit: per 100,000
         display:
           name: Confirmed COVID-19 cases per 100k, weekly rolling average
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       weekly_cases_rolling:
         title: weekly_cases_rolling
         unit: ''
         display:
           name: Confirmed COVID-19 cases, weekly rolling average
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       weekly_cases_rolling_normalized:
         title: weekly_cases_rolling_normalized
         unit: '%'
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'
       weekly_deaths_rate:
@@ -146,20 +146,20 @@ tables:
         unit: per 100,000
         display:
           name: Confirmed COVID-19 deaths per 100k, weekly rolling average
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       weekly_deaths_rolling:
         title: weekly_deaths_rolling
         unit: ''
         display:
           name: Confirmed COVID-19 deaths, weekly rolling average
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
       weekly_deaths_rolling_normalized:
         title: weekly_deaths_rolling_normalized
         unit: '%'
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-01'
         short_unit: '%'
       weekly_hospital_admissions:

--- a/etl/steps/data/garden/covid/latest/vaccinations.meta.yml
+++ b/etl/steps/data/garden/covid/latest/vaccinations.meta.yml
@@ -14,7 +14,7 @@ tables:
         title: new_people_vaccinated_smoothed
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       new_people_vaccinated_smoothed_per_hundred:
         title: new_people_vaccinated_smoothed_per_hundred
@@ -23,7 +23,7 @@ tables:
         title: new_vaccinations
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       new_vaccinations_smoothed:
         title: new_vaccinations_smoothed
@@ -33,7 +33,7 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
       new_vaccinations_smoothed_per_million:
         title: new_vaccinations_smoothed_per_million
         description: Not all countries report vaccination data on a daily basis. To generate this series we assume that vaccination
@@ -42,7 +42,7 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
       people_fully_vaccinated:
         title: people_fully_vaccinated
         unit: ''
@@ -52,7 +52,7 @@ tables:
             Upper middle income: Data for China reported at irregular intervals
             Asia: Data for China reported at irregular intervals
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       people_fully_vaccinated_per_hundred:
         title: people_fully_vaccinated_per_hundred
@@ -63,14 +63,14 @@ tables:
             Upper middle income: Data for China reported at irregular intervals
             Asia: Data for China reported at irregular intervals
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       people_unvaccinated:
         title: people_unvaccinated
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       people_vaccinated:
         title: people_vaccinated
@@ -81,7 +81,7 @@ tables:
             Upper middle income: Data for China reported at irregular intervals
             Asia: Data for China reported at irregular intervals
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       people_vaccinated_per_hundred:
         title: people_vaccinated_per_hundred
@@ -93,26 +93,26 @@ tables:
             Upper middle income: Data for China reported at irregular intervals
             Asia: Data for China reported at irregular intervals
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       share_of_boosters:
         title: share_of_boosters
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_boosters:
         title: total_boosters
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_boosters_per_hundred:
         title: total_boosters_per_hundred
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2020-01-21'
       total_vaccinations:
         title: total_vaccinations
@@ -121,11 +121,11 @@ tables:
           includeInTable: true
           name: Cumulative COVID-19 vaccinations
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
       total_vaccinations_per_hundred:
         title: total_vaccinations_per_hundred
         unit: ''
         display:
           includeInTable: true
           name: Cumulative COVID-19 vaccinations per 100 people
-          yearIsDay: true
+          timeInterval: day

--- a/etl/steps/data/garden/covid/latest/vaccinations_by_age_group.meta.yml
+++ b/etl/steps/data/garden/covid/latest/vaccinations_by_age_group.meta.yml
@@ -15,32 +15,32 @@ tables:
         title: 0-15_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_15_fully:
         title: 0-15_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_15_partly:
         title: 0-15_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_15_start:
         title: 0-15_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_17_booster:
         title: 0-17_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _0_17_fully:
@@ -48,93 +48,93 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_17_partly:
         title: 0-17_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_17_start:
         title: 0-17_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_19_booster:
         title: 0-19_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_19_fully:
         title: 0-19_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_19_partly:
         title: 0-19_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_19_start:
         title: 0-19_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_4_booster:
         title: 0-4_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_4_fully:
         title: 0-4_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_4_partly:
         title: 0-4_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_4_start:
         title: 0-4_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_5_booster:
         title: 0-5_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_5_fully:
         title: 0-5_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_5_partly:
         title: 0-5_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_5_start:
         title: 0-5_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_9_start:
         title: 0-9_start
@@ -142,33 +142,33 @@ tables:
         display:
           includeInTable: true
           name: 0-9 years
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _10_14_booster:
         title: 10-14_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _10_14_fully:
         title: 10-14_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _10_14_partly:
         title: 10-14_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _10_14_start:
         title: 10-14_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _10_19_start:
         title: 10-19_start
@@ -176,214 +176,214 @@ tables:
         display:
           includeInTable: true
           name: 10-19 years
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _100plus_booster:
         title: 100+_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _100plus_fully:
         title: 100+_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _100plus_partly:
         title: 100+_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _100plus_start:
         title: 100+_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _12_15_booster:
         title: 12-15_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _12_15_fully:
         title: 12-15_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _12_15_partly:
         title: 12-15_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _12_15_start:
         title: 12-15_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _12_17_booster:
         title: 12-17_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _12_17_fully:
         title: 12-17_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _12_17_partly:
         title: 12-17_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _12_17_start:
         title: 12-17_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _12_64_booster:
         title: 12-64_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _12_64_fully:
         title: 12-64_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _12_64_partly:
         title: 12-64_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _12_64_start:
         title: 12-64_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _15_17_booster:
         title: 15-17_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _15_17_fully:
         title: 15-17_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _15_17_partly:
         title: 15-17_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _15_17_start:
         title: 15-17_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_17_booster:
         title: 16-17_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_17_fully:
         title: 16-17_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_17_partly:
         title: 16-17_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_17_start:
         title: 16-17_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_19_booster:
         title: 16-19_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _16_19_fully:
         title: 16-19_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_19_partly:
         title: 16-19_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_19_start:
         title: 16-19_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_69_booster:
         title: 16-69_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_69_fully:
         title: 16-69_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_69_partly:
         title: 16-69_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _16_69_start:
         title: 16-69_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _18_24_booster:
         title: 18-24_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _18_24_fully:
@@ -391,28 +391,28 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _18_24_partly:
         title: 18-24_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _18_24_start:
         title: 18-24_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _18_29_booster:
         title: 18-29_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _18_29_fully:
@@ -420,52 +420,52 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _18_29_partly:
         title: 18-29_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _18_29_start:
         title: 18-29_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _18_69_booster:
         title: 18-69_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _18_69_fully:
         title: 18-69_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _18_69_partly:
         title: 18-69_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _18_69_start:
         title: 18-69_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _20_29_booster:
         title: 20-29_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _20_29_fully:
@@ -474,7 +474,7 @@ tables:
         display:
           includeInTable: true
           name: 20-29 years
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _20_29_partly:
         title: 20-29_partly
@@ -482,7 +482,7 @@ tables:
         display:
           includeInTable: true
           name: 20-29 years
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _20_29_start:
         title: 20-29_start
@@ -490,35 +490,35 @@ tables:
         display:
           includeInTable: true
           name: 20-29 years
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _25_34_fully:
         title: 25-34_fully
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _25_34_partly:
         title: 25-34_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _25_34_start:
         title: 25-34_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _25_49_booster:
         title: 25-49_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _25_49_fully:
@@ -526,52 +526,52 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _25_49_partly:
         title: 25-49_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _25_49_start:
         title: 25-49_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _3_11_booster:
         title: 3-11_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _3_11_fully:
         title: 3-11_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _3_11_partly:
         title: 3-11_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _3_11_start:
         title: 3-11_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _30_39_booster:
         title: 30-39_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _30_39_fully:
@@ -579,49 +579,49 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _30_39_partly:
         title: 30-39_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _30_39_start:
         title: 30-39_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _35_44_fully:
         title: 35-44_fully
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _35_44_partly:
         title: 35-44_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _35_44_start:
         title: 35-44_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _40_49_booster:
         title: 40-49_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _40_49_fully:
@@ -629,49 +629,49 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _40_49_partly:
         title: 40-49_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _40_49_start:
         title: 40-49_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _45_54_fully:
         title: 45-54_fully
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _45_54_partly:
         title: 45-54_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _45_54_start:
         title: 45-54_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _5_11_booster:
         title: 5-11_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _5_11_fully:
@@ -679,54 +679,54 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _5_11_partly:
         title: 5-11_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _5_11_start:
         title: 5-11_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _5_9_booster:
         title: 5-9_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _5_9_fully:
         title: 5-9_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _5_9_partly:
         title: 5-9_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _5_9_start:
         title: 5-9_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _50_54_booster:
         title: 50-54_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _50_54_fully:
@@ -734,28 +734,28 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _50_54_partly:
         title: 50-54_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _50_54_start:
         title: 50-54_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _50_59_booster:
         title: 50-59_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _50_59_fully:
@@ -763,28 +763,28 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _50_59_partly:
         title: 50-59_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _50_59_start:
         title: 50-59_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _55_59_booster:
         title: 55-59_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _55_59_fully:
@@ -792,49 +792,49 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _55_59_partly:
         title: 55-59_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _55_59_start:
         title: 55-59_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _55_64_fully:
         title: 55-64_fully
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _55_64_partly:
         title: 55-64_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _55_64_start:
         title: 55-64_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _60_64_booster:
         title: 60-64_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _60_64_fully:
@@ -842,28 +842,28 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _60_64_partly:
         title: 60-64_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _60_64_start:
         title: 60-64_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _60_69_booster:
         title: 60-69_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _60_69_fully:
@@ -871,52 +871,52 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _60_69_partly:
         title: 60-69_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _60_69_start:
         title: 60-69_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _65plus_booster:
         title: 65+_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _65plus_fully:
         title: 65+_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _65plus_partly:
         title: 65+_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _65plus_start:
         title: 65+_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _65_69_booster:
         title: 65-69_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _65_69_fully:
@@ -924,49 +924,49 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _65_69_partly:
         title: 65-69_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _65_69_start:
         title: 65-69_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _65_74_fully:
         title: 65-74_fully
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _65_74_partly:
         title: 65-74_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _65_74_start:
         title: 65-74_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _70_74_booster:
         title: 70-74_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _70_74_fully:
@@ -974,28 +974,28 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _70_74_partly:
         title: 70-74_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _70_74_start:
         title: 70-74_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _70_79_booster:
         title: 70-79_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _70_79_fully:
@@ -1003,49 +1003,49 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _70_79_partly:
         title: 70-79_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _70_79_start:
         title: 70-79_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _75plus_fully:
         title: 75+_fully
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _75plus_partly:
         title: 75+_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _75plus_start:
         title: 75+_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _75_79_booster:
         title: 75-79_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _75_79_fully:
@@ -1053,28 +1053,28 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _75_79_partly:
         title: 75-79_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _75_79_start:
         title: 75-79_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _80plus_booster:
         title: 80+_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _80plus_fully:
@@ -1082,95 +1082,95 @@ tables:
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _80plus_partly:
         title: 80+_partly
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _80plus_start:
         title: 80+_start
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _80_89_booster:
         title: 80-89_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _80_89_fully:
         title: 80-89_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _80_89_partly:
         title: 80-89_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _80_89_start:
         title: 80-89_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _90plus_booster:
         title: 90+_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _90plus_fully:
         title: 90+_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _90plus_partly:
         title: 90+_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _90plus_start:
         title: 90+_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _90_99_booster:
         title: 90-99_booster
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _90_99_fully:
         title: 90-99_fully
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _90_99_partly:
         title: 90-99_partly
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _90_99_start:
         title: 90-99_start
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_9_fully:
         title: 0-9_fully
@@ -1178,7 +1178,7 @@ tables:
         display:
           includeInTable: true
           name: 0-9 years
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _10_19_partly:
         title: 10-19_partly
@@ -1186,7 +1186,7 @@ tables:
         display:
           includeInTable: true
           name: 10-19 years
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _0_9_partly:
         title: 0-9_partly
@@ -1194,7 +1194,7 @@ tables:
         display:
           includeInTable: true
           name: 0-9 years
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _10_19_fully:
         title: 10-19_fully
@@ -1202,14 +1202,14 @@ tables:
         display:
           includeInTable: true
           name: 10-19 years
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       _25_34_booster:
         title: 25-34_booster
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _75plus_booster:
@@ -1217,7 +1217,7 @@ tables:
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _35_44_booster:
@@ -1225,7 +1225,7 @@ tables:
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _55_64_booster:
@@ -1233,7 +1233,7 @@ tables:
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _0_9_booster:
@@ -1241,7 +1241,7 @@ tables:
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _65_74_booster:
@@ -1249,7 +1249,7 @@ tables:
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _45_54_booster:
@@ -1257,7 +1257,7 @@ tables:
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'
       _10_19_booster:
@@ -1265,6 +1265,6 @@ tables:
         unit: '%'
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
         short_unit: '%'

--- a/etl/steps/data/garden/covid/latest/vaccinations_by_manufacturer.meta.yml
+++ b/etl/steps/data/garden/covid/latest/vaccinations_by_manufacturer.meta.yml
@@ -15,93 +15,93 @@ tables:
         title: CanSino
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       covaxin:
         title: Covaxin
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       johnson_and_johnson:
         title: Johnson&Johnson
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       medicago:
         title: Medicago
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       moderna:
         title: Moderna
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       novavax:
         title: Novavax
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       oxford_astrazeneca:
         title: Oxford/AstraZeneca
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       pfizer_biontech:
         title: Pfizer/BioNTech
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       skycovione:
         title: SKYCovione
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       sanofi_gsk:
         title: Sanofi/GSK
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       sinopharm_beijing:
         title: Sinopharm/Beijing
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       sinovac:
         title: Sinovac
         unit: ''
         display:
           includeInTable: true
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       sputnik_light:
         title: Sputnik Light
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       sputnik_v:
         title: Sputnik V
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'
       valneva:
         title: Valneva
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
           zeroDay: '2021-01-01'

--- a/etl/steps/data/garden/covid/latest/vaccinations_global.meta.yml
+++ b/etl/steps/data/garden/covid/latest/vaccinations_global.meta.yml
@@ -11,7 +11,7 @@ definitions:
   others:
     zero_day: &zero_day
       zeroDay: 2020-01-21
-      yearIsDay: true
+      timeInterval: day
     per_capita: &per_capita |-
       Per-capita values have been estimated by using the population in 2022 as a reference.
   common:

--- a/etl/steps/data/garden/covid/latest/variants.meta.yml
+++ b/etl/steps/data/garden/covid/latest/variants.meta.yml
@@ -1,6 +1,6 @@
 definitions:
   default_display: &default_display
-    yearIsDay: true
+    timeInterval: day
     zeroDay: '2020-01-21'
 
 dataset:

--- a/etl/steps/data/garden/covid/latest/yougov.meta.yml
+++ b/etl/steps/data/garden/covid/latest/yougov.meta.yml
@@ -96,7 +96,7 @@ tables:
           Average response-score to question: {definitions.question_mapper}
         display:
           numDecimalPlaces: 3
-          yearIsDay: true
+          timeInterval: day
           zeroDay: "2020-01-21"
       num_responses:
         title: "Question: << question >> - Number of responses"
@@ -105,7 +105,7 @@ tables:
           Number of responses to question: {definitions.question_mapper}
         display:
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: "2020-01-21"
 
 
@@ -114,7 +114,7 @@ tables:
     common:
       display:
         numDecimalPlaces: 2
-        yearIsDay: true
+        timeInterval: day
         zeroDay: "2020-01-21"
     variables:
       people_vaccinated_per_hundred:

--- a/etl/steps/data/garden/covid/latest/yougov_imperial_behavior_tracker_composite.meta.yml
+++ b/etl/steps/data/garden/covid/latest/yougov_imperial_behavior_tracker_composite.meta.yml
@@ -45,7 +45,7 @@ tables:
           includeInTable: true
           name: Share of people who have received at least one dose of a COVID-19 vaccine
           numDecimalPlaces: 2
-          yearIsDay: true
+          timeInterval: day
         short_unit: '%'
       uncertain_covid_vaccinate_this_week_pct_pop:
         title: uncertain_covid_vaccinate_this_week_pct_pop
@@ -77,7 +77,7 @@ tables:
           name: Share of people who have not received a COVID-19 vaccine and are uncertain if they would get a COVID-19 vaccine
             if it was available to them this week
           numDecimalPlaces: 2
-          yearIsDay: true
+          timeInterval: day
         short_unit: '%'
       unwillingness_covid_vaccinate_this_week_pct_pop:
         title: unwillingness_covid_vaccinate_this_week_pct_pop
@@ -109,7 +109,7 @@ tables:
           name: Share of people who have not received a COVID-19 vaccine and would not get a COVID-19 vaccine if it was available
             to them this week
           numDecimalPlaces: 2
-          yearIsDay: true
+          timeInterval: day
         short_unit: '%'
       willingness_covid_vaccinate_this_week_pct_pop:
         title: willingness_covid_vaccinate_this_week_pct_pop
@@ -140,5 +140,5 @@ tables:
           name: Share of people who have not received a COVID-19 vaccine and would get a COVID-19 vaccine if it was available
             to them this week
           numDecimalPlaces: 2
-          yearIsDay: true
+          timeInterval: day
         short_unit: '%'

--- a/etl/steps/data/garden/demography/2025-01-23/us_state_population.meta.yml
+++ b/etl/steps/data/garden/demography/2025-01-23/us_state_population.meta.yml
@@ -51,7 +51,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/etl/steps/data/garden/dummy/2020-01-01/dummy.meta.yml
+++ b/etl/steps/data/garden/dummy/2020-01-01/dummy.meta.yml
@@ -21,7 +21,6 @@ tables:
           conversionFactor: 1000
           numDecimalPlaces: 1
           tolerance: 5
-          yearIsDay: false
           zeroDay: '1900-01-01'
           entityAnnotationsMap: 'Germany: dummy annotation'
           includeInTable: true

--- a/etl/steps/data/garden/dummy/2020-01-01/dummy_full.meta.yml
+++ b/etl/steps/data/garden/dummy/2020-01-01/dummy_full.meta.yml
@@ -29,7 +29,6 @@ tables:
           conversionFactor: 9999
           numDecimalPlaces: 9
           tolerance: 9
-          yearIsDay: false
           zeroDay: '1900-01-01'
           entityAnnotationsMap: 'France: [display.entityAnnotationsMap example France]'
           includeInTable: true

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality_economist/excess_mortality_economist.meta.yml
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality_economist/excess_mortality_economist.meta.yml
@@ -18,7 +18,7 @@ definitions:
     display: &common_display
       numDecimalPlaces: 0
       zeroDay: "2020-01-01"
-      yearIsDay: true
+      timeInterval: day
       includeInTable: true
     description_key:
       - Data from The Economist estimating the number of excess deaths, from all causes, during the COVID-19 pandemic for 223 countries & regions. The Economist publishes new estimates each day. We update our charts with the latest available data each week.

--- a/etl/steps/data/garden/geography/2025-06-26/wb_admin_boundaries.meta.yml
+++ b/etl/steps/data/garden/geography/2025-06-26/wb_admin_boundaries.meta.yml
@@ -51,7 +51,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/etl/steps/data/garden/health/2020-11-01/swedish_covid_19_deaths_comparison.meta.yml
+++ b/etl/steps/data/garden/health/2020-11-01/swedish_covid_19_deaths_comparison.meta.yml
@@ -9,7 +9,7 @@ tables:
         title: new_deaths_smoothed
         unit: ''
         display:
-          yearIsDay: true
+          timeInterval: day
     dimensions:
       - name: year
         slug: year

--- a/etl/steps/data/garden/oecd/2025-03-11/co2_air_transport.meta.yml
+++ b/etl/steps/data/garden/oecd/2025-03-11/co2_air_transport.meta.yml
@@ -87,7 +87,7 @@ tables:
         short_unit: t
         display:
           zeroDay: '2019-01-01'
-          yearIsDay: true
+          timeInterval: day
 
       ter_int_m:
         title: Monthly CO₂ emissions from international aviation
@@ -96,7 +96,7 @@ tables:
         short_unit: t
         display:
           zeroDay: '2019-01-01'
-          yearIsDay: true
+          timeInterval: day
 
       per_capita_ter_dom_m:
         title: Monthly CO₂ emissions from domestic aviation per capita
@@ -106,7 +106,7 @@ tables:
         short_unit: kg
         display:
           zeroDay: '2019-01-01'
-          yearIsDay: true
+          timeInterval: day
 
       per_capita_ter_int_m:
         title: Monthly CO₂ emissions from international aviation per capita
@@ -116,7 +116,7 @@ tables:
         short_unit: kg
         display:
           zeroDay: '2019-01-01'
-          yearIsDay: true
+          timeInterval: day
 
       total_monthly_emissions:
         title: Monthly CO₂ total emissions from aviation
@@ -125,7 +125,7 @@ tables:
         short_unit: t
         display:
           zeroDay: '2019-01-01'
-          yearIsDay: true
+          timeInterval: day
 
       total_annual_emissions:
         title: Total annual CO₂ emissions from aviation

--- a/etl/steps/data/garden/public_health_reports/2025-03-04/diphtheria_deaths.meta.yml
+++ b/etl/steps/data/garden/public_health_reports/2025-03-04/diphtheria_deaths.meta.yml
@@ -51,7 +51,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/etl/steps/data/garden/un/2026-02-11/energy_statistics_database.meta.yml
+++ b/etl/steps/data/garden/un/2026-02-11/energy_statistics_database.meta.yml
@@ -51,7 +51,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/etl/steps/data/garden/us_census_bureau/2025-03-04/diphtheria_deaths.meta.yml
+++ b/etl/steps/data/garden/us_census_bureau/2025-03-04/diphtheria_deaths.meta.yml
@@ -51,7 +51,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/etl/steps/data/garden/us_census_bureau/2025-03-06/pertussis_deaths.meta.yml
+++ b/etl/steps/data/garden/us_census_bureau/2025-03-06/pertussis_deaths.meta.yml
@@ -51,7 +51,7 @@ tables:
       #     tableDisplay:
       #       hideAbsoluteChange:
       #       hideRelativeChange:
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data
       #     zeroDay:
       #     roundingMode:
       #     numSignificantFigures:

--- a/etl/steps/data/garden/war/2023-11-29/chupilkin_koczan.meta.yml
+++ b/etl/steps/data/garden/war/2023-11-29/chupilkin_koczan.meta.yml
@@ -53,7 +53,7 @@ tables:
       #       hideRelativeChange:
       #     tolerance: 0
       #     unit: arbitrary units
-      #     yearIsDay: false
+      #     timeInterval: day  # day | week | month | quarter | year | decade; omit for yearly data
       #     zeroDay:
         {}
 

--- a/etl/steps/data/garden/who/2025-03-19/flu_yamagata.meta.yml
+++ b/etl/steps/data/garden/who/2025-03-19/flu_yamagata.meta.yml
@@ -22,5 +22,5 @@ tables:
         unit: cases
         display:
           numDecimalPlaces: 0
-          yearIsDay: true
+          timeInterval: day
           zeroDay: "1995-01-02"

--- a/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch.meta.yml
+++ b/etl/steps/data/grapher/artificial_intelligence/2025-03-12/epoch.meta.yml
@@ -4,7 +4,7 @@ definitions:
     short_unit: ''
     display:
       zeroDay: '1949-01-01'
-      yearIsDay: true
+      timeInterval: day
 
 tables:
   epoch:

--- a/etl/steps/data/grapher/climate/2026-07-10/surface_temperature.py
+++ b/etl/steps/data/grapher/climate/2026-07-10/surface_temperature.py
@@ -29,7 +29,7 @@ def run() -> None:
     for column in tb.columns:
         tb[column].metadata.display = {}
         tb[column].metadata.display["zeroDay"] = "1949-01-01"
-        tb[column].metadata.display["yearIsDay"] = True
+        tb[column].metadata.display["timeInterval"] = "day"
 
     # Save outputs.
     #

--- a/etl/steps/data/grapher/climate/2026-07-10/weekly_wildfires.py
+++ b/etl/steps/data/grapher/climate/2026-07-10/weekly_wildfires.py
@@ -30,7 +30,7 @@ def run(dest_dir: str) -> None:
     for column in tb.columns:
         tb[column].metadata.display = {}
         tb[column].metadata.display["zeroDay"] = "2000-01-01"
-        tb[column].metadata.display["yearIsDay"] = True
+        tb[column].metadata.display["timeInterval"] = "day"
 
     #
     # Save outputs.

--- a/etl/steps/data/grapher/survey/2026-02-02/dietary_choices.py
+++ b/etl/steps/data/grapher/survey/2026-02-02/dietary_choices.py
@@ -60,7 +60,7 @@ def run() -> None:
     # Prepare display metadata.
     date_earliest = tb["year"].astype(str).min()
     for column in tb.drop(columns=["country", "year", "group"]).columns:
-        tb[column].metadata.display["yearIsDay"] = True
+        tb[column].metadata.display["timeInterval"] = "day"
         tb[column].metadata.display["zeroDay"] = date_earliest
 
     # Convert year column into a number of days since the earliest date in the table.

--- a/etl/steps/data/grapher/survey/2026-02-02/dietary_choices_uk_by_age.py
+++ b/etl/steps/data/grapher/survey/2026-02-02/dietary_choices_uk_by_age.py
@@ -53,7 +53,7 @@ def run() -> None:
     # Prepare display metadata.
     date_earliest = tb["year"].astype(str).min()
     for column in tb.drop(columns=["country", "year"]).columns:
-        tb[column].metadata.display["yearIsDay"] = True
+        tb[column].metadata.display["timeInterval"] = "day"
         tb[column].metadata.display["zeroDay"] = date_earliest
 
     # Convert year column into a number of days since the earliest date in the table.

--- a/etl/steps/data/grapher/who/2023-08-14/avian_influenza_ah5n1_year.py
+++ b/etl/steps/data/grapher/who/2023-08-14/avian_influenza_ah5n1_year.py
@@ -2,7 +2,7 @@
 
 from typing import cast
 
-from owid.catalog import Dataset, Table
+from owid.catalog import Dataset
 
 from etl.helpers import PathFinder, create_dataset, grapher_checks
 
@@ -27,9 +27,6 @@ def run(dest_dir: str) -> None:
     tb["year"] = tb["date"].dt.year
     tb = tb.groupby(["year", "country"], as_index=False)["avian_cases"].sum()
 
-    # Get zeroDay as the minimum date in the dataset and set it to zeroDay
-    # tb = add_num_days(tb)
-
     tb = tb.set_index(["country", "year"], verify_integrity=True)
 
     #
@@ -47,26 +44,3 @@ def run(dest_dir: str) -> None:
 
     # Save changes in the new grapher dataset.
     ds_grapher.save()
-
-
-def add_num_days(tb: Table) -> Table:
-    """Add column with number of days after zero_day.
-
-    Also, drop `date` column.
-    """
-    column_indicator = "avian_cases"
-
-    if tb[column_indicator].metadata.display is None:
-        tb[column_indicator].metadata.display = {}
-
-    zero_day = tb["date"].min()
-    tb[column_indicator].metadata.display["yearIsDay"] = True
-    tb[column_indicator].metadata.display["zeroDay"] = zero_day.strftime("%Y-%m-%d")
-
-    # Add column with number of days after zero_day
-    tb["year"] = (tb["date"] - zero_day).dt.days
-
-    # Drop date column
-    tb = tb.drop(columns=["date"])
-
-    return tb

--- a/lib/catalog/owid/catalog/core/meta.py
+++ b/lib/catalog/owid/catalog/core/meta.py
@@ -408,7 +408,8 @@ class VariableMeta(MetaBase):
     """Allowed fields for `display` attribute used for grapher:
         name
         zeroDay
-        yearIsDay
+        yearIsDay  # deprecated, use timeInterval instead
+        timeInterval  # one of: day, week, month, quarter, year, decade
         includeInTable
         numDecimalPlaces
         conversionFactor

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -717,7 +717,19 @@
       "yearIsDay": {
         "type": "boolean",
         "default": false,
-        "description": "Switch to indicate if the number in the year column represents a day (since zeroDay) or a year."
+        "description": "Deprecated: use `timeInterval` instead. Switch to indicate if the number in the year column represents a day (since zeroDay) or a year."
+      },
+      "timeInterval": {
+        "type": "string",
+        "description": "Interval that each value in the year/time column represents. Sub-yearly intervals (day, week, month, quarter) are encoded as days-since-`zeroDay` integers.",
+        "enum": [
+          "day",
+          "week",
+          "month",
+          "quarter",
+          "year",
+          "decade"
+        ]
       },
       "color": {
         "type": "string",


### PR DESCRIPTION
> _Written by Claude Code — @sophiamersmann at the wheel._

Stacked on #6370. Tags every dataset that used `yearIsDay` with `display.timeInterval: day`.

Metadata-only — the underlying days-since-`zeroDay` encoding is unchanged, so no new variable IDs and no ghost-variable remapping.

**Deliberately uniform `day`**: even datasets that are really weekly/monthly (`flu_yamagata`, `co2_air_transport`, `surface_temperature`, `weekly_wildfires`) are tagged `day`. Data owners can switch them to their true interval later — a one-line `timeInterval` change with no data impact.

Also: dropped redundant `yearIsDay: false` from dummy fixtures; `avian_influenza_ah5n1_year` loses its dead `add_num_days` helper (it already emits real yearly data — no change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)