### PR TITLE
📜 Cloud sandbox setup script for Claude Code on the web

### DIFF
--- a/.claude/docs/cloud-sandbox.md
+++ b/.claude/docs/cloud-sandbox.md
@@ -64,22 +64,40 @@ script, environment variables), see
   rather than working around it.
 
 - **Admin links can't be opened; resolve the id instead.** When the user shares
-  `https://admin.owid.io/admin/variables/<id>` (or `/admin/charts/<id>`), don't
-  fetch it. Pull the id out and query the public Datasette mirror, which needs
-  no auth and covers `variables` including unpublished ones:
+  an `admin.owid.io` link, don't fetch it — pull the id out of the URL and query
+  the public Datasette mirror, which needs no auth.
+
+  `/admin/variables/<id>` — indicator metadata, including unpublished
+  indicators:
 
   ```bash
   curl -s "https://datasette-public.owid.io/owid/variables.json?id__in=<id>&_shape=array"
   ```
 
+  `/admin/charts/<id>/edit` — the chart's full config. It comes back as a JSON
+  string inside the row, so unwrap it:
+
+  ```bash
+  curl -s "https://datasette-public.owid.io/owid/charts.json?id__exact=<id>&_shape=array&_col=config" \
+    | .venv/bin/python -c "import json,sys; print(json.dumps(json.loads(json.load(sys.stdin)[0]['config']), indent=2))"
+  ```
+
+  `chart_dimensions` maps that chart to its indicators
+  (`?chartId__exact=<id>&_shape=array`), so the two together answer "what is
+  this chart built from". If you already have the slug rather than the id,
+  `https://ourworldindata.org/grapher/<slug>.config.json` returns the same thing
+  in one call.
+
   Filter with `?<col>__in=` / `?<col>__exact=` and select columns with repeated
   `&_col=`. The `?sql=` form documented in the root CLAUDE.md works too, but a
   long encoded query has 403'd intermittently, so prefer the filter form for
-  simple lookups. Charts and gdocs in Datasette are filtered to published only —
-  for a *draft* chart, ask the user to paste
-  `admin.owid.io/admin/api/charts/<id>.config.json`, which renders as JSON in
-  their already-authenticated browser. Never guess what an id refers to: say you
-  couldn't resolve it and ask.
+  simple lookups.
+
+  Charts and gdocs in Datasette are **filtered to published only**, so an empty
+  result for a plausible chart id usually means it's a draft, not that the id is
+  wrong. Drafts are only reachable from an authenticated browser: ask the user
+  to open `admin.owid.io/admin/api/charts/<id>.config.json` and paste it. Never
+  guess what an id refers to — say you couldn't resolve it and ask.
 
 - **After pushing, hand the user a staging link**, deep-linked to the affected
   chart or page. Don't derive the name by hand:

--- a/.claude/docs/cloud-sandbox.md
+++ b/.claude/docs/cloud-sandbox.md
@@ -29,27 +29,28 @@ script, environment variables), see
   `.venv/bin/etl diff REMOTE data/ --include <dataset>` (add `--verbose`, or
   `--output-html` for a report). This answers "did my rebuild change any
   values?", which is most of why you'd run a step by hand, and needs no MySQL —
-  but it does fetch from `catalog.ourworldindata.org`, so confirm that host is
-  reachable first (see below). "The step completed" is not the same as "the data
-  is right"; say which one you verified.
+  only `catalog.ourworldindata.org`, which is reachable under `Full` network
+  access (see below). "The step completed" is not the same as "the data is
+  right"; say which one you verified.
 
-- **Don't assume any OWID host is reachable — check the one you need.** Egress
-  goes through a gateway proxy that allows hosts by policy, and the policy is
-  not the same in every environment. `snapshots.owid.io` has worked (so `etlr`
-  resolves dependencies normally), while `datasette-public.owid.io`,
-  `api.ourworldindata.org` and `catalog.ourworldindata.org` have all been denied
-  in at least one session. One `curl -s -o /dev/null -w "%{http_code}\n" <url>`
-  settles it in a second — do that before building a plan on top of a host.
-  `admin.owid.io` is the exception that never works: Cloudflare Access rejects
-  every non-browser client at the edge, whatever the proxy allows.
+- **OWID hosts are reachable, but only with `Full` network access.** Snapshots,
+  the catalog, the public API and Datasette all work in an environment set to
+  `Full`. Under `Trusted` the gateway refuses them, and `etlr` snapshot
+  downloads, `etl diff` and every Datasette lookup fail together. If that
+  happens, the fix is a setting, not a workaround: tell the user to switch the
+  environment's network access to `Full` (see
+  [claude-code-web.md](../../docs/guides/data-work/claude-code-web.md)).
+
+  `admin.owid.io` is the one host that never works regardless: Cloudflare Access
+  rejects every non-browser client at the edge.
 
   Creating a *new* snapshot with `etls` needs the `R2_*` environment variables;
   if they're missing, the environment was set up without them and the user needs
   to add them (they're in 1Password — never scrape credentials from anywhere
   else).
 
-- **A blocked host looks like an auth problem — it isn't.** WebFetch reports a
-  gateway denial as `HTTP 403 Forbidden` with the hint *"If this URL requires
+- **A refused host looks like an auth problem — it isn't.** WebFetch reports a
+  gateway refusal as `HTTP 403 Forbidden` with the hint *"If this URL requires
   authentication, use an authenticated tool"*, and `curl` just returns `000`.
   Chasing that hint means hunting for credentials that would not have helped.
   Confirm the real cause before concluding anything:
@@ -60,7 +61,7 @@ script, environment variables), see
 
   `"kind": "connect_rejected"` names the host the gateway refused — the request
   died before TLS, so no key, token, or login would have changed the outcome.
-  Report it as a sandbox network limit and ask the user to allowlist the host,
+  That's the `Trusted`-network signature above; report it and ask for `Full`
   rather than working around it.
 
 - **Admin links can't be opened; resolve the id instead.** When the user shares

--- a/.claude/docs/cloud-sandbox.md
+++ b/.claude/docs/cloud-sandbox.md
@@ -1,0 +1,44 @@
+# Cloud sandbox sessions (claude.ai/code)
+
+Notes for agent sessions running in a Claude Code cloud sandbox
+(`CLAUDE_CODE_REMOTE=true`). For how the environment itself is set up (setup
+script, environment variables), see
+[docs/guides/data-work/claude-code-web.md](../../docs/guides/data-work/claude-code-web.md).
+
+- **Never commit a `uv.lock` diff that appeared on its own.** `uv sync` only
+  rewrites the lockfile when it decided to re-resolve, which here means the
+  sandbox's uv was too old to parse `exclude-newer = "3 days"` in
+  `pyproject.toml` (needs >= 0.10). The diff is ~2000 lines and silently bumps
+  hundreds of packages. Discard it with `git checkout -- uv.lock`. The
+  `SessionStart` hook installs a current uv and warns if the lockfile went
+  dirty, but check `git status` before committing regardless.
+
+- **Rename the pre-created branch before the first push.** The sandbox creates
+  `claude/<slug>-<random-suffix>`, which violates the repo's branch-naming
+  rules (short, no prefix — see the root CLAUDE.md). Use
+  `git branch -m <short-descriptive-name>`, or let `etl pr` create a properly
+  named branch.
+
+- **There is no MySQL in the sandbox and staging servers are on Tailscale.** So
+  `--grapher` (the MySQL upsert), `make query`, and `OWID_ENV.read_sql` are not
+  available. Run steps without `--grapher`: that still builds meadow, garden,
+  and the grapher dataset feather, which is enough to verify the data. Anything
+  DB-side — variable upserts, chart-diff, the admin — happens on the PR's
+  staging server after you push.
+
+- **Snapshot downloads work** (`snapshots.owid.io` is reachable), so `etlr` can
+  resolve dependencies normally. Creating a *new* snapshot with `etls` needs the
+  `R2_*` environment variables; if they're missing, the environment was set up
+  without them and the user needs to add them (they're in 1Password — never
+  scrape credentials from anywhere else).
+
+- **After pushing, hand the user a staging link**, deep-linked to the affected
+  chart or page. Don't derive the name by hand:
+
+  ```bash
+  .venv/bin/python -c "from etl.config import get_container_name; import subprocess; \
+    print('http://' + get_container_name(subprocess.check_output(['git','branch','--show-current'], text=True).strip()))"
+  ```
+
+  Mention that the staging server takes a while to build after a push,
+  especially the first one.

--- a/.claude/docs/cloud-sandbox.md
+++ b/.claude/docs/cloud-sandbox.md
@@ -22,15 +22,64 @@ script, environment variables), see
 - **There is no MySQL in the sandbox and staging servers are on Tailscale.** So
   `--grapher` (the MySQL upsert), `make query`, and `OWID_ENV.read_sql` are not
   available. Run steps without `--grapher`: that still builds meadow, garden,
-  and the grapher dataset feather, which is enough to verify the data. Anything
-  DB-side — variable upserts, chart-diff, the admin — happens on the PR's
-  staging server after you push.
+  and the grapher dataset feather. Anything DB-side — variable upserts,
+  chart-diff, the admin — happens on the PR's staging server after you push.
 
-- **Snapshot downloads work** (`snapshots.owid.io` is reachable), so `etlr` can
-  resolve dependencies normally. Creating a *new* snapshot with `etls` needs the
-  `R2_*` environment variables; if they're missing, the environment was set up
-  without them and the user needs to add them (they're in 1Password — never
-  scrape credentials from anywhere else).
+- **To check a build without a database, diff it against the remote catalog:**
+  `.venv/bin/etl diff REMOTE data/ --include <dataset>` (add `--verbose`, or
+  `--output-html` for a report). This answers "did my rebuild change any
+  values?", which is most of why you'd run a step by hand, and needs no MySQL —
+  but it does fetch from `catalog.ourworldindata.org`, so confirm that host is
+  reachable first (see below). "The step completed" is not the same as "the data
+  is right"; say which one you verified.
+
+- **Don't assume any OWID host is reachable — check the one you need.** Egress
+  goes through a gateway proxy that allows hosts by policy, and the policy is
+  not the same in every environment. `snapshots.owid.io` has worked (so `etlr`
+  resolves dependencies normally), while `datasette-public.owid.io`,
+  `api.ourworldindata.org` and `catalog.ourworldindata.org` have all been denied
+  in at least one session. One `curl -s -o /dev/null -w "%{http_code}\n" <url>`
+  settles it in a second — do that before building a plan on top of a host.
+  `admin.owid.io` is the exception that never works: Cloudflare Access rejects
+  every non-browser client at the edge, whatever the proxy allows.
+
+  Creating a *new* snapshot with `etls` needs the `R2_*` environment variables;
+  if they're missing, the environment was set up without them and the user needs
+  to add them (they're in 1Password — never scrape credentials from anywhere
+  else).
+
+- **A blocked host looks like an auth problem — it isn't.** WebFetch reports a
+  gateway denial as `HTTP 403 Forbidden` with the hint *"If this URL requires
+  authentication, use an authenticated tool"*, and `curl` just returns `000`.
+  Chasing that hint means hunting for credentials that would not have helped.
+  Confirm the real cause before concluding anything:
+
+  ```bash
+  curl -sS "$HTTPS_PROXY/__agentproxy/status" | grep -A4 recentRelayFailures
+  ```
+
+  `"kind": "connect_rejected"` names the host the gateway refused — the request
+  died before TLS, so no key, token, or login would have changed the outcome.
+  Report it as a sandbox network limit and ask the user to allowlist the host,
+  rather than working around it.
+
+- **Admin links can't be opened; resolve the id instead.** When the user shares
+  `https://admin.owid.io/admin/variables/<id>` (or `/admin/charts/<id>`), don't
+  fetch it. Pull the id out and query the public Datasette mirror, which needs
+  no auth and covers `variables` including unpublished ones:
+
+  ```bash
+  curl -s "https://datasette-public.owid.io/owid/variables.json?id__in=<id>&_shape=array"
+  ```
+
+  Filter with `?<col>__in=` / `?<col>__exact=` and select columns with repeated
+  `&_col=`. The `?sql=` form documented in the root CLAUDE.md works too, but a
+  long encoded query has 403'd intermittently, so prefer the filter form for
+  simple lookups. Charts and gdocs in Datasette are filtered to published only —
+  for a *draft* chart, ask the user to paste
+  `admin.owid.io/admin/api/charts/<id>.config.json`, which renders as JSON in
+  their already-authenticated browser. Never guess what an id refers to: say you
+  couldn't resolve it and ask.
 
 - **After pushing, hand the user a staging link**, deep-linked to the affected
   chart or page. Don't derive the name by hand:

--- a/.claude/docs/cloud-sandbox.md
+++ b/.claude/docs/cloud-sandbox.md
@@ -1,123 +1,68 @@
 # Cloud sandbox sessions (claude.ai/code)
 
-Notes for agent sessions running in a Claude Code cloud sandbox
-(`CLAUDE_CODE_REMOTE=true`). For how the environment itself is set up (setup
-script, environment variables), see
+For agent sessions running in a Claude Code cloud sandbox
+(`CLAUDE_CODE_REMOTE=true`). Environment setup is documented in
 [docs/guides/data-work/claude-code-web.md](../../docs/guides/data-work/claude-code-web.md).
 
-- **Never commit a `uv.lock` diff that appeared on its own.** `uv sync` only
-  rewrites the lockfile when it decided to re-resolve, which here means the
-  sandbox's uv was too old to parse `exclude-newer = "3 days"` in
-  `pyproject.toml` (needs >= 0.10). The diff is ~2000 lines and silently bumps
-  hundreds of packages. Discard it with `git checkout -- uv.lock`. The
-  `SessionStart` hook installs a current uv and warns if the lockfile went
-  dirty, but check `git status` before committing regardless.
+- **A `uv.lock` diff you didn't intend is a re-resolve, never a real change.**
+  Discard it with `git checkout -- uv.lock`.
 
-- **Rename the pre-created branch before the first push.** The sandbox creates
-  `claude/<slug>-<random-suffix>`, which violates the repo's branch-naming
-  rules (short, no prefix — see the root CLAUDE.md). Use
-  `git branch -m <short-descriptive-name>`, or let `etl pr` create a properly
-  named branch.
+- **Rename the pre-created `claude/<slug>-<suffix>` branch before pushing** —
+  `git branch -m <short-name>`, or let `etl pr` name it (see the root CLAUDE.md).
 
-- **There is no MySQL in the sandbox and staging servers are on Tailscale.** So
-  `--grapher` (the MySQL upsert), `make query`, and `OWID_ENV.read_sql` are not
-  available. Run steps without `--grapher`: that still builds meadow, garden,
-  and the grapher dataset feather. **This overrides the root CLAUDE.md's "for
-  `grapher://` steps, always add `--grapher`" rule** — following it here only
-  buys you `No grapher user id has been set in the environment` and a wasted
-  run. Anything DB-side — variable upserts, chart-diff, the admin — happens on
+- **No MySQL here, and staging is on Tailscale**, so `--grapher`, `make query`
+  and `OWID_ENV.read_sql` don't work. **This overrides the root CLAUDE.md's
+  "always add `--grapher`" rule** — run steps without it and meadow, garden and
+  the grapher feather still build. Upserts, chart-diff and the admin happen on
   the PR's staging server after you push.
 
-- **Fetch upstream dependencies instead of rebuilding them:** `PREFER_DOWNLOAD=1
-  .venv/bin/etlr <step> --private` pulls already-published upstream datasets
-  from the catalog rather than recomputing the whole chain inside the VM. It
-  makes no difference for a small step, but without it a step sitting on a heavy
-  dependency (population, WDI, FAOSTAT) rebuilds all of it. Needs `Full` network
-  access, and it only works for versions already in the catalog — never for the
-  step you are currently building.
+- **`PREFER_DOWNLOAD=1 .venv/bin/etlr <step> --private`** fetches published
+  upstream datasets instead of rebuilding the chain inside the VM. Not usable for
+  the step you're building — it isn't in the catalog yet.
 
-- **To check a build without a database, diff it against the remote catalog:**
-  `.venv/bin/etl diff REMOTE data/ --include <dataset>` (add `--verbose`, or
-  `--output-html` for a report). This answers "did my rebuild change any
-  values?", which is most of why you'd run a step by hand, and needs no MySQL —
-  only `catalog.ourworldindata.org`, which is reachable under `Full` network
-  access (see below). "The step completed" is not the same as "the data is
-  right"; say which one you verified.
+- **Verify the build against the catalog rather than by exit code:**
+  `.venv/bin/etl diff REMOTE data/ --include <dataset> --verbose`
+  (`--output-html` writes a report). Needs no MySQL.
 
-- **OWID hosts are reachable, but only with `Full` network access.** Snapshots,
-  the catalog, the public API and Datasette all work in an environment set to
-  `Full`. Under `Trusted` the gateway refuses them, and `etlr` snapshot
-  downloads, `etl diff` and every Datasette lookup fail together. If that
-  happens, the fix is a setting, not a workaround: tell the user to switch the
-  environment's network access to `Full` (see
-  [claude-code-web.md](../../docs/guides/data-work/claude-code-web.md)).
+- **OWID hosts require `Full` network access.** Under `Trusted` the gateway
+  refuses snapshots, the catalog and Datasette together — a setting to fix, not
+  to work around, so ask the user to switch it. `admin.owid.io` never works:
+  Cloudflare Access rejects non-browser clients. Creating snapshots with `etls`
+  needs the `R2_*` variables (in 1Password — never scrape credentials elsewhere).
 
-  `admin.owid.io` is the one host that never works regardless: Cloudflare Access
-  rejects every non-browser client at the edge.
-
-  Creating a *new* snapshot with `etls` needs the `R2_*` environment variables;
-  if they're missing, the environment was set up without them and the user needs
-  to add them (they're in 1Password — never scrape credentials from anywhere
-  else).
-
-- **A refused host looks like an auth problem — it isn't.** WebFetch reports a
-  gateway refusal as `HTTP 403 Forbidden` with the hint *"If this URL requires
-  authentication, use an authenticated tool"*, and `curl` just returns `000`.
-  Chasing that hint means hunting for credentials that would not have helped.
-  Confirm the real cause before concluding anything:
+- **A refused host looks like an auth failure.** WebFetch reports `403 Forbidden`
+  and suggests an authenticated tool; `curl` returns `000`. Confirm the cause
+  before hunting for credentials that wouldn't have helped:
 
   ```bash
   curl -sS "$HTTPS_PROXY/__agentproxy/status" | grep -A4 recentRelayFailures
   ```
 
-  `"kind": "connect_rejected"` names the host the gateway refused — the request
-  died before TLS, so no key, token, or login would have changed the outcome.
-  That's the `Trusted`-network signature above; report it and ask for `Full`
-  rather than working around it.
+  `"kind": "connect_rejected"` means the gateway refused it before TLS.
 
-- **Admin links can't be opened; resolve the id instead.** When the user shares
-  an `admin.owid.io` link, don't fetch it — pull the id out of the URL and query
-  the public Datasette mirror, which needs no auth.
-
-  `/admin/variables/<id>` — indicator metadata, including unpublished
-  indicators:
+- **Resolve `admin.owid.io` links through the public Datasette instead of opening
+  them:**
 
   ```bash
+  # /admin/variables/<id> — indicator metadata, including unpublished
   curl -s "https://datasette-public.owid.io/owid/variables.json?id__in=<id>&_shape=array"
-  ```
 
-  `/admin/charts/<id>/edit` — the chart's full config. It comes back as a JSON
-  string inside the row, so unwrap it:
-
-  ```bash
+  # /admin/charts/<id>/edit — config arrives as a JSON string, so unwrap it
   curl -s "https://datasette-public.owid.io/owid/charts.json?id__exact=<id>&_shape=array&_col=config" \
     | .venv/bin/python -c "import json,sys; print(json.dumps(json.loads(json.load(sys.stdin)[0]['config']), indent=2))"
   ```
 
-  `chart_dimensions` maps that chart to its indicators
-  (`?chartId__exact=<id>&_shape=array`), so the two together answer "what is
-  this chart built from". If you already have the slug rather than the id,
-  `https://ourworldindata.org/grapher/<slug>.config.json` returns the same thing
-  in one call.
+  `chart_dimensions?chartId__exact=<id>` maps a chart to its indicators; if you
+  have the slug, `https://ourworldindata.org/grapher/<slug>.config.json` does it
+  in one call. Prefer `?<col>__exact=` filters over `?sql=`, which 403s
+  intermittently on long queries. Charts and gdocs are published-only, so an
+  empty result usually means a draft — ask the user to paste
+  `admin.owid.io/admin/api/charts/<id>.config.json` rather than guessing.
 
-  Filter with `?<col>__in=` / `?<col>__exact=` and select columns with repeated
-  `&_col=`. The `?sql=` form documented in the root CLAUDE.md works too, but a
-  long encoded query has 403'd intermittently, so prefer the filter form for
-  simple lookups.
-
-  Charts and gdocs in Datasette are **filtered to published only**, so an empty
-  result for a plausible chart id usually means it's a draft, not that the id is
-  wrong. Drafts are only reachable from an authenticated browser: ask the user
-  to open `admin.owid.io/admin/api/charts/<id>.config.json` and paste it. Never
-  guess what an id refers to — say you couldn't resolve it and ask.
-
-- **After pushing, hand the user a staging link**, deep-linked to the affected
-  chart or page. Don't derive the name by hand:
+- **After pushing, give the user a deep-linked staging URL** (it takes a while to
+  build, especially the first time):
 
   ```bash
   .venv/bin/python -c "from etl.config import get_container_name; import subprocess; \
     print('http://' + get_container_name(subprocess.check_output(['git','branch','--show-current'], text=True).strip()))"
   ```
-
-  Mention that the staging server takes a while to build after a push,
-  especially the first one.

--- a/.claude/docs/cloud-sandbox.md
+++ b/.claude/docs/cloud-sandbox.md
@@ -22,8 +22,19 @@ script, environment variables), see
 - **There is no MySQL in the sandbox and staging servers are on Tailscale.** So
   `--grapher` (the MySQL upsert), `make query`, and `OWID_ENV.read_sql` are not
   available. Run steps without `--grapher`: that still builds meadow, garden,
-  and the grapher dataset feather. Anything DB-side — variable upserts,
-  chart-diff, the admin — happens on the PR's staging server after you push.
+  and the grapher dataset feather. **This overrides the root CLAUDE.md's "for
+  `grapher://` steps, always add `--grapher`" rule** — following it here only
+  buys you `No grapher user id has been set in the environment` and a wasted
+  run. Anything DB-side — variable upserts, chart-diff, the admin — happens on
+  the PR's staging server after you push.
+
+- **Fetch upstream dependencies instead of rebuilding them:** `PREFER_DOWNLOAD=1
+  .venv/bin/etlr <step> --private` pulls already-published upstream datasets
+  from the catalog rather than recomputing the whole chain inside the VM. It
+  makes no difference for a small step, but without it a step sitting on a heavy
+  dependency (population, WDI, FAOSTAT) rebuilds all of it. Needs `Full` network
+  access, and it only works for versions already in the catalog — never for the
+  step you are currently building.
 
 - **To check a build without a database, diff it against the remote catalog:**
   `.venv/bin/etl diff REMOTE data/ --include <dataset>` (add `--verbose`, or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,21 @@ Internal terms that recur across this guide, the skills, and the codebase:
 
 Key flags: `--grapher/-g` (upload), `--dry-run` (preview), `--force/-f` (re-run), `--only/-o` (no deps), `--private` (always use)
 
+**"The step completed" is not "the data is right".** A step exiting 0 says
+nothing about its output — a unit regression, a silent row drop, or a no-op
+rebuild all finish cleanly. Whenever you run a step on someone's behalf, report
+what came out of it, not just that it ran:
+
+```bash
+.venv/bin/etl diff REMOTE data/ --include <dataset> --verbose   # did values change vs the published catalog?
+```
+
+Alongside that, state the shape of the output — row count, year range, entities,
+and a couple of actual values from the latest year — so the numbers are
+checkable by a human. `✅ No differences found` is a real result worth
+reporting: it means the rebuild reproduced published data and there was nothing
+to fix.
+
 ### Running Snapshot Steps
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,6 +417,11 @@ When editing `.github/workflows/**` or `.github/actions/**`, follow the SHA-pinn
 See `.claude/docs/` for:
 - `debugging.md` - Data quality debugging approach
 - `pipeline-stages.md` - Pipeline architecture details
+- `cloud-sandbox.md` - Claude Code on the web: what a cloud session can and can't do
+
+If you are running in a Claude Code cloud sandbox (`CLAUDE_CODE_REMOTE=true`), read
+`.claude/docs/cloud-sandbox.md` **before starting work** — it covers the pre-created
+branch name, spurious `uv.lock` diffs, and the absence of a database.
 
 ## Individual Preferences
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,20 +116,14 @@ Internal terms that recur across this guide, the skills, and the codebase:
 
 Key flags: `--grapher/-g` (upload), `--dry-run` (preview), `--force/-f` (re-run), `--only/-o` (no deps), `--private` (always use)
 
-**"The step completed" is not "the data is right".** A step exiting 0 says
-nothing about its output — a unit regression, a silent row drop, or a no-op
-rebuild all finish cleanly. Whenever you run a step on someone's behalf, report
-what came out of it, not just that it ran:
+**"The step completed" is not "the data is right".** After running a step for
+someone, report what came out of it: row count, year range, entities, and a few
+values from the latest year, plus whether anything changed against the published
+catalog. `✅ No differences found` is itself a result worth reporting.
 
 ```bash
-.venv/bin/etl diff REMOTE data/ --include <dataset> --verbose   # did values change vs the published catalog?
+.venv/bin/etl diff REMOTE data/ --include <dataset> --verbose
 ```
-
-Alongside that, state the shape of the output — row count, year range, entities,
-and a couple of actual values from the latest year — so the numbers are
-checkable by a human. `✅ No differences found` is a real result worth
-reporting: it means the rebuild reproduced published data and there was nothing
-to fix.
 
 ### Running Snapshot Steps
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,7 +421,8 @@ See `.claude/docs/` for:
 
 If you are running in a Claude Code cloud sandbox (`CLAUDE_CODE_REMOTE=true`), read
 `.claude/docs/cloud-sandbox.md` **before starting work** — it covers the pre-created
-branch name, spurious `uv.lock` diffs, and the absence of a database.
+branch name, spurious `uv.lock` diffs, the absence of a database, which OWID hosts
+the egress proxy blocks, and how to resolve an `admin.owid.io` link you can't open.
 
 ## Individual Preferences
 

--- a/docs/guides/data-work/claude-code-web.md
+++ b/docs/guides/data-work/claude-code-web.md
@@ -23,8 +23,11 @@ power users).
 
 1. Open <https://claude.ai/code>.
     - **First-time users** are redirected to an onboarding flow: use the name
-      `etl` and `Trusted` or `Full` network access (you can switch to `Full`
-      later if `Trusted` turns out to be limiting).
+      `etl` and **`Full`** network access. `Trusted` blocks our own hosts —
+      `datasette-public.owid.io`, `api.ourworldindata.org` and
+      `catalog.ourworldindata.org` are all refused — which quietly breaks
+      indicator lookups and `etl diff`, and the failure looks like an
+      authentication error rather than a network one.
     - **Existing users** won't see onboarding: click the environment selector
       (":cloud: Default") above the chat input and create a new `etl`
       environment with the same settings.

--- a/docs/guides/data-work/claude-code-web.md
+++ b/docs/guides/data-work/claude-code-web.md
@@ -102,6 +102,41 @@ From there:
    the PR).
 3. Merge the PR — this syncs your charts to production.
 
+## Drive cloud sessions from the terminal
+
+If you already work in the terminal, you don't have to switch to the browser to
+use the cloud environment — and you don't have to copy results back by hand.
+From the ETL repository:
+
+```bash
+claude --cloud "Run the cherry blossom step and report what breaks"
+```
+
+This starts a cloud session on the same environment while you keep working
+locally. The VM clones from GitHub rather than from your machine, so **push
+your branch first**. Then:
+
+- `/tasks` — check on running sessions (each `claude --cloud` is its own
+  session, so you can start several in parallel).
+- `/teleport` (or `/tp`) — pull a session into your terminal: it checks out the
+  branch and loads the full conversation history, so the local session
+  continues where the cloud one left off.
+
+Neither flag appears in `claude --help`, but both work.
+
+This is the practical way to debug the cloud environment itself: run
+`check-tools` in a session to get the exact versions of everything installed
+(the command only exists there), then reproduce locally against that specific
+version rather than trying to recreate the whole VM — there is no published
+image for it.
+
+!!! note
+
+    Cloud sessions get the repository's `CLAUDE.md`, `.claude/` skills and
+    agents, and the `SessionStart` hook, but **not** your personal
+    `~/.claude/CLAUDE.md`. Anything a cloud session needs to know has to live
+    in the repo — see [`.claude/docs/cloud-sandbox.md`](https://github.com/owid/etl/blob/master/.claude/docs/cloud-sandbox.md).
+
 ## Feedback
 
 This workflow is actively evolving. If you try it, share your session or

--- a/docs/guides/data-work/claude-code-web.md
+++ b/docs/guides/data-work/claude-code-web.md
@@ -67,13 +67,8 @@ export PATH="$HOME/.local/bin:$PATH"
 # hard-codes absolute paths — but sessions rebuild it in seconds from cache.)
 git clone --depth 1 https://github.com/owid/etl /opt/etl-setup
 cd /opt/etl-setup
-UV_HTTP_TIMEOUT=300 uv sync --all-extras --group dev
+uv sync --all-extras --group dev
 ```
-
-Also add `UV_HTTP_TIMEOUT=300` to the environment variables. `--all-extras`
-pulls 4.1 GB of linux-only torch/CUDA wheels; downloading them saturates the
-sandbox's egress proxy until some other download stalls past uv's 30-second read
-timeout.
 
 Sessions still build their own `.venv` via `scripts/remote_setup.sh`, wired as a
 `SessionStart` hook.

--- a/docs/guides/data-work/claude-code-web.md
+++ b/docs/guides/data-work/claude-code-web.md
@@ -76,9 +76,12 @@ cd /opt/etl-setup
 UV_HTTP_TIMEOUT=300 uv sync --all-extras --group dev
 ```
 
-Also add `UV_HTTP_TIMEOUT=300` to the environment variables: uv's 30-second
-default times out on large wheels (grpcio, torch) through the sandbox's egress
-proxy.
+Also add `UV_HTTP_TIMEOUT=300` to the environment variables. `--all-extras`
+pulls `sentence-transformers`, and with it torch and the CUDA stack — 4.1 GB of
+linux-only wheels that don't exist on macOS. Downloading those in parallel
+saturates the sandbox's egress proxy, and uv's 30-second default is a *read*
+timeout, so any other download that goes half a minute without receiving a byte
+is killed. Which package dies varies from run to run.
 
 Sessions still build their own `.venv` — that part runs from
 `scripts/remote_setup.sh`, wired as a `SessionStart` hook — but from a warm

--- a/docs/guides/data-work/claude-code-web.md
+++ b/docs/guides/data-work/claude-code-web.md
@@ -48,44 +48,35 @@ power users).
 
 ### Setup script
 
-The sandbox image ships an old `uv` and an empty package cache, which makes
-every session slow to start and can silently rewrite `uv.lock` (see below).
-This script fixes both. It runs once, and the resulting filesystem is
-snapshotted, so later sessions skip it entirely; the snapshot rebuilds when you
-edit the environment settings and automatically after ~7 days.
+The sandbox ships a `uv` too old to read our `pyproject.toml` (it silently
+rewrites `uv.lock`) and an empty package cache, so every session starts slowly.
+This script fixes both. It runs once and the filesystem is snapshotted, so later
+sessions skip it; the snapshot rebuilds when you edit the environment settings
+and automatically after ~7 days.
 
 ```bash
 #!/bin/bash
 set -euo pipefail
 
-# The sandbox has shipped uv 0.8.17, which cannot parse the relative
-# `exclude-newer = "3 days"` in pyproject.toml: it discards the whole [tool.uv]
-# table, concludes the lockfile's cutoff was removed, and re-resolves every
-# dependency — a ~2000-line uv.lock diff that silently bumps hundreds of
-# packages. uv 0.10 is the first release that handles it. The install script is
-# used rather than `uv self update`, which hits GitHub API rate limits here.
+# uv >= 0.10 is required. `uv self update` hits GitHub API rate limits here.
 curl -LsSf https://astral.sh/uv/install.sh | sh
 export PATH="$HOME/.local/bin:$PATH"
 
-# The setup script runs before the session's repo is cloned, so clone it here
-# to warm the uv cache. The .venv itself cannot be reused (it hard-codes
-# absolute paths), but ~/.cache/uv goes into the snapshot, which turns the
-# session's own `uv sync` from a multi-minute download into a few seconds.
+# This runs before the session's repo is cloned, so clone it here to warm
+# ~/.cache/uv, which the snapshot keeps. (The .venv itself can't be reused — it
+# hard-codes absolute paths — but sessions rebuild it in seconds from cache.)
 git clone --depth 1 https://github.com/owid/etl /opt/etl-setup
 cd /opt/etl-setup
 UV_HTTP_TIMEOUT=300 uv sync --all-extras --group dev
 ```
 
 Also add `UV_HTTP_TIMEOUT=300` to the environment variables. `--all-extras`
-pulls `sentence-transformers`, and with it torch and the CUDA stack — 4.1 GB of
-linux-only wheels that don't exist on macOS. Downloading those in parallel
-saturates the sandbox's egress proxy, and uv's 30-second default is a *read*
-timeout, so any other download that goes half a minute without receiving a byte
-is killed. Which package dies varies from run to run.
+pulls 4.1 GB of linux-only torch/CUDA wheels; downloading them saturates the
+sandbox's egress proxy until some other download stalls past uv's 30-second read
+timeout.
 
-Sessions still build their own `.venv` — that part runs from
-`scripts/remote_setup.sh`, wired as a `SessionStart` hook — but from a warm
-cache and with a current uv.
+Sessions still build their own `.venv` via `scripts/remote_setup.sh`, wired as a
+`SessionStart` hook.
 
 ## Create a dataset
 
@@ -119,22 +110,15 @@ claude --cloud "Run the cherry blossom step and report what breaks"
 ```
 
 This starts a cloud session on the same environment while you keep working
-locally. The VM clones from GitHub rather than from your machine, so **push
-your branch first**. Then:
+locally. The VM clones from GitHub rather than from your machine, so **push your
+branch first**. Then `/tasks` lists running sessions (each `claude --cloud` is
+its own, so they can run in parallel), and `/teleport` (or `/tp`) pulls one into
+your terminal with the branch checked out and the full conversation history
+loaded. Neither flag appears in `claude --help`, but both work.
 
-- `/tasks` — check on running sessions (each `claude --cloud` is its own
-  session, so you can start several in parallel).
-- `/teleport` (or `/tp`) — pull a session into your terminal: it checks out the
-  branch and loads the full conversation history, so the local session
-  continues where the cloud one left off.
-
-Neither flag appears in `claude --help`, but both work.
-
-This is the practical way to debug the cloud environment itself: run
-`check-tools` in a session to get the exact versions of everything installed
-(the command only exists there), then reproduce locally against that specific
-version rather than trying to recreate the whole VM — there is no published
-image for it.
+To debug the environment itself, run `check-tools` in a session for exact tool
+versions — the command only exists there — then reproduce against that version
+locally. There is no published image to run.
 
 !!! note
 

--- a/docs/guides/data-work/claude-code-web.md
+++ b/docs/guides/data-work/claude-code-web.md
@@ -39,8 +39,47 @@ power users).
         environment — only put values there that are okay to share within the
         org (like the 1Password ones above).
 
-3. Next to the environment selector is the repository picker — choose
+3. In the same settings, paste the [setup script](#setup-script) below.
+4. Next to the environment selector is the repository picker — choose
    `owid/etl`.
+
+### Setup script
+
+The sandbox image ships an old `uv` and an empty package cache, which makes
+every session slow to start and can silently rewrite `uv.lock` (see below).
+This script fixes both. It runs once, and the resulting filesystem is
+snapshotted, so later sessions skip it entirely; the snapshot rebuilds when you
+edit the environment settings and automatically after ~7 days.
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# The sandbox has shipped uv 0.8.17, which cannot parse the relative
+# `exclude-newer = "3 days"` in pyproject.toml: it discards the whole [tool.uv]
+# table, concludes the lockfile's cutoff was removed, and re-resolves every
+# dependency — a ~2000-line uv.lock diff that silently bumps hundreds of
+# packages. uv 0.10 is the first release that handles it. The install script is
+# used rather than `uv self update`, which hits GitHub API rate limits here.
+curl -LsSf https://astral.sh/uv/install.sh | sh
+export PATH="$HOME/.local/bin:$PATH"
+
+# The setup script runs before the session's repo is cloned, so clone it here
+# to warm the uv cache. The .venv itself cannot be reused (it hard-codes
+# absolute paths), but ~/.cache/uv goes into the snapshot, which turns the
+# session's own `uv sync` from a multi-minute download into a few seconds.
+git clone --depth 1 https://github.com/owid/etl /opt/etl-setup
+cd /opt/etl-setup
+UV_HTTP_TIMEOUT=300 uv sync --all-extras --group dev
+```
+
+Also add `UV_HTTP_TIMEOUT=300` to the environment variables: uv's 30-second
+default times out on large wheels (grpcio, torch) through the sandbox's egress
+proxy.
+
+Sessions still build their own `.venv` — that part runs from
+`scripts/remote_setup.sh`, wired as a `SessionStart` hook — but from a warm
+cache and with a current uv.
 
 ## Create a dataset
 

--- a/scripts/remote_setup.sh
+++ b/scripts/remote_setup.sh
@@ -10,9 +10,11 @@
 #     so we cd there if set and otherwise derive the root from this script.
 #   * We do NOT use `set -e`, and we always `exit 0`: a SessionStart hook hiccup
 #     must never block the session from starting.
-#   * Dependency install belongs in a SessionStart hook, not the cloud
-#     environment "setup script" — the setup script runs outside the repo, so
-#     `uv sync` / `make .venv` can't find pyproject.toml there.
+#   * The `.venv` must be created in the session's own checkout, so building it
+#     belongs here rather than in the cloud environment "setup script" (which
+#     runs before the repo is cloned). The setup script still matters: it
+#     installs a current uv and warms the uv cache, both of which land in the
+#     environment snapshot. See docs/guides/data-work/claude-code-web.md.
 #   * The hook also runs on `resume`, so a rare transient `uv sync` failure at
 #     first boot self-heals on the next resume — no in-script retry needed.
 
@@ -43,18 +45,49 @@ if [ ! -f pyproject.toml ]; then
   exit 0
 fi
 
+# --- Make sure uv is new enough ---------------------------------------------
+# The sandbox image has shipped uv 0.8.17, which cannot parse the relative
+# `exclude-newer = "3 days"` in pyproject.toml. On that failure uv discards the
+# WHOLE [tool.uv] table, concludes the lockfile's cutoff was removed, and
+# re-resolves every dependency — a ~2000-line uv.lock diff that silently bumps
+# hundreds of packages and can leak into an unrelated PR. uv 0.10 is the first
+# release that handles it; anything older re-resolves.
+#
+# The environment setup script installs a current uv (and the snapshot keeps
+# it), so this is a fallback for environments created before that script
+# existed. `uv self update` is not used: it needs the GitHub API and hits
+# anonymous rate limits in the sandbox.
+UV_MIN_MINOR=10
+echo ""
+if uv --version | awk '{split($2, v, "."); exit !(v[1] > 0 || v[2] >= '"$UV_MIN_MINOR"')}'; then
+  echo "🔧 uv is current ($(uv --version))"
+else
+  echo "⬆️  $(uv --version) is too old (need >= 0.$UV_MIN_MINOR) — installing a current uv..."
+  if curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1; then
+    export PATH="$HOME/.local/bin:$PATH"
+    hash -r
+    echo "   ✓ now on $(uv --version)"
+  else
+    echo "   ✗ install failed — uv.lock may pick up a spurious full re-resolve."
+    echo "     Check 'git status' before committing."
+  fi
+fi
+
 # --- Install dependencies (the critical step) -------------------------------
 # `uv sync` is exactly what `make .venv` runs underneath, without the extra
 # install-hooks / sanity-check layers that aren't needed in a cloud sandbox.
-# uv is pre-installed in cloud sessions and idempotent, so it's safe to run on
-# every session/resume. Capture output so a failure shows WHY (uv's own error)
-# instead of a bare "failed".
+# uv is idempotent, so it's safe to run on every session/resume. Capture output
+# so a failure shows WHY (uv's own error) instead of a bare "failed".
+#
+# UV_HTTP_TIMEOUT is raised from uv's 30s default: some wheels here are large
+# (grpcio, torch) and the sandbox's egress proxy is slow enough that the
+# default times out on a cold cache.
 echo ""
 echo "📦 Installing dependencies (uv sync)..."
 INSTALL_START=$(date +%s)
 
 SYNC_LOG=$(mktemp)
-if uv sync --all-extras --group dev >"$SYNC_LOG" 2>&1; then
+if UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-300}" uv sync --all-extras --group dev >"$SYNC_LOG" 2>&1; then
   echo "✅ Dependencies installed ($(($(date +%s) - INSTALL_START))s)"
 else
   echo "❌ uv sync failed — the session may not have a working .venv:"
@@ -69,6 +102,14 @@ if [ -x .venv/bin/etl ]; then
   echo "   ✓ ETL CLI available ($(.venv/bin/python --version 2>&1))"
 else
   echo "   ✗ .venv/bin/etl not found — run 'uv sync --all-extras --group dev' in the session."
+fi
+
+# A dirty uv.lock here is never intentional — `uv sync` only rewrites it when it
+# decided to re-resolve. Say so loudly, because the diff is easy to commit by
+# accident and carries unintended dependency bumps.
+if ! git diff --quiet -- uv.lock 2>/dev/null; then
+  echo "   ⚠ uv sync modified uv.lock — this is a re-resolve, not a real change."
+  echo "     Discard it with 'git checkout -- uv.lock' and don't commit it."
 fi
 
 echo ""

--- a/scripts/remote_setup.sh
+++ b/scripts/remote_setup.sh
@@ -69,16 +69,12 @@ fi
 # `uv sync` is what `make .venv` runs underneath, minus the install-hooks layer
 # a sandbox doesn't need, and it's idempotent across resumes. Output is captured
 # so a failure shows uv's own error rather than a bare "failed".
-#
-# uv's 30s default is a *read* timeout, and on a cold cache --all-extras pulls
-# 4.1 GB of linux-only torch/CUDA wheels that saturate the egress proxy until
-# some other download stalls out — hence the longer timeout.
 echo ""
 echo "📦 Installing dependencies (uv sync)..."
 INSTALL_START=$(date +%s)
 
 SYNC_LOG=$(mktemp)
-if UV_HTTP_TIMEOUT="${UV_HTTP_TIMEOUT:-300}" uv sync --all-extras --group dev >"$SYNC_LOG" 2>&1; then
+if uv sync --all-extras --group dev >"$SYNC_LOG" 2>&1; then
   echo "✅ Dependencies installed ($(($(date +%s) - INSTALL_START))s)"
 else
   echo "❌ uv sync failed — the session may not have a working .venv:"

--- a/scripts/remote_setup.sh
+++ b/scripts/remote_setup.sh
@@ -10,11 +10,10 @@
 #     so we cd there if set and otherwise derive the root from this script.
 #   * We do NOT use `set -e`, and we always `exit 0`: a SessionStart hook hiccup
 #     must never block the session from starting.
-#   * The `.venv` must be created in the session's own checkout, so building it
-#     belongs here rather than in the cloud environment "setup script" (which
-#     runs before the repo is cloned). The setup script still matters: it
-#     installs a current uv and warms the uv cache, both of which land in the
-#     environment snapshot. See docs/guides/data-work/claude-code-web.md.
+#   * The `.venv` must live in the session's own checkout, so it's built here
+#     rather than in the environment setup script, which runs before the repo is
+#     cloned and instead installs uv and warms its cache. See
+#     docs/guides/data-work/claude-code-web.md.
 #   * The hook also runs on `resume`, so a rare transient `uv sync` failure at
 #     first boot self-heals on the next resume — no in-script retry needed.
 
@@ -46,17 +45,10 @@ if [ ! -f pyproject.toml ]; then
 fi
 
 # --- Make sure uv is new enough ---------------------------------------------
-# The sandbox image has shipped uv 0.8.17, which cannot parse the relative
-# `exclude-newer = "3 days"` in pyproject.toml. On that failure uv discards the
-# WHOLE [tool.uv] table, concludes the lockfile's cutoff was removed, and
-# re-resolves every dependency — a ~2000-line uv.lock diff that silently bumps
-# hundreds of packages and can leak into an unrelated PR. uv 0.10 is the first
-# release that handles it; anything older re-resolves.
-#
-# The environment setup script installs a current uv (and the snapshot keeps
-# it), so this is a fallback for environments created before that script
-# existed. `uv self update` is not used: it needs the GitHub API and hits
-# anonymous rate limits in the sandbox.
+# Below 0.10, uv can't parse `exclude-newer = "3 days"` in pyproject.toml and
+# silently re-resolves the whole lockfile. The environment setup script installs
+# a current uv, so this only fires in environments created before it existed.
+# (`uv self update` hits GitHub API rate limits here.)
 UV_MIN_MINOR=10
 echo ""
 if uv --version | awk '{split($2, v, "."); exit !(v[1] > 0 || v[2] >= '"$UV_MIN_MINOR"')}'; then
@@ -74,16 +66,13 @@ else
 fi
 
 # --- Install dependencies (the critical step) -------------------------------
-# `uv sync` is exactly what `make .venv` runs underneath, without the extra
-# install-hooks / sanity-check layers that aren't needed in a cloud sandbox.
-# uv is idempotent, so it's safe to run on every session/resume. Capture output
-# so a failure shows WHY (uv's own error) instead of a bare "failed".
+# `uv sync` is what `make .venv` runs underneath, minus the install-hooks layer
+# a sandbox doesn't need, and it's idempotent across resumes. Output is captured
+# so a failure shows uv's own error rather than a bare "failed".
 #
-# UV_HTTP_TIMEOUT is raised from uv's 30s default, which is a *read* timeout
-# (30s without receiving a byte), not a transfer timeout. On a cold cache
-# --all-extras pulls torch and the CUDA stack — 4.1 GB of linux-only wheels —
-# and downloading those in parallel saturates the sandbox's egress proxy until
-# some unrelated download stalls out. Which one dies varies from run to run.
+# uv's 30s default is a *read* timeout, and on a cold cache --all-extras pulls
+# 4.1 GB of linux-only torch/CUDA wheels that saturate the egress proxy until
+# some other download stalls out — hence the longer timeout.
 echo ""
 echo "📦 Installing dependencies (uv sync)..."
 INSTALL_START=$(date +%s)

--- a/scripts/remote_setup.sh
+++ b/scripts/remote_setup.sh
@@ -79,9 +79,11 @@ fi
 # uv is idempotent, so it's safe to run on every session/resume. Capture output
 # so a failure shows WHY (uv's own error) instead of a bare "failed".
 #
-# UV_HTTP_TIMEOUT is raised from uv's 30s default: some wheels here are large
-# (grpcio, torch) and the sandbox's egress proxy is slow enough that the
-# default times out on a cold cache.
+# UV_HTTP_TIMEOUT is raised from uv's 30s default, which is a *read* timeout
+# (30s without receiving a byte), not a transfer timeout. On a cold cache
+# --all-extras pulls torch and the CUDA stack — 4.1 GB of linux-only wheels —
+# and downloading those in parallel saturates the sandbox's egress proxy until
+# some unrelated download stalls out. Which one dies varies from run to run.
 echo ""
 echo "📦 Installing dependencies (uv sync)..."
 INSTALL_START=$(date +%s)


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

## Problem

A cloud session flagged that every `uv sync` there rewrites `uv.lock` wholesale — ~2100 insertions / 1850 deletions with no dependency actually changed ([#6525 comment](https://github.com/owid/etl/pull/6525#issuecomment-5090536316)).

The cause is the sandbox image's uv version, not our config. `pyproject.toml` sets `exclude-newer = "3 days"`; uv 0.8.17 can't parse the relative form:

```
warning: Failed to parse pyproject.toml during settings discovery:
  TOML parse error at line 90, column 17
  90 | exclude-newer = "3 days"
  failed to parse year in date "3 days"
Ignoring existing lockfile due to removal of timestamp cutoff
Resolved 457 packages
```

It then discards the **entire `[tool.uv]` table** (so `link-mode = "hardlink"` is lost too), concludes the lockfile's cutoff was removed, and re-resolves from scratch — silently bumping ~300 packages (`anthropic 0.107.1 → 0.120.0`, `xarray 2026.4.0 → 2026.7.0`, …). That diff is easy to commit by accident into an unrelated PR.

I bisected the version bar against the committed lockfile:

| uv | result |
|---|---|
| 0.8.17 (sandbox), 0.9.0, 0.9.5, 0.9.8 | parse error → full re-resolve, 2149/1851 diff |
| **0.10.0** and later (incl. 0.11.x) | clean, zero diff |

Two related papercuts turned up in the same sessions: the `SessionStart` hook's `uv sync` times out downloading large wheels on a cold cache (needs `UV_HTTP_TIMEOUT`), and sessions push the sandbox's pre-created `claude/<slug>-<suffix>` branch, which violates our branch-naming rule.

## Change

Adopts the owid-grapher pattern (`owid-grapher/docs/claude-code-web.md`), which already solves the same shape of problem for Node: do the toolchain work in the cloud **environment setup script**, whose filesystem is snapshotted, so it's paid once instead of per session.

- **`docs/guides/data-work/claude-code-web.md`** — adds the setup script to paste into the environment settings. It installs a current uv (via `astral.sh/uv/install.sh`, since `uv self update` hits GitHub API rate limits in the sandbox) and warms `~/.cache/uv` from a throwaway `--depth 1` clone. The `.venv` itself can't be pre-built there (absolute paths), but the warm cache turns the session's own `uv sync` from a multi-minute download into seconds. Also documents `UV_HTTP_TIMEOUT=300` as an environment variable.
- **`scripts/remote_setup.sh`** — keeps building the `.venv` (it must live in the session's checkout), but now: upgrades uv if it's older than 0.10, so environments created before the setup script existed self-heal; passes `UV_HTTP_TIMEOUT`; and warns loudly if `uv sync` left `uv.lock` dirty. That last one matters because the failure is otherwise silent — it only surfaces when someone happens to run `git status`.
- **`.claude/docs/cloud-sandbox.md`** (new, + pointer from `CLAUDE.md`) — agent-facing counterpart to the human-facing doc, mirroring grapher's split. Covers the spurious `uv.lock` diff, renaming the pre-created branch, the absence of MySQL (so `--grapher`, `make query` and `OWID_ENV.read_sql` aren't available and DB-side work happens on the PR's staging server), and how to compute the staging link with `get_container_name`.

Deliberately **not** done: adding `required-version` under `[tool.uv]`, which was the other suggestion in the thread. I tested it — it doesn't work here. With `exclude-newer = "3 days"` present, old uv fails to parse the table and drops `required-version` along with it, so `uv sync` runs and churns the lock anyway. It only fires if `exclude-newer` is absolute, i.e. exactly the case we don't want.

No change to `pyproject.toml` or `uv.lock` — the 3-day rolling cutoff stays as-is.

## How to test it

The real test is a cloud session, and it needs the environment edited first:

1. At <https://claude.ai/code> → environment selector → edit the `etl` environment → paste the setup script from the updated doc, add `UV_HTTP_TIMEOUT=300`, save. Saving triggers a snapshot rebuild (a few minutes).
2. Start a session on this branch and check the startup banner: it should print `🔧 uv is current (uv 0.11.x …)` rather than upgrading, and `uv sync` should finish in seconds from the warm cache.
3. Ask it to do anything that touches the venv, then `git status` — `uv.lock` must be clean.

Locally, `bash -n scripts/remote_setup.sh` and running the script outside a sandbox (it no-ops unless `CLAUDE_CODE_REMOTE=true`).

Already verified: `make check` passes; the version gate was exercised against real uv 0.8.17, 0.9.x, 0.10.0, 0.11.x and a synthetic 1.0.0 binary; the churn and the clean-lock outcomes in the table above were reproduced by running `uv lock` with each of those versions against a clean worktree. Not verified: the setup script end-to-end in an actual sandbox — that needs someone to edit the environment and start a session.
