### PR TITLE
📜 Fix stale and broken references in agent guides

### DIFF
--- a/.claude/docs/pipeline-stages.md
+++ b/.claude/docs/pipeline-stages.md
@@ -12,7 +12,7 @@ Basic cleaning and format standardization. Minimal transformations - mostly load
 
 ### Garden (`etl/steps/data/garden/`)
 Business logic layer:
-- Country harmonization via `geo.harmonize_countries()`
+- Country harmonization via `paths.regions.harmonize_names()`
 - Indicator calculations and derivations
 - Metadata enrichment
 - Data validation
@@ -20,8 +20,8 @@ Business logic layer:
 ### Grapher (`etl/steps/data/grapher/`)
 MySQL database ingestion for OWID visualization platform.
 
-### Export (`etl/steps/data/export/`)
-Final outputs - explorers, collections, APIs.
+### Export (`etl/steps/export/`)
+Final outputs - explorers, collections, APIs. Addressed as `export://...`, not `data://export/...`.
 
 ## Step URI Pattern
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Our World in Data's ETL system - a content-addressable data pipeline with DAG-ba
 - **`dag/archive/*.yml` is a generated record** — it is reconstructed from git history by `etl archive-dag`, so never hand-edit it. It lists steps that were once active (with the commit where they were last active) purely for recovery; to bring one back, `git checkout` that commit.
 - **Never delete a step without archiving it.** Removing or superseding an active step (new version, retirement, replacement) obligates you to archive it — deleting the files alone is a bug. Procedure: remove its `dag/*.yml` entry and delete its files → **commit** → run `etl archive-dag` (it reads *committed* history, so the removal must be committed first) → commit the regenerated `dag/archive/*.yml`. If `archive-dag` sweeps in unrelated steps others left un-archived, `git checkout` those files to keep your PR scoped (never hand-edit the archive). For a migrated/backport dataset, also delete its now-orphaned `snapshots/backport/latest/dataset_<id>_*` mirror files.
 - **Ask the user** if unsure - don't guess
-- **Always run `make check` before committing**
+- **Always run `make check` before committing** (format, lint, typecheck on changed files). Run the test suite with `make unittest` (or `make test` for checks + tests + version-tracker); `lib/*` packages have their own venv and Makefile — run it from inside that directory.
 - If not told otherwise, save outputs to `ai/` directory.
 - **Notebooks**: Always create AND execute immediately using `uv run jupyter nbconvert --to notebook --execute --inplace <path>`
 - **Skills**: When creating new skills in `.claude/skills/`, always include `metadata: { internal: true }` in the SKILL.md frontmatter unless the user explicitly asks for the skill to be public. This prevents external skill indexes from crawling and listing our internal skills.
@@ -52,7 +52,7 @@ Bastian Herre            @bastianherre
 Bertha Rohenkohl         @bertharc
 Charlie Giattino         @CGiattino
 Pablo Rosado             @pabloarosado
-Lucas Rodés-Guirao       @lucasrodesi ask
+Lucas Rodés-Guirao       @lucasrodes
 Matthieu Bergel          @mlbrgl
 Marcel Gerber            @marcelgerber
 Sophia Mersmann          @sophiamersmann
@@ -79,6 +79,7 @@ The disclosure rule does **not** apply to OWID-reader-facing artifacts (e.g. the
 | meadow | `etl/steps/data/meadow/` | Basic cleaning |
 | garden | `etl/steps/data/garden/` | Business logic, harmonization |
 | grapher | `etl/steps/data/grapher/` | MySQL ingestion |
+| export | `etl/steps/export/` | Explorers, collections, APIs |
 
 **Snapshot is raw passthrough only.** It downloads the source files and writes them out using the source's own row labels, column labels, and period labels. That's it. The following all belong in **garden**, not in the snapshot script:
 
@@ -269,10 +270,16 @@ with open(file_path, 'w') as f:
 
 ### Writing origin / metadata fields
 
-- **Consult the reference** — before writing `.dvc` `origin` or `.meta.yml` fields, look the field up in `schemas/definitions.json` (rendered at the [metadata reference](https://docs.owid.io/projects/etl/architecture/metadata/reference/)) and follow its `guidelines`. They're detailed and per-field: requirement level, good/bad examples, and when to omit optional fields (`title_snapshot`, `description_snapshot`, `attribution` all default to null / auto-generated). Each field has one job — don't fold content that belongs in one field into another.
+**Consult the reference first.** Before writing `.dvc` `origin` or `.meta.yml` fields, look the field up in `schemas/definitions.json` (rendered at the [metadata reference](https://docs.owid.io/projects/etl/architecture/metadata/reference/)) and follow its `guidelines`. They're detailed and per-field: requirement level, good/bad examples, and when to omit optional fields. Each field has one job — don't fold content that belongs in one field into another. Don't infer field usage by copying other `.dvc` files; they may use optional fields for reasons that don't apply to your snapshot.
+
+Mistakes the reference already covers but that keep happening:
+
 - **License goes under `origin`, not at the top level.** In a snapshot `.dvc`, the license is `meta.origin.license` (4-space, inside `origin`) — never the top-level `meta.license` (2-space). Both parse (they differ only by indentation), but the top-level form is a deprecated `SnapshotMeta` field that doesn't travel with the origin, so the license is dropped from Grapher's per-origin metadata (which matters for multi-origin datasets). The wizard cookiecutter already does this correctly; a schema `not`-constraint + `test_snapshot_license_lives_under_origin` enforce it. Each origin in a multi-origin `.dvc` needs its own `license`.
 - **`license.url` points to the producer's own license statement** — the page or PDF download link where the producer states the terms (often the same landing page as `url_main`). Never a `creativecommons.org` deed or other generic license page. If the producer states no license anywhere, leave `url` empty (don't fall back to the dataset's main page).
-- **American spelling always**.
+- **`title_snapshot` / `description_snapshot`**: default to omitting both. Only use them when several snapshots are created from the same data product and need disambiguation. If a data product maps to a single snapshot — even one that is a subset of the product — describe that subset in `description` instead.
+- **`attribution`**: omit — grapher builds `producer (year)` automatically. Only set it when that automatic format is genuinely uninformative (e.g. a well-known data product title should be cited alongside the producer).
+- **`citation_full`**: follow the producer's requested citation, but with appropriate minor edits: don't fold other metadata fields into it — e.g. license text like "Licence: CC BY-NC-SA 3.0 IGO" belongs in `license`, not in the citation.
+- **American spelling, always** — even when the producer's own text uses British spelling (adapting it is one of the "minor edits" the reference allows).
 
 ### Description fields: `.dvc` vs garden `description_processing`
 
@@ -282,17 +289,6 @@ Two different descriptions, two different jobs. Don't mix them:
 - **Garden `description_processing`** describes what **OWID** does to that data — aggregation, relabeling, deduplication, derivations, date conversion.
 
 If the same sentence could fit in both, it belongs in garden — not in `.dvc`. Don't repeat producer-side facts in `description_processing`, and don't put OWID-side transformations in the `.dvc`.
-
-### Origin metadata fields: follow the metadata reference
-
-When writing or editing `.dvc` origin fields, follow the ETL metadata reference — `schemas/definitions.json` in this repo (rendered at https://docs.owid.io/projects/etl/architecture/metadata/reference/). It defines, per field, the requirement level, formatting guidelines, and good/bad examples. Don't infer field usage by copying other `.dvc` files — they may use optional fields for reasons that don't apply to your snapshot.
-
-Mistakes the reference already covers but that keep happening:
-
-- **`title_snapshot` / `description_snapshot`**: default to omitting both. Only use them when several snapshots are created from the same data product and need disambiguation. If a data product maps to a single snapshot — even one that is a subset of the product — describe that subset in `description` instead.
-- **`attribution`**: omit — grapher builds `producer (year)` automatically. Only set it when that automatic format is genuinely uninformative (e.g. a well-known data product title should be cited alongside the producer).
-- **`citation_full`**: follow the producer's requested citation, but with appropriate minor edits: don't fold other metadata fields into it — e.g. license text like "Licence: CC BY-NC-SA 3.0 IGO" belongs in `license`, not in the citation.
-- **American spelling, always** — even when the producer's own text uses British spelling (adapting it is one of the "minor edits" the reference allows).
 
 ## Sanity checks
 
@@ -424,4 +420,4 @@ See `.claude/docs/` for:
 
 ## Individual Preferences
 
-- @~/.claude/instructions/etl.md
+Personal, non-shared preferences go in `CLAUDE.local.md` at the repo root (already gitignored). Claude Code also auto-loads your own `~/.claude/CLAUDE.md`, so there is nothing to import here.

--- a/lib/catalog/CLAUDE.md
+++ b/lib/catalog/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-This is **owid-catalog** - a Python library (version 0.4.3) that provides core data types for Our World in Data's data catalog system. It's published as a PyPI package and serves as the foundation for OWID's ETL system.
+This is **owid-catalog** - a Python library that provides core data types for Our World in Data's data catalog system. It's published as a PyPI package and serves as the foundation for OWID's ETL system.
 
 The library provides pandas-enhanced data structures with rich metadata support:
 - **Dataset**: Container for multiple tables with shared metadata
@@ -37,8 +37,9 @@ pytest tests/          # ❌
 ```bash
 uv add package_name     # Add a new package
 uv remove package_name  # Remove a package
-uv sync                 # Sync dependencies
 ```
+
+**Never run bare `uv sync`** — it prunes optional deps the repo needs and breaks the `etl` CLI. To install or repair the environment, use `uv sync --all-extras --group dev` (what `make .venv` runs).
 
 ### Common Development Tasks
 
@@ -289,7 +290,7 @@ uv build
 
 ## Important Notes
 
-- Python 3.10+ required (supports 3.10, 3.11, 3.12, 3.13)
+- Python 3.10+ required — see `requires-python` in `pyproject.toml` for the supported range
 - This library is experimental - APIs may change
 - Extends ruff configuration from parent `../../pyproject.toml`
 - Always run `make check` before committing changes


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Audited our agent guides (`CLAUDE.md`, `lib/catalog/CLAUDE.md`) against the current codebase and fixed everything that had drifted. Every path, symbol, CLI subcommand, and test name referenced in the root guide was checked — the vast majority were correct, and this PR fixes the handful that weren't.

## What was wrong

| Finding | Impact |
|---|---|
| `@~/.claude/instructions/etl.md` imported an **empty directory** | The "Individual Preferences" import silently loaded nothing |
| A GitHub handle in the roster read `@lucasrodesi ask` | The roster whose own rule is "don't guess — a wrong tag pings a real person" had a wrong handle |
| No test command documented anywhere | The guide mandates `make check` before committing but never says how to run tests |
| `export` stage missing from the pipeline table | It appears in the stage arrow but had no location row |
| Two overlapping origin-metadata sections | Both opened with "consult `schemas/definitions.json`" and both ended with "American spelling always" |
| `lib/catalog` claimed version `0.4.3` | Actual is `1.2.3` — stale by a major version |
| `lib/catalog` claimed Python `3.10–3.13` | Actual `requires-python` is `>=3.10, <3.15` |
| `lib/catalog` documented bare `uv sync` | The root guide explicitly forbids it (prunes optional deps, breaks the `etl` CLI) — an agent reading both would follow the wrong one |
| `.claude/docs/pipeline-stages.md` used `geo.harmonize_countries()` and `etl/steps/data/export/` | The superseded harmonization API and a path that doesn't exist |

For the two stale `lib/catalog` values I removed the restated literal and pointed at `pyproject.toml` instead, rather than hardcoding today's value for it to drift again.

## How to test it

Nothing to run — it's documentation. To confirm the fixes are real rather than plausible:

```bash
# 1. The import target was an empty dir (this is why the line loaded nothing)
ls -la ~/.claude/instructions/

# 2. Version and Python range claims vs. reality
grep -E "^version|requires-python" lib/catalog/pyproject.toml

# 3. Export step location, as fixed
ls -d etl/steps/export && ls -d etl/steps/data/export   # second one errors

# 4. The harmonization API the docs now reference
rg -n "def harmonize_names" etl/data_helpers/geo.py

# 5. No duplicate section headings remain
rg -n "^### .*origin|^### .*metadata reference" CLAUDE.md
```

Lucas's handle was confirmed as `@lucasrodes` by @Marigold rather than inferred.

## Already verified

`make check` passes (lint, format, types). Every remaining reference in the root guide was verified present during the audit and left untouched: `.claude/docs/*`, `etl/data_corrections.py`, `etl/http.py` (`session`/`HEADERS`/`STORAGE_OPTIONS`), `schemas/dataset-schema.json`, `etl.owners.resolve_owner`, `etl/config.py:DEFAULT_GRAPHER_SCHEMA`, `paths.apply_corrections`, `Regions.harmonize_names`/`.add_population`, `tests/test_metadata_schemas.py::test_snapshot_license_lives_under_origin`, both cited example steps, and the `pr` / `pr-clean` / `archive-dag` / `corrections` / `indicator-upgrade` subcommands.

## Deliberately out of scope

The audit also flagged that the root guide is 420 lines and heavily prohibition-shaped, which current prompting guidance suggests can cost quality on newer models. Cutting or restructuring that is a judgment call per rule, not a factual fix, so it is not in this PR — keeping the two separate makes this one reviewable as pure fact-correction.

Also noticed but not addressed: `etl/steps/graph/` is a step directory that no guide mentions, and `lib/datautils`, `lib/owl`, and `lib/repack` have no `CLAUDE.md` of their own.
