### PR TITLE
📜 update-dataset: auto-create /latest Google Doc, keep announcements out of PR, and captured lessons

### DIFF
--- a/.claude/skills/update-dataset/SKILL.md
+++ b/.claude/skills/update-dataset/SKILL.md
@@ -47,7 +47,7 @@ Assumptions:
 - [ ] Run indicator upgrade on staging and persist report
 - [ ] Update `update-context.yml` with published chart count and 1–3 chart views for the public announcement
 - [ ] Render Slack announcement via `data-updates-comms`, save to workbench, post `@codex review` as a separate PR comment, and notify user to post it to #data-updates-comms
-- [ ] Draft public-facing "Data update" post for OWID /latest, save to workbench, hand to user for review and publication
+- [ ] Draft public-facing "Data update" post for OWID /latest, get the user's sign-off on the markdown, create the Google Doc in /Data updates, and hand the user the link (not added to the PR)
 - [ ] Address Codex review comments (fix valid ones + resolve all threads)
 - [ ] Run downstream-dependency check (`rg "<namespace>/<old_version>/<short_name>" dag/ -g "*.yml" | grep -v "^dag/archive"`); for each consumer outside the dataset's own chain, decide with the user whether to bump in this PR or document under "Downstream dependencies" for a follow-up PR (see "Downstream dependency check" section below for details)
 - [ ] Ask the user whether to remove the old DAG entries; if yes, delete them and their files AND relocate the new entries into the old slot (see "Removing the old version & reordering the DAG") — don't forget this step
@@ -115,6 +115,10 @@ For the **long-format with dimensions** sub-case specifically (e.g. one row per 
        ```
        etl update snapshot://<ns>/<old_v>/<short>.<ext> --include-usages
        ```
+     - **Foundational / widely-used datasets (e.g. `wb/*/income_groups`, `regions`, `population`): add `--direct-only`.** Plain `--include-usages` follows usages *transitively* and would try to version-bump every downstream consumer (income_groups has ~85 across 15 dag files). `--direct-only` restricts the bump to steps sharing the dataset's own `namespace/version/short_name`, i.e. just its chain. Caveat: `--direct-only` **excludes sibling steps with a different short_name** that belong to the same chain (e.g. `income_groups_aggregations`, which the grapher step also depends on) — pass those as **extra seed steps** so the grapher doesn't end up mixing a new-version garden with an old-version sibling. Dry-run and confirm the proposed set is exactly the chain before executing:
+       ```
+       etl update snapshot://<ns>/<old_v>/<short>.<ext> data://garden/<ns>/<old_v>/<sibling> --include-usages --direct-only --dry-run
+       ```
      - If only garden logic / metadata is changing and the source data is unchanged, run from the **garden URI**. This bumps garden and grapher only; snapshot and meadow stay on the old version.
    - Either way, run `etl update` **once**. Don't call it separately per channel — that leaves stale version references in the DAG (e.g., new garden pointing to old meadow).
    - Perform help check, dry run, approval, then real execution; capture summary for later PR notes
@@ -170,6 +174,7 @@ For the **long-format with dimensions** sub-case specifically (e.g. one row per 
 4) Meadow step repair/verify (step-fixer subagent, channel=meadow)
    - Run, fix, re-run; produce diffs
    - Save diffs and summaries
+   - **Watch for meadow input checks keyed on absolute row/column positions.** Producers quietly restructure their files (e.g. this session, the WB dropped the legend rows above the first country, shifting the row count 239→234 and moving "Afghanistan" from row 10 to row 5). Data extraction that keys off content (drop rows without an id, then melt) survives, but hardcoded `tb.loc[N]` / exact-row-count asserts break — update them to the new positions/counts and drop a `# NOTE` so the next maintainer re-checks. The break is the check doing its job; don't loosen it into uselessness.
 
 5) Garden step repair/verify (step-fixer subagent, channel=garden)
    - Run, fix, re-run; produce diffs
@@ -498,6 +503,13 @@ For the **long-format with dimensions** sub-case specifically (e.g. one row per 
      ```bash
      STAGING=<branch> .venv/bin/etlr data://grapher/<namespace>/<new_version>/<short_name> --grapher --private
      ```
+     **Then confirm the variables actually landed in MySQL** — `data://grapher/... --grapher` sometimes only builds the feather without upserting (observed: 0 rows in `variables` afterward). If the count is 0, run the separate `grapher://` step, which does the MySQL upsert:
+     ```bash
+     # verify
+     STAGING=<branch> .venv/bin/python -c "from etl.config import OWIDEnv; print(OWIDEnv.from_staging('<branch>').read_sql(\"SELECT COUNT(*) n FROM variables WHERE catalogPath LIKE %(p)s\", params={'p':'%<namespace>/<new_version>/<short_name>%'}).n[0])"
+     # if 0, force the upsert:
+     STAGING=<branch> .venv/bin/etlr grapher://grapher/<namespace>/<new_version>/<short_name> --grapher --private
+     ```
    - Then run the automatic upgrader:
      ```bash
      STAGING=<branch> .venv/bin/etl indicator-upgrade auto
@@ -640,16 +652,17 @@ For the **long-format with dimensions** sub-case specifically (e.g. one row per 
    - Run the `data-updates-comms` skill with `workbench/<short_name>/update-context.yml` as input. `data-updates-comms` is the canonical owner of the Slack form wording, copy-paste format, editorial framing, search URL, and any standalone fallback gathering. Do not duplicate that rendering logic here.
    - Save the rendered draft to `workbench/<short_name>/slack-announcement.md`.
    - If `data-updates-comms` reports missing mechanical fields, gather them, update `update-context.yml`, and re-render rather than inventing values. Ask the user if a missing field requires judgment.
+   - **Do not put the announcement in the PR at all** — no embed and no pointer. The draft stays as the `workbench/<short_name>/slack-announcement.md` file (the user copies from there); comms drafts are internal and are kept out of the public data-update PR.
    - **Post `@codex review` as a separate PR comment** (not in the PR description) to trigger an automated code review. Use:
      ```bash
      gh pr comment <pr_number> --body "@codex review"
      ```
-   - Tell the user, with a **markdown link to the saved file** so they can click through to open it: `"Slack announcement drafted at [workbench/<short_name>/slack-announcement.md](workbench/<short_name>/slack-announcement.md). Please review and post it to #data-updates-comms."` Always render the path as a markdown link `[…](…)`, not as inline-code — the chat UI renders it as clickable that way.
+   - At the end of the update, tell the user, with a **markdown link to the saved file** so they can click through to open it: `"Slack announcement drafted at [workbench/<short_name>/slack-announcement.md](workbench/<short_name>/slack-announcement.md). Please review and post it to #data-updates-comms."` Always render the path as a markdown link `[…](…)`, not as inline-code — the chat UI renders it as clickable that way. (Slack can't be auto-posted — the user posts it.)
 
 9b) Data update post (for OWID /latest)
    Draft the short reader-facing post that gets published on [https://ourworldindata.org/latest](https://ourworldindata.org/latest). The team drafts these in **Google Docs** in the shared `/Data updates` Drive folder (`https://drive.google.com/drive/folders/1oL0uLHKI6f2qi1rJA6-qFFRYEBw_-rfm`), and OWID's CMS ingests the doc into the published feed.
 
-   **The skill's job is to produce paste-ready Google Doc content** in the exact CMS format the team uses (frontmatter `title` / `excerpt` / `type` / `authors` / `kicker` → `\[+body\]` marker → body prose with inline markdown links → `{.cta}` block → `{.image}` block → `\[\]` end marker). Don't invent your own format — every published post in the Drive folder follows the same shape.
+   **The skill's job is to produce paste-ready Google Doc content** in the exact CMS format the team uses (frontmatter `title` / `excerpt` / `type` / `authors` / `kicker` → `[+body]` marker → body prose with inline markdown links → `{.cta}` block → `{.image}` block → `[]` end marker). Don't invent your own format — every published post in the Drive folder follows the same shape.
 
    This is **separate from the Slack announcement** — that one is a 10-field form for the internal channel; this one is a mini-blog-post for OWID readers, and the format is structured for CMS ingestion.
 
@@ -668,7 +681,15 @@ For the **long-format with dimensions** sub-case specifically (e.g. one row per 
    - **CTA text** — descriptive: "Explore the updated data in our interactive charts" (default), "Explore all of the updated data in our interactive charts" (broad), "Explore the interactive version of this chart" (single chart), "Explore this data going back to YYYY in our interactive chart" (single chart with date depth).
    - **Image filename** — `YYYY-MM-data-update-<slug>.png` (e.g. `2026-04-data-update-h5n1-flu.png`). The skill doesn't generate the image; the user adds it to the Doc separately.
    - Save the draft to `workbench/<short_name>/data-update.md`.
-   - Tell the user, with a **markdown link to the saved file** so they can click through to open it: `"Data update post drafted at [workbench/<short_name>/data-update.md](workbench/<short_name>/data-update.md) in the Google Docs CMS format. Please create a new Google Doc in /Data updates, paste the draft, attach the chart screenshot, and share for review."` Always render `workbench/<short_name>/data-update.md` as a markdown link `[…](…)` rather than as a bare path or inline-code path — the chat UI renders it as clickable that way.
+   - **Propose the draft as markdown and get sign-off before creating the Doc.** Show the user the full post rendered as markdown (in chat) so they can read it and request edits inline, and ask whether they're happy to publish it as a Google Doc. Iterate on `workbench/<short_name>/data-update.md` until they approve — *then* create the Doc. This ordering matters: the Drive API can't edit or delete a Doc once created, so getting the content approved first avoids orphaned drafts. (Like the Slack draft, the /latest post is **not** added to the PR.)
+   - **Once the user approves, create the Google Doc** in the `/Data updates` folder so they don't have to copy-paste, using the Drive MCP `create_file` tool. Match the folder's title convention (e.g. "2026-06 Data update: Homicides").
+     - **Upload styled HTML** (`contentMimeType: "text/html"`), applying the OWID CMS colors and indents from the template's "OWID CMS Doc styling" table (blue keys, black frontmatter values, grey body, orange `[+body]`/`[]`, green `{...}` markers, blue-underline links; body indent 10pt, `url:`/`text:`/`filename:` 20pt). Verified: HTML import preserves colors + `margin-left` indents + hyperlinks, and lands a fully-styled doc that needs no add-on pass. This is preferred over a `text/markdown` upload (which gives hyperlinks but no OWID colors/indents).
+     - **Encode all non-ASCII as HTML entities** (e.g. `&mdash;` for an em-dash). Entities decode correctly on import; **raw 4-byte chars (emoji) mojibake** to `ð`, so use the entity form (`&#NNNNN;`) if you ever need one.
+     - Each CMS line is its own `<p>` (one paragraph per line, no empty "spacer" paragraphs — the team's docs are compact). Empty `<p></p>` between sections is fine and matches the reference docs.
+     - **Verify** with `download_file_content(exportMimeType="text/html")` and confirm the `color:` / `margin-left:` styles survived. The MCP has **no delete or edit-content tool**, so get it right on the first `create_file`; a bad create leaves an orphan Doc the user must delete manually — don't recreate on a trivial issue (tell the user the one-line fix instead).
+     - The **OWID GDocs Add-on** (Extensions menu in the Doc) is the team's canonical formatter; it can't be run via the API, so it's an optional human validation pass on top of the styled upload. If the shared folder rejects the write, create in My Drive and share the link.
+   - **Register the Doc in the CMS.** A Google Doc only reaches the `/latest` feed once it's added at the OWID admin GDocs page — [https://admin.owid.io/admin/gdocs](https://admin.owid.io/admin/gdocs) — where the doc ID is registered so it can be previewed and published. This is a human action (admin login required); the skill can't do it via the API, so include it in the handoff.
+   - At the end of the update, tell the user with **markdown links** to both the created Doc and the local draft, and **make clear it's a first draft for people to modify** (not a finished post): `"Data update post created at [<Doc title>](<doc viewUrl>) in /Data updates — this is a first draft for you and the team to review and edit. Please refine the copy as needed, add the chart screenshot, add the doc at https://admin.owid.io/admin/gdocs to bring it into the CMS, then preview, publish, and share. Draft source: [workbench/<short_name>/data-update.md](workbench/<short_name>/data-update.md)."`
 
 10) Codex review: address comments and resolve threads
    - **Codex's delivery channel depends on the verdict — poll both.** A **clean pass** arrives as an *issue comment* ("Didn't find any major issues") from `chatgpt-codex-connector[bot]`, with zero inline comments and no formal review object. A review **with findings** arrives as a formal review ("💡 Codex Review") with inline comments, and *no* issue comment. A watcher polling only one channel waits forever on the other outcome — treat a hit on either as completion.
@@ -718,9 +739,14 @@ rg "<namespace>/<old_version>/<short_name>" dag/ -g "*.yml" | grep -v "^dag/arch
 
 Filter out the old dataset's own DAG entries (snapshot → meadow → garden → grapher chain). Any remaining references are **downstream dependents** that still point to the old version.
 
-If downstream dependents exist:
-- **Tell the user** which datasets depend on the old version and need updating in a follow-up PR
-- **Add a "Downstream dependencies" section to the PR description** (not collapsed — this is important) listing the dependent datasets with a note that they should be updated to point to the new version in a follow-up PR
+If downstream dependents exist, **decide with the user** whether to bump them in this PR or defer to a follow-up:
+- **Tell the user** which datasets depend on the old version.
+- **Follow-up PR (default for a big fan-out):** add a "Downstream dependencies" section to the PR description (not collapsed) listing the dependents, to be repointed in a separate PR. This mirrors the historical two-PR pattern for foundational datasets (e.g. income_groups: chain-update PR, then a "🐝 Update all datasets to latest …" bulk-bump PR).
+- **Bump in this PR (if the user wants it self-contained):** repoint every downstream ref and remove/archive the old chain in the same PR. Mechanics that bit this session:
+  - Bulk-replace with a **negative-lookahead** so a prefix match doesn't corrupt sibling short_names — e.g. `re.sub(r"garden/wb/<old_v>/income_groups(?!_)", "garden/wb/<new_v>/income_groups", text)` leaves `income_groups_aggregations` alone.
+  - **Remove the old own-chain block from `dag/main.yml` *before* the bulk sweep**, or the sweep turns the old definition into a duplicate of the new key. Relocate the new block into the old slot (nested form) as part of the same edit.
+  - Downstream datasets **keep their own version and variable IDs** — only their *dependency* on the updated dataset changes — so **no chart remapping is needed for them**; their aggregates just recompute against the new data (visible in Chart Diff). The indicator upgrade (step 7) still only concerns charts that use the updated dataset's *own* variables.
+  - This is the only case where "Removing the old version" happens in the same PR — otherwise the old chain must stay until the follow-up repoints its consumers.
 
 ## Removing the old version & reordering the DAG
 
@@ -729,6 +755,7 @@ After the ETL update, `etl update` appends the new version entries to the **bott
 Workflow when the user agrees:
 
 1. **Delete the old version.** Remove its entries (snapshot → meadow → garden → grapher) from the main DAG file (e.g., `dag/poverty_inequality.yml`) and delete its files (`etl/steps/...`, `snapshots/...`). The archive dag (`dag/archive/*.yml`) is **not** edited by hand — `etl archive-dag` reconstructs it from git history, recording each removed step with the commit where it was last active (for recovery via `git checkout`).
+   - **`etl archive-dag` reconciles the *entire* archive, not just your dataset.** If the archive was stale, one run can append **hundreds of unrelated lines** (e.g. this session pulled in ~180 lines across `climate.yml`/`education.yml`/etc. plus marker comments) — noise that doesn't belong in a data-update PR and that Codex will question. Keep the commit scoped: after running it, `git checkout -- dag/archive/` to drop the unrelated files, then re-add **only** your dataset's block to `dag/archive/main.yml` (copy the exact entry `archive-dag` generated, including its `# archived; last active in <sha> on <date>` marker). The block you keep is genuine tool output, so it stays consistent with future full regenerations.
 2. **Move the new entries into the old slot** so the dataset stays grouped with its neighbours and section comment. The new entries should not remain at the bottom of the main DAG.
 3. Preserve the original section comment (same indentation as the old block) above the new entries.
 4. **Prefer the nested (compact) DAG format.** `etl update` emits the *flat* form (each step a separate top-level key with a flat dep list); the loader (`etl/dag_helpers.py:_parse_dag_yaml`) also accepts the **nested** form, where the chain is declared inline and flattens to the same graph. The nested form is the team's preferred style and is usually what the archived old block already used:

--- a/.claude/skills/update-dataset/data-update-template.md
+++ b/.claude/skills/update-dataset/data-update-template.md
@@ -1,6 +1,6 @@
 # Data Update Post Template (for OWID /latest)
 
-Use this template to draft the short reader-facing post that gets published on [https://ourworldindata.org/latest](https://ourworldindata.org/latest) when a dataset refresh ships. **The published format is a Google Doc** that gets ingested by OWID's CMS — the doc has structured frontmatter fields (`title`, `excerpt`, `type`, `authors`, `kicker`), a `\[+body\]` marker, body prose, and trailing `{.cta}` and `{.image}` blocks. The skill should produce output in **exactly that format** so the runner can paste it into a new Google Doc in the team's `/Data updates` Drive folder.
+Use this template to draft the short reader-facing post that gets published on [https://ourworldindata.org/latest](https://ourworldindata.org/latest) when a dataset refresh ships. **The published format is a Google Doc** that gets ingested by OWID's CMS — the doc has structured frontmatter fields (`title`, `excerpt`, `type`, `authors`, `kicker`), a `[+body]` marker, body prose, and trailing `{.cta}` and `{.image}` blocks. The skill should produce output in **exactly that format** so the runner can paste it into a new Google Doc in the team's `/Data updates` Drive folder.
 
 This is **separate from the Slack announcement** — that one is a 10-field form for the internal #data-updates-comms channel; this one is a mini-blog-post for OWID readers. They share editorial content but live in different formats.
 
@@ -10,16 +10,38 @@ Hand the draft to the user for review and publication. The skill does not presum
 
 ---
 
+## Keep the style in sync (re-check ~monthly)
+
+The `/latest` house style drifts over time (title shape, `kicker` value, body length, closing line). The **source of truth is the team's `/Data updates` Drive folder**: https://drive.google.com/drive/folders/1oL0uLHKI6f2qi1rJA6-qFFRYEBw_-rfm
+
+**Conventions last verified against the folder: 2026-07-01.**
+
+When you draft a `/latest` post (step 9b of `update-dataset`), check the date above. **If more than a month has passed**, first read the **5 most recent** docs in that folder, reconcile the guidance in this file with what they actually do, then update this template and bump the "last verified" date. Reconcile at least:
+
+- `kicker` value (currently `data-update`, lowercase-hyphenated)
+- title shape (question / action / finding — currently mostly questions)
+- `excerpt` pattern
+- body length and shape, and the closing "I recently updated our charts … + cadence" line
+- `{.cta}` URL/text conventions
+
+Reading the folder: the Google Drive `parentId` search often returns nothing for this shared drive — fall back to `fullText contains 'datasetProducts'` (matches the search-URL CTA) or `title contains '<recent dataset>'` to surface the docs, then `read_file_content` each.
+
+---
+
 ## Template (paste-ready for a new Google Doc)
 
 ```
+:skip
+preview
+:endskip
+
 title: [Punchy title — a finding/claim, a question, or an action/invitation. Examples: "Nearly one in ten people worldwide still live in extreme poverty", "How much do governments spend, and what do they spend it on?", "Track confirmed human cases of H5N1 'bird flu' since 1997". NOT just the dataset name.]
 excerpt: [One short sentence summary that's distinct from the title. Common patterns: "Explore updated data from <producer>." / "Explore updated data on <topic> from <producer>." / "Track <topic descriptor>." / "We've updated <N> charts with the latest data from <producer>." / "We updated nearly N of our charts with the latest data."]
 type: announcement
 authors: [Author name(s). Comma-separated for co-authors, e.g. "Hannah Ritchie, Edouard Mathieu".]
-kicker: Data update
+kicker: data-update
 
-\[+body\]
+[+body]
 
 [Body — 100–200 words of flowing prose, first-person, conversational. Recipe (mirroring the published examples — ATUS, PIP, NVIDIA, OECD Government at a Glance, UNU-WIDER, robots, ozone, mobile money, fertilizers, democracy, WASH):
 
@@ -49,28 +71,44 @@ text: [Descriptive link text. One of:
 - "Explore the data in our new interactive chart" (new chart/MDIM)]
 {}
 
-:skip
-**👉 Add a picture here.** Attach a chart screenshot to the Google Doc and use the filename below.
-:endskip
-
 {.image}
 filename: [YYYY-MM-data-update-<slug>.png — a chart screenshot the user adds to the Doc separately. The slug is a short, lowercase-hyphenated topic tag, e.g. world-bank-pip, nvidia-revenue, h5n1-flu, govt-revenue, ozone-hole, robots-per-worker.]
 {}
 
-\[\]
+[]
 ```
 
-The `\[+body\]` and `\[\]` markers use backslash-escaped brackets — that's how they appear in the published Google Docs (the escapes prevent Google Docs' auto-link rendering from collapsing the brackets). Keep the escapes when pasting into the Doc; the OWID CMS strips them on ingest.
+The `[+body]` and `[]` markers are plain brackets — do **not** add backslash escapes to them. (Any backslashes that show up in a `read_file_content` dump are an artifact of that markdown representation, not the real Doc content.) The OWID CMS reads the plain markers directly.
 
-**Spacing rules** the team prefers (different from the raw Google Docs export, which inserts paragraph breaks everywhere):
+**Formatting the Google Doc — use the OWID GDocs Add-on.** OWID has a Google Docs Add-on (Extensions menu in the Doc) that formats these CMS docs into the right shape. Rely on it to finalize the doc rather than hand-tuning spacing. The **finished Doc is compact: every line is its own paragraph with no empty "spacer" paragraphs between them** — frontmatter fields, the `[+body]` marker, body paragraphs, and the `{.cta}`/`{.image}` blocks are all consecutive (Google Docs uses one paragraph per Enter, so blank lines are not needed and read as empty paragraphs to delete).
+
+**Spacing rules for the paste-ready *markdown draft*** (this file's output — the source you paste in or upload; the Add-on / import then collapses it to the compact Doc form above):
 
 - **Frontmatter section** (`title:` through `kicker:`) — one field per line, **no blank lines** between fields.
-- **Body** — keep blank lines between paragraphs.
+- **Body** — keep blank lines between paragraphs (so markdown treats each as its own paragraph).
 - **`{.cta}` and `{.image}` blocks** — opening tag, fields, closing tag all on consecutive lines with **no blank lines inside**. Keep one blank line between the body and `{.cta}`, and between `{.cta}` and `{.image}`.
+- **When auto-creating the Doc via the Drive `create_file` API** (skill step 9b): don't insert blank spacer lines to force paragraph separation — they become empty paragraphs the user must delete. Upload with single newlines and let the OWID GDocs Add-on finalize the formatting.
+
+### OWID CMS Doc styling — colors & indents (reproducible via an HTML upload)
+
+The OWID GDocs Add-on colors and indents these docs. You can reproduce that styling **directly on `create_file`** by uploading `contentMimeType: "text/html"` with the inline styles below (verified: Google Docs' HTML import preserves the colors, the `margin-left` indents, hyperlinks, and — crucially — decodes HTML **entities**, so `&mdash;` → "—" and `&#128073;` → "👉" come through clean, unlike raw 4-byte chars in a markdown upload which mojibake). This lands a fully-styled doc that needs no add-on pass. The scheme (extracted from a correctly-formatted doc, e.g. Homicides):
+
+| Element | Text color | Left indent |
+|---|---|---|
+| Field keys (`title: `, `excerpt: `, `type: `, `authors: `, `kicker: `, `url: `, `text: `, `filename: `) | blue `#0094ff` | — |
+| Frontmatter **values** (title/excerpt/type/authors/kicker) | black `#000000` | 0 |
+| `[+body]` and `[]` | orange `#f47835` | 0 |
+| Body paragraphs, and `url:`/`text:`/`filename:` **values** | grey `#666666` | body 10pt; url/text/filename 20pt |
+| `{.cta}`, `{}`, `{.image}` | green `#23974a` | 10pt |
+| Inline links | blue `#1155cc`, underlined | — |
+
+Per-line HTML shape: `<p style="margin-left:10pt"><span style="color:#666666">…</span></p>`; links `<a href="…" style="color:#1155cc;text-decoration:underline">…</a>`; encode all non-ASCII as HTML entities. Verify afterward with `download_file_content(exportMimeType="text/html")` and check the `color:` / `margin-left:` survived. (If OWID changes the scheme, re-extract it from a recent correctly-formatted doc rather than trusting these hex values.)
 
 ---
 
 ## Field-by-field guidance
+
+**Top `:skip` / `preview` / `:endskip` block** — Sits at the very top of the doc, before the frontmatter. It's a `:skip` block (not published) that holds the doc's preview link — paste the admin GDoc preview URL (from [https://admin.owid.io/admin/gdocs](https://admin.owid.io/admin/gdocs) once the doc is registered) in place of the literal word `preview`. Keep the literal `preview` placeholder in the paste-ready template.
 
 **`title`** — A punchy claim, a question, or an action/invitation. The title is the part that pulls readers into the feed; "Luxembourg Income Study" is descriptive but unmemorable. Three observed patterns:
 
@@ -92,9 +130,9 @@ If the dataset doesn't lend itself to a single headline finding, the question fo
 
 **`authors`** — The person who did the work, by name. Comma-separated for co-authors. Pull from the user (or the slack-announcement.md draft if it lists one).
 
-**`kicker`** — Always `Data update`. (One example used `Data Update` with capital U — both work; lowercase `update` matches the more recent posts.)
+**`kicker`** — Use `data-update` (lowercase, hyphenated). This is the current convention — all five most recent posts as of July 2026 (oil spills, homicides, wildfires, democracy, SIPRI) use `kicker: data-update`. Older posts used `Data update` / `Data Update`; the CMS accepts those too, but match the current lowercase-hyphenated form.
 
-**`\[+body\]`** — Literal marker. Always sits between the frontmatter and the body. Keep the backslash escapes.
+**`[+body]`** — Literal marker (plain brackets, no backslashes). Always sits between the frontmatter and the body.
 
 **Body voice** — First-person, conversational, author voice. The post reads like the person who did the work telling you about it. **Not** corporate ("OWID has updated…" is wrong); **yes** "I recently updated…", "I've just updated…", "I just updated…", or "We recently updated…" / "We've just updated…" for joint work.
 
@@ -132,11 +170,11 @@ For releases that meaningfully extend coverage (new countries, new years), the u
 
 The `text:` is descriptive — see the patterns under "Field-by-field guidance" above.
 
-**`{.image}` block** — Filename of the chart screenshot. Pattern: `YYYY-MM-data-update-<slug>.png`. The image itself isn't generated by the skill; it's added to the Google Doc separately by the user. The skill just fills in the expected filename so the slot is reserved. **Always precede the `{.image}` block with a `:skip … :endskip` wrapped "👉 Add a picture here" reminder line** so the user notices the slot when copy-pasting into the Doc, and so the reminder won't leak to the published post if the user forgets to remove it.
+**`{.image}` block** — Filename of the chart screenshot. Pattern: `YYYY-MM-data-update-<slug>.png`. The image itself isn't generated by the skill; the user adds the screenshot to the Google Doc separately, so the skill just fills in the expected filename to reserve the slot. Don't add a `:skip`-wrapped "add a picture" reminder to the doc — the real published docs don't use one; just tell the user to add the screenshot in the handoff message.
 
-**`\[\]`** — Literal end-of-post marker. Always sits at the very end of the published content.
+**`[]`** — Literal end-of-post marker. Always sits at the very end of the published content.
 
-**Optional `:skip` ... `:endskip` block (after `\[\]`)** — For paragraphs the author drafted but cut from the final version. Won't be published. The skill should NOT generate `:skip` content automatically; it's a human editing tool. Mention it only if the user asks how to keep deleted material around.
+**Optional `:skip` ... `:endskip` block (after `[]`)** — For paragraphs the author drafted but cut from the final version. Won't be published. The skill should NOT generate `:skip` content automatically; it's a human editing tool. Mention it only if the user asks how to keep deleted material around.
 
 ---
 
@@ -153,7 +191,7 @@ type: announcement
 authors: Veronika Samborska
 kicker: Data update
 
-\[+body\]
+[+body]
 
 [Most of the chips](https://epoch.ai/data/ai-chip-sales?view=graph&tab=h100_equivalents&proportion=share&viewType=designer) used to train and run AI models come from NVIDIA. This makes NVIDIA's data center & AI revenue one of the clearest public figures available for tracking demand for AI hardware.
 
@@ -172,7 +210,7 @@ text: Explore this data going back to 2014 in our interactive chart
 filename: 2026-04-data-update-nvidia-revenue.png
 {}
 
-\[\]
+[]
 ```
 
 ### Action-titled, with caveat and quarterly cadence (H5N1, ~135 words)
@@ -184,7 +222,7 @@ type: announcement
 authors: Lucas Rodés-Guirao
 kicker: Data update
 
-\[+body\]
+[+body]
 
 Avian influenza A (H5N1), often referred to as "bird flu", is a subtype of influenza virus that infects birds and mammals. In rare cases, humans can also be infected.
 
@@ -205,7 +243,7 @@ text: Explore the updated data in our interactive chart
 filename: 2026-04-data-update-h5n1-flu.png
 {}
 
-\[\]
+[]
 ```
 
 ### Finding-titled, with cross-reference (World Bank PIP, ~190 words)
@@ -217,7 +255,7 @@ type: announcement
 authors: Pablo Arriagada
 kicker: Data update
 
-\[+body\]
+[+body]
 
 How many people live in poverty around the world, and how has that changed over the last decades?
 
@@ -242,5 +280,5 @@ text: Explore all of the updated data in our interactive charts
 filename: 2026-04-data-update-world-bank-pip.png
 {}
 
-\[\]
+[]
 ```


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

Documentation-only changes to the `update-dataset` skill and its `/latest` data-update template, **split out of the income_groups data PR ([#6369](https://github.com/owid/etl/pull/6369))** so that PR stays focused on the data.

## What changed

**`/latest` data-update post workflow (step 9b)**
- Propose the draft as **markdown for sign-off first**, then **auto-create a fully-styled Google Doc** in `/Data updates` via the Drive `create_file` API — `text/html` upload reproduces the OWID CMS colors/indents (verified round-trip), HTML entities for non-ASCII to avoid emoji mojibake.
- **Register the doc at `admin.owid.io/admin/gdocs`** to reach the `/latest` feed; hand the user the link framed as a **first draft** to edit.
- Announcements are **kept out of the PR** (aligns with #6368) — Slack + /latest drafts stay in `workbench/`.

**Template**
- `kicker` convention is `data-update` (lowercase-hyphenated).
- Dated **~monthly style-sync check** against the `/Data updates` folder (re-read the 5 most recent posts, reconcile, bump the date).
- Compact finished-doc form + an **OWID CMS styling table** (colors/indents) + plain `[+body]`/`[]` markers; dropped the `:skip` picture reminder.

**Lessons captured from the income_groups run (SKILL.md)**
- `etl update --include-usages --direct-only` (+ sibling seed) for foundational/widely-used datasets so the bump doesn't cascade into every consumer.
- Meadow input checks keyed on absolute row positions break when a producer restructures the file — update positions/counts + `# NOTE`.
- Verify the `grapher://` MySQL upsert actually landed (a `data://grapher --grapher` run may only build the feather).
- In-PR downstream-bump mechanics (negative-lookahead replace; remove the old own-chain before the sweep; downstream keeps its own variable IDs so no chart remap).
- `etl archive-dag` reconciles the **whole** archive — scope the commit to your dataset's block.

No code or data changes; no pipeline impact.
