### PR TITLE
🔨🤖 (etl) Drop yearIsDay support

### DIFF
--- a/apps/wizard/app_pages/indicator_upgrade/indicator_mapping.py
+++ b/apps/wizard/app_pages/indicator_upgrade/indicator_mapping.py
@@ -526,23 +526,21 @@ def convert_year_to_date(df: pd.DataFrame, indicator_ids: list[int]) -> pd.DataF
     select
         id as variableId,
         display->>'$.timeInterval' as timeInterval,
-        display->>'$.yearIsDay' as yearIsDay,
         display->>'$.zeroDay' as zeroDay
     from variables where id in %(indicator_ids)s;
     """
     mf = read_sql(q, get_engine(), params={"indicator_ids": tuple(indicator_ids)})
     df = df.merge(mf, on="variableId")
 
-    # Sub-yearly data is encoded as days-since-zeroDay integers, tagged via timeInterval
-    # (or the deprecated yearIsDay flag, kept as a fallback for un-migrated DB rows).
-    ix = df.timeInterval.isin(["day", "week", "month", "quarter"]) | (df.yearIsDay == "true")
+    # Sub-yearly data is encoded as days-since-zeroDay integers, tagged via timeInterval.
+    ix = df.timeInterval.isin(["day", "week", "month", "quarter"])
     if ix.any():
         df.year = df.year.astype(object)  # ty: ignore[unresolved-attribute]
         df.loc[ix, "year"] = pd.to_datetime(df.loc[ix, "zeroDay"]).dt.date + np.array(
             [pd.Timedelta(days=y) for y in df.loc[ix, "year"]]
         )
 
-    return df.drop(columns=["timeInterval", "yearIsDay", "zeroDay"])
+    return df.drop(columns=["timeInterval", "zeroDay"])
 
 
 def reset_indicator_form() -> None:

--- a/docs/libraries/catalog/llms.txt
+++ b/docs/libraries/catalog/llms.txt
@@ -3015,7 +3015,7 @@ VariablePresentationMeta(grapher_config: dict[str, typing.Any] | None = None, ti
 Allowed fields for `display` attribute used for grapher:
     name
     zeroDay
-    yearIsDay
+    timeInterval
     includeInTable
     numDecimalPlaces
     conversionFactor

--- a/etl/grapher/helpers.py
+++ b/etl/grapher/helpers.py
@@ -746,8 +746,12 @@ TIME_INTERVALS = {"day", "week", "month", "quarter", "year", "decade"}
 
 
 def _validate_time_interval(tab: Table, col: str) -> None:
-    """Validate the display.timeInterval field, if set."""
+    """Validate the display.timeInterval field, and guard against the removed yearIsDay flag."""
     display = tab[col].m.display or {}
+    # yearIsDay has been fully replaced by timeInterval; catch any regression or stray copy-paste.
+    assert "yearIsDay" not in display, (
+        f"Column `{col}` sets the removed display.yearIsDay flag; use display.timeInterval instead."
+    )
     time_interval = display.get("timeInterval")
     if time_interval is not None:
         assert time_interval in TIME_INTERVALS, (

--- a/etl/grapher/to_db.py
+++ b/etl/grapher/to_db.py
@@ -537,7 +537,7 @@ def _get_timespan(table: pd.DataFrame, variable_meta: VariableMeta) -> str:
     display = variable_meta.display or {}
 
     # Timespan does not work for sub-yearly data.
-    if display.get("yearIsDay") or display.get("timeInterval") in {"day", "week", "month", "quarter"}:
+    if display.get("timeInterval") in {"day", "week", "month", "quarter"}:
         return ""
 
     years = table.year.unique()

--- a/lib/catalog/owid/catalog/core/meta.py
+++ b/lib/catalog/owid/catalog/core/meta.py
@@ -448,7 +448,6 @@ class VariableMeta(MetaBase):
     """Allowed fields for `display` attribute used for grapher:
         name
         zeroDay
-        yearIsDay  # deprecated, use timeInterval instead
         timeInterval  # one of: day, week, month, quarter, year, decade
         includeInTable
         numDecimalPlaces

--- a/schemas/definitions.json
+++ b/schemas/definitions.json
@@ -714,11 +714,6 @@
         "type": "string",
         "description": "Entity annotations"
       },
-      "yearIsDay": {
-        "type": "boolean",
-        "default": false,
-        "description": "Deprecated: use `timeInterval` instead. Switch to indicate if the number in the year column represents a day (since zeroDay) or a year."
-      },
       "timeInterval": {
         "type": "string",
         "description": "Interval that each value in the year/time column represents. Sub-yearly intervals (day, week, month, quarter) are encoded as days-since-`zeroDay` integers.",
@@ -795,7 +790,7 @@
       },
       "zeroDay": {
         "type": "string",
-        "description": "ISO date day string for the starting date if `yearIsDay` is `True`."
+        "description": "ISO date string for the day that time value 0 represents, for sub-yearly (day/week/month) `timeInterval` data encoded as days-since-`zeroDay` integers."
       }
     },
     "additionalProperties": false


### PR DESCRIPTION
> _Written by Claude Code — @sophiamersmann at the wheel._

Stacked on #6371. Final step: removes ETL's use of the deprecated `display.yearIsDay` flag now that all datasets use `timeInterval`. `zeroDay` stays (the day-encoding still needs it).

- `definitions.json`: remove the `yearIsDay` property.
- `to_db` + wizard `indicator_mapping.py`: rely solely on `timeInterval` (fallback read removed).
- `VariableMeta` docstring + generated `llms.txt`: drop `yearIsDay`.
- `grapher_checks`: assert `yearIsDay` never reappears (regression guard).

Scope: this drops ETL's *use* of `yearIsDay`. The vendored grapher chart-config schema still defines it (it mirrors upstream) until the web team ships v11 — that schema removal + version bump go through `/sync-grapher-schema` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)