### PR TITLE
🐛 Fix UCDP multidim description_key str or list handling

### DIFF
--- a/etl/steps/export/multidim/war/latest/ucdp.py
+++ b/etl/steps/export/multidim/war/latest/ucdp.py
@@ -279,6 +279,20 @@ def adjust_dimensions(tb):
     return tb
 
 
+def _description_key_as_list(description_key) -> list[str]:
+    # `description_key` may be the new free-form markdown string or a legacy list of bullets
+    # (see owid.catalog.core.meta.description_key_to_string). Normalize to a list of bullets so
+    # the list-based logic below keeps working.
+    if description_key is None:
+        return []
+    if isinstance(description_key, list):
+        return description_key
+    text = description_key.strip()
+    if text.startswith("- "):
+        return [item.strip() for item in text[2:].split("\n- ")]
+    return [text]
+
+
 def _set_description_key(view, tb):
     if view.d.conflict_type in ("all", "all_stacked"):
         column = "number_deaths_ongoing_conflicts__conflict_type_all"
@@ -290,7 +304,7 @@ def _set_description_key(view, tb):
         column = "number_deaths_ongoing_conflicts__conflict_type_non_state_conflict"
     else:
         return []
-    keys = tb[column].m.description_key
+    keys = _description_key_as_list(tb[column].m.description_key)
 
     if (view.d.estimate == "best_ci") or (view.d.indicator == "num_conflicts"):
         assert keys[-1].startswith('We show here the "best" death')

--- a/etl/steps/export/multidim/war/latest/ucdp_prio.py
+++ b/etl/steps/export/multidim/war/latest/ucdp_prio.py
@@ -256,23 +256,41 @@ def edit_faust(c, tb_ucdp, tb_up, region_names):
     )
 
 
+def _description_key_as_list(description_key) -> list[str]:
+    # `description_key` may be the new free-form markdown string or a legacy list of bullets
+    # (see owid.catalog.core.meta.description_key_to_string). Normalize to a list of bullets so
+    # the list-based logic below keeps working.
+    if description_key is None:
+        return []
+    if isinstance(description_key, list):
+        return description_key
+    text = description_key.strip()
+    if text.startswith("- "):
+        return [item.strip() for item in text[2:].split("\n- ")]
+    return [text]
+
+
 def _set_description_key(view, tb_ucdp, tb_up):
     UCDP_ONLY = "[Uppsala Conflict Data Program (UCDP)](https://ucdp.uu.se/)"
     UCDP_AND_PRIO = f"{UCDP_ONLY} and the [Peace Research Institute Oslo (PRIO)](https://www.prio.org/data/1)"
     keys = None
     if (view.d.conflict_type == "state_based_stacked") or (view.d.estimate == "best_ci"):
         if view.d.indicator == "deaths":
-            keys = tb_up["number_deaths_ongoing_conflicts__conflict_type_state_based"].metadata.description_key
+            keys = _description_key_as_list(
+                tb_up["number_deaths_ongoing_conflicts__conflict_type_state_based"].metadata.description_key
+            )
         elif view.d.indicator == "death_rate":
-            keys = tb_up[
-                "number_deaths_ongoing_conflicts_per_capita__conflict_type_state_based"
-            ].metadata.description_key
+            keys = _description_key_as_list(
+                tb_up["number_deaths_ongoing_conflicts_per_capita__conflict_type_state_based"].metadata.description_key
+            )
         elif view.d.indicator == "wars_ongoing":
-            keys = tb_ucdp["number_ongoing_conflicts__conflict_type_all"].metadata.description_key + [TEXT_KEY_EXTRA]
+            keys = _description_key_as_list(
+                tb_ucdp["number_ongoing_conflicts__conflict_type_all"].metadata.description_key
+            ) + [TEXT_KEY_EXTRA]
         elif view.d.indicator == "wars_ongoing_country_rate":
-            keys = tb_ucdp["number_ongoing_conflicts_per_country__conflict_type_all"].metadata.description_key + [
-                TEXT_KEY_EXTRA
-            ]
+            keys = _description_key_as_list(
+                tb_ucdp["number_ongoing_conflicts_per_country__conflict_type_all"].metadata.description_key
+            ) + [TEXT_KEY_EXTRA]
         else:
             raise ValueError(f"Unknown indicator: {view.d.indicator}")
 
@@ -282,12 +300,14 @@ def _set_description_key(view, tb_ucdp, tb_up):
 
     elif view.d.indicator == "wars_ongoing":
         ctype = view.d.conflict_type.replace(" ", "_").replace("-", "_").replace("(", "_").lower().strip(")")
-        keys = tb_ucdp[f"number_ongoing_conflicts__conflict_type_{ctype}"].metadata.description_key + [TEXT_KEY_EXTRA]
+        keys = _description_key_as_list(
+            tb_ucdp[f"number_ongoing_conflicts__conflict_type_{ctype}"].metadata.description_key
+        ) + [TEXT_KEY_EXTRA]
     elif view.d.indicator == "wars_ongoing_country_rate":
         ctype = view.d.conflict_type.replace(" ", "_").replace("-", "_").replace("(", "_").lower().strip(")")
-        keys = tb_ucdp[f"number_ongoing_conflicts_per_country__conflict_type_{ctype}"].metadata.description_key + [
-            TEXT_KEY_EXTRA
-        ]
+        keys = _description_key_as_list(
+            tb_ucdp[f"number_ongoing_conflicts_per_country__conflict_type_{ctype}"].metadata.description_key
+        ) + [TEXT_KEY_EXTRA]
 
     if keys is not None:
         for i, key in enumerate(keys):


### PR DESCRIPTION
## Human summary

Hey @lucasrodes a UCDP step was failing in production (my regions PR triggered this). I've created this temporary solution to unblock production, but I haven't looked into the root of the problem. Feel free to tackle it whenever you have some time. Thanks!

> _Written by Claude Code (Opus 4.8), @pabloarosado at the wheel._

## Problem (prod-blocking)

The `Build mdims and explorers` phase of the production ETL deploy crashes on the war UCDP multidims (`export://multidim/war/latest/ucdp` and `ucdp_prio`):

- `ucdp_prio.py`: `…metadata.description_key + [TEXT_KEY_EXTRA]` → `TypeError: can only concatenate str (not "list") to str`
- `ucdp.py`: `assert keys[-1].startswith('We show here the "best" death')` → `AssertionError` (matching the last *character* of a string)

## Cause

`description_key` is now allowed to be either the new free-form **markdown string** or a legacy **list** of bullets. These two steps still assume it's always a list. They'd been dormant because the mdims hadn't been rebuilt since the format change; a DAG-wide rebuild (from an unrelated regions-dataset merge) forced the rebuild and surfaced the latent bug.

## Fix

Add a small `_description_key_as_list()` normalizer in each step that reconstructs the bullet list from the markdown string (inverse of `owid.catalog.core.meta.description_key_to_string`), and wrap every `description_key` read with it. All the existing strip/append/replace logic is then unchanged.

## Verification

- Round-tripped the normalizer against `description_key_to_string`: multi-item strings reconstruct to the exact bullet list (so the `…"best" death…` caveat is correctly the last element and the asserts pass), single-item prose → one bullet, `None` → `[]`, and existing lists pass through untouched.
- `make check` passes (lint, format, types).
- The full export step needs the grapher DB + the whole war chain, so it isn't runnable in isolation locally — the staging build on this PR exercises the `Build mdims` phase end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)