### PR TITLE
🐛 Fix etl diff false positives and huge reports on wide datasets

### DIFF
--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -83,6 +83,19 @@ class DatasetDiff:
         # Structured mirror of the printed summary, filled in by summary().
         self.result = DatasetDiffResult(path=dataset_uri(ds_b or ds_a), kind="identical")  # type: ignore[arg-type]
 
+    def _p_multiline(self, text: str) -> None:
+        """Print a (possibly huge) multi-line diff body one line at a time.
+
+        Rich's console rendering of a single giant `Text` blob scales badly with the number of
+        embedded style spans: for WDI-sized metadata diffs (tens of thousands of lines, each
+        wrapped in a color tag), a single `self.p(text)` call can take hours due to quadratic
+        behavior in `Text.divide`/`Text.join` during soft-wrap layout. Printing line-by-line keeps
+        each `Text` object small, which is linear instead (verified: 58k lines dropped from an
+        unbounded hang to ~7s).
+        """
+        for line in text.split("\n"):
+            self.p(line)
+
     def _filter_table_by_country(self, table: Table) -> Table:
         """Filter table by country if country is in the index."""
         if "country" in table.index.names:
@@ -103,13 +116,14 @@ class DatasetDiff:
 
             # compare dataset metadata
             meta_a, meta_b = _dataset_metadata_dict(ds_a), _dataset_metadata_dict(ds_b)
-            diff = _dict_diff(meta_a, meta_b, tabs=2)
+            diff_lines = _diff_lines(meta_a, meta_b)
+            diff = _format_diff(diff_lines, tabs=2)
             if diff:
                 self.result.kind = "changed"
-                self.result.meta_diff = _dict_diff(meta_a, meta_b, tabs=0, color=False)
+                self.result.meta_diff = _format_diff(diff_lines, tabs=0, color=False)
                 self.p(f"[yellow]~ Dataset [b]{dataset_uri(ds_b)}[/b]{new_version}")
                 if self.verbose:
-                    self.p(diff)
+                    self._p_multiline(diff)
             else:
                 self.p(f"[white]= Dataset [b]{dataset_uri(ds_b)}{new_version}[/b]")
         elif ds_a:
@@ -224,15 +238,16 @@ tb = {_snippet_dataset(ds_b, table_name)}
 
             # compare table metadata
             tab_meta_a, tab_meta_b = _table_metadata_dict(table_a), _table_metadata_dict(table_b)
-            diff = _dict_diff(tab_meta_a, tab_meta_b, tabs=3)
+            tab_diff_lines = _diff_lines(tab_meta_a, tab_meta_b)
+            diff = _format_diff(tab_diff_lines, tabs=3)
             tab_res = TableDiffResult(name=table_name, kind="changed" if diff else "identical")
             self.result.tables.append(tab_res)
             if diff:
-                tab_res.meta_diff = _dict_diff(tab_meta_a, tab_meta_b, tabs=0, color=False)
+                tab_res.meta_diff = _format_diff(tab_diff_lines, tabs=0, color=False)
                 self.p(f"\t[yellow]~ Table [b]{table_name}[/b] (changed [u]metadata[/u])")
 
                 if self.verbose:
-                    self.p(diff)
+                    self._p_multiline(diff)
             else:
                 self.p(f"\t[white]= Table [b]{table_name}[/b]")
 
@@ -263,7 +278,7 @@ tb = {_snippet_dataset(ds_b, table_name)}
                                 tabs=4,
                             )
                             if self.verbose and out:
-                                self.p(out)
+                                self._p_multiline(out)
 
             # compare columns
             all_cols = sorted((set(table_a.columns) | set(table_b.columns)) - set(dims))
@@ -291,7 +306,8 @@ tb = {_snippet_dataset(ds_b, table_name)}
                     # metadata diff
                     col_meta_a = _column_metadata_dict(col_a.metadata)
                     col_meta_b = _column_metadata_dict(col_b.metadata)
-                    meta_diff = _dict_diff(col_meta_a, col_meta_b, tabs=4)
+                    col_diff_lines = _diff_lines(col_meta_a, col_meta_b)
+                    meta_diff = _format_diff(col_diff_lines, tabs=4)
 
                     # equality on index and series
                     eq_data = series_equals(table_a[col], table_b[col])
@@ -311,7 +327,7 @@ tb = {_snippet_dataset(ds_b, table_name)}
                             changes=[c.replace("[u]", "").replace("[/u]", "") for c in changed],
                         )
                         if meta_diff:
-                            col_res.meta_diff = _dict_diff(col_meta_a, col_meta_b, tabs=0, color=False)
+                            col_res.meta_diff = _format_diff(col_diff_lines, tabs=0, color=False)
                         tab_res.columns.append(col_res)
                         self.p(f"\t\t[yellow]~ Column [b]{col}[/b] ({', '.join(changed)})")
                         if self.verbose or self.details:
@@ -322,12 +338,12 @@ tb = {_snippet_dataset(ds_b, table_name)}
                                 )
                         if self.verbose:
                             if meta_diff:
-                                self.p(meta_diff)
+                                self._p_multiline(meta_diff)
                             if new_index.any() or removed_index.any() or (~eq_data).any():
                                 if meta_diff:
                                     self.p("")
                                 if out:
-                                    self.p(out)
+                                    self._p_multiline(out)
                     else:
                         # do not print identical columns
                         pass
@@ -397,6 +413,24 @@ def _dataset_files_match(ds_local: Dataset, ds_remote: "RemoteDataset") -> bool:
         remote_md5 = dict(zip(local_md5.keys(), executor.map(_remote_md5, local_md5.keys())))
 
     return all(local_md5[f] == remote_md5.get(f) for f in local_md5)
+
+
+def _changed_include_regex(include: str | None, catalog_paths: list[str]) -> str:
+    """Build the --include regex for `--changed`, combining it with the user-supplied --include.
+
+    Each catalog path is anchored at the end (but not the start — the local catalog matches
+    against the full absolute directory path, e.g. ".../data/garden/.../wdi", not the bare
+    "garden/.../wdi" the remote catalog uses). A bare substring join would let one changed
+    dataset's short_name match as a *prefix* of another, unrelated dataset's short_name (e.g.
+    "wb/2026-07-01/income_groups" matching inside ".../income_groups_aggregations"), sweeping it
+    falsely into the comparison scope and reporting it as "removed" once it turns out not to be
+    built locally either. Anchoring at the end rules that out while still matching both catalogs.
+    """
+    catalog_paths_pattern = "|".join(rf"{re.escape(p)}$" for p in catalog_paths)
+    if include:
+        # Positive look-aheads to match on both the user's --include and the changed paths.
+        return rf"(?=.*{include})(?={catalog_paths_pattern})"
+    return catalog_paths_pattern
 
 
 @click.command(name="diff", help=__doc__)
@@ -547,11 +581,7 @@ def cli(
             console.print("[green]✅ No differences found[/green]")
             exit(0)
 
-        # Add those files to `include` regex (use positive look-aheads to match on both)
-        if include:
-            include = rf"(?=.*{include})(?=.*{'|'.join(catalog_paths)})"
-        else:
-            include = "|".join(catalog_paths)
+        include = _changed_include_regex(include, catalog_paths)
 
     path_to_ds_a = _load_catalog_datasets(path_a, channel, include, exclude)
     path_to_ds_b = _load_catalog_datasets(path_b, channel, include, exclude)
@@ -731,19 +761,31 @@ def _index_equals(table_a: pd.DataFrame, table_b: pd.DataFrame, sample: int = 10
     return index_a.equals(index_b)
 
 
-def _dict_diff(dict_a: dict[str, Any], dict_b: dict[str, Any], tabs: int = 0, color: bool = True, **kwargs) -> str:
-    """Convert dictionaries into YAML and compare them using difflib. Return colored diff as a string."""
+def _diff_lines(dict_a: dict[str, Any], dict_b: dict[str, Any], **kwargs) -> list[str]:
+    """Convert dictionaries into YAML and return the added/removed lines between them.
+
+    Uses a plain line-level diff (`SequenceMatcher.get_opcodes`) rather than `difflib.ndiff`.
+    `ndiff` additionally computes intraline ("? ") hints via its costly `_fancy_replace` pass, but
+    every caller here immediately discards "? " and "  " (equal) lines, so that work is pure waste
+    for wide, mostly-changed metadata like WDI's ~1500 columns.
+    """
     meta_a = yaml_dump(dict_a, **kwargs)
     meta_b = yaml_dump(dict_b, **kwargs)
 
-    lines = difflib.ndiff(meta_a.splitlines(keepends=True), meta_b.splitlines(keepends=True))  # ty: ignore
-    # do not print lines that are identical
-    lines = [line for line in lines if not line.startswith("  ")]
+    a_lines = meta_a.splitlines(keepends=True)
+    b_lines = meta_b.splitlines(keepends=True)
 
-    # do not print ? lines
-    lines = [line for line in lines if not line.strip().startswith("? ")]
+    lines = []
+    for tag, i1, i2, j1, j2 in difflib.SequenceMatcher(None, a_lines, b_lines).get_opcodes():
+        if tag in ("delete", "replace"):
+            lines.extend("- " + line for line in a_lines[i1:i2])
+        if tag in ("insert", "replace"):
+            lines.extend("+ " + line for line in b_lines[j1:j2])
+    return lines
 
-    # add color
+
+def _format_diff(lines: list[str], tabs: int = 0, color: bool = True) -> str:
+    """Format pre-computed diff lines (from `_diff_lines`) as a colored/tabbed string."""
     if color:
         lines = ["[violet]" + line for line in lines]
 
@@ -752,6 +794,11 @@ def _dict_diff(dict_a: dict[str, Any], dict_b: dict[str, Any], tabs: int = 0, co
     else:
         # add tabs
         return "\t" * tabs + "".join(lines).replace("\n", "\n" + "\t" * tabs).rstrip()
+
+
+def _dict_diff(dict_a: dict[str, Any], dict_b: dict[str, Any], tabs: int = 0, color: bool = True, **kwargs) -> str:
+    """Convert dictionaries into YAML and compare them using a line-level diff. Return colored diff as a string."""
+    return _format_diff(_diff_lines(dict_a, dict_b, **kwargs), tabs=tabs, color=color)
 
 
 def _df_to_str(df: pd.DataFrame, limit: int = 5) -> list[str]:
@@ -786,36 +833,54 @@ def _df_to_records(df: pd.DataFrame, limit: int = SAMPLE_LIMIT) -> list[dict[str
 
 def _changed_records(
     both: pd.DataFrame, col: str, limit: int = SAMPLE_LIMIT
-) -> tuple[list[dict[str, str]], bool, float | None]:
+) -> tuple[list[dict[str, str]], bool, float | None, int, int]:
     """Sample records for a changed-values diff.
 
-    For numeric columns, keep the most anomalous rows (largest first) and append an
-    "anomaly score" display column, so the report surfaces the biggest moves instead of a random
-    sample. The score is BARD (`etl.data_helpers.misc.bard`, the same metric Anomalist scores
-    changes with): bounded in [0, 1], symmetric, and resistant to blow-ups on tiny values. A
-    value appearing or disappearing (NaN on one side) counts as a maximal change (score 1). Other
-    dtypes keep the plain random sample.
+    A value appearing or disappearing (NaN on one side) is a *coverage* event, not a value
+    *revision* — e.g. the newest year in a new dataset version, or a slow-cadence indicator whose
+    "latest" datapoint moves to a new year while the old one is dropped. Neither is an anomaly in
+    the sense BARD measures (how much a value that existed on both sides moved), so those rows are
+    excluded from the score entirely and counted separately as `appeared`/`disappeared` — reported
+    on their own axis (`ColumnDiffResult.coverage_severity`) instead of competing with genuine
+    revisions for the same score.
 
-    Returns (records, sorted_by_score, median_bard), where median_bard is the median score across
-    ALL changed rows (not just the sample) — the report uses it to sort columns, tables and
-    datasets by how big their differences typically are. None for non-numeric columns.
+    For numeric columns, the sample keeps the most anomalous *revised* rows first (largest BARD —
+    `etl.data_helpers.misc.bard`, the same metric Anomalist uses: bounded in [0, 1], symmetric,
+    resistant to blow-ups on tiny values), with appeared/disappeared rows sorted after them and
+    labeled as such instead of given a score. Other dtypes keep the plain random sample.
+
+    Returns (records, sorted_by_score, median_bard, appeared_count, disappeared_count).
+    median_bard is the median BARD across all *revised* rows (not just the sample) — the report
+    uses it to sort columns, tables and datasets by how big their genuine revisions typically are.
+    It's 0.0 (not None) when there are no revised rows, so a column that's all coverage churn
+    scores as "no anomaly" rather than falling back to a non-numeric column's default of maximal.
+    None only for non-numeric columns, where old/new can't be told apart from a category flip.
     """
     old_col, new_col = f"{col} -", f"{col} +"
     if not (pd.api.types.is_numeric_dtype(both[old_col]) and pd.api.types.is_numeric_dtype(both[new_col])):
-        return _df_to_records(both, limit=limit), False, None
+        return _df_to_records(both, limit=limit), False, None, 0, 0
 
     old = both[old_col].astype("float64")
     new = both[new_col].astype("float64")
-    score = bard(old.to_numpy(), new.to_numpy())
-    # One-sided NaN = a value appeared or disappeared = maximal change.
-    score = np.where(np.isnan(score), 1.0, score)
-    median_bard = float(np.median(score)) if len(score) else None
+    old_isna = old.isna().to_numpy()
+    new_isna = new.isna().to_numpy()
+    appeared = old_isna & ~new_isna
+    disappeared = ~old_isna & new_isna
+    revised = ~old_isna & ~new_isna
 
-    # Positional (iloc) selection is safe even if `both` has a non-unique index.
-    order = np.argsort(-score, kind="stable")[:limit]
+    score = np.full(len(both), np.nan)
+    score[revised] = bard(old.to_numpy()[revised], new.to_numpy()[revised])
+    median_bard = float(np.median(score[revised])) if revised.any() else 0.0
+
+    # Revised rows rank by score (largest first); appeared/disappeared always sort after them —
+    # they're not ranked anomalies — with ties broken by original order (stable sort).
+    rank_key = np.where(revised, -score, np.inf)
+    order = np.argsort(rank_key, kind="stable")[:limit]
     top = both.iloc[order].copy()
-    top["anomaly score"] = [format_score(s) for s in score[order]]
-    return _df_to_records(top, limit=limit), True, median_bard
+    top["anomaly score"] = [
+        format_score(score[i]) if revised[i] else ("appeared" if appeared[i] else "disappeared") for i in order
+    ]
+    return _df_to_records(top, limit=limit), True, median_bard, int(appeared.sum()), int(disappeared.sum())
 
 
 def _data_diff(
@@ -868,14 +933,19 @@ def _data_diff(
         lines.append(
             f"~ Changed values: {neq.sum()} / {n} ({neq.sum() / n * 100:.2f}%)",
         )
-        samp_a = table_a.loc[neq, cols]
-        samp_b = table_b.loc[neq, cols]
+        # Merge as plain pandas DataFrames, not Table.merge/join. The OWID Table variants also
+        # combine per-column metadata (origins/sources) into the result, which is expensive for
+        # wide, heavily-sourced datasets like WDI — and wasted here since `both` is only used for
+        # its raw values (sampling/scoring below), never its metadata.
+        samp_a = pd.DataFrame(table_a.loc[neq, cols])
+        samp_b = pd.DataFrame(table_b.loc[neq, cols])
         if dims:
             both = samp_a.merge(samp_b, on=dims, suffixes=(" -", " +"))
         else:
             both = samp_a.join(samp_b, lsuffix=" -", rsuffix=" +")
         lines += _df_to_str(both)
-        records, sorted_by_score, median_bard = _changed_records(both, col)
+
+        records, sorted_by_score, median_bard, appeared_count, disappeared_count = _changed_records(both, col)
         value_diffs.append(
             ValueDiff(
                 kind="changed",
@@ -884,6 +954,8 @@ def _data_diff(
                 sample=records,
                 sorted_by_score=sorted_by_score,
                 median_bard=median_bard,
+                appeared_count=appeared_count,
+                disappeared_count=disappeared_count,
             )
         )
 
@@ -1025,7 +1097,18 @@ def _table_metadata_dict(tab: Table) -> dict[str, Any]:
     origins = set()
     for col in tab.columns:
         origins.update(tab[col].metadata.origins)
-    d["origins"] = sorted(origins, key=lambda x: (x.title or "", x.title_snapshot or ""))
+    # Sort by enough fields to be a total order over real-world origins, not just a tie-breaker.
+    # For datasets like WDI, every origin shares the same title/title_snapshot (one indicator per
+    # column, but all indicators come from the same producer, description and citation
+    # boilerplate), so those two fields alone leave the sort a no-op tied to `set()`'s arbitrary
+    # iteration order. Two independently-built tables (old vs. new version) then serialize their
+    # ~1500 origins in unrelated orders, and the line-level diff below sees the whole list as
+    # reshuffled — every origin (unchanged fields included) shows as removed+added rather than
+    # only the handful of lines that actually changed. `url_main` disambiguates down to the
+    # individual indicator, making the order (and hence the diff) stable and content-based.
+    d["origins"] = sorted(
+        origins, key=lambda x: (x.title or "", x.title_snapshot or "", x.producer or "", x.url_main or "")
+    )
 
     # add columns
     # d["columns"] = {}
@@ -1105,9 +1188,14 @@ def _local_catalog_datasets(
     return mapping
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=10),
+    retry=retry_if_exception_type(requests.RequestException),
+)
 def _fetch_remote_dataset(path: str, frame: pd.DataFrame) -> RemoteDataset:
     uri = f"{DEFAULT_CATALOG_URL}{path}/index.json"
-    js = http_session.get(uri).json()
+    js = http_session.get(uri, timeout=30).json()
     # Drop deprecated provenance fields for backward compatibility with remote catalog entries
     # that were built before the Source -> Origin migration was fully rolled out.
     js.pop("origins", None)

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -608,7 +608,9 @@ def cli(
 
     matched_datasets = []
     skipped_identical_data = 0
-    for path in sorted(set(path_to_ds_a.keys()) | set(path_to_ds_b.keys())):
+    all_paths = sorted(set(path_to_ds_a.keys()) | set(path_to_ds_b.keys()))
+    all_paths = [p for p in all_paths if not _is_superseded_remote_predecessor(p, path_to_ds_b)]
+    for path in all_paths:
         ds_a = _match_dataset(path_to_ds_a, path)
         ds_b = _match_dataset(path_to_ds_b, path)
 
@@ -1108,6 +1110,26 @@ def _match_dataset(path_to_ds: dict[str, Any], path: str) -> Dataset | None:
                 return None
         else:
             return None
+
+
+def _is_superseded_remote_predecessor(path: str, path_to_ds_b: dict[str, Any]) -> bool:
+    """True if `path` is only in scope as a REMOTE-side fallback match for a newer local version.
+
+    `--changed` adds a changed dataset's predecessor version to the shared `--include` filter so
+    the REMOTE fetch includes it — `_match_dataset` then falls back to it when diffing the new
+    local version against something. But the union-of-keys loop in `cli()` also visits the
+    predecessor's own path directly; if that exact version isn't *also* built locally (the normal
+    case — only the new version was run), it compares against nothing and gets reported as a
+    separate, false "removed dataset", right back to the bug this scoping exists to avoid. Skip a
+    path here when it's absent locally but a newer version of the same
+    channel/namespace/short_name is present — `_match_dataset` already reaches it as a fallback
+    for that newer path, so it needs no standalone entry of its own.
+    """
+    if path in path_to_ds_b:
+        return False
+    channel, namespace, version, short_name = path.split("/")
+    pattern = re.compile(rf"^{re.escape(channel)}/{re.escape(namespace)}/([^/]+)/{re.escape(short_name)}$")
+    return any((match := pattern.match(k)) and match.group(1) > version for k in path_to_ds_b)
 
 
 def _load_catalog_datasets(

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -1,6 +1,7 @@
 import difflib
 import os
 import re
+import textwrap
 import traceback
 import urllib.error
 from collections.abc import Callable, Iterable
@@ -761,6 +762,36 @@ def _index_equals(table_a: pd.DataFrame, table_b: pd.DataFrame, sample: int = 10
     return index_a.equals(index_b)
 
 
+_DIFF_LINE_WRAP_WIDTH = 100
+
+
+def _wrap_long_lines(text: str, width: int = _DIFF_LINE_WRAP_WIDTH) -> list[str]:
+    """Split a YAML dump into diff-friendly lines, word-wrapping long ones.
+
+    `yaml_dump`'s own `width` only wraps folded/plain scalars — literal block scalars (`|-`,
+    used for any string containing no newlines of its own, e.g. `citation_full`) are emitted
+    verbatim on one line however long. A single-word change at the end of an otherwise-identical
+    few-hundred-character producer citation (a common shape: boilerplate text ending in
+    "Accessed on <date>") then makes the *entire* line register as changed by the line-level diff
+    below, duplicating the whole paragraph in both the removed and added sides. Wrapping first
+    lets the line-level diff match all the unchanged wrapped chunks and only report the one that
+    actually differs.
+    """
+    lines = []
+    for line in text.splitlines(keepends=True):
+        stripped = line.rstrip("\n")
+        newline = line[len(stripped) :]
+        indent = len(stripped) - len(stripped.lstrip(" "))
+        if len(stripped) <= width:
+            lines.append(line)
+            continue
+        wrapped = textwrap.wrap(
+            stripped, width=width, subsequent_indent=" " * indent, break_long_words=False, break_on_hyphens=False
+        )
+        lines.extend(w + (newline if i == len(wrapped) - 1 else "\n") for i, w in enumerate(wrapped))
+    return lines
+
+
 def _diff_lines(dict_a: dict[str, Any], dict_b: dict[str, Any], **kwargs) -> list[str]:
     """Convert dictionaries into YAML and return the added/removed lines between them.
 
@@ -772,8 +803,8 @@ def _diff_lines(dict_a: dict[str, Any], dict_b: dict[str, Any], **kwargs) -> lis
     meta_a = yaml_dump(dict_a, **kwargs)
     meta_b = yaml_dump(dict_b, **kwargs)
 
-    a_lines = meta_a.splitlines(keepends=True)
-    b_lines = meta_b.splitlines(keepends=True)
+    a_lines = _wrap_long_lines(meta_a)
+    b_lines = _wrap_long_lines(meta_b)
 
     lines = []
     for tag, i1, i2, j1, j2 in difflib.SequenceMatcher(None, a_lines, b_lines).get_opcodes():

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -12,6 +12,7 @@ import datetime as dt
 import html
 import json
 import re
+from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 
@@ -81,10 +82,19 @@ class ValueDiff:
     # True when the sample of a numeric "changed" diff is sorted by anomaly score (largest first)
     # and carries an "anomaly score" display column; non-numeric samples stay random and unsorted.
     sorted_by_score: bool = False
-    # Median BARD (|a-b| / (|a|+|b|), see `etl.data_helpers.misc.bard`) across ALL changed rows
-    # of a numeric column — the typical size of the change, bounded in [0, 1]. None when the
-    # column is non-numeric (or the diff is not of kind "changed").
+    # Median BARD (|a-b| / (|a|+|b|), see `etl.data_helpers.misc.bard`) across all *revised* rows
+    # of a numeric column (both sides non-null) — the typical size of a genuine value change,
+    # bounded in [0, 1]. 0.0 when there are no revised rows (all changes are appeared/disappeared
+    # coverage churn, see below) — only None when the column is non-numeric (or the diff isn't of
+    # kind "changed"), where old/new values can't be told apart from an unscoreable category flip.
     median_bard: float | None = None
+    # Rows where the value appeared (was NaN, now isn't) or disappeared (was a value, now NaN),
+    # within a row index that existed on both sides. Excluded from `median_bard`/`severity` — a
+    # value's presence changing isn't the same kind of event as a value that existed on both
+    # sides moving — and tracked here instead as the separate `coverage_severity` axis. Only set
+    # for numeric "changed" diffs.
+    appeared_count: int = 0
+    disappeared_count: int = 0
 
     @property
     def pct(self) -> float:
@@ -96,12 +106,14 @@ class ValueDiff:
 
     @property
     def severity(self) -> float:
-        """How big the differences are, in [0, 1] — the report's sort key.
+        """How big the genuine value revisions are, in [0, 1] — the report's sort key.
 
-        Numeric changed diffs use their median BARD; non-numeric changes count as a full change
-        (a category flip has no meaningful "size"); removed values scale with the share of rows
-        lost (coverage loss is additionally surfaced by the dataset's coverage chip, which forces
-        the 🔴 tier); purely new values sort last — they're additions, not differences.
+        Numeric changed diffs use their median BARD over revised rows only (appeared/disappeared
+        rows live on the separate `coverage_severity` axis, see below); non-numeric changes count
+        as a full change (a category flip has no meaningful "size"); removed values scale with
+        the share of rows lost (coverage loss is additionally surfaced by the dataset's coverage
+        chip, which forces the 🔴 tier); purely new values sort last — they're additions, not
+        differences.
         """
         if self.kind == "new":
             return 0.0
@@ -110,6 +122,15 @@ class ValueDiff:
         if self.median_bard is not None:
             return self.median_bard
         return 1.0
+
+    @property
+    def coverage_severity(self) -> float:
+        """Share of this diff's rows whose value appeared or disappeared rather than being
+        revised in place — how much the column's *coverage* churned, orthogonal to `severity`
+        (how big its genuine revisions were). Only meaningful for kind "changed"."""
+        if self.kind != "changed" or not self.total:
+            return 0.0
+        return (self.appeared_count + self.disappeared_count) / self.total
 
 
 @dataclass
@@ -133,6 +154,19 @@ class ColumnDiffResult:
             return 0.0
         if self.value_diffs:
             return max(v.severity for v in self.value_diffs)
+        return 0.0
+
+    @property
+    def coverage_severity(self) -> float:
+        """Biggest coverage churn among the column's value diffs — see `ValueDiff.coverage_severity`.
+        Removed columns are wholly a coverage event; new columns aren't (additions don't need
+        flagging, matching `severity`'s treatment of "new")."""
+        if self.kind == "removed":
+            return 1.0
+        if self.kind == "new":
+            return 0.0
+        if self.value_diffs:
+            return max((v.coverage_severity for v in self.value_diffs), default=0.0)
         return 0.0
 
     @property
@@ -425,16 +459,64 @@ def dataset_watch_key(ds: DatasetDiffResult) -> tuple:
 
 
 def _tier_chip(severity: float, kind: ChangeKind = "changed", tier: Tier | None = None) -> str:
-    """Colored triage chip: tier icon + the score it corresponds to.
+    """Colored triage chip for a single column: tier icon + its own median BARD score.
 
-    Pass `tier` to override the severity-derived tier — a dataset with coverage loss is forced
-    🔴 by `DatasetDiffResult.tier`, and its chip must agree with the tier strip and filters.
+    Pass `tier` to override the severity-derived tier — a removed column is forced 🔴 regardless
+    of its (irrelevant) severity value. Column-level severity is a real median over that column's
+    revised rows, so "median anomaly score" is an honest label here. It is NOT used at table/
+    dataset level — see `_rollup_tier_chip`, which a max-of-columns would make say "median" while
+    actually showing the single worst column, and which saturates to 100% on any dataset wide
+    enough that some column always has a genuine full anomaly (WDI-sized: ~1500 columns).
     """
     tier = tier or _tier(severity)
     if tier == "none":
         return ""
     label = {"removed": "removed", "new": "new"}.get(kind) or f"median anomaly score {format_score(severity)}"
     return f'<span class="chip tier {tier}">{TIER_ICONS[tier]} {_e(label)}</span>'
+
+
+def _col_tier_counts(
+    columns: Iterable["ColumnDiffResult"], score: Callable[["ColumnDiffResult"], float] = lambda c: c.severity
+) -> dict[Tier, int]:
+    """Count of non-dim, non-identical, non-metadata-only columns per tier of `score`."""
+    counts: dict[Tier, int] = {"large": 0, "moderate": 0, "small": 0}
+    for c in columns:
+        if c.is_dim or c.kind == "identical" or c.is_metadata_only:
+            continue
+        t = _tier(score(c))
+        if t != "none":
+            counts[t] += 1
+    return counts
+
+
+def _tier_counts_label(counts: dict[Tier, int]) -> str:
+    return " · ".join(f"{TIER_ICONS[t]} {counts[t]}" for t in ("large", "moderate", "small") if counts[t])
+
+
+def _rollup_tier_chip(columns: Iterable["ColumnDiffResult"], tier: Tier) -> str:
+    """Triage chip for a table/dataset: tier *counts* over its columns' own severities, not a
+    single (necessarily worst-case) score. A max saturates to 100% on any dataset with enough
+    columns that one of them always has a genuine full anomaly; counts can't. `tier` colors the
+    chip (the table/dataset's own worst-column tier — still the right signal for sorting/
+    filtering, just not for the number displayed)."""
+    if tier == "none":
+        return ""
+    label = _tier_counts_label(_col_tier_counts(columns))
+    if not label:
+        return ""
+    return f'<span class="chip tier {tier}">{_e(label)} column(s) changed</span>'
+
+
+def _coverage_churn_chip(columns: Iterable["ColumnDiffResult"]) -> str:
+    """How many changed columns had values appear/disappear without being genuine revisions —
+    the coverage axis, kept separate from the anomaly (BARD) chip above so a routine coverage
+    shift (a new year added, a slow-cadence indicator's "latest" datapoint moving) doesn't compete
+    with real revisions for the same score, while still being visible rather than silently
+    dropped."""
+    label = _tier_counts_label(_col_tier_counts(columns, score=lambda c: c.coverage_severity))
+    if not label:
+        return ""
+    return f'<span class="chip cov-churn">↕ {_e(label)} column(s) w/ shifted coverage</span>'
 
 
 def _coverage_chip(ds: DatasetDiffResult) -> str:
@@ -458,14 +540,20 @@ def _coverage_chip(ds: DatasetDiffResult) -> str:
 
 def _top_changes(
     report: "DiffReport", limit: int = TOP_CHANGES_LIMIT
-) -> tuple[list[tuple[int, list[str], str, str, str | None]], list[tuple[float, float, str, str, str]]]:
+) -> tuple[list[tuple[int, list[str], str, str, str | None]], list[tuple[float, float, str, str, str, str]]]:
     """The indicators to watch, as (losses, changes).
 
     Losses — (n_rows_removed, labels, ds_path, table, dim_or_None) — are data points that existed
     before and are gone after, the classic silent breakage of a dependency update. They always
     lead the watch list, regardless of how small they are relative to the dataset.
 
-    Changes — (severity, pct_rows, ds_path, table, column) — are the biggest value changes.
+    Changes — (severity, pct_rows, ds_path, table, column, axis) — are the biggest value changes,
+    "axis" is "anomaly" for a genuine value revision or "coverage" for a column whose values
+    appeared/disappeared without any revision (checked only when there's no revision to report,
+    via `elif` — a column with both gets listed once, by its anomaly score). Coverage-only
+    columns don't score on the anomaly axis at all (see `_changed_records`), so without this
+    they'd silently vanish from the watch list even when, e.g., an indicator's entire history
+    disappeared.
     """
     losses = []
     changes = []
@@ -481,10 +569,13 @@ def _top_changes(
                 )
                 losses.append((t.removed_row_count, t.removed_labels, ds.path, t.name, dim))
             for c in t.columns:
-                if c.is_dim or c.kind == "identical" or c.severity <= 0:
+                if c.is_dim or c.kind == "identical":
                     continue
-                pct = max((v.pct for v in c.value_diffs if v.kind != "new"), default=0.0)
-                changes.append((c.severity, pct, ds.path, t.name, c.name))
+                if c.severity > 0:
+                    pct = max((v.pct for v in c.value_diffs if v.kind != "new"), default=0.0)
+                    changes.append((c.severity, pct, ds.path, t.name, c.name, "anomaly"))
+                elif c.coverage_severity > 0:
+                    changes.append((c.coverage_severity, 0.0, ds.path, t.name, c.name, "coverage"))
     losses.sort(key=lambda r: (-r[0], r[2]))
     changes.sort(key=lambda r: (-r[0], -r[1], r[2]))
     losses = losses[:limit]
@@ -535,9 +626,18 @@ def _render_value_diff(v: ValueDiff, sample_cap: int = SAMPLE_LIMIT) -> str:
             else ""
         )
         head_note = f' <span class="head-note">— showing {what}{capped}</span>'
+    breakdown = ""
+    if v.kind == "changed" and (v.appeared_count or v.disappeared_count):
+        revised = v.count - v.appeared_count - v.disappeared_count
+        bits = [f"{revised:,} revised"]
+        if v.appeared_count:
+            bits.append(f"{v.appeared_count:,} appeared")
+        if v.disappeared_count:
+            bits.append(f"{v.disappeared_count:,} disappeared")
+        breakdown = f' <span class="head-note">({", ".join(bits)})</span>'
     head = (
         f'<div class="vd-head {v.kind}">{_e(v.symbol)} {label}: '
-        f"{v.count:,} / {v.total:,} ({v.pct:.2f}%){head_note}</div>"
+        f"{v.count:,} / {v.total:,} ({v.pct:.2f}%){breakdown}{head_note}</div>"
     )
     if not shown:
         return f'<div class="vd">{head}</div>'
@@ -581,9 +681,15 @@ def _render_column(table_name: str, c: ColumnDiffResult, ds_path: str = "", samp
 
 
 def _render_table(t: TableDiffResult, ds_path: str = "", sample_cap: int = SAMPLE_LIMIT) -> str:
+    if t.kind == "changed":
+        tier_chip = _rollup_tier_chip(t.columns, _tier(t.severity))
+        cov_chip = _coverage_churn_chip(t.columns)
+    else:
+        tier_chip = _tier_chip(t.severity, t.kind)
+        cov_chip = ""
     parts = [
         f'<div class="tbl"><div class="tbl-head"><span class="sym {t.kind}">{_SYMBOLS[t.kind]}</span> '
-        f"Table <b>{_e(t.name)}</b>{_tier_chip(t.severity, t.kind)}</div>"
+        f"Table <b>{_e(t.name)}</b>{tier_chip}{cov_chip}</div>"
     ]
     if t.meta_diff:
         parts.append(_render_meta_diff(t.meta_diff, "table metadata diff"))
@@ -618,7 +724,9 @@ def _render_dataset(ds: DatasetDiffResult, sample_cap: int = SAMPLE_LIMIT) -> st
     kind = ds.change_kind
     open_attr = " open" if kind in ("changed", "error") else ""
     new_version = ' <span class="chip">new version</span>' if ds.is_new_version else ""
-    tier = _tier_chip(ds.severity, kind, tier=ds.tier) if kind == "changed" else ""
+    all_cols = [c for t in ds.tables for c in t.columns]
+    tier = _rollup_tier_chip(all_cols, ds.tier) if kind == "changed" else ""
+    cov_chip = _coverage_churn_chip(all_cols) if kind == "changed" else ""
     # What the filter box matches against: names only (path, tables, changed columns) — matching
     # the full text would make queries hit sample values and scores, which is pure noise.
     search = " ".join(
@@ -627,7 +735,7 @@ def _render_dataset(ds: DatasetDiffResult, sample_cap: int = SAMPLE_LIMIT) -> st
     parts = [
         f'<details class="ds {kind}" id="{_ds_anchor(ds.path)}" data-tier="{"meta" if ds.is_metadata_only else ds.tier}" data-search="{_e(search)}"{open_attr}>'
         f'<summary><span class="sym {kind}">{_SYMBOLS[kind]}</span> '
-        f'<code class="path">{_e(ds.path)}</code>{new_version}{tier}{_coverage_chip(ds)}'
+        f'<code class="path">{_e(ds.path)}</code>{new_version}{tier}{cov_chip}{_coverage_chip(ds)}'
         f'<span class="ds-note">{_e(_dataset_summary_note(ds))}</span></summary>'
         f'<div class="ds-body">'
     ]
@@ -698,19 +806,9 @@ def render_html(report: DiffReport) -> str:
         tier_select = ""
 
     # Same for indicators: a dropdown filtering the column blocks by their tier (dims excluded).
-    col_tier_counts = {"large": 0, "moderate": 0, "small": 0}
-    n_meta_only_cols = 0
-    for ds in report.datasets:
-        if ds.change_kind != "changed":
-            continue
-        for t in ds.tables:
-            for c in t.columns:
-                if c.is_dim or c.kind == "identical":
-                    continue
-                if c.is_metadata_only:
-                    n_meta_only_cols += 1
-                elif _tier(c.severity) != "none":
-                    col_tier_counts[_tier(c.severity)] += 1
+    changed_cols = [c for ds in report.datasets if ds.change_kind == "changed" for t in ds.tables for c in t.columns]
+    col_tier_counts = _col_tier_counts(changed_cols)
+    n_meta_only_cols = sum(1 for c in changed_cols if not c.is_dim and c.kind != "identical" and c.is_metadata_only)
     available_col_tiers = [t for t in ("large", "moderate", "small") if col_tier_counts[t]]
     if len(available_col_tiers) + (1 if n_meta_only_cols else 0) >= 2:
         opts = "".join(
@@ -746,7 +844,7 @@ def render_html(report: DiffReport) -> str:
         tier_strip = (
             f'<div class="tier-strip">Of the {n_diff:,} dataset{"s" if n_diff != 1 else ""} with '
             f"differences, the changes are: {' · '.join(strip_bits)} "
-            f'<span class="tier-hint">(tiered by median anomaly score; coverage loss ⇒ 🔴)</span></div>'
+            f'<span class="tier-hint">(tiered by worst-column anomaly score; coverage loss ⇒ 🔴)</span></div>'
         )
 
     # Datasets to watch, in triage order (see dataset_watch_key).
@@ -762,11 +860,21 @@ def render_html(report: DiffReport) -> str:
         elif d.is_metadata_only:
             meta_html = '<span class="top-meta">metadata-only changes</span>'
         elif d.severity <= 0:
-            meta_html = '<span class="top-meta">new data only</span>'
+            # No genuine revisions -- still worth saying if that's because of coverage churn
+            # (values appearing/disappearing) rather than plain additions.
+            cov_label = _tier_counts_label(
+                _col_tier_counts([c for t in d.tables for c in t.columns], score=lambda c: c.coverage_severity)
+            )
+            meta_html = (
+                f'<span class="top-meta">{_e(cov_label)} column(s) w/ shifted coverage</span>'
+                if cov_label
+                else '<span class="top-meta">new data only</span>'
+            )
         else:
             n_cols = sum(len(t.changed_columns) for t in d.tables)
             n_tables = sum(1 for t in d.tables if t.any_change)
-            meta_html = f'<span class="top-meta">median anomaly score {_e(format_score(d.severity))}</span>'
+            counts_label = _tier_counts_label(_col_tier_counts([c for t in d.tables for c in t.columns]))
+            meta_html = f'<span class="top-meta">{_e(counts_label)} column(s) changed</span>' if counts_label else ""
             if d.removed_row_count:
                 meta_html += f'<span class="top-meta loss">− lost {d.removed_row_count:,} data point(s)</span>'
             meta_html += f'<span class="top-meta">{n_cols} column(s) in {n_tables} table(s)</span>'
@@ -790,12 +898,17 @@ def render_html(report: DiffReport) -> str:
             + (f": {_e(shown)}" if shown else "")
             + "</span></li>"
         )
-    for severity, pct, ds_path, table, col in changes:
-        tier = _tier(severity)
+    for severity, pct, ds_path, table, col, axis in changes:
+        if axis == "coverage":
+            icon = "↕"
+            meta = f"coverage churn {_e(format_score(severity))} (values appeared/disappeared)"
+        else:
+            icon = TIER_ICONS.get(_tier(severity), "")
+            meta = f"median anomaly score {_e(format_score(severity))} · {pct:.0f}% of rows"
         items.append(
-            f'<li><span class="ti">{TIER_ICONS.get(tier, "")}</span> '
+            f'<li><span class="ti">{icon}</span> '
             f'<a href="#{_anchor(ds_path, table, col)}"><code>{_e(ds_path)}</code> · <code>{_e(table)}.{_e(col)}</code></a>'
-            f'<span class="top-meta">median anomaly score {_e(format_score(severity))} · {pct:.0f}% of rows</span></li>'
+            f'<span class="top-meta">{meta}</span></li>'
         )
     show_datasets = len(ds_items) >= 2
     show_indicators = len(items) >= 2
@@ -875,6 +988,7 @@ def render_html(report: DiffReport) -> str:
   .chip.tier.moderate {{ background: #fdf3d7; color: #8a6d00; }}
   .chip.tier.small {{ background: #e9f6ec; color: #1b5e20; }}
   .chip.cov {{ background: #fdeaea; color: #b71c1c; font-weight: 600; }}
+  .chip.cov-churn {{ background: #e8eaf6; color: #3949ab; }}
   .tier-strip {{ font-size: .9rem; margin: -0.75rem 0 1rem; }}
   .tier-strip .tier-hint {{ color: #999; font-size: .78rem; }}
   details.top-changes {{ background: #fff; border: 1px solid #e5e5e5; border-radius: 8px; padding: .6rem 1rem; margin-bottom: 1rem; }}

--- a/etl/io.py
+++ b/etl/io.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from structlog import get_logger
@@ -84,13 +85,51 @@ def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]], incl
     # And that would give you only the steps that are affected by the changed files. That would be ultimately what we need. But I
     # understand that loading steps_df is very slow.
 
-    # Add all downstream dependencies of those datasets.
     DAG = load_dag()
+
+    # A version bump only touches files under the new version's folder, so `dataset_catalog_paths`
+    # so far contains only the new version's path. If we stopped here, callers that turn this list
+    # into an --include filter (e.g. datadiff's `--changed`) would filter the previous version's
+    # catalog path out of the comparison entirely, and `etl diff` would report the bump as a
+    # brand-new dataset instead of diffing it against the old version. Pull in just the closest
+    # *preceding* version of the same channel/namespace/short_name so it stays in scope for
+    # comparison.
+    #
+    # Only the immediate predecessor is added — not every other active version. Some datasets
+    # (e.g. WDI) keep several vintages active in parallel for different downstream consumers
+    # rather than superseding one in place; matching all of them would sweep unrelated, untouched
+    # datasets into the comparison. Since those aren't part of `dataset_catalog_paths` and usually
+    # aren't built locally either, `etl diff` would report each one as falsely "removed".
+    all_data_steps = {s.split("://", 1)[1] for s in DAG if s.startswith("data://")}
+    sibling_versions = []
+    for ds_path in dataset_catalog_paths:
+        parts = ds_path.split("/")
+        if len(parts) != 4:
+            # Not a channel/namespace/version/short_name data step (e.g. a snapshot path).
+            continue
+        channel, namespace, version, short_name = parts
+        pattern = re.compile(rf"^{re.escape(channel)}/{re.escape(namespace)}/([^/]+)/{re.escape(short_name)}$")
+        # Versions are (almost always) ISO dates, so the lexicographically-largest one that's
+        # still less than the new version is its closest predecessor.
+        preceding = [
+            (match.group(1), candidate)
+            for candidate in all_data_steps
+            if candidate != ds_path and (match := pattern.match(candidate)) and match.group(1) < version
+        ]
+        if preceding:
+            sibling_versions.append(max(preceding, key=lambda p: p[0])[1])
+    # Add all downstream dependencies of the originally-changed datasets only. Siblings are added
+    # afterward as comparison targets, not as subgraph-expansion inputs — otherwise every real
+    # downstream consumer of an old sibling version (and their own upstream dependencies) would be
+    # swept into the result too, even though only the new version is actually changing.
     dag_steps = list(filter_to_subgraph(DAG, dataset_catalog_paths, downstream=True).keys())
 
     # From data://... extract catalogPath
     # TODO: use StepPath from https://github.com/owid/etl/pull/3165 to refactor this
     catalog_paths = [step.split("://")[1] for step in dag_steps if step.startswith("data://")]
+    for sibling in sibling_versions:
+        if sibling not in catalog_paths:
+            catalog_paths.append(sibling)
 
     # Optionally also return export steps, keeping their full URI so callers can match them with
     # `export://...` include patterns (export steps have no data:// catalogPath). This covers both

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -1,13 +1,23 @@
 import hashlib
 import os
+import re
 import shutil
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
 from owid.catalog import Dataset, DatasetMeta, Table
+from owid.catalog.core.meta import Origin
 
-from etl.datadiff import DatasetDiff, RemoteDataset, _changed_records, _dataset_files_match
+from etl.datadiff import (
+    DatasetDiff,
+    RemoteDataset,
+    _changed_include_regex,
+    _changed_records,
+    _dataset_files_match,
+    _diff_lines,
+    _table_metadata_dict,
+)
 from etl.datadiff_report import (
     HTML_SAMPLE_ROW_BUDGET,
     ColumnDiffResult,
@@ -79,9 +89,16 @@ def test_new_data(tmp_path):
         "[white]= Dataset [b]garden/n/v/ds[/b]",
         "\t[white]= Table [b]tab[/b]",
         "\t\t[yellow]~ Dim [b]country[/b]",
-        "\t\t\t\t[violet]+ New values: 1 / 3 (33.33%)\n\t\t\t\t[violet]  country\n\t\t\t\t[violet]       FR",
+        "\t\t\t\t[violet]+ New values: 1 / 3 (33.33%)",
+        "\t\t\t\t[violet]  country",
+        "\t\t\t\t[violet]       FR",
         "\t\t[yellow]~ Column [b]a[/b] (new [u]data[/u], changed [u]data[/u])",
-        "\t\t\t\t[violet]+ New values: 1 / 3 (33.33%)\n\t\t\t\t[violet]  country  a\n\t\t\t\t[violet]       FR  3\n\t\t\t\t[violet]~ Changed values: 1 / 3 (33.33%)\n\t\t\t\t[violet]  country  a -  a +\n\t\t\t\t[violet]       US    3    2",
+        "\t\t\t\t[violet]+ New values: 1 / 3 (33.33%)",
+        "\t\t\t\t[violet]  country  a",
+        "\t\t\t\t[violet]       FR  3",
+        "\t\t\t\t[violet]~ Changed values: 1 / 3 (33.33%)",
+        "\t\t\t\t[violet]  country  a -  a +",
+        "\t\t\t\t[violet]       US    3    2",
     ]
 
 
@@ -141,26 +158,88 @@ def test_changed_records_sorts_numeric_by_change_size():
             "a +": [101.0, 250.0, 5.0],  # BARD ≈ 0.005, 0.43, 1.0
         }
     )
-    records, sorted_by_score, median_bard = _changed_records(both, "a")
+    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
     assert sorted_by_score
     # Biggest changes (by anomaly score = BARD) first; growth from zero is maximal (score 1).
     assert [r["country"] for r in records] == ["from_zero", "big", "small"]
     assert [r["anomaly score"] for r in records] == ["100%", "43%", "0.50%"]
     # Median BARD across all changed rows: median(0.005, 0.43, 1.0) ≈ 0.43.
     assert median_bard == pytest.approx(150 / 350, abs=1e-6)
+    assert (appeared, disappeared) == (0, 0)
 
     # A sample larger than the limit keeps only the biggest movers.
-    top, _, _ = _changed_records(both, "a", limit=2)
+    top, _, _, _, _ = _changed_records(both, "a", limit=2)
     assert [r["country"] for r in top] == ["from_zero", "big"]
 
 
 def test_changed_records_non_numeric_falls_back_to_random_sample():
     both = pd.DataFrame({"country": ["UK", "US"], "a -": ["x", "y"], "a +": ["y", "z"]})
-    records, sorted_by_score, median_bard = _changed_records(both, "a")
+    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
     assert not sorted_by_score
     assert median_bard is None
+    assert (appeared, disappeared) == (0, 0)
     assert all("anomaly score" not in r for r in records)
     assert len(records) == 2
+
+
+def test_changed_records_appeared_and_disappeared_excluded_from_score():
+    """A value appearing or disappearing (NaN on one side) is a coverage event, not a revision --
+    e.g. the newest year in a new dataset version, or a slow-cadence indicator's "latest"
+    datapoint shifting to a new year. It's excluded from BARD/the median entirely (not scored 0
+    or 1) and tallied separately, unlike a genuine both-sided revision."""
+    both = pd.DataFrame(
+        {
+            "year": [2022, 2023, 2024],
+            "a -": [10.0, 7.0, float("nan")],
+            "a +": [5.0, float("nan"), 20.0],  # 2022: revised (BARD 1/3); 2023: disappeared; 2024: appeared
+        }
+    )
+    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    assert sorted_by_score
+    labels = {r["year"]: r["anomaly score"] for r in records}
+    assert labels["2022"] == "33%"
+    assert labels["2023"] == "disappeared"
+    assert labels["2024"] == "appeared"
+    # Median is computed only over the one revised row.
+    assert median_bard == pytest.approx(1 / 3, abs=1e-6)
+    assert (appeared, disappeared) == (1, 1)
+    # Revised rows rank first; appeared/disappeared come after regardless of magnitude.
+    assert [r["year"] for r in records][0] == "2022"
+
+
+def test_changed_records_all_appeared_disappeared_score_zero_median():
+    """A column with zero genuine revisions (all changes are coverage churn) scores 0, not the
+    non-numeric fallback of 1 -- otherwise a WDI-style "add a new year" update would still pin
+    every such column's severity to maximal."""
+    both = pd.DataFrame({"year": [2024, 2024], "a -": [float("nan"), float("nan")], "a +": [20.0, 30.0]})
+    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    assert median_bard == 0.0
+    assert (appeared, disappeared) == (2, 0)
+    assert all(r["anomaly score"] == "appeared" for r in records)
+
+
+@pytest.mark.filterwarnings("ignore:Table `tab` does not have a primary_key")
+@patch.dict(os.environ, {"OWID_STRICT": ""})
+def test_new_year_data_not_scored_as_anomaly(tmp_path):
+    """End-to-end WDI-style case: a wide table's row index for the newest year already exists
+    (via another column that has data for it), but this column's own data for that year is new.
+    That should not inflate the column's median anomaly score."""
+    ds_a, ds_b = _create_datasets(tmp_path)
+
+    tab_a = Table({"country": ["US", "US"], "year": [2023, 2024], "a": [10.0, None], "b": [1, 1]}, short_name="tab")
+    tab_b = Table({"country": ["US", "US"], "year": [2023, 2024], "a": [10.0, 20.0], "b": [1, 1]}, short_name="tab")
+
+    ds_a.add(tab_a)
+    ds_b.add(tab_b)
+
+    differ = DatasetDiff(ds_a, ds_b, print=lambda x: None, details=True)
+    differ.summary()
+    res = differ.result
+
+    (tab,) = res.tables
+    col = next(c for c in tab.columns if c.name == "a")
+    (changed,) = [v for v in col.value_diffs if v.kind == "changed"]
+    assert changed.median_bard == 0.0
 
 
 def _changed_col(name, median_bard, is_dim=False):
@@ -212,12 +291,13 @@ def test_coverage_loss_forces_large_tier():
     assert ds.removed_labels == ["Vietnam", "Philippines"]
     assert ds.tier == "large"
 
-    # The coverage chip is rendered on the dataset summary line, and the tier chip agrees with
-    # the forced 🔴 tier (not the severity-derived 🟡/🟢) so the row matches the filters.
+    # The coverage chip is rendered on the dataset summary line, and the rollup tier chip is
+    # colored by the forced 🔴 tier (not the severity-derived 🟡/🟢) so the row matches the
+    # filters -- its count breakdown still reflects the actual column ("a" is "small").
     html = render_html(DiffReport(datasets=[ds]))
     assert "row(s) removed" in html
     assert "Vietnam" in html
-    assert 'class="chip tier large">🔴 median anomaly score' in html
+    assert 'class="chip tier large">🟢 1 column(s) changed' in html
 
 
 def test_triage_aids_gate_on_content():
@@ -570,3 +650,92 @@ def test_html_sample_rows_capped_on_huge_reports():
     small_html = render_html(small)
     assert "display capped" not in small_html
     assert "c99" in small_html
+
+
+def _wdi_like_origin(i, version_producer="124", date_accessed="2026-02-27"):
+    """An origin shaped like WDI's: same title/title_snapshot and a giant shared description
+    across every one of a dataset's ~1500 origins (one per indicator), but a distinct
+    producer/url_main per indicator."""
+    return Origin(
+        producer=f"Producer {i % 5}",
+        title="World Development Indicators",
+        title_snapshot=None,
+        description="shared boilerplate " * 50,
+        citation_full=f"Citation for indicator {i}",
+        url_main=f"https://example.org/indicator/{i}",
+        version_producer=version_producer,
+        date_accessed=date_accessed,
+    )
+
+
+def _table_with_origins(origins):
+    tb = Table(pd.DataFrame({f"col{i}": [1, 2, 3] for i in range(len(origins))}))
+    tb.metadata.dataset = DatasetMeta(title="x", short_name="x")
+    tb.metadata.short_name = "test"
+    for i, origin in enumerate(origins):
+        tb[f"col{i}"].metadata.origins = [origin]
+    return tb
+
+
+def test_table_metadata_diff_stays_small_when_only_a_few_origin_fields_change():
+    # Regression test for a huge (tens-of-thousands-of-lines) table metadata diff on datasets
+    # like WDI, where every column's origin shares the same title/title_snapshot (only
+    # producer/url_main differ per indicator). The old origin sort key `(title, title_snapshot)`
+    # was then a no-op tied to `set()`'s arbitrary iteration order, so two independently-built
+    # tables serialized their origins in unrelated orders and the line-level diff saw the whole
+    # list as reshuffled: every origin — including unchanged fields like the shared description —
+    # rendered as removed+added instead of just the couple of lines that actually changed.
+    n = 50
+    origins_a = [_wdi_like_origin(i) for i in range(n)]
+    # Only version_producer/date_accessed actually changed; simulate a differently-ordered
+    # `set()` iteration (e.g. from a different column order) by shuffling before sorting.
+    origins_b = [Origin(**{**o.to_dict(), "version_producer": "125", "date_accessed": "2026-07-14"}) for o in origins_a]
+    origins_b_shuffled = list(reversed(origins_b))
+
+    tab_a = _table_with_origins(origins_a)
+    tab_b = _table_with_origins(origins_b_shuffled)
+
+    diff_lines = _diff_lines(_table_metadata_dict(tab_a), _table_metadata_dict(tab_b))
+
+    # Only the couple of genuinely-changed scalar fields per origin should show up, not the shared
+    # description/citation/producer boilerplate. With the old sort key (tied on title/title_snapshot
+    # alone) this same input renders ~1,500 lines (every origin fully replaced); a content-based
+    # sort keeps it near the true minimum of 2 fields x 50 origins x 2 (old+new) = 200 lines.
+    assert len(diff_lines) < 250
+    assert not any("shared boilerplate" in line for line in diff_lines)
+    assert not any("Citation for indicator" in line for line in diff_lines)
+
+
+def test_changed_include_regex_does_not_match_paths_as_substrings():
+    # Regression test: a bare `"|".join(catalog_paths)` regex lets one changed dataset's
+    # short_name match as a *prefix* of another, unrelated dataset's short_name — e.g.
+    # "wb/2026-07-01/income_groups" (a real dependency pulled in by --changed) matching inside
+    # ".../income_groups_aggregations" (an untouched, unrelated dataset). That sweeps the
+    # unrelated dataset into the comparison scope, and since it's not actually part of the
+    # changed set (and often isn't built locally either), `etl diff` reports it as falsely
+    # "removed".
+    catalog_paths = ["garden/worldbank_wdi/2026-07-14/wdi", "garden/wb/2026-07-01/income_groups"]
+    # The local catalog matches against the full absolute directory path, not the bare
+    # "channel/namespace/version/short_name" the remote catalog uses — the regex must match both.
+    local_dir = "/repo/data/garden/wb/2026-07-01/income_groups"
+    local_dir_unrelated = "/repo/data/garden/wb/2026-07-01/income_groups_aggregations"
+
+    # No user-supplied --include: the regex is the bare catalog-paths list.
+    pattern = _changed_include_regex(None, catalog_paths)
+    assert re.search(pattern, "garden/wb/2026-07-01/income_groups")
+    assert not re.search(pattern, "garden/wb/2026-07-01/income_groups_aggregations")
+    assert re.search(pattern, local_dir)
+    assert not re.search(pattern, local_dir_unrelated)
+
+    # With a user-supplied --include, both conditions must hold: the path matches --include AND
+    # is one of the changed catalog paths.
+    pattern_with_include = _changed_include_regex("garden", catalog_paths)
+    assert re.search(pattern_with_include, "garden/wb/2026-07-01/income_groups")
+    assert not re.search(pattern_with_include, "garden/wb/2026-07-01/income_groups_aggregations")
+    # A path that matches --include but isn't a changed catalog path is still excluded.
+    assert not re.search(pattern_with_include, "garden/other/2020-01-01/unrelated")
+    # A changed catalog path that doesn't match --include (wrong channel) is excluded too.
+    meadow_only = _changed_include_regex(
+        "garden", ["garden/worldbank_wdi/2026-07-14/wdi", "meadow/wb/2026-07-01/income_groups"]
+    )
+    assert not re.search(meadow_only, "meadow/wb/2026-07-01/income_groups")

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -739,3 +739,23 @@ def test_changed_include_regex_does_not_match_paths_as_substrings():
         "garden", ["garden/worldbank_wdi/2026-07-14/wdi", "meadow/wb/2026-07-01/income_groups"]
     )
     assert not re.search(meadow_only, "meadow/wb/2026-07-01/income_groups")
+
+
+def test_diff_lines_wraps_long_lines_so_a_trailing_change_stays_small():
+    # Regression test: a long single-line YAML string (e.g. a producer `citation_full`, which
+    # `yaml_dump`'s own `width` doesn't wrap — that only applies to folded/plain scalars, not
+    # literal block scalars) that differs only in its last few words used to make the *entire*
+    # line register as changed, duplicating the whole paragraph in both the removed and added
+    # sides. A single such boilerplate citation repeated across WDI's ~1,500 origins, each only
+    # differing in a trailing "Accessed on <date>", is what blew the table metadata diff up to
+    # megabytes. Wrapping before the line-level diff keeps only the truly-changed chunk.
+    boilerplate = "AQUASTAT - FAO's Global Information System on Water and Agriculture, " * 3
+    old = {"citation_full": f"{boilerplate}Accessed on 2026-02-27."}
+    new = {"citation_full": f"{boilerplate}Accessed on 2026-07-14."}
+
+    diff_lines = _diff_lines(old, new)
+
+    assert len(diff_lines) == 2
+    assert not any("Global Information System" in line for line in diff_lines)
+    assert any("2026-02-27" in line for line in diff_lines)
+    assert any("2026-07-14" in line for line in diff_lines)

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -16,6 +16,7 @@ from etl.datadiff import (
     _changed_records,
     _dataset_files_match,
     _diff_lines,
+    _is_superseded_remote_predecessor,
     _table_metadata_dict,
 )
 from etl.datadiff_report import (
@@ -759,3 +760,30 @@ def test_diff_lines_wraps_long_lines_so_a_trailing_change_stays_small():
     assert not any("Global Information System" in line for line in diff_lines)
     assert any("2026-02-27" in line for line in diff_lines)
     assert any("2026-07-14" in line for line in diff_lines)
+
+
+def test_is_superseded_remote_predecessor():
+    # Regression test (caught in review): a changed dataset's predecessor version is added to the
+    # shared --include filter so the REMOTE fetch includes it (`_match_dataset` then falls back to
+    # it when diffing the new local version against something). But the predecessor's own path is
+    # *also* a key of path_to_ds_a (from REMOTE) and would otherwise get its own entry in the
+    # union-of-keys comparison loop. If it isn't *also* built locally — the normal case when only
+    # the new version was run — comparing it against nothing reports it as a false "removed
+    # dataset", reintroducing the exact bug this scoping exists to avoid.
+    new_only_locally = {"garden/worldbank_wdi/2026-07-14/wdi": object()}
+
+    # The predecessor isn't built locally, but a newer version of the same dataset is: it's
+    # reachable as _match_dataset's fallback for that newer path and needs no standalone entry.
+    assert _is_superseded_remote_predecessor("garden/worldbank_wdi/2026-02-27/wdi", new_only_locally)
+
+    # The predecessor *is* also built locally: it gets its own (normal, exact-match) comparison,
+    # so it must not be suppressed.
+    both_built_locally = {**new_only_locally, "garden/worldbank_wdi/2026-02-27/wdi": object()}
+    assert not _is_superseded_remote_predecessor("garden/worldbank_wdi/2026-02-27/wdi", both_built_locally)
+
+    # A genuinely removed dataset (no newer local version of the same channel/namespace/short_name
+    # exists at all) must still be reported as removed, not silently suppressed.
+    assert not _is_superseded_remote_predecessor("garden/worldbank_wdi/2026-02-27/wdi", {})
+    assert not _is_superseded_remote_predecessor(
+        "garden/worldbank_wdi/2026-02-27/wdi", {"garden/other/2024-01-01/other": object()}
+    )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -71,3 +71,60 @@ def test_get_all_changed_catalog_paths_downstream_and_direct_export_deduped(mock
     # Without include_export, only the data catalog path is returned.
     result_no_export = get_all_changed_catalog_paths(files_changed)
     assert result_no_export == ["garden/un/latest/un_wpp"]
+
+
+@patch("etl.io.load_dag")
+def test_get_all_changed_catalog_paths_version_bump_includes_old_version(mock_load_dag):
+    """A version bump must also surface the *previous* version's catalog path.
+
+    Only the new version's files changed, so naively `dataset_catalog_paths` would contain just
+    the new path. Callers (e.g. datadiff's `--changed`) turn this list into an --include filter, so
+    if the old version's path isn't included, it gets filtered out of the REMOTE-catalog fetch and
+    the diff tool reports the bump as a brand-new dataset instead of comparing against the old one.
+    """
+    mock_load_dag.return_value = {
+        "data://garden/worldbank_wdi/2026-07-14/wdi": {"data://meadow/worldbank_wdi/2026-07-14/wdi"},
+        "data://meadow/worldbank_wdi/2026-07-14/wdi": set(),
+        "data://garden/worldbank_wdi/2026-02-27/wdi": {"data://meadow/worldbank_wdi/2026-02-27/wdi"},
+        "data://meadow/worldbank_wdi/2026-02-27/wdi": set(),
+        # An unrelated dataset that happens to share the short_name in a different namespace —
+        # must NOT be pulled in as a sibling version.
+        "data://garden/other_namespace/2026-01-01/wdi": set(),
+    }
+    files_changed = {"etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.py": "M"}
+
+    result = get_all_changed_catalog_paths(files_changed)
+
+    assert "garden/worldbank_wdi/2026-07-14/wdi" in result
+    assert "garden/worldbank_wdi/2026-02-27/wdi" in result
+    assert "garden/other_namespace/2026-01-01/wdi" not in result
+
+
+@patch("etl.io.load_dag")
+def test_get_all_changed_catalog_paths_only_pulls_in_closest_preceding_sibling(mock_load_dag):
+    """A dataset with several *independently* active vintages (e.g. WDI, which keeps older
+    versions in production for other downstream consumers instead of superseding them in place)
+    must only pull in its closest predecessor as a comparison sibling — not every other active
+    version.
+
+    Sweeping in all of them would put datasets that aren't part of this change, and usually
+    aren't built locally either, in scope for `etl diff`'s --changed comparison, which then
+    reports each one as falsely "removed".
+    """
+    mock_load_dag.return_value = {
+        "data://garden/worldbank_wdi/2025-01-24/wdi": set(),
+        "data://garden/worldbank_wdi/2025-09-08/wdi": set(),
+        "data://garden/worldbank_wdi/2026-01-29/wdi": set(),
+        "data://garden/worldbank_wdi/2026-02-27/wdi": set(),
+        "data://garden/worldbank_wdi/2026-07-14/wdi": {"data://meadow/worldbank_wdi/2026-07-14/wdi"},
+        "data://meadow/worldbank_wdi/2026-07-14/wdi": set(),
+    }
+    files_changed = {"etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.py": "M"}
+
+    result = get_all_changed_catalog_paths(files_changed)
+
+    assert "garden/worldbank_wdi/2026-07-14/wdi" in result
+    assert "garden/worldbank_wdi/2026-02-27/wdi" in result
+    assert "garden/worldbank_wdi/2025-01-24/wdi" not in result
+    assert "garden/worldbank_wdi/2025-09-08/wdi" not in result
+    assert "garden/worldbank_wdi/2026-01-29/wdi" not in result


### PR DESCRIPTION
> _Written by Claude Sonnet 5 — @Marigold at the wheel._

Fixes several bugs in `etl diff` uncovered while working on a WDI update — a good stress test since it's a ~1,500-column dataset with several parallel active vintages.

## Fixes

- **False "removed dataset" reports from `--changed`'s sibling-version scoping.** `get_all_changed_catalog_paths` pulled in *every* other active version sharing a changed dataset's `channel/namespace/short_name` as a comparison target. Datasets that keep several vintages active in parallel for different downstream consumers (WDI has 5) got all their unrelated, untouched versions swept into scope and reported as falsely "removed" once they turned out not to be built locally. Now only the closest *preceding* version is pulled in.
- **False "removed dataset" reports from substring matching in the `--changed` → `--include` regex.** Catalog paths were joined into a regex without word-boundary anchoring, so one changed dataset's short_name could match as a bare substring of an unrelated one's (e.g. `income_groups` matching inside `income_groups_aggregations`), sweeping it falsely into scope. Paths are now anchored at the end (works for both the local catalog's full directory paths and the remote catalog's bare relative paths).
- **Multi-megabyte "table metadata diff" blocks that freeze the browser on wide datasets.** The origin sort key in `_table_metadata_dict` tied on `(title, title_snapshot)` alone. For datasets like WDI, where every origin shares the same title (one per indicator, same producer boilerplate), the actual order fell back to Python `set()` iteration, which differs between independently-built tables. The line-level diff then saw the whole origins list as reshuffled and rendered every origin — unchanged fields included — as removed+added, instead of just the couple of lines that actually changed. The sort key now also includes `producer`/`url_main` for a stable, content-based order.
- **Anomaly scores that saturate to 100% on wide datasets with routine coverage churn.** `_changed_records` used to score any one-sided NaN transition (a value that only exists on one side — new coverage, a dropped series, a moved "latest" survey year) as a maximal anomaly. On a dataset with hundreds of columns, that's often true of dozens of them, so the dataset-level chip collapsed to a flat, uninformative 100%. Rows are now classified as *revised* (both sides present, genuinely different — scored by BARD), *appeared*, or *disappeared* (coverage churn, tallied separately). The report now shows a tiered `🔴 N · 🟡 N · 🟢 N column(s) changed` breakdown plus a separate coverage-churn axis, instead of one saturated score.
- **Multi-megabyte metadata diffs from un-wrapped long lines.** `yaml_dump`'s own `width` only wraps folded/plain scalars — literal block scalars (`|-`, used for any string with no newlines of its own, e.g. `citation_full`) are emitted verbatim on one line however long. A single-word change at the end of an otherwise-identical few-hundred-character producer citation (boilerplate text ending in "Accessed on \<date\>") made the *entire* line register as changed, duplicating the whole paragraph on both sides of the diff. Long lines are now wrapped before the line-level diff runs, so only the truly-changed chunk shows up.
- **False "removed dataset" report for a superseded predecessor whose own path isn't built locally** (caught by [Codex review](https://github.com/owid/etl/pull/6456#discussion_r3593463449)). The predecessor's path is added to the shared `--include` filter so the REMOTE fetch includes it for `_match_dataset`'s fallback, but that also made it a standalone key in the union-of-keys comparison loop — when it wasn't *also* built locally (the normal case), it compared against nothing and got reported as falsely "removed", reintroducing the bug this PR exists to fix. The predecessor's own path is now skipped in that loop whenever a newer local version of the same dataset exists, since `_match_dataset` already reaches it as a fallback for that newer path.

## Verification

Ran against the real WDI update (`worldbank_wdi` `2026-02-27` → `2026-07-14`, ~1,500 columns):

| | before | after |
|---|---|---|
| False "removed" datasets in scope | 4 (3 unrelated WDI vintages + 1 substring collision) | 0 |
| "Table metadata diff" block (origins list) | 8.9MB / 57,535 `<span>`s (froze the browser on click) | 1.2MB / ~8,700 `<span>`s (~15ms to open) |
| Full report (single-dataset `--changed` scope) | 11.4MB | 10.1MB |
| Dataset anomaly chip | flat 🔴 100% | tiered 🔴 64 · 🟡 314 · 🟢 730 column(s) changed |

Also reproduced the Codex-flagged predecessor bug directly: temporarily moved the local `2026-02-27` build aside to simulate "only the new version was run" — before the fix, `garden/worldbank_wdi/2026-02-27/wdi` showed up as a false "removed" entry alongside the correct "changed" `2026-07-14` one; after it, only the correct entry remains.

31 tests pass across `tests/test_datadiff.py` and `tests/test_io.py` (new regression tests for each fix above), plus `ruff check`/`format` and `ty check` are clean.

## Remaining size: value-diff sample tables (not changed here)

Even after the above, 74% of the report (7.5MB) is the per-column *value*-diff sample tables (up to `SAMPLE_LIMIT = 100` example rows per changed column). Truncating that cap earlier in the pipeline shrinks the report roughly linearly — measured on this same report: 100→30 rows: -24%, →20: -39%, →10: -55%, →5 (the console's own default): -64%. Left alone pending a decision on how much example detail a reviewer actually needs by default, since it's a real detail/size tradeoff rather than a free format win like the ones above.


