### PR TITLE
📊 Refine PIP MDim description_key bullets

### DIFF
--- a/etl/steps/data/garden/wb/2026-06-26/world_bank_pip.meta.yml
+++ b/etl/steps/data/garden/wb/2026-06-26/world_bank_pip.meta.yml
@@ -203,7 +203,7 @@ definitions:
     This data comes from the [World Bank's Poverty and Inequality Platform](https://pip.worldbank.org/), which is based on a large collection of national survey data. To achieve wide coverage, it pools data from two kinds of surveys. For high-income countries, the data measures people's incomes after taxes and benefits. For most low- and middle-income countries, it instead measures their consumption — a different but [closely related](#dod:read-more-income-consumption-pip) measure.
     <%- endif %>
 
-  description_key_not_market_income: In lower-income countries, many people produce food for their own use or exchange goods without money. This data accounts for that by estimating what these goods would have cost if bought in the market and adding that value to their consumption or income.
+  description_key_not_market_income: In lower-income countries, many people produce food for their own use or exchange goods without money. This data accounts for that by estimating what these goods would have cost if bought in the market and adding that value to their consumption.
 
   description_key_show_breaks: |-
     <% if survey_comparability is defined and (table is not defined or table != "Income or consumption intra/extrapolated") and (welfare_type == "income or consumption" or survey_comparability != "No spells") %>
@@ -229,7 +229,7 @@ definitions:
     <% if table is defined and table == "Income or consumption intra/extrapolated" %>
     Country estimates are interpolated and extrapolated to the year of the data release using GDP growth estimates and forecasts. This data is then used to produce regional and global aggregates available for each year. For more details about the methodology, please refer to the [World Bank PIP documentation](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html).
     <%- else %>
-    Regional and global estimates are extrapolated to the year of the data release using GDP growth estimates and forecasts. For more details about the methodology, please refer to the [World Bank PIP documentation](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html#nowcasts).
+    Regional and global estimates are extrapolated to the year of the data release using growth estimates and forecasts from [national accounts](#dod:national-accounts). For more details about the methodology, please refer to the [World Bank PIP documentation](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html#nowcasts).
     <%- endif %>
     <%- endif %>
 

--- a/etl/steps/export/multidim/wb/latest/poverty_pip.config.yml
+++ b/etl/steps/export/multidim/wb/latest/poverty_pip.config.yml
@@ -62,7 +62,7 @@ definitions:
   description_key_source_world_bank: |-
     This data comes from the [World Bank's Poverty and Inequality Platform](https://pip.worldbank.org/), which is based on a large collection of national survey data. To achieve wide coverage, it pools data from two kinds of surveys. For high-income countries, the data measures people's incomes after taxes and benefits. For most low- and middle-income countries, it instead measures their consumption — a different but [closely related](#dod:read-more-income-consumption-pip) measure.
 
-  description_key_not_market_income: In lower-income countries, many people produce food for their own use or exchange goods without money. This data accounts for that by estimating what these goods would have cost if bought in the market and adding that value to their consumption or income.
+  description_key_not_market_income: In lower-income countries, many people produce food for their own use or exchange goods without money. This data accounts for that by estimating what these goods would have cost if bought in the market and adding that value to their consumption.
 
   # These views group several poverty lines and expose no "show breaks in the data" toggle, so the
   # show-breaks bullet is omitted entirely and the income/consumption bullet drops its breaks reference.
@@ -70,7 +70,7 @@ definitions:
     For a small number of countries and years, the data source provides two estimates: one measuring households' income and one measuring consumption. To show a single series over time, we keep only one of these observations.
 
   description_key_regional_global_estimates: |-
-    Regional and global estimates are extrapolated to the year of the data release using GDP growth estimates and forecasts. For more details about the methodology, please refer to the [World Bank PIP documentation](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html#nowcasts).
+    Regional and global estimates are extrapolated to the year of the data release using growth estimates and forecasts from [national accounts](#dod:national-accounts). For more details about the methodology, please refer to the [World Bank PIP documentation](https://datanalytics.worldbank.org/PIP-Methodology/lineupestimates.html#nowcasts).
 
 
 dimensions:


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

Two small refinements to the World Bank PIP `description_key` bullets, on top of the scheme merged in #6508.

## Changes
1. **monetary-income** — drops the "or income" clause: "In lower-income countries, many people produce food for their own use or exchange goods without money. This data accounts for that by estimating what these goods would have cost if bought in the market and adding that value to their **consumption**."
2. **regional-global-estimates** — attributes the nowcast growth estimates to national accounts: "Regional and global estimates are extrapolated to the year of the data release using **growth estimates and forecasts from [national accounts](#dod:national-accounts)**. …"

Both are shared garden bullets in `world_bank_pip.meta.yml`, so they apply across the incomes, inequality and poverty indicators (and the data pages), not only the `incomes_pip`/`gini_pip`/`palma_ratio_pip` MDims. `poverty_pip`'s config-level copies of the two bullets were aligned to match, so its multi-poverty-line comparison views stay consistent with the single-line (inherited) views.

## Notes
- The `#dod:national-accounts` detail-on-demand does **not** exist in the grapher DB yet — the link renders dead until it's created in the admin (same pending DOD as the WID work).
- The intra/extrapolated branch of the regional bullet still reads "GDP growth estimates and forecasts"; left as-is since it's a different (country-nowcast) series and wasn't in the target — easy to align on request.
