### PR TITLE
🐛 Post data-diff comment even when some datasets error

### DIFF
--- a/apps/owidbot/data_diff.py
+++ b/apps/owidbot/data_diff.py
@@ -248,8 +248,12 @@ def call_etl_diff(include: str, output_json: Path, output_html: Path) -> None:
     # Remove all warnings from stderr
     stderr = re.sub(r"^.*WARNING.*", "", stderr, flags=re.MULTILINE).strip()
 
-    if result.returncode == 1 and "Found differences" in stdout:
-        log.info("etl diff found differences", returncode=result.returncode)
+    # `etl diff` exits 1 for any completed run with findings; when a dataset fails to compare,
+    # the summary line is "⚠ Found errors, create an issue please" *instead of* "Found
+    # differences". The JSON/HTML reports are fully written before it exits either way (error
+    # datasets are included with an ⚠ icon), so both outcomes must be posted, not raised.
+    if result.returncode == 1 and ("Found differences" in stdout or "Found errors" in stdout):
+        log.info("etl diff found differences or errors", returncode=result.returncode)
     elif result.returncode != 0:
         details = [f"etl diff failed (exit {result.returncode})", f"Command: {cmd_str}"]
         if stderr:

--- a/tests/apps/test_owidbot_data_diff.py
+++ b/tests/apps/test_owidbot_data_diff.py
@@ -1,3 +1,6 @@
+import pytest
+
+from apps.owidbot import data_diff
 from apps.owidbot.data_diff import format_comment
 from etl.datadiff_report import (
     ColumnDiffResult,
@@ -131,3 +134,37 @@ def test_format_comment_puts_data_losses_first():
     )
     body = format_comment(DiffReport(datasets=[big, lossy]), None)
     assert body.index("garden/n/v/lossy") < body.index("garden/n/v/big")
+
+
+class _FakePopen:
+    def __init__(self, returncode: int, stdout: str):
+        self.returncode = returncode
+        self._stdout = stdout
+
+    def communicate(self):
+        return self._stdout, ""
+
+
+def test_call_etl_diff_accepts_completed_runs(monkeypatch, tmp_path):
+    """Exit code 1 means the diff completed and wrote its reports — whether the summary line says
+    "Found differences" or "Found errors" (some dataset failed to compare). Neither must raise,
+    otherwise the PR comment silently keeps its stale content."""
+
+    def use_popen(returncode: int, stdout: str) -> None:
+        monkeypatch.setattr(data_diff.subprocess, "Popen", lambda *a, **kw: _FakePopen(returncode, stdout))
+
+    out_json, out_html = tmp_path / "d.json", tmp_path / "d.html"
+
+    use_popen(1, "⚠ Found errors, create an issue please")
+    data_diff.call_etl_diff("garden", output_json=out_json, output_html=out_html)
+
+    use_popen(1, "❌ Found differences")
+    data_diff.call_etl_diff("garden", output_json=out_json, output_html=out_html)
+
+    use_popen(2, "some hard failure")
+    with pytest.raises(RuntimeError):
+        data_diff.call_etl_diff("garden", output_json=out_json, output_html=out_html)
+
+    use_popen(1, "output without a summary line")
+    with pytest.raises(RuntimeError):
+        data_diff.call_etl_diff("garden", output_json=out_json, output_html=out_html)


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

## Problem

When any dataset fails to compare, `etl diff` prints `⚠ Found errors, create an issue please` **instead of** `❌ Found differences` (they're `elif` branches) and exits 1. owidbot's gate in `call_etl_diff` only tolerates exit 1 when stdout contains the literal `"Found differences"`, so it raises `RuntimeError`, the owidbot process dies before posting, and the ops wrapper's `|| true` swallows the crash. Net effect: the PR comment silently keeps whatever stale content it had (typically the pre-bake `✅ no differences`).

This is exactly what happened on #6416: the bake finished at 16:34 UTC, every subsequent owidbot run crashed on this gate, and the comment stayed frozen at the 15:57 pre-bake state. Reproduced manually on the staging box:

```
RuntimeError: etl diff failed (exit 1)
...
⚠ Found errors, create an issue please
```

## Fix

Accept exit 1 when stdout contains either summary line. This is safe because `etl diff` calls `_write_reports()` **before** exiting, so the JSON/HTML reports are always complete — and the report pipeline already models error datasets explicitly (`⚠️` status icon, `! path — error: ...` lines in the comment, severity override in the HTML report). The gate was just never updated for that.

Runs that exit 1 *without* either summary line (a genuinely broken run) still raise, as do exit codes ≥ 2.

## Test

`test_call_etl_diff_accepts_completed_runs` covers all four gate outcomes (errors line, differences line, exit 2, exit 1 with no summary line) with a stubbed `Popen`.
