### PR TITLE
📊 Clarify income shares in WID incomes MDim

### DIFF
--- a/etl/steps/export/multidim/wid/latest/incomes_wid.config.yml
+++ b/etl/steps/export/multidim/wid/latest/incomes_wid.config.yml
@@ -1,5 +1,5 @@
 title:
-  title: Incomes of the richest
+  title: Income shares of the richest
   title_variant: World Inequality Database
 topic_tags:
   - Economic Inequality
@@ -27,14 +27,21 @@ dimensions:
     choices:
       - slug: Richest 0.1%
         name: Richest 0.1%
+        group: Top income groups
       - slug: Richest 1%
         name: Richest 1%
+        group: Top income groups
       - slug: "10"
         name: Richest 10%
+        group: Top income groups
       - slug: all
         name: All deciles
+        description: The share of income received by each tenth of the population, from poorest to richest
+        group: Whole distribution
       - slug: "10_40_50"
         name: Poorest 50%, middle 40%, next 9% and richest 1%
+        description: The share of income received by each of these groups
+        group: Whole distribution
 
   - name: Income measure
     slug: welfare_type


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

Implements reviewer feedback on the WID incomes MDim (`export://multidim/wid/latest/incomes_wid`) to make it clearer that all options show **income shares**:

- Rename the MDim title: "Incomes of the richest" → **"Income shares of the richest"**.
- Split the **Group** dropdown into two sections:
  - **Top income groups**: Richest 0.1%, Richest 1%, Richest 10%
  - **Whole distribution**: All deciles, Poorest 50%/middle 40%/next 9%/richest 1% — each with a short note (`description`) explaining what the option shows (e.g. "The share of income received by each tenth of the population, from poorest to richest").

Notes:
- Config-only change; choice slugs and indicators are untouched, so no chart remapping is needed.
- The MDim schema has no group-level note, so the explanatory text lives on the individual choices (same pattern as `incomes_lis` and `economic_damages`).
- No `.py` changes: YAML-declared choice attributes survive `group_views` since the `all` choice slug is already declared in the config.

**Preview** (MDim is unpublished, admin only): http://staging-site-data-incomeshares-wid-mdim/admin/grapher/wid%2Flatest%2Fincomes_wid%23incomes_wid/