### PR TITLE
📊 Add numeric population peak status code for line-chart coloring

### DIFF
--- a/etl/steps/data/garden/un/2024-07-12/un_wpp.meta.yml
+++ b/etl/steps/data/garden/un/2024-07-12/un_wpp.meta.yml
@@ -204,6 +204,22 @@ tables:
           grapher_config:
             subtitle: |-
               Whether the population has passed its highest value between 1950 and 2100, based on UN estimates and [medium-scenario](#dod:un-projection-scenarios) projections.
+      population_peak_status_code:
+        title: Population peak status (numeric code)
+        unit: ""
+        description_short: |-
+          Whether the population has passed its peak — its highest value between 1950 and 2100, based on UN estimates and medium-scenario projections. Years before the peak are coded -1, the peak year 0, and years after the peak 1.
+        description_key:
+          - This is a numeric version of the population peak status, coded as -1 ("Before peak"), 0 ("Peak year"), and 1 ("After peak").
+          - The peak year is the year in which the population reaches its highest value over the period 1950–2100, combining UN estimates for 1950–2023 with [medium-scenario](#dod:un-projection-scenarios) projections for 2024–2100.
+          - Populations that are still growing in 2100 are coded -1 ("Before peak") for all years, since their peak lies beyond the UN's projection horizon.
+        description_processing: |-
+          We combine the UN's population estimates (1950–2023) with its medium-scenario projections (2024–2100) and identify the year in which each population reaches its highest value. Years before that peak are coded -1 ("Before peak"), the peak year itself is coded 0 ("Peak year"), and later years are coded 1 ("After peak"). If the highest value occurs in more than one year, the first is used as the peak year. Populations that are still growing in 2100 are coded -1 throughout.
+        display:
+          name: Population peak status
+          numDecimalPlaces: 0
+        presentation:
+          title_public: Population peak status
 
   growth_rate:
     variables:

--- a/etl/steps/data/garden/un/2024-07-12/un_wpp.py
+++ b/etl/steps/data/garden/un/2024-07-12/un_wpp.py
@@ -331,7 +331,15 @@ def process_population_peak(tb: Table) -> Table:
     tb_peak.loc[tb_peak["year_peak"] == year_max, column] = "Before peak"
     tb_peak[column] = tb_peak[column].copy_metadata(tb_peak["population"])
 
-    return tb_peak[["country", "year", column]]
+    # Numeric companion (-1=Before peak, 0=Peak year, 1=After peak): grapher's line-chart color
+    # dimension only accepts numeric indicators, so the ordinal alone can't color a timeseries.
+    column_code = "population_peak_status_code"
+    tb_peak[column_code] = -1
+    tb_peak.loc[tb_peak[column] == "Peak year", column_code] = 0
+    tb_peak.loc[tb_peak[column] == "After peak", column_code] = 1
+    tb_peak[column_code] = tb_peak[column_code].copy_metadata(tb_peak["population"])
+
+    return tb_peak[["country", "year", column, column_code]]
 
 
 def process_dependency(tb: Table) -> Table:


### PR DESCRIPTION
> _Written by Claude Fable 5 — @lucasrodes at the wheel._

Builds on #6442 (base branch: `data-add-population-peak`).

Adds `population_peak_status_code` to the `population_peak` table — a numeric companion to the ordinal (`-1` = Before peak, `0` = Peak year, `1` = After peak). Grapher's line-chart `color` dimension only accepts numeric indicators, so this makes it possible to add a line-chart tab showing the population timeseries colored by peak status, in the style of [birth-rate-colored-by-peak-birth-month](https://ourworldindata.org/grapher/birth-rate-colored-by-peak-birth-month) (chart 8357).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
