### PR TITLE
✨ Data-diff report: anomaly-score triage view (ranking, tiers, coverage loss, watch lists)

### DIFF
--- a/apps/owidbot/data_diff.py
+++ b/apps/owidbot/data_diff.py
@@ -79,7 +79,10 @@ def upload_html_report(html_path: Path, branch: str) -> str | None:
 def format_comment(report: DiffReport, report_url: str | None) -> str:
     summary = _format_summary(report, report_url)
 
-    changed = [ds for ds in report.datasets if ds.change_kind != "identical"]
+    # Biggest differences first, same ordering as the HTML report.
+    changed = sorted(
+        (ds for ds in report.datasets if ds.change_kind != "identical"), key=lambda ds: (-ds.severity, ds.path)
+    )
     diff = "\n".join(line for ds in changed for line in _format_dataset(ds))
     diff = _truncate_diff(diff)
 

--- a/apps/owidbot/data_diff.py
+++ b/apps/owidbot/data_diff.py
@@ -187,7 +187,8 @@ def _format_row(row: dict[str, str], col: str) -> str:
     old = row.get(f"{col} -")
     new = row.get(f"{col} +")
     val = row.get(col)
-    dims = " ".join(v for k, v in row.items() if k not in (col, f"{col} -", f"{col} +"))
+    # "anomaly score" is a display column of the HTML report, not a dim.
+    dims = " ".join(v for k, v in row.items() if k not in (col, f"{col} -", f"{col} +", "anomaly score"))
     if old is not None or new is not None:
         return f"{dims}: {old} → {new}" if dims else f"{old} → {new}"
     if val is not None:

--- a/apps/owidbot/data_diff.py
+++ b/apps/owidbot/data_diff.py
@@ -18,7 +18,7 @@ import structlog
 from botocore.exceptions import BotoCoreError
 from owid.catalog import s3_utils
 
-from etl.datadiff_report import ColumnDiffResult, DatasetDiffResult, DiffReport
+from etl.datadiff_report import ColumnDiffResult, DatasetDiffResult, DiffReport, dataset_watch_key
 from etl.paths import BASE_DIR
 
 log = structlog.get_logger()
@@ -79,10 +79,9 @@ def upload_html_report(html_path: Path, branch: str) -> str | None:
 def format_comment(report: DiffReport, report_url: str | None) -> str:
     summary = _format_summary(report, report_url)
 
-    # Biggest differences first, same ordering as the HTML report.
-    changed = sorted(
-        (ds for ds in report.datasets if ds.change_kind != "identical"), key=lambda ds: (-ds.severity, ds.path)
-    )
+    # Triage order, same as the HTML report's watch list: tier first, data loss ahead of
+    # bigger-but-benign changes — so truncation (MAX_DIFF_CHARS) never drops a lossy dataset.
+    changed = sorted((ds for ds in report.datasets if ds.change_kind != "identical"), key=dataset_watch_key)
     diff = "\n".join(line for ds in changed for line in _format_dataset(ds))
     diff = _truncate_diff(diff)
 

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -805,11 +805,12 @@ def _changed_records(both: pd.DataFrame, col: str, limit: int = SAMPLE_LIMIT) ->
     top = both.iloc[order].copy()
 
     def _fmt_delta(o: float, n: float) -> str:
+        # Absolute relative change — direction is already visible in the old/new columns.
         if pd.isna(o) or pd.isna(n):
             return "—"
         if o == 0:
-            return "+∞%" if n > o else "-∞%"
-        return f"{(n - o) / abs(o) * 100:+.1f}%"
+            return "∞%"
+        return f"{abs(n - o) / abs(o) * 100:.1f}%"
 
     top["Δ %"] = [_fmt_delta(o, n) for o, n in zip(old.iloc[order], new.iloc[order])]
     return _df_to_records(top, limit=limit), True

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -31,6 +31,7 @@ from etl.datadiff_report import (
     DiffReport,
     TableDiffResult,
     ValueDiff,
+    format_score,
     render_html,
 )
 from etl.files import yaml_dump
@@ -788,14 +789,14 @@ def _changed_records(
 ) -> tuple[list[dict[str, str]], bool, float | None]:
     """Sample records for a changed-values diff.
 
-    For numeric columns, keep the rows with the largest changes (largest first) and append a
-    "Δ %" display column, so the report surfaces the biggest moves instead of a random sample.
-    Rows are ranked by BARD (`etl.data_helpers.misc.bard`, the same metric Anomalist scores
+    For numeric columns, keep the most anomalous rows (largest first) and append an
+    "anomaly score" display column, so the report surfaces the biggest moves instead of a random
+    sample. The score is BARD (`etl.data_helpers.misc.bard`, the same metric Anomalist scores
     changes with): bounded in [0, 1], symmetric, and resistant to blow-ups on tiny values. A
-    value appearing or disappearing (NaN on one side) counts as a maximal change. Other dtypes
-    keep the plain random sample.
+    value appearing or disappearing (NaN on one side) counts as a maximal change (score 1). Other
+    dtypes keep the plain random sample.
 
-    Returns (records, sorted_by_delta, median_bard), where median_bard is the median BARD across
+    Returns (records, sorted_by_score, median_bard), where median_bard is the median score across
     ALL changed rows (not just the sample) — the report uses it to sort columns, tables and
     datasets by how big their differences typically are. None for non-numeric columns.
     """
@@ -813,16 +814,7 @@ def _changed_records(
     # Positional (iloc) selection is safe even if `both` has a non-unique index.
     order = np.argsort(-score, kind="stable")[:limit]
     top = both.iloc[order].copy()
-
-    def _fmt_delta(o: float, n: float) -> str:
-        # Absolute relative change — direction is already visible in the old/new columns.
-        if pd.isna(o) or pd.isna(n):
-            return "—"
-        if o == 0:
-            return "∞%"
-        return f"{abs(n - o) / abs(o) * 100:.1f}%"
-
-    top["Δ %"] = [_fmt_delta(o, n) for o, n in zip(old.iloc[order], new.iloc[order])]
+    top["anomaly score"] = [format_score(s) for s in score[order]]
     return _df_to_records(top, limit=limit), True, median_bard
 
 
@@ -883,14 +875,14 @@ def _data_diff(
         else:
             both = samp_a.join(samp_b, lsuffix=" -", rsuffix=" +")
         lines += _df_to_str(both)
-        records, sorted_by_delta, median_bard = _changed_records(both, col)
+        records, sorted_by_score, median_bard = _changed_records(both, col)
         value_diffs.append(
             ValueDiff(
                 kind="changed",
                 count=int(neq.sum()),
                 total=int(n),
                 sample=records,
-                sorted_by_delta=sorted_by_delta,
+                sorted_by_score=sorted_by_score,
                 median_bard=median_bard,
             )
         )

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -782,6 +782,39 @@ def _df_to_records(df: pd.DataFrame, limit: int = SAMPLE_LIMIT) -> list[dict[str
     return [{str(k): _fmt(v) for k, v in row.items()} for row in df_samp.to_dict("records")]
 
 
+def _changed_records(both: pd.DataFrame, col: str, limit: int = SAMPLE_LIMIT) -> tuple[list[dict[str, str]], bool]:
+    """Sample records for a changed-values diff.
+
+    For numeric columns, keep the rows with the largest |relative change| (largest first) and
+    append a "Δ %" display column, so the report surfaces the biggest moves instead of a random
+    sample. Other dtypes keep the plain random sample. Returns (records, sorted_by_delta).
+    """
+    old_col, new_col = f"{col} -", f"{col} +"
+    if not (pd.api.types.is_numeric_dtype(both[old_col]) and pd.api.types.is_numeric_dtype(both[new_col])):
+        return _df_to_records(both, limit=limit), False
+
+    old = both[old_col].astype("float64")
+    new = both[new_col].astype("float64")
+    # Sort magnitude: a value appearing/disappearing (NaN on one side) or growing from zero is a
+    # maximal change, so rank it above any finite percentage.
+    magnitude = ((new - old) / old.abs() * 100).abs().to_numpy()
+    magnitude[~np.isfinite(magnitude)] = np.inf
+
+    # Positional (iloc) selection is safe even if `both` has a non-unique index.
+    order = np.argsort(-magnitude, kind="stable")[:limit]
+    top = both.iloc[order].copy()
+
+    def _fmt_delta(o: float, n: float) -> str:
+        if pd.isna(o) or pd.isna(n):
+            return "—"
+        if o == 0:
+            return "+∞%" if n > o else "-∞%"
+        return f"{(n - o) / abs(o) * 100:+.1f}%"
+
+    top["Δ %"] = [_fmt_delta(o, n) for o, n in zip(old.iloc[order], new.iloc[order])]
+    return _df_to_records(top, limit=limit), True
+
+
 def _data_diff(
     table_a: Table,
     table_b: Table,
@@ -839,7 +872,12 @@ def _data_diff(
         else:
             both = samp_a.join(samp_b, lsuffix=" -", rsuffix=" +")
         lines += _df_to_str(both)
-        value_diffs.append(ValueDiff(kind="changed", count=int(neq.sum()), total=int(n), sample=_df_to_records(both)))
+        records, sorted_by_delta = _changed_records(both, col)
+        value_diffs.append(
+            ValueDiff(
+                kind="changed", count=int(neq.sum()), total=int(n), sample=records, sorted_by_delta=sorted_by_delta
+            )
+        )
 
     # add color
     lines = ["[violet]" + line for line in lines]

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -23,6 +23,7 @@ from rich.syntax import Syntax
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from etl.dag_helpers import load_dag
+from etl.data_helpers.misc import bard
 from etl.datadiff_report import (
     SAMPLE_LIMIT,
     ColumnDiffResult,
@@ -782,26 +783,35 @@ def _df_to_records(df: pd.DataFrame, limit: int = SAMPLE_LIMIT) -> list[dict[str
     return [{str(k): _fmt(v) for k, v in row.items()} for row in df_samp.to_dict("records")]
 
 
-def _changed_records(both: pd.DataFrame, col: str, limit: int = SAMPLE_LIMIT) -> tuple[list[dict[str, str]], bool]:
+def _changed_records(
+    both: pd.DataFrame, col: str, limit: int = SAMPLE_LIMIT
+) -> tuple[list[dict[str, str]], bool, float | None]:
     """Sample records for a changed-values diff.
 
-    For numeric columns, keep the rows with the largest |relative change| (largest first) and
-    append a "Δ %" display column, so the report surfaces the biggest moves instead of a random
-    sample. Other dtypes keep the plain random sample. Returns (records, sorted_by_delta).
+    For numeric columns, keep the rows with the largest changes (largest first) and append a
+    "Δ %" display column, so the report surfaces the biggest moves instead of a random sample.
+    Rows are ranked by BARD (`etl.data_helpers.misc.bard`, the same metric Anomalist scores
+    changes with): bounded in [0, 1], symmetric, and resistant to blow-ups on tiny values. A
+    value appearing or disappearing (NaN on one side) counts as a maximal change. Other dtypes
+    keep the plain random sample.
+
+    Returns (records, sorted_by_delta, median_bard), where median_bard is the median BARD across
+    ALL changed rows (not just the sample) — the report uses it to sort columns, tables and
+    datasets by how big their differences typically are. None for non-numeric columns.
     """
     old_col, new_col = f"{col} -", f"{col} +"
     if not (pd.api.types.is_numeric_dtype(both[old_col]) and pd.api.types.is_numeric_dtype(both[new_col])):
-        return _df_to_records(both, limit=limit), False
+        return _df_to_records(both, limit=limit), False, None
 
     old = both[old_col].astype("float64")
     new = both[new_col].astype("float64")
-    # Sort magnitude: a value appearing/disappearing (NaN on one side) or growing from zero is a
-    # maximal change, so rank it above any finite percentage.
-    magnitude = ((new - old) / old.abs() * 100).abs().to_numpy()
-    magnitude[~np.isfinite(magnitude)] = np.inf
+    score = bard(old.to_numpy(), new.to_numpy())
+    # One-sided NaN = a value appeared or disappeared = maximal change.
+    score = np.where(np.isnan(score), 1.0, score)
+    median_bard = float(np.median(score)) if len(score) else None
 
     # Positional (iloc) selection is safe even if `both` has a non-unique index.
-    order = np.argsort(-magnitude, kind="stable")[:limit]
+    order = np.argsort(-score, kind="stable")[:limit]
     top = both.iloc[order].copy()
 
     def _fmt_delta(o: float, n: float) -> str:
@@ -813,7 +823,7 @@ def _changed_records(both: pd.DataFrame, col: str, limit: int = SAMPLE_LIMIT) ->
         return f"{abs(n - o) / abs(o) * 100:.1f}%"
 
     top["Δ %"] = [_fmt_delta(o, n) for o, n in zip(old.iloc[order], new.iloc[order])]
-    return _df_to_records(top, limit=limit), True
+    return _df_to_records(top, limit=limit), True, median_bard
 
 
 def _data_diff(
@@ -873,10 +883,15 @@ def _data_diff(
         else:
             both = samp_a.join(samp_b, lsuffix=" -", rsuffix=" +")
         lines += _df_to_str(both)
-        records, sorted_by_delta = _changed_records(both, col)
+        records, sorted_by_delta, median_bard = _changed_records(both, col)
         value_diffs.append(
             ValueDiff(
-                kind="changed", count=int(neq.sum()), total=int(n), sample=records, sorted_by_delta=sorted_by_delta
+                kind="changed",
+                count=int(neq.sum()),
+                total=int(n),
+                sample=records,
+                sorted_by_delta=sorted_by_delta,
+                median_bard=median_bard,
             )
         )
 

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -130,6 +130,11 @@ class ColumnDiffResult:
             return max(v.severity for v in self.value_diffs)
         return 0.0
 
+    @property
+    def is_metadata_only(self) -> bool:
+        """A changed column whose diff carries no value changes at all — only metadata edits."""
+        return self.kind == "changed" and not self.value_diffs
+
 
 @dataclass
 class TableDiffResult:
@@ -254,6 +259,15 @@ class DatasetDiffResult:
         if self.change_kind == "new":
             return "small"
         return _tier(self.severity)
+
+    @property
+    def is_metadata_only(self) -> bool:
+        """A changed dataset whose diff carries no value changes anywhere — only metadata edits.
+
+        Stricter than `tier == "none"`: a dataset whose only change is *added* values also scores
+        0 (additions aren't anomalies) but is not metadata-only.
+        """
+        return self.change_kind == "changed" and not any(c.value_diffs for t in self.tables for c in t.columns)
 
 
 @dataclass
@@ -516,7 +530,8 @@ def _render_column(table_name: str, c: ColumnDiffResult, ds_path: str = "") -> s
     tier = _tier_chip(c.severity, c.kind) if not c.is_dim else ""
     anchor = f' id="{_anchor(ds_path, table_name, c.name)}"' if ds_path else ""
     # Dims are navigation context, not indicators — the indicator tier filter skips them.
-    tier_attr = f' data-tier="{_tier(c.severity)}"' if not c.is_dim else ""
+    # Metadata-only columns get their own filterable category ("meta") instead of a tier.
+    tier_attr = "" if c.is_dim else f' data-tier="{"meta" if c.is_metadata_only else _tier(c.severity)}"'
     parts = [
         f'<div class="col {c.kind}"{anchor}{tier_attr}>'
         f'<div class="col-head"><span class="sym {c.kind}">{_SYMBOLS[c.kind]}</span> '
@@ -575,7 +590,7 @@ def _render_dataset(ds: DatasetDiffResult) -> str:
         [ds.path] + [t.name for t in ds.tables] + [c.name for t in ds.tables for c in t.changed_columns]
     ).lower()
     parts = [
-        f'<details class="ds {kind}" id="{_ds_anchor(ds.path)}" data-tier="{ds.tier}" data-search="{_e(search)}"{open_attr}>'
+        f'<details class="ds {kind}" id="{_ds_anchor(ds.path)}" data-tier="{"meta" if ds.is_metadata_only else ds.tier}" data-search="{_e(search)}"{open_attr}>'
         f'<summary><span class="sym {kind}">{_SYMBOLS[kind]}</span> '
         f'<code class="path">{_e(ds.path)}</code>{new_version}{tier}{_coverage_chip(ds)}'
         f'<span class="ds-note">{_e(_dataset_summary_note(ds))}</span></summary>'
@@ -625,27 +640,37 @@ def render_html(report: DiffReport) -> str:
     # The tier dropdown offers only tiers that exist in the report (with their counts), and is
     # dropped entirely when there are fewer than two to tell apart — a filter with one choice
     # is dead weight.
+    n_meta_only_datasets = sum(1 for ds in report.datasets if ds.is_metadata_only)
     available_tiers = [t for t in ("large", "moderate", "small") if tier_counts[t]]
-    if len(available_tiers) >= 2:
+    if len(available_tiers) + (1 if n_meta_only_datasets else 0) >= 2:
         opts = "".join(f'<option value="{t}">{TIER_ICONS[t]} {t} ({tier_counts[t]})</option>' for t in available_tiers)
+        if n_meta_only_datasets:
+            opts += f'<option value="meta">📝 metadata-only ({n_meta_only_datasets})</option>'
         tier_select = f'<select id="tier-filter"><option value="all">all dataset tiers</option>{opts}</select>'
     else:
         tier_select = ""
 
     # Same for indicators: a dropdown filtering the column blocks by their tier (dims excluded).
     col_tier_counts = {"large": 0, "moderate": 0, "small": 0}
+    n_meta_only_cols = 0
     for ds in report.datasets:
         if ds.change_kind != "changed":
             continue
         for t in ds.tables:
             for c in t.columns:
-                if not c.is_dim and c.kind != "identical" and _tier(c.severity) != "none":
+                if c.is_dim or c.kind == "identical":
+                    continue
+                if c.is_metadata_only:
+                    n_meta_only_cols += 1
+                elif _tier(c.severity) != "none":
                     col_tier_counts[_tier(c.severity)] += 1
     available_col_tiers = [t for t in ("large", "moderate", "small") if col_tier_counts[t]]
-    if len(available_col_tiers) >= 2:
+    if len(available_col_tiers) + (1 if n_meta_only_cols else 0) >= 2:
         opts = "".join(
             f'<option value="{t}">{TIER_ICONS[t]} {t} ({col_tier_counts[t]})</option>' for t in available_col_tiers
         )
+        if n_meta_only_cols:
+            opts += f'<option value="meta">📝 metadata-only ({n_meta_only_cols})</option>'
         ind_tier_select = (
             f'<select id="ind-tier-filter"><option value="all">all indicator tiers</option>{opts}</select>'
         )
@@ -659,10 +684,16 @@ def render_html(report: DiffReport) -> str:
         strip_bits = [f"{TIER_ICONS[t]} {n} {t}" for t, n in tier_counts.items() if n]
         # Datasets whose only differences are metadata edits carry no anomaly tier — list them
         # separately so the strip total still matches the headline's differing-dataset count.
-        n_meta_only = sum(1 for ds in report.datasets if ds.change_kind == "changed" and ds.tier == "none")
+        # (A changed dataset can also score 0 from purely *added* values; that gets its own bucket.)
+        n_meta_only = sum(1 for ds in report.datasets if ds.is_metadata_only)
         if n_meta_only:
             strip_bits.append(f"📝 {n_meta_only} metadata-only")
-        n_diff = sum(tier_counts.values()) + n_meta_only
+        n_new_only = sum(
+            1 for ds in report.datasets if ds.change_kind == "changed" and ds.tier == "none" and not ds.is_metadata_only
+        )
+        if n_new_only:
+            strip_bits.append(f"➕ {n_new_only} new-data-only")
+        n_diff = sum(tier_counts.values()) + n_meta_only + n_new_only
         if strip_bits and n_diff:
             tier_strip = (
                 f'<div class="tier-strip">Of the {n_diff:,} dataset{"s" if n_diff != 1 else ""} with '
@@ -680,8 +711,10 @@ def render_html(report: DiffReport) -> str:
                 meta_html = '<span class="top-meta loss">failed to compare</span>'
             elif d.change_kind == "removed":
                 meta_html = '<span class="top-meta loss">removed dataset</span>'
-            elif d.severity <= 0:
+            elif d.is_metadata_only:
                 meta_html = '<span class="top-meta">metadata-only changes</span>'
+            elif d.severity <= 0:
+                meta_html = '<span class="top-meta">new data only</span>'
             else:
                 n_cols = sum(len(t.changed_columns) for t in d.tables)
                 n_tables = sum(1 for t in d.tables if t.any_change)
@@ -689,7 +722,7 @@ def render_html(report: DiffReport) -> str:
                 if d.removed_row_count:
                     meta_html += f'<span class="top-meta loss">− lost {d.removed_row_count:,} data point(s)</span>'
                 meta_html += f'<span class="top-meta">{n_cols} column(s) in {n_tables} table(s)</span>'
-            icon = TIER_ICONS.get(d.tier) or ("📝" if d.severity <= 0 else "")
+            icon = TIER_ICONS.get(d.tier) or ("📝" if d.is_metadata_only else "")
             ds_items.append(
                 f'<li><span class="ti">{icon}</span> '
                 f'<a href="#{_ds_anchor(d.path)}"><code>{_e(d.path)}</code></a>{meta_html}</li>'

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -384,22 +384,39 @@ def _coverage_chip(ds: DatasetDiffResult) -> str:
     return f'<span class="chip cov">− {_e(" · ".join(bits))}</span>'
 
 
-def _top_changes(report: "DiffReport", limit: int = TOP_CHANGES_LIMIT) -> list[tuple[float, float, str, str, str]]:
-    """The indicators to watch: (severity, pct_rows, ds_path, table, column) across all changed
-    datasets, biggest changes first. Dims are excluded — entity-level losses surface via the
-    coverage chip instead."""
-    rows = []
+def _top_changes(
+    report: "DiffReport", limit: int = TOP_CHANGES_LIMIT
+) -> tuple[list[tuple[int, list[str], str, str, str | None]], list[tuple[float, float, str, str, str]]]:
+    """The indicators to watch, as (losses, changes).
+
+    Losses — (n_rows_removed, labels, ds_path, table, dim_or_None) — are data points that existed
+    before and are gone after, the classic silent breakage of a dependency update. They always
+    lead the watch list, regardless of how small they are relative to the dataset.
+
+    Changes — (severity, pct_rows, ds_path, table, column) — are the biggest value changes.
+    """
+    losses = []
+    changes = []
     for ds in report.datasets:
         if ds.change_kind != "changed":
             continue
         for t in ds.tables:
+            if t.removed_row_count:
+                # Link to the dim column whose detail block holds the removed-rows sample.
+                dim = next(
+                    (c.name for c in t.columns if c.is_dim and any(v.kind == "removed" for v in c.value_diffs)),
+                    None,
+                )
+                losses.append((t.removed_row_count, t.removed_labels, ds.path, t.name, dim))
             for c in t.columns:
                 if c.is_dim or c.kind == "identical" or c.severity <= 0.001:
                     continue
                 pct = max((v.pct for v in c.value_diffs if v.kind != "new"), default=0.0)
-                rows.append((c.severity, pct, ds.path, t.name, c.name))
-    rows.sort(key=lambda r: (-r[0], -r[1], r[2]))
-    return rows[:limit]
+                changes.append((c.severity, pct, ds.path, t.name, c.name))
+    losses.sort(key=lambda r: (-r[0], r[2]))
+    changes.sort(key=lambda r: (-r[0], -r[1], r[2]))
+    losses = losses[:limit]
+    return losses, changes[: max(0, limit - len(losses))]
 
 
 def _render_meta_diff(meta_diff: str, label: str) -> str:
@@ -553,10 +570,22 @@ def render_html(report: DiffReport) -> str:
         if strip_bits:
             tier_strip = f'<div class="tier-strip">{" · ".join(strip_bits)} <span class="tier-hint">(by typical change size; coverage loss ⇒ 🔴)</span></div>'
 
-        top = _top_changes(report)
-        if top:
+        losses, changes = _top_changes(report)
+        if losses or changes:
             items = []
-            for severity, pct, ds_path, table, col in top:
+            # Data-point losses lead the list — make it unmistakable that rows disappeared.
+            for n_removed, labels, ds_path, table, dim in losses:
+                shown = ", ".join(labels[:4]) + ("…" if len(labels) > 4 else "")
+                link_open = f'<a href="#{_anchor(ds_path, table, dim)}">' if dim else ""
+                link_close = "</a>" if dim else ""
+                items.append(
+                    f'<li class="loss"><span class="ti">🔴</span> '
+                    f"{link_open}<code>{_e(ds_path)}</code> · <code>{_e(table)}</code>{link_close}"
+                    f'<span class="top-meta loss">− lost {n_removed:,} data point(s)'
+                    + (f": {_e(shown)}" if shown else "")
+                    + "</span></li>"
+                )
+            for severity, pct, ds_path, table, col in changes:
                 tier = _tier(severity)
                 items.append(
                     f'<li><span class="ti">{TIER_ICONS.get(tier, "")}</span> '
@@ -630,6 +659,7 @@ def render_html(report: DiffReport) -> str:
   details.top-changes a {{ text-decoration: none; color: inherit; }}
   details.top-changes a:hover code {{ background: #eef; }}
   .top-meta {{ color: #888; font-size: .78rem; margin-left: .5rem; }}
+  .top-meta.loss {{ color: #b71c1c; font-weight: 600; }}
   .ti {{ margin-right: .15rem; }}
   .tbl {{ margin: .75rem 0 0; }}
   .tbl-head {{ font-size: .9rem; margin-bottom: .25rem; }}

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -30,6 +30,9 @@ class ValueDiff:
     total: int
     # Display-ready records; rows of a "changed" diff have "<col> -" (old) and "<col> +" (new) keys.
     sample: list[dict[str, str]] = field(default_factory=list)
+    # True when the sample of a numeric "changed" diff is sorted by |relative change| (largest
+    # first) and carries a "Δ %" display column; non-numeric samples stay random and unsorted.
+    sorted_by_delta: bool = False
 
     @property
     def pct(self) -> float:
@@ -219,7 +222,11 @@ def _render_value_diff(v: ValueDiff) -> str:
             for c in cols
         )
         trs.append(f"<tr>{tds}</tr>")
-    note = f'<div class="note">showing {len(v.sample):,} of {v.count:,} rows</div>' if v.count > len(v.sample) else ""
+    if v.count > len(v.sample):
+        what = "largest relative changes" if v.sorted_by_delta else "rows"
+        note = f'<div class="note">showing {len(v.sample):,} {what} of {v.count:,} rows</div>'
+    else:
+        note = ""
     return (
         f'<div class="vd">{head}<div class="table-wrap"><table><thead><tr>{ths}</tr></thead>'
         f"<tbody>{''.join(trs)}</tbody></table></div>{note}</div>"

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -30,9 +30,13 @@ class ValueDiff:
     total: int
     # Display-ready records; rows of a "changed" diff have "<col> -" (old) and "<col> +" (new) keys.
     sample: list[dict[str, str]] = field(default_factory=list)
-    # True when the sample of a numeric "changed" diff is sorted by |relative change| (largest
-    # first) and carries a "Δ %" display column; non-numeric samples stay random and unsorted.
+    # True when the sample of a numeric "changed" diff is sorted by change size (largest first)
+    # and carries a "Δ %" display column; non-numeric samples stay random and unsorted.
     sorted_by_delta: bool = False
+    # Median BARD (|a-b| / (|a|+|b|), see `etl.data_helpers.misc.bard`) across ALL changed rows
+    # of a numeric column — the typical size of the change, bounded in [0, 1]. None when the
+    # column is non-numeric (or the diff is not of kind "changed").
+    median_bard: float | None = None
 
     @property
     def pct(self) -> float:
@@ -41,6 +45,20 @@ class ValueDiff:
     @property
     def symbol(self) -> str:
         return {"new": "+", "removed": "-", "changed": "~"}[self.kind]
+
+    @property
+    def severity(self) -> float:
+        """How big the differences are, in [0, 1] — the report's sort key.
+
+        Numeric changed diffs use their median BARD; non-numeric changes and removed values
+        count as a full change (a category flip / lost value has no meaningful "size"); purely
+        new values sort last — they're additions, not differences.
+        """
+        if self.kind == "new":
+            return 0.0
+        if self.median_bard is not None:
+            return self.median_bard
+        return 1.0
 
 
 @dataclass
@@ -52,6 +70,18 @@ class ColumnDiffResult:
     changes: list[str] = field(default_factory=list)
     meta_diff: str = ""
     value_diffs: list[ValueDiff] = field(default_factory=list)
+
+    @property
+    def severity(self) -> float:
+        """Biggest change among the column's value diffs; removed columns are maximal, new ones
+        minimal, metadata-only changes just above identical."""
+        if self.kind == "removed":
+            return 1.0
+        if self.kind == "new":
+            return 0.0
+        if self.value_diffs:
+            return max(v.severity for v in self.value_diffs)
+        return 0.001 if self.kind != "identical" else 0.0
 
 
 @dataclass
@@ -69,6 +99,13 @@ class TableDiffResult:
     @property
     def any_change(self) -> bool:
         return self.kind != "identical" or bool(self.changed_columns)
+
+    @property
+    def severity(self) -> float:
+        """A table is as critical as its most-changed column."""
+        s = max((c.severity for c in self.columns), default=0.0)
+        # Metadata-only table changes rank just above identical.
+        return max(s, 0.001) if self.kind != "identical" else s
 
 
 @dataclass
@@ -93,6 +130,22 @@ class DatasetDiffResult:
         if self.kind in ("new", "removed"):
             return self.kind
         return "changed" if self.any_change else "identical"
+
+    @property
+    def severity(self) -> float:
+        """A dataset is as critical as its most-changed table.
+
+        Comparison errors rank above everything (they hide unknown changes), removed datasets
+        above any value change (data loss), and brand-new datasets low (additions, self-evident
+        in a version bump).
+        """
+        if self.change_kind == "error":
+            return 3.0
+        if self.change_kind == "removed":
+            return 2.0
+        if self.change_kind == "new":
+            return 0.005
+        return max((t.severity for t in self.tables), default=0.0)
 
 
 @dataclass
@@ -256,7 +309,8 @@ def _render_table(t: TableDiffResult) -> str:
     ]
     if t.meta_diff:
         parts.append(_render_meta_diff(t.meta_diff, "table metadata diff"))
-    for c in t.columns:
+    # Most-changed columns first (stable: ties keep collection order).
+    for c in sorted(t.columns, key=lambda c: -c.severity):
         if c.kind == "identical":
             continue
         parts.append(_render_column(t.name, c))
@@ -297,7 +351,8 @@ def _render_dataset(ds: DatasetDiffResult) -> str:
         parts.append(f'<div class="error-msg">⚠ {_e(ds.error)}</div>')
     if ds.meta_diff:
         parts.append(_render_meta_diff(ds.meta_diff, "dataset metadata diff"))
-    for t in ds.tables:
+    # Most-changed tables first (stable: ties keep collection order).
+    for t in sorted(ds.tables, key=lambda t: -t.severity):
         if t.any_change or ds.kind in ("new", "removed"):
             parts.append(_render_table(t))
     parts.append("</div></details>")
@@ -322,9 +377,10 @@ def render_html(report: DiffReport) -> str:
                 f'<div class="card {kind}"><div class="count">{count:,}</div><div class="label">{label}</div></div>'
             )
 
-    # Changed/new/removed/errored datasets first, identical last.
-    order = {"error": 0, "changed": 1, "new": 2, "removed": 3, "identical": 4}
-    datasets = sorted(report.datasets, key=lambda ds: (order[ds.change_kind], ds.path))
+    # Biggest differences first: comparison errors, then removed datasets (data loss), then
+    # changed datasets ranked by the size of their changes (median BARD of the most-changed
+    # column), then new datasets; identical last. Path as tie-break for determinism.
+    datasets = sorted(report.datasets, key=lambda ds: (-ds.severity, ds.path))
     sections = "".join(_render_dataset(ds) for ds in datasets)
 
     skipped_note = (

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -477,7 +477,20 @@ def _render_meta_diff(meta_diff: str, label: str) -> str:
 
 def _render_value_diff(v: ValueDiff) -> str:
     label = {"new": "New values", "removed": "Removed values", "changed": "Changed values"}[v.kind]
-    head = f'<div class="vd-head {v.kind}">{_e(v.symbol)} {label}: {v.count:,} / {v.total:,} ({v.pct:.2f}%)</div>'
+    # Say up front that the table is a sample — a note below a 100-row scrollable table is only
+    # discovered after scrolling past rows the reader didn't know were truncated.
+    head_note = ""
+    if v.count > len(v.sample):
+        what = (
+            f"the {len(v.sample):,} most anomalous rows"
+            if v.sorted_by_score
+            else f"a random sample of {len(v.sample):,} rows"
+        )
+        head_note = f' <span class="head-note">— showing {what}</span>'
+    head = (
+        f'<div class="vd-head {v.kind}">{_e(v.symbol)} {label}: '
+        f"{v.count:,} / {v.total:,} ({v.pct:.2f}%){head_note}</div>"
+    )
     if not v.sample:
         return f'<div class="vd">{head}</div>'
 
@@ -492,14 +505,9 @@ def _render_value_diff(v: ValueDiff) -> str:
             for c in cols
         )
         trs.append(f"<tr>{tds}</tr>")
-    if v.count > len(v.sample):
-        what = "most anomalous" if v.sorted_by_score else "rows"
-        note = f'<div class="note">showing the {len(v.sample):,} {what} of {v.count:,} rows</div>'
-    else:
-        note = ""
     return (
         f'<div class="vd">{head}<div class="table-wrap"><table><thead><tr>{ths}</tr></thead>'
-        f"<tbody>{''.join(trs)}</tbody></table></div>{note}</div>"
+        f"<tbody>{''.join(trs)}</tbody></table></div></div>"
     )
 
 
@@ -808,6 +816,7 @@ def render_html(report: DiffReport) -> str:
   .vd-head.new {{ color: #2e7d32; }}
   .vd-head.removed {{ color: #c62828; }}
   .vd-head.changed {{ color: #8a6d00; }}
+  .vd-head .head-note {{ color: #888; font-weight: 400; font-size: .75rem; }}
   .table-wrap {{ overflow-x: auto; max-height: 420px; overflow-y: auto; border: 1px solid #eee; border-radius: 6px; display: inline-block; max-width: 100%; }}
   .vd table {{ border-collapse: collapse; font-size: .78rem; }}
   .vd th, .vd td {{ padding: .3rem .6rem; border-bottom: 1px solid #f0f0f0; text-align: left; white-space: nowrap; }}

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -262,12 +262,23 @@ class DatasetDiffResult:
 
     @property
     def is_metadata_only(self) -> bool:
-        """A changed dataset whose diff carries no value changes anywhere — only metadata edits.
+        """A changed dataset whose diff is purely metadata edits: no value changes anywhere and
+        no structural changes (added/removed tables or columns) either.
 
         Stricter than `tier == "none"`: a dataset whose only change is *added* values also scores
-        0 (additions aren't anomalies) but is not metadata-only.
+        0 (additions aren't anomalies) but is not metadata-only. Structural changes matter too —
+        a removed table/column is coverage loss (🔴), and classifying it "meta" would let the
+        tier filter hide it.
         """
-        return self.change_kind == "changed" and not any(c.value_diffs for t in self.tables for c in t.columns)
+        if self.change_kind != "changed":
+            return False
+        for t in self.tables:
+            if t.kind in ("new", "removed"):
+                return False
+            for c in t.columns:
+                if c.kind in ("new", "removed") or c.value_diffs:
+                    return False
+        return True
 
 
 @dataclass

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -11,6 +11,7 @@ This module must not import from `etl.datadiff` to avoid a circular dependency.
 import datetime as dt
 import html
 import json
+import re
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
@@ -19,6 +20,43 @@ ChangeKind = Literal["new", "removed", "changed", "identical", "error"]
 # Number of sample rows stored per value diff (the text output shows only 5; the HTML report
 # can afford more).
 SAMPLE_LIMIT = 100
+
+# Severity tiers (thresholds on the BARD-based severity score in [0, 1]): they tell a reviewer
+# where to stop reading. In "typical relative change" terms: large ≳ 35%, moderate ≳ 2%,
+# small = anything non-zero below that (usually rounding-level noise).
+Tier = Literal["large", "moderate", "small", "none"]
+TIER_LARGE = 0.15
+TIER_MODERATE = 0.01
+TIER_ICONS = {"large": "🔴", "moderate": "🟡", "small": "🟢"}
+
+# Entries shown in the "Top changes" watch list at the head of the report.
+TOP_CHANGES_LIMIT = 15
+# The triage aids (Top changes section, tier strip) only appear when there's something to
+# triage: a report with a couple of changed datasets is already scannable, and on the common
+# single-dataset PR they'd be redundant noise. Per-row tier chips render at any size.
+TRIAGE_MIN_DATASETS = 3
+
+
+def _tier(severity: float) -> Tier:
+    if severity >= TIER_LARGE:
+        return "large"
+    if severity >= TIER_MODERATE:
+        return "moderate"
+    if severity > 0:
+        return "small"
+    return "none"
+
+
+def _bard_to_rel(severity: float) -> str:
+    """Human-readable typical relative change for a BARD-based severity.
+
+    For same-sign values, BARD t corresponds to a relative change of 2t/(1-t) — e.g. t=0.2 is a
+    ~50% change. Above ~0.83 the equivalent exceeds 1000%, where a precise number stops being
+    informative.
+    """
+    if severity >= 0.83:
+        return ">1000%"
+    return f"~{200 * severity / (1 - severity):.0f}%"
 
 
 @dataclass
@@ -50,12 +88,15 @@ class ValueDiff:
     def severity(self) -> float:
         """How big the differences are, in [0, 1] — the report's sort key.
 
-        Numeric changed diffs use their median BARD; non-numeric changes and removed values
-        count as a full change (a category flip / lost value has no meaningful "size"); purely
-        new values sort last — they're additions, not differences.
+        Numeric changed diffs use their median BARD; non-numeric changes count as a full change
+        (a category flip has no meaningful "size"); removed values scale with the share of rows
+        lost (coverage loss is additionally surfaced by the dataset's coverage chip, which forces
+        the 🔴 tier); purely new values sort last — they're additions, not differences.
         """
         if self.kind == "new":
             return 0.0
+        if self.kind == "removed":
+            return self.pct / 100
         if self.median_bard is not None:
             return self.median_bard
         return 1.0
@@ -107,6 +148,32 @@ class TableDiffResult:
         # Metadata-only table changes rank just above identical.
         return max(s, 0.001) if self.kind != "identical" else s
 
+    @property
+    def removed_row_count(self) -> int:
+        """Rows present before and gone after (index-level removals; coverage loss)."""
+        # All dims of a table share the same removed index rows — the first dim suffices.
+        for c in self.columns:
+            if c.is_dim:
+                for v in c.value_diffs:
+                    if v.kind == "removed":
+                        return v.count
+        return 0
+
+    @property
+    def removed_labels(self) -> list[str]:
+        """Entity/dim labels of removed rows (from the stored sample, so possibly a subset)."""
+        for c in self.columns:
+            if c.is_dim:
+                for v in c.value_diffs:
+                    if v.kind == "removed":
+                        seen: list[str] = []
+                        for row in v.sample:
+                            label = row.get(c.name, "")
+                            if label and label not in seen:
+                                seen.append(label)
+                        return seen
+        return []
+
 
 @dataclass
 class DatasetDiffResult:
@@ -146,6 +213,43 @@ class DatasetDiffResult:
         if self.change_kind == "new":
             return 0.005
         return max((t.severity for t in self.tables), default=0.0)
+
+    @property
+    def removed_row_count(self) -> int:
+        return sum(t.removed_row_count for t in self.tables)
+
+    @property
+    def removed_labels(self) -> list[str]:
+        seen: list[str] = []
+        for t in self.tables:
+            for label in t.removed_labels:
+                if label not in seen:
+                    seen.append(label)
+        return seen
+
+    @property
+    def has_coverage_loss(self) -> bool:
+        """Rows/entities, columns or whole tables that existed before and are gone after."""
+        return (
+            self.removed_row_count > 0
+            or any(t.kind == "removed" for t in self.tables)
+            or any(c.kind == "removed" for t in self.tables for c in t.columns)
+        )
+
+    @property
+    def tier(self) -> Tier:
+        """Reviewer triage tier. Coverage loss always makes a dataset 🔴 — a disappearing
+        entity/series is the classic silent breakage of a dependency update, regardless of how
+        small it is relative to the dataset."""
+        if self.change_kind in ("error", "removed"):
+            return "large"
+        if self.change_kind == "identical":
+            return "none"
+        if self.has_coverage_loss:
+            return "large"
+        if self.change_kind == "new":
+            return "small"
+        return _tier(self.severity)
 
 
 @dataclass
@@ -247,6 +351,57 @@ def _e(s: Any) -> str:
     return html.escape(str(s))
 
 
+def _anchor(ds_path: str, table: str, col: str) -> str:
+    """Stable element id for a column's detail block, so the Top changes list can link to it."""
+    return "c-" + re.sub(r"[^a-z0-9]+", "-", f"{ds_path}-{table}-{col}".lower()).strip("-")
+
+
+def _tier_chip(severity: float, kind: ChangeKind = "changed") -> str:
+    """Colored triage chip: tier icon + the typical relative change it corresponds to."""
+    tier = _tier(severity)
+    if tier == "none":
+        return ""
+    label = {"removed": "removed", "new": "new"}.get(kind) or f"typical change {_bard_to_rel(severity)}"
+    return f'<span class="chip tier {tier}">{TIER_ICONS[tier]} {_e(label)}</span>'
+
+
+def _coverage_chip(ds: DatasetDiffResult) -> str:
+    """Coverage-loss chip: entities/rows that existed before and are gone after."""
+    if not ds.has_coverage_loss:
+        return ""
+    bits = []
+    if ds.removed_row_count:
+        labels = ds.removed_labels[:4]
+        shown = ", ".join(labels)
+        more = "…" if len(ds.removed_labels) > len(labels) else ""
+        bits.append(f"{ds.removed_row_count:,} row(s) removed" + (f": {shown}{more}" if shown else ""))
+    n_removed_cols = sum(1 for t in ds.tables for c in t.columns if c.kind == "removed")
+    if n_removed_cols:
+        bits.append(f"{n_removed_cols} column(s) removed")
+    n_removed_tables = sum(1 for t in ds.tables if t.kind == "removed")
+    if n_removed_tables:
+        bits.append(f"{n_removed_tables} table(s) removed")
+    return f'<span class="chip cov">− {_e(" · ".join(bits))}</span>'
+
+
+def _top_changes(report: "DiffReport", limit: int = TOP_CHANGES_LIMIT) -> list[tuple[float, float, str, str, str]]:
+    """The indicators to watch: (severity, pct_rows, ds_path, table, column) across all changed
+    datasets, biggest changes first. Dims are excluded — entity-level losses surface via the
+    coverage chip instead."""
+    rows = []
+    for ds in report.datasets:
+        if ds.change_kind != "changed":
+            continue
+        for t in ds.tables:
+            for c in t.columns:
+                if c.is_dim or c.kind == "identical" or c.severity <= 0.001:
+                    continue
+                pct = max((v.pct for v in c.value_diffs if v.kind != "new"), default=0.0)
+                rows.append((c.severity, pct, ds.path, t.name, c.name))
+    rows.sort(key=lambda r: (-r[0], -r[1], r[2]))
+    return rows[:limit]
+
+
 def _render_meta_diff(meta_diff: str, label: str) -> str:
     """Render an ndiff metadata diff as a collapsible block with +/- lines colored."""
     if not meta_diff:
@@ -286,13 +441,15 @@ def _render_value_diff(v: ValueDiff) -> str:
     )
 
 
-def _render_column(table_name: str, c: ColumnDiffResult) -> str:
+def _render_column(table_name: str, c: ColumnDiffResult, ds_path: str = "") -> str:
     chips = "".join(f'<span class="chip">{_e(ch)}</span>' for ch in c.changes)
     dim = '<span class="chip dim">dim</span>' if c.is_dim else ""
+    tier = _tier_chip(c.severity, c.kind) if not c.is_dim else ""
+    anchor = f' id="{_anchor(ds_path, table_name, c.name)}"' if ds_path else ""
     parts = [
-        f'<div class="col {c.kind}">'
+        f'<div class="col {c.kind}"{anchor}>'
         f'<div class="col-head"><span class="sym {c.kind}">{_SYMBOLS[c.kind]}</span> '
-        f"<code>{_e(table_name)}.{_e(c.name)}</code> {dim}{chips}</div>"
+        f"<code>{_e(table_name)}.{_e(c.name)}</code> {dim}{tier}{chips}</div>"
     ]
     if c.meta_diff:
         parts.append(_render_meta_diff(c.meta_diff, "metadata diff"))
@@ -302,10 +459,10 @@ def _render_column(table_name: str, c: ColumnDiffResult) -> str:
     return "".join(parts)
 
 
-def _render_table(t: TableDiffResult) -> str:
+def _render_table(t: TableDiffResult, ds_path: str = "") -> str:
     parts = [
         f'<div class="tbl"><div class="tbl-head"><span class="sym {t.kind}">{_SYMBOLS[t.kind]}</span> '
-        f"Table <b>{_e(t.name)}</b></div>"
+        f"Table <b>{_e(t.name)}</b>{_tier_chip(t.severity, t.kind)}</div>"
     ]
     if t.meta_diff:
         parts.append(_render_meta_diff(t.meta_diff, "table metadata diff"))
@@ -313,7 +470,7 @@ def _render_table(t: TableDiffResult) -> str:
     for c in sorted(t.columns, key=lambda c: -c.severity):
         if c.kind == "identical":
             continue
-        parts.append(_render_column(t.name, c))
+        parts.append(_render_column(t.name, c, ds_path))
     parts.append("</div>")
     return "".join(parts)
 
@@ -340,10 +497,11 @@ def _render_dataset(ds: DatasetDiffResult) -> str:
     kind = ds.change_kind
     open_attr = " open" if kind in ("changed", "error") else ""
     new_version = ' <span class="chip">new version</span>' if ds.is_new_version else ""
+    tier = _tier_chip(ds.severity, kind) if kind == "changed" else ""
     parts = [
         f'<details class="ds {kind}"{open_attr}>'
         f'<summary><span class="sym {kind}">{_SYMBOLS[kind]}</span> '
-        f'<code class="path">{_e(ds.path)}</code>{new_version}'
+        f'<code class="path">{_e(ds.path)}</code>{new_version}{tier}{_coverage_chip(ds)}'
         f'<span class="ds-note">{_e(_dataset_summary_note(ds))}</span></summary>'
         f'<div class="ds-body">'
     ]
@@ -354,7 +512,7 @@ def _render_dataset(ds: DatasetDiffResult) -> str:
     # Most-changed tables first (stable: ties keep collection order).
     for t in sorted(ds.tables, key=lambda t: -t.severity):
         if t.any_change or ds.kind in ("new", "removed"):
-            parts.append(_render_table(t))
+            parts.append(_render_table(t, ds.path))
     parts.append("</div></details>")
     return "".join(parts)
 
@@ -382,6 +540,33 @@ def render_html(report: DiffReport) -> str:
     # column), then new datasets; identical last. Path as tie-break for determinism.
     datasets = sorted(report.datasets, key=lambda ds: (-ds.severity, ds.path))
     sections = "".join(_render_dataset(ds) for ds in datasets)
+
+    # Triage aids — only when the report is big enough to need them.
+    tier_strip = ""
+    top_block = ""
+    if report.n_changed >= TRIAGE_MIN_DATASETS:
+        tier_counts = {"large": 0, "moderate": 0, "small": 0}
+        for ds in report.datasets:
+            if ds.change_kind != "identical" and ds.tier != "none":
+                tier_counts[ds.tier] += 1
+        strip_bits = [f"{TIER_ICONS[t]} {n} {t}" for t, n in tier_counts.items() if n]
+        if strip_bits:
+            tier_strip = f'<div class="tier-strip">{" · ".join(strip_bits)} <span class="tier-hint">(by typical change size; coverage loss ⇒ 🔴)</span></div>'
+
+        top = _top_changes(report)
+        if top:
+            items = []
+            for severity, pct, ds_path, table, col in top:
+                tier = _tier(severity)
+                items.append(
+                    f'<li><span class="ti">{TIER_ICONS.get(tier, "")}</span> '
+                    f'<a href="#{_anchor(ds_path, table, col)}"><code>{_e(ds_path)}</code> · <code>{_e(table)}.{_e(col)}</code></a>'
+                    f'<span class="top-meta">typical change {_e(_bard_to_rel(severity))} · {pct:.0f}% of rows</span></li>'
+                )
+            top_block = (
+                '<details class="top-changes" open><summary><b>Top changes — indicators to watch</b></summary>'
+                f"<ol>{''.join(items)}</ol></details>"
+            )
 
     skipped_note = (
         f'<div class="skipped-note">= {report.skipped_cascade:,} more dataset(s) skipped: '
@@ -432,6 +617,20 @@ def render_html(report: DiffReport) -> str:
   .sym.error {{ color: #c62828; }}
   .chip {{ font-size: .7rem; background: #fdf3d7; color: #8a6d00; border-radius: 10px; padding: .1rem .5rem; margin-left: .3rem; white-space: nowrap; }}
   .chip.dim {{ background: #e8eaf6; color: #3949ab; }}
+  .chip.tier.large {{ background: #fdeaea; color: #b71c1c; }}
+  .chip.tier.moderate {{ background: #fdf3d7; color: #8a6d00; }}
+  .chip.tier.small {{ background: #e9f6ec; color: #1b5e20; }}
+  .chip.cov {{ background: #fdeaea; color: #b71c1c; font-weight: 600; }}
+  .tier-strip {{ font-size: .9rem; margin: -0.75rem 0 1rem; }}
+  .tier-strip .tier-hint {{ color: #999; font-size: .78rem; }}
+  details.top-changes {{ background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; padding: .6rem 1rem; margin-bottom: 1rem; }}
+  details.top-changes > summary {{ cursor: pointer; font-size: .95rem; }}
+  details.top-changes ol {{ margin: .5rem 0 .25rem; padding-left: 1.5rem; }}
+  details.top-changes li {{ font-size: .85rem; margin: .25rem 0; }}
+  details.top-changes a {{ text-decoration: none; color: inherit; }}
+  details.top-changes a:hover code {{ background: #eef; }}
+  .top-meta {{ color: #888; font-size: .78rem; margin-left: .5rem; }}
+  .ti {{ margin-right: .15rem; }}
   .tbl {{ margin: .75rem 0 0; }}
   .tbl-head {{ font-size: .9rem; margin-bottom: .25rem; }}
   .col {{ margin: .5rem 0 .5rem 1.5rem; }}
@@ -463,6 +662,8 @@ def render_html(report: DiffReport) -> str:
   <div class="sub">generated {generated_at} · <code>etl diff</code> report</div>
   <div class="headline">{_STATUS_HEADLINE[report.status]}</div>
   <div class="cards">{"".join(cards)}</div>
+  {tier_strip}
+  {top_block}
   <div class="controls">
     <input type="search" id="filter" placeholder="Filter datasets (path, table, column…)">
     <label><input type="checkbox" id="show-identical"> show identical datasets</label>

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -599,23 +599,22 @@ def render_html(report: DiffReport) -> str:
         watch = sorted((d for d in datasets if d.change_kind in ("changed", "error", "removed")), key=_watch_key)
         ds_items = []
         for d in watch[:TOP_DATASETS_LIMIT]:
+            # Red is reserved for the alarming part only: the data-loss fragment (or a dataset
+            # that failed to compare / was removed) — not the whole meta line.
             if d.change_kind == "error":
-                meta = "failed to compare"
+                meta_html = '<span class="top-meta loss">failed to compare</span>'
             elif d.change_kind == "removed":
-                meta = "removed dataset"
+                meta_html = '<span class="top-meta loss">removed dataset</span>'
             else:
-                bits = [f"median anomaly score {format_score(d.severity)}"]
-                if d.removed_row_count:
-                    bits.append(f"− lost {d.removed_row_count:,} data point(s)")
                 n_cols = sum(len(t.changed_columns) for t in d.tables)
                 n_tables = sum(1 for t in d.tables if t.any_change)
-                bits.append(f"{n_cols} column(s) in {n_tables} table(s)")
-                meta = " · ".join(bits)
-            loss_cls = " loss" if d.change_kind != "changed" or d.has_coverage_loss else ""
+                meta_html = f'<span class="top-meta">median anomaly score {_e(format_score(d.severity))}</span>'
+                if d.removed_row_count:
+                    meta_html += f'<span class="top-meta loss">− lost {d.removed_row_count:,} data point(s)</span>'
+                meta_html += f'<span class="top-meta">{n_cols} column(s) in {n_tables} table(s)</span>'
             ds_items.append(
                 f'<li><span class="ti">{TIER_ICONS.get(d.tier, "")}</span> '
-                f'<a href="#{_ds_anchor(d.path)}"><code>{_e(d.path)}</code></a>'
-                f'<span class="top-meta{loss_cls}">{_e(meta)}</span></li>'
+                f'<a href="#{_ds_anchor(d.path)}"><code>{_e(d.path)}</code></a>{meta_html}</li>'
             )
 
         losses, changes = _top_changes(report)

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -372,9 +372,23 @@ def _ds_anchor(ds_path: str) -> str:
     return "d-" + re.sub(r"[^a-z0-9]+", "-", ds_path.lower()).strip("-")
 
 
-def _tier_chip(severity: float, kind: ChangeKind = "changed") -> str:
-    """Colored triage chip: tier icon + the typical relative change it corresponds to."""
-    tier = _tier(severity)
+def dataset_watch_key(ds: DatasetDiffResult) -> tuple:
+    """Triage sort key for dataset summaries (watch list, owidbot PR comment): tier first, and
+    within a tier data loss (or a failed/removed dataset) outranks a bigger-but-benign change;
+    then change size. Plain severity ordering would let a truncated summary drop a small-but-lossy
+    dataset below big value changes — defeating the "data loss is unmissable" signal."""
+    tier_rank = {"large": 0, "moderate": 1, "small": 2, "none": 3}
+    lossy_first = 0 if (ds.change_kind in ("error", "removed") or ds.has_coverage_loss) else 1
+    return (tier_rank[ds.tier], lossy_first, -ds.severity, ds.path)
+
+
+def _tier_chip(severity: float, kind: ChangeKind = "changed", tier: Tier | None = None) -> str:
+    """Colored triage chip: tier icon + the score it corresponds to.
+
+    Pass `tier` to override the severity-derived tier — a dataset with coverage loss is forced
+    🔴 by `DatasetDiffResult.tier`, and its chip must agree with the tier strip and filters.
+    """
+    tier = tier or _tier(severity)
     if tier == "none":
         return ""
     label = {"removed": "removed", "new": "new"}.get(kind) or f"median anomaly score {format_score(severity)}"
@@ -547,7 +561,7 @@ def _render_dataset(ds: DatasetDiffResult) -> str:
     kind = ds.change_kind
     open_attr = " open" if kind in ("changed", "error") else ""
     new_version = ' <span class="chip">new version</span>' if ds.is_new_version else ""
-    tier = _tier_chip(ds.severity, kind) if kind == "changed" else ""
+    tier = _tier_chip(ds.severity, kind, tier=ds.tier) if kind == "changed" else ""
     # What the filter box matches against: names only (path, tables, changed columns) — matching
     # the full text would make queries hit sample values and scores, which is pure noise.
     search = " ".join(
@@ -644,15 +658,8 @@ def render_html(report: DiffReport) -> str:
                 f'<span class="tier-hint">(tiered by median anomaly score; coverage loss ⇒ 🔴)</span></div>'
             )
 
-        # Datasets to watch: tier first, and within a tier data loss (or a failed/removed
-        # dataset) outranks a bigger-but-benign change; then change size.
-        tier_rank = {"large": 0, "moderate": 1, "small": 2, "none": 3}
-
-        def _watch_key(d: DatasetDiffResult) -> tuple:
-            lossy_first = 0 if (d.change_kind in ("error", "removed") or d.has_coverage_loss) else 1
-            return (tier_rank[d.tier], lossy_first, -d.severity, d.path)
-
-        watch = sorted((d for d in datasets if d.change_kind in ("changed", "error", "removed")), key=_watch_key)
+        # Datasets to watch, in triage order (see dataset_watch_key).
+        watch = sorted((d for d in datasets if d.change_kind in ("changed", "error", "removed")), key=dataset_watch_key)
         ds_items = []
         for d in watch[:TOP_DATASETS_MAX]:
             # Red is reserved for the alarming part only: the data-loss fragment (or a dataset

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -120,14 +120,15 @@ class ColumnDiffResult:
     @property
     def severity(self) -> float:
         """Biggest change among the column's value diffs; removed columns are maximal, new ones
-        minimal, metadata-only changes just above identical."""
+        minimal. Metadata-only changes score 0 — they are not anomalies, so they get no tier and
+        no score chip (they surface as "metadata-only" instead)."""
         if self.kind == "removed":
             return 1.0
         if self.kind == "new":
             return 0.0
         if self.value_diffs:
             return max(v.severity for v in self.value_diffs)
-        return 0.001 if self.kind != "identical" else 0.0
+        return 0.0
 
 
 @dataclass
@@ -148,10 +149,8 @@ class TableDiffResult:
 
     @property
     def severity(self) -> float:
-        """A table is as critical as its most-changed column."""
-        s = max((c.severity for c in self.columns), default=0.0)
-        # Metadata-only table changes rank just above identical.
-        return max(s, 0.001) if self.kind != "identical" else s
+        """A table is as critical as its most-changed column (metadata-only changes score 0)."""
+        return max((c.severity for c in self.columns), default=0.0)
 
     @property
     def removed_row_count(self) -> int:
@@ -439,7 +438,7 @@ def _top_changes(
                 )
                 losses.append((t.removed_row_count, t.removed_labels, ds.path, t.name, dim))
             for c in t.columns:
-                if c.is_dim or c.kind == "identical" or c.severity <= 0.001:
+                if c.is_dim or c.kind == "identical" or c.severity <= 0:
                     continue
                 pct = max((v.pct for v in c.value_diffs if v.kind != "new"), default=0.0)
                 changes.append((c.severity, pct, ds.path, t.name, c.name))
@@ -658,10 +657,15 @@ def render_html(report: DiffReport) -> str:
     top_block = ""
     if report.n_changed >= TRIAGE_MIN_DATASETS:
         strip_bits = [f"{TIER_ICONS[t]} {n} {t}" for t, n in tier_counts.items() if n]
-        n_tiered = sum(tier_counts.values())
-        if strip_bits and n_tiered:
+        # Datasets whose only differences are metadata edits carry no anomaly tier — list them
+        # separately so the strip total still matches the headline's differing-dataset count.
+        n_meta_only = sum(1 for ds in report.datasets if ds.change_kind == "changed" and ds.tier == "none")
+        if n_meta_only:
+            strip_bits.append(f"📝 {n_meta_only} metadata-only")
+        n_diff = sum(tier_counts.values()) + n_meta_only
+        if strip_bits and n_diff:
             tier_strip = (
-                f'<div class="tier-strip">Of the {n_tiered:,} dataset{"s" if n_tiered != 1 else ""} with '
+                f'<div class="tier-strip">Of the {n_diff:,} dataset{"s" if n_diff != 1 else ""} with '
                 f"differences, the changes are: {' · '.join(strip_bits)} "
                 f'<span class="tier-hint">(tiered by median anomaly score; coverage loss ⇒ 🔴)</span></div>'
             )
@@ -676,6 +680,8 @@ def render_html(report: DiffReport) -> str:
                 meta_html = '<span class="top-meta loss">failed to compare</span>'
             elif d.change_kind == "removed":
                 meta_html = '<span class="top-meta loss">removed dataset</span>'
+            elif d.severity <= 0:
+                meta_html = '<span class="top-meta">metadata-only changes</span>'
             else:
                 n_cols = sum(len(t.changed_columns) for t in d.tables)
                 n_tables = sum(1 for t in d.tables if t.any_change)

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -525,8 +525,13 @@ def _render_dataset(ds: DatasetDiffResult) -> str:
     open_attr = " open" if kind in ("changed", "error") else ""
     new_version = ' <span class="chip">new version</span>' if ds.is_new_version else ""
     tier = _tier_chip(ds.severity, kind) if kind == "changed" else ""
+    # What the filter box matches against: names only (path, tables, changed columns) — matching
+    # the full text would make queries hit sample values and scores, which is pure noise.
+    search = " ".join(
+        [ds.path] + [t.name for t in ds.tables] + [c.name for t in ds.tables for c in t.changed_columns]
+    ).lower()
     parts = [
-        f'<details class="ds {kind}" id="{_ds_anchor(ds.path)}"{open_attr}>'
+        f'<details class="ds {kind}" id="{_ds_anchor(ds.path)}" data-tier="{ds.tier}" data-search="{_e(search)}"{open_attr}>'
         f'<summary><span class="sym {kind}">{_SYMBOLS[kind]}</span> '
         f'<code class="path">{_e(ds.path)}</code>{new_version}{tier}{_coverage_chip(ds)}'
         f'<span class="ds-note">{_e(_dataset_summary_note(ds))}</span></summary>'
@@ -676,7 +681,10 @@ def render_html(report: DiffReport) -> str:
   details.ds > summary:hover {{ background: #fcfcff; }}
   details.ds.identical {{ display: none; }}
   body.show-identical details.ds.identical {{ display: block; }}
+  details.ds.identical.match-visible {{ display: block; }}
   details.ds.hidden {{ display: none !important; }}
+  select {{ padding: .45rem .5rem; border: 1px solid #ccc; border-radius: 6px; font-size: .85rem; background: #fff; }}
+  .match-count {{ color: #999; font-size: .8rem; margin-left: auto; }}
   .ds-body {{ padding: .25rem 1rem 1rem; border-top: 1px solid #f0f0f0; }}
   .ds-note {{ margin-left: auto; color: #999; font-size: .8rem; }}
   code {{ font-size: .82rem; background: #f3f3f3; padding: .1rem .3rem; border-radius: 3px; }}
@@ -742,19 +750,50 @@ def render_html(report: DiffReport) -> str:
   {top_block}
   <div class="controls">
     <input type="search" id="filter" placeholder="Filter datasets (path, table, column…)">
+    <select id="tier-filter">
+      <option value="all">all tiers</option>
+      <option value="large">🔴 large</option>
+      <option value="moderate">🟡 moderate</option>
+      <option value="small">🟢 small</option>
+    </select>
     <label><input type="checkbox" id="show-identical"> show identical datasets</label>
+    <span class="match-count" id="match-count"></span>
   </div>
   {sections}
   {skipped_note}
 <script>
   const dsBlocks = Array.from(document.querySelectorAll('details.ds'));
-  document.getElementById('show-identical').addEventListener('change', (e) => {{
+  const filterInput = document.getElementById('filter');
+  const tierSelect = document.getElementById('tier-filter');
+  const showIdentical = document.getElementById('show-identical');
+  const matchCount = document.getElementById('match-count');
+
+  function applyFilters() {{
+    // Multi-term AND over names only (path + table + changed-column names, via data-search).
+    const terms = filterInput.value.toLowerCase().split(/\\s+/).filter(Boolean);
+    const tier = tierSelect.value;
+    const filtering = terms.length > 0 || tier !== 'all';
+    let shown = 0;
+    dsBlocks.forEach(d => {{
+      const hay = d.dataset.search || '';
+      const match = terms.every(t => hay.includes(t)) && (tier === 'all' || d.dataset.tier === tier);
+      d.classList.toggle('hidden', !match);
+      // An active filter reveals matching identical datasets even when the toggle is off —
+      // searching for a dataset you know was compared should always find it.
+      d.classList.toggle('match-visible', match && filtering);
+      const visible = match && (!d.classList.contains('identical') || showIdentical.checked || filtering);
+      if (visible) shown++;
+    }});
+    matchCount.textContent = `${{shown}} of ${{dsBlocks.length}} datasets shown`;
+  }}
+
+  showIdentical.addEventListener('change', (e) => {{
     document.body.classList.toggle('show-identical', e.target.checked);
+    applyFilters();
   }});
-  document.getElementById('filter').addEventListener('input', (e) => {{
-    const q = e.target.value.toLowerCase();
-    dsBlocks.forEach(d => d.classList.toggle('hidden', !d.textContent.toLowerCase().includes(q)));
-  }});
+  filterInput.addEventListener('input', applyFilters);
+  tierSelect.addEventListener('change', applyFilters);
+  applyFilters();
 </script>
 </body>
 </html>

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -689,8 +689,9 @@ def render_html(report: DiffReport) -> str:
                 if d.removed_row_count:
                     meta_html += f'<span class="top-meta loss">− lost {d.removed_row_count:,} data point(s)</span>'
                 meta_html += f'<span class="top-meta">{n_cols} column(s) in {n_tables} table(s)</span>'
+            icon = TIER_ICONS.get(d.tier) or ("📝" if d.severity <= 0 else "")
             ds_items.append(
-                f'<li><span class="ti">{TIER_ICONS.get(d.tier, "")}</span> '
+                f'<li><span class="ti">{icon}</span> '
                 f'<a href="#{_ds_anchor(d.path)}"><code>{_e(d.path)}</code></a>{meta_html}</li>'
             )
 

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -21,9 +21,9 @@ ChangeKind = Literal["new", "removed", "changed", "identical", "error"]
 # can afford more).
 SAMPLE_LIMIT = 100
 
-# Severity tiers (thresholds on the BARD-based severity score in [0, 1]): they tell a reviewer
-# where to stop reading. In "typical relative change" terms: large ≳ 35%, moderate ≳ 2%,
-# small = anything non-zero below that (usually rounding-level noise).
+# Severity tiers (thresholds on the BARD-based anomaly score, stored in [0, 1] and displayed
+# as a percentage): they tell a reviewer where to stop reading. large = score ≥ 15%, moderate
+# ≥ 1%, small = anything non-zero below that (usually rounding-level noise).
 Tier = Literal["large", "moderate", "small", "none"]
 TIER_LARGE = 0.15
 TIER_MODERATE = 0.01
@@ -49,13 +49,16 @@ def _tier(severity: float) -> Tier:
 
 
 def format_score(score: float) -> str:
-    """Display format for an anomaly score (BARD, in [0, 1]).
+    """Display format for an anomaly score: a percentage in [0, 100], like Anomalist shows it.
 
-    Two decimals normally; three below 0.01 so the "small" tier doesn't collapse to 0.00. As a
-    rule of thumb for same-sign values, a score t corresponds to a relative change of 2t/(1-t):
-    0.01 ≈ 2%, 0.15 ≈ 35%, 0.5 ≈ 200%.
+    Integer above 10%, more precision below so the smaller tiers don't collapse to 0%. As a rule
+    of thumb for same-sign values, a score of s% corresponds to a relative change of roughly
+    2s/(100-s): 1% ≈ 2%, 15% ≈ 35%, 50% ≈ 200%.
     """
-    return f"{score:.2f}" if score >= 0.01 else f"{score:.3f}"
+    pct = 100 * score
+    if pct >= 10:
+        return f"{pct:.0f}%"
+    return f"{pct:.1f}%" if pct >= 1 else f"{pct:.2f}%"
 
 
 @dataclass
@@ -371,7 +374,7 @@ def _tier_chip(severity: float, kind: ChangeKind = "changed") -> str:
     tier = _tier(severity)
     if tier == "none":
         return ""
-    label = {"removed": "removed", "new": "new"}.get(kind) or f"anomaly score {format_score(severity)}"
+    label = {"removed": "removed", "new": "new"}.get(kind) or f"median anomaly score {format_score(severity)}"
     return f'<span class="chip tier {tier}">{TIER_ICONS[tier]} {_e(label)}</span>'
 
 
@@ -583,7 +586,7 @@ def render_html(report: DiffReport) -> str:
                 tier_counts[ds.tier] += 1
         strip_bits = [f"{TIER_ICONS[t]} {n} {t}" for t, n in tier_counts.items() if n]
         if strip_bits:
-            tier_strip = f'<div class="tier-strip">{" · ".join(strip_bits)} <span class="tier-hint">(by anomaly score; coverage loss ⇒ 🔴)</span></div>'
+            tier_strip = f'<div class="tier-strip">{" · ".join(strip_bits)} <span class="tier-hint">(by median anomaly score; coverage loss ⇒ 🔴)</span></div>'
 
         # Datasets to watch: tier first, and within a tier data loss (or a failed/removed
         # dataset) outranks a bigger-but-benign change; then change size.
@@ -601,7 +604,7 @@ def render_html(report: DiffReport) -> str:
             elif d.change_kind == "removed":
                 meta = "removed dataset"
             else:
-                bits = [f"anomaly score {format_score(d.severity)}"]
+                bits = [f"median anomaly score {format_score(d.severity)}"]
                 if d.removed_row_count:
                     bits.append(f"− lost {d.removed_row_count:,} data point(s)")
                 n_cols = sum(len(t.changed_columns) for t in d.tables)
@@ -634,7 +637,7 @@ def render_html(report: DiffReport) -> str:
             items.append(
                 f'<li><span class="ti">{TIER_ICONS.get(tier, "")}</span> '
                 f'<a href="#{_anchor(ds_path, table, col)}"><code>{_e(ds_path)}</code> · <code>{_e(table)}.{_e(col)}</code></a>'
-                f'<span class="top-meta">anomaly score {_e(format_score(severity))} · {pct:.0f}% of rows</span></li>'
+                f'<span class="top-meta">median anomaly score {_e(format_score(severity))} · {pct:.0f}% of rows</span></li>'
             )
         if ds_items or items:
             parts = ['<details class="top-changes" open><summary><b>Top changes — what to watch</b></summary>']
@@ -650,6 +653,16 @@ def render_html(report: DiffReport) -> str:
         "their data files are byte-identical, the source checksum changed only because an upstream "
         "metadata change cascaded.</div>"
         if report.skipped_cascade
+        else ""
+    )
+
+    # Identical datasets render at the bottom (severity 0) and are hidden by default; carry the
+    # count in the label so the toggle's effect is discoverable, and drop it when there's nothing
+    # to show.
+    identical_toggle = (
+        f'<label><input type="checkbox" id="show-identical"> '
+        f"show {report.n_identical:,} identical dataset{'s' if report.n_identical != 1 else ''}</label>"
+        if report.n_identical
         else ""
     )
 
@@ -756,7 +769,7 @@ def render_html(report: DiffReport) -> str:
       <option value="moderate">🟡 moderate</option>
       <option value="small">🟢 small</option>
     </select>
-    <label><input type="checkbox" id="show-identical"> show identical datasets</label>
+    {identical_toggle}
     <span class="match-count" id="match-count"></span>
   </div>
   {sections}
@@ -781,16 +794,18 @@ def render_html(report: DiffReport) -> str:
       // An active filter reveals matching identical datasets even when the toggle is off —
       // searching for a dataset you know was compared should always find it.
       d.classList.toggle('match-visible', match && filtering);
-      const visible = match && (!d.classList.contains('identical') || showIdentical.checked || filtering);
+      const visible = match && (!d.classList.contains('identical') || (showIdentical && showIdentical.checked) || filtering);
       if (visible) shown++;
     }});
     matchCount.textContent = `${{shown}} of ${{dsBlocks.length}} datasets shown`;
   }}
 
-  showIdentical.addEventListener('change', (e) => {{
-    document.body.classList.toggle('show-identical', e.target.checked);
-    applyFilters();
-  }});
+  if (showIdentical) {{
+    showIdentical.addEventListener('change', (e) => {{
+      document.body.classList.toggle('show-identical', e.target.checked);
+      applyFilters();
+    }});
+  }}
   filterInput.addEventListener('input', applyFilters);
   tierSelect.addEventListener('change', applyFilters);
   applyFilters();

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -31,6 +31,7 @@ TIER_ICONS = {"large": "🔴", "moderate": "🟡", "small": "🟢"}
 
 # Entries shown in the "Top changes" watch list at the head of the report.
 TOP_CHANGES_LIMIT = 15
+TOP_DATASETS_LIMIT = 10
 # The triage aids (Top changes section, tier strip) only appear when there's something to
 # triage: a report with a couple of changed datasets is already scannable, and on the common
 # single-dataset PR they'd be redundant noise. Per-row tier chips render at any size.
@@ -340,11 +341,17 @@ def _dataset_from_dict(d: dict[str, Any]) -> DatasetDiffResult:
 
 _SYMBOLS = {"new": "+", "removed": "-", "changed": "~", "identical": "=", "error": "⚠"}
 
-_STATUS_HEADLINE = {
-    "clean": "✅ No differences found",
-    "changed": "❌ Found differences",
-    "error": "⚠ Found errors",
-}
+
+def _headline(report: "DiffReport") -> str:
+    """Status headline. All counts in this report are about datasets — say so explicitly."""
+    n = len(report.datasets)
+    total = f"{n:,} compared dataset{'s' if n != 1 else ''}"
+    if report.status == "error":
+        return f"⚠ {report.n_errors:,} of {total} failed to compare"
+    if report.status == "changed":
+        n_diff = report.n_changed + report.n_new + report.n_removed
+        return f"❌ Found differences in {n_diff:,} of {total}"
+    return f"✅ No differences found across {total}"
 
 
 def _e(s: Any) -> str:
@@ -354,6 +361,11 @@ def _e(s: Any) -> str:
 def _anchor(ds_path: str, table: str, col: str) -> str:
     """Stable element id for a column's detail block, so the Top changes list can link to it."""
     return "c-" + re.sub(r"[^a-z0-9]+", "-", f"{ds_path}-{table}-{col}".lower()).strip("-")
+
+
+def _ds_anchor(ds_path: str) -> str:
+    """Stable element id for a dataset's detail block, so the Datasets watch list can link to it."""
+    return "d-" + re.sub(r"[^a-z0-9]+", "-", ds_path.lower()).strip("-")
 
 
 def _tier_chip(severity: float, kind: ChangeKind = "changed") -> str:
@@ -516,7 +528,7 @@ def _render_dataset(ds: DatasetDiffResult) -> str:
     new_version = ' <span class="chip">new version</span>' if ds.is_new_version else ""
     tier = _tier_chip(ds.severity, kind) if kind == "changed" else ""
     parts = [
-        f'<details class="ds {kind}"{open_attr}>'
+        f'<details class="ds {kind}" id="{_ds_anchor(ds.path)}"{open_attr}>'
         f'<summary><span class="sym {kind}">{_SYMBOLS[kind]}</span> '
         f'<code class="path">{_e(ds.path)}</code>{new_version}{tier}{_coverage_chip(ds)}'
         f'<span class="ds-note">{_e(_dataset_summary_note(ds))}</span></summary>'
@@ -570,32 +582,65 @@ def render_html(report: DiffReport) -> str:
         if strip_bits:
             tier_strip = f'<div class="tier-strip">{" · ".join(strip_bits)} <span class="tier-hint">(by typical change size; coverage loss ⇒ 🔴)</span></div>'
 
-        losses, changes = _top_changes(report)
-        if losses or changes:
-            items = []
-            # Data-point losses lead the list — make it unmistakable that rows disappeared.
-            for n_removed, labels, ds_path, table, dim in losses:
-                shown = ", ".join(labels[:4]) + ("…" if len(labels) > 4 else "")
-                link_open = f'<a href="#{_anchor(ds_path, table, dim)}">' if dim else ""
-                link_close = "</a>" if dim else ""
-                items.append(
-                    f'<li class="loss"><span class="ti">🔴</span> '
-                    f"{link_open}<code>{_e(ds_path)}</code> · <code>{_e(table)}</code>{link_close}"
-                    f'<span class="top-meta loss">− lost {n_removed:,} data point(s)'
-                    + (f": {_e(shown)}" if shown else "")
-                    + "</span></li>"
-                )
-            for severity, pct, ds_path, table, col in changes:
-                tier = _tier(severity)
-                items.append(
-                    f'<li><span class="ti">{TIER_ICONS.get(tier, "")}</span> '
-                    f'<a href="#{_anchor(ds_path, table, col)}"><code>{_e(ds_path)}</code> · <code>{_e(table)}.{_e(col)}</code></a>'
-                    f'<span class="top-meta">typical change {_e(_bard_to_rel(severity))} · {pct:.0f}% of rows</span></li>'
-                )
-            top_block = (
-                '<details class="top-changes" open><summary><b>Top changes — indicators to watch</b></summary>'
-                f"<ol>{''.join(items)}</ol></details>"
+        # Datasets to watch: tier first, and within a tier data loss (or a failed/removed
+        # dataset) outranks a bigger-but-benign change; then change size.
+        tier_rank = {"large": 0, "moderate": 1, "small": 2, "none": 3}
+
+        def _watch_key(d: DatasetDiffResult) -> tuple:
+            lossy_first = 0 if (d.change_kind in ("error", "removed") or d.has_coverage_loss) else 1
+            return (tier_rank[d.tier], lossy_first, -d.severity, d.path)
+
+        watch = sorted((d for d in datasets if d.change_kind in ("changed", "error", "removed")), key=_watch_key)
+        ds_items = []
+        for d in watch[:TOP_DATASETS_LIMIT]:
+            if d.change_kind == "error":
+                meta = "failed to compare"
+            elif d.change_kind == "removed":
+                meta = "removed dataset"
+            else:
+                bits = [f"typical change {_bard_to_rel(d.severity)}"]
+                if d.removed_row_count:
+                    bits.append(f"− lost {d.removed_row_count:,} data point(s)")
+                n_cols = sum(len(t.changed_columns) for t in d.tables)
+                n_tables = sum(1 for t in d.tables if t.any_change)
+                bits.append(f"{n_cols} column(s) in {n_tables} table(s)")
+                meta = " · ".join(bits)
+            loss_cls = " loss" if d.change_kind != "changed" or d.has_coverage_loss else ""
+            ds_items.append(
+                f'<li><span class="ti">{TIER_ICONS.get(d.tier, "")}</span> '
+                f'<a href="#{_ds_anchor(d.path)}"><code>{_e(d.path)}</code></a>'
+                f'<span class="top-meta{loss_cls}">{_e(meta)}</span></li>'
             )
+
+        losses, changes = _top_changes(report)
+        items = []
+        # Data-point losses lead the indicators list — make it unmistakable that rows disappeared.
+        for n_removed, labels, ds_path, table, dim in losses:
+            shown = ", ".join(labels[:4]) + ("…" if len(labels) > 4 else "")
+            link_open = f'<a href="#{_anchor(ds_path, table, dim)}">' if dim else ""
+            link_close = "</a>" if dim else ""
+            items.append(
+                f'<li class="loss"><span class="ti">🔴</span> '
+                f"{link_open}<code>{_e(ds_path)}</code> · <code>{_e(table)}</code>{link_close}"
+                f'<span class="top-meta loss">− lost {n_removed:,} data point(s)'
+                + (f": {_e(shown)}" if shown else "")
+                + "</span></li>"
+            )
+        for severity, pct, ds_path, table, col in changes:
+            tier = _tier(severity)
+            items.append(
+                f'<li><span class="ti">{TIER_ICONS.get(tier, "")}</span> '
+                f'<a href="#{_anchor(ds_path, table, col)}"><code>{_e(ds_path)}</code> · <code>{_e(table)}.{_e(col)}</code></a>'
+                f'<span class="top-meta">typical change {_e(_bard_to_rel(severity))} · {pct:.0f}% of rows</span></li>'
+            )
+        if ds_items or items:
+            parts = ['<details class="top-changes" open><summary><b>Top changes — what to watch</b></summary>']
+            if ds_items:
+                parts.append(f"<div class='tc-h'>Datasets</div><ol>{''.join(ds_items)}</ol>")
+            if items:
+                parts.append(f"<div class='tc-h'>Indicators</div><ol>{''.join(items)}</ol>")
+            parts.append("</details>")
+            top_block = "".join(parts)
 
     skipped_note = (
         f'<div class="skipped-note">= {report.skipped_cascade:,} more dataset(s) skipped: '
@@ -661,6 +706,8 @@ def render_html(report: DiffReport) -> str:
   .top-meta {{ color: #888; font-size: .78rem; margin-left: .5rem; }}
   .top-meta.loss {{ color: #b71c1c; font-weight: 600; }}
   .ti {{ margin-right: .15rem; }}
+  .tc-h {{ font-size: .72rem; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: #999; margin: .6rem 0 .1rem; }}
+  .cards-caption {{ color: #aaa; font-size: .72rem; margin: -1.25rem 0 1.25rem; }}
   .tbl {{ margin: .75rem 0 0; }}
   .tbl-head {{ font-size: .9rem; margin-bottom: .25rem; }}
   .col {{ margin: .5rem 0 .5rem 1.5rem; }}
@@ -690,8 +737,9 @@ def render_html(report: DiffReport) -> str:
 <body>
   <h1>data-diff</h1>
   <div class="sub">generated {generated_at} · <code>etl diff</code> report</div>
-  <div class="headline">{_STATUS_HEADLINE[report.status]}</div>
+  <div class="headline">{_headline(report)}</div>
   <div class="cards">{"".join(cards)}</div>
+  <div class="cards-caption">counts are datasets</div>
   {tier_strip}
   {top_block}
   <div class="controls">

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -596,8 +596,13 @@ def render_html(report: DiffReport) -> str:
     top_block = ""
     if report.n_changed >= TRIAGE_MIN_DATASETS:
         strip_bits = [f"{TIER_ICONS[t]} {n} {t}" for t, n in tier_counts.items() if n]
-        if strip_bits:
-            tier_strip = f'<div class="tier-strip">{" · ".join(strip_bits)} <span class="tier-hint">(by median anomaly score; coverage loss ⇒ 🔴)</span></div>'
+        n_tiered = sum(tier_counts.values())
+        if strip_bits and n_tiered:
+            tier_strip = (
+                f'<div class="tier-strip">Of the {n_tiered:,} dataset{"s" if n_tiered != 1 else ""} with '
+                f"differences, the changes are: {' · '.join(strip_bits)} "
+                f'<span class="tier-hint">(tiered by median anomaly score; coverage loss ⇒ 🔴)</span></div>'
+            )
 
         # Datasets to watch: tier first, and within a tier data loss (or a failed/removed
         # dataset) outranks a bigger-but-benign change; then change size.

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -48,16 +48,14 @@ def _tier(severity: float) -> Tier:
     return "none"
 
 
-def _bard_to_rel(severity: float) -> str:
-    """Human-readable typical relative change for a BARD-based severity.
+def format_score(score: float) -> str:
+    """Display format for an anomaly score (BARD, in [0, 1]).
 
-    For same-sign values, BARD t corresponds to a relative change of 2t/(1-t) — e.g. t=0.2 is a
-    ~50% change. Above ~0.83 the equivalent exceeds 1000%, where a precise number stops being
-    informative.
+    Two decimals normally; three below 0.01 so the "small" tier doesn't collapse to 0.00. As a
+    rule of thumb for same-sign values, a score t corresponds to a relative change of 2t/(1-t):
+    0.01 ≈ 2%, 0.15 ≈ 35%, 0.5 ≈ 200%.
     """
-    if severity >= 0.83:
-        return ">1000%"
-    return f"~{200 * severity / (1 - severity):.0f}%"
+    return f"{score:.2f}" if score >= 0.01 else f"{score:.3f}"
 
 
 @dataclass
@@ -69,9 +67,9 @@ class ValueDiff:
     total: int
     # Display-ready records; rows of a "changed" diff have "<col> -" (old) and "<col> +" (new) keys.
     sample: list[dict[str, str]] = field(default_factory=list)
-    # True when the sample of a numeric "changed" diff is sorted by change size (largest first)
-    # and carries a "Δ %" display column; non-numeric samples stay random and unsorted.
-    sorted_by_delta: bool = False
+    # True when the sample of a numeric "changed" diff is sorted by anomaly score (largest first)
+    # and carries an "anomaly score" display column; non-numeric samples stay random and unsorted.
+    sorted_by_score: bool = False
     # Median BARD (|a-b| / (|a|+|b|), see `etl.data_helpers.misc.bard`) across ALL changed rows
     # of a numeric column — the typical size of the change, bounded in [0, 1]. None when the
     # column is non-numeric (or the diff is not of kind "changed").
@@ -373,7 +371,7 @@ def _tier_chip(severity: float, kind: ChangeKind = "changed") -> str:
     tier = _tier(severity)
     if tier == "none":
         return ""
-    label = {"removed": "removed", "new": "new"}.get(kind) or f"typical change {_bard_to_rel(severity)}"
+    label = {"removed": "removed", "new": "new"}.get(kind) or f"anomaly score {format_score(severity)}"
     return f'<span class="chip tier {tier}">{TIER_ICONS[tier]} {_e(label)}</span>'
 
 
@@ -460,8 +458,8 @@ def _render_value_diff(v: ValueDiff) -> str:
         )
         trs.append(f"<tr>{tds}</tr>")
     if v.count > len(v.sample):
-        what = "largest relative changes" if v.sorted_by_delta else "rows"
-        note = f'<div class="note">showing {len(v.sample):,} {what} of {v.count:,} rows</div>'
+        what = "most anomalous" if v.sorted_by_score else "rows"
+        note = f'<div class="note">showing the {len(v.sample):,} {what} of {v.count:,} rows</div>'
     else:
         note = ""
     return (
@@ -580,7 +578,7 @@ def render_html(report: DiffReport) -> str:
                 tier_counts[ds.tier] += 1
         strip_bits = [f"{TIER_ICONS[t]} {n} {t}" for t, n in tier_counts.items() if n]
         if strip_bits:
-            tier_strip = f'<div class="tier-strip">{" · ".join(strip_bits)} <span class="tier-hint">(by typical change size; coverage loss ⇒ 🔴)</span></div>'
+            tier_strip = f'<div class="tier-strip">{" · ".join(strip_bits)} <span class="tier-hint">(by anomaly score; coverage loss ⇒ 🔴)</span></div>'
 
         # Datasets to watch: tier first, and within a tier data loss (or a failed/removed
         # dataset) outranks a bigger-but-benign change; then change size.
@@ -598,7 +596,7 @@ def render_html(report: DiffReport) -> str:
             elif d.change_kind == "removed":
                 meta = "removed dataset"
             else:
-                bits = [f"typical change {_bard_to_rel(d.severity)}"]
+                bits = [f"anomaly score {format_score(d.severity)}"]
                 if d.removed_row_count:
                     bits.append(f"− lost {d.removed_row_count:,} data point(s)")
                 n_cols = sum(len(t.changed_columns) for t in d.tables)
@@ -631,7 +629,7 @@ def render_html(report: DiffReport) -> str:
             items.append(
                 f'<li><span class="ti">{TIER_ICONS.get(tier, "")}</span> '
                 f'<a href="#{_anchor(ds_path, table, col)}"><code>{_e(ds_path)}</code> · <code>{_e(table)}.{_e(col)}</code></a>'
-                f'<span class="top-meta">typical change {_e(_bard_to_rel(severity))} · {pct:.0f}% of rows</span></li>'
+                f'<span class="top-meta">anomaly score {_e(format_score(severity))} · {pct:.0f}% of rows</span></li>'
             )
         if ds_items or items:
             parts = ['<details class="top-changes" open><summary><b>Top changes — what to watch</b></summary>']

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -576,14 +576,25 @@ def render_html(report: DiffReport) -> str:
     datasets = sorted(report.datasets, key=lambda ds: (-ds.severity, ds.path))
     sections = "".join(_render_dataset(ds) for ds in datasets)
 
+    tier_counts = {"large": 0, "moderate": 0, "small": 0}
+    for ds in report.datasets:
+        if ds.change_kind != "identical" and ds.tier != "none":
+            tier_counts[ds.tier] += 1
+
+    # The tier dropdown offers only tiers that exist in the report (with their counts), and is
+    # dropped entirely when there are fewer than two to tell apart — a filter with one choice
+    # is dead weight.
+    available_tiers = [t for t in ("large", "moderate", "small") if tier_counts[t]]
+    if len(available_tiers) >= 2:
+        opts = "".join(f'<option value="{t}">{TIER_ICONS[t]} {t} ({tier_counts[t]})</option>' for t in available_tiers)
+        tier_select = f'<select id="tier-filter"><option value="all">all tiers</option>{opts}</select>'
+    else:
+        tier_select = ""
+
     # Triage aids — only when the report is big enough to need them.
     tier_strip = ""
     top_block = ""
     if report.n_changed >= TRIAGE_MIN_DATASETS:
-        tier_counts = {"large": 0, "moderate": 0, "small": 0}
-        for ds in report.datasets:
-            if ds.change_kind != "identical" and ds.tier != "none":
-                tier_counts[ds.tier] += 1
         strip_bits = [f"{TIER_ICONS[t]} {n} {t}" for t, n in tier_counts.items() if n]
         if strip_bits:
             tier_strip = f'<div class="tier-strip">{" · ".join(strip_bits)} <span class="tier-hint">(by median anomaly score; coverage loss ⇒ 🔴)</span></div>'
@@ -762,12 +773,7 @@ def render_html(report: DiffReport) -> str:
   {top_block}
   <div class="controls">
     <input type="search" id="filter" placeholder="Filter datasets (path, table, column…)">
-    <select id="tier-filter">
-      <option value="all">all tiers</option>
-      <option value="large">🔴 large</option>
-      <option value="moderate">🟡 moderate</option>
-      <option value="small">🟢 small</option>
-    </select>
+    {tier_select}
     {identical_toggle}
     <span class="match-count" id="match-count"></span>
   </div>
@@ -783,7 +789,7 @@ def render_html(report: DiffReport) -> str:
   function applyFilters() {{
     // Multi-term AND over names only (path + table + changed-column names, via data-search).
     const terms = filterInput.value.toLowerCase().split(/\\s+/).filter(Boolean);
-    const tier = tierSelect.value;
+    const tier = tierSelect ? tierSelect.value : 'all';
     const filtering = terms.length > 0 || tier !== 'all';
     let shown = 0;
     dsBlocks.forEach(d => {{
@@ -806,7 +812,7 @@ def render_html(report: DiffReport) -> str:
     }});
   }}
   filterInput.addEventListener('input', applyFilters);
-  tierSelect.addEventListener('change', applyFilters);
+  if (tierSelect) tierSelect.addEventListener('change', applyFilters);
   applyFilters();
 </script>
 </body>

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -494,8 +494,10 @@ def _render_column(table_name: str, c: ColumnDiffResult, ds_path: str = "") -> s
     dim = '<span class="chip dim">dim</span>' if c.is_dim else ""
     tier = _tier_chip(c.severity, c.kind) if not c.is_dim else ""
     anchor = f' id="{_anchor(ds_path, table_name, c.name)}"' if ds_path else ""
+    # Dims are navigation context, not indicators — the indicator tier filter skips them.
+    tier_attr = f' data-tier="{_tier(c.severity)}"' if not c.is_dim else ""
     parts = [
-        f'<div class="col {c.kind}"{anchor}>'
+        f'<div class="col {c.kind}"{anchor}{tier_attr}>'
         f'<div class="col-head"><span class="sym {c.kind}">{_SYMBOLS[c.kind]}</span> '
         f"<code>{_e(table_name)}.{_e(c.name)}</code> {dim}{tier}{chips}</div>"
     ]
@@ -605,9 +607,29 @@ def render_html(report: DiffReport) -> str:
     available_tiers = [t for t in ("large", "moderate", "small") if tier_counts[t]]
     if len(available_tiers) >= 2:
         opts = "".join(f'<option value="{t}">{TIER_ICONS[t]} {t} ({tier_counts[t]})</option>' for t in available_tiers)
-        tier_select = f'<select id="tier-filter"><option value="all">all tiers</option>{opts}</select>'
+        tier_select = f'<select id="tier-filter"><option value="all">all dataset tiers</option>{opts}</select>'
     else:
         tier_select = ""
+
+    # Same for indicators: a dropdown filtering the column blocks by their tier (dims excluded).
+    col_tier_counts = {"large": 0, "moderate": 0, "small": 0}
+    for ds in report.datasets:
+        if ds.change_kind != "changed":
+            continue
+        for t in ds.tables:
+            for c in t.columns:
+                if not c.is_dim and c.kind != "identical" and _tier(c.severity) != "none":
+                    col_tier_counts[_tier(c.severity)] += 1
+    available_col_tiers = [t for t in ("large", "moderate", "small") if col_tier_counts[t]]
+    if len(available_col_tiers) >= 2:
+        opts = "".join(
+            f'<option value="{t}">{TIER_ICONS[t]} {t} ({col_tier_counts[t]})</option>' for t in available_col_tiers
+        )
+        ind_tier_select = (
+            f'<select id="ind-tier-filter"><option value="all">all indicator tiers</option>{opts}</select>'
+        )
+    else:
+        ind_tier_select = ""
 
     # Triage aids — only when the report is big enough to need them.
     tier_strip = ""
@@ -729,6 +751,7 @@ def render_html(report: DiffReport) -> str:
   body.show-identical details.ds.identical {{ display: block; }}
   details.ds.identical.match-visible {{ display: block; }}
   details.ds.hidden {{ display: none !important; }}
+  div.col.hidden {{ display: none; }}
   select {{ padding: .45rem .5rem; border: 1px solid #ccc; border-radius: 6px; font-size: .85rem; background: #fff; }}
   .match-count {{ color: #999; font-size: .8rem; margin-left: auto; }}
   .ds-body {{ padding: .25rem 1rem 1rem; border-top: 1px solid #f0f0f0; }}
@@ -801,6 +824,7 @@ def render_html(report: DiffReport) -> str:
   <div class="controls">
     <input type="search" id="filter" placeholder="Filter datasets (path, table, column…)">
     {tier_select}
+    {ind_tier_select}
     {identical_toggle}
     <span class="match-count" id="match-count"></span>
   </div>
@@ -810,6 +834,8 @@ def render_html(report: DiffReport) -> str:
   const dsBlocks = Array.from(document.querySelectorAll('details.ds'));
   const filterInput = document.getElementById('filter');
   const tierSelect = document.getElementById('tier-filter');
+  const indTierSelect = document.getElementById('ind-tier-filter');
+  const colBlocks = Array.from(document.querySelectorAll('div.col[data-tier]'));
   const showIdentical = document.getElementById('show-identical');
   const matchCount = document.getElementById('match-count');
 
@@ -840,6 +866,12 @@ def render_html(report: DiffReport) -> str:
   }}
   filterInput.addEventListener('input', applyFilters);
   if (tierSelect) tierSelect.addEventListener('change', applyFilters);
+  if (indTierSelect) {{
+    indTierSelect.addEventListener('change', () => {{
+      const t = indTierSelect.value;
+      colBlocks.forEach(c => c.classList.toggle('hidden', t !== 'all' && c.dataset.tier !== t));
+    }});
+  }}
   document.querySelectorAll('.show-more').forEach(btn => {{
     btn.addEventListener('click', () => {{
       const ol = btn.previousElementSibling;

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -29,9 +29,12 @@ TIER_LARGE = 0.15
 TIER_MODERATE = 0.01
 TIER_ICONS = {"large": "🔴", "moderate": "🟡", "small": "🟢"}
 
-# Entries shown in the "Top changes" watch list at the head of the report.
+# Entries shown in the "Top changes" watch list at the head of the report before the
+# "show more" toggle, and the hard cap on how many are rendered (hidden) behind it.
 TOP_CHANGES_LIMIT = 15
 TOP_DATASETS_LIMIT = 10
+TOP_CHANGES_MAX = 100
+TOP_DATASETS_MAX = 50
 # The triage aids (Top changes section, tier strip) only appear when there's something to
 # triage: a report with a couple of changed datasets is already scannable, and on the common
 # single-dataset PR they'd be redundant noise. Per-row tier chips render at any size.
@@ -432,6 +435,21 @@ def _top_changes(
     return losses, changes[: max(0, limit - len(losses))]
 
 
+def _expandable_list(items: list[str], visible: int) -> str:
+    """An <ol> of rendered <li> strings; entries beyond `visible` hide behind a show-more toggle."""
+    if len(items) <= visible:
+        return f"<ol>{''.join(items)}</ol>"
+
+    def _mark_extra(li: str) -> str:
+        if li.startswith('<li class="'):
+            return li.replace('<li class="', '<li class="extra ', 1)
+        return li.replace("<li>", '<li class="extra">', 1)
+
+    lis = "".join(items[:visible]) + "".join(_mark_extra(li) for li in items[visible:])
+    n_extra = len(items) - visible
+    return f'<ol>{lis}</ol><button class="show-more" data-more="{n_extra}">show {n_extra} more</button>'
+
+
 def _render_meta_diff(meta_diff: str, label: str) -> str:
     """Render an ndiff metadata diff as a collapsible block with +/- lines colored."""
     if not meta_diff:
@@ -614,7 +632,7 @@ def render_html(report: DiffReport) -> str:
 
         watch = sorted((d for d in datasets if d.change_kind in ("changed", "error", "removed")), key=_watch_key)
         ds_items = []
-        for d in watch[:TOP_DATASETS_LIMIT]:
+        for d in watch[:TOP_DATASETS_MAX]:
             # Red is reserved for the alarming part only: the data-loss fragment (or a dataset
             # that failed to compare / was removed) — not the whole meta line.
             if d.change_kind == "error":
@@ -633,7 +651,7 @@ def render_html(report: DiffReport) -> str:
                 f'<a href="#{_ds_anchor(d.path)}"><code>{_e(d.path)}</code></a>{meta_html}</li>'
             )
 
-        losses, changes = _top_changes(report)
+        losses, changes = _top_changes(report, limit=TOP_CHANGES_MAX)
         items = []
         # Data-point losses lead the indicators list — make it unmistakable that rows disappeared.
         for n_removed, labels, ds_path, table, dim in losses:
@@ -657,9 +675,9 @@ def render_html(report: DiffReport) -> str:
         if ds_items or items:
             parts = ['<details class="top-changes" open><summary><b>Top changes — what to watch</b></summary>']
             if ds_items:
-                parts.append(f"<div class='tc-h'>Datasets</div><ol>{''.join(ds_items)}</ol>")
+                parts.append(f"<div class='tc-h'>Datasets</div>{_expandable_list(ds_items, TOP_DATASETS_LIMIT)}")
             if items:
-                parts.append(f"<div class='tc-h'>Indicators</div><ol>{''.join(items)}</ol>")
+                parts.append(f"<div class='tc-h'>Indicators</div>{_expandable_list(items, TOP_CHANGES_LIMIT)}")
             parts.append("</details>")
             top_block = "".join(parts)
 
@@ -741,6 +759,10 @@ def render_html(report: DiffReport) -> str:
   .top-meta.loss {{ color: #b71c1c; font-weight: 600; }}
   .ti {{ margin-right: .15rem; }}
   .tc-h {{ font-size: .72rem; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: #999; margin: .6rem 0 .1rem; }}
+  .top-changes li.extra {{ display: none; }}
+  .top-changes ol.expanded li.extra {{ display: list-item; }}
+  .show-more {{ background: none; border: none; color: #3949ab; font-size: .8rem; cursor: pointer; padding: 0 0 .2rem 1.5rem; }}
+  .show-more:hover {{ text-decoration: underline; }}
   .cards-caption {{ color: #aaa; font-size: .72rem; margin: -1.25rem 0 1.25rem; }}
   .tbl {{ margin: .75rem 0 0; }}
   .tbl-head {{ font-size: .9rem; margin-bottom: .25rem; }}
@@ -818,6 +840,13 @@ def render_html(report: DiffReport) -> str:
   }}
   filterInput.addEventListener('input', applyFilters);
   if (tierSelect) tierSelect.addEventListener('change', applyFilters);
+  document.querySelectorAll('.show-more').forEach(btn => {{
+    btn.addEventListener('click', () => {{
+      const ol = btn.previousElementSibling;
+      const expanded = ol.classList.toggle('expanded');
+      btn.textContent = expanded ? 'show fewer' : `show ${{btn.dataset.more}} more`;
+    }});
+  }});
   applyFilters();
 </script>
 </body>

--- a/tests/apps/test_owidbot_data_diff.py
+++ b/tests/apps/test_owidbot_data_diff.py
@@ -82,3 +82,52 @@ def test_format_comment_error():
 
     assert "⚠️ 1 error(s)" in body
     assert "! garden/n/v/ds — error: Index must be unique." in body
+
+
+def test_format_comment_puts_data_losses_first():
+    # A small-severity dataset with coverage loss must lead the (truncatable) comment, ahead of
+    # a big-but-benign value change — same triage order as the HTML report's watch list.
+    lossy = DatasetDiffResult(
+        path="garden/n/v/lossy",
+        kind="identical",
+        tables=[
+            TableDiffResult(
+                name="t",
+                kind="identical",
+                columns=[
+                    ColumnDiffResult(
+                        name="country",
+                        kind="changed",
+                        is_dim=True,
+                        value_diffs=[ValueDiff(kind="removed", count=2, total=1000, sample=[{"country": "Vietnam"}])],
+                    ),
+                    ColumnDiffResult(
+                        name="a",
+                        kind="changed",
+                        changes=["changed data"],
+                        value_diffs=[ValueDiff(kind="changed", count=10, total=100, median_bard=0.001)],
+                    ),
+                ],
+            )
+        ],
+    )
+    big = DatasetDiffResult(
+        path="garden/n/v/big",
+        kind="identical",
+        tables=[
+            TableDiffResult(
+                name="t",
+                kind="identical",
+                columns=[
+                    ColumnDiffResult(
+                        name="a",
+                        kind="changed",
+                        changes=["changed data"],
+                        value_diffs=[ValueDiff(kind="changed", count=10, total=100, median_bard=0.9)],
+                    )
+                ],
+            )
+        ],
+    )
+    body = format_comment(DiffReport(datasets=[big, lossy]), None)
+    assert body.index("garden/n/v/lossy") < body.index("garden/n/v/big")

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -118,7 +118,7 @@ def test_structured_result(tmp_path):
     assert value_diffs["new"].total == 3
     assert value_diffs["new"].sample == [{"country": "FR", "a": "3"}]
     # Numeric changed samples carry an "anomaly score" (BARD) display column, sorted by it.
-    assert value_diffs["changed"].sample == [{"country": "US", "a -": "3", "a +": "2", "anomaly score": "0.20"}]
+    assert value_diffs["changed"].sample == [{"country": "US", "a -": "3", "a +": "2", "anomaly score": "20%"}]
     assert value_diffs["changed"].sorted_by_score
     # 3 -> 2: BARD = |3-2| / (3+2) = 0.2
     assert value_diffs["changed"].median_bard == pytest.approx(0.2)
@@ -144,7 +144,7 @@ def test_changed_records_sorts_numeric_by_change_size():
     assert sorted_by_score
     # Biggest changes (by anomaly score = BARD) first; growth from zero is maximal (score 1).
     assert [r["country"] for r in records] == ["from_zero", "big", "small"]
-    assert [r["anomaly score"] for r in records] == ["1.00", "0.43", "0.005"]
+    assert [r["anomaly score"] for r in records] == ["100%", "43%", "0.50%"]
     # Median BARD across all changed rows: median(0.005, 0.43, 1.0) ≈ 0.43.
     assert median_bard == pytest.approx(150 / 350, abs=1e-6)
 
@@ -248,6 +248,13 @@ def test_filter_attributes():
     assert 'data-tier="large"' in html
     assert 'id="tier-filter"' in html
     assert 'id="match-count"' in html
+    # No identical datasets -> the show-identical toggle is dropped entirely.
+    assert 'id="show-identical"' not in html
+
+    # With identical datasets, the toggle carries the count so its effect is discoverable.
+    mixed = DiffReport(datasets=[ds, DatasetDiffResult(path="garden/n/v/same", kind="identical")])
+    html_mixed = render_html(mixed)
+    assert "show 1 identical dataset<" in html_mixed
 
 
 def test_headline_counts_datasets():

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -110,8 +110,8 @@ def test_structured_result(tmp_path):
     assert value_diffs["new"].count == 1
     assert value_diffs["new"].total == 3
     assert value_diffs["new"].sample == [{"country": "FR", "a": "3"}]
-    # Numeric changed samples carry a "Δ %" display column and are marked delta-sorted.
-    assert value_diffs["changed"].sample == [{"country": "US", "a -": "3", "a +": "2", "Δ %": "-33.3%"}]
+    # Numeric changed samples carry an absolute "Δ %" display column and are marked delta-sorted.
+    assert value_diffs["changed"].sample == [{"country": "US", "a -": "3", "a +": "2", "Δ %": "33.3%"}]
     assert value_diffs["changed"].sorted_by_delta
 
     # JSON round-trip
@@ -133,9 +133,9 @@ def test_changed_records_sorts_numeric_by_relative_change():
     )
     records, sorted_by_delta = _changed_records(both, "a")
     assert sorted_by_delta
-    # Largest relative change first; growth from zero counts as an infinite change and ranks on top.
+    # Largest absolute relative change first; growth from zero counts as infinite and ranks on top.
     assert [r["country"] for r in records] == ["from_zero", "big", "small"]
-    assert [r["Δ %"] for r in records] == ["+∞%", "+150.0%", "+1.0%"]
+    assert [r["Δ %"] for r in records] == ["∞%", "150.0%", "1.0%"]
 
     # A sample larger than the limit keeps only the biggest movers.
     top, _ = _changed_records(both, "a", limit=2)

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -117,9 +117,9 @@ def test_structured_result(tmp_path):
     assert value_diffs["new"].count == 1
     assert value_diffs["new"].total == 3
     assert value_diffs["new"].sample == [{"country": "FR", "a": "3"}]
-    # Numeric changed samples carry an absolute "Δ %" display column and are marked delta-sorted.
-    assert value_diffs["changed"].sample == [{"country": "US", "a -": "3", "a +": "2", "Δ %": "33.3%"}]
-    assert value_diffs["changed"].sorted_by_delta
+    # Numeric changed samples carry an "anomaly score" (BARD) display column, sorted by it.
+    assert value_diffs["changed"].sample == [{"country": "US", "a -": "3", "a +": "2", "anomaly score": "0.20"}]
+    assert value_diffs["changed"].sorted_by_score
     # 3 -> 2: BARD = |3-2| / (3+2) = 0.2
     assert value_diffs["changed"].median_bard == pytest.approx(0.2)
 
@@ -140,11 +140,11 @@ def test_changed_records_sorts_numeric_by_change_size():
             "a +": [101.0, 250.0, 5.0],  # BARD ≈ 0.005, 0.43, 1.0
         }
     )
-    records, sorted_by_delta, median_bard = _changed_records(both, "a")
-    assert sorted_by_delta
-    # Biggest changes (by BARD) first; growth from zero is a maximal change and ranks on top.
+    records, sorted_by_score, median_bard = _changed_records(both, "a")
+    assert sorted_by_score
+    # Biggest changes (by anomaly score = BARD) first; growth from zero is maximal (score 1).
     assert [r["country"] for r in records] == ["from_zero", "big", "small"]
-    assert [r["Δ %"] for r in records] == ["∞%", "150.0%", "1.0%"]
+    assert [r["anomaly score"] for r in records] == ["1.00", "0.43", "0.005"]
     # Median BARD across all changed rows: median(0.005, 0.43, 1.0) ≈ 0.43.
     assert median_bard == pytest.approx(150 / 350, abs=1e-6)
 
@@ -155,10 +155,10 @@ def test_changed_records_sorts_numeric_by_change_size():
 
 def test_changed_records_non_numeric_falls_back_to_random_sample():
     both = pd.DataFrame({"country": ["UK", "US"], "a -": ["x", "y"], "a +": ["y", "z"]})
-    records, sorted_by_delta, median_bard = _changed_records(both, "a")
-    assert not sorted_by_delta
+    records, sorted_by_score, median_bard = _changed_records(both, "a")
+    assert not sorted_by_score
     assert median_bard is None
-    assert all("Δ %" not in r for r in records)
+    assert all("anomaly score" not in r for r in records)
     assert len(records) == 2
 
 
@@ -224,7 +224,7 @@ def test_triage_aids_only_on_big_reports():
     # (Assert on rendered elements, not bare class names — those always appear in the stylesheet.)
     assert "Top changes" not in html_small
     assert '<div class="tier-strip">' not in html_small
-    assert "typical change" in html_small
+    assert "anomaly score" in html_small
 
     big = DiffReport(datasets=[_changed_ds(f"garden/n/v/d{i}", 0.5 - i * 0.1) for i in range(4)])
     html_big = render_html(big)

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -264,8 +264,17 @@ def test_filter_attributes():
     html_mixed = render_html(mixed)
     assert "show 1 identical dataset<" in html_mixed
     assert 'id="tier-filter"' in html_mixed
+    assert "all dataset tiers" in html_mixed
     assert "🔴 large (1)" in html_mixed and "🟡 moderate (1)" in html_mixed
     assert "🟢 small" not in html_mixed.split('id="tier-filter"')[1].split("</select>")[0]
+
+    # The indicator tier dropdown follows the same rules, counting non-dim changed columns;
+    # column blocks carry data-tier for it to filter on.
+    assert 'id="ind-tier-filter"' in html_mixed
+    assert "all indicator tiers" in html_mixed
+    assert '<div class="col changed" id="c-garden-n-v-a-t-a" data-tier="large">' in html_mixed
+    # Single-tier report -> no indicator dropdown either.
+    assert 'id="ind-tier-filter"' not in html
 
 
 def test_top_changes_show_more():

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -478,3 +478,32 @@ def test_metadata_only_changes_are_not_tiered():
     # dropdowns offer as an option.
     assert 'data-tier="meta" data-search="garden/n/v/meta t a"' in html
     assert html.count('<option value="meta">📝 metadata-only (1)</option>') == 2
+
+
+def test_structural_changes_are_not_metadata_only():
+    # A removed column is coverage loss (🔴) — classifying it "meta" would let the tier filter
+    # hide it. Added/removed tables and columns carry no value_diffs but are structural.
+    removed_col = DatasetDiffResult(
+        path="garden/n/v/dropped_col",
+        kind="identical",
+        tables=[
+            TableDiffResult(
+                name="t",
+                kind="identical",
+                columns=[ColumnDiffResult(name="gone", kind="removed")],
+            )
+        ],
+    )
+    assert not removed_col.is_metadata_only
+    assert removed_col.has_coverage_loss
+    assert removed_col.tier == "large"
+    html = render_html(DiffReport(datasets=[removed_col]))
+    assert 'data-tier="large"' in html
+    assert 'data-tier="meta"' not in html
+
+    new_table = DatasetDiffResult(
+        path="garden/n/v/new_table",
+        kind="identical",
+        tables=[TableDiffResult(name="extra", kind="new", columns=[ColumnDiffResult(name="a", kind="new")])],
+    )
+    assert not new_table.is_metadata_only

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -246,15 +246,26 @@ def test_filter_attributes():
     html = render_html(DiffReport(datasets=[ds]))
     assert 'data-search="garden/n/v/a t a"' in html
     assert 'data-tier="large"' in html
-    assert 'id="tier-filter"' in html
     assert 'id="match-count"' in html
-    # No identical datasets -> the show-identical toggle is dropped entirely.
+    # No identical datasets -> the show-identical toggle is dropped entirely; a single tier ->
+    # the tier dropdown is dropped too (a filter with one choice is dead weight).
     assert 'id="show-identical"' not in html
+    assert 'id="tier-filter"' not in html
 
-    # With identical datasets, the toggle carries the count so its effect is discoverable.
-    mixed = DiffReport(datasets=[ds, DatasetDiffResult(path="garden/n/v/same", kind="identical")])
+    # With identical datasets, the toggle carries the count so its effect is discoverable; with
+    # two tiers present, the dropdown appears offering exactly those (with counts).
+    mixed = DiffReport(
+        datasets=[
+            ds,
+            _changed_ds("garden/n/v/b", 0.05),
+            DatasetDiffResult(path="garden/n/v/same", kind="identical"),
+        ]
+    )
     html_mixed = render_html(mixed)
     assert "show 1 identical dataset<" in html_mixed
+    assert 'id="tier-filter"' in html_mixed
+    assert "🔴 large (1)" in html_mixed and "🟡 moderate (1)" in html_mixed
+    assert "🟢 small" not in html_mixed.split('id="tier-filter"')[1].split("</select>")[0]
 
 
 def test_headline_counts_datasets():

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -268,6 +268,18 @@ def test_filter_attributes():
     assert "🟢 small" not in html_mixed.split('id="tier-filter"')[1].split("</select>")[0]
 
 
+def test_top_changes_show_more():
+    # 12 changed datasets: the Datasets watch list shows 10 and hides 2 behind "show 2 more";
+    # 12 indicators fit within the visible limit (15), so only one toggle renders.
+    report = DiffReport(datasets=[_changed_ds(f"garden/n/v/d{i:02d}", 0.9 - i * 0.01) for i in range(12)])
+    html = render_html(report)
+    assert html.count('<button class="show-more"') == 1
+    assert 'data-more="2">show 2 more</button>' in html
+    # The hidden entries carry the extra class and are the lowest-ranked ones.
+    assert html.count('<li class="extra">') == 2
+    assert 'class="extra"><span class="ti">🔴</span> <a href="#d-garden-n-v-d11"' in html
+
+
 def test_headline_counts_datasets():
     one = DiffReport(datasets=[_changed_ds("garden/n/v/a", 0.5)])
     assert "❌ Found differences in 1 of 1 compared dataset" in render_html(one)

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -445,3 +445,34 @@ def test_sample_note_in_header():
     )
     html = render_html(DiffReport(datasets=[ds]))
     assert '(15.46%) <span class="head-note">— showing the 1 most anomalous rows</span>' in html
+
+
+def test_metadata_only_changes_are_not_tiered():
+    # A metadata-only change is not an anomaly: no tier, no score chip, no tier-strip count —
+    # it surfaces as "metadata-only" instead.
+    meta_only = DatasetDiffResult(
+        path="garden/n/v/meta",
+        kind="identical",
+        tables=[
+            TableDiffResult(
+                name="t",
+                kind="identical",
+                columns=[
+                    ColumnDiffResult(name="a", kind="changed", changes=["changed metadata"], meta_diff="- x\n+ y")
+                ],
+            )
+        ],
+    )
+    assert meta_only.change_kind == "changed"
+    assert meta_only.severity == 0.0
+    assert meta_only.tier == "none"
+
+    others = [_changed_ds(f"garden/n/v/d{i}", 0.5) for i in range(3)]
+    html = render_html(DiffReport(datasets=[*others, meta_only]))
+    # Strip total matches the headline (4 differing datasets) and lists the metadata-only one.
+    assert "Of the 4 datasets with differences" in html
+    assert "📝 1 metadata-only" in html
+    # The watch list labels it honestly instead of a 0% anomaly score.
+    assert "metadata-only changes" in html
+    # And its dataset row carries no score chip.
+    assert 'data-tier="none" data-search="garden/n/v/meta t a"' in html

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -474,5 +474,7 @@ def test_metadata_only_changes_are_not_tiered():
     assert "📝 1 metadata-only" in html
     # The watch list labels it honestly instead of a 0% anomaly score.
     assert "metadata-only changes" in html
-    # And its dataset row carries no score chip.
-    assert 'data-tier="none" data-search="garden/n/v/meta t a"' in html
+    # Its dataset row carries no score chip and a filterable "meta" category, which both
+    # dropdowns offer as an option.
+    assert 'data-tier="meta" data-search="garden/n/v/meta t a"' in html
+    assert html.count('<option value="meta">📝 metadata-only (1)</option>') == 2

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -421,3 +421,27 @@ def test_render_html(tmp_path):
     # old/new sample values are rendered in the table
     assert ">US<" in html
     assert "2 more dataset(s) skipped" in html
+
+
+def test_sample_note_in_header():
+    # Truncated samples announce it up front, in the header line — not below the table.
+    col = ColumnDiffResult(
+        name="a",
+        kind="changed",
+        changes=["changed data"],
+        value_diffs=[
+            ValueDiff(
+                kind="changed",
+                count=18479,
+                total=119537,
+                sample=[{"country": "FR", "a -": "1", "a +": "2", "anomaly score": "33%"}],
+                sorted_by_score=True,
+                median_bard=0.2,
+            )
+        ],
+    )
+    ds = DatasetDiffResult(
+        path="garden/n/v/x", kind="identical", tables=[TableDiffResult(name="t", kind="identical", columns=[col])]
+    )
+    html = render_html(DiffReport(datasets=[ds]))
+    assert '(15.46%) <span class="head-note">— showing the 1 most anomalous rows</span>' in html

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 from owid.catalog import Dataset, DatasetMeta, Table
 
-from etl.datadiff import DatasetDiff, RemoteDataset, _dataset_files_match
+from etl.datadiff import DatasetDiff, RemoteDataset, _changed_records, _dataset_files_match
 from etl.datadiff_report import DiffReport, render_html
 
 
@@ -110,7 +110,9 @@ def test_structured_result(tmp_path):
     assert value_diffs["new"].count == 1
     assert value_diffs["new"].total == 3
     assert value_diffs["new"].sample == [{"country": "FR", "a": "3"}]
-    assert value_diffs["changed"].sample == [{"country": "US", "a -": "3", "a +": "2"}]
+    # Numeric changed samples carry a "Δ %" display column and are marked delta-sorted.
+    assert value_diffs["changed"].sample == [{"country": "US", "a -": "3", "a +": "2", "Δ %": "-33.3%"}]
+    assert value_diffs["changed"].sorted_by_delta
 
     # JSON round-trip
     report = DiffReport(datasets=[res], skipped_cascade=2)
@@ -119,6 +121,33 @@ def test_structured_result(tmp_path):
     assert report2.n_changed == 1
     assert report2.n_identical == 0
     assert report2.status == "changed"
+
+
+def test_changed_records_sorts_numeric_by_relative_change():
+    both = pd.DataFrame(
+        {
+            "country": ["small", "big", "from_zero"],
+            "a -": [100.0, 100.0, 0.0],
+            "a +": [101.0, 250.0, 5.0],  # +1%, +150%, +∞%
+        }
+    )
+    records, sorted_by_delta = _changed_records(both, "a")
+    assert sorted_by_delta
+    # Largest relative change first; growth from zero counts as an infinite change and ranks on top.
+    assert [r["country"] for r in records] == ["from_zero", "big", "small"]
+    assert [r["Δ %"] for r in records] == ["+∞%", "+150.0%", "+1.0%"]
+
+    # A sample larger than the limit keeps only the biggest movers.
+    top, _ = _changed_records(both, "a", limit=2)
+    assert [r["country"] for r in top] == ["from_zero", "big"]
+
+
+def test_changed_records_non_numeric_falls_back_to_random_sample():
+    both = pd.DataFrame({"country": ["UK", "US"], "a -": ["x", "y"], "a +": ["y", "z"]})
+    records, sorted_by_delta = _changed_records(both, "a")
+    assert not sorted_by_delta
+    assert all("Δ %" not in r for r in records)
+    assert len(records) == 2
 
 
 @pytest.mark.filterwarnings("ignore:Table `tab` does not have a primary_key")

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -233,6 +233,26 @@ def test_triage_aids_only_on_big_reports():
     # Watch-list entries link to the column detail blocks (anchor present in both places).
     assert 'href="#c-garden-n-v-d0-t-a"' in html_big
     assert 'id="c-garden-n-v-d0-t-a"' in html_big
+    # Both perspectives: a Datasets sub-list (linking to dataset blocks) and an Indicators one.
+    assert ">Datasets<" in html_big and ">Indicators<" in html_big
+    assert 'href="#d-garden-n-v-d0"' in html_big
+    assert 'id="d-garden-n-v-d0"' in html_big
+
+
+def test_headline_counts_datasets():
+    one = DiffReport(datasets=[_changed_ds("garden/n/v/a", 0.5)])
+    assert "❌ Found differences in 1 of 1 compared dataset" in render_html(one)
+
+    mixed = DiffReport(
+        datasets=[
+            _changed_ds("garden/n/v/a", 0.5),
+            DatasetDiffResult(path="garden/n/v/b", kind="identical"),
+        ]
+    )
+    assert "❌ Found differences in 1 of 2 compared datasets" in render_html(mixed)
+
+    clean = DiffReport(datasets=[DatasetDiffResult(path="garden/n/v/b", kind="identical")])
+    assert "✅ No differences found across 1 compared dataset" in render_html(clean)
 
 
 def test_top_changes_lists_data_losses_first():
@@ -253,9 +273,12 @@ def test_top_changes_lists_data_losses_first():
     html = render_html(DiffReport(datasets=[*others, lossy]))
 
     assert "lost 111 data point(s): Low-income countries" in html
-    # The loss entry leads the watch list, even though the other datasets have larger changes.
-    top_start = html.index("Top changes")
-    assert html.index("lossy", top_start) < html.index("garden/n/v/d0", top_start)
+    # The loss entry leads the Indicators list, even though other datasets have larger changes.
+    ind_start = html.index(">Indicators<")
+    assert html.index("lossy", ind_start) < html.index("garden/n/v/d0", ind_start)
+    # And the lossy dataset (🔴 via coverage loss) leads the Datasets list despite its small severity.
+    ds_start = html.index(">Datasets<")
+    assert html.index("lossy", ds_start) < html.index("garden/n/v/d0", ds_start)
 
 
 def test_report_sorts_by_severity():

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -211,10 +211,12 @@ def test_coverage_loss_forces_large_tier():
     assert ds.removed_labels == ["Vietnam", "Philippines"]
     assert ds.tier == "large"
 
-    # The coverage chip is rendered on the dataset summary line.
+    # The coverage chip is rendered on the dataset summary line, and the tier chip agrees with
+    # the forced 🔴 tier (not the severity-derived 🟡/🟢) so the row matches the filters.
     html = render_html(DiffReport(datasets=[ds]))
     assert "row(s) removed" in html
     assert "Vietnam" in html
+    assert 'class="chip tier large">🔴 median anomaly score' in html
 
 
 def test_triage_aids_only_on_big_reports():

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -8,7 +8,14 @@ import pytest
 from owid.catalog import Dataset, DatasetMeta, Table
 
 from etl.datadiff import DatasetDiff, RemoteDataset, _changed_records, _dataset_files_match
-from etl.datadiff_report import DiffReport, render_html
+from etl.datadiff_report import (
+    ColumnDiffResult,
+    DatasetDiffResult,
+    DiffReport,
+    TableDiffResult,
+    ValueDiff,
+    render_html,
+)
 
 
 def _create_datasets(tmp_path):
@@ -113,6 +120,8 @@ def test_structured_result(tmp_path):
     # Numeric changed samples carry an absolute "Δ %" display column and are marked delta-sorted.
     assert value_diffs["changed"].sample == [{"country": "US", "a -": "3", "a +": "2", "Δ %": "33.3%"}]
     assert value_diffs["changed"].sorted_by_delta
+    # 3 -> 2: BARD = |3-2| / (3+2) = 0.2
+    assert value_diffs["changed"].median_bard == pytest.approx(0.2)
 
     # JSON round-trip
     report = DiffReport(datasets=[res], skipped_cascade=2)
@@ -123,31 +132,71 @@ def test_structured_result(tmp_path):
     assert report2.status == "changed"
 
 
-def test_changed_records_sorts_numeric_by_relative_change():
+def test_changed_records_sorts_numeric_by_change_size():
     both = pd.DataFrame(
         {
             "country": ["small", "big", "from_zero"],
             "a -": [100.0, 100.0, 0.0],
-            "a +": [101.0, 250.0, 5.0],  # +1%, +150%, +∞%
+            "a +": [101.0, 250.0, 5.0],  # BARD ≈ 0.005, 0.43, 1.0
         }
     )
-    records, sorted_by_delta = _changed_records(both, "a")
+    records, sorted_by_delta, median_bard = _changed_records(both, "a")
     assert sorted_by_delta
-    # Largest absolute relative change first; growth from zero counts as infinite and ranks on top.
+    # Biggest changes (by BARD) first; growth from zero is a maximal change and ranks on top.
     assert [r["country"] for r in records] == ["from_zero", "big", "small"]
     assert [r["Δ %"] for r in records] == ["∞%", "150.0%", "1.0%"]
+    # Median BARD across all changed rows: median(0.005, 0.43, 1.0) ≈ 0.43.
+    assert median_bard == pytest.approx(150 / 350, abs=1e-6)
 
     # A sample larger than the limit keeps only the biggest movers.
-    top, _ = _changed_records(both, "a", limit=2)
+    top, _, _ = _changed_records(both, "a", limit=2)
     assert [r["country"] for r in top] == ["from_zero", "big"]
 
 
 def test_changed_records_non_numeric_falls_back_to_random_sample():
     both = pd.DataFrame({"country": ["UK", "US"], "a -": ["x", "y"], "a +": ["y", "z"]})
-    records, sorted_by_delta = _changed_records(both, "a")
+    records, sorted_by_delta, median_bard = _changed_records(both, "a")
     assert not sorted_by_delta
+    assert median_bard is None
     assert all("Δ %" not in r for r in records)
     assert len(records) == 2
+
+
+def test_report_sorts_by_severity():
+    """Datasets, tables and columns render biggest-differences-first."""
+
+    def col(name, median_bard):
+        return ColumnDiffResult(
+            name=name,
+            kind="changed",
+            changes=["changed data"],
+            value_diffs=[ValueDiff(kind="changed", count=10, total=100, median_bard=median_bard)],
+        )
+
+    # Table/column order in the model is deliberately "small change first".
+    ds_small = DatasetDiffResult(
+        path="garden/n/v/small",
+        kind="identical",
+        tables=[TableDiffResult(name="t", kind="identical", columns=[col("a", 0.01)])],
+    )
+    ds_big = DatasetDiffResult(
+        path="garden/n/v/big",
+        kind="identical",
+        tables=[
+            TableDiffResult(name="minor", kind="identical", columns=[col("x", 0.05)]),
+            TableDiffResult(name="major", kind="identical", columns=[col("tiny", 0.02), col("huge", 0.9)]),
+        ],
+    )
+    html = render_html(DiffReport(datasets=[ds_small, ds_big]))
+
+    # Dataset with the biggest change first.
+    assert html.index("garden/n/v/big") < html.index("garden/n/v/small")
+    # Within a dataset, the most-changed table first; within a table, the most-changed column first.
+    assert html.index("major") < html.index("minor")
+    assert html.index("major.huge") < html.index("major.tiny")
+    # Severity levels: dataset takes the max of its tables.
+    assert ds_big.severity == pytest.approx(0.9)
+    assert ds_small.severity == pytest.approx(0.01)
 
 
 @pytest.mark.filterwarnings("ignore:Table `tab` does not have a primary_key")

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -239,6 +239,17 @@ def test_triage_aids_only_on_big_reports():
     assert 'id="d-garden-n-v-d0"' in html_big
 
 
+def test_filter_attributes():
+    # The filter box matches on names only, via data-search (path + tables + changed columns);
+    # data-tier feeds the tier dropdown.
+    ds = _changed_ds("garden/n/v/a", 0.5)
+    html = render_html(DiffReport(datasets=[ds]))
+    assert 'data-search="garden/n/v/a t a"' in html
+    assert 'data-tier="large"' in html
+    assert 'id="tier-filter"' in html
+    assert 'id="match-count"' in html
+
+
 def test_headline_counts_datasets():
     one = DiffReport(datasets=[_changed_ds("garden/n/v/a", 0.5)])
     assert "❌ Found differences in 1 of 1 compared dataset" in render_html(one)
@@ -304,8 +315,9 @@ def test_report_sorts_by_severity():
 
     # Dataset with the biggest change first.
     assert html.index("garden/n/v/big") < html.index("garden/n/v/small")
-    # Within a dataset, the most-changed table first; within a table, the most-changed column first.
-    assert html.index("major") < html.index("minor")
+    # Within a dataset, the most-changed table first; within a table, the most-changed column
+    # first. (Match the rendered markup, not bare names — those also occur in data-search attrs.)
+    assert html.index("Table <b>major</b>") < html.index("Table <b>minor</b>")
     assert html.index("major.huge") < html.index("major.tiny")
     # Severity levels: dataset takes the max of its tables.
     assert ds_big.severity == pytest.approx(0.9)

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -162,16 +162,83 @@ def test_changed_records_non_numeric_falls_back_to_random_sample():
     assert len(records) == 2
 
 
+def _changed_col(name, median_bard, is_dim=False):
+    return ColumnDiffResult(
+        name=name,
+        kind="changed",
+        is_dim=is_dim,
+        changes=["changed data"],
+        value_diffs=[ValueDiff(kind="changed", count=10, total=100, median_bard=median_bard)],
+    )
+
+
+def _changed_ds(path, median_bard):
+    return DatasetDiffResult(
+        path=path,
+        kind="identical",
+        tables=[TableDiffResult(name="t", kind="identical", columns=[_changed_col("a", median_bard)])],
+    )
+
+
+def test_severity_tiers():
+    assert _changed_ds("garden/n/v/x", 0.5).tier == "large"
+    assert _changed_ds("garden/n/v/x", 0.05).tier == "moderate"
+    assert _changed_ds("garden/n/v/x", 0.002).tier == "small"
+    assert DatasetDiffResult(path="garden/n/v/x", kind="identical").tier == "none"
+    # Errors and removed datasets are always large.
+    assert DatasetDiffResult(path="garden/n/v/x", kind="identical", error="boom").tier == "large"
+    assert DatasetDiffResult(path="garden/n/v/x", kind="removed").tier == "large"
+
+
+def test_coverage_loss_forces_large_tier():
+    # A dim with removed values = entities that disappeared -> coverage loss -> 🔴, even though
+    # the value change itself is tiny.
+    dim = ColumnDiffResult(
+        name="country",
+        kind="changed",
+        is_dim=True,
+        value_diffs=[
+            ValueDiff(kind="removed", count=2, total=100, sample=[{"country": "Vietnam"}, {"country": "Philippines"}])
+        ],
+    )
+    ds = DatasetDiffResult(
+        path="garden/n/v/x",
+        kind="identical",
+        tables=[TableDiffResult(name="t", kind="identical", columns=[dim, _changed_col("a", 0.001)])],
+    )
+    assert ds.has_coverage_loss
+    assert ds.removed_row_count == 2
+    assert ds.removed_labels == ["Vietnam", "Philippines"]
+    assert ds.tier == "large"
+
+    # The coverage chip is rendered on the dataset summary line.
+    html = render_html(DiffReport(datasets=[ds]))
+    assert "row(s) removed" in html
+    assert "Vietnam" in html
+
+
+def test_triage_aids_only_on_big_reports():
+    small = DiffReport(datasets=[_changed_ds("garden/n/v/a", 0.5)])
+    html_small = render_html(small)
+    # A single changed dataset: no watch list, no tier strip — but the row chip still renders.
+    # (Assert on rendered elements, not bare class names — those always appear in the stylesheet.)
+    assert "Top changes" not in html_small
+    assert '<div class="tier-strip">' not in html_small
+    assert "typical change" in html_small
+
+    big = DiffReport(datasets=[_changed_ds(f"garden/n/v/d{i}", 0.5 - i * 0.1) for i in range(4)])
+    html_big = render_html(big)
+    assert "Top changes" in html_big
+    assert '<div class="tier-strip">' in html_big
+    # Watch-list entries link to the column detail blocks (anchor present in both places).
+    assert 'href="#c-garden-n-v-d0-t-a"' in html_big
+    assert 'id="c-garden-n-v-d0-t-a"' in html_big
+
+
 def test_report_sorts_by_severity():
     """Datasets, tables and columns render biggest-differences-first."""
 
-    def col(name, median_bard):
-        return ColumnDiffResult(
-            name=name,
-            kind="changed",
-            changes=["changed data"],
-            value_diffs=[ValueDiff(kind="changed", count=10, total=100, median_bard=median_bard)],
-        )
+    col = _changed_col
 
     # Table/column order in the model is deliberately "small change first".
     ds_small = DatasetDiffResult(

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -235,6 +235,29 @@ def test_triage_aids_only_on_big_reports():
     assert 'id="c-garden-n-v-d0-t-a"' in html_big
 
 
+def test_top_changes_lists_data_losses_first():
+    # A dataset that lost rows (removed dim values) plus bigger-magnitude changed datasets:
+    # the loss entry must lead the watch list and say explicitly that data points are gone.
+    dim = ColumnDiffResult(
+        name="country",
+        kind="changed",
+        is_dim=True,
+        value_diffs=[ValueDiff(kind="removed", count=111, total=1000, sample=[{"country": "Low-income countries"}])],
+    )
+    lossy = DatasetDiffResult(
+        path="garden/n/v/lossy",
+        kind="identical",
+        tables=[TableDiffResult(name="t", kind="identical", columns=[dim, _changed_col("a", 0.02)])],
+    )
+    others = [_changed_ds(f"garden/n/v/d{i}", 0.9) for i in range(3)]
+    html = render_html(DiffReport(datasets=[*others, lossy]))
+
+    assert "lost 111 data point(s): Low-income countries" in html
+    # The loss entry leads the watch list, even though the other datasets have larger changes.
+    top_start = html.index("Top changes")
+    assert html.index("lossy", top_start) < html.index("garden/n/v/d0", top_start)
+
+
 def test_report_sorts_by_severity():
     """Datasets, tables and columns render biggest-differences-first."""
 


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## Why

The data-diff HTML report (#6404) lists changed datasets in collection order with random sample rows, so reviewing a big diff — e.g. a foundational-dataset bump like the income-groups update (#6369/#6416), where ~85 consumers recompute — means scanning noise with no sense of where the big or dangerous changes are. This PR turns the report into a **triage view**: everything is ranked by how big the changes are, data loss is unmissable, and the reviewer is told where to stop reading.

## The metric

Everything is scored with **BARD** (`etl.data_helpers.misc.bard`, the same metric Anomalist scores changes with): `|a − b| / (|a| + |b| + eps)` — bounded, symmetric, resistant to blow-ups on tiny values. Scores display as **percentages in [0, 100]** ("anomaly score"); a value appearing/disappearing or growing from zero counts as a maximal change (100%). Each numeric changed column stores the **median score across all its changed rows** (`ValueDiff.median_bard`, kept raw in JSON); summaries label it "median anomaly score 43%".

## What the report now does

**Ranking (biggest differences first, at every level)**
- Sample rows within a column: sorted by per-row score, shown in an "anomaly score" column (replaces the old random sample).
- Columns by their median score; tables by their most-changed column; datasets by their most-changed table. Comparison errors rank above everything, removed datasets above any value change, new datasets low. The owidbot PR comment sorts its changed-dataset list with the same key.

**Tiers (where to stop reading)**
- 🔴 large (score ≥ 15%) / 🟡 moderate (≥ 1%) / 🟢 small, as chips on every dataset/table/column row.
- A strip under the summary cards: *"Of the 21 datasets with differences, the changes are: 🔴 12 large · 🟡 8 moderate · 🟢 1 small"*.

**Coverage loss (the silent-breakage signal)**
- A red chip per dataset — rows/entities, columns or tables that existed before and are gone after — which always forces 🔴, regardless of relative size.
- On the income-groups downstream diff this immediately flagged real review candidates: income-group aggregate rows removed in `natural_hazards` (111), `renewable_energy_patents` (76), `energy_statistics_database` and `bilateral_remittance`.

**Metadata-only and new-data-only changes (not anomalies)**
- A changed dataset/column with **no value diffs at all** is metadata-only (strict `is_metadata_only` predicate): it scores 0, carries no tier and no score chip, and is filterable via the 📝 dropdown option. The tier strip lists it separately (*"… · 📝 2 metadata-only"*) so its total still matches the headline's differing-dataset count, and the watch list labels it "metadata-only changes".
- A dataset whose only change is **added values** (a pure append) also scores 0 but is *not* metadata-only — it gets its own *"➕ N new-data-only"* strip bucket and "new data only" watch-list label.
- The truncation of sample tables is announced in the header line: *"~ Changed values: 18,479 / 119,537 (15.46%) — showing the 100 most anomalous rows"* (or "a random sample of 100 rows" for non-numeric columns).

**"Top changes — what to watch"** (only on reports with ≥ 3 changed datasets; a single-dataset PR stays clean)
- A **Datasets** sub-list (tier first; within a tier, data loss / failed / removed outranks bigger-but-benign; linked to each dataset's block) and an **Indicators** sub-list where **data-point losses lead** ("− lost 111 data point(s): …", red, anchor-linked).
- Full ranking rendered behind a **"show N more"** toggle (visible 10 datasets / 15 indicators, capped at 50/100).

**Clarity & controls**
- Headline says what it counts: *"❌ Found differences in 21 of 25 compared datasets"* (+ "counts are datasets" caption on the summary cards).
- Filter box matches **names only** (path/table/changed columns), ANDs multiple terms, shows an "N of M datasets shown" counter, and reveals matching identical datasets while filtering.
- **Two tier dropdowns**: one filtering dataset blocks, one filtering indicator (column) blocks — each offering only categories present in the report (with counts) and disappearing when fewer than two exist. Alongside the tiers, both offer **📝 metadata-only** to isolate (or hide) diffs that are purely metadata edits.
- The show-identical toggle carries its count ("show 4 identical datasets") and disappears when there are none.

## Examples (live, interactive)

- **Large report** — [the income-groups downstream diff](https://catalog.ourworldindata.org/diffs/enhance-sort-datadiff-relativechange/example-large.html): 25 datasets, 451 changed indicators. Shows the full triage view — headline with dataset counts, tier strip, the Datasets/Indicators watch lists with data-loss entries leading and "show more" toggles, both tier dropdowns, and the coverage-loss chips (e.g. `natural_hazards − 111 row(s) removed`).
- **Small report** — [a single-dataset diff](https://catalog.ourworldindata.org/diffs/enhance-sort-datadiff-relativechange/example-small.html) (`electricity_mix`): the triage aids stay out of the way — no watch list, no tier strip, no dropdowns, no identical-toggle — just the ordered detail view with per-row anomaly scores and tier chips.

(Both diff a local rebuild against the production catalog; uploaded to the same R2 bucket owidbot uses for its reports.)

## Compatibility

The printed terminal output is **byte-identical** to before — only the structured JSON/HTML changes. `ValueDiff` gains `sorted_by_score` and `median_bard` (defaulted, JSON round-trip safe via `ValueDiff(**v)`).

## Verification

- 17 tests in `tests/test_datadiff.py` + 4 in `tests/apps/test_owidbot_data_diff.py`: BARD row ranking (from-zero maximal, limit truncation), median score, non-numeric fallback, render order at all three levels, tier thresholds, coverage-loss detection incl. the 🔴 override, loss-first watch lists, triage-aid gating, headline counts, filter attributes, conditional dropdowns incl. the 📝 option, show-more toggle, metadata-only classification, header-line sample notes. Format/lint/type green.
- Exercised end-to-end on the income-groups downstream diff (25 datasets, 451 changed indicators) and on a single-dataset diff to confirm the small-report behavior (no triage aids, chips only).
