### PR TITLE
📊 Improve metadata of prevalence of undernourishment in developing countries

### DIFF
--- a/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
+++ b/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
@@ -17,7 +17,7 @@ tables:
         title: Prevalence of undernourishment in developing countries
         unit: '%'
         short_unit: '%'
-        description_short: Percentage of the population in developing countries defined as undernourished.
+        description_short: Share of people in developing countries whose habitual food consumption is insufficient to provide the dietary energy required to maintain a normal, active and healthy life.
         description_key:
           - Undernourishment is solely determined by the sufficiency of energy (calorie) intake. It does not consider the quality or diversity of someone's diet.
           - |-

--- a/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
+++ b/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
@@ -22,6 +22,7 @@ tables:
           - Undernourishment is solely determined by the sufficiency of energy (calorie) intake. It does not consider the quality or diversity of someone's diet.
           - |-
             The FAO maintained a constant definition of "developing countries" throughout the data series, with the following definition: "Includes all countries other than developed countries, namely: all countries in Africa except South Africa, all countries in Asia except Israel and Japan, all countries in Oceania except Australia and New Zealand, and all countries in North and Central America except Canada and USA, and all countries in South America."
+          - In the last few years, the FAO has adapted its methodology for estimating undernourishment and no longer updates this long-term series from the 1970s.
           - Figures for 1970 and 1980 are the average between two FAO estimates from annual "State of Food Insecurity in the World" reports in 2006 and 2010. Therefore, these estimates should be interpreted cautiously but have been included for a longer-term perspective on reduction trends.
         description_processing: |-
           The figures for 1970 and 1980 have been taken as the average between two FAO estimates from the annual "State of Food Insecurity in the World" reports of 2006 and 2010. All other years are from FAO's Food Security Indicators.

--- a/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
+++ b/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
@@ -22,7 +22,7 @@ tables:
           - Undernourishment is solely determined by the sufficiency of energy (calorie) intake. It does not consider the quality or diversity of someone's diet.
           - |-
             The FAO maintained a constant definition of "developing countries" throughout the data series, with the following definition: "Includes all countries other than developed countries, namely: all countries in Africa except South Africa, all countries in Asia except Israel and Japan, all countries in Oceania except Australia and New Zealand, and all countries in North and Central America except Canada and USA, and all countries in South America."
-          - In the last few years, the FAO has adapted its methodology for estimating undernourishment and no longer updates this long-term series from the 1970s.
+          - FAO has adapted its methodology for estimating undernourishment and no longer updates this long-term series from the 1970s.
           - Figures for 1970 and 1980 are the average between two FAO estimates from annual "State of Food Insecurity in the World" reports in 2006 and 2010. Therefore, these estimates should be interpreted cautiously but have been included for a longer-term perspective on reduction trends.
         description_processing: |-
           The figures for 1970 and 1980 have been taken as the average between two FAO estimates from the annual "State of Food Insecurity in the World" reports of 2006 and 2010. All other years are from FAO's Food Security Indicators.

--- a/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
+++ b/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
@@ -1,7 +1,6 @@
 definitions:
   common:
     presentation:
-      attribution_short: FAO
       topic_tags:
         - Hunger & Undernourishment
 
@@ -9,6 +8,7 @@ dataset:
   title: Prevalence of Undernourishment in Developing Countries - FAO (Food Security Indicators) (2017)
   owners:
     - Hannah Ritchie
+    - Pablo Rosado
   update_period_days: 0
 
 tables:

--- a/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
+++ b/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
@@ -18,12 +18,6 @@ tables:
         unit: '%'
         short_unit: '%'
         description_short: Percentage of the population in developing countries defined as undernourished.
-        description_from_producer: |-
-          The prevalence of undernourishment expresses the probability that a randomly selected individual from the population consumes an amount of calories that is insufficient to cover her/his energy requirement for an active and healthy life. The indicator is computed by comparing a probability distribution of habitual daily dietary energy consumption with a threshold level called the minimum dietary energy requirement. Both are based on the notion of an average individual in the reference population.
-
-          This is the traditional FAO hunger indicator, adopted as official Millennium Development Goal indicator for Goal 1, Target 1.9.
-
-          The indicator is calculated in three year averages, from 1969-71 to 2014-16 to reduce the impact of possible errors in estimated DES, due to the difficulties in properly accounting of stock variations in major food.
         description_key:
           - Undernourishment is solely determined by the sufficiency of energy (calorie) intake. It does not consider the quality or diversity of someone's diet.
           - |-

--- a/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
+++ b/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
@@ -1,24 +1,33 @@
+definitions:
+  common:
+    presentation:
+      topic_tags:
+        - Hunger & Undernourishment
+
 dataset:
   title: Prevalence of Undernourishment in Developing Countries - FAO (Food Security Indicators) (2017)
-  owners:
-    - Hannah Ritchie  # backport
+  update_period_days: 0
+
 tables:
   prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017:
     variables:
       prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017:
-        title: Prevalence of undernourishment in developing countries - FAO (Food Security Indicators) (2017)
+        title: Prevalence of undernourishment in developing countries
         unit: '%'
         short_unit: '%'
-        display:
-          shortUnit: '%'
-          unit: '%'
-        description: Percentage of the population in developing countries defined as undernourished
-    dimensions:
-      - name: year
-        slug: year
-      - name: entity_name
-        slug: entity_name
-      - name: entity_id
-        slug: entity_id
-      - name: entity_code
-        slug: entity_code
+        description_short: |-
+          Share of people in developing countries whose habitual food consumption is insufficient to provide the dietary energy required to maintain a normal, active and healthy life.
+        description_from_producer: |-
+          The prevalence of undernourishment expresses the probability that a randomly selected individual from the population consumes an amount of calories that is insufficient to cover their energy requirement for an active and healthy life. The indicator is computed by comparing a probability distribution of habitual daily dietary energy consumption with a threshold level called the minimum dietary energy requirement. Both are based on the notion of an average individual in the reference population.
+
+          This is the traditional FAO hunger indicator, adopted as the official Millennium Development Goal indicator for Goal 1, Target 1.9. It is reported as three-year averages to reduce the impact of possible errors in estimated dietary energy supply. Aggregates are computed as population-weighted averages.
+        description_key:
+          - Undernourishment is determined solely by the sufficiency of energy (calorie) intake. It does not account for the quality or diversity of a person's diet, or for deficiencies in specific nutrients.
+          - Values are three-year averages, which smooth out year-to-year noise in the underlying food supply estimates. Each value is labelled here by the middle year of the three-year window (for example, the 1990-92 average is shown as 1991).
+          - FAO maintained a constant definition of "developing countries" throughout this series — all countries other than developed countries, namely all of Africa except South Africa, all of Asia except Israel and Japan, all of Oceania except Australia and New Zealand, all of North and Central America except Canada and the United States, and all of South America.
+          - The figures for 1970 and 1980 are the average of two FAO estimates published in the "State of Food Insecurity in the World" reports of 2006 and 2010. Because the methodology for estimating undernourishment was refined for tracking the Millennium Development Goals from 1990 onwards, these two earlier points carry greater uncertainty and should be interpreted with caution; they are included to give a longer-term perspective on the reduction in hunger.
+          - FAO has since revised its methodology for estimating undernourishment and no longer publishes this long-term "developing countries" series. It is preserved here for its long-run historical perspective and is not updated beyond 2015. More recent, methodologically consistent estimates are available by region from FAO's current data.
+        description_processing: |-
+          This series combines FAO's Food Security Indicators estimates of the prevalence of undernourishment in developing countries (three-year averages from 1990-92 to 2014-16, labelled here by the middle year of each window, i.e. 1991 to 2015) with two earlier data points for 1970 and 1980.
+
+          Each of the 1970 and 1980 values was computed as the average of the corresponding estimates published in FAO's "State of Food Insecurity in the World" reports of 2006 and 2010.

--- a/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
+++ b/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
@@ -1,6 +1,7 @@
 definitions:
   common:
     presentation:
+      attribution_short: FAO
       topic_tags:
         - Hunger & Undernourishment
 

--- a/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
+++ b/etl/steps/data/garden/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.meta.yml
@@ -6,6 +6,8 @@ definitions:
 
 dataset:
   title: Prevalence of Undernourishment in Developing Countries - FAO (Food Security Indicators) (2017)
+  owners:
+    - Hannah Ritchie
   update_period_days: 0
 
 tables:
@@ -15,19 +17,17 @@ tables:
         title: Prevalence of undernourishment in developing countries
         unit: '%'
         short_unit: '%'
-        description_short: |-
-          Share of people in developing countries whose habitual food consumption is insufficient to provide the dietary energy required to maintain a normal, active and healthy life.
+        description_short: Percentage of the population in developing countries defined as undernourished.
         description_from_producer: |-
-          The prevalence of undernourishment expresses the probability that a randomly selected individual from the population consumes an amount of calories that is insufficient to cover their energy requirement for an active and healthy life. The indicator is computed by comparing a probability distribution of habitual daily dietary energy consumption with a threshold level called the minimum dietary energy requirement. Both are based on the notion of an average individual in the reference population.
+          The prevalence of undernourishment expresses the probability that a randomly selected individual from the population consumes an amount of calories that is insufficient to cover her/his energy requirement for an active and healthy life. The indicator is computed by comparing a probability distribution of habitual daily dietary energy consumption with a threshold level called the minimum dietary energy requirement. Both are based on the notion of an average individual in the reference population.
 
-          This is the traditional FAO hunger indicator, adopted as the official Millennium Development Goal indicator for Goal 1, Target 1.9. It is reported as three-year averages to reduce the impact of possible errors in estimated dietary energy supply. Aggregates are computed as population-weighted averages.
+          This is the traditional FAO hunger indicator, adopted as official Millennium Development Goal indicator for Goal 1, Target 1.9.
+
+          The indicator is calculated in three year averages, from 1969-71 to 2014-16 to reduce the impact of possible errors in estimated DES, due to the difficulties in properly accounting of stock variations in major food.
         description_key:
-          - Undernourishment is determined solely by the sufficiency of energy (calorie) intake. It does not account for the quality or diversity of a person's diet, or for deficiencies in specific nutrients.
-          - Values are three-year averages, which smooth out year-to-year noise in the underlying food supply estimates. Each value is labelled here by the middle year of the three-year window (for example, the 1990-92 average is shown as 1991).
-          - FAO maintained a constant definition of "developing countries" throughout this series — all countries other than developed countries, namely all of Africa except South Africa, all of Asia except Israel and Japan, all of Oceania except Australia and New Zealand, all of North and Central America except Canada and the United States, and all of South America.
-          - The figures for 1970 and 1980 are the average of two FAO estimates published in the "State of Food Insecurity in the World" reports of 2006 and 2010. Because the methodology for estimating undernourishment was refined for tracking the Millennium Development Goals from 1990 onwards, these two earlier points carry greater uncertainty and should be interpreted with caution; they are included to give a longer-term perspective on the reduction in hunger.
-          - FAO has since revised its methodology for estimating undernourishment and no longer publishes this long-term "developing countries" series. It is preserved here for its long-run historical perspective and is not updated beyond 2015. More recent, methodologically consistent estimates are available by region from FAO's current data.
+          - Undernourishment is solely determined by the sufficiency of energy (calorie) intake. It does not consider the quality or diversity of someone's diet.
+          - |-
+            The FAO maintained a constant definition of "developing countries" throughout the data series, with the following definition: "Includes all countries other than developed countries, namely: all countries in Africa except South Africa, all countries in Asia except Israel and Japan, all countries in Oceania except Australia and New Zealand, and all countries in North and Central America except Canada and USA, and all countries in South America."
+          - Figures for 1970 and 1980 are the average between two FAO estimates from annual "State of Food Insecurity in the World" reports in 2006 and 2010. Therefore, these estimates should be interpreted cautiously but have been included for a longer-term perspective on reduction trends.
         description_processing: |-
-          This series combines FAO's Food Security Indicators estimates of the prevalence of undernourishment in developing countries (three-year averages from 1990-92 to 2014-16, labelled here by the middle year of each window, i.e. 1991 to 2015) with two earlier data points for 1970 and 1980.
-
-          Each of the 1970 and 1980 values was computed as the average of the corresponding estimates published in FAO's "State of Food Insecurity in the World" reports of 2006 and 2010.
+          The figures for 1970 and 1980 have been taken as the average between two FAO estimates from the annual "State of Food Insecurity in the World" reports of 2006 and 2010. All other years are from FAO's Food Security Indicators.

--- a/snapshots/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.feather.dvc
+++ b/snapshots/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.feather.dvc
@@ -1,30 +1,27 @@
 meta:
   origin:
-    producer: FAO
+    producer: Food and Agriculture Organization of the United Nations
     title: Food Security Indicators
     title_snapshot: Food Security Indicators - Prevalence of undernourishment in developing countries
-    description_snapshot: |-
-      The prevalence of undernourishment expresses the probability that a randomly selected individual from the population consumes an amount of calories that is insufficient to cover her/his energy requirement for an active and healthy life. The indicator is computed by comparing a probability distribution of habitual daily dietary energy consumption with a threshold level called the minimum dietary energy requirement. Both are based on the notion of an average individual in the reference population.
+    description: |-
+      The Food Security Indicators, published by the Statistics Division of the Food and Agriculture Organization of the United Nations, compile a suite of indicators that measure people's access to food and the prevalence of hunger at the national, regional and global level.
 
-      This is the traditional FAO hunger indicator, adopted as official Millennium Development Goal indicator for Goal 1, Target 1.9.
+      The prevalence of undernourishment expresses the probability that a randomly selected individual from the population consumes an amount of calories that is insufficient to cover their energy requirement for an active and healthy life. It is computed by comparing a probability distribution of habitual daily dietary energy consumption with a threshold level called the minimum dietary energy requirement. Both are based on the notion of an average individual in the reference population. This is the traditional FAO hunger indicator, adopted as the official Millennium Development Goal indicator for Goal 1, Target 1.9.
 
-      The indicator is calculated in three year averages, from 1969-71 to 2014-16 to reduce the impact of possible errors in estimated DES, due to the difficulties in properly accounting of stock variations in major food.
+      The indicator is reported as three-year averages (from 1969-71 to 2014-16) to reduce the impact of possible errors in estimated dietary energy supply, which arise from the difficulty of properly accounting for stock variations in major foods. Aggregates are computed as population-weighted averages.
 
-      The FAO has maintained a constant definition of "developing countries" throughout the data series, with the following definition: "Includes all countries other than developed countries, namely: all countries in Africa except South Africa, all countries in Asia except Israel and Japan, all countries in Oceania except Australia and New Zealand, and all countries in North and Central America except Canada and USA, and all countries in South America."
+      Throughout this series, FAO maintained a constant definition of "developing countries": all countries other than developed countries, namely all countries in Africa except South Africa, all countries in Asia except Israel and Japan, all countries in Oceania except Australia and New Zealand, all countries in North and Central America except Canada and the United States, and all countries in South America.
+    citation_full: |-
+      Food and Agriculture Organization of the United Nations (2017). Food Security Indicators - Prevalence of undernourishment in developing countries. FAOSTAT.
 
-      The aggregates are computed using a weighted population average.
-
-      Earlier estimates for the prevalence of undernourishment in developing countries for 1970 and 1980. Over this period, methodological methods for the estimation of undernourishment have been refined for use in tracking progress on MDGs from 1990 onwards- this means earlier estimates have a higher level of uncertainty. Figures given here for 1970 and 1980 have been taken as the average between two FAO estimates from annual "State of Food Insecurity in the World" reports in 2006 and 2010 (referenced below). These estimates should therefore be utilised with caution, but have been included for longer-term perspective on reduction trends.
-
-      References:
-
-      FAO. 2006. The State of Food Insecurity in the World 2006. Rome. Available at: http://www.fao.org/docrep/009/a0750e/a0750e00.htm
-
-      FAO, 2010. The State of Food Insecurity in the World: Addressing food insecurity in protracted crises. Rome. Available at: http://www.fao.org/docrep/016/i3027e/i3027e.pdf
-    citation_full: FAO (2017). Food Security Indicators.
+      The estimates for 1970 and 1980 are the average of two figures published in: Food and Agriculture Organization of the United Nations (2006), The State of Food Insecurity in the World 2006, Rome; and Food and Agriculture Organization of the United Nations (2010), The State of Food Insecurity in the World 2010: Addressing food insecurity in protracted crises, Rome.
+    attribution_short: FAO
     url_main: http://www.fao.org/economic/ess/ess-fs/ess-fadata/en/
     date_accessed: '2017-05-23'
     date_published: '2017'
+    license:
+      name: CC BY-NC-SA 3.0 IGO
+      url: http://www.fao.org/contact-us/terms/db-terms-of-use/en
 outs:
   - md5: 49bd5c3852a40726f824c45c70b83d1b
     size: 3586

--- a/snapshots/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.feather.dvc
+++ b/snapshots/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.feather.dvc
@@ -14,14 +14,20 @@ meta:
 
       The aggregates are computed using a weighted population average.
 
-      Earlier estimates for the prevalence of undernourishment in developing countries for 1970 and 1980. Over this period, methodological methods for the estimation of undernourishment have been refined for use in tracking progress on MDGs from 1990 onwards- this means earlier estimates have a higher level of uncertainty. Figures given here for 1970 and 1980 have been taken as the average between two FAO estimates from annual "State of Food Insecurity in the World" reports in 2006 and 2010 (referenced below). These estimates should therefore be utilised with caution, but have been included for longer-term perspective on reduction trends.
+      Earlier estimates of the prevalence of undernourishment in developing countries are also given for 1970 and 1980. Over this period, the methods for estimating undernourishment have been refined for use in tracking progress on the MDGs from 1990 onwards; this means the earlier estimates have a higher level of uncertainty. The figures given here for 1970 and 1980 have been taken as the average between two FAO estimates from the annual "State of Food Insecurity in the World" reports of 2006 and 2010 (referenced below). These estimates should therefore be used with caution, but have been included for a longer-term perspective on reduction trends.
 
       References:
 
       FAO. 2006. The State of Food Insecurity in the World 2006. Rome. Available at: http://www.fao.org/docrep/009/a0750e/a0750e00.htm
 
       FAO, 2010. The State of Food Insecurity in the World: Addressing food insecurity in protracted crises. Rome. Available at: http://www.fao.org/docrep/016/i3027e/i3027e.pdf
-    citation_full: Food and Agriculture Organization of the United Nations (2017). Food Security Indicators.
+    citation_full: |-
+      Food and Agriculture Organization of the United Nations (2017). Food Security Indicators.
+
+      The estimates for 1970 and 1980 are the average of two figures published in:
+
+      - Food and Agriculture Organization of the United Nations (2006). The State of Food Insecurity in the World 2006. Rome.
+      - Food and Agriculture Organization of the United Nations (2010). The State of Food Insecurity in the World: Addressing food insecurity in protracted crises. Rome.
     attribution_short: FAO
     url_main: http://www.fao.org/economic/ess/ess-fs/ess-fadata/en/
     date_accessed: '2017-05-23'

--- a/snapshots/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.feather.dvc
+++ b/snapshots/food/2017-05-23/prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017.feather.dvc
@@ -3,18 +3,25 @@ meta:
     producer: Food and Agriculture Organization of the United Nations
     title: Food Security Indicators
     title_snapshot: Food Security Indicators - Prevalence of undernourishment in developing countries
-    description: |-
-      The Food Security Indicators, published by the Statistics Division of the Food and Agriculture Organization of the United Nations, compile a suite of indicators that measure people's access to food and the prevalence of hunger at the national, regional and global level.
+    description_snapshot: |-
+      The prevalence of undernourishment expresses the probability that a randomly selected individual from the population consumes an amount of calories that is insufficient to cover her/his energy requirement for an active and healthy life. The indicator is computed by comparing a probability distribution of habitual daily dietary energy consumption with a threshold level called the minimum dietary energy requirement. Both are based on the notion of an average individual in the reference population.
 
-      The prevalence of undernourishment expresses the probability that a randomly selected individual from the population consumes an amount of calories that is insufficient to cover their energy requirement for an active and healthy life. It is computed by comparing a probability distribution of habitual daily dietary energy consumption with a threshold level called the minimum dietary energy requirement. Both are based on the notion of an average individual in the reference population. This is the traditional FAO hunger indicator, adopted as the official Millennium Development Goal indicator for Goal 1, Target 1.9.
+      This is the traditional FAO hunger indicator, adopted as official Millennium Development Goal indicator for Goal 1, Target 1.9.
 
-      The indicator is reported as three-year averages (from 1969-71 to 2014-16) to reduce the impact of possible errors in estimated dietary energy supply, which arise from the difficulty of properly accounting for stock variations in major foods. Aggregates are computed as population-weighted averages.
+      The indicator is calculated in three year averages, from 1969-71 to 2014-16 to reduce the impact of possible errors in estimated DES, due to the difficulties in properly accounting of stock variations in major food.
 
-      Throughout this series, FAO maintained a constant definition of "developing countries": all countries other than developed countries, namely all countries in Africa except South Africa, all countries in Asia except Israel and Japan, all countries in Oceania except Australia and New Zealand, all countries in North and Central America except Canada and the United States, and all countries in South America.
-    citation_full: |-
-      Food and Agriculture Organization of the United Nations (2017). Food Security Indicators - Prevalence of undernourishment in developing countries. FAOSTAT.
+      The FAO has maintained a constant definition of "developing countries" throughout the data series, with the following definition: "Includes all countries other than developed countries, namely: all countries in Africa except South Africa, all countries in Asia except Israel and Japan, all countries in Oceania except Australia and New Zealand, and all countries in North and Central America except Canada and USA, and all countries in South America."
 
-      The estimates for 1970 and 1980 are the average of two figures published in: Food and Agriculture Organization of the United Nations (2006), The State of Food Insecurity in the World 2006, Rome; and Food and Agriculture Organization of the United Nations (2010), The State of Food Insecurity in the World 2010: Addressing food insecurity in protracted crises, Rome.
+      The aggregates are computed using a weighted population average.
+
+      Earlier estimates for the prevalence of undernourishment in developing countries for 1970 and 1980. Over this period, methodological methods for the estimation of undernourishment have been refined for use in tracking progress on MDGs from 1990 onwards- this means earlier estimates have a higher level of uncertainty. Figures given here for 1970 and 1980 have been taken as the average between two FAO estimates from annual "State of Food Insecurity in the World" reports in 2006 and 2010 (referenced below). These estimates should therefore be utilised with caution, but have been included for longer-term perspective on reduction trends.
+
+      References:
+
+      FAO. 2006. The State of Food Insecurity in the World 2006. Rome. Available at: http://www.fao.org/docrep/009/a0750e/a0750e00.htm
+
+      FAO, 2010. The State of Food Insecurity in the World: Addressing food insecurity in protracted crises. Rome. Available at: http://www.fao.org/docrep/016/i3027e/i3027e.pdf
+    citation_full: Food and Agriculture Organization of the United Nations (2017). Food Security Indicators.
     attribution_short: FAO
     url_main: http://www.fao.org/economic/ess/ess-fs/ess-fadata/en/
     date_accessed: '2017-05-23'


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

Improves the metadata of the snapshot and garden steps for `prevalence_of_undernourishment_in_developing_countries__fao__food_security_indicators__2017`. The steps were auto-migrated from a backport and their metadata was incomplete. **Data is unchanged** — metadata only.

Context: this is a closed historical series. FAO revised its undernourishment methodology and discontinued the "developing countries" aggregate, so it cannot be reproduced from current FAOSTAT and is preserved as-is. Part of owid/owid-issues#915.

## Snapshot `.dvc`
- `producer`: `FAO` → `Food and Agriculture Organization of the United Nations`; added `attribution_short: FAO`.
- `citation_full`: completed the incomplete `FAO (2017). Food Security Indicators.` to use the full producer name. Kept single-line; the SOFI 2006/2010 reports (source of the 1970/1980 points) remain documented verbatim in `description_snapshot`.
- `description_snapshot`: kept **verbatim** from the source record (FAO/OWID `additionalInfo`), including its original wording — not paraphrased or copy-edited.
- Added `license` (CC BY-NC-SA 3.0 IGO).

## Garden `.meta.yml`
- `description_short`: replaced the circular "defined as undernourished" with wording matching FAO's verified SDG-portal definition.
- `description_key`: 4 points, taken verbatim from the chart's existing "what you should know" text — calorie-only definition, the "developing countries" definition, that FAO changed methodology and no longer updates this series, and the 1970/1980 averaging caveat.
- `description_processing`: documents the construction (1970/1980 = average of the two SOFI reports; other years from FAO's Food Security Indicators).
- `presentation.attribution_short: FAO` so the variable's `attributionShort` is populated.
- Added the `Hunger & Undernourishment` topic tag and `update_period_days: 0`. Restored `Hannah Ritchie` as owner (matches the dataset record). Removed backport cruft (`dimensions` block, redundant `display`).
- **No `description_from_producer`**: the PoU definition in the backport `additionalInfo` could not be matched to FAO's own published wording, so it is not a genuine producer description and was omitted.

Garden and grapher steps rebuild cleanly; `make check` passes.

## Follow-up (not in this PR)
The chart's manual footnote ("...and ESS Indicators") lives in the grapher chart config, not ETL, and will be updated separately.