### PR TITLE
✨ Order FAO region map legends left-to-right

### DIFF
--- a/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
+++ b/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
@@ -519,10 +519,10 @@ tables:
           Level-1 broad regions (continents) defined by the Food and Agriculture Organization of the United Nations (FAO).
         type: ordinal
         sort:
-          - "Africa (FAO)"
           - "Americas (FAO)"
-          - "Asia (FAO)"
+          - "Africa (FAO)"
           - "Europe (FAO)"
+          - "Asia (FAO)"
           - "Oceania (FAO)"
         origins:
           - *origins_fao
@@ -547,24 +547,24 @@ tables:
           Level-2 regions (subregions) defined by the Food and Agriculture Organization of the United Nations (FAO).
         type: ordinal
         sort:
+          - "Northern America (FAO)"
+          - "Caribbean (FAO)"
+          - "Central America (FAO)"
+          - "South America (FAO)"
           - "Northern Africa (FAO)"
           - "Eastern Africa (FAO)"
           - "Middle Africa (FAO)"
           - "Southern Africa (FAO)"
           - "Western Africa (FAO)"
-          - "Northern America (FAO)"
-          - "Caribbean (FAO)"
-          - "Central America (FAO)"
-          - "South America (FAO)"
+          - "Southern Europe (FAO)"
+          - "Western Europe (FAO)"
+          - "Northern Europe (FAO)"
+          - "Eastern Europe (FAO)"
           - "Western Asia (FAO)"
           - "Central Asia (FAO)"
           - "Southern Asia (FAO)"
           - "Eastern Asia (FAO)"
           - "South-eastern Asia (FAO)"
-          - "Southern Europe (FAO)"
-          - "Western Europe (FAO)"
-          - "Northern Europe (FAO)"
-          - "Eastern Europe (FAO)"
           - "Australia and New Zealand (FAO)"
           - "Melanesia (FAO)"
           - "Micronesia (FAO)"
@@ -609,9 +609,9 @@ tables:
           Regions defined by the Food and Agriculture Organization of the United Nations (FAO) for its SDG (Sustainable Development Goals) reporting, following the UN SDG regional groupings.
         type: ordinal
         sort:
-          - "Sub-Saharan Africa (FAO)"
           - "Northern America and Europe (FAO)"
           - "Latin America and the Caribbean (FAO)"
+          - "Sub-Saharan Africa (FAO)"
           - "Western Asia and Northern Africa (FAO)"
           - "Central Asia and Southern Asia (FAO)"
           - "Eastern Asia and South-eastern Asia (FAO)"


### PR DESCRIPTION
> _Written by Claude Opus 4.8 — @pabloarosado at the wheel._

Reorder the categorical map legends for the three FAO region indicators so they read geographically from left to right on the map — Americas, then Africa and Europe, then Asia and Oceania — instead of alphabetically (`fao_1`) or Africa-first (`fao_2`, `fao_sdg`).

## What & where

`etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml` — the `sort:` list for each of `fao_1_region`, `fao_2_region`, `fao_sdg_region`. These ordinal `sort` orders become the indicators' category order, which Grapher renders verbatim as the categorical map legend.

The new order matches the existing UN (M49) and UN SDG region orderings, and lines up with the FAO region tooltip order in the Grapher frontend (owid/owid-grapher#6724), so the map legend and the region-composition tooltip now present regions in the same order.

## Notes

- Only the `sort:` lists changed; the `customCategoryLabels` maps are order-agnostic and left untouched, keeping the diff to the behavior change (11 insertions, 11 deletions).
- The FAO regions grapher step needs to re-run for the new `sort` to propagate to the indicator metadata (I haven't run it — leaving the data rebuild to you).
