### PR TITLE
🐛 Fix flunet meadow free-text columns misclassified as numeric

### DIFF
--- a/etl/steps/data/meadow/who/latest/flunet.py
+++ b/etl/steps/data/meadow/who/latest/flunet.py
@@ -33,9 +33,13 @@ def run(dest_dir: str) -> None:
     # numeric in some CSV chunks but encountered stray strings like 'RSV' or 'ES' in others.
     # Detect these by checking for actual float/int objects inside an object-dtype column,
     # then coerce the stray strings to NaN. Pure text columns are left as str.
+    # aother_subtype_details/other_respvirus_details are free-text notes columns: some entries
+    # happen to be bare numbers, but the column as a whole isn't numeric, so they're always
+    # treated as text rather than run through the numeric-coercion heuristic below.
     KNOWN_STRAY_STRINGS = {"RSV", "ES"}
+    ALWAYS_TEXT_COLUMNS = {"aother_subtype_details", "other_respvirus_details"}
     for col in tb.columns[tb.dtypes == "object"]:
-        if tb[col].dropna().apply(lambda x: isinstance(x, (int, float))).any():
+        if col not in ALWAYS_TEXT_COLUMNS and tb[col].dropna().apply(lambda x: isinstance(x, (int, float))).any():
             stray = {
                 v for v in tb[col] if isinstance(v, str) and pd.isna(pd.to_numeric(v, errors="coerce"))
             } - KNOWN_STRAY_STRINGS


### PR DESCRIPTION
## Summary

- `data://meadow/who/latest/flunet` was failing with `ValueError: Column 'aother_subtype_details' contains unexpected non-numeric strings: {...}`.
- The step's generic numeric-vs-text heuristic misclassified `aother_subtype_details` and `other_respvirus_details` as numeric columns, because some of their free-text entries happen to be bare numbers. This made the step raise on any new non-numeric note added by a source update.
- These two columns are known free-text fields (previously handled with an explicit string cast before a later refactor generalized the type detection). This PR excludes them from the numeric heuristic so they're always cast to string.

## Test plan

- [x] `etlr data://meadow/who/latest/flunet --private` runs successfully
- [x] `etlr data://garden/who/latest/flunet --private` runs successfully
