### PR TITLE
♻️ Repoint producer analytics to renamed BQ dataset prod_ga4

### DIFF
--- a/apps/wizard/app_pages/producer_analytics/data_io.py
+++ b/apps/wizard/app_pages/producer_analytics/data_io.py
@@ -98,7 +98,7 @@ def get_chart_views_from_bq(
     query = f"""
         SELECT
             {select_clause}
-        FROM prod_google_analytics4.grapher_views_by_day_page_grapher_device_country_iframe
+        FROM prod_ga4.grapher_views_by_day_page_grapher_device_country_iframe
         WHERE
             day >= '{date_start}'
             AND day <= '{date_end}'


### PR DESCRIPTION
owid/analytics renamed the GA dbt dataset `prod_google_analytics4` → `prod_ga4` ([owid/analytics#969](https://github.com/owid/analytics/pull/969)). This repoints the producer-analytics wizard's one reference.

No behavior change: the table is byte-identical (the old name currently resolves through a shim view to the same data). The shim will be dropped after a query-log audit (~2–4 weeks), at which point the old name would 404 — hence this repoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)