### PR TITLE
📊 🐛 Correct India universal suffrage years in Lexical Index

### DIFF
--- a/etl/steps/data/garden/democracy/2026-04-02/lexical_index.corrections.yml
+++ b/etl/steps/data/garden/democracy/2026-04-02/lexical_index.corrections.yml
@@ -16,7 +16,7 @@
     Universal male suffrage in India is coded as beginning in 1947 (independence), but it began in
     1950 (Constitution in force). Confirmed with Svend-Erik Skaaning; fix due in the 2027 release.
   provider: Lexical Index
-  reported: 2026-07-09
+  reported: "2026-07-09"
   status: acknowledged
 - indicator: female_suffrage_lied
   entity: India
@@ -28,5 +28,5 @@
     Universal female suffrage in India is coded as beginning in 1947 (independence), but it began in
     1950 (Constitution in force). Confirmed with Svend-Erik Skaaning; fix due in the 2027 release.
   provider: Lexical Index
-  reported: 2026-07-09
+  reported: "2026-07-09"
   status: acknowledged

--- a/etl/steps/data/garden/democracy/2026-04-02/lexical_index.corrections.yml
+++ b/etl/steps/data/garden/democracy/2026-04-02/lexical_index.corrections.yml
@@ -1,0 +1,32 @@
+# Known errors in the Lexical Index source data (Skaaning et al.), patched locally until the
+# provider ships the fix. See etl/data_corrections.py for the format.
+#
+# India's universal right to vote (men and women) is coded as beginning in 1947 (independence),
+# but it began in 1950, when the Constitution came into force. Confirmed with Svend-Erik Skaaning;
+# the fix is due in the next annual release (2027). Correcting the two raw suffrage columns here
+# propagates to every derived indicator (suffrage_lied, suffrage_in_practice_lied,
+# suffrage_in_practice_trich_lied, and the num_* region counts).
+- indicator: male_suffrage_lied
+  entity: India
+  years: {from: 1947, to: 1949}
+  action: override
+  value: 0
+  expect: {eq: 1} # still coded as 1 (the error); fails loudly once the 2027 release fixes it
+  reason: >-
+    Universal male suffrage in India is coded as beginning in 1947 (independence), but it began in
+    1950 (Constitution in force). Confirmed with Svend-Erik Skaaning; fix due in the 2027 release.
+  provider: Lexical Index
+  reported: 2026-07-09
+  status: acknowledged
+- indicator: female_suffrage_lied
+  entity: India
+  years: {from: 1947, to: 1949}
+  action: override
+  value: 0
+  expect: {eq: 1} # still coded as 1 (the error); fails loudly once the 2027 release fixes it
+  reason: >-
+    Universal female suffrage in India is coded as beginning in 1947 (independence), but it began in
+    1950 (Constitution in force). Confirmed with Svend-Erik Skaaning; fix due in the 2027 release.
+  provider: Lexical Index
+  reported: 2026-07-09
+  status: acknowledged

--- a/etl/steps/data/garden/democracy/2026-04-02/lexical_index.py
+++ b/etl/steps/data/garden/democracy/2026-04-02/lexical_index.py
@@ -113,6 +113,10 @@ def run() -> None:
     # Initial cleaning
     tb = preprocess(tb)
 
+    # Correct known errors in the source data (see lexical_index.corrections.yml). Applied on the raw
+    # suffrage columns so the fix propagates to every derived indicator built below.
+    tb = paths.apply_corrections(tb)
+
     # Create variable distinguishing between democracies and autocracies:
     tb = add_is_democracy(tb)
 


### PR DESCRIPTION
> _Written by Claude Code — @lucasrodes at the wheel._

Corrects a confirmed error in the Lexical Index source data (Skaaning et al.), requested in [owid-issues#2301](https://github.com/owid/owid-issues/issues/2301#issuecomment-4924264618).

India's universal right to vote (men **and** women) is coded as beginning in **1947** (independence) but actually began in **1950**, when the Constitution came into force. Bastian confirmed this with Svend-Erik Skaaning; the upstream fix is due in the next annual release (2027).

**Approach:** a `lexical_index.corrections.yml` (the standard mechanism for known upstream errors) overrides `male_suffrage_lied` / `female_suffrage_lied` to `0` for India, 1947–1949. It's applied on the raw suffrage columns right after `preprocess`, so the fix propagates automatically to every derived indicator — universal right to vote in practice, the three-tier classification, and all the `num_*` region counts used on the new democracy topic page.

An `expect: {eq: 1}` guard makes the step fail loudly once the 2027 release flips the source values, so the correction can't silently re-mangle fixed data.
