### PR TITLE
🎉 Metadata Review: collaborative FAUST/metadata review tool

### DIFF
--- a/apps/cli/__init__.py
+++ b/apps/cli/__init__.py
@@ -157,6 +157,7 @@ GROUPS = (
             "name": "Metadata",
             "commands": {
                 "metadata-export": "etl.metadata_export.cli",
+                "metadata-review": "apps.metadata_review.cli.cli",
             },
         },
         {

--- a/apps/metadata_review/__init__.py
+++ b/apps/metadata_review/__init__.py
@@ -1,0 +1,11 @@
+"""Metadata Review — collaborative review of user-facing chart text (FAUST) and metadata.
+
+UI-agnostic core shared by the Metadata Review wizard app and the
+`etl metadata-review` CLI:
+
+- `targets`: dataclasses describing reviewable fields and pages.
+- `resolution`: DB-based resolution of MDim / indicator fields with provenance
+  (override / inherited / missing), ported from the faust-metadata-audit rules.
+- `trace`: repo-aware back-tracing of a rendered field to its editable YAML source.
+- `export`: the `suggestions.yml` handoff consumed by Claude to implement changes.
+"""

--- a/apps/metadata_review/cli.py
+++ b/apps/metadata_review/cli.py
@@ -78,5 +78,8 @@ def resolve_cli(suggestion_id: int, status: str) -> None:
         suggestion = session.get(gm.MetadataReviewSuggestion, suggestion_id)
         if suggestion is None:
             raise click.ClickException(f"No suggestion with id {suggestion_id}.")
-        suggestion.set_status(session, status, user_id=int(config.GRAPHER_USER_ID))  # type: ignore[arg-type]
+        try:
+            suggestion.set_status(session, status, user_id=int(config.GRAPHER_USER_ID))  # type: ignore[arg-type]
+        except ValueError as e:
+            raise click.ClickException(str(e))
     console.print(f"[green]Suggestion {suggestion_id} set to {status}.[/green]")

--- a/apps/metadata_review/cli.py
+++ b/apps/metadata_review/cli.py
@@ -1,0 +1,82 @@
+"""CLI for the Metadata Review tool.
+
+    etl metadata-review export <target> [-o out.yml] [--status open]
+    etl metadata-review resolve <id> --status implemented
+
+`<target>` is an MDim catalogPath ('ns/version/short#short'), an MDim slug, or a
+grapher dataset catalogPath ('ns/version/dataset', 'grapher/' prefix optional).
+
+The export runs in the repo so every suggestion is traced to a concrete edit
+location (garden .meta.yml key, MDim config .yml key, or the step .py when the
+value is generated programmatically). Point it at the environment where the
+suggestions were filed: `STAGING=<branch> etl metadata-review export ...` for a
+branch's staging server, or the default env from your `.env`.
+"""
+
+from pathlib import Path
+
+import rich_click as click
+from rich.console import Console
+from sqlalchemy.orm import Session
+
+import etl.grapher.model as gm
+from apps.metadata_review.export import build_export, export_to_yaml
+from etl import config
+from etl.paths import BASE_DIR
+
+console = Console()
+
+STATUSES = ["open", "implemented", "rejected"]
+
+
+@click.group(name="metadata-review", help=__doc__)
+def cli() -> None:
+    pass
+
+
+@cli.command(name="export")
+@click.argument("target")
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help="Output YAML path. Defaults to ai/metadata_review_<slug>.yml.",
+)
+@click.option(
+    "--status",
+    "statuses",
+    type=click.Choice(STATUSES),
+    multiple=True,
+    help="Only export suggestions with these statuses (default: all).",
+)
+def export_cli(target: str, output: Path | None, statuses: tuple[str, ...]) -> None:
+    """Export suggestions for TARGET to the YAML handoff consumed by Claude."""
+    with Session(config.OWID_ENV.engine) as session:
+        document = build_export(session, target, statuses=list(statuses) or None)
+
+    if output is None:
+        slug = (document["metadata_review_export"]["target"].get("slug") or target).replace("/", "_").replace("#", "_")
+        output = BASE_DIR / "ai" / f"metadata_review_{slug}.yml"
+    path = export_to_yaml(document, output)
+    n = document["metadata_review_export"]["n_suggestions"]
+    console.print(f"[green]Exported {n} suggestion(s) to[/green] {path}")
+    if n == 0:
+        console.print(
+            f"[yellow]No suggestions matched — is the environment right? (env: {config.OWID_ENV.name})[/yellow]"
+        )
+
+
+@cli.command(name="resolve")
+@click.argument("suggestion_id", type=int)
+@click.option("--status", type=click.Choice(STATUSES), required=True, help="New status.")
+def resolve_cli(suggestion_id: int, status: str) -> None:
+    """Set the resolution status of one suggestion (terminal-side alternative to the wizard app)."""
+    if not config.GRAPHER_USER_ID:
+        raise click.ClickException("GRAPHER_USER_ID must be set in your .env to resolve suggestions from the CLI.")
+    with Session(config.OWID_ENV.engine) as session:
+        suggestion = session.get(gm.MetadataReviewSuggestion, suggestion_id)
+        if suggestion is None:
+            raise click.ClickException(f"No suggestion with id {suggestion_id}.")
+        suggestion.set_status(session, status, user_id=int(config.GRAPHER_USER_ID))  # type: ignore[arg-type]
+    console.print(f"[green]Suggestion {suggestion_id} set to {status}.[/green]")

--- a/apps/metadata_review/diffs.py
+++ b/apps/metadata_review/diffs.py
@@ -6,10 +6,16 @@ reduce a proposal to only what changed, bullet by bullet.
 """
 
 import difflib
+import html
+import re
 from dataclasses import dataclass
 from typing import Literal
 
 DiffOp = Literal["keep", "add", "remove"]
+
+# Google-Docs-style tracked changes: deletions struck through, insertions tinted.
+_DEL_STYLE = "color:#b3261e;text-decoration:line-through;background:#fbe9e7;border-radius:2px;"
+_INS_STYLE = "color:#0b6e4f;background:#e6f4ea;border-radius:2px;text-decoration:none;"
 
 
 @dataclass
@@ -67,6 +73,73 @@ def diff_summary(ops: list[BulletDiff]) -> str:
         part for part in [f"{n_add} added" if n_add else "", f"{n_remove} removed" if n_remove else ""] if part
     )
     return f"{changed or 'no bullet changes'}; {n_keep} unchanged"
+
+
+def _tokenize(text: str) -> list[str]:
+    """Split into words + whitespace runs, so the diff rejoins losslessly."""
+    return re.findall(r"\S+|\s+", text or "")
+
+
+def word_diff_html(current: str | None, proposed: str | None) -> str:
+    """The proposed text rendered AS the current text with tracked changes:
+    removed words struck through, inserted words tinted — Google-Docs style."""
+    a, b = _tokenize(current or ""), _tokenize(proposed or "")
+    parts: list[str] = []
+    matcher = difflib.SequenceMatcher(a=a, b=b, autojunk=False)
+    for tag, a0, a1, b0, b1 in matcher.get_opcodes():
+        if tag == "equal":
+            parts.append(html.escape("".join(a[a0:a1])))
+        else:
+            removed = "".join(a[a0:a1]).strip()
+            added = "".join(b[b0:b1]).strip()
+            if removed:
+                parts.append(f'<del style="{_DEL_STYLE}">{html.escape(removed)}</del> ')
+            if added:
+                parts.append(f'<ins style="{_INS_STYLE}">{html.escape(added)}</ins> ')
+    return "".join(parts).strip()
+
+
+def tracked_changes_html(current: str | None, proposed: str | None, is_bullet_list: bool = False) -> str:
+    """Full tracked-changes rendering of a proposal, ready for st.html.
+
+    Bullet-list fields diff bullet-by-bullet: changed bullets get inline word
+    tracking, added/removed bullets are marked whole, unchanged runs collapse.
+    """
+    if not is_bullet_list:
+        body = word_diff_html(current, proposed)
+        return f'<div style="line-height:1.55;font-size:0.95rem;">{body}</div>'
+
+    lines: list[str] = []
+    ops = bullet_diff(current, proposed)
+    i, keep_run = 0, 0
+
+    def flush_keeps() -> None:
+        nonlocal keep_run
+        if keep_run:
+            noun = "bullet" if keep_run == 1 else "bullets"
+            lines.append(f'<li style="color:#888;list-style:none;">… {keep_run} unchanged {noun}</li>')
+            keep_run = 0
+
+    while i < len(ops):
+        op = ops[i]
+        if op.op == "keep":
+            keep_run += 1
+            i += 1
+        elif op.op == "remove" and i + 1 < len(ops) and ops[i + 1].op == "add":
+            # A changed bullet: render as one bullet with inline word tracking.
+            flush_keeps()
+            lines.append(f"<li>{word_diff_html(op.text, ops[i + 1].text)}</li>")
+            i += 2
+        elif op.op == "remove":
+            flush_keeps()
+            lines.append(f'<li><del style="{_DEL_STYLE}">{html.escape(op.text)}</del></li>')
+            i += 1
+        else:
+            flush_keeps()
+            lines.append(f'<li><ins style="{_INS_STYLE}">{html.escape(op.text)}</ins></li>')
+            i += 1
+    flush_keeps()
+    return '<ul style="line-height:1.55;font-size:0.95rem;margin:0;padding-left:1.2rem;">' + "".join(lines) + "</ul>"
 
 
 def diff_markdown_lines(ops: list[BulletDiff], collapse_keeps: bool = True) -> list[str]:

--- a/apps/metadata_review/diffs.py
+++ b/apps/metadata_review/diffs.py
@@ -188,10 +188,18 @@ def apply_bullet_edits(
         except ValueError:
             return -1
 
+    units = paired_ops(ops)
+    # Pure additions may carry page-specific content (e.g. a bullet about one
+    # dimension's data availability). They only ride along when EVERY rewrite in
+    # the proposal applied here — a partial match means this page's list is a
+    # different variant, and injected additions would mix contexts.
+    rewrites = [(kind, removed) for kind, removed, _ in units if kind in ("pair", "remove")]
+    all_rewrites_apply = all(find(removed or "") >= 0 for _, removed in rewrites)
+
     anchor = -1  # last position in `target` we matched or touched.
     anchored = False
     applied, total = 0, 0
-    for kind, removed, added in paired_ops(ops):
+    for kind, removed, added in units:
         if kind == "keep":
             pos = find(removed or "")
             if pos >= 0:
@@ -212,8 +220,8 @@ def apply_bullet_edits(
             anchored = True
             applied += 1
         elif added is not None:  # pure addition
-            if not anchored:
-                continue  # no shared context to anchor the new bullet to.
+            if not anchored or not all_rewrites_apply:
+                continue
             target.insert(anchor + 1, added)
             anchor += 1
             applied += 1

--- a/apps/metadata_review/diffs.py
+++ b/apps/metadata_review/diffs.py
@@ -1,0 +1,97 @@
+"""Compact diff helpers for suggestion rendering.
+
+`description_key` is a markdown bullet list that can run to a dozen bullets;
+repeating the whole list in every thread drowns the actual change. These helpers
+reduce a proposal to only what changed, bullet by bullet.
+"""
+
+import difflib
+from dataclasses import dataclass
+from typing import Literal
+
+DiffOp = Literal["keep", "add", "remove"]
+
+
+@dataclass
+class BulletDiff:
+    op: DiffOp
+    text: str
+
+
+def split_bullets(value: str | None) -> list[str]:
+    """Split a markdown bullet-list string into bullets.
+
+    A single description_key item is stored as prose (no leading "- "); several
+    items as "- " lines. Continuation lines are folded into the preceding bullet.
+    """
+    if not value or not value.strip():
+        return []
+    lines = value.splitlines()
+    if not any(line.lstrip().startswith("- ") for line in lines):
+        return [value.strip()]
+    bullets: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("- "):
+            bullets.append(stripped[2:].strip())
+        elif bullets:
+            bullets[-1] += " " + stripped
+        else:
+            bullets.append(stripped)
+    return bullets
+
+
+def bullet_diff(current: str | None, proposed: str | None) -> list[BulletDiff]:
+    """Bullet-level diff between the current and proposed markdown lists."""
+    current_bullets = split_bullets(current)
+    proposed_bullets = split_bullets(proposed)
+    ops: list[BulletDiff] = []
+    matcher = difflib.SequenceMatcher(a=current_bullets, b=proposed_bullets, autojunk=False)
+    for tag, a0, a1, b0, b1 in matcher.get_opcodes():
+        if tag == "equal":
+            ops.extend(BulletDiff("keep", b) for b in current_bullets[a0:a1])
+        else:
+            ops.extend(BulletDiff("remove", b) for b in current_bullets[a0:a1])
+            ops.extend(BulletDiff("add", b) for b in proposed_bullets[b0:b1])
+    return ops
+
+
+def diff_summary(ops: list[BulletDiff]) -> str:
+    """One-line summary, e.g. '2 added, 1 removed; 4 unchanged'."""
+    n_add = sum(1 for op in ops if op.op == "add")
+    n_remove = sum(1 for op in ops if op.op == "remove")
+    n_keep = sum(1 for op in ops if op.op == "keep")
+    changed = ", ".join(
+        part for part in [f"{n_add} added" if n_add else "", f"{n_remove} removed" if n_remove else ""] if part
+    )
+    return f"{changed or 'no bullet changes'}; {n_keep} unchanged"
+
+
+def diff_markdown_lines(ops: list[BulletDiff], collapse_keeps: bool = True) -> list[str]:
+    """Markdown lines showing only the changed bullets; unchanged runs are summarized."""
+    lines: list[str] = []
+    keep_run = 0
+
+    def flush_keeps() -> None:
+        nonlocal keep_run
+        if keep_run:
+            noun = "bullet" if keep_run == 1 else "bullets"
+            lines.append(f"- _… {keep_run} unchanged {noun}_")
+            keep_run = 0
+
+    for op in ops:
+        if op.op == "keep":
+            if collapse_keeps:
+                keep_run += 1
+            else:
+                lines.append(f"- {op.text}")
+        elif op.op == "remove":
+            flush_keeps()
+            lines.append(f"- :red[−] ~~{op.text}~~")
+        else:
+            flush_keeps()
+            lines.append(f"- :green[+] {op.text}")
+    flush_keeps()
+    return lines

--- a/apps/metadata_review/diffs.py
+++ b/apps/metadata_review/diffs.py
@@ -112,8 +112,7 @@ def tracked_changes_html(current: str | None, proposed: str | None, is_bullet_li
         return f'<div style="line-height:1.55;font-size:0.95rem;">{body}</div>'
 
     lines: list[str] = []
-    ops = bullet_diff(current, proposed)
-    i, keep_run = 0, 0
+    keep_run = 0
 
     def flush_keeps() -> None:
         nonlocal keep_run
@@ -122,26 +121,118 @@ def tracked_changes_html(current: str | None, proposed: str | None, is_bullet_li
             lines.append(f'<li style="color:#888;list-style:none;">… {keep_run} unchanged {noun}</li>')
             keep_run = 0
 
-    while i < len(ops):
-        op = ops[i]
-        if op.op == "keep":
+    for kind, removed, added in paired_ops(bullet_diff(current, proposed)):
+        if kind == "keep":
             keep_run += 1
-            i += 1
-        elif op.op == "remove" and i + 1 < len(ops) and ops[i + 1].op == "add":
+        elif kind == "pair":
             # A changed bullet: render as one bullet with inline word tracking.
             flush_keeps()
-            lines.append(f"<li>{word_diff_html(op.text, ops[i + 1].text)}</li>")
-            i += 2
-        elif op.op == "remove":
+            lines.append(f"<li>{word_diff_html(removed, added)}</li>")
+        elif kind == "remove":
             flush_keeps()
-            lines.append(f'<li><del style="{_DEL_STYLE}">{html.escape(op.text)}</del></li>')
-            i += 1
+            lines.append(f'<li><del style="{_DEL_STYLE}">{html.escape(removed or "")}</del></li>')
         else:
             flush_keeps()
-            lines.append(f'<li><ins style="{_INS_STYLE}">{html.escape(op.text)}</ins></li>')
-            i += 1
+            lines.append(f'<li><ins style="{_INS_STYLE}">{html.escape(added or "")}</ins></li>')
     flush_keeps()
     return '<ul style="line-height:1.55;font-size:0.95rem;margin:0;padding-left:1.2rem;">' + "".join(lines) + "</ul>"
+
+
+def paired_ops(ops: list[BulletDiff]) -> list[tuple[str, str | None, str | None]]:
+    """Regroup a bullet-diff into edit units, pairing removes with adds positionally.
+
+    SequenceMatcher emits a replace block as ALL removes followed by ALL adds;
+    pairing them index-wise turns that into per-bullet rewrites. Yields tuples
+    ("keep", text, None) | ("pair", removed, added) | ("remove", removed, None)
+    | ("add", None, added).
+    """
+    units: list[tuple[str, str | None, str | None]] = []
+    i = 0
+    while i < len(ops):
+        if ops[i].op == "keep":
+            units.append(("keep", ops[i].text, None))
+            i += 1
+            continue
+        removes: list[str] = []
+        adds: list[str] = []
+        while i < len(ops) and ops[i].op == "remove":
+            removes.append(ops[i].text)
+            i += 1
+        while i < len(ops) and ops[i].op == "add":
+            adds.append(ops[i].text)
+            i += 1
+        for j in range(max(len(removes), len(adds))):
+            removed = removes[j] if j < len(removes) else None
+            added = adds[j] if j < len(adds) else None
+            if removed is not None and added is not None:
+                units.append(("pair", removed, added))
+            elif removed is not None:
+                units.append(("remove", removed, None))
+            else:
+                units.append(("add", None, added))
+    return units
+
+
+def apply_bullet_edits(
+    proposal_current: str | None,
+    proposal_suggested: str | None,
+    target_current: str | None,
+) -> tuple[str, int, int] | None:
+    """Re-apply a bullet-list proposal to ANOTHER field's bullet list.
+
+    Different pages (e.g. two MDims built from the same garden metadata) often
+    share individual bullets via YAML anchors while their full lists differ. Each
+    edit unit (a bullet rewrite/removal, or an addition anchored after a bullet)
+    carries over when its bullet exists verbatim in the target list; units
+    touching page-specific bullets are skipped. Returns
+    (transferred text, edits applied, edits in the proposal), or None when
+    nothing applies.
+    """
+    ops = bullet_diff(proposal_current, proposal_suggested)
+    if all(op.op == "keep" for op in ops):
+        return None
+    target = split_bullets(target_current)
+
+    def find(bullet: str) -> int:
+        try:
+            return target.index(bullet)
+        except ValueError:
+            return -1
+
+    anchor = -1  # last position in `target` we matched or touched.
+    anchored = False
+    applied, total = 0, 0
+    for kind, removed, added in paired_ops(ops):
+        if kind == "keep":
+            pos = find(removed or "")
+            if pos >= 0:
+                anchor = pos
+                anchored = True
+            continue
+        total += 1
+        if kind in ("pair", "remove"):
+            pos = find(removed or "")
+            if pos < 0:
+                continue  # page-specific bullet — this edit doesn't apply here.
+            if kind == "pair" and added is not None:
+                target[pos] = added
+                anchor = pos
+            else:
+                del target[pos]
+                anchor = pos - 1
+            anchored = True
+            applied += 1
+        elif added is not None:  # pure addition
+            if not anchored:
+                continue  # no shared context to anchor the new bullet to.
+            target.insert(anchor + 1, added)
+            anchor += 1
+            applied += 1
+
+    if applied == 0:
+        return None
+    text = target[0] if len(target) == 1 else "\n".join(f"- {b}" for b in target)
+    return text, applied, total
 
 
 def diff_markdown_lines(ops: list[BulletDiff], collapse_keeps: bool = True) -> list[str]:

--- a/apps/metadata_review/diffs.py
+++ b/apps/metadata_review/diffs.py
@@ -92,10 +92,12 @@ def word_diff_html(current: str | None, proposed: str | None) -> str:
         else:
             removed = "".join(a[a0:a1]).strip()
             added = "".join(b[b0:b1]).strip()
+            # Leading space so a change never fuses with the preceding word when the
+            # diff consumed the whitespace token (HTML collapses doubled spaces).
             if removed:
-                parts.append(f'<del style="{_DEL_STYLE}">{html.escape(removed)}</del> ')
+                parts.append(f' <del style="{_DEL_STYLE}">{html.escape(removed)}</del> ')
             if added:
-                parts.append(f'<ins style="{_INS_STYLE}">{html.escape(added)}</ins> ')
+                parts.append(f' <ins style="{_INS_STYLE}">{html.escape(added)}</ins> ')
     return "".join(parts).strip()
 
 

--- a/apps/metadata_review/diffs.py
+++ b/apps/metadata_review/diffs.py
@@ -1,8 +1,9 @@
-"""Compact diff helpers for suggestion rendering.
+"""Diff helpers for suggestion rendering.
 
-`description_key` is a markdown bullet list that can run to a dozen bullets;
-repeating the whole list in every thread drowns the actual change. These helpers
-reduce a proposal to only what changed, bullet by bullet.
+Proposals render as tracked changes over the FULL text — the reader always sees
+the entire field as it would read, with deletions struck through and insertions
+tinted. `description_key` (a markdown bullet list) diffs bullet-by-bullet so a
+rewritten bullet tracks inline instead of appearing as a remove+add pair.
 """
 
 import difflib
@@ -105,36 +106,24 @@ def tracked_changes_html(current: str | None, proposed: str | None, is_bullet_li
     """Full tracked-changes rendering of a proposal, ready for st.html.
 
     Bullet-list fields diff bullet-by-bullet: changed bullets get inline word
-    tracking, added/removed bullets are marked whole, unchanged runs collapse.
+    tracking, added/removed bullets are marked whole, and unchanged bullets are
+    shown in full — the reader always sees the entire text as it would read.
     """
     if not is_bullet_list:
         body = word_diff_html(current, proposed)
         return f'<div style="line-height:1.55;font-size:0.95rem;">{body}</div>'
 
     lines: list[str] = []
-    keep_run = 0
-
-    def flush_keeps() -> None:
-        nonlocal keep_run
-        if keep_run:
-            noun = "bullet" if keep_run == 1 else "bullets"
-            lines.append(f'<li style="color:#888;list-style:none;">… {keep_run} unchanged {noun}</li>')
-            keep_run = 0
-
     for kind, removed, added in paired_ops(bullet_diff(current, proposed)):
         if kind == "keep":
-            keep_run += 1
+            lines.append(f"<li>{html.escape(removed or '')}</li>")
         elif kind == "pair":
             # A changed bullet: render as one bullet with inline word tracking.
-            flush_keeps()
             lines.append(f"<li>{word_diff_html(removed, added)}</li>")
         elif kind == "remove":
-            flush_keeps()
             lines.append(f'<li><del style="{_DEL_STYLE}">{html.escape(removed or "")}</del></li>')
         else:
-            flush_keeps()
             lines.append(f'<li><ins style="{_INS_STYLE}">{html.escape(added or "")}</ins></li>')
-    flush_keeps()
     return '<ul style="line-height:1.55;font-size:0.95rem;margin:0;padding-left:1.2rem;">' + "".join(lines) + "</ul>"
 
 
@@ -233,31 +222,3 @@ def apply_bullet_edits(
         return None
     text = target[0] if len(target) == 1 else "\n".join(f"- {b}" for b in target)
     return text, applied, total
-
-
-def diff_markdown_lines(ops: list[BulletDiff], collapse_keeps: bool = True) -> list[str]:
-    """Markdown lines showing only the changed bullets; unchanged runs are summarized."""
-    lines: list[str] = []
-    keep_run = 0
-
-    def flush_keeps() -> None:
-        nonlocal keep_run
-        if keep_run:
-            noun = "bullet" if keep_run == 1 else "bullets"
-            lines.append(f"- _… {keep_run} unchanged {noun}_")
-            keep_run = 0
-
-    for op in ops:
-        if op.op == "keep":
-            if collapse_keeps:
-                keep_run += 1
-            else:
-                lines.append(f"- {op.text}")
-        elif op.op == "remove":
-            flush_keeps()
-            lines.append(f"- :red[−] ~~{op.text}~~")
-        else:
-            flush_keeps()
-            lines.append(f"- :green[+] {op.text}")
-    flush_keeps()
-    return lines

--- a/apps/metadata_review/export.py
+++ b/apps/metadata_review/export.py
@@ -14,13 +14,14 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 import etl.grapher.model as gm
+from apps.metadata_review.diffs import apply_bullet_edits
 from apps.metadata_review.resolution import (
     check_staleness,
     resolve_dataset,
     resolve_mdim,
     shared_view_ids,
 )
-from apps.metadata_review.targets import MdimReview, ReviewableField
+from apps.metadata_review.targets import VIEW_TO_INDICATOR_FIELD, MdimReview, ReviewableField
 from apps.metadata_review.trace import EditCandidate, trace_indicator_field, trace_mdim_field
 from etl.config import OWID_ENV, OWIDEnv
 from etl.files import yaml_dump
@@ -68,7 +69,10 @@ def build_export(
         paths = review.indicator_paths
         target_info = {"type": "dataset", "catalog_path": target_path, "name": review.name}
 
-    suggestions = gm.MetadataReviewSuggestion.load_for_paths(session, paths, statuses=statuses)
+    # Widen to the whole grapher dataset(s), matching the wizard's loading: threads
+    # filed on sibling pages built from the same metadata belong in this export too.
+    prefixes = sorted({"/".join(p.split("/")[:4]) for p in review.indicator_paths})
+    suggestions = gm.MetadataReviewSuggestion.load_for_paths(session, paths, statuses=statuses, path_prefixes=prefixes)
     comments = gm.MetadataReviewComment.load_for_suggestions(session, [s.id for s in suggestions])
     comments_by_suggestion: dict[int, list[gm.MetadataReviewComment]] = {}
     for comment in comments:
@@ -160,9 +164,13 @@ def _export_suggestion(
     users: dict[int, str],
     trace_cache: dict[tuple, list[EditCandidate]],
 ) -> dict[str, Any]:
-    staleness = check_staleness(suggestion, fields_by_key)
     key = (suggestion.targetType, suggestion.targetPath, suggestion.viewId, suggestion.fieldPath)
     live_field = fields_by_key.get(key)
+    if live_field is None:
+        # A thread borrowed from a sibling page: judge it against the field on THIS
+        # page that displays it (text-matched), not as target-gone.
+        live_field = _matching_display_field(suggestion, fields_by_key.values())
+    staleness = check_staleness(suggestion, fields_by_key, display_field=live_field)
     trace_value = live_field.current_value if live_field is not None else suggestion.currentValue
 
     if key not in trace_cache:
@@ -234,6 +242,24 @@ def _export_suggestion(
         for c in comments
     ]
     return entry
+
+
+def _matching_display_field(suggestion: gm.MetadataReviewSuggestion, fields) -> ReviewableField | None:
+    """The field on this page that displays a borrowed (cross-page) thread, if any."""
+    for field in fields:
+        mapped = VIEW_TO_INDICATOR_FIELD.get(field.field_path, field.field_path)
+        if mapped != suggestion.fieldPath or field.current_value is None:
+            continue
+        if str(field.current_value).strip() == str(suggestion.currentValue or "").strip():
+            return field
+        if (
+            mapped == "description_key"
+            and suggestion.suggestedValue is not None
+            and apply_bullet_edits(suggestion.currentValue, suggestion.suggestedValue, str(field.current_value))
+            is not None
+        ):
+            return field
+    return None
 
 
 def _affected_views(

--- a/apps/metadata_review/export.py
+++ b/apps/metadata_review/export.py
@@ -1,0 +1,277 @@
+"""Export metadata-review suggestions to the YAML handoff consumed by Claude.
+
+The export runs inside the ETL repo, so it can do what the DB-only wizard can't:
+trace every suggestion to a concrete edit location (file + YAML key path, or the
+step .py when the value is generated programmatically) via `trace.py`.
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+import etl.grapher.model as gm
+from apps.metadata_review.resolution import (
+    check_staleness,
+    resolve_dataset,
+    resolve_mdim,
+    shared_view_ids,
+)
+from apps.metadata_review.targets import MdimReview, ReviewableField
+from apps.metadata_review.trace import EditCandidate, trace_indicator_field, trace_mdim_field
+from etl.config import OWID_ENV, OWIDEnv
+from etl.files import yaml_dump
+
+log = structlog.get_logger()
+
+INSTRUCTIONS = """\
+Each suggestion below carries a resolved edit location. To implement one:
+
+1. Apply `suggested_value` (or what the comments converge on) at `edit.file` /
+   `edit.yaml_path`. Preserve YAML comments (ruamel-style editing).
+2. If `edit.generated` is true, the value is built programmatically — edit the
+   step .py; `edit.notes` lists the relevant call sites.
+3. `edit.kind` explains how the value is built. For `jinja` templates, splice
+   dimension words into the existing sentence instead of duplicating `<% if %>`
+   branches. For `common-block` / `mdim-common-views` edits, check
+   `edit.shared_with` / `affected_views` — the edit applies to all of them.
+4. `edit.render_verified: true` means re-rendering the traced template reproduced
+   the live value, so the location is confirmed. When false or absent, verify the
+   location before editing.
+5. Suggestions with `stale` flags were filed against an older version of the
+   page — read the comments and re-check against the current text.
+6. After implementing, rebuild the affected steps and mark the suggestion as
+   implemented (wizard Metadata Review app, or `etl metadata-review resolve <id>
+   --status implemented`).
+"""
+
+
+def build_export(
+    session: Session,
+    target: str,
+    statuses: list[str] | None = None,
+    owid_env: OWIDEnv | None = None,
+) -> dict[str, Any]:
+    """Build the export document for an MDim (catalogPath or slug) or a grapher dataset."""
+    owid_env = owid_env or OWID_ENV
+    target_type, target_path = _normalize_target(session, target)
+
+    if target_type == "mdim":
+        review = resolve_mdim(session, target_path, owid_env=owid_env)
+        paths = [target_path] + review.indicator_paths
+        target_info = {"type": "mdim", "catalog_path": target_path, "slug": review.slug, "title": review.title}
+    else:
+        review = resolve_dataset(session, target_path, owid_env=owid_env)
+        paths = review.indicator_paths
+        target_info = {"type": "dataset", "catalog_path": target_path, "name": review.name}
+
+    suggestions = gm.MetadataReviewSuggestion.load_for_paths(session, paths, statuses=statuses)
+    comments = gm.MetadataReviewComment.load_for_suggestions(session, [s.id for s in suggestions])
+    comments_by_suggestion: dict[int, list[gm.MetadataReviewComment]] = {}
+    for comment in comments:
+        comments_by_suggestion.setdefault(comment.suggestionId, []).append(comment)
+    users = _user_names(session, suggestions, comments)
+
+    fields_by_key: dict[tuple, ReviewableField] = {}
+    if isinstance(review, MdimReview):
+        all_fields = review.all_fields
+    else:
+        all_fields = [f for ind in review.indicators for f in ind.fields]
+    for field in all_fields:
+        fields_by_key.setdefault(field.source_key(), field)
+
+    trace_cache: dict[tuple, list[EditCandidate]] = {}
+    entries = []
+    for suggestion in suggestions:
+        entries.append(
+            _export_suggestion(
+                session,
+                suggestion,
+                review if isinstance(review, MdimReview) else None,
+                fields_by_key,
+                comments_by_suggestion.get(suggestion.id, []),
+                users,
+                trace_cache,
+            )
+        )
+
+    return {
+        "metadata_review_export": {
+            "generated_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "environment": owid_env.name,
+            "target": target_info,
+            "n_suggestions": len(entries),
+            "instructions": INSTRUCTIONS,
+        },
+        "suggestions": entries,
+    }
+
+
+def export_to_yaml(document: dict[str, Any], output_path: str | Path) -> Path:
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(yaml_dump(document))  # type: ignore[arg-type]
+    return output_path
+
+
+def _normalize_target(session: Session, target: str) -> tuple[str, str]:
+    """Resolve a user-supplied target to ('mdim'|'dataset', canonical catalogPath)."""
+    # MDim catalogPath as stored ('ns/ver/short#short')?
+    if "#" in target:
+        if gm.MultiDimDataPage.load_mdim(session, catalogPath=target) is not None:
+            return "mdim", target
+        raise ValueError(f"No MDim with catalogPath '{target}' found in multi_dim_data_pages.")
+    # MDim slug?
+    mdim = session.scalars(select(gm.MultiDimDataPage).where(gm.MultiDimDataPage.slug == target)).one_or_none()
+    if mdim is not None and mdim.catalogPath:
+        return "mdim", mdim.catalogPath
+    # Dataset catalogPath, with or without the 'grapher/' prefix.
+    dataset_path = target.removeprefix("grapher/")
+    dataset = session.scalars(select(gm.Dataset).where(gm.Dataset.catalogPath == dataset_path)).one_or_none()
+    if dataset is not None:
+        return "dataset", dataset_path
+    raise ValueError(
+        f"Target '{target}' is neither an MDim catalogPath/slug nor a grapher dataset catalogPath ('ns/version/dataset')."
+    )
+
+
+def _user_names(
+    session: Session,
+    suggestions: list[gm.MetadataReviewSuggestion],
+    comments: list[gm.MetadataReviewComment],
+) -> dict[int, str]:
+    user_ids = {s.createdBy for s in suggestions} | {c.userId for c in comments}
+    user_ids |= {s.resolvedBy for s in suggestions if s.resolvedBy is not None}
+    if not user_ids:
+        return {}
+    rows = session.execute(select(gm.User.id, gm.User.fullName).where(gm.User.id.in_(user_ids))).all()
+    return {user_id: full_name for user_id, full_name in rows}
+
+
+def _export_suggestion(
+    session: Session,
+    suggestion: gm.MetadataReviewSuggestion,
+    mdim_review: MdimReview | None,
+    fields_by_key: dict[tuple, ReviewableField],
+    comments: list[gm.MetadataReviewComment],
+    users: dict[int, str],
+    trace_cache: dict[tuple, list[EditCandidate]],
+) -> dict[str, Any]:
+    staleness = check_staleness(suggestion, fields_by_key)
+    key = (suggestion.targetType, suggestion.targetPath, suggestion.viewId, suggestion.fieldPath)
+    live_field = fields_by_key.get(key)
+    trace_value = live_field.current_value if live_field is not None else suggestion.currentValue
+
+    if key not in trace_cache:
+        try:
+            if suggestion.targetType == "indicator":
+                trace = trace_indicator_field(session, suggestion.targetPath, suggestion.fieldPath, trace_value)
+            else:
+                trace = trace_mdim_field(suggestion.targetPath, suggestion.viewId, suggestion.fieldPath, trace_value)
+            trace_cache[key] = trace.edits
+        except Exception as e:
+            log.warning("metadata_review.export.trace_failed", suggestion=suggestion.id, error=str(e))
+            trace_cache[key] = []
+    edits = trace_cache[key]
+
+    entry: dict[str, Any] = {
+        "id": suggestion.id,
+        "status": suggestion.status,
+        "field": suggestion.fieldPath,
+        "target": {"type": suggestion.targetType, "path": suggestion.targetPath},
+        "provenance": suggestion.provenance,
+        "current_value": suggestion.currentValue,
+        "suggested_value": suggestion.suggestedValue,
+        "suggested_by": users.get(suggestion.createdBy, f"user {suggestion.createdBy}"),
+        "created_at": suggestion.createdAt.isoformat(timespec="seconds"),
+    }
+    if suggestion.inheritedFromPath:
+        entry["inherited_from"] = suggestion.inheritedFromPath
+    if suggestion.viewId:
+        entry["view_id"] = suggestion.viewId
+    if suggestion.filedFromViewId:
+        entry["filed_from_view"] = suggestion.filedFromViewId
+
+    # Human-readable view selection + all surfaces the parameter renders on.
+    if mdim_review is not None:
+        views_by_id = {v.view_id: v for v in mdim_review.views}
+        shown_view = views_by_id.get(suggestion.viewId or suggestion.filedFromViewId or "")
+        if shown_view is not None:
+            entry["view"] = mdim_review.human_dimensions(shown_view.dimensions)
+        entry["affected_views"] = _affected_views(suggestion, mdim_review, live_field)
+
+    if staleness.is_stale or staleness.page_changed:
+        stale: dict[str, Any] = {
+            "target_gone": staleness.target_gone,
+            "field_changed": staleness.field_changed,
+            "page_changed": staleness.page_changed,
+        }
+        if staleness.field_changed:
+            stale["value_now"] = staleness.current_value
+        entry["stale"] = stale
+
+    if suggestion.status != "open":
+        entry["resolved_by"] = users.get(suggestion.resolvedBy or -1)
+        entry["resolved_at"] = suggestion.resolvedAt.isoformat(timespec="seconds") if suggestion.resolvedAt else None
+
+    if edits:
+        entry["edit"] = _edit_to_dict(edits[0])
+        if len(edits) > 1:
+            entry["other_edit_candidates"] = [_edit_to_dict(e) for e in edits[1:]]
+    else:
+        entry["edit"] = None
+
+    entry["comments"] = [
+        {
+            "author": users.get(c.userId, f"user {c.userId}"),
+            "at": c.createdAt.isoformat(timespec="seconds"),
+            "text": c.text,
+            **({"kind": c.kind} if c.kind != "comment" else {}),
+        }
+        for c in comments
+    ]
+    return entry
+
+
+def _affected_views(
+    suggestion: gm.MetadataReviewSuggestion,
+    review: MdimReview,
+    live_field: ReviewableField | None,
+) -> list[str]:
+    """All surfaces rendering the suggestion's parameter — one edit fixes them all."""
+    if suggestion.targetType == "indicator":
+        views = [
+            view.view_id
+            for view in review.views
+            if view.indicator_path == suggestion.targetPath
+            and any(f.source_key()[3] == suggestion.fieldPath and f.provenance != "override" for f in view.fields)
+        ]
+        return views + [f"data page of {suggestion.targetPath}"]
+    if suggestion.viewId and live_field is not None:
+        return [suggestion.viewId] + shared_view_ids(review, live_field)
+    return []
+
+
+def _edit_to_dict(edit: EditCandidate) -> dict[str, Any]:
+    out: dict[str, Any] = {"file": edit.file, "kind": edit.kind}
+    if edit.yaml_path:
+        out["yaml_path"] = edit.yaml_path
+    out["exact_key_found"] = edit.exact_key_found
+    if edit.generated:
+        out["generated"] = True
+    if edit.template is not None:
+        out["template"] = edit.template
+    if edit.render_context:
+        out["render_context"] = edit.render_context
+    if edit.supplied_by:
+        out["supplied_by"] = edit.supplied_by
+    if edit.render_verified is not None:
+        out["render_verified"] = edit.render_verified
+    if edit.shared_with:
+        out["shared_with"] = edit.shared_with
+    if edit.notes:
+        out["notes"] = edit.notes
+    return out

--- a/apps/metadata_review/export.py
+++ b/apps/metadata_review/export.py
@@ -241,14 +241,29 @@ def _affected_views(
     review: MdimReview,
     live_field: ReviewableField | None,
 ) -> list[str]:
-    """All surfaces rendering the suggestion's parameter — one edit fixes them all."""
+    """All surfaces rendering the suggestion's text — one edit fixes them all.
+
+    Matched by identical rendered value (not only the same source indicator):
+    MDims fan one garden template out into a different expanded indicator per
+    view, all rendering the same text.
+    """
     if suggestion.targetType == "indicator":
-        views = [
-            view.view_id
-            for view in review.views
-            if view.indicator_path == suggestion.targetPath
-            and any(f.source_key()[3] == suggestion.fieldPath and f.provenance != "override" for f in view.fields)
-        ]
+        views = []
+        for view in review.views:
+            for field in view.fields:
+                if field.source_key() == (
+                    suggestion.targetType,
+                    suggestion.targetPath,
+                    suggestion.viewId,
+                    suggestion.fieldPath,
+                ) or (
+                    live_field is not None
+                    and field.field_path == live_field.field_path
+                    and field.current_value is not None
+                    and str(field.current_value).strip() == str(live_field.current_value or "").strip()
+                ):
+                    views.append(view.view_id)
+                    break
         return views + [f"data page of {suggestion.targetPath}"]
     if suggestion.viewId and live_field is not None:
         return [suggestion.viewId] + shared_view_ids(review, live_field)

--- a/apps/metadata_review/resolution.py
+++ b/apps/metadata_review/resolution.py
@@ -454,6 +454,83 @@ def suggestions_by_source_key(
     return grouped
 
 
+def parametrize_value(
+    review: MdimReview, view_dims: dict[str, str], value: str | None
+) -> tuple[str, dict[str, str]] | None:
+    """Replace the view's own dimension words in `value` with `{dim}` placeholders.
+
+    Views of one MDim often render a single garden template whose output differs
+    only by dimension-derived words ("Income share of the richest 1%" vs "...the
+    richest 0.1%"). Substituting each dimension's surface form (the choice's human
+    name or slug variants, longest candidate first, case-insensitive) yields the
+    shared pattern; two views connect when their patterns match.
+
+    Returns (pattern, {dim_slug: matched substring}) when at least one dimension
+    word was found, else None.
+    """
+    if not value:
+        return None
+    dims_by_slug = {d.slug: d for d in review.dimensions}
+    pattern = str(value)
+    matches: dict[str, str] = {}
+    for dim_slug, choice_slug in view_dims.items():
+        dim = dims_by_slug.get(dim_slug)
+        candidates = {str(choice_slug), str(choice_slug).replace("_", " "), str(choice_slug).replace("_", "-")}
+        if dim is not None:
+            candidates.add(dim.choice_name(str(choice_slug)))
+        candidates |= {c.lstrip("_ -") for c in set(candidates)}
+        for candidate in sorted({c.strip() for c in candidates if len(c.strip()) >= 2}, key=len, reverse=True):
+            idx = pattern.lower().find(candidate.lower())
+            if idx >= 0:
+                matches[dim_slug] = pattern[idx : idx + len(candidate)]
+                pattern = pattern[:idx] + "{" + dim_slug + "}" + pattern[idx + len(candidate) :]
+                break
+    if not matches:
+        return None
+    return pattern, matches
+
+
+def _field_pattern(review: MdimReview, view: "ViewReview", field: ReviewableField) -> str | None:
+    parametrized = parametrize_value(review, view.dimensions, _norm(field.current_value))
+    return parametrized[0] if parametrized else None
+
+
+def transfer_proposal(
+    review: MdimReview,
+    proposal: gm.MetadataReviewSuggestion,
+    to_field: ReviewableField,
+) -> str | None:
+    """Re-render a pattern-shared proposal for another view.
+
+    Substitutes the filing view's dimension words in the proposed text with the
+    target view's — so a wording change filed on "richest 1%" displays with
+    "richest 0.1%" on that view. Returns None when the proposal edited the
+    dimension words themselves (no faithful transfer possible).
+    """
+    if proposal.suggestedValue is None or to_field.view_id is None:
+        return None
+    views_by_id = {v.view_id: v for v in review.views}
+    filing_view = views_by_id.get(proposal.filedFromViewId or "")
+    target_view = views_by_id.get(to_field.view_id)
+    if filing_view is None or target_view is None:
+        return None
+    source = parametrize_value(review, filing_view.dimensions, _norm(proposal.currentValue))
+    target = parametrize_value(review, target_view.dimensions, _norm(to_field.current_value))
+    if source is None or target is None or source[0] != target[0]:
+        return None
+    transferred = str(proposal.suggestedValue)
+    for dim_slug, source_word in source[1].items():
+        target_word = target[1].get(dim_slug)
+        if target_word is None:
+            return None
+        idx = transferred.lower().find(source_word.lower())
+        if idx < 0:
+            # The proposal changed the dimension word itself — don't transfer.
+            return None
+        transferred = transferred[:idx] + target_word + transferred[idx + len(source_word) :]
+    return transferred
+
+
 def shared_view_ids(review: MdimReview, field: ReviewableField) -> list[str]:
     """View ids (other than the field's own) rendering the same text for this field.
 
@@ -467,12 +544,18 @@ def shared_view_ids(review: MdimReview, field: ReviewableField) -> list[str]:
     if field.view_id is None or field.current_value is None:
         return []
     value = _norm(field.current_value)
+    own_view = next((v for v in review.views if v.view_id == field.view_id), None)
+    pattern = _field_pattern(review, own_view, field) if own_view is not None else None
     shared = []
     for view in review.views:
         if view.view_id == field.view_id:
             continue
         for other in view.fields:
-            if other.field_path == field.field_path and _norm(other.current_value) == value:
+            if other.field_path != field.field_path:
+                continue
+            if _norm(other.current_value) == value or (
+                pattern is not None and _field_pattern(review, view, other) == pattern
+            ):
                 shared.append(view.view_id)
     return shared
 
@@ -492,9 +575,15 @@ def threads_for_field(
     keys = {field.source_key()}
     if field.view_id is not None and field.current_value is not None:
         value = _norm(field.current_value)
+        own_view = next((v for v in review.views if v.view_id == field.view_id), None)
+        pattern = _field_pattern(review, own_view, field) if own_view is not None else None
         for view in review.views:
             for other in view.fields:
-                if other.field_path == field.field_path and _norm(other.current_value) == value:
+                if other.field_path != field.field_path:
+                    continue
+                if _norm(other.current_value) == value or (
+                    pattern is not None and _field_pattern(review, view, other) == pattern
+                ):
                     keys.add(other.source_key())
     seen: dict[int, gm.MetadataReviewSuggestion] = {}
     for key in keys:

--- a/apps/metadata_review/resolution.py
+++ b/apps/metadata_review/resolution.py
@@ -22,10 +22,11 @@ from typing import Any
 from urllib.parse import quote, urlencode
 
 import structlog
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
 
 import etl.grapher.model as gm
+from apps.metadata_review.diffs import apply_bullet_edits
 from apps.metadata_review.targets import (
     FIELD_LABELS,
     VIEW_TO_INDICATOR_FIELD,
@@ -409,18 +410,33 @@ def resolve_dataset(session: Session, dataset_catalog_path: str, owid_env: OWIDE
 
 
 def list_mdims(session: Session) -> list[dict[str, Any]]:
-    """All MDims with a catalogPath: [{catalog_path, slug, published, updated_at}]."""
+    """All MDims with a catalogPath: [{catalog_path, slug, title, title_variant, published, updated_at}].
+
+    Title fields are extracted server-side (JSON_EXTRACT) so the big config
+    columns never leave the database.
+    """
     rows = session.execute(
         select(
             gm.MultiDimDataPage.catalogPath,
             gm.MultiDimDataPage.slug,
+            func.json_unquote(func.json_extract(gm.MultiDimDataPage.config, "$.title.title")),
+            func.json_unquote(func.json_extract(gm.MultiDimDataPage.config, "$.title.titleVariant")),
             gm.MultiDimDataPage.published,
             gm.MultiDimDataPage.updatedAt,
         ).where(gm.MultiDimDataPage.catalogPath.is_not(None))
     ).all()
     return [
-        {"catalog_path": catalog_path, "slug": slug, "published": bool(published), "updated_at": updated_at}
-        for catalog_path, slug, published, updated_at in sorted(rows, key=lambda r: r[3], reverse=True)
+        {
+            "catalog_path": catalog_path,
+            "slug": slug,
+            "title": title,
+            "title_variant": title_variant,
+            "published": bool(published),
+            "updated_at": updated_at,
+        }
+        for catalog_path, slug, title, title_variant, published, updated_at in sorted(
+            rows, key=lambda r: r[5], reverse=True
+        )
     ]
 
 
@@ -561,19 +577,21 @@ def shared_view_ids(review: MdimReview, field: ReviewableField) -> list[str]:
 
 
 def threads_for_field(
-    review: MdimReview,
+    review: MdimReview | None,
     field: ReviewableField,
     suggestions_by_key: dict[tuple[str, str, str | None, str], list[gm.MetadataReviewSuggestion]],
 ) -> list[gm.MetadataReviewSuggestion]:
     """All suggestion threads that belong on this field's panel.
 
     Includes the field's own source-keyed threads plus threads filed on any other
-    view's field (same field, identical rendered text) — even when those views
-    inherit from *different* expanded indicators of the same garden template.
-    Deduplicated by suggestion id, oldest first.
+    view's field (same field, identical rendered text or matching dimension
+    pattern) — even when those views inherit from *different* expanded indicators
+    of the same garden template — plus text-matched threads keyed to indicators of
+    sibling pages (e.g. another MDim built from the same garden metadata).
+    Deduplicated by suggestion id, oldest first. `review` may be None (dataset mode).
     """
     keys = {field.source_key()}
-    if field.view_id is not None and field.current_value is not None:
+    if review is not None and field.view_id is not None and field.current_value is not None:
         value = _norm(field.current_value)
         own_view = next((v for v in review.views if v.view_id == field.view_id), None)
         pattern = _field_pattern(review, own_view, field) if own_view is not None else None
@@ -589,6 +607,27 @@ def threads_for_field(
     for key in keys:
         for suggestion in suggestions_by_key.get(key, []):
             seen[suggestion.id] = suggestion
+
+    # Cross-page sharing: threads keyed to indicators NOT used by this page (e.g.
+    # filed on another MDim built from the same garden metadata) still belong here
+    # when they target the equivalent field and either their text snapshot matches
+    # ours, or — for bullet lists — the bullets they edit exist in our list too
+    # (lists share individual bullets via YAML anchors while differing as a whole).
+    if field.current_value is not None:
+        value = _norm(field.current_value)
+        indicator_field = VIEW_TO_INDICATOR_FIELD.get(field.field_path, field.field_path)
+        is_bullets = indicator_field == "description_key"
+        for key, threads in suggestions_by_key.items():
+            if key in keys or key[0] != "indicator" or key[3] != indicator_field:
+                continue
+            for suggestion in threads:
+                if _norm(suggestion.currentValue) == value or (
+                    is_bullets
+                    and suggestion.suggestedValue is not None
+                    and apply_bullet_edits(suggestion.currentValue, suggestion.suggestedValue, field.current_value)
+                    is not None
+                ):
+                    seen.setdefault(suggestion.id, suggestion)
     return sorted(seen.values(), key=lambda s: s.createdAt)
 
 
@@ -610,15 +649,20 @@ class Staleness:
 def check_staleness(
     suggestion: gm.MetadataReviewSuggestion,
     current_fields_by_key: dict[tuple[str, str, str | None, str], ReviewableField],
+    display_field: ReviewableField | None = None,
 ) -> Staleness:
     """Field-level staleness: the suggestion's snapshot vs the live resolved field.
 
     `current_fields_by_key` maps `ReviewableField.source_key()` of every field on the
     page being rendered. A suggestion whose key is absent points at a view/indicator
-    that no longer exists (`target_gone`).
+    that isn't on this page — that's `target_gone`, unless `display_field` is given
+    (a cross-page borrowed thread shown on a text-matched field), in which case
+    staleness is judged against the field actually displaying it.
     """
     key = (suggestion.targetType, suggestion.targetPath, suggestion.viewId, suggestion.fieldPath)
     field = current_fields_by_key.get(key)
+    if field is None:
+        field = display_field
     if field is None:
         return Staleness(target_gone=True)
     return Staleness(

--- a/apps/metadata_review/resolution.py
+++ b/apps/metadata_review/resolution.py
@@ -455,27 +455,52 @@ def suggestions_by_source_key(
 
 
 def shared_view_ids(review: MdimReview, field: ReviewableField) -> list[str]:
-    """View ids (other than the field's own) rendering the same parameter.
+    """View ids (other than the field's own) rendering the same text for this field.
 
-    Non-overridden fields share their source indicator; overridden fields share by
-    identical resolved value (shared `common_views` / generated blocks arrive in the
-    DB config as per-view copies, so value equality is the detectable signal).
+    Sharing is by identical rendered value, regardless of provenance or source
+    indicator: MDims commonly fan one garden Jinja template out into a different
+    expanded indicator per view, all rendering the same text — a suggestion on
+    that text belongs to every one of those views. (Shared `common_views` /
+    generated overrides likewise arrive in the DB config as per-view copies, so
+    value equality is the detectable signal there too.)
     """
-    if field.view_id is None:
+    if field.view_id is None or field.current_value is None:
         return []
+    value = _norm(field.current_value)
     shared = []
     for view in review.views:
         if view.view_id == field.view_id:
             continue
         for other in view.fields:
-            if other.field_path != field.field_path:
-                continue
-            if field.provenance != "override":
-                if other.provenance != "override" and other.inherited_from == field.inherited_from:
-                    shared.append(view.view_id)
-            elif other.provenance == "override" and other.current_value == field.current_value:
+            if other.field_path == field.field_path and _norm(other.current_value) == value:
                 shared.append(view.view_id)
     return shared
+
+
+def threads_for_field(
+    review: MdimReview,
+    field: ReviewableField,
+    suggestions_by_key: dict[tuple[str, str, str | None, str], list[gm.MetadataReviewSuggestion]],
+) -> list[gm.MetadataReviewSuggestion]:
+    """All suggestion threads that belong on this field's panel.
+
+    Includes the field's own source-keyed threads plus threads filed on any other
+    view's field (same field, identical rendered text) — even when those views
+    inherit from *different* expanded indicators of the same garden template.
+    Deduplicated by suggestion id, oldest first.
+    """
+    keys = {field.source_key()}
+    if field.view_id is not None and field.current_value is not None:
+        value = _norm(field.current_value)
+        for view in review.views:
+            for other in view.fields:
+                if other.field_path == field.field_path and _norm(other.current_value) == value:
+                    keys.add(other.source_key())
+    seen: dict[int, gm.MetadataReviewSuggestion] = {}
+    for key in keys:
+        for suggestion in suggestions_by_key.get(key, []):
+            seen[suggestion.id] = suggestion
+    return sorted(seen.values(), key=lambda s: s.createdAt)
 
 
 @dataclass

--- a/apps/metadata_review/resolution.py
+++ b/apps/metadata_review/resolution.py
@@ -1,0 +1,523 @@
+"""DB-based resolution of reviewable fields with provenance.
+
+Reads the enriched MDim config from `multi_dim_data_pages` and indicator metadata
+from `variables` + `chart_configs.patch` (via `grapherConfigIdETL`), so it works
+against any grapher database (staging or production) without a local ETL catalog.
+
+Inheritance rules ported from the faust-metadata-audit skill
+(.claude/skills/faust-metadata-audit/scripts/_common.py):
+
+- Chart Title / Subtitle / Footnote inherit ONLY from
+  `presentation.grapher_config.{title,subtitle,note}` — in DB terms, the
+  `chart_configs.patch` of the variable's `grapherConfigIdETL`. Never fall back
+  to `name` / `titlePublic` / `display.name`; those are data-page fields that do
+  not match what Grapher renders.
+- description_short / description_key inherit from the namesake `variables` columns.
+- An explicit empty-string override counts as an override (Grapher renders blank).
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote, urlencode
+
+import structlog
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+import etl.grapher.model as gm
+from apps.metadata_review.targets import (
+    FIELD_LABELS,
+    VIEW_TO_INDICATOR_FIELD,
+    DatasetReview,
+    DimensionChoice,
+    DimensionInfo,
+    IndicatorReview,
+    MdimReview,
+    Provenance,
+    ReviewableField,
+    ViewReview,
+)
+from etl.config import OWID_ENV, OWIDEnv
+
+log = structlog.get_logger()
+
+# (view config key, view metadata key) -> canonical view fieldPath, in display order.
+VIEW_FAUST_FIELDS = [
+    ("config.title", ("config", "title")),
+    ("config.subtitle", ("config", "subtitle")),
+    ("config.note", ("config", "note")),
+    ("metadata.description_short", ("metadata", "descriptionShort")),
+    ("metadata.description_key", ("metadata", "descriptionKey")),
+]
+
+# Indicator fieldPath -> where the inherited value lives.
+INDICATOR_FIELDS = [
+    "grapher_config.title",
+    "grapher_config.subtitle",
+    "grapher_config.note",
+    "description_short",
+    "description_key",
+]
+
+
+# ---------------------------------------------------------------------------
+# View ids (port of owid-grapher's dimensionsToViewId + slugify, Util.ts)
+# ---------------------------------------------------------------------------
+
+_SUB_SUPERSCRIPTS = str.maketrans("₀₁₂₃₄₅₆₇₈₉⁰¹²³⁴⁵⁶⁷⁸⁹", "01234567890123456789")
+
+
+def slugify(s: str) -> str:
+    """Port of owid-grapher's `slugify` (Util.ts). Identity for snake_case slugs."""
+    s = s.translate(_SUB_SUPERSCRIPTS).lower().strip()
+    s = re.sub(r"\s*\*.+\*", "", s)
+    s = re.sub(r"[^\w\- /]+", "", s)
+    s = re.sub(r" +", "-", s)
+    return s.replace("/", "")
+
+
+def dimensions_to_view_id(dimensions: dict[str, str]) -> str:
+    """Port of owid-grapher's `dimensionsToViewId` (Util.ts): the stable,
+    environment-agnostic key of an MDim view."""
+    return "__".join(f"{slugify(k)}={slugify(str(v))}" for k, v in sorted(dimensions.items())).lower()
+
+
+# ---------------------------------------------------------------------------
+# Field resolution (ported from faust-metadata-audit _common.py)
+# ---------------------------------------------------------------------------
+
+
+def resolve_field(view_value: Any, inherited_value: Any) -> tuple[Provenance, Any]:
+    """Pick override if set, else inherited. Return (provenance, value).
+
+    An explicit empty string (e.g. `note: ""` in an MDim view to suppress an
+    inherited footnote) counts as an override — Grapher renders that as empty.
+    Only `None` means "not set at this layer".
+    """
+    if view_value is not None:
+        return "override", view_value
+    if inherited_value is not None:
+        return "inherited", inherited_value
+    return "missing", None
+
+
+@dataclass
+class IndicatorMeta:
+    """The inheritance-relevant metadata of one variable, loaded from the DB."""
+
+    catalog_path: str
+    variable_id: int
+    name: str | None
+    description_short: str | None
+    description_key: str | None
+    metadata_checksum: str | None
+    # The ETL-authored grapher config (chart_configs.patch), {} when absent.
+    grapher_config: dict[str, Any]
+
+    def inherited(self, indicator_field_path: str) -> str | None:
+        if indicator_field_path == "description_short":
+            return self.description_short
+        if indicator_field_path == "description_key":
+            return self.description_key
+        assert indicator_field_path.startswith("grapher_config.")
+        return self.grapher_config.get(indicator_field_path.removeprefix("grapher_config."))
+
+
+def load_indicator_metas(
+    session: Session,
+    catalog_paths: list[str] | None = None,
+    variable_ids: list[int] | None = None,
+) -> dict[str, IndicatorMeta]:
+    """Bulk-load IndicatorMeta for catalog paths and/or variable ids, keyed by catalog path."""
+    v, cc = gm.Variable, gm.ChartConfig
+    conditions = []
+    if catalog_paths:
+        conditions.append(v.catalogPath.in_(catalog_paths))
+    if variable_ids:
+        conditions.append(v.id.in_(variable_ids))
+    if not conditions:
+        return {}
+
+    rows = session.execute(
+        select(
+            v.id,
+            v.catalogPath,
+            v.name,
+            v.descriptionShort,
+            v.descriptionKey,
+            v.metadataChecksum,
+            cc.patch,
+        )
+        .outerjoin(cc, cc.id == v.grapherConfigIdETL)
+        .where(or_(*conditions))
+    ).all()
+
+    metas = {}
+    for var_id, catalog_path, name, description_short, description_key, metadata_checksum, patch in rows:
+        if catalog_path is None:
+            continue
+        metas[catalog_path] = IndicatorMeta(
+            catalog_path=catalog_path,
+            variable_id=var_id,
+            name=name,
+            description_short=description_short,
+            description_key=description_key,
+            metadata_checksum=metadata_checksum,
+            grapher_config=patch if isinstance(patch, dict) else {},
+        )
+    return metas
+
+
+# ---------------------------------------------------------------------------
+# Edit hints (coarse; the export CLI traces the exact file/key)
+# ---------------------------------------------------------------------------
+
+
+def _edit_hint(provenance: Provenance, inherited_from: str | None) -> str:
+    if provenance == "override":
+        return "Set in the MDim config (override)."
+    if provenance == "inherited":
+        return f"Inherited from `{inherited_from}` — edited in the garden step metadata."
+    if inherited_from:
+        return "Not set — usually added in the garden step metadata (preferred) or as an MDim override."
+    return "Not set."
+
+
+MDIM_CONFIG_HINT = "Set in the MDim config."
+
+
+# ---------------------------------------------------------------------------
+# MDim resolution
+# ---------------------------------------------------------------------------
+
+
+def _primary_indicator(view: dict[str, Any]) -> tuple[str | None, int | None]:
+    """Return (catalogPath, variable_id) of the first y indicator of a view.
+
+    All inheritance resolves from y[0] — same convention as the faust-metadata-audit
+    skill. Entries may be strings (catalog paths) or dicts with catalogPath and/or id.
+    """
+    y = (view.get("indicators") or {}).get("y") or []
+    if not y:
+        return None, None
+    first = y[0]
+    if isinstance(first, str):
+        return first, None
+    return first.get("catalogPath"), first.get("id")
+
+
+def _mdim_preview_url(owid_env: OWIDEnv, catalog_path: str, dimensions: dict[str, str] | None = None) -> str:
+    url = f"{owid_env.admin_site}/grapher/{quote(catalog_path, safe='')}"
+    if dimensions:
+        url = f"{url}?{urlencode(dimensions)}"
+    return url
+
+
+def resolve_mdim(session: Session, catalog_path: str, owid_env: OWIDEnv | None = None) -> MdimReview:
+    """Resolve every reviewable field of an MDim from its enriched DB config."""
+    owid_env = owid_env or OWID_ENV
+    mdim = gm.MultiDimDataPage.load_mdim(session, catalogPath=catalog_path)
+    if mdim is None:
+        raise ValueError(f"MDim not found in multi_dim_data_pages: {catalog_path}")
+    config = mdim.config
+    page_checksum = mdim.configMd5
+
+    review = MdimReview(
+        target_path=catalog_path,
+        slug=mdim.slug,
+        title=(config.get("title") or {}).get("title"),
+        title_variant=(config.get("title") or {}).get("titleVariant"),
+        page_checksum=page_checksum,
+    )
+
+    def page_field(field_path: str, value: str | None, provenance: Provenance = "override") -> ReviewableField:
+        return ReviewableField(
+            target_type="mdim",
+            target_path=catalog_path,
+            view_id=None,
+            field_path=field_path,
+            label=FIELD_LABELS.get(field_path, field_path),
+            provenance=provenance,
+            current_value=value,
+            edit_hint=MDIM_CONFIG_HINT,
+            page_checksum=page_checksum,
+            preview_url=_mdim_preview_url(owid_env, catalog_path),
+        )
+
+    # Page-level title fields.
+    review.page_fields.append(page_field("title.title", review.title))
+    review.page_fields.append(
+        page_field("title.title_variant", review.title_variant, "override" if review.title_variant else "missing")
+    )
+
+    # Dropdown labels: dimension names and choice names/descriptions.
+    for dim in config.get("dimensions") or []:
+        dim_info = DimensionInfo(slug=dim["slug"], name=dim.get("name") or dim["slug"])
+        review.page_fields.append(page_field(f"dimensions.{dim_info.slug}.name", dim.get("name")))
+        for choice in dim.get("choices") or []:
+            dim_info.choices.append(
+                DimensionChoice(
+                    slug=choice["slug"],
+                    name=choice.get("name") or choice["slug"],
+                    description=choice.get("description"),
+                    group=choice.get("group"),
+                )
+            )
+            base = f"dimensions.{dim_info.slug}.choices.{choice['slug']}"
+            review.page_fields.append(page_field(f"{base}.name", choice.get("name")))
+            review.page_fields.append(
+                page_field(
+                    f"{base}.description",
+                    choice.get("description"),
+                    "override" if choice.get("description") is not None else "missing",
+                )
+            )
+        review.dimensions.append(dim_info)
+
+    for field in review.page_fields:
+        if field.field_path.startswith("dimensions."):
+            field.label = _dropdown_label(review, field.field_path)
+
+    # Views. First pass: collect inheritance sources so we can bulk-load them.
+    views = config.get("views") or []
+    paths_needed = []
+    ids_needed = []
+    for view in views:
+        path, var_id = _primary_indicator(view)
+        if path:
+            paths_needed.append(path)
+        elif var_id:
+            ids_needed.append(var_id)
+    metas = load_indicator_metas(session, catalog_paths=paths_needed, variable_ids=ids_needed)
+    metas_by_id = {meta.variable_id: meta for meta in metas.values()}
+
+    for view in views:
+        dims = view.get("dimensions") or {}
+        view_id = dimensions_to_view_id(dims)
+        path, var_id = _primary_indicator(view)
+        meta = metas.get(path) if path else None
+        if meta is None and var_id is not None:
+            meta = metas_by_id.get(var_id)
+        if meta is None:
+            log.warning("metadata_review.unresolved_indicator", mdim=catalog_path, view=view_id, path=path, id=var_id)
+
+        view_review = ViewReview(
+            view_id=view_id,
+            dimensions=dims,
+            indicator_path=meta.catalog_path if meta else path,
+        )
+        overrides = {"config": view.get("config") or {}, "metadata": view.get("metadata") or {}}
+        for field_path, (section, key) in VIEW_FAUST_FIELDS:
+            override_value = overrides[section].get(key)
+            inherited_value = meta.inherited(VIEW_TO_INDICATOR_FIELD[field_path]) if meta else None
+            provenance, value = resolve_field(override_value, inherited_value)
+            view_review.fields.append(
+                ReviewableField(
+                    target_type="mdim",
+                    target_path=catalog_path,
+                    view_id=view_id,
+                    field_path=field_path,
+                    label=FIELD_LABELS[field_path],
+                    provenance=provenance,
+                    current_value=value,
+                    inherited_value=inherited_value,
+                    inherited_from=view_review.indicator_path,
+                    page_checksum=page_checksum,
+                    edit_hint=_edit_hint(provenance, view_review.indicator_path),
+                    preview_url=_mdim_preview_url(owid_env, catalog_path, dims),
+                )
+            )
+        review.views.append(view_review)
+
+    return review
+
+
+def _dropdown_label(review: MdimReview, field_path: str) -> str:
+    """Human label for a dropdown-label field, e.g. 'Metric ▸ Total number — name'."""
+    parts = field_path.split(".")
+    dim = next((d for d in review.dimensions if d.slug == parts[1]), None)
+    dim_name = dim.name if dim else parts[1]
+    if len(parts) == 3:  # dimensions.<dim>.name
+        return f"Dropdown “{dim_name}” — name"
+    choice_slug = parts[3]
+    choice_name = dim.choice_name(choice_slug) if dim else choice_slug
+    what = "name" if parts[4] == "name" else "description"
+    return f"Dropdown “{dim_name}” ▸ “{choice_name}” — {what}"
+
+
+# ---------------------------------------------------------------------------
+# Indicator / dataset resolution (data pages)
+# ---------------------------------------------------------------------------
+
+
+def resolve_indicator_fields(meta: IndicatorMeta, owid_env: OWIDEnv | None = None) -> list[ReviewableField]:
+    """Resolve the five indicator-level fields (inherited/missing only — no views here)."""
+    owid_env = owid_env or OWID_ENV
+    fields = []
+    for field_path in INDICATOR_FIELDS:
+        inherited_value = meta.inherited(field_path)
+        provenance, value = resolve_field(None, inherited_value)
+        fields.append(
+            ReviewableField(
+                target_type="indicator",
+                target_path=meta.catalog_path,
+                view_id=None,
+                field_path=field_path,
+                label=FIELD_LABELS[field_path],
+                provenance=provenance,
+                current_value=value,
+                inherited_value=inherited_value,
+                inherited_from=meta.catalog_path,
+                page_checksum=meta.metadata_checksum,
+                edit_hint=_edit_hint(provenance, meta.catalog_path),
+                preview_url=owid_env.indicator_admin_site(meta.variable_id),
+            )
+        )
+    return fields
+
+
+def resolve_dataset(session: Session, dataset_catalog_path: str, owid_env: OWIDEnv | None = None) -> DatasetReview:
+    """Resolve all indicators of a grapher dataset (datasets.catalogPath = 'ns/version/dataset')."""
+    owid_env = owid_env or OWID_ENV
+    dataset = session.scalars(select(gm.Dataset).where(gm.Dataset.catalogPath == dataset_catalog_path)).one_or_none()
+    if dataset is None:
+        raise ValueError(f"Dataset not found in grapher DB: {dataset_catalog_path}")
+
+    variable_ids = [
+        row for row in session.scalars(select(gm.Variable.id).where(gm.Variable.datasetId == dataset.id)).all()
+    ]
+    metas = load_indicator_metas(session, variable_ids=variable_ids)
+
+    review = DatasetReview(dataset_catalog_path=dataset_catalog_path, name=dataset.name)
+    for meta in sorted(metas.values(), key=lambda m: m.catalog_path):
+        review.indicators.append(
+            IndicatorReview(
+                catalog_path=meta.catalog_path,
+                variable_id=meta.variable_id,
+                name=meta.name,
+                metadata_checksum=meta.metadata_checksum,
+                fields=resolve_indicator_fields(meta, owid_env=owid_env),
+            )
+        )
+    return review
+
+
+# ---------------------------------------------------------------------------
+# Listings
+# ---------------------------------------------------------------------------
+
+
+def list_mdims(session: Session) -> list[dict[str, Any]]:
+    """All MDims with a catalogPath: [{catalog_path, slug, published, updated_at}]."""
+    rows = session.execute(
+        select(
+            gm.MultiDimDataPage.catalogPath,
+            gm.MultiDimDataPage.slug,
+            gm.MultiDimDataPage.published,
+            gm.MultiDimDataPage.updatedAt,
+        ).where(gm.MultiDimDataPage.catalogPath.is_not(None))
+    ).all()
+    return [
+        {"catalog_path": catalog_path, "slug": slug, "published": bool(published), "updated_at": updated_at}
+        for catalog_path, slug, published, updated_at in sorted(rows, key=lambda r: r[3], reverse=True)
+    ]
+
+
+def list_datasets(session: Session) -> list[dict[str, Any]]:
+    """All non-archived grapher datasets with a catalogPath: [{catalog_path, name, updated_at}]."""
+    rows = session.execute(
+        select(gm.Dataset.catalogPath, gm.Dataset.name, gm.Dataset.updatedAt)
+        .where(gm.Dataset.catalogPath.is_not(None))
+        .where(gm.Dataset.isArchived == 0)
+        .order_by(gm.Dataset.updatedAt.desc())
+    ).all()
+    return [
+        {"catalog_path": catalog_path, "name": name, "updated_at": updated_at}
+        for catalog_path, name, updated_at in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Suggestions: source-keyed lookup, shared views, staleness
+# ---------------------------------------------------------------------------
+
+
+def suggestions_by_source_key(
+    suggestions: list[gm.MetadataReviewSuggestion],
+) -> dict[tuple[str, str, str | None, str], list[gm.MetadataReviewSuggestion]]:
+    """Group persisted suggestions by their source key (targetType, targetPath, viewId, fieldPath)."""
+    grouped: dict[tuple[str, str, str | None, str], list[gm.MetadataReviewSuggestion]] = {}
+    for suggestion in suggestions:
+        key = (suggestion.targetType, suggestion.targetPath, suggestion.viewId, suggestion.fieldPath)
+        grouped.setdefault(key, []).append(suggestion)
+    return grouped
+
+
+def shared_view_ids(review: MdimReview, field: ReviewableField) -> list[str]:
+    """View ids (other than the field's own) rendering the same parameter.
+
+    Non-overridden fields share their source indicator; overridden fields share by
+    identical resolved value (shared `common_views` / generated blocks arrive in the
+    DB config as per-view copies, so value equality is the detectable signal).
+    """
+    if field.view_id is None:
+        return []
+    shared = []
+    for view in review.views:
+        if view.view_id == field.view_id:
+            continue
+        for other in view.fields:
+            if other.field_path != field.field_path:
+                continue
+            if field.provenance != "override":
+                if other.provenance != "override" and other.inherited_from == field.inherited_from:
+                    shared.append(view.view_id)
+            elif other.provenance == "override" and other.current_value == field.current_value:
+                shared.append(view.view_id)
+    return shared
+
+
+@dataclass
+class Staleness:
+    """Result of comparing a persisted suggestion against the currently resolved field."""
+
+    target_gone: bool = False
+    field_changed: bool = False
+    page_changed: bool = False
+    current_value: str | None = None
+    current_provenance: str | None = None
+
+    @property
+    def is_stale(self) -> bool:
+        return self.target_gone or self.field_changed
+
+
+def check_staleness(
+    suggestion: gm.MetadataReviewSuggestion,
+    current_fields_by_key: dict[tuple[str, str, str | None, str], ReviewableField],
+) -> Staleness:
+    """Field-level staleness: the suggestion's snapshot vs the live resolved field.
+
+    `current_fields_by_key` maps `ReviewableField.source_key()` of every field on the
+    page being rendered. A suggestion whose key is absent points at a view/indicator
+    that no longer exists (`target_gone`).
+    """
+    key = (suggestion.targetType, suggestion.targetPath, suggestion.viewId, suggestion.fieldPath)
+    field = current_fields_by_key.get(key)
+    if field is None:
+        return Staleness(target_gone=True)
+    return Staleness(
+        field_changed=(field.provenance != suggestion.provenance)
+        or (_norm(field.current_value) != _norm(suggestion.currentValue)),
+        page_changed=suggestion.pageChecksum is not None and suggestion.pageChecksum != field.page_checksum,
+        current_value=field.current_value,
+        current_provenance=field.provenance,
+    )
+
+
+def _norm(value: Any) -> str | None:
+    """Normalize a field value for staleness comparison (values are stored as text)."""
+    if value is None:
+        return None
+    return str(value).strip()

--- a/apps/metadata_review/resolution.py
+++ b/apps/metadata_review/resolution.py
@@ -636,6 +636,47 @@ def threads_for_field(
     return sorted(seen.values(), key=lambda s: s.createdAt or datetime.min)
 
 
+def combined_display_value(
+    field: ReviewableField,
+    open_threads: list[gm.MetadataReviewSuggestion],
+    review: MdimReview | None = None,
+) -> tuple[str | None, dict[int, bool]]:
+    """The field's text with ALL applicable open proposals applied (Google-Docs style).
+
+    Own threads (base text matches this field) apply directly — newest wins when
+    legacy duplicates exist; borrowed threads then layer on top: bullet lists via
+    verbatim-bullet transfer, other fields via dimension-word transfer (only when
+    no own proposal supplied the text). Returns (combined text or None when no
+    proposal applies, {thread id: applied on this field?}).
+    """
+    is_bullets = field.field_path in DESCRIPTION_KEY_FIELDS
+    current = str(field.current_value) if field.current_value is not None else ""
+    own = [
+        s for s in open_threads if s.suggestedValue is not None and str(s.currentValue or "").strip() == current.strip()
+    ]
+    borrowed = [s for s in open_threads if s.suggestedValue is not None and s not in own]
+    applied: dict[int, bool] = {s.id: False for s in open_threads}
+
+    display: str | None = None
+    if own:
+        canonical = max(own, key=lambda s: s.createdAt or datetime.min)
+        display = canonical.suggestedValue
+        applied[canonical.id] = True
+
+    for thread in sorted(borrowed, key=lambda s: s.createdAt or datetime.min):
+        if is_bullets:
+            transfer = apply_bullet_edits(thread.currentValue, thread.suggestedValue, display or current)
+            if transfer is not None:
+                display = transfer[0]
+                applied[thread.id] = True
+        elif display is None and review is not None:
+            transferred = transfer_proposal(review, thread, field)
+            if transferred is not None:
+                display = transferred
+                applied[thread.id] = True
+    return display, applied
+
+
 @dataclass
 class Staleness:
     """Result of comparing a persisted suggestion against the currently resolved field."""

--- a/apps/metadata_review/resolution.py
+++ b/apps/metadata_review/resolution.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm import Session
 import etl.grapher.model as gm
 from apps.metadata_review.diffs import apply_bullet_edits
 from apps.metadata_review.targets import (
+    DESCRIPTION_KEY_FIELDS,
     FIELD_LABELS,
     VIEW_TO_INDICATOR_FIELD,
     DatasetReview,
@@ -561,7 +562,8 @@ def shared_view_ids(review: MdimReview, field: ReviewableField) -> list[str]:
         return []
     value = _norm(field.current_value)
     own_view = next((v for v in review.views if v.view_id == field.view_id), None)
-    pattern = _field_pattern(review, own_view, field) if own_view is not None else None
+    use_pattern = own_view is not None and field.field_path not in DESCRIPTION_KEY_FIELDS
+    pattern = _field_pattern(review, own_view, field) if use_pattern else None
     shared = []
     for view in review.views:
         if view.view_id == field.view_id:
@@ -594,7 +596,8 @@ def threads_for_field(
     if review is not None and field.view_id is not None and field.current_value is not None:
         value = _norm(field.current_value)
         own_view = next((v for v in review.views if v.view_id == field.view_id), None)
-        pattern = _field_pattern(review, own_view, field) if own_view is not None else None
+        use_pattern = own_view is not None and field.field_path not in DESCRIPTION_KEY_FIELDS
+        pattern = _field_pattern(review, own_view, field) if use_pattern else None
         for view in review.views:
             for other in view.fields:
                 if other.field_path != field.field_path:
@@ -613,12 +616,18 @@ def threads_for_field(
     # when they target the equivalent field and either their text snapshot matches
     # ours, or — for bullet lists — the bullets they edit exist in our list too
     # (lists share individual bullets via YAML anchors while differing as a whole).
+    # NOTE: indicators backing OTHER VIEWS of this same page are excluded — sibling
+    # views (e.g. before vs after tax) are governed by the exact-text/pattern rules
+    # above; bullet-matching across them would mix dimension-specific content.
     if field.current_value is not None:
         value = _norm(field.current_value)
+        own_page_indicators = set(review.indicator_paths) if review is not None else set()
         indicator_field = VIEW_TO_INDICATOR_FIELD.get(field.field_path, field.field_path)
         is_bullets = indicator_field == "description_key"
         for key, threads in suggestions_by_key.items():
             if key in keys or key[0] != "indicator" or key[3] != indicator_field:
+                continue
+            if key[1] in own_page_indicators:
                 continue
             for suggestion in threads:
                 if _norm(suggestion.currentValue) == value or (

--- a/apps/metadata_review/resolution.py
+++ b/apps/metadata_review/resolution.py
@@ -18,6 +18,7 @@ Inheritance rules ported from the faust-metadata-audit skill
 
 import re
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 from urllib.parse import quote, urlencode
 
@@ -611,23 +612,18 @@ def threads_for_field(
         for suggestion in suggestions_by_key.get(key, []):
             seen[suggestion.id] = suggestion
 
-    # Cross-page sharing: threads keyed to indicators NOT used by this page (e.g.
-    # filed on another MDim built from the same garden metadata) still belong here
-    # when they target the equivalent field and either their text snapshot matches
-    # ours, or — for bullet lists — the bullets they edit exist in our list too
-    # (lists share individual bullets via YAML anchors while differing as a whole).
-    # NOTE: indicators backing OTHER VIEWS of this same page are excluded — sibling
-    # views (e.g. before vs after tax) are governed by the exact-text/pattern rules
-    # above; bullet-matching across them would mix dimension-specific content.
+    # Cross-source sharing: threads keyed to OTHER indicators (sibling views of this
+    # MDim, or pages built from the same garden metadata) still belong here when they
+    # target the equivalent field and either their text snapshot matches ours, or —
+    # for bullet lists — the bullets they edit exist verbatim in our list too (lists
+    # share individual bullets via YAML anchors while differing as a whole; edits to
+    # variant-specific bullets don't match and stay on their own views).
     if field.current_value is not None:
         value = _norm(field.current_value)
-        own_page_indicators = set(review.indicator_paths) if review is not None else set()
         indicator_field = VIEW_TO_INDICATOR_FIELD.get(field.field_path, field.field_path)
         is_bullets = indicator_field == "description_key"
         for key, threads in suggestions_by_key.items():
             if key in keys or key[0] != "indicator" or key[3] != indicator_field:
-                continue
-            if key[1] in own_page_indicators:
                 continue
             for suggestion in threads:
                 if _norm(suggestion.currentValue) == value or (
@@ -637,7 +633,7 @@ def threads_for_field(
                     is not None
                 ):
                     seen.setdefault(suggestion.id, suggestion)
-    return sorted(seen.values(), key=lambda s: s.createdAt)
+    return sorted(seen.values(), key=lambda s: s.createdAt or datetime.min)
 
 
 @dataclass

--- a/apps/metadata_review/targets.py
+++ b/apps/metadata_review/targets.py
@@ -30,6 +30,10 @@ FIELD_LABELS = {
     "description_key": "Key information",
 }
 
+# Bullet-list fields: tracked/diffed bullet-by-bullet, shared by bullet transfer
+# (never by dimension-word pattern — word substitution is meaningless for lists).
+DESCRIPTION_KEY_FIELDS = {"metadata.description_key", "description_key"}
+
 # View-level fieldPath -> the indicator-level fieldPath it inherits from.
 VIEW_TO_INDICATOR_FIELD = {
     "config.title": "grapher_config.title",

--- a/apps/metadata_review/targets.py
+++ b/apps/metadata_review/targets.py
@@ -1,0 +1,181 @@
+"""Dataclasses describing what can be reviewed in the Metadata Review tool.
+
+A `ReviewableField` is one commentable unit of user-facing text (a chart title,
+a dropdown label, a description_short, ...) with its provenance resolved, so a
+reviewer sees where the text comes from and the implementer knows where to edit.
+"""
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+Provenance = Literal["override", "inherited", "missing"]
+TargetType = Literal["mdim", "indicator"]
+
+# Canonical fieldPath -> human label shown in the UI.
+FIELD_LABELS = {
+    # MDim page level.
+    "title.title": "Title",
+    "title.title_variant": "Title variant",
+    # MDim view level.
+    "config.title": "Title",
+    "config.subtitle": "Subtitle",
+    "config.note": "Footnote",
+    "metadata.description_short": "Description (short)",
+    "metadata.description_key": "Key information",
+    # Indicator level (data pages).
+    "grapher_config.title": "Title",
+    "grapher_config.subtitle": "Subtitle",
+    "grapher_config.note": "Footnote",
+    "description_short": "Description (short)",
+    "description_key": "Key information",
+}
+
+# View-level fieldPath -> the indicator-level fieldPath it inherits from.
+VIEW_TO_INDICATOR_FIELD = {
+    "config.title": "grapher_config.title",
+    "config.subtitle": "grapher_config.subtitle",
+    "config.note": "grapher_config.note",
+    "metadata.description_short": "description_short",
+    "metadata.description_key": "description_key",
+}
+
+
+@dataclass
+class ReviewableField:
+    """One commentable field with resolved provenance."""
+
+    target_type: TargetType
+    # MDim catalogPath (as stored in multi_dim_data_pages) or variable catalogPath.
+    target_path: str
+    # Normalized dimensionsToViewId string; None for page-level and indicator fields.
+    view_id: str | None
+    field_path: str
+    label: str
+    provenance: Provenance
+    # The value Grapher renders (override if set, else inherited; None when missing).
+    current_value: str | None
+    # What inheritance would give — shown alongside overridden values.
+    inherited_value: str | None = None
+    # Indicator catalogPath the field inherits from (primary y indicator for views).
+    inherited_from: str | None = None
+    # MDim configMd5 / variables.metadataChecksum at resolution time.
+    page_checksum: str | None = None
+    # Coarse "where to edit" text for the UI (the export CLI traces the exact location).
+    edit_hint: str = ""
+    preview_url: str | None = None
+
+    def source_key(self) -> tuple[str, str, str | None, str]:
+        """The persistence key a suggestion on this field uses.
+
+        Suggestions attach to the *underlying parameter*, not the page where they
+        were filed: view-level fields that are not overridden (inherited or missing
+        with a known source indicator) key to the source indicator, so the same
+        thread surfaces on every view and data page rendering that text.
+        """
+        if (
+            self.target_type == "mdim"
+            and self.view_id is not None
+            and self.provenance != "override"
+            and self.inherited_from is not None
+            and self.field_path in VIEW_TO_INDICATOR_FIELD
+        ):
+            return ("indicator", self.inherited_from, None, VIEW_TO_INDICATOR_FIELD[self.field_path])
+        return (self.target_type, self.target_path, self.view_id, self.field_path)
+
+
+@dataclass
+class DimensionChoice:
+    slug: str
+    name: str
+    description: str | None = None
+    group: str | None = None
+
+
+@dataclass
+class DimensionInfo:
+    slug: str
+    name: str
+    choices: list[DimensionChoice] = field(default_factory=list)
+
+    def choice_name(self, choice_slug: str) -> str:
+        for choice in self.choices:
+            if choice.slug == choice_slug:
+                return choice.name
+        return choice_slug
+
+
+@dataclass
+class ViewReview:
+    """One MDim view with its resolved FAUST fields."""
+
+    view_id: str
+    # Dimension selection, e.g. {"indicator": "deaths", "estimate": "best"}.
+    dimensions: dict[str, str]
+    # Primary y indicator catalogPath (inheritance source), if resolvable.
+    indicator_path: str | None
+    fields: list[ReviewableField] = field(default_factory=list)
+
+
+@dataclass
+class MdimReview:
+    """A fully resolved MDim page: page-level fields, dropdown labels, and views."""
+
+    target_path: str
+    slug: str | None
+    title: str | None
+    title_variant: str | None
+    page_checksum: str | None
+    dimensions: list[DimensionInfo] = field(default_factory=list)
+    # title/title_variant + dimension/choice label fields.
+    page_fields: list[ReviewableField] = field(default_factory=list)
+    views: list[ViewReview] = field(default_factory=list)
+
+    @property
+    def all_fields(self) -> list[ReviewableField]:
+        return self.page_fields + [f for view in self.views for f in view.fields]
+
+    @property
+    def indicator_paths(self) -> list[str]:
+        """All source indicator catalogPaths used by views (deduplicated, ordered)."""
+        seen: dict[str, None] = {}
+        for view in self.views:
+            if view.indicator_path:
+                seen.setdefault(view.indicator_path, None)
+        return list(seen)
+
+    def human_dimensions(self, dims: dict[str, str]) -> dict[str, str]:
+        """Map a view's {dim_slug: choice_slug} to {dim name: choice name}."""
+        by_slug = {d.slug: d for d in self.dimensions}
+        out = {}
+        for dim_slug, choice_slug in dims.items():
+            dim = by_slug.get(dim_slug)
+            if dim is None:
+                out[dim_slug] = choice_slug
+            else:
+                out[dim.name] = dim.choice_name(choice_slug)
+        return out
+
+
+@dataclass
+class IndicatorReview:
+    """One indicator (data page) with its resolved fields — inherited/missing only."""
+
+    catalog_path: str
+    variable_id: int | None
+    name: str | None
+    metadata_checksum: str | None
+    fields: list[ReviewableField] = field(default_factory=list)
+
+
+@dataclass
+class DatasetReview:
+    """A grapher dataset: one IndicatorReview per variable."""
+
+    # datasets.catalogPath form: "namespace/version/dataset" (no channel prefix).
+    dataset_catalog_path: str
+    name: str | None
+    indicators: list[IndicatorReview] = field(default_factory=list)
+
+    @property
+    def indicator_paths(self) -> list[str]:
+        return [ind.catalog_path for ind in self.indicators]

--- a/apps/metadata_review/trace.py
+++ b/apps/metadata_review/trace.py
@@ -1,0 +1,589 @@
+"""Field-build tracing: map a rendered metadata field back to its editable source.
+
+The value the DB serves is the *output* of a three-phase build:
+
+- Phase A — dynamic-yaml resolves ``{definitions.xxx}`` references and YAML anchors
+  at load time (plus ``shared.meta.yml`` merging).
+- Phase B — precedence merge: ``definitions.common`` < ``tables.<t>.common`` <
+  ``tables.<t>.variables.<v>`` (``presentation``/``grapher_config`` deep-merged).
+- Phase C — Jinja (``<% %>`` / ``<< >>`` delimiters) rendered per expanded column
+  with a dimensions-only context (``etl/grapher/helpers.py::_metadata_for_dimensions``).
+
+MDim configs use anchors + ``{definitions.xxx}`` and a dimension-matched
+``definitions.common_views`` merge, but no Jinja; views may also be generated
+programmatically in the step ``.py`` (``str.format`` params via ``fill_placeholders``).
+
+The tracer replays these builds so the export can say exactly what to edit, and
+verifies itself by re-rendering the traced template and comparing against the
+value the suggestion was filed on (``render_verified``).
+"""
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import structlog
+from owid.catalog.core import jinja
+from owid.catalog.core.meta import description_key_to_string
+from owid.catalog.core.utils import dynamic_yaml_load, dynamic_yaml_to_dict, underscore
+from owid.catalog.core.yaml_metadata import merge_with_shared_meta
+from sqlalchemy.orm import Session
+
+import etl.grapher.model as gm
+from apps.metadata_review.resolution import dimensions_to_view_id
+from etl import paths
+from etl.dag_helpers import load_dag
+from etl.files import ruamel_load
+
+log = structlog.get_logger()
+
+# Indicator fieldPath -> key path inside a variable metadata block.
+FIELD_KEY_PATHS = {
+    "grapher_config.title": ["presentation", "grapher_config", "title"],
+    "grapher_config.subtitle": ["presentation", "grapher_config", "subtitle"],
+    "grapher_config.note": ["presentation", "grapher_config", "note"],
+    "description_short": ["description_short"],
+    "description_key": ["description_key"],
+}
+
+
+@dataclass
+class EditCandidate:
+    """One place where the suggested change can be applied."""
+
+    # Repo-relative file path.
+    file: str
+    # Dotted key path inside the file (None when the target is a .py).
+    yaml_path: str | None
+    # literal | jinja | common-block | mdim-page | mdim-view | mdim-common-views |
+    # grapher-step-override | programmatic
+    kind: str
+    # Raw, unrendered template text (Jinja / {definitions.*} / {params} intact).
+    template: str | None = None
+    # Jinja dimension context used to render this indicator's value.
+    render_context: dict[str, Any] | None = None
+    # The YAML block that supplies the value (Phase-B precedence winner).
+    supplied_by: str | None = None
+    # True when re-rendering `template` reproduces the suggestion's current value;
+    # None when the replay could not run.
+    render_verified: bool | None = None
+    exact_key_found: bool = True
+    generated: bool = False
+    # Other variables / views affected by editing this source.
+    shared_with: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class FieldTrace:
+    target_type: str
+    target_path: str
+    view_id: str | None
+    field_path: str
+    # Ordered: preferred edit location first.
+    edits: list[EditCandidate] = field(default_factory=list)
+
+    @property
+    def preferred(self) -> EditCandidate | None:
+        return self.edits[0] if self.edits else None
+
+
+def _norm(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value).strip()
+
+
+def _dig(d: Any, keys: list[str]) -> Any:
+    for key in keys:
+        if not isinstance(d, dict):
+            return None
+        d = d.get(key)
+        if d is None:
+            return None
+    return d
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(paths.BASE_DIR))
+    except ValueError:
+        return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Indicator fields (garden / grapher .meta.yml)
+# ---------------------------------------------------------------------------
+
+
+def trace_indicator_field(
+    session: Session,
+    catalog_path: str,
+    field_path: str,
+    current_value: str | None,
+) -> FieldTrace:
+    """Trace an indicator-level field back to the .meta.yml (or .py) that builds it."""
+    trace = FieldTrace(target_type="indicator", target_path=catalog_path, view_id=None, field_path=field_path)
+    assert field_path in FIELD_KEY_PATHS, f"Unknown indicator field path: {field_path}"
+
+    # 1. The stored back-trace key: base variable name + Jinja dimension context.
+    variable = gm.Variable.from_catalog_path(session, catalog_path)
+    path_part, column = catalog_path.split("#", 1)
+    channel, namespace, version, dataset, table_name = path_part.split("/")
+    assert channel == "grapher", f"Expected a grapher catalog path, got: {catalog_path}"
+    dims = variable.dimensions or {}
+    original_short_name = dims.get("originalShortName") or column
+    dim_dict = {f["name"]: f["value"] for f in dims.get("filters", [])}
+
+    # 2. Candidate .meta.yml files: grapher-step override first (it wins when present),
+    #    then the garden step(s) resolved through the DAG.
+    grapher_meta = paths.STEPS_GRAPHER_DIR / namespace / version / f"{dataset}.meta.yml"
+    garden_metas = _garden_meta_files(namespace, version, dataset)
+
+    for meta_path, is_grapher_step in [(grapher_meta, True)] + [(p, False) for p in garden_metas]:
+        if not meta_path.exists():
+            continue
+        candidate = _trace_in_meta_yaml(
+            meta_path,
+            table_name=table_name,
+            var_name=original_short_name,
+            field_path=field_path,
+            dim_dict=dim_dict,
+            current_value=current_value,
+        )
+        if candidate is None:
+            continue
+        if is_grapher_step:
+            candidate.kind = "grapher-step-override"
+            candidate.notes.append(
+                "This grapher-step .meta.yml layers on top of the garden metadata — "
+                "edit here, or remove the override so the garden value applies."
+            )
+        trace.edits.append(candidate)
+
+    if not trace.edits:
+        # Not defined in any YAML: the field is set programmatically in the step code.
+        garden_py = [p.parent / (p.name.removesuffix(".meta.yml") + ".py") for p in garden_metas] or [
+            paths.STEPS_GARDEN_DIR / namespace / version / f"{dataset}.py"
+        ]
+        for py in garden_py:
+            trace.edits.append(
+                EditCandidate(
+                    file=_rel(py),
+                    yaml_path=None,
+                    kind="programmatic",
+                    render_context=dim_dict or None,
+                    exact_key_found=False,
+                    generated=True,
+                    notes=[
+                        f"`{field_path}` is not defined in any .meta.yml for `{original_short_name}` — "
+                        "it is most likely set programmatically in the step code (or the .meta.yml "
+                        "could not be located). Search the step for the field assignment."
+                    ],
+                )
+            )
+    return trace
+
+
+def _garden_meta_files(namespace: str, version: str, dataset: str) -> list[Path]:
+    """Garden .meta.yml candidates for a grapher dataset, resolved through the DAG."""
+    dag = load_dag()
+    deps = None
+    for prefix in ("data://", "data-private://"):
+        deps = dag.get(f"{prefix}grapher/{namespace}/{version}/{dataset}")
+        if deps:
+            break
+    candidates = []
+    for dep in sorted(deps or []):
+        match = re.match(r"data(?:-private)?://garden/([^/]+)/([^/]+)/(.+)", dep)
+        if match:
+            garden_ns, garden_version, garden_short = match.groups()
+            candidates.append(paths.STEPS_GARDEN_DIR / garden_ns / garden_version / f"{garden_short}.meta.yml")
+    # Prefer the garden step matching the dataset short name.
+    candidates.sort(key=lambda p: (p.stem.removesuffix(".meta") != dataset, str(p)))
+    if not candidates:
+        # No DAG entry (e.g. archived) — fall back to the conventional location.
+        candidates = [paths.STEPS_GARDEN_DIR / namespace / version / f"{dataset}.meta.yml"]
+    return candidates
+
+
+def _trace_in_meta_yaml(
+    meta_path: Path,
+    table_name: str,
+    var_name: str,
+    field_path: str,
+    dim_dict: dict[str, Any],
+    current_value: str | None,
+) -> EditCandidate | None:
+    """Locate `field_path` for one variable inside one .meta.yml; None when absent."""
+    keys = FIELD_KEY_PATHS[field_path]
+    try:
+        annot = dynamic_yaml_to_dict(dynamic_yaml_load(merge_with_shared_meta(meta_path)))
+    except Exception as e:
+        log.warning("metadata_review.trace.yaml_load_failed", path=str(meta_path), error=str(e))
+        return None
+
+    table_annot = (annot.get("tables") or {}).get(table_name) or {}
+    variables = table_annot.get("variables") or {}
+    # Phase-B precedence, highest first: the first block defining the leaf wins.
+    blocks = [
+        (f"tables.{table_name}.variables.{var_name}", variables.get(var_name) or {}),
+        (f"tables.{table_name}.common", table_annot.get("common") or {}),
+        ("definitions.common", (annot.get("definitions") or {}).get("common") or {}),
+    ]
+    supplied_by, template = None, None
+    for block_name, block in blocks:
+        value = _dig(block, keys)
+        if value is not None:
+            supplied_by, template = block_name, value
+            break
+    if supplied_by is None:
+        return None
+
+    template_text = template if isinstance(template, str) else str(template)
+    is_jinja = "<%" in template_text or "<<" in template_text
+    kind = "jinja" if is_jinja else ("common-block" if supplied_by.endswith("common") else "literal")
+
+    candidate = EditCandidate(
+        file=_rel(meta_path),
+        yaml_path=f"{supplied_by}.{'.'.join(keys)}",
+        kind=kind,
+        template=template_text,
+        render_context=dim_dict or None,
+        supplied_by=supplied_by,
+    )
+
+    if is_jinja:
+        candidate.notes.append(
+            "Jinja template rendered with the dimension context above. When changing wording, "
+            "splice dimension words into the existing sentence rather than duplicating "
+            "`<% if %>` branches."
+        )
+
+    _annotate_references(candidate, meta_path, table_name, var_name, keys, template)
+    _collect_shared_with(candidate, supplied_by, variables, var_name, keys, template)
+    _verify_render(candidate, blocks, keys, field_path, dim_dict, var_name, current_value)
+    return candidate
+
+
+def _annotate_references(
+    candidate: EditCandidate,
+    meta_path: Path,
+    table_name: str,
+    var_name: str,
+    keys: list[str],
+    resolved_template: Any,
+) -> None:
+    """Detect `{definitions.*}` references / anchors / shared.meta.yml indirection.
+
+    Compares the raw file (ruamel: anchors resolved by YAML, `{definitions.*}` strings
+    intact) against the dynamic-yaml value at the same key path.
+    """
+    try:
+        with open(meta_path) as f:
+            raw = ruamel_load(f)
+    except Exception:
+        return
+    block_keys = candidate.supplied_by.split(".") if candidate.supplied_by else []
+    raw_value = _dig(raw, block_keys + keys)
+    if raw_value is None:
+        # Present after merging but absent from the raw file: comes from shared.meta.yml.
+        shared = meta_path.parent / "shared.meta.yml"
+        if shared.exists():
+            candidate.notes.append(f"Value is defined in `{_rel(shared)}` (merged via shared definitions).")
+            candidate.file = _rel(shared)
+        return
+    raw_text = raw_value if isinstance(raw_value, str) else str(raw_value)
+    refs = re.findall(r"\{definitions\.([a-zA-Z0-9_.]+)\}", raw_text)
+    if refs:
+        candidate.template = raw_text
+        candidate.notes.append(
+            f"The raw value references {', '.join(f'`definitions.{r}`' for r in sorted(set(refs)))} — "
+            "editing those definitions affects every field referencing them."
+        )
+    # A value identical to a `definitions:` entry usually means a YAML anchor.
+    definitions = raw.get("definitions") or {}
+    for def_key, def_value in definitions.items():
+        if def_key == "common":
+            continue
+        if def_value == raw_value or (isinstance(def_value, dict) and _dig(def_value, keys) == raw_value):
+            candidate.notes.append(
+                f"Value matches `definitions.{def_key}` — likely shared via a YAML anchor; "
+                "editing the anchor affects every referent."
+            )
+            break
+
+
+def _collect_shared_with(
+    candidate: EditCandidate,
+    supplied_by: str,
+    variables: dict[str, Any],
+    var_name: str,
+    keys: list[str],
+    template: Any,
+) -> None:
+    """Enumerate the other variables affected by editing this source."""
+    if supplied_by.endswith("common"):
+        # A common block applies to every variable that doesn't override the leaf itself.
+        candidate.shared_with = sorted(
+            name for name, block in variables.items() if name != var_name and _dig(block or {}, keys) is None
+        )
+        if candidate.shared_with:
+            candidate.notes.append("This common block also supplies the field for the variables in shared_with.")
+    else:
+        candidate.shared_with = sorted(
+            name for name, block in variables.items() if name != var_name and _dig(block or {}, keys) == template
+        )
+
+
+def _verify_render(
+    candidate: EditCandidate,
+    blocks: list[tuple[str, dict[str, Any]]],
+    keys: list[str],
+    field_path: str,
+    dim_dict: dict[str, Any],
+    var_name: str,
+    current_value: str | None,
+) -> None:
+    """Replay Phase C (Jinja with the dimension context) on the traced template
+    and compare with the live value.
+
+    Renders only the traced field — a whole-VariableMeta render would fail on
+    *other* fields whose Jinja needs dimensions this indicator doesn't have.
+    """
+    if current_value is None:
+        return
+    try:
+        # The winning block's raw value (Jinja intact), pre-Phase-C.
+        template = None
+        for _, block in blocks:
+            template = _dig(block, keys)
+            if template is not None:
+                break
+        if isinstance(template, list):
+            items = [jinja._expand_jinja_text(str(item), dim_dict) for item in template]
+            value = description_key_to_string([str(item) for item in items if item])
+        else:
+            value = jinja._expand_jinja_text(str(template), dim_dict)
+        candidate.render_verified = _norm(value) == _norm(current_value)
+        if candidate.render_verified is False:
+            candidate.notes.append(
+                "Re-rendering the traced template did NOT reproduce the live value — the value may "
+                "have moved (e.g. edited since the suggestion) or the trace may be incomplete. "
+                "Double-check before editing."
+            )
+    except Exception as e:
+        candidate.render_verified = None
+        candidate.notes.append(f"Render replay could not run ({e}).")
+
+
+# ---------------------------------------------------------------------------
+# MDim fields (export step config .yml / .py)
+# ---------------------------------------------------------------------------
+
+
+def trace_mdim_field(
+    target_path: str,
+    view_id: str | None,
+    field_path: str,
+    current_value: str | None,
+) -> FieldTrace:
+    """Trace an MDim page-level or view-override field to the export step config."""
+    trace = FieldTrace(target_type="mdim", target_path=target_path, view_id=view_id, field_path=field_path)
+    namespace, version, short = target_path.split("#")[0].split("/")
+    step_dir = paths.STEP_DIR / "export" / "multidim" / namespace / version
+    step_py = step_dir / f"{short}.py"
+
+    config_path, ambiguity = _find_mdim_config(step_dir, short)
+    if config_path is None:
+        trace.edits.append(_generated_mdim_edit(step_py, field_path, [ambiguity] if ambiguity else []))
+        return trace
+
+    try:
+        config = dynamic_yaml_to_dict(dynamic_yaml_load(config_path))
+    except Exception as e:
+        trace.edits.append(_generated_mdim_edit(step_py, field_path, [f"Could not parse {_rel(config_path)}: {e}"]))
+        return trace
+
+    if view_id is None:
+        candidate = _trace_mdim_page_field(config, config_path, field_path)
+    else:
+        candidate = _trace_mdim_view_field(config, config_path, view_id, field_path)
+
+    if candidate is None:
+        notes = [
+            f"`{field_path}` was not found in `{_rel(config_path)}` — the view/label is generated "
+            "programmatically in the step code."
+        ]
+        notes.extend(_py_call_sites(step_py))
+        candidate = _generated_mdim_edit(step_py, field_path, notes)
+    else:
+        if ambiguity:
+            candidate.notes.append(ambiguity)
+        if current_value is not None and candidate.template is not None:
+            candidate.render_verified = _norm(candidate.template) == _norm(current_value)
+            if candidate.render_verified is False and re.search(r"\{[a-zA-Z0-9_.]+\}", candidate.template):
+                candidate.notes.append(
+                    "The raw value contains `{placeholder}` params filled by the step code "
+                    "(str.format, not Jinja) — the rendered value differs from the template."
+                )
+            elif candidate.render_verified is False:
+                candidate.notes.append(
+                    "The YAML value does not match the live value — the config may have changed "
+                    "since the suggestion, or the step code post-processes this field."
+                )
+    trace.edits.append(candidate)
+    return trace
+
+
+def _find_mdim_config(step_dir: Path, short: str) -> tuple[Path | None, str | None]:
+    exact = step_dir / f"{short}.config.yml"
+    if exact.exists():
+        return exact, None
+    matches = sorted(step_dir.glob(f"{short}*.yml"))
+    if len(matches) == 1:
+        return matches[0], None
+    if matches:
+        return matches[0], (
+            f"Several config files match `{short}*.yml` in `{_rel(step_dir)}`: "
+            f"{', '.join(m.name for m in matches)} — traced the first; verify."
+        )
+    return None, f"No config .yml matching `{short}*` found in `{_rel(step_dir)}`."
+
+
+def _generated_mdim_edit(step_py: Path, field_path: str, notes: list[str]) -> EditCandidate:
+    return EditCandidate(
+        file=_rel(step_py),
+        yaml_path=None,
+        kind="programmatic",
+        exact_key_found=False,
+        generated=True,
+        notes=notes or [f"`{field_path}` is set programmatically — inspect the step code."],
+    )
+
+
+def _py_call_sites(step_py: Path) -> list[str]:
+    """Line hints for the places a step .py typically sets view config/metadata."""
+    if not step_py.exists():
+        return [f"Step file `{_rel(step_py)}` not found."]
+    hints = []
+    markers = ("common_views", "edit_views", "group_views", "view_config", "view_metadata", "set_global_config")
+    for i, line in enumerate(step_py.read_text().splitlines(), start=1):
+        if any(marker in line for marker in markers):
+            hints.append(f"{_rel(step_py)}:{i}: {line.strip()[:100]}")
+    return hints[:15]
+
+
+def _trace_mdim_page_field(config: dict[str, Any], config_path: Path, field_path: str) -> EditCandidate | None:
+    """Page-level fields: title.title / title.title_variant / dimensions.<dim>...."""
+    parts = field_path.split(".")
+    if parts[0] == "title":
+        value = _dig(config, ["title", parts[1]])
+        if value is None and parts[1] == "title_variant":
+            # DB key is camelized from title_variant; some configs use topic_tags-style keys.
+            value = _dig(config, ["title", "titleVariant"])
+        if value is None:
+            return None
+        return EditCandidate(
+            file=_rel(config_path),
+            yaml_path=f"title.{parts[1]}",
+            kind="mdim-page",
+            template=str(value),
+        )
+
+    # dimensions.<dim_slug>.name or dimensions.<dim_slug>.choices.<choice_slug>.{name,description}
+    dim_slug = parts[1]
+    for i, dim in enumerate(config.get("dimensions") or []):
+        if underscore(str(dim.get("slug", "")), validate=False) != dim_slug:
+            continue
+        if len(parts) == 3:  # .name
+            if dim.get("name") is None:
+                return None
+            return EditCandidate(
+                file=_rel(config_path),
+                yaml_path=f"dimensions[{i}].name",
+                kind="mdim-page",
+                template=str(dim.get("name")),
+            )
+        choice_slug, leaf = parts[3], parts[4]
+        for j, choice in enumerate(dim.get("choices") or []):
+            if underscore(str(choice.get("slug", "")), validate=False) != choice_slug:
+                continue
+            if choice.get(leaf) is None:
+                return None
+            return EditCandidate(
+                file=_rel(config_path),
+                yaml_path=f"dimensions[{i}].choices[{j}].{leaf}",
+                kind="mdim-page",
+                template=str(choice.get(leaf)),
+            )
+    return None
+
+
+def _trace_mdim_view_field(
+    config: dict[str, Any], config_path: Path, view_id: str, field_path: str
+) -> EditCandidate | None:
+    """View-level overrides: literal `views:` entry first, then `definitions.common_views`."""
+    section, leaf = field_path.split(".", 1)  # e.g. ("config", "subtitle")
+    view_dims: dict[str, str] = dict(pair.split("=", 1) for pair in view_id.split("__") if "=" in pair)
+
+    # 1. Literal views: entry whose (normalized) dimensions match the view id.
+    for i, view in enumerate(config.get("views") or []):
+        dims = {
+            underscore(str(k), validate=False): underscore(str(v), validate=False)
+            for k, v in (view.get("dimensions") or {}).items()
+        }
+        if dimensions_to_view_id(dims) != view_id:
+            continue
+        # Authoring format is snake_case; tolerate camelCase for copy-pasted configs.
+        value = _dig(view, [section, leaf])
+        if value is None and section == "metadata":
+            value = _dig(view, [section, _camel(leaf)])
+        if value is None:
+            break  # view exists in YAML but the key doesn't — try common_views.
+        if isinstance(value, list):
+            value = description_key_to_string([str(v) for v in value])
+        return EditCandidate(
+            file=_rel(config_path),
+            yaml_path=f"views[{i}].{section}.{leaf}",
+            kind="mdim-view",
+            template=str(value),
+        )
+
+    # 2. definitions.common_views entries, most specific matching entry first.
+    common_views = (config.get("definitions") or {}).get("common_views") or []
+    matching = [
+        (j, entry)
+        for j, entry in enumerate(common_views)
+        if _common_view_matches(entry.get("dimensions") or {}, view_dims)
+    ]
+    matching.sort(key=lambda item: -len(item[1].get("dimensions") or {}))
+    for j, entry in matching:
+        value = _dig(entry, [section, leaf])
+        if value is None:
+            continue
+        if isinstance(value, list):
+            value = description_key_to_string([str(v) for v in value])
+        affected = f"applies to every view matching {entry.get('dimensions') or 'ALL views'}"
+        return EditCandidate(
+            file=_rel(config_path),
+            yaml_path=f"definitions.common_views[{j}].{section}.{leaf}",
+            kind="mdim-common-views",
+            template=str(value),
+            notes=[f"Shared `common_views` entry — editing it {affected}."],
+        )
+    return None
+
+
+def _common_view_matches(entry_dims: dict[str, Any], view_dims: dict[str, str]) -> bool:
+    """A common_views entry applies when all its dimension constraints match the view."""
+    for key, value in entry_dims.items():
+        if view_dims.get(underscore(str(key), validate=False)) != underscore(str(value), validate=False):
+            return False
+    return True
+
+
+def _camel(snake: str) -> str:
+    parts = snake.split("_")
+    return parts[0] + "".join(p.title() for p in parts[1:])

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -167,6 +167,10 @@ def _page_embed(url: str, height: int = 850) -> None:
     MDim page rewrites its own query params client-side — so swapping the `src`
     prop doesn't always navigate. Rendering the iframe as raw HTML makes the
     component content change with the URL, forcing a remount.
+
+    NOTE: streamlit deprecates `components.html` in favor of `st.iframe`, but
+    `st.iframe` has no `key` to force a remount — don't swap this back without
+    verifying the embedded MDim page follows the view selectors across reruns.
     """
     components.html(
         f'<iframe src="{html_lib.escape(url, quote=True)}" loading="lazy" '

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -71,11 +71,18 @@ def main() -> None:
 
 def mdim_page(user) -> None:
     mdims = state.cached_list_mdims()
+    open_counts = state.open_counts_by_page()
+    # Pages with open proposals first, then by recency.
+    mdims.sort(key=lambda m: m["updated_at"], reverse=True)
+    mdims.sort(key=lambda m: open_counts.get(m["catalog_path"], 0), reverse=True)
     options = [m["catalog_path"] for m in mdims]
-    labels = {
-        m["catalog_path"]: f"{m['slug'] or m['catalog_path']}" + ("" if m["published"] else " (unpublished)")
-        for m in mdims
-    }
+    labels = {}
+    for m in mdims:
+        label = f"{m['slug'] or m['catalog_path']}" + ("" if m["published"] else " (unpublished)")
+        n_open = open_counts.get(m["catalog_path"], 0)
+        if n_open:
+            label += f" — 💬 {n_open} open"
+        labels[m["catalog_path"]] = label
     catalog_path = url_persist(st.selectbox)(
         "MDim",
         options=options,
@@ -85,6 +92,7 @@ def mdim_page(user) -> None:
         placeholder="Pick an MDim to review...",
     )
     if not catalog_path:
+        _open_overview()
         st.stop()
 
     review = state.cached_resolve_mdim(catalog_path)
@@ -156,6 +164,30 @@ def mdim_page(user) -> None:
 
     with tab_all:
         _all_suggestions_tab(suggestions, comments_by_suggestion, users, user, fields_by_key, catalog_path)
+
+
+def _open_overview() -> None:
+    """Landing overview: every page with open proposals, so returning reviewers
+    see at a glance where the discussion is (instead of an empty picker)."""
+    summary = state.load_open_summary()
+    if not summary:
+        st.info("No open proposals anywhere right now. Pick a page above to start reviewing.")
+        return
+    st.subheader("Pages with open proposals")
+    for group in summary:
+        page = group["page"]
+        if group["kind"] == "mdim":
+            link = f"?mr_mode=MDims&mr_mdim={quote(page, safe='')}"
+            label = page
+        else:
+            # Indicator catalogPath 'grapher/ns/ver/ds/table#col' -> its dataset page.
+            dataset_path = "/".join(page.split("#")[0].split("/")[1:4])
+            link = f"?mr_mode=Datasets&mr_dataset={quote(dataset_path, safe='')}"
+            label = dataset_path
+        n = group["n_open"]
+        st.markdown(
+            f"- [{label}]({link}) — :orange-badge[💬 {n} open] · last activity {group['last_activity']:%Y-%m-%d %H:%M}"
+        )
 
 
 def _page_embed(url: str, height: int = 850, hide_page_selectors: bool = False) -> None:
@@ -241,6 +273,7 @@ def dataset_page(user) -> None:
         placeholder="Pick a grapher dataset to review...",
     )
     if not catalog_path:
+        _open_overview()
         st.stop()
 
     review = state.cached_resolve_dataset(catalog_path)

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -163,7 +163,9 @@ def mdim_page(user) -> None:
                     )
 
     with tab_all:
-        _all_suggestions_tab(suggestions, comments_by_suggestion, users, user, fields_by_key, catalog_path)
+        _all_suggestions_tab(
+            suggestions, comments_by_suggestion, users, user, fields_by_key, catalog_path, mdim_review=review
+        )
 
 
 def _open_overview() -> None:
@@ -337,8 +339,11 @@ def _all_suggestions_tab(
     user,
     fields_by_key,
     export_target: str,
+    mdim_review=None,
     header: bool = False,
 ) -> None:
+    """The worklist: every field with suggestions, rendered with the SAME component
+    as the main tab (tracked text, thread strip, controls), grouped by field."""
     if header:
         st.divider()
         st.subheader("All suggestions")
@@ -351,19 +356,46 @@ def _all_suggestions_tab(
     filtered = [s for s in suggestions if s.status in status_filter]
     if not filtered:
         st.info("No suggestions with the selected status.")
+
+    # One entry per field (source key), newest activity first.
+    grouped: dict[tuple, list] = {}
     for suggestion in filtered:
-        author = users.get(suggestion.createdBy, f"user {suggestion.createdBy}")
-        with st.container(border=True):
-            st.markdown(
-                f"**#{suggestion.id}** `{suggestion.fieldPath}` on `{suggestion.targetPath}`"
-                + (f" (view `{suggestion.viewId}`)" if suggestion.viewId else "")
-            )
-            st.caption(f"{suggestion.status} · by {author} · {suggestion.createdAt:%Y-%m-%d}")
-            if suggestion.suggestedValue:
-                st.markdown(f"> {suggestion.suggestedValue}")
-            for comment in comments_by_suggestion.get(suggestion.id, []):
-                if comment.kind == "comment":
-                    st.caption(f"💬 {users.get(comment.userId, '?')}: {comment.text}")
+        key = (suggestion.targetType, suggestion.targetPath, suggestion.viewId, suggestion.fieldPath)
+        grouped.setdefault(key, []).append(suggestion)
+    ordered = sorted(grouped.items(), key=lambda kv: max(s.updatedAt for s in kv[1]), reverse=True)
+
+    for key, threads in ordered:
+        field = fields_by_key.get(key)
+        if field is None:
+            # The view/indicator no longer exists on this page — compact stale card.
+            with st.container(border=True):
+                st.markdown(f"**#{threads[0].id}** `{key[3]}` on `{key[1]}`")
+                st.warning("The view/indicator this suggestion targets no longer exists on this page.")
+                for suggestion in threads:
+                    if suggestion.suggestedValue:
+                        st.markdown(f"> {suggestion.suggestedValue}")
+            continue
+        # Where the field lives (human-readable view selection for MDims).
+        view_id = field.view_id or threads[0].filedFromViewId
+        if mdim_review is not None and view_id:
+            view = next((v for v in mdim_review.views if v.view_id == view_id), None)
+            if view is not None:
+                dims = mdim_review.human_dimensions(view.dimensions)
+                st.caption("View: " + " · ".join(f"**{k}:** {v}" for k, v in dims.items()))
+        elif field.target_type == "indicator":
+            st.caption(f"Indicator: `{field.target_path}`")
+        shared = shared_view_ids(mdim_review, field) if mdim_review is not None else None
+        render_field(
+            field,
+            threads,
+            comments_by_suggestion,
+            users,
+            user,
+            fields_by_key,
+            shared_views=shared,
+            mdim_review=mdim_review,
+            key_ns="all",
+        )
 
     st.divider()
     st.markdown("**Implementing these suggestions?** Export them with resolved edit locations:")

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -29,7 +29,7 @@ from etl.config import OWID_ENV  # noqa: E402
 st.title(":material/rate_review: Metadata Review")
 st.markdown(
     "Review the user-facing text of MDims and data pages, and leave field-level suggestions. "
-    "Each field shows **where its text comes from**, so the implementer knows what to edit."
+    "Where the text comes from (and what to edit) is resolved automatically for the implementer."
 )
 
 
@@ -132,7 +132,7 @@ def mdim_page(user) -> None:
     )
 
     with tab_page:
-        st.caption("The MDim title and every dropdown label. All of these live in the MDim config.")
+        st.caption("The MDim title and every dropdown label.")
         for field in review.page_fields:
             render_field(
                 field,
@@ -350,8 +350,7 @@ def dataset_page(user) -> None:
 
     st.header(review.name or catalog_path)
     st.caption(
-        f"{len(review.indicators)} indicators. Fields here are all **inherited** from the ETL metadata "
-        "(or missing) — suggestions filed here also surface on MDim views using these indicators."
+        f"{len(review.indicators)} indicators — suggestions filed here also surface on MDim views showing the same text."
     )
 
     query = st.text_input("Filter indicators", key="mr_ds_filter", placeholder="Type to filter by name or path...")
@@ -443,7 +442,7 @@ def _all_suggestions_tab(
                 dims = mdim_review.human_dimensions(view.dimensions)
                 st.caption("View: " + " · ".join(f"**{k}:** {v}" for k, v in dims.items()))
         elif field.target_type == "indicator":
-            st.caption(f"Indicator: `{field.target_path}`")
+            st.caption(f"Indicator: {field.target_path.split('#')[-1].replace('_', ' ')}")
         shared = shared_view_ids(mdim_review, field) if mdim_review is not None else None
         render_field(
             field,

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -1,0 +1,282 @@
+"""Metadata Review — collaborative review of user-facing chart text and metadata.
+
+Reviewers browse the deployed MDim views / data-page indicators, see every
+user-facing text field with its provenance (override / inherited / missing), and
+file field-level suggestions with threaded comments. The data scientist exports
+them with `etl metadata-review export <target>` and implements the changes in ETL.
+"""
+
+from urllib.parse import quote
+
+import streamlit as st
+
+st.set_page_config(page_title="Wizard: Metadata Review", page_icon="🪄", layout="wide")
+
+from apps.metadata_review.resolution import shared_view_ids, suggestions_by_source_key  # noqa: E402
+from apps.metadata_review.targets import MdimReview, ReviewableField  # noqa: E402
+from apps.wizard.app_pages.metadata_review import state  # noqa: E402
+from apps.wizard.app_pages.metadata_review.field_panel import render_field  # noqa: E402
+from apps.wizard.utils.components import Pagination, mdim_chart, url_persist  # noqa: E402
+from etl.config import OWID_ENV  # noqa: E402
+
+st.title(":material/rate_review: Metadata Review")
+st.markdown(
+    "Review the user-facing text of MDims and data pages, and leave field-level suggestions. "
+    "Each field shows **where its text comes from**, so the implementer knows what to edit."
+)
+
+
+def main() -> None:
+    if not state.review_tables_exist():
+        st.error(
+            "The `metadata_review_suggestions` / `metadata_review_comments` tables don't exist in this "
+            "database yet — they are created by the owid-grapher migration `AddMetadataReviewTables`. "
+            "Until that reaches production (and new staging servers inherit it), create them manually "
+            "for testing:\n\n"
+            "```python\n"
+            "import etl.grapher.model as gm\n"
+            "from etl.config import OWID_ENV\n"
+            "gm.MetadataReviewSuggestion.create_table(OWID_ENV.engine, if_exists='skip')\n"
+            "gm.MetadataReviewComment.create_table(OWID_ENV.engine, if_exists='skip')\n"
+            "```"
+        )
+        st.stop()
+
+    user = state.current_user()
+    if user is None:
+        st.warning(
+            "Could not identify you (no Tailscale user on this connection and no `GRAPHER_USER_ID` locally). "
+            "You can browse, but filing suggestions is disabled."
+        )
+
+    mode = url_persist(st.segmented_control)(
+        "What do you want to review?",
+        options=["MDims", "Datasets"],
+        key="mr_mode",
+        default="MDims",
+    )
+    if mode == "Datasets":
+        dataset_page(user)
+    else:
+        mdim_page(user)
+
+
+# ---------------------------------------------------------------------------
+# MDim mode
+# ---------------------------------------------------------------------------
+
+
+def mdim_page(user) -> None:
+    mdims = state.cached_list_mdims()
+    options = [m["catalog_path"] for m in mdims]
+    labels = {
+        m["catalog_path"]: f"{m['slug'] or m['catalog_path']}" + ("" if m["published"] else " (unpublished)")
+        for m in mdims
+    }
+    catalog_path = url_persist(st.selectbox)(
+        "MDim",
+        options=options,
+        format_func=lambda p: labels.get(p, p),
+        key="mr_mdim",
+        index=None,
+        placeholder="Pick an MDim to review...",
+    )
+    if not catalog_path:
+        st.stop()
+
+    review = state.cached_resolve_mdim(catalog_path)
+    suggestions, comments_by_suggestion, users = state.load_suggestions([catalog_path] + review.indicator_paths)
+    suggestions_by_key = suggestions_by_source_key(suggestions)
+    fields_by_key: dict[tuple, ReviewableField] = {}
+    for field in review.all_fields:
+        fields_by_key.setdefault(field.source_key(), field)
+
+    # Header.
+    st.header(review.title or catalog_path)
+    n_by_status = {"open": 0, "implemented": 0, "rejected": 0}
+    for suggestion in suggestions:
+        n_by_status[suggestion.status] = n_by_status.get(suggestion.status, 0) + 1
+    preview = f"{OWID_ENV.admin_site}/grapher/{quote(catalog_path, safe='')}"
+    st.markdown(
+        f":orange-badge[{n_by_status['open']} open] :green-badge[{n_by_status['implemented']} implemented] "
+        f":gray-badge[{n_by_status['rejected']} rejected] &nbsp; [Open the MDim preview]({preview})"
+    )
+
+    tab_views, tab_page, tab_all = st.tabs(
+        [":material/stacked_line_chart: Views", ":material/tune: Title & dropdowns", ":material/list: All suggestions"]
+    )
+
+    with tab_page:
+        st.caption("The MDim title and every dropdown label. All of these live in the MDim config.")
+        for field in review.page_fields:
+            render_field(
+                field,
+                suggestions_by_key.get(field.source_key(), []),
+                comments_by_suggestion,
+                users,
+                user,
+                fields_by_key,
+            )
+
+    with tab_views:
+        view = _view_browser(review)
+        if view is None:
+            st.info("No view matches this dimension combination — pick another.")
+        else:
+            col_chart, col_fields = st.columns([1, 1])
+            with col_chart:
+                mdim_chart(f"{OWID_ENV.admin_site}/grapher/{quote(catalog_path, safe='')}", view=view.dimensions)
+                st.caption(f"View: `{view.view_id}`")
+            with col_fields:
+                for field in view.fields:
+                    shared = shared_view_ids(review, field)
+                    threads = list(suggestions_by_key.get(field.source_key(), []))
+                    # Overridden fields also show threads filed on other views sharing the same text.
+                    if field.provenance == "override":
+                        for other_view_id in shared:
+                            threads += suggestions_by_key.get(
+                                ("mdim", catalog_path, other_view_id, field.field_path), []
+                            )
+                    render_field(
+                        field,
+                        threads,
+                        comments_by_suggestion,
+                        users,
+                        user,
+                        fields_by_key,
+                        shared_views=shared,
+                        mdim_review=review,
+                    )
+
+    with tab_all:
+        _all_suggestions_tab(suggestions, comments_by_suggestion, users, user, fields_by_key, catalog_path)
+
+
+def _view_browser(review: MdimReview):
+    """One selectbox per dimension; returns the matching ViewReview (or None)."""
+    cols = st.columns(max(len(review.dimensions), 1))
+    selection = {}
+    for col, dim in zip(cols, review.dimensions):
+        with col:
+            choice_slugs = [c.slug for c in dim.choices]
+            selection[dim.slug] = url_persist(st.selectbox)(
+                dim.name,
+                options=choice_slugs,
+                format_func=dim.choice_name,
+                key=f"mr_dim_{dim.slug}",
+            )
+    for view in review.views:
+        if all(view.dimensions.get(dim_slug) == choice for dim_slug, choice in selection.items()):
+            return view
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Dataset mode
+# ---------------------------------------------------------------------------
+
+
+def dataset_page(user) -> None:
+    datasets = state.cached_list_datasets()
+    options = [d["catalog_path"] for d in datasets]
+    labels = {d["catalog_path"]: f"{d['name']} · {d['catalog_path']}" for d in datasets}
+    catalog_path = url_persist(st.selectbox)(
+        "Dataset",
+        options=options,
+        format_func=lambda p: labels.get(p, p),
+        key="mr_dataset",
+        index=None,
+        placeholder="Pick a grapher dataset to review...",
+    )
+    if not catalog_path:
+        st.stop()
+
+    review = state.cached_resolve_dataset(catalog_path)
+    suggestions, comments_by_suggestion, users = state.load_suggestions(review.indicator_paths)
+    suggestions_by_key = suggestions_by_source_key(suggestions)
+    fields_by_key: dict[tuple, ReviewableField] = {}
+    for indicator in review.indicators:
+        for field in indicator.fields:
+            fields_by_key.setdefault(field.source_key(), field)
+
+    st.header(review.name or catalog_path)
+    st.caption(
+        f"{len(review.indicators)} indicators. Fields here are all **inherited** from the ETL metadata "
+        "(or missing) — suggestions filed here also surface on MDim views using these indicators."
+    )
+
+    query = st.text_input("Filter indicators", key="mr_ds_filter", placeholder="Type to filter by name or path...")
+    indicators = review.indicators
+    if query:
+        q = query.lower()
+        indicators = [i for i in indicators if q in (i.name or "").lower() or q in i.catalog_path.lower()]
+
+    pagination = Pagination(indicators, items_per_page=10, pagination_key="mr_ds_page")
+    pagination.show_controls()
+    for indicator in pagination.get_page_items():
+        n_open = sum(
+            1 for f in indicator.fields for s in suggestions_by_key.get(f.source_key(), []) if s.status == "open"
+        )
+        label = indicator.name or indicator.catalog_path.split("#")[-1]
+        with st.expander(f"{label}" + (f" — :orange[{n_open} open]" if n_open else ""), expanded=False):
+            st.caption(f"`{indicator.catalog_path}`")
+            for field in indicator.fields:
+                render_field(
+                    field,
+                    suggestions_by_key.get(field.source_key(), []),
+                    comments_by_suggestion,
+                    users,
+                    user,
+                    fields_by_key,
+                )
+
+    _all_suggestions_tab(suggestions, comments_by_suggestion, users, user, fields_by_key, catalog_path, header=True)
+
+
+# ---------------------------------------------------------------------------
+# Shared: flat worklist + export hint
+# ---------------------------------------------------------------------------
+
+
+def _all_suggestions_tab(
+    suggestions,
+    comments_by_suggestion,
+    users,
+    user,
+    fields_by_key,
+    export_target: str,
+    header: bool = False,
+) -> None:
+    if header:
+        st.divider()
+        st.subheader("All suggestions")
+    status_filter = st.multiselect(
+        "Status",
+        options=["open", "implemented", "rejected"],
+        default=["open"],
+        key=f"mr_status_filter_{export_target}",
+    )
+    filtered = [s for s in suggestions if s.status in status_filter]
+    if not filtered:
+        st.info("No suggestions with the selected status.")
+    for suggestion in filtered:
+        author = users.get(suggestion.createdBy, f"user {suggestion.createdBy}")
+        with st.container(border=True):
+            st.markdown(
+                f"**#{suggestion.id}** `{suggestion.fieldPath}` on `{suggestion.targetPath}`"
+                + (f" (view `{suggestion.viewId}`)" if suggestion.viewId else "")
+            )
+            st.caption(f"{suggestion.status} · by {author} · {suggestion.createdAt:%Y-%m-%d}")
+            if suggestion.suggestedValue:
+                st.markdown(f"> {suggestion.suggestedValue}")
+            for comment in comments_by_suggestion.get(suggestion.id, []):
+                if comment.kind == "comment":
+                    st.caption(f"💬 {users.get(comment.userId, '?')}: {comment.text}")
+
+    st.divider()
+    st.markdown("**Implementing these suggestions?** Export them with resolved edit locations:")
+    staging_hint = "" if OWID_ENV.env_local == "dev" else f"STAGING={OWID_ENV.name.removeprefix('staging-site-')} "
+    st.code(f"{staging_hint}.venv/bin/etl metadata-review export {export_target}", language="bash")
+
+
+main()

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -138,28 +138,23 @@ def mdim_page(user) -> None:
         if view is None:
             st.info("No view matches this dimension combination — pick another.")
         else:
-            col_page, col_fields = st.columns([3, 2])
+            # Text gets the room: fields take the wider column; the live page stays
+            # visible in a smaller column while the field rail scrolls internally.
+            col_page, col_fields = st.columns([2, 3], gap="medium")
             with col_page:
-                # The real MDim page (admin preview renders the full page, controls included),
-                # so the reviewer sees exactly what readers see.
                 page_url = f"{OWID_ENV.admin_site}/grapher/{quote(catalog_path, safe='')}?{urlencode(view.dimensions)}"
-                _page_embed(page_url, height=850, hide_page_selectors=True)
-                st.caption("This is the live page — navigate views with the selectors above.")
+                _page_embed(page_url, height=620, hide_page_selectors=True)
+                st.caption("Live page — scroll inside for key information and sources.")
             with col_fields:
-                for field in view.fields:
-                    shared = shared_view_ids(review, field)
-                    # Threads filed on ANY view rendering this same text (even via a
-                    # different expanded indicator of the same garden template).
-                    threads = threads_for_field(review, field, suggestions_by_key)
-                    render_field(
-                        field,
-                        threads,
+                with st.container(height=780, border=False):
+                    _render_grouped_fields(
+                        view.fields,
+                        review,
+                        suggestions_by_key,
                         comments_by_suggestion,
                         users,
                         user,
                         fields_by_key,
-                        shared_views=shared,
-                        mdim_review=review,
                     )
 
     with tab_all:
@@ -238,6 +233,57 @@ frame.addEventListener("load", () => {{
     )
 
 
+# What each field annotates on the page: the chart itself vs the sections below it.
+CHART_TEXT_FIELDS = {
+    "config.title",
+    "config.subtitle",
+    "config.note",
+    "grapher_config.title",
+    "grapher_config.subtitle",
+    "grapher_config.note",
+}
+
+
+def _render_grouped_fields(
+    fields,
+    mdim_review,
+    suggestions_by_key,
+    comments_by_suggestion,
+    users,
+    user,
+    fields_by_key,
+) -> None:
+    """Field boxes grouped by what they annotate: chart text, then data-page metadata."""
+    chart_fields = [f for f in fields if f.field_path in CHART_TEXT_FIELDS]
+    data_fields = [f for f in fields if f.field_path not in CHART_TEXT_FIELDS]
+    groups = [
+        (":material/bar_chart: Chart text — title, subtitle and footnote as rendered on the chart", chart_fields),
+        (":material/description: About the data — shown on the data page below the chart", data_fields),
+    ]
+    for header, group in groups:
+        if not group:
+            continue
+        st.markdown(f"##### {header.split(' — ')[0]}")
+        st.caption(header.split(" — ")[1].capitalize())
+        for field in group:
+            if mdim_review is not None:
+                shared = shared_view_ids(mdim_review, field)
+                threads = threads_for_field(mdim_review, field, suggestions_by_key)
+            else:
+                shared = None
+                threads = suggestions_by_key.get(field.source_key(), [])
+            render_field(
+                field,
+                threads,
+                comments_by_suggestion,
+                users,
+                user,
+                fields_by_key,
+                shared_views=shared,
+                mdim_review=mdim_review,
+            )
+
+
 def _view_browser(review: MdimReview):
     """One selectbox per dimension; returns the matching ViewReview (or None)."""
     cols = st.columns(max(len(review.dimensions), 1))
@@ -307,22 +353,23 @@ def dataset_page(user) -> None:
         label = indicator.name or indicator.catalog_path.split("#")[-1]
         with st.expander(f"{label}" + (f" — :orange[{n_open} open]" if n_open else ""), expanded=False):
             st.caption(f"`{indicator.catalog_path}`")
-            col_page, col_fields = st.columns([3, 2])
+            col_page, col_fields = st.columns([2, 3], gap="medium")
             with col_page:
                 if indicator.variable_id is not None:
                     # The real data page (admin preview), so the reviewer sees exactly
                     # what readers see — key information, sources, and all.
-                    _page_embed(OWID_ENV.data_page_preview(indicator.variable_id), height=850)
+                    _page_embed(OWID_ENV.data_page_preview(indicator.variable_id), height=620)
+                    st.caption("Live data page — scroll inside for key information and sources.")
             with col_fields:
-                for field in indicator.fields:
-                    render_field(
-                        field,
-                        suggestions_by_key.get(field.source_key(), []),
-                        comments_by_suggestion,
-                        users,
-                        user,
-                        fields_by_key,
-                    )
+                _render_grouped_fields(
+                    indicator.fields,
+                    None,
+                    suggestions_by_key,
+                    comments_by_suggestion,
+                    users,
+                    user,
+                    fields_by_key,
+                )
 
     _all_suggestions_tab(suggestions, comments_by_suggestion, users, user, fields_by_key, catalog_path, header=True)
 

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -82,7 +82,12 @@ def mdim_page(user) -> None:
     options = [m["catalog_path"] for m in mdims]
     labels = {}
     for m in mdims:
-        label = f"{m['slug'] or m['catalog_path']}" + ("" if m["published"] else " (unpublished)")
+        label = m["title"] or m["slug"] or m["catalog_path"]
+        if m["title_variant"]:
+            label += f" · {m['title_variant']}"
+        label += f"  ({m['slug'] or m['catalog_path']})"
+        if not m["published"]:
+            label += " (unpublished)"
         n_open = open_counts.get(m["catalog_path"], 0)
         if n_open:
             label += f" — 💬 {n_open} open"
@@ -100,7 +105,12 @@ def mdim_page(user) -> None:
         st.stop()
 
     review = state.cached_resolve_mdim(catalog_path)
-    suggestions, comments_by_suggestion, users = state.load_suggestions([catalog_path] + review.indicator_paths)
+    # Widen to the whole grapher dataset(s): threads filed on sibling MDims built
+    # from the same metadata (e.g. incomes_wid <-> palma_ratio_wid) surface here too.
+    prefixes = sorted({"/".join(p.split("/")[:4]) for p in review.indicator_paths})
+    suggestions, comments_by_suggestion, users = state.load_suggestions(
+        [catalog_path] + review.indicator_paths, path_prefixes=prefixes
+    )
     suggestions_by_key = suggestions_by_source_key(suggestions)
     fields_by_key: dict[tuple, ReviewableField] = {}
     for field in review.all_fields:
@@ -146,16 +156,15 @@ def mdim_page(user) -> None:
                 _page_embed(page_url, height=620, hide_page_selectors=True)
                 st.caption("Live page — scroll inside for key information and sources.")
             with col_fields:
-                with st.container(height=780, border=False):
-                    _render_grouped_fields(
-                        view.fields,
-                        review,
-                        suggestions_by_key,
-                        comments_by_suggestion,
-                        users,
-                        user,
-                        fields_by_key,
-                    )
+                _render_grouped_fields(
+                    view.fields,
+                    review,
+                    suggestions_by_key,
+                    comments_by_suggestion,
+                    users,
+                    user,
+                    fields_by_key,
+                )
 
     with tab_all:
         _all_suggestions_tab(
@@ -264,35 +273,30 @@ def _render_grouped_fields(
     user,
     fields_by_key,
 ) -> None:
-    """Field boxes grouped by what they annotate: chart text, then data-page metadata."""
+    """Field boxes split into tabs by what they annotate — chart text vs data-page
+    metadata — so neither list needs its own scroll."""
     chart_fields = [f for f in fields if f.field_path in CHART_TEXT_FIELDS]
     data_fields = [f for f in fields if f.field_path not in CHART_TEXT_FIELDS]
-    groups = [
-        (":material/bar_chart: Chart text — title, subtitle and footnote as rendered on the chart", chart_fields),
-        (":material/description: About the data — shown on the data page below the chart", data_fields),
-    ]
-    for header, group in groups:
-        if not group:
-            continue
-        st.markdown(f"##### {header.split(' — ')[0]}")
-        st.caption(header.split(" — ")[1].capitalize())
-        for field in group:
-            if mdim_review is not None:
-                shared = shared_view_ids(mdim_review, field)
+    tab_chart, tab_data = st.tabs([":material/bar_chart: Chart text", ":material/description: About the data"])
+    for tab, caption, group in [
+        (tab_chart, "Title, subtitle and footnote as rendered on the chart.", chart_fields),
+        (tab_data, "Shown on the data page below the chart.", data_fields),
+    ]:
+        with tab:
+            st.caption(caption)
+            for field in group:
+                shared = shared_view_ids(mdim_review, field) if mdim_review is not None else None
                 threads = threads_for_field(mdim_review, field, suggestions_by_key)
-            else:
-                shared = None
-                threads = suggestions_by_key.get(field.source_key(), [])
-            render_field(
-                field,
-                threads,
-                comments_by_suggestion,
-                users,
-                user,
-                fields_by_key,
-                shared_views=shared,
-                mdim_review=mdim_review,
-            )
+                render_field(
+                    field,
+                    threads,
+                    comments_by_suggestion,
+                    users,
+                    user,
+                    fields_by_key,
+                    shared_views=shared,
+                    mdim_review=mdim_review,
+                )
 
 
 def _view_browser(review: MdimReview):
@@ -336,7 +340,8 @@ def dataset_page(user) -> None:
         st.stop()
 
     review = state.cached_resolve_dataset(catalog_path)
-    suggestions, comments_by_suggestion, users = state.load_suggestions(review.indicator_paths)
+    prefixes = sorted({"/".join(p.split("/")[:4]) for p in review.indicator_paths})
+    suggestions, comments_by_suggestion, users = state.load_suggestions(review.indicator_paths, path_prefixes=prefixes)
     suggestions_by_key = suggestions_by_source_key(suggestions)
     fields_by_key: dict[tuple, ReviewableField] = {}
     for indicator in review.indicators:
@@ -414,25 +419,22 @@ def _all_suggestions_tab(
     filtered = [s for s in suggestions if s.status in status_filter]
     if not filtered:
         st.info("No suggestions with the selected status.")
+    filtered_ids = {s.id for s in filtered}
 
-    # One entry per field (source key), newest activity first.
-    grouped: dict[tuple, list] = {}
-    for suggestion in filtered:
-        key = (suggestion.targetType, suggestion.targetPath, suggestion.viewId, suggestion.fieldPath)
-        grouped.setdefault(key, []).append(suggestion)
-    ordered = sorted(grouped.items(), key=lambda kv: max(s.updatedAt for s in kv[1]), reverse=True)
-
-    for key, threads in ordered:
-        field = fields_by_key.get(key)
-        if field is None:
-            # The view/indicator no longer exists on this page — compact stale card.
-            with st.container(border=True):
-                st.markdown(f"**#{threads[0].id}** `{key[3]}` on `{key[1]}`")
-                st.warning("The view/indicator this suggestion targets no longer exists on this page.")
-                for suggestion in threads:
-                    if suggestion.suggestedValue:
-                        st.markdown(f"> {suggestion.suggestedValue}")
+    # One entry per FIELD with threads (same component as the main tab); threads
+    # borrowed across views/pages land under the field that displays them.
+    suggestions_by_key = suggestions_by_source_key(suggestions)
+    claimed: set[int] = set()
+    entries = []
+    for field in fields_by_key.values():
+        threads = [t for t in threads_for_field(mdim_review, field, suggestions_by_key) if t.id in filtered_ids]
+        if not threads or all(t.id in claimed for t in threads):
             continue
+        claimed.update(t.id for t in threads)
+        entries.append((field, threads, max(t.updatedAt for t in threads)))
+    entries.sort(key=lambda e: e[2], reverse=True)
+
+    for field, threads, _ts in entries:
         # Where the field lives (human-readable view selection for MDims).
         view_id = field.view_id or threads[0].filedFromViewId
         if mdim_review is not None and view_id:
@@ -454,6 +456,14 @@ def _all_suggestions_tab(
             mdim_review=mdim_review,
             key_ns="all",
         )
+
+    # Suggestions no field on this page displays (their target vanished).
+    for suggestion in [s for s in filtered if s.id not in claimed]:
+        with st.container(border=True):
+            st.markdown(f"**#{suggestion.id}** `{suggestion.fieldPath}` on `{suggestion.targetPath}`")
+            st.warning("No field on this page currently renders the text this suggestion targets.")
+            if suggestion.suggestedValue:
+                st.markdown(f"> {suggestion.suggestedValue}")
 
     st.divider()
     st.markdown("**Implementing these suggestions?** Export them with resolved edit locations:")

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -7,6 +7,7 @@ them with `etl metadata-review export <target>` and implements the changes in ET
 """
 
 import html as html_lib
+import json
 from urllib.parse import quote, urlencode
 
 import streamlit as st
@@ -130,11 +131,8 @@ def mdim_page(user) -> None:
                 # The real MDim page (admin preview renders the full page, controls included),
                 # so the reviewer sees exactly what readers see.
                 page_url = f"{OWID_ENV.admin_site}/grapher/{quote(catalog_path, safe='')}?{urlencode(view.dimensions)}"
-                _page_embed(page_url, height=850)
-                st.caption(
-                    "This is the live page. Note: changing the dropdowns *inside* the page won't move the "
-                    "field panel — use the selectors above to switch views."
-                )
+                _page_embed(page_url, height=850, hide_page_selectors=True)
+                st.caption("This is the live page — navigate views with the selectors above.")
             with col_fields:
                 for field in view.fields:
                     shared = shared_view_ids(review, field)
@@ -160,7 +158,7 @@ def mdim_page(user) -> None:
         _all_suggestions_tab(suggestions, comments_by_suggestion, users, user, fields_by_key, catalog_path)
 
 
-def _page_embed(url: str, height: int = 850) -> None:
+def _page_embed(url: str, height: int = 850, hide_page_selectors: bool = False) -> None:
     """Embed a live page in an iframe that reliably reloads when the URL changes.
 
     `st.iframe` keeps the same component instance across reruns, and the embedded
@@ -171,11 +169,37 @@ def _page_embed(url: str, height: int = 850) -> None:
     NOTE: streamlit deprecates `components.html` in favor of `st.iframe`, but
     `st.iframe` has no `key` to force a remount — don't swap this back without
     verifying the embedded MDim page follows the view selectors across reruns.
+
+    With `hide_page_selectors=True`, the MDim page's own dropdown panel is hidden
+    (the wizard's selectors are the single source of truth — two competing sets of
+    dropdowns that can't stay in sync would be confusing). The full page has no
+    `hideControls` support, so this injects CSS into the loaded document — which
+    works on staging because the wizard and the admin preview share an origin;
+    cross-origin contexts (local dev) silently keep the page's dropdowns visible.
     """
+    hide_css = ".settings-row__wrapper, .multi-dim-settings { display: none !important; }"
     components.html(
-        f'<iframe src="{html_lib.escape(url, quote=True)}" loading="lazy" '
+        f'<iframe id="mr_page_embed" src="{html_lib.escape(url, quote=True)}" loading="lazy" '
         f'style="width:100%;height:{height - 20}px;border:1px solid #e6e6e6;border-radius:4px;background:#fff;">'
-        "</iframe>",
+        "</iframe>"
+        + (
+            f"""
+<script>
+const frame = document.getElementById("mr_page_embed");
+frame.addEventListener("load", () => {{
+    try {{
+        const doc = frame.contentDocument;
+        const style = doc.createElement("style");
+        style.textContent = {json.dumps(hide_css)};
+        doc.head.appendChild(style);
+    }} catch (e) {{
+        // Cross-origin (e.g. local dev wizard vs. admin) — leave the page's controls visible.
+    }}
+}});
+</script>"""
+            if hide_page_selectors
+            else ""
+        ),
         height=height,
     )
 

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -208,27 +208,38 @@ def _page_embed(url: str, height: int = 850, hide_page_selectors: bool = False) 
     """
     hide_css = ".settings-row__wrapper, .multi-dim-settings { display: none !important; }"
     components.html(
-        f'<iframe id="mr_page_embed" src="{html_lib.escape(url, quote=True)}" loading="lazy" '
-        f'style="width:100%;height:{height - 20}px;border:1px solid #e6e6e6;border-radius:4px;background:#fff;">'
-        "</iframe>"
-        + (
-            f"""
+        f"""
+<div id="mr_rebuilding" style="display:none;padding:0.5rem 0.8rem;margin-bottom:0.4rem;border-radius:6px;
+     background:#fff8e1;border:1px solid #f0dc9a;color:#6d5c1e;font:0.85rem -apple-system,sans-serif;">
+  ⏳ The site preview is rebuilding after a deploy — retrying automatically...
+</div>
+<iframe id="mr_page_embed" src="{html_lib.escape(url, quote=True)}" loading="lazy"
+        style="width:100%;height:{height - 20}px;border:1px solid #e6e6e6;border-radius:4px;background:#fff;"></iframe>
 <script>
 const frame = document.getElementById("mr_page_embed");
+const rebuilding = document.getElementById("mr_rebuilding");
 frame.addEventListener("load", () => {{
     try {{
         const doc = frame.contentDocument;
-        const style = doc.createElement("style");
-        style.textContent = {json.dumps(hide_css)};
-        doc.head.appendChild(style);
+        const text = (doc.body && doc.body.innerText) || "";
+        // Right after a deploy the admin preview 500s until the grapher assets are
+        // rebuilt — detect it and retry instead of showing raw JSON to reviewers.
+        if (text.includes("build manifest") || text.startsWith('{{"error"')) {{
+            rebuilding.style.display = "block";
+            setTimeout(() => {{ frame.src = frame.src; }}, 12000);
+            return;
+        }}
+        rebuilding.style.display = "none";
+        if ({json.dumps(hide_page_selectors)}) {{
+            const style = doc.createElement("style");
+            style.textContent = {json.dumps(hide_css)};
+            doc.head.appendChild(style);
+        }}
     }} catch (e) {{
-        // Cross-origin (e.g. local dev wizard vs. admin) — leave the page's controls visible.
+        // Cross-origin (e.g. local dev wizard vs. admin) — leave the page as is.
     }}
 }});
-</script>"""
-            if hide_page_selectors
-            else ""
-        ),
+</script>""",
         height=height,
     )
 

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -6,7 +6,7 @@ file field-level suggestions with threaded comments. The data scientist exports
 them with `etl metadata-review export <target>` and implements the changes in ETL.
 """
 
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 import streamlit as st
 
@@ -16,7 +16,7 @@ from apps.metadata_review.resolution import shared_view_ids, suggestions_by_sour
 from apps.metadata_review.targets import MdimReview, ReviewableField  # noqa: E402
 from apps.wizard.app_pages.metadata_review import state  # noqa: E402
 from apps.wizard.app_pages.metadata_review.field_panel import render_field  # noqa: E402
-from apps.wizard.utils.components import Pagination, mdim_chart, url_persist  # noqa: E402
+from apps.wizard.utils.components import Pagination, url_persist  # noqa: E402
 from etl.config import OWID_ENV  # noqa: E402
 
 st.title(":material/rate_review: Metadata Review")
@@ -123,10 +123,16 @@ def mdim_page(user) -> None:
         if view is None:
             st.info("No view matches this dimension combination — pick another.")
         else:
-            col_chart, col_fields = st.columns([1, 1])
-            with col_chart:
-                mdim_chart(f"{OWID_ENV.admin_site}/grapher/{quote(catalog_path, safe='')}", view=view.dimensions)
-                st.caption(f"View: `{view.view_id}`")
+            col_page, col_fields = st.columns([3, 2])
+            with col_page:
+                # The real MDim page (admin preview renders the full page, controls included),
+                # so the reviewer sees exactly what readers see.
+                page_url = f"{OWID_ENV.admin_site}/grapher/{quote(catalog_path, safe='')}?{urlencode(view.dimensions)}"
+                st.iframe(page_url, height=850)
+                st.caption(
+                    "This is the live page. Note: changing the dropdowns *inside* the page won't move the "
+                    "field panel — use the selectors above to switch views."
+                )
             with col_fields:
                 for field in view.fields:
                     shared = shared_view_ids(review, field)
@@ -220,15 +226,22 @@ def dataset_page(user) -> None:
         label = indicator.name or indicator.catalog_path.split("#")[-1]
         with st.expander(f"{label}" + (f" — :orange[{n_open} open]" if n_open else ""), expanded=False):
             st.caption(f"`{indicator.catalog_path}`")
-            for field in indicator.fields:
-                render_field(
-                    field,
-                    suggestions_by_key.get(field.source_key(), []),
-                    comments_by_suggestion,
-                    users,
-                    user,
-                    fields_by_key,
-                )
+            col_page, col_fields = st.columns([3, 2])
+            with col_page:
+                if indicator.variable_id is not None:
+                    # The real data page (admin preview), so the reviewer sees exactly
+                    # what readers see — key information, sources, and all.
+                    st.iframe(OWID_ENV.data_page_preview(indicator.variable_id), height=850)
+            with col_fields:
+                for field in indicator.fields:
+                    render_field(
+                        field,
+                        suggestions_by_key.get(field.source_key(), []),
+                        comments_by_suggestion,
+                        users,
+                        user,
+                        fields_by_key,
+                    )
 
     _all_suggestions_tab(suggestions, comments_by_suggestion, users, user, fields_by_key, catalog_path, header=True)
 

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -6,9 +6,11 @@ file field-level suggestions with threaded comments. The data scientist exports
 them with `etl metadata-review export <target>` and implements the changes in ETL.
 """
 
+import html as html_lib
 from urllib.parse import quote, urlencode
 
 import streamlit as st
+import streamlit.components.v1 as components
 
 st.set_page_config(page_title="Wizard: Metadata Review", page_icon="🪄", layout="wide")
 
@@ -128,7 +130,7 @@ def mdim_page(user) -> None:
                 # The real MDim page (admin preview renders the full page, controls included),
                 # so the reviewer sees exactly what readers see.
                 page_url = f"{OWID_ENV.admin_site}/grapher/{quote(catalog_path, safe='')}?{urlencode(view.dimensions)}"
-                st.iframe(page_url, height=850)
+                _page_embed(page_url, height=850)
                 st.caption(
                     "This is the live page. Note: changing the dropdowns *inside* the page won't move the "
                     "field panel — use the selectors above to switch views."
@@ -156,6 +158,22 @@ def mdim_page(user) -> None:
 
     with tab_all:
         _all_suggestions_tab(suggestions, comments_by_suggestion, users, user, fields_by_key, catalog_path)
+
+
+def _page_embed(url: str, height: int = 850) -> None:
+    """Embed a live page in an iframe that reliably reloads when the URL changes.
+
+    `st.iframe` keeps the same component instance across reruns, and the embedded
+    MDim page rewrites its own query params client-side — so swapping the `src`
+    prop doesn't always navigate. Rendering the iframe as raw HTML makes the
+    component content change with the URL, forcing a remount.
+    """
+    components.html(
+        f'<iframe src="{html_lib.escape(url, quote=True)}" loading="lazy" '
+        f'style="width:100%;height:{height - 20}px;border:1px solid #e6e6e6;border-radius:4px;background:#fff;">'
+        "</iframe>",
+        height=height,
+    )
 
 
 def _view_browser(review: MdimReview):
@@ -231,7 +249,7 @@ def dataset_page(user) -> None:
                 if indicator.variable_id is not None:
                     # The real data page (admin preview), so the reviewer sees exactly
                     # what readers see — key information, sources, and all.
-                    st.iframe(OWID_ENV.data_page_preview(indicator.variable_id), height=850)
+                    _page_embed(OWID_ENV.data_page_preview(indicator.variable_id), height=850)
             with col_fields:
                 for field in indicator.fields:
                     render_field(

--- a/apps/wizard/app_pages/metadata_review/app.py
+++ b/apps/wizard/app_pages/metadata_review/app.py
@@ -15,7 +15,11 @@ import streamlit.components.v1 as components
 
 st.set_page_config(page_title="Wizard: Metadata Review", page_icon="🪄", layout="wide")
 
-from apps.metadata_review.resolution import shared_view_ids, suggestions_by_source_key  # noqa: E402
+from apps.metadata_review.resolution import (  # noqa: E402
+    shared_view_ids,
+    suggestions_by_source_key,
+    threads_for_field,
+)
 from apps.metadata_review.targets import MdimReview, ReviewableField  # noqa: E402
 from apps.wizard.app_pages.metadata_review import state  # noqa: E402
 from apps.wizard.app_pages.metadata_review.field_panel import render_field  # noqa: E402
@@ -144,13 +148,9 @@ def mdim_page(user) -> None:
             with col_fields:
                 for field in view.fields:
                     shared = shared_view_ids(review, field)
-                    threads = list(suggestions_by_key.get(field.source_key(), []))
-                    # Overridden fields also show threads filed on other views sharing the same text.
-                    if field.provenance == "override":
-                        for other_view_id in shared:
-                            threads += suggestions_by_key.get(
-                                ("mdim", catalog_path, other_view_id, field.field_path), []
-                            )
+                    # Threads filed on ANY view rendering this same text (even via a
+                    # different expanded indicator of the same garden template).
+                    threads = threads_for_field(review, field, suggestions_by_key)
                     render_field(
                         field,
                         threads,

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -234,7 +234,8 @@ def _render_edit_controls(
 ) -> None:
     """In-place tracked-changes editing: the displayed text becomes editable, with a
     live diff preview; saving files onto the field's consolidated proposal."""
-    editing_key = _key(field, "editing", key_ns)
+    sid = str(existing.id) if existing is not None else "new"
+    editing_key = _key(field, f"editing_{sid}", key_ns)
     current = str(field.current_value) if field.current_value is not None else ""
 
     if st.session_state.get(editing_key):
@@ -250,10 +251,10 @@ def _render_edit_controls(
         result = tracked_editor(
             original=current,
             initial=initial,
-            key=_key(field, "editor", key_ns),
+            key=_key(field, f"editor_{sid}", key_ns),
             bullet_list=field.field_path in DESCRIPTION_KEY_FIELDS,
         )
-        handled_key = _key(field, "nonce", key_ns)
+        handled_key = _key(field, f"nonce_{sid}", key_ns)
         if result and result.get("nonce") != st.session_state.get(handled_key):
             st.session_state[handled_key] = result.get("nonce")
             if result.get("action") == "save":
@@ -292,15 +293,15 @@ def _render_edit_controls(
     label = "✏️ Refine proposed text" if existing is not None else "✏️ Suggest an edit"
     col_edit, col_comment = st.columns([1, 1])
     with col_edit:
-        if st.button(label, key=_key(field, "editbtn", key_ns)):
+        if st.button(label, key=_key(field, f"editbtn_{sid}", key_ns)):
             st.session_state[editing_key] = True
             st.rerun()
     if existing is None:
         with col_comment, st.popover("💬 Comment only"):
-            with st.form(key=_key(field, "cform", key_ns), clear_on_submit=True, border=False):
+            with st.form(key=_key(field, f"cform_{sid}", key_ns), clear_on_submit=True, border=False):
                 comment = st.text_area(
                     "Comment",
-                    key=_key(field, "comment", key_ns),
+                    key=_key(field, f"comment_{sid}", key_ns),
                     height=80,
                     label_visibility="collapsed",
                     placeholder="A remark without proposing text...",

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -274,7 +274,9 @@ def _render_edit_controls(
     current = str(field.current_value) if field.current_value is not None else ""
 
     if st.session_state.get(editing_key):
-        initial = existing.suggestedValue if existing is not None and existing.suggestedValue else current
+        # `is not None`, not truthiness: an empty string is a real proposal (clear the
+        # field) and must survive a refine round-trip.
+        initial = existing.suggestedValue if existing is not None and existing.suggestedValue is not None else current
         result = tracked_editor(
             original=current,
             initial=initial,

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -1,10 +1,18 @@
-"""The field row: provenance badge, current text, threads, and suggestion controls."""
+"""The field row: provenance badge, current text, one consolidated proposal, and controls.
+
+A field carries at most one OPEN proposal (enforced by
+`MetadataReviewSuggestion.file_or_update`): later reviewers refine the same
+proposed text or join its thread, instead of stacking parallel threads that each
+repeat the field's content. For `description_key` the proposal renders as a
+bullet-level diff, so only the changed bullets show.
+"""
 
 import hashlib
 
 import streamlit as st
 
 import etl.grapher.model as gm
+from apps.metadata_review.diffs import bullet_diff, diff_markdown_lines, diff_summary
 from apps.metadata_review.resolution import Staleness, check_staleness
 from apps.metadata_review.targets import MdimReview, ReviewableField
 from apps.wizard.app_pages.metadata_review import state
@@ -15,6 +23,8 @@ PROVENANCE_BADGES = {
     "missing": ("red", "not set anywhere"),
 }
 STATUS_ICONS = {"open": "💬", "implemented": "✅", "rejected": "🚫"}
+
+DESCRIPTION_KEY_FIELDS = {"metadata.description_key", "description_key"}
 
 
 def _key(field: ReviewableField, suffix: str) -> str:
@@ -32,19 +42,23 @@ def render_field(
     shared_views: list[str] | None = None,
     mdim_review: MdimReview | None = None,
 ) -> None:
-    """Render one reviewable field with its threads and controls."""
+    """Render one reviewable field with its consolidated proposal and history."""
     color, explanation = PROVENANCE_BADGES[field.provenance]
-    header = st.container(border=True)
-    with header:
+    open_suggestions = [s for s in suggestions if s.status == "open"]
+    resolved = [s for s in suggestions if s.status != "open"]
+    # At most one open proposal per field going forward; render the newest as
+    # canonical if legacy parallel threads exist.
+    open_suggestions.sort(key=lambda s: s.createdAt, reverse=True)
+    proposal = open_suggestions[0] if open_suggestions else None
+
+    with st.container(border=True):
         title_col, badge_col = st.columns([4, 2], vertical_alignment="center")
         with title_col:
             st.markdown(f"**{field.label}**")
         with badge_col:
             badges = [f":{color}-badge[{field.provenance}]"]
-            if suggestions:
-                n_open = sum(1 for s in suggestions if s.status == "open")
-                if n_open:
-                    badges.append(f":orange-badge[{n_open} open]")
+            if proposal is not None:
+                badges.append(":orange-badge[open proposal]")
             if shared_views:
                 badges.append(f":gray-badge[appears in {len(shared_views) + 1} views]")
             st.markdown(" ".join(badges))
@@ -70,49 +84,70 @@ def render_field(
                     dims = mdim_review.human_dimensions(view.dimensions) if view else {}
                     st.markdown("- " + (" · ".join(f"**{k}:** {v}" for k, v in dims.items()) or view_id))
 
-        for suggestion in suggestions:
-            _render_thread(suggestion, comments_by_suggestion.get(suggestion.id, []), users, user, fields_by_key)
+        if proposal is not None:
+            _render_proposal(
+                field,
+                proposal,
+                extra_threads=open_suggestions[1:],
+                comments_by_suggestion=comments_by_suggestion,
+                users=users,
+                user=user,
+                fields_by_key=fields_by_key,
+            )
+        elif user is not None:
+            _render_suggestion_form(field, user, existing=None)
 
-        _render_new_suggestion_control(field, user)
+        for suggestion in resolved:
+            _render_resolved(suggestion, comments_by_suggestion.get(suggestion.id, []), users, user)
 
 
-def _render_thread(
-    suggestion: gm.MetadataReviewSuggestion,
-    comments: list,
+def _render_proposal(
+    field: ReviewableField,
+    proposal: gm.MetadataReviewSuggestion,
+    extra_threads: list[gm.MetadataReviewSuggestion],
+    comments_by_suggestion: dict[int, list],
     users: dict[int, str],
     user: gm.User | None,
     fields_by_key: dict[tuple, ReviewableField],
 ) -> None:
-    staleness: Staleness = check_staleness(suggestion, fields_by_key)
-    icon = STATUS_ICONS.get(suggestion.status, "💬")
-    author = users.get(suggestion.createdBy, f"user {suggestion.createdBy}")
-    label = f"{icon} #{suggestion.id} by {author} — {suggestion.status}"
-    if staleness.is_stale:
-        label += " ⚠️ stale"
+    """The single consolidated proposal block for a field."""
+    staleness: Staleness = check_staleness(proposal, fields_by_key)
+    author = users.get(proposal.createdBy, f"user {proposal.createdBy}")
 
-    with st.expander(label, expanded=suggestion.status == "open"):
+    with st.container(border=True):
+        header = f"**✏️ Proposed change** — started by {author}, {proposal.createdAt:%Y-%m-%d}"
+        if staleness.is_stale:
+            header += " · :orange-badge[⚠️ page changed since]"
+        st.markdown(header)
+
         if staleness.target_gone:
-            st.warning("The view/indicator this suggestion was filed on no longer exists on this page.")
+            st.warning("The view/indicator this proposal was filed on no longer exists on this page.")
         elif staleness.field_changed:
-            st.warning("The field changed since this suggestion was filed.")
-            col_then, col_now = st.columns(2)
-            with col_then:
-                st.caption("Text when filed")
-                st.markdown(f"> {suggestion.currentValue or '_(not set)_'}")
-            with col_now:
-                st.caption("Text now")
-                st.markdown(f"> {staleness.current_value or '_(not set)_'}")
-        elif staleness.page_changed:
-            st.caption("ℹ️ Other parts of this page changed since the suggestion was filed; this field did not.")
+            st.warning(
+                "The field's text changed since this proposal was filed — "
+                "re-check the proposal against the current text above."
+            )
+            with st.expander("Text when the proposal was filed", expanded=False):
+                st.markdown(f"> {proposal.currentValue or '_(not set)_'}")
 
-        if suggestion.suggestedValue:
-            st.markdown("**Suggested text:**")
-            st.markdown(f"> {suggestion.suggestedValue}")
+        if proposal.suggestedValue is None:
+            st.caption("_Discussion only — no replacement text proposed yet._")
+        elif field.field_path in DESCRIPTION_KEY_FIELDS:
+            ops = bullet_diff(field.current_value, proposal.suggestedValue)
+            st.caption(f"Bullet changes ({diff_summary(ops)}):")
+            st.markdown("\n".join(diff_markdown_lines(ops)))
+        else:
+            st.markdown(f"> {proposal.suggestedValue}")
 
+        # Thread: comments from the canonical proposal plus any legacy parallel threads.
+        comments = list(comments_by_suggestion.get(proposal.id, []))
+        for legacy in extra_threads:
+            comments += comments_by_suggestion.get(legacy.id, [])
+        comments.sort(key=lambda c: c.createdAt)
         for comment in comments:
             comment_author = users.get(comment.userId, f"user {comment.userId}")
             when = comment.createdAt.strftime("%Y-%m-%d %H:%M")
-            if comment.kind == "status_change":
+            if comment.kind in ("status_change", "revision"):
                 st.caption(f"_{comment.text}_ — {comment_author}, {when}")
             else:
                 st.markdown(f"**{comment_author}** · {when}")
@@ -122,41 +157,78 @@ def _render_thread(
             st.caption("Sign-in not detected — reply/status controls disabled.")
             return
 
-        reply_key = f"mrs_reply_{suggestion.id}"
+        reply_key = f"mrs_reply_{proposal.id}"
         with st.form(key=f"{reply_key}_form", clear_on_submit=True, border=False):
             reply = st.text_area(
                 "Reply", key=reply_key, height=80, label_visibility="collapsed", placeholder="Reply..."
             )
-            col_send, col_status = st.columns([1, 3])
-            with col_send:
-                submitted = st.form_submit_button("Reply", use_container_width=True)
-            if submitted and reply.strip():
-                state.add_comment(suggestion.id, user.id, reply.strip())
+            if st.form_submit_button("Reply") and reply.strip():
+                state.add_comment(proposal.id, user.id, reply.strip())
                 st.rerun()
 
-        status = st.segmented_control(
-            "Status",
-            options=["open", "implemented", "rejected"],
-            default=suggestion.status,
-            key=f"mrs_status_{suggestion.id}",
-            label_visibility="collapsed",
-        )
-        if status and status != suggestion.status:
-            state.set_status(suggestion.id, user.id, status)
-            st.rerun()
+        control_col, edit_col = st.columns([3, 2], vertical_alignment="center")
+        with control_col:
+            status = st.segmented_control(
+                "Status",
+                options=["open", "implemented", "rejected"],
+                default=proposal.status,
+                key=f"mrs_status_{proposal.id}",
+                label_visibility="collapsed",
+            )
+            if status and status != proposal.status:
+                state.set_status(proposal.id, user.id, status)
+                st.rerun()
+        with edit_col:
+            _render_suggestion_form(field, user, existing=proposal)
 
 
-def _render_new_suggestion_control(field: ReviewableField, user: gm.User | None) -> None:
-    if user is None:
-        return
-    with st.popover("✏️ Suggest a change / comment", use_container_width=False):
+def _render_resolved(
+    suggestion: gm.MetadataReviewSuggestion,
+    comments: list,
+    users: dict[int, str],
+    user: gm.User | None,
+) -> None:
+    """Resolved proposals collapse to a single history line."""
+    icon = STATUS_ICONS.get(suggestion.status, "💬")
+    author = users.get(suggestion.createdBy, f"user {suggestion.createdBy}")
+    with st.expander(
+        f"{icon} {suggestion.status} — proposal by {author}, {suggestion.createdAt:%Y-%m-%d}", expanded=False
+    ):
+        if suggestion.suggestedValue:
+            st.markdown(f"> {suggestion.suggestedValue}")
+        for comment in comments:
+            comment_author = users.get(comment.userId, f"user {comment.userId}")
+            when = comment.createdAt.strftime("%Y-%m-%d %H:%M")
+            if comment.kind in ("status_change", "revision"):
+                st.caption(f"_{comment.text}_ — {comment_author}, {when}")
+            else:
+                st.markdown(f"**{comment_author}** · {when}: {comment.text}")
+        if user is not None:
+            if st.button("Reopen", key=f"mrs_reopen_{suggestion.id}"):
+                state.set_status(suggestion.id, user.id, "open")
+                st.rerun()
+
+
+def _render_suggestion_form(
+    field: ReviewableField,
+    user: gm.User,
+    existing: gm.MetadataReviewSuggestion | None,
+) -> None:
+    """Popover to start a proposal, or refine the field's existing one."""
+    label = "✏️ Edit proposed text" if existing is not None else "✏️ Suggest a change / comment"
+    prefill = (
+        existing.suggestedValue
+        if existing is not None and existing.suggestedValue is not None
+        else (str(field.current_value) if field.current_value is not None else "")
+    )
+    with st.popover(label, use_container_width=False):
         with st.form(key=_key(field, "form"), clear_on_submit=True, border=False):
             suggested = st.text_area(
-                "Suggested text",
-                value=str(field.current_value) if field.current_value is not None else "",
+                "Proposed text",
+                value=prefill,
                 key=_key(field, "value"),
                 height=120,
-                help="Edit the text as you think it should read. Leave unchanged for a comment-only thread.",
+                help="Edit the text as you think it should read. Leave unchanged for a comment-only entry.",
             )
             comment = st.text_area(
                 "Comment (why / context)",
@@ -165,7 +237,7 @@ def _render_new_suggestion_control(field: ReviewableField, user: gm.User | None)
                 placeholder="Optional: explain the reasoning...",
             )
             if st.form_submit_button("Submit"):
-                unchanged = suggested.strip() == str(field.current_value or "").strip()
+                unchanged = suggested.strip() == prefill.strip()
                 if unchanged and not comment.strip():
                     st.warning("Nothing to submit — edit the text or add a comment.")
                 else:

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -240,6 +240,16 @@ def _render_suggestion_form(
                 unchanged = suggested.strip() == prefill.strip()
                 if unchanged and not comment.strip():
                     st.warning("Nothing to submit — edit the text or add a comment.")
+                elif existing is not None:
+                    # Refine the existing thread in place — it may be keyed to another
+                    # view's source (borrowed by identical text).
+                    state.update_proposal(
+                        existing.id,
+                        user_id=user.id,
+                        suggested_value=None if unchanged else suggested.strip(),
+                        comment_text=comment.strip() or None,
+                    )
+                    st.rerun()
                 else:
                     state.create_suggestion(
                         field,

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -254,8 +254,12 @@ def _render_resolved(
                 st.markdown(f"**{comment_author}** · {when}: {comment.text}")
         if user is not None:
             if st.button("Reopen", key=f"mrs_reopen_{key_ns}_{suggestion.id}"):
-                state.set_status(suggestion.id, user.id, "open")
-                st.rerun()
+                try:
+                    state.set_status(suggestion.id, user.id, "open")
+                except ValueError as e:
+                    st.warning(str(e))
+                else:
+                    st.rerun()
 
 
 def _render_edit_controls(

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -8,6 +8,7 @@ bullet-level diff, so only the changed bullets show.
 """
 
 import hashlib
+from datetime import datetime
 
 import streamlit as st
 
@@ -19,6 +20,8 @@ from apps.wizard.app_pages.metadata_review import state
 from apps.wizard.app_pages.metadata_review.tracked_editor import tracked_editor
 
 STATUS_ICONS = {"open": "💬", "implemented": "✅", "rejected": "🚫"}
+
+_EPOCH = datetime.min
 
 
 def _key(field: ReviewableField, suffix: str, ns: str = "main") -> str:
@@ -91,20 +94,17 @@ def render_field(
             st.markdown(f"> {field.current_value}")
 
         if open_suggestions:
-            for thread in open_suggestions:
-                borrowed = str(thread.currentValue or "").strip() != str(field.current_value or "").strip()
-                _render_thread(
-                    field,
-                    thread,
-                    comments_by_suggestion=comments_by_suggestion,
-                    users=users,
-                    user=user,
-                    fields_by_key=fields_by_key,
-                    key_ns=key_ns,
-                    borrowed=borrowed,
-                    applied_here=applied_by_thread.get(thread.id, False),
-                    initial_override=display_value if borrowed else None,
-                )
+            _render_discussion(
+                field,
+                open_suggestions,
+                comments_by_suggestion=comments_by_suggestion,
+                users=users,
+                user=user,
+                fields_by_key=fields_by_key,
+                key_ns=key_ns,
+                applied_by_thread=applied_by_thread,
+                display_value=display_value,
+            )
         elif user is not None:
             _render_edit_controls(field, user, existing=None, key_ns=key_ns)
 
@@ -112,44 +112,47 @@ def render_field(
             _render_resolved(suggestion, comments_by_suggestion.get(suggestion.id, []), users, user, key_ns=key_ns)
 
 
-def _render_thread(
+def _render_discussion(
     field: ReviewableField,
-    proposal: gm.MetadataReviewSuggestion,
+    threads: list[gm.MetadataReviewSuggestion],
     comments_by_suggestion: dict[int, list],
     users: dict[int, str],
     user: gm.User | None,
     fields_by_key: dict[tuple, ReviewableField],
     key_ns: str = "main",
-    borrowed: bool = False,
-    applied_here: bool = True,
-    initial_override: str | None = None,
+    applied_by_thread: dict[int, bool] | None = None,
+    display_value: str | None = None,
 ) -> None:
-    """The compact discussion strip under the field's (tracked) text.
+    """ONE discussion strip per field, covering all threads contributing to the
+    tracked text above: merged comments, one Reply, one status control (applies
+    to all contributing threads) and one Refine.
 
     The proposed text itself is NOT repeated here — the field's main text block
-    above already shows it as tracked changes.
+    already shows the combined tracked changes.
     """
-    staleness: Staleness = check_staleness(proposal, fields_by_key, display_field=field)
-    author = users.get(proposal.createdBy, f"user {proposal.createdBy}")
+    applied_by_thread = applied_by_thread or {}
+    # The field's own thread anchors refinement; the newest thread anchors replies
+    # when the field has no own thread.
+    own = [t for t in threads if str(t.currentValue or "").strip() == str(field.current_value or "").strip()]
+    anchor = max(own, key=lambda t: t.createdAt or _EPOCH) if own else max(threads, key=lambda t: t.createdAt or _EPOCH)
+    borrowed_anchor = not own
 
-    meta = f"✏️ Proposed by **{author}**, {proposal.createdAt:%Y-%m-%d}"
-    if proposal.filedFromPath and proposal.filedFromPath != field.target_path:
-        # Cross-page thread (e.g. filed on a sibling MDim sharing this metadata).
-        meta += f" — filed on `{proposal.filedFromPath}`"
-    if not applied_here and proposal.suggestedValue is not None:
-        meta += " — ⚠️ its edits don't apply to this view's text (shown where filed)"
+    authors = list(dict.fromkeys(users.get(t.createdBy, f"user {t.createdBy}") for t in threads))
+    started = min((t.createdAt for t in threads if t.createdAt), default=None)
+    meta = "✏️ Proposed by **" + "**, **".join(authors) + "**"
+    if started:
+        meta += f", {started:%Y-%m-%d}"
     st.caption(meta)
 
-    if staleness.target_gone:
-        st.warning("The view/indicator this proposal was filed on no longer exists on this page.")
-    elif staleness.field_changed:
-        with st.expander("Text when the proposal was filed", expanded=False):
-            st.markdown(f"> {proposal.currentValue or '_(not set)_'}")
-
-    if proposal.suggestedValue is None:
+    staleness: Staleness = check_staleness(anchor, fields_by_key, display_field=field)
+    if staleness.field_changed:
+        st.warning("The field's text changed since this proposal was filed — re-check the tracked changes.")
+    if any(not applied_by_thread.get(t.id, False) and t.suggestedValue is not None for t in threads):
+        st.caption("⚠️ Some proposed edits don't apply to this view's text — they show on the views they were made for.")
+    if all(t.suggestedValue is None for t in threads):
         st.caption("_Discussion only — no replacement text proposed yet._")
 
-    comments = sorted(comments_by_suggestion.get(proposal.id, []), key=lambda c: c.createdAt)
+    comments = sorted((c for t in threads for c in comments_by_suggestion.get(t.id, [])), key=lambda c: c.createdAt)
     for comment in comments:
         comment_author = users.get(comment.userId, f"user {comment.userId}")
         when = comment.createdAt.strftime("%Y-%m-%d %H:%M")
@@ -162,37 +165,56 @@ def _render_thread(
         st.caption("Sign-in not detected — reply/status controls disabled.")
         return
 
-    if st.session_state.get(_key(field, f"editing_{proposal.id}", key_ns)):
+    if st.session_state.get(_key(field, f"editing_{anchor.id}", key_ns)):
         # The editor must span the whole section, not sit inside a button column.
         _render_edit_controls(
-            field, user, existing=proposal, key_ns=key_ns, borrowed=borrowed, initial_override=initial_override
+            field,
+            user,
+            existing=anchor,
+            key_ns=key_ns,
+            borrowed=borrowed_anchor,
+            initial_override=display_value if borrowed_anchor else None,
         )
     else:
         # One slim controls row: reply (popover), status, refine.
         reply_col, status_col, edit_col = st.columns([1.1, 2.2, 1.7], vertical_alignment="center")
         with reply_col, st.popover("💬 Reply"):
-            reply_key = f"mrs_reply_{key_ns}_{proposal.id}"
+            reply_key = f"mrs_reply_{key_ns}_{anchor.id}"
             with st.form(key=f"{reply_key}_form", clear_on_submit=True, border=False):
                 reply = st.text_area(
                     "Reply", key=reply_key, height=80, label_visibility="collapsed", placeholder="Reply..."
                 )
                 if st.form_submit_button("Send") and reply.strip():
-                    state.add_comment(proposal.id, user.id, reply.strip())
+                    state.add_comment(anchor.id, user.id, reply.strip())
                     st.rerun()
         with status_col:
             status = st.segmented_control(
                 "Status",
                 options=["open", "implemented", "rejected"],
-                default=proposal.status,
-                key=f"mrs_status_{key_ns}_{proposal.id}",
+                default="open",
+                key=f"mrs_status_{key_ns}_{anchor.id}",
                 label_visibility="collapsed",
             )
-            if status and status != proposal.status:
-                state.set_status(proposal.id, user.id, status)
-                st.rerun()
+            if status and status != "open":
+                # Resolving applies to every thread whose edits are shown here.
+                errors = []
+                for thread in threads:
+                    try:
+                        state.set_status(thread.id, user.id, status)
+                    except ValueError as e:
+                        errors.append(str(e))
+                if errors:
+                    st.warning(errors[0])
+                else:
+                    st.rerun()
         with edit_col:
             _render_edit_controls(
-                field, user, existing=proposal, key_ns=key_ns, borrowed=borrowed, initial_override=initial_override
+                field,
+                user,
+                existing=anchor,
+                key_ns=key_ns,
+                borrowed=borrowed_anchor,
+                initial_override=display_value if borrowed_anchor else None,
             )
 
 

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -176,20 +176,24 @@ def _render_thread(
                 state.add_comment(proposal.id, user.id, reply.strip())
                 st.rerun()
 
-        control_col, edit_col = st.columns([3, 2], vertical_alignment="center")
-        with control_col:
-            status = st.segmented_control(
-                "Status",
-                options=["open", "implemented", "rejected"],
-                default=proposal.status,
-                key=f"mrs_status_{proposal.id}",
-                label_visibility="collapsed",
-            )
-            if status and status != proposal.status:
-                state.set_status(proposal.id, user.id, status)
-                st.rerun()
-        with edit_col:
+        if st.session_state.get(_key(field, "editing")):
+            # The editor must span the whole section, not sit inside a button column.
             _render_edit_controls(field, user, existing=proposal)
+        else:
+            control_col, edit_col = st.columns([3, 2], vertical_alignment="center")
+            with control_col:
+                status = st.segmented_control(
+                    "Status",
+                    options=["open", "implemented", "rejected"],
+                    default=proposal.status,
+                    key=f"mrs_status_{proposal.id}",
+                    label_visibility="collapsed",
+                )
+                if status and status != proposal.status:
+                    state.set_status(proposal.id, user.id, status)
+                    st.rerun()
+            with edit_col:
+                _render_edit_controls(field, user, existing=proposal)
 
 
 def _render_resolved(

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -18,7 +18,6 @@ from apps.metadata_review.targets import MdimReview, ReviewableField
 from apps.wizard.app_pages.metadata_review import state
 from apps.wizard.app_pages.metadata_review.tracked_editor import tracked_editor
 
-PROVENANCE_COLORS = {"override": "green", "inherited": "blue", "missing": "red"}
 STATUS_ICONS = {"open": "💬", "implemented": "✅", "rejected": "🚫"}
 
 DESCRIPTION_KEY_FIELDS = {"metadata.description_key", "description_key"}
@@ -41,7 +40,6 @@ def render_field(
     key_ns: str = "main",
 ) -> None:
     """Render one reviewable field with its consolidated proposal and history."""
-    color = PROVENANCE_COLORS[field.provenance]
     open_suggestions = [s for s in suggestions if s.status == "open"]
     resolved = [s for s in suggestions if s.status != "open"]
     # At most one open proposal per field going forward; render the newest as
@@ -65,12 +63,15 @@ def render_field(
         with title_col:
             st.markdown(f"**{field.label}**")
         with badge_col:
-            badges = [f":{color}-badge[{field.provenance}]"]
+            # Provenance (override/inherited) is data-scientist information — it
+            # stays in the export, not in the reviewer-facing UI.
+            badges = []
             if proposal is not None:
                 badges.append(":orange-badge[open proposal]")
             if shared_views:
                 badges.append(f":gray-badge[in {len(shared_views) + 1} views]")
-            st.markdown(" ".join(badges), help=shared_tooltip)
+            if badges:
+                st.markdown(" ".join(badges), help=shared_tooltip)
 
         # The field's text, shown ONCE: tracked changes when a proposal exists
         # (deletions struck through, insertions tinted), plain text otherwise.
@@ -122,15 +123,9 @@ def render_field(
         elif field.current_value is None:
             st.caption("_(not set — the chart renders without it)_")
         elif str(field.current_value) == "":
-            st.caption("_(explicitly blank — the view suppresses the inherited text)_")
+            st.caption("_(explicitly blank — this view shows no text here on purpose)_")
         else:
             st.markdown(f"> {field.current_value}")
-        inherited_tooltip = None
-        if field.provenance == "override" and field.inherited_value is not None:
-            inherited_tooltip = (
-                f"Inherited value this override replaces:\n\n{field.inherited_value}\n\n(from `{field.inherited_from}`)"
-            )
-        st.caption(field.edit_hint, help=inherited_tooltip)
 
         if proposal is not None:
             _render_thread(

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -14,13 +14,11 @@ import streamlit as st
 import etl.grapher.model as gm
 from apps.metadata_review.diffs import apply_bullet_edits, bullet_diff, diff_summary, tracked_changes_html
 from apps.metadata_review.resolution import Staleness, check_staleness, transfer_proposal
-from apps.metadata_review.targets import MdimReview, ReviewableField
+from apps.metadata_review.targets import DESCRIPTION_KEY_FIELDS, MdimReview, ReviewableField
 from apps.wizard.app_pages.metadata_review import state
 from apps.wizard.app_pages.metadata_review.tracked_editor import tracked_editor
 
 STATUS_ICONS = {"open": "💬", "implemented": "✅", "rejected": "🚫"}
-
-DESCRIPTION_KEY_FIELDS = {"metadata.description_key", "description_key"}
 
 
 def _key(field: ReviewableField, suffix: str, ns: str = "main") -> str:
@@ -128,6 +126,7 @@ def render_field(
             st.markdown(f"> {field.current_value}")
 
         if proposal is not None:
+            borrowed = str(proposal.currentValue or "").strip() != str(field.current_value or "").strip()
             _render_thread(
                 field,
                 proposal,
@@ -137,6 +136,8 @@ def render_field(
                 user=user,
                 fields_by_key=fields_by_key,
                 key_ns=key_ns,
+                borrowed=borrowed,
+                initial_override=display_value if borrowed else None,
             )
         elif user is not None:
             _render_edit_controls(field, user, existing=None, key_ns=key_ns)
@@ -154,6 +155,8 @@ def _render_thread(
     user: gm.User | None,
     fields_by_key: dict[tuple, ReviewableField],
     key_ns: str = "main",
+    borrowed: bool = False,
+    initial_override: str | None = None,
 ) -> None:
     """The compact discussion strip under the field's (tracked) text.
 
@@ -262,6 +265,8 @@ def _render_edit_controls(
     user: gm.User,
     existing: gm.MetadataReviewSuggestion | None,
     key_ns: str = "main",
+    borrowed: bool = False,
+    initial_override: str | None = None,
 ) -> None:
     """In-place tracked-changes editing: the displayed text becomes editable, with a
     live diff preview; saving files onto the field's consolidated proposal."""
@@ -270,8 +275,14 @@ def _render_edit_controls(
 
     if st.session_state.get(editing_key):
         # `is not None`, not truthiness: an empty string is a real proposal (clear the
-        # field) and must survive a refine round-trip.
-        initial = existing.suggestedValue if existing is not None and existing.suggestedValue is not None else current
+        # field) and must survive a refine round-trip. For a borrowed thread (filed on
+        # a page with different text), seed with the version transferred to THIS view.
+        if initial_override is not None:
+            initial = initial_override
+        elif existing is not None and existing.suggestedValue is not None and not borrowed:
+            initial = existing.suggestedValue
+        else:
+            initial = current
         result = tracked_editor(
             original=current,
             initial=initial,
@@ -284,14 +295,23 @@ def _render_edit_controls(
             if result.get("action") == "save":
                 text = (result.get("text") or "").strip()
                 comment = (result.get("comment") or "").strip() or None
-                if existing is not None:
-                    # Refine the existing thread in place — it may be keyed to another
-                    # view's source (borrowed by identical text).
+                if existing is not None and not borrowed:
+                    # Refine the existing thread in place (same-text source key).
                     proposal_unchanged = text == (existing.suggestedValue or "").strip()
                     state.update_proposal(
                         existing.id,
                         user_id=user.id,
                         suggested_value=None if proposal_unchanged else text,
+                        comment_text=comment,
+                    )
+                elif existing is not None:
+                    # A borrowed thread belongs to another page's text — refining it
+                    # from here files onto THIS field's own source instead, so the
+                    # foreign row keeps its alignment.
+                    state.create_suggestion(
+                        field,
+                        user_id=user.id,
+                        suggested_value=None if text == current.strip() else text,
                         comment_text=comment,
                     )
                 elif text != current.strip() or comment:

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -13,7 +13,7 @@ import streamlit as st
 
 import etl.grapher.model as gm
 from apps.metadata_review.diffs import bullet_diff, diff_summary, tracked_changes_html
-from apps.metadata_review.resolution import Staleness, check_staleness
+from apps.metadata_review.resolution import Staleness, check_staleness, transfer_proposal
 from apps.metadata_review.targets import MdimReview, ReviewableField
 from apps.wizard.app_pages.metadata_review import state
 from apps.wizard.app_pages.metadata_review.tracked_editor import tracked_editor
@@ -67,16 +67,36 @@ def render_field(
 
         # The field's text, shown ONCE: tracked changes when a proposal exists
         # (deletions struck through, insertions tinted), plain text otherwise.
+        display_value = None
+        transferred = False
         if proposal is not None and proposal.suggestedValue is not None:
+            base_matches = str(proposal.currentValue or "").strip() == str(field.current_value or "").strip()
+            if base_matches:
+                display_value = proposal.suggestedValue
+            elif mdim_review is not None:
+                # Pattern-shared thread filed on a view whose rendered text differs
+                # only by dimension words — re-render the proposal for THIS view.
+                display_value = transfer_proposal(mdim_review, proposal, field)
+                transferred = display_value is not None
+        if proposal is not None and display_value is not None:
             staleness = check_staleness(proposal, fields_by_key)
             if staleness.field_changed:
                 st.warning("The field's text changed since this proposal was filed — re-check the tracked changes.")
             is_bullets = field.field_path in DESCRIPTION_KEY_FIELDS
             if is_bullets:
-                st.caption(
-                    f"Bullet changes ({diff_summary(bullet_diff(field.current_value, proposal.suggestedValue))}):"
-                )
-            st.html(tracked_changes_html(field.current_value, proposal.suggestedValue, is_bullet_list=is_bullets))
+                st.caption(f"Bullet changes ({diff_summary(bullet_diff(field.current_value, display_value))}):")
+            st.html(tracked_changes_html(field.current_value, display_value, is_bullet_list=is_bullets))
+            if transferred:
+                st.caption("↳ Shared pattern — the proposed wording is shown with this view's dimension words.")
+        elif proposal is not None and proposal.suggestedValue is not None:
+            # Connected thread, but the proposal can't be re-rendered for this view
+            # (it changed the dimension words themselves). Show the current text.
+            if field.current_value is not None:
+                st.markdown(f"> {field.current_value}")
+            st.caption(
+                "✏️ A change to this text's shared pattern is proposed on another view — "
+                "open that view to see the tracked wording."
+            )
         elif field.current_value is None:
             st.caption("_(not set — the chart renders without it)_")
         elif str(field.current_value) == "":

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -1,0 +1,178 @@
+"""The field row: provenance badge, current text, threads, and suggestion controls."""
+
+import hashlib
+
+import streamlit as st
+
+import etl.grapher.model as gm
+from apps.metadata_review.resolution import Staleness, check_staleness
+from apps.metadata_review.targets import MdimReview, ReviewableField
+from apps.wizard.app_pages.metadata_review import state
+
+PROVENANCE_BADGES = {
+    "override": ("green", "set in the MDim config"),
+    "inherited": ("blue", "inherited from the indicator (garden metadata)"),
+    "missing": ("red", "not set anywhere"),
+}
+STATUS_ICONS = {"open": "💬", "implemented": "✅", "rejected": "🚫"}
+
+
+def _key(field: ReviewableField, suffix: str) -> str:
+    digest = hashlib.md5("|".join(str(p) for p in field.source_key()).encode()).hexdigest()[:12]
+    return f"mrf_{digest}_{suffix}"
+
+
+def render_field(
+    field: ReviewableField,
+    suggestions: list[gm.MetadataReviewSuggestion],
+    comments_by_suggestion: dict[int, list],
+    users: dict[int, str],
+    user: gm.User | None,
+    fields_by_key: dict[tuple, ReviewableField],
+    shared_views: list[str] | None = None,
+    mdim_review: MdimReview | None = None,
+) -> None:
+    """Render one reviewable field with its threads and controls."""
+    color, explanation = PROVENANCE_BADGES[field.provenance]
+    header = st.container(border=True)
+    with header:
+        title_col, badge_col = st.columns([4, 2], vertical_alignment="center")
+        with title_col:
+            st.markdown(f"**{field.label}**")
+        with badge_col:
+            badges = [f":{color}-badge[{field.provenance}]"]
+            if suggestions:
+                n_open = sum(1 for s in suggestions if s.status == "open")
+                if n_open:
+                    badges.append(f":orange-badge[{n_open} open]")
+            if shared_views:
+                badges.append(f":gray-badge[appears in {len(shared_views) + 1} views]")
+            st.markdown(" ".join(badges))
+
+        if field.current_value is None:
+            st.caption("_(not set — the chart renders without it)_")
+        elif str(field.current_value) == "":
+            st.caption("_(explicitly blank — the view suppresses the inherited text)_")
+        else:
+            st.markdown(f"> {field.current_value}")
+        st.caption(f"{explanation.capitalize()}. {field.edit_hint}")
+
+        if field.provenance == "override" and field.inherited_value is not None:
+            with st.expander("Inherited value this override replaces", expanded=False):
+                st.markdown(f"> {field.inherited_value}")
+                st.caption(f"From `{field.inherited_from}`")
+
+        if shared_views and mdim_review is not None:
+            with st.expander(f"Also shown in {len(shared_views)} other view(s)", expanded=False):
+                views_by_id = {v.view_id: v for v in mdim_review.views}
+                for view_id in shared_views:
+                    view = views_by_id.get(view_id)
+                    dims = mdim_review.human_dimensions(view.dimensions) if view else {}
+                    st.markdown("- " + (" · ".join(f"**{k}:** {v}" for k, v in dims.items()) or view_id))
+
+        for suggestion in suggestions:
+            _render_thread(suggestion, comments_by_suggestion.get(suggestion.id, []), users, user, fields_by_key)
+
+        _render_new_suggestion_control(field, user)
+
+
+def _render_thread(
+    suggestion: gm.MetadataReviewSuggestion,
+    comments: list,
+    users: dict[int, str],
+    user: gm.User | None,
+    fields_by_key: dict[tuple, ReviewableField],
+) -> None:
+    staleness: Staleness = check_staleness(suggestion, fields_by_key)
+    icon = STATUS_ICONS.get(suggestion.status, "💬")
+    author = users.get(suggestion.createdBy, f"user {suggestion.createdBy}")
+    label = f"{icon} #{suggestion.id} by {author} — {suggestion.status}"
+    if staleness.is_stale:
+        label += " ⚠️ stale"
+
+    with st.expander(label, expanded=suggestion.status == "open"):
+        if staleness.target_gone:
+            st.warning("The view/indicator this suggestion was filed on no longer exists on this page.")
+        elif staleness.field_changed:
+            st.warning("The field changed since this suggestion was filed.")
+            col_then, col_now = st.columns(2)
+            with col_then:
+                st.caption("Text when filed")
+                st.markdown(f"> {suggestion.currentValue or '_(not set)_'}")
+            with col_now:
+                st.caption("Text now")
+                st.markdown(f"> {staleness.current_value or '_(not set)_'}")
+        elif staleness.page_changed:
+            st.caption("ℹ️ Other parts of this page changed since the suggestion was filed; this field did not.")
+
+        if suggestion.suggestedValue:
+            st.markdown("**Suggested text:**")
+            st.markdown(f"> {suggestion.suggestedValue}")
+
+        for comment in comments:
+            comment_author = users.get(comment.userId, f"user {comment.userId}")
+            when = comment.createdAt.strftime("%Y-%m-%d %H:%M")
+            if comment.kind == "status_change":
+                st.caption(f"_{comment.text}_ — {comment_author}, {when}")
+            else:
+                st.markdown(f"**{comment_author}** · {when}")
+                st.markdown(comment.text)
+
+        if user is None:
+            st.caption("Sign-in not detected — reply/status controls disabled.")
+            return
+
+        reply_key = f"mrs_reply_{suggestion.id}"
+        with st.form(key=f"{reply_key}_form", clear_on_submit=True, border=False):
+            reply = st.text_area(
+                "Reply", key=reply_key, height=80, label_visibility="collapsed", placeholder="Reply..."
+            )
+            col_send, col_status = st.columns([1, 3])
+            with col_send:
+                submitted = st.form_submit_button("Reply", use_container_width=True)
+            if submitted and reply.strip():
+                state.add_comment(suggestion.id, user.id, reply.strip())
+                st.rerun()
+
+        status = st.segmented_control(
+            "Status",
+            options=["open", "implemented", "rejected"],
+            default=suggestion.status,
+            key=f"mrs_status_{suggestion.id}",
+            label_visibility="collapsed",
+        )
+        if status and status != suggestion.status:
+            state.set_status(suggestion.id, user.id, status)
+            st.rerun()
+
+
+def _render_new_suggestion_control(field: ReviewableField, user: gm.User | None) -> None:
+    if user is None:
+        return
+    with st.popover("✏️ Suggest a change / comment", use_container_width=False):
+        with st.form(key=_key(field, "form"), clear_on_submit=True, border=False):
+            suggested = st.text_area(
+                "Suggested text",
+                value=str(field.current_value) if field.current_value is not None else "",
+                key=_key(field, "value"),
+                height=120,
+                help="Edit the text as you think it should read. Leave unchanged for a comment-only thread.",
+            )
+            comment = st.text_area(
+                "Comment (why / context)",
+                key=_key(field, "comment"),
+                height=80,
+                placeholder="Optional: explain the reasoning...",
+            )
+            if st.form_submit_button("Submit"):
+                unchanged = suggested.strip() == str(field.current_value or "").strip()
+                if unchanged and not comment.strip():
+                    st.warning("Nothing to submit — edit the text or add a comment.")
+                else:
+                    state.create_suggestion(
+                        field,
+                        user_id=user.id,
+                        suggested_value=None if unchanged else suggested.strip(),
+                        comment_text=comment.strip() or None,
+                    )
+                    st.rerun()

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -12,7 +12,7 @@ import hashlib
 import streamlit as st
 
 import etl.grapher.model as gm
-from apps.metadata_review.diffs import bullet_diff, diff_summary, tracked_changes_html
+from apps.metadata_review.diffs import apply_bullet_edits, bullet_diff, diff_summary, tracked_changes_html
 from apps.metadata_review.resolution import Staleness, check_staleness, transfer_proposal
 from apps.metadata_review.targets import MdimReview, ReviewableField
 from apps.wizard.app_pages.metadata_review import state
@@ -75,26 +75,41 @@ def render_field(
         # The field's text, shown ONCE: tracked changes when a proposal exists
         # (deletions struck through, insertions tinted), plain text otherwise.
         display_value = None
-        transferred = False
+        transfer_note = None
         if proposal is not None and proposal.suggestedValue is not None:
             base_matches = str(proposal.currentValue or "").strip() == str(field.current_value or "").strip()
             if base_matches:
                 display_value = proposal.suggestedValue
+            elif field.field_path in DESCRIPTION_KEY_FIELDS:
+                # Bullet lists share individual bullets across pages — re-apply the
+                # proposal's bullet edits to THIS field's list (partially if needed).
+                transfer = apply_bullet_edits(
+                    proposal.currentValue, proposal.suggestedValue, str(field.current_value or "")
+                )
+                if transfer is not None:
+                    display_value, n_applied, n_total = transfer
+                    transfer_note = "↳ Shared bullets — the proposal's edits are applied to this page's list."
+                    if n_applied < n_total:
+                        transfer_note = (
+                            f"↳ {n_applied} of {n_total} bullet edits apply here — "
+                            "the rest touch bullets this page doesn't have."
+                        )
             elif mdim_review is not None:
                 # Pattern-shared thread filed on a view whose rendered text differs
                 # only by dimension words — re-render the proposal for THIS view.
                 display_value = transfer_proposal(mdim_review, proposal, field)
-                transferred = display_value is not None
+                if display_value is not None:
+                    transfer_note = "↳ Shared pattern — the proposed wording is shown with this view's dimension words."
         if proposal is not None and display_value is not None:
-            staleness = check_staleness(proposal, fields_by_key)
+            staleness = check_staleness(proposal, fields_by_key, display_field=field)
             if staleness.field_changed:
                 st.warning("The field's text changed since this proposal was filed — re-check the tracked changes.")
             is_bullets = field.field_path in DESCRIPTION_KEY_FIELDS
             if is_bullets:
                 st.caption(f"Bullet changes ({diff_summary(bullet_diff(field.current_value, display_value))}):")
             st.html(tracked_changes_html(field.current_value, display_value, is_bullet_list=is_bullets))
-            if transferred:
-                st.caption("↳ Shared pattern — the proposed wording is shown with this view's dimension words.")
+            if transfer_note:
+                st.caption(transfer_note)
         elif proposal is not None and proposal.suggestedValue is not None:
             # Connected thread, but the proposal can't be re-rendered for this view
             # (it changed the dimension words themselves). Show the current text.
@@ -150,10 +165,14 @@ def _render_thread(
     The proposed text itself is NOT repeated here — the field's main text block
     above already shows it as tracked changes.
     """
-    staleness: Staleness = check_staleness(proposal, fields_by_key)
+    staleness: Staleness = check_staleness(proposal, fields_by_key, display_field=field)
     author = users.get(proposal.createdBy, f"user {proposal.createdBy}")
 
-    st.caption(f"✏️ Proposed by **{author}**, {proposal.createdAt:%Y-%m-%d}")
+    meta = f"✏️ Proposed by **{author}**, {proposal.createdAt:%Y-%m-%d}"
+    if proposal.filedFromPath and proposal.filedFromPath != field.target_path:
+        # Cross-page thread (e.g. filed on a sibling MDim sharing this metadata).
+        meta += f" — filed on `{proposal.filedFromPath}`"
+    st.caption(meta)
 
     if staleness.target_gone:
         st.warning("The view/indicator this proposal was filed on no longer exists on this page.")

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -12,8 +12,8 @@ import hashlib
 import streamlit as st
 
 import etl.grapher.model as gm
-from apps.metadata_review.diffs import apply_bullet_edits, bullet_diff, diff_summary, tracked_changes_html
-from apps.metadata_review.resolution import Staleness, check_staleness, transfer_proposal
+from apps.metadata_review.diffs import bullet_diff, diff_summary, tracked_changes_html
+from apps.metadata_review.resolution import Staleness, check_staleness, combined_display_value
 from apps.metadata_review.targets import DESCRIPTION_KEY_FIELDS, MdimReview, ReviewableField
 from apps.wizard.app_pages.metadata_review import state
 from apps.wizard.app_pages.metadata_review.tracked_editor import tracked_editor
@@ -71,53 +71,18 @@ def render_field(
             if badges:
                 st.markdown(" ".join(badges), help=shared_tooltip)
 
-        # The field's text, shown ONCE: tracked changes when a proposal exists
-        # (deletions struck through, insertions tinted), plain text otherwise.
-        display_value = None
-        transfer_note = None
-        if proposal is not None and proposal.suggestedValue is not None:
-            base_matches = str(proposal.currentValue or "").strip() == str(field.current_value or "").strip()
-            if base_matches:
-                display_value = proposal.suggestedValue
-            elif field.field_path in DESCRIPTION_KEY_FIELDS:
-                # Bullet lists share individual bullets across pages — re-apply the
-                # proposal's bullet edits to THIS field's list (partially if needed).
-                transfer = apply_bullet_edits(
-                    proposal.currentValue, proposal.suggestedValue, str(field.current_value or "")
-                )
-                if transfer is not None:
-                    display_value, n_applied, n_total = transfer
-                    transfer_note = "↳ Shared bullets — the proposal's edits are applied to this page's list."
-                    if n_applied < n_total:
-                        transfer_note = (
-                            f"↳ {n_applied} of {n_total} bullet edits apply here — "
-                            "the rest touch bullets this page doesn't have."
-                        )
-            elif mdim_review is not None:
-                # Pattern-shared thread filed on a view whose rendered text differs
-                # only by dimension words — re-render the proposal for THIS view.
-                display_value = transfer_proposal(mdim_review, proposal, field)
-                if display_value is not None:
-                    transfer_note = "↳ Shared pattern — the proposed wording is shown with this view's dimension words."
-        if proposal is not None and display_value is not None:
-            staleness = check_staleness(proposal, fields_by_key, display_field=field)
-            if staleness.field_changed:
-                st.warning("The field's text changed since this proposal was filed — re-check the tracked changes.")
+        # The field's text, shown ONCE, with ALL applicable open proposals applied
+        # (own proposal first, borrowed ones layered on top) — Google-Docs style.
+        display_value, applied_by_thread = combined_display_value(field, open_suggestions, review=mdim_review)
+        if display_value is not None:
+            if proposal is not None:
+                staleness = check_staleness(proposal, fields_by_key, display_field=field)
+                if staleness.field_changed:
+                    st.warning("The field's text changed since a proposal was filed — re-check the tracked changes.")
             is_bullets = field.field_path in DESCRIPTION_KEY_FIELDS
             if is_bullets:
                 st.caption(f"Bullet changes ({diff_summary(bullet_diff(field.current_value, display_value))}):")
             st.html(tracked_changes_html(field.current_value, display_value, is_bullet_list=is_bullets))
-            if transfer_note:
-                st.caption(transfer_note)
-        elif proposal is not None and proposal.suggestedValue is not None:
-            # Connected thread, but the proposal can't be re-rendered for this view
-            # (it changed the dimension words themselves). Show the current text.
-            if field.current_value is not None:
-                st.markdown(f"> {field.current_value}")
-            st.caption(
-                "✏️ A change to this text's shared pattern is proposed on another view — "
-                "open that view to see the tracked wording."
-            )
         elif field.current_value is None:
             st.caption("_(not set — the chart renders without it)_")
         elif str(field.current_value) == "":
@@ -125,20 +90,21 @@ def render_field(
         else:
             st.markdown(f"> {field.current_value}")
 
-        if proposal is not None:
-            borrowed = str(proposal.currentValue or "").strip() != str(field.current_value or "").strip()
-            _render_thread(
-                field,
-                proposal,
-                extra_threads=open_suggestions[1:],
-                comments_by_suggestion=comments_by_suggestion,
-                users=users,
-                user=user,
-                fields_by_key=fields_by_key,
-                key_ns=key_ns,
-                borrowed=borrowed,
-                initial_override=display_value if borrowed else None,
-            )
+        if open_suggestions:
+            for thread in open_suggestions:
+                borrowed = str(thread.currentValue or "").strip() != str(field.current_value or "").strip()
+                _render_thread(
+                    field,
+                    thread,
+                    comments_by_suggestion=comments_by_suggestion,
+                    users=users,
+                    user=user,
+                    fields_by_key=fields_by_key,
+                    key_ns=key_ns,
+                    borrowed=borrowed,
+                    applied_here=applied_by_thread.get(thread.id, False),
+                    initial_override=display_value if borrowed else None,
+                )
         elif user is not None:
             _render_edit_controls(field, user, existing=None, key_ns=key_ns)
 
@@ -149,13 +115,13 @@ def render_field(
 def _render_thread(
     field: ReviewableField,
     proposal: gm.MetadataReviewSuggestion,
-    extra_threads: list[gm.MetadataReviewSuggestion],
     comments_by_suggestion: dict[int, list],
     users: dict[int, str],
     user: gm.User | None,
     fields_by_key: dict[tuple, ReviewableField],
     key_ns: str = "main",
     borrowed: bool = False,
+    applied_here: bool = True,
     initial_override: str | None = None,
 ) -> None:
     """The compact discussion strip under the field's (tracked) text.
@@ -170,6 +136,8 @@ def _render_thread(
     if proposal.filedFromPath and proposal.filedFromPath != field.target_path:
         # Cross-page thread (e.g. filed on a sibling MDim sharing this metadata).
         meta += f" — filed on `{proposal.filedFromPath}`"
+    if not applied_here and proposal.suggestedValue is not None:
+        meta += " — ⚠️ its edits don't apply to this view's text (shown where filed)"
     st.caption(meta)
 
     if staleness.target_gone:
@@ -181,11 +149,7 @@ def _render_thread(
     if proposal.suggestedValue is None:
         st.caption("_Discussion only — no replacement text proposed yet._")
 
-    # Thread: comments from the canonical proposal plus any legacy parallel threads.
-    comments = list(comments_by_suggestion.get(proposal.id, []))
-    for legacy in extra_threads:
-        comments += comments_by_suggestion.get(legacy.id, [])
-    comments.sort(key=lambda c: c.createdAt)
+    comments = sorted(comments_by_suggestion.get(proposal.id, []), key=lambda c: c.createdAt)
     for comment in comments:
         comment_author = users.get(comment.userId, f"user {comment.userId}")
         when = comment.createdAt.strftime("%Y-%m-%d %H:%M")

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -18,11 +18,7 @@ from apps.metadata_review.targets import MdimReview, ReviewableField
 from apps.wizard.app_pages.metadata_review import state
 from apps.wizard.app_pages.metadata_review.tracked_editor import tracked_editor
 
-PROVENANCE_BADGES = {
-    "override": ("green", "set in the MDim config"),
-    "inherited": ("blue", "inherited from the indicator (garden metadata)"),
-    "missing": ("red", "not set anywhere"),
-}
+PROVENANCE_COLORS = {"override": "green", "inherited": "blue", "missing": "red"}
 STATUS_ICONS = {"open": "💬", "implemented": "✅", "rejected": "🚫"}
 
 DESCRIPTION_KEY_FIELDS = {"metadata.description_key", "description_key"}
@@ -45,7 +41,7 @@ def render_field(
     key_ns: str = "main",
 ) -> None:
     """Render one reviewable field with its consolidated proposal and history."""
-    color, explanation = PROVENANCE_BADGES[field.provenance]
+    color = PROVENANCE_COLORS[field.provenance]
     open_suggestions = [s for s in suggestions if s.status == "open"]
     resolved = [s for s in suggestions if s.status != "open"]
     # At most one open proposal per field going forward; render the newest as
@@ -103,7 +99,7 @@ def render_field(
             st.caption("_(explicitly blank — the view suppresses the inherited text)_")
         else:
             st.markdown(f"> {field.current_value}")
-        st.caption(f"{explanation.capitalize()}. {field.edit_hint}")
+        st.caption(field.edit_hint)
 
         if field.provenance == "override" and field.inherited_value is not None:
             with st.expander("Inherited value this override replaces", expanded=False):

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -12,10 +12,11 @@ import hashlib
 import streamlit as st
 
 import etl.grapher.model as gm
-from apps.metadata_review.diffs import bullet_diff, diff_markdown_lines, diff_summary
+from apps.metadata_review.diffs import bullet_diff, diff_summary, tracked_changes_html
 from apps.metadata_review.resolution import Staleness, check_staleness
 from apps.metadata_review.targets import MdimReview, ReviewableField
 from apps.wizard.app_pages.metadata_review import state
+from apps.wizard.app_pages.metadata_review.tracked_editor import tracked_editor
 
 PROVENANCE_BADGES = {
     "override": ("green", "set in the MDim config"),
@@ -95,7 +96,7 @@ def render_field(
                 fields_by_key=fields_by_key,
             )
         elif user is not None:
-            _render_suggestion_form(field, user, existing=None)
+            _render_edit_controls(field, user, existing=None)
 
         for suggestion in resolved:
             _render_resolved(suggestion, comments_by_suggestion.get(suggestion.id, []), users, user)
@@ -132,12 +133,14 @@ def _render_proposal(
 
         if proposal.suggestedValue is None:
             st.caption("_Discussion only — no replacement text proposed yet._")
-        elif field.field_path in DESCRIPTION_KEY_FIELDS:
-            ops = bullet_diff(field.current_value, proposal.suggestedValue)
-            st.caption(f"Bullet changes ({diff_summary(ops)}):")
-            st.markdown("\n".join(diff_markdown_lines(ops)))
         else:
-            st.markdown(f"> {proposal.suggestedValue}")
+            # Tracked changes: the text as it currently reads, with deletions struck
+            # through and insertions tinted (Google-Docs style).
+            is_bullets = field.field_path in DESCRIPTION_KEY_FIELDS
+            if is_bullets:
+                ops = bullet_diff(field.current_value, proposal.suggestedValue)
+                st.caption(f"Bullet changes ({diff_summary(ops)}):")
+            st.html(tracked_changes_html(field.current_value, proposal.suggestedValue, is_bullet_list=is_bullets))
 
         # Thread: comments from the canonical proposal plus any legacy parallel threads.
         comments = list(comments_by_suggestion.get(proposal.id, []))
@@ -179,7 +182,7 @@ def _render_proposal(
                 state.set_status(proposal.id, user.id, status)
                 st.rerun()
         with edit_col:
-            _render_suggestion_form(field, user, existing=proposal)
+            _render_edit_controls(field, user, existing=proposal)
 
 
 def _render_resolved(
@@ -209,52 +212,67 @@ def _render_resolved(
                 st.rerun()
 
 
-def _render_suggestion_form(
+def _render_edit_controls(
     field: ReviewableField,
     user: gm.User,
     existing: gm.MetadataReviewSuggestion | None,
 ) -> None:
-    """Popover to start a proposal, or refine the field's existing one."""
-    label = "✏️ Edit proposed text" if existing is not None else "✏️ Suggest a change / comment"
-    prefill = (
-        existing.suggestedValue
-        if existing is not None and existing.suggestedValue is not None
-        else (str(field.current_value) if field.current_value is not None else "")
-    )
-    with st.popover(label, use_container_width=False):
-        with st.form(key=_key(field, "form"), clear_on_submit=True, border=False):
-            suggested = st.text_area(
-                "Proposed text",
-                value=prefill,
-                key=_key(field, "value"),
-                height=120,
-                help="Edit the text as you think it should read. Leave unchanged for a comment-only entry.",
-            )
-            comment = st.text_area(
-                "Comment (why / context)",
-                key=_key(field, "comment"),
-                height=80,
-                placeholder="Optional: explain the reasoning...",
-            )
-            if st.form_submit_button("Submit"):
-                unchanged = suggested.strip() == prefill.strip()
-                if unchanged and not comment.strip():
-                    st.warning("Nothing to submit — edit the text or add a comment.")
-                elif existing is not None:
+    """In-place tracked-changes editing: the displayed text becomes editable, with a
+    live diff preview; saving files onto the field's consolidated proposal."""
+    editing_key = _key(field, "editing")
+    current = str(field.current_value) if field.current_value is not None else ""
+
+    if st.session_state.get(editing_key):
+        initial = existing.suggestedValue if existing is not None and existing.suggestedValue else current
+        result = tracked_editor(
+            original=current,
+            initial=initial,
+            key=_key(field, "editor"),
+            bullet_list=field.field_path in DESCRIPTION_KEY_FIELDS,
+        )
+        handled_key = _key(field, "nonce")
+        if result and result.get("nonce") != st.session_state.get(handled_key):
+            st.session_state[handled_key] = result.get("nonce")
+            if result.get("action") == "save":
+                text = (result.get("text") or "").strip()
+                comment = (result.get("comment") or "").strip() or None
+                if existing is not None:
                     # Refine the existing thread in place — it may be keyed to another
                     # view's source (borrowed by identical text).
+                    proposal_unchanged = text == (existing.suggestedValue or "").strip()
                     state.update_proposal(
                         existing.id,
                         user_id=user.id,
-                        suggested_value=None if unchanged else suggested.strip(),
-                        comment_text=comment.strip() or None,
+                        suggested_value=None if proposal_unchanged else text,
+                        comment_text=comment,
                     )
-                    st.rerun()
-                else:
+                elif text != current.strip() or comment:
                     state.create_suggestion(
                         field,
                         user_id=user.id,
-                        suggested_value=None if unchanged else suggested.strip(),
-                        comment_text=comment.strip() or None,
+                        suggested_value=None if text == current.strip() else text,
+                        comment_text=comment,
                     )
+            st.session_state[editing_key] = False
+            st.rerun()
+        return
+
+    label = "✏️ Refine proposed text" if existing is not None else "✏️ Suggest an edit"
+    col_edit, col_comment = st.columns([1, 1])
+    with col_edit:
+        if st.button(label, key=_key(field, "editbtn")):
+            st.session_state[editing_key] = True
+            st.rerun()
+    if existing is None:
+        with col_comment, st.popover("💬 Comment only"):
+            with st.form(key=_key(field, "cform"), clear_on_submit=True, border=False):
+                comment = st.text_area(
+                    "Comment",
+                    key=_key(field, "comment"),
+                    height=80,
+                    label_visibility="collapsed",
+                    placeholder="A remark without proposing text...",
+                )
+                if st.form_submit_button("Post") and comment.strip():
+                    state.create_suggestion(field, user_id=user.id, suggested_value=None, comment_text=comment.strip())
                     st.rerun()

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -64,7 +64,19 @@ def render_field(
                 badges.append(f":gray-badge[appears in {len(shared_views) + 1} views]")
             st.markdown(" ".join(badges))
 
-        if field.current_value is None:
+        # The field's text, shown ONCE: tracked changes when a proposal exists
+        # (deletions struck through, insertions tinted), plain text otherwise.
+        if proposal is not None and proposal.suggestedValue is not None:
+            staleness = check_staleness(proposal, fields_by_key)
+            if staleness.field_changed:
+                st.warning("The field's text changed since this proposal was filed — re-check the tracked changes.")
+            is_bullets = field.field_path in DESCRIPTION_KEY_FIELDS
+            if is_bullets:
+                st.caption(
+                    f"Bullet changes ({diff_summary(bullet_diff(field.current_value, proposal.suggestedValue))}):"
+                )
+            st.html(tracked_changes_html(field.current_value, proposal.suggestedValue, is_bullet_list=is_bullets))
+        elif field.current_value is None:
             st.caption("_(not set — the chart renders without it)_")
         elif str(field.current_value) == "":
             st.caption("_(explicitly blank — the view suppresses the inherited text)_")
@@ -86,7 +98,7 @@ def render_field(
                     st.markdown("- " + (" · ".join(f"**{k}:** {v}" for k, v in dims.items()) or view_id))
 
         if proposal is not None:
-            _render_proposal(
+            _render_thread(
                 field,
                 proposal,
                 extra_threads=open_suggestions[1:],
@@ -94,6 +106,7 @@ def render_field(
                 users=users,
                 user=user,
                 fields_by_key=fields_by_key,
+                n_shared_views=len(shared_views) if shared_views else 0,
             )
         elif user is not None:
             _render_edit_controls(field, user, existing=None)
@@ -102,7 +115,7 @@ def render_field(
             _render_resolved(suggestion, comments_by_suggestion.get(suggestion.id, []), users, user)
 
 
-def _render_proposal(
+def _render_thread(
     field: ReviewableField,
     proposal: gm.MetadataReviewSuggestion,
     extra_threads: list[gm.MetadataReviewSuggestion],
@@ -110,37 +123,31 @@ def _render_proposal(
     users: dict[int, str],
     user: gm.User | None,
     fields_by_key: dict[tuple, ReviewableField],
+    n_shared_views: int = 0,
 ) -> None:
-    """The single consolidated proposal block for a field."""
+    """The compact discussion strip under the field's (tracked) text.
+
+    The proposed text itself is NOT repeated here — the field's main text block
+    above already shows it as tracked changes.
+    """
     staleness: Staleness = check_staleness(proposal, fields_by_key)
     author = users.get(proposal.createdBy, f"user {proposal.createdBy}")
 
     with st.container(border=True):
-        header = f"**✏️ Proposed change** — started by {author}, {proposal.createdAt:%Y-%m-%d}"
-        if staleness.is_stale:
-            header += " · :orange-badge[⚠️ page changed since]"
-        st.markdown(header)
+        meta = f"✏️ Proposed by **{author}**, {proposal.createdAt:%Y-%m-%d}"
+        if n_shared_views:
+            noun = "view" if n_shared_views == 1 else "views"
+            meta += f" — this change applies here and in **{n_shared_views}** other {noun}"
+        st.markdown(meta)
 
         if staleness.target_gone:
             st.warning("The view/indicator this proposal was filed on no longer exists on this page.")
         elif staleness.field_changed:
-            st.warning(
-                "The field's text changed since this proposal was filed — "
-                "re-check the proposal against the current text above."
-            )
             with st.expander("Text when the proposal was filed", expanded=False):
                 st.markdown(f"> {proposal.currentValue or '_(not set)_'}")
 
         if proposal.suggestedValue is None:
             st.caption("_Discussion only — no replacement text proposed yet._")
-        else:
-            # Tracked changes: the text as it currently reads, with deletions struck
-            # through and insertions tinted (Google-Docs style).
-            is_bullets = field.field_path in DESCRIPTION_KEY_FIELDS
-            if is_bullets:
-                ops = bullet_diff(field.current_value, proposal.suggestedValue)
-                st.caption(f"Bullet changes ({diff_summary(ops)}):")
-            st.html(tracked_changes_html(field.current_value, proposal.suggestedValue, is_bullet_list=is_bullets))
 
         # Thread: comments from the canonical proposal plus any legacy parallel threads.
         comments = list(comments_by_suggestion.get(proposal.id, []))

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -162,9 +162,11 @@ def _render_thread(
         st.caption("Sign-in not detected — reply/status controls disabled.")
         return
 
-    if st.session_state.get(_key(field, "editing", key_ns)):
+    if st.session_state.get(_key(field, f"editing_{proposal.id}", key_ns)):
         # The editor must span the whole section, not sit inside a button column.
-        _render_edit_controls(field, user, existing=proposal, key_ns=key_ns)
+        _render_edit_controls(
+            field, user, existing=proposal, key_ns=key_ns, borrowed=borrowed, initial_override=initial_override
+        )
     else:
         # One slim controls row: reply (popover), status, refine.
         reply_col, status_col, edit_col = st.columns([1.1, 2.2, 1.7], vertical_alignment="center")
@@ -189,7 +191,9 @@ def _render_thread(
                 state.set_status(proposal.id, user.id, status)
                 st.rerun()
         with edit_col:
-            _render_edit_controls(field, user, existing=proposal, key_ns=key_ns)
+            _render_edit_controls(
+                field, user, existing=proposal, key_ns=key_ns, borrowed=borrowed, initial_override=initial_override
+            )
 
 
 def _render_resolved(

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -28,9 +28,9 @@ STATUS_ICONS = {"open": "💬", "implemented": "✅", "rejected": "🚫"}
 DESCRIPTION_KEY_FIELDS = {"metadata.description_key", "description_key"}
 
 
-def _key(field: ReviewableField, suffix: str) -> str:
+def _key(field: ReviewableField, suffix: str, ns: str = "main") -> str:
     digest = hashlib.md5("|".join(str(p) for p in field.source_key()).encode()).hexdigest()[:12]
-    return f"mrf_{digest}_{suffix}"
+    return f"mrf_{ns}_{digest}_{suffix}"
 
 
 def render_field(
@@ -42,6 +42,7 @@ def render_field(
     fields_by_key: dict[tuple, ReviewableField],
     shared_views: list[str] | None = None,
     mdim_review: MdimReview | None = None,
+    key_ns: str = "main",
 ) -> None:
     """Render one reviewable field with its consolidated proposal and history."""
     color, explanation = PROVENANCE_BADGES[field.provenance]
@@ -107,12 +108,13 @@ def render_field(
                 user=user,
                 fields_by_key=fields_by_key,
                 n_shared_views=len(shared_views) if shared_views else 0,
+                key_ns=key_ns,
             )
         elif user is not None:
-            _render_edit_controls(field, user, existing=None)
+            _render_edit_controls(field, user, existing=None, key_ns=key_ns)
 
         for suggestion in resolved:
-            _render_resolved(suggestion, comments_by_suggestion.get(suggestion.id, []), users, user)
+            _render_resolved(suggestion, comments_by_suggestion.get(suggestion.id, []), users, user, key_ns=key_ns)
 
 
 def _render_thread(
@@ -124,6 +126,7 @@ def _render_thread(
     user: gm.User | None,
     fields_by_key: dict[tuple, ReviewableField],
     n_shared_views: int = 0,
+    key_ns: str = "main",
 ) -> None:
     """The compact discussion strip under the field's (tracked) text.
 
@@ -167,7 +170,7 @@ def _render_thread(
             st.caption("Sign-in not detected — reply/status controls disabled.")
             return
 
-        reply_key = f"mrs_reply_{proposal.id}"
+        reply_key = f"mrs_reply_{key_ns}_{proposal.id}"
         with st.form(key=f"{reply_key}_form", clear_on_submit=True, border=False):
             reply = st.text_area(
                 "Reply", key=reply_key, height=80, label_visibility="collapsed", placeholder="Reply..."
@@ -176,9 +179,9 @@ def _render_thread(
                 state.add_comment(proposal.id, user.id, reply.strip())
                 st.rerun()
 
-        if st.session_state.get(_key(field, "editing")):
+        if st.session_state.get(_key(field, "editing", key_ns)):
             # The editor must span the whole section, not sit inside a button column.
-            _render_edit_controls(field, user, existing=proposal)
+            _render_edit_controls(field, user, existing=proposal, key_ns=key_ns)
         else:
             control_col, edit_col = st.columns([3, 2], vertical_alignment="center")
             with control_col:
@@ -186,14 +189,14 @@ def _render_thread(
                     "Status",
                     options=["open", "implemented", "rejected"],
                     default=proposal.status,
-                    key=f"mrs_status_{proposal.id}",
+                    key=f"mrs_status_{key_ns}_{proposal.id}",
                     label_visibility="collapsed",
                 )
                 if status and status != proposal.status:
                     state.set_status(proposal.id, user.id, status)
                     st.rerun()
             with edit_col:
-                _render_edit_controls(field, user, existing=proposal)
+                _render_edit_controls(field, user, existing=proposal, key_ns=key_ns)
 
 
 def _render_resolved(
@@ -201,6 +204,7 @@ def _render_resolved(
     comments: list,
     users: dict[int, str],
     user: gm.User | None,
+    key_ns: str = "main",
 ) -> None:
     """Resolved proposals collapse to a single history line."""
     icon = STATUS_ICONS.get(suggestion.status, "💬")
@@ -218,7 +222,7 @@ def _render_resolved(
             else:
                 st.markdown(f"**{comment_author}** · {when}: {comment.text}")
         if user is not None:
-            if st.button("Reopen", key=f"mrs_reopen_{suggestion.id}"):
+            if st.button("Reopen", key=f"mrs_reopen_{key_ns}_{suggestion.id}"):
                 state.set_status(suggestion.id, user.id, "open")
                 st.rerun()
 
@@ -227,10 +231,11 @@ def _render_edit_controls(
     field: ReviewableField,
     user: gm.User,
     existing: gm.MetadataReviewSuggestion | None,
+    key_ns: str = "main",
 ) -> None:
     """In-place tracked-changes editing: the displayed text becomes editable, with a
     live diff preview; saving files onto the field's consolidated proposal."""
-    editing_key = _key(field, "editing")
+    editing_key = _key(field, "editing", key_ns)
     current = str(field.current_value) if field.current_value is not None else ""
 
     if st.session_state.get(editing_key):
@@ -238,10 +243,10 @@ def _render_edit_controls(
         result = tracked_editor(
             original=current,
             initial=initial,
-            key=_key(field, "editor"),
+            key=_key(field, "editor", key_ns),
             bullet_list=field.field_path in DESCRIPTION_KEY_FIELDS,
         )
-        handled_key = _key(field, "nonce")
+        handled_key = _key(field, "nonce", key_ns)
         if result and result.get("nonce") != st.session_state.get(handled_key):
             st.session_state[handled_key] = result.get("nonce")
             if result.get("action") == "save":
@@ -271,15 +276,15 @@ def _render_edit_controls(
     label = "✏️ Refine proposed text" if existing is not None else "✏️ Suggest an edit"
     col_edit, col_comment = st.columns([1, 1])
     with col_edit:
-        if st.button(label, key=_key(field, "editbtn")):
+        if st.button(label, key=_key(field, "editbtn", key_ns)):
             st.session_state[editing_key] = True
             st.rerun()
     if existing is None:
         with col_comment, st.popover("💬 Comment only"):
-            with st.form(key=_key(field, "cform"), clear_on_submit=True, border=False):
+            with st.form(key=_key(field, "cform", key_ns), clear_on_submit=True, border=False):
                 comment = st.text_area(
                     "Comment",
-                    key=_key(field, "comment"),
+                    key=_key(field, "comment", key_ns),
                     height=80,
                     label_visibility="collapsed",
                     placeholder="A remark without proposing text...",

--- a/apps/wizard/app_pages/metadata_review/field_panel.py
+++ b/apps/wizard/app_pages/metadata_review/field_panel.py
@@ -49,6 +49,17 @@ def render_field(
     open_suggestions.sort(key=lambda s: s.createdAt, reverse=True)
     proposal = open_suggestions[0] if open_suggestions else None
 
+    # The list of other views rendering this same text lives in a hover tooltip.
+    shared_tooltip = None
+    if shared_views and mdim_review is not None:
+        views_by_id = {v.view_id: v for v in mdim_review.views}
+        lines = []
+        for view_id in shared_views:
+            view = views_by_id.get(view_id)
+            dims = mdim_review.human_dimensions(view.dimensions) if view else {}
+            lines.append("- " + (" · ".join(f"{k}: {v}" for k, v in dims.items()) or view_id))
+        shared_tooltip = "Also shown in:\n\n" + "\n".join(lines)
+
     with st.container(border=True):
         title_col, badge_col = st.columns([4, 2], vertical_alignment="center")
         with title_col:
@@ -58,8 +69,8 @@ def render_field(
             if proposal is not None:
                 badges.append(":orange-badge[open proposal]")
             if shared_views:
-                badges.append(f":gray-badge[appears in {len(shared_views) + 1} views]")
-            st.markdown(" ".join(badges))
+                badges.append(f":gray-badge[in {len(shared_views) + 1} views]")
+            st.markdown(" ".join(badges), help=shared_tooltip)
 
         # The field's text, shown ONCE: tracked changes when a proposal exists
         # (deletions struck through, insertions tinted), plain text otherwise.
@@ -99,20 +110,12 @@ def render_field(
             st.caption("_(explicitly blank — the view suppresses the inherited text)_")
         else:
             st.markdown(f"> {field.current_value}")
-        st.caption(field.edit_hint)
-
+        inherited_tooltip = None
         if field.provenance == "override" and field.inherited_value is not None:
-            with st.expander("Inherited value this override replaces", expanded=False):
-                st.markdown(f"> {field.inherited_value}")
-                st.caption(f"From `{field.inherited_from}`")
-
-        if shared_views and mdim_review is not None:
-            with st.expander(f"Also shown in {len(shared_views)} other view(s)", expanded=False):
-                views_by_id = {v.view_id: v for v in mdim_review.views}
-                for view_id in shared_views:
-                    view = views_by_id.get(view_id)
-                    dims = mdim_review.human_dimensions(view.dimensions) if view else {}
-                    st.markdown("- " + (" · ".join(f"**{k}:** {v}" for k, v in dims.items()) or view_id))
+            inherited_tooltip = (
+                f"Inherited value this override replaces:\n\n{field.inherited_value}\n\n(from `{field.inherited_from}`)"
+            )
+        st.caption(field.edit_hint, help=inherited_tooltip)
 
         if proposal is not None:
             _render_thread(
@@ -123,7 +126,6 @@ def render_field(
                 users=users,
                 user=user,
                 fields_by_key=fields_by_key,
-                n_shared_views=len(shared_views) if shared_views else 0,
                 key_ns=key_ns,
             )
         elif user is not None:
@@ -141,7 +143,6 @@ def _render_thread(
     users: dict[int, str],
     user: gm.User | None,
     fields_by_key: dict[tuple, ReviewableField],
-    n_shared_views: int = 0,
     key_ns: str = "main",
 ) -> None:
     """The compact discussion strip under the field's (tracked) text.
@@ -152,67 +153,62 @@ def _render_thread(
     staleness: Staleness = check_staleness(proposal, fields_by_key)
     author = users.get(proposal.createdBy, f"user {proposal.createdBy}")
 
-    with st.container(border=True):
-        meta = f"✏️ Proposed by **{author}**, {proposal.createdAt:%Y-%m-%d}"
-        if n_shared_views:
-            noun = "view" if n_shared_views == 1 else "views"
-            meta += f" — this change applies here and in **{n_shared_views}** other {noun}"
-        st.markdown(meta)
+    st.caption(f"✏️ Proposed by **{author}**, {proposal.createdAt:%Y-%m-%d}")
 
-        if staleness.target_gone:
-            st.warning("The view/indicator this proposal was filed on no longer exists on this page.")
-        elif staleness.field_changed:
-            with st.expander("Text when the proposal was filed", expanded=False):
-                st.markdown(f"> {proposal.currentValue or '_(not set)_'}")
+    if staleness.target_gone:
+        st.warning("The view/indicator this proposal was filed on no longer exists on this page.")
+    elif staleness.field_changed:
+        with st.expander("Text when the proposal was filed", expanded=False):
+            st.markdown(f"> {proposal.currentValue or '_(not set)_'}")
 
-        if proposal.suggestedValue is None:
-            st.caption("_Discussion only — no replacement text proposed yet._")
+    if proposal.suggestedValue is None:
+        st.caption("_Discussion only — no replacement text proposed yet._")
 
-        # Thread: comments from the canonical proposal plus any legacy parallel threads.
-        comments = list(comments_by_suggestion.get(proposal.id, []))
-        for legacy in extra_threads:
-            comments += comments_by_suggestion.get(legacy.id, [])
-        comments.sort(key=lambda c: c.createdAt)
-        for comment in comments:
-            comment_author = users.get(comment.userId, f"user {comment.userId}")
-            when = comment.createdAt.strftime("%Y-%m-%d %H:%M")
-            if comment.kind in ("status_change", "revision"):
-                st.caption(f"_{comment.text}_ — {comment_author}, {when}")
-            else:
-                st.markdown(f"**{comment_author}** · {when}")
-                st.markdown(comment.text)
-
-        if user is None:
-            st.caption("Sign-in not detected — reply/status controls disabled.")
-            return
-
-        reply_key = f"mrs_reply_{key_ns}_{proposal.id}"
-        with st.form(key=f"{reply_key}_form", clear_on_submit=True, border=False):
-            reply = st.text_area(
-                "Reply", key=reply_key, height=80, label_visibility="collapsed", placeholder="Reply..."
-            )
-            if st.form_submit_button("Reply") and reply.strip():
-                state.add_comment(proposal.id, user.id, reply.strip())
-                st.rerun()
-
-        if st.session_state.get(_key(field, "editing", key_ns)):
-            # The editor must span the whole section, not sit inside a button column.
-            _render_edit_controls(field, user, existing=proposal, key_ns=key_ns)
+    # Thread: comments from the canonical proposal plus any legacy parallel threads.
+    comments = list(comments_by_suggestion.get(proposal.id, []))
+    for legacy in extra_threads:
+        comments += comments_by_suggestion.get(legacy.id, [])
+    comments.sort(key=lambda c: c.createdAt)
+    for comment in comments:
+        comment_author = users.get(comment.userId, f"user {comment.userId}")
+        when = comment.createdAt.strftime("%Y-%m-%d %H:%M")
+        if comment.kind in ("status_change", "revision"):
+            st.caption(f"_{comment.text}_ — {comment_author}, {when}")
         else:
-            control_col, edit_col = st.columns([3, 2], vertical_alignment="center")
-            with control_col:
-                status = st.segmented_control(
-                    "Status",
-                    options=["open", "implemented", "rejected"],
-                    default=proposal.status,
-                    key=f"mrs_status_{key_ns}_{proposal.id}",
-                    label_visibility="collapsed",
+            st.markdown(f"**{comment_author}** · {when}: {comment.text}")
+
+    if user is None:
+        st.caption("Sign-in not detected — reply/status controls disabled.")
+        return
+
+    if st.session_state.get(_key(field, "editing", key_ns)):
+        # The editor must span the whole section, not sit inside a button column.
+        _render_edit_controls(field, user, existing=proposal, key_ns=key_ns)
+    else:
+        # One slim controls row: reply (popover), status, refine.
+        reply_col, status_col, edit_col = st.columns([1.1, 2.2, 1.7], vertical_alignment="center")
+        with reply_col, st.popover("💬 Reply"):
+            reply_key = f"mrs_reply_{key_ns}_{proposal.id}"
+            with st.form(key=f"{reply_key}_form", clear_on_submit=True, border=False):
+                reply = st.text_area(
+                    "Reply", key=reply_key, height=80, label_visibility="collapsed", placeholder="Reply..."
                 )
-                if status and status != proposal.status:
-                    state.set_status(proposal.id, user.id, status)
+                if st.form_submit_button("Send") and reply.strip():
+                    state.add_comment(proposal.id, user.id, reply.strip())
                     st.rerun()
-            with edit_col:
-                _render_edit_controls(field, user, existing=proposal, key_ns=key_ns)
+        with status_col:
+            status = st.segmented_control(
+                "Status",
+                options=["open", "implemented", "rejected"],
+                default=proposal.status,
+                key=f"mrs_status_{key_ns}_{proposal.id}",
+                label_visibility="collapsed",
+            )
+            if status and status != proposal.status:
+                state.set_status(proposal.id, user.id, status)
+                st.rerun()
+        with edit_col:
+            _render_edit_controls(field, user, existing=proposal, key_ns=key_ns)
 
 
 def _render_resolved(

--- a/apps/wizard/app_pages/metadata_review/state.py
+++ b/apps/wizard/app_pages/metadata_review/state.py
@@ -73,6 +73,39 @@ def load_suggestions(target_paths: list[str]) -> tuple[list, dict[int, list], di
     return suggestions, comments_by_suggestion, users
 
 
+def load_open_summary() -> list[dict]:
+    """Open proposals grouped by the page they were filed from (for the landing overview).
+
+    Returns [{page, kind ('mdim'|'indicator'), n_open, last_activity}] sorted by recency.
+    Uncached so a freshly filed proposal shows up when the reviewer returns to the landing.
+    """
+    with Session(get_engine()) as session:
+        from sqlalchemy import select
+
+        rows = session.execute(
+            select(
+                gm.MetadataReviewSuggestion.filedFromPath,
+                gm.MetadataReviewSuggestion.targetPath,
+                gm.MetadataReviewSuggestion.targetType,
+                gm.MetadataReviewSuggestion.updatedAt,
+            ).where(gm.MetadataReviewSuggestion.status == "open")
+        ).all()
+    groups: dict[str, dict] = {}
+    for filed_from, target_path, target_type, updated_at in rows:
+        page = filed_from or target_path
+        # A page path with '#' but no channel prefix is an MDim catalogPath.
+        kind = "mdim" if ("#" in page and not page.startswith("grapher/")) else "indicator"
+        group = groups.setdefault(page, {"page": page, "kind": kind, "n_open": 0, "last_activity": updated_at})
+        group["n_open"] += 1
+        group["last_activity"] = max(group["last_activity"], updated_at)
+    return sorted(groups.values(), key=lambda g: g["last_activity"], reverse=True)
+
+
+def open_counts_by_page() -> dict[str, int]:
+    """Open-proposal counts keyed by the page the suggestion was filed from."""
+    return {g["page"]: g["n_open"] for g in load_open_summary()}
+
+
 def current_user() -> gm.User | None:
     """The grapher user (Tailscale IP on staging, GRAPHER_USER_ID locally); None when unknown."""
     try:

--- a/apps/wizard/app_pages/metadata_review/state.py
+++ b/apps/wizard/app_pages/metadata_review/state.py
@@ -136,7 +136,9 @@ def create_suggestion(
             user_id=user_id,
             provenance=field.provenance,
             current_value=str(field.current_value) if field.current_value is not None else None,
-            suggested_value=suggested_value or None,
+            # NOTE: an empty string is a real proposal (e.g. clearing an inherited
+            # footnote) — only None means "comment-only thread".
+            suggested_value=suggested_value,
             comment_text=comment_text,
             inherited_from_path=field.inherited_from,
             filed_from_path=field.target_path,

--- a/apps/wizard/app_pages/metadata_review/state.py
+++ b/apps/wizard/app_pages/metadata_review/state.py
@@ -1,0 +1,123 @@
+"""DB read/write wrappers for the Metadata Review wizard app.
+
+Reads that are expensive and stable within a session (page resolution, listings)
+are cached; suggestion/comment reads stay uncached so writes show up on the next
+rerun without cache gymnastics.
+"""
+
+import streamlit as st
+from sqlalchemy.orm import Session
+
+import etl.grapher.model as gm
+from apps.metadata_review.resolution import (
+    list_datasets,
+    list_mdims,
+    resolve_dataset,
+    resolve_mdim,
+)
+from apps.metadata_review.targets import DatasetReview, MdimReview, ReviewableField
+from apps.wizard.utils.cached import get_grapher_user
+from etl.db import get_engine
+
+
+@st.cache_data(show_spinner=False, ttl="5m")
+def review_tables_exist() -> bool:
+    """The metadata_review_* tables ship via an owid-grapher migration; until that
+    reaches production, staging DBs (prod copies) don't have them."""
+    from sqlalchemy import inspect as sa_inspect
+
+    return sa_inspect(get_engine()).has_table("metadata_review_suggestions")
+
+
+@st.cache_data(show_spinner="Loading MDims...", ttl="5m")
+def cached_list_mdims() -> list[dict]:
+    with Session(get_engine()) as session:
+        return list_mdims(session)
+
+
+@st.cache_data(show_spinner="Loading datasets...", ttl="5m")
+def cached_list_datasets() -> list[dict]:
+    with Session(get_engine()) as session:
+        return list_datasets(session)
+
+
+@st.cache_data(show_spinner="Resolving fields...", ttl="2m")
+def cached_resolve_mdim(catalog_path: str) -> MdimReview:
+    with Session(get_engine()) as session:
+        return resolve_mdim(session, catalog_path)
+
+
+@st.cache_data(show_spinner="Resolving indicators...", ttl="2m")
+def cached_resolve_dataset(catalog_path: str) -> DatasetReview:
+    with Session(get_engine()) as session:
+        return resolve_dataset(session, catalog_path)
+
+
+def load_suggestions(target_paths: list[str]) -> tuple[list, dict[int, list], dict[int, str]]:
+    """Suggestions for the given paths + their comments + user id -> name map. Uncached."""
+    with Session(get_engine()) as session:
+        suggestions = gm.MetadataReviewSuggestion.load_for_paths(session, target_paths)
+        comments = gm.MetadataReviewComment.load_for_suggestions(session, [s.id for s in suggestions])
+        comments_by_suggestion: dict[int, list] = {}
+        for comment in comments:
+            comments_by_suggestion.setdefault(comment.suggestionId, []).append(comment)
+        user_ids = {s.createdBy for s in suggestions} | {c.userId for c in comments}
+        users = {}
+        if user_ids:
+            from sqlalchemy import select
+
+            rows = session.execute(select(gm.User.id, gm.User.fullName).where(gm.User.id.in_(user_ids))).all()
+            users = dict(rows)
+        # Detach ORM objects so they can be used after the session closes.
+        session.expunge_all()
+    return suggestions, comments_by_suggestion, users
+
+
+def current_user() -> gm.User | None:
+    """The grapher user (Tailscale IP on staging, GRAPHER_USER_ID locally); None when unknown."""
+    try:
+        return get_grapher_user()
+    except Exception:
+        return None
+
+
+def create_suggestion(
+    field: ReviewableField,
+    user_id: int,
+    suggested_value: str | None,
+    comment_text: str | None,
+) -> None:
+    target_type, target_path, view_id, field_path = field.source_key()
+    with Session(get_engine()) as session:
+        suggestion = gm.MetadataReviewSuggestion(
+            targetType=target_type,
+            targetPath=target_path,
+            viewId=view_id,
+            fieldPath=field_path,
+            provenance=field.provenance,
+            createdBy=user_id,
+            inheritedFromPath=field.inherited_from,
+            filedFromPath=field.target_path,
+            filedFromViewId=field.view_id,
+            currentValue=str(field.current_value) if field.current_value is not None else None,
+            suggestedValue=suggested_value or None,
+            pageChecksum=field.page_checksum,
+        )
+        session.add(suggestion)
+        session.commit()
+        if comment_text:
+            suggestion.add_comment(session, user_id=user_id, text=comment_text)
+
+
+def add_comment(suggestion_id: int, user_id: int, text: str) -> None:
+    with Session(get_engine()) as session:
+        suggestion = session.get(gm.MetadataReviewSuggestion, suggestion_id)
+        assert suggestion is not None
+        suggestion.add_comment(session, user_id=user_id, text=text)
+
+
+def set_status(suggestion_id: int, user_id: int, status: str) -> None:
+    with Session(get_engine()) as session:
+        suggestion = session.get(gm.MetadataReviewSuggestion, suggestion_id)
+        assert suggestion is not None
+        suggestion.set_status(session, status, user_id=user_id)  # type: ignore[arg-type]

--- a/apps/wizard/app_pages/metadata_review/state.py
+++ b/apps/wizard/app_pages/metadata_review/state.py
@@ -53,10 +53,14 @@ def cached_resolve_dataset(catalog_path: str) -> DatasetReview:
         return resolve_dataset(session, catalog_path)
 
 
-def load_suggestions(target_paths: list[str]) -> tuple[list, dict[int, list], dict[int, str]]:
-    """Suggestions for the given paths + their comments + user id -> name map. Uncached."""
+def load_suggestions(
+    target_paths: list[str], path_prefixes: list[str] | None = None
+) -> tuple[list, dict[int, list], dict[int, str]]:
+    """Suggestions for the given paths (plus, optionally, whole grapher datasets by
+    prefix — so threads filed on sibling MDims sharing the metadata surface here)
+    + their comments + user id -> name map. Uncached."""
     with Session(get_engine()) as session:
-        suggestions = gm.MetadataReviewSuggestion.load_for_paths(session, target_paths)
+        suggestions = gm.MetadataReviewSuggestion.load_for_paths(session, target_paths, path_prefixes=path_prefixes)
         comments = gm.MetadataReviewComment.load_for_suggestions(session, [s.id for s in suggestions])
         comments_by_suggestion: dict[int, list] = {}
         for comment in comments:

--- a/apps/wizard/app_pages/metadata_review/state.py
+++ b/apps/wizard/app_pages/metadata_review/state.py
@@ -87,26 +87,25 @@ def create_suggestion(
     suggested_value: str | None,
     comment_text: str | None,
 ) -> None:
+    """File onto the field's consolidated thread (one open proposal per field)."""
     target_type, target_path, view_id, field_path = field.source_key()
     with Session(get_engine()) as session:
-        suggestion = gm.MetadataReviewSuggestion(
-            targetType=target_type,
-            targetPath=target_path,
-            viewId=view_id,
-            fieldPath=field_path,
+        gm.MetadataReviewSuggestion.file_or_update(
+            session,
+            target_type=target_type,
+            target_path=target_path,
+            view_id=view_id,
+            field_path=field_path,
+            user_id=user_id,
             provenance=field.provenance,
-            createdBy=user_id,
-            inheritedFromPath=field.inherited_from,
-            filedFromPath=field.target_path,
-            filedFromViewId=field.view_id,
-            currentValue=str(field.current_value) if field.current_value is not None else None,
-            suggestedValue=suggested_value or None,
-            pageChecksum=field.page_checksum,
+            current_value=str(field.current_value) if field.current_value is not None else None,
+            suggested_value=suggested_value or None,
+            comment_text=comment_text,
+            inherited_from_path=field.inherited_from,
+            filed_from_path=field.target_path,
+            filed_from_view_id=field.view_id,
+            page_checksum=field.page_checksum,
         )
-        session.add(suggestion)
-        session.commit()
-        if comment_text:
-            suggestion.add_comment(session, user_id=user_id, text=comment_text)
 
 
 def add_comment(suggestion_id: int, user_id: int, text: str) -> None:

--- a/apps/wizard/app_pages/metadata_review/state.py
+++ b/apps/wizard/app_pages/metadata_review/state.py
@@ -141,6 +141,31 @@ def create_suggestion(
         )
 
 
+def update_proposal(suggestion_id: int, user_id: int, suggested_value: str | None, comment_text: str | None) -> None:
+    """Refine an existing proposal in place (revision-tracked).
+
+    Used when the thread being refined may have been filed from a different view
+    (borrowed by identical text) — the update must land on that same row, not
+    open a new thread keyed to the current view's source.
+    """
+    with Session(get_engine()) as session:
+        suggestion = session.get(gm.MetadataReviewSuggestion, suggestion_id)
+        assert suggestion is not None
+        if suggested_value is not None and suggested_value != suggestion.suggestedValue:
+            had_proposal = suggestion.suggestedValue is not None
+            suggestion.suggestedValue = suggested_value
+            session.add(suggestion)
+            session.commit()
+            suggestion.add_comment(
+                session,
+                user_id=user_id,
+                text="Updated the proposed text." if had_proposal else "Added a proposed text.",
+                kind="revision",
+            )
+        if comment_text:
+            suggestion.add_comment(session, user_id=user_id, text=comment_text)
+
+
 def add_comment(suggestion_id: int, user_id: int, text: str) -> None:
     with Session(get_engine()) as session:
         suggestion = session.get(gm.MetadataReviewSuggestion, suggestion_id)

--- a/apps/wizard/app_pages/metadata_review/tracked_editor/__init__.py
+++ b/apps/wizard/app_pages/metadata_review/tracked_editor/__init__.py
@@ -1,0 +1,36 @@
+"""In-place tracked-changes text editor (custom bidirectional Streamlit component).
+
+Renders the field's text as an editable area with a live Google-Docs-style
+tracked-changes preview (deletions struck through, insertions tinted), plus an
+optional comment box. Returns `{"action": "save"|"cancel", "text": ..., "comment":
+..., "nonce": ...}` when the reviewer clicks a button; the `nonce` lets the caller
+deduplicate across Streamlit reruns.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import streamlit.components.v1 as components
+
+_tracked_editor = components.declare_component(
+    "metadata_review_tracked_editor",
+    path=str(Path(__file__).parent / "frontend"),
+)
+
+
+def tracked_editor(
+    original: str,
+    initial: str,
+    key: str,
+    bullet_list: bool = False,
+) -> dict[str, Any] | None:
+    """Show the editor; `original` is the diff base (the field's current text),
+    `initial` what the editable area starts with (current text or the existing
+    proposal when refining)."""
+    return _tracked_editor(
+        original=original,
+        initial=initial,
+        bullet_list=bullet_list,
+        key=key,
+        default=None,
+    )

--- a/apps/wizard/app_pages/metadata_review/tracked_editor/frontend/index.html
+++ b/apps/wizard/app_pages/metadata_review/tracked_editor/frontend/index.html
@@ -1,0 +1,136 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<style>
+  :root { color-scheme: light; }
+  body { margin: 0; font-family: -apple-system, "Segoe UI", Roboto, sans-serif; color: #262730; }
+  .editor {
+    width: 100%; box-sizing: border-box; min-height: 4.5rem;
+    border: 1px solid #d5dae5; border-radius: 6px; padding: 0.6rem 0.7rem;
+    font-size: 0.95rem; line-height: 1.55; white-space: pre-wrap; outline: none; background: #fff;
+  }
+  .editor:focus { border-color: #ff4b4b; }
+  .preview {
+    margin-top: 0.5rem; padding: 0.6rem 0.7rem; border-left: 3px solid #d5dae5;
+    background: #fafafa; border-radius: 0 6px 6px 0; font-size: 0.95rem; line-height: 1.55;
+    white-space: pre-wrap;
+  }
+  .preview-label { font-size: 0.75rem; color: #808495; margin-top: 0.6rem; }
+  del { color: #b3261e; text-decoration: line-through; background: #fbe9e7; border-radius: 2px; }
+  ins { color: #0b6e4f; background: #e6f4ea; border-radius: 2px; text-decoration: none; }
+  .comment {
+    width: 100%; box-sizing: border-box; margin-top: 0.6rem; border: 1px solid #d5dae5;
+    border-radius: 6px; padding: 0.45rem 0.7rem; font-size: 0.9rem; font-family: inherit; resize: vertical;
+  }
+  .buttons { margin-top: 0.6rem; display: flex; gap: 0.5rem; }
+  button {
+    border-radius: 6px; padding: 0.4rem 0.9rem; font-size: 0.9rem; cursor: pointer;
+    border: 1px solid #d5dae5; background: #fff;
+  }
+  button.primary { background: #ff4b4b; border-color: #ff4b4b; color: #fff; }
+  button.primary:disabled { background: #f0f2f6; border-color: #d5dae5; color: #a3a8b8; cursor: default; }
+</style>
+</head>
+<body>
+  <div id="editor" class="editor" contenteditable="true" spellcheck="true"></div>
+  <div class="preview-label">Tracked changes vs. the current text:</div>
+  <div id="preview" class="preview"></div>
+  <textarea id="comment" class="comment" rows="2" placeholder="Optional comment — why this change?"></textarea>
+  <div class="buttons">
+    <button id="save" class="primary" disabled>Save proposal</button>
+    <button id="cancel">Cancel</button>
+  </div>
+
+<script>
+(function () {
+  function sendMessage(type, data) {
+    window.parent.postMessage(Object.assign({ isStreamlitMessage: true, type: type }, data), "*");
+  }
+  function setValue(value) { sendMessage("streamlit:setComponentValue", { value: value, dataType: "json" }); }
+  function setHeight() {
+    sendMessage("streamlit:setFrameHeight", { height: document.body.scrollHeight + 8 });
+  }
+
+  // --- word-level diff (LCS over word/whitespace tokens) ---------------------
+  function tokenize(text) { return (text || "").match(/\S+|\s+/g) || []; }
+  function wordDiffHtml(a0, b0) {
+    const a = tokenize(a0), b = tokenize(b0);
+    const n = a.length, m = b.length;
+    // LCS table (fields are short; O(n*m) is fine).
+    const dp = Array.from({ length: n + 1 }, () => new Uint16Array(m + 1));
+    for (let i = n - 1; i >= 0; i--)
+      for (let j = m - 1; j >= 0; j--)
+        dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    let i = 0, j = 0, out = [], delBuf = [], insBuf = [];
+    function flush() {
+      const d = delBuf.join("").trim(), s = insBuf.join("").trim();
+      if (d) out.push("<del>" + esc(d) + "</del> ");
+      if (s) out.push("<ins>" + esc(s) + "</ins> ");
+      delBuf = []; insBuf = [];
+    }
+    while (i < n && j < m) {
+      if (a[i] === b[j]) { flush(); out.push(esc(a[i])); i++; j++; }
+      else if (dp[i + 1][j] >= dp[i][j + 1]) { delBuf.push(a[i]); i++; }
+      else { insBuf.push(b[j]); j++; }
+    }
+    while (i < n) delBuf.push(a[i++]);
+    while (j < m) insBuf.push(b[j++]);
+    flush();
+    return out.join("");
+  }
+
+  // --- component wiring -------------------------------------------------------
+  const editor = document.getElementById("editor");
+  const preview = document.getElementById("preview");
+  const comment = document.getElementById("comment");
+  const saveBtn = document.getElementById("save");
+  let original = "", initialized = false;
+
+  function refresh() {
+    const text = editor.innerText.replace(/\n$/, "");
+    preview.innerHTML = wordDiffHtml(original, text) || "<em>(empty)</em>";
+    saveBtn.disabled = text.trim() === original.trim() && !comment.value.trim();
+    setHeight();
+  }
+  let debounce = null;
+  editor.addEventListener("input", () => { clearTimeout(debounce); debounce = setTimeout(refresh, 250); });
+  comment.addEventListener("input", () => { clearTimeout(debounce); debounce = setTimeout(refresh, 250); });
+  // Paste as plain text so page formatting doesn't leak into the proposal.
+  editor.addEventListener("paste", (e) => {
+    e.preventDefault();
+    document.execCommand("insertText", false, e.clipboardData.getData("text/plain"));
+  });
+
+  saveBtn.addEventListener("click", () => {
+    setValue({
+      action: "save",
+      text: editor.innerText.replace(/\n$/, ""),
+      comment: comment.value.trim(),
+      nonce: Date.now(),
+    });
+  });
+  document.getElementById("cancel").addEventListener("click", () => {
+    setValue({ action: "cancel", nonce: Date.now() });
+  });
+
+  window.addEventListener("message", (event) => {
+    const data = event.data;
+    if (!data || data.type !== "streamlit:render") return;
+    const args = data.args || {};
+    original = args.original || "";
+    if (!initialized) {
+      editor.innerText = args.initial || "";
+      initialized = true;
+      editor.focus();
+    }
+    refresh();
+  });
+
+  sendMessage("streamlit:componentReady", { apiVersion: 1 });
+  setHeight();
+})();
+</script>
+</body>
+</html>

--- a/apps/wizard/config/config.yml
+++ b/apps/wizard/config/config.yml
@@ -115,6 +115,16 @@ sections:
         disable:
           production: True
 
+      - title: "Metadata Review"
+        alias: metadata-review
+        entrypoint: app_pages/metadata_review/app.py
+        description: Review FAUST & metadata of MDims and data pages, with suggestions and comments
+        maintainer: "@pablo.arriagada"
+        icon: ":material/rate_review:"
+        image_url: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8b/Manuscript_correction_at_proof_stage.jpg/960px-Manuscript_correction_at_proof_stage.jpg"
+        disable:
+          production: True
+
   - title: "Data tools"
     description: |-
       Control panel for ETL steps.

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -2024,7 +2024,11 @@ class MetadataReviewSuggestion(Base):
         return {status: n for status, n in rows}
 
     def set_status(self, session: Session, status: METADATA_REVIEW_STATUS, user_id: int) -> None:
-        """Set the resolution status and record who did it as a status_change comment."""
+        """Set the resolution status and record who did it as a status_change comment.
+
+        Raises ValueError when reopening would collide with a newer open thread on
+        the same field (the unique openKeyHash index is authoritative).
+        """
         assert status in get_args(METADATA_REVIEW_STATUS), f"Invalid status: {status}"
         self.status = status
         if status == "open":
@@ -2034,6 +2038,13 @@ class MetadataReviewSuggestion(Base):
             self.resolvedBy = user_id
             self.resolvedAt = datetime.now(timezone.utc)
         session.add(self)
+        try:
+            session.commit()
+        except IntegrityError:
+            session.rollback()
+            raise ValueError(
+                "This field already has a newer open proposal — reply there instead of reopening this thread."
+            )
         self.add_comment(session, user_id=user_id, text=f"Status set to {status}.", kind="status_change")
 
     def add_comment(

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -58,6 +58,7 @@ from sqlalchemy.dialects.mysql import (
     ENUM,
     LONGBLOB,
     LONGTEXT,
+    MEDIUMTEXT,
     TEXT,
     TINYINT,
     VARCHAR,
@@ -1820,6 +1821,176 @@ class ChartDiffConflicts(Base):
         assert len(chart_ids) == len(conflicts), "Length of chart_ids and conflicts must be the same."
 
         return conflicts
+
+
+METADATA_REVIEW_STATUS = Literal["open", "implemented", "rejected"]
+
+
+class MetadataReviewSuggestion(Base):
+    """A field-level suggestion/comment on the user-facing metadata of an MDim or indicator.
+
+    Filed from the Metadata Review wizard app; consumed by `etl metadata-review export`.
+
+    Addressing is environment-agnostic (catalog paths, MDim view ids — never numeric
+    chart/variable ids, which diverge between staging and production databases).
+    A suggestion attaches to the *underlying parameter*, not the page where it was filed:
+    inherited fields are stored against the source indicator (`targetType='indicator'`),
+    so the same thread surfaces on every MDim view and data page rendering that text;
+    the MDim view the reviewer was looking at is kept in `filedFromPath`/`filedFromViewId`.
+
+    Staleness is detected by re-resolving the field and comparing against the
+    `currentValue`/`provenance` snapshot (not by timestamp matching as in chart-diff),
+    so rows are mutable; status changes append a `status_change` comment for history.
+    """
+
+    __tablename__ = "metadata_review_suggestions"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["createdBy"], ["users.id"], ondelete="RESTRICT", name="metadata_review_suggestions_createdBy_fk"
+        ),
+        ForeignKeyConstraint(
+            ["resolvedBy"], ["users.id"], ondelete="RESTRICT", name="metadata_review_suggestions_resolvedBy_fk"
+        ),
+        Index("idx_mrs_target", "targetType", "targetPath", mysql_length={"targetPath": 191}),
+        Index(
+            "idx_mrs_field",
+            "targetPath",
+            "viewId",
+            "fieldPath",
+            mysql_length={"targetPath": 191, "viewId": 191, "fieldPath": 64},
+        ),
+        Index("idx_mrs_status", "status"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
+    # 'mdim' or 'indicator'.
+    targetType: Mapped[str] = mapped_column(VARCHAR(32))
+    # MDim: multi_dim_data_pages.catalogPath; indicator: variables.catalogPath.
+    targetPath: Mapped[str] = mapped_column(VARCHAR(767))
+    # e.g. 'config.subtitle', 'description_short', 'dimensions.<dim>.choices.<choice>.name'.
+    fieldPath: Mapped[str] = mapped_column(VARCHAR(255))
+    # 'override' / 'inherited' / 'missing' at suggestion time.
+    provenance: Mapped[str] = mapped_column(VARCHAR(16))
+    createdBy: Mapped[int] = mapped_column(Integer)
+    # Normalized dimensionsToViewId string; only for MDim view-scoped fields.
+    viewId: Mapped[str | None] = mapped_column(VARCHAR(512), default=None)
+    # Indicator catalogPath the value inherits from (when filed on an MDim view).
+    inheritedFromPath: Mapped[str | None] = mapped_column(VARCHAR(767), default=None)
+    filedFromPath: Mapped[str | None] = mapped_column(VARCHAR(767), default=None)
+    filedFromViewId: Mapped[str | None] = mapped_column(VARCHAR(512), default=None)
+    currentValue: Mapped[str | None] = mapped_column(MEDIUMTEXT, default=None)
+    # NULL means a comment-only thread anchored to the field.
+    suggestedValue: Mapped[str | None] = mapped_column(MEDIUMTEXT, default=None)
+    # MDim configMd5 or variables.metadataChecksum at suggestion time.
+    pageChecksum: Mapped[str | None] = mapped_column(VARCHAR(64), default=None)
+    status: Mapped[METADATA_REVIEW_STATUS] = mapped_column(VARCHAR(32), default="open")
+    resolvedBy: Mapped[int | None] = mapped_column(Integer, default=None)
+    resolvedAt: Mapped[datetime | None] = mapped_column(DateTime, default=None)
+    createdAt: Mapped[datetime] = mapped_column(DateTime, server_default=text("CURRENT_TIMESTAMP"), init=False)
+    updatedAt: Mapped[datetime] = mapped_column(
+        DateTime, server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"), init=False
+    )
+
+    @classmethod
+    def load_for_paths(
+        cls,
+        session: Session,
+        target_paths: list[str],
+        statuses: list[str] | None = None,
+    ) -> list["MetadataReviewSuggestion"]:
+        """Load suggestions for a set of target paths (an MDim page plus all its source indicators)."""
+        if not target_paths:
+            return []
+        q = select(cls).where(cls.targetPath.in_(target_paths))
+        if statuses:
+            q = q.where(cls.status.in_(statuses))
+        return list(session.scalars(q.order_by(cls.createdAt.asc())).all())
+
+    @classmethod
+    def counts_by_status(cls, session: Session, target_paths: list[str]) -> builtins.dict[str, int]:
+        if not target_paths:
+            return {}
+        rows = session.execute(
+            select(cls.status, func.count()).where(cls.targetPath.in_(target_paths)).group_by(cls.status)
+        ).all()
+        return {status: n for status, n in rows}
+
+    def set_status(self, session: Session, status: METADATA_REVIEW_STATUS, user_id: int) -> None:
+        """Set the resolution status and record who did it as a status_change comment."""
+        assert status in get_args(METADATA_REVIEW_STATUS), f"Invalid status: {status}"
+        self.status = status
+        if status == "open":
+            self.resolvedBy = None
+            self.resolvedAt = None
+        else:
+            self.resolvedBy = user_id
+            self.resolvedAt = datetime.now(timezone.utc)
+        session.add(self)
+        self.add_comment(session, user_id=user_id, text=f"Status set to {status}.", kind="status_change")
+
+    def add_comment(
+        self,
+        session: Session,
+        user_id: int,
+        text: str,
+        parent_comment_id: int | None = None,
+        kind: str = "comment",
+    ) -> "MetadataReviewComment":
+        assert self.id is not None, "Suggestion must be persisted before commenting."
+        comment = MetadataReviewComment(
+            suggestionId=self.id,
+            userId=user_id,
+            text=text,
+            parentCommentId=parent_comment_id,
+            kind=kind,
+        )
+        session.add(comment)
+        session.commit()
+        return comment
+
+
+class MetadataReviewComment(Base):
+    """A threaded comment under a MetadataReviewSuggestion."""
+
+    __tablename__ = "metadata_review_comments"
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["suggestionId"],
+            ["metadata_review_suggestions.id"],
+            ondelete="CASCADE",
+            name="metadata_review_comments_suggestionId_fk",
+        ),
+        ForeignKeyConstraint(
+            ["parentCommentId"],
+            ["metadata_review_comments.id"],
+            ondelete="CASCADE",
+            name="metadata_review_comments_parentCommentId_fk",
+        ),
+        ForeignKeyConstraint(["userId"], ["users.id"], ondelete="RESTRICT", name="metadata_review_comments_userId_fk"),
+        Index("idx_mrc_suggestion", "suggestionId"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
+    suggestionId: Mapped[int] = mapped_column(Integer)
+    userId: Mapped[int] = mapped_column(Integer)
+    # NOTE: this column shadows sqlalchemy's `text()` inside the class body; keep
+    # timestamp defaults func-based below.
+    text: Mapped[str] = mapped_column(MEDIUMTEXT)
+    parentCommentId: Mapped[int | None] = mapped_column(Integer, default=None)
+    # 'comment' or 'status_change' (auto-comment recording a status flip).
+    kind: Mapped[str] = mapped_column(VARCHAR(32), default="comment")
+    createdAt: Mapped[datetime] = mapped_column(DateTime, default=func.utc_timestamp(), init=False)
+    updatedAt: Mapped[datetime] = mapped_column(
+        DateTime, default=func.utc_timestamp(), onupdate=func.utc_timestamp(), init=False
+    )
+
+    @classmethod
+    def load_for_suggestions(cls, session: Session, suggestion_ids: list[int]) -> list["MetadataReviewComment"]:
+        if not suggestion_ids:
+            return []
+        return list(
+            session.scalars(select(cls).where(cls.suggestionId.in_(suggestion_ids)).order_by(cls.createdAt.asc())).all()
+        )
 
 
 class MultiDimDataPage(Base):

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -64,7 +64,7 @@ from sqlalchemy.dialects.mysql import (
     VARCHAR,
 )
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import NoResultFound, ProgrammingError
+from sqlalchemy.exc import IntegrityError, NoResultFound, ProgrammingError
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (  # ty: ignore
     DeclarativeBase,
@@ -1860,6 +1860,9 @@ class MetadataReviewSuggestion(Base):
             mysql_length={"targetPath": 191, "viewId": 191, "fieldPath": 64},
         ),
         Index("idx_mrs_status", "status"),
+        # One OPEN thread per field, enforced at the database level: the generated
+        # column is NULL for resolved rows (NULLs never collide in a unique index).
+        Index("idx_mrs_open_unique", "openKeyHash", unique=True),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, init=False)
@@ -1890,6 +1893,14 @@ class MetadataReviewSuggestion(Base):
     updatedAt: Mapped[datetime] = mapped_column(
         DateTime, server_default=text("CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP"), init=False
     )
+    openKeyHash: Mapped[str | None] = mapped_column(
+        CHAR(32),
+        Computed(
+            "(IF(status = 'open', MD5(CONCAT_WS('|', targetType, targetPath, IFNULL(viewId, ''), fieldPath)), NULL))",
+            persisted=True,
+        ),
+        init=False,
+    )
 
     @classmethod
     def file_or_update(
@@ -1915,19 +1926,24 @@ class MetadataReviewSuggestion(Base):
         exists for the same source key, the new proposed text replaces it (the
         edit is recorded as a `revision` comment) and any comment joins the same
         thread — instead of piling up parallel threads that each repeat the text.
+        The unique `openKeyHash` index enforces this at the database level; a
+        concurrent filing that loses the race merges into the winner's thread.
         """
-        existing = session.scalars(
-            select(cls)
-            .where(
-                cls.targetType == target_type,
-                cls.targetPath == target_path,
-                cls.viewId.is_(None) if view_id is None else cls.viewId == view_id,
-                cls.fieldPath == field_path,
-                cls.status == "open",
-            )
-            .order_by(cls.createdAt.desc())
-        ).first()
 
+        def find_open() -> "MetadataReviewSuggestion | None":
+            return session.scalars(
+                select(cls)
+                .where(
+                    cls.targetType == target_type,
+                    cls.targetPath == target_path,
+                    cls.viewId.is_(None) if view_id is None else cls.viewId == view_id,
+                    cls.fieldPath == field_path,
+                    cls.status == "open",
+                )
+                .order_by(cls.createdAt.desc())
+            ).first()
+
+        existing = find_open()
         if existing is None:
             suggestion = cls(
                 targetType=target_type,
@@ -1944,8 +1960,16 @@ class MetadataReviewSuggestion(Base):
                 pageChecksum=page_checksum,
             )
             session.add(suggestion)
-            session.commit()
-        else:
+            try:
+                session.commit()
+            except IntegrityError:
+                # Lost a concurrent-filing race: merge into the winner's thread.
+                session.rollback()
+                existing = find_open()
+                if existing is None:
+                    raise
+
+        if existing is not None:
             suggestion = existing
             if suggested_value is not None and suggested_value != suggestion.suggestedValue:
                 had_proposal = suggestion.suggestedValue is not None

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -1968,11 +1968,20 @@ class MetadataReviewSuggestion(Base):
         session: Session,
         target_paths: list[str],
         statuses: list[str] | None = None,
+        path_prefixes: list[str] | None = None,
     ) -> list["MetadataReviewSuggestion"]:
-        """Load suggestions for a set of target paths (an MDim page plus all its source indicators)."""
-        if not target_paths:
+        """Load suggestions for a set of target paths (an MDim page plus all its source
+        indicators). `path_prefixes` widens the scope to sibling indicators of the same
+        grapher dataset(s), so threads filed on another MDim built from the same
+        metadata can surface here too."""
+        if not target_paths and not path_prefixes:
             return []
-        q = select(cls).where(cls.targetPath.in_(target_paths))
+        conditions = []
+        if target_paths:
+            conditions.append(cls.targetPath.in_(target_paths))
+        for prefix in path_prefixes or []:
+            conditions.append(cls.targetPath.like(prefix.replace("%", r"\%") + "%"))
+        q = select(cls).where(or_(*conditions))
         if statuses:
             q = q.where(cls.status.in_(statuses))
         return list(session.scalars(q.order_by(cls.createdAt.asc())).all())

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -1980,7 +1980,11 @@ class MetadataReviewSuggestion(Base):
         if target_paths:
             conditions.append(cls.targetPath.in_(target_paths))
         for prefix in path_prefixes or []:
-            conditions.append(cls.targetPath.like(prefix.replace("%", r"\%") + "%"))
+            # Anchor at a path boundary so 'grapher/ns/ver/population' doesn't also
+            # match 'grapher/ns/ver/population_historical'; escape LIKE wildcards
+            # ('_' is common in dataset names).
+            escaped = prefix.rstrip("/").replace("%", r"\%").replace("_", r"\_")
+            conditions.append(cls.targetPath.like(escaped + "/%"))
         q = select(cls).where(or_(*conditions))
         if statuses:
             q = q.where(cls.status.in_(statuses))

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -1892,6 +1892,77 @@ class MetadataReviewSuggestion(Base):
     )
 
     @classmethod
+    def file_or_update(
+        cls,
+        session: Session,
+        target_type: str,
+        target_path: str,
+        view_id: str | None,
+        field_path: str,
+        user_id: int,
+        provenance: str,
+        current_value: str | None,
+        suggested_value: str | None,
+        comment_text: str | None = None,
+        inherited_from_path: str | None = None,
+        filed_from_path: str | None = None,
+        filed_from_view_id: str | None = None,
+        page_checksum: str | None = None,
+    ) -> "MetadataReviewSuggestion":
+        """File a suggestion, consolidating onto the field's existing OPEN thread.
+
+        A field has at most one open proposal: when an open suggestion already
+        exists for the same source key, the new proposed text replaces it (the
+        edit is recorded as a `revision` comment) and any comment joins the same
+        thread — instead of piling up parallel threads that each repeat the text.
+        """
+        existing = session.scalars(
+            select(cls)
+            .where(
+                cls.targetType == target_type,
+                cls.targetPath == target_path,
+                cls.viewId.is_(None) if view_id is None else cls.viewId == view_id,
+                cls.fieldPath == field_path,
+                cls.status == "open",
+            )
+            .order_by(cls.createdAt.desc())
+        ).first()
+
+        if existing is None:
+            suggestion = cls(
+                targetType=target_type,
+                targetPath=target_path,
+                viewId=view_id,
+                fieldPath=field_path,
+                provenance=provenance,
+                createdBy=user_id,
+                inheritedFromPath=inherited_from_path,
+                filedFromPath=filed_from_path,
+                filedFromViewId=filed_from_view_id,
+                currentValue=current_value,
+                suggestedValue=suggested_value,
+                pageChecksum=page_checksum,
+            )
+            session.add(suggestion)
+            session.commit()
+        else:
+            suggestion = existing
+            if suggested_value is not None and suggested_value != suggestion.suggestedValue:
+                had_proposal = suggestion.suggestedValue is not None
+                suggestion.suggestedValue = suggested_value
+                session.add(suggestion)
+                session.commit()
+                suggestion.add_comment(
+                    session,
+                    user_id=user_id,
+                    text="Updated the proposed text." if had_proposal else "Added a proposed text.",
+                    kind="revision",
+                )
+        if comment_text:
+            suggestion.add_comment(session, user_id=user_id, text=comment_text)
+        return suggestion
+
+    @classmethod
     def load_for_paths(
         cls,
         session: Session,

--- a/tests/test_metadata_review.py
+++ b/tests/test_metadata_review.py
@@ -442,9 +442,10 @@ def test_apply_bullet_edits_additions_need_full_rewrite_match():
     assert out == ("- OTHER dimension bullet\n- Shared note, reworded", 1, 3)
 
 
-def test_threads_do_not_bullet_borrow_across_sibling_views():
-    """Views of the SAME MDim (e.g. before vs after tax) must not borrow bullet-list
-    threads from each other — only exact-text/pattern sharing applies there."""
+def test_threads_bullet_borrow_across_sibling_views_only_for_shared_bullets():
+    """Across views of one MDim (e.g. before vs after tax), a bullet-list thread
+    carries only when it edits bullets shared VERBATIM by both lists; edits to
+    dimension-specific bullets stay on their own views."""
     from apps.metadata_review.resolution import suggestions_by_source_key, threads_for_field
     from apps.metadata_review.targets import MdimReview, ViewReview
 
@@ -474,9 +475,9 @@ def test_threads_do_not_bullet_borrow_across_sibling_views():
                 ],
             )
         )
-    # A thread on the after-tax indicator edits the shared bullet (so bullet-transfer
-    # WOULD match) — it must still not surface on the before-tax view.
-    suggestion = gm.MetadataReviewSuggestion(
+    # A thread on the after-tax indicator editing the SHARED bullet carries to the
+    # before-tax view (the edit genuinely applies there).
+    shared_edit = gm.MetadataReviewSuggestion(
         targetType="indicator",
         targetPath="grapher/wid/latest/inc/t#share__after_tax",
         fieldPath="description_key",
@@ -486,13 +487,25 @@ def test_threads_do_not_bullet_borrow_across_sibling_views():
         suggestedValue="- Shared generic bullet, reworded\n- Income is measured after taxes.",
         filedFromViewId="welfare_type=after_tax",
     )
-    suggestion.id = 7
-    grouped = suggestions_by_source_key([suggestion])
+    shared_edit.id = 7
+    # A thread editing only the DIMENSION-SPECIFIC bullet stays on its own views.
+    variant_edit = gm.MetadataReviewSuggestion(
+        targetType="indicator",
+        targetPath="grapher/wid/latest/inc/t#share__after_tax",
+        fieldPath="description_key",
+        provenance="inherited",
+        createdBy=1,
+        currentValue=lists["after_tax"],
+        suggestedValue="- Shared generic bullet\n- Income is measured after taxes, reworded.",
+        filedFromViewId="welfare_type=after_tax",
+    )
+    variant_edit.id = 8
+    grouped = suggestions_by_source_key([shared_edit, variant_edit])
     before_field = review.views[0].fields[0]
-    assert threads_for_field(review, before_field, grouped) == []
-    # Its own view still shows it.
+    assert [s.id for s in threads_for_field(review, before_field, grouped)] == [7]
+    # Its own view shows both.
     after_field = review.views[1].fields[0]
-    assert [s.id for s in threads_for_field(review, after_field, grouped)] == [7]
+    assert [s.id for s in threads_for_field(review, after_field, grouped)] == [7, 8]
 
 
 def test_bullet_diff_no_changes():

--- a/tests/test_metadata_review.py
+++ b/tests/test_metadata_review.py
@@ -1,0 +1,424 @@
+"""Unit tests for the Metadata Review core (apps/metadata_review)."""
+
+import textwrap
+
+import pytest
+
+import etl.grapher.model as gm
+from apps.metadata_review.resolution import (
+    Staleness,
+    check_staleness,
+    dimensions_to_view_id,
+    resolve_field,
+    slugify,
+    suggestions_by_source_key,
+)
+from apps.metadata_review.targets import ReviewableField
+from apps.metadata_review.trace import (
+    EditCandidate,
+    _trace_in_meta_yaml,
+    _trace_mdim_page_field,
+    _trace_mdim_view_field,
+)
+
+
+def _must(candidate: EditCandidate | None) -> EditCandidate:
+    assert candidate is not None
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# dimensionsToViewId / slugify parity (fixtures mirror owid-grapher's Util.ts)
+# ---------------------------------------------------------------------------
+
+
+def test_slugify_identity_for_snake_case():
+    assert slugify("conflict_type") == "conflict_type"
+    assert slugify("no_spells") == "no_spells"
+
+
+def test_slugify_matches_js_behavior():
+    assert slugify("CO₂ emissions") == "co2-emissions"
+    assert slugify("Income/Wealth") == "incomewealth"
+    assert slugify("  padded  ") == "padded"
+
+
+def test_dimensions_to_view_id_sorts_and_joins():
+    dims = {"indicator": "deaths", "conflict_type": "all", "people": "all", "estimate": "best"}
+    assert dimensions_to_view_id(dims) == "conflict_type=all__estimate=best__indicator=deaths__people=all"
+
+
+def test_dimensions_to_view_id_lowercases():
+    assert dimensions_to_view_id({"Sex": "Female"}) == "sex=female"
+
+
+# ---------------------------------------------------------------------------
+# resolve_field (ported from faust-metadata-audit)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "override,inherited,expected",
+    [
+        ("A", "B", ("override", "A")),
+        ("", "B", ("override", "")),  # explicit empty string suppresses inherited text
+        (None, "B", ("inherited", "B")),
+        (None, None, ("missing", None)),
+        (None, "", ("inherited", "")),
+    ],
+)
+def test_resolve_field(override, inherited, expected):
+    assert resolve_field(override, inherited) == expected
+
+
+# ---------------------------------------------------------------------------
+# Source-keyed suggestions
+# ---------------------------------------------------------------------------
+
+
+def _field(**kwargs) -> ReviewableField:
+    defaults = dict(
+        target_type="mdim",
+        target_path="ns/latest/thing#thing",
+        view_id="metric=total",
+        field_path="config.subtitle",
+        label="Subtitle",
+        provenance="inherited",
+        current_value="Some text.",
+        inherited_from="grapher/ns/latest/ds/table#col",
+    )
+    defaults.update(kwargs)
+    return ReviewableField(**defaults)
+
+
+def test_source_key_inherited_view_field_routes_to_indicator():
+    field = _field(provenance="inherited")
+    assert field.source_key() == ("indicator", "grapher/ns/latest/ds/table#col", None, "grapher_config.subtitle")
+
+
+def test_source_key_missing_view_field_routes_to_indicator():
+    field = _field(provenance="missing", current_value=None)
+    assert field.source_key()[0] == "indicator"
+
+
+def test_source_key_override_stays_on_view():
+    field = _field(provenance="override")
+    assert field.source_key() == ("mdim", "ns/latest/thing#thing", "metric=total", "config.subtitle")
+
+
+def test_source_key_page_level_stays_on_mdim():
+    field = _field(view_id=None, field_path="title.title", provenance="override", inherited_from=None)
+    assert field.source_key() == ("mdim", "ns/latest/thing#thing", None, "title.title")
+
+
+def test_suggestions_by_source_key_groups():
+    s1 = gm.MetadataReviewSuggestion(
+        targetType="indicator", targetPath="grapher/a/b/c/t#x", fieldPath="description_short",
+        provenance="inherited", createdBy=1,
+    )  # fmt: skip
+    s2 = gm.MetadataReviewSuggestion(
+        targetType="indicator", targetPath="grapher/a/b/c/t#x", fieldPath="description_short",
+        provenance="inherited", createdBy=2,
+    )  # fmt: skip
+    grouped = suggestions_by_source_key([s1, s2])
+    assert list(grouped) == [("indicator", "grapher/a/b/c/t#x", None, "description_short")]
+    assert len(grouped[("indicator", "grapher/a/b/c/t#x", None, "description_short")]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Staleness
+# ---------------------------------------------------------------------------
+
+
+def _suggestion(**kwargs) -> gm.MetadataReviewSuggestion:
+    defaults = dict(
+        targetType="indicator",
+        targetPath="grapher/ns/latest/ds/table#col",
+        viewId=None,
+        fieldPath="grapher_config.subtitle",
+        provenance="inherited",
+        createdBy=1,
+        currentValue="Old text.",
+        pageChecksum="abc",
+    )
+    defaults.update(kwargs)
+    return gm.MetadataReviewSuggestion(**defaults)
+
+
+def _fields_by_key(field: ReviewableField) -> dict:
+    return {field.source_key(): field}
+
+
+def test_staleness_unchanged():
+    field = _field(current_value="Old text.", page_checksum="abc")
+    staleness = check_staleness(_suggestion(), _fields_by_key(field))
+    assert not staleness.is_stale and not staleness.page_changed
+
+
+def test_staleness_value_changed():
+    field = _field(current_value="New text.", page_checksum="abc")
+    staleness = check_staleness(_suggestion(), _fields_by_key(field))
+    assert staleness.field_changed and staleness.current_value == "New text."
+
+
+def test_staleness_provenance_flipped():
+    # The view gained an override replacing the inherited text -> stale.
+    field = _field(provenance="override", current_value="Old text.")
+    # An override field keys to the view, so the indicator key disappears -> target_gone.
+    staleness = check_staleness(_suggestion(), _fields_by_key(field))
+    assert staleness.target_gone
+
+
+def test_staleness_page_changed_only():
+    field = _field(current_value="Old text.", page_checksum="different")
+    staleness = check_staleness(_suggestion(), _fields_by_key(field))
+    assert not staleness.is_stale and staleness.page_changed
+
+
+def test_staleness_target_gone():
+    staleness = check_staleness(_suggestion(), {})
+    assert staleness.target_gone and staleness.is_stale
+    assert Staleness(target_gone=True).is_stale
+
+
+# ---------------------------------------------------------------------------
+# Tracer: garden .meta.yml (Phase A/B/C replay)
+# ---------------------------------------------------------------------------
+
+GARDEN_META = """\
+definitions:
+  attention: &attention |-
+    This is a shared warning.
+  common:
+    presentation:
+      grapher_config:
+        note: A note for every variable in every table.
+
+tables:
+  main:
+    common:
+      description_short: Common description.
+    variables:
+      deaths:
+        title: Deaths
+        description_short: |-
+          <% if cause == "all" %>Deaths from all causes.<% else %>Deaths from << cause >>.<% endif %>
+        presentation:
+          grapher_config:
+            subtitle: *attention
+      births:
+        title: Births
+        presentation:
+          grapher_config:
+            subtitle: *attention
+"""
+
+
+@pytest.fixture
+def garden_meta(tmp_path):
+    path = tmp_path / "ds.meta.yml"
+    path.write_text(textwrap.dedent(GARDEN_META))
+    return path
+
+
+def test_trace_jinja_variable_field(garden_meta):
+    candidate = _trace_in_meta_yaml(
+        garden_meta,
+        table_name="main",
+        var_name="deaths",
+        field_path="description_short",
+        dim_dict={"cause": "malaria"},
+        current_value="Deaths from malaria.",
+    )
+    assert candidate is not None
+    assert candidate.kind == "jinja"
+    assert candidate.supplied_by == "tables.main.variables.deaths"
+    assert candidate.yaml_path == "tables.main.variables.deaths.description_short"
+    assert candidate.render_verified is True
+    assert candidate.render_context == {"cause": "malaria"}
+
+
+def test_trace_jinja_other_branch(garden_meta):
+    candidate = _must(
+        _trace_in_meta_yaml(
+            garden_meta,
+            table_name="main",
+            var_name="deaths",
+            field_path="description_short",
+            dim_dict={"cause": "all"},
+            current_value="Deaths from all causes.",
+        )
+    )
+    assert candidate.render_verified is True
+
+
+def test_trace_common_block(garden_meta):
+    # `births` has no description_short of its own -> supplied by tables.main.common.
+    candidate = _must(
+        _trace_in_meta_yaml(
+            garden_meta,
+            table_name="main",
+            var_name="births",
+            field_path="description_short",
+            dim_dict={},
+            current_value="Common description.",
+        )
+    )
+    assert candidate.kind == "common-block"
+    assert candidate.supplied_by == "tables.main.common"
+    assert candidate.render_verified is True
+    # deaths overrides the key itself, so it is NOT affected by editing the common block.
+    assert candidate.shared_with == []
+
+
+def test_trace_definitions_common(garden_meta):
+    candidate = _must(
+        _trace_in_meta_yaml(
+            garden_meta,
+            table_name="main",
+            var_name="deaths",
+            field_path="grapher_config.note",
+            dim_dict={},
+            current_value="A note for every variable in every table.",
+        )
+    )
+    assert candidate.supplied_by == "definitions.common"
+    assert candidate.render_verified is True
+    # births doesn't define note itself -> affected by editing definitions.common.
+    assert candidate.shared_with == ["births"]
+
+
+def test_trace_anchor_detection(garden_meta):
+    candidate = _must(
+        _trace_in_meta_yaml(
+            garden_meta,
+            table_name="main",
+            var_name="deaths",
+            field_path="grapher_config.subtitle",
+            dim_dict={},
+            current_value="This is a shared warning.",
+        )
+    )
+    assert candidate.supplied_by == "tables.main.variables.deaths"
+    assert candidate.render_verified is True
+    # The anchor is shared with births.
+    assert candidate.shared_with == ["births"]
+    assert any("anchor" in note for note in candidate.notes)
+
+
+def test_trace_absent_field_returns_none(garden_meta):
+    candidate = _trace_in_meta_yaml(
+        garden_meta,
+        table_name="main",
+        var_name="deaths",
+        field_path="grapher_config.title",
+        dim_dict={},
+        current_value="whatever",
+    )
+    assert candidate is None
+
+
+def test_trace_render_mismatch_flagged(garden_meta):
+    candidate = _must(
+        _trace_in_meta_yaml(
+            garden_meta,
+            table_name="main",
+            var_name="deaths",
+            field_path="description_short",
+            dim_dict={"cause": "malaria"},
+            current_value="Completely different live text.",
+        )
+    )
+    assert candidate.render_verified is False
+    assert any("did NOT reproduce" in note for note in candidate.notes)
+
+
+# ---------------------------------------------------------------------------
+# Tracer: MDim config .yml
+# ---------------------------------------------------------------------------
+
+MDIM_CONFIG = """\
+definitions:
+  common_views:
+    - config:
+        note: A footnote for all views.
+    - dimensions:
+        metric: total
+      config:
+        subtitle: Total subtitle from common_views.
+
+title:
+  title: My MDim
+  title_variant: by metric
+
+dimensions:
+  - slug: metric
+    name: Metric
+    choices:
+      - slug: total
+        name: Total number
+      - slug: rate
+        name: Rate
+        description: Per 100,000 people.
+
+views:
+  - dimensions:
+      metric: rate
+    config:
+      title: Rate view title
+"""
+
+
+@pytest.fixture
+def mdim_config(tmp_path):
+    path = tmp_path / "thing.config.yml"
+    path.write_text(textwrap.dedent(MDIM_CONFIG))
+    return path
+
+
+def test_trace_mdim_page_title(mdim_config):
+    config = _load_mdim(mdim_config)
+    candidate = _must(_trace_mdim_page_field(config, mdim_config, "title.title"))
+    assert candidate.yaml_path == "title.title"
+    assert candidate.template == "My MDim"
+
+
+def test_trace_mdim_choice_description(mdim_config):
+    config = _load_mdim(mdim_config)
+    candidate = _must(_trace_mdim_page_field(config, mdim_config, "dimensions.metric.choices.rate.description"))
+    assert candidate.yaml_path == "dimensions[0].choices[1].description"
+    assert candidate.template == "Per 100,000 people."
+
+
+def test_trace_mdim_missing_choice_returns_none(mdim_config):
+    config = _load_mdim(mdim_config)
+    assert _trace_mdim_page_field(config, mdim_config, "dimensions.metric.choices.total.description") is None
+
+
+def test_trace_mdim_literal_view(mdim_config):
+    config = _load_mdim(mdim_config)
+    candidate = _must(_trace_mdim_view_field(config, mdim_config, "metric=rate", "config.title"))
+    assert candidate.kind == "mdim-view"
+    assert candidate.yaml_path == "views[0].config.title"
+
+
+def test_trace_mdim_common_views(mdim_config):
+    config = _load_mdim(mdim_config)
+    # subtitle comes from the metric=total common_views entry (more specific).
+    candidate = _must(_trace_mdim_view_field(config, mdim_config, "metric=total", "config.subtitle"))
+    assert candidate.kind == "mdim-common-views"
+    assert candidate.yaml_path == "definitions.common_views[1].config.subtitle"
+    # note comes from the catch-all entry.
+    candidate = _must(_trace_mdim_view_field(config, mdim_config, "metric=total", "config.note"))
+    assert candidate.yaml_path == "definitions.common_views[0].config.note"
+
+
+def test_trace_mdim_generated_view_returns_none(mdim_config):
+    config = _load_mdim(mdim_config)
+    assert _trace_mdim_view_field(config, mdim_config, "metric=total", "config.title") is None
+
+
+def _load_mdim(path):
+    from owid.catalog.core.utils import dynamic_yaml_load, dynamic_yaml_to_dict
+
+    return dynamic_yaml_to_dict(dynamic_yaml_load(path))

--- a/tests/test_metadata_review.py
+++ b/tests/test_metadata_review.py
@@ -126,6 +126,74 @@ def test_suggestions_by_source_key_groups():
 
 
 # ---------------------------------------------------------------------------
+# Shared text across views (different expanded indicators, same rendered value)
+# ---------------------------------------------------------------------------
+
+
+def _mdim_with_shared_text():
+    from apps.metadata_review.targets import MdimReview, ViewReview
+
+    def view_field(view_id, indicator, value):
+        return _field(
+            view_id=view_id,
+            provenance="inherited",
+            current_value=value,
+            inherited_from=indicator,
+            field_path="config.subtitle",
+        )
+
+    review = MdimReview(
+        target_path="ns/latest/thing#thing", slug="thing", title="T", title_variant=None, page_checksum="x"
+    )
+    # Views a and b render the SAME text via DIFFERENT expanded indicators; c differs.
+    for view_id, indicator, value in [
+        ("metric=a", "grapher/ns/latest/ds/t#col__a", "Shared subtitle."),
+        ("metric=b", "grapher/ns/latest/ds/t#col__b", "Shared subtitle."),
+        ("metric=c", "grapher/ns/latest/ds/t#col__c", "Different subtitle."),
+    ]:
+        review.views.append(
+            ViewReview(
+                view_id=view_id,
+                dimensions={"metric": view_id.split("=")[1]},
+                indicator_path=indicator,
+                fields=[view_field(view_id, indicator, value)],
+            )
+        )
+    return review
+
+
+def test_shared_view_ids_matches_by_value_across_indicators():
+    from apps.metadata_review.resolution import shared_view_ids
+
+    review = _mdim_with_shared_text()
+    field_a = review.views[0].fields[0]
+    assert shared_view_ids(review, field_a) == ["metric=b"]
+    field_c = review.views[2].fields[0]
+    assert shared_view_ids(review, field_c) == []
+
+
+def test_threads_for_field_borrows_across_indicators():
+    from apps.metadata_review.resolution import suggestions_by_source_key, threads_for_field
+
+    review = _mdim_with_shared_text()
+    # A suggestion filed on view a's indicator must show on view b's identical field.
+    suggestion = gm.MetadataReviewSuggestion(
+        targetType="indicator",
+        targetPath="grapher/ns/latest/ds/t#col__a",
+        fieldPath="grapher_config.subtitle",
+        provenance="inherited",
+        createdBy=1,
+        currentValue="Shared subtitle.",
+    )
+    suggestion.id = 1
+    grouped = suggestions_by_source_key([suggestion])
+    field_b = review.views[1].fields[0]
+    assert [s.id for s in threads_for_field(review, field_b, grouped)] == [1]
+    field_c = review.views[2].fields[0]
+    assert threads_for_field(review, field_c, grouped) == []
+
+
+# ---------------------------------------------------------------------------
 # Bullet diffs (description_key consolidation)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_metadata_review.py
+++ b/tests/test_metadata_review.py
@@ -346,7 +346,7 @@ def test_split_bullets_prose_and_list():
 
 
 def test_bullet_diff_only_changed_bullets():
-    from apps.metadata_review.diffs import bullet_diff, diff_markdown_lines, diff_summary
+    from apps.metadata_review.diffs import bullet_diff, diff_summary, tracked_changes_html
 
     current = "- Keep me\n- Old wording\n- Also keep"
     proposed = "- Keep me\n- New wording\n- Also keep\n- Brand new bullet"
@@ -359,12 +359,14 @@ def test_bullet_diff_only_changed_bullets():
         ("add", "Brand new bullet"),
     ]
     assert diff_summary(ops) == "2 added, 1 removed; 2 unchanged"
-    lines = diff_markdown_lines(ops)
-    # Unchanged bullets are summarized, not repeated.
-    assert "- _… 1 unchanged bullet_" in lines
-    assert any("~~Old wording~~" in line for line in lines)
-    assert any(":green[+] New wording" in line for line in lines)
-    assert not any("Keep me" in line for line in lines)
+    # The tracked rendering shows the ENTIRE list: unchanged bullets in full,
+    # the changed one with inline word tracking, additions tinted.
+    out = tracked_changes_html(current, proposed, is_bullet_list=True)
+    assert "Keep me" in out and "Also keep" in out
+    assert "unchanged" not in out  # no collapsed placeholders
+    assert "<del" in out and "Old" in out
+    # The changed bullet tracks word-by-word, so markup splits the phrase.
+    assert "<ins" in out and "New" in out and "wording" in out and "Brand new bullet" in out
 
 
 def test_word_diff_html_tracks_changes_inline():
@@ -384,10 +386,12 @@ def test_tracked_changes_html_bullets():
     out = tracked_changes_html(
         "- Keep\n- Old wording here\n- Tail", "- Keep\n- New wording here\n- Tail", is_bullet_list=True
     )
-    # The changed bullet is ONE bullet with inline word tracking, not a remove+add pair.
-    assert out.count("<li>") == 1
+    # Every bullet shows (full text always); the changed one is a single bullet
+    # with inline word tracking, not a remove+add pair.
+    assert out.count("<li>") == 3
+    assert "Keep" in out and "Tail" in out
     assert "<del" in out and "Old" in out and "<ins" in out and "New" in out
-    assert "unchanged" in out  # kept bullets collapsed
+    assert "unchanged" not in out
 
 
 def test_apply_bullet_edits_transfers_shared_bullet():

--- a/tests/test_metadata_review.py
+++ b/tests/test_metadata_review.py
@@ -813,3 +813,55 @@ def _load_mdim(path):
     from owid.catalog.core.utils import dynamic_yaml_load, dynamic_yaml_to_dict
 
     return dynamic_yaml_to_dict(dynamic_yaml_load(path))
+
+
+# ---------------------------------------------------------------------------
+# Combined display: all applicable proposals in one tracked text
+# ---------------------------------------------------------------------------
+
+
+def test_combined_display_value_layers_own_and_borrowed():
+    from apps.metadata_review.resolution import combined_display_value
+
+    field = _field(
+        field_path="metadata.description_key",
+        provenance="inherited",
+        current_value="- Shared A\n- Own specific\n- Shared B",
+    )
+    own = gm.MetadataReviewSuggestion(
+        targetType="indicator", targetPath=field.inherited_from, fieldPath="description_key",
+        provenance="inherited", createdBy=1,
+        currentValue="- Shared A\n- Own specific\n- Shared B",
+        suggestedValue="- Shared A\n- Own specific, reworded\n- Shared B",
+    )  # fmt: skip
+    own.id = 1
+    borrowed = gm.MetadataReviewSuggestion(
+        targetType="indicator", targetPath="grapher/x/l/d/t#other", fieldPath="description_key",
+        provenance="inherited", createdBy=2,
+        currentValue="- Shared A\n- Other specific\n- Shared B",
+        suggestedValue="- Shared A, reworded\n- Other specific\n- Shared B",
+    )  # fmt: skip
+    borrowed.id = 2
+    display, applied = combined_display_value(field, [own, borrowed])
+    # Both proposals visible in ONE combined text: own edit + borrowed shared-bullet edit.
+    assert display == "- Shared A, reworded\n- Own specific, reworded\n- Shared B"
+    assert applied == {1: True, 2: True}
+
+
+def test_combined_display_value_skips_inapplicable_borrowed():
+    from apps.metadata_review.resolution import combined_display_value
+
+    field = _field(
+        field_path="metadata.description_key",
+        provenance="inherited",
+        current_value="- Shared A\n- Own specific",
+    )
+    foreign_only = gm.MetadataReviewSuggestion(
+        targetType="indicator", targetPath="grapher/x/l/d/t#other", fieldPath="description_key",
+        provenance="inherited", createdBy=2,
+        currentValue="- Shared A\n- Other specific",
+        suggestedValue="- Shared A\n- Other specific, reworded",
+    )  # fmt: skip
+    foreign_only.id = 3
+    display, applied = combined_display_value(field, [foreign_only])
+    assert display is None and applied == {3: False}

--- a/tests/test_metadata_review.py
+++ b/tests/test_metadata_review.py
@@ -283,6 +283,34 @@ def test_pattern_connects_titles_across_views():
     assert [s.id for s in threads_for_field(review, field_01, grouped)] == [1]
 
 
+def test_threads_borrow_across_pages_by_snapshot_text():
+    """A thread filed on another MDim's indicator (same garden metadata, identical
+    text) surfaces on this page's matching field."""
+    from apps.metadata_review.resolution import check_staleness, suggestions_by_source_key, threads_for_field
+
+    review = _mdim_with_shared_text()
+    foreign = gm.MetadataReviewSuggestion(
+        targetType="indicator",
+        # An indicator NOT used by any view of this MDim (sibling MDim's source).
+        targetPath="grapher/ns/latest/ds/other_table#palma",
+        fieldPath="grapher_config.subtitle",
+        provenance="inherited",
+        createdBy=1,
+        currentValue="Shared subtitle.",
+        filedFromPath="ns/latest/other#other",
+    )
+    foreign.id = 99
+    grouped = suggestions_by_source_key([foreign])
+    field_a = review.views[0].fields[0]
+    assert [s.id for s in threads_for_field(review, field_a, grouped)] == [99]
+    # Different text on view c -> not borrowed there.
+    assert threads_for_field(review, review.views[2].fields[0], grouped) == []
+    # Staleness judged against the displaying field, not flagged target_gone.
+    fields_by_key = {field_a.source_key(): field_a}
+    staleness = check_staleness(foreign, fields_by_key, display_field=field_a)
+    assert not staleness.target_gone and not staleness.field_changed
+
+
 def test_transfer_proposal_rerenders_dimension_words():
     from apps.metadata_review.resolution import transfer_proposal
 
@@ -360,6 +388,34 @@ def test_tracked_changes_html_bullets():
     assert out.count("<li>") == 1
     assert "<del" in out and "Old" in out and "<ins" in out and "New" in out
     assert "unchanged" in out  # kept bullets collapsed
+
+
+def test_apply_bullet_edits_transfers_shared_bullet():
+    from apps.metadata_review.diffs import apply_bullet_edits
+
+    # The proposal edits a shared (anchored) bullet inside a DIFFERENT list.
+    out = apply_bullet_edits(
+        "- Own bullet A\n- Shared warning\n- Own bullet B",
+        "- Own bullet A\n- Shared warning, reworded\n- Own bullet B",
+        "- Other page intro\n- Shared warning\n- Other page outro",
+    )
+    assert out == ("- Other page intro\n- Shared warning, reworded\n- Other page outro", 1, 1)
+    # Editing a bullet the target list doesn't have -> no transfer.
+    assert apply_bullet_edits("- Not shared", "- Not shared, changed", "- Something else entirely") is None
+    # A no-op proposal never transfers.
+    assert apply_bullet_edits("- A", "- A", "- A\n- B") is None
+
+
+def test_apply_bullet_edits_partial_transfer():
+    from apps.metadata_review.diffs import apply_bullet_edits
+
+    # One edited bullet is shared, the other is page-specific -> partial carry.
+    out = apply_bullet_edits(
+        "- Page-specific intro\n- Shared source note",
+        "- Page-specific intro, reworded\n- Shared source note, reworded",
+        "- DIFFERENT intro\n- Shared source note\n- Extra bullet",
+    )
+    assert out == ("- DIFFERENT intro\n- Shared source note, reworded\n- Extra bullet", 1, 2)
 
 
 def test_bullet_diff_no_changes():

--- a/tests/test_metadata_review.py
+++ b/tests/test_metadata_review.py
@@ -126,6 +126,49 @@ def test_suggestions_by_source_key_groups():
 
 
 # ---------------------------------------------------------------------------
+# Bullet diffs (description_key consolidation)
+# ---------------------------------------------------------------------------
+
+
+def test_split_bullets_prose_and_list():
+    from apps.metadata_review.diffs import split_bullets
+
+    assert split_bullets(None) == []
+    assert split_bullets("Single prose item.") == ["Single prose item."]
+    assert split_bullets("- One\n- Two\n  continued\n- Three") == ["One", "Two continued", "Three"]
+
+
+def test_bullet_diff_only_changed_bullets():
+    from apps.metadata_review.diffs import bullet_diff, diff_markdown_lines, diff_summary
+
+    current = "- Keep me\n- Old wording\n- Also keep"
+    proposed = "- Keep me\n- New wording\n- Also keep\n- Brand new bullet"
+    ops = bullet_diff(current, proposed)
+    assert [(o.op, o.text) for o in ops] == [
+        ("keep", "Keep me"),
+        ("remove", "Old wording"),
+        ("add", "New wording"),
+        ("keep", "Also keep"),
+        ("add", "Brand new bullet"),
+    ]
+    assert diff_summary(ops) == "2 added, 1 removed; 2 unchanged"
+    lines = diff_markdown_lines(ops)
+    # Unchanged bullets are summarized, not repeated.
+    assert "- _… 1 unchanged bullet_" in lines
+    assert any("~~Old wording~~" in line for line in lines)
+    assert any(":green[+] New wording" in line for line in lines)
+    assert not any("Keep me" in line for line in lines)
+
+
+def test_bullet_diff_no_changes():
+    from apps.metadata_review.diffs import bullet_diff, diff_summary
+
+    ops = bullet_diff("- A\n- B", "- A\n- B")
+    assert all(o.op == "keep" for o in ops)
+    assert diff_summary(ops) == "no bullet changes; 2 unchanged"
+
+
+# ---------------------------------------------------------------------------
 # Staleness
 # ---------------------------------------------------------------------------
 

--- a/tests/test_metadata_review.py
+++ b/tests/test_metadata_review.py
@@ -422,6 +422,79 @@ def test_apply_bullet_edits_partial_transfer():
     assert out == ("- DIFFERENT intro\n- Shared source note, reworded\n- Extra bullet", 1, 2)
 
 
+def test_apply_bullet_edits_additions_need_full_rewrite_match():
+    from apps.metadata_review.diffs import apply_bullet_edits
+
+    # A pure addition rides along when ALL rewrites apply...
+    out = apply_bullet_edits(
+        "- Shared note",
+        "- Shared note, reworded\n- Brand new bullet",
+        "- Shared note\n- Other page tail",
+    )
+    assert out == ("- Shared note, reworded\n- Brand new bullet\n- Other page tail", 2, 2)
+    # ...but NOT when a page-specific rewrite was skipped (different list variant —
+    # the addition may carry that variant's context, e.g. after-tax-only content).
+    out = apply_bullet_edits(
+        "- Dimension-specific bullet\n- Shared note",
+        "- Dimension-specific bullet, reworded\n- Shared note, reworded\n- Dimension-specific addition",
+        "- OTHER dimension bullet\n- Shared note",
+    )
+    assert out == ("- OTHER dimension bullet\n- Shared note, reworded", 1, 3)
+
+
+def test_threads_do_not_bullet_borrow_across_sibling_views():
+    """Views of the SAME MDim (e.g. before vs after tax) must not borrow bullet-list
+    threads from each other — only exact-text/pattern sharing applies there."""
+    from apps.metadata_review.resolution import suggestions_by_source_key, threads_for_field
+    from apps.metadata_review.targets import MdimReview, ViewReview
+
+    review = MdimReview(
+        target_path="wid/latest/incomes#incomes", slug="incomes", title="T", title_variant=None, page_checksum="x"
+    )
+    lists = {
+        "before_tax": "- Shared generic bullet\n- Income is measured before taxes.",
+        "after_tax": "- Shared generic bullet\n- Income is measured after taxes.",
+    }
+    for welfare, bullets in lists.items():
+        view_id = f"welfare_type={welfare}"
+        indicator = f"grapher/wid/latest/inc/t#share__{welfare}"
+        review.views.append(
+            ViewReview(
+                view_id=view_id,
+                dimensions={"welfare_type": welfare},
+                indicator_path=indicator,
+                fields=[
+                    _field(
+                        view_id=view_id,
+                        field_path="metadata.description_key",
+                        provenance="inherited",
+                        current_value=bullets,
+                        inherited_from=indicator,
+                    )
+                ],
+            )
+        )
+    # A thread on the after-tax indicator edits the shared bullet (so bullet-transfer
+    # WOULD match) — it must still not surface on the before-tax view.
+    suggestion = gm.MetadataReviewSuggestion(
+        targetType="indicator",
+        targetPath="grapher/wid/latest/inc/t#share__after_tax",
+        fieldPath="description_key",
+        provenance="inherited",
+        createdBy=1,
+        currentValue=lists["after_tax"],
+        suggestedValue="- Shared generic bullet, reworded\n- Income is measured after taxes.",
+        filedFromViewId="welfare_type=after_tax",
+    )
+    suggestion.id = 7
+    grouped = suggestions_by_source_key([suggestion])
+    before_field = review.views[0].fields[0]
+    assert threads_for_field(review, before_field, grouped) == []
+    # Its own view still shows it.
+    after_field = review.views[1].fields[0]
+    assert [s.id for s in threads_for_field(review, after_field, grouped)] == [7]
+
+
 def test_bullet_diff_no_changes():
     from apps.metadata_review.diffs import bullet_diff, diff_summary
 

--- a/tests/test_metadata_review.py
+++ b/tests/test_metadata_review.py
@@ -194,6 +194,117 @@ def test_threads_for_field_borrows_across_indicators():
 
 
 # ---------------------------------------------------------------------------
+# Pattern sharing: same template, different dimension words per view
+# ---------------------------------------------------------------------------
+
+
+def _mdim_with_patterned_titles():
+    from apps.metadata_review.targets import DimensionChoice, DimensionInfo, MdimReview, ViewReview
+
+    review = MdimReview(
+        target_path="wid/latest/incomes#incomes", slug="incomes", title="T", title_variant=None, page_checksum="x"
+    )
+    review.dimensions = [
+        DimensionInfo(
+            slug="quantile",
+            name="Group",
+            choices=[
+                DimensionChoice(slug="richest_1pct", name="Richest 1%"),
+                DimensionChoice(slug="richest_0_1pct", name="Richest 0.1%"),
+            ],
+        ),
+        DimensionInfo(
+            slug="welfare_type",
+            name="Income measure",
+            choices=[DimensionChoice(slug="before_tax", name="before tax")],
+        ),
+    ]
+    titles = {
+        "richest_1pct": "Income share of the richest 1% (before tax)",
+        "richest_0_1pct": "Income share of the richest 0.1% (before tax)",
+    }
+    for quantile, title in titles.items():
+        view_id = f"quantile={quantile}__welfare_type=before_tax"
+        review.views.append(
+            ViewReview(
+                view_id=view_id,
+                dimensions={"quantile": quantile, "welfare_type": "before_tax"},
+                indicator_path=f"grapher/wid/latest/incomes/t#share__{quantile}",
+                fields=[
+                    _field(
+                        view_id=view_id,
+                        field_path="config.title",
+                        provenance="inherited",
+                        current_value=title,
+                        inherited_from=f"grapher/wid/latest/incomes/t#share__{quantile}",
+                    )
+                ],
+            )
+        )
+    return review
+
+
+def test_parametrize_value_uses_choice_names():
+    from apps.metadata_review.resolution import parametrize_value
+
+    review = _mdim_with_patterned_titles()
+    out = parametrize_value(
+        review,
+        {"quantile": "richest_1pct", "welfare_type": "before_tax"},
+        "Income share of the richest 1% (before tax)",
+    )
+    assert out is not None
+    pattern, matches = out
+    assert pattern == "Income share of the {quantile} ({welfare_type})"
+    assert matches == {"quantile": "richest 1%", "welfare_type": "before tax"}
+
+
+def test_pattern_connects_titles_across_views():
+    from apps.metadata_review.resolution import shared_view_ids, suggestions_by_source_key, threads_for_field
+
+    review = _mdim_with_patterned_titles()
+    field_1pct = review.views[0].fields[0]
+    assert shared_view_ids(review, field_1pct) == ["quantile=richest_0_1pct__welfare_type=before_tax"]
+    # A title suggestion filed on the 1% view shows on the 0.1% view.
+    suggestion = gm.MetadataReviewSuggestion(
+        targetType="indicator",
+        targetPath="grapher/wid/latest/incomes/t#share__richest_1pct",
+        fieldPath="grapher_config.title",
+        provenance="inherited",
+        createdBy=1,
+        currentValue="Income share of the richest 1% (before tax)",
+        suggestedValue="Income share received by the richest 1% (before tax)",
+        filedFromViewId="quantile=richest_1pct__welfare_type=before_tax",
+    )
+    suggestion.id = 1
+    grouped = suggestions_by_source_key([suggestion])
+    field_01 = review.views[1].fields[0]
+    # NOTE: view fields map config.title -> indicator key grapher_config.title.
+    assert [s.id for s in threads_for_field(review, field_01, grouped)] == [1]
+
+
+def test_transfer_proposal_rerenders_dimension_words():
+    from apps.metadata_review.resolution import transfer_proposal
+
+    review = _mdim_with_patterned_titles()
+    suggestion = gm.MetadataReviewSuggestion(
+        targetType="indicator",
+        targetPath="grapher/wid/latest/incomes/t#share__richest_1pct",
+        fieldPath="grapher_config.title",
+        provenance="inherited",
+        createdBy=1,
+        currentValue="Income share of the richest 1% (before tax)",
+        suggestedValue="Income share received by the richest 1% (before tax)",
+        filedFromViewId="quantile=richest_1pct__welfare_type=before_tax",
+    )
+    field_01 = review.views[1].fields[0]
+    assert transfer_proposal(review, suggestion, field_01) == "Income share received by the richest 0.1% (before tax)"
+    # Editing the dimension word itself blocks the transfer.
+    suggestion.suggestedValue = "Income share of the wealthiest people (before tax)"
+    assert transfer_proposal(review, suggestion, field_01) is None
+
+
+# ---------------------------------------------------------------------------
 # Bullet diffs (description_key consolidation)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_metadata_review.py
+++ b/tests/test_metadata_review.py
@@ -228,6 +228,29 @@ def test_bullet_diff_only_changed_bullets():
     assert not any("Keep me" in line for line in lines)
 
 
+def test_word_diff_html_tracks_changes_inline():
+    from apps.metadata_review.diffs import word_diff_html
+
+    out = word_diff_html("The mean income per person.", "The median income per capita.")
+    assert "<del" in out and "mean" in out
+    assert "<ins" in out and "median" in out
+    assert "income" in out  # unchanged words kept as plain text
+    # HTML in field text must be escaped, not rendered.
+    assert "<b>" not in word_diff_html("a <b>bold</b> word", "a <b>bold</b> word changed")
+
+
+def test_tracked_changes_html_bullets():
+    from apps.metadata_review.diffs import tracked_changes_html
+
+    out = tracked_changes_html(
+        "- Keep\n- Old wording here\n- Tail", "- Keep\n- New wording here\n- Tail", is_bullet_list=True
+    )
+    # The changed bullet is ONE bullet with inline word tracking, not a remove+add pair.
+    assert out.count("<li>") == 1
+    assert "<del" in out and "Old" in out and "<ins" in out and "New" in out
+    assert "unchanged" in out  # kept bullets collapsed
+
+
 def test_bullet_diff_no_changes():
     from apps.metadata_review.diffs import bullet_diff, diff_summary
 


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

## Metadata Review: collaborative FAUST/metadata review tool

A tool for reviewing the user-facing text of MDims and data pages with non-technical colleagues, replacing the copy-audit-markdown-into-a-Google-Doc loop around `/faust-metadata-audit`.

### What it does

- **Wizard app** (`metadata-review`, staging + local only): browse an MDim view-by-view or a grapher dataset indicator-by-indicator, with the **real page embedded** (full MDim page in MDim mode; the indicator's full data page in dataset mode) so reviewers see exactly what readers see. Every reviewable field — MDim title, title variant, dropdown labels, per-view Title/Subtitle/Footnote, `description_short`, `description_key` — shows its **provenance**: `override` (set in the MDim config), `inherited` (from garden metadata via `presentation.grapher_config`), or `missing`.
- **One consolidated proposal per field**: filing on a field that already has an open proposal refines the same proposed text (revision-tracked) and joins its thread — no parallel threads repeating the content. Proposals render as **Google-Docs-style tracked changes**: the current text with deletions struck through and insertions tinted (word-level diff; `description_key` diffs bullet-by-bullet with unchanged bullets collapsed). Reviewers edit **in place**: “Suggest an edit” turns the displayed text itself into an editable area with a live tracked-changes preview while typing. Threads support replies and a status lifecycle (open / implemented / rejected), with resolved proposals collapsing to one-line history.
- **Suggestions travel with the text**: threads surface on every view rendering the same field text — including views backed by *different* expanded indicators of one garden Jinja template — with an “appears in N views” badge; refining a borrowed thread updates it in place. A landing overview lists every page with open proposals.
- **Staleness**: each proposal re-resolves its field against the live value — if the text changed after the review, the thread is flagged with the text-as-filed kept visible; vanished views/indicators are flagged, with a newest-version fallback.
- **`etl metadata-review export <target>`**: the handoff for implementing changes. It traces every suggestion through the actual metadata build — dynamic-yaml `{definitions.*}`/anchors/`shared.meta.yml`, `common`-block precedence, dimension-context Jinja, MDim `common_views` specificity, programmatic views — to a concrete edit location (file + YAML key path, or the step `.py` with call-site hints), and **verifies itself** by re-rendering the traced template against the live value (`render_verified`). Shared sources list everything an edit affects.

### Companion PR

The two MySQL tables (`metadata_review_suggestions`, `metadata_review_comments`) ship via owid/owid-grapher#6804 (`AddMetadataReviewTables`) — staging DBs are prod copies, so new staging servers get them once that deploys. Until then the app shows a notice with the one-liner to create them manually (already done on this branch's staging server, which has demo suggestions on the UCDP MDim).

### Try it

- App: http://staging-site-feature-metadatareview-faust/etl/wizard/metadata-review
- Export: `STAGING=feature-metadatareview-faust .venv/bin/etl metadata-review export war/latest/ucdp#ucdp`

### Verification

- 35 unit tests (`tests/test_metadata_review.py`): view-id parity with grapher's `dimensionsToViewId`, provenance resolution, source-key routing, staleness matrix, bullet-diff behavior, and tracer golden tests (Jinja branches, common blocks, anchors, `common_views` specificity).
- Real-data checks: UCDP inherited footnote traced to its `tables.*.common` block and PIP's macro-heavy Jinja `description_short` traced to its exact key, both `render_verified: true`; UCDP's programmatic views correctly flagged with call-site hints; migration SQL executed verbatim (up/down/up) against a real DB; proposal consolidation exercised end-to-end (same-field filings merge, resolved threads don't absorb new filings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
