### PR TITLE
🐛 Retry Admin API 401s to survive staging migration races

### DIFF
--- a/apps/chart_sync/admin_api.py
+++ b/apps/chart_sync/admin_api.py
@@ -289,7 +289,9 @@ class AdminAPI:
 def requests_with_retry() -> requests.Session:
     s = requests.Session()
     s.headers["User-Agent"] = USER_AGENT
-    retries = Retry(total=5, backoff_factor=1, status_forcelist=[500, 502, 503, 504])
+    # 401 is included because staging's admin API can transiently reject a valid key while
+    # grapher-build's DB migrations run concurrently with this build (see owid/ops#540).
+    retries = Retry(total=5, backoff_factor=1, status_forcelist=[401, 500, 502, 503, 504])
     s.mount("http://", HTTPAdapter(max_retries=retries))
     s.mount("https://", HTTPAdapter(max_retries=retries))
     return s


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

[owid/ops#540](https://github.com/owid/ops/issues/540) flagged a recurring `buildkite/etl-automated-staging-environment` failure on unrelated PRs — the "Build ETL catalog" step fails intermittently with `401 Unauthorized` from the grapher Admin API, even though `ADMIN_API_KEY` is valid and other calls in the same run succeed with it.

Root cause: in `.buildkite/etl/automated_staging_environment.yml`, the `etl-build` step (which pushes to the Admin API) only depends on `etl-update`, not on `grapher-build`. The two run concurrently. `grapher-build.sh`'s last action is `yarn runDbMigrations` against the same staging DB — if an Admin API request lands while a migration is briefly touching `admin_api_keys`/`users`, the key lookup can transiently see zero rows and the server correctly (from its point of view) returns a clean 401. This explains why some concurrent requests in the same run succeed and others fail with the identical token.

## Fix

Add `401` to the retry `status_forcelist` in `requests_with_retry()` (`apps/chart_sync/admin_api.py`), alongside the existing `500/502/503/504` — which already carry the comment "Retry in case we're restarting Admin on staging server". This covers `put_grapher_config`, `put_mdim_config`, and `put_explorer_config`, the calls that hit the failure in both observed builds ([#39697](https://buildkite.com/our-world-in-data/etl-automated-staging-environment/builds/39697), [#39715](https://buildkite.com/our-world-in-data/etl-automated-staging-environment/builds/39715)).

This is the quick mitigation, not a root-cause fix — the actual race (no dependency edge between `etl-build` and `grapher-build`/its migrations) still exists in `owid/ops`. Chosen for speed; happy to also fix the pipeline ordering in ops if wanted.

## Test plan

- [x] `make check` passes
- [ ] Watch the next few `etl-automated-staging-environment` builds for a drop in this specific 401 flake
