### PR TITLE
📊 Add population peak indicator to UN WPP

### DIFF
--- a/etl/steps/data/garden/un/2024-07-12/un_wpp.meta.yml
+++ b/etl/steps/data/garden/un/2024-07-12/un_wpp.meta.yml
@@ -182,6 +182,29 @@ tables:
       #     grapher_config:
       #       subtitle: *pop2_description_short
 
+  population_peak:
+    variables:
+      population_peak_status:
+        title: Population peak status
+        unit: ""
+        type: ordinal
+        sort:
+          - Before peak
+          - Peak year
+          - After peak
+        description_short: |-
+          Whether the population has passed its peak — its highest value between 1950 and 2100, based on UN estimates and medium-scenario projections.
+        description_key:
+          - The peak year is the year in which the population reaches its highest value over the period 1950–2100, combining UN estimates for 1950–2023 with [medium-scenario](#dod:un-projection-scenarios) projections for 2024–2100.
+          - Populations that are still growing in 2100 are labeled "Before peak" for all years, since their peak lies beyond the UN's projection horizon.
+        description_processing: |-
+          We combine the UN's population estimates (1950–2023) with its medium-scenario projections (2024–2100) and identify the year in which each population reaches its highest value. Years before that peak are labeled "Before peak", the peak year itself is labeled "Peak year", and later years are labeled "After peak". If the highest value occurs in more than one year, the first is used as the peak year. Populations that are still growing in 2100 are labeled "Before peak" throughout.
+        presentation:
+          title_public: Population peak status
+          grapher_config:
+            subtitle: |-
+              Whether the population has passed its highest value between 1950 and 2100, based on UN estimates and [medium-scenario](#dod:un-projection-scenarios) projections.
+
   growth_rate:
     variables:
       growth_rate:

--- a/etl/steps/data/garden/un/2024-07-12/un_wpp.meta.yml
+++ b/etl/steps/data/garden/un/2024-07-12/un_wpp.meta.yml
@@ -204,6 +204,22 @@ tables:
           grapher_config:
             subtitle: |-
               Whether the population has passed its highest value between 1950 and 2100, based on UN estimates and [medium-scenario](#dod:un-projection-scenarios) projections.
+      population_peak_status_code:
+        title: Population peak status (numeric code)
+        unit: ""
+        description_short: |-
+          Whether the population has passed its peak — its highest value between 1950 and 2100, based on UN estimates and medium-scenario projections. Years before the peak are coded -1, the peak year 0, and years after the peak 1.
+        description_key:
+          - This is a numeric version of the population peak status, coded as -1 ("Before peak"), 0 ("Peak year"), and 1 ("After peak").
+          - The peak year is the year in which the population reaches its highest value over the period 1950–2100, combining UN estimates for 1950–2023 with [medium-scenario](#dod:un-projection-scenarios) projections for 2024–2100.
+          - Populations that are still growing in 2100 are coded -1 ("Before peak") for all years, since their peak lies beyond the UN's projection horizon.
+        description_processing: |-
+          We combine the UN's population estimates (1950–2023) with its medium-scenario projections (2024–2100) and identify the year in which each population reaches its highest value. Years before that peak are coded -1 ("Before peak"), the peak year itself is coded 0 ("Peak year"), and later years are coded 1 ("After peak"). If the highest value occurs in more than one year, the first is used as the peak year. Populations that are still growing in 2100 are coded -1 throughout.
+        display:
+          name: Population peak status
+          numDecimalPlaces: 0
+        presentation:
+          title_public: Population peak status
 
   growth_rate:
     variables:

--- a/etl/steps/data/garden/un/2024-07-12/un_wpp.py
+++ b/etl/steps/data/garden/un/2024-07-12/un_wpp.py
@@ -90,9 +90,12 @@ def run() -> None:
     # POPULATION #
     tb_population_jan, tb_population, tb_sex_ratio = process_population_sex_ratio(tb_population, tb_population_density)
     tb_population = add_owid_regions(tb_population, indicators=["population"])
+    ## Population peak status (before/at/after the 1950-2100 population peak)
+    tb_population_peak = process_population_peak(tb_population)
     ## Format
     tb_population = tb_population.format(COLUMNS_INDEX)
     tb_population_jan = tb_population_jan.format(COLUMNS_INDEX, short_name="population_january")  # January data
+    tb_population_peak = tb_population_peak.format(["country", "year"], short_name="population_peak")
 
     # SEX RATIO #
     tb_sex_ratio = set_variant_to_estimates(tb_sex_ratio)
@@ -167,6 +170,7 @@ def run() -> None:
     tables = [
         tb_population_jan,
         tb_population,
+        tb_population_peak,
         tb_growth_rate,
         tb_nat_change,
         tb_fertility,
@@ -287,6 +291,47 @@ def process_population_sex_ratio(tb: Table, tb_density: Table) -> tuple[Table, T
     tb_sex = tb_sex.drop(columns=["month"])
 
     return tb_jan, tb, tb_sex
+
+
+def process_population_peak(tb: Table) -> Table:
+    """Derive each population's peak status over 1950-2100.
+
+    Uses total population (sex='all', age='all'), combining estimates (pre-2024) with
+    medium-variant projections. Each country-year is labeled relative to the year in which
+    the population reaches its maximum over the full period: "Before peak", "Peak year", or
+    "After peak". Populations still growing in 2100 are labeled "Before peak" throughout,
+    since their peak lies beyond the projection horizon.
+    """
+    paths.log.info("Processing population peak status...")
+
+    # Total population series: estimates (1950-2023) + medium projections (2024-2100).
+    mask = (tb["sex"] == "all") & (tb["age"] == "all") & (tb["variant"].isin(["estimates", "medium"]))
+    tb_peak = tb.loc[mask, ["country", "year", "population"]].copy()
+
+    # Sanity checks: one row per country-year, continuous 1950-2100 coverage, no NaNs.
+    assert not tb_peak.duplicated(subset=["country", "year"]).any(), "Duplicate country-year in population data."
+    assert tb_peak["population"].notna().all(), "NaN population values."
+    year_min, year_max = tb_peak["year"].min(), tb_peak["year"].max()
+    assert (year_min, year_max) == (1950, 2100), f"Unexpected year range: {year_min}-{year_max}."
+    counts = tb_peak.groupby("country", observed=True)["year"].count()
+    assert (counts == year_max - year_min + 1).all(), "Gaps in yearly population series."
+
+    # Find each country's peak year (first year of maximum population, in case of ties).
+    tb_peak = tb_peak.sort_values(["country", "year"])
+    idx_peak = tb_peak.groupby("country", observed=True)["population"].idxmax()
+    tb_year_peak = tb_peak.loc[idx_peak, ["country", "year"]].rename(columns={"year": "year_peak"})
+    tb_peak = tb_peak.merge(tb_year_peak, on="country", how="left")
+
+    # Label each year relative to the peak year.
+    column = "population_peak_status"
+    tb_peak[column] = "Before peak"
+    tb_peak.loc[tb_peak["year"] == tb_peak["year_peak"], column] = "Peak year"
+    tb_peak.loc[tb_peak["year"] > tb_peak["year_peak"], column] = "After peak"
+    # Populations still growing at the end of the projection period have not peaked.
+    tb_peak.loc[tb_peak["year_peak"] == year_max, column] = "Before peak"
+    tb_peak[column] = tb_peak[column].copy_metadata(tb_peak["population"])
+
+    return tb_peak[["country", "year", column]]
 
 
 def process_dependency(tb: Table) -> Table:

--- a/etl/steps/data/garden/un/2024-07-12/un_wpp.py
+++ b/etl/steps/data/garden/un/2024-07-12/un_wpp.py
@@ -331,7 +331,15 @@ def process_population_peak(tb: Table) -> Table:
     tb_peak.loc[tb_peak["year_peak"] == year_max, column] = "Before peak"
     tb_peak[column] = tb_peak[column].copy_metadata(tb_peak["population"])
 
-    return tb_peak[["country", "year", column]]
+    # Numeric companion (-1=Before peak, 0=Peak year, 1=After peak): grapher's line-chart color
+    # dimension only accepts numeric indicators, so the ordinal alone can't color a timeseries.
+    column_code = "population_peak_status_code"
+    tb_peak[column_code] = -1
+    tb_peak.loc[tb_peak[column] == "Peak year", column_code] = 0
+    tb_peak.loc[tb_peak[column] == "After peak", column_code] = 1
+    tb_peak[column_code] = tb_peak[column_code].copy_metadata(tb_peak["population"])
+
+    return tb_peak[["country", "year", column, column_code]]
 
 
 def process_dependency(tb: Table) -> Table:

--- a/etl/steps/data/grapher/un/2024-07-12/un_wpp.py
+++ b/etl/steps/data/grapher/un/2024-07-12/un_wpp.py
@@ -16,6 +16,7 @@ def run() -> None:
     # Import tables
     tables = [
         ds_garden["population"],
+        ds_garden["population_peak"],
         ds_garden["growth_rate"],
         ds_garden["natural_change_rate"],
         ds_garden["fertility_rate"],

--- a/etl/steps/data/grapher/un/2024-07-12/un_wpp_full.py
+++ b/etl/steps/data/grapher/un/2024-07-12/un_wpp_full.py
@@ -7,8 +7,9 @@ from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
-# Exclude the last three as we want to treat them differently and remove the january rows from them
-TABLES_EXCLUDE = ["fertility_single", "population_january"]
+# Exclude tables that don't fit the estimates-into-each-variant reshape: fertility_single and
+# population_january are treated differently, and population_peak has no variant dimension.
+TABLES_EXCLUDE = ["fertility_single", "population_january", "population_peak"]
 
 
 def run() -> None:


### PR DESCRIPTION
> _Written by Claude Fable 5 — @edomt at the wheel._

## Summary

Adds a derived **population peak status** indicator to the UN WPP dataset (`garden/un/2024-07-12/un_wpp`), for a map chart showing whether each country's population has peaked over 1950–2100.

## How it works

- Combines UN population estimates (1950–2023) with medium-scenario projections (2024–2100), for total population (all sexes, all ages).
- Each country-year is labeled with one of three ordinal categories relative to the year of maximum population: **Before peak**, **Peak year** (the peak year itself), or **After peak**.
- Populations still growing in 2100 (e.g. the United States, Niger) are labeled "Before peak" throughout, since their peak lies beyond the projection horizon.
- Computed for all entities in the population table (countries, continents, World), though only countries will be shown on the map.
- New table `population_peak` exposed via the main `grapher/un/2024-07-12/un_wpp` step.

## Sanity checks

Verified on a country subset: China peaks in 2021, Japan in 2009, Bulgaria in 1988, India in 2061 (projected); US and Niger never flip to "peaked". The step asserts unique country-years, continuous 1950–2100 coverage, and no missing population values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)