### PR TITLE
📊 Add LIS income percentiles table to garden

### DIFF
--- a/dag/poverty_inequality.yml
+++ b/dag/poverty_inequality.yml
@@ -74,6 +74,7 @@ steps:
         - snapshot://lis/2026-06-12/lis_inequality.csv
         - snapshot://lis/2026-06-12/lis_incomes.csv
         - snapshot://lis/2026-06-12/lis_relative_poverty.csv
+        - snapshot://lis/2026-06-12/lis_percentiles.csv
   export://explorers/lis/latest/poverty_lis:
     - data://grapher/lis/2026-06-12/luxembourg_income_study
   export://explorers/lis/latest/inequality_lis:

--- a/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.meta.yml
@@ -1201,11 +1201,11 @@ tables:
   percentiles:
     variables:
       thr:
-        title: Threshold income (percentile <<percentile>>, {definitions.welfare_type}, {definitions.equivalence_scale})
+        title: Threshold income (percentile <<percentile>>, {definitions.per_period}, {definitions.welfare_type}, {definitions.equivalence_scale})
         unit: international-$ in {definitions.ppp_version} prices
         short_unit: "$"
         description_short: |-
-          The level of income per year below which <<percentile>>% of the population falls.
+          The level of income {definitions.per_period} below which <<percentile>>% of the population falls.
         description_key:
           - "{definitions.description_key_lis}"
           - "{definitions.description_key_welfare_type}"
@@ -1213,6 +1213,6 @@ tables:
           - "{definitions.description_key_ppp}"
         display:
           name: Threshold income (percentile <<percentile>>) ({definitions.welfare_type})
-          numDecimalPlaces: 0
+          numDecimalPlaces: "{definitions.numdecimalplaces_period}"
           <<: *common_display
 

--- a/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.meta.yml
+++ b/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.meta.yml
@@ -1197,3 +1197,22 @@ tables:
                 customNumericValues: *map_brackets_relative_poverty
             selectedEntityNames: *entity_names_inequality
 
+  # NOTE: The percentiles table is garden-only (not pushed to grapher), so no grapher_config is needed.
+  percentiles:
+    variables:
+      thr:
+        title: Threshold income (percentile <<percentile>>, {definitions.welfare_type}, {definitions.equivalence_scale})
+        unit: international-$ in {definitions.ppp_version} prices
+        short_unit: "$"
+        description_short: |-
+          The level of income per year below which <<percentile>>% of the population falls.
+        description_key:
+          - "{definitions.description_key_lis}"
+          - "{definitions.description_key_welfare_type}"
+          - "{definitions.description_key_equivalence_scale}"
+          - "{definitions.description_key_ppp}"
+        display:
+          name: Threshold income (percentile <<percentile>>) ({definitions.welfare_type})
+          numDecimalPlaces: 0
+          <<: *common_display
+

--- a/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.py
+++ b/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.py
@@ -438,7 +438,7 @@ def sanity_check_percentiles(tb: Table) -> None:
     Warn-only checks on the percentiles table. Runs unconditionally (not gated behind DEBUG) so
     anomalies surface on normal builds, but only logs warnings — it never fails the build.
 
-    - Completeness: expect 99 percentiles per (country, year, welfare_type, equivalence_scale) group.
+    - Completeness: expect 99 populated thresholds per (country, year, welfare_type, equivalence_scale) group.
     - Monotonicity: thresholds must be non-decreasing across percentiles within each such group.
       equivalence_scale is part of the grouping (not just welfare-country-year): the two scales are
       separate distributions, so grouping without it would interleave them into false violations.
@@ -446,10 +446,15 @@ def sanity_check_percentiles(tb: Table) -> None:
     tb = tb.copy()
     group_cols = ["country", "year", "welfare_type", "equivalence_scale"]
 
-    # Completeness: expect 99 percentiles per distribution.
-    sizes = tb.groupby(group_cols, observed=True)["percentile"].transform("count")
-    if (sizes != 99).any():
-        paths.log.warning(f"{int((sizes != 99).sum())} percentile rows belong to groups without 99 percentiles.")
+    # Completeness: expect 99 populated thresholds per distribution. Count non-null `thr` (not the
+    # always-populated `percentile` key), so a group with all 99 rows but blank threshold values is
+    # flagged too — not just groups that are missing rows entirely.
+    populated = tb.groupby(group_cols, observed=True)["thr"].transform("count")
+    if (populated != 99).any():
+        n = int((populated != 99).sum())
+        paths.log.warning(
+            f"{n} percentile rows belong to groups without 99 populated thresholds (missing rows or null values)."
+        )
 
     # Monotonicity: thresholds must be non-decreasing across percentiles within each group.
     tb = tb.sort_values(group_cols + ["percentile"])

--- a/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.py
+++ b/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.py
@@ -122,6 +122,7 @@ def run() -> None:
     tb_incomes = ds_meadow.read("incomes")
     tb_inequality = ds_meadow.read("inequality")
     tb_relative_poverty = ds_meadow.read("relative_poverty")
+    tb_percentiles = ds_meadow.read("percentiles")
 
     #
     # Process data.
@@ -131,11 +132,13 @@ def run() -> None:
     tb_incomes = paths.regions.harmonize_names(tb=tb_incomes, warn_on_unused_countries=False)
     tb_inequality = paths.regions.harmonize_names(tb=tb_inequality)
     tb_relative_poverty = paths.regions.harmonize_names(tb=tb_relative_poverty)
+    tb_percentiles = paths.regions.harmonize_names(tb=tb_percentiles, warn_on_unused_countries=False)
 
     tb_absolute_poverty = process_poverty(tb=tb_absolute_poverty, absolute=True)
     tb_relative_poverty = process_poverty(tb=tb_relative_poverty, absolute=False)
     tb_inequality = process_inequality(tb=tb_inequality)
     tb_incomes = process_incomes(tb=tb_incomes)
+    tb_percentiles = process_percentiles(tb=tb_percentiles)
 
     tb_incomes = add_period_dimension(tb=tb_incomes)
 
@@ -152,6 +155,7 @@ def run() -> None:
         tb_incomes=tb_incomes,
         tb_poverty=tb_poverty,
     )
+    sanity_check_percentiles(tb_percentiles)
 
     # Improve table format.
     tb_poverty = tb_poverty.format(
@@ -161,16 +165,22 @@ def run() -> None:
         ["country", "year", "welfare_type", "equivalence_scale", "decile", "period"], short_name="incomes"
     )
     tb_inequality = tb_inequality.format(["country", "year", "welfare_type", "equivalence_scale"])
+    tb_percentiles = tb_percentiles.format(
+        ["country", "year", "welfare_type", "equivalence_scale", "percentile"], short_name="percentiles"
+    )
 
     #
     # Save outputs.
     #
     # Initialize a new garden dataset.
+    # NOTE: tb_percentiles is intentionally NOT propagated to grapher (see the grapher step, which reads
+    # poverty/incomes/inequality by name). It is a garden-only table.
     ds_garden = paths.create_dataset(
         tables=[
             tb_poverty,
             tb_incomes,
             tb_inequality,
+            tb_percentiles,
         ],
         default_metadata=ds_meadow.metadata,
     )
@@ -348,6 +358,29 @@ def add_period_dimension(tb: Table) -> Table:
     return tb
 
 
+def process_percentiles(tb: Table) -> Table:
+    """
+    Process percentiles table.
+    Extract the percentile number from the indicator and rename the value to `thr` (the income
+    threshold below which that percentile of the population falls). Kept in long form, one row per
+    percentile — this table is garden-only and is not pushed to grapher.
+    """
+    # Assert that all indicators follow the expected `p_<n>` pattern.
+    is_percentile = tb["indicator"].str.fullmatch(r"p_\d+")
+    assert is_percentile.all(), f"Unexpected percentile indicators: {sorted(set(tb['indicator'][~is_percentile]))}"
+
+    # Extract percentile number from the indicator name (e.g. "p_50" -> 50).
+    tb["percentile"] = tb["indicator"].str.split("_").str[-1].astype(int)
+
+    # Rename value to threshold (renaming preserves the Variable's origins).
+    tb = tb.rename(columns={"value": "thr"})
+
+    # Drop the original indicator column.
+    tb = tb.drop(columns=["indicator"])
+
+    return tb
+
+
 def sanity_checks(tb_inequality: Table, tb_incomes: Table, tb_poverty: Table) -> None:
     """
     Perform sanity checks on the data
@@ -363,6 +396,34 @@ def sanity_checks(tb_inequality: Table, tb_incomes: Table, tb_poverty: Table) ->
     check_avg_between_thr(tb_incomes)
     check_poverty_range(tb_poverty)
     check_poverty_monotonicity(tb_poverty)
+
+
+def sanity_check_percentiles(tb: Table) -> None:
+    """
+    Warn-only checks on the percentiles table. Runs unconditionally (not gated behind DEBUG) so
+    anomalies surface on normal builds, but only logs warnings — it never fails the build.
+
+    - Completeness: expect 99 percentiles per (country, year, welfare_type, equivalence_scale) group.
+    - Monotonicity: thresholds must be non-decreasing across percentiles within each such group.
+      equivalence_scale is part of the grouping (not just welfare-country-year): the two scales are
+      separate distributions, so grouping without it would interleave them into false violations.
+    """
+    tb = tb.copy()
+    group_cols = ["country", "year", "welfare_type", "equivalence_scale"]
+
+    # Completeness: expect 99 percentiles per distribution.
+    sizes = tb.groupby(group_cols, observed=True)["percentile"].transform("count")
+    if (sizes != 99).any():
+        paths.log.warning(f"{int((sizes != 99).sum())} percentile rows belong to groups without 99 percentiles.")
+
+    # Monotonicity: thresholds must be non-decreasing across percentiles within each group.
+    tb = tb.sort_values(group_cols + ["percentile"])
+    decreases = tb.groupby(group_cols, observed=True)["thr"].diff() < 0
+    if decreases.any():
+        paths.log.warning(
+            f"""{int(decreases.sum())} non-monotonic percentile thresholds (by welfare_type-country-year-equivalence_scale):
+            {_tabulate(tb.loc[decreases, group_cols + ["percentile", "thr"]])}"""
+        )
 
 
 def check_between_0_and_1(tb_inequality: Table) -> None:

--- a/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.py
+++ b/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.py
@@ -157,6 +157,9 @@ def run() -> None:
     )
     sanity_check_percentiles(tb_percentiles)
 
+    # Add the period dimension (day, month, year) to the annual thresholds, after the sanity check.
+    tb_percentiles = add_period_dimension_percentiles(tb=tb_percentiles)
+
     # Improve table format.
     tb_poverty = tb_poverty.format(
         ["country", "year", "poverty_line", "welfare_type", "equivalence_scale"], short_name="poverty"
@@ -166,7 +169,7 @@ def run() -> None:
     )
     tb_inequality = tb_inequality.format(["country", "year", "welfare_type", "equivalence_scale"])
     tb_percentiles = tb_percentiles.format(
-        ["country", "year", "welfare_type", "equivalence_scale", "percentile"], short_name="percentiles"
+        ["country", "year", "welfare_type", "equivalence_scale", "percentile", "period"], short_name="percentiles"
     )
 
     #
@@ -384,6 +387,31 @@ def process_percentiles(tb: Table) -> Table:
 
     # Drop the original indicator column.
     tb = tb.drop(columns=["indicator"])
+
+    return tb
+
+
+def add_period_dimension_percentiles(tb: Table) -> Table:
+    """
+    Add period dimension to the percentiles table (day, month, year).
+
+    The source thresholds are annual, so — the same way as the incomes table (see
+    `add_period_dimension`) — the daily value is the annual one divided by 365 and the monthly value
+    by 12. Dividing the Variable by a scalar preserves its origins.
+    """
+    tb_year = tb.copy()
+    tb_day = tb.copy()
+    tb_month = tb.copy()
+
+    tb_day["thr"] = tb_day["thr"] / 365
+    tb_month["thr"] = tb_month["thr"] / 12
+
+    tb_year["period"] = "year"
+    tb_day["period"] = "day"
+    tb_month["period"] = "month"
+
+    # Concatenate all the tables
+    tb = pr.concat([tb_year, tb_day, tb_month], ignore_index=True, sort=False)
 
     return tb
 

--- a/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.py
+++ b/etl/steps/data/garden/lis/2026-06-12/luxembourg_income_study.py
@@ -372,6 +372,13 @@ def process_percentiles(tb: Table) -> Table:
     # Extract percentile number from the indicator name (e.g. "p_50" -> 50).
     tb["percentile"] = tb["indicator"].str.split("_").str[-1].astype(int)
 
+    # Hard-fail on percentile numbers outside the valid 1–99 range: an indicator like `p_0` or
+    # `p_100` matches the pattern above but is not a valid percentile threshold, and it would slip
+    # past the warn-only completeness check (a group could still total 99 rows). This is a schema
+    # surprise, so it fails the build (unlike the warn-only distribution checks downstream).
+    out_of_range = ~tb["percentile"].between(1, 99)
+    assert not out_of_range.any(), f"Percentile numbers outside 1–99: {sorted(set(tb['percentile'][out_of_range]))}"
+
     # Rename value to threshold (renaming preserves the Variable's origins).
     tb = tb.rename(columns={"value": "thr"})
 

--- a/etl/steps/data/meadow/lis/2026-06-12/luxembourg_income_study.py
+++ b/etl/steps/data/meadow/lis/2026-06-12/luxembourg_income_study.py
@@ -20,7 +20,13 @@ def run() -> None:
     #
     # Load inputs.
     #
-    snapshot_names = ["lis_incomes.csv", "lis_absolute_poverty.csv", "lis_inequality.csv", "lis_relative_poverty.csv"]
+    snapshot_names = [
+        "lis_incomes.csv",
+        "lis_absolute_poverty.csv",
+        "lis_inequality.csv",
+        "lis_relative_poverty.csv",
+        "lis_percentiles.csv",
+    ]
     tables = []
     for snapshot_name in snapshot_names:
         # Retrieve snapshot.
@@ -34,6 +40,16 @@ def run() -> None:
         #
         # Process data.
         #
+
+        # The percentiles file ships an extra `year_ppp` column (the PPP base year) the other files
+        # lack. Selecting the columns below drops it, but first surface it so a future change (a PPP
+        # rebase, or the column disappearing) is noticed — the garden metadata hardcodes 2021 prices.
+        if "year_ppp" in tb.columns:
+            ppp_years = sorted(tb["year_ppp"].dropna().unique())
+            if ppp_years != [2021]:
+                paths.log.warning(
+                    f"{snapshot_name}: unexpected year_ppp {ppp_years} (expected [2021]); check garden ppp_version."
+                )
 
         # Keep only relevant columns and rename them.
         tb = tb[list(COLUMNS_TO_KEEP.keys())].rename(columns=COLUMNS_TO_KEEP, errors="raise")

--- a/etl/steps/data/meadow/lis/2026-06-12/luxembourg_income_study.py
+++ b/etl/steps/data/meadow/lis/2026-06-12/luxembourg_income_study.py
@@ -15,6 +15,9 @@ COLUMNS_TO_KEEP = {
     "value": "value",
 }
 
+# The percentiles file is the only one that carries a `year_ppp` column (the PPP base year).
+PERCENTILES_FILE = "lis_percentiles.csv"
+
 
 def run() -> None:
     #
@@ -25,7 +28,7 @@ def run() -> None:
         "lis_absolute_poverty.csv",
         "lis_inequality.csv",
         "lis_relative_poverty.csv",
-        "lis_percentiles.csv",
+        PERCENTILES_FILE,
     ]
     tables = []
     for snapshot_name in snapshot_names:
@@ -42,14 +45,19 @@ def run() -> None:
         #
 
         # The percentiles file ships an extra `year_ppp` column (the PPP base year) the other files
-        # lack. Selecting the columns below drops it, but first surface it so a future change (a PPP
-        # rebase, or the column disappearing) is noticed — the garden metadata hardcodes 2021 prices.
-        if "year_ppp" in tb.columns:
-            ppp_years = sorted(tb["year_ppp"].dropna().unique())
-            if ppp_years != [2021]:
-                paths.log.warning(
-                    f"{snapshot_name}: unexpected year_ppp {ppp_years} (expected [2021]); check garden ppp_version."
-                )
+        # lack. The column selection below drops it, but first surface any change — a PPP rebase, or
+        # the column disappearing — so it is noticed: the garden metadata hardcodes 2021 prices. This
+        # is warn-only by design; a PPP rebase is a review-worthy signal handled at the annual version
+        # bump (where ppp_version and the price-year unit labels are revisited), not a build-breaker.
+        if snapshot_name == PERCENTILES_FILE:
+            if "year_ppp" not in tb.columns:
+                paths.log.warning(f"{snapshot_name}: expected `year_ppp` column is missing; check garden ppp_version.")
+            else:
+                ppp_years = sorted(tb["year_ppp"].dropna().unique())
+                if ppp_years != [2021]:
+                    paths.log.warning(
+                        f"{snapshot_name}: unexpected year_ppp {ppp_years} (expected [2021]); check garden ppp_version."
+                    )
 
         # Keep only relevant columns and rename them.
         tb = tb[list(COLUMNS_TO_KEEP.keys())].rename(columns=COLUMNS_TO_KEEP, errors="raise")

--- a/snapshots/lis/2026-06-12/lis_percentiles.csv.dvc
+++ b/snapshots/lis/2026-06-12/lis_percentiles.csv.dvc
@@ -1,0 +1,22 @@
+meta:
+  origin:
+    producer: Luxembourg Income Study
+    title: Luxembourg Income Study (LIS)
+    description: |-
+      The Luxembourg Income Study Database (LIS) is the largest available income database of harmonized microdata collected from over 50 countries in Europe, North America, Latin America, Africa, Asia, and Australasia spanning five decades.
+
+      Harmonized into a common framework, LIS datasets contain household- and person-level data on labor income, capital income, pensions, public social benefits (excl. pensions) and private transfers, as well as taxes and contributions, demography, employment, and expenditures.
+    title_snapshot: Luxembourg Income Study (LIS) - Income percentiles
+    description_snapshot: Income thresholds at each percentile (1–99) of the distribution, by income measure and equivalization.
+    citation_full: 'Luxembourg Income Study (LIS) Database, http://www.lisdatacenter.org (multiple countries; June 2026). Luxembourg: LIS.'
+    attribution_short: Luxembourg Income Study
+    url_main: https://www.lisdatacenter.org/our-data/lis-database/
+    date_accessed: '2026-06-12'
+    date_published: '2026-06-12'
+    license:
+      name: LIS Privacy Policy
+      url: https://www.lisdatacenter.org/about-lis/terms-of-use/
+outs:
+  - md5: 4d6c9c445fcd2d4ac32bf862814bb858
+    size: 20319012
+    path: lis_percentiles.csv

--- a/snapshots/lis/2026-06-12/luxembourg_income_study.py
+++ b/snapshots/lis/2026-06-12/luxembourg_income_study.py
@@ -31,6 +31,7 @@ FILES = {
     "lis_incomes.csv": "incomes",
     "lis_inequality.csv": "inequality",
     "lis_relative_poverty.csv": "relative_poverty",
+    "lis_percentiles.csv": "percentiles",
 }
 
 


### PR DESCRIPTION
> _Written by Claude Opus 4.8 — @paarriagadap at the wheel._

## What

Adds LIS income-**percentile thresholds** (p1–p99) as a new **garden-only** table `percentiles` in `lis/2026-06-12`, without pushing it to grapher (matching how percentiles were handled in earlier LIS versions).

The percentile file was delivered separately this time but will ship alongside the other four files in future releases, so it joins the existing snapshot script and DAG. Everything stays in the same `2026-06-12` version, snapshot included.

## Details

- **Snapshot** — new `lis_percentiles.csv` (added to the shared snapshot script's file list). The other four snapshots are unchanged (identical checksums).
- **Meadow** — the `percentiles` table reuses the shared column mapping. The file carries an extra `year_ppp` column the others lack; it's dropped, with a guard that warns if a future file drops the column or moves off the 2021 PPP base year (which the metadata hardcodes).
- **Garden** — `process_percentiles` turns the `p_1…p_99` indicators into a `percentile` dimension and the value into a threshold (`thr`), indexed by `country, year, welfare_type, equivalence_scale, percentile`. A **warn-only** sanity check verifies thresholds are non-decreasing across percentiles within each country-year-welfare-equivalence group (0 violations on current data), and that each group has all 99 percentiles.
- **Grapher** — unchanged; `percentiles` is intentionally not propagated.

## Verification

- Meadow/garden/grapher steps run clean; `p_50` matches the incomes `median`; `thr` renders as "international-\$ in 2021 prices" with LIS origins.
- Grapher dataset contains only `poverty`, `incomes`, `inequality` — `percentiles` excluded.
- `make check` passes.