### PR TITLE
📜 Drop the blanket never-commit rule for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,6 @@ Our World in Data's ETL system - a content-addressable data pipeline with DAG-ba
 - **Trace issues upstream**: snapshot → meadow → garden → grapher
 - **`dag/archive/*.yml` is a generated record** — it is reconstructed from git history by `etl archive-dag`, so never hand-edit it. It lists steps that were once active (with the commit where they were last active) purely for recovery; to bring one back, `git checkout` that commit.
 - **Never delete a step without archiving it.** Removing or superseding an active step (new version, retirement, replacement) obligates you to archive it — deleting the files alone is a bug. Procedure: remove its `dag/*.yml` entry and delete its files → **commit** → run `etl archive-dag` (it reads *committed* history, so the removal must be committed first) → commit the regenerated `dag/archive/*.yml`. If `archive-dag` sweeps in unrelated steps others left un-archived, `git checkout` those files to keep your PR scoped (never hand-edit the archive). For a migrated/backport dataset, also delete its now-orphaned `snapshots/backport/latest/dataset_<id>_*` mirror files.
-- **Never push, commit, or open PRs** unless explicitly told to
 - **Ask the user** if unsure - don't guess
 - **Always run `make check` before committing**
 - If not told otherwise, save outputs to `ai/` directory.


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Removes the "Never push, commit, or open PRs unless explicitly told to" bullet from the Critical Rules. In practice it blocks routine flows where committing is clearly implied by the task, and judgment plus the surrounding rules (run `make check` before committing, ask when unsure) already govern this — like they do in our other repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
