### PR TITLE
🐛 Preserve nested-only DAG definitions when updating parent steps

### DIFF
--- a/etl/dag_helpers.py
+++ b/etl/dag_helpers.py
@@ -422,11 +422,21 @@ def _write_to_nested_dag_file(dag_file: Path, dag_part: dict[str, Any], comments
     original_steps = set(_parse_dag_yaml(doc))
     declared_steps = set(original_steps)
 
+    # Replacing a dependency list below wipes any nested definitions that lived inside it. Those
+    # nested definitions may be the only place a step is declared, so collect them here and
+    # re-declare the lost ones at the top level after all updates (see issue #6165).
+    displaced: list[tuple[str, Any]] = []
+
     for step, dependencies in dag_part.items():
         node = _find_step_mapping(steps, step)
         if node is None:
             continue
         mapping, key = node
+        displaced_here = list(_iter_nested_dep_items(mapping[key]))
+        displaced.extend(displaced_here)
+        # The wiped definitions are no longer declared, so the new sequence is free to re-nest them
+        # (e.g. a child that is updated in this same call keeps its nested place under this step).
+        declared_steps -= {sub_step for sub_step, _ in displaced_here}
         mapping[key] = _build_dependency_sequence(dependencies, dag_part, declared_steps, {step})
         declared_steps.update(_collect_declared_steps(mapping[key]))
 
@@ -438,6 +448,22 @@ def _write_to_nested_dag_file(dag_file: Path, dag_part: dict[str, Any], comments
             steps.yaml_set_comment_before_after_key(step, before=_normalise_ruamel_comment(comments[step]), indent=2)
         declared_steps.add(step)
         declared_steps.update(_collect_declared_steps(steps[step]))
+
+    # Re-declare displaced nested definitions that are no longer present anywhere in the document,
+    # so their steps stay in the DAG (and can later be flagged as unused/archivable) instead of
+    # disappearing without a trace. Parents are yielded before their children, so hoisting a parent
+    # (with its subtree intact) marks its children as declared and they are skipped.
+    still_declared = set(_parse_dag_yaml(doc))
+    for step, dependencies in displaced:
+        if step in still_declared:
+            continue
+        if step in dag_part:
+            # The step was updated in this same call but its declaration was already wiped by the
+            # time it was looked up; write its new dependency list rather than the stale one.
+            dependencies = _build_dependency_sequence(dag_part[step], dag_part, set(still_declared), {step})
+        steps[step] = dependencies
+        still_declared.add(step)
+        still_declared.update(_collect_declared_steps(dependencies))
 
     with open(dag_file, "w") as ostream:
         yaml_rt.dump(doc, ostream)

--- a/tests/test_dag_utils.py
+++ b/tests/test_dag_utils.py
@@ -1171,6 +1171,101 @@ steps:
         assert load_dag(p)["data://grapher/foo/2025/bar"] == {"data://garden/foo/2025/bar"}
 
 
+def test_write_to_dag_file_nested_update_preserves_displaced_nested_definitions():
+    # When a parent's dependency list is rewritten (e.g. by `etl update --include-usages`), step
+    # definitions that existed only nested inside it must survive as top-level entries instead of
+    # being silently wiped. See https://github.com/owid/etl/issues/6165.
+    old_content = """\
+steps:
+  export://multidim/foo/latest/bar:
+    - data://grapher/foo/2025-01-01/bar:
+      - data://garden/foo/2025-01-01/bar:
+        - snapshot://foo/2025-01-01/bar.csv
+"""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "dag.yml"
+        p.write_text(old_content)
+        write_to_dag_file(
+            p,
+            dag_part={
+                "export://multidim/foo/latest/bar": ["data://grapher/foo/2026-01-01/bar"],
+                "data://grapher/foo/2026-01-01/bar": ["data://garden/foo/2026-01-01/bar"],
+                "data://garden/foo/2026-01-01/bar": ["snapshot://foo/2026-01-01/bar.csv"],
+            },
+        )
+        dag = load_dag(p)
+        # The updated chain points at the new version.
+        assert dag["export://multidim/foo/latest/bar"] == {"data://grapher/foo/2026-01-01/bar"}
+        assert dag["data://grapher/foo/2026-01-01/bar"] == {"data://garden/foo/2026-01-01/bar"}
+        assert dag["data://garden/foo/2026-01-01/bar"] == {"snapshot://foo/2026-01-01/bar.csv"}
+        # The old nested-only definitions survive (as top-level entries) instead of being wiped.
+        assert dag["data://grapher/foo/2025-01-01/bar"] == {"data://garden/foo/2025-01-01/bar"}
+        assert dag["data://garden/foo/2025-01-01/bar"] == {"snapshot://foo/2025-01-01/bar.csv"}
+
+
+def test_write_to_dag_file_nested_update_preserves_nested_definition_of_unchanged_child():
+    # Rewriting a parent's dependency list while keeping a nested child as a dependency (e.g. just
+    # adding another dependency to the parent) must not lose the child's definition.
+    old_content = """\
+steps:
+  export://multidim/foo/latest/bar:
+    - data://grapher/foo/2025-01-01/bar:
+      - data://garden/foo/2025-01-01/bar:
+        - snapshot://foo/2025-01-01/bar.csv
+"""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "dag.yml"
+        p.write_text(old_content)
+        write_to_dag_file(
+            p,
+            dag_part={
+                "export://multidim/foo/latest/bar": [
+                    "data://grapher/foo/2025-01-01/bar",
+                    "data://garden/regions/latest/regions",
+                ],
+            },
+        )
+        dag = load_dag(p)
+        assert dag["export://multidim/foo/latest/bar"] == {
+            "data://grapher/foo/2025-01-01/bar",
+            "data://garden/regions/latest/regions",
+        }
+        assert dag["data://grapher/foo/2025-01-01/bar"] == {"data://garden/foo/2025-01-01/bar"}
+        assert dag["data://garden/foo/2025-01-01/bar"] == {"snapshot://foo/2025-01-01/bar.csv"}
+
+
+def test_write_to_dag_file_nested_update_does_not_duplicate_redeclared_children():
+    # If the new dependency sequence re-declares a nested child (because the child is also updated
+    # in the same call), the displaced-definition handling must not declare it a second time.
+    old_content = """\
+steps:
+  data://grapher/foo/2025-01-01/bar:
+    - data://garden/foo/2025-01-01/bar:
+      - snapshot://foo/2025-01-01/bar.csv
+"""
+    expected_content = """\
+steps:
+  data://grapher/foo/2025-01-01/bar:
+    - data://garden/foo/2025-01-01/bar:
+      - snapshot://foo/2025-01-01/bar.csv
+      - data://garden/regions/latest/regions
+"""
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / "dag.yml"
+        p.write_text(old_content)
+        write_to_dag_file(
+            p,
+            dag_part={
+                "data://grapher/foo/2025-01-01/bar": ["data://garden/foo/2025-01-01/bar"],
+                "data://garden/foo/2025-01-01/bar": [
+                    "snapshot://foo/2025-01-01/bar.csv",
+                    "data://garden/regions/latest/regions",
+                ],
+            },
+        )
+        assert p.read_text() == expected_content
+
+
 def test_remove_steps_from_dag_file_handles_nested_input():
     old_content = """\
 steps:


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

Fixes #6165

## Problem

The nested DAG format lets a step be defined only as a nested dependency under a parent (with no top-level entry). When the parent's dependency list was rewritten (for example by `etl update --include-usages`), `_write_to_nested_dag_file` replaced the entire dependency subtree, so any step definitions that lived only inside it were silently wiped. The version tracker never got a chance to flag the old steps as unused/archivable.

## Fix

Before replacing a step's dependency list, the writer now collects the nested definitions inside it. After all updates are applied, any collected definition that is no longer declared anywhere in the document is re-declared as a top-level entry (with its own nested subtree intact).

Two related refinements in the same code path:

- The wiped definitions are removed from the `declared_steps` set before building the replacement sequence, so a child updated in the same call keeps its nested place under the parent instead of being flattened.
- If a displaced step was itself part of the update (its declaration was wiped before it was looked up), its **new** dependency list is written rather than the stale one.

## Example

Updating the DAG from the issue now produces:

```yaml
steps:
  export://multidim/foo/latest/bar:
    - data://grapher/foo/2026-01-01/bar:
      - data://garden/foo/2026-01-01/bar:
        - snapshot://foo/2026-01-01/bar.csv
  data://grapher/foo/2025-01-01/bar:
    - data://garden/foo/2025-01-01/bar:
      - snapshot://foo/2025-01-01/bar.csv
```

The old `2025-01-01` chain survives as a top-level entry, so it can later be flagged `UNUSED → ARCHIVABLE` and archived through the normal procedure.

## Tests

Three new tests in `tests/test_dag_utils.py` cover the issue scenario, a parent update that keeps an unchanged nested child, and the no-duplication case where the child is re-declared in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
