### PR TITLE
🐛 Fix measles snapshot 403 from cdc.gov Akamai WAF

### DIFF
--- a/snapshots/cdc/latest/measles_cases.py
+++ b/snapshots/cdc/latest/measles_cases.py
@@ -24,7 +24,9 @@ def main(upload: bool) -> None:
     # snap.create_snapshot(upload=upload)
     snap = modify_metadata(snap, date)
     # Add the file to DVC and optionally upload it to S3, based on the `upload` parameter.
-    snap.create_snapshot(upload=upload)
+    # cdc.gov's Akamai WAF blocks browser-like User-Agents (our download default) on this
+    # endpoint but allows honest client UAs, so send the real `python-requests` UA here.
+    snap.create_snapshot(upload=upload, user_agent=requests.utils.default_user_agent())
 
 
 def modify_metadata(snap: Snapshot, date: str) -> Snapshot:


### PR DESCRIPTION
The scheduled `Update measles` Buildkite job ([build #1259](https://buildkite.com/our-world-in-data/etl-automatic-dataset-updates-master/builds/1259)) has been failing with `403 Forbidden` when downloading `https://www.cdc.gov/wcms/vizdata/measles/MeaslesCasesYear.json`.

Reproduced from `etl-prod-2`: cdc.gov's Akamai WAF blocks browser-like User-Agents (including our `download_helpers.py` default Firefox UA) but lets honest client UAs like `curl` and `python-requests` through — the reverse of the usual bot-wall pattern. Our existing Anubis-style bot-challenge retry doesn't catch this since it's a different WAF signature.

Fix: pass `requests.utils.default_user_agent()` explicitly to `snap.create_snapshot()` so the download uses the real `python-requests/x.x.x` UA that Akamai allows.

Verified the snapshot downloads successfully with `etls cdc/latest/measles_cases --skip-upload` after the fix.
