### PR TITLE
📜 Notion sync date + auto-refresh for check-metadata-style skill

### DIFF
--- a/.claude/skills/check-metadata-style/SKILL.md
+++ b/.claude/skills/check-metadata-style/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 Audit the user-facing text in a grapher step's metadata against OWID's Writing and Style Guide. Flags fields that break the rules and offers to rewrite them.
 
-Rules live in [STYLE_GUIDE.md](STYLE_GUIDE.md) next to this file — a committed snapshot of the [OWID Notion page](https://www.notion.so/owid/Writing-and-style-guide-d51a3739ff8542ca90297fa8de40437c). Keep `STYLE_GUIDE.md` in sync via a PR whenever the Notion page changes.
+Rules live in [STYLE_GUIDE.md](STYLE_GUIDE.md) next to this file — a committed snapshot of the [OWID Notion page](https://app.notion.com/p/owid/Writing-and-style-guide-d51a3739ff8542ca90297fa8de40437c). The file records a `Last synced from Notion` date in its header; the skill checks that date on every run and refreshes the snapshot from Notion when it is more than two months old (see step 1). Refreshes are committed via a PR.
 
 ## When to use
 
@@ -25,13 +25,34 @@ Rules live in [STYLE_GUIDE.md](STYLE_GUIDE.md) next to this file — a committed
 
 ## Implementation
 
-### 1. Read the Writing and Style Guide
+### 1. Check the guide is fresh
+
+Read the `> Last synced from Notion: YYYY-MM-DD` line in the header of [STYLE_GUIDE.md](STYLE_GUIDE.md).
+
+- If the date is **less than two months** before today, skip to step 2 — no fetch needed.
+- If the line is missing or the date is **two months old or more**, refresh the snapshot, trying in order:
+
+1. **Notion MCP.** Load the Notion tools with `ToolSearch` (query `+notion fetch`) and fetch the [Notion page](https://app.notion.com/p/owid/Writing-and-style-guide-d51a3739ff8542ca90297fa8de40437c). Use the result only if it looks complete: all sections present (Branding, Capitalization, Grammar and syntax, Short citations for charts, Writing in GDoc, Descriptions, Dates, Punctuation, Spelling) with the ❌/✅ examples intact. Note: authorizing the connector **mid-session doesn't help** — MCP tool lists are fixed at session start (subagents inherit the same registry, and resuming the session doesn't refresh it either), so a newly authorized connector is only reachable from a brand-new session.
+2. **Manual export.** If the Notion MCP is unavailable or unauthenticated, or the fetched content is incomplete or mangled, ask the user to download a markdown export of the page (open the Notion link → `•••` menu → **Export** → format **Markdown & CSV**) and provide the file path.
+3. **Skip.** If neither works, warn the user that the committed guide may be stale (state its `Last synced` date) and continue the audit with the committed copy. Never block the audit on the refresh.
+
+On a successful fetch/export:
+
+- Convert the content to the existing file's structure (same heading hierarchy, ❌/✅ example formatting) and keep the 3-line header block.
+- **Preserve sections marked `NOTE: local addition`** — rules agreed in PRs that aren't on the Notion page yet. Their absence from the fetched content is not a removal; drop one only when Notion covers the same rule (then remove the note too).
+- Diff against the committed copy and summarize any rule changes to the user in-conversation.
+- Rewrite the body only if the content changed; stamp today's date on the `Last synced from Notion:` line either way.
+- Remind the user that the modified `STYLE_GUIDE.md` should be committed via a PR. Do **not** commit or push as part of this skill.
+
+> Plain `WebFetch`/`curl` does **not** work for the refresh: `app.notion.com` serves a JavaScript shell with no page content (verified 2026-07-07). Don't waste time trying it.
+
+### 2. Read the Writing and Style Guide
 
 Read [STYLE_GUIDE.md](STYLE_GUIDE.md) in this skill's folder. That file is the source of truth the skill evaluates against — do not fall back to memory, and do not invent rules that aren't in the file.
 
-If the file is missing, stop and tell the user to restore it from the [Notion page](https://www.notion.so/owid/Writing-and-style-guide-d51a3739ff8542ca90297fa8de40437c).
+If the file is missing, rebuild it from Notion via the refresh flow in step 1 (treat it as stale).
 
-### 2. Collect user-facing strings from the step
+### 3. Collect user-facing strings from the step
 
 Prefer the **rendered** (post-Jinja) metadata from the built catalog, so template artifacts are included in the check.
 
@@ -121,7 +142,7 @@ If `DATA_DIR / step_path` does not exist, parse the `.meta.yml` directly with `e
 
 Drop `--only` here on purpose: when the catalog is missing, upstream meadow/garden outputs are usually missing too, and `--only` would skip them and fail on missing inputs.
 
-### 3. Evaluate each string against the guide
+### 4. Evaluate each string against the guide
 
 Claude reads `STYLE_GUIDE.md` and checks every collected string. Keep the evaluation **rule-driven**: cite the specific section/heading of the guide, not a generic "doesn't sound right".
 
@@ -140,7 +161,7 @@ Group the blocks by variable for readability. End with a summary count.
 
 If no violations are found, say so and list the fields that were inspected — the user should know what was checked, not just that nothing came up.
 
-### 4. Offer to fix
+### 5. Offer to fix
 
 Match the pattern in [check-metadata-typos](../check-metadata-typos/SKILL.md) §4–5:
 
@@ -160,7 +181,7 @@ with open(meta_yml_path, 'w') as f:
 
 If a violation only shows up in the rendered output because of a Jinja definition (e.g. the issue is inside `{definitions.foo}`), flag it for manual fix — don't auto-rewrite the definition without asking.
 
-### 5. Verify
+### 6. Verify
 
 After fixes:
 
@@ -168,7 +189,7 @@ After fixes:
    ```bash
    .venv/bin/etlr grapher/<namespace>/<version>/<dataset> --grapher --private --force --only
    ```
-2. Re-run steps 2–3 of this skill on the same step. Expect zero violations.
+2. Re-run steps 3–4 of this skill on the same step. Expect zero violations.
 3. Run `make check` to confirm no lint/format regressions from the YAML edits.
 
 ---
@@ -177,6 +198,6 @@ After fixes:
 
 - **No persistent output.** Analysis results stay in-conversation: no report `.md`, no scripts under `scripts/`. The only persistent file tied to this skill is `STYLE_GUIDE.md` (the committed rulebook).
 - **Current step only.** If the user asks to audit the whole catalog, say the skill is scoped to one step and suggest running it per dataset.
-- **Keep `STYLE_GUIDE.md` in sync with Notion.** If the Notion page changes, update the committed file via a PR — that way guide changes are reviewed and the skill stays deterministic and offline-capable.
+- **Keep `STYLE_GUIDE.md` in sync with Notion.** The header's `Last synced from Notion` date is checked on every run (step 1); when it is more than two months old the skill refreshes the snapshot — Notion MCP first, manual markdown export as fallback — and the refresh is committed via a PR. Between syncs the skill stays deterministic and offline-capable by always auditing against the committed file.
 - **Archive-aware.** If the provided step path is under `dag/archive/*.yml`, point that out and confirm the user still wants to check it.
 - **Don't hallucinate rules.** If `STYLE_GUIDE.md` doesn't say something, don't flag it. Prefer false negatives over false positives.

--- a/.claude/skills/check-metadata-style/STYLE_GUIDE.md
+++ b/.claude/skills/check-metadata-style/STYLE_GUIDE.md
@@ -1,7 +1,8 @@
 # Writing and style guide
 
-> Source: OWID Notion page — [Writing and style guide](https://www.notion.so/owid/Writing-and-style-guide-d51a3739ff8542ca90297fa8de40437c).
-> Keep this file in sync with the Notion page. Refresh it via a PR whenever the Notion page is edited.
+> Source: OWID Notion page — [Writing and style guide](https://app.notion.com/p/owid/Writing-and-style-guide-d51a3739ff8542ca90297fa8de40437c).
+> Last synced from Notion: 2026-07-07
+> The check-metadata-style skill verifies this date on every run and refreshes this file from Notion when it is more than two months old. Commit refreshes via a PR.
 
 This guide establishes a uniform style for all OWID content to ensure consistency, clarity, and accuracy across our publications. The rules in this guide apply to all writing we do on OWID, whether in articles, topic pages, or charts.
 
@@ -228,6 +229,8 @@ Always use double quotes for quotations and titles. Single quotes are used only 
 
 ### Use curly apostrophes and quotation marks
 
+> NOTE: local addition (PR #6171) — an OWID-agreed rule not yet on the Notion page. Keep this section during refreshes until Notion covers the same rule.
+
 Use curly (“typographic”) apostrophes and quotation marks, not straight ones. Word processors curl these automatically, but LLMs and code editors emit the straight versions — so a mix of straight and curly marks in the same text is a tell-tale sign of pasted machine output.
 
 - Apostrophe: `’` (U+2019), not `'`
@@ -281,7 +284,6 @@ Spell out the full form of an acronym the first time it is used in a text, follo
 - **tonnes**, not tons. We always use what's called the "tonne" or "metric ton" across OWID, equivalent to 1,000 kg — but we always write it as "tonne". We never use the American "short ton" or "long ton".
 - **acknowledgments**, not acknowledgements.
 - **sub-Saharan Africa**, not Sub-Saharan Africa.
-- **Corn**, not maize.
 - **COVID-19**, not Covid-19 or COVID.
 - **The Internet**, not the internet.
 - **vs.**, not vs

--- a/.claude/skills/update-dataset/SKILL.md
+++ b/.claude/skills/update-dataset/SKILL.md
@@ -398,7 +398,7 @@ For the **long-format with dimensions** sub-case specifically (e.g. one row per 
 
    - **Typos** — `/check-metadata-typos` scoped to the current step. Run on each of the new `.meta.yml` files (garden first, then grapher). Accept or skip each suggested fix.
    - **Jinja spacing** — `/check-metadata-spacing` on the built garden and grapher datasets. Catches template artifacts like doubled spaces or stray newlines that only appear after Jinja rendering.
-   - **Style guide** — `/check-metadata-style` on the grapher step. Audits user-facing fields (title, subtitle, description_short, display.name, presentation.*) against OWID's Writing and Style Guide. Rules live in `.claude/skills/check-metadata-style/STYLE_GUIDE.md`, so no Notion access is needed — but if the guide looks out of date, refresh that file from Notion in a separate PR.
+   - **Style guide** — `/check-metadata-style` on the grapher step. Audits user-facing fields (title, subtitle, description_short, display.name, presentation.*) against OWID's Writing and Style Guide. Rules live in `.claude/skills/check-metadata-style/STYLE_GUIDE.md`, so no Notion access is usually needed — the skill checks the file's `Last synced from Notion` date and refreshes it from Notion (in a separate PR) when it is more than two months old.
    - **Clarity for a general audience** — read every user-facing field with non-specialist eyes. The other three skills enforce structure and style; this one judges whether the text is *understandable*.
 
    ### Clarity checklist (do manually, no skill yet)


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## What this does

`STYLE_GUIDE.md` (the committed snapshot of the Notion [Writing and style guide](https://app.notion.com/p/owid/Writing-and-style-guide-d51a3739ff8542ca90297fa8de40437c)) had no date tracking and only a manual "refresh via PR when Notion changes" instruction, so nobody could tell when it had drifted. This PR adds a freshness mechanism and performs the first sync.

### Skill mechanism (`check-metadata-style/SKILL.md`)

- New **step 1 — "Check the guide is fresh"**: reads a `Last synced from Notion` date from the guide's header on every run; when it is **more than two months old** (cadence chosen to match the observed change rate of ~1 rule change per 2.5 months), refreshes the snapshot:
  1. **Notion MCP** (`notion-fetch`) — primary path.
  2. **Manual markdown export** (Notion → `•••` → Export → Markdown & CSV) — fallback, validated live in this PR.
  3. **Warn and continue** with the committed copy if neither is available — the refresh never blocks the audit.
- Documents two hard-won operational facts: plain `curl`/`WebFetch` cannot extract the page (`app.notion.com` serves a JS shell), and connectors authorized mid-session are only reachable from a brand-new session.
- Sections marked `NOTE: local addition` are preserved during refreshes (rules agreed in PRs that aren't on the Notion page yet).
- Old steps renumbered 1–5 → 2–6; cross-references fixed.

### Guide sync (`STYLE_GUIDE.md`, against the 2026-07-07 Notion export)

- Header now carries `Last synced from Notion: 2026-07-07`.
- **Dropped "Corn, not maize"** — present at the April extraction, removed from the Notion page since.
- **Kept "Use curly apostrophes and quotation marks"** — local addition from #6171 that was never added to Notion; now marked with a `NOTE: local addition` so future refreshes don't treat its absence upstream as a removal.
- Everything else matches the Notion page 1:1.

### Mirror (`update-dataset/SKILL.md`)

- One-line update of the style-guide QA reference to describe the new self-refresh behavior.

## Follow-ups (Notion-side, not in this PR)

- Add the curly apostrophes/quotes rule to the Notion page so the source of truth catches up.
- Fix a typo on the Notion page: "we alwas write it as tonne" in the tonnes bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)