### PR TITLE
🐛 data-diff: tolerate Jinja processing levels and cap huge HTML reports

### DIFF
--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -21,6 +21,15 @@ ChangeKind = Literal["new", "removed", "changed", "identical", "error"]
 # can afford more).
 SAMPLE_LIMIT = 100
 
+# Cap on the total sample rows rendered into the HTML report. PRs that touch hundreds of
+# datasets (e.g. a regions or income-groups update) can otherwise produce a >100 MB page that
+# no browser opens. When over budget, each value diff renders only its first rows (the most
+# anomalous ones when the sample is score-sorted) with an explicit note; the JSON output always
+# keeps the full samples.
+HTML_SAMPLE_ROW_BUDGET = 50_000
+# Never render fewer than this many rows per value diff, however big the report.
+HTML_SAMPLE_ROW_MIN = 5
+
 # Severity tiers (thresholds on the BARD-based anomaly score, stored in [0, 1] and displayed
 # as a percentage): they tell a reviewer where to stop reading. large = score ≥ 15%, moderate
 # ≥ 1%, small = anything non-zero below that (usually rounding-level noise).
@@ -508,31 +517,37 @@ def _render_meta_diff(meta_diff: str, label: str) -> str:
     return f'<details class="meta"><summary>{_e(label)}</summary><pre>{chr(10).join(lines)}</pre></details>'
 
 
-def _render_value_diff(v: ValueDiff) -> str:
+def _render_value_diff(v: ValueDiff, sample_cap: int = SAMPLE_LIMIT) -> str:
     label = {"new": "New values", "removed": "Removed values", "changed": "Changed values"}[v.kind]
+    shown = v.sample[:sample_cap]
     # Say up front that the table is a sample — a note below a 100-row scrollable table is only
     # discovered after scrolling past rows the reader didn't know were truncated.
     head_note = ""
-    if v.count > len(v.sample):
+    if v.count > len(shown):
         what = (
-            f"the {len(v.sample):,} most anomalous rows"
+            f"the {len(shown):,} most anomalous rows"
             if v.sorted_by_score
-            else f"a random sample of {len(v.sample):,} rows"
+            else f"a random sample of {len(shown):,} rows"
         )
-        head_note = f' <span class="head-note">— showing {what}</span>'
+        capped = (
+            f" (of {len(v.sample):,} sampled — display capped to keep this report loadable)"
+            if len(shown) < len(v.sample)
+            else ""
+        )
+        head_note = f' <span class="head-note">— showing {what}{capped}</span>'
     head = (
         f'<div class="vd-head {v.kind}">{_e(v.symbol)} {label}: '
         f"{v.count:,} / {v.total:,} ({v.pct:.2f}%){head_note}</div>"
     )
-    if not v.sample:
+    if not shown:
         return f'<div class="vd">{head}</div>'
 
-    cols = list(v.sample[0].keys())
+    cols = list(shown[0].keys())
     ths = "".join(
         f'<th class="{"old" if c.endswith(" -") else "new" if c.endswith(" +") else ""}">{_e(c)}</th>' for c in cols
     )
     trs = []
-    for row in v.sample:
+    for row in shown:
         tds = "".join(
             f'<td class="{"old" if c.endswith(" -") else "new" if c.endswith(" +") else ""}">{_e(row.get(c, ""))}</td>'
             for c in cols
@@ -544,7 +559,7 @@ def _render_value_diff(v: ValueDiff) -> str:
     )
 
 
-def _render_column(table_name: str, c: ColumnDiffResult, ds_path: str = "") -> str:
+def _render_column(table_name: str, c: ColumnDiffResult, ds_path: str = "", sample_cap: int = SAMPLE_LIMIT) -> str:
     chips = "".join(f'<span class="chip">{_e(ch)}</span>' for ch in c.changes)
     dim = '<span class="chip dim">dim</span>' if c.is_dim else ""
     tier = _tier_chip(c.severity, c.kind) if not c.is_dim else ""
@@ -560,12 +575,12 @@ def _render_column(table_name: str, c: ColumnDiffResult, ds_path: str = "") -> s
     if c.meta_diff:
         parts.append(_render_meta_diff(c.meta_diff, "metadata diff"))
     for v in c.value_diffs:
-        parts.append(_render_value_diff(v))
+        parts.append(_render_value_diff(v, sample_cap))
     parts.append("</div>")
     return "".join(parts)
 
 
-def _render_table(t: TableDiffResult, ds_path: str = "") -> str:
+def _render_table(t: TableDiffResult, ds_path: str = "", sample_cap: int = SAMPLE_LIMIT) -> str:
     parts = [
         f'<div class="tbl"><div class="tbl-head"><span class="sym {t.kind}">{_SYMBOLS[t.kind]}</span> '
         f"Table <b>{_e(t.name)}</b>{_tier_chip(t.severity, t.kind)}</div>"
@@ -576,7 +591,7 @@ def _render_table(t: TableDiffResult, ds_path: str = "") -> str:
     for c in sorted(t.columns, key=lambda c: -c.severity):
         if c.kind == "identical":
             continue
-        parts.append(_render_column(t.name, c, ds_path))
+        parts.append(_render_column(t.name, c, ds_path, sample_cap))
     parts.append("</div>")
     return "".join(parts)
 
@@ -599,7 +614,7 @@ def _dataset_summary_note(ds: DatasetDiffResult) -> str:
     return ", ".join(notes) if notes else "identical"
 
 
-def _render_dataset(ds: DatasetDiffResult) -> str:
+def _render_dataset(ds: DatasetDiffResult, sample_cap: int = SAMPLE_LIMIT) -> str:
     kind = ds.change_kind
     open_attr = " open" if kind in ("changed", "error") else ""
     new_version = ' <span class="chip">new version</span>' if ds.is_new_version else ""
@@ -623,7 +638,7 @@ def _render_dataset(ds: DatasetDiffResult) -> str:
     # Most-changed tables first (stable: ties keep collection order).
     for t in sorted(ds.tables, key=lambda t: -t.severity):
         if t.any_change or ds.kind in ("new", "removed"):
-            parts.append(_render_table(t, ds.path))
+            parts.append(_render_table(t, ds.path, sample_cap))
     parts.append("</div></details>")
     return "".join(parts)
 
@@ -650,7 +665,19 @@ def render_html(report: DiffReport) -> str:
     # changed datasets ranked by the size of their changes (median BARD of the most-changed
     # column), then new datasets; identical last. Path as tie-break for determinism.
     datasets = sorted(report.datasets, key=lambda ds: (-ds.severity, ds.path))
-    sections = "".join(_render_dataset(ds) for ds in datasets)
+
+    # Spread the HTML sample-row budget evenly over all sampled value diffs; small reports keep
+    # their full samples, huge ones (hundreds of changed datasets) get capped per diff so the
+    # page stays openable in a browser.
+    sampled_counts = [
+        len(v.sample) for ds in datasets for t in ds.tables for c in t.columns for v in c.value_diffs if v.sample
+    ]
+    if sum(sampled_counts) > HTML_SAMPLE_ROW_BUDGET:
+        sample_cap = max(HTML_SAMPLE_ROW_MIN, HTML_SAMPLE_ROW_BUDGET // len(sampled_counts))
+    else:
+        sample_cap = SAMPLE_LIMIT
+
+    sections = "".join(_render_dataset(ds, sample_cap) for ds in datasets)
 
     tier_counts = {"large": 0, "moderate": 0, "small": 0}
     for ds in report.datasets:

--- a/lib/catalog/owid/catalog/core/indicators.py
+++ b/lib/catalog/owid/catalog/core/indicators.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import copy
 import json
 import os
+import re
 from collections import defaultdict
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
@@ -748,11 +749,13 @@ def combine_indicators_processing_level(indicators: list[Indicator]) -> PROCESSI
         # keep the template so it still renders per dimension downstream.
         return cast(PROCESSING_LEVELS, templates[0])
 
-    # A template's rendered value is unknown here, but it can only produce the level names
-    # spelled out in its text — count the highest of those, so combining with a literal never
-    # understates the result (a maybe-major template + "minor" must combine to "major", since
-    # processing_level feeds licensing downstream).
-    template_levels = [level for template in templates for level in PROCESSING_LEVELS_ORDER if level in template]
+    # A template's rendered value is unknown here, but its possible outputs are the literal text
+    # outside its `<% ... %>` statement tags (conditions never render, so a level name inside
+    # e.g. `sector == "major donors"` doesn't count) — take the highest level named there, so
+    # combining with a literal never understates the result (a maybe-major template + "minor"
+    # must combine to "major", since processing_level feeds licensing downstream).
+    rendered_text = " ".join(re.sub(r"<%.*?%>", " ", template, flags=re.DOTALL) for template in templates)
+    template_levels = [level for level in PROCESSING_LEVELS_ORDER if level in rendered_text]
 
     candidate_levels = literal_levels + template_levels
     if not candidate_levels:

--- a/lib/catalog/owid/catalog/core/indicators.py
+++ b/lib/catalog/owid/catalog/core/indicators.py
@@ -749,13 +749,19 @@ def combine_indicators_processing_level(indicators: list[Indicator]) -> PROCESSI
         # keep the template so it still renders per dimension downstream.
         return cast(PROCESSING_LEVELS, templates[0])
 
-    # A template's rendered value is unknown here, but its possible outputs are the literal text
+    # A template's rendered value is unknown here. Its possible outputs are the literal text
     # outside its `<% ... %>` statement tags (conditions never render, so a level name inside
     # e.g. `sector == "major donors"` doesn't count) — take the highest level named there, so
     # combining with a literal never understates the result (a maybe-major template + "minor"
-    # must combine to "major", since processing_level feeds licensing downstream).
-    rendered_text = " ".join(re.sub(r"<%.*?%>", " ", template, flags=re.DOTALL) for template in templates)
-    template_levels = [level for level in PROCESSING_LEVELS_ORDER if level in rendered_text]
+    # must combine to "major", since processing_level feeds licensing downstream). When the
+    # output is routed through a variable (e.g. `<% set level = "major" if ... %><< level >>`)
+    # the output text names no level — fall back to scanning the whole source, deliberately
+    # overstating rather than understating.
+    template_levels: list[str] = []
+    for template in templates:
+        rendered_text = re.sub(r"<%.*?%>", " ", template, flags=re.DOTALL)
+        levels = [level for level in PROCESSING_LEVELS_ORDER if level in rendered_text]
+        template_levels += levels or [level for level in PROCESSING_LEVELS_ORDER if level in template]
 
     candidate_levels = literal_levels + template_levels
     if not candidate_levels:

--- a/lib/catalog/owid/catalog/core/indicators.py
+++ b/lib/catalog/owid/catalog/core/indicators.py
@@ -743,13 +743,24 @@ def combine_indicators_processing_level(indicators: list[Indicator]) -> PROCESSI
     unknown_processing_levels = set(literal_levels) - set(PROCESSING_LEVELS_ORDER)
     assert len(unknown_processing_levels) == 0, f"Unknown processing levels: {unknown_processing_levels}"
 
-    if not literal_levels:
-        # Only templates: keep the template when all indicators share the same one (e.g. when
-        # comparing two versions of the same column), otherwise there is no sensible combination.
-        return cast(PROCESSING_LEVELS, templates[0]) if len(set(templates)) == 1 else None
+    if not literal_levels and len(set(templates)) == 1:
+        # Only templates and all identical (e.g. comparing two versions of the same column):
+        # keep the template so it still renders per dimension downstream.
+        return cast(PROCESSING_LEVELS, templates[0])
 
-    # If any of the indicators has a literal processing level, take the highest level.
-    maximum_level = max([PROCESSING_LEVELS_ORDER[level] for level in literal_levels])
+    # A template's rendered value is unknown here, but it can only produce the level names
+    # spelled out in its text — count the highest of those, so combining with a literal never
+    # understates the result (a maybe-major template + "minor" must combine to "major", since
+    # processing_level feeds licensing downstream).
+    template_levels = [level for template in templates for level in PROCESSING_LEVELS_ORDER if level in template]
+
+    candidate_levels = literal_levels + template_levels
+    if not candidate_levels:
+        # Distinct templates that spell out no known level — there is no sensible combination.
+        return None
+
+    # Take the highest level any of the indicators has (or could render).
+    maximum_level = max([PROCESSING_LEVELS_ORDER[level] for level in candidate_levels])
 
     # Return the maximum level as a string.
     combined_processing_level = {value: key for key, value in PROCESSING_LEVELS_ORDER.items()}[maximum_level]

--- a/lib/catalog/owid/catalog/core/indicators.py
+++ b/lib/catalog/owid/catalog/core/indicators.py
@@ -733,12 +733,23 @@ def combine_indicators_processing_level(indicators: list[Indicator]) -> PROCESSI
         # If there are no processing levels, return None.
         return None
 
-    # Ensure that all processing levels are known.
-    unknown_processing_levels = {level for level in processing_levels} - set(PROCESSING_LEVELS_ORDER)
+    # Unrendered Jinja templates are valid processing levels at authoring time (the dataset
+    # schema allows "<%"-patterned strings, rendered per dimension at grapher time), but they
+    # can't participate in the level comparison below.
+    templates = [level for level in processing_levels if "<%" in level]
+    literal_levels = [level for level in processing_levels if "<%" not in level]
+
+    # Ensure that all literal processing levels are known.
+    unknown_processing_levels = set(literal_levels) - set(PROCESSING_LEVELS_ORDER)
     assert len(unknown_processing_levels) == 0, f"Unknown processing levels: {unknown_processing_levels}"
 
-    # If any of the indicators has a processing level, take the highest level.
-    maximum_level = max([PROCESSING_LEVELS_ORDER[level] for level in processing_levels])
+    if not literal_levels:
+        # Only templates: keep the template when all indicators share the same one (e.g. when
+        # comparing two versions of the same column), otherwise there is no sensible combination.
+        return cast(PROCESSING_LEVELS, templates[0]) if len(set(templates)) == 1 else None
+
+    # If any of the indicators has a literal processing level, take the highest level.
+    maximum_level = max([PROCESSING_LEVELS_ORDER[level] for level in literal_levels])
 
     # Return the maximum level as a string.
     combined_processing_level = {value: key for key, value in PROCESSING_LEVELS_ORDER.items()}[maximum_level]

--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -11,6 +11,7 @@ from owid.catalog.core.indicators import (
     License,
     Variable,
     combine_indicators_metadata,
+    combine_indicators_processing_level,
     get_unique_licenses_from_indicators,
     get_unique_origins_from_indicators,
 )
@@ -646,3 +647,26 @@ def test_variable_to_frame_with_custom_name() -> None:
     # Note: Metadata is not automatically copied when renaming via name parameter
     # This is consistent with pandas Series.to_frame() behavior
     # If you need to preserve metadata when renaming, copy it manually after conversion
+
+
+def test_combine_indicators_processing_level_with_jinja_templates() -> None:
+    # The dataset schema allows unrendered Jinja templates in processing_level (they render per
+    # dimension at grapher time), so combining indicators must not choke on them.
+    template = '<% if sector == "Non-humanitarian aid" %>major<% else %>minor<%- endif -%>'
+
+    def _var(processing_level: str):
+        v = Variable([1, 2], name="v")
+        v.metadata.processing_level = processing_level  # type: ignore[assignment]
+        return v
+
+    # Identical templates (e.g. comparing two versions of the same column) are kept.
+    assert combine_indicators_processing_level([_var(template), _var(template)]) == template
+    # Templates mixed with literals: the highest literal wins.
+    assert combine_indicators_processing_level([_var(template), _var("minor")]) == "minor"
+    # Different templates with no literals can't be combined.
+    assert combine_indicators_processing_level([_var(template), _var(template.replace("minor", "major"))]) is None
+    # Literal levels behave as before.
+    assert combine_indicators_processing_level([_var("minor"), _var("major")]) == "major"
+    # Unknown literal levels still fail loudly.
+    with pytest.raises(AssertionError):
+        combine_indicators_processing_level([_var("mjor")])

--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -661,10 +661,15 @@ def test_combine_indicators_processing_level_with_jinja_templates() -> None:
 
     # Identical templates (e.g. comparing two versions of the same column) are kept.
     assert combine_indicators_processing_level([_var(template), _var(template)]) == template
-    # Templates mixed with literals: the highest literal wins.
-    assert combine_indicators_processing_level([_var(template), _var("minor")]) == "minor"
-    # Different templates with no literals can't be combined.
-    assert combine_indicators_processing_level([_var(template), _var(template.replace("minor", "major"))]) is None
+    # A template counts as the highest level it can render: maybe-major + minor -> major
+    # (understating would mislabel licensing downstream).
+    assert combine_indicators_processing_level([_var(template), _var("minor")]) == "major"
+    only_minor = '<% if sector == "X" %>minor<% else %>minor<%- endif -%>'
+    assert combine_indicators_processing_level([_var(only_minor), _var("minor")]) == "minor"
+    # Different templates with no literals combine to the highest renderable level.
+    assert combine_indicators_processing_level([_var(template), _var(only_minor)]) == "major"
+    # Templates that spell out no known level can't be combined.
+    assert combine_indicators_processing_level([_var("<% weird %>"), _var("<% weirder %>")]) is None
     # Literal levels behave as before.
     assert combine_indicators_processing_level([_var("minor"), _var("major")]) == "major"
     # Unknown literal levels still fail loudly.

--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -669,6 +669,10 @@ def test_combine_indicators_processing_level_with_jinja_templates() -> None:
     # Level names inside statement tags (conditions) never render, so they don't count.
     tricky = '<% if sector == "major donors" %>minor<% else %>minor<% endif %>'
     assert combine_indicators_processing_level([_var(tricky), _var("minor")]) == "minor"
+    # When the output is routed through a variable, the output text names no level: fall back to
+    # a whole-source scan, deliberately overstating rather than understating.
+    routed = '<% set level = "major" if sector == "x" else "minor" %><< level >>'
+    assert combine_indicators_processing_level([_var(routed), _var("minor")]) == "major"
     # Different templates with no literals combine to the highest renderable level.
     assert combine_indicators_processing_level([_var(template), _var(only_minor)]) == "major"
     # Templates that spell out no known level can't be combined.

--- a/lib/catalog/tests/test_variables.py
+++ b/lib/catalog/tests/test_variables.py
@@ -666,6 +666,9 @@ def test_combine_indicators_processing_level_with_jinja_templates() -> None:
     assert combine_indicators_processing_level([_var(template), _var("minor")]) == "major"
     only_minor = '<% if sector == "X" %>minor<% else %>minor<%- endif -%>'
     assert combine_indicators_processing_level([_var(only_minor), _var("minor")]) == "minor"
+    # Level names inside statement tags (conditions) never render, so they don't count.
+    tricky = '<% if sector == "major donors" %>minor<% else %>minor<% endif %>'
+    assert combine_indicators_processing_level([_var(tricky), _var("minor")]) == "minor"
     # Different templates with no literals combine to the highest renderable level.
     assert combine_indicators_processing_level([_var(template), _var(only_minor)]) == "major"
     # Templates that spell out no known level can't be combined.

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -9,6 +9,7 @@ from owid.catalog import Dataset, DatasetMeta, Table
 
 from etl.datadiff import DatasetDiff, RemoteDataset, _changed_records, _dataset_files_match
 from etl.datadiff_report import (
+    HTML_SAMPLE_ROW_BUDGET,
     ColumnDiffResult,
     DatasetDiffResult,
     DiffReport,
@@ -534,3 +535,38 @@ def test_structural_changes_are_not_metadata_only():
         tables=[TableDiffResult(name="extra", kind="new", columns=[ColumnDiffResult(name="a", kind="new")])],
     )
     assert not new_table.is_metadata_only
+
+
+def _sampled_ds(path, n_diffs, rows_per_diff):
+    sample = [{"country": f"c{i}", "year": "2020", "x -": "1", "x +": "2"} for i in range(rows_per_diff)]
+    cols = [
+        ColumnDiffResult(
+            name=f"col{j}",
+            kind="changed",
+            changes=["changed data"],
+            value_diffs=[ValueDiff(kind="changed", count=rows_per_diff, total=10_000, sample=list(sample))],
+        )
+        for j in range(n_diffs)
+    ]
+    return DatasetDiffResult(
+        path=path, kind="identical", tables=[TableDiffResult(name="t", kind="identical", columns=cols)]
+    )
+
+
+def test_html_sample_rows_capped_on_huge_reports():
+    # 1,200 value diffs x 100 rows = 120,000 sampled rows — over the budget, so each diff
+    # renders only its first rows with an explicit note.
+    report = DiffReport(datasets=[_sampled_ds(f"garden/n/v/ds{i}", n_diffs=120, rows_per_diff=100) for i in range(10)])
+    html = render_html(report)
+    per_diff = max(5, HTML_SAMPLE_ROW_BUDGET // 1200)
+    assert "of 100 sampled — display capped" in html
+    # The first rows survive, anything past the cap is dropped.
+    assert ">c0<" in html
+    assert f">c{per_diff - 1}<" in html
+    assert f">c{per_diff}<" not in html
+
+    # A small report keeps its full samples, with no cap note.
+    small = DiffReport(datasets=[_sampled_ds("garden/n/v/small", n_diffs=2, rows_per_diff=100)])
+    small_html = render_html(small)
+    assert "display capped" not in small_html
+    assert "c99" in small_html


### PR DESCRIPTION
> _Written by Claude Code — @paarriagadap at the wheel._

Two robustness fixes for `etl diff` at scale, both found while debugging the missing data-diff report on #6416. Follow-up to #6420.

## 1. Tolerate Jinja templates in `processing_level` when combining indicators

The dataset schema explicitly allows Jinja templates in `processing_level` (`{"oneOf": [{"enum": ["minor", "major"]}, {"type": "string", "pattern": "<%"}]}`) — they render per dimension at grapher time. But `combine_indicators_processing_level` in owid-catalog only knew the two literals, so any indicator operation on such a column asserted:

```
Unknown processing levels: {'<% if sector == "Non-humanitarian aid" %>\nmajor\n<% else %>\nminor\n<%- endif -%>'}
```

`etl diff` compares columns with `==` (an indicator op), so `garden/oecd/2025-12-23/official_development_assistance` — the only dataset currently using this pattern — errored in every diff run that included it. On #6416, that error then triggered the owidbot gate crash fixed in #6420.

New behavior when combining: identical templates are kept (the common case — comparing two versions of the same column); otherwise a template counts as the **highest level named in its output branches** (text outside `<% ... %>` statement tags — level names inside conditions don't count); when the output is routed through a variable (`<% set level = ... %><< level >>`) and the output text names no level, it falls back to a whole-source scan, deliberately overstating rather than understating (a maybe-major template + literal `minor` combines to `major`, never understating — `processing_level` feeds licensing); templates that mention no known level combine to `None`. Unknown *literal* levels (typos) still assert.

## 2. Cap sample rows rendered into huge HTML reports

#6416's staging diff (≈300 changed datasets downstream of income groups) produced a **108 MB** HTML report — beyond what a browser will open. `render_html` now spreads a global budget (`HTML_SAMPLE_ROW_BUDGET = 50,000` rows) evenly across all sampled value diffs when the total exceeds it, with a floor of 5 rows per diff. Since samples are sorted by anomaly score, the retained head rows are exactly the most anomalous ones. The header note says explicitly: *"showing the N most anomalous rows (of 100 sampled — display capped to keep this report loadable)"*. Small reports are unaffected, and the JSON output always keeps full samples.

## Tests

- `test_combine_indicators_processing_level_with_jinja_templates` (lib/catalog): identical templates kept, mixed falls back to literal, distinct templates → None, literal behavior unchanged, typo literals still assert.
- `test_html_sample_rows_capped_on_huge_reports`: a 120k-sample-row report gets capped per diff with the explicit note; a small report keeps full samples and no note.
