### PR TITLE
🐛 Fix owid_co2 garden dataset title and description

### DIFF
--- a/etl/steps/data/garden/emissions/2025-12-04/owid_co2.meta.yml
+++ b/etl/steps/data/garden/emissions/2025-12-04/owid_co2.meta.yml
@@ -1,3 +1,8 @@
 dataset:
+  title: OWID CO2 dataset
+  description: |-
+    OWID CO2 dataset.
+
+    This dataset will be loaded by [the co2-data repository](https://github.com/owid/co2-data), to create a csv file of the dataset that can be downloaded in one click.
   owners:
     - Pablo Rosado


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## What & why

The `garden/emissions/2025-12-04/owid_co2` step never set a dataset-level `title`/`description`, so the built dataset inherited junk from an auxiliary input via `default_metadata`:

- `title` = `"Population"`
- `description` = the Maddison Project Database (GDP) text

This surfaced in the catalog `schema.org/Dataset` JSON-LD, whose top-level description falls back to `dataset.description`. (Found while working on the JSON-LD description fallback in #6375.)

This sets the canonical OWID CO2 title and description — the exact text already served in production and mirroring how `owid_energy.meta.yml` does it. No new prose is invented.

## Verification

Rebuilt the step and confirmed:

- `Dataset(...).metadata.title` → `"OWID CO2 dataset"` (was `"Population"`)
- `.metadata.description` → the CO2 text (was the Maddison/GDP text)
- emitted JSON-LD `name` / `description` are now the correct CO2 values

🤖 Generated with [Claude Code](https://claude.com/claude-code)
