### PR TITLE
📊 Add long-run Norway emigration data (SSB)

### DIFF
--- a/dag/migration.yml
+++ b/dag/migration.yml
@@ -2,58 +2,58 @@ steps:
   # Internal displacement monitoring centre
   data://grapher/idmc/2024-08-02/internal_displacement:
     - data://meadow/idmc/2024-08-02/internal_displacement:
-      - snapshot://idmc/2024-08-02/internal_displacement.xlsx
-      - data://garden/demography/2024-07-15/population
+        - snapshot://idmc/2024-08-02/internal_displacement.xlsx
+        - data://garden/demography/2024-07-15/population
 
   # UNHCR refugee data
   data://grapher/un/2024-07-25/refugee_data:
     - data://garden/un/2024-07-25/refugee_data:
-      - data://meadow/un/2024-07-25/refugee_data:
-        - snapshot://un/2024-07-25/refugee_data.zip
-      - data://garden/demography/2024-07-15/population
-      # UNHCR resettlement data
-      - data://garden/un/2024-07-25/resettlement:
-        - data://meadow/un/2024-07-25/resettlement:
-          - snapshot://un/2024-07-25/resettlement.zip
+        - data://meadow/un/2024-07-25/refugee_data:
+            - snapshot://un/2024-07-25/refugee_data.zip
         - data://garden/demography/2024-07-15/population
+      # UNHCR resettlement data
+        - data://garden/un/2024-07-25/resettlement:
+            - data://meadow/un/2024-07-25/resettlement:
+                - snapshot://un/2024-07-25/resettlement.zip
+            - data://garden/demography/2024-07-15/population
 
   # Child migration (UNICEF)
   data://grapher/unicef/2024-07-30/child_migration:
     - data://garden/unicef/2024-07-30/child_migration:
-      - data://meadow/unicef/2024-07-30/child_migration:
-        - snapshot://unicef/2024-07-30/child_migration.csv
-      - data://garden/demography/2024-07-15/population
+        - data://meadow/unicef/2024-07-30/child_migration:
+            - snapshot://unicef/2024-07-30/child_migration.csv
+        - data://garden/demography/2024-07-15/population
 
   #KNOMAD
   data://grapher/wb/2024-12-17/bilateral_remittance:
     - data://garden/wb/2024-12-17/bilateral_remittance:
-      - data://meadow/wb/2024-12-17/knomad:
-        - snapshot://wb/2024-12-17/knomad.xlsx
-      - data://garden/regions/2023-01-01/regions
-      - data://garden/wb/2026-07-01/income_groups
+        - data://meadow/wb/2024-12-17/knomad:
+            - snapshot://wb/2024-12-17/knomad.xlsx
+        - data://garden/regions/2023-01-01/regions
+        - data://garden/wb/2026-07-01/income_groups
 
   # Migration between regions, based on UN DESA flows
   data://grapher/migration/2024-11-18/migration_between_regions:
     - data://garden/migration/2024-11-18/migration_between_regions:
-      - data://garden/un/2025-03-12/migrant_stock
-      - data://garden/regions/2023-01-01/regions
-      - data://garden/wb/2026-07-01/income_groups
+        - data://garden/un/2025-03-12/migrant_stock
+        - data://garden/regions/2023-01-01/regions
+        - data://garden/wb/2026-07-01/income_groups
 
   # UN DESA migrant stock (2024)
   data://garden/un/2025-03-12/migrant_stock:
     - data://meadow/un/2025-03-12/migrant_stock:
-      - snapshot://un/2025-03-12/migrant_stock_dest.xlsx
-      - snapshot://un/2025-03-12/migrant_stock_origin.xlsx
-      - snapshot://un/2025-03-12/migrant_stock_dest_origin.xlsx
+        - snapshot://un/2025-03-12/migrant_stock_dest.xlsx
+        - snapshot://un/2025-03-12/migrant_stock_origin.xlsx
+        - snapshot://un/2025-03-12/migrant_stock_dest_origin.xlsx
     - data://garden/wb/2026-07-01/income_groups
     - data://garden/regions/2023-01-01/regions
 
   # UN DESA migrant stock flows (2024)
   data://grapher/un/2025-03-18/migration_stock_flows:
     - data://garden/un/2025-03-18/migration_stock_flows:
-      - data://garden/un/2025-03-12/migrant_stock
-      - data://garden/wb/2026-07-01/income_groups
-      - data://garden/regions/2023-01-01/regions
+        - data://garden/un/2025-03-12/migrant_stock
+        - data://garden/wb/2026-07-01/income_groups
+        - data://garden/regions/2023-01-01/regions
     - data://garden/regions/2023-01-01/regions
 
   # UN DESA multidim migration flows (2024)
@@ -66,30 +66,36 @@ steps:
   export://explorers/migration/2026-01-27/migration:
     # UNICEF child migration data (up to 2024)
     - data://grapher/unicef/2026-01-07/child_migration:
-      - data://garden/unicef/2026-01-07/child_migration:
-        - data://meadow/unicef/2026-01-07/child_migration:
-          - snapshot://unicef/2026-01-07/child_migration.csv
-        - data://garden/demography/2024-07-15/population
-        - data://garden/regions/2023-01-01/regions
+        - data://garden/unicef/2026-01-07/child_migration:
+            - data://meadow/unicef/2026-01-07/child_migration:
+                - snapshot://unicef/2026-01-07/child_migration.csv
+            - data://garden/demography/2024-07-15/population
+            - data://garden/regions/2023-01-01/regions
     # UNHCR refugee data (2025)
     - data://grapher/un/2025-07-03/refugee_data:
-      - data://garden/un/2025-07-03/refugee_data:
-        - data://meadow/un/2025-07-03/refugee_data:
-          - snapshot://un/2025-07-03/refugee_data.zip
-        - data://garden/demography/2024-07-15/population
+        - data://garden/un/2025-07-03/refugee_data:
+            - data://meadow/un/2025-07-03/refugee_data:
+                - snapshot://un/2025-07-03/refugee_data.zip
+            - data://garden/demography/2024-07-15/population
     - data://grapher/un/2025-03-12/migrant_stock:
-      - data://garden/un/2025-03-12/migrant_stock
+        - data://garden/un/2025-03-12/migrant_stock
     - data://grapher/un/2024-07-12/un_wpp
     - data://grapher/worldbank_wdi/2026-07-14/wdi
     # IDMC Internal Displacement Data (2025 update)
     - data://grapher/idmc/2026-01-19/internal_displacement:
-      - data://garden/idmc/2026-01-19/internal_displacement:
-        - data://meadow/idmc/2026-01-19/internal_displacement:
-          - snapshot://idmc/2026-01-19/internal_displacement.csv
-        - data://garden/demography/2024-07-15/population
+        - data://garden/idmc/2026-01-19/internal_displacement:
+            - data://meadow/idmc/2026-01-19/internal_displacement:
+                - snapshot://idmc/2026-01-19/internal_displacement.csv
+            - data://garden/demography/2024-07-15/population
 
 
   # UN DESA migration flows S3 JSON export (2024)
   export://s3/un_migration/latest/migration_stock_flows_json:
     - data://garden/demography/2024-07-15/population
     - data://garden/un/2025-03-18/migration_stock_flows
+  data://meadow/migration/2026-07-23/norway_emigration:
+    - snapshot://migration/2026-07-23/norway_emigration_historical_statistics.html
+  data://garden/migration/2026-07-23/norway_emigration:
+    - data://meadow/migration/2026-07-23/norway_emigration
+  data://grapher/migration/2026-07-23/norway_emigration:
+    - data://garden/migration/2026-07-23/norway_emigration

--- a/etl/steps/data/garden/migration/2026-07-23/norway_emigration.meta.yml
+++ b/etl/steps/data/garden/migration/2026-07-23/norway_emigration.meta.yml
@@ -18,7 +18,9 @@ tables:
         description_key: |-
           This data counts people who left Norway for overseas countries outside Europe — [overwhelmingly North America](https://www.ssb.no/a/histstat/nos/nos_vii_025.pdf).
 
-          From 1867, they were registered by the police when departing on emigrant ships from Norwegian ports; earlier figures were compiled from local administrative reports. People moving to other European countries were not recorded, and some overseas emigrants were also missed, for example those who traveled via ports in other countries.
+          From 1867, they were registered by the police when departing on emigrant ships from Norwegian ports; earlier figures were compiled from reports by parish priests. People moving to other European countries were not recorded, and some overseas emigrants were also missed, for example those who traveled via ports in other countries.
+
+          There is no data for most years before 1836, when records were sparse, and none for 1941–1945, during the German occupation of Norway.
 
           The series ends in 1950, because from 1951 onward Statistics Norway counted all emigration rather than only emigration to overseas countries.
         description_processing: |-

--- a/etl/steps/data/garden/migration/2026-07-23/norway_emigration.meta.yml
+++ b/etl/steps/data/garden/migration/2026-07-23/norway_emigration.meta.yml
@@ -11,18 +11,18 @@ tables:
   norway_emigration:
     variables:
       overseas_emigration_share:
-        title: Share of Norway's population emigrating to overseas countries
+        title: Annual share of Norway's population emigrating outside Europe
         unit: "%"
         short_unit: "%"
+        description_short: Only emigration to overseas destinations outside Europe is counted — mostly to North America. People moving to other European countries are not included.
         description_key: |-
-          The figures count people leaving Norway each year for countries outside Europe — mostly North America. They were recorded through passenger lists of emigrant ships. People moving to other European countries were not recorded, so total emigration was higher than these figures show.
+          This data counts people who left Norway for overseas countries outside Europe — [overwhelmingly North America](https://www.ssb.no/a/histstat/nos/nos_vii_025.pdf).
+
+          From 1867, they were registered by the police when departing on emigrant ships from Norwegian ports; earlier figures were compiled from local administrative reports. People moving to other European countries were not recorded, and some overseas emigrants were also missed, for example those who traveled via ports in other countries.
 
           The series ends in 1950, because from 1951 onward Statistics Norway counted all emigration rather than only emigration to overseas countries.
         description_processing: |-
           We calculated this indicator by dividing the number of emigrations by the population of Norway at the start of the same year, reported in the same source table.
-        processing_level: major
+        processing_level: minor
         display:
           numDecimalPlaces: 1
-        presentation:
-          grapher_config:
-            note: Only emigration to destinations outside Europe is counted — mostly to North America. People moving to other European countries are not included.

--- a/etl/steps/data/garden/migration/2026-07-23/norway_emigration.meta.yml
+++ b/etl/steps/data/garden/migration/2026-07-23/norway_emigration.meta.yml
@@ -1,0 +1,28 @@
+# Learn more about the available fields:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+definitions: {}
+
+dataset:
+  update_period_days: 0
+  owners:
+    - Edouard Mathieu
+
+tables:
+  norway_emigration:
+    variables:
+      overseas_emigration_share:
+        title: Share of Norway's population emigrating to overseas countries
+        unit: "%"
+        short_unit: "%"
+        description_key: |-
+          The figures count people leaving Norway each year for countries outside Europe — mostly North America. They were recorded through passenger lists of emigrant ships. People moving to other European countries were not recorded, so total emigration was higher than these figures show.
+
+          The series ends in 1950, because from 1951 onward Statistics Norway counted all emigration rather than only emigration to overseas countries.
+        description_processing: |-
+          We calculated this indicator by dividing the number of emigrations by the population of Norway at the start of the same year, reported in the same source table.
+        processing_level: major
+        display:
+          numDecimalPlaces: 1
+        presentation:
+          grapher_config:
+            note: Only emigration to destinations outside Europe is counted — mostly to North America. People moving to other European countries are not included.

--- a/etl/steps/data/garden/migration/2026-07-23/norway_emigration.py
+++ b/etl/steps/data/garden/migration/2026-07-23/norway_emigration.py
@@ -1,0 +1,49 @@
+"""Emigration from Norway to overseas countries, 1821-1950, as a share of the population.
+
+The series stops in 1950: from 1951 onward, Statistics Norway counted all emigration rather
+than only emigration to overseas countries, so later years are not comparable.
+"""
+
+from owid.catalog import Table
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def sanity_check(tb: Table) -> None:
+    assert not tb["year"].duplicated().any(), "Duplicate years."
+    share = tb.set_index("year")["overseas_emigration_share"]
+    # The all-time peak was in 1882, during the great overseas emigration wave.
+    assert share.idxmax() == 1882, "Peak emigration share is no longer in 1882."
+    assert 1.4 < share.loc[1882] < 1.6, "The 1882 peak is off (expected about 1.5% of the population)."
+    assert (share >= 0).all() and (share < 2).all(), "Share outside the plausible range."
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_meadow = paths.load_dataset("norway_emigration")
+    tb = ds_meadow.read("norway_emigration")
+
+    #
+    # Process data.
+    #
+    # Keep the overseas-only era: from 1951 onward the source counts all emigration instead.
+    tb = tb[tb["year"] <= 1950].copy()
+    tb["country"] = "Norway"
+
+    # The population (per 1 January) comes from the same source table.
+    tb["overseas_emigration_share"] = tb["emigration"] / tb["population"] * 100
+    tb = tb.drop(columns=["population", "emigration"])
+
+    sanity_check(tb)
+
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
+    #
+    # Save outputs.
+    #
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden.save()

--- a/etl/steps/data/grapher/migration/2026-07-23/norway_emigration.py
+++ b/etl/steps/data/grapher/migration/2026-07-23/norway_emigration.py
@@ -1,0 +1,19 @@
+"""Load the garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_garden = paths.load_dataset("norway_emigration")
+    tb = ds_garden.read("norway_emigration", reset_index=False)
+
+    #
+    # Save outputs.
+    #
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/migration/2026-07-23/norway_emigration.py
+++ b/etl/steps/data/meadow/migration/2026-07-23/norway_emigration.py
@@ -1,0 +1,57 @@
+"""Load the snapshot of Statistics Norway's historical statistics and create a meadow dataset.
+
+Table 3.13 (an HTML page) gives yearly emigration from Norway from 1821. Before 1951, the
+figures only count emigration to overseas countries (destinations outside Europe).
+"""
+
+import pandas as pd
+
+from etl.helpers import PathFinder
+from etl.snapshot import Snapshot
+
+paths = PathFinder(__file__)
+
+
+def parse_historical_statistics(snap: Snapshot):
+    """Parse table 3.13: one row per year; the emigration column starts in 1821."""
+    tables = pd.read_html(snap.path)
+    # The page holds several small layout tables; the data table is the large one.
+    df = max(tables, key=len)
+
+    df.columns = range(df.shape[1])
+    df = df.rename(columns={0: "year", 1: "population", 10: "emigration"})[["year", "population", "emigration"]]
+    df["year"] = pd.to_numeric(df["year"], errors="coerce")
+    df = df.dropna(subset=["year"])
+    df["year"] = df["year"].astype(int)
+    for col in ["population", "emigration"]:
+        df[col] = pd.to_numeric(df[col].astype(str).str.replace(" ", "").str.replace("\xa0", ""), errors="coerce")
+    df = df.dropna(subset=["emigration"])
+
+    tb = snap.read_from_df(df)
+
+    assert tb["year"].min() == 1821, "Emigration series no longer starts in 1821."
+    assert tb["population"].notna().all(), "Missing population values in emigration years."
+    # Spot-checks: the first emigrant ship in 1825, and the all-time peak in 1882.
+    assert tb.loc[tb["year"] == 1825, "emigration"].item() == 53
+    assert tb.loc[tb["year"] == 1882, "emigration"].item() == 28_804
+    return tb
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    snap = paths.load_snapshot("norway_emigration_historical_statistics.html")
+
+    #
+    # Process data.
+    #
+    tb = parse_historical_statistics(snap)
+
+    #
+    # Save outputs.
+    #
+    ds_meadow = paths.create_dataset(
+        tables=[tb.format(["year"], short_name=paths.short_name)], default_metadata=snap.metadata
+    )
+    ds_meadow.save()

--- a/snapshots/migration/2026-07-23/norway_emigration_historical_statistics.html.dvc
+++ b/snapshots/migration/2026-07-23/norway_emigration_historical_statistics.html.dvc
@@ -1,0 +1,33 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Historical statistics of Norway
+    title_snapshot: Historical statistics of Norway - Population, births, deaths, marriages, migration and population increase
+    description: |-
+      A collection of long-run statistical tables for Norway, published online by Statistics Norway as a continuation of its book Historical Statistics 1994. The tables cover population, industry, and society, with some series reaching back to the 17th century.
+    description_snapshot: |-
+      Table 3.13 of the collection, which gives the population and the yearly numbers of births, deaths, marriages, immigrations, and emigrations in Norway from 1735 to 2015. Emigration figures start in 1821 and only count emigration to overseas countries before 1951; immigration figures start in 1951.
+    # The page states no publication date; the table ends with 2015 data, so it was published in 2016 or later.
+    date_published: "2016"
+
+    # Citation
+    producer: Statistics Norway
+    citation_full: |-
+      Statistics Norway. Historical statistics, table 3.13: Population, births, deaths, marriages, migration and population increase, 1735-2015.
+    attribution_short: SSB
+
+    # Files
+    url_main: https://www.ssb.no/a/en/histstat/
+    url_download: https://www.ssb.no/a/histstat/tabeller/3-13-en.html
+    date_accessed: "2026-07-23"
+
+    # License
+    license:
+      name: CC BY 4.0
+      url: https://www.ssb.no/en/diverse/lisens
+outs:
+  - md5: 20a3cedc4969e936efe859293414ff99
+    size: 111431
+    path: norway_emigration_historical_statistics.html


### PR DESCRIPTION
> _Written by Claude Fable 5 — @edomt at the wheel._

Part of https://github.com/owid/owid-issues/issues/2468 (long-term migration data for Norway).

Adds one indicator: **emigration from Norway to overseas countries as a share of the population, 1821–1950**, from table 3.13 of Statistics Norway's historical statistics.

Notes:
- The series is deliberately labeled as overseas-only: before 1951, Norway only recorded emigration to destinations outside Europe (via emigrant-ship passenger lists), so moves to other European countries are not counted. From 1951 the source switches to counting all emigration, so later years are excluded rather than mixed in.
- Norway's immigration data only starts in 1951, and emigration by destination in 1961, so neither is included — this project focuses on long-run (pre-1950) series.
- The denominator is the population column of the same source table (per 1 January), so the share is internally consistent.
- Sanity checks pin the 1825 value (53 emigrants, the first emigrant ship) and the 1882 peak (28,804 people, about 1.5% of the population in a single year).

🤖 Generated with [Claude Code](https://claude.com/claude-code)