### PR TITLE
📊 Clean up dated-path JSON-LD for superseded dataset versions

### DIFF
--- a/etl/catalog_jsonld/artifacts.py
+++ b/etl/catalog_jsonld/artifacts.py
@@ -281,6 +281,10 @@ def find_inactive_dataset_entries(
         return [], []
     inactive = inactive.copy()
     inactive["dataset_path"] = inactive["path"].map(lambda p: str(p).rsplit("/", 1)[0])
+    # `frame` has one row per table, but `dataset_path` strips the table name — dedupe so a
+    # multi-table dataset doesn't produce repeated identical entries (inflated report counts,
+    # redundant HEAD/DELETE calls on the same key).
+    inactive = inactive.drop_duplicates(["channel", "namespace", "version", "dataset"])
 
     def to_entries(rows: pd.DataFrame) -> list[LatestDatasetPath]:
         entries = [

--- a/etl/catalog_jsonld/artifacts.py
+++ b/etl/catalog_jsonld/artifacts.py
@@ -58,6 +58,7 @@ class JsonLdBuildResult:
     skipped_entries: list[LatestDatasetPath] = field(default_factory=list)
     warnings: list[DatasetQualityResult] = field(default_factory=list)
     archived_entries: list[LatestDatasetPath] = field(default_factory=list)
+    superseded_entries: list[LatestDatasetPath] = field(default_factory=list)
 
 
 def build_catalog_jsonld_artifacts(
@@ -86,18 +87,25 @@ def build_catalog_jsonld_artifacts(
     result = JsonLdBuildResult()
     sitemap_entries: list[SitemapEntry] = []
 
-    # A dataset can be archived outright, with no active replacement at all — every on-disk
-    # version of it is excluded from `latest_paths` above, so it never becomes an emitted or
-    # skipped entry either. Without this, a dataset.jsonld it published before being archived
-    # (at its dated path and/or its stable short key) would linger on R2 forever, since nothing
-    # would ever schedule its deletion again.
-    result.archived_entries = find_archived_dataset_entries(
+    # Every on-disk build whose step isn't in the active DAG is excluded from `latest_paths`
+    # above, so a superseded or fully-archived version never becomes an emitted or skipped
+    # entry. Without this, a dataset.jsonld published before the step went inactive (at its
+    # old dated path, and — for a fully-archived dataset with no active replacement at all —
+    # its stable short key too) would linger on R2 forever, since nothing would ever schedule
+    # its deletion again.
+    result.archived_entries, result.superseded_entries = find_inactive_dataset_entries(
         catalog.frame, channel=channel, only=only, active_steps=active_steps
     )
     for entry in result.archived_entries:
         if not dry_run:
             _remove_if_exists(catalog_dir / entry.catalog_path / DATASET_JSONLD_FILENAME)
             _remove_if_exists(catalog_dir / entry.namespace / entry.dataset / DATASET_JSONLD_FILENAME)
+    for entry in result.superseded_entries:
+        # Its short key is legitimately owned by the active version emitted elsewhere in this
+        # same build (or by nothing, if that active version is itself quality-skipped) — only
+        # this specific old dated path needs cleaning up, never the short key.
+        if not dry_run:
+            _remove_if_exists(catalog_dir / entry.catalog_path / DATASET_JSONLD_FILENAME)
 
     duplicate_catalog_paths = find_duplicate_short_key_paths(
         (entry.catalog_path, entry.namespace, entry.dataset) for entry in latest_paths
@@ -231,26 +239,31 @@ def latest_dataset_paths(
     return sorted(entries, key=lambda entry: entry.catalog_path)
 
 
-def find_archived_dataset_entries(
+def find_inactive_dataset_entries(
     frame: pd.DataFrame,
     *,
     channel: CHANNEL = "garden",
     only: set[str] | None = None,
     active_steps: set[str] | None = None,
-) -> list[LatestDatasetPath]:
-    """Return one entry per ``<namespace>/<dataset>`` group that has NO active-DAG
-    representative at all — every on-disk version of it has been archived, with no
-    replacement. These are never emitted, but a prior build may have published a
-    dataset.jsonld for them (at their old dated catalog path and/or their stable short key)
-    that must be cleaned up now that the step is gone for good.
+) -> tuple[list[LatestDatasetPath], list[LatestDatasetPath]]:
+    """Return every on-disk build whose step is not in the active DAG, split into two lists:
 
-    The returned entry's ``catalog_path``/``version`` are the most-recent on-disk build
-    found, used only to target the cleanup; there's no "current version" for an archived
-    dataset. Respects ``only``/``active_steps`` the same way :func:`latest_dataset_paths` does.
+    - ``archived``: builds belonging to a ``<namespace>/<dataset>`` group with NO active-DAG
+      representative at all (the step was removed outright, with no replacement). A prior
+      build may have published a dataset.jsonld for them at both their dated catalog path and
+      their stable short key, and both need cleaning up now that the step is gone for good.
+    - ``superseded``: builds belonging to a group that DOES have an active representative
+      (just not this particular on-disk version — e.g. an old ``.../latest/...`` build left
+      behind after re-versioning to a dated one). Only their dated-path JSON-LD needs cleaning
+      up; their short key is legitimately owned by the active version instead.
+
+    Every inactive on-disk version is returned (not just the newest per group), since any of
+    them may carry a leftover dated-path dataset.jsonld from when it used to be current.
+    Respects ``only``/``active_steps`` the same way :func:`latest_dataset_paths` does.
     """
     df = frame.loc[(frame["channel"] == channel) & (frame["is_public"] == True)].copy()  # noqa: E712
     if df.empty:
-        return []
+        return [], []
     if active_steps is None:
         active_steps = graph_nodes(load_dag())
     df["step"] = (
@@ -260,26 +273,30 @@ def find_archived_dataset_entries(
     if only is not None:
         df = df[df["dataset_key"].isin(only)]
         if df.empty:
-            return []
-    active_keys = set(df.loc[df["step"].isin(active_steps), "dataset_key"])
-    orphaned = df[~df["dataset_key"].isin(active_keys)]
-    if orphaned.empty:
-        return []
-    orphaned = orphaned.copy()
-    orphaned["dataset_path"] = orphaned["path"].map(lambda p: str(p).rsplit("/", 1)[0])
-    orphaned = orphaned.sort_values("version")
-    latest_orphaned = orphaned.drop_duplicates(["channel", "namespace", "dataset"], keep="last")
+            return [], []
+    is_active = df["step"].isin(active_steps)
+    active_keys = set(df.loc[is_active, "dataset_key"])
+    inactive = df[~is_active]
+    if inactive.empty:
+        return [], []
+    inactive = inactive.copy()
+    inactive["dataset_path"] = inactive["path"].map(lambda p: str(p).rsplit("/", 1)[0])
 
-    entries = [
-        LatestDatasetPath(
-            catalog_path=str(row.dataset_path),
-            namespace=str(row.namespace),
-            dataset=str(row.dataset),
-            version=str(row.version),
-        )
-        for row in latest_orphaned.itertuples()
-    ]
-    return sorted(entries, key=lambda entry: entry.catalog_path)
+    def to_entries(rows: pd.DataFrame) -> list[LatestDatasetPath]:
+        entries = [
+            LatestDatasetPath(
+                catalog_path=str(row.dataset_path),
+                namespace=str(row.namespace),
+                dataset=str(row.dataset),
+                version=str(row.version),
+            )
+            for row in rows.itertuples()
+        ]
+        return sorted(entries, key=lambda entry: entry.catalog_path)
+
+    archived = to_entries(inactive[~inactive["dataset_key"].isin(active_keys)])
+    superseded = to_entries(inactive[inactive["dataset_key"].isin(active_keys)])
+    return archived, superseded
 
 
 def load_table_schema_inputs(ds: Dataset) -> list[TableSchemaInput]:

--- a/etl/catalog_jsonld/publish.py
+++ b/etl/catalog_jsonld/publish.py
@@ -70,9 +70,16 @@ def build_and_publish_catalog_jsonld(
     delete_keys.extend(f"{entry.short_key}/{DATASET_JSONLD_FILENAME}" for entry in result.skipped_entries)
     # Also delete both locations for datasets archived outright (no active replacement at
     # all) — they never appear in emitted/skipped above, since no on-disk version of them is
-    # active, but a prior publish may still have left their JSON-LD live on R2.
+    # active, but a prior publish may still have left their JSON-LD live on R2. Several
+    # archived_entries can share the same short key (every inactive version of a fully-dead
+    # dataset is included), so dedupe with a set to avoid redundant delete calls.
     delete_keys.extend(f"{entry.catalog_path}/{DATASET_JSONLD_FILENAME}" for entry in result.archived_entries)
-    delete_keys.extend(f"{entry.short_key}/{DATASET_JSONLD_FILENAME}" for entry in result.archived_entries)
+    delete_keys.extend({f"{entry.short_key}/{DATASET_JSONLD_FILENAME}" for entry in result.archived_entries})
+    # Also delete the old dated path for versions superseded by an active replacement under
+    # the same short key (e.g. a stale ".../latest/..." build left behind after re-versioning
+    # to a dated one) — only the dated path, never the short key, which the active version
+    # legitimately owns instead.
+    delete_keys.extend(f"{entry.catalog_path}/{DATASET_JSONLD_FILENAME}" for entry in result.superseded_entries)
 
     sync_jsonld_artifacts(connect_r2(), bucket, catalog_dir, keys, delete_keys=delete_keys)
 

--- a/tests/catalog_jsonld/test_artifacts.py
+++ b/tests/catalog_jsonld/test_artifacts.py
@@ -213,6 +213,11 @@ def test_build_catalog_jsonld_artifacts_ignores_stale_archived_latest_version(tm
     stale_latest = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="latest")
     current = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="2025-12-04")
     LocalCatalog(data_dir, channels=("garden",)).reindex()
+    # A prior build (from before "latest" was superseded) may have left a dataset.jsonld at
+    # its own dated path — it must be cleaned up even though the dataset itself is still active
+    # under a different version.
+    stale_dated = data_dir / stale_latest / "dataset.jsonld"
+    stale_dated.write_text('{"from": "before supersession"}')
 
     result = build_catalog_jsonld_artifacts(
         catalog_dir=data_dir,
@@ -225,6 +230,8 @@ def test_build_catalog_jsonld_artifacts_ignores_stale_archived_latest_version(tm
     assert stale_latest not in result.emitted
     # The dataset has an active replacement, so it's superseded, not archived outright.
     assert result.archived_entries == []
+    assert [entry.catalog_path for entry in result.superseded_entries] == [stale_latest]
+    assert not stale_dated.exists()
 
 
 def test_build_catalog_jsonld_artifacts_cleans_up_dataset_archived_with_no_replacement(tmp_path: Path) -> None:

--- a/tests/catalog_jsonld/test_artifacts.py
+++ b/tests/catalog_jsonld/test_artifacts.py
@@ -263,6 +263,32 @@ def test_build_catalog_jsonld_artifacts_cleans_up_dataset_archived_with_no_repla
     assert not stale_short_key.exists()
 
 
+def test_build_catalog_jsonld_artifacts_archived_multi_table_dataset_yields_one_entry(tmp_path: Path) -> None:
+    # Regression test: LocalCatalog.frame has one row per table, but dataset_path strips the
+    # table name — a multi-table archived dataset must still yield exactly one archived_entries
+    # item, not one per table (which would inflate report counts and schedule redundant
+    # HEAD/DELETE calls against the same dataset.jsonld key on every publish).
+    data_dir = tmp_path / "data"
+    dataset_dir = data_dir / "garden" / "emissions" / "2024-01-01" / "owid_co2"
+    ds = Dataset.create_empty(
+        dataset_dir,
+        DatasetMeta(channel="garden", namespace="emissions", version="2024-01-01", short_name="owid_co2"),
+    )
+    for table_name in ("table_one", "table_two"):
+        tb = Table(pd.DataFrame({"year": [2020], "value": [1]}), short_name=table_name)
+        tb = tb.set_index("year")
+        tb.metadata.title = "Example table"
+        tb.metadata.description = "Table description"
+        ds.add(tb)
+    ds.save()
+    archived = "garden/emissions/2024-01-01/owid_co2"
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    result = build_catalog_jsonld_artifacts(catalog_dir=data_dir, channel="garden", active_steps=set())
+
+    assert [entry.catalog_path for entry in result.archived_entries] == [archived]
+
+
 def test_build_catalog_jsonld_artifacts_only_unmatched_entry_warns_and_emits_nothing(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     co2_path = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2")

--- a/tests/catalog_jsonld/test_publish.py
+++ b/tests/catalog_jsonld/test_publish.py
@@ -187,3 +187,35 @@ def test_build_and_publish_catalog_jsonld_deletes_both_locations_for_archived_da
     assert f"emissions/owid_co2/{DATASET_JSONLD_FILENAME}" not in captured["keys"]
     assert f"emissions/owid_co2/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]
     assert f"{archived_path}/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]
+
+
+def test_build_and_publish_catalog_jsonld_deletes_dated_path_for_superseded_version(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A dataset version superseded by an active replacement under the same short key (e.g. a
+    stale ".../latest/..." build left behind after re-versioning to a dated one) must have its
+    own old dated-path JSON-LD scheduled for deletion — but not the short key, which the
+    active version legitimately owns and keeps serving."""
+    data_dir = tmp_path / "data"
+    stale_path = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="latest")
+    current_path = _add_eligible_dataset(data_dir, namespace="emissions", dataset="owid_co2", version="2025-12-04")
+    LocalCatalog(data_dir, channels=("garden",)).reindex()
+
+    captured: dict[str, Any] = {}
+
+    def fake_sync_jsonld_artifacts(s3, bucket, catalog_dir, keys, delete_keys=None):
+        captured["keys"] = keys
+        captured["delete_keys"] = delete_keys
+
+    monkeypatch.setattr("etl.catalog_jsonld.publish.connect_r2", lambda: object())
+    monkeypatch.setattr("etl.catalog_jsonld.publish.sync_jsonld_artifacts", fake_sync_jsonld_artifacts)
+
+    build_and_publish_catalog_jsonld(
+        bucket="test-bucket", catalog_dir=data_dir, channel="garden", active_steps={_step_uri(current_path)}
+    )
+
+    assert f"emissions/owid_co2/{DATASET_JSONLD_FILENAME}" in captured["keys"]
+    assert f"{stale_path}/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]
+    assert f"{current_path}/{DATASET_JSONLD_FILENAME}" in captured["delete_keys"]
+    # The short key is actively served by the current version, so it must never be deleted.
+    assert f"emissions/owid_co2/{DATASET_JSONLD_FILENAME}" not in captured["delete_keys"]


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

Codex's review on #6379 flagged a real gap that landed too late to fix in that PR (it got merged before I could push the fix): `find_archived_dataset_entries()` only caught datasets with **no active representative at all**. It missed the exact production case that motivated #6379 in the first place — a version *superseded* by an active replacement under the same short key. `garden/emissions/latest/owid_co2` (stale, archived) sits alongside the active `garden/emissions/2025-12-04/owid_co2`, sharing the short key `emissions/owid_co2`. The stale one is excluded from `emitted_entries` (it's not the active version) *and* from `archived_entries` (its dataset key **is** active, just via a different version) — so its own dated-path `dataset.jsonld` never gets scheduled for R2 deletion again.

## What changed

Replaced `find_archived_dataset_entries()` with `find_inactive_dataset_entries()`, which returns every inactive on-disk version split into:
- **`archived`**: no active sibling at all — needs both dated-path and short-key cleanup (unchanged from #6379's behavior).
- **`superseded`**: has an active sibling — needs dated-path cleanup only; the short key is legitimately owned by the active version and must never be deleted.

Added `JsonLdBuildResult.superseded_entries`, wired local + R2 cleanup for it, and added regression tests reproducing the exact `emissions/owid_co2` scenario for both the local-cleanup path (`test_artifacts.py`) and the R2 delete-keys path (`test_publish.py`). 33/33 tests pass, `make check` clean.

## Note

Replied to Codex's finding on #6379 and posted this as a fast follow-up rather than reopening that PR, since it had already merged.
