### PR TITLE
🐝 sync grapher schema

### DIFF
--- a/schemas/grapher-schema.010.json
+++ b/schemas/grapher-schema.010.json
@@ -146,10 +146,23 @@
                 "type": "string",
                 "description": "Entity annotations"
               },
+              "timeInterval": {
+                "type": "string",
+                "default": "year",
+                "description": "Resolution at which the time values should be interpreted and formatted.",
+                "enum": [
+                  "day",
+                  "week",
+                  "month",
+                  "quarter",
+                  "year",
+                  "decade"
+                ]
+              },
               "yearIsDay": {
                 "type": "boolean",
                 "default": false,
-                "description": "Switch to indicate if the number in the year column represents a day (since zeroDay) or not i.e. a year"
+                "description": "(Deprecated, use timeInterval instead) Switch to indicate if the number in the year column represents a day (since zeroDay) or not i.e. a year"
               },
               "color": {
                 "type": "string",
@@ -195,7 +208,7 @@
               },
               "zeroDay": {
                 "type": "string",
-                "description": "Iso date day string for the starting date if yearIsDay is used",
+                "description": "Iso date day string used as the reference date for day-encoded values",
                 "default": "2020-01-21"
               }
             },


### PR DESCRIPTION
Syncs the vendored grapher chart-config schema with upstream, which was stale (failing `test_grapher_config_schema_sync`).

Upstream change: `dimensions[].display` gained a `timeInterval` enum (`day`/`week`/`month`/`quarter`/`year`/`decade`) as the typed replacement for the `yearIsDay` boolean, plus updated `yearIsDay`/`zeroDay` descriptions. This mirrors the `display.timeInterval` field already added on the ETL side in `71940771f0`.

No manual propagation was needed:
- `schemas/multidim-schema.json` reaches `dimensions[].display` via a `$ref` into the vendored schema, so it resolves automatically.
- `schemas/dataset-schema.json`'s `dimensions[].display` is `$ref`'d to `definitions.json#/display`, which already had `timeInterval` from the earlier ETL-side change.
- `etl/collection/model/schema_types.py` regeneration produced no diff.

Ran `scripts/generate_schema_types.py --refresh`, the schema/collection test suite, and `make check` — all green.
