### PR TITLE
📊 Clarify Russia's status on the Comprehensive Nuclear-Test-Ban Treaty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ Everything you post to GitHub or Slack goes out under a **human's identity**. An
 
    The disclosure rule does **not** apply to OWID-reader-facing artifacts (e.g. the `/latest` data-update post on ourworldindata.org) — those are authored by the named human, not by Claude.
 
+3. **This repo is public — keep internal context out of it.** PR descriptions, commit messages, and issue/review comments must never identify people who contact us (no names, roles, or employers — say "a reader pointed out ..." instead), and must not reference internal discussions (Slack threads, Notion docs) or who suggested what internally. Motivate changes using public facts only; internal context stays internal.
+
 ## Pipeline Overview
 
 **snapshot** → **meadow** → **garden** → **grapher** → **export**

--- a/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.meta.yml
+++ b/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.meta.yml
@@ -6,7 +6,7 @@ definitions:
   definition_status_not_signed: |-
     The status "Not signed" means that the country has neither signed nor committed to a treaty.
   definition_russia_ctbt: |-
-    Russia ratified the Comprehensive Nuclear-Test-Ban Treaty in 2000, but revoked its ratification in 2023. Since it remains a signatory, with the same obligations as countries that have signed but not approved the treaty, it is shown as "Signed" from 2023 onward.
+    Russia ratified the Comprehensive Nuclear-Test-Ban Treaty in 2000, but withdrew its ratification in 2023. Since it remains a signatory, with the same obligations as countries that have signed but not approved the treaty, it is classified as "Signed" from 2023 onward.
   definition_all_statuses: |-
     A country's position on a treaty can be ["Not signed"](#dod:treaty-status-not-signed), ["Signed"](#dod:treaty-status-signed), or ["Approved"](#dod:treaty-status-committed).
   common:
@@ -20,7 +20,7 @@ definitions:
     description_processing: |-
       - Countries are classified as "Approved" if they have either a "Ratification", "Accession", or "Succession" action (as defined by UNODA).
       - Countries are classified as "Signed" if they only have a "Signatory" action (as defined by UNODA).
-      - Countries with a "Withdrawal" action (as defined by UNODA) are classified as "Signed" if they remain signatories of the treaty. This is currently only the case for Russia, which revoked its ratification of the Comprehensive Nuclear-Test-Ban Treaty in 2023 but remains a signatory.
+      - Countries with a "Withdrawal" action (as defined by UNODA) are classified as "Signed" if they remain signatories of the treaty. This is currently only the case for Russia, which withdrew its ratification of the Comprehensive Nuclear-Test-Ban Treaty in 2023 but remains a signatory.
       - Countries are classified as "Not signed" if they have none of the previous actions.
     description_key:
       - "{definitions.definition_status_signed}"

--- a/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.meta.yml
+++ b/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.meta.yml
@@ -6,11 +6,11 @@ definitions:
   definition_status_not_signed: |-
     The status "Not signed" means that the country has neither signed nor committed to a treaty.
   definition_status_withdrawn: |-
-    The status "Withdrawn" means that the country has withdrawn from its legal commitment to a treaty.
+    The status "Approval withdrawn" means that the country had approved the treaty, but later withdrew its approval (for example, by revoking its ratification). The country remains a signatory, with the same obligations as countries that have signed but not approved the treaty.
   definition_all_statuses_excluding_withdrawal: |-
     A country's position on a treaty can be ["Not signed"](#dod:treaty-status-not-signed), ["Signed"](#dod:treaty-status-signed), or ["Approved"](#dod:treaty-status-committed).
   definition_all_statuses_including_withdrawal: |-
-    A country's position on a treaty can be ["Not signed"](#dod:treaty-status-not-signed), ["Signed"](#dod:treaty-status-signed), ["Approved"](#dod:treaty-status-committed), or ["Withdrawn"](#dod:treaty-status-withdrawn).
+    A country's position on a treaty can be ["Not signed"](#dod:treaty-status-not-signed), ["Signed"](#dod:treaty-status-signed), ["Approved"](#dod:treaty-status-committed), or ["Approval withdrawn"](#dod:treaty-status-withdrawn).
   common:
     unit: ""
     short_unit: ""
@@ -22,7 +22,7 @@ definitions:
     description_processing: |-
       - Countries are classified as "Approved" if they have either a "Ratification", "Accession", or "Succession" action (as defined by UNODA).
       - Countries are classified as "Signed" if they only have a "Signatory" action  (as defined by UNODA).
-      - Countries are classified as "Withdrawn" if they have a "Withdrawal" action (as defined by UNODA).
+      - Countries are classified as "Approval withdrawn" if they have a "Withdrawal" action (as defined by UNODA).
       - Countries are classified as "Not signed" if they have none of the previous actions.
     description_key:
       - "{definitions.definition_status_signed}"

--- a/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.meta.yml
+++ b/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.meta.yml
@@ -5,12 +5,10 @@ definitions:
     The status "Approved" means that the country has legally committed to a treaty.
   definition_status_not_signed: |-
     The status "Not signed" means that the country has neither signed nor committed to a treaty.
-  definition_status_withdrawn: |-
-    The status "Approval withdrawn" means that the country had approved the treaty, but later withdrew its approval (for example, by revoking its ratification). The country remains a signatory, with the same obligations as countries that have signed but not approved the treaty.
-  definition_all_statuses_excluding_withdrawal: |-
+  definition_russia_ctbt: |-
+    Russia ratified the Comprehensive Nuclear-Test-Ban Treaty in 2000, but revoked its ratification in 2023. Since it remains a signatory, with the same obligations as countries that have signed but not approved the treaty, it is shown as "Signed" from 2023 onward.
+  definition_all_statuses: |-
     A country's position on a treaty can be ["Not signed"](#dod:treaty-status-not-signed), ["Signed"](#dod:treaty-status-signed), or ["Approved"](#dod:treaty-status-committed).
-  definition_all_statuses_including_withdrawal: |-
-    A country's position on a treaty can be ["Not signed"](#dod:treaty-status-not-signed), ["Signed"](#dod:treaty-status-signed), ["Approved"](#dod:treaty-status-committed), or ["Approval withdrawn"](#dod:treaty-status-withdrawn).
   common:
     unit: ""
     short_unit: ""
@@ -21,14 +19,13 @@ definitions:
         - War & Peace
     description_processing: |-
       - Countries are classified as "Approved" if they have either a "Ratification", "Accession", or "Succession" action (as defined by UNODA).
-      - Countries are classified as "Signed" if they only have a "Signatory" action  (as defined by UNODA).
-      - Countries are classified as "Approval withdrawn" if they have a "Withdrawal" action (as defined by UNODA).
+      - Countries are classified as "Signed" if they only have a "Signatory" action (as defined by UNODA).
+      - Countries with a "Withdrawal" action (as defined by UNODA) are classified as "Signed" if they remain signatories of the treaty. This is currently only the case for Russia, which revoked its ratification of the Comprehensive Nuclear-Test-Ban Treaty in 2023 but remains a signatory.
       - Countries are classified as "Not signed" if they have none of the previous actions.
     description_key:
       - "{definitions.definition_status_signed}"
       - "{definitions.definition_status_committed}"
       - "{definitions.definition_status_not_signed}"
-      - "{definitions.definition_status_withdrawn}"
 
 dataset:
   update_period_days: 365
@@ -43,7 +40,12 @@ tables:
       comprehensive_nuclear_test_ban_treaty:
         title: Comprehensive Nuclear-Test-Ban Treaty
         description_short: |-
-          The treaty's objective is to stop nuclear weapons tests in the atmosphere, in outer space, under water, and underground. {definitions.definition_all_statuses_including_withdrawal}
+          The treaty's objective is to stop nuclear weapons tests in the atmosphere, in outer space, under water, and underground. {definitions.definition_all_statuses}
+        description_key:
+          - "{definitions.definition_status_signed}"
+          - "{definitions.definition_status_committed}"
+          - "{definitions.definition_status_not_signed}"
+          - "{definitions.definition_russia_ctbt}"
         display:
           name: Comprehensive Test Ban
         presentation:
@@ -51,7 +53,7 @@ tables:
       geneva_protocol:
         title: Geneva Protocol
         description_short: |-
-          The goal of the Geneva Protocol is to prohibit the use of chemical and biological weapons in international armed conflicts. {definitions.definition_all_statuses_excluding_withdrawal}
+          The goal of the Geneva Protocol is to prohibit the use of chemical and biological weapons in international armed conflicts. {definitions.definition_all_statuses}
         display:
           name: Geneva Protocol
         presentation:
@@ -59,7 +61,7 @@ tables:
       nuclear_non_proliferation_treaty:
         title: Nuclear Non-Proliferation Treaty
         description_short: |-
-          The treaty's objective is to prevent the spread of nuclear weapons, to promote cooperation in the peaceful uses of nuclear energy, and to pursue nuclear and general disarmament. {definitions.definition_all_statuses_excluding_withdrawal}
+          The treaty's objective is to prevent the spread of nuclear weapons, to promote cooperation in the peaceful uses of nuclear energy, and to pursue nuclear and general disarmament. {definitions.definition_all_statuses}
         display:
           name: Non-Proliferation Treaty
         presentation:
@@ -67,7 +69,7 @@ tables:
       partial_test_ban_treaty:
         title: Partial Test Ban Treaty
         description_short: |-
-          The treaty's objective is to stop nuclear weapons tests in the atmosphere, in outer space, and under water. {definitions.definition_all_statuses_excluding_withdrawal}
+          The treaty's objective is to stop nuclear weapons tests in the atmosphere, in outer space, and under water. {definitions.definition_all_statuses}
         display:
           name: Partial Test Ban
         presentation:
@@ -75,7 +77,7 @@ tables:
       treaty_on_the_prohibition_of_nuclear_weapons:
         title: Treaty on the Prohibition of Nuclear Weapons
         description_short: |-
-          The treaty's objective is to stop developing, testing, producing, acquiring, possessing, stockpiling, deploying, using, and threatening nuclear weapons, as well as assisting other countries in these actions. {definitions.definition_all_statuses_excluding_withdrawal}
+          The treaty's objective is to stop developing, testing, producing, acquiring, possessing, stockpiling, deploying, using, and threatening nuclear weapons, as well as assisting other countries in these actions. {definitions.definition_all_statuses}
         display:
           name: Prohibition
         presentation:
@@ -85,6 +87,11 @@ tables:
     variables:
       comprehensive_nuclear_test_ban_treaty:
         title: Number of countries with a given status on the Comprehensive Nuclear-Test-Ban Treaty
+        description_key:
+          - "{definitions.definition_status_signed}"
+          - "{definitions.definition_status_committed}"
+          - "{definitions.definition_status_not_signed}"
+          - "{definitions.definition_russia_ctbt}"
         display:
           name: Comprehensive Test Ban
           numDecimalPlaces: 0

--- a/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.py
+++ b/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.py
@@ -28,13 +28,13 @@ LABEL_AGREED = "Signed"
 # NOTE: A priori it may be possible that a country inherits the status "Signatory" from a predecessor, but later on I
 # check that this is never the case.
 LABEL_COMMITTED = "Approved"
-# Label for the exceptional status "Withdrawal", which denotes a country that had approved the treaty but later
-# withdrew its approval (e.g. by revoking its ratification). Such a country remains a signatory, with the same
-# obligations as countries that have signed but not approved the treaty. The only known case is Russia, which revoked
-# its ratification of the Comprehensive Nuclear-Test-Ban Treaty in 2023 while explicitly remaining a signatory.
-LABEL_WITHDRAWN = "Approval withdrawn"
 # Label for all countries-years that are not posterior to either an agreement or a commitment.
 LABEL_NOT_SIGNED = "Not signed"
+# NOTE: There is one more exceptional action, "Withdrawal", which denotes a country that had approved the treaty but
+# later withdrew its approval (e.g. by revoking its ratification). Such a country remains a signatory, with the same
+# obligations as countries that have signed but not approved the treaty, so we assign it LABEL_AGREED again.
+# The only known case is Russia, which revoked its ratification of the Comprehensive Nuclear-Test-Ban Treaty in 2023
+# while explicitly remaining a signatory (as stated in its note verbale to the UN Secretary-General).
 
 # List of known withdrawals of any treaty.
 WITHDRAWALS = [{"treaty": "Comprehensive Nuclear-Test-Ban Treaty", "country": "Russia", "date": "2023-11-03"}]
@@ -64,14 +64,11 @@ def run_sanity_checks(tb: Table) -> None:
 
 def prioritize_status(statuses):
     # Prioritize the status of a country.
-    if LABEL_WITHDRAWN in statuses:
-        # I assume that a country does not withdraw from a treaty in the same year that it joins, and that it
-        # doesn't rejoin the treaty in the same year.
-        assert set(statuses) == {LABEL_WITHDRAWN}
-        return LABEL_WITHDRAWN
-
+    # NOTE: A withdrawal of approval in the same year as a ratification would be mis-prioritized as LABEL_COMMITTED.
+    # This cannot currently happen: the WITHDRAWALS sanity check pins the only known withdrawal (Russia, 2023, having
+    # ratified in 2000), and any new withdrawal will make run_sanity_checks fail, forcing us to revisit this logic.
     if LABEL_COMMITTED in statuses:
-        # If a country commits, that should be the final status (unless there is a withdrawal).
+        # If a country commits, that should be the final status (unless there is a later withdrawal of approval).
         return LABEL_COMMITTED
     else:
         # If not withdrawn or committed, the only possible status should be agreed. Check that.
@@ -141,7 +138,9 @@ def run() -> None:
     # For simplicity, rename the status of a country to simpler terms.
     tb.loc[tb["status"] == "Signatory", "status"] = LABEL_AGREED
     tb.loc[tb["status"].isin(["Succession", "Accession", "Ratification"]), "status"] = LABEL_COMMITTED
-    tb.loc[tb["status"] == "Withdrawal", "status"] = LABEL_WITHDRAWN
+    # A "Withdrawal" action means the country withdrew its approval while remaining a signatory, so it goes back to
+    # the "Signed" status (see NOTE next to LABEL_NOT_SIGNED above).
+    tb.loc[tb["status"] == "Withdrawal", "status"] = LABEL_AGREED
 
     # Add a column for the year of each event.
     tb["year"] = tb["date"].str[:4].astype(int)

--- a/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.py
+++ b/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.py
@@ -28,8 +28,11 @@ LABEL_AGREED = "Signed"
 # NOTE: A priori it may be possible that a country inherits the status "Signatory" from a predecessor, but later on I
 # check that this is never the case.
 LABEL_COMMITTED = "Approved"
-# Label for the exceptional status "Withdrawal", which denotes a country that has withdrawn from the legal commitment.
-LABEL_WITHDRAWN = "Withdrawn"
+# Label for the exceptional status "Withdrawal", which denotes a country that had approved the treaty but later
+# withdrew its approval (e.g. by revoking its ratification). Such a country remains a signatory, with the same
+# obligations as countries that have signed but not approved the treaty. The only known case is Russia, which revoked
+# its ratification of the Comprehensive Nuclear-Test-Ban Treaty in 2023 while explicitly remaining a signatory.
+LABEL_WITHDRAWN = "Approval withdrawn"
 # Label for all countries-years that are not posterior to either an agreement or a commitment.
 LABEL_NOT_SIGNED = "Not signed"
 

--- a/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.py
+++ b/etl/steps/data/garden/war/2026-05-13/nuclear_weapons_treaties.py
@@ -30,13 +30,15 @@ LABEL_AGREED = "Signed"
 LABEL_COMMITTED = "Approved"
 # Label for all countries-years that are not posterior to either an agreement or a commitment.
 LABEL_NOT_SIGNED = "Not signed"
-# NOTE: There is one more exceptional action, "Withdrawal", which denotes a country that had approved the treaty but
-# later withdrew its approval (e.g. by revoking its ratification). Such a country remains a signatory, with the same
-# obligations as countries that have signed but not approved the treaty, so we assign it LABEL_AGREED again.
-# The only known case is Russia, which revoked its ratification of the Comprehensive Nuclear-Test-Ban Treaty in 2023
-# while explicitly remaining a signatory (as stated in its note verbale to the UN Secretary-General).
 
 # List of known withdrawals of any treaty.
+# NOTE: A "Withdrawal" action denotes a country that had approved the treaty but later withdrew its approval (e.g. by
+# revoking its ratification). Such a country remains a signatory, with the same obligations as countries that have
+# signed but not approved the treaty, so it is assigned LABEL_AGREED again. The only known case is Russia, which
+# revoked its ratification of the Comprehensive Nuclear-Test-Ban Treaty in 2023 while explicitly remaining a signatory
+# (as stated in its note verbale to the UN Secretary-General). This assumption is asserted in run() right before
+# relabeling withdrawals; if a new withdrawal ever appears in the data, that assertion will fail, and this logic may
+# need to be revisited.
 WITHDRAWALS = [{"treaty": "Comprehensive Nuclear-Test-Ban Treaty", "country": "Russia", "date": "2023-11-03"}]
 
 
@@ -56,22 +58,17 @@ def run_sanity_checks(tb: Table) -> None:
         # Check that a country that has the status "Accession" does not have any prior status "Signatory".
         countries_with_accession = set(_tb[_tb["status"] == "Accession"]["country"])
         assert "Signatory" not in set(_tb[_tb["country"].isin(countries_with_accession)]["status"])
-    error = "The list of withdrawals has changed."
-    assert sorted(tb[tb["status"] == "Withdrawal"].drop(columns=["status"]).to_dict(orient="records")) == sorted(
-        WITHDRAWALS  # ty: ignore
-    ), error
 
 
 def prioritize_status(statuses):
     # Prioritize the status of a country.
-    # NOTE: A withdrawal of approval in the same year as a ratification would be mis-prioritized as LABEL_COMMITTED.
-    # This cannot currently happen: the WITHDRAWALS sanity check pins the only known withdrawal (Russia, 2023, having
-    # ratified in 2000), and any new withdrawal will make run_sanity_checks fail, forcing us to revisit this logic.
+    # NOTE: A withdrawal of approval in the same year as a ratification would be mis-prioritized as LABEL_COMMITTED,
+    # but this cannot currently happen (see NOTE above WITHDRAWALS).
     if LABEL_COMMITTED in statuses:
         # If a country commits, that should be the final status (unless there is a later withdrawal of approval).
         return LABEL_COMMITTED
     else:
-        # If not withdrawn or committed, the only possible status should be agreed. Check that.
+        # If not committed, the only possible status should be agreed. Check that.
         assert set(statuses) == {LABEL_AGREED}
         return LABEL_AGREED
 
@@ -139,7 +136,9 @@ def run() -> None:
     tb.loc[tb["status"] == "Signatory", "status"] = LABEL_AGREED
     tb.loc[tb["status"].isin(["Succession", "Accession", "Ratification"]), "status"] = LABEL_COMMITTED
     # A "Withdrawal" action means the country withdrew its approval while remaining a signatory, so it goes back to
-    # the "Signed" status (see NOTE next to LABEL_NOT_SIGNED above).
+    # the "Signed" status. Check that the only such case is the known one (see NOTE above WITHDRAWALS).
+    error = "The list of withdrawals has changed. Check whether the new case also remains a signatory (and should therefore be relabeled as 'Signed')."
+    assert tb[tb["status"] == "Withdrawal"].drop(columns=["status"]).to_dict(orient="records") == WITHDRAWALS, error
     tb.loc[tb["status"] == "Withdrawal", "status"] = LABEL_AGREED
 
     # Add a column for the year of each event.


### PR DESCRIPTION
> _Written by Claude Code — @pabloarosado at the wheel._

## Context

In 2023, Russia withdrew its **ratification** of the Comprehensive Nuclear-Test-Ban Treaty, but it did not withdraw from the treaty itself: it explicitly remains a signatory (as stated in its note verbale to the UN Secretary-General, published by UNODA, and confirmed by the CTBTO), with the same obligations as other signatories such as the US and China.

Our [CTBT chart](https://ourworldindata.org/grapher/comprehensive-nuclear-test-ban-treaty) showed Russia under a dedicated "Withdrawn" status, whose definition ("the country has withdrawn from its legal commitment to a treaty") invited the wrong reading, namely that Russia had left the treaty entirely.

This PR removes the single-country "Withdrawn" category altogether and shows Russia as "Signed" from 2023 onward (the same status as other signatories that have not ratified, like the US and China), with a footnote explaining the special case.

## Changes

- **Garden step**: the UNODA "Withdrawal" action now maps back to "Signed" instead of a dedicated "Withdrawn" status. An assertion pins Russia/CTBT/2023 as the only withdrawal on record, so any future withdrawal will fail loudly and force us to revisit this logic.
- **Metadata**: removed the "Withdrawn" definitions; added a key point on both CTBT indicators explaining that Russia ratified in 2000, withdrew its ratification in 2023, and remains a signatory.
- **Chart 7538 (on staging)**: removed the now-unused "Withdrawn" map color and added a footnote: *"Russia approved the treaty in 2000 but withdrew its approval in 2023, while remaining a signatory."* This will reach production via chart-diff on merge.
- The `treaty-status-withdrawn` DoD is now unreferenced (no charts, no gdocs). It was left untouched; it can be deleted from the admin at some point.

## Verification

On the staging chart:
- Russia renders in the "Signed" color (#bc8e5a), same as the US and China; the time slider still shows it as "Approved" for 2000-2022.
- The legend shows only Approved / Signed / Not signed / No data.
- The footnote renders correctly.
- The 2023 country counts are consistent (Russia left "Approved" the same year two new ratifiers joined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
