### PR TITLE
📜 Document region-rename wrinkles in add-provider-regions skill

### DIFF
--- a/.claude/skills/add-provider-regions/SKILL.md
+++ b/.claude/skills/add-provider-regions/SKILL.md
@@ -369,6 +369,13 @@ yarn fixLintChanged     # lint the changed files; yarn fixFormatChanged to forma
 ```
 Confirm the provider appears in `regionGroupLabels` and the relevant label record(s), and that typecheck is clean (a missing entry in a `Record<RegionDataProvider, …>` / `Record<TooltipKey, …>` registry is a compile error — that's your safety net). Open a PR in `owid-grapher` (title like `🔨 update regions file`), with the disclosure blockquote in the body.
 
+### Renaming existing regions (not a fresh add)
+
+Occasionally you're not adding a provider but **renaming** its already-published regions (e.g. WID's `MENA (WID)` → `Middle East and North Africa (WID)`, or `&` → `and`). The Step 9 flow is the same, with two wrinkles:
+
+- **Finish with `runRegionsUpdater` from prod — never merge on a hand-edit.** Renaming a region's `name` shifts the derived name / `RegionDataProvider` union types, so it's tempting to hand-edit the `name`s directly in `regions.data.ts` to keep `yarn typecheck` green before the prod catalog has rebuilt. That stopgap is **always incomplete**: the updater also regenerates each region's `shortName` and `slug` *from* the name, which a hand-edit silently misses (on the WID rename the stopgap kept the stale `mena-wid` slug and dropped MENA's `shortName`). Once the rename is live on prod, run `runRegionsUpdater` and let it overwrite the file — the diff exposes any derived field the stopgap got wrong. Treat the regenerated file as the source of truth, not the hand-edit.
+- **Ignore the "set up redirects" message for provider regions.** The updater unconditionally prints *"Be sure to set up redirects for any slugs that have changed"* on **any** change to `regions.data.ts`. But a `slug` only drives a URL for a **country** profile page (`/country/<slug>`, baked only for `regionType: "country"` — see `countries` in `regionsUtils.ts`). Provider regions are `regionType: "aggregate"` and have no country page, so their slug changes need **no** redirect. Only act on that warning if a real *country's* slug changed.
+
 ---
 
 ## Step 10 — Add the provider to the world-region-map-definitions article


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## What

Adds a **"Renaming existing regions (not a fresh add)"** subsection to Step 9 of the `add-provider-regions` skill, capturing two lessons from the WID region rename ([owid/etl#6314](https://github.com/owid/etl/pull/6314) + [owid/owid-grapher#6641](https://github.com/owid/owid-grapher/pull/6641)).

The skill was written for *adding* a provider; renaming an already-published provider's regions has two wrinkles the skill didn't cover:

1. **The pre-prod hand-edit of `regions.data.ts` is always lossy.** Renaming a region's `name` shifts the derived union types, so it's tempting to hand-edit the `name`s to keep `yarn typecheck` green before the prod catalog rebuilds. But `runRegionsUpdater` also regenerates each region's `shortName` and `slug` *from* the name — which a hand-edit silently misses (on the WID rename it kept the stale `mena-wid` slug and dropped MENA's `shortName`). The note makes clear the regenerated file is the source of truth.

2. **The updater's "set up redirects" message is a false alarm for provider regions.** It prints unconditionally on any `regions.data.ts` change, but a `slug` only drives a `/country/<slug>` profile page — baked only for `regionType: "country"`. Provider regions are `aggregate`, so their slug changes need no redirect. The note says to ignore it unless a real country's slug changed.

## Why

Both are non-obvious and cost time to rediscover: the first is a silent data-loss trap, the second sends you to wp-admin for nothing. Documenting them keeps the next region rename fast and correct.

## Scope

Docs only — one subsection added to `.claude/skills/add-provider-regions/SKILL.md`. No code or pipeline changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
