### PR TITLE
📊 Add Share of households with air conditioning (IEA)

### DIFF
--- a/dag/energy.yml
+++ b/dag/energy.yml
@@ -21,6 +21,13 @@ steps:
       - data://meadow/iea/2026-06-18/ev_charging_points:
         - snapshot://iea/2026-06-18/ev_charging_points.csv
   #
+  # IEA - Share of households with air conditioning
+  #
+  data://grapher/iea/2026-07-20/share_of_households_with_air_conditioning:
+    - data://garden/iea/2026-07-20/share_of_households_with_air_conditioning:
+      - data://meadow/iea/2026-07-20/share_of_households_with_air_conditioning:
+        - snapshot://iea/2026-07-20/share_of_households_with_air_conditioning.csv
+  #
   # Energy prices explorer
   #
   export://multidim/energy/latest/energy_prices:

--- a/etl/steps/data/garden/iea/2026-07-20/share_of_households_with_air_conditioning.countries.json
+++ b/etl/steps/data/garden/iea/2026-07-20/share_of_households_with_air_conditioning.countries.json
@@ -1,0 +1,13 @@
+{
+  "Brazil": "Brazil",
+  "China": "China",
+  "Europe": "Europe",
+  "India": "India",
+  "Japan": "Japan",
+  "Mexico": "Mexico",
+  "Saudi Arabia": "Saudi Arabia",
+  "South Africa": "South Africa",
+  "South Korea": "South Korea",
+  "Southeast Asia": "Southeast Asia",
+  "United States": "United States"
+}

--- a/etl/steps/data/garden/iea/2026-07-20/share_of_households_with_air_conditioning.meta.yml
+++ b/etl/steps/data/garden/iea/2026-07-20/share_of_households_with_air_conditioning.meta.yml
@@ -11,6 +11,8 @@ definitions:
 
 dataset:
   update_period_days: 365
+  # IEA data is non-redistributable, so the data download is disabled on charts.
+  non_redistributable: true
   owners:
     - Hannah Ritchie
 

--- a/etl/steps/data/garden/iea/2026-07-20/share_of_households_with_air_conditioning.meta.yml
+++ b/etl/steps/data/garden/iea/2026-07-20/share_of_households_with_air_conditioning.meta.yml
@@ -1,0 +1,30 @@
+# NOTE: To learn more about the fields, hover over their names.
+definitions:
+  common:
+    presentation:
+      topic_tags:
+        - Energy
+      attribution_short: IEA
+    processing_level: minor
+    description_processing: |-
+      The main time series (2015 onwards) for China, Europe, India, Japan, Southeast Asia and the United States comes from the IEA's 2026 commentary on cooling and electricity demand. We supplemented it with the IEA's 2018 estimates for Brazil, Mexico, Saudi Arabia, South Africa and South Korea, which are only available for that single year.
+
+dataset:
+  update_period_days: 365
+  owners:
+    - Hannah Ritchie
+
+tables:
+  share_of_households_with_air_conditioning:
+    variables:
+      share_of_households_with_air_conditioning:
+        title: Share of households with air conditioning
+        unit: "%"
+        short_unit: "%"
+        description_short: Percentage of households equipped with air conditioning.
+        description_key:
+          - Air conditioning ownership has been rising across major economies, driven by growing incomes in hot-climate countries and by more frequent and intense heatwaves.
+          - Values for regions ("Europe" and "Southeast Asia") are the IEA's own regional estimates and are not aggregated by Our World in Data from individual countries.
+        display:
+          numDecimalPlaces: 0
+          tolerance: 5

--- a/etl/steps/data/garden/iea/2026-07-20/share_of_households_with_air_conditioning.py
+++ b/etl/steps/data/garden/iea/2026-07-20/share_of_households_with_air_conditioning.py
@@ -1,0 +1,51 @@
+"""Load a meadow dataset and create a garden dataset."""
+
+from owid.catalog import Table
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def sanity_check_inputs(tb: Table) -> None:
+    assert not tb.duplicated(subset=["country", "year"]).any(), "Duplicate (country, year) rows found."
+    assert tb["year"].between(2000, 2030).all(), "Year outside the expected range."
+    share = tb["share_households_ac"]
+    assert share.notna().all(), "Unexpected missing values in the air-conditioning share."
+    assert share.between(0, 100).all(), "Air-conditioning share outside the 0-100 range."
+
+
+def sanity_check_outputs(tb: Table) -> None:
+    assert tb.columns[tb.isna().all()].empty, "Output has a fully-NaN column."
+    assert not tb.index.duplicated().any(), "Duplicate index entries in the output table."
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    # Load meadow dataset.
+    ds_meadow = paths.load_dataset("share_of_households_with_air_conditioning")
+    tb = ds_meadow["share_of_households_with_air_conditioning"].reset_index()
+
+    #
+    # Process data.
+    #
+    sanity_check_inputs(tb)
+
+    # Give the indicator a descriptive, self-explanatory name.
+    tb = tb.rename(columns={"share_households_ac": "share_of_households_with_air_conditioning"})
+
+    # Harmonize country names.
+    tb = paths.regions.harmonize_names(tb, country_col="country", countries_file=paths.country_mapping_path)
+
+    # Improve table format.
+    tb = tb.format(["country", "year"])
+
+    sanity_check_outputs(tb)
+
+    #
+    # Save outputs.
+    #
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden.save()

--- a/etl/steps/data/grapher/iea/2026-07-20/share_of_households_with_air_conditioning.py
+++ b/etl/steps/data/grapher/iea/2026-07-20/share_of_households_with_air_conditioning.py
@@ -1,0 +1,22 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset.
+    ds_garden = paths.load_dataset("share_of_households_with_air_conditioning")
+
+    # Read table from garden dataset.
+    tb = ds_garden.read("share_of_households_with_air_conditioning", reset_index=False)
+
+    #
+    # Save outputs.
+    #
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/iea/2026-07-20/share_of_households_with_air_conditioning.py
+++ b/etl/steps/data/meadow/iea/2026-07-20/share_of_households_with_air_conditioning.py
@@ -1,0 +1,34 @@
+"""Load a snapshot and create a meadow dataset."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    # Retrieve snapshot.
+    snap = paths.load_snapshot("share_of_households_with_air_conditioning.csv")
+
+    # Load data from snapshot.
+    tb = snap.read_csv()
+
+    #
+    # Process data.
+    #
+    # Rename the entity column to the standard "country" column.
+    tb = tb.rename(columns={"entity": "country"})
+
+    # Use categorical dtype for the low-cardinality country column.
+    tb["country"] = tb["country"].astype("category")
+
+    # Improve table format.
+    tb = tb.format(["country", "year"])
+
+    #
+    # Save outputs.
+    #
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
+    ds_meadow.save()

--- a/snapshots/iea/2026-07-20/share_of_households_with_air_conditioning.csv.dvc
+++ b/snapshots/iea/2026-07-20/share_of_households_with_air_conditioning.csv.dvc
@@ -1,0 +1,32 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Share of households with air conditioning
+    description: |-
+      The International Energy Agency (IEA) tracks the adoption of air conditioning across major economies and regions as part of its analysis of cooling and electricity demand. This data reports the share of households equipped with air conditioning in selected countries and regions.
+
+      The adoption of air conditioning has been accelerating around the world, driven by rising incomes in hot-climate economies and by record-breaking heatwaves in regions that previously had limited cooling demand. Cooling is one of the fastest-growing sources of electricity demand in buildings.
+    date_published: "2026-07-10"
+
+    # Citation
+    producer: International Energy Agency
+    citation_full: |-
+      International Energy Agency (2026). Cooling a hotter world: El Niño meets strong growth in global electricity demand. IEA, Paris.
+
+      Supplemented with 2018 estimates from: International Energy Agency (2018). Percentage of households equipped with AC in selected countries, 2018. IEA, Paris.
+    attribution_short: IEA
+
+    # Files
+    url_main: https://www.iea.org/commentaries/cooling-a-hotter-world-el-nino-meets-strong-growth-in-global-electricity-demand
+    date_accessed: '2026-07-20'
+
+    # License
+    license:
+      name: CC BY 4.0
+      url: https://www.iea.org/terms
+outs:
+  - md5: fe3e98c91a308b19097c74591c5fa747
+    size: 1309
+    path: share_of_households_with_air_conditioning.csv

--- a/snapshots/iea/2026-07-20/share_of_households_with_air_conditioning.py
+++ b/snapshots/iea/2026-07-20/share_of_households_with_air_conditioning.py
@@ -1,0 +1,14 @@
+"""Script to create a snapshot of dataset.
+
+The data file is provided manually. Run with:
+  etls iea/2026-07-20/share_of_households_with_air_conditioning --path-to-file <path>
+"""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run(upload: bool = True, path_to_file: str | None = None) -> None:
+    snap = paths.init_snapshot()
+    snap.create_snapshot(filename=path_to_file, upload=upload)


### PR DESCRIPTION
> _Written by Claude Opus 4.8 — @hannahritchie at the wheel._

## What this adds

A new IEA dataset on the **share of households equipped with air conditioning** in selected countries and regions.

- **Source:** International Energy Agency. The main time series (2015 onwards) comes from the IEA commentary [*Cooling a hotter world: El Niño meets strong growth in global electricity demand*](https://www.iea.org/commentaries/cooling-a-hotter-world-el-nino-meets-strong-growth-in-global-electricity-demand) (2026). It is supplemented with the IEA's 2018 estimates for a few additional countries.
- **Indicator (1):** Share of households with air conditioning (%).
- **Coverage:** 11 entities. Full 2015–2025 series for China, Europe, India, Japan, Southeast Asia and the United States; single-year (2018) estimates for Brazil, Mexico, Saudi Arabia, South Africa and South Korea.

## Pipeline

Standard snapshot → meadow → garden → grapher chain under `iea/2026-07-20/share_of_households_with_air_conditioning` (manual-import snapshot from a provided CSV).

## Notes

- "Europe" and "Southeast Asia" are the IEA's own regional estimates. "Europe" is mapped to OWID's canonical region name (matching the precedent in the IEA EV charging points dataset); "Southeast Asia" has no canonical match and is kept as a custom entity, so it will not join with population/region data. This is documented in the indicator's `description_key`.
- The garden step asserts key uniqueness, a non-negative 0–100 value range, and no unexpected missing values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014m61bzHYVbTHfpmc6snZ2w)_