### PR TITLE
🐛 Fix owid_mcp Datasette error parsing for DuckDB backend

### DIFF
--- a/owid_mcp/data_utils.py
+++ b/owid_mcp/data_utils.py
@@ -37,6 +37,12 @@ _NAME_TO_CODE_MAPPING: dict[str, str] | None = None
 # SQL validation pattern
 SQL_SELECT_RE = re.compile(r"^\s*select\b", re.IGNORECASE | re.DOTALL)
 
+# DuckDB (Datasette's current query backend) reports a missing column as a
+# "Binder Error", e.g.:
+#   Binder Error: Referenced column "abc" not found in FROM clause!
+#   Candidate bindings: "attribution", "dataChecksum", ...
+DUCKDB_MISSING_COLUMN_RE = re.compile(r'Referenced column "([^"]+)" not found')
+
 
 def _load_regions_mapping() -> dict[str, str]:
     """Load OWID regions mapping from YAML file."""
@@ -245,17 +251,15 @@ async def run_sql(query: str, max_rows: int = MAX_ROWS_DEFAULT) -> dict[str, Any
         if "error" in json_data and json_data["error"] is not None:
             error_msg = json_data["error"]
 
-            # Handle specific case: missing column error like "['\"abc\"']"
-            if isinstance(error_msg, str) and error_msg.startswith("['") and error_msg.endswith("']"):
-                # Extract column name from string like "['\"abc\"']"
-                column_name = error_msg[2:-2].strip("\"'")  # Remove ['"] and quotes
-                if column_name:
-                    error_msg = (
-                        f"SQL Error: Column '{column_name}' does not exist in the table. "
-                        f"You can check columns with: SELECT column_name FROM information_schema.columns WHERE table_name = 'table_name';"
-                    )
-                else:
-                    error_msg = f"SQL Query Error: {error_msg}"
+            # Handle specific case: DuckDB's "missing column" binder error, e.g.
+            # 'Binder Error: Referenced column "abc" not found in FROM clause!\n...'
+            column_match = DUCKDB_MISSING_COLUMN_RE.search(error_msg) if isinstance(error_msg, str) else None
+            if column_match:
+                column_name = column_match.group(1)
+                error_msg = (
+                    f"SQL Error: Column '{column_name}' does not exist in the table. "
+                    f"You can check columns with: SELECT column_name FROM information_schema.columns WHERE table_name = 'table_name';"
+                )
             # For all other errors, just pass through the original message
             else:
                 error_msg = f"SQL Query Error: {error_msg}"

--- a/tests/owid_mcp/test_server.py
+++ b/tests/owid_mcp/test_server.py
@@ -441,6 +441,7 @@ async def test_run_sql_invalid_column_error():
         # Use raise_on_error=False to get the error in the result instead of raising an exception
         output = await client.call_tool("run_sql", {"query": sql_query})
         error = output.structured_content["error"]  # ty: ignore
+        # We rewrite Datasette/DuckDB's raw binder error into our own friendly message.
         assert "column 'abc' does not exist" in error.lower()
 
 
@@ -453,4 +454,5 @@ async def test_run_sql_syntax_error():
 
         output = await client.call_tool("run_sql", {"query": sql_query})
         error = output.structured_content["error"]  # ty: ignore
-        assert "invalid expression" in error.lower() or "unexpected token" in error.lower()
+        # No special enrichment for generic syntax errors — passed through from Datasette/DuckDB.
+        assert "syntax error" in error.lower() or "parser error" in error.lower()


### PR DESCRIPTION
> _Written by Claude Sonnet 5 — @Marigold at the wheel._

## Summary

OWID's public Datasette instance (`https://datasette-public.owid.io/owid.json`, used by the `owid_mcp` `run_sql` tool) migrated its query backend to DuckDB, which changed the raw error text it returns. This broke two things:

- `tests/owid_mcp/test_server.py::test_run_sql_invalid_column_error` and `::test_run_sql_syntax_error` were failing on master, since they asserted on the old error wording — causing the `buildkite/etl-unit-tests` check to fail on every PR.
- `run_sql`'s error-enrichment logic in `owid_mcp/data_utils.py`, which is supposed to rewrite a missing-column error into a friendly message, only matched the old wording (`"['\"abc\"']"`). Against the new DuckDB wording (`Binder Error: Referenced column "abc" not found in FROM clause!\nCandidate bindings: ...`) that branch silently stopped firing, so users hit DuckDB's raw, verbose error text instead.

## Changes

- `owid_mcp/data_utils.py`: detect DuckDB's `Binder Error: Referenced column "..." not found` phrasing (verified against a live call to the Datasette endpoint) and extract the column name from it, restoring the friendly `SQL Error: Column '...' does not exist in the table...` message.
- `tests/owid_mcp/test_server.py`: keep asserting on our own friendly message for the missing-column case (that's the point of the enrichment code), and loosen the syntax-error assertion to match DuckDB's actual phrasing (`"syntax error"` / `"parser error"`) instead of the old SQLite-era wording.

## Test plan

- [x] `pytest tests/owid_mcp/ -q` — all 11 tests pass
- [x] `make check` (lint, format, typecheck) — passes via pre-commit hook
- [x] Verified live Datasette error format directly with `curl` for both a missing-column query and a syntax-error query before writing the fix
