### PR TITLE
📊 Exclude stale archived datasets from catalog JSON-LD generation

### DIFF
--- a/etl/catalog_jsonld/artifacts.py
+++ b/etl/catalog_jsonld/artifacts.py
@@ -20,6 +20,7 @@ from structlog import get_logger
 
 from etl.catalog_jsonld.quality import DatasetQualityResult, assess_dataset_quality, find_duplicate_short_key_paths
 from etl.catalog_jsonld.sitemap import SitemapEntry, sitemap_xml
+from etl.dag_helpers import load_dag
 from etl.paths import DATA_DIR
 
 log = get_logger()
@@ -65,6 +66,7 @@ def build_catalog_jsonld_artifacts(
     base_url: str = DEFAULT_CATALOG_BASE_URL,
     dry_run: bool = False,
     only: set[str] | None = None,
+    active_steps: set[str] | None = None,
 ) -> JsonLdBuildResult:
     """Generate dataset JSON-LD files, sitemap, and quality report locally.
 
@@ -73,9 +75,13 @@ def build_catalog_jsonld_artifacts(
     dataset's own dated catalog folder, so the public landing page URL doesn't change every
     time the dataset gets a new version. When ``only`` is given, restrict generation to
     datasets whose ``"<namespace>/<dataset>"`` is in the set (version-agnostic allowlist).
+
+    ``active_steps`` overrides the set of active DAG step URIs used to exclude stale,
+    archived on-disk builds (see :func:`latest_dataset_paths`). Defaults to the real DAG;
+    tests should pass an explicit set instead of relying on ``dag/*.yml``.
     """
     catalog = LocalCatalog(catalog_dir, channels=(channel,))
-    latest_paths = latest_dataset_paths(catalog.frame, channel=channel, only=only)
+    latest_paths = latest_dataset_paths(catalog.frame, channel=channel, only=only, active_steps=active_steps)
     result = JsonLdBuildResult()
     sitemap_entries: list[SitemapEntry] = []
 
@@ -151,16 +157,36 @@ def _remove_if_exists(path: Path) -> None:
 
 
 def latest_dataset_paths(
-    frame: pd.DataFrame, *, channel: CHANNEL = "garden", only: set[str] | None = None
+    frame: pd.DataFrame,
+    *,
+    channel: CHANNEL = "garden",
+    only: set[str] | None = None,
+    active_steps: set[str] | None = None,
 ) -> list[LatestDatasetPath]:
     """Return latest public dataset entries for a catalog channel.
 
-    Private datasets are always excluded (``is_public == True`` filter). When ``only`` is
+    Private datasets are always excluded (``is_public == True`` filter). Datasets whose step
+    is no longer in the active DAG are also excluded — otherwise a stale on-disk build left
+    over from before a dataset was re-versioned (e.g. an archived ``.../latest/...`` step
+    superseded by a dated version) can outrank the real latest version, since ``"latest"``
+    sorts after any ``YYYY-MM-DD`` version string. ``active_steps`` defaults to the real DAG
+    (``load_dag()``); pass an explicit set to override it (e.g. in tests). When ``only`` is
     provided, the result is further restricted to datasets whose ``"<namespace>/<dataset>"``
     is in the set. Matching is version-agnostic so it survives data re-versioning. Allowlist
     entries that match no dataset are logged as a warning (typo / renamed dataset).
     """
     df = frame.loc[(frame["channel"] == channel) & (frame["is_public"] == True)].copy()  # noqa: E712
+    if df.empty:
+        if only:
+            for dataset_key in sorted(only):
+                log.warning("catalog_jsonld.allowlist_entry_unmatched", dataset=dataset_key, channel=channel)
+        return []
+    if active_steps is None:
+        active_steps = set(load_dag())
+    df["step"] = (
+        "data://" + df["channel"] + "/" + df["namespace"] + "/" + df["version"].astype(str) + "/" + df["dataset"]
+    )
+    df = df[df["step"].isin(active_steps)]
     if df.empty:
         if only:
             for dataset_key in sorted(only):

--- a/etl/catalog_jsonld/artifacts.py
+++ b/etl/catalog_jsonld/artifacts.py
@@ -20,7 +20,7 @@ from structlog import get_logger
 
 from etl.catalog_jsonld.quality import DatasetQualityResult, assess_dataset_quality, find_duplicate_short_key_paths
 from etl.catalog_jsonld.sitemap import SitemapEntry, sitemap_xml
-from etl.dag_helpers import load_dag
+from etl.dag_helpers import graph_nodes, load_dag
 from etl.paths import DATA_DIR
 
 log = get_logger()
@@ -170,7 +170,9 @@ def latest_dataset_paths(
     over from before a dataset was re-versioned (e.g. an archived ``.../latest/...`` step
     superseded by a dated version) can outrank the real latest version, since ``"latest"``
     sorts after any ``YYYY-MM-DD`` version string. ``active_steps`` defaults to the real DAG
-    (``load_dag()``); pass an explicit set to override it (e.g. in tests). When ``only`` is
+    (``graph_nodes(load_dag())``, matching keys and dependency values alike — a step can be
+    active purely as someone else's dependency without its own top-level DAG entry); pass an
+    explicit set to override it (e.g. in tests). When ``only`` is
     provided, the result is further restricted to datasets whose ``"<namespace>/<dataset>"``
     is in the set. Matching is version-agnostic so it survives data re-versioning. Allowlist
     entries that match no dataset are logged as a warning (typo / renamed dataset).
@@ -182,7 +184,7 @@ def latest_dataset_paths(
                 log.warning("catalog_jsonld.allowlist_entry_unmatched", dataset=dataset_key, channel=channel)
         return []
     if active_steps is None:
-        active_steps = set(load_dag())
+        active_steps = graph_nodes(load_dag())
     df["step"] = (
         "data://" + df["channel"] + "/" + df["namespace"] + "/" + df["version"].astype(str) + "/" + df["dataset"]
     )

--- a/etl/catalog_jsonld/artifacts.py
+++ b/etl/catalog_jsonld/artifacts.py
@@ -57,6 +57,7 @@ class JsonLdBuildResult:
     skipped: list[DatasetQualityResult] = field(default_factory=list)
     skipped_entries: list[LatestDatasetPath] = field(default_factory=list)
     warnings: list[DatasetQualityResult] = field(default_factory=list)
+    archived_entries: list[LatestDatasetPath] = field(default_factory=list)
 
 
 def build_catalog_jsonld_artifacts(
@@ -84,6 +85,19 @@ def build_catalog_jsonld_artifacts(
     latest_paths = latest_dataset_paths(catalog.frame, channel=channel, only=only, active_steps=active_steps)
     result = JsonLdBuildResult()
     sitemap_entries: list[SitemapEntry] = []
+
+    # A dataset can be archived outright, with no active replacement at all — every on-disk
+    # version of it is excluded from `latest_paths` above, so it never becomes an emitted or
+    # skipped entry either. Without this, a dataset.jsonld it published before being archived
+    # (at its dated path and/or its stable short key) would linger on R2 forever, since nothing
+    # would ever schedule its deletion again.
+    result.archived_entries = find_archived_dataset_entries(
+        catalog.frame, channel=channel, only=only, active_steps=active_steps
+    )
+    for entry in result.archived_entries:
+        if not dry_run:
+            _remove_if_exists(catalog_dir / entry.catalog_path / DATASET_JSONLD_FILENAME)
+            _remove_if_exists(catalog_dir / entry.namespace / entry.dataset / DATASET_JSONLD_FILENAME)
 
     duplicate_catalog_paths = find_duplicate_short_key_paths(
         (entry.catalog_path, entry.namespace, entry.dataset) for entry in latest_paths
@@ -217,6 +231,57 @@ def latest_dataset_paths(
     return sorted(entries, key=lambda entry: entry.catalog_path)
 
 
+def find_archived_dataset_entries(
+    frame: pd.DataFrame,
+    *,
+    channel: CHANNEL = "garden",
+    only: set[str] | None = None,
+    active_steps: set[str] | None = None,
+) -> list[LatestDatasetPath]:
+    """Return one entry per ``<namespace>/<dataset>`` group that has NO active-DAG
+    representative at all — every on-disk version of it has been archived, with no
+    replacement. These are never emitted, but a prior build may have published a
+    dataset.jsonld for them (at their old dated catalog path and/or their stable short key)
+    that must be cleaned up now that the step is gone for good.
+
+    The returned entry's ``catalog_path``/``version`` are the most-recent on-disk build
+    found, used only to target the cleanup; there's no "current version" for an archived
+    dataset. Respects ``only``/``active_steps`` the same way :func:`latest_dataset_paths` does.
+    """
+    df = frame.loc[(frame["channel"] == channel) & (frame["is_public"] == True)].copy()  # noqa: E712
+    if df.empty:
+        return []
+    if active_steps is None:
+        active_steps = graph_nodes(load_dag())
+    df["step"] = (
+        "data://" + df["channel"] + "/" + df["namespace"] + "/" + df["version"].astype(str) + "/" + df["dataset"]
+    )
+    df["dataset_key"] = df["namespace"].astype(str).str.cat(df["dataset"].astype(str), sep="/")
+    if only is not None:
+        df = df[df["dataset_key"].isin(only)]
+        if df.empty:
+            return []
+    active_keys = set(df.loc[df["step"].isin(active_steps), "dataset_key"])
+    orphaned = df[~df["dataset_key"].isin(active_keys)]
+    if orphaned.empty:
+        return []
+    orphaned = orphaned.copy()
+    orphaned["dataset_path"] = orphaned["path"].map(lambda p: str(p).rsplit("/", 1)[0])
+    orphaned = orphaned.sort_values("version")
+    latest_orphaned = orphaned.drop_duplicates(["channel", "namespace", "dataset"], keep="last")
+
+    entries = [
+        LatestDatasetPath(
+            catalog_path=str(row.dataset_path),
+            namespace=str(row.namespace),
+            dataset=str(row.dataset),
+            version=str(row.version),
+        )
+        for row in latest_orphaned.itertuples()
+    ]
+    return sorted(entries, key=lambda entry: entry.catalog_path)
+
+
 def load_table_schema_inputs(ds: Dataset) -> list[TableSchemaInput]:
     tables = []
     dataset_path = Path(ds.path)
@@ -253,10 +318,12 @@ def quality_report(result: JsonLdBuildResult) -> dict[str, Any]:
             "emitted": len(result.emitted),
             "skipped": len(result.skipped),
             "warnings": len(result.warnings),
+            "archived": len(result.archived_entries),
         },
         "emitted": result.emitted,
         "skipped": [_quality_to_record(item, include_blockers=True) for item in result.skipped],
         "warnings": [_quality_to_record(item, include_blockers=False) for item in result.warnings],
+        "archived": [entry.catalog_path for entry in result.archived_entries],
     }
 
 

--- a/etl/catalog_jsonld/publish.py
+++ b/etl/catalog_jsonld/publish.py
@@ -28,11 +28,16 @@ def build_and_publish_catalog_jsonld(
     dry_run: bool = False,
     base_url: str = "https://catalog.ourworldindata.org",
     only: set[str] | None = None,
+    active_steps: set[str] | None = None,
 ) -> None:
     """Build catalog JSON-LD artifacts locally and sync them to R2.
 
     When ``only`` is given, restrict generation to datasets whose
     ``"<namespace>/<dataset>"`` is in the set (version-agnostic allowlist).
+
+    ``active_steps`` overrides the set of active DAG step URIs used to exclude stale,
+    archived on-disk builds (see :func:`etl.catalog_jsonld.artifacts.latest_dataset_paths`).
+    Defaults to the real DAG; tests should pass an explicit set instead.
     """
     result = build_catalog_jsonld_artifacts(
         catalog_dir=catalog_dir,
@@ -40,6 +45,7 @@ def build_and_publish_catalog_jsonld(
         dry_run=dry_run,
         base_url=base_url,
         only=only,
+        active_steps=active_steps,
     )
     if dry_run:
         print(

--- a/etl/catalog_jsonld/publish.py
+++ b/etl/catalog_jsonld/publish.py
@@ -68,6 +68,11 @@ def build_and_publish_catalog_jsonld(
     # dataset that becomes ineligible (e.g. non_redistributable) must stop being served.
     delete_keys.extend(f"{item.catalog_path}/{DATASET_JSONLD_FILENAME}" for item in result.skipped)
     delete_keys.extend(f"{entry.short_key}/{DATASET_JSONLD_FILENAME}" for entry in result.skipped_entries)
+    # Also delete both locations for datasets archived outright (no active replacement at
+    # all) — they never appear in emitted/skipped above, since no on-disk version of them is
+    # active, but a prior publish may still have left their JSON-LD live on R2.
+    delete_keys.extend(f"{entry.catalog_path}/{DATASET_JSONLD_FILENAME}" for entry in result.archived_entries)
+    delete_keys.extend(f"{entry.short_key}/{DATASET_JSONLD_FILENAME}" for entry in result.archived_entries)
 
     sync_jsonld_artifacts(connect_r2(), bucket, catalog_dir, keys, delete_keys=delete_keys)
 

--- a/tests/catalog_jsonld/test_artifacts.py
+++ b/tests/catalog_jsonld/test_artifacts.py
@@ -9,6 +9,11 @@ from structlog.testing import capture_logs
 from etl.catalog_jsonld.artifacts import build_catalog_jsonld_artifacts
 
 
+def _step_uri(catalog_path: str) -> str:
+    """Convert a catalog dataset path (e.g. 'garden/ns/2025-01-01/short_name') to its DAG step URI."""
+    return f"data://{catalog_path}"
+
+
 def _add_eligible_dataset(
     data_dir: Path,
     *,
@@ -81,7 +86,11 @@ def test_build_catalog_jsonld_artifacts_writes_dataset_jsonld_sitemap_and_report
 
     LocalCatalog(data_dir, channels=("garden",)).reindex()
 
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    result = build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir,
+        channel="garden",
+        active_steps={_step_uri("garden/example/2025-01-01/example_dataset")},
+    )
 
     assert result.emitted == ["garden/example/2025-01-01/example_dataset"]
     # dataset.jsonld now lives at the stable "<namespace>/<dataset>" short key, not inside the
@@ -141,7 +150,11 @@ def test_build_catalog_jsonld_artifacts_cleans_up_stale_old_location_for_emitted
     stale_old_location.write_text("{}")
 
     LocalCatalog(data_dir, channels=("garden",)).reindex()
-    build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir,
+        channel="garden",
+        active_steps={_step_uri("garden/example/2025-01-01/example_dataset")},
+    )
 
     assert not stale_old_location.exists()
     assert (data_dir / "example" / "example_dataset" / "dataset.jsonld").exists()
@@ -150,11 +163,16 @@ def test_build_catalog_jsonld_artifacts_cleans_up_stale_old_location_for_emitted
 def test_build_catalog_jsonld_artifacts_only_allowlist_restricts_emission(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     co2_path = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2")
-    _add_eligible_dataset(data_dir, namespace="energy_data", dataset="owid_energy")
-    _add_eligible_dataset(data_dir, namespace="demography", dataset="population")
+    energy_path = _add_eligible_dataset(data_dir, namespace="energy_data", dataset="owid_energy")
+    population_path = _add_eligible_dataset(data_dir, namespace="demography", dataset="population")
     LocalCatalog(data_dir, channels=("garden",)).reindex()
 
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden", only={"emissions/owid_co2"})
+    result = build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir,
+        channel="garden",
+        only={"emissions/owid_co2"},
+        active_steps={_step_uri(p) for p in (co2_path, energy_path, population_path)},
+    )
 
     # Only the allowlisted dataset is emitted; the others are not even assessed.
     assert result.emitted == [co2_path]
@@ -172,22 +190,53 @@ def test_build_catalog_jsonld_artifacts_only_allowlist_restricts_emission(tmp_pa
 def test_build_catalog_jsonld_artifacts_only_is_version_agnostic(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     # Two versions of the same dataset: the allowlist matches on namespace/dataset, latest wins.
-    _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="2024-01-01")
+    older = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="2024-01-01")
     newer = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="2025-12-04")
     LocalCatalog(data_dir, channels=("garden",)).reindex()
 
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden", only={"emissions/owid_co2"})
+    result = build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir,
+        channel="garden",
+        only={"emissions/owid_co2"},
+        active_steps={_step_uri(older), _step_uri(newer)},
+    )
 
     assert result.emitted == [newer]
 
 
+def test_build_catalog_jsonld_artifacts_ignores_stale_archived_latest_version(tmp_path: Path) -> None:
+    # Regression test: a dataset re-versioned from "latest" to a dated version leaves a stale
+    # on-disk "latest" build behind. Since the string "latest" sorts after any YYYY-MM-DD
+    # version, naive version-max selection would wrongly pick the stale archived build over
+    # the real, active, dated one. Excluding non-active-DAG steps must prevent that.
+    data_dir = tmp_path / "data"
+    stale_latest = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="latest")
+    current = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="2025-12-04")
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    result = build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir,
+        channel="garden",
+        # Only the dated version is in the active DAG; "latest" is a stale, archived leftover.
+        active_steps={_step_uri(current)},
+    )
+
+    assert result.emitted == [current]
+    assert stale_latest not in result.emitted
+
+
 def test_build_catalog_jsonld_artifacts_only_unmatched_entry_warns_and_emits_nothing(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
-    _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2")
+    co2_path = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2")
     LocalCatalog(data_dir, channels=("garden",)).reindex()
 
     with capture_logs() as logs:
-        result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden", only={"wb/does_not_exist"})
+        result = build_catalog_jsonld_artifacts(
+            catalog_dir=data_dir,
+            channel="garden",
+            only={"wb/does_not_exist"},
+            active_steps={_step_uri(co2_path)},
+        )
 
     assert result.emitted == []
     assert (data_dir / "sitemap.xml").read_text().count("<url>") == 0
@@ -197,10 +246,12 @@ def test_build_catalog_jsonld_artifacts_only_unmatched_entry_warns_and_emits_not
 
 def test_build_catalog_jsonld_artifacts_excludes_non_redistributable(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
-    _add_eligible_dataset(data_dir, namespace="wb", dataset="restricted", non_redistributable=True)
+    restricted_path = _add_eligible_dataset(data_dir, namespace="wb", dataset="restricted", non_redistributable=True)
     LocalCatalog(data_dir, channels=("garden",)).reindex()
 
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    result = build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir, channel="garden", active_steps={_step_uri(restricted_path)}
+    )
 
     assert result.emitted == []
     assert [item.catalog_path for item in result.skipped] == ["garden/wb/2025-01-01/restricted"]
@@ -213,10 +264,10 @@ def test_build_catalog_jsonld_artifacts_omits_lastmod_for_non_date_version(tmp_p
     lastmod rather than stamping the build date, which would falsely mark the page as modified
     on every publish."""
     data_dir = tmp_path / "data"
-    _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="latest")
+    path = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="latest")
     LocalCatalog(data_dir, channels=("garden",)).reindex()
 
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden", active_steps={_step_uri(path)})
 
     assert result.emitted == ["garden/emissions/latest/owid_co2"]
     sitemap = (data_dir / "sitemap.xml").read_text()
@@ -230,13 +281,13 @@ def test_build_catalog_jsonld_artifacts_removes_short_key_artifact_when_dataset_
     """A dataset emitted at its short key by a prior build must have that local artifact removed
     once it fails a quality gate, so an ineligible dataset can't keep a stale public JSON-LD."""
     data_dir = tmp_path / "data"
-    _add_eligible_dataset(data_dir, namespace="wb", dataset="restricted", non_redistributable=True)
+    path = _add_eligible_dataset(data_dir, namespace="wb", dataset="restricted", non_redistributable=True)
     LocalCatalog(data_dir, channels=("garden",)).reindex()
     stale_short_key = data_dir / "wb" / "restricted" / "dataset.jsonld"
     stale_short_key.parent.mkdir(parents=True)
     stale_short_key.write_text('{"from": "a prior build"}')
 
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden", active_steps={_step_uri(path)})
 
     assert result.emitted == []
     assert [entry.short_key for entry in result.skipped_entries] == ["wb/restricted"]
@@ -250,7 +301,7 @@ def test_build_catalog_jsonld_artifacts_blocks_reserved_namespace(tmp_path: Path
     path = _add_eligible_dataset(data_dir, namespace="garden", dataset="something")
     LocalCatalog(data_dir, channels=("garden",)).reindex()
 
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden", active_steps={_step_uri(path)})
 
     assert result.emitted == []
     assert [item.catalog_path for item in result.skipped] == [path]
@@ -272,8 +323,8 @@ def test_build_catalog_jsonld_artifacts_blocks_duplicate_short_keys(tmp_path: Pa
 
     real_latest_dataset_paths = artifacts_module.latest_dataset_paths
 
-    def fake_latest_dataset_paths(frame, *, channel="garden", only=None):
-        entries = real_latest_dataset_paths(frame, channel=channel, only=only)
+    def fake_latest_dataset_paths(frame, *, channel="garden", only=None, active_steps=None):
+        entries = real_latest_dataset_paths(frame, channel=channel, only=only, active_steps=active_steps)
         return [
             artifacts_module.LatestDatasetPath(
                 catalog_path=entry.catalog_path, namespace="emissions", dataset="owid_co2", version=entry.version
@@ -283,7 +334,11 @@ def test_build_catalog_jsonld_artifacts_blocks_duplicate_short_keys(tmp_path: Pa
 
     monkeypatch.setattr(artifacts_module, "latest_dataset_paths", fake_latest_dataset_paths)
 
-    result = artifacts_module.build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    result = artifacts_module.build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir,
+        channel="garden",
+        active_steps={_step_uri(path_a), _step_uri(path_b)},
+    )
 
     assert result.emitted == []
     assert {item.catalog_path for item in result.skipped} == {path_a, path_b}

--- a/tests/catalog_jsonld/test_artifacts.py
+++ b/tests/catalog_jsonld/test_artifacts.py
@@ -223,6 +223,37 @@ def test_build_catalog_jsonld_artifacts_ignores_stale_archived_latest_version(tm
 
     assert result.emitted == [current]
     assert stale_latest not in result.emitted
+    # The dataset has an active replacement, so it's superseded, not archived outright.
+    assert result.archived_entries == []
+
+
+def test_build_catalog_jsonld_artifacts_cleans_up_dataset_archived_with_no_replacement(tmp_path: Path) -> None:
+    # Regression test: unlike the "superseded" case above, a dataset removed from the DAG with
+    # NO active replacement at all has every on-disk version excluded from latest_dataset_paths,
+    # so it never becomes an emitted or skipped entry either. Without explicit archived-entry
+    # tracking, a dataset.jsonld it published before being archived (at its old dated path and
+    # its stable short key) would never be scheduled for deletion again.
+    data_dir = tmp_path / "data"
+    archived = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="2024-01-01")
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+    stale_dated = data_dir / archived / "dataset.jsonld"
+    stale_dated.write_text('{"from": "before archiving"}')
+    stale_short_key = data_dir / "emissions" / "owid_co2" / "dataset.jsonld"
+    stale_short_key.parent.mkdir(parents=True)
+    stale_short_key.write_text('{"from": "before archiving"}')
+
+    result = build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir,
+        channel="garden",
+        # Nothing is active: the dataset has been archived with no replacement.
+        active_steps=set(),
+    )
+
+    assert result.emitted == []
+    assert result.skipped == []
+    assert [entry.catalog_path for entry in result.archived_entries] == [archived]
+    assert not stale_dated.exists()
+    assert not stale_short_key.exists()
 
 
 def test_build_catalog_jsonld_artifacts_only_unmatched_entry_warns_and_emits_nothing(tmp_path: Path) -> None:

--- a/tests/catalog_jsonld/test_publish.py
+++ b/tests/catalog_jsonld/test_publish.py
@@ -10,6 +10,11 @@ from etl.catalog_jsonld.artifacts import DATASET_JSONLD_FILENAME, QUALITY_REPORT
 from etl.catalog_jsonld.publish import build_and_publish_catalog_jsonld, sync_jsonld_artifacts
 
 
+def _step_uri(catalog_path: str) -> str:
+    """Convert a catalog dataset path (e.g. 'garden/ns/2025-01-01/short_name') to its DAG step URI."""
+    return f"data://{catalog_path}"
+
+
 class FakeS3:
     """Minimal stand-in for the boto3 S3 client used by sync_jsonld_artifacts."""
 
@@ -119,7 +124,9 @@ def test_build_and_publish_catalog_jsonld_uses_short_keys_and_deletes_old_dated_
     monkeypatch.setattr("etl.catalog_jsonld.publish.connect_r2", lambda: object())
     monkeypatch.setattr("etl.catalog_jsonld.publish.sync_jsonld_artifacts", fake_sync_jsonld_artifacts)
 
-    build_and_publish_catalog_jsonld(bucket="test-bucket", catalog_dir=data_dir, channel="garden")
+    build_and_publish_catalog_jsonld(
+        bucket="test-bucket", catalog_dir=data_dir, channel="garden", active_steps={_step_uri(co2_path)}
+    )
 
     assert f"emissions/owid_co2/{DATASET_JSONLD_FILENAME}" in captured["keys"]
     assert SITEMAP_FILENAME in captured["keys"]
@@ -147,7 +154,9 @@ def test_build_and_publish_catalog_jsonld_deletes_short_key_for_skipped_dataset(
     monkeypatch.setattr("etl.catalog_jsonld.publish.connect_r2", lambda: object())
     monkeypatch.setattr("etl.catalog_jsonld.publish.sync_jsonld_artifacts", fake_sync_jsonld_artifacts)
 
-    build_and_publish_catalog_jsonld(bucket="test-bucket", catalog_dir=data_dir, channel="garden")
+    build_and_publish_catalog_jsonld(
+        bucket="test-bucket", catalog_dir=data_dir, channel="garden", active_steps={_step_uri(restricted_path)}
+    )
 
     assert f"wb/restricted/{DATASET_JSONLD_FILENAME}" not in captured["keys"]
     assert f"wb/restricted/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]

--- a/tests/catalog_jsonld/test_publish.py
+++ b/tests/catalog_jsonld/test_publish.py
@@ -161,3 +161,29 @@ def test_build_and_publish_catalog_jsonld_deletes_short_key_for_skipped_dataset(
     assert f"wb/restricted/{DATASET_JSONLD_FILENAME}" not in captured["keys"]
     assert f"wb/restricted/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]
     assert f"{restricted_path}/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]
+
+
+def test_build_and_publish_catalog_jsonld_deletes_both_locations_for_archived_dataset(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A dataset removed from the DAG with no active replacement at all must have both its old
+    dated-path and stable short-key JSON-LD scheduled for deletion, even though it never shows
+    up as emitted or skipped (no on-disk version of it is active)."""
+    data_dir = tmp_path / "data"
+    archived_path = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="2024-01-01")
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    captured: dict[str, Any] = {}
+
+    def fake_sync_jsonld_artifacts(s3, bucket, catalog_dir, keys, delete_keys=None):
+        captured["keys"] = keys
+        captured["delete_keys"] = delete_keys
+
+    monkeypatch.setattr("etl.catalog_jsonld.publish.connect_r2", lambda: object())
+    monkeypatch.setattr("etl.catalog_jsonld.publish.sync_jsonld_artifacts", fake_sync_jsonld_artifacts)
+
+    build_and_publish_catalog_jsonld(bucket="test-bucket", catalog_dir=data_dir, channel="garden", active_steps=set())
+
+    assert f"emissions/owid_co2/{DATASET_JSONLD_FILENAME}" not in captured["keys"]
+    assert f"emissions/owid_co2/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]
+    assert f"{archived_path}/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

While checking that removing `owid_energy`'s boilerplate description (#6378) had propagated to `catalog.ourworldindata.org`, I noticed `emissions/owid_co2`'s catalog JSON-LD was serving `"identifier": "garden/emissions/latest/owid_co2"` — a stale, archived build (`dag/archive/emissions.yml`), not the active `garden/emissions/2025-12-04/owid_co2` step.

Root cause: `latest_dataset_paths()` in `etl/catalog_jsonld/artifacts.py` picks the newest version per `(namespace, dataset)` by sorting the raw `version` string and keeping the last one. The literal string `"latest"` sorts after any `YYYY-MM-DD` date. So once a dataset is re-versioned off an unversioned `latest` step onto a dated one, any leftover on-disk build of the old `latest` step permanently outranks the real, active version — silently and indefinitely, since nothing prompts a rebuild of the stale directory to notice it's gone from the DAG.

## What changed

`latest_dataset_paths()` (and `build_catalog_jsonld_artifacts()` / `build_and_publish_catalog_jsonld()`, which thread it through) now cross-reference the on-disk catalog against the active DAG (`load_dag()`) and drop any dataset whose step URI isn't currently active, before picking the latest version among what's left.

Added `active_steps: set[str] | None` as an injectable override (defaults to the real DAG) so tests don't depend on `dag/*.yml` contents, plus a regression test (`test_build_catalog_jsonld_artifacts_ignores_stale_archived_latest_version`) reproducing the exact scenario found in production.

## Note

This branch was rebased after a concurrent PR (#6374/#6377) landed a larger refactor of this same module (stable short-key JSON-LD paths). My change is layered on top of that, and all existing + new tests pass against the current structure.
