### PR TITLE
🐛 Fix air traffic units (millions of seat/passenger-km)

### DIFF
--- a/etl/steps/data/garden/aviation/2026-04-02/air_traffic.meta.yml
+++ b/etl/steps/data/garden/aviation/2026-04-02/air_traffic.meta.yml
@@ -60,11 +60,12 @@ tables:
         display:
           numDecimalPlaces: 0
           name: Passenger-km
+        description_processing: The source publishes this data in millions of passenger-kilometres. We converted it to passenger-kilometres.
 
       available_seat_kilometers:
         title: Available seat-kilometres
         unit: seat-kilometres
-        short_unit: km
+        short_unit: seat-km
         description_short: The total seating capacity provided by airlines, also known as available seat-kilometres.
         description_key:
           - Available seat-kilometres measure how much passenger-carrying capacity airlines offered.
@@ -77,3 +78,4 @@ tables:
         display:
           numDecimalPlaces: 0
           name: Available seat-km
+        description_processing: The source publishes this data in millions of seat-kilometres. We converted it to seat-kilometres.

--- a/etl/steps/data/garden/aviation/2026-04-02/air_traffic.py
+++ b/etl/steps/data/garden/aviation/2026-04-02/air_traffic.py
@@ -24,6 +24,15 @@ def run() -> None:
     tb["share_empty_seats"] = 100 - tb["passenger_load_factor"]
     tb["share_empty_seats"].metadata.origins = tb["passenger_load_factor"].metadata.origins
 
+    # The source publishes RPKs and ASKs in millions (columns "RPKs (mils)" and "ASKs (mils)").
+    # Convert to actual passenger-kilometres and seat-kilometres.
+    for col in ["revenue_passenger_kilometers", "available_seat_kilometers"]:
+        tb[col] *= 1e6
+
+    # Sanity check: after conversion, recent global traffic and capacity should be in the trillions.
+    for col in ["revenue_passenger_kilometers", "available_seat_kilometers"]:
+        assert 1e12 < tb[col].max() < 1e14, f"Unexpected magnitude for {col} — check the source units."
+
     # Improve table format.
     tb = tb.format(["country", "year"])
 


### PR DESCRIPTION
> _Written by Claude Code — @edomt at the wheel._

## Problem

A reader [reported](https://ourworldindata.org/grapher/airline-capacity-and-traffic) that global available seat-kilometres showing as ~10 **million** km seemed far too low — it should be on the order of 10¹² (trillions).

**The reader is right.** The source ([World Airlines Traffic and Capacity, A4A/ICAO](https://www.airlines.org/dataset/world-airlines-traffic-and-capacity/)) publishes these columns as `RPKs (mils)` and `ASKs (mils)` — i.e. **millions** of passenger/seat-kilometres. The ETL passed the values through unconverted while declaring the unit as plain `passenger-kilometres` / `seat-kilometres`, understating the values by a factor of 10⁶.

### Verification

Internal consistency of the source table (2024), interpreted as millions:
- Average trip length = RPK ÷ passengers = **1,949 km** ✓
- Average seats per aircraft = ASK ÷ aircraft-km = **186 seats** ✓
- RPK ÷ ASK = **83.2%** = the source's own published load factor ✓

Interpreted as raw units (the live behaviour): each passenger flies **1.9 metres**. 🛬

Converted 2010 ASK = 6.3×10¹², matching the independent figure the reader cited (order of 10¹² in 2010).

## Fix

In garden (`aviation/2026-04-02/air_traffic`):
- Multiply RPKs and ASKs by 1e6, with a `description_processing` note on both indicators
- Add a magnitude sanity check (recent values must be in the trillions)
- Fix ASK `short_unit` from `km` → `seat-km` (the bare `km` made the axis read like a distance)

## Scope

Checked all usages of this dataset in production (Datasette):
- `airline-capacity-and-traffic` — **affected**, fixed by this PR (chart has no unit overrides or fixed axis bounds; it inherits everything from the indicators)
- `airline-passenger-load-factor` — uses the % indicators only, **unaffected**
- No narrative charts, explorers, or MDims use these indicators
- The one linked data insight ("How quickly has global air travel recovered from the COVID-19 pandemic?") doesn't quote absolute magnitudes in prose, so no text needs correcting

No version bump → variable IDs are preserved, no chart remapping needed.

Dataset owner: Tuna (@antea04) — FYI since Veronika has left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## History — when did this break?

The error went live on **2026-04-10**, with the `aviation/2026-04-02` dataset update (#5886). The source did not change, and the chart config never had a unit multiplier — the ×1e6 conversion always lived in the data pipeline, and was lost in the last rewrite:

| Period | Data behind the chart | Magnitude |
|---|---|---|
| 2020 → May 2025 | Pre-ETL grapher dataset *Global airline traffic and capacity (ICAO)* (vars 143541/143548) | ✅ trillions (values stored pre-converted; [Wayback, Jun 2024](http://web.archive.org/web/20240607071631/https://ourworldindata.org/grapher/airline-capacity-and-traffic)) |
| May 2025 → Apr 2026 | `aviation/2025-04-01` (#4205) | ✅ trillions (garden step multiplied `__mils` columns by 1e6) |
| Apr 2026 → now | `aviation/2026-04-02` (#5886) | ❌ raw millions (column rename moved to meadow, `(mils)` suffix stripped, multiplication dropped) |

This PR restores the conversion, in garden, with a sanity check so it can't silently regress again.
