### PR TITLE
🐝 Enable uv hardlink mode for cheaper worktree venvs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dependencies = [
 
 [tool.uv]
 exclude-newer = "3 days"
+link-mode = "hardlink"
 
 [tool.uv.sources]
 owid-owl = { path = "lib/owl", editable = true }


### PR DESCRIPTION
> _Written by Claude Fable 5 — @Marigold at the wheel._

## Why

`etl pr --worktree` creates a full independent checkout per branch, including its own `.venv`. With uv's default link-mode on macOS/APFS, every worktree's venv turned out to be a fully independent set of files rather than a shared/linked one — verified directly: two venvs installing the same package landed on different inodes with `nlink=1`.

Across a handful of worktrees that adds up to several GB of pure duplication for identical package versions.

## What

Set `link-mode = "hardlink"` under `[tool.uv]` in `pyproject.toml`. This makes `uv sync`/`uv venv` link package files from the shared `uv` cache into each venv instead of copying them — confirmed with a clean re-sync (`nlink=2` afterward, i.e. cache and venv now share the same file).

Safe because installed packages are never modified in place after install, so there's no risk of one venv's edits leaking into another's.
