### PR TITLE
✨ data-diff report: same format for small and large reports

### DIFF
--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -684,8 +684,9 @@ def render_html(report: DiffReport) -> str:
     else:
         ind_tier_select = ""
 
-    # Triage aids — one format for every report size; content-based gating on the controls
-    # (dropdowns, toggles, show-more) already prevents dead UI on small diffs.
+    # Triage aids gate on content, not report size: each element renders only when it can
+    # discriminate — the strip needs >= 2 differing datasets ("Of the 1 dataset…" restates the
+    # headline), and a watch sub-list needs >= 2 entries (a ranking of one thing ranks nothing).
     tier_strip = ""
     top_block = ""
     strip_bits = [f"{TIER_ICONS[t]} {n} {t}" for t, n in tier_counts.items() if n]
@@ -701,7 +702,7 @@ def render_html(report: DiffReport) -> str:
     if n_new_only:
         strip_bits.append(f"➕ {n_new_only} new-data-only")
     n_diff = sum(tier_counts.values()) + n_meta_only + n_new_only
-    if strip_bits and n_diff:
+    if strip_bits and n_diff >= 2:
         tier_strip = (
             f'<div class="tier-strip">Of the {n_diff:,} dataset{"s" if n_diff != 1 else ""} with '
             f"differences, the changes are: {' · '.join(strip_bits)} "
@@ -756,11 +757,13 @@ def render_html(report: DiffReport) -> str:
             f'<a href="#{_anchor(ds_path, table, col)}"><code>{_e(ds_path)}</code> · <code>{_e(table)}.{_e(col)}</code></a>'
             f'<span class="top-meta">median anomaly score {_e(format_score(severity))} · {pct:.0f}% of rows</span></li>'
         )
-    if ds_items or items:
+    show_datasets = len(ds_items) >= 2
+    show_indicators = len(items) >= 2
+    if show_datasets or show_indicators:
         parts = ['<details class="top-changes" open><summary><b>Top changes — what to watch</b></summary>']
-        if ds_items:
+        if show_datasets:
             parts.append(f"<div class='tc-h'>Datasets</div>{_expandable_list(ds_items, TOP_DATASETS_LIMIT)}")
-        if items:
+        if show_indicators:
             parts.append(f"<div class='tc-h'>Indicators</div>{_expandable_list(items, TOP_CHANGES_LIMIT)}")
         parts.append("</details>")
         top_block = "".join(parts)

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -367,13 +367,26 @@ _SYMBOLS = {"new": "+", "removed": "-", "changed": "~", "identical": "=", "error
 
 
 def _headline(report: "DiffReport") -> str:
-    """Status headline. All counts in this report are about datasets — say so explicitly."""
+    """Status headline. All counts in this report are about datasets — say so explicitly.
+
+    Trivial ratios read awkwardly, so "1 of 1" becomes "the compared dataset" and "N of N"
+    becomes "all N compared datasets".
+    """
     n = len(report.datasets)
-    total = f"{n:,} compared dataset{'s' if n != 1 else ''}"
+    if n == 1:
+        if report.status == "error":
+            return "⚠ The compared dataset failed to compare"
+        if report.status == "changed":
+            return "❌ Found differences in the compared dataset"
+        return "✅ No differences found in the compared dataset"
+
+    total = f"{n:,} compared datasets"
     if report.status == "error":
         return f"⚠ {report.n_errors:,} of {total} failed to compare"
     if report.status == "changed":
         n_diff = report.n_changed + report.n_new + report.n_removed
+        if n_diff == n:
+            return f"❌ Found differences in all {total}"
         return f"❌ Found differences in {n_diff:,} of {total}"
     return f"✅ No differences found across {total}"
 

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -35,10 +35,6 @@ TOP_CHANGES_LIMIT = 15
 TOP_DATASETS_LIMIT = 10
 TOP_CHANGES_MAX = 100
 TOP_DATASETS_MAX = 50
-# The triage aids (Top changes section, tier strip) only appear when there's something to
-# triage: a report with a couple of changed datasets is already scannable, and on the common
-# single-dataset PR they'd be redundant noise. Per-row tier chips render at any size.
-TRIAGE_MIN_DATASETS = 3
 
 
 def _tier(severity: float) -> Tier:
@@ -688,86 +684,86 @@ def render_html(report: DiffReport) -> str:
     else:
         ind_tier_select = ""
 
-    # Triage aids — only when the report is big enough to need them.
+    # Triage aids — one format for every report size; content-based gating on the controls
+    # (dropdowns, toggles, show-more) already prevents dead UI on small diffs.
     tier_strip = ""
     top_block = ""
-    if report.n_changed >= TRIAGE_MIN_DATASETS:
-        strip_bits = [f"{TIER_ICONS[t]} {n} {t}" for t, n in tier_counts.items() if n]
-        # Datasets whose only differences are metadata edits carry no anomaly tier — list them
-        # separately so the strip total still matches the headline's differing-dataset count.
-        # (A changed dataset can also score 0 from purely *added* values; that gets its own bucket.)
-        n_meta_only = sum(1 for ds in report.datasets if ds.is_metadata_only)
-        if n_meta_only:
-            strip_bits.append(f"📝 {n_meta_only} metadata-only")
-        n_new_only = sum(
-            1 for ds in report.datasets if ds.change_kind == "changed" and ds.tier == "none" and not ds.is_metadata_only
+    strip_bits = [f"{TIER_ICONS[t]} {n} {t}" for t, n in tier_counts.items() if n]
+    # Datasets whose only differences are metadata edits carry no anomaly tier — list them
+    # separately so the strip total still matches the headline's differing-dataset count.
+    # (A changed dataset can also score 0 from purely *added* values; that gets its own bucket.)
+    n_meta_only = sum(1 for ds in report.datasets if ds.is_metadata_only)
+    if n_meta_only:
+        strip_bits.append(f"📝 {n_meta_only} metadata-only")
+    n_new_only = sum(
+        1 for ds in report.datasets if ds.change_kind == "changed" and ds.tier == "none" and not ds.is_metadata_only
+    )
+    if n_new_only:
+        strip_bits.append(f"➕ {n_new_only} new-data-only")
+    n_diff = sum(tier_counts.values()) + n_meta_only + n_new_only
+    if strip_bits and n_diff:
+        tier_strip = (
+            f'<div class="tier-strip">Of the {n_diff:,} dataset{"s" if n_diff != 1 else ""} with '
+            f"differences, the changes are: {' · '.join(strip_bits)} "
+            f'<span class="tier-hint">(tiered by median anomaly score; coverage loss ⇒ 🔴)</span></div>'
         )
-        if n_new_only:
-            strip_bits.append(f"➕ {n_new_only} new-data-only")
-        n_diff = sum(tier_counts.values()) + n_meta_only + n_new_only
-        if strip_bits and n_diff:
-            tier_strip = (
-                f'<div class="tier-strip">Of the {n_diff:,} dataset{"s" if n_diff != 1 else ""} with '
-                f"differences, the changes are: {' · '.join(strip_bits)} "
-                f'<span class="tier-hint">(tiered by median anomaly score; coverage loss ⇒ 🔴)</span></div>'
-            )
 
-        # Datasets to watch, in triage order (see dataset_watch_key).
-        watch = sorted((d for d in datasets if d.change_kind in ("changed", "error", "removed")), key=dataset_watch_key)
-        ds_items = []
-        for d in watch[:TOP_DATASETS_MAX]:
-            # Red is reserved for the alarming part only: the data-loss fragment (or a dataset
-            # that failed to compare / was removed) — not the whole meta line.
-            if d.change_kind == "error":
-                meta_html = '<span class="top-meta loss">failed to compare</span>'
-            elif d.change_kind == "removed":
-                meta_html = '<span class="top-meta loss">removed dataset</span>'
-            elif d.is_metadata_only:
-                meta_html = '<span class="top-meta">metadata-only changes</span>'
-            elif d.severity <= 0:
-                meta_html = '<span class="top-meta">new data only</span>'
-            else:
-                n_cols = sum(len(t.changed_columns) for t in d.tables)
-                n_tables = sum(1 for t in d.tables if t.any_change)
-                meta_html = f'<span class="top-meta">median anomaly score {_e(format_score(d.severity))}</span>'
-                if d.removed_row_count:
-                    meta_html += f'<span class="top-meta loss">− lost {d.removed_row_count:,} data point(s)</span>'
-                meta_html += f'<span class="top-meta">{n_cols} column(s) in {n_tables} table(s)</span>'
-            icon = TIER_ICONS.get(d.tier) or ("📝" if d.is_metadata_only else "")
-            ds_items.append(
-                f'<li><span class="ti">{icon}</span> '
-                f'<a href="#{_ds_anchor(d.path)}"><code>{_e(d.path)}</code></a>{meta_html}</li>'
-            )
+    # Datasets to watch, in triage order (see dataset_watch_key).
+    watch = sorted((d for d in datasets if d.change_kind in ("changed", "error", "removed")), key=dataset_watch_key)
+    ds_items = []
+    for d in watch[:TOP_DATASETS_MAX]:
+        # Red is reserved for the alarming part only: the data-loss fragment (or a dataset
+        # that failed to compare / was removed) — not the whole meta line.
+        if d.change_kind == "error":
+            meta_html = '<span class="top-meta loss">failed to compare</span>'
+        elif d.change_kind == "removed":
+            meta_html = '<span class="top-meta loss">removed dataset</span>'
+        elif d.is_metadata_only:
+            meta_html = '<span class="top-meta">metadata-only changes</span>'
+        elif d.severity <= 0:
+            meta_html = '<span class="top-meta">new data only</span>'
+        else:
+            n_cols = sum(len(t.changed_columns) for t in d.tables)
+            n_tables = sum(1 for t in d.tables if t.any_change)
+            meta_html = f'<span class="top-meta">median anomaly score {_e(format_score(d.severity))}</span>'
+            if d.removed_row_count:
+                meta_html += f'<span class="top-meta loss">− lost {d.removed_row_count:,} data point(s)</span>'
+            meta_html += f'<span class="top-meta">{n_cols} column(s) in {n_tables} table(s)</span>'
+        icon = TIER_ICONS.get(d.tier) or ("📝" if d.is_metadata_only else "")
+        ds_items.append(
+            f'<li><span class="ti">{icon}</span> '
+            f'<a href="#{_ds_anchor(d.path)}"><code>{_e(d.path)}</code></a>{meta_html}</li>'
+        )
 
-        losses, changes = _top_changes(report, limit=TOP_CHANGES_MAX)
-        items = []
-        # Data-point losses lead the indicators list — make it unmistakable that rows disappeared.
-        for n_removed, labels, ds_path, table, dim in losses:
-            shown = ", ".join(labels[:4]) + ("…" if len(labels) > 4 else "")
-            link_open = f'<a href="#{_anchor(ds_path, table, dim)}">' if dim else ""
-            link_close = "</a>" if dim else ""
-            items.append(
-                f'<li class="loss"><span class="ti">🔴</span> '
-                f"{link_open}<code>{_e(ds_path)}</code> · <code>{_e(table)}</code>{link_close}"
-                f'<span class="top-meta loss">− lost {n_removed:,} data point(s)'
-                + (f": {_e(shown)}" if shown else "")
-                + "</span></li>"
-            )
-        for severity, pct, ds_path, table, col in changes:
-            tier = _tier(severity)
-            items.append(
-                f'<li><span class="ti">{TIER_ICONS.get(tier, "")}</span> '
-                f'<a href="#{_anchor(ds_path, table, col)}"><code>{_e(ds_path)}</code> · <code>{_e(table)}.{_e(col)}</code></a>'
-                f'<span class="top-meta">median anomaly score {_e(format_score(severity))} · {pct:.0f}% of rows</span></li>'
-            )
-        if ds_items or items:
-            parts = ['<details class="top-changes" open><summary><b>Top changes — what to watch</b></summary>']
-            if ds_items:
-                parts.append(f"<div class='tc-h'>Datasets</div>{_expandable_list(ds_items, TOP_DATASETS_LIMIT)}")
-            if items:
-                parts.append(f"<div class='tc-h'>Indicators</div>{_expandable_list(items, TOP_CHANGES_LIMIT)}")
-            parts.append("</details>")
-            top_block = "".join(parts)
+    losses, changes = _top_changes(report, limit=TOP_CHANGES_MAX)
+    items = []
+    # Data-point losses lead the indicators list — make it unmistakable that rows disappeared.
+    for n_removed, labels, ds_path, table, dim in losses:
+        shown = ", ".join(labels[:4]) + ("…" if len(labels) > 4 else "")
+        link_open = f'<a href="#{_anchor(ds_path, table, dim)}">' if dim else ""
+        link_close = "</a>" if dim else ""
+        items.append(
+            f'<li class="loss"><span class="ti">🔴</span> '
+            f"{link_open}<code>{_e(ds_path)}</code> · <code>{_e(table)}</code>{link_close}"
+            f'<span class="top-meta loss">− lost {n_removed:,} data point(s)'
+            + (f": {_e(shown)}" if shown else "")
+            + "</span></li>"
+        )
+    for severity, pct, ds_path, table, col in changes:
+        tier = _tier(severity)
+        items.append(
+            f'<li><span class="ti">{TIER_ICONS.get(tier, "")}</span> '
+            f'<a href="#{_anchor(ds_path, table, col)}"><code>{_e(ds_path)}</code> · <code>{_e(table)}.{_e(col)}</code></a>'
+            f'<span class="top-meta">median anomaly score {_e(format_score(severity))} · {pct:.0f}% of rows</span></li>'
+        )
+    if ds_items or items:
+        parts = ['<details class="top-changes" open><summary><b>Top changes — what to watch</b></summary>']
+        if ds_items:
+            parts.append(f"<div class='tc-h'>Datasets</div>{_expandable_list(ds_items, TOP_DATASETS_LIMIT)}")
+        if items:
+            parts.append(f"<div class='tc-h'>Indicators</div>{_expandable_list(items, TOP_CHANGES_LIMIT)}")
+        parts.append("</details>")
+        top_block = "".join(parts)
 
     skipped_note = (
         f'<div class="skipped-note">= {report.skipped_cascade:,} more dataset(s) skipped: '

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -219,16 +219,38 @@ def test_coverage_loss_forces_large_tier():
     assert 'class="chip tier large">🔴 median anomaly score' in html
 
 
-def test_triage_aids_render_at_any_size():
-    # One format for every report size: even a single-dataset diff gets the tier strip and the
-    # watch lists (its Indicators list is exactly where a many-column dataset needs ranking).
+def test_triage_aids_gate_on_content():
+    # Each triage element renders only when it can discriminate.
     # (Assert on rendered elements, not bare class names — those always appear in the stylesheet.)
-    small = DiffReport(datasets=[_changed_ds("garden/n/v/a", 0.5)])
-    html_small = render_html(small)
-    assert "Top changes" in html_small
-    assert '<div class="tier-strip">' in html_small
-    assert "Of the 1 dataset with differences" in html_small
-    assert "anomaly score" in html_small
+
+    # One dataset, ONE indicator: nothing to rank — no watch list, no tier strip; chips only.
+    tiny = DiffReport(datasets=[_changed_ds("garden/n/v/a", 0.5)])
+    html_tiny = render_html(tiny)
+    assert "Top changes" not in html_tiny
+    assert '<div class="tier-strip">' not in html_tiny
+    assert "anomaly score" in html_tiny
+
+    # One dataset, MANY indicators: the Indicators list ranks them (that's where it helps most),
+    # but the singleton Datasets sub-list and the "Of the 1 dataset" strip stay hidden.
+    many_cols = DiffReport(
+        datasets=[
+            DatasetDiffResult(
+                path="garden/n/v/wide",
+                kind="identical",
+                tables=[
+                    TableDiffResult(
+                        name="t",
+                        kind="identical",
+                        columns=[_changed_col(f"c{i}", 0.5 - i * 0.1) for i in range(4)],
+                    )
+                ],
+            )
+        ]
+    )
+    html_many = render_html(many_cols)
+    assert ">Indicators<" in html_many
+    assert ">Datasets<" not in html_many
+    assert '<div class="tier-strip">' not in html_many
 
     big = DiffReport(datasets=[_changed_ds(f"garden/n/v/d{i}", 0.5 - i * 0.1) for i in range(4)])
     html_big = render_html(big)

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -219,13 +219,15 @@ def test_coverage_loss_forces_large_tier():
     assert 'class="chip tier large">🔴 median anomaly score' in html
 
 
-def test_triage_aids_only_on_big_reports():
+def test_triage_aids_render_at_any_size():
+    # One format for every report size: even a single-dataset diff gets the tier strip and the
+    # watch lists (its Indicators list is exactly where a many-column dataset needs ranking).
+    # (Assert on rendered elements, not bare class names — those always appear in the stylesheet.)
     small = DiffReport(datasets=[_changed_ds("garden/n/v/a", 0.5)])
     html_small = render_html(small)
-    # A single changed dataset: no watch list, no tier strip — but the row chip still renders.
-    # (Assert on rendered elements, not bare class names — those always appear in the stylesheet.)
-    assert "Top changes" not in html_small
-    assert '<div class="tier-strip">' not in html_small
+    assert "Top changes" in html_small
+    assert '<div class="tier-strip">' in html_small
+    assert "Of the 1 dataset with differences" in html_small
     assert "anomaly score" in html_small
 
     big = DiffReport(datasets=[_changed_ds(f"garden/n/v/d{i}", 0.5 - i * 0.1) for i in range(4)])

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -317,7 +317,7 @@ def test_top_changes_show_more():
 
 def test_headline_counts_datasets():
     one = DiffReport(datasets=[_changed_ds("garden/n/v/a", 0.5)])
-    assert "❌ Found differences in 1 of 1 compared dataset" in render_html(one)
+    assert "❌ Found differences in the compared dataset" in render_html(one)
 
     mixed = DiffReport(
         datasets=[
@@ -328,7 +328,10 @@ def test_headline_counts_datasets():
     assert "❌ Found differences in 1 of 2 compared datasets" in render_html(mixed)
 
     clean = DiffReport(datasets=[DatasetDiffResult(path="garden/n/v/b", kind="identical")])
-    assert "✅ No differences found across 1 compared dataset" in render_html(clean)
+    assert "✅ No differences found in the compared dataset" in render_html(clean)
+
+    all_changed = DiffReport(datasets=[_changed_ds(f"garden/n/v/d{i}", 0.5) for i in range(3)])
+    assert "❌ Found differences in all 3 compared datasets" in render_html(all_changed)
 
 
 def test_top_changes_lists_data_losses_first():


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

Follow-up to #6415.

## Why

The triage aids (tier strip + "Top changes" watch lists) only rendered on reports with ≥ 3 changed datasets. Two problems: reviewers get two different report formats depending on diff size, and the gate keyed on *dataset count* — so a **single-dataset diff with hundreds of changed indicators** (WDI-style, exactly where a ranked Indicators watch list helps most) got no watch list at all. Conversely, a fully uniform format would add pure duplication to a one-indicator diff.

## What

Replace the size gate (`TRIAGE_MIN_DATASETS`) with **per-element content gates** — each element renders only when it can discriminate, the same principle already used for the controls:

- **Tier strip**: ≥ 2 differing datasets ("Of the 1 dataset with differences…" restates the headline).
- **Datasets watch sub-list**: ≥ 2 entries.
- **Indicators watch sub-list**: ≥ 2 entries (losses + changes) — a ranking of one thing ranks nothing.

Resulting behavior: a one-indicator diff gets a clean minimal report (chips only); a single-dataset/many-indicators diff keeps the ranked **Indicators** list without the singleton Datasets list or the strip; big reports keep everything. The control gating (tier dropdowns ≥ 2 categories, identical-toggle only when identical datasets exist, show-more only when truncated) is unchanged.

## Verification

22 + 4 tests pass (`test_triage_aids_gate_on_content` covers all three shapes); verified on a real single-dataset diff (`electricity_mix` vs production): no tier strip, no Datasets sub-list, ranked Indicators list present with anchors.