### PR TITLE
🐝 sync grapher schema (bump to 011)

### DIFF
--- a/docs/guides/schema-management.md
+++ b/docs/guides/schema-management.md
@@ -17,7 +17,7 @@ When the grapher API changes and requires a new schema version, you need to upda
 
 1. **Update the default schema version** in `etl/config.py`:
    ```python
-   DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
+   DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
    ```
 
 2. **Update schema references** in these files:

--- a/etl/collection/model/schema_types.py
+++ b/etl/collection/model/schema_types.py
@@ -6,7 +6,7 @@ Run `python scripts/generate_schema_types.py` to regenerate.
 
 Provides strongly-typed interfaces for:
 - View configuration (based on multidim-schema.json, resolving $refs against the
-  vendored schemas/grapher-schema.010.json — refresh it with --refresh)
+  vendored schemas/grapher-schema.011.json — refresh it with --refresh)
 - View metadata (based on dataset-schema.json)
 """
 

--- a/etl/config.py
+++ b/etl/config.py
@@ -320,7 +320,7 @@ GITHUB_API_URL = f"{GITHUB_API_BASE}/pulls"
 TLS_VERIFY = bool(int(env.get("TLS_VERIFY", 1)))
 
 # Default schema for presentation.grapher_config in metadata. Try to keep it up to date with the latest schema.
-DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
+DEFAULT_GRAPHER_SCHEMA = "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
 
 # Google Cloud service account path (used for BigQuery)
 GOOGLE_APPLICATION_CREDENTIALS = env.get("GOOGLE_APPLICATION_CREDENTIALS")

--- a/etl/files.py
+++ b/etl/files.py
@@ -429,7 +429,7 @@ def read_json_schema(path: Path | str) -> dict[str, Any]:
 def get_schema_from_url(schema_url: str) -> dict:
     """Get the schema of a chart configuration. Schema URL is saved in config["$schema"] and looks like:
 
-    https://files.ourworldindata.org/schemas/grapher-schema.010.json
+    https://files.ourworldindata.org/schemas/grapher-schema.011.json
 
     More details on available versions can be found
     at https://github.com/owid/owid-grapher/tree/master/packages/%40ourworldindata/grapher/src/schema

--- a/schemas/explorer-schema.json
+++ b/schemas/explorer-schema.json
@@ -238,19 +238,19 @@
                         "description": "A subset of the grapher config.",
                         "properties": {
                             "$schema": {
-                                "$ref": "grapher-schema.010.json#/properties/$schema"
+                                "$ref": "grapher-schema.011.json#/properties/$schema"
                             },
                             "addCountryMode": {
-                                "$ref": "grapher-schema.010.json#/properties/addCountryMode"
+                                "$ref": "grapher-schema.011.json#/properties/addCountryMode"
                             },
                             "compareEndPointsOnly": {
-                                "$ref": "grapher-schema.010.json#/properties/compareEndPointsOnly"
+                                "$ref": "grapher-schema.011.json#/properties/compareEndPointsOnly"
                             },
                             "selectedEntityColors": {
-                                "$ref": "grapher-schema.010.json#/properties/selectedEntityColors"
+                                "$ref": "grapher-schema.011.json#/properties/selectedEntityColors"
                             },
                             "relatedQuestions": {
-                                "$ref": "grapher-schema.010.json#/properties/relatedQuestions"
+                                "$ref": "grapher-schema.011.json#/properties/relatedQuestions"
                             },
                             "relatedQuestionText": {
                                 "type": "string",
@@ -261,155 +261,155 @@
                                 "description": "URL for a related question link"
                             },
                             "title": {
-                                "$ref": "grapher-schema.010.json#/properties/title"
+                                "$ref": "grapher-schema.011.json#/properties/title"
                             },
                             "map": {
-                                "$ref": "grapher-schema.010.json#/properties/map"
+                                "$ref": "grapher-schema.011.json#/properties/map"
                             },
                             "maxTime": {
-                                "$ref": "grapher-schema.010.json#/properties/maxTime"
+                                "$ref": "grapher-schema.011.json#/properties/maxTime"
                             },
                             "subtitle": {
-                                "$ref": "grapher-schema.010.json#/properties/subtitle"
+                                "$ref": "grapher-schema.011.json#/properties/subtitle"
                             },
                             "selectedEntityNames": {
-                                "$ref": "grapher-schema.010.json#/properties/selectedEntityNames"
+                                "$ref": "grapher-schema.011.json#/properties/selectedEntityNames"
                             },
                             "focusedSeriesNames": {
-                                "$ref": "grapher-schema.010.json#/properties/focusedSeriesNames"
+                                "$ref": "grapher-schema.011.json#/properties/focusedSeriesNames"
                             },
                             "baseColorScheme": {
-                                "$ref": "grapher-schema.010.json#/properties/baseColorScheme"
+                                "$ref": "grapher-schema.011.json#/properties/baseColorScheme"
                             },
                             "yAxis": {
-                                "$ref": "grapher-schema.010.json#/properties/yAxis"
+                                "$ref": "grapher-schema.011.json#/properties/yAxis"
                             },
                             "tab": {
-                                "$ref": "grapher-schema.010.json#/properties/tab"
+                                "$ref": "grapher-schema.011.json#/properties/tab"
                             },
                             "matchingEntitiesOnly": {
-                                "$ref": "grapher-schema.010.json#/properties/matchingEntitiesOnly"
+                                "$ref": "grapher-schema.011.json#/properties/matchingEntitiesOnly"
                             },
                             "hideLogo": {
-                                "$ref": "grapher-schema.010.json#/properties/hideLogo"
+                                "$ref": "grapher-schema.011.json#/properties/hideLogo"
                             },
                             "timelineMinTime": {
-                                "$ref": "grapher-schema.010.json#/properties/timelineMinTime"
+                                "$ref": "grapher-schema.011.json#/properties/timelineMinTime"
                             },
                             "variantName": {
-                                "$ref": "grapher-schema.010.json#/properties/variantName"
+                                "$ref": "grapher-schema.011.json#/properties/variantName"
                             },
                             "hideTimeline": {
-                                "$ref": "grapher-schema.010.json#/properties/hideTimeline"
+                                "$ref": "grapher-schema.011.json#/properties/hideTimeline"
                             },
                             "originUrl": {
-                                "$ref": "grapher-schema.010.json#/properties/originUrl"
+                                "$ref": "grapher-schema.011.json#/properties/originUrl"
                             },
                             "license": {
-                                "$ref": "grapher-schema.010.json#/properties/license"
+                                "$ref": "grapher-schema.011.json#/properties/license"
                             },
                             "colorScale": {
-                                "$ref": "grapher-schema.010.json#/properties/colorScale"
+                                "$ref": "grapher-schema.011.json#/properties/colorScale"
                             },
                             "scatterPointLabelStrategy": {
-                                "$ref": "grapher-schema.010.json#/properties/scatterPointLabelStrategy"
+                                "$ref": "grapher-schema.011.json#/properties/scatterPointLabelStrategy"
                             },
                             "selectedFacetStrategy": {
-                                "$ref": "grapher-schema.010.json#/properties/selectedFacetStrategy"
+                                "$ref": "grapher-schema.011.json#/properties/selectedFacetStrategy"
                             },
                             "sourceDesc": {
-                                "$ref": "grapher-schema.010.json#/properties/sourceDesc"
+                                "$ref": "grapher-schema.011.json#/properties/sourceDesc"
                             },
                             "invertColorScheme": {
-                                "$ref": "grapher-schema.010.json#/properties/invertColorScheme"
+                                "$ref": "grapher-schema.011.json#/properties/invertColorScheme"
                             },
                             "hideRelativeToggle": {
-                                "$ref": "grapher-schema.010.json#/properties/hideRelativeToggle"
+                                "$ref": "grapher-schema.011.json#/properties/hideRelativeToggle"
                             },
                             "comparisonLines": {
-                                "$ref": "grapher-schema.010.json#/properties/comparisonLines"
+                                "$ref": "grapher-schema.011.json#/properties/comparisonLines"
                             },
                             "internalNotes": {
-                                "$ref": "grapher-schema.010.json#/properties/internalNotes"
+                                "$ref": "grapher-schema.011.json#/properties/internalNotes"
                             },
                             "version": {
-                                "$ref": "grapher-schema.010.json#/properties/version"
+                                "$ref": "grapher-schema.011.json#/properties/version"
                             },
                             "logo": {
-                                "$ref": "grapher-schema.010.json#/properties/logo"
+                                "$ref": "grapher-schema.011.json#/properties/logo"
                             },
                             "entityType": {
-                                "$ref": "grapher-schema.010.json#/properties/entityType"
+                                "$ref": "grapher-schema.011.json#/properties/entityType"
                             },
                             "facettingLabelByYVariables": {
-                                "$ref": "grapher-schema.010.json#/properties/facettingLabelByYVariables"
+                                "$ref": "grapher-schema.011.json#/properties/facettingLabelByYVariables"
                             },
                             "note": {
-                                "$ref": "grapher-schema.010.json#/properties/note"
+                                "$ref": "grapher-schema.011.json#/properties/note"
                             },
                             "chartTypes": {
-                                "$ref": "grapher-schema.010.json#/properties/chartTypes"
+                                "$ref": "grapher-schema.011.json#/properties/chartTypes"
                             },
                             "hasMapTab": {
-                                "$ref": "grapher-schema.010.json#/properties/hasMapTab"
+                                "$ref": "grapher-schema.011.json#/properties/hasMapTab"
                             },
                             "stackMode": {
-                                "$ref": "grapher-schema.010.json#/properties/stackMode"
+                                "$ref": "grapher-schema.011.json#/properties/stackMode"
                             },
                             "minTime": {
-                                "$ref": "grapher-schema.010.json#/properties/minTime"
+                                "$ref": "grapher-schema.011.json#/properties/minTime"
                             },
                             "hideAnnotationFieldsInTitle": {
                                 "type": "boolean",
                                 "description": "Whether to hide annotation fields in the title"
                             },
                             "excludedEntityNames": {
-                                "$ref": "grapher-schema.010.json#/properties/excludedEntityNames"
+                                "$ref": "grapher-schema.011.json#/properties/excludedEntityNames"
                             },
                             "xAxis": {
-                                "$ref": "grapher-schema.010.json#/properties/xAxis"
+                                "$ref": "grapher-schema.011.json#/properties/xAxis"
                             },
                             "timelineMaxTime": {
-                                "$ref": "grapher-schema.010.json#/properties/timelineMaxTime"
+                                "$ref": "grapher-schema.011.json#/properties/timelineMaxTime"
                             },
                             "hideConnectedScatterLines": {
-                                "$ref": "grapher-schema.010.json#/properties/hideConnectedScatterLines"
+                                "$ref": "grapher-schema.011.json#/properties/hideConnectedScatterLines"
                             },
                             "showNoDataArea": {
-                                "$ref": "grapher-schema.010.json#/properties/showNoDataArea"
+                                "$ref": "grapher-schema.011.json#/properties/showNoDataArea"
                             },
                             "zoomToSelection": {
-                                "$ref": "grapher-schema.010.json#/properties/zoomToSelection"
+                                "$ref": "grapher-schema.011.json#/properties/zoomToSelection"
                             },
                             "showYearLabels": {
-                                "$ref": "grapher-schema.010.json#/properties/showYearLabels"
+                                "$ref": "grapher-schema.011.json#/properties/showYearLabels"
                             },
                             "hideTotalValueLabel": {
-                                "$ref": "grapher-schema.010.json#/properties/hideTotalValueLabel"
+                                "$ref": "grapher-schema.011.json#/properties/hideTotalValueLabel"
                             },
                             "hideScatterLabels": {
-                                "$ref": "grapher-schema.010.json#/properties/hideScatterLabels"
+                                "$ref": "grapher-schema.011.json#/properties/hideScatterLabels"
                             },
                             "sortBy": {
-                                "$ref": "grapher-schema.010.json#/properties/sortBy"
+                                "$ref": "grapher-schema.011.json#/properties/sortBy"
                             },
                             "sortOrder": {
-                                "$ref": "grapher-schema.010.json#/properties/sortOrder"
+                                "$ref": "grapher-schema.011.json#/properties/sortOrder"
                             },
                             "sortColumnSlug": {
-                                "$ref": "grapher-schema.010.json#/properties/sortColumnSlug"
+                                "$ref": "grapher-schema.011.json#/properties/sortColumnSlug"
                             },
                             "hideFacetControl": {
-                                "$ref": "grapher-schema.010.json#/properties/hideFacetControl"
+                                "$ref": "grapher-schema.011.json#/properties/hideFacetControl"
                             },
                             "includedEntityNames": {
-                                "$ref": "grapher-schema.010.json#/properties/includedEntityNames"
+                                "$ref": "grapher-schema.011.json#/properties/includedEntityNames"
                             },
                             "entityTypePlural": {
-                                "$ref": "grapher-schema.010.json#/properties/entityTypePlural"
+                                "$ref": "grapher-schema.011.json#/properties/entityTypePlural"
                             },
                             "missingDataStrategy": {
-                                "$ref": "grapher-schema.010.json#/properties/missingDataStrategy"
+                                "$ref": "grapher-schema.011.json#/properties/missingDataStrategy"
                             },
                             "yScaleToggle": {
                                 "type": "boolean",

--- a/schemas/grapher-schema.011.json
+++ b/schemas/grapher-schema.011.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+  "$id": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
   "required": [
     "$schema",
     "dimensions"
@@ -12,8 +12,8 @@
       "type": "string",
       "description": "Url of the concrete schema version to use to validate this document",
       "format": "uri",
-      "default": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
-      "const": "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
+      "default": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
+      "const": "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
     },
     "id": {
       "type": "integer",
@@ -158,11 +158,6 @@
                   "year",
                   "decade"
                 ]
-              },
-              "yearIsDay": {
-                "type": "boolean",
-                "default": false,
-                "description": "(Deprecated, use timeInterval instead) Switch to indicate if the number in the year column represents a day (since zeroDay) or not i.e. a year"
               },
               "color": {
                 "type": "string",

--- a/schemas/multidim-schema.json
+++ b/schemas/multidim-schema.json
@@ -77,12 +77,12 @@
                 ]
             ],
             "examples": [
-                "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
+                "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
             ],
             "examples_bad": [
                 [
                     "http://invalid-url.com/schema.json",
-                    "grapher-schema.010.json"
+                    "grapher-schema.011.json"
                 ]
             ]
         },
@@ -720,175 +720,175 @@
                         ],
                         "properties": {
                             "$schema": {
-                                "$ref": "grapher-schema.010.json#/properties/$schema"
+                                "$ref": "grapher-schema.011.json#/properties/$schema"
                             },
                             "addCountryMode": {
-                                "$ref": "grapher-schema.010.json#/properties/addCountryMode"
+                                "$ref": "grapher-schema.011.json#/properties/addCountryMode"
                             },
                             "compareEndPointsOnly": {
-                                "$ref": "grapher-schema.010.json#/properties/compareEndPointsOnly"
+                                "$ref": "grapher-schema.011.json#/properties/compareEndPointsOnly"
                             },
                             "selectedEntityColors": {
-                                "$ref": "grapher-schema.010.json#/properties/selectedEntityColors"
+                                "$ref": "grapher-schema.011.json#/properties/selectedEntityColors"
                             },
                             "relatedQuestions": {
-                                "$ref": "grapher-schema.010.json#/properties/relatedQuestions"
+                                "$ref": "grapher-schema.011.json#/properties/relatedQuestions"
                             },
                             "title": {
-                                "$ref": "grapher-schema.010.json#/properties/title"
+                                "$ref": "grapher-schema.011.json#/properties/title"
                             },
                             "map": {
-                                "$ref": "grapher-schema.010.json#/properties/map"
+                                "$ref": "grapher-schema.011.json#/properties/map"
                             },
                             "maxTime": {
-                                "$ref": "grapher-schema.010.json#/properties/maxTime"
+                                "$ref": "grapher-schema.011.json#/properties/maxTime"
                             },
                             "subtitle": {
-                                "$ref": "grapher-schema.010.json#/properties/subtitle"
+                                "$ref": "grapher-schema.011.json#/properties/subtitle"
                             },
                             "selectedEntityNames": {
-                                "$ref": "grapher-schema.010.json#/properties/selectedEntityNames"
+                                "$ref": "grapher-schema.011.json#/properties/selectedEntityNames"
                             },
                             "focusedSeriesNames": {
-                                "$ref": "grapher-schema.010.json#/properties/focusedSeriesNames"
+                                "$ref": "grapher-schema.011.json#/properties/focusedSeriesNames"
                             },
                             "baseColorScheme": {
-                                "$ref": "grapher-schema.010.json#/properties/baseColorScheme"
+                                "$ref": "grapher-schema.011.json#/properties/baseColorScheme"
                             },
                             "yAxis": {
-                                "$ref": "grapher-schema.010.json#/properties/yAxis"
+                                "$ref": "grapher-schema.011.json#/properties/yAxis"
                             },
                             "tab": {
-                                "$ref": "grapher-schema.010.json#/properties/tab"
+                                "$ref": "grapher-schema.011.json#/properties/tab"
                             },
                             "matchingEntitiesOnly": {
-                                "$ref": "grapher-schema.010.json#/properties/matchingEntitiesOnly"
+                                "$ref": "grapher-schema.011.json#/properties/matchingEntitiesOnly"
                             },
                             "hideSeriesLabels": {
-                                "$ref": "grapher-schema.010.json#/properties/hideSeriesLabels"
+                                "$ref": "grapher-schema.011.json#/properties/hideSeriesLabels"
                             },
                             "hideLogo": {
-                                "$ref": "grapher-schema.010.json#/properties/hideLogo"
+                                "$ref": "grapher-schema.011.json#/properties/hideLogo"
                             },
                             "timelineMinTime": {
-                                "$ref": "grapher-schema.010.json#/properties/timelineMinTime"
+                                "$ref": "grapher-schema.011.json#/properties/timelineMinTime"
                             },
                             "variantName": {
-                                "$ref": "grapher-schema.010.json#/properties/variantName"
+                                "$ref": "grapher-schema.011.json#/properties/variantName"
                             },
                             "hideTimeline": {
-                                "$ref": "grapher-schema.010.json#/properties/hideTimeline"
+                                "$ref": "grapher-schema.011.json#/properties/hideTimeline"
                             },
                             "originUrl": {
-                                "$ref": "grapher-schema.010.json#/properties/originUrl"
+                                "$ref": "grapher-schema.011.json#/properties/originUrl"
                             },
                             "license": {
-                                "$ref": "grapher-schema.010.json#/properties/license"
+                                "$ref": "grapher-schema.011.json#/properties/license"
                             },
                             "colorScale": {
-                                "$ref": "grapher-schema.010.json#/properties/colorScale"
+                                "$ref": "grapher-schema.011.json#/properties/colorScale"
                             },
                             "scatterPointLabelStrategy": {
-                                "$ref": "grapher-schema.010.json#/properties/scatterPointLabelStrategy"
+                                "$ref": "grapher-schema.011.json#/properties/scatterPointLabelStrategy"
                             },
                             "selectedFacetStrategy": {
-                                "$ref": "grapher-schema.010.json#/properties/selectedFacetStrategy"
+                                "$ref": "grapher-schema.011.json#/properties/selectedFacetStrategy"
                             },
                             "sourceDesc": {
-                                "$ref": "grapher-schema.010.json#/properties/sourceDesc"
+                                "$ref": "grapher-schema.011.json#/properties/sourceDesc"
                             },
                             "invertColorScheme": {
-                                "$ref": "grapher-schema.010.json#/properties/invertColorScheme"
+                                "$ref": "grapher-schema.011.json#/properties/invertColorScheme"
                             },
                             "hideRelativeToggle": {
-                                "$ref": "grapher-schema.010.json#/properties/hideRelativeToggle"
+                                "$ref": "grapher-schema.011.json#/properties/hideRelativeToggle"
                             },
                             "comparisonLines": {
-                                "$ref": "grapher-schema.010.json#/properties/comparisonLines"
+                                "$ref": "grapher-schema.011.json#/properties/comparisonLines"
                             },
                             "internalNotes": {
-                                "$ref": "grapher-schema.010.json#/properties/internalNotes"
+                                "$ref": "grapher-schema.011.json#/properties/internalNotes"
                             },
                             "version": {
-                                "$ref": "grapher-schema.010.json#/properties/version"
+                                "$ref": "grapher-schema.011.json#/properties/version"
                             },
                             "logo": {
-                                "$ref": "grapher-schema.010.json#/properties/logo"
+                                "$ref": "grapher-schema.011.json#/properties/logo"
                             },
                             "entityType": {
-                                "$ref": "grapher-schema.010.json#/properties/entityType"
+                                "$ref": "grapher-schema.011.json#/properties/entityType"
                             },
                             "facettingLabelByYVariables": {
-                                "$ref": "grapher-schema.010.json#/properties/facettingLabelByYVariables"
+                                "$ref": "grapher-schema.011.json#/properties/facettingLabelByYVariables"
                             },
                             "note": {
-                                "$ref": "grapher-schema.010.json#/properties/note"
+                                "$ref": "grapher-schema.011.json#/properties/note"
                             },
                             "chartTypes": {
-                                "$ref": "grapher-schema.010.json#/properties/chartTypes"
+                                "$ref": "grapher-schema.011.json#/properties/chartTypes"
                             },
                             "dumbbell": {
-                                "$ref": "grapher-schema.010.json#/properties/dumbbell"
+                                "$ref": "grapher-schema.011.json#/properties/dumbbell"
                             },
                             "hasMapTab": {
-                                "$ref": "grapher-schema.010.json#/properties/hasMapTab"
+                                "$ref": "grapher-schema.011.json#/properties/hasMapTab"
                             },
                             "stackMode": {
-                                "$ref": "grapher-schema.010.json#/properties/stackMode"
+                                "$ref": "grapher-schema.011.json#/properties/stackMode"
                             },
                             "minTime": {
-                                "$ref": "grapher-schema.010.json#/properties/minTime"
+                                "$ref": "grapher-schema.011.json#/properties/minTime"
                             },
                             "hideAnnotationFieldsInTitle": {
-                                "$ref": "grapher-schema.010.json#/properties/hideAnnotationFieldsInTitle"
+                                "$ref": "grapher-schema.011.json#/properties/hideAnnotationFieldsInTitle"
                             },
                             "excludedEntityNames": {
-                                "$ref": "grapher-schema.010.json#/properties/excludedEntityNames"
+                                "$ref": "grapher-schema.011.json#/properties/excludedEntityNames"
                             },
                             "xAxis": {
-                                "$ref": "grapher-schema.010.json#/properties/xAxis"
+                                "$ref": "grapher-schema.011.json#/properties/xAxis"
                             },
                             "timelineMaxTime": {
-                                "$ref": "grapher-schema.010.json#/properties/timelineMaxTime"
+                                "$ref": "grapher-schema.011.json#/properties/timelineMaxTime"
                             },
                             "hideConnectedScatterLines": {
-                                "$ref": "grapher-schema.010.json#/properties/hideConnectedScatterLines"
+                                "$ref": "grapher-schema.011.json#/properties/hideConnectedScatterLines"
                             },
                             "showNoDataArea": {
-                                "$ref": "grapher-schema.010.json#/properties/showNoDataArea"
+                                "$ref": "grapher-schema.011.json#/properties/showNoDataArea"
                             },
                             "zoomToSelection": {
-                                "$ref": "grapher-schema.010.json#/properties/zoomToSelection"
+                                "$ref": "grapher-schema.011.json#/properties/zoomToSelection"
                             },
                             "showYearLabels": {
-                                "$ref": "grapher-schema.010.json#/properties/showYearLabels"
+                                "$ref": "grapher-schema.011.json#/properties/showYearLabels"
                             },
                             "hideTotalValueLabel": {
-                                "$ref": "grapher-schema.010.json#/properties/hideTotalValueLabel"
+                                "$ref": "grapher-schema.011.json#/properties/hideTotalValueLabel"
                             },
                             "hideScatterLabels": {
-                                "$ref": "grapher-schema.010.json#/properties/hideScatterLabels"
+                                "$ref": "grapher-schema.011.json#/properties/hideScatterLabels"
                             },
                             "sortBy": {
-                                "$ref": "grapher-schema.010.json#/properties/sortBy"
+                                "$ref": "grapher-schema.011.json#/properties/sortBy"
                             },
                             "sortOrder": {
-                                "$ref": "grapher-schema.010.json#/properties/sortOrder"
+                                "$ref": "grapher-schema.011.json#/properties/sortOrder"
                             },
                             "sortColumnSlug": {
-                                "$ref": "grapher-schema.010.json#/properties/sortColumnSlug"
+                                "$ref": "grapher-schema.011.json#/properties/sortColumnSlug"
                             },
                             "hideFacetControl": {
-                                "$ref": "grapher-schema.010.json#/properties/hideFacetControl"
+                                "$ref": "grapher-schema.011.json#/properties/hideFacetControl"
                             },
                             "includedEntityNames": {
-                                "$ref": "grapher-schema.010.json#/properties/includedEntityNames"
+                                "$ref": "grapher-schema.011.json#/properties/includedEntityNames"
                             },
                             "entityTypePlural": {
-                                "$ref": "grapher-schema.010.json#/properties/entityTypePlural"
+                                "$ref": "grapher-schema.011.json#/properties/entityTypePlural"
                             },
                             "missingDataStrategy": {
-                                "$ref": "grapher-schema.010.json#/properties/missingDataStrategy"
+                                "$ref": "grapher-schema.011.json#/properties/missingDataStrategy"
                             }
                         },
                         "additionalProperties": false
@@ -985,7 +985,7 @@
                             "Common overrides include name, unit, and color settings."
                         ]
                     ],
-                    "$ref": "grapher-schema.010.json#/properties/dimensions/items/properties/display"
+                    "$ref": "grapher-schema.011.json#/properties/dimensions/items/properties/display"
                 }
             },
             "required": [

--- a/tests/test_indicator_upgrade_schema.py
+++ b/tests/test_indicator_upgrade_schema.py
@@ -40,7 +40,7 @@ def test_map_column_slug_is_updated_when_stored_as_string():
     }
 
     config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "id": 755,
         "hasMapTab": True,
         "map": {"columnSlug": "100"},  # stored as a string, as it is in real configs
@@ -87,7 +87,7 @@ def test_dimension_display_stripped_against_variable_baseline():
     }
 
     config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "id": 755,
         "dimensions": [
             {
@@ -129,7 +129,7 @@ def test_inheritance_pruning_uses_patch_not_full_config():
     # `full`: the resolved config as chart.config would present it -- title is present only
     # because it's inherited from the *old* indicator, never set by the chart itself.
     full_config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "id": 755,
         "isInheritanceEnabled": True,
         "title": "Old indicator title",
@@ -137,13 +137,13 @@ def test_inheritance_pruning_uses_patch_not_full_config():
     }
     # The chart's *actual* stored patch never touched title at all.
     original_patch = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "id": 755,
         "dimensions": [{"variableId": 100, "property": "y"}],
     }
     # The new indicator has since renamed its title.
     indicator_config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "title": "New indicator title",
     }
 
@@ -193,7 +193,7 @@ def test_inheritance_preserves_schema_default_overrides():
     # Chart has inheritance enabled; user disabled map (hasMapTab=false)
     # even though the indicator's ETL config has hasMapTab=true.
     config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "id": 7742,
         "version": 1,
         "isInheritanceEnabled": True,
@@ -257,7 +257,7 @@ def test_inheritance_with_indicator_config_preserves_real_overrides():
     schema = _inheritance_schema()
 
     config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "id": 7742,
         "version": 1,
         "isInheritanceEnabled": True,
@@ -265,7 +265,7 @@ def test_inheritance_with_indicator_config_preserves_real_overrides():
         "dimensions": [{"variableId": 100, "property": "y"}],
     }
     indicator_config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "hasMapTab": True,
     }
 
@@ -283,7 +283,7 @@ def test_inheritance_with_indicator_config_strips_untouched_fields():
     schema = _inheritance_schema()
 
     config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "id": 7742,
         "version": 1,
         "isInheritanceEnabled": True,
@@ -293,7 +293,7 @@ def test_inheritance_with_indicator_config_strips_untouched_fields():
     # Indicator never sets hideLogo or map.colorScale.midpoint either -- both should
     # resolve to their schema defaults on both sides and therefore get stripped.
     indicator_config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "hasMapTab": True,
     }
 
@@ -315,7 +315,7 @@ def test_inheritance_with_indicator_config_strips_redundant_explicit_match():
     schema = _inheritance_schema()
 
     config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "id": 7742,
         "version": 1,
         "isInheritanceEnabled": True,
@@ -323,7 +323,7 @@ def test_inheritance_with_indicator_config_strips_redundant_explicit_match():
         "dimensions": [{"variableId": 100, "property": "y"}],
     }
     indicator_config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "hasMapTab": True,
     }
 
@@ -345,7 +345,7 @@ def test_inheritance_with_empty_indicator_config_does_not_crash():
     schema["required"] = ["$schema", "dimensions"]
 
     config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "id": 7742,
         "version": 1,
         "isInheritanceEnabled": True,
@@ -386,7 +386,7 @@ def test_no_inheritance_strips_schema_defaults():
     }
 
     config = {
-        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.010.json",
+        "$schema": "https://files.ourworldindata.org/schemas/grapher-schema.011.json",
         "id": 7742,
         "version": 1,
         "hasMapTab": False,


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

Upstream published a new grapher schema version, `grapher-schema.011.json`, so this bumps ETL's pinned version from `010`.

### Upstream diff (`010` → `011`)

Only one substantive change: `display.yearIsDay` is gone. It had been deprecated in favour of `display.timeInterval`, and ETL already dropped support for it in d334f7fee, so nothing in this repo relied on it. Everything else is the `$id` / `$schema` version string.

### Files touched

| File | Change |
|---|---|
| `schemas/grapher-schema.011.json` | New vendored copy (`--refresh`); `grapher-schema.010.json` removed |
| `schemas/multidim-schema.json`, `schemas/explorer-schema.json` | All `$ref`s repointed to the `011` filename |
| `etl/config.py` | `DEFAULT_GRAPHER_SCHEMA` → `011` |
| `etl/collection/model/schema_types.py` | Regenerated (docstring only — no type changes, since `yearIsDay` was never exposed there) |
| `schemas/dataset-schema.json` | No change needed — the embedded `grapher_config` block already had no `yearIsDay` |
| `etl/files.py`, `docs/guides/schema-management.md`, `tests/test_indicator_upgrade_schema.py` | Stale `010` references in a docstring, a doc example, and test fixtures |

Historical mentions of `010` (e.g. "dumbbell plots landed in `grapher-schema.010.json`") were left alone.

### Verification

- `tests/test_schema_types_generation.py` and `tests/test_metadata_schemas.py` pass, including `test_grapher_config_schema_sync`.
- `test_no_newer_grapher_schema_version` now passes against upstream `grapher-schema.latest.json`, confirming `011` is current.
- Full unit suite (605 tests) and `make check` are green.