### PR TITLE
✨ Keep Jinja templates out of catalog JSON-LD

### DIFF
--- a/etl/catalog_jsonld/artifacts.py
+++ b/etl/catalog_jsonld/artifacts.py
@@ -15,10 +15,20 @@ import pyarrow.parquet as pq
 from owid.catalog.api.legacy import CHANNEL, LocalCatalog
 from owid.catalog.core.datasets import SUPPORTED_FORMATS, Dataset
 from owid.catalog.core.meta import TableMeta, VariableMeta
-from owid.catalog.schema_org import DEFAULT_CATALOG_BASE_URL, TableSchemaInput, dataset_to_schema_org
+from owid.catalog.schema_org import (
+    DEFAULT_CATALOG_BASE_URL,
+    ENTITY_TIME_DIMENSIONS,
+    TableSchemaInput,
+    dataset_to_schema_org,
+)
 from structlog import get_logger
 
-from etl.catalog_jsonld.quality import DatasetQualityResult, assess_dataset_quality, find_duplicate_short_key_paths
+from etl.catalog_jsonld.quality import (
+    DatasetQualityResult,
+    assess_dataset_quality,
+    find_duplicate_short_key_paths,
+    jsonld_contains_raw_jinja,
+)
 from etl.catalog_jsonld.sitemap import SitemapEntry, sitemap_xml
 from etl.dag_helpers import graph_nodes, load_dag
 from etl.paths import DATA_DIR
@@ -76,7 +86,8 @@ def build_catalog_jsonld_artifacts(
     (``catalog_dir / "<namespace>" / "<dataset>" / "dataset.jsonld"``) rather than inside the
     dataset's own dated catalog folder, so the public landing page URL doesn't change every
     time the dataset gets a new version. When ``only`` is given, restrict generation to
-    datasets whose ``"<namespace>/<dataset>"`` is in the set (version-agnostic allowlist).
+    datasets whose ``"<namespace>/<dataset>"`` is in the set (version-agnostic allowlist);
+    otherwise only datasets that opt in via ``DatasetMeta.jsonld`` are considered.
 
     ``active_steps`` overrides the set of active DAG step URIs used to exclude stale,
     archived on-disk builds (see :func:`latest_dataset_paths`). Defaults to the real DAG;
@@ -114,6 +125,12 @@ def build_catalog_jsonld_artifacts(
     for entry in latest_paths:
         catalog_path = entry.catalog_path
         ds = Dataset(catalog_dir / catalog_path)
+        # Without an explicit allowlist, only datasets that opt in via `dataset: jsonld: true`
+        # in their metadata are considered (canary rollout of the catalog-discovery project).
+        # Unflagged datasets are invisible to this build: not emitted, not reported, and any
+        # previously published artifacts are left untouched.
+        if only is None and not ds.metadata.jsonld:
+            continue
         tables = load_table_schema_inputs(ds)
         quality = assess_dataset_quality(
             catalog_path=catalog_path,
@@ -141,6 +158,19 @@ def build_catalog_jsonld_artifacts(
             tables=tables,
             base_url=base_url,
         )
+        # Safety net: metadata fields can be Jinja templates (long-format tables render them
+        # per dimension combination elsewhere). schema_org guards the known fields, but any
+        # template that still leaks into the output must never ship — skip the dataset instead.
+        if jsonld_contains_raw_jinja(jsonld):
+            quality.blockers.append("raw_jinja_in_jsonld")
+            result.skipped.append(quality)
+            result.skipped_entries.append(entry)
+            log.warning("catalog_jsonld.raw_jinja_in_jsonld", dataset=catalog_path)
+            if not dry_run:
+                _remove_if_exists(Path(ds.path) / DATASET_JSONLD_FILENAME)
+                _remove_if_exists(catalog_dir / entry.namespace / entry.dataset / DATASET_JSONLD_FILENAME)
+            continue
+
         result.emitted.append(catalog_path)
         result.emitted_entries.append(entry)
         if quality.warnings or quality.table_warnings:
@@ -318,6 +348,12 @@ def load_table_schema_inputs(ds: Dataset) -> list[TableSchemaInput]:
             formats=formats,
             primary_key=table_meta.primary_key,
         )
+        dimension_values, representative_dimensions = _dimension_values_from_table_data(
+            dataset_path=dataset_path,
+            table_name=table_meta.short_name,
+            formats=formats,
+            table_meta=table_meta,
+        )
         tables.append(
             TableSchemaInput(
                 short_name=table_meta.short_name,
@@ -327,6 +363,8 @@ def load_table_schema_inputs(ds: Dataset) -> list[TableSchemaInput]:
                 primary_key=table_meta.primary_key,
                 temporal_coverage=temporal_coverage,
                 spatial_coverage=spatial_coverage,
+                dimension_values=dimension_values,
+                representative_dimensions=representative_dimensions,
             )
         )
     return tables
@@ -371,9 +409,7 @@ def _coverage_from_table_data(
     if not wanted_columns:
         return None, None
 
-    tb = _read_coverage_columns(
-        dataset_path=dataset_path, table_name=table_name, formats=formats, columns=wanted_columns
-    )
+    tb = _read_table_columns(dataset_path=dataset_path, table_name=table_name, formats=formats, columns=wanted_columns)
     if tb is None:
         return None, "Worldwide" if "country" in columns else None
 
@@ -382,7 +418,51 @@ def _coverage_from_table_data(
     return temporal_coverage, spatial_coverage
 
 
-def _read_coverage_columns(
+def _dimension_values_from_table_data(
+    *, dataset_path: Path, table_name: str, formats: list[str], table_meta: TableMeta
+) -> tuple[dict[str, list[Any]], dict[str, Any]]:
+    """Read distinct values per dimension column, plus one representative dimension combination.
+
+    Long-format tables declare their dimension columns in ``TableMeta.dimensions``; the values
+    only exist in the data. The representative combination (the most frequent one) is used to
+    render Jinja-templated variable metadata into a concrete example.
+    """
+    slugs = [
+        dimension["slug"]
+        for dimension in table_meta.dimensions or []
+        if dimension["slug"] not in ENTITY_TIME_DIMENSIONS
+    ]
+    if not slugs:
+        return {}, {}
+    df = _read_table_columns(dataset_path=dataset_path, table_name=table_name, formats=formats, columns=slugs)
+    if df is None:
+        return {}, {}
+
+    dimension_values: dict[str, list[Any]] = {}
+    for slug in slugs:
+        values = [_as_python_scalar(value) for value in df[slug].dropna().unique()]
+        try:
+            values.sort()
+        except TypeError:
+            values.sort(key=str)
+        dimension_values[slug] = values
+
+    representative_dimensions: dict[str, Any] = {}
+    combos = df.dropna()
+    if not combos.empty:
+        top = combos.value_counts().index[0]
+        if not isinstance(top, tuple):
+            top = (top,)
+        representative_dimensions = {slug: _as_python_scalar(value) for slug, value in zip(combos.columns, top)}
+    return dimension_values, representative_dimensions
+
+
+def _as_python_scalar(value: Any) -> Any:
+    # numpy scalars compare fine but serialize badly (json.dump chokes on np.int64).
+    return value.item() if hasattr(value, "item") else value
+
+
+def _read_table_columns(
     *, dataset_path: Path, table_name: str, formats: list[str], columns: list[str]
 ) -> pd.DataFrame | None:
     for format in formats:

--- a/etl/catalog_jsonld/publish.py
+++ b/etl/catalog_jsonld/publish.py
@@ -34,6 +34,8 @@ def build_and_publish_catalog_jsonld(
 
     When ``only`` is given, restrict generation to datasets whose
     ``"<namespace>/<dataset>"`` is in the set (version-agnostic allowlist).
+    Otherwise only datasets that opt in via ``dataset: jsonld: true`` in their
+    metadata are considered.
 
     ``active_steps`` overrides the set of active DAG step URIs used to exclude stale,
     archived on-disk builds (see :func:`etl.catalog_jsonld.artifacts.latest_dataset_paths`).

--- a/etl/catalog_jsonld/quality.py
+++ b/etl/catalog_jsonld/quality.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from collections import Counter
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from typing import Any
 
 from owid.catalog.core.datasets import CHANNEL
 from owid.catalog.core.meta import DatasetMeta
@@ -41,6 +43,18 @@ def is_reserved_namespace(namespace: str) -> bool:
     if namespace.startswith("sitemap") and namespace.endswith(".xml"):
         return True
     return False
+
+
+def jsonld_contains_raw_jinja(jsonld: dict[str, Any]) -> bool:
+    """Return True if the serialized JSON-LD still contains Jinja template markers.
+
+    Variable metadata in long-format tables is Jinja-templated (rendered per dimension
+    combination by grapher, not by the catalog). ``schema_org`` guards the fields it knows
+    about; this is the last line of defense so an unguarded field can never ship a raw
+    template to the public page.
+    """
+    text = json.dumps(jsonld, ensure_ascii=False)
+    return "<%" in text or "<<" in text
 
 
 def find_duplicate_short_key_paths(entries: Iterable[tuple[str, str, str]]) -> set[str]:

--- a/etl/publish.py
+++ b/etl/publish.py
@@ -64,7 +64,8 @@ class CannotPublish(Exception):
     "--jsonld",
     is_flag=True,
     default=False,
-    help="Generate and publish Schema.org Dataset JSON-LD artifacts for eligible catalog datasets.",
+    help="Generate and publish Schema.org Dataset JSON-LD artifacts for catalog datasets that "
+    "opt in via `dataset: jsonld: true` in their metadata (and pass the quality gates).",
 )
 @click.option(
     "--jsonld-base-url",
@@ -76,7 +77,8 @@ class CannotPublish(Exception):
     "--jsonld-only",
     multiple=True,
     help="Restrict JSON-LD generation to these datasets, as '<namespace>/<dataset>' "
-    "(repeatable). Default: all eligible garden datasets.",
+    "(repeatable). Overrides the metadata opt-in: listed datasets are considered even "
+    "without `dataset: jsonld: true`.",
 )
 def publish_cli(
     dry_run: bool,

--- a/etl/steps/data/garden/emissions/2025-12-04/owid_co2.meta.yml
+++ b/etl/steps/data/garden/emissions/2025-12-04/owid_co2.meta.yml
@@ -1,4 +1,6 @@
 dataset:
+  # Canary for the public catalog landing page / Schema.org JSON-LD (catalog-discovery project).
+  jsonld: true
   title: OWID CO2 dataset
   description: |-
     OWID CO2 dataset.

--- a/etl/steps/data/garden/energy_data/2026-04-24/owid_energy.meta.yml
+++ b/etl/steps/data/garden/energy_data/2026-04-24/owid_energy.meta.yml
@@ -1,4 +1,6 @@
 dataset:
+  # Canary for the public catalog landing page / Schema.org JSON-LD (catalog-discovery project).
+  jsonld: true
   title: Energy dataset
   description: |-
     Our complete Energy dataset is a collection of key metrics maintained by Our World in Data. It includes data on energy consumption (primary energy, per capita, and growth rates), energy mix, electricity mix, and fossil fuel production.

--- a/etl/steps/data/garden/wb/2026-06-26/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2026-06-26/world_bank_pip.meta.yml
@@ -725,6 +725,8 @@ definitions:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/
 dataset:
   update_period_days: 180
+  # Canary for the public catalog landing page / Schema.org JSON-LD (catalog-discovery project).
+  jsonld: true
 
   owners:
     - Pablo Arriagada

--- a/lib/catalog/owid/catalog/core/meta.py
+++ b/lib/catalog/owid/catalog/core/meta.py
@@ -537,6 +537,10 @@ class DatasetMeta(MetaBase):
     update_period_days: int | None = None
     # prohibit redistribution (disable chart download)
     non_redistributable: bool = False
+    # opt this dataset into the public catalog landing page / Schema.org JSON-LD publication
+    # (canary rollout of the catalog-discovery project; set via `dataset: jsonld: true` in
+    # the garden step's .meta.yml)
+    jsonld: bool = False
     # OWID team members who maintain this dataset; first entry is the accountable owner
     owners: list[str] = field(default_factory=list)
 

--- a/lib/catalog/owid/catalog/schema_org.py
+++ b/lib/catalog/owid/catalog/schema_org.py
@@ -6,12 +6,20 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
+import jinja2
+
+from owid.catalog.core.jinja import _expand_jinja_text, _uses_jinja
 from owid.catalog.core.meta import DatasetMeta, License, Origin, TableMeta, VariableMeta
+from owid.catalog.core.utils import remove_details_on_demand
 
 DEFAULT_CATALOG_BASE_URL = "https://catalog.ourworldindata.org"
 DEFAULT_LOGO_URL = "https://ourworldindata.org/owid-logo.svg"
 DEFAULT_THUMBNAIL_URL = DEFAULT_LOGO_URL
 MAX_VARIABLES_MEASURED = 100
+MAX_DIMENSION_VALUES_LISTED = 40
+# Dimensions that every table has and that are already conveyed by temporalCoverage /
+# spatialCoverage — not worth a PropertyValue of their own.
+ENTITY_TIME_DIMENSIONS = {"country", "year", "date"}
 KNOWN_LICENSE_URLS = {
     "CC BY 4.0": "https://creativecommons.org/licenses/by/4.0/",
     "CC-BY 4.0": "https://creativecommons.org/licenses/by/4.0/",
@@ -30,6 +38,11 @@ class TableSchemaInput:
     primary_key: list[str] = field(default_factory=list)
     temporal_coverage: str | None = None
     spatial_coverage: str | None = None
+    # For long-format tables: distinct values per dimension column (slug -> sorted values)
+    # and one representative dimension combination observed in the data, used to render
+    # Jinja-templated variable metadata into an example instead of leaking the raw template.
+    dimension_values: dict[str, list[Any]] = field(default_factory=dict)
+    representative_dimensions: dict[str, Any] = field(default_factory=dict)
 
 
 def dataset_to_schema_org(
@@ -194,23 +207,89 @@ def _table_dataset(
 def _variable_measured(table: TableSchemaInput) -> list[dict[str, Any]]:
     variables = []
     primary_key = set(table.primary_key or table.metadata.primary_key or [])
+
+    # In long-format tables one physical column holds many logical indicators; the dimension
+    # columns select among them. They are part of the primary key (so the loop below skips
+    # them), yet they carry the information a consumer needs to slice the table — emit them
+    # first, with their observed values.
+    dimension_items = _dimension_property_values(table)
+    dimension_slugs = {item["identifier"] for item in dimension_items}
+    variables.extend(dimension_items[:MAX_VARIABLES_MEASURED])
+
     for name, meta in table.variables.items():
-        if name in primary_key:
+        if name in primary_key or name in dimension_slugs:
             continue
+        if len(variables) >= MAX_VARIABLES_MEASURED:
+            break
         item: dict[str, Any] = {
             "@type": "PropertyValue",
             "name": _variable_title(name, meta),
             "identifier": name,
         }
-        description = _variable_description(meta)
+        description = _variable_description(meta) or _example_description(meta, table)
         if description:
             item["description"] = description
-        if meta.unit:
+        if meta.unit and not _uses_jinja(meta.unit):
+            # A templated unit (e.g. "international-$ in <<ppp_version>> prices") is only
+            # correct for one slice of the column; omit it rather than emit a wrong or raw value.
             item["unitText"] = meta.unit
         variables.append(_drop_empty(item))
-        if len(variables) >= MAX_VARIABLES_MEASURED:
-            break
     return variables
+
+
+def _dimension_property_values(table: TableSchemaInput) -> list[dict[str, Any]]:
+    items = []
+    for dimension in table.metadata.dimensions or []:
+        slug = dimension["slug"]
+        if slug in ENTITY_TIME_DIMENSIONS:
+            continue
+        parts = ["Dimension column: selects one of the data series stored in this table."]
+        dimension_description = dimension.get("description")
+        if dimension_description and not _uses_jinja(dimension_description):
+            parts.append(dimension_description)
+        values = table.dimension_values.get(slug) or []
+        if values:
+            listed = ", ".join(str(value) for value in values[:MAX_DIMENSION_VALUES_LISTED])
+            if len(values) > MAX_DIMENSION_VALUES_LISTED:
+                listed += f", … ({len(values)} values in total)"
+            parts.append(f"Values: {listed}.")
+        items.append(
+            {
+                "@type": "PropertyValue",
+                "name": dimension.get("name") or slug,
+                "identifier": slug,
+                "description": " ".join(parts),
+            }
+        )
+    return items
+
+
+def _example_description(meta: VariableMeta, table: TableSchemaInput) -> str | None:
+    """Render a Jinja-templated description for one representative dimension combination.
+
+    Used when every description field of a variable is templated (long-format tables), so
+    the plain-text fallback chain in ``_variable_description`` comes up empty. The rendered
+    text describes a single slice of the column, so it is explicitly labelled as an example.
+    """
+    dimensions = table.representative_dimensions
+    if not dimensions:
+        return None
+    for template in (meta.description_short, meta.description_from_producer, meta.description, meta.title):
+        if not template or not _uses_jinja(template):
+            continue
+        try:
+            rendered = _expand_jinja_text(template, dimensions, remove_dods=True)
+        except jinja2.TemplateError:
+            continue
+        if not isinstance(rendered, str) or not rendered.strip():
+            continue
+        rendered = rendered.strip()
+        if not rendered.endswith((".", "!", "?")):
+            rendered += "."
+        example = ", ".join(f"{slug}={value}" for slug, value in dimensions.items())
+        varies_by = ", ".join(dimensions)
+        return f"For example, for {example}: {rendered} Varies by the dimension columns: {varies_by}."
+    return None
 
 
 def _distributions(file_base_url: str, table: TableSchemaInput) -> list[dict[str, Any]]:
@@ -381,22 +460,28 @@ def _keywords(tables: list[TableSchemaInput]) -> list[str]:
 
 
 def _variable_title(name: str, meta: VariableMeta) -> str:
-    if meta.presentation and meta.presentation.title_public:
+    # Jinja-templated candidates are skipped: a template only makes sense once rendered with
+    # dimension values, and the raw text is noise for JSON-LD consumers. The identifier is
+    # the honest fallback for a column whose title varies by slice.
+    if meta.presentation and meta.presentation.title_public and not _uses_jinja(meta.presentation.title_public):
         return meta.presentation.title_public
-    if meta.title:
+    if meta.title and not _uses_jinja(meta.title):
         return meta.title
     return name
 
 
 def _variable_description(meta: VariableMeta) -> str | None:
-    if meta.description_short:
-        return meta.description_short
-    if meta.description_key:
-        return " ".join(meta.description_key)
-    if meta.description_from_producer:
-        return meta.description_from_producer
-    if meta.description:
-        return meta.description
+    candidates = (
+        meta.description_short,
+        " ".join(meta.description_key) if meta.description_key else None,
+        meta.description_from_producer,
+        meta.description,
+    )
+    for candidate in candidates:
+        if candidate and not _uses_jinja(candidate):
+            # Descriptions may contain markdown detail-on-demand links ("[term](#dod:term)")
+            # that only resolve on ourworldindata.org; keep just the link text here.
+            return remove_details_on_demand(candidate)
     return None
 
 

--- a/lib/catalog/owid/catalog/schema_org.py
+++ b/lib/catalog/owid/catalog/schema_org.py
@@ -113,9 +113,14 @@ def dataset_to_schema_org(
     if license_url:
         result["license"] = license_url
 
-    creator = _creator_from_origins(origins)
-    if creator:
-        result["creator"] = creator
+    # Creator is the author of this artifact (the OWID-processed dataset), matching how
+    # compiled datasets are marked up elsewhere (HuggingFace, Zenodo, Google's own examples).
+    # Upstream producers keep credit in isBasedOn (name + URL) and citation.
+    result["creator"] = {
+        "@type": "Organization",
+        "name": "Our World in Data",
+        "url": "https://ourworldindata.org",
+    }
 
     citations = _citations(origins)
     if citations:
@@ -395,34 +400,40 @@ def _license_to_url(license: License | None) -> str | None:
     return license_to_url(license)
 
 
-def _citations(origins: list[Origin]) -> list[str]:
-    """Unique full citations, main source first (origins are pre-ordered by variable usage).
+_DOI_RE = re.compile(r"(?:https?://(?:dx\.)?doi\.org/|\bdoi:\s*)(10\.\d{4,9}/[^\s\"'\)\]]+)", re.IGNORECASE)
 
-    schema.org allows multiple ``citation`` values; a single arbitrary citation (e.g. the
-    population helper source of a CO2 dataset) misrepresents the dataset.
+
+def _citations(origins: list[Origin]) -> list[str]:
+    """Short citation snippets with DOIs for the source papers, main source first.
+
+    Per Google's dataset guidance, ``citation`` identifies *related academic articles*
+    (data papers, data descriptors) — not the dataset itself — and should carry a DOI.
+    Each snippet pairs the origin's short attribution with the first DOI found in its
+    full citation. Origins without a DOI (helper sources like population, web-only data)
+    are covered by ``isBasedOn`` instead.
     """
     citations: list[str] = []
     for origin in origins:
-        if origin.citation_full and origin.citation_full not in citations:
-            citations.append(origin.citation_full)
+        if not origin.citation_full:
+            continue
+        match = _DOI_RE.search(origin.citation_full)
+        if not match:
+            continue
+        doi_url = f"https://doi.org/{match.group(1).rstrip('.,;')}"
+        label = origin.attribution or _producer_with_year(origin)
+        snippet = f"{label.rstrip('.')}. {doi_url}" if label else doi_url
+        if snippet not in citations:
+            citations.append(snippet)
     return citations[:5]
 
 
-def _creator_from_origins(origins: list[Origin]) -> dict[str, str] | list[dict[str, str]] | None:
-    producers = []
-    for origin in origins:
-        # `attribution` is a citation-style label with edition years ("Global Carbon Budget
-        # (2025)"); `producer` is the actual organization/author name, which is what a
-        # schema.org creator should carry.
-        producer = origin.producer or origin.attribution
-        if producer and producer not in producers:
-            producers.append(producer)
-    creators = [{"@type": "Organization", "name": producer} for producer in producers[:5]]
-    if not creators:
+def _producer_with_year(origin: Origin) -> str | None:
+    if not origin.producer:
         return None
-    if len(creators) == 1:
-        return creators[0]
-    return creators
+    year = str(origin.date_published or "")[:4]
+    if year.isdigit():
+        return f"{origin.producer} ({year})"
+    return origin.producer
 
 
 def _is_based_on(origins: list[Origin]) -> list[dict[str, Any]] | dict[str, Any] | None:

--- a/lib/catalog/owid/catalog/schema_org.py
+++ b/lib/catalog/owid/catalog/schema_org.py
@@ -117,9 +117,9 @@ def dataset_to_schema_org(
     if creator:
         result["creator"] = creator
 
-    citation = _first_non_empty(origin.citation_full for origin in origins)
-    if citation:
-        result["citation"] = citation
+    citations = _citations(origins)
+    if citations:
+        result["citation"] = citations[0] if len(citations) == 1 else citations
 
     date_published = _first_valid_date(origin.date_published for origin in origins)
     if date_published:
@@ -340,16 +340,23 @@ def _dataset_description(dataset_meta: DatasetMeta) -> str:
 
 
 def _unique_origins(tables: list[TableSchemaInput]) -> list[Origin]:
-    origins: list[Origin] = []
-    seen = set()
+    """Return unique origins, ordered by how many variables reference each one.
+
+    Column order is meaningless here: helper columns (ISO codes, population, GDP) often come
+    first in a table, and everything derived from the origin list (creator, citation,
+    isBasedOn, datePublished) should lead with the dataset's main source, which is the origin
+    the most variables reference — not whichever origin the first column happens to use.
+    """
+    origins: dict[Any, Origin] = {}
+    counts: dict[Any, int] = {}
     for table in tables:
         for variable in table.variables.values():
             for origin in variable.origins:
                 key = (origin.producer, origin.title, origin.url_main, origin.url_download, origin.citation_full)
-                if key not in seen:
-                    seen.add(key)
-                    origins.append(origin)
-    return origins
+                origins.setdefault(key, origin)
+                counts[key] = counts.get(key, 0) + 1
+    order = sorted(origins, key=lambda key: -counts[key])
+    return [origins[key] for key in order]
 
 
 def _license_url(dataset_meta: DatasetMeta, origins: list[Origin], tables: list[TableSchemaInput]) -> str | None:
@@ -388,10 +395,26 @@ def _license_to_url(license: License | None) -> str | None:
     return license_to_url(license)
 
 
+def _citations(origins: list[Origin]) -> list[str]:
+    """Unique full citations, main source first (origins are pre-ordered by variable usage).
+
+    schema.org allows multiple ``citation`` values; a single arbitrary citation (e.g. the
+    population helper source of a CO2 dataset) misrepresents the dataset.
+    """
+    citations: list[str] = []
+    for origin in origins:
+        if origin.citation_full and origin.citation_full not in citations:
+            citations.append(origin.citation_full)
+    return citations[:5]
+
+
 def _creator_from_origins(origins: list[Origin]) -> dict[str, str] | list[dict[str, str]] | None:
     producers = []
     for origin in origins:
-        producer = origin.attribution or origin.producer
+        # `attribution` is a citation-style label with edition years ("Global Carbon Budget
+        # (2025)"); `producer` is the actual organization/author name, which is what a
+        # schema.org creator should carry.
+        producer = origin.producer or origin.attribution
         if producer and producer not in producers:
             producers.append(producer)
     creators = [{"@type": "Organization", "name": producer} for producer in producers[:5]]

--- a/lib/catalog/tests/test_datasets.py
+++ b/lib/catalog/tests/test_datasets.py
@@ -42,7 +42,7 @@ def test_create_empty():
         assert exists(join(dirname, "index.json"))
         with open(join(dirname, "index.json")) as istream:
             doc = json.load(istream)
-        assert doc == {"is_public": True, "non_redistributable": False}
+        assert doc == {"is_public": True, "non_redistributable": False, "jsonld": False}
 
         assert len(ds.index()) == 0
 
@@ -75,7 +75,8 @@ def test_create_overwrites_entire_folder():
         open(d._index_file).read().strip()
         == """{
   "is_public": true,
-  "non_redistributable": false
+  "non_redistributable": false,
+  "jsonld": false
 }"""
     )
 

--- a/lib/catalog/tests/test_meta.py
+++ b/lib/catalog/tests/test_meta.py
@@ -49,7 +49,7 @@ def test_dict_mixin_nested():
 
 def test_empty_dataset_metadata():
     d1 = meta.DatasetMeta()
-    assert d1.to_dict() == {"is_public": True, "non_redistributable": False}
+    assert d1.to_dict() == {"is_public": True, "non_redistributable": False, "jsonld": False}
 
 
 def test_dataset_version():

--- a/lib/catalog/tests/test_schema_org.py
+++ b/lib/catalog/tests/test_schema_org.py
@@ -322,3 +322,92 @@ def test_license_to_url_resolves_known_license_names() -> None:
     assert license_to_url(License(name="CC BY 4.0")) == "https://creativecommons.org/licenses/by/4.0/"
     assert license_to_url(License(name=" CC-BY 4.0 ")) == "https://creativecommons.org/licenses/by/4.0/"
     assert license_to_url(License(name="Custom license")) is None
+
+
+def test_templated_variable_metadata_is_never_emitted_raw() -> None:
+    meta = VariableMeta(
+        title='<% if poverty_line == "215" %>Below $2.15<% else %>Below the line<% endif %>',
+        description_short="The share of population below <<poverty_line>> a day.",
+        unit="international-$ in <<ppp_version>> prices",
+    )
+    table = TableSchemaInput(
+        short_name="poverty",
+        metadata=TableMeta(short_name="poverty", title="Poverty", description="Table description"),
+        variables={"headcount_ratio": meta},
+        formats=["feather"],
+    )
+    jsonld = dataset_to_schema_org(
+        dataset_path="garden/wb/2025-01-01/pip",
+        page_path="wb/pip",
+        dataset_meta=DatasetMeta(short_name="pip", title="PIP", description="Dataset description"),
+        tables=[table],
+    )
+    (variable,) = jsonld["variableMeasured"]
+    # Without representative dimension values nothing can be rendered: fall back to the
+    # identifier and omit the templated fields entirely.
+    assert variable["name"] == "headcount_ratio"
+    assert "description" not in variable
+    assert "unitText" not in variable
+    serialized = str(jsonld)
+    assert "<%" not in serialized and "<<" not in serialized
+
+
+def test_templated_description_renders_example_using_representative_dimensions() -> None:
+    meta = VariableMeta(
+        title="Poverty headcount",
+        description_short='People below <% if poverty_line == "215" %>$2.15<% else %>the line<% endif %> a day.',
+        unit="people in <<ppp_version>> prices",
+    )
+    table = TableSchemaInput(
+        short_name="poverty",
+        metadata=TableMeta(
+            short_name="poverty",
+            title="Poverty",
+            description="Table description",
+            dimensions=[
+                {"name": "country", "slug": "country"},
+                {"name": "year", "slug": "year"},
+                {"name": "Poverty line", "slug": "poverty_line"},
+            ],
+        ),
+        variables={"headcount": meta},
+        formats=["feather"],
+        primary_key=["country", "year", "poverty_line"],
+        dimension_values={"poverty_line": ["215", "365"]},
+        representative_dimensions={"poverty_line": "215"},
+    )
+    jsonld = dataset_to_schema_org(
+        dataset_path="garden/wb/2025-01-01/pip",
+        page_path="wb/pip",
+        dataset_meta=DatasetMeta(short_name="pip", title="PIP", description="Dataset description"),
+        tables=[table],
+    )
+    variables = {variable["identifier"]: variable for variable in jsonld["variableMeasured"]}
+    # country/year are conveyed by temporal/spatialCoverage, not emitted as dimensions.
+    assert set(variables) == {"poverty_line", "headcount"}
+    assert variables["poverty_line"]["name"] == "Poverty line"
+    assert "Values: 215, 365." in variables["poverty_line"]["description"]
+    assert variables["headcount"]["description"] == (
+        "For example, for poverty_line=215: People below $2.15 a day. Varies by the dimension columns: poverty_line."
+    )
+    # A templated unit is only correct for one slice of the column: omitted.
+    assert "unitText" not in variables["headcount"]
+
+
+def test_plain_description_strips_detail_on_demand_links() -> None:
+    meta = VariableMeta(title="Consumption", description_short="Measured in [terawatt-hours](#dod:watt-hours).")
+    table = TableSchemaInput(
+        short_name="energy",
+        metadata=TableMeta(short_name="energy", title="Energy", description="Table description"),
+        variables={"consumption": meta},
+        formats=["feather"],
+    )
+    jsonld = dataset_to_schema_org(
+        dataset_path="garden/energy/2025-01-01/energy",
+        page_path="energy/energy",
+        dataset_meta=DatasetMeta(short_name="energy", title="Energy", description="Dataset description"),
+        tables=[table],
+    )
+    (variable,) = jsonld["variableMeasured"]
+    # Detail-on-demand links only resolve on ourworldindata.org; keep just the link text.
+    assert variable["description"] == "Measured in terawatt-hours."

--- a/lib/catalog/tests/test_schema_org.py
+++ b/lib/catalog/tests/test_schema_org.py
@@ -411,3 +411,48 @@ def test_plain_description_strips_detail_on_demand_links() -> None:
     (variable,) = jsonld["variableMeasured"]
     # Detail-on-demand links only resolve on ourworldindata.org; keep just the link text.
     assert variable["description"] == "Measured in terawatt-hours."
+
+
+def test_creator_and_citation_lead_with_most_used_origin() -> None:
+    main_origin = Origin(
+        producer="Global Carbon Project",
+        attribution="Global Carbon Budget (2025)",
+        title="Global Carbon Budget",
+        citation_full="Global Carbon Project (2025). Global Carbon Budget.",
+        url_main="https://globalcarbonbudget.org",
+    )
+    helper_origin = Origin(
+        producer="Various sources",
+        attribution="Population based on various sources (2024)",
+        title="Population",
+        citation_full="Population is based on various sources.",
+        url_main="https://example.com/population",
+    )
+    # The helper origin (population) backs the *first* column; the main origin backs the
+    # remaining columns. Creator/citation must still lead with the main origin.
+    variables = {"population": VariableMeta(title="Population", origins=[helper_origin])}
+    for name in ("co2", "co2_per_capita", "cumulative_co2"):
+        variables[name] = VariableMeta(title=name, origins=[main_origin])
+    table = TableSchemaInput(
+        short_name="owid_co2",
+        metadata=TableMeta(short_name="owid_co2", title="CO2", description="Table description"),
+        variables=variables,
+        formats=["feather"],
+    )
+    jsonld = dataset_to_schema_org(
+        dataset_path="garden/emissions/2025-12-04/owid_co2",
+        page_path="emissions/owid_co2",
+        dataset_meta=DatasetMeta(short_name="owid_co2", title="CO2 dataset", description="Dataset description"),
+        tables=[table],
+    )
+    # creator carries producer names (no edition years from `attribution`), main source first.
+    assert jsonld["creator"] == [
+        {"@type": "Organization", "name": "Global Carbon Project"},
+        {"@type": "Organization", "name": "Various sources"},
+    ]
+    # All sources are cited, main source first — not whichever origin the first column uses.
+    assert jsonld["citation"] == [
+        "Global Carbon Project (2025). Global Carbon Budget.",
+        "Population is based on various sources.",
+    ]
+    assert jsonld["isBasedOn"][0]["url"] == "https://globalcarbonbudget.org"

--- a/lib/catalog/tests/test_schema_org.py
+++ b/lib/catalog/tests/test_schema_org.py
@@ -55,7 +55,14 @@ def test_single_table_dataset_flattens_table_metadata() -> None:
     assert jsonld["publisher"]["logo"] == "https://ourworldindata.org/owid-logo.svg"
     assert jsonld["temporalCoverage"] == "1812/2023"
     assert jsonld["spatialCoverage"] == "Worldwide"
-    assert jsonld["creator"] == {"@type": "Organization", "name": "Example Producer"}
+    assert jsonld["creator"] == {
+        "@type": "Organization",
+        "name": "Our World in Data",
+        "url": "https://ourworldindata.org",
+    }
+    # The origin has no DOI in its citation, so no related-article citation is emitted;
+    # the producer is still credited via isBasedOn below.
+    assert "citation" not in jsonld
     assert jsonld["isBasedOn"]["url"] == "https://example.com/source"
     assert jsonld["keywords"] == ["Biodiversity"]
     assert jsonld["variableMeasured"][0]["identifier"] == "full_flowering_date"
@@ -413,26 +420,39 @@ def test_plain_description_strips_detail_on_demand_links() -> None:
     assert variable["description"] == "Measured in terawatt-hours."
 
 
-def test_creator_and_citation_lead_with_most_used_origin() -> None:
+def test_citation_extracts_dois_and_leads_with_most_used_origin() -> None:
     main_origin = Origin(
         producer="Global Carbon Project",
         attribution="Global Carbon Budget (2025)",
         title="Global Carbon Budget",
-        citation_full="Global Carbon Project (2025). Global Carbon Budget.",
+        citation_full=(
+            "Friedlingstein, P. et al.: Global Carbon Budget 2024, Earth Syst. Sci. Data, "
+            "https://doi.org/10.5194/essd-17-965-2025, 2025."
+        ),
         url_main="https://globalcarbonbudget.org",
     )
     helper_origin = Origin(
         producer="Various sources",
         attribution="Population based on various sources (2024)",
         title="Population",
-        citation_full="Population is based on various sources.",
+        # No DOI: helper source stays out of citation, but keeps its isBasedOn entry.
+        citation_full="Population is based on various sources: https://ourworldindata.org/population-sources",
         url_main="https://example.com/population",
     )
-    # The helper origin (population) backs the *first* column; the main origin backs the
-    # remaining columns. Creator/citation must still lead with the main origin.
+    doi_prefix_origin = Origin(
+        producer="Bolt and van Zanden",
+        title="Maddison Project Database",
+        date_published="2024-04-26",
+        # "DOI: <id>" form (no doi.org URL) must be recognized too.
+        citation_full='Bolt and van Zanden (2024), "Maddison style estimates". DOI: 10.1111/joes.12618.',
+        url_main="https://example.com/maddison",
+    )
+    # The helper origin backs the *first* column; the main origin backs the remaining
+    # columns. Citation must still lead with the main origin, not follow column order.
     variables = {"population": VariableMeta(title="Population", origins=[helper_origin])}
-    for name in ("co2", "co2_per_capita", "cumulative_co2"):
+    for name in ("co2", "co2_per_capita"):
         variables[name] = VariableMeta(title=name, origins=[main_origin])
+    variables["gdp"] = VariableMeta(title="gdp", origins=[doi_prefix_origin])
     table = TableSchemaInput(
         short_name="owid_co2",
         metadata=TableMeta(short_name="owid_co2", title="CO2", description="Table description"),
@@ -445,14 +465,16 @@ def test_creator_and_citation_lead_with_most_used_origin() -> None:
         dataset_meta=DatasetMeta(short_name="owid_co2", title="CO2 dataset", description="Dataset description"),
         tables=[table],
     )
-    # creator carries producer names (no edition years from `attribution`), main source first.
-    assert jsonld["creator"] == [
-        {"@type": "Organization", "name": "Global Carbon Project"},
-        {"@type": "Organization", "name": "Various sources"},
-    ]
-    # All sources are cited, main source first — not whichever origin the first column uses.
+    # Creator is the author of this compiled artifact; producers keep credit in isBasedOn.
+    assert jsonld["creator"] == {
+        "@type": "Organization",
+        "name": "Our World in Data",
+        "url": "https://ourworldindata.org",
+    }
     assert jsonld["citation"] == [
-        "Global Carbon Project (2025). Global Carbon Budget.",
-        "Population is based on various sources.",
+        "Global Carbon Budget (2025). https://doi.org/10.5194/essd-17-965-2025",
+        # Attribution missing: fall back to producer (year of date_published).
+        "Bolt and van Zanden (2024). https://doi.org/10.1111/joes.12618",
     ]
     assert jsonld["isBasedOn"][0]["url"] == "https://globalcarbonbudget.org"
+    assert {item["url"] for item in jsonld["isBasedOn"]} >= {"https://example.com/population"}

--- a/schemas/dataset-schema.json
+++ b/schemas/dataset-schema.json
@@ -403,6 +403,11 @@
           "title": "Non-redistribution of dataset ",
           "description": "Whether the dataset is non-redistributable, and therefore data should not be downloadable from the chart."
         },
+        "jsonld": {
+          "type": "boolean",
+          "title": "Publish catalog landing page / JSON-LD",
+          "description": "Opt this dataset into the public catalog landing page with Schema.org Dataset JSON-LD (`etl d publish --jsonld`). Canary rollout of the catalog-discovery project; the dataset must also pass the JSON-LD quality gates."
+        },
         "licenses": {
           "type": "array",
           "description": "List of all licenses that have been involved in the processing history of the indicators in this dataset.",

--- a/tests/catalog_jsonld/test_artifacts.py
+++ b/tests/catalog_jsonld/test_artifacts.py
@@ -21,6 +21,7 @@ def _add_eligible_dataset(
     dataset: str,
     version: str = "2025-01-01",
     non_redistributable: bool = False,
+    jsonld: bool = True,
 ) -> str:
     """Create a minimal, quality-eligible garden dataset and return its catalog path."""
     dataset_dir = data_dir / "garden" / namespace / version / dataset
@@ -41,6 +42,7 @@ def _add_eligible_dataset(
             title=f"{dataset} title",
             description=f"{dataset} description",
             non_redistributable=non_redistributable,
+            jsonld=jsonld,
         ),
     )
     tb = Table(pd.DataFrame({"year": [2020], "value": [1]}), short_name="example_table")
@@ -72,6 +74,7 @@ def test_build_catalog_jsonld_artifacts_writes_dataset_jsonld_sitemap_and_report
             short_name="example_dataset",
             title="Example dataset",
             description="Dataset description",
+            jsonld=True,
         ),
     )
     tb = Table(pd.DataFrame({"year": [2020], "value": [1]}), short_name="example_table")
@@ -137,6 +140,7 @@ def test_build_catalog_jsonld_artifacts_cleans_up_stale_old_location_for_emitted
             short_name="example_dataset",
             title="Example dataset",
             description="Dataset description",
+            jsonld=True,
         ),
     )
     tb = Table(pd.DataFrame({"year": [2020], "value": [1]}), short_name="example_table")
@@ -407,3 +411,107 @@ def test_build_catalog_jsonld_artifacts_blocks_duplicate_short_keys(tmp_path: Pa
     assert result.emitted == []
     assert {item.catalog_path for item in result.skipped} == {path_a, path_b}
     assert all("duplicate_short_key" in item.blockers for item in result.skipped)
+
+
+def test_build_catalog_jsonld_artifacts_renders_templated_metadata_via_dimensions(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    dataset_dir = data_dir / "garden" / "example" / "2025-01-01" / "long_dataset"
+    origin = Origin(
+        producer="Example Producer",
+        title="Original dataset",
+        description="Original description",
+        citation_full="Example Producer (2025). Original dataset.",
+        license=License(name="CC BY 4.0"),
+    )
+    ds = Dataset.create_empty(
+        dataset_dir,
+        DatasetMeta(
+            channel="garden",
+            namespace="example",
+            version="2025-01-01",
+            short_name="long_dataset",
+            title="Long dataset",
+            description="Dataset description",
+            jsonld=True,
+        ),
+    )
+    tb = Table(
+        pd.DataFrame(
+            {
+                "year": [2020, 2020, 2021],
+                "poverty_line": ["national", "extreme", "national"],
+                "headcount": [1, 2, 3],
+            }
+        ),
+        short_name="long_table",
+    )
+    tb = tb.set_index(["year", "poverty_line"])
+    tb.metadata.title = "Long table"
+    tb.metadata.description = "Table description"
+    tb.metadata.dimensions = [
+        {"name": "year", "slug": "year"},
+        {"name": "Poverty line", "slug": "poverty_line"},
+    ]
+    # NOTE: dimension values must be non-numeric here — repack converts numeric-looking
+    # strings to ints on save, and templates are rendered with the stored type.
+    tb._fields["headcount"] = VariableMeta(
+        title='<% if poverty_line == "national" %>Below the national line<% else %>Below another line<% endif %>',
+        description_short='People below the <% if poverty_line == "national" %>national<% else %>other<% endif %> line.',
+        origins=[origin],
+    )
+    ds.add(tb)
+    ds.save()
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+
+    assert result.emitted == ["garden/example/2025-01-01/long_dataset"]
+    jsonld = json.loads((data_dir / "example" / "long_dataset" / "dataset.jsonld").read_text())
+    serialized = json.dumps(jsonld)
+    assert "<%" not in serialized and "<<" not in serialized
+    variables = {variable["identifier"]: variable for variable in jsonld["variableMeasured"]}
+    # The dimension column is emitted with its observed values (year is entity/time: skipped).
+    assert "year" not in variables
+    assert "Values: extreme, national." in variables["poverty_line"]["description"]
+    # "national" is the most frequent poverty_line: it is the representative example slice.
+    assert variables["headcount"]["description"] == (
+        "For example, for poverty_line=national: People below the national line. "
+        "Varies by the dimension columns: poverty_line."
+    )
+    assert variables["headcount"]["name"] == "headcount"
+
+
+def test_build_catalog_jsonld_artifacts_blocks_raw_jinja_leaking_from_unguarded_fields(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    catalog_path = _add_eligible_dataset(data_dir, namespace="example", dataset="leaky_dataset")
+    # The dataset description is emitted verbatim by schema_org (it has no per-variable jinja
+    # guard); a template here must trip the post-generation safety net, not ship.
+    ds = Dataset(data_dir / catalog_path)
+    ds.metadata.description = "Data about <<country>>."
+    ds.save()
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+
+    assert result.emitted == []
+    assert [quality.blockers for quality in result.skipped] == [["raw_jinja_in_jsonld"]]
+    assert not (data_dir / "example" / "leaky_dataset" / "dataset.jsonld").exists()
+
+
+def test_build_catalog_jsonld_artifacts_requires_metadata_opt_in_without_allowlist(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _add_eligible_dataset(data_dir, namespace="example", dataset="flagged", jsonld=True)
+    _add_eligible_dataset(data_dir, namespace="example", dataset="unflagged", jsonld=False)
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    # Without an allowlist, only the dataset that opts in via metadata is considered; the
+    # unflagged one is invisible (not emitted, but also not reported as skipped).
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    assert result.emitted == ["garden/example/2025-01-01/flagged"]
+    assert result.skipped == []
+    assert (data_dir / "example" / "flagged" / "dataset.jsonld").exists()
+    assert not (data_dir / "example" / "unflagged" / "dataset.jsonld").exists()
+
+    # An explicit allowlist overrides the metadata opt-in.
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden", only={"example/unflagged"})
+    assert result.emitted == ["garden/example/2025-01-01/unflagged"]

--- a/tests/catalog_jsonld/test_artifacts.py
+++ b/tests/catalog_jsonld/test_artifacts.py
@@ -463,7 +463,9 @@ def test_build_catalog_jsonld_artifacts_renders_templated_metadata_via_dimension
     ds.save()
     LocalCatalog(data_dir, channels=("garden",)).reindex()
 
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    result = build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir, channel="garden", active_steps={_step_uri("garden/example/2025-01-01/long_dataset")}
+    )
 
     assert result.emitted == ["garden/example/2025-01-01/long_dataset"]
     jsonld = json.loads((data_dir / "example" / "long_dataset" / "dataset.jsonld").read_text())
@@ -491,7 +493,9 @@ def test_build_catalog_jsonld_artifacts_blocks_raw_jinja_leaking_from_unguarded_
     ds.save()
     LocalCatalog(data_dir, channels=("garden",)).reindex()
 
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    result = build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir, channel="garden", active_steps={_step_uri(catalog_path)}
+    )
 
     assert result.emitted == []
     assert [quality.blockers for quality in result.skipped] == [["raw_jinja_in_jsonld"]]
@@ -504,14 +508,17 @@ def test_build_catalog_jsonld_artifacts_requires_metadata_opt_in_without_allowli
     _add_eligible_dataset(data_dir, namespace="example", dataset="unflagged", jsonld=False)
     LocalCatalog(data_dir, channels=("garden",)).reindex()
 
+    active_steps = {_step_uri("garden/example/2025-01-01/flagged"), _step_uri("garden/example/2025-01-01/unflagged")}
     # Without an allowlist, only the dataset that opts in via metadata is considered; the
     # unflagged one is invisible (not emitted, but also not reported as skipped).
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden")
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden", active_steps=active_steps)
     assert result.emitted == ["garden/example/2025-01-01/flagged"]
     assert result.skipped == []
     assert (data_dir / "example" / "flagged" / "dataset.jsonld").exists()
     assert not (data_dir / "example" / "unflagged" / "dataset.jsonld").exists()
 
     # An explicit allowlist overrides the metadata opt-in.
-    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden", only={"example/unflagged"})
+    result = build_catalog_jsonld_artifacts(
+        catalog_dir=data_dir, channel="garden", only={"example/unflagged"}, active_steps=active_steps
+    )
     assert result.emitted == ["garden/example/2025-01-01/unflagged"]

--- a/tests/catalog_jsonld/test_publish.py
+++ b/tests/catalog_jsonld/test_publish.py
@@ -61,6 +61,8 @@ def _add_eligible_dataset(
             title=f"{dataset} title",
             description=f"{dataset} description",
             non_redistributable=non_redistributable,
+            # Opt in via metadata: the publish default only considers flagged datasets.
+            jsonld=True,
         ),
     )
     tb = Table(pd.DataFrame({"year": [2020], "value": [1]}), short_name="example_table")

--- a/tests/catalog_jsonld/test_quality.py
+++ b/tests/catalog_jsonld/test_quality.py
@@ -174,3 +174,11 @@ def test_missing_table_description_warned_when_no_description_anywhere() -> None
         tables=[_table("table_a")],
     )
     assert result.table_warnings["table_a"] == ["missing_table_description"]
+
+
+def test_jsonld_contains_raw_jinja_detects_template_markers() -> None:
+    from etl.catalog_jsonld.quality import jsonld_contains_raw_jinja
+
+    assert jsonld_contains_raw_jinja({"name": '<% if x == "a" %>A<% endif %>'})
+    assert jsonld_contains_raw_jinja({"hasPart": [{"description": "The value of <<x>>."}]})
+    assert not jsonld_contains_raw_jinja({"name": "Plain text", "description": "1 < 2 and 3 > 2"})


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Problem

The catalog JSON-LD (`catalog.ourworldindata.org/<ns>/<ds>/dataset.jsonld`) copied variable metadata verbatim. For long-format tables like `wb/world_bank_pip`, that metadata is Jinja-templated (rendered per dimension combination by grapher, never by the catalog), so the public pages shipped raw templates — the `name` of `headcount_ratio` was a ~200-line Jinja program, and some variables in the `incomes` table shipped entire `<% macro %>` definitions as their names. On top of that, `creator` and `citation` were derived from origins in column order, so `emissions/owid_co2` listed "Population based on various sources (2024)" as a creator organization and cited population data as its source.

## Variable metadata: describe columns, not rendered indicators

**Before** (live until this PR's republish):

```json
{
  "@type": "PropertyValue",
  "identifier": "headcount_ratio",
  "name": "<% if survey_comparability != \"No spells\" %>\nShare of population in poverty (<% if poverty_line == \"215\" %>\n$2.15\n<%- elif poverty_line == \"365\" %>\n$3.65\n... (~200 more lines)"
}
```

**After** (already republished, see below):

```json
{
  "@type": "PropertyValue",
  "identifier": "poverty_line",
  "name": "poverty_line",
  "description": "Dimension column: selects one of the data series stored in this table. Values: 100, 215, 300, 365, 40% of the median, 50% of the median, 685, 830, ..."
},
{
  "@type": "PropertyValue",
  "identifier": "headcount_ratio",
  "name": "headcount_ratio",
  "description": "For example, for ppp_version=2021, poverty_line=830 and 1000, welfare_type=income or consumption, ...: Percentage of population living in households with an income or consumption below $8.30 and $10 per day. Varies by the dimension columns: ppp_version, poverty_line, welfare_type, table, survey_comparability.",
  "unitText": "%"
}
```

The principle: the metadata unit of a long-format table is the **column**, not the rendered indicator. Measure columns get a rendered *example* slice (labelled as such); dimension columns are emitted as first-class `PropertyValue`s with their observed values — exactly what a consumer (human or LLM writing a duckdb query) needs to reconstruct any slice, without exploding the table to wide.

Layers, in order:

1. **Never emit raw Jinja** (`schema_org.py`): templated `title`/`description*`/`unit` candidates are skipped in the fallback chains; a templated unit is omitted (it's only correct for one slice).
2. **Render an example** for variables whose every description field is templated: `artifacts.py` reads the dimension columns from the data (column-pruned, same mechanism as temporal coverage) and picks the most frequent dimension combination; `schema_org.py` renders per-field with graceful degradation and labels the result `For example, for <dims>: …`.
3. **Emit dimension columns** from `TableMeta.dimensions` with their distinct values (capped at 40 listed; `country`/`year`/`date` stay implicit via `temporalCoverage`/`spatialCoverage`).
4. **Safety net** (`quality.py` + `artifacts.py`): after generation, the serialized JSON-LD is scanned for `<%`/`<<`; a leak from any unguarded field becomes a `raw_jinja_in_jsonld` blocker and the dataset is skipped instead of shipped.

Bonus: plain descriptions now strip detail-on-demand links — `owid_energy` descriptions read `Measured in kilowatt-hours per person.` instead of `Measured in [kilowatt-hours](#dod:watt-hours) per person.`

## creator & citation: align with schema.org semantics

Per Google's dataset guidance and common practice (HuggingFace croissant, Zenodo, Google's own examples), `creator` is the author of *this artifact*, and `citation` "identifies related academic articles … not the dataset itself" and should carry a DOI. So:

- **Origins are ordered by variable usage** (main source first) — this drives `citation`, `isBasedOn`, `datePublished`. Previously order was column order, so helper columns (ISO codes, population, GDP) came first.
- **`creator` = Our World in Data** (single org with URL). Upstream producers keep credit in `isBasedOn` (name + URL).
- **`citation` = related papers with DOIs**, built mechanically: short attribution + first DOI extracted from each origin's `citation_full`. Origins without a DOI (e.g. the population helper source) drop out of citation on their own and stay in `isBasedOn`.

`owid_co2` now reads:

```json
"creator": {"@type": "Organization", "name": "Our World in Data", "url": "https://ourworldindata.org"},
"citation": [
  "Global Carbon Budget (2025). https://doi.org/10.5281/zenodo.17417124",
  "Jones et al. (2025). https://doi.org/10.5281/zenodo.16640595",
  "Bolt and van Zanden – Maddison Project Database 2023. https://doi.org/10.1111/joes.12618"
]
```

## Metadata opt-in replaces the ops-side allowlist

Datasets opt into JSON-LD publication via their garden meta.yml:

```yaml
dataset:
  jsonld: true
```

New `DatasetMeta.jsonld` field (serializes as `false` by default, matching the `non_redistributable` precedent), plus the corresponding `dataset-schema.json` property. `etl d publish --jsonld` without `--jsonld-only` now considers only flagged datasets, so the ops cron simplifies to `etl d publish --private --bucket owid-catalog --jsonld` — see the counterpart PR owid/ops#548, which should merge **after** this PR lands and the prod ETL rebuilds the three flagged canaries (`emissions/owid_co2`, `energy_data/owid_energy`, `wb/world_bank_pip` — flagged in this PR, so the meta.yml change triggers their rebuild on merge).

`--jsonld-only` still works and overrides the flag (useful for ad-hoc runs). Caveats, same as the old allowlist: removing the flag makes the dataset invisible to the build (its already-published R2 page lingers until cleaned up manually or by a quality-gate skip), and unflagged datasets are not reported as skipped in the quality report.

## Already verified on prod

I ran the JSON-LD publish path against the prod `owid-catalog` bucket with the rebuilt local datasets (only the JSON-LD artifacts are synced — 3 × `dataset.jsonld` + sitemap + quality report; catalog data files are untouched):

- https://catalog.ourworldindata.org/wb/world_bank_pip/dataset.jsonld — no Jinja markers, dimension columns present
- https://catalog.ourworldindata.org/emissions/owid_co2/dataset.jsonld — OWID creator, DOI citations
- https://catalog.ourworldindata.org/energy_data/owid_energy/dataset.jsonld — dod-links stripped

(You may need a cache-busting query param; Cloudflare caches the old copies for a while.)

## Notes

- Rebased on master; the branch integrates with the recent `active_steps`/archived-cleanup machinery (#6379, #6381) and the stricter description gate (#6385) — the tests added here pass explicit `active_steps` like the rest of the suite.
- `owid_energy`'s citation is just the Maddison paper (Energy Institute/Ember publish no papers — they're credited via `isBasedOn`), and `world_bank_pip` has no citation (PIP's citation has no DOI). Both are correct under the "related papers" semantics; adding DOIs to `citation_full` upstream is the way to enrich them.

## Tests

- `lib/catalog/tests/test_schema_org.py`: raw-template guard, example rendering with representative dimensions, dimension `PropertyValue`s, dod-link stripping, DOI citation extraction and usage ordering
- `tests/catalog_jsonld/test_artifacts.py`: end-to-end dimension-values read from data + example rendering, `raw_jinja_in_jsonld` safety net, metadata opt-in vs `--jsonld-only` override
- `tests/catalog_jsonld/test_quality.py`: Jinja-marker detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)
