### PR TITLE
📊 Add consumer price inflation description bullet

### DIFF
--- a/etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.meta.override.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.meta.override.yml
@@ -523,6 +523,13 @@ tables:
 
       ####################################################################################################
 
+      fp_cpi_totl_zg:
+        title: Inflation, consumer prices (annual %)
+        description_key:
+          - Inflation as measured by the consumer price index reflects the annual percentage change in the cost to the average consumer of acquiring a basket of goods and services that may be fixed or changed at specified intervals, such as yearly.
+
+      ####################################################################################################
+
       it_net_user_zs:
         title: Individuals using the Internet (% of population)
         description_short: Share of the population who used the Internet in the last three months.

--- a/etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.meta.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.meta.yml
@@ -1074,6 +1074,8 @@ tables:
         title: Inflation, consumer prices (annual %)
         short_unit: '%'
         unit: annual %
+        description_key: |-
+          Inflation as measured by the consumer price index reflects the annual percentage change in the cost to the average consumer of acquiring a basket of goods and services that may be fixed or changed at specified intervals, such as yearly.
       fp_wpi_totl:
         title: Wholesale price index (2010 = 100)
         unit: 2010 = 100

--- a/etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.meta.yml
+++ b/etl/steps/data/garden/worldbank_wdi/2026-07-14/wdi.meta.yml
@@ -1074,8 +1074,6 @@ tables:
         title: Inflation, consumer prices (annual %)
         short_unit: '%'
         unit: annual %
-        description_key: |-
-          Inflation as measured by the consumer price index reflects the annual percentage change in the cost to the average consumer of acquiring a basket of goods and services that may be fixed or changed at specified intervals, such as yearly.
       fp_wpi_totl:
         title: Wholesale price index (2010 = 100)
         unit: 2010 = 100


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

## What this does

Adds a `description_key` to the World Bank WDI indicator `fp_cpi_totl_zg` (Inflation, consumer prices, annual %), which previously had no description. The text appears in the "What you should know about this data" section of the [inflation-of-consumer-prices](https://ourworldindata.org/grapher/inflation-of-consumer-prices) data page.

The added text is the World Bank's own definition of the indicator, verified character-for-character against their metadata API (`FP.CPI.TOTL.ZG` sourceNote).

The block lives in `wdi.meta.override.yml` — WDI's manual-curation surface — not in `wdi.meta.yml`, which is auto-generated and would lose hand edits on the next regeneration.

## Blast radius

The variable is used by exactly one published chart (`inflation-of-consumer-prices`, chart 5384) — no other charts, MDim views, explorer views, or narrative charts carry it. One published article embeds that chart; the new text simply appears on its linked data page.

## Verification

- Rebuilt garden + grapher and upserted to the branch staging server; confirmed via the staging metadata API (`descriptionKey` on variable 1291901) and a grep of the rendered staging data page.
- Preview: http://staging-site-data-add-consumer-price/grapher/inflation-of-consumer-prices

*Note: this PR was made as an end-to-end test of the new `edit-faust-metadata` skill (#6517).*
