### PR TITLE
🐝 Bump lib package versions for PyPI republish after ty upgrade

### DIFF
--- a/lib/catalog/pyproject.toml
+++ b/lib/catalog/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-catalog"
-version = "1.2.1"
+version = "1.2.2"
 description = "Core data types used by OWID for managing data."
 readme = "README.md"
 authors = [{ name = "Our World in Data", email = "tech@ourworldindata.org" }]

--- a/lib/catalog/uv.lock
+++ b/lib/catalog/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-29T15:46:36.03299Z"
+exclude-newer = "2026-06-29T17:40:06.761929Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -1521,7 +1521,7 @@ wheels = [
 
 [[package]]
 name = "owid-catalog"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "brotli" },
@@ -1607,7 +1607,7 @@ dev = [
 
 [[package]]
 name = "owid-datautils"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "../datautils" }
 dependencies = [
     { name = "boto3" },
@@ -1673,7 +1673,7 @@ dev = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "../repack" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/lib/datautils/pyproject.toml
+++ b/lib/datautils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-datautils"
-version = "0.6.4"
+version = "0.6.5"
 description = "Data utils library by the Data Team at Our World in Data"
 authors = [
     {name = "Our World in Data", email = "tech@ourworldindata.org"},

--- a/lib/datautils/uv.lock
+++ b/lib/datautils/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-29T15:46:36.03296Z"
+exclude-newer = "2026-06-29T17:40:07.250206Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -1651,7 +1651,7 @@ wheels = [
 
 [[package]]
 name = "owid-datautils"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },

--- a/lib/owl/uv.lock
+++ b/lib/owl/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-29T15:46:36.033082Z"
+exclude-newer = "2026-06-29T17:40:16.004327Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -1350,7 +1350,7 @@ wheels = [
 
 [[package]]
 name = "owid-catalog"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "../catalog" }
 dependencies = [
     { name = "brotli" },
@@ -1424,7 +1424,7 @@ dev = [
 
 [[package]]
 name = "owid-datautils"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "../datautils" }
 dependencies = [
     { name = "boto3" },
@@ -1539,7 +1539,7 @@ dev = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "../repack" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/lib/repack/pyproject.toml
+++ b/lib/repack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "owid-repack"
-version = "0.1.9"
+version = "0.1.10"
 description = "Pack Pandas data frames into smaller, more memory-efficient data types."
 authors = [
     {name = "Our World in Data", email = "tech@ourworldindata.org"},

--- a/lib/repack/uv.lock
+++ b/lib/repack/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-29T15:46:36.032957Z"
+exclude-newer = "2026-06-29T17:40:06.237779Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -344,7 +344,7 @@ wheels = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-29T15:46:24.579671Z"
+exclude-newer = "2026-06-29T17:40:24.701759Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -4715,7 +4715,7 @@ wheels = [
 
 [[package]]
 name = "owid-catalog"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "lib/catalog" }
 dependencies = [
     { name = "brotli" },
@@ -4789,7 +4789,7 @@ dev = [
 
 [[package]]
 name = "owid-datautils"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "lib/datautils" }
 dependencies = [
     { name = "boto3" },
@@ -4896,7 +4896,7 @@ dev = [
 
 [[package]]
 name = "owid-repack"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "lib/repack" }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

The `ty` 0.0.26 → 0.0.55 upgrade in #6384 touched `lib/catalog/pyproject.toml`, `lib/datautils/pyproject.toml`, and `lib/repack/pyproject.toml` (dev dependency version) without bumping the packages' own versions. Since `publish-owid-packages.yml` triggers on any push to master touching those paths, all three publish jobs failed: the versions already existed on PyPI (same pattern as #6106).

- `owid-catalog` 1.2.1 → 1.2.2
- `owid-datautils` 0.6.4 → 0.6.5
- `owid-repack` 0.1.9 → 0.1.10

Re-ran `uv lock` in each `lib/*` dir plus the repo root so the lockfiles reflect the new versions.
