### PR TITLE
✨ Improve data-diff PR comment and add HTML report

### DIFF
--- a/apps/owidbot/cli.py
+++ b/apps/owidbot/cli.py
@@ -82,7 +82,7 @@ def cli(
     services_body = {}
     for service in services:
         if service == "data-diff":
-            services_body["data-diff"] = data_diff.run(include)
+            services_body["data-diff"] = data_diff.run(include, branch=branch)
 
         elif service == "chart-diff":
             charts_df = chart_diff.call_chart_diff(branch)

--- a/apps/owidbot/data_diff.py
+++ b/apps/owidbot/data_diff.py
@@ -48,7 +48,9 @@ def run(include: str, branch: str | None = None) -> str:
         call_etl_diff(include, output_json=json_path, output_html=html_path)
 
         report = DiffReport.from_json(json_path.read_text())
-        report_url = upload_html_report(html_path, branch) if branch else None
+        # A report that just says "no differences" isn't worth hosting — upload only when
+        # there's something to show.
+        report_url = upload_html_report(html_path, branch) if branch and report.status != "clean" else None
 
     return format_comment(report, report_url)
 

--- a/apps/owidbot/data_diff.py
+++ b/apps/owidbot/data_diff.py
@@ -1,77 +1,204 @@
+"""data-diff service for owidbot.
+
+Runs `etl diff` against the remote catalog, uploads the full self-contained HTML report to R2
+(publicly served at https://catalog.ourworldindata.org/) and posts a compact, signal-first
+summary to the PR: only changed datasets with a few sample rows, everything deeper lives in
+the linked report.
+"""
+
 import os
 import re
 import shlex
 import subprocess
+import tempfile
+import time
+from pathlib import Path
 
 import structlog
-from rich.ansi import AnsiDecoder
+from botocore.exceptions import BotoCoreError
+from owid.catalog import s3_utils
 
+from etl.datadiff_report import ColumnDiffResult, DatasetDiffResult, DiffReport
 from etl.paths import BASE_DIR
 
 log = structlog.get_logger()
 
 EXCLUDE_DATASETS = "excess_mortality|covid|fluid|flunet|country_profile|garden/ihme_gbd/2019/gbd_risk"
 
+# The owid-catalog R2 bucket is publicly served at https://catalog.ourworldindata.org/.
+REPORT_S3_PATH = "s3://owid-catalog/diffs/{branch}/data-diff.html"
+REPORT_URL = "https://catalog.ourworldindata.org/diffs/{branch}/data-diff.html"
 
-def run(include: str) -> str:
-    lines = call_etl_diff(include)
-    data_diff, data_diff_summary = format_etl_diff(lines)
+# Keep the comment body comfortably under GitHub's 65,536-char limit.
+MAX_DIFF_CHARS = 50000
+# Sample rows shown per value diff in the PR comment (the HTML report holds up to SAMPLE_LIMIT).
+MAX_SAMPLE_ROWS = 3
+# Cap on a single sample line; long text values (e.g. descriptions) get truncated.
+MAX_LINE_CHARS = 160
 
-    body = f"""
-<details>
-<summary><b>data-diff</b>: {data_diff_summary}</summary>
-
-```diff
-{data_diff}
-```
-
-Automatically updated datasets matching _{EXCLUDE_DATASETS}_ are not included
-</details>
-    """.strip()
-
-    return body
+_SYMBOLS = {"new": "+", "removed": "-", "changed": "~", "error": "!"}
+_ICONS = {"clean": "✅", "changed": "❌", "error": "⚠️"}
 
 
-def format_etl_diff(lines: list[str]) -> tuple[str, str]:
-    new_lines = []
-    result = ""
-    for line in lines:
-        # extract result
-        if line and line[0] in ("✅", "❌", "⚠️", "❓"):
-            result = line
+def run(include: str, branch: str | None = None) -> str:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        json_path = Path(tmp_dir) / "data-diff.json"
+        html_path = Path(tmp_dir) / "data-diff.html"
+
+        call_etl_diff(include, output_json=json_path, output_html=html_path)
+
+        report = DiffReport.from_json(json_path.read_text())
+        report_url = upload_html_report(html_path, branch) if branch else None
+
+    return format_comment(report, report_url)
+
+
+def upload_html_report(html_path: Path, branch: str) -> str | None:
+    """Upload the full HTML report to R2 and return its public URL, or None if the upload fails."""
+    # Branch names can contain characters that don't belong in an URL path (e.g. slashes).
+    safe_branch = re.sub(r"[^A-Za-z0-9._-]", "-", branch)
+    try:
+        s3_utils.upload(
+            REPORT_S3_PATH.format(branch=safe_branch),
+            html_path,
+            public=True,
+            content_type="text/html; charset=utf-8",
+            # The object is overwritten on every push; keep CDN caching short.
+            cache_control="max-age=60",
+        )
+    except (s3_utils.UploadError, s3_utils.MissingCredentialsError, BotoCoreError) as e:
+        log.warning("Failed to upload data-diff HTML report", error=str(e))
+        return None
+    # Cloudflare caches the object at the edge for a few minutes; a fresh query param on every
+    # run makes the PR comment always link to the latest report.
+    return REPORT_URL.format(branch=safe_branch) + f"?v={int(time.time())}"
+
+
+def format_comment(report: DiffReport, report_url: str | None) -> str:
+    summary = _format_summary(report, report_url)
+
+    changed = [ds for ds in report.datasets if ds.change_kind != "identical"]
+    diff = "\n".join(line for ds in changed for line in _format_dataset(ds))
+    diff = _truncate_diff(diff)
+
+    diff_block = f"\n```diff\n{diff}\n```\n" if diff else "\nNo differences found.\n"
+
+    tail_bits = []
+    if report.n_identical:
+        tail_bits.append(f"{report.n_identical} compared dataset(s) turned out identical")
+    if report.skipped_cascade:
+        tail_bits.append(f"{report.skipped_cascade} skipped (data files unchanged, only the source checksum cascaded)")
+    tail_note = (
+        "= " + " · ".join(tail_bits) + ("; details in the full report" if report_url else "") if tail_bits else ""
+    )
+
+    footer = (
+        f"Automatically updated datasets matching _{EXCLUDE_DATASETS}_ are not included. "
+        "Run locally with `etl diff REMOTE data/ --include <dataset> --verbose`."
+    )
+
+    sections = [
+        # <summary> must directly follow <details> for GitHub to render the block
+        f"<details>\n<summary><b>data-diff</b>: {summary}</summary>",
+        diff_block.strip(),
+        *([tail_note] if tail_note else []),
+        footer,
+        "</details>",
+    ]
+    return "\n\n".join(sections)
+
+
+def _format_summary(report: DiffReport, report_url: str | None) -> str:
+    parts = []
+    for label, n in [
+        ("changed", report.n_changed),
+        ("new", report.n_new),
+        ("removed", report.n_removed),
+        ("error(s)", report.n_errors),
+    ]:
+        if n:
+            parts.append(f"{n} {label}")
+    if not parts:
+        parts.append("no differences")
+    if report.n_identical:
+        parts.append(f"{report.n_identical} identical")
+    if report.skipped_cascade:
+        parts.append(f"{report.skipped_cascade} skipped")
+
+    summary = f"{_ICONS[report.status]} " + " · ".join(parts)
+    if report_url:
+        summary += f' — <a href="{report_url}"><b>full report</b></a>'
+    return summary
+
+
+def _format_dataset(ds: DatasetDiffResult) -> list[str]:
+    kind = ds.change_kind
+    if kind == "error":
+        return [f"! {ds.path} — error: {_truncate(ds.error or '', 300)}"]
+    if kind == "new":
+        n_tables = len(ds.tables)
+        n_cols = sum(len(t.columns) for t in ds.tables)
+        return [f"+ {ds.path} (new dataset: {n_tables} table(s), {n_cols} column(s))"]
+    if kind == "removed":
+        return [f"- {ds.path} (removed dataset)"]
+
+    suffix = " (new version)" if ds.is_new_version else ""
+    lines = [f"~ {ds.path}{suffix}"]
+    if ds.meta_diff:
+        lines.append("    ~ dataset metadata changed")
+    for t in ds.tables:
+        if t.kind == "changed":
+            lines.append(f"    ~ {t.name} (changed table metadata)")
+        elif t.kind in ("new", "removed"):
+            lines.append(f"    {_SYMBOLS[t.kind]} {t.name} ({t.kind} table, {len(t.columns)} column(s))")
             continue
+        for c in t.columns:
+            if c.kind == "identical":
+                continue
+            lines += _format_column(t.name, c)
+    return lines
 
-        # skip some lines
-        if "this may get slow" in line or "comparison with compare" in line:
-            continue
 
-        if line.strip().startswith("-"):
-            line = "-" + line[1:]
-        if line.strip().startswith("+"):
-            line = "+" + line[1:]
+def _format_column(table_name: str, c: ColumnDiffResult) -> list[str]:
+    name = f"{table_name}.{c.name}"
+    if c.kind in ("new", "removed"):
+        return [f"    {_SYMBOLS[c.kind]} {name} ({c.kind} column)"]
 
-        new_lines.append(line)
+    label = ", ".join(c.changes) if c.changes else "changed"
+    dim = " dim" if c.is_dim else ""
+    lines = [f"    ~ {name}{dim} ({label})"]
+    for v in c.value_diffs:
+        head = {"new": "New", "removed": "Removed", "changed": "Changed"}[v.kind]
+        lines.append(f"        {v.symbol} {head} values: {v.count:,} / {v.total:,} ({v.pct:.2f}%)")
+        for row in v.sample[:MAX_SAMPLE_ROWS]:
+            lines.append("            " + _truncate(_format_row(row, c.name), MAX_LINE_CHARS))
+        if v.count > MAX_SAMPLE_ROWS:
+            lines.append(f"            (+{v.count - min(len(v.sample), MAX_SAMPLE_ROWS):,} more)")
+    return lines
 
-    diff = "\n".join(new_lines)
 
-    # Don't show output if there are no changes and the diff is just too long
-    # Example:
-    # = Dataset meadow/agriculture/2024-03-26/attainable_yields
-    #     = Table attainable_yields
-    # = Dataset garden/agriculture/2024-03-26/attainable_yields
-    #     = Table attainable_yields
-    #        ~ Column A
-    # = Dataset grapher/agriculture/2024-03-26/attainable_yields
-    #     = Table attainable_yields
-    if len(diff) > 64000:
-        pattern = r"(= Dataset.*(?:\n\s+=.*)+)\n(?=. Dataset|\n)"
-        diff = re.sub(pattern, "", diff)
+def _format_row(row: dict[str, str], col: str) -> str:
+    """Format a sample record as `dim1 dim2: value` or `dim1 dim2: old → new`."""
+    old = row.get(f"{col} -")
+    new = row.get(f"{col} +")
+    val = row.get(col)
+    dims = " ".join(v for k, v in row.items() if k not in (col, f"{col} -", f"{col} +"))
+    if old is not None or new is not None:
+        return f"{dims}: {old} → {new}" if dims else f"{old} → {new}"
+    if val is not None:
+        return f"{dims}: {val}" if dims else val
+    return dims
 
-    # Github has limit of 65,536 characters
-    if len(diff) > 64000:
-        diff = diff[:64000] + "\n\n...diff too long, truncated..."
 
-    return diff, result
+def _truncate(s: str, limit: int) -> str:
+    return s if len(s) <= limit else s[: limit - 1] + "…"
+
+
+def _truncate_diff(diff: str) -> str:
+    if len(diff) <= MAX_DIFF_CHARS:
+        return diff
+    cut = diff.rfind("\n", 0, MAX_DIFF_CHARS)
+    return diff[:cut] + "\n\n... diff too long, truncated — see the full report ..."
 
 
 def _tail_output(output: str, max_lines: int = 80) -> str:
@@ -82,7 +209,7 @@ def _tail_output(output: str, max_lines: int = 80) -> str:
     return "\n".join(lines)
 
 
-def call_etl_diff(include: str) -> list[str]:
+def call_etl_diff(include: str, output_json: Path, output_html: Path) -> None:
     cmd = [
         "uv",
         "run",
@@ -98,6 +225,10 @@ def call_etl_diff(include: str) -> list[str]:
         "--verbose",
         "--workers",
         "3",
+        "--output-json",
+        str(output_json),
+        "--output-html",
+        str(output_html),
     ]
 
     cmd_str = shlex.join(cmd)
@@ -112,11 +243,6 @@ def call_etl_diff(include: str) -> list[str]:
     # Remove all warnings from stderr
     stderr = re.sub(r"^.*WARNING.*", "", stderr, flags=re.MULTILINE).strip()
 
-    # Remove certain warnings from stdout
-    stdout = re.sub(
-        r"^.*You're on master branch, using local env instead of STAGING=master*", "", stdout, flags=re.MULTILINE
-    )
-
     if result.returncode == 1 and "Found differences" in stdout:
         log.info("etl diff found differences", returncode=result.returncode)
     elif result.returncode != 0:
@@ -130,5 +256,3 @@ def call_etl_diff(include: str) -> list[str]:
         raise RuntimeError("\n\n".join(details))
     if stderr:
         log.warning("etl diff produced stderr output", stderr=stderr)
-
-    return [str(line) for line in AnsiDecoder().decode(stdout)]

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -22,6 +22,15 @@ from rich.syntax import Syntax
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from etl.dag_helpers import load_dag
+from etl.datadiff_report import (
+    SAMPLE_LIMIT,
+    ColumnDiffResult,
+    DatasetDiffResult,
+    DiffReport,
+    TableDiffResult,
+    ValueDiff,
+    render_html,
+)
 from etl.files import yaml_dump
 from etl.git_helpers import get_changed_files
 from etl.http import session as http_session
@@ -48,6 +57,7 @@ class DatasetDiff:
         print: Callable = rich.print,
         snippet: bool = False,
         country: str | None = None,
+        details: bool = False,
     ):
         """
         :param cols: Only compare columns matching pattern
@@ -55,6 +65,7 @@ class DatasetDiff:
         :param print: Function to print the diff summary. Defaults to rich.print.
         :param snippet: Print snippet for loading both tables
         :param country: Filter tables by country if it is in the index
+        :param details: Compute value-level diffs for the structured `result` even without verbose
         """
         assert ds_a or ds_b, "At least one Dataset must be provided"
         self.ds_a = ds_a
@@ -65,6 +76,9 @@ class DatasetDiff:
         self.tables = tables
         self.snippet = snippet
         self.country = country
+        self.details = details
+        # Structured mirror of the printed summary, filled in by summary().
+        self.result = DatasetDiffResult(path=dataset_uri(ds_b or ds_a), kind="identical")  # type: ignore[arg-type]
 
     def _filter_table_by_country(self, table: Table) -> Table:
         """Filter table by country if country is in the index."""
@@ -82,23 +96,32 @@ class DatasetDiff:
             assert ds_short_name
 
             new_version = " (new version)" if ds_a.metadata.version != ds_b.metadata.version else ""
+            self.result.is_new_version = bool(new_version)
 
             # compare dataset metadata
-            diff = _dict_diff(_dataset_metadata_dict(ds_a), _dataset_metadata_dict(ds_b), tabs=2)
+            meta_a, meta_b = _dataset_metadata_dict(ds_a), _dataset_metadata_dict(ds_b)
+            diff = _dict_diff(meta_a, meta_b, tabs=2)
             if diff:
+                self.result.kind = "changed"
+                self.result.meta_diff = _dict_diff(meta_a, meta_b, tabs=0, color=False)
                 self.p(f"[yellow]~ Dataset [b]{dataset_uri(ds_b)}[/b]{new_version}")
                 if self.verbose:
                     self.p(diff)
             else:
                 self.p(f"[white]= Dataset [b]{dataset_uri(ds_b)}{new_version}[/b]")
         elif ds_a:
+            self.result.kind = "removed"
             self.p(f"[red]- Dataset [b]{dataset_uri(ds_a)}[/b]")
         elif ds_b:
+            self.result.kind = "new"
             self.p(f"[green]+ Dataset [b]{dataset_uri(ds_b)}[/b]")
             for table_name in ds_b.table_names:
                 self.p(f"\t[green]+ Table [b]{table_name}[/b]")
+                tab_res = TableDiffResult(name=table_name, kind="new")
+                self.result.tables.append(tab_res)
                 for col in ds_b[table_name].columns:
                     self.p(f"\t\t[green]+ Column [b]{col}[/b]")
+                    tab_res.columns.append(ColumnDiffResult(name=col, kind="new"))
 
     def _snippet(self, ds_a: Dataset, ds_b: Dataset, table_name: str) -> Panel:
         """Print code for loading both tables."""
@@ -127,12 +150,18 @@ tb = {_snippet_dataset(ds_b, table_name)}
 
         if table_name not in ds_b.table_names:
             self.p(f"\t[red]- Table [b]{table_name}[/b]")
+            tab_res = TableDiffResult(name=table_name, kind="removed")
+            self.result.tables.append(tab_res)
             for col in ds_a[table_name].columns:
                 self.p(f"\t\t[red]- Column [b]{col}[/b]")
+                tab_res.columns.append(ColumnDiffResult(name=col, kind="removed"))
         elif table_name not in ds_a.table_names:
             self.p(f"\t[green]+ Table [b]{table_name}[/b]")
+            tab_res = TableDiffResult(name=table_name, kind="new")
+            self.result.tables.append(tab_res)
             for col in ds_b[table_name].columns:
                 self.p(f"\t\t[green]+ Column [b]{col}[/b]")
+                tab_res.columns.append(ColumnDiffResult(name=col, kind="new"))
         else:
             # get both tables in parallel
             with ThreadPoolExecutor() as executor:
@@ -191,8 +220,12 @@ tb = {_snippet_dataset(ds_b, table_name)}
             removed_index = cast(pd.Series, removed_index.reset_index(drop=True))
 
             # compare table metadata
-            diff = _dict_diff(_table_metadata_dict(table_a), _table_metadata_dict(table_b), tabs=3)
+            tab_meta_a, tab_meta_b = _table_metadata_dict(table_a), _table_metadata_dict(table_b)
+            diff = _dict_diff(tab_meta_a, tab_meta_b, tabs=3)
+            tab_res = TableDiffResult(name=table_name, kind="changed" if diff else "identical")
+            self.result.tables.append(tab_res)
             if diff:
+                tab_res.meta_diff = _dict_diff(tab_meta_a, tab_meta_b, tabs=0, color=False)
                 self.p(f"\t[yellow]~ Table [b]{table_name}[/b] (changed [u]metadata[/u])")
 
                 if self.verbose:
@@ -207,9 +240,15 @@ tb = {_snippet_dataset(ds_b, table_name)}
                         self.p(f"\t\t[white]= Dim [b]{dim}[/b]")
                     else:
                         self.p(f"\t\t[yellow]~ Dim [b]{dim}[/b]")
-                        if self.verbose:
+                        dim_res = ColumnDiffResult(name=dim, kind="changed", is_dim=True)
+                        if new_index.any():
+                            dim_res.changes.append("new data")
+                        if removed_index.any():
+                            dim_res.changes.append("removed data")
+                        tab_res.columns.append(dim_res)
+                        if self.verbose or self.details:
                             dims_without_dim = [d for d in dims if d != dim]
-                            out = _data_diff(
+                            out, dim_res.value_diffs = _data_diff(
                                 table_a,
                                 table_b,
                                 dim,
@@ -220,7 +259,7 @@ tb = {_snippet_dataset(ds_b, table_name)}
                                 removed_index,
                                 tabs=4,
                             )
-                            if out:
+                            if self.verbose and out:
                                 self.p(out)
 
             # compare columns
@@ -231,8 +270,10 @@ tb = {_snippet_dataset(ds_b, table_name)}
 
                 if col not in table_a.columns:
                     self.p(f"\t\t[green]+ Column [b]{col}[/b]")
+                    tab_res.columns.append(ColumnDiffResult(name=col, kind="new"))
                 elif col not in table_b.columns:
                     self.p(f"\t\t[red]- Column [b]{col}[/b]")
+                    tab_res.columns.append(ColumnDiffResult(name=col, kind="removed"))
                 else:
                     col_a = table_a[col]
                     col_b = table_b[col]
@@ -245,9 +286,9 @@ tb = {_snippet_dataset(ds_b, table_name)}
                         )
 
                     # metadata diff
-                    meta_diff = _dict_diff(
-                        _column_metadata_dict(col_a.metadata), _column_metadata_dict(col_b.metadata), tabs=4
-                    )
+                    col_meta_a = _column_metadata_dict(col_a.metadata)
+                    col_meta_b = _column_metadata_dict(col_b.metadata)
+                    meta_diff = _dict_diff(col_meta_a, col_meta_b, tabs=4)
 
                     # equality on index and series
                     eq_data = series_equals(table_a[col], table_b[col])
@@ -261,16 +302,27 @@ tb = {_snippet_dataset(ds_b, table_name)}
                         changed.append("changed [u]data[/u]")
 
                     if changed:
+                        col_res = ColumnDiffResult(
+                            name=col,
+                            kind="changed",
+                            changes=[c.replace("[u]", "").replace("[/u]", "") for c in changed],
+                        )
+                        if meta_diff:
+                            col_res.meta_diff = _dict_diff(col_meta_a, col_meta_b, tabs=0, color=False)
+                        tab_res.columns.append(col_res)
                         self.p(f"\t\t[yellow]~ Column [b]{col}[/b] ({', '.join(changed)})")
+                        if self.verbose or self.details:
+                            out = ""
+                            if new_index.any() or removed_index.any() or (~eq_data).any():
+                                out, col_res.value_diffs = _data_diff(
+                                    table_a, table_b, col, dims, eq_data, eq_index, new_index, removed_index, tabs=4
+                                )
                         if self.verbose:
                             if meta_diff:
                                 self.p(meta_diff)
                             if new_index.any() or removed_index.any() or (~eq_data).any():
                                 if meta_diff:
                                     self.p("")
-                                out = _data_diff(
-                                    table_a, table_b, col, dims, eq_data, eq_index, new_index, removed_index, tabs=4
-                                )
                                 if out:
                                     self.p(out)
                     else:
@@ -406,6 +458,16 @@ def _data_files_match(ds_local: Dataset, ds_remote: "RemoteDataset") -> bool:
     help="Use multiple threads.",
     default=1,
 )
+@click.option(
+    "--output-json",
+    type=click.Path(dir_okay=False),
+    help="Write structured diff results as JSON to this path.",
+)
+@click.option(
+    "--output-html",
+    type=click.Path(dir_okay=False),
+    help="Write a self-contained HTML report of the diff to this path.",
+)
 def cli(
     path_a: str,
     path_b: str,
@@ -419,6 +481,8 @@ def cli(
     snippet: bool,
     country: str | None,
     workers: int,
+    output_json: str | None,
+    output_html: str | None,
 ) -> None:
     """Compare all datasets from two catalogs and print out a summary of their differences.
 
@@ -456,12 +520,23 @@ def cli(
     """
     console = Console(tab_size=2, soft_wrap=True)
 
+    report = DiffReport()
+    # collect value-level samples for the structured report even without --verbose
+    details = bool(output_json or output_html)
+
+    def _write_reports() -> None:
+        if output_json:
+            Path(output_json).write_text(report.to_json())
+        if output_html:
+            Path(output_html).write_text(render_html(report))
+
     if changed:
         # Get all changed files in the current git repository
         files_changed = get_changed_files()
         catalog_paths = get_all_changed_catalog_paths(files_changed)
 
         if not catalog_paths:
+            _write_reports()
             console.print("[green]✅ No differences found[/green]")
             exit(0)
 
@@ -482,9 +557,11 @@ def cli(
         path_to_ds_b = {k: v for k, v in path_to_ds_b.items() if k in dag_steps}
 
     if not path_to_ds_a:
+        _write_reports()
         console.print(f"[yellow]❓ No datasets found in {path_a}[/yellow]")
         exit(0)
     if not path_to_ds_b:
+        _write_reports()
         console.print(f"[yellow]❓ No datasets found in {path_b}[/yellow]")
         exit(0)
 
@@ -515,6 +592,7 @@ def cli(
         matched_datasets.append((ds_a, ds_b))
 
     if skipped_identical_data:
+        report.skipped_cascade = skipped_identical_data
         log.info("Skipped datasets with identical data (source_checksum cascade)", count=skipped_identical_data)
 
     if workers > 1:
@@ -534,24 +612,31 @@ def cli(
                         verbose=verbose,
                         snippet=snippet,
                         country=country,
+                        details=details,
                     )
                     differ.summary()
-                    return lines
+                    return lines, differ.result
 
                 futures.append(executor.submit(func, ds_a, ds_b))
 
-            for future in futures:
+            for (ds_a, ds_b), future in zip(matched_datasets, futures):
                 try:
-                    lines = future.result()
+                    lines, result = future.result()
                 except DatasetError as e:
                     # soft fail and continue with another dataset
                     lines = [f"[bold red]⚠ Error: {e}[/bold red]"]
+                    result = DatasetDiffResult(path=dataset_uri(ds_b or ds_a), kind="error", error=str(e))
                 except Exception as e:
                     # soft fail and continue with another dataset
                     log.error("\n".join(traceback.format_exception(type(e), e, e.__traceback__)))
                     any_error = True
+                    report.datasets.append(
+                        DatasetDiffResult(path=dataset_uri(ds_b or ds_a), kind="error", error=str(e))
+                    )
                     lines = []
                     continue
+
+                report.datasets.append(result)
 
                 for line in lines:
                     console.print(line)
@@ -576,20 +661,27 @@ def cli(
                     verbose=verbose,
                     snippet=snippet,
                     country=country,
+                    details=details,
                 )
                 differ.summary()
             except DatasetError as e:
                 # soft fail and continue with another dataset
                 _append_and_print(f"[bold red]⚠ Error: {e}[/bold red]")
+                report.datasets.append(DatasetDiffResult(path=dataset_uri(ds_b or ds_a), kind="error", error=str(e)))
                 continue
             except Exception as e:
                 # soft fail and continue with another dataset
                 log.error("\n".join(traceback.format_exception(type(e), e, e.__traceback__)))
                 any_error = True
+                report.datasets.append(DatasetDiffResult(path=dataset_uri(ds_b or ds_a), kind="error", error=str(e)))
                 continue
+
+            report.datasets.append(differ.result)
 
             if any("~" in line for line in lines if isinstance(line, str)):
                 any_diff = True
+
+    _write_reports()
 
     console.print()
     if not path_to_ds_a and not path_to_ds_b:
@@ -661,6 +753,24 @@ def _df_to_str(df: pd.DataFrame, limit: int = 5) -> list[str]:
     return lines
 
 
+def _df_to_records(df: pd.DataFrame, limit: int = SAMPLE_LIMIT) -> list[dict[str, str]]:
+    """Sample the dataframe and convert it to display-ready records with stringified values."""
+    if len(df) > limit:
+        df_samp = df.sample(limit, random_state=0).sort_index()
+    else:
+        df_samp = df
+
+    def _fmt(v: Any) -> str:
+        try:
+            if pd.isna(v):
+                return "NaN"
+        except (TypeError, ValueError):
+            pass
+        return str(v)
+
+    return [{str(k): _fmt(v) for k, v in row.items()} for row in df_samp.to_dict("records")]
+
+
 def _data_diff(
     table_a: Table,
     table_b: Table,
@@ -671,12 +781,13 @@ def _data_diff(
     new_index: pd.Series,
     removed_index: pd.Series,
     tabs: int = 0,
-) -> str:
-    """Return summary of data differences."""
+) -> tuple[str, list[ValueDiff]]:
+    """Return summary of data differences as text and as structured value diffs."""
     # eq = eq_data & eq_index
     n = (eq_index | new_index).sum()
 
     lines = []
+    value_diffs = []
 
     cols = [d for d in dims if d is not None] + [col]
 
@@ -685,14 +796,24 @@ def _data_diff(
         lines.append(
             f"+ New values: {new_index.sum()} / {n} ({new_index.sum() / n * 100:.2f}%)",
         )
-        lines += _df_to_str(table_b.loc[new_index, cols])
+        new_values = table_b.loc[new_index, cols]
+        lines += _df_to_str(new_values)
+        value_diffs.append(
+            ValueDiff(kind="new", count=int(new_index.sum()), total=int(n), sample=_df_to_records(new_values))
+        )
 
     # removed values
     if removed_index.any():
         lines.append(
             f"- Removed values: {removed_index.sum()} / {n} ({removed_index.sum() / n * 100:.2f}%)",
         )
-        lines += _df_to_str(table_a.loc[removed_index, cols])
+        removed_values = table_a.loc[removed_index, cols]
+        lines += _df_to_str(removed_values)
+        value_diffs.append(
+            ValueDiff(
+                kind="removed", count=int(removed_index.sum()), total=int(n), sample=_df_to_records(removed_values)
+            )
+        )
 
     # changed values
     neq = ~eq_data & eq_index
@@ -707,15 +828,16 @@ def _data_diff(
         else:
             both = samp_a.join(samp_b, lsuffix=" -", rsuffix=" +")
         lines += _df_to_str(both)
+        value_diffs.append(ValueDiff(kind="changed", count=int(neq.sum()), total=int(n), sample=_df_to_records(both)))
 
     # add color
     lines = ["[violet]" + line for line in lines]
 
     if not lines:
-        return ""
+        return "", value_diffs
     else:
         # add tabs
-        return "\t" * tabs + "\n".join(lines).replace("\n", "\n" + "\t" * tabs).rstrip()
+        return "\t" * tabs + "\n".join(lines).replace("\n", "\n" + "\t" * tabs).rstrip(), value_diffs
 
     """OLD CODE, PARTS OF IT COULD BE STILL USEFUL
     # changes in index

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 
 import numpy as np
 import pandas as pd
+import requests
 import rich
 import rich_click as click
 import structlog
@@ -353,12 +354,15 @@ class RemoteDataset:
         return tb
 
 
-def _data_files_match(ds_local: Dataset, ds_remote: "RemoteDataset") -> bool:
-    """Return True if every local table's feather file is byte-identical to its remote counterpart.
+def _dataset_files_match(ds_local: Dataset, ds_remote: "RemoteDataset") -> bool:
+    """Return True if every local table's feather AND .meta.json file is byte-identical to its
+    remote counterpart.
 
     Compares the local MD5 to the remote object's S3/R2 ETag (which is the file's MD5 for
-    OWID's non-multipart uploads). Used to skip data diffs when ``source_checksum`` cascades
-    from an upstream metadata-only change but the actual feather bytes are unchanged.
+    OWID's non-multipart uploads). Used to skip diffs when ``source_checksum`` cascades
+    from an upstream change but neither the data nor the table metadata changed. Dataset-level
+    metadata (``index.json``) is compared in-memory by the caller — its bytes always differ
+    because they contain the source checksum itself.
     """
     from owid.catalog.core.datasets import checksum_file
 
@@ -367,20 +371,21 @@ def _data_files_match(ds_local: Dataset, ds_remote: "RemoteDataset") -> bool:
 
     local_md5: dict[str, str] = {}
     for t in ds_local.table_names:
-        path = Path(ds_local.path) / f"{t}.feather"
-        if not path.exists():
-            return False
-        local_md5[t] = checksum_file(path.as_posix()).hexdigest()
+        for fname in (f"{t}.feather", f"{t}.meta.json"):
+            path = Path(ds_local.path) / fname
+            if not path.exists():
+                return False
+            local_md5[fname] = checksum_file(path.as_posix()).hexdigest()
 
     base = (
         f"{DEFAULT_CATALOG_URL}{ds_remote.metadata.channel}/{ds_remote.metadata.namespace}/"
         f"{ds_remote.metadata.version}/{ds_remote.metadata.short_name}"
     )
 
-    def _remote_md5(table_name: str) -> str | None:
+    def _remote_md5(fname: str) -> str | None:
         try:
-            r = http_session.head(f"{base}/{table_name}.feather", timeout=10)
-        except Exception:
+            r = http_session.head(f"{base}/{fname}", timeout=10)
+        except requests.RequestException:
             return None
         if r.status_code != 200:
             return None
@@ -389,7 +394,7 @@ def _data_files_match(ds_local: Dataset, ds_remote: "RemoteDataset") -> bool:
     with ThreadPoolExecutor(max_workers=min(8, max(1, len(local_md5)))) as executor:
         remote_md5 = dict(zip(local_md5.keys(), executor.map(_remote_md5, local_md5.keys())))
 
-    return all(local_md5[t] == remote_md5.get(t) for t in local_md5)
+    return all(local_md5[f] == remote_md5.get(f) for f in local_md5)
 
 
 @click.command(name="diff", help=__doc__)
@@ -579,13 +584,19 @@ def cli(
             # to improve performance. Source checksum should be enough
             continue
 
-        # Fast-path: source_checksum differs (typical when an upstream metadata change cascades)
-        # but the feather files are byte-identical. Compare local MD5 to remote S3/R2 ETag and
-        # skip the full data download/diff when they match.
+        # Fast-path: source_checksum differs (typical when an upstream change cascades) but
+        # nothing observable changed. Skip the full download/diff only when dataset-level
+        # metadata is equal AND every table's feather + .meta.json is byte-identical (local MD5
+        # vs remote S3/R2 ETag) — a metadata-only change must still get a full diff.
         if ds_a and ds_b:
             local_ds = ds_b if isinstance(ds_a, RemoteDataset) else ds_a
             remote_ds = ds_a if isinstance(ds_a, RemoteDataset) else (ds_b if isinstance(ds_b, RemoteDataset) else None)
-            if remote_ds is not None and isinstance(local_ds, Dataset) and _data_files_match(local_ds, remote_ds):
+            if (
+                remote_ds is not None
+                and isinstance(local_ds, Dataset)
+                and _dataset_metadata_dict(ds_a) == _dataset_metadata_dict(ds_b)
+                and _dataset_files_match(local_ds, remote_ds)
+            ):
                 skipped_identical_data += 1
                 continue
 

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -1,0 +1,421 @@
+"""Structured results for `etl diff` and an HTML renderer on top of them.
+
+`etl.datadiff.DatasetDiff` collects one `DatasetDiffResult` per compared dataset while it
+prints its usual rich-text summary. The results aggregate into a `DiffReport`, which can be
+serialized to JSON (consumed by owidbot to build the PR comment) or rendered as a
+self-contained HTML report (uploaded to R2 and linked from the PR comment).
+
+This module must not import from `etl.datadiff` to avoid a circular dependency.
+"""
+
+import datetime as dt
+import html
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+ChangeKind = Literal["new", "removed", "changed", "identical", "error"]
+
+# Number of sample rows stored per value diff (the text output shows only 5; the HTML report
+# can afford more).
+SAMPLE_LIMIT = 100
+
+
+@dataclass
+class ValueDiff:
+    """New, removed or changed values of a single column."""
+
+    kind: Literal["new", "removed", "changed"]
+    count: int
+    total: int
+    # Display-ready records; rows of a "changed" diff have "<col> -" (old) and "<col> +" (new) keys.
+    sample: list[dict[str, str]] = field(default_factory=list)
+
+    @property
+    def pct(self) -> float:
+        return self.count / self.total * 100 if self.total else 0.0
+
+    @property
+    def symbol(self) -> str:
+        return {"new": "+", "removed": "-", "changed": "~"}[self.kind]
+
+
+@dataclass
+class ColumnDiffResult:
+    name: str
+    kind: ChangeKind
+    is_dim: bool = False
+    # Subset of ["changed metadata", "new data", "changed data"].
+    changes: list[str] = field(default_factory=list)
+    meta_diff: str = ""
+    value_diffs: list[ValueDiff] = field(default_factory=list)
+
+
+@dataclass
+class TableDiffResult:
+    name: str
+    # "changed" means the table-level metadata changed; column changes live in `columns`.
+    kind: ChangeKind
+    meta_diff: str = ""
+    columns: list[ColumnDiffResult] = field(default_factory=list)
+
+    @property
+    def changed_columns(self) -> list[ColumnDiffResult]:
+        return [c for c in self.columns if c.kind != "identical"]
+
+    @property
+    def any_change(self) -> bool:
+        return self.kind != "identical" or bool(self.changed_columns)
+
+
+@dataclass
+class DatasetDiffResult:
+    path: str
+    # "changed" means the dataset-level metadata changed; table changes live in `tables`.
+    kind: ChangeKind
+    is_new_version: bool = False
+    meta_diff: str = ""
+    tables: list[TableDiffResult] = field(default_factory=list)
+    error: str | None = None
+
+    @property
+    def any_change(self) -> bool:
+        return self.kind != "identical" or any(t.any_change for t in self.tables)
+
+    @property
+    def change_kind(self) -> ChangeKind:
+        """Overall classification of the dataset for summary counts."""
+        if self.error:
+            return "error"
+        if self.kind in ("new", "removed"):
+            return self.kind
+        return "changed" if self.any_change else "identical"
+
+
+@dataclass
+class DiffReport:
+    datasets: list[DatasetDiffResult] = field(default_factory=list)
+    # Datasets skipped because their data files are byte-identical (source_checksum cascade).
+    skipped_cascade: int = 0
+
+    def _count(self, kind: ChangeKind) -> int:
+        return sum(1 for ds in self.datasets if ds.change_kind == kind)
+
+    @property
+    def n_changed(self) -> int:
+        return self._count("changed")
+
+    @property
+    def n_new(self) -> int:
+        return self._count("new")
+
+    @property
+    def n_removed(self) -> int:
+        return self._count("removed")
+
+    @property
+    def n_identical(self) -> int:
+        return self._count("identical")
+
+    @property
+    def n_errors(self) -> int:
+        return self._count("error")
+
+    @property
+    def status(self) -> Literal["clean", "changed", "error"]:
+        if self.n_errors:
+            return "error"
+        if self.n_changed or self.n_new or self.n_removed:
+            return "changed"
+        return "clean"
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {"skipped_cascade": self.skipped_cascade, "datasets": [asdict(ds) for ds in self.datasets]},
+            indent=1,
+            default=str,
+        )
+
+    @classmethod
+    def from_json(cls, s: str) -> "DiffReport":
+        d = json.loads(s)
+        return cls(
+            datasets=[_dataset_from_dict(ds) for ds in d["datasets"]],
+            skipped_cascade=d["skipped_cascade"],
+        )
+
+
+def _dataset_from_dict(d: dict[str, Any]) -> DatasetDiffResult:
+    return DatasetDiffResult(
+        path=d["path"],
+        kind=d["kind"],
+        is_new_version=d["is_new_version"],
+        meta_diff=d["meta_diff"],
+        error=d["error"],
+        tables=[
+            TableDiffResult(
+                name=t["name"],
+                kind=t["kind"],
+                meta_diff=t["meta_diff"],
+                columns=[
+                    ColumnDiffResult(
+                        name=c["name"],
+                        kind=c["kind"],
+                        is_dim=c["is_dim"],
+                        changes=c["changes"],
+                        meta_diff=c["meta_diff"],
+                        value_diffs=[ValueDiff(**v) for v in c["value_diffs"]],
+                    )
+                    for c in t["columns"]
+                ],
+            )
+            for t in d["tables"]
+        ],
+    )
+
+
+########################################################################################################################
+# HTML report
+########################################################################################################################
+
+_SYMBOLS = {"new": "+", "removed": "-", "changed": "~", "identical": "=", "error": "⚠"}
+
+_STATUS_HEADLINE = {
+    "clean": "✅ No differences found",
+    "changed": "❌ Found differences",
+    "error": "⚠ Found errors",
+}
+
+
+def _e(s: Any) -> str:
+    return html.escape(str(s))
+
+
+def _render_meta_diff(meta_diff: str, label: str) -> str:
+    """Render an ndiff metadata diff as a collapsible block with +/- lines colored."""
+    if not meta_diff:
+        return ""
+    lines = []
+    for line in meta_diff.splitlines():
+        cls = "add" if line.startswith("+") else "del" if line.startswith("-") else ""
+        lines.append(f'<span class="{cls}">{_e(line)}</span>')
+    return f'<details class="meta"><summary>{_e(label)}</summary><pre>{chr(10).join(lines)}</pre></details>'
+
+
+def _render_value_diff(v: ValueDiff) -> str:
+    label = {"new": "New values", "removed": "Removed values", "changed": "Changed values"}[v.kind]
+    head = f'<div class="vd-head {v.kind}">{_e(v.symbol)} {label}: {v.count:,} / {v.total:,} ({v.pct:.2f}%)</div>'
+    if not v.sample:
+        return f'<div class="vd">{head}</div>'
+
+    cols = list(v.sample[0].keys())
+    ths = "".join(
+        f'<th class="{"old" if c.endswith(" -") else "new" if c.endswith(" +") else ""}">{_e(c)}</th>' for c in cols
+    )
+    trs = []
+    for row in v.sample:
+        tds = "".join(
+            f'<td class="{"old" if c.endswith(" -") else "new" if c.endswith(" +") else ""}">{_e(row.get(c, ""))}</td>'
+            for c in cols
+        )
+        trs.append(f"<tr>{tds}</tr>")
+    note = f'<div class="note">showing {len(v.sample):,} of {v.count:,} rows</div>' if v.count > len(v.sample) else ""
+    return (
+        f'<div class="vd">{head}<div class="table-wrap"><table><thead><tr>{ths}</tr></thead>'
+        f"<tbody>{''.join(trs)}</tbody></table></div>{note}</div>"
+    )
+
+
+def _render_column(table_name: str, c: ColumnDiffResult) -> str:
+    chips = "".join(f'<span class="chip">{_e(ch)}</span>' for ch in c.changes)
+    dim = '<span class="chip dim">dim</span>' if c.is_dim else ""
+    parts = [
+        f'<div class="col {c.kind}">'
+        f'<div class="col-head"><span class="sym {c.kind}">{_SYMBOLS[c.kind]}</span> '
+        f"<code>{_e(table_name)}.{_e(c.name)}</code> {dim}{chips}</div>"
+    ]
+    if c.meta_diff:
+        parts.append(_render_meta_diff(c.meta_diff, "metadata diff"))
+    for v in c.value_diffs:
+        parts.append(_render_value_diff(v))
+    parts.append("</div>")
+    return "".join(parts)
+
+
+def _render_table(t: TableDiffResult) -> str:
+    parts = [
+        f'<div class="tbl"><div class="tbl-head"><span class="sym {t.kind}">{_SYMBOLS[t.kind]}</span> '
+        f"Table <b>{_e(t.name)}</b></div>"
+    ]
+    if t.meta_diff:
+        parts.append(_render_meta_diff(t.meta_diff, "table metadata diff"))
+    for c in t.columns:
+        if c.kind == "identical":
+            continue
+        parts.append(_render_column(t.name, c))
+    parts.append("</div>")
+    return "".join(parts)
+
+
+def _dataset_summary_note(ds: DatasetDiffResult) -> str:
+    """Short human summary shown next to the dataset path."""
+    if ds.error:
+        return "error"
+    if ds.kind in ("new", "removed"):
+        return f"{ds.kind} dataset"
+    notes = []
+    if ds.meta_diff:
+        notes.append("dataset metadata")
+    n_cols = sum(len(t.changed_columns) for t in ds.tables)
+    n_tables = sum(1 for t in ds.tables if t.any_change)
+    if n_cols:
+        notes.append(f"{n_cols} column{'s' if n_cols != 1 else ''} in {n_tables} table{'s' if n_tables != 1 else ''}")
+    elif n_tables:
+        notes.append(f"{n_tables} table{'s' if n_tables != 1 else ''} metadata")
+    return ", ".join(notes) if notes else "identical"
+
+
+def _render_dataset(ds: DatasetDiffResult) -> str:
+    kind = ds.change_kind
+    open_attr = " open" if kind in ("changed", "error") else ""
+    new_version = ' <span class="chip">new version</span>' if ds.is_new_version else ""
+    parts = [
+        f'<details class="ds {kind}"{open_attr}>'
+        f'<summary><span class="sym {kind}">{_SYMBOLS[kind]}</span> '
+        f'<code class="path">{_e(ds.path)}</code>{new_version}'
+        f'<span class="ds-note">{_e(_dataset_summary_note(ds))}</span></summary>'
+        f'<div class="ds-body">'
+    ]
+    if ds.error:
+        parts.append(f'<div class="error-msg">⚠ {_e(ds.error)}</div>')
+    if ds.meta_diff:
+        parts.append(_render_meta_diff(ds.meta_diff, "dataset metadata diff"))
+    for t in ds.tables:
+        if t.any_change or ds.kind in ("new", "removed"):
+            parts.append(_render_table(t))
+    parts.append("</div></details>")
+    return "".join(parts)
+
+
+def render_html(report: DiffReport) -> str:
+    """Render the report as a single self-contained HTML page."""
+    generated_at = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    cards = []
+    for label, count, kind in [
+        ("changed", report.n_changed, "changed"),
+        ("new", report.n_new, "new"),
+        ("removed", report.n_removed, "removed"),
+        ("errors", report.n_errors, "error"),
+        ("identical", report.n_identical, "identical"),
+        ("skipped", report.skipped_cascade, "skipped"),
+    ]:
+        if count or kind in ("changed", "identical", "skipped"):
+            cards.append(
+                f'<div class="card {kind}"><div class="count">{count:,}</div><div class="label">{label}</div></div>'
+            )
+
+    # Changed/new/removed/errored datasets first, identical last.
+    order = {"error": 0, "changed": 1, "new": 2, "removed": 3, "identical": 4}
+    datasets = sorted(report.datasets, key=lambda ds: (order[ds.change_kind], ds.path))
+    sections = "".join(_render_dataset(ds) for ds in datasets)
+
+    skipped_note = (
+        f'<div class="skipped-note">= {report.skipped_cascade:,} more dataset(s) skipped: '
+        "their data files are byte-identical, the source checksum changed only because an upstream "
+        "metadata change cascaded.</div>"
+        if report.skipped_cascade
+        else ""
+    )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>data-diff</title>
+<style>
+  :root {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }}
+  body {{ margin: 0; padding: 2rem; color: #1a1a1a; background: #fafafa; }}
+  h1 {{ font-size: 1.4rem; margin: 0 0 .25rem; }}
+  .sub {{ color: #777; font-size: .85rem; margin-bottom: 1.5rem; }}
+  .cards {{ display: flex; gap: 1rem; margin-bottom: 1.5rem; flex-wrap: wrap; }}
+  .card {{ background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; padding: .75rem 1.25rem; text-align: center; min-width: 90px; }}
+  .card .count {{ font-size: 1.6rem; font-weight: 700; }}
+  .card.changed .count {{ color: #b58900; }}
+  .card.new .count {{ color: #2e7d32; }}
+  .card.removed .count {{ color: #c62828; }}
+  .card.error .count {{ color: #c62828; }}
+  .card.identical .count, .card.skipped .count {{ color: #999; }}
+  .card .label {{ font-size: .75rem; color: #777; text-transform: uppercase; letter-spacing: .04em; }}
+  .controls {{ display: flex; gap: 1.5rem; align-items: center; margin-bottom: 1rem; flex-wrap: wrap; }}
+  input[type="search"] {{ width: 100%; max-width: 420px; padding: .5rem .75rem; border: 1px solid #ccc; border-radius: 6px; font-size: .9rem; }}
+  .controls label {{ font-size: .85rem; color: #444; user-select: none; }}
+  details.ds {{ background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; margin-bottom: .75rem; }}
+  details.ds > summary {{ padding: .7rem 1rem; cursor: pointer; display: flex; align-items: center; gap: .6rem; flex-wrap: wrap; }}
+  details.ds > summary:hover {{ background: #fcfcff; }}
+  details.ds.identical {{ display: none; }}
+  body.show-identical details.ds.identical {{ display: block; }}
+  details.ds.hidden {{ display: none !important; }}
+  .ds-body {{ padding: .25rem 1rem 1rem; border-top: 1px solid #f0f0f0; }}
+  .ds-note {{ margin-left: auto; color: #999; font-size: .8rem; }}
+  code {{ font-size: .82rem; background: #f3f3f3; padding: .1rem .3rem; border-radius: 3px; }}
+  code.path {{ font-weight: 600; }}
+  .sym {{ font-family: ui-monospace, Menlo, monospace; font-weight: 700; width: 1rem; display: inline-block; text-align: center; }}
+  .sym.changed {{ color: #b58900; }}
+  .sym.new {{ color: #2e7d32; }}
+  .sym.removed {{ color: #c62828; }}
+  .sym.identical {{ color: #bbb; }}
+  .sym.error {{ color: #c62828; }}
+  .chip {{ font-size: .7rem; background: #fdf3d7; color: #8a6d00; border-radius: 10px; padding: .1rem .5rem; margin-left: .3rem; white-space: nowrap; }}
+  .chip.dim {{ background: #e8eaf6; color: #3949ab; }}
+  .tbl {{ margin: .75rem 0 0; }}
+  .tbl-head {{ font-size: .9rem; margin-bottom: .25rem; }}
+  .col {{ margin: .5rem 0 .5rem 1.5rem; }}
+  .col-head {{ font-size: .85rem; margin-bottom: .25rem; }}
+  details.meta {{ margin: .3rem 0 .3rem 1.5rem; }}
+  details.meta > summary {{ font-size: .78rem; color: #777; cursor: pointer; }}
+  details.meta pre {{ background: #fbfbfd; border: 1px solid #f0f0f0; border-radius: 6px; padding: .6rem .8rem; font-size: .75rem; overflow-x: auto; }}
+  details.meta pre .add {{ color: #2e7d32; }}
+  details.meta pre .del {{ color: #c62828; }}
+  .vd {{ margin: .4rem 0 .6rem 1.5rem; }}
+  .vd-head {{ font-size: .8rem; font-weight: 600; margin-bottom: .3rem; }}
+  .vd-head.new {{ color: #2e7d32; }}
+  .vd-head.removed {{ color: #c62828; }}
+  .vd-head.changed {{ color: #8a6d00; }}
+  .table-wrap {{ overflow-x: auto; max-height: 420px; overflow-y: auto; border: 1px solid #eee; border-radius: 6px; display: inline-block; max-width: 100%; }}
+  .vd table {{ border-collapse: collapse; font-size: .78rem; }}
+  .vd th, .vd td {{ padding: .3rem .6rem; border-bottom: 1px solid #f0f0f0; text-align: left; white-space: nowrap; }}
+  .vd th {{ position: sticky; top: 0; background: #f7f7f7; font-weight: 600; }}
+  .vd th.old, .vd td.old {{ background: #fdeaea; }}
+  .vd th.new, .vd td.new {{ background: #e9f6ec; }}
+  .note {{ color: #888; font-size: .74rem; margin-top: .25rem; }}
+  .error-msg {{ color: #c62828; font-size: .85rem; margin: .5rem 0; }}
+  .skipped-note {{ color: #999; font-size: .82rem; margin-top: 1rem; }}
+  .headline {{ font-size: 1rem; font-weight: 600; margin-bottom: 1rem; }}
+</style>
+</head>
+<body>
+  <h1>data-diff</h1>
+  <div class="sub">generated {generated_at} · <code>etl diff</code> report</div>
+  <div class="headline">{_STATUS_HEADLINE[report.status]}</div>
+  <div class="cards">{"".join(cards)}</div>
+  <div class="controls">
+    <input type="search" id="filter" placeholder="Filter datasets (path, table, column…)">
+    <label><input type="checkbox" id="show-identical"> show identical datasets</label>
+  </div>
+  {sections}
+  {skipped_note}
+<script>
+  const dsBlocks = Array.from(document.querySelectorAll('details.ds'));
+  document.getElementById('show-identical').addEventListener('change', (e) => {{
+    document.body.classList.toggle('show-identical', e.target.checked);
+  }});
+  document.getElementById('filter').addEventListener('input', (e) => {{
+    const q = e.target.value.toLowerCase();
+    dsBlocks.forEach(d => d.classList.toggle('hidden', !d.textContent.toLowerCase().includes(q)));
+  }});
+</script>
+</body>
+</html>
+"""

--- a/lib/catalog/owid/catalog/s3_utils.py
+++ b/lib/catalog/owid/catalog/s3_utils.py
@@ -258,7 +258,13 @@ def download_s3_folder(
 
 
 def upload(
-    s3_url: str, filename: str | Path, public: bool = False, quiet: bool = False, downloadable: bool = False
+    s3_url: str,
+    filename: str | Path,
+    public: bool = False,
+    quiet: bool = False,
+    downloadable: bool = False,
+    content_type: str | None = None,
+    cache_control: str | None = None,
 ) -> None:
     """Upload the file at the given local filename to the S3 URL.
 
@@ -268,6 +274,8 @@ def upload(
         public: Whether to make the file publicly readable
         quiet: Whether to suppress log messages
         downloadable: If True, force browsers to download the file instead of displaying it inline. Sets Content-Disposition header to 'attachment; filename="..."'
+        content_type: Content-Type header to set on the object (e.g. 'text/html; charset=utf-8' so browsers render the file inline)
+        cache_control: Cache-Control header to set on the object (e.g. 'max-age=60' for frequently overwritten objects)
     """
     client = connect_r2()
     bucket, key = s3_bucket_key(s3_url)
@@ -277,6 +285,11 @@ def upload(
     if downloadable:
         file_name = Path(filename).name
         extra_args["ContentDisposition"] = f'attachment; filename="{file_name}"'
+
+    if content_type:
+        extra_args["ContentType"] = content_type
+    if cache_control:
+        extra_args["CacheControl"] = cache_control
 
     filename_str = str(filename)
     try:

--- a/tests/apps/test_owidbot_data_diff.py
+++ b/tests/apps/test_owidbot_data_diff.py
@@ -1,0 +1,84 @@
+from apps.owidbot.data_diff import format_comment
+from etl.datadiff_report import (
+    ColumnDiffResult,
+    DatasetDiffResult,
+    DiffReport,
+    TableDiffResult,
+    ValueDiff,
+)
+
+
+def _sample_report() -> DiffReport:
+    return DiffReport(
+        datasets=[
+            DatasetDiffResult(
+                path="garden/who/2025-01-17/vaccine_stock_out",
+                kind="identical",
+                tables=[
+                    TableDiffResult(name="global_cause", kind="identical"),
+                    TableDiffResult(
+                        name="vaccine_stock_out",
+                        kind="identical",
+                        columns=[
+                            ColumnDiffResult(
+                                name="value",
+                                kind="changed",
+                                changes=["changed data"],
+                                value_diffs=[
+                                    ValueDiff(
+                                        kind="changed",
+                                        count=4,
+                                        total=119537,
+                                        sample=[
+                                            {
+                                                "country": "Austria",
+                                                "year": "2019",
+                                                "value -": "Inaccurtae forecasts",
+                                                "value +": "Inaccurate forecasts",
+                                            }
+                                        ]
+                                        * 4,
+                                    )
+                                ],
+                            )
+                        ],
+                    ),
+                ],
+            ),
+            DatasetDiffResult(path="garden/worldbank_wdi/2026-02-27/wdi", kind="identical", tables=[]),
+        ],
+        skipped_cascade=16,
+    )
+
+
+def test_format_comment_changed():
+    body = format_comment(_sample_report(), "https://example.org/data-diff.html")
+
+    # summary line leads with the counts and links to the full report
+    assert "❌ 1 changed · 1 identical · 16 skipped" in body
+    assert '<a href="https://example.org/data-diff.html">' in body
+
+    # only the changed dataset appears in the diff block
+    assert "~ garden/who/2025-01-17/vaccine_stock_out" in body
+    assert "garden/worldbank_wdi/2026-02-27/wdi" not in body
+
+    # counts and capped sample rows
+    assert "~ Changed values: 4 / 119,537 (0.00%)" in body
+    assert body.count("Inaccurtae forecasts → Inaccurate forecasts") == 3
+    assert "(+1 more)" in body
+
+
+def test_format_comment_clean():
+    body = format_comment(DiffReport(datasets=[], skipped_cascade=3), None)
+
+    assert "✅ no differences · 3 skipped" in body
+    assert "No differences found." in body
+    assert "```diff" not in body
+
+
+def test_format_comment_error():
+    report = DiffReport(datasets=[DatasetDiffResult(path="garden/n/v/ds", kind="error", error="Index must be unique.")])
+    body = format_comment(report, None)
+
+    assert "⚠️ 1 error(s)" in body
+    assert "! garden/n/v/ds — error: Index must be unique." in body

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -1,11 +1,13 @@
+import hashlib
 import os
-from unittest.mock import patch
+import shutil
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
 from owid.catalog import Dataset, DatasetMeta, Table
 
-from etl.datadiff import DatasetDiff
+from etl.datadiff import DatasetDiff, RemoteDataset, _dataset_files_match
 from etl.datadiff_report import DiffReport, render_html
 
 
@@ -117,6 +119,40 @@ def test_structured_result(tmp_path):
     assert report2.n_changed == 1
     assert report2.n_identical == 0
     assert report2.status == "changed"
+
+
+@pytest.mark.filterwarnings("ignore:Table `tab` does not have a primary_key")
+@patch.dict(os.environ, {"OWID_STRICT": ""})
+def test_dataset_files_match_covers_metadata(tmp_path):
+    """The checksum-cascade fast path must not skip datasets whose table metadata changed."""
+    ds_a, _ = _create_datasets(tmp_path)
+    tab = Table({"country": ["UK"], "a": [1]}, short_name="tab")
+    ds_a.add(tab)
+
+    # "remote" is a frozen copy of the dataset as currently published
+    remote_dir = tmp_path / "remote"
+    shutil.copytree(ds_a.path, remote_dir)
+    ds_remote = RemoteDataset(ds_a.metadata, ["tab"])
+
+    def fake_head(url, timeout=None):
+        resp = MagicMock()
+        remote_file = remote_dir / url.rsplit("/", 1)[1]
+        if remote_file.exists():
+            resp.status_code = 200
+            resp.headers = {"ETag": f'"{hashlib.md5(remote_file.read_bytes()).hexdigest()}"'}
+        else:
+            resp.status_code = 404
+            resp.headers = {}
+        return resp
+
+    with patch("etl.datadiff.http_session.head", side_effect=fake_head):
+        # nothing changed -> skip is allowed
+        assert _dataset_files_match(ds_a, ds_remote)
+
+        # metadata-only change (feather untouched) -> must NOT be skipped
+        meta_json = tmp_path / "catalog_a" / "ds" / "tab.meta.json"
+        meta_json.write_text(meta_json.read_text().replace("{", '{"description": "new", ', 1))
+        assert not _dataset_files_match(ds_a, ds_remote)
 
 
 @pytest.mark.filterwarnings("ignore:Table `tab` does not have a primary_key")

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -6,6 +6,7 @@ import pytest
 from owid.catalog import Dataset, DatasetMeta, Table
 
 from etl.datadiff import DatasetDiff
+from etl.datadiff_report import DiffReport, render_html
 
 
 def _create_datasets(tmp_path):
@@ -72,3 +73,71 @@ def test_new_data(tmp_path):
         "\t\t[yellow]~ Column [b]a[/b] (new [u]data[/u], changed [u]data[/u])",
         "\t\t\t\t[violet]+ New values: 1 / 3 (33.33%)\n\t\t\t\t[violet]  country  a\n\t\t\t\t[violet]       FR  3\n\t\t\t\t[violet]~ Changed values: 1 / 3 (33.33%)\n\t\t\t\t[violet]  country  a -  a +\n\t\t\t\t[violet]       US    3    2",
     ]
+
+
+@pytest.mark.filterwarnings("ignore:Table `tab` does not have a primary_key")
+@patch.dict(os.environ, {"OWID_STRICT": ""})
+def test_structured_result(tmp_path):
+    """The structured `result` mirrors the printed summary, even without verbose."""
+    ds_a, ds_b = _create_datasets(tmp_path)
+
+    tab_a = Table({"country": ["UK", "US"], "a": [1, 3]}, short_name="tab")
+    tab_b = Table({"country": ["UK", "US", "FR"], "a": [1, 2, 3]}, short_name="tab")
+
+    ds_a.add(tab_a)
+    ds_b.add(tab_b)
+
+    differ = DatasetDiff(ds_a, ds_b, print=lambda x: None, details=True)
+    differ.summary()
+    res = differ.result
+
+    assert res.path == "garden/n/v/ds"
+    assert res.change_kind == "changed"
+
+    (tab,) = res.tables
+    assert tab.kind == "identical"  # table metadata unchanged
+
+    dim = next(c for c in tab.columns if c.is_dim)
+    assert dim.name == "country"
+    assert [v.kind for v in dim.value_diffs] == ["new"]
+
+    col = next(c for c in tab.columns if not c.is_dim)
+    assert col.name == "a"
+    assert col.changes == ["new data", "changed data"]
+    value_diffs = {v.kind: v for v in col.value_diffs}
+    assert value_diffs["new"].count == 1
+    assert value_diffs["new"].total == 3
+    assert value_diffs["new"].sample == [{"country": "FR", "a": "3"}]
+    assert value_diffs["changed"].sample == [{"country": "US", "a -": "3", "a +": "2"}]
+
+    # JSON round-trip
+    report = DiffReport(datasets=[res], skipped_cascade=2)
+    report2 = DiffReport.from_json(report.to_json())
+    assert report2.to_json() == report.to_json()
+    assert report2.n_changed == 1
+    assert report2.n_identical == 0
+    assert report2.status == "changed"
+
+
+@pytest.mark.filterwarnings("ignore:Table `tab` does not have a primary_key")
+@patch.dict(os.environ, {"OWID_STRICT": ""})
+def test_render_html(tmp_path):
+    ds_a, ds_b = _create_datasets(tmp_path)
+
+    tab_a = Table({"country": ["UK", "US"], "a": [1, 3]}, short_name="tab")
+    tab_b = Table({"country": ["UK", "US", "FR"], "a": [1, 2, 3]}, short_name="tab")
+
+    ds_a.add(tab_a)
+    ds_b.add(tab_b)
+
+    differ = DatasetDiff(ds_a, ds_b, print=lambda x: None, details=True)
+    differ.summary()
+
+    html = render_html(DiffReport(datasets=[differ.result], skipped_cascade=2))
+
+    assert "❌ Found differences" in html
+    assert "garden/n/v/ds" in html
+    assert "Changed values" in html
+    # old/new sample values are rendered in the table
+    assert ">US<" in html
+    assert "2 more dataset(s) skipped" in html


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

## Why

The data-diff comment is posted on every PR but rarely used, while chart-diff is popular. The gap is structural: chart-diff's comment is a compact scoreboard linking to an interactive page, whereas data-diff's comment *is* the whole deliverable — a wall of monospace text that leads with `= Dataset` noise, buries the actual signal, truncates at 64k chars, and whose call-to-action is "re-run this locally with more flags".

## What

Two-part redesign, deliberately lightweight (no new Wizard app):

**1. Signal-first PR comment** — only changed/new/removed datasets appear, with per-column counts and up to 3 sample rows; identical datasets collapse to a single count line:

```
data-diff: ❌ 1 changed · 3 identical · 16 skipped — full report ↗

~ garden/who/2025-01-17/vaccine_stock_out
    ~ vaccine_stock_out.value (changed data)
        ~ Changed values: 4 / 119,537 (0.00%)
            Austria 2019 …: Inaccurtae forecasts → Inaccurate forecasts
            (+3 more)
```

**2. Sidecar HTML report** — a self-contained page with the full diff (old→new value tables with up to 100 sample rows, metadata diffs, "show identical" toggle, live filter), uploaded to `s3://owid-catalog/diffs/<branch>/data-diff.html` and linked from the comment at `https://catalog.ourworldindata.org/diffs/<branch>/data-diff.html`. Cloudflare edge-caches for ~5 min, so the link carries a `?v=<timestamp>` param to always point at the latest run.

## How

- `etl/datadiff_report.py` (new): structured diff model + JSON serialization + HTML renderer.
- `etl/datadiff.py`: `DatasetDiff` fills a structured `result` while printing; new `--output-json` / `--output-html` CLI flags. **The printed text output is byte-identical to before** (existing exact-string tests pass unchanged).
- `apps/owidbot/data_diff.py`: builds the comment from the structured JSON instead of ANSI-decoding stdout; uploads the HTML report (degrades gracefully to a link-less comment if the upload fails).
- `lib/catalog/owid/catalog/s3_utils.py`: `upload()` gains `content_type` / `cache_control` params so the report renders inline in the browser.

## Verification

- 7 tests pass (`tests/test_datadiff.py`, new `tests/apps/test_owidbot_data_diff.py`); `make check` green here and in `lib/catalog`.
- End-to-end: tweaked a local dataset value, ran `etl diff REMOTE data/ --output-html/--output-json`, verified text/JSON/HTML all show the change; browser-checked the report incl. toggle and filter.
- Confirmed `catalog.ourworldindata.org` serves uploaded reports with `content-type: text/html` (test objects deleted afterwards).
- Real output demo: see the refreshed owidbot comment on #6397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
