### PR TITLE
📊 Migrate more inline data fixes to .corrections.yml

### DIFF
--- a/etl/data_corrections.py
+++ b/etl/data_corrections.py
@@ -69,6 +69,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import pandas as pd
 import yaml
 from owid.catalog import Table
 from structlog import get_logger
@@ -227,6 +228,16 @@ def _year_mask(years: Any, year_values: np.ndarray, label: str) -> np.ndarray:
     )
 
 
+def _eq_mask(values: np.ndarray, target: Any) -> np.ndarray:
+    """Elementwise equality that treats missing values as non-matching rather than raising.
+
+    `values` may be an object array holding `pd.NA`/`None` (e.g. a nullable string column) — comparing
+    those to a scalar with plain `==` yields `pd.NA` instead of `False`, which blows up a later `&=`
+    with a `TypeError: boolean value of NA is ambiguous`.
+    """
+    return pd.Series(values).eq(target).fillna(False).to_numpy()
+
+
 def _row_mask(tb: Table, correction: dict[str, Any], country_col: str, year_col: str) -> np.ndarray:
     """Return a positional boolean mask over `tb` selecting the rows a correction targets."""
     index_names = [name for name in tb.index.names if name is not None]
@@ -237,10 +248,10 @@ def _row_mask(tb: Table, correction: dict[str, Any], country_col: str, year_col:
         for key, value in correction["match"].items():
             # `value` is shorthand for the indicator column; any other key matches that column by name.
             col = correction["indicator"] if key == "value" else key
-            mask &= _column_values(tb, col, index_names) == value
+            mask &= _eq_mask(_column_values(tb, col, index_names), value)
         return mask
 
-    entity_mask = _column_values(tb, country_col, index_names) == correction["entity"]
+    entity_mask = _eq_mask(_column_values(tb, country_col, index_names), correction["entity"])
     year_values = _column_values(tb, year_col, index_names)
     return entity_mask & _year_mask(correction["years"], year_values, label)
 
@@ -335,6 +346,19 @@ def _to_float(value: Any) -> float | None:
     return None if f != f else f  # drop NaN
 
 
+def _to_int(value: Any) -> int | None:
+    """Coerce a value to int, or None if it's not a whole-number label.
+
+    Some tables carry non-integer year labels for rows unrelated to a given correction (e.g. a
+    reporting-period range like "1872-6") — those points simply can't be placed on the audit's
+    year axis, so they're dropped rather than raising.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def audit_path_for(corrections_path: Path | str) -> Path:
     """Where the audit JSON for a given `.corrections.yml` lives (under the gitignored data/ tree)."""
     rel = Path(corrections_path).resolve().relative_to(STEP_DIR.resolve())  # data/<channel>/.../x.corrections.yml
@@ -373,16 +397,20 @@ def build_audit(
         for ent in sorted(set(entity_vals[mask].tolist())):
             ent_mask = entity_vals == ent
             series = sorted(
-                [int(y), fv]
+                [y_int, fv]
                 for y, v in zip(year_vals[ent_mask].tolist(), ind_vals[ent_mask].tolist())
-                if (fv := _to_float(v)) is not None
+                if (fv := _to_float(v)) is not None and (y_int := _to_int(y)) is not None
             )
             any_numeric = any_numeric or bool(series)
             affected = []
-            for y, v in sorted(zip(year_vals[(ent_mask & mask)].tolist(), ind_vals[(ent_mask & mask)].tolist())):
+            for y, v in sorted(
+                zip(year_vals[(ent_mask & mask)].tolist(), ind_vals[(ent_mask & mask)].tolist()),
+                key=lambda pair: str(pair[0]),
+            ):
                 before = _to_float(v)
-                if before is None:
-                    continue  # a matched-but-empty cell carries no value to show
+                y_int = _to_int(y)
+                if before is None or y_int is None:
+                    continue  # a matched-but-empty cell, or a non-integer year label, carries nothing to plot
                 if action == "drop":
                     after = None
                 elif action == "override":
@@ -391,7 +419,7 @@ def build_audit(
                     after = before * float(factor) if before is not None else None
                 else:
                     after = before
-                affected.append([int(y), before, after])
+                affected.append([y_int, before, after])
             entities.append({"entity": ent, "series": series, "affected": affected})
 
         records.append(

--- a/etl/data_corrections.py
+++ b/etl/data_corrections.py
@@ -34,6 +34,14 @@ Rows can also be located by their current value instead of entity+years::
       value: 5
       ...
 
+A `match` value can also reference another column of the *same row* instead of a literal, to express
+a relationship between two columns rather than a fixed constant::
+
+    - indicator: barn
+      match: {country: Belgium, year: 2025, value: {column: free_range}}
+      action: drop                                # drop the row where barn == free_range
+      ...
+
 Actions:
 - ``drop``     — remove the matched rows (use for long/tidy tables, where a row *is* one data point).
 - ``override`` — replace the indicator value of the matched rows with ``value``. Set ``value: null``
@@ -86,6 +94,14 @@ VALID_ACTIONS = {"drop", "override", "scale", "flag"}
 VALID_STATUSES = {"open", "reported", "acknowledged", "fixed_upstream"}
 
 # Comparison operators allowed in an `expect:` guard, mapping to the function applied elementwise.
+#
+# `expect`'s threshold is deliberately literal-only (unlike `match`, which also accepts a
+# `{column: <name>}` reference — see `_resolve`). No correction needs a cross-column `expect` yet, and
+# wiring it up isn't free: `_resolve` returns a table-length array, but `_check_expectation` compares
+# against `tb.loc[mask, indicator]` (already mask-narrowed), so the resolved array would need slicing
+# by the same `mask` before the elementwise comparison — an extra step with no test coverage today. If
+# this is ever needed: resolve the threshold via `_resolve(tb, threshold, index_names, label)`, then
+# index it with `mask` before passing it to the operator lambda.
 EXPECT_OPERATORS = {
     "eq": lambda values, threshold: values == threshold,
     "ne": lambda values, threshold: values != threshold,
@@ -159,9 +175,26 @@ def _validate_correction(correction: Any, path: Path | str) -> None:
         # (they would be silently ignored), so reject the combination.
         mixed = {"entity", "years"} & set(correction)
         assert not mixed, f"Correction [{label}]: do not combine 'match' with {sorted(mixed)}."
+        # A match value may reference another column of the same row (`{column: <name>}`) instead of a
+        # literal. Reject any other dict shape now, rather than letting it silently build an all-false
+        # mask (a literal `==` against a dict never matches) that only surfaces as a confusing
+        # "matched no rows" at apply time.
+        for key, value in match.items():
+            if isinstance(value, dict):
+                assert set(value) == {"column"} and isinstance(value.get("column"), str) and value["column"], (
+                    f"Correction [{label}]: match.{key} must be a literal or {{'column': <name>}}, got {value!r}."
+                )
 
     if action == "override":
         assert "value" in correction, f"Correction [{label}]: action 'override' requires a 'value'."
+        # `{column: ...}` references are only resolved inside `match` (to compare two columns of the
+        # same row); resolving one as the top-level override target isn't implemented, so a value
+        # shaped that way would be assigned into every matched cell as a literal dict — reject it.
+        value = correction["value"]
+        assert not (isinstance(value, dict) and "column" in value), (
+            f"Correction [{label}]: action 'override' does not support a {{'column': ...}} reference as "
+            f"'value' — that form is only resolved inside 'match'."
+        )
 
     if action == "scale":
         factor = correction.get("factor")
@@ -233,9 +266,23 @@ def _eq_mask(values: np.ndarray, target: Any) -> np.ndarray:
 
     `values` may be an object array holding `pd.NA`/`None` (e.g. a nullable string column) — comparing
     those to a scalar with plain `==` yields `pd.NA` instead of `False`, which blows up a later `&=`
-    with a `TypeError: boolean value of NA is ambiguous`.
+    with a `TypeError: boolean value of NA is ambiguous`. `target` may itself be an array (see
+    `_resolve`), in which case this compares elementwise position-by-position, same as against a scalar.
     """
     return pd.Series(values).eq(target).fillna(False).to_numpy()
+
+
+def _resolve(tb: Table, spec: Any, index_names: list[str], label: str) -> Any:
+    """Resolve a `match` operand: `{"column": <name>}` resolves to that column's full array, so the
+    caller ends up comparing two columns of the same row elementwise instead of a column against a
+    fixed constant. Anything else is returned unchanged (the literal case).
+    """
+    if isinstance(spec, dict):
+        assert "column" in spec, (
+            f"Correction [{label}]: expected a column reference like {{'column': <name>}}, got {spec!r}."
+        )
+        return _column_values(tb, spec["column"], index_names)
+    return spec
 
 
 def _row_mask(tb: Table, correction: dict[str, Any], country_col: str, year_col: str) -> np.ndarray:
@@ -248,7 +295,8 @@ def _row_mask(tb: Table, correction: dict[str, Any], country_col: str, year_col:
         for key, value in correction["match"].items():
             # `value` is shorthand for the indicator column; any other key matches that column by name.
             col = correction["indicator"] if key == "value" else key
-            mask &= _eq_mask(_column_values(tb, col, index_names), value)
+            target = _resolve(tb, value, index_names, label)
+            mask &= _eq_mask(_column_values(tb, col, index_names), target)
         return mask
 
     entity_mask = _eq_mask(_column_values(tb, country_col, index_names), correction["entity"])
@@ -390,6 +438,10 @@ def build_audit(
         mask = _row_mask(tb, correction, country_col, year_col)
         action = correction["action"]
         factor = correction.get("factor")
+        # `correction.get("value")` here is the top-level override target, not a `match`-nested
+        # `{column: ...}` reference (those live inside `match["value"]`, a different dict) — the two
+        # `"value"` keys never collide, so `_to_float` seeing a real reference dict can't happen for a
+        # correction that's valid per `_validate_correction`.
         override_value = _to_float(correction.get("value"))
 
         any_numeric = False

--- a/etl/steps/data/garden/animal_welfare/2026-06-11/laying_hens_keeping_eu.corrections.yml
+++ b/etl/steps/data/garden/animal_welfare/2026-06-11/laying_hens_keeping_eu.corrections.yml
@@ -1,0 +1,20 @@
+# Known upstream data errors in the EU laying-hens-keeping-methods data, corrected locally until
+# fixed at the source. See etl/data_corrections.py for the format.
+- indicator: barn
+  match: {country: Belgium, year: 2025, value: {column: free_range}}
+  action: drop
+  reason: The Belgium 2025 barn value is a copy of the free_range value, which makes the total
+    inconsistent with the EU eggs dashboard's reported ~5.27M barn / ~11.34M total for the same
+    notification (https://agriculture.ec.europa.eu/document/download/9bdf9842-1eb6-41a2-8845-49738b812b2b_en).
+  provider: European Commission (eggs dashboard)
+  status: open
+
+- indicator: total
+  entity: Greece
+  years: [2013]
+  action: drop
+  expect: {lt: 100000}
+  reason: Greece's 2013 total of 23,166 hens is far below its other years (~4-5 million); most
+    likely an incomplete notification.
+  provider: European Commission (eggs dashboard)
+  status: open

--- a/etl/steps/data/garden/animal_welfare/2026-06-11/laying_hens_keeping_eu.py
+++ b/etl/steps/data/garden/animal_welfare/2026-06-11/laying_hens_keeping_eu.py
@@ -34,26 +34,8 @@ def run() -> None:
     # Remove rows of country-years for which the source reports no data at all.
     tb = tb.dropna(subset=DATA_COLUMNS, how="all").reset_index(drop=True)
 
-    ####################################################################################################################
-    # In the current snapshot, the Belgium 2025 row is spurious: the barn value is a copy of the
-    # free range value, which makes the total inconsistent with the EU eggs dashboard (where the same
-    # notification is reported with a ~5.27 million barn value and a ~11.34 million total):
-    # https://agriculture.ec.europa.eu/document/download/9bdf9842-1eb6-41a2-8845-49738b812b2b_en?filename=eggs-dashboard_en.pdf
-    # So we remove the 2025 row.
-    error = "Belgium 2025 row may have been fixed in the source file; remove this workaround."
-    belgium_2025 = tb[(tb["country"] == "Belgium") & (tb["year"] == 2025)]
-    assert len(belgium_2025) == 1, error
-    assert (belgium_2025["barn"] == belgium_2025["free_range"]).all(), error
-    tb = tb.drop(index=belgium_2025.index).reset_index(drop=True)
-
-    # The Greece 2013 row reports a total of just 23,166 hens, whereas Greece's other years are
-    # around 4-5 million; it is most likely an incomplete notification, so we remove it.
-    error = "Greece 2013 row may have been fixed in the source file; remove this workaround."
-    greece_2013 = tb[(tb["country"] == "Greece") & (tb["year"] == 2013)]
-    assert len(greece_2013) == 1, error
-    assert (greece_2013["total"] < 100_000).all(), error
-    tb = tb.drop(index=greece_2013.index).reset_index(drop=True)
-    ####################################################################################################################
+    # Remove two known-erroneous rows (Belgium 2025, Greece 2013) — see laying_hens_keeping_eu.corrections.yml.
+    tb = paths.apply_corrections(tb)
 
     # Run sanity checks on outputs.
     sanity_check_outputs(tb)

--- a/etl/steps/data/garden/gfs/2026-04-08/gfs_wave_two.corrections.yml
+++ b/etl/steps/data/garden/gfs/2026-04-08/gfs_wave_two.corrections.yml
@@ -1,0 +1,9 @@
+# Known upstream data errors in the Gallup World Poll (GFS) wave two data, corrected locally until
+# fixed at the source. See etl/data_corrections.py for the format.
+- indicator: drinks
+  match: {value: 4.5}
+  action: override
+  value: 5
+  reason: The "drinks" scale is reported in whole numbers, so a single respondent's value of 4.5 is likely a data error. Treated as 5.
+  provider: Gallup World Poll
+  status: open

--- a/etl/steps/data/garden/gfs/2026-04-08/gfs_wave_two.py
+++ b/etl/steps/data/garden/gfs/2026-04-08/gfs_wave_two.py
@@ -307,8 +307,8 @@ def run() -> None:
     # drinks and cigarettes are topcoded to 97, we treat them as 97 rather than 97+
     # drinks: 116 rows with maximum value of 97
     # cigarettes: 45 rows with maximum value of 97
-    # drinks has one entry which is 4.5. We treat this as 5 (the scale is in whole numbers, so this is likely a data error).
-    tb["drinks"] = tb["drinks"].astype(float).replace(4.5, 5)
+    tb["drinks"] = tb["drinks"].astype(float)
+    tb = paths.apply_corrections(tb)
 
     tb_scored_97 = average_scored(tb, groups=GROUPS, cols=["cigarettes", "drinks"])
 

--- a/etl/steps/data/garden/health/2024-04-12/polio_free_countries.corrections.yml
+++ b/etl/steps/data/garden/health/2024-04-12/polio_free_countries.corrections.yml
@@ -1,0 +1,8 @@
+# Known upstream data errors in the GPEI wild-polio-free-countries data, corrected locally until
+# fixed at the source. See etl/data_corrections.py for the format.
+- indicator: year
+  match: {country: Somalia, year: "2000"}
+  action: drop
+  reason: Somalia has two rows in the source; confirmed with GPEI that Somalia's last wild polio case was in 2002, so the earlier (2000) row is dropped.
+  provider: Global Polio Eradication Initiative
+  status: acknowledged

--- a/etl/steps/data/garden/health/2024-04-12/polio_free_countries.py
+++ b/etl/steps/data/garden/health/2024-04-12/polio_free_countries.py
@@ -32,8 +32,7 @@ def run(dest_dir: str) -> None:
     ###### Confirmed that the value for Palestine NA is the correct one with GPEI
 
     tb = tb[tb["country"] != "West Bank and Gaza"]
-    ##### There are also two values for Somalia, I will drop the least recent one - confirmed with GPEI that Somalia's last wild polio case was in 2002
-    tb = tb[~((tb["country"] == "Somalia") & (tb["year"] == "2000"))]
+    tb = paths.apply_corrections(tb)
 
     # Loading the polio status data for WHO regions
     ds_region_status = paths.load_dataset(short_name="polio_status", channel="meadow")

--- a/etl/steps/data/garden/papers/2026-01-20/anshassi_waste_management.corrections.yml
+++ b/etl/steps/data/garden/papers/2026-01-20/anshassi_waste_management.corrections.yml
@@ -1,0 +1,19 @@
+# Known upstream data errors in the Anshassi et al. waste management data, corrected locally until
+# fixed at the source. See etl/data_corrections.py for the format.
+- indicator: collected
+  match: {country: United Arab Emirates}
+  action: scale
+  factor: 100
+  expect: {lt: 5}
+  reason: UAE's collected/uncollected waste shares appear swapped by a factor of 100 - UAE is classified as a level-2 country so cannot plausibly have such a low share of collected waste.
+  provider: Anshassi et al. (2023)
+  status: open
+
+- indicator: uncollected
+  match: {country: United Arab Emirates}
+  action: scale
+  factor: 0.01
+  expect: {gt: 90}
+  reason: UAE's collected/uncollected waste shares appear swapped by a factor of 100 - UAE is classified as a level-2 country so cannot plausibly have such a high share of uncollected waste.
+  provider: Anshassi et al. (2023)
+  status: open

--- a/etl/steps/data/garden/papers/2026-01-20/anshassi_waste_management.py
+++ b/etl/steps/data/garden/papers/2026-01-20/anshassi_waste_management.py
@@ -21,10 +21,7 @@ def run() -> None:
     # Harmonize country names.
     tb = paths.regions.harmonize_names(tb)
 
-    # Fix UAE data error (collected and uncollected values were swapped by factor of 100) - classfied as level 2 country so can't possibly have such low values of collected waste and likely a decimal place error
-    uae_mask = tb["country"] == "United Arab Emirates"
-    tb.loc[uae_mask, "collected"] = tb.loc[uae_mask, "collected"] * 100
-    tb.loc[uae_mask, "uncollected"] = tb.loc[uae_mask, "uncollected"] / 100
+    tb = paths.apply_corrections(tb)
 
     # Check and fix floating-point rounding errors in percentages
     # Collected + uncollected should equal 100%

--- a/etl/steps/data/garden/who/2025-01-17/vaccine_stock_out.corrections.yml
+++ b/etl/steps/data/garden/who/2025-01-17/vaccine_stock_out.corrections.yml
@@ -1,0 +1,9 @@
+# Known upstream data errors in the WHO vaccine stock-out data, corrected locally until fixed at
+# the source. See etl/data_corrections.py for the format.
+- indicator: value
+  match: {value: "Inaccurtae forecasts"}
+  action: override
+  value: "Inaccurate forecasts"
+  reason: Typo in the source's "reason for stockout" answer option.
+  provider: World Health Organization
+  status: open

--- a/etl/steps/data/garden/who/2025-01-17/vaccine_stock_out.py
+++ b/etl/steps/data/garden/who/2025-01-17/vaccine_stock_out.py
@@ -26,6 +26,7 @@ def run() -> None:
     origins = tb["value"].origins
     tb = geo.harmonize_countries(df=tb, countries_file=paths.country_mapping_path)
     tb = clean_data(tb)
+    tb = paths.apply_corrections(tb)
 
     # Calculate derived metrics
     tb_agg, tb_cause, tb_global, tb_global_cause = calculate_derived_metrics(tb, origins)
@@ -120,8 +121,6 @@ def reason_for_stockout(tb: Table, origin: Origin) -> Table:
     ]
     # Dropping rows where the values are 'Yes' or 'No' as they are incorrect
     tb_cause = tb_cause[~tb_cause["value"].isin(["Yes", "No"])]
-    # Fix typo in the data
-    tb_cause["value"] = tb_cause["value"].replace("Inaccurtae forecasts", "Inaccurate forecasts")
 
     tb_agg = (
         tb_cause.assign(yes="Yes")

--- a/etl/steps/data/garden/who/latest/avian_influenza_ah5n1.corrections.yml
+++ b/etl/steps/data/garden/who/latest/avian_influenza_ah5n1.corrections.yml
@@ -1,0 +1,9 @@
+# Known upstream data errors in the WHO avian influenza (H5N1) data, corrected locally until fixed
+# at the source. See etl/data_corrections.py for the format.
+- indicator: month
+  match: {value: "12/1/225"}
+  action: override
+  value: "12/1/2025"
+  reason: "Month label is missing a digit in the year (\"225\" instead of \"2025\")."
+  provider: World Health Organization
+  status: open

--- a/etl/steps/data/garden/who/latest/avian_influenza_ah5n1.py
+++ b/etl/steps/data/garden/who/latest/avian_influenza_ah5n1.py
@@ -44,9 +44,7 @@ def run() -> None:
     ## Yearly data
     tb_year = tb_year.rename(columns={"month": "date"})
     ## Monthly data
-    ## FIXES
-    ## Fix "225" should be "2025"
-    tb_month["month"] = tb_month["month"].str.replace("12/1/225", "12/1/2025")
+    tb_month = paths.apply_corrections(tb_month)
     # date_1 = pd.to_datetime(tb_month["month"], format="%b-%y", errors="coerce")
     # date_2 = pd.to_datetime(tb_month["month"], format="%y-%b", errors="coerce")
     # date_3 = pd.to_datetime("200" + tb_month["month"].astype(str), format="%Y-%b", errors="coerce")

--- a/etl/steps/data/meadow/gapminder/2024-07-08/maternal_mortality.corrections.yml
+++ b/etl/steps/data/meadow/gapminder/2024-07-08/maternal_mortality.corrections.yml
@@ -1,0 +1,90 @@
+# Known upstream data errors in the Gapminder maternal mortality data, corrected locally until fixed
+# at the source. See etl/data_corrections.py for the format.
+
+# Australia's first two rows span 110 years each, when they should only span 10 (see
+# https://docs.google.com/spreadsheets/u/0/d/14ZtQy9kd0pMRKWg_zKsTg3qKHoGtflj-Ekal9gIPZ4A/pub?gid=1#).
+# Replaced with the midpoint of the decade.
+- indicator: year
+  match: {value: "1871-1980", Country: Australia}
+  action: override
+  value: "1875"
+  reason: Year range spans 110 years instead of 10; replaced with the decade's midpoint.
+  provider: Gapminder
+  status: open
+
+- indicator: year
+  match: {value: "1881-1990", Country: Australia}
+  action: override
+  value: "1885"
+  reason: Year range spans 110 years instead of 10; replaced with the decade's midpoint.
+  provider: Gapminder
+  status: open
+
+# Finland: duplicate years 1772, 1775, 1967 should be 1872, 1875, 1957.
+- indicator: year
+  match: {value: "1772", Country: Finland, Maternal deaths: 487}
+  action: override
+  value: "1872"
+  reason: Duplicate year 1772 is a typo for 1872.
+  provider: Gapminder
+  status: open
+
+- indicator: year
+  match: {value: "1775", Country: Finland, Maternal deaths: 629}
+  action: override
+  value: "1875"
+  reason: Duplicate year 1775 is a typo for 1875.
+  provider: Gapminder
+  status: open
+
+- indicator: year
+  match: {value: "1967", Country: Finland, Maternal deaths: 77}
+  action: override
+  value: "1957"
+  reason: Duplicate year 1967 is a typo for 1957.
+  provider: Gapminder
+  status: open
+
+# Sweden: duplicate year 1967 should be 1957.
+- indicator: year
+  match: {value: "1967", Country: Sweden, Maternal deaths: 39}
+  action: override
+  value: "1957"
+  reason: Duplicate year 1967 is a typo for 1957.
+  provider: Gapminder
+  status: open
+
+# United States: duplicate year 1967 should be 1957.
+- indicator: year
+  match: {value: "1967", Country: United States, Live Births: 4308000}
+  action: override
+  value: "1957"
+  reason: Duplicate year 1967 is a typo for 1957.
+  provider: Gapminder
+  status: open
+
+# Belgium: duplicate year 1973 should be 1873.
+- indicator: year
+  match: {value: "1973", Country: Belgium, Maternal deaths: 1283}
+  action: override
+  value: "1873"
+  reason: Duplicate year 1973 is a typo for 1873.
+  provider: Gapminder
+  status: open
+
+# New Zealand: range 1989-02 should be 1898-02; take the midpoint 1900.
+- indicator: year
+  match: {value: "1989-02", Country: New Zealand}
+  action: override
+  value: "1900"
+  reason: Year range "1989-02" is a typo for "1898-02"; replaced with the midpoint 1900.
+  provider: Gapminder
+  status: open
+
+# New Zealand: duplicate 1950 entry from a different source (Loudon), dropped in favor of the other row.
+- indicator: MMR
+  match: {Country: New Zealand, year: "1950", value: 90}
+  action: drop
+  reason: Duplicate 1950 entry sourced from Loudon; dropped in favor of the other 1950 row.
+  provider: Gapminder
+  status: open

--- a/etl/steps/data/meadow/gapminder/2024-07-08/maternal_mortality.py
+++ b/etl/steps/data/meadow/gapminder/2024-07-08/maternal_mortality.py
@@ -50,32 +50,7 @@ def run(dest_dir: str) -> None:
 
     #
     # cleaning errors (manually):
-    # Australia (first two rows span 110 years, when they should only span 10 as seen in https://docs.google.com/spreadsheets/u/0/d/14ZtQy9kd0pMRKWg_zKsTg3qKHoGtflj-Ekal9gIPZ4A/pub?gid=1#)
-    # replace with middle of the decade numbers
-    tb.loc[(tb["Country"] == "Australia") & (tb["year"] == "1871-1980"), "year"] = "1875"
-    tb.loc[(tb["Country"] == "Australia") & (tb["year"] == "1881-1990"), "year"] = "1885"
-
-    # wrong entries for Finland (duplicate 1772, 1775, 1967 -> should be 1872, 1875, 1957)
-    tb.loc[(tb["year"] == "1772") & (tb["Country"] == "Finland") & (tb["Maternal deaths"] == 487), "year"] = "1872"
-    tb.loc[(tb["year"] == "1775") & (tb["Country"] == "Finland") & (tb["Maternal deaths"] == 629), "year"] = "1875"
-    tb.loc[(tb["year"] == "1967") & (tb["Country"] == "Finland") & (tb["Maternal deaths"] == 77), "year"] = "1957"
-
-    # wrong entry for Sweden (duplicate 1967 -> should be 1957)
-    tb.loc[(tb["year"] == "1967") & (tb["Country"] == "Sweden") & (tb["Maternal deaths"] == 39), "year"] = "1957"
-
-    # wrong entry for US (duplicate 1967 -> should be 1957)
-    tb.loc[(tb["year"] == "1967") & (tb["Country"] == "United States") & (tb["Live Births"] == 4308000), "year"] = (
-        "1957"
-    )
-
-    # wrong entry for Belgium (duplicate 1973 -> should be 1873)
-    tb.loc[(tb["year"] == "1973") & (tb["Country"] == "Belgium") & (tb["Maternal deaths"] == 1283), "year"] = "1873"
-
-    # wrong entry for New Zealand (range 1989-02 -> should be 1898-02, take midpoint 1900)
-    tb.loc[(tb["year"] == "1989-02") & (tb["Country"] == "New Zealand"), "year"] = "1900"
-
-    # duplicate entry for New Zealand (1950, drop Loudon data)
-    tb = tb.drop(tb[(tb["year"] == "1950") & (tb["Country"] == "New Zealand") & (tb["MMR"] == 90)].index)
+    tb = paths.apply_corrections(tb, country_col="Country", year_col="year")
 
     # remove zeros from data (these are artifacts)
     # check with - print(tb.loc[tb[tb==0].dropna(how="all").index])

--- a/schemas/corrections-schema.json
+++ b/schemas/corrections-schema.json
@@ -2,6 +2,22 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ETL data corrections",
   "description": "Declarative corrections for known upstream data errors. See etl/data_corrections.py.",
+  "definitions": {
+    "matchValue": {
+      "description": "A literal to match, or {column: <name>} to compare elementwise against another column of the same row.",
+      "oneOf": [
+        { "type": ["string", "number", "boolean", "null"] },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["column"],
+          "properties": {
+            "column": { "type": "string", "minLength": 1 }
+          }
+        }
+      ]
+    }
+  },
   "type": "array",
   "items": {
     "type": "object",
@@ -42,7 +58,8 @@
       "match": {
         "type": "object",
         "minProperties": 1,
-        "description": "Locate rows by their current value(s), e.g. {value: 4.5}. Mutually exclusive with entity/years."
+        "additionalProperties": { "$ref": "#/definitions/matchValue" },
+        "description": "Locate rows by their current value(s), e.g. {value: 4.5}, or by comparison to another column of the same row, e.g. {value: {column: free_range}}. Mutually exclusive with entity/years."
       },
       "action": {
         "enum": ["drop", "override", "scale", "flag"],

--- a/tests/test_data_corrections.py
+++ b/tests/test_data_corrections.py
@@ -2,6 +2,7 @@
 
 import json
 
+import pandas as pd
 import pytest
 import yaml
 from owid.catalog import Table
@@ -95,6 +96,24 @@ def test_override_requires_value():
 
     with pytest.raises(AssertionError):
         _validate_correction(_correction(action="override", match={"value": 10.0}), "<test>")
+
+
+def test_match_ignores_missing_values_in_other_rows():
+    # A `match` correction must not blow up when other rows of the same column hold pandas' NA
+    # sentinel (e.g. a nullable "string" dtype column) — comparing NA to the match target should
+    # read as "no match", not raise `TypeError: boolean value of NA is ambiguous`.
+    tb = Table(
+        {
+            "country": ["Panama", "France", "France"],
+            "year": [2006, 2006, 2016],
+            "value": pd.array(["-1", pd.NA, "Inaccurtae forecasts"], dtype="string"),
+        }
+    )
+    out = apply_corrections(
+        tb,
+        [_correction(action="override", match={"value": "Inaccurtae forecasts"}, value="Inaccurate forecasts")],
+    )
+    assert out.loc[out["country"] == "France", "value"].tolist()[-1] == "Inaccurate forecasts"
 
 
 def test_flag_is_a_noop_on_data():
@@ -258,6 +277,26 @@ def test_build_audit_captures_scale_before_after():
     records = build_audit(tb, [_correction(action="scale", factor=0.5, entity="France", years="all")])
     ent = records[0]["entities"][0]
     # before → before*factor for every affected point.
+    assert ent["affected"] == [[2006, 10.0, 5.0], [2016, 20.0, 10.0]]
+
+
+def test_build_audit_skips_non_integer_year_labels():
+    from etl.data_corrections import build_audit
+
+    # Some tables carry non-integer year labels for rows unrelated to the correction (e.g. a
+    # reporting-period range like "1872-6") — those points should be dropped, not raise.
+    tb = Table(
+        {
+            "country": ["France", "France", "France"],
+            "year": ["1872-6", "2006", "2016"],
+            "value": [5.0, 10.0, 20.0],
+        }
+    )
+    records = build_audit(tb, [_correction(action="scale", factor=0.5, entity="France", years="all")])
+    ent = records[0]["entities"][0]
+    # The "1872-6" row is dropped from both the full series and (since `years: all` also matches it)
+    # the affected points, while the two integer-year rows are kept.
+    assert ent["series"] == [[2006, 10.0], [2016, 20.0]]
     assert ent["affected"] == [[2006, 10.0, 5.0], [2016, 20.0, 10.0]]
 
 

--- a/tests/test_data_corrections.py
+++ b/tests/test_data_corrections.py
@@ -98,6 +98,103 @@ def test_override_requires_value():
         _validate_correction(_correction(action="override", match={"value": 10.0}), "<test>")
 
 
+def test_match_column_reference_matches_across_columns():
+    # A `match` value of {column: <name>} compares against another column of the same row instead
+    # of a literal — e.g. dropping a row where two columns happen to hold the same (spurious) value.
+    tb = Table(
+        {
+            "country": ["Belgium", "Belgium", "France"],
+            "year": [2024, 2025, 2025],
+            "barn": [5.0, 3.0, 3.0],
+            "free_range": [5.0, 3.0, 4.0],
+        }
+    )
+    out = apply_corrections(
+        tb,
+        [
+            _correction(
+                indicator="barn",
+                action="drop",
+                match={"country": "Belgium", "year": 2025, "value": {"column": "free_range"}},
+            )
+        ],
+    )
+    assert list(zip(out["country"], out["year"])) == [("Belgium", 2024), ("France", 2025)]
+
+
+def test_match_column_reference_no_match_when_columns_differ():
+    tb = Table({"country": ["Belgium"], "year": [2025], "barn": [5.0], "free_range": [7.0]})
+    with pytest.raises(AssertionError, match="matched no rows"):
+        apply_corrections(
+            tb,
+            [
+                _correction(
+                    indicator="barn",
+                    action="drop",
+                    match={"country": "Belgium", "year": 2025, "value": {"column": "free_range"}},
+                )
+            ],
+        )
+
+
+def test_match_column_reference_missing_column_raises():
+    tb = _make_table()
+    with pytest.raises(KeyError, match="not found"):
+        apply_corrections(tb, [_correction(action="drop", match={"value": {"column": "does_not_exist"}})])
+
+
+def test_validate_rejects_malformed_match_column_reference():
+    from etl.data_corrections import _validate_correction
+
+    with pytest.raises(AssertionError, match="column"):
+        _validate_correction(_correction(action="drop", match={"value": {"col": "free_range"}}), "<test>")
+
+
+def test_validate_rejects_column_reference_as_override_value():
+    from etl.data_corrections import _validate_correction
+
+    with pytest.raises(AssertionError, match="column"):
+        _validate_correction(_correction(action="override", match={"value": 10.0}, value={"column": "other"}), "<test>")
+
+
+def test_load_corrections_accepts_column_reference_match(tmp_path):
+    p = tmp_path / "x.corrections.yml"
+    p.write_text(
+        "- indicator: barn\n"
+        "  match: {country: Belgium, year: 2025, value: {column: free_range}}\n"
+        "  action: drop\n"
+        "  reason: r\n"
+        "  provider: p\n"
+        "  status: open\n"
+    )
+    corrections = load_corrections(p)
+    assert corrections[0]["match"]["value"] == {"column": "free_range"}
+
+
+def test_build_audit_handles_column_reference_match():
+    from etl.data_corrections import build_audit
+
+    tb = Table(
+        {
+            "country": ["Belgium", "France"],
+            "year": [2025, 2025],
+            "barn": [5.0, 3.0],
+            "free_range": [5.0, 4.0],
+        }
+    )
+    records = build_audit(
+        tb,
+        [
+            _correction(
+                indicator="barn",
+                action="drop",
+                match={"country": "Belgium", "year": 2025, "value": {"column": "free_range"}},
+            )
+        ],
+    )
+    assert records[0]["entities"][0]["entity"] == "Belgium"
+
+
 def test_match_ignores_missing_values_in_other_rows():
     # A `match` correction must not blow up when other rows of the same column hold pandas' NA
     # sentinel (e.g. a nullable "string" dtype column) — comparing NA to the match target should


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Follow-up to #6318: migrates the candidates from that PR's "surveyed but intentionally not migrated" list, from inline `.loc[...]`/`.replace(...)` exceptions to declarative `.corrections.yml`, plus a small mechanism extension for the one case the original mechanism couldn't express.

## 🔎 Visual review

**[Open the corrections dashboard →](https://htmlpreview.github.io/?https://gist.githubusercontent.com/Marigold/46fe95f5e4d0748dbd7929be9c7a6392/raw/fc18835ce39df545846e14c1a13f8f92e97b6ec9/corrections.html)** — every correction in the repo (including these 7), generated by `etl corrections -o out.html --charts`.

## Migrated

| Step | Correction | Action |
|---|---|---|
| `gfs/2026-04-08/gfs_wave_two` | `drinks` value 4.5 (implausible on a whole-number scale) | `override`, matched by value |
| `who/latest/avian_influenza_ah5n1` | `month` label typo `"12/1/225"` → `"12/1/2025"` | `override`, matched by value (25 rows share that date) |
| `who/2025-01-17/vaccine_stock_out` | `value` typo `"Inaccurtae forecasts"` → `"Inaccurate forecasts"` | `override`, matched by value |
| `gapminder/2024-07-08/maternal_mortality` (meadow) | 9 year-typo overrides + 1 duplicate-row drop (Australia, Finland ×3, Sweden, US, Belgium, New Zealand ×2) | `override`/`drop`, each row disambiguated by country + a second column's value |
| `health/2024-04-12/polio_free_countries` | Somalia's stale duplicate 2000 row (last wild polio case confirmed 2002) | `drop`, matched by entity + value |
| `papers/2026-01-20/anshassi_waste_management` | UAE's `collected`/`uncollected` shares swapped by ×100 | two `scale` entries with `expect` guards |
| `animal_welfare/2026-06-11/laying_hens_keeping_eu` | Belgium 2025 (`barn` value is a copy of `free_range`) + Greece 2013 (implausibly low total) | `drop` × 2 — Belgium via the new column-reference `match`, Greece via `expect: {lt: 100000}` |

## Mechanism extension: same-row column references

`laying_hens_keeping_eu`'s Belgium guard (`barn == free_range`) compares two *columns of the same row*, which neither `match` (literal-only) nor `expect` (numeric-threshold-only) could express before this PR. Added a `{column: <name>}` form for `match` values, resolved to that column's full array and compared elementwise instead of against a constant:

```yaml
- indicator: barn
  match: {country: Belgium, year: 2025, value: {column: free_range}}
  action: drop
  ...
```

Scoped to `match` only — `expect` doesn't need it for any current correction, and wiring it up isn't free (the resolved array would need slicing by the correction's mask before the comparison, an untested path). Left a comment recording the extension recipe if it's ever needed. The JSON schema is tightened accordingly (`match` values are now "literal or `{column: str}`" instead of unconstrained), which catches a typo like `{col: ...}` at lint time instead of a confusing runtime "matched no rows" — confirmed this breaks none of the other 6 `.corrections.yml` files in the repo.

We also considered a fancier `@correction` Python decorator with arbitrary custom code as a more general escape hatch, and rejected it: there's no decorator/registry precedent anywhere in `etl/`/`apps/`, and the closest analog (FAOSTAT's `detected_anomalies.py`) is class-based with hand-maintained dict registration — no scanning, no audit tooling. A decorator would mean the `etl corrections` dashboard needs to import every step module to discover corrections (slow, fragile) and lose automatic before/after audit generation, for a gap the declarative extension closes cleanly.

## Notes for review

- **`vaccine_stock_out` behaviour change (beyond refactor):** the old inline fix only patched the typo inside a filtered copy used for the `reason_for_stockout` derived table — the main published `vaccine_stock_out` table kept the raw `"Inaccurtae forecasts"` value for 4 Austria rows. The correction now applies to the shared table before any derivation, so it's fixed everywhere consistently.
- **`laying_hens_keeping_eu` failure-mode nuance:** the original code asserted `len(...) == 1` per anomaly *before* checking the content guard, so a future duplicate row would fail with an explicit "may have been fixed" message. The new `match` folds both into one AND'd mask — if two rows ever matched, both would be dropped silently by this correction, though `sanity_check_outputs`'s pre-existing duplicate-row assertion would still catch the same underlying anomaly downstream, just with a different error message. Not a behaviour difference on today's data (exactly one row each), but a real difference in failure mode worth knowing about.
- **All migrations are value-identical** to the old inline code (`assert_frame_equal(check_exact=True)` old vs. new, plus per-column origins-count equality) — built each dataset with the old code and the new `.corrections.yml`, byte-for-byte same output, except the one documented `vaccine_stock_out` improvement above.
- **Mechanism hardening**, surfaced by real data in this migration, not by the previous PR's synthetic test cases:
  - `match` now treats `pd.NA` in unrelated rows as non-matching instead of raising `TypeError: boolean value of NA is ambiguous` (hit by `vaccine_stock_out`'s nullable `value` column).
  - The audit no longer crashes on non-integer year labels elsewhere in an entity's series (e.g. Gapminder's `"1872-6"` reporting-period ranges) — those points are just dropped from the visualisation.
  - Added regression tests for both, plus the column-reference extension.
