### PR TITLE
🔨🤖 (etl) Set true time intervals for weekly/monthly datasets

### DIFF
--- a/etl/steps/data/garden/oecd/2025-03-11/co2_air_transport.meta.yml
+++ b/etl/steps/data/garden/oecd/2025-03-11/co2_air_transport.meta.yml
@@ -87,7 +87,7 @@ tables:
         short_unit: t
         display:
           zeroDay: '2019-01-01'
-          timeInterval: day
+          timeInterval: month
 
       ter_int_m:
         title: Monthly CO₂ emissions from international aviation
@@ -96,7 +96,7 @@ tables:
         short_unit: t
         display:
           zeroDay: '2019-01-01'
-          timeInterval: day
+          timeInterval: month
 
       per_capita_ter_dom_m:
         title: Monthly CO₂ emissions from domestic aviation per capita
@@ -106,7 +106,7 @@ tables:
         short_unit: kg
         display:
           zeroDay: '2019-01-01'
-          timeInterval: day
+          timeInterval: month
 
       per_capita_ter_int_m:
         title: Monthly CO₂ emissions from international aviation per capita
@@ -116,7 +116,7 @@ tables:
         short_unit: kg
         display:
           zeroDay: '2019-01-01'
-          timeInterval: day
+          timeInterval: month
 
       total_monthly_emissions:
         title: Monthly CO₂ total emissions from aviation
@@ -125,7 +125,7 @@ tables:
         short_unit: t
         display:
           zeroDay: '2019-01-01'
-          timeInterval: day
+          timeInterval: month
 
       total_annual_emissions:
         title: Total annual CO₂ emissions from aviation

--- a/etl/steps/data/garden/who/2025-03-19/flu_yamagata.meta.yml
+++ b/etl/steps/data/garden/who/2025-03-19/flu_yamagata.meta.yml
@@ -22,5 +22,5 @@ tables:
         unit: cases
         display:
           numDecimalPlaces: 0
-          timeInterval: day
+          timeInterval: week
           zeroDay: "1995-01-02"

--- a/etl/steps/data/grapher/climate/2026-07-10/climate_change_impacts_monthly.py
+++ b/etl/steps/data/grapher/climate/2026-07-10/climate_change_impacts_monthly.py
@@ -22,7 +22,7 @@ def run() -> None:
     tb = tb.rename(columns={"location": "country"}, errors="raise")
 
     # Adapt table with dates to grapher requirements.
-    tb = adapt_table_with_dates_to_grapher(tb)
+    tb = adapt_table_with_dates_to_grapher(tb, time_interval="month")
 
     # Set an appropriate index and sort conveniently.
     tb = tb.format(["country", "year"])

--- a/etl/steps/data/grapher/climate/2026-07-10/sst_by_month.py
+++ b/etl/steps/data/grapher/climate/2026-07-10/sst_by_month.py
@@ -2,6 +2,7 @@
 
 import pandas as pd
 
+from etl.grapher.helpers import adapt_table_with_dates_to_grapher
 from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
@@ -47,7 +48,8 @@ def run() -> None:
     # Drop the original year and month columns
     tb = tb.drop(columns=["year", "month"])
 
-    tb = tb.format(["date", "country"])
+    tb = adapt_table_with_dates_to_grapher(tb, time_interval="month")
+    tb = tb.format(["country", "year"])
     #
     # Save outputs.
     #

--- a/etl/steps/data/grapher/climate/2026-07-10/surface_temperature.py
+++ b/etl/steps/data/grapher/climate/2026-07-10/surface_temperature.py
@@ -29,7 +29,7 @@ def run() -> None:
     for column in tb.columns:
         tb[column].metadata.display = {}
         tb[column].metadata.display["zeroDay"] = "1949-01-01"
-        tb[column].metadata.display["timeInterval"] = "day"
+        tb[column].metadata.display["timeInterval"] = "month"
 
     # Save outputs.
     #

--- a/etl/steps/data/grapher/climate/2026-08-01/weekly_wildfires.py
+++ b/etl/steps/data/grapher/climate/2026-08-01/weekly_wildfires.py
@@ -30,7 +30,7 @@ def run(dest_dir: str) -> None:
     for column in tb.columns:
         tb[column].metadata.display = {}
         tb[column].metadata.display["zeroDay"] = "2000-01-01"
-        tb[column].metadata.display["timeInterval"] = "day"
+        tb[column].metadata.display["timeInterval"] = "week"
 
     #
     # Save outputs.


### PR DESCRIPTION
> _Written by Claude Code — @sophiamersmann at the wheel._

(Note by Sophia: It’s useful for me to have a few indicators migrated to the new time intervals while working on Grapher, so this PR migrates a handful that Claude identified as trivial - there are probably more.)

Follow-up to the `yearIsDay → timeInterval` migration. That migration tagged everything `timeInterval: day` uniformly (even genuinely sub-yearly data); this PR sets the **true** interval on the datasets that are actually weekly/monthly. Metadata/display-only — no data change (same days-since-`zeroDay` encoding).

## Re-tags

| Dataset | → |
|---|---|
| `who/2025-03-19/flu_yamagata` | **week** (FluNet ISO-weekly) |
| `climate/2026-07-10/weekly_wildfires` | **week** |
| `climate/2026-07-10/surface_temperature` | **month** |
| `climate/2026-07-10/climate_change_impacts_monthly` | **month** (helper `time_interval="month"`) |
| `climate/2026-07-10/sst_by_month` (ONI) | **month** (helper `time_interval="month"`) |
| `oecd/2025-03-11/co2_air_transport` | **month** — the 5 `_m` vars only; annual `_a`/seasonal untouched |

## Affected published charts (links to staging)

All are genuinely monthly/weekly, so this just improves their axis/tooltip formatting.

**`flu_yamagata` → week (0)** — currently unused in any published chart/explorer.

**`weekly_wildfires` → week (2)**
- [weekly-area-burnt-by-wildfires](http://staging-site-non-daily-intervals/grapher/weekly-area-burnt-by-wildfires)
- [weekly-share-of-the-total-land-area-burnt-by-wildfires](http://staging-site-non-daily-intervals/grapher/weekly-share-of-the-total-land-area-burnt-by-wildfires)

**`surface_temperature` + `sst_by_month` → month (3)**
- [average-monthly-surface-temperature](http://staging-site-non-daily-intervals/grapher/average-monthly-surface-temperature)
- [global-temperature-anomalies-by-el-nino-la-nina](http://staging-site-non-daily-intervals/grapher/global-temperature-anomalies-by-el-nino-la-nina) — the ONI color-join fix
- [monthly-temperature-anomalies](http://staging-site-non-daily-intervals/grapher/monthly-temperature-anomalies)

**`climate_change_impacts_monthly` → month (10 charts + the `climate-change` explorer)**
- [global-co2-concentration](http://staging-site-non-daily-intervals/grapher/global-co2-concentration)
- [global-methane-concentrations](http://staging-site-non-daily-intervals/grapher/global-methane-concentrations)
- [global-nitrous-oxide-concentration](http://staging-site-non-daily-intervals/grapher/global-nitrous-oxide-concentration)
- [ice-sheet-mass-balance](http://staging-site-non-daily-intervals/grapher/ice-sheet-mass-balance)
- [monthly-ocean-heat-2000m](http://staging-site-non-daily-intervals/grapher/monthly-ocean-heat-2000m)
- [monthly-upper-ocean-heat](http://staging-site-non-daily-intervals/grapher/monthly-upper-ocean-heat)
- [sea-level](http://staging-site-non-daily-intervals/grapher/sea-level)
- [sea-surface-temperature](http://staging-site-non-daily-intervals/grapher/sea-surface-temperature)
- [seawater-ph](http://staging-site-non-daily-intervals/grapher/seawater-ph)
- [snow-cover-north-america](http://staging-site-non-daily-intervals/grapher/snow-cover-north-america)
- Explorer: [climate-change](http://staging-site-non-daily-intervals/explorers/climate-change)

**`co2_air_transport` `_m` → month (2)**
- [monthly-co2-emissions-from-international-and-domestic-flights](http://staging-site-non-daily-intervals/grapher/monthly-co2-emissions-from-international-and-domestic-flights)
- [monthly-co2-emissions-from-international-aviation](http://staging-site-non-daily-intervals/grapher/monthly-co2-emissions-from-international-aviation)

## Deferred (need owner sign-off, not in this PR)

- `survey/2026-02-02/dietary_choices` + `_uk_by_age` — irregular YouGov waves (→ Pablo).
- `covid/latest/*` — per-variable weekly/biweekly inside otherwise-daily tables; `biweekly` has no enum value (→ Lucas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)