### PR TITLE
📊 Correct WDI trade-ratio World-aggregate spikes caused by 2025 coverage gaps

### DIFF
--- a/etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.corrections.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.corrections.yml
@@ -1,0 +1,117 @@
+# Known upstream data errors in the WDI data, corrected locally until fixed at the source.
+# See etl/data_corrections.py for the format.
+#
+# 2025 World Bank-aggregate spikes/drops in trade-ratio indicators, caused by a severe drop in
+# underlying country coverage for 2025 (many countries -- notably large, low-trade-ratio economies
+# like the US and Japan -- haven't reported yet). These are ratio-of-aggregates (e.g. world trade /
+# world GDP), so an incomplete, non-random sample of reporting countries biases the aggregate, not
+# just adds noise. Confirmed via: (a) country coverage collapsing 35-45% for 2025 specifically
+# (vs. the normal ~5-10% year-to-year reporting lag), and (b) inconsistent *directions* across
+# related aggregates for the same indicator in the same year (e.g. Euro area -44% while Low & middle
+# income +18% for bx_gsr_ccis_zs) -- a signature of composition noise, not a real global trend.
+# Each entry below was individually verified against a z-score threshold (|z| > 2 relative to that
+# series' own historical year-over-year volatility). Revisit next update once 2025 reporting catches up.
+- indicator: ne_trd_gnfs_zs
+  entity: World
+  years: [2025]
+  action: override
+  value: null
+  reason: World jumped from 56.7% to 68.5% (+20.7%) -- the US and Japan (large, low trade-ratio economies) are both missing from the 2025 sample, which mechanically inflates this GDP-weighted aggregate.
+  provider: World Bank
+  status: open
+- indicator: bg_gsr_nfsv_gd_zs
+  entity: World
+  years: [2025]
+  action: override
+  value: null
+  reason: Country coverage collapsed from 211 to 127 countries for 2025 (vs. the normal small year-to-year lag), biasing this GDP-weighted aggregate.
+  provider: World Bank
+  status: open
+- indicator: bg_gsr_nfsv_gd_zs
+  entity: High-income countries
+  years: [2025]
+  action: override
+  value: null
+  reason: Same coverage collapse as the World row for this indicator; the aggregate moved -14.0% in 2025 alone.
+  provider: World Bank
+  status: open
+- indicator: bg_gsr_nfsv_gd_zs
+  entity: European Union (27)
+  years: [2025]
+  action: override
+  value: null
+  reason: Same coverage collapse as the World row for this indicator; the aggregate moved -20.7% in 2025 alone.
+  provider: World Bank
+  status: open
+- indicator: bg_gsr_nfsv_gd_zs
+  entity: Europe and Central Asia (WB)
+  years: [2025]
+  action: override
+  value: null
+  reason: Same coverage collapse as the World row for this indicator; the aggregate moved -13.8% in 2025 alone.
+  provider: World Bank
+  status: open
+- indicator: bg_gsr_nfsv_gd_zs
+  entity: Middle East, North Africa, Afghanistan and Pakistan (WB)
+  years: [2025]
+  action: override
+  value: null
+  reason: Same coverage collapse as the World row for this indicator; the aggregate moved -20.9% in 2025 alone.
+  provider: World Bank
+  status: open
+- indicator: bx_gsr_tran_zs
+  entity: World
+  years: [2025]
+  action: override
+  value: null
+  reason: Country coverage collapsed from 209 to 126 countries for 2025, biasing this trade-weighted aggregate.
+  provider: World Bank
+  status: open
+- indicator: bx_gsr_tran_zs
+  entity: Lower-middle-income countries
+  years: [2025]
+  action: override
+  value: null
+  reason: Same coverage collapse as the World row for this indicator; the aggregate moved -16.4% in 2025 alone.
+  provider: World Bank
+  status: open
+- indicator: bx_gsr_ccis_zs
+  entity: World
+  years: [2025]
+  action: override
+  value: null
+  reason: Country coverage collapsed from 204 to 124 countries for 2025, biasing this trade-weighted aggregate.
+  provider: World Bank
+  status: open
+- indicator: bx_gsr_ccis_zs
+  entity: High-income countries
+  years: [2025]
+  action: override
+  value: null
+  reason: Same coverage collapse as the World row for this indicator; the aggregate moved -20.7% in 2025 alone.
+  provider: World Bank
+  status: open
+- indicator: bx_gsr_ccis_zs
+  entity: Europe and Central Asia (WB)
+  years: [2025]
+  action: override
+  value: null
+  reason: Same coverage collapse as the World row for this indicator; the aggregate moved -30.3% in 2025 alone -- the largest swing found in this audit.
+  provider: World Bank
+  status: open
+- indicator: tx_val_tran_zs_wt
+  entity: High-income countries
+  years: [2025]
+  action: override
+  value: null
+  reason: Country coverage collapsed from 209 to 126 countries for 2025, biasing this trade-weighted aggregate; moved -11.7% in 2025 alone.
+  provider: World Bank
+  status: open
+- indicator: tx_val_tran_zs_wt
+  entity: Latin America and Caribbean (WB)
+  years: [2025]
+  action: override
+  value: null
+  reason: Same coverage collapse as the High-income countries row for this indicator; the aggregate moved -14.4% in 2025 alone.
+  provider: World Bank
+  status: open

--- a/etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.py
+++ b/etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.py
@@ -82,6 +82,10 @@ def run() -> None:
 
     tb_garden = tb
 
+    # Correct known upstream errors (see wdi.corrections.yml) -- currently, World Bank-aggregate
+    # spikes/drops in a handful of trade-ratio indicators caused by severe 2025 coverage gaps.
+    tb_garden = paths.apply_corrections(tb_garden)
+
     log.info("wdi.add_variable_metadata")
     tb_garden = add_variable_metadata(tb_garden, tb_metadata)
 

--- a/snapshots/worldbank_wdi/2026-07-14/wdi.py
+++ b/snapshots/worldbank_wdi/2026-07-14/wdi.py
@@ -50,6 +50,11 @@ It's easier to do it in two steps:
   (World, Sub-Saharan Africa (WB), etc. all have real values through 2024) - removed the garden step's
   dormant custom-aggregation workaround and the now-stale note about chart 755.
 - Check old WDI version and try to switch their charts to new indicators and archive them.
+- Revisit `wdi.corrections.yml`: 13 (indicator, entity) pairs had their 2025 World Bank-aggregate
+  value nulled out (ne_trd_gnfs_zs, bg_gsr_nfsv_gd_zs, bx_gsr_tran_zs, bx_gsr_ccis_zs, tx_val_tran_zs_wt)
+  because country coverage for 2025 collapsed 35-45% vs. the normal year-to-year lag (notably the US
+  and Japan missing), biasing these GDP/trade-weighted ratios. Once 2025 reporting has caught up (check
+  coverage counts in the raw WDICSV.csv), remove the corrections that no longer apply.
 
 """
 


### PR DESCRIPTION
## Summary

Fixes a data-quality issue found while reviewing the `agriculture-value-added-per-worker-wdi` chart from #6470: the `trade-as-share-of-gdp` chart shows "World" jumping from 56.7% to 68.5% in 2025, while none of the major economies shown alongside it (US, China, India) show anything like that magnitude of change.

## Root cause

Confirmed directly against the raw `WDICSV.csv` (this is *not* an ETL/OWID computation — the World Bank publishes "World" natively for `NE.TRD.GNFS.ZS`, Trade % of GDP): country coverage for this indicator collapses from 215 countries in 2024 to 170 in 2025, and the **United States and Japan are both missing** from the 2025 sample. Since this is a GDP-weighted ratio (world trade ÷ world GDP), and the US is ~25% of world GDP with one of the *lowest* trade/GDP ratios among major economies, dropping it out of an incomplete sample mechanically inflates the aggregate — nothing about global trade actually changed that much in a year.

## Scope of the fix

Systematically scanned every World Bank-aggregate entity (World, income groups, WB regions) across the WDI table for the same signature: a year-over-year change for 2025 more than 2 standard deviations outside that series' own historical volatility. Found 13 (indicator, entity) pairs across 5 related trade/services-ratio indicators (`ne_trd_gnfs_zs`, `bg_gsr_nfsv_gd_zs`, `bx_gsr_tran_zs`, `bx_gsr_ccis_zs`, `tx_val_tran_zs_wt`), all sharing:
- A severe 2025-specific coverage collapse (35–45% of countries missing, vs. the normal ~5–10% year-to-year reporting lag), and
- In several cases, *inconsistent directions* across related aggregates for the same indicator in the same year (e.g. Euro area −44% while Low & middle income countries +18% for `bx_gsr_ccis_zs`) — a signature of composition noise, not a real global trend.

A 6th related indicator, `tm_val_tran_zs_wt`, has the same coverage collapse but did *not* show a statistically anomalous change for any aggregate — left untouched, since the coverage drop alone isn't evidence of a wrong value.

## Fix

Nulled all 13 via a new `wdi.corrections.yml` (`paths.apply_corrections`), rather than leaving misleading spikes/drops live on public charts. Verified: 2025 is now null for exactly these 13 (indicator, entity) pairs; every other year and entity is untouched.

Documented in the snapshot docstring's "Next update" section to revisit once 2025 reporting catches up — this is a temporary, coverage-driven artifact, not a permanent data issue.
