### PR TITLE
🐛 vdem: fix subtitles of the "ever had a woman chief executive" indicators

### DIFF
--- a/etl/steps/data/garden/democracy/2026-03-17/vdem/vdem.meta.yml
+++ b/etl/steps/data/garden/democracy/2026-03-17/vdem/vdem.meta.yml
@@ -634,7 +634,7 @@ tables:
       wom_hoe_ever: # wom_hoe_vdem_owid
         title: Country had a woman chief executive at least once
         description_short: |-
-          The variable denotes whether a country ever had a female chief executive of government in office at any point during the year.
+          Denotes whether a country ever had a woman chief executive.
         description_processing: |-
           We derive this indicator as follows:
 
@@ -662,7 +662,7 @@ tables:
       wom_hoe_ever_dem: # wom_hoe_vdem_owid
         title: Country had a woman chief executive democratically elected at least once
         description_short: |-
-          The variable denotes whether a country ever had a democratically elected female chief executive of government in office at any point during the year.
+          Denotes whether a country ever had a democratically elected woman chief executive.
         description_processing: |-
           We derive this indicator as follows:
 

--- a/etl/steps/data/garden/democracy/2026-03-17/vdem/vdem.meta.yml
+++ b/etl/steps/data/garden/democracy/2026-03-17/vdem/vdem.meta.yml
@@ -634,7 +634,7 @@ tables:
       wom_hoe_ever: # wom_hoe_vdem_owid
         title: Country had a woman chief executive at least once
         description_short: |-
-          The variable denotes whether a country ever had a female chief executive of government in office as of December 31 of the given year.
+          The variable denotes whether a country ever had a female chief executive of government in office at any point during the year.
         description_processing: |-
           We derive this indicator as follows:
 
@@ -662,7 +662,7 @@ tables:
       wom_hoe_ever_dem: # wom_hoe_vdem_owid
         title: Country had a woman chief executive democratically elected at least once
         description_short: |-
-          The variable denotes whether a country ever had a democratically elected female chief executive of government in office as of December 31 of the given year.
+          The variable denotes whether a country ever had a democratically elected female chief executive of government in office at any point during the year.
         description_processing: |-
           We derive this indicator as follows:
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @bastianherre at the wheel._

## Problem

`wom_hoe_ever` and `wom_hoe_ever_dem` are both derived from `v2exfemhoe` — "chief executive was a woman at any point during the year" (`vdem_clean.py:1135` and `:1149`, cumulative max over `v2exfemhoe`).

But their `description_short` said "as of **December 31** of the given year". That wording describes the sibling indicator `wom_hoe_vdem`, which is the one built from the December-31-corrected gender flags. So the subtitle shown on charts contradicted what the step computes.

## Change

Drop the timing claim from both subtitles instead of restating it — "ever had" already carries the meaning, and naming a specific point in the year is what invited the confusion:

| Indicator | New subtitle |
|---|---|
| `wom_hoe_ever` | Denotes whether a country ever had a woman chief executive. |
| `wom_hoe_ever_dem` | Denotes whether a country ever had a democratically elected woman chief executive. |

Metadata text only — **no data changes**, no new variable IDs.

Note that the underlying "at any point during the year" basis is now not stated in any user-facing field. Happy to add it to `description_processing` if that's worth surfacing.

## Still open

The alternative fix would be to switch the two `_ever` indicators to read from `wom_hoe_vdem`, making them genuinely December-31-based. That would change values — it would push back the first "ever" year for countries where a woman served only part of a year, such as Norway 1981 or Ukraine 2005 — so it is deliberately not done here. Happy to do it that way instead if that is the intended definition.

The same wording exists in the archived `2025-03-17` version, left untouched.
