### PR TITLE
📊 Remove boilerplate description from energy dataset

### DIFF
--- a/etl/steps/data/garden/energy_data/2026-04-24/owid_energy.meta.yml
+++ b/etl/steps/data/garden/energy_data/2026-04-24/owid_energy.meta.yml
@@ -1,8 +1,4 @@
 dataset:
   title: Energy dataset
-  description: |-
-    OWID Energy dataset.
-
-    This dataset will be loaded by [the energy-data repository](https://github.com/owid/energy-data), to create a csv file of the dataset that can be downloaded in one click.
   owners:
     - Pablo Rosado


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

`owid_energy.meta.yml`'s dataset description just restated that the energy-data GitHub repo consumes this dataset ("This dataset will be loaded by [the energy-data repository]... to create a csv file... that can be downloaded in one click") — not useful, user-facing metadata.

## What changed

Removed the `description` field entirely from `etl/steps/data/garden/energy_data/2026-04-24/owid_energy.meta.yml`, keeping `title` and `owners`.

This matches the sibling `owid_co2` dataset (`etl/steps/data/garden/emissions/2025-12-04/owid_co2.meta.yml`) — also a multi-source combined dataset exported to a GitHub repo (`github/co2_data`) — which already omits `description` entirely.

Since this step combines 6 upstream garden datasets with no single origin passed as `default_metadata`, `ds.metadata.description` simply becomes `None` (there's no auto-inherited replacement). The only fallback that exists is in the JSON-LD generator (`schema_org.py`), which would pick an arbitrary origin's description or a generic string — but only for that artifact, not the dataset metadata itself.
