### PR TITLE
📊 Give owid_co2 dataset a real catalog description

### DIFF
--- a/etl/steps/data/garden/emissions/2025-12-04/owid_co2.meta.yml
+++ b/etl/steps/data/garden/emissions/2025-12-04/owid_co2.meta.yml
@@ -2,9 +2,5 @@ dataset:
   # Canary for the public catalog landing page / Schema.org JSON-LD (catalog-discovery project).
   jsonld: true
   title: OWID CO2 dataset
-  description: |-
-    OWID CO2 dataset.
-
-    This dataset will be loaded by [the co2-data repository](https://github.com/owid/co2-data), to create a csv file of the dataset that can be downloaded in one click.
   owners:
     - Pablo Rosado

--- a/etl/steps/data/garden/emissions/2025-12-04/owid_co2.meta.yml
+++ b/etl/steps/data/garden/emissions/2025-12-04/owid_co2.meta.yml
@@ -2,5 +2,9 @@ dataset:
   # Canary for the public catalog landing page / Schema.org JSON-LD (catalog-discovery project).
   jsonld: true
   title: OWID CO2 dataset
+  description: |-
+    Our complete CO2 and Greenhouse Gas Emissions dataset is a collection of key metrics maintained by Our World in Data. It includes data on CO2 emissions (annual, per capita, cumulative, and consumption-based), other greenhouse gases, and energy mix.
+
+    It is compiled from a variety of secondary sources, including the Global Carbon Project's Global Carbon Budget, Jones et al.'s national contributions to climate change, and the Energy Institute's Statistical Review of World Energy, alongside auxiliary population, income group, and GDP data used to calculate per-capita and per-GDP indicators.
   owners:
     - Pablo Rosado


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

`catalog.ourworldindata.org/emissions/owid_co2/dataset.jsonld` was still serving the old boilerplate description ("This dataset will be loaded by the co2-data repository...") after #6377/#6378/#6385 merged. Turns out those three PRs landed within a few hours of each other on the same day and ended up contradicting each other:

- #6377 added the boilerplate description back to `owid_co2` (to fix it inheriting junk metadata from an auxiliary input).
- #6378 removed that same boilerplate from `owid_energy`, on the assumption that `owid_co2` already had no description — which was stale by the time it was written, since #6377 had just added it.
- #6385 (the real fix) discovered that removing `owid_energy`'s description without replacing it just resurrected the inherited-junk bug, so it added a proper hand-written description to `owid_energy` instead and tightened the JSON-LD quality gate to require one. It never touched `owid_co2`.

Net result: `owid_co2` was left with the old boilerplate, and nobody had applied the #6385 pattern (a real description) to it.

This PR gives `owid_co2` the same treatment as `owid_energy`: a description adapted from the [co2-data repo's README](https://github.com/owid/co2-data#readme), describing the dataset's actual content and sources.

Verified locally: rebuilt `garden/emissions/2025-12-04/owid_co2` and ran `build_catalog_jsonld_artifacts` directly — it emits cleanly with no warnings and the generated `dataset.jsonld` carries the new description.
