### PR TITLE
✨ Support x, size, and color indicators in expand_config

### DIFF
--- a/etl/collection/core/expand.py
+++ b/etl/collection/core/expand.py
@@ -15,6 +15,9 @@ def expand_config(
     indicator_as_dimension: bool = False,
     indicators_slug: str | None = None,
     expand_path_mode: Literal["table", "dataset", "full"] = "table",
+    indicator_x: str | None = None,
+    indicator_size: str | None = None,
+    indicator_color: str | None = None,
 ) -> dict[str, Any]:
     """Create partial config (dimensions and views) from multi-dimensional indicator in table `tb`.
 
@@ -48,7 +51,8 @@ def expand_config(
         - Out-of-the box sorting for dimension values.
             - Example: This could be alphabetically ascending or descending, or numerically ascending or descending.
             - IDEA: We could pass strings as values directly to the keys in dimensions dictionary, e.g. `dimensions={"sex": "alph_desc", "age": "numerical_desc", "cause": ["aids", "cancer"]}`. To some extent, we already support the function "*" (i.e. show all values without sorting).
-        - Support using charts with 'x', 'size' and 'color' indicators. Also support display settings for each indicator.
+        - Support display settings for each indicator.
+        - Support 'x', 'size' and 'color' indicators that vary per view (currently the same indicator is applied to all views).
 
     Parameters:
     -----------
@@ -78,6 +82,12 @@ def expand_config(
         Set to True to keep the indicator as a dimension. For instance, if you expand a table with multiple - dimensional - indicators (e.g. 'population', 'population_density'), a dimension is added in the config that specifies the indicator. If there are more than one indicators being expanded, the indicator information is kept as a dimension regardless of this flag.
     indicators_slug: str
         Name to use as the slug for the indicator dimension. Default is 'indicator'. This is used to identify the indicator in a view using dimensional information.
+    indicator_x : str | None
+        Indicator to use on the x-axis of every generated view (e.g. for scatter plots). Give either the name of a column in `tb` (its path is expanded like the y-indicator paths, following `expand_path_mode`), or a catalog path containing '#' (e.g. 'population#population'), which is used as given (short forms are resolved against the collection dependencies when saving).
+    indicator_size : str | None
+        Indicator to use for the marker size of every generated view. Same format as `indicator_x`.
+    indicator_color : str | None
+        Indicator to use for the marker color of every generated view. Same format as `indicator_x`.
 
     EXAMPLES
     --------
@@ -154,6 +164,9 @@ def expand_config(
     config_partial["views"] = expander.build_views(
         common_view_config=common_view_config,
         dimension_choices=dimension_choices,
+        indicator_x=indicator_x,
+        indicator_size=indicator_size,
+        indicator_color=indicator_color,
     )
 
     return config_partial
@@ -293,6 +306,9 @@ class CollectionConfigExpander:
         self,
         dimension_choices: dict[str, list[str]] | None = None,
         common_view_config: dict[str, Any] | None = None,
+        indicator_x: str | None = None,
+        indicator_size: str | None = None,
+        indicator_color: str | None = None,
     ):
         """Generate one view for each indicator in the table."""
         df_dims_filt = self.df_dims.copy()
@@ -302,15 +318,21 @@ class CollectionConfigExpander:
             for dim_name, choices in dimension_choices.items():
                 df_dims_filt = df_dims_filt[df_dims_filt[dim_name].isin(choices)]
 
+        # Indicators shared by all views, on dimensions other than 'y' (e.g. for scatter plots).
+        indicators_extra = {
+            dim: self._expand_extra_indicator_path(indicator)
+            for dim, indicator in [("x", indicator_x), ("size", indicator_size), ("color", indicator_color)]
+            if indicator is not None
+        }
+
         # Filter to only relevant dimensions
         config_views = []
         for _, indicator in df_dims_filt.iterrows():
             view = {
                 "dimensions": {dim_name: indicator[dim_name] for dim_name in self.dimension_names},
                 "indicators": {
-                    "y": self._expand_indicator_path(
-                        indicator.short_name
-                    ),  # TODO: Add support for (i) support "x", "color", "size"; (ii) display settings
+                    "y": self._expand_indicator_path(indicator.short_name),  # TODO: support display settings
+                    **indicators_extra,
                 },
             }
             if common_view_config:
@@ -329,6 +351,21 @@ class CollectionConfigExpander:
         else:
             raise ValueError(f"Unknown expand_path_mode: {self.expand_path_mode}")
         return f"{table_path}#{indicator_slug}"
+
+    def _expand_extra_indicator_path(self, indicator: str) -> str:
+        """Resolve an x/size/color indicator given either as a column of the table or as a catalog path.
+
+        A value containing '#' is treated as a catalog path and used as given (short forms like
+        'table#indicator' are resolved against the collection dependencies when saving). Otherwise,
+        it must be a column of the table, and its path is expanded following `expand_path_mode`.
+        """
+        if "#" in indicator:
+            return indicator
+        assert indicator in self.tb.columns, (
+            f"Indicator `{indicator}` not found in table `{self.table_name}`. Give either a column of the table, "
+            "or a catalog path (containing '#')."
+        )
+        return self._expand_indicator_path(indicator)
 
     def build_df_dims(self, tb: Table, indicator_names: str | list[str] | None):
         """Build dataframe with dimensional information from table tb.

--- a/tests/collections/test_expand_config.py
+++ b/tests/collections/test_expand_config.py
@@ -248,6 +248,67 @@ class TestExpandConfig:
         indicator_path_full = config_full["views"][0]["indicators"]["y"]
         assert indicator_path_full == "garden/test/2024/test_dataset/test_table#deaths__sex_male"
 
+    def test_extra_indicators_from_table_columns(self):
+        """Test expand_config with x/size/color indicators given as columns of the table.
+
+        Their paths should be expanded like the y-indicator paths, following `expand_path_mode`.
+        """
+        tb = create_test_table()
+
+        config = expand_config(
+            tb,
+            indicator_names="deaths",
+            indicator_x="cases__sex_male",
+            indicator_size="cases__sex_female",
+        )
+
+        # All views share the same x/size indicators, with expanded paths
+        assert len(config["views"]) == 2
+        for view in config["views"]:
+            assert view["indicators"]["x"] == "test_table#cases__sex_male"
+            assert view["indicators"]["size"] == "test_table#cases__sex_female"
+            # 'color' was not requested
+            assert "color" not in view["indicators"]
+
+    def test_extra_indicators_from_catalog_paths(self):
+        """Test expand_config with x/size/color indicators given as catalog paths.
+
+        Paths (values containing '#') should be used as given.
+        """
+        tb = create_test_table()
+
+        config = expand_config(
+            tb,
+            indicator_names="deaths",
+            indicator_size="population#population",
+            indicator_color="grapher/regions/2023-01-01/regions/regions#owid_region",
+        )
+
+        for view in config["views"]:
+            assert view["indicators"]["size"] == "population#population"
+            assert view["indicators"]["color"] == "grapher/regions/2023-01-01/regions/regions#owid_region"
+
+    def test_extra_indicators_follow_expand_path_mode(self):
+        """Test that x/size/color indicators given as columns follow `expand_path_mode`."""
+        tb = create_table_with_metadata()
+
+        config = expand_config(
+            tb,
+            indicator_names="deaths",
+            expand_path_mode="full",
+            indicator_x="cases__sex_male",
+        )
+
+        for view in config["views"]:
+            assert view["indicators"]["x"] == "garden/test/2024/test_dataset/test_table#cases__sex_male"
+
+    def test_extra_indicator_unknown_column_error(self):
+        """Test error when an x/size/color indicator is neither a table column nor a catalog path."""
+        tb = create_test_table()
+
+        with pytest.raises(AssertionError, match="not found in table"):
+            expand_config(tb, indicator_names="deaths", indicator_x="nonexistent_column")
+
     def test_auto_indicator_detection(self):
         """Test expand_config auto-detects single indicator when none specified."""
         tb = create_test_table()


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

Fixes #5665

## What this does

`expand_config` could only generate views with a `y` indicator, so building scatter views meant hand-editing views afterwards and hardcoding complete ETL paths for `x`, `size`, and `color` (see the example in the issue, from `incomes_wid.py`).

This PR adds three new parameters to `expand_config` (and `CollectionConfigExpander.build_views`): `indicator_x`, `indicator_size`, and `indicator_color`. Each one is applied to every generated view and accepts either:

- **a column of the table** — its path is expanded exactly like the `y` indicator paths, following `expand_path_mode` (this removes the hardcoding), or
- **a catalog path** (any value containing `#`) — used as given; short forms like `table#indicator` are still resolved against the collection dependencies at save time, since `ViewIndicators.expand_paths` already supports all chart dimensions.

A value that is neither (no `#` and not a column of the table) fails with a clear assertion message.

## Example

```python
config = expand_config(
    tb=tb,
    indicator_names="disposable_income",
    indicator_x="market_income",             # column of tb -> expanded automatically
    indicator_size="population#population",  # short catalog path -> resolved at save time
    common_view_config={"chartTypes": ["ScatterPlot"]},
)
```

## Notes

- The same indicator is applied to all generated views. Per-view-varying `x`/`size`/`color` (e.g. an x-indicator that follows each view's dimensions) is left as a future improvement, noted in the docstring.
- Not plumbed through `create_collection` / `paths.create_collection` in this PR: those handle lists of tables with per-table parameter distribution, which would grow the API surface considerably. Happy to add it as a follow-up if it turns out to be useful there too.

## Tests

Four new tests in `tests/collections/test_expand_config.py`: expansion from table columns, catalog paths used as given, `expand_path_mode` being honored, and the error case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
