### PR TITLE
📜 Document creating datasets via Claude Code on the web

### DIFF
--- a/docs/guides/data-work/ai-workflow.md
+++ b/docs/guides/data-work/ai-workflow.md
@@ -26,6 +26,12 @@ icon: lucide/sparkles
 
 At the moment it is mostly useful for updating datasets.
 
+!!! tip "No local setup? Use Claude Code on the web"
+
+    You can create simple datasets entirely from your browser (or phone) with
+    [Claude Code on the web](claude-code-web.md) — no VSCode or terminal
+    required.
+
 !!! warning "Work in Progress"
 
     This AI workflow is actively evolving! Updating a dataset was a proof of concept, and we're continuously improving Claude's capabilities and documentation based on real-world usage.

--- a/docs/guides/data-work/claude-code-web.md
+++ b/docs/guides/data-work/claude-code-web.md
@@ -1,0 +1,70 @@
+---
+tags:
+  - 👷 Staff
+  - Data Workflow
+  - AI
+icon: lucide/cloud
+---
+
+# Claude Code on the web
+
+Create (simple) datasets from your browser — or your phone — with no local
+setup at all: no VSCode, no terminal, no sandbox. [Claude Code on the
+web](https://claude.ai/code) runs sessions in a cloud environment with the ETL
+repository checked out, creates a pull request with a staging server, and
+fills in the metadata for you.
+
+This is the low-friction alternative to [Fast-track](https://etl.owid.io/wizard/fasttrack)
+(no spreadsheets, full traceability in ETL) and to the
+[terminal-based AI workflow](ai-workflow.md) (which remains the right tool for
+power users).
+
+## Set up the environment (once)
+
+1. Open <https://claude.ai/code>.
+    - **First-time users** are redirected to an onboarding flow: use the name
+      `etl` and `Trusted` or `Full` network access (you can switch to `Full`
+      later if `Trusted` turns out to be limiting).
+    - **Existing users** won't see onboarding: click the environment selector
+      (":cloud: Default") above the chat input and create a new `etl`
+      environment with the same settings.
+2. Edit the `etl` environment and paste the environment variables from
+   [1Password](https://ourworldindata.1password.com/app#/E46VV72PBZFZXCCJCLRXIFV4WY/Vault/E46VV72PBZFZXCCJCLRXIFV4WY:7ysaett3c574wa3qsud2olpbde:w354idcwbqxggt2snaz7d5yigi?itemListId=E46VV72PBZFZXCCJCLRXIFV4WY%3A7ysaett3c574wa3qsud2olpbde)
+   into **Environment variables** (three lines, `R2_ENDPOINT=...`) → Save
+   changes.
+
+    !!! warning
+
+        Environment variables are visible to anyone who can edit the
+        environment — only put values there that are okay to share within the
+        org (like the 1Password ones above).
+
+3. Next to the environment selector is the repository picker — choose
+   `owid/etl`.
+
+## Create a dataset
+
+Drag a CSV into the chat (or give Claude a URL with data) and ask:
+
+```
+Create a dataset from the attached CSV
+```
+
+Claude will create a pull request with a staging server and fill in all the
+metadata. It might ask a few clarifying questions, and you can steer it
+however you like — ask it to edit metadata, visualise the data in the chat,
+add custom processing, and so on.
+
+From there:
+
+1. Create or edit charts on the staging server via its **Admin** (link in the
+   PR).
+2. When you're happy, approve your changes in **chart-diff** (also linked in
+   the PR).
+3. Merge the PR — this syncs your charts to production.
+
+## Feedback
+
+This workflow is actively evolving. If you try it, share your session or
+reach out in #data-scientists on Slack — every attempt improves the dataset
+creation skill.


### PR DESCRIPTION
> _Written by Claude Code — @Marigold at the wheel._

Turns the [Slack announcement](https://owid.slack.com/archives/C014SGT6W9X/p1781685444077649) of the Claude Code on the web workflow into a docs page, so the instructions have a canonical, versioned home next to the terminal-based [AI workflow guide](https://docs.owid.io/projects/etl/guides/data-work/ai-workflow/).

- **`docs/guides/data-work/claude-code-web.md`** — one-time environment setup (with both entry paths spelled out: first-time users get redirected to onboarding, existing users go through the environment selector — the step that caused confusion in the Slack thread), the 1Password env vars with a visibility warning, and the drag-a-CSV → PR → staging admin → chart-diff → merge flow.
- **`ai-workflow.md`** — a short tip box pointing readers without a local setup at the new page.

The grapher repo is getting an equivalent guide in owid/owid-grapher#6738; once both land they can cross-reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
