### PR TITLE
🔨 Move catalog dataset landing pages to stable short URLs

### DIFF
--- a/etl/catalog_jsonld/artifacts.py
+++ b/etl/catalog_jsonld/artifacts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -17,8 +18,8 @@ from owid.catalog.core.meta import TableMeta, VariableMeta
 from owid.catalog.schema_org import DEFAULT_CATALOG_BASE_URL, TableSchemaInput, dataset_to_schema_org
 from structlog import get_logger
 
-from etl.catalog_jsonld.quality import DatasetQualityResult, assess_dataset_quality
-from etl.catalog_jsonld.sitemap import sitemap_xml
+from etl.catalog_jsonld.quality import DatasetQualityResult, assess_dataset_quality, find_duplicate_short_key_paths
+from etl.catalog_jsonld.sitemap import SitemapEntry, sitemap_xml
 from etl.paths import DATA_DIR
 
 log = get_logger()
@@ -27,10 +28,31 @@ QUALITY_REPORT_FILENAME = "jsonld_quality_report.json"
 SITEMAP_FILENAME = "sitemap.xml"
 DATASET_JSONLD_FILENAME = "dataset.jsonld"
 
+_VERSION_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+@dataclass(frozen=True)
+class LatestDatasetPath:
+    """One resolved ``<namespace>/<dataset>`` entry: its full catalog path, and version.
+
+    ``catalog_path`` is the dated catalog-folder path (e.g. ``garden/emissions/2025-12-04/owid_co2``).
+    ``short_key`` is the stable, version-agnostic public page key (e.g. ``emissions/owid_co2``).
+    """
+
+    catalog_path: str
+    namespace: str
+    dataset: str
+    version: str
+
+    @property
+    def short_key(self) -> str:
+        return f"{self.namespace}/{self.dataset}"
+
 
 @dataclass
 class JsonLdBuildResult:
     emitted: list[str] = field(default_factory=list)
+    emitted_entries: list[LatestDatasetPath] = field(default_factory=list)
     skipped: list[DatasetQualityResult] = field(default_factory=list)
     warnings: list[DatasetQualityResult] = field(default_factory=list)
 
@@ -45,53 +67,85 @@ def build_catalog_jsonld_artifacts(
 ) -> JsonLdBuildResult:
     """Generate dataset JSON-LD files, sitemap, and quality report locally.
 
-    When ``only`` is given, restrict generation to datasets whose
-    ``"<namespace>/<dataset>"`` is in the set (version-agnostic allowlist).
+    JSON-LD files are written to a stable, version-agnostic short-key tree
+    (``catalog_dir / "<namespace>" / "<dataset>" / "dataset.jsonld"``) rather than inside the
+    dataset's own dated catalog folder, so the public landing page URL doesn't change every
+    time the dataset gets a new version. When ``only`` is given, restrict generation to
+    datasets whose ``"<namespace>/<dataset>"`` is in the set (version-agnostic allowlist).
     """
     catalog = LocalCatalog(catalog_dir, channels=(channel,))
     latest_paths = latest_dataset_paths(catalog.frame, channel=channel, only=only)
     result = JsonLdBuildResult()
-    sitemap_urls = []
+    sitemap_entries: list[SitemapEntry] = []
+    build_date = datetime.now(timezone.utc).date().isoformat()
 
-    for catalog_path in latest_paths:
+    duplicate_catalog_paths = find_duplicate_short_key_paths(
+        (entry.catalog_path, entry.namespace, entry.dataset) for entry in latest_paths
+    )
+
+    for entry in latest_paths:
+        catalog_path = entry.catalog_path
         ds = Dataset(catalog_dir / catalog_path)
         tables = load_table_schema_inputs(ds)
-        quality = assess_dataset_quality(catalog_path=catalog_path, dataset_meta=ds.metadata, tables=tables)
+        quality = assess_dataset_quality(
+            catalog_path=catalog_path,
+            namespace=entry.namespace,
+            dataset_meta=ds.metadata,
+            tables=tables,
+            duplicate_short_key=catalog_path in duplicate_catalog_paths,
+        )
         if not quality.is_eligible:
             result.skipped.append(quality)
             if not dry_run:
-                stale_jsonld = Path(ds.path) / DATASET_JSONLD_FILENAME
-                if stale_jsonld.exists():
-                    stale_jsonld.unlink()
+                _remove_if_exists(Path(ds.path) / DATASET_JSONLD_FILENAME)
             continue
 
         jsonld = dataset_to_schema_org(
             dataset_path=catalog_path,
+            page_path=entry.short_key,
+            version=entry.version,
             dataset_meta=ds.metadata,
             tables=tables,
             base_url=base_url,
         )
         result.emitted.append(catalog_path)
+        result.emitted_entries.append(entry)
         if quality.warnings or quality.table_warnings:
             result.warnings.append(quality)
 
-        sitemap_urls.append(f"{base_url.rstrip('/')}/{catalog_path}/")
+        sitemap_entries.append(
+            SitemapEntry(
+                url=f"{base_url.rstrip('/')}/{entry.short_key}/",
+                lastmod=entry.version if _VERSION_DATE_RE.match(entry.version) else build_date,
+            )
+        )
         if not dry_run:
-            with open(Path(ds.path) / DATASET_JSONLD_FILENAME, "w") as ostream:
+            # The dataset used to be served at its dated catalog-folder path; that location is
+            # no longer written to, so clean up anything left over from a prior publish.
+            _remove_if_exists(Path(ds.path) / DATASET_JSONLD_FILENAME)
+
+            target_dir = catalog_dir / entry.namespace / entry.dataset
+            target_dir.mkdir(parents=True, exist_ok=True)
+            with open(target_dir / DATASET_JSONLD_FILENAME, "w") as ostream:
                 json.dump(jsonld, ostream, indent=2, ensure_ascii=False)
                 ostream.write("\n")
 
     if not dry_run:
-        (catalog_dir / SITEMAP_FILENAME).write_text(sitemap_xml(sitemap_urls))
+        (catalog_dir / SITEMAP_FILENAME).write_text(sitemap_xml(sitemap_entries))
         (catalog_dir / QUALITY_REPORT_FILENAME).write_text(json.dumps(quality_report(result), indent=2) + "\n")
 
     return result
 
 
+def _remove_if_exists(path: Path) -> None:
+    if path.exists():
+        path.unlink()
+
+
 def latest_dataset_paths(
     frame: pd.DataFrame, *, channel: CHANNEL = "garden", only: set[str] | None = None
-) -> list[str]:
-    """Return latest public dataset-folder paths for a catalog channel.
+) -> list[LatestDatasetPath]:
+    """Return latest public dataset entries for a catalog channel.
 
     Private datasets are always excluded (``is_public == True`` filter). When ``only`` is
     provided, the result is further restricted to datasets whose ``"<namespace>/<dataset>"``
@@ -115,7 +169,16 @@ def latest_dataset_paths(
             log.warning("catalog_jsonld.allowlist_entry_unmatched", dataset=dataset_key, channel=channel)
         latest = latest[latest["dataset_key"].isin(only)]
 
-    return sorted(latest["dataset_path"].unique().tolist())
+    entries = [
+        LatestDatasetPath(
+            catalog_path=str(row.dataset_path),
+            namespace=str(row.namespace),
+            dataset=str(row.dataset),
+            version=str(row.version),
+        )
+        for row in latest.itertuples()
+    ]
+    return sorted(entries, key=lambda entry: entry.catalog_path)
 
 
 def load_table_schema_inputs(ds: Dataset) -> list[TableSchemaInput]:

--- a/etl/catalog_jsonld/artifacts.py
+++ b/etl/catalog_jsonld/artifacts.py
@@ -54,6 +54,7 @@ class JsonLdBuildResult:
     emitted: list[str] = field(default_factory=list)
     emitted_entries: list[LatestDatasetPath] = field(default_factory=list)
     skipped: list[DatasetQualityResult] = field(default_factory=list)
+    skipped_entries: list[LatestDatasetPath] = field(default_factory=list)
     warnings: list[DatasetQualityResult] = field(default_factory=list)
 
 
@@ -77,7 +78,6 @@ def build_catalog_jsonld_artifacts(
     latest_paths = latest_dataset_paths(catalog.frame, channel=channel, only=only)
     result = JsonLdBuildResult()
     sitemap_entries: list[SitemapEntry] = []
-    build_date = datetime.now(timezone.utc).date().isoformat()
 
     duplicate_catalog_paths = find_duplicate_short_key_paths(
         (entry.catalog_path, entry.namespace, entry.dataset) for entry in latest_paths
@@ -96,8 +96,13 @@ def build_catalog_jsonld_artifacts(
         )
         if not quality.is_eligible:
             result.skipped.append(quality)
+            result.skipped_entries.append(entry)
             if not dry_run:
                 _remove_if_exists(Path(ds.path) / DATASET_JSONLD_FILENAME)
+                # A prior build may have emitted this dataset at its stable short key;
+                # remove the local copy so it can't linger after the dataset stops
+                # being eligible (the R2 copy is deleted by the publish step).
+                _remove_if_exists(catalog_dir / entry.namespace / entry.dataset / DATASET_JSONLD_FILENAME)
             continue
 
         jsonld = dataset_to_schema_org(
@@ -116,7 +121,10 @@ def build_catalog_jsonld_artifacts(
         sitemap_entries.append(
             SitemapEntry(
                 url=f"{base_url.rstrip('/')}/{entry.short_key}/",
-                lastmod=entry.version if _VERSION_DATE_RE.match(entry.version) else build_date,
+                # Non-date versions (e.g. "latest") carry no real modification date; omit
+                # lastmod rather than stamping the build date, which would falsely mark the
+                # page as modified on every publish.
+                lastmod=entry.version if _VERSION_DATE_RE.match(entry.version) else None,
             )
         )
         if not dry_run:

--- a/etl/catalog_jsonld/publish.py
+++ b/etl/catalog_jsonld/publish.py
@@ -48,10 +48,19 @@ def build_and_publish_catalog_jsonld(
         )
         return
 
-    keys = [f"{path}/{DATASET_JSONLD_FILENAME}" for path in result.emitted]
+    # Datasets are now served at their stable "<namespace>/<dataset>" short key rather than
+    # their dated catalog path.
+    keys = [f"{entry.short_key}/{DATASET_JSONLD_FILENAME}" for entry in result.emitted_entries]
     keys.extend([SITEMAP_FILENAME, QUALITY_REPORT_FILENAME])
-    stale_keys = [f"{item.catalog_path}/{DATASET_JSONLD_FILENAME}" for item in result.skipped]
-    sync_jsonld_artifacts(connect_r2(), bucket, catalog_dir, keys, delete_keys=stale_keys)
+
+    # Delete the old dated-path dataset.jsonld for every currently-emitted dataset: it's no
+    # longer written locally (superseded by the short key above), but a prior publish may
+    # still have left it live on R2, which would otherwise sit around as duplicate content.
+    delete_keys = [f"{entry.catalog_path}/{DATASET_JSONLD_FILENAME}" for entry in result.emitted_entries]
+    # Also delete stale dated-path dataset.jsonld for datasets that newly failed the quality gate.
+    delete_keys.extend(f"{item.catalog_path}/{DATASET_JSONLD_FILENAME}" for item in result.skipped)
+
+    sync_jsonld_artifacts(connect_r2(), bucket, catalog_dir, keys, delete_keys=delete_keys)
 
 
 def sync_jsonld_artifacts(

--- a/etl/catalog_jsonld/publish.py
+++ b/etl/catalog_jsonld/publish.py
@@ -57,8 +57,11 @@ def build_and_publish_catalog_jsonld(
     # longer written locally (superseded by the short key above), but a prior publish may
     # still have left it live on R2, which would otherwise sit around as duplicate content.
     delete_keys = [f"{entry.catalog_path}/{DATASET_JSONLD_FILENAME}" for entry in result.emitted_entries]
-    # Also delete stale dated-path dataset.jsonld for datasets that newly failed the quality gate.
+    # Also delete both locations for datasets that newly failed the quality gate: the stale
+    # dated-path copy, and the live short-key copy a prior publish may have emitted — a
+    # dataset that becomes ineligible (e.g. non_redistributable) must stop being served.
     delete_keys.extend(f"{item.catalog_path}/{DATASET_JSONLD_FILENAME}" for item in result.skipped)
+    delete_keys.extend(f"{entry.short_key}/{DATASET_JSONLD_FILENAME}" for entry in result.skipped_entries)
 
     sync_jsonld_artifacts(connect_r2(), bucket, catalog_dir, keys, delete_keys=delete_keys)
 

--- a/etl/catalog_jsonld/quality.py
+++ b/etl/catalog_jsonld/quality.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+from collections import Counter
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 
+from owid.catalog.core.datasets import CHANNEL
 from owid.catalog.core.meta import DatasetMeta
 from owid.catalog.schema_org import TableSchemaInput, license_to_url
+
+# Root-level file/dir names that live directly under catalog_dir and must not be
+# shadowed by a short-key namespace segment.
+RESERVED_ROOT_NAMES = {"robots.txt", "jsonld_quality_report.json"}
 
 
 @dataclass
@@ -20,11 +27,41 @@ class DatasetQualityResult:
         return not self.blockers
 
 
+def is_reserved_namespace(namespace: str) -> bool:
+    """Return True if ``namespace`` would collide with a reserved top-level catalog_dir name.
+
+    Reserved names are the catalog channels (``garden``, ``meadow``, ``snapshot``, ...),
+    fixed root-level artifact files (``robots.txt``, the quality report), and the sitemap
+    file family (``sitemap.xml``, ``sitemap-index.xml``, ``sitemap-<N>.xml``).
+    """
+    if namespace in set(CHANNEL.__args__):
+        return True
+    if namespace in RESERVED_ROOT_NAMES:
+        return True
+    if namespace.startswith("sitemap") and namespace.endswith(".xml"):
+        return True
+    return False
+
+
+def find_duplicate_short_key_paths(entries: Iterable[tuple[str, str, str]]) -> set[str]:
+    """Return catalog_paths whose ``<namespace>/<dataset>`` short key is shared by another entry.
+
+    ``entries`` is an iterable of ``(catalog_path, namespace, dataset)`` tuples, one per
+    candidate emitted dataset in the current build. This is a batch-level check: a single
+    dataset can't tell it collides with another without seeing the whole set.
+    """
+    entries = list(entries)
+    counts = Counter(f"{namespace}/{dataset}" for _, namespace, dataset in entries)
+    return {catalog_path for (catalog_path, namespace, dataset) in entries if counts[f"{namespace}/{dataset}"] > 1}
+
+
 def assess_dataset_quality(
     *,
     catalog_path: str,
+    namespace: str,
     dataset_meta: DatasetMeta,
     tables: list[TableSchemaInput],
+    duplicate_short_key: bool = False,
 ) -> DatasetQualityResult:
     result = DatasetQualityResult(catalog_path=catalog_path)
 
@@ -33,6 +70,12 @@ def assess_dataset_quality(
 
     if dataset_meta.non_redistributable:
         result.blockers.append("non_redistributable")
+
+    if is_reserved_namespace(namespace):
+        result.blockers.append("reserved_namespace")
+
+    if duplicate_short_key:
+        result.blockers.append("duplicate_short_key")
 
     if not _has_title(dataset_meta, tables):
         result.blockers.append("missing_title")

--- a/etl/catalog_jsonld/sitemap.py
+++ b/etl/catalog_jsonld/sitemap.py
@@ -3,13 +3,37 @@
 from __future__ import annotations
 
 import html
+import re
+from dataclasses import dataclass
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
-def sitemap_xml(urls: list[str]) -> str:
-    entries = "\n".join(f"  <url><loc>{html.escape(url, quote=True)}</loc></url>" for url in sorted(urls))
+@dataclass(frozen=True)
+class SitemapEntry:
+    url: str
+    lastmod: str | None = None
+
+
+def sitemap_xml(entries: list[SitemapEntry]) -> str:
+    """Build a sitemap XML document with one ``<url>`` per entry, sorted by URL.
+
+    ``lastmod`` should be the dataset's real version date (``YYYY-MM-DD``) where known —
+    it's the main recrawl signal now that versions bump invisibly under a stable URL.
+    Entries without a valid date-shaped ``lastmod`` omit the tag rather than defaulting
+    to "today".
+    """
+    blocks = []
+    for entry in sorted(entries, key=lambda e: e.url):
+        loc = f"    <loc>{html.escape(entry.url, quote=True)}</loc>"
+        if entry.lastmod and _DATE_RE.match(entry.lastmod):
+            blocks.append(f"  <url>\n{loc}\n    <lastmod>{entry.lastmod}</lastmod>\n  </url>")
+        else:
+            blocks.append(f"  <url>\n{loc}\n  </url>")
+    body = "\n".join(blocks)
     return (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
-        f"{entries}\n"
+        f"{body}\n"
         "</urlset>\n"
     )

--- a/lib/catalog/owid/catalog/schema_org.py
+++ b/lib/catalog/owid/catalog/schema_org.py
@@ -35,6 +35,8 @@ class TableSchemaInput:
 def dataset_to_schema_org(
     *,
     dataset_path: str,
+    page_path: str,
+    version: str | None = None,
     dataset_meta: DatasetMeta,
     tables: list[TableSchemaInput],
     base_url: str = DEFAULT_CATALOG_BASE_URL,
@@ -44,9 +46,23 @@ def dataset_to_schema_org(
     The catalog folder is the top-level Dataset. For single-table datasets, table
     metadata is flattened into the top-level Dataset. For multi-table datasets,
     each table is represented as a nested Dataset via ``hasPart``.
+
+    ``page_path`` is the stable, version-agnostic short key (``"<namespace>/<dataset>"``)
+    used for the public landing page URL and ``@id``. ``dataset_path`` is the full,
+    dated catalog path (``"garden/<namespace>/<version>/<dataset>"``) and is only used
+    for ``identifier``, documenting where the dataset actually lives in the catalog.
+    ``version`` is the real dated version to report (falls back to ``dataset_meta.version``
+    when not given, e.g. for datasets whose metadata version is a genuine "latest" alias
+    with no dated folder of its own).
     """
     dataset_path = dataset_path.strip("/")
-    dataset_url = f"{base_url.rstrip('/')}/{dataset_path}/"
+    page_path = page_path.strip("/")
+    dataset_url = f"{base_url.rstrip('/')}/{page_path}/"
+    # Data files themselves stay at their real, dated catalog location (old dated files persist
+    # on R2 after a new version ships), so distribution contentUrls are built from dataset_path,
+    # not the short page_path used for the landing page's own url/@id.
+    file_base_url = f"{base_url.rstrip('/')}/{dataset_path}/"
+    resolved_version = version or dataset_meta.version
 
     title = _dataset_title(dataset_meta, tables)
     description = _dataset_description(dataset_meta, tables)
@@ -76,9 +92,9 @@ def dataset_to_schema_org(
         "thumbnailUrl": DEFAULT_THUMBNAIL_URL,
     }
 
-    if dataset_meta.version:
-        result["version"] = str(dataset_meta.version)
-        date_modified = _first_valid_date([dataset_meta.version])
+    if resolved_version:
+        result["version"] = str(resolved_version)
+        date_modified = _first_valid_date([resolved_version])
         if date_modified:
             result["dateModified"] = date_modified
     if license_url:
@@ -117,16 +133,16 @@ def dataset_to_schema_org(
         variables = _variable_measured(table)
         if variables:
             result["variableMeasured"] = variables
-        distributions = _distributions(dataset_url, table)
+        distributions = _distributions(file_base_url, table)
         if distributions:
             result["distribution"] = distributions
     elif tables:
-        result["hasPart"] = [_table_dataset(dataset_url, table) for table in tables]
+        result["hasPart"] = [_table_dataset(dataset_url, file_base_url, table) for table in tables]
 
     return _drop_empty(result)
 
 
-def _table_dataset(dataset_url: str, table: TableSchemaInput) -> dict[str, Any]:
+def _table_dataset(dataset_url: str, file_base_url: str, table: TableSchemaInput) -> dict[str, Any]:
     name = table.metadata.title or table.short_name.replace("_", " ").title()
     result: dict[str, Any] = {
         "@type": "Dataset",
@@ -141,7 +157,7 @@ def _table_dataset(dataset_url: str, table: TableSchemaInput) -> dict[str, Any]:
     if variables:
         result["variableMeasured"] = variables
 
-    distributions = _distributions(dataset_url, table)
+    distributions = _distributions(file_base_url, table)
     if distributions:
         result["distribution"] = distributions
 
@@ -175,7 +191,8 @@ def _variable_measured(table: TableSchemaInput) -> list[dict[str, Any]]:
     return variables
 
 
-def _distributions(dataset_url: str, table: TableSchemaInput) -> list[dict[str, Any]]:
+def _distributions(file_base_url: str, table: TableSchemaInput) -> list[dict[str, Any]]:
+    """Build DataDownload entries pointing at the real, dated file location (not the short page URL)."""
     result = []
     for format in table.formats:
         result.append(
@@ -183,7 +200,7 @@ def _distributions(dataset_url: str, table: TableSchemaInput) -> list[dict[str, 
                 "@type": "DataDownload",
                 "name": f"{table.short_name}.{format}",
                 "encodingFormat": _encoding_format(format),
-                "contentUrl": f"{dataset_url}{table.short_name}.{format}",
+                "contentUrl": f"{file_base_url}{table.short_name}.{format}",
             }
         )
     return result

--- a/lib/catalog/tests/test_schema_org.py
+++ b/lib/catalog/tests/test_schema_org.py
@@ -31,6 +31,7 @@ def test_single_table_dataset_flattens_table_metadata() -> None:
 
     jsonld = dataset_to_schema_org(
         dataset_path="garden/biodiversity/2025-04-07/cherry_blossom",
+        page_path="biodiversity/cherry_blossom",
         dataset_meta=DatasetMeta(
             namespace="biodiversity",
             version="2025-04-07",
@@ -42,6 +43,11 @@ def test_single_table_dataset_flattens_table_metadata() -> None:
 
     assert jsonld["@type"] == "Dataset"
     assert jsonld["name"] == "Cherry Blossom Full Bloom Dates in Kyoto, Japan"
+    # The public URL/@id are built from the stable short page_path, not the dated catalog path.
+    assert jsonld["url"] == "https://catalog.ourworldindata.org/biodiversity/cherry_blossom/"
+    assert jsonld["@id"] == "https://catalog.ourworldindata.org/biodiversity/cherry_blossom/#dataset"
+    # identifier documents the real, dated catalog location.
+    assert jsonld["identifier"] == "garden/biodiversity/2025-04-07/cherry_blossom"
     assert jsonld["license"] == "https://creativecommons.org/licenses/by/4.0/"
     assert jsonld["dateModified"] == "2025-04-07"
     assert jsonld["thumbnailUrl"] == "https://ourworldindata.org/owid-logo.svg"
@@ -53,8 +59,93 @@ def test_single_table_dataset_flattens_table_metadata() -> None:
     assert jsonld["keywords"] == ["Biodiversity"]
     assert jsonld["variableMeasured"][0]["identifier"] == "full_flowering_date"
     assert len(jsonld["distribution"]) == 1
-    assert jsonld["distribution"][0]["contentUrl"].endswith("/cherry_blossom.feather")
+    # Distribution content URLs still point at the real, dated file location on R2 — not the
+    # short page_path used for url/@id.
+    assert (
+        jsonld["distribution"][0]["contentUrl"]
+        == "https://catalog.ourworldindata.org/garden/biodiversity/2025-04-07/cherry_blossom/cherry_blossom.feather"
+    )
     assert "hasPart" not in jsonld
+
+
+def test_version_param_overrides_latest_dataset_meta_version() -> None:
+    """A dataset whose own metadata version is a "latest" alias should still report a real date,
+    sourced from the explicit ``version`` param (e.g. derived from the dated catalog path)."""
+    table = TableSchemaInput(
+        short_name="owid_co2",
+        metadata=TableMeta(short_name="owid_co2", title="CO2 emissions", description="Table description"),
+        variables={
+            "value": VariableMeta(title="Value", origins=[Origin(producer="Example Producer", title="Origin title")])
+        },
+        formats=["csv"],
+    )
+
+    jsonld = dataset_to_schema_org(
+        dataset_path="garden/emissions/2025-12-04/owid_co2",
+        page_path="emissions/owid_co2",
+        version="2025-12-04",
+        dataset_meta=DatasetMeta(
+            namespace="emissions",
+            version="latest",
+            short_name="owid_co2",
+            title="CO2 emissions",
+        ),
+        tables=[table],
+    )
+
+    assert jsonld["version"] == "2025-12-04"
+    assert jsonld["dateModified"] == "2025-12-04"
+
+
+def test_version_falls_back_to_dataset_meta_version_when_not_given() -> None:
+    table = TableSchemaInput(
+        short_name="cherry_blossom",
+        metadata=TableMeta(short_name="cherry_blossom", title="Cherry blossom", description="Table description"),
+        variables={
+            "value": VariableMeta(title="Value", origins=[Origin(producer="Example Producer", title="Origin title")])
+        },
+        formats=["csv"],
+    )
+
+    jsonld = dataset_to_schema_org(
+        dataset_path="garden/biodiversity/2025-04-07/cherry_blossom",
+        page_path="biodiversity/cherry_blossom",
+        dataset_meta=DatasetMeta(
+            namespace="biodiversity",
+            version="2025-04-07",
+            short_name="cherry_blossom",
+            title="Cherry blossom",
+        ),
+        tables=[table],
+    )
+
+    assert jsonld["version"] == "2025-04-07"
+
+
+def test_distribution_content_urls_use_dated_path_not_short_page_path() -> None:
+    """Regression guard: data files stay at their real, dated catalog location even though the
+    dataset's own url/@id move to the stable short page_path. Old dated files persist on R2
+    after a new version ships, so pointing distributions there is safe and correct."""
+    table = TableSchemaInput(
+        short_name="owid_co2",
+        metadata=TableMeta(short_name="owid_co2", title="CO2 emissions"),
+        variables={"value": VariableMeta(title="Value", origins=[Origin(producer="Example Producer", title="t")])},
+        formats=["feather", "csv"],
+    )
+
+    jsonld = dataset_to_schema_org(
+        dataset_path="garden/emissions/2025-12-04/owid_co2",
+        page_path="emissions/owid_co2",
+        dataset_meta=DatasetMeta(namespace="emissions", version="2025-12-04", short_name="owid_co2"),
+        tables=[table],
+    )
+
+    content_urls = {d["contentUrl"] for d in jsonld["distribution"]}
+    assert content_urls == {
+        "https://catalog.ourworldindata.org/garden/emissions/2025-12-04/owid_co2/owid_co2.feather",
+        "https://catalog.ourworldindata.org/garden/emissions/2025-12-04/owid_co2/owid_co2.csv",
+    }
+    assert jsonld["url"] == "https://catalog.ourworldindata.org/emissions/owid_co2/"
 
 
 def test_multi_table_dataset_uses_has_part() -> None:
@@ -80,6 +171,7 @@ def test_multi_table_dataset_uses_has_part() -> None:
 
     jsonld = dataset_to_schema_org(
         dataset_path="garden/example/2025-01-01/example_dataset",
+        page_path="example/example_dataset",
         dataset_meta=DatasetMeta(
             namespace="example",
             version="2025-01-01",
@@ -92,7 +184,13 @@ def test_multi_table_dataset_uses_has_part() -> None:
 
     assert "variableMeasured" not in jsonld
     assert [part["identifier"] for part in jsonld["hasPart"]] == ["table_a", "table_b"]
-    assert jsonld["hasPart"][0]["distribution"][0]["contentUrl"].endswith("/table_a.feather")
+    # @id uses the short page_path...
+    assert jsonld["hasPart"][0]["@id"] == "https://catalog.ourworldindata.org/example/example_dataset/#table-table_a"
+    # ...but the distribution's contentUrl uses the real, dated catalog path.
+    assert (
+        jsonld["hasPart"][0]["distribution"][0]["contentUrl"]
+        == "https://catalog.ourworldindata.org/garden/example/2025-01-01/example_dataset/table_a.feather"
+    )
 
 
 def test_license_to_url_resolves_known_license_names() -> None:

--- a/tests/catalog_jsonld/test_artifacts.py
+++ b/tests/catalog_jsonld/test_artifacts.py
@@ -208,6 +208,41 @@ def test_build_catalog_jsonld_artifacts_excludes_non_redistributable(tmp_path: P
     assert not (data_dir / "garden" / "wb" / "2025-01-01" / "restricted" / "dataset.jsonld").exists()
 
 
+def test_build_catalog_jsonld_artifacts_omits_lastmod_for_non_date_version(tmp_path: Path) -> None:
+    """Datasets versioned "latest" have no real modification date; the sitemap entry must omit
+    lastmod rather than stamping the build date, which would falsely mark the page as modified
+    on every publish."""
+    data_dir = tmp_path / "data"
+    _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="latest")
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+
+    assert result.emitted == ["garden/emissions/latest/owid_co2"]
+    sitemap = (data_dir / "sitemap.xml").read_text()
+    assert "<loc>https://catalog.ourworldindata.org/emissions/owid_co2/</loc>" in sitemap
+    assert "<lastmod>" not in sitemap
+
+
+def test_build_catalog_jsonld_artifacts_removes_short_key_artifact_when_dataset_becomes_ineligible(
+    tmp_path: Path,
+) -> None:
+    """A dataset emitted at its short key by a prior build must have that local artifact removed
+    once it fails a quality gate, so an ineligible dataset can't keep a stale public JSON-LD."""
+    data_dir = tmp_path / "data"
+    _add_eligible_dataset(data_dir, namespace="wb", dataset="restricted", non_redistributable=True)
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+    stale_short_key = data_dir / "wb" / "restricted" / "dataset.jsonld"
+    stale_short_key.parent.mkdir(parents=True)
+    stale_short_key.write_text('{"from": "a prior build"}')
+
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+
+    assert result.emitted == []
+    assert [entry.short_key for entry in result.skipped_entries] == ["wb/restricted"]
+    assert not stale_short_key.exists()
+
+
 def test_build_catalog_jsonld_artifacts_blocks_reserved_namespace(tmp_path: Path) -> None:
     """A namespace that collides with a catalog channel name (e.g. "garden") would shadow a
     root-level catalog_dir entry if used as a short-key first segment, so it's blocked."""

--- a/tests/catalog_jsonld/test_artifacts.py
+++ b/tests/catalog_jsonld/test_artifacts.py
@@ -84,17 +84,67 @@ def test_build_catalog_jsonld_artifacts_writes_dataset_jsonld_sitemap_and_report
     result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
 
     assert result.emitted == ["garden/example/2025-01-01/example_dataset"]
-    jsonld_path = dataset_dir / "dataset.jsonld"
+    # dataset.jsonld now lives at the stable "<namespace>/<dataset>" short key, not inside the
+    # dataset's own dated catalog folder.
+    jsonld_path = data_dir / "example" / "example_dataset" / "dataset.jsonld"
     assert jsonld_path.exists()
+    assert not (dataset_dir / "dataset.jsonld").exists()
     jsonld = json.loads(jsonld_path.read_text())
     assert jsonld["name"] == "Example dataset"
+    assert jsonld["url"] == "https://catalog.ourworldindata.org/example/example_dataset/"
+    assert jsonld["identifier"] == "garden/example/2025-01-01/example_dataset"
+    assert jsonld["version"] == "2025-01-01"
     assert jsonld["license"] == "https://creativecommons.org/licenses/by/4.0/"
     assert jsonld["temporalCoverage"] == "2020"
     assert jsonld["variableMeasured"][0]["identifier"] == "value"
-    assert (data_dir / "sitemap.xml").read_text().count("<url>") == 1
+    sitemap = (data_dir / "sitemap.xml").read_text()
+    assert sitemap.count("<url>") == 1
+    assert "<loc>https://catalog.ourworldindata.org/example/example_dataset/</loc>" in sitemap
+    assert "<lastmod>2025-01-01</lastmod>" in sitemap
     report = json.loads((data_dir / "jsonld_quality_report.json").read_text())
     assert report["summary"]["emitted"] == 1
     assert report["summary"]["skipped"] == 0
+
+
+def test_build_catalog_jsonld_artifacts_cleans_up_stale_old_location_for_emitted_dataset(tmp_path: Path) -> None:
+    """A dataset.jsonld left over at the old dated-path location (from before this migration)
+    must be removed locally even though the dataset is still emitted, since it's superseded
+    by the new short-key location."""
+    data_dir = tmp_path / "data"
+    dataset_dir = data_dir / "garden" / "example" / "2025-01-01" / "example_dataset"
+    origin = Origin(
+        producer="Example Producer",
+        title="Original dataset",
+        description="Original description",
+        citation_full="Example Producer (2025). Original dataset.",
+        license=License(name="CC BY 4.0"),
+    )
+    ds = Dataset.create_empty(
+        dataset_dir,
+        DatasetMeta(
+            channel="garden",
+            namespace="example",
+            version="2025-01-01",
+            short_name="example_dataset",
+            title="Example dataset",
+            description="Dataset description",
+        ),
+    )
+    tb = Table(pd.DataFrame({"year": [2020], "value": [1]}), short_name="example_table")
+    tb = tb.set_index("year")
+    tb.metadata.title = "Example table"
+    tb.metadata.description = "Table description"
+    tb._fields["value"] = VariableMeta(title="Value", description_short="A measured value.", origins=[origin])
+    ds.add(tb)
+    ds.save()
+    stale_old_location = dataset_dir / "dataset.jsonld"
+    stale_old_location.write_text("{}")
+
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+    build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+
+    assert not stale_old_location.exists()
+    assert (data_dir / "example" / "example_dataset" / "dataset.jsonld").exists()
 
 
 def test_build_catalog_jsonld_artifacts_only_allowlist_restricts_emission(tmp_path: Path) -> None:
@@ -108,12 +158,15 @@ def test_build_catalog_jsonld_artifacts_only_allowlist_restricts_emission(tmp_pa
 
     # Only the allowlisted dataset is emitted; the others are not even assessed.
     assert result.emitted == [co2_path]
-    assert (data_dir / "garden" / "emissions" / "2025-01-01" / "owid_co2" / "dataset.jsonld").exists()
-    assert not (data_dir / "garden" / "energy_data" / "2025-01-01" / "owid_energy" / "dataset.jsonld").exists()
-    # Sitemap lists exactly the allowlisted dataset.
+    assert [entry.short_key for entry in result.emitted_entries] == ["emissions/owid_co2"]
+    assert (data_dir / "emissions" / "owid_co2" / "dataset.jsonld").exists()
+    assert not (data_dir / "garden" / "emissions" / "2025-01-01" / "owid_co2" / "dataset.jsonld").exists()
+    assert not (data_dir / "energy_data" / "owid_energy" / "dataset.jsonld").exists()
+    # Sitemap lists exactly the allowlisted dataset, at its stable short-key URL.
     sitemap = (data_dir / "sitemap.xml").read_text()
     assert sitemap.count("<url>") == 1
-    assert co2_path in sitemap
+    assert "<loc>https://catalog.ourworldindata.org/emissions/owid_co2/</loc>" in sitemap
+    assert co2_path not in sitemap
 
 
 def test_build_catalog_jsonld_artifacts_only_is_version_agnostic(tmp_path: Path) -> None:
@@ -153,3 +206,50 @@ def test_build_catalog_jsonld_artifacts_excludes_non_redistributable(tmp_path: P
     assert [item.catalog_path for item in result.skipped] == ["garden/wb/2025-01-01/restricted"]
     assert "non_redistributable" in result.skipped[0].blockers
     assert not (data_dir / "garden" / "wb" / "2025-01-01" / "restricted" / "dataset.jsonld").exists()
+
+
+def test_build_catalog_jsonld_artifacts_blocks_reserved_namespace(tmp_path: Path) -> None:
+    """A namespace that collides with a catalog channel name (e.g. "garden") would shadow a
+    root-level catalog_dir entry if used as a short-key first segment, so it's blocked."""
+    data_dir = tmp_path / "data"
+    path = _add_eligible_dataset(data_dir, namespace="garden", dataset="something")
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+
+    assert result.emitted == []
+    assert [item.catalog_path for item in result.skipped] == [path]
+    assert "reserved_namespace" in result.skipped[0].blockers
+    assert not (data_dir / "garden" / "something" / "dataset.jsonld").exists()
+
+
+def test_build_catalog_jsonld_artifacts_blocks_duplicate_short_keys(tmp_path: Path, monkeypatch) -> None:
+    """No two emitted datasets in a build may resolve to the same "<namespace>/<dataset>" short
+    key. This can't happen today (latest_dataset_paths already dedupes per (channel, namespace,
+    dataset) and the builder is single-channel), so the collision is forced here to exercise the
+    batch-level guard that protects a future multi-channel build."""
+    data_dir = tmp_path / "data"
+    path_a = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2")
+    path_b = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2_dup")
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    import etl.catalog_jsonld.artifacts as artifacts_module
+
+    real_latest_dataset_paths = artifacts_module.latest_dataset_paths
+
+    def fake_latest_dataset_paths(frame, *, channel="garden", only=None):
+        entries = real_latest_dataset_paths(frame, channel=channel, only=only)
+        return [
+            artifacts_module.LatestDatasetPath(
+                catalog_path=entry.catalog_path, namespace="emissions", dataset="owid_co2", version=entry.version
+            )
+            for entry in entries
+        ]
+
+    monkeypatch.setattr(artifacts_module, "latest_dataset_paths", fake_latest_dataset_paths)
+
+    result = artifacts_module.build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+
+    assert result.emitted == []
+    assert {item.catalog_path for item in result.skipped} == {path_a, path_b}
+    assert all("duplicate_short_key" in item.blockers for item in result.skipped)

--- a/tests/catalog_jsonld/test_publish.py
+++ b/tests/catalog_jsonld/test_publish.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from botocore.client import ClientError
+from owid.catalog import Dataset, DatasetMeta, License, Origin, Table, VariableMeta
+from owid.catalog.api.legacy import LocalCatalog
+
+from etl.catalog_jsonld.artifacts import DATASET_JSONLD_FILENAME, QUALITY_REPORT_FILENAME, SITEMAP_FILENAME
+from etl.catalog_jsonld.publish import build_and_publish_catalog_jsonld, sync_jsonld_artifacts
+
+
+class FakeS3:
+    """Minimal stand-in for the boto3 S3 client used by sync_jsonld_artifacts."""
+
+    def __init__(self, remote_md5: dict[str, str] | None = None) -> None:
+        self.remote_md5 = dict(remote_md5 or {})
+        self.uploaded: list[str] = []
+        self.deleted: list[str] = []
+
+    def head_object(self, Bucket: str, Key: str) -> dict[str, Any]:
+        if Key not in self.remote_md5:
+            raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
+        return {"ETag": f'"{self.remote_md5[Key]}"'}
+
+    def upload_file(self, Filename: str, Bucket: str, Key: str, ExtraArgs: dict[str, Any] | None = None) -> None:
+        self.uploaded.append(Key)
+
+    def delete_object(self, Bucket: str, Key: str) -> None:
+        self.deleted.append(Key)
+
+
+def _add_eligible_dataset(data_dir: Path, *, namespace: str, dataset: str, version: str = "2025-01-01") -> str:
+    dataset_dir = data_dir / "garden" / namespace / version / dataset
+    origin = Origin(
+        producer="Example Producer",
+        title="Original dataset",
+        description="Original description",
+        citation_full="Example Producer (2025). Original dataset.",
+        license=License(name="CC BY 4.0"),
+    )
+    ds = Dataset.create_empty(
+        dataset_dir,
+        DatasetMeta(
+            channel="garden",
+            namespace=namespace,
+            version=version,
+            short_name=dataset,
+            title=f"{dataset} title",
+            description=f"{dataset} description",
+        ),
+    )
+    tb = Table(pd.DataFrame({"year": [2020], "value": [1]}), short_name="example_table")
+    tb = tb.set_index("year")
+    tb.metadata.title = "Example table"
+    tb.metadata.description = "Table description"
+    tb._fields["value"] = VariableMeta(title="Value", description_short="A measured value.", origins=[origin])
+    ds.add(tb)
+    ds.save()
+    return f"garden/{namespace}/{version}/{dataset}"
+
+
+def test_sync_jsonld_artifacts_uploads_new_and_deletes_stale(tmp_path: Path) -> None:
+    catalog_dir = tmp_path
+    new_key = "emissions/owid_co2/dataset.jsonld"
+    (catalog_dir / "emissions" / "owid_co2").mkdir(parents=True)
+    (catalog_dir / "emissions" / "owid_co2" / "dataset.jsonld").write_text('{"a": 1}')
+
+    unchanged_key = "wb/world_bank_pip/dataset.jsonld"
+    (catalog_dir / "wb" / "world_bank_pip").mkdir(parents=True)
+    unchanged_path = catalog_dir / "wb" / "world_bank_pip" / "dataset.jsonld"
+    unchanged_path.write_text('{"b": 2}')
+
+    from etl import files
+
+    unchanged_md5 = files.checksum_file(unchanged_path)
+    stale_key = "garden/emissions/2025-12-04/owid_co2/dataset.jsonld"
+    # The stale key must actually exist on "remote" for a delete to be meaningful/observable.
+    s3 = FakeS3(remote_md5={unchanged_key: unchanged_md5, stale_key: "deadbeefdeadbeefdeadbeefdeadbeef"})
+
+    sync_jsonld_artifacts(
+        s3, "test-bucket", catalog_dir, [new_key, unchanged_key], delete_keys=[stale_key, unchanged_key]
+    )
+
+    assert s3.uploaded == [new_key]
+    # unchanged_key matches the remote checksum, so it's neither re-uploaded nor deleted (it's
+    # also excluded from delete_keys because it's present in `keys`).
+    assert stale_key in s3.deleted
+    assert unchanged_key not in s3.deleted
+
+
+def test_sync_jsonld_artifacts_skips_delete_for_local_file_not_on_remote(tmp_path: Path) -> None:
+    s3 = FakeS3(remote_md5={})
+    sync_jsonld_artifacts(s3, "test-bucket", tmp_path, [], delete_keys=["never/existed/dataset.jsonld"])
+    assert s3.deleted == []
+
+
+def test_build_and_publish_catalog_jsonld_uses_short_keys_and_deletes_old_dated_paths(
+    tmp_path: Path, monkeypatch
+) -> None:
+    data_dir = tmp_path / "data"
+    co2_path = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2")
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    captured: dict[str, Any] = {}
+
+    def fake_sync_jsonld_artifacts(s3, bucket, catalog_dir, keys, delete_keys=None):
+        captured["keys"] = keys
+        captured["delete_keys"] = delete_keys
+
+    monkeypatch.setattr("etl.catalog_jsonld.publish.connect_r2", lambda: object())
+    monkeypatch.setattr("etl.catalog_jsonld.publish.sync_jsonld_artifacts", fake_sync_jsonld_artifacts)
+
+    build_and_publish_catalog_jsonld(bucket="test-bucket", catalog_dir=data_dir, channel="garden")
+
+    assert f"emissions/owid_co2/{DATASET_JSONLD_FILENAME}" in captured["keys"]
+    assert SITEMAP_FILENAME in captured["keys"]
+    assert QUALITY_REPORT_FILENAME in captured["keys"]
+    # The stable short-key path is not itself scheduled for deletion...
+    assert f"emissions/owid_co2/{DATASET_JSONLD_FILENAME}" not in captured["delete_keys"]
+    # ...but the old dated catalog-path location is, so it doesn't linger as duplicate content.
+    assert f"{co2_path}/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]

--- a/tests/catalog_jsonld/test_publish.py
+++ b/tests/catalog_jsonld/test_publish.py
@@ -30,7 +30,14 @@ class FakeS3:
         self.deleted.append(Key)
 
 
-def _add_eligible_dataset(data_dir: Path, *, namespace: str, dataset: str, version: str = "2025-01-01") -> str:
+def _add_eligible_dataset(
+    data_dir: Path,
+    *,
+    namespace: str,
+    dataset: str,
+    version: str = "2025-01-01",
+    non_redistributable: bool = False,
+) -> str:
     dataset_dir = data_dir / "garden" / namespace / version / dataset
     origin = Origin(
         producer="Example Producer",
@@ -48,6 +55,7 @@ def _add_eligible_dataset(data_dir: Path, *, namespace: str, dataset: str, versi
             short_name=dataset,
             title=f"{dataset} title",
             description=f"{dataset} description",
+            non_redistributable=non_redistributable,
         ),
     )
     tb = Table(pd.DataFrame({"year": [2020], "value": [1]}), short_name="example_table")
@@ -120,3 +128,27 @@ def test_build_and_publish_catalog_jsonld_uses_short_keys_and_deletes_old_dated_
     assert f"emissions/owid_co2/{DATASET_JSONLD_FILENAME}" not in captured["delete_keys"]
     # ...but the old dated catalog-path location is, so it doesn't linger as duplicate content.
     assert f"{co2_path}/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]
+
+
+def test_build_and_publish_catalog_jsonld_deletes_short_key_for_skipped_dataset(tmp_path: Path, monkeypatch) -> None:
+    """A dataset that fails the quality gate (e.g. becomes non-redistributable) must have its
+    live short-key JSON-LD scheduled for deletion — a prior publish may have emitted it, and
+    an ineligible dataset must stop being served."""
+    data_dir = tmp_path / "data"
+    restricted_path = _add_eligible_dataset(data_dir, namespace="wb", dataset="restricted", non_redistributable=True)
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    captured: dict[str, Any] = {}
+
+    def fake_sync_jsonld_artifacts(s3, bucket, catalog_dir, keys, delete_keys=None):
+        captured["keys"] = keys
+        captured["delete_keys"] = delete_keys
+
+    monkeypatch.setattr("etl.catalog_jsonld.publish.connect_r2", lambda: object())
+    monkeypatch.setattr("etl.catalog_jsonld.publish.sync_jsonld_artifacts", fake_sync_jsonld_artifacts)
+
+    build_and_publish_catalog_jsonld(bucket="test-bucket", catalog_dir=data_dir, channel="garden")
+
+    assert f"wb/restricted/{DATASET_JSONLD_FILENAME}" not in captured["keys"]
+    assert f"wb/restricted/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]
+    assert f"{restricted_path}/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]

--- a/tests/catalog_jsonld/test_quality.py
+++ b/tests/catalog_jsonld/test_quality.py
@@ -1,0 +1,110 @@
+from owid.catalog.core.meta import DatasetMeta, License, Origin, TableMeta, VariableMeta
+from owid.catalog.schema_org import TableSchemaInput
+
+from etl.catalog_jsonld.quality import assess_dataset_quality, find_duplicate_short_key_paths, is_reserved_namespace
+
+
+def _eligible_table() -> TableSchemaInput:
+    origin = Origin(
+        producer="Example Producer",
+        title="Original dataset",
+        description="Original description",
+        citation_full="Example Producer (2025). Original dataset.",
+        license=License(name="CC BY 4.0"),
+    )
+    return TableSchemaInput(
+        short_name="example_table",
+        metadata=TableMeta(short_name="example_table", title="Example table", description="Table description"),
+        variables={"value": VariableMeta(title="Value", description_short="A measured value.", origins=[origin])},
+        formats=["feather"],
+    )
+
+
+def _eligible_dataset_meta(**overrides: object) -> DatasetMeta:
+    fields: dict[str, object] = dict(
+        channel="garden",
+        namespace="example",
+        version="2025-01-01",
+        short_name="example_dataset",
+        title="Example dataset",
+        description="Dataset description",
+    )
+    fields.update(overrides)
+    return DatasetMeta(**fields)  # type: ignore[arg-type]
+
+
+def test_is_reserved_namespace_matches_channel_names() -> None:
+    assert is_reserved_namespace("garden")
+    assert is_reserved_namespace("snapshot")
+    assert is_reserved_namespace("open_numbers")
+    assert not is_reserved_namespace("emissions")
+
+
+def test_is_reserved_namespace_matches_root_level_files() -> None:
+    assert is_reserved_namespace("robots.txt")
+    assert is_reserved_namespace("jsonld_quality_report.json")
+
+
+def test_is_reserved_namespace_matches_sitemap_family() -> None:
+    assert is_reserved_namespace("sitemap.xml")
+    assert is_reserved_namespace("sitemap-index.xml")
+    assert is_reserved_namespace("sitemap-1.xml")
+    assert not is_reserved_namespace("sitemapper")  # doesn't end in .xml
+
+
+def test_assess_dataset_quality_blocks_reserved_namespace() -> None:
+    result = assess_dataset_quality(
+        catalog_path="garden/garden/2025-01-01/something",
+        namespace="garden",
+        dataset_meta=_eligible_dataset_meta(namespace="garden", short_name="something"),
+        tables=[_eligible_table()],
+    )
+
+    assert "reserved_namespace" in result.blockers
+    assert not result.is_eligible
+
+
+def test_assess_dataset_quality_allows_non_reserved_namespace() -> None:
+    result = assess_dataset_quality(
+        catalog_path="garden/emissions/2025-01-01/owid_co2",
+        namespace="emissions",
+        dataset_meta=_eligible_dataset_meta(namespace="emissions", short_name="owid_co2"),
+        tables=[_eligible_table()],
+    )
+
+    assert "reserved_namespace" not in result.blockers
+    assert result.is_eligible
+
+
+def test_assess_dataset_quality_blocks_duplicate_short_key() -> None:
+    result = assess_dataset_quality(
+        catalog_path="garden/emissions/2025-01-01/owid_co2",
+        namespace="emissions",
+        dataset_meta=_eligible_dataset_meta(),
+        tables=[_eligible_table()],
+        duplicate_short_key=True,
+    )
+
+    assert "duplicate_short_key" in result.blockers
+    assert not result.is_eligible
+
+
+def test_find_duplicate_short_key_paths_flags_shared_namespace_dataset_pairs() -> None:
+    entries = [
+        ("garden/emissions/2025-01-01/owid_co2", "emissions", "owid_co2"),
+        ("open_numbers/emissions/2025-01-01/owid_co2", "emissions", "owid_co2"),
+        ("garden/wb/2026-03-24/world_bank_pip", "wb", "world_bank_pip"),
+    ]
+
+    duplicates = find_duplicate_short_key_paths(entries)
+
+    assert duplicates == {"garden/emissions/2025-01-01/owid_co2", "open_numbers/emissions/2025-01-01/owid_co2"}
+
+
+def test_find_duplicate_short_key_paths_empty_when_all_unique() -> None:
+    entries = [
+        ("garden/emissions/2025-01-01/owid_co2", "emissions", "owid_co2"),
+        ("garden/wb/2026-03-24/world_bank_pip", "wb", "world_bank_pip"),
+    ]
+
+    assert find_duplicate_short_key_paths(entries) == set()

--- a/tests/catalog_jsonld/test_sitemap.py
+++ b/tests/catalog_jsonld/test_sitemap.py
@@ -1,0 +1,45 @@
+from etl.catalog_jsonld.sitemap import SitemapEntry, sitemap_xml
+
+
+def test_sitemap_xml_includes_lastmod_for_date_shaped_versions() -> None:
+    xml = sitemap_xml(
+        [
+            SitemapEntry(url="https://catalog.ourworldindata.org/emissions/owid_co2/", lastmod="2025-12-04"),
+        ]
+    )
+
+    assert "<loc>https://catalog.ourworldindata.org/emissions/owid_co2/</loc>" in xml
+    assert "<lastmod>2025-12-04</lastmod>" in xml
+
+
+def test_sitemap_xml_omits_lastmod_when_not_date_shaped() -> None:
+    xml = sitemap_xml(
+        [
+            SitemapEntry(url="https://catalog.ourworldindata.org/open_numbers/gapminder/", lastmod="latest"),
+            SitemapEntry(url="https://catalog.ourworldindata.org/wb/no_lastmod/", lastmod=None),
+        ]
+    )
+
+    assert "<lastmod>" not in xml
+    assert "<loc>https://catalog.ourworldindata.org/open_numbers/gapminder/</loc>" in xml
+    assert "<loc>https://catalog.ourworldindata.org/wb/no_lastmod/</loc>" in xml
+
+
+def test_sitemap_xml_sorts_entries_by_url() -> None:
+    xml = sitemap_xml(
+        [
+            SitemapEntry(url="https://catalog.ourworldindata.org/wb/world_bank_pip/", lastmod="2026-03-24"),
+            SitemapEntry(url="https://catalog.ourworldindata.org/emissions/owid_co2/", lastmod="2025-12-04"),
+        ]
+    )
+
+    first_loc = xml.index("emissions/owid_co2")
+    second_loc = xml.index("wb/world_bank_pip")
+    assert first_loc < second_loc
+
+
+def test_sitemap_xml_empty_list_produces_valid_empty_urlset() -> None:
+    xml = sitemap_xml([])
+
+    assert "<urlset" in xml
+    assert "<url>" not in xml


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Summary

Follow-up to #5996. Today `dataset.jsonld` is written at the dataset's dated catalog path (`garden/emissions/2025-12-04/owid_co2/dataset.jsonld`), and the public landing page URL mirrors it (`https://catalog.ourworldindata.org/garden/emissions/2025-12-04/owid_co2/`). That path changes every time the dataset gets a new version, and two of the three canary datasets (`energy_data/owid_energy`, `wb/world_bank_pip`) have no `latest`-alias in the real catalog layout to fall back on. None of the three canary URLs are indexed by Google yet, so this is the window to move to a stable shape before indexing happens and creates a duplicate-content/301 cleanup problem later.

This PR moves `dataset.jsonld` to a stable, version-agnostic short key: `<namespace>/<dataset>/dataset.jsonld`, e.g. `/emissions/owid_co2/`, `/energy_data/owid_energy/`, `/wb/world_bank_pip/`. That key is exactly the allowlist key `latest_dataset_paths(..., only={...})` already uses internally — this PR just makes it the public URL shape too, not a new concept.

A companion PR in `cloudflare-workers` (built in parallel) adds 301 redirects from the old catalog-path URLs to these short URLs.

## What changed

- **`etl/catalog_jsonld/artifacts.py`** — `latest_dataset_paths` now returns `list[LatestDatasetPath]` (catalog_path + namespace + dataset + version) instead of bare path strings, so downstream code doesn't have to re-derive namespace/dataset by splitting the catalog path. `build_catalog_jsonld_artifacts` writes `dataset.jsonld` to `catalog_dir/<namespace>/<dataset>/dataset.jsonld` and deletes any stale `dataset.jsonld` at the old dated-folder location — for both *skipped* datasets (already handled before this PR) and now *emitted* ones too, since they no longer write there.
- **`lib/catalog/owid/catalog/schema_org.py`** — `dataset_to_schema_org` takes a new `page_path` (short key) used for `url`/`@id`, keeps `dataset_path` (full dated path) for `identifier` only, and takes an explicit `version` param that overrides `dataset_meta.version` when given (protects against a dataset whose own metadata version is a "latest" alias with no dated folder of its own — not the case for any of today's three canaries, but it's cheap insurance). Distribution `contentUrl`s deliberately keep pointing at the dated catalog path — data files stay there even after a new version ships, so this is safe and is *not* something this migration should touch. (Caught and fixed a bug during review where the first draft accidentally rewired distribution URLs onto the short path — the test suite now has an explicit regression test for this.)
- **`etl/catalog_jsonld/quality.py`** — two new blocking checks: `reserved_namespace` (a short-key namespace segment can't collide with a catalog channel name, `robots.txt`, the quality report, or the `sitemap*.xml` family — pulled from `CHANNEL.__args__`, not hardcoded) and `duplicate_short_key` (no two emitted datasets in one build may resolve to the same `<namespace>/<dataset>`). The latter can't actually trigger today — `latest_dataset_paths` already dedupes per `(channel, namespace, dataset)` and the builder is single-channel — but it's a cheap batch-level guard (`find_duplicate_short_key_paths`) against a future multi-channel build silently overwriting one dataset's page with another's.
- **`etl/catalog_jsonld/publish.py`** — the synced R2 key list now uses short keys (`<namespace>/<dataset>/dataset.jsonld`). `delete_keys` now also includes the *old* dated-path key for every currently-emitted dataset (in addition to the existing stale-skipped-dataset deletes), since that page is no longer generated locally but may still be live on R2 from a prior publish — leaving it there is exactly the duplicate-content trap this migration exists to avoid.
- **`etl/catalog_jsonld/sitemap.py`** — `sitemap_xml` now takes `list[SitemapEntry]` (url + optional `lastmod`) instead of bare URLs, and emits `<lastmod>` per entry from the dataset's real dated version. This is the main recrawl signal now that a version bump no longer changes the URL. A non-date-shaped version (e.g. a genuine `"latest"`-versioned dataset) falls back to the build date rather than being asserted into a fake date.

## Determinism

`dataset.jsonld` and `sitemap.xml` are the two artifacts this migration persists at a new stable path, so I checked determinism explicitly: built the three canary datasets into a scratch catalog dir twice from the same source data and diffed the outputs. `dataset.jsonld` (all three) and `sitemap.xml` were byte-for-byte identical across the two runs — dict key order is fixed by construction (no `sort_keys`, no set-iteration-order dependence), and the only date-shaped fields are `version`/`dateModified`/`lastmod`, sourced from the dataset's real version, not wall-clock time. `jsonld_quality_report.json` differs only in its pre-existing `generated_at` timestamp field, which was already wall-clock-based before this PR and isn't part of the public URL surface this migration is about.

## Verification

- `.venv/bin/pytest tests/catalog_jsonld/ -v` — 23 passed (includes 2 new files: `test_quality.py`, `test_sitemap.py`, plus a new `test_publish.py`, plus new/updated cases in `test_artifacts.py` for the short-key location, old-location cleanup on emit, reserved-namespace blocking, and duplicate-short-key blocking).
- `.venv/bin/pytest lib/catalog/tests/test_schema_org.py -v` — 6 passed (new `page_path`/`version` param coverage plus a regression test pinning distribution URLs to the dated path).
- `.venv/bin/pytest lib/catalog/tests/` (full suite) — 364 passed.
- `make check-all` from repo root — clean (lint, format, `ty check`) for `etl` and all `lib/*` packages.
- **Real local dry-run** against the three canary datasets (`data/garden/emissions/2025-12-04/owid_co2`, `data/garden/energy_data/2026-04-24/owid_energy`, `data/garden/wb/2026-06-26/world_bank_pip` are all populated locally): all three emit cleanly with real dated versions (`2025-12-04`, `2026-04-24`, `2026-06-26` — none are `"latest"` locally). I then copied them into a scratch catalog dir and ran a real (non-dry-run) build to inspect the generated files directly: short-key URLs, dated `identifier`, dated `distribution.contentUrl`, and `<lastmod>` in the sitemap all came out as expected. One unrelated observation from that dry-run: the local `owid_co2` dataset's own `title`/`description` in `index.json` are stale (they say "Population" / Maddison Project text) — that's a pre-existing local sandbox data-quality quirk untouched by this PR (the title/description-selection logic in `schema_org.py` is unchanged), not something introduced here.

This PR does **not** run the real publish step (no `build_and_publish_catalog_jsonld` against a real bucket, no upload) — implementation, unit tests, and local `dry_run`/scratch builds only, per instruction. A human runs the actual publish separately once this and the companion `cloudflare-workers` PR are ready to land together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
