### PR TITLE
📊 Require an explicit dataset description for catalog JSON-LD

### DIFF
--- a/etl/catalog_jsonld/quality.py
+++ b/etl/catalog_jsonld/quality.py
@@ -117,14 +117,10 @@ def _has_title(dataset_meta: DatasetMeta, tables: list[TableSchemaInput]) -> boo
 
 
 def _has_description(dataset_meta: DatasetMeta, tables: list[TableSchemaInput]) -> bool:
-    if dataset_meta.description or any(table.metadata.description for table in tables):
-        return True
-    for table in tables:
-        for variable in table.variables.values():
-            for origin in variable.origins:
-                if origin.description or origin.description_snapshot:
-                    return True
-    return False
+    # Matches the contract in owid.catalog.schema_org._dataset_description: an indicator
+    # origin's description (e.g. an auxiliary population/GDP column) does not count as the
+    # dataset having a description of its own — only an explicit dataset- or table-level one does.
+    return bool(dataset_meta.description or any(table.metadata.description for table in tables))
 
 
 def _has_license_url(dataset_meta: DatasetMeta, tables: list[TableSchemaInput]) -> bool:

--- a/etl/catalog_jsonld/quality.py
+++ b/etl/catalog_jsonld/quality.py
@@ -80,7 +80,7 @@ def assess_dataset_quality(
     if not _has_title(dataset_meta, tables):
         result.blockers.append("missing_title")
 
-    if not _has_description(dataset_meta, tables):
+    if not _has_description(dataset_meta):
         result.blockers.append("missing_description")
 
     if not _has_license_url(dataset_meta, tables):
@@ -116,11 +116,12 @@ def _has_title(dataset_meta: DatasetMeta, tables: list[TableSchemaInput]) -> boo
     return bool(dataset_meta.title or dataset_meta.short_name or any(table.metadata.title for table in tables))
 
 
-def _has_description(dataset_meta: DatasetMeta, tables: list[TableSchemaInput]) -> bool:
-    # Matches the contract in owid.catalog.schema_org._dataset_description: an indicator
-    # origin's description (e.g. an auxiliary population/GDP column) does not count as the
-    # dataset having a description of its own — only an explicit dataset- or table-level one does.
-    return bool(dataset_meta.description or any(table.metadata.description for table in tables))
+def _has_description(dataset_meta: DatasetMeta) -> bool:
+    # Matches the contract in owid.catalog.schema_org._dataset_description: neither an
+    # indicator origin's description (e.g. an auxiliary population/GDP column) nor
+    # TableMeta.description (a mostly-internal field) counts as the dataset having a
+    # description of its own — only an explicit dataset.description does.
+    return bool(dataset_meta.description)
 
 
 def _has_license_url(dataset_meta: DatasetMeta, tables: list[TableSchemaInput]) -> bool:

--- a/etl/steps/data/garden/energy_data/2026-04-24/owid_energy.meta.yml
+++ b/etl/steps/data/garden/energy_data/2026-04-24/owid_energy.meta.yml
@@ -1,6 +1,8 @@
 dataset:
   title: Energy dataset
   description: |-
-    This dataset combines key global energy indicators — energy mix, fossil fuel production, primary energy consumption, and electricity mix — compiled from the Energy Institute's Statistical Review of World Energy, Ember, Shift, and the U.S. Energy Information Administration, alongside auxiliary population and GDP data used to calculate per-capita and per-GDP indicators.
+    Our complete Energy dataset is a collection of key metrics maintained by Our World in Data. It includes data on energy consumption (primary energy, per capita, and growth rates), energy mix, electricity mix, and fossil fuel production.
+
+    It is compiled from a variety of secondary sources, including the Energy Institute's Statistical Review of World Energy, Ember's electricity data, the U.S. Energy Information Administration, and the Shift Dataportal, alongside auxiliary population and GDP data used to calculate per-capita and per-GDP indicators.
   owners:
     - Pablo Rosado

--- a/etl/steps/data/garden/energy_data/2026-04-24/owid_energy.meta.yml
+++ b/etl/steps/data/garden/energy_data/2026-04-24/owid_energy.meta.yml
@@ -1,4 +1,6 @@
 dataset:
   title: Energy dataset
+  description: |-
+    This dataset combines key global energy indicators — energy mix, fossil fuel production, primary energy consumption, and electricity mix — compiled from the Energy Institute's Statistical Review of World Energy, Ember, Shift, and the U.S. Energy Information Administration, alongside auxiliary population and GDP data used to calculate per-capita and per-GDP indicators.
   owners:
     - Pablo Rosado

--- a/lib/catalog/owid/catalog/schema_org.py
+++ b/lib/catalog/owid/catalog/schema_org.py
@@ -240,15 +240,27 @@ def _dataset_title(dataset_meta: DatasetMeta, tables: list[TableSchemaInput]) ->
 
 
 def _dataset_description(dataset_meta: DatasetMeta, tables: list[TableSchemaInput]) -> str:
+    """Return the dataset's own description — never guessed from indicator origins.
+
+    A dataset's variables can span several unrelated origins: its own primary source plus
+    auxiliary indicators (population, GDP, regions, ...) pulled in for per-capita or aggregate
+    columns. Picking a description from any single one of those origins says nothing reliable
+    about the dataset as a whole, and which one gets picked is an implementation detail (e.g.
+    column order) rather than a meaningful choice. Every public dataset is expected to set its
+    own ``dataset.description`` in its ``.meta.yml`` (or, for a single-table dataset, the
+    table's ``description``); ``assess_dataset_quality`` blocks datasets that don't, via the
+    ``missing_description`` check, before this function is ever called. Raising here — rather
+    than inventing something — is a backstop in case that gate is ever bypassed.
+    """
     if dataset_meta.description:
         return dataset_meta.description
-    if len(tables) == 1 and tables[0].metadata.description:
-        return tables[0].metadata.description
-    origins = _unique_origins(tables)
-    description = _first_non_empty(origin.description_snapshot or origin.description for origin in origins)
-    if description:
-        return description
-    return "Dataset published in the Our World in Data catalog."
+    table_description_value = _first_non_empty(table.metadata.description for table in tables)
+    if table_description_value:
+        return table_description_value
+    raise ValueError(
+        f"Dataset '{dataset_meta.short_name}' has no description set. "
+        "Add `dataset.description` to its .meta.yml — it must not be guessed from indicator origins."
+    )
 
 
 def _unique_origins(tables: list[TableSchemaInput]) -> list[Origin]:

--- a/lib/catalog/owid/catalog/schema_org.py
+++ b/lib/catalog/owid/catalog/schema_org.py
@@ -65,7 +65,7 @@ def dataset_to_schema_org(
     resolved_version = version or dataset_meta.version
 
     title = _dataset_title(dataset_meta, tables)
-    description = _dataset_description(dataset_meta, tables)
+    description = _dataset_description(dataset_meta)
     origins = _unique_origins(tables)
     license_url = _license_url(dataset_meta, origins, tables)
 
@@ -145,14 +145,13 @@ def dataset_to_schema_org(
 def table_description(table: TableSchemaInput, dataset_meta: DatasetMeta) -> str | None:
     """Return the best available description for a single table node.
 
-    Tables rarely set their own ``description`` (a mostly-internal field), so for
-    the ``hasPart`` representation we fall back to descriptions that already exist
-    in the metadata — the producer's (origin) description, then the dataset-level
-    description — rather than leaving the node blank. Nothing is synthesized here;
-    if none of these are populated the node has no description.
+    ``TableMeta.description`` is a mostly-internal field, never set with a public-facing
+    description in mind, so it is never used for JSON-LD. For the ``hasPart`` representation
+    we instead fall back to descriptions that already exist in the metadata — the producer's
+    (origin) description, then the dataset-level description — rather than leaving the node
+    blank. Nothing is synthesized here; if none of these are populated the node has no
+    description.
     """
-    if table.metadata.description:
-        return table.metadata.description
     origins = _unique_origins([table])
     description = _first_non_empty(origin.description_snapshot or origin.description for origin in origins)
     if description:
@@ -239,24 +238,22 @@ def _dataset_title(dataset_meta: DatasetMeta, tables: list[TableSchemaInput]) ->
     return "Untitled OWID catalog dataset"
 
 
-def _dataset_description(dataset_meta: DatasetMeta, tables: list[TableSchemaInput]) -> str:
-    """Return the dataset's own description — never guessed from indicator origins.
+def _dataset_description(dataset_meta: DatasetMeta) -> str:
+    """Return the dataset's own description — never guessed from indicator origins or tables.
 
     A dataset's variables can span several unrelated origins: its own primary source plus
     auxiliary indicators (population, GDP, regions, ...) pulled in for per-capita or aggregate
     columns. Picking a description from any single one of those origins says nothing reliable
     about the dataset as a whole, and which one gets picked is an implementation detail (e.g.
-    column order) rather than a meaningful choice. Every public dataset is expected to set its
-    own ``dataset.description`` in its ``.meta.yml`` (or, for a single-table dataset, the
-    table's ``description``); ``assess_dataset_quality`` blocks datasets that don't, via the
+    column order) rather than a meaningful choice. ``TableMeta.description`` isn't a substitute
+    either — it's a mostly-internal field that authors rarely set with a public-facing dataset
+    description in mind. Every public dataset is expected to set its own ``dataset.description``
+    in its ``.meta.yml``; ``assess_dataset_quality`` blocks datasets that don't, via the
     ``missing_description`` check, before this function is ever called. Raising here — rather
     than inventing something — is a backstop in case that gate is ever bypassed.
     """
     if dataset_meta.description:
         return dataset_meta.description
-    table_description_value = _first_non_empty(table.metadata.description for table in tables)
-    if table_description_value:
-        return table_description_value
     raise ValueError(
         f"Dataset '{dataset_meta.short_name}' has no description set. "
         "Add `dataset.description` to its .meta.yml — it must not be guessed from indicator origins."

--- a/lib/catalog/tests/test_schema_org.py
+++ b/lib/catalog/tests/test_schema_org.py
@@ -37,6 +37,7 @@ def test_single_table_dataset_flattens_table_metadata() -> None:
             version="2025-04-07",
             short_name="cherry_blossom",
             title="Cherry Blossom Full Bloom Dates in Kyoto, Japan",
+            description="Cherry blossom bloom dates in Kyoto.",
         ),
         tables=[table],
     )
@@ -89,6 +90,7 @@ def test_version_param_overrides_latest_dataset_meta_version() -> None:
             version="latest",
             short_name="owid_co2",
             title="CO2 emissions",
+            description="CO2 emissions dataset.",
         ),
         tables=[table],
     )
@@ -115,6 +117,7 @@ def test_version_falls_back_to_dataset_meta_version_when_not_given() -> None:
             version="2025-04-07",
             short_name="cherry_blossom",
             title="Cherry blossom",
+            description="Cherry blossom bloom dates in Kyoto.",
         ),
         tables=[table],
     )
@@ -237,7 +240,7 @@ def test_table_description_falls_back_to_origin_then_dataset() -> None:
     assert parts["no_origin_desc"]["description"] == "Dataset-level description"
 
 
-def test_table_description_helper_prefers_explicit_and_returns_none_without_any_source() -> None:
+def test_table_description_ignores_internal_table_metadata_description() -> None:
     origin_without_desc = Origin(producer="Producer", title="Original")
     table = TableSchemaInput(
         short_name="t",
@@ -245,11 +248,14 @@ def test_table_description_helper_prefers_explicit_and_returns_none_without_any_
         variables={"value": VariableMeta(title="Value", origins=[origin_without_desc])},
         formats=["feather"],
     )
-    # No table/origin/dataset description available anywhere -> None (nothing is synthesized).
+    # No origin/dataset description available anywhere -> None (nothing is synthesized).
     assert table_description(table, DatasetMeta(short_name="d")) is None
-    # An explicit table description wins over origin and dataset descriptions.
-    table.metadata.description = "Explicit table description"
-    assert table_description(table, DatasetMeta(short_name="d", description="ds")) == "Explicit table description"
+    # TableMeta.description is a mostly-internal field and must never leak into JSON-LD, even
+    # when explicitly set: it neither wins over an available dataset description...
+    table.metadata.description = "Internal table description"
+    assert table_description(table, DatasetMeta(short_name="d", description="ds")) == "ds"
+    # ...nor gets used as a last resort when nothing else is available.
+    assert table_description(table, DatasetMeta(short_name="d")) is None
 
 
 def test_dataset_description_raises_without_explicit_description() -> None:
@@ -284,12 +290,13 @@ def test_dataset_description_raises_without_explicit_description() -> None:
         assert "owid_energy" in str(error)
 
 
-def test_dataset_description_falls_back_to_single_table_description_only() -> None:
-    """A single-table dataset may rely on the table's own description in lieu of a dataset-level
-    one, but that shortcut does not extend to picking an indicator origin's description."""
+def test_dataset_description_ignores_table_level_description() -> None:
+    """A table's own ``description`` (a mostly-internal field) must never substitute for a real
+    ``dataset.description`` — only an explicit dataset-level description satisfies the
+    requirement, even for a single-table dataset."""
     table = TableSchemaInput(
         short_name="owid_energy",
-        metadata=TableMeta(short_name="owid_energy", title="Energy", description="Table-level description."),
+        metadata=TableMeta(short_name="owid_energy", title="Energy", description="Internal table description."),
         variables={
             "population": VariableMeta(
                 title="Population",
@@ -299,14 +306,16 @@ def test_dataset_description_falls_back_to_single_table_description_only() -> No
         formats=["feather"],
     )
 
-    jsonld = dataset_to_schema_org(
-        dataset_path="garden/energy_data/2026-04-24/owid_energy",
-        page_path="energy_data/owid_energy",
-        dataset_meta=DatasetMeta(namespace="energy_data", version="2026-04-24", short_name="owid_energy"),
-        tables=[table],
-    )
-
-    assert jsonld["description"] == "Table-level description."
+    try:
+        dataset_to_schema_org(
+            dataset_path="garden/energy_data/2026-04-24/owid_energy",
+            page_path="energy_data/owid_energy",
+            dataset_meta=DatasetMeta(namespace="energy_data", version="2026-04-24", short_name="owid_energy"),
+            tables=[table],
+        )
+        raise AssertionError("Expected dataset_to_schema_org to raise ValueError for a missing description.")
+    except ValueError as error:
+        assert "owid_energy" in str(error)
 
 
 def test_license_to_url_resolves_known_license_names() -> None:

--- a/lib/catalog/tests/test_schema_org.py
+++ b/lib/catalog/tests/test_schema_org.py
@@ -136,7 +136,9 @@ def test_distribution_content_urls_use_dated_path_not_short_page_path() -> None:
     jsonld = dataset_to_schema_org(
         dataset_path="garden/emissions/2025-12-04/owid_co2",
         page_path="emissions/owid_co2",
-        dataset_meta=DatasetMeta(namespace="emissions", version="2025-12-04", short_name="owid_co2"),
+        dataset_meta=DatasetMeta(
+            namespace="emissions", version="2025-12-04", short_name="owid_co2", description="CO2 emissions dataset."
+        ),
         tables=[table],
     )
 
@@ -248,6 +250,63 @@ def test_table_description_helper_prefers_explicit_and_returns_none_without_any_
     # An explicit table description wins over origin and dataset descriptions.
     table.metadata.description = "Explicit table description"
     assert table_description(table, DatasetMeta(short_name="d", description="ds")) == "Explicit table description"
+
+
+def test_dataset_description_raises_without_explicit_description() -> None:
+    """Regression guard: a dataset with no dataset- or table-level description must fail loudly
+    rather than silently borrow a description from one of its indicators' origins. Previously, a
+    dataset combining many indicators from its own primary source with a borrowed auxiliary
+    indicator (e.g. population, added for per-capita columns) would describe itself using
+    whichever origin happened to be attached to the first column defined in the table — here,
+    population's origin — even though population has nothing to do with the dataset's actual
+    subject matter."""
+    population_origin = Origin(producer="Our World in Data", title="Population", description="Population blurb.")
+    energy_origin = Origin(producer="Energy Institute", title="Statistical Review", description="Energy blurb.")
+    table = TableSchemaInput(
+        short_name="owid_energy",
+        metadata=TableMeta(short_name="owid_energy", title="Energy"),
+        variables={
+            "population": VariableMeta(title="Population", origins=[population_origin]),
+            "coal_consumption": VariableMeta(title="Coal consumption", origins=[energy_origin]),
+        },
+        formats=["feather"],
+    )
+
+    try:
+        dataset_to_schema_org(
+            dataset_path="garden/energy_data/2026-04-24/owid_energy",
+            page_path="energy_data/owid_energy",
+            dataset_meta=DatasetMeta(namespace="energy_data", version="2026-04-24", short_name="owid_energy"),
+            tables=[table],
+        )
+        raise AssertionError("Expected dataset_to_schema_org to raise ValueError for a missing description.")
+    except ValueError as error:
+        assert "owid_energy" in str(error)
+
+
+def test_dataset_description_falls_back_to_single_table_description_only() -> None:
+    """A single-table dataset may rely on the table's own description in lieu of a dataset-level
+    one, but that shortcut does not extend to picking an indicator origin's description."""
+    table = TableSchemaInput(
+        short_name="owid_energy",
+        metadata=TableMeta(short_name="owid_energy", title="Energy", description="Table-level description."),
+        variables={
+            "population": VariableMeta(
+                title="Population",
+                origins=[Origin(producer="Our World in Data", title="Population", description="Population blurb.")],
+            )
+        },
+        formats=["feather"],
+    )
+
+    jsonld = dataset_to_schema_org(
+        dataset_path="garden/energy_data/2026-04-24/owid_energy",
+        page_path="energy_data/owid_energy",
+        dataset_meta=DatasetMeta(namespace="energy_data", version="2026-04-24", short_name="owid_energy"),
+        tables=[table],
+    )
+
+    assert jsonld["description"] == "Table-level description."
 
 
 def test_license_to_url_resolves_known_license_names() -> None:

--- a/tests/catalog_jsonld/test_quality.py
+++ b/tests/catalog_jsonld/test_quality.py
@@ -139,6 +139,21 @@ def test_missing_table_description_not_warned_when_dataset_description_present()
     assert result.table_warnings == {}
 
 
+def test_assess_dataset_quality_blocks_missing_description_even_with_origin_description() -> None:
+    # An indicator origin's description (e.g. a borrowed population/GDP column) must not count as
+    # the dataset having a description of its own — only an explicit dataset- or table-level one
+    # does. Otherwise a dataset could pass this gate and then blow up in dataset_to_schema_org,
+    # which refuses to guess a description from origins.
+    result = assess_dataset_quality(
+        catalog_path="garden/example/2025-01-01/example_dataset",
+        namespace="example",
+        dataset_meta=DatasetMeta(short_name="example_dataset", title="Example"),
+        tables=[_table("table_a", origin_desc="Producer description of the data.")],
+    )
+    assert "missing_description" in result.blockers
+    assert not result.is_eligible
+
+
 def test_missing_table_description_not_warned_when_origin_description_present() -> None:
     # No table or dataset description, but the producer (origin) provides one.
     result = assess_dataset_quality(


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## What

`owid_energy`'s catalog page description was silently the population dataset's blurb ("Our World in Data builds and maintains a long-run dataset on population..."), even though `owid_energy` has nothing to do with population.

`owid_energy.meta.yml` has no `dataset.description` (removed in #6378 for being unhelpful boilerplate). With no explicit description, `owid.catalog.schema_org._dataset_description()` fell back to scanning every column's indicator origins and used the description of whichever one it hit first — which happened to be the `population` column's origin, an auxiliary indicator pulled in only for per-capita calculations.

## Fix

- Removed the origin-scanning fallback from `_dataset_description()` entirely. A dataset must now have an explicit `dataset.description` — otherwise `dataset_to_schema_org()` raises instead of guessing.
- `TableMeta.description` is also never used as a substitute, even for single-table datasets — it's a mostly-internal field authors rarely set with a public-facing description in mind. Only `dataset_meta.description` counts.
- Tightened `assess_dataset_quality`'s `missing_description` check to match: neither an origin's description nor `TableMeta.description` counts as the dataset "having" a description anymore. This means datasets lacking a real `dataset.description` are blocked from JSON-LD generation (skipped, reported in the quality report) *before* they'd ever reach the new raise — consistent with how `missing_title`/`missing_license_url`/`missing_provenance` already work.
- Added a real `dataset.description` to `owid_energy.meta.yml`, written from the language actually published in the [energy-data repo's README](https://github.com/owid/energy-data) (the public-facing repo this dataset is exported to), rather than an invented summary.
- `table_description()` (used only for individual table nodes in multi-table `hasPart` datasets) still falls back to an origin's or the dataset's description when a table lacks one of its own — that part is pre-existing, deliberate, and already covered by its own tests. It just no longer considers `TableMeta.description` first.

## Note

`emissions/2025-12-04/owid_co2.meta.yml` still has the same kind of boilerplate description that was removed from `owid_energy` in #6378 ("this dataset will be loaded by the co2-data repository..."). Left untouched here since it's out of scope and already has *an* explicit description, but worth cleaning up separately.

## Test plan

- [x] `pytest lib/catalog/tests/test_schema_org.py` — tests for the raise, and confirming `TableMeta.description` is never used
- [x] `pytest tests/catalog_jsonld/` — a test confirming `missing_description` blocks a dataset that only has an origin-level description
- [x] `pytest lib/catalog` (full suite) — 368 passed
- [x] `make check`
