### PR TITLE
📜 Slim down CLAUDE.md with lazy-loaded guidance

### DIFF
--- a/.claude/rules/sanity-checks.md
+++ b/.claude/rules/sanity-checks.md
@@ -1,6 +1,10 @@
-# Writing ETL steps
+---
+paths:
+  - "etl/steps/**/*.py"
+  - "snapshots/**/*.py"
+---
 
-## Sanity checks
+# Sanity checks in ETL steps and snapshots
 
 Silent data corruption is one of the easier bugs to miss. A step can run cleanly, pass type checks, and ship to staging while producing wrong numbers — and by the time someone notices on a chart, the bad data may already be live. Sanity checks are how we catch that at build time instead.
 
@@ -9,7 +13,7 @@ Silent data corruption is one of the easier bugs to miss. A step can run cleanly
 ### Where they go
 
 - **Garden** is the main home. The input tables, the transformations, and the output table are all in one place, and that's where business logic lives. Put one `sanity_check_inputs(...)` right after loading meadow tables (before any transform), and one `sanity_check_outputs(...)` right before `paths.create_dataset(...)`. Call both from `run()`. See `etl/steps/data/garden/rff/2026-06-10/emissions_weighted_carbon_price.py` for a clean, recent example.
-- **Snapshot** usually doesn't need checks — most snapshots just download and write. But when the snapshot itself does non-trivial parsing (PDF tables, custom binary formats, scraping), add integrity checks right before `snap.create_snapshot(...)`. If the parser can produce silently-wrong rows, the snapshot is the only place to catch it before the bad rows leak into meadow. (Snapshot scripts live in `snapshots/`, outside this directory.)
+- **Snapshot** usually doesn't need checks — most snapshots just download and write. But when the snapshot itself does non-trivial parsing (PDF tables, custom binary formats, scraping), add integrity checks right before `snap.create_snapshot(...)`. If the parser can produce silently-wrong rows, the snapshot is the only place to catch it before the bad rows leak into meadow.
 - **Meadow** should stay light. If you find yourself wanting checks there, it usually means the logic belongs in garden instead.
 
 ### How they look

--- a/.claude/skills/query-grapher-db/SKILL.md
+++ b/.claude/skills/query-grapher-db/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: query-grapher-db
+description: Query the grapher MySQL database (local dev, a branch's staging server, or production via the public Datasette) and verify indicators and charts on a staging server. Use when you need to run SQL against grapher, find which charts use an indicator, assess the blast radius of a data fix, or check that a chart/indicator renders correctly on staging-site-<branch>.
+metadata:
+  internal: true
+---
+
+# Querying grapher MySQL and verifying charts on staging
+
+## Quick queries (staging)
+
+```bash
+make query SQL="SELECT COUNT(*) FROM variables WHERE catalogPath IS NULL"
+```
+
+Automatically connects to `staging-site-{branch}` based on current git branch.
+
+## Python (for more control)
+
+```python
+from etl.config import OWID_ENV
+df = OWID_ENV.read_sql("SELECT * FROM datasets LIMIT 10")
+```
+
+**Prefer Python when the SQL contains `%` (LIKE patterns, JSON_EXTRACT paths) or single-quoted strings — `make query` re-interprets those via shell + make and breaks unpredictably.** Use `params={...}` for `%`/quoted values to dodge pymysql's own `%`-format-string parsing.
+
+**`OWID_ENV` targets your local dev DB even when you're on a branch.** To query the branch's staging DB from Python, use `OWIDEnv.from_staging('<branch>')` (`from etl.config import OWIDEnv`) — e.g. `OWIDEnv.from_staging('my-branch').read_sql(...)`. Also note `make query` shells out to the `mysql` CLI, which may not be installed; if it errors with `mysql: command not found`, use the Python `from_staging(...).read_sql(...)` path instead.
+
+## Production queries via public Datasette
+
+When you need production data (which charts use an indicator, chart configs, gdoc links) and local/prod MySQL isn't reachable, query the public Datasette over HTTP:
+
+```bash
+curl -s "https://datasette-public.owid.io/owid.json?sql=<url-encoded SQL>"
+```
+
+`chart_dimensions` + `charts` + `chart_configs` answer "which charts use variable X"; `narrative_charts` and `posts_gdocs_links` cover derived charts and article references — together they answer the full "what does this dataset affect?" question when assessing the blast radius of a data fix.
+
+## Verifying charts on staging
+
+- **Indicator data/metadata API**: `https://api-staging.owid.io/staging-site-<branch>/v1/indicators/<id>.data.json` (and `.metadata.json`). The path prefix is `staging-site-<branch>`, **not** the bare branch name — a wrong prefix silently serves data from a different environment instead of 404ing, which looks exactly like "my fix didn't take". When in doubt, grep the staging chart page (`http://staging-site-<branch>/grapher/<slug>`) for `data.json` to get the exact URLs it loads.
+- **Rendered chart without a browser**: `http://staging-site-<branch>/grapher/<slug>.svg` returns a server-side render — grep it for axis labels / entity names to verify a fix end-to-end (e.g. `grep -oE '>[0-9]+ [a-z]+[^<]*<'` to read the y-axis ticks).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,23 +239,6 @@ def run() -> None:
 
 For a known *source* error we patch locally until the provider fixes it, don't inline `.loc[...]`/`.drop(...)` — declare it in a `<short_name>.corrections.yml` next to the step and apply with `tb = paths.apply_corrections(tb)`. See `etl/data_corrections.py` for the format; `etl corrections -o /tmp/c.html --charts` inventories and visualises them all. For enumerated provider point-errors only — systematic recoding *rules* and aggregation stay in step code.
 
-### Ad-hoc Data Exploration
-```python
-from etl.snapshot import Snapshot
-snap = Snapshot("namespace/version/file.csv")
-tb = snap.read_csv()
-```
-
-### Catalog System
-
-Built on **owid.catalog** library:
-- **Dataset**: Container for multiple tables with shared metadata
-- **Table**: pandas.DataFrame subclass with rich metadata per column
-- **Variable**: pandas.Series subclass with variable-specific metadata
-- Content-based checksums for change detection
-- Multiple formats (feather, parquet, csv) with automatic schema validation
-
-
 ### HTTP calls to OWID infra
 
 When internal code hits an OWID host (catalog, grapher, `files.ourworldindata.org`, `search.owid.io`, Datasette, admin API, etc.), use the shared session from `etl.http` instead of bare `requests` / `httpx` / `pd.read_*(url)`. It pre-sets a `User-Agent: owid-etl/...` header so our traffic is distinguishable in CDN logs.
@@ -301,119 +284,15 @@ If the same sentence could fit in both, it belongs in garden — not in `.dvc`. 
 
 ## Sanity checks
 
-Silent data corruption is one of the easier bugs to miss. A step can run cleanly, pass type checks, and ship to staging while producing wrong numbers — and by the time someone notices on a chart, the bad data may already be live. Sanity checks are how we catch that at build time instead.
+Silent data corruption is one of the easier bugs to miss: a step can run cleanly, pass type checks, and ship wrong numbers to staging. Every garden step that does more than a straight load-and-format asserts its assumptions about its inputs and its output — and so does any snapshot that parses non-trivially (PDF tables, custom binary formats, scraping). Where they go, what they look like, and which categories are worth checking are in `etl/steps/CLAUDE.md`, which loads whenever you work under `etl/steps/`.
 
-**Write them. Make them strict.** Every garden step that does anything more than a straight load-and-format should assert its assumptions about both the input it received and the output it produced. The bar isn't "would I notice this on a chart" — it's "could this go wrong, and if it did, would the step still finish without complaining?". If yes, that's a check.
+## Querying MySQL, and verifying charts on staging
 
-### Where they go
-
-- **Garden** is the main home. The input tables, the transformations, and the output table are all in one place, and that's where business logic lives. Put one `sanity_check_inputs(...)` right after loading meadow tables (before any transform), and one `sanity_check_outputs(...)` right before `paths.create_dataset(...)`. Call both from `run()`. See [`rff/2026-06-10/emissions_weighted_carbon_price.py`](etl/steps/data/garden/rff/2026-06-10/emissions_weighted_carbon_price.py) for a clean, recent example.
-- **Snapshot** usually doesn't need checks — most snapshots just download and write. But when the snapshot itself does non-trivial parsing (PDF tables, custom binary formats, scraping), add integrity checks right before `snap.create_snapshot(...)`. If the parser can produce silently-wrong rows, the snapshot is the only place to catch it before the bad rows leak into meadow.
-- **Meadow** should stay light. If you find yourself wanting checks there, it usually means the logic belongs in garden instead.
-
-### How they look
-
-Use plain `assert` with a clear error message. Hard-fail is the default — let the step crash loudly. Save `log.warning(...)` for checks that flag suspicious patterns the maintainer should *review* but that aren't always wrong (e.g., a country dropping to zero in the latest year — could be a real signal, could be incomplete reporting).
-
-```python
-def sanity_check_inputs(tb_economy: Table, tb_coverage: Table) -> None:
-    assert set(tb_economy["jurisdiction"]) == set(tb_coverage["jurisdiction"]), "Jurisdictions don't match between the two input tables."
-    assert not tb_economy.duplicated(subset=["jurisdiction", "year"]).any(), "Duplicate (jurisdiction, year) rows in economy table."
-    price_cols = [c for c in tb_economy.columns if c not in ["jurisdiction", "year"]]
-    assert tb_economy[price_cols].min().min() >= 0, "Negative price found — source error or unit mistake."
-
-
-def sanity_check_outputs(tb: Table) -> None:
-    assert tb.columns[tb.isna().all()].empty, "Output has a fully-NaN column."
-    # Soft signal — surface for review, don't fail.
-    dropped = sorted(set(tb[tb["year"] == tb["year"].max()].query("value == 0")["country"]))
-    if dropped:
-        log.warning(f"Countries that dropped to zero in the latest year: {dropped}")
-```
-
-### Categories worth checking
-
-Pick whichever apply to your step. Don't write all of these by default — write the ones that would catch a real failure mode for this dataset.
-
-- **Shape / schema invariants.** Set-equality on the columns, categories, subcategories, variables, or any other identifier list you expect to be stable across versions. (`set(tb["category"]) == set(EXPECTED_CATEGORIES)`.) Catches schema changes at the source.
-- **Key uniqueness.** `assert not tb.duplicated(subset=[...]).any()` on whatever key columns the table is supposed to be unique on. Catches accidental row duplication from joins.
-- **Value ranges.** Non-negative where it should be, within plausible bounds where you know them, no NaN where you don't expect any. Catches unit mistakes and parser drift.
-- **Cross-table / cross-source agreement.** If two source tables both report the same key, their overlap should agree to the dollar (or within a documented tolerance). Catches misaligned extractions.
-- **Sum reconciles with published total.** If the source publishes both the components and the total, assert that summing the components equals the total within tolerance. See [`emissions/2026-02-11/emissions_by_custom_sector.py`](etl/steps/data/garden/emissions/2026-02-11/emissions_by_custom_sector.py:172) for an example. Catches row-shift extraction bugs and unit-mismatches.
-- **No silent drops.** If you filter, dedupe, or aggregate, assert that the row count or aggregate matches what you'd expect. (`assert len(tb) == n_expected`.) Catches transforms that quietly lose data.
-- **Coverage didn't shrink.** When updating a dataset version, check that you still have at least as many countries / quarters / categories as the previous version — a sudden drop is usually a parsing regression, not a real change.
-- **Magnitude matches the previous version.** When rewriting or updating a step, compare output values against the previous live version — a silent unit regression (e.g. a dropped ×1e6 conversion) passes every schema check and ships wrong-by-a-million values. Source columns whose headers carry unit markers (`(mils)`, `(000)`, `%`) demand an explicit conversion in garden **plus** a magnitude assert (`assert 1e12 < tb[col].max() < 1e14`), so the conversion can't be lost in a future rewrite.
-
-### When checks fail
-
-Don't suppress the assertion to get the step to pass. Treat the failure as the signal it is: investigate, then either fix the upstream logic or — if the source genuinely changed — update the assertion (and document why in a `# NOTE:` comment near the check).
-
-## Querying MySQL
-
-### Quick queries (staging)
-```bash
-make query SQL="SELECT COUNT(*) FROM variables WHERE catalogPath IS NULL"
-```
-Automatically connects to `staging-site-{branch}` based on current git branch.
-
-### Python (for more control)
-```python
-from etl.config import OWID_ENV
-df = OWID_ENV.read_sql("SELECT * FROM datasets LIMIT 10")
-```
-
-**Prefer Python when the SQL contains `%` (LIKE patterns, JSON_EXTRACT paths) or single-quoted strings — `make query` re-interprets those via shell + make and breaks unpredictably.** Use `params={...}` for `%`/quoted values to dodge pymysql's own `%`-format-string parsing.
-
-**`OWID_ENV` targets your local dev DB even when you're on a branch.** To query the branch's staging DB from Python, use `OWIDEnv.from_staging('<branch>')` (`from etl.config import OWIDEnv`) — e.g. `OWIDEnv.from_staging('my-branch').read_sql(...)`. Also note `make query` shells out to the `mysql` CLI, which may not be installed; if it errors with `mysql: command not found`, use the Python `from_staging(...).read_sql(...)` path instead.
-
-### Production queries via public Datasette
-
-When you need production data (which charts use an indicator, chart configs, gdoc links) and local/prod MySQL isn't reachable, query the public Datasette over HTTP:
-
-```bash
-curl -s "https://datasette-public.owid.io/owid.json?sql=<url-encoded SQL>"
-```
-
-`chart_dimensions` + `charts` + `chart_configs` answer "which charts use variable X"; `narrative_charts` and `posts_gdocs_links` cover derived charts and article references — together they answer the full "what does this dataset affect?" question when assessing the blast radius of a data fix.
-
-## Verifying charts on staging
-
-- **Indicator data/metadata API**: `https://api-staging.owid.io/staging-site-<branch>/v1/indicators/<id>.data.json` (and `.metadata.json`). The path prefix is `staging-site-<branch>`, **not** the bare branch name — a wrong prefix silently serves data from a different environment instead of 404ing, which looks exactly like "my fix didn't take". When in doubt, grep the staging chart page (`http://staging-site-<branch>/grapher/<slug>`) for `data.json` to get the exact URLs it loads.
-- **Rendered chart without a browser**: `http://staging-site-<branch>/grapher/<slug>.svg` returns a server-side render — grep it for axis labels / entity names to verify a fix end-to-end (e.g. `grep -oE '>[0-9]+ [a-z]+[^<]*<'` to read the y-axis ticks).
-
-## Additional Tools
-
-Get `--help` for details on any command.
-
-### Fast File Searching
-
-Use `rg` (ripgrep) instead of `find -exec grep` - it's ~100x faster:
-```bash
-rg -l "pattern" -g "*.py" -g "!.venv"
-```
+Use the `query-grapher-db` skill — it covers the local dev DB, a branch's staging DB, production via the public Datasette, and the staging indicator/SVG endpoints.
 
 ## Package Management
 
-Use `uv` (not pip):
-```bash
-uv add package_name
-uv remove package_name
-```
-
 **Never run bare `uv sync`** — it prunes optional deps the repo needs (streamlit, etc.) and breaks `etl`/`etl pr`. The full environment is `uv sync --all-extras --group dev` (what `make .venv` runs); use that to install or repair the venv.
-
-## VSCode Extensions
-
-Extensions live in `vscode_extensions/<name>/`. After **every** code change, you must compile, package, and install — just compiling is NOT enough:
-
-```bash
-cd vscode_extensions/<name>
-npm run compile
-npx @vscode/vsce package --out install/<name>-<version>.vsix
-code --install-extension install/<name>-<version>.vsix --force
-```
-
-Then tell the user to reload: `Cmd+Shift+P` → "Developer: Reload Window".
 
 ## GitHub Actions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,7 @@ If the same sentence could fit in both, it belongs in garden — not in `.dvc`. 
 
 ## Sanity checks
 
-Silent data corruption is one of the easier bugs to miss: a step can run cleanly, pass type checks, and ship wrong numbers to staging. Every garden step that does more than a straight load-and-format asserts its assumptions about its inputs and its output — and so does any snapshot that parses non-trivially (PDF tables, custom binary formats, scraping). Where they go, what they look like, and which categories are worth checking are in `etl/steps/CLAUDE.md`, which loads whenever you work under `etl/steps/`.
+Silent data corruption is one of the easier bugs to miss: a step can run cleanly, pass type checks, and ship wrong numbers to staging. Every garden step that does more than a straight load-and-format asserts its assumptions about its inputs and its output — and so does any snapshot that parses non-trivially (PDF tables, custom binary formats, scraping). Where they go, what they look like, and which categories are worth checking are in `.claude/rules/sanity-checks.md`, which loads on its own when you open a step or snapshot script.
 
 ## Querying MySQL, and verifying charts on staging
 

--- a/etl/steps/CLAUDE.md
+++ b/etl/steps/CLAUDE.md
@@ -1,0 +1,50 @@
+# Writing ETL steps
+
+## Sanity checks
+
+Silent data corruption is one of the easier bugs to miss. A step can run cleanly, pass type checks, and ship to staging while producing wrong numbers — and by the time someone notices on a chart, the bad data may already be live. Sanity checks are how we catch that at build time instead.
+
+**Write them. Make them strict.** Every garden step that does anything more than a straight load-and-format should assert its assumptions about both the input it received and the output it produced. The bar isn't "would I notice this on a chart" — it's "could this go wrong, and if it did, would the step still finish without complaining?". If yes, that's a check.
+
+### Where they go
+
+- **Garden** is the main home. The input tables, the transformations, and the output table are all in one place, and that's where business logic lives. Put one `sanity_check_inputs(...)` right after loading meadow tables (before any transform), and one `sanity_check_outputs(...)` right before `paths.create_dataset(...)`. Call both from `run()`. See `etl/steps/data/garden/rff/2026-06-10/emissions_weighted_carbon_price.py` for a clean, recent example.
+- **Snapshot** usually doesn't need checks — most snapshots just download and write. But when the snapshot itself does non-trivial parsing (PDF tables, custom binary formats, scraping), add integrity checks right before `snap.create_snapshot(...)`. If the parser can produce silently-wrong rows, the snapshot is the only place to catch it before the bad rows leak into meadow. (Snapshot scripts live in `snapshots/`, outside this directory.)
+- **Meadow** should stay light. If you find yourself wanting checks there, it usually means the logic belongs in garden instead.
+
+### How they look
+
+Use plain `assert` with a clear error message. Hard-fail is the default — let the step crash loudly. Save `log.warning(...)` for checks that flag suspicious patterns the maintainer should *review* but that aren't always wrong (e.g., a country dropping to zero in the latest year — could be a real signal, could be incomplete reporting).
+
+```python
+def sanity_check_inputs(tb_economy: Table, tb_coverage: Table) -> None:
+    assert set(tb_economy["jurisdiction"]) == set(tb_coverage["jurisdiction"]), "Jurisdictions don't match between the two input tables."
+    assert not tb_economy.duplicated(subset=["jurisdiction", "year"]).any(), "Duplicate (jurisdiction, year) rows in economy table."
+    price_cols = [c for c in tb_economy.columns if c not in ["jurisdiction", "year"]]
+    assert tb_economy[price_cols].min().min() >= 0, "Negative price found — source error or unit mistake."
+
+
+def sanity_check_outputs(tb: Table) -> None:
+    assert tb.columns[tb.isna().all()].empty, "Output has a fully-NaN column."
+    # Soft signal — surface for review, don't fail.
+    dropped = sorted(set(tb[tb["year"] == tb["year"].max()].query("value == 0")["country"]))
+    if dropped:
+        log.warning(f"Countries that dropped to zero in the latest year: {dropped}")
+```
+
+### Categories worth checking
+
+Pick whichever apply to your step. Don't write all of these by default — write the ones that would catch a real failure mode for this dataset.
+
+- **Shape / schema invariants.** Set-equality on the columns, categories, subcategories, variables, or any other identifier list you expect to be stable across versions. (`set(tb["category"]) == set(EXPECTED_CATEGORIES)`.) Catches schema changes at the source.
+- **Key uniqueness.** `assert not tb.duplicated(subset=[...]).any()` on whatever key columns the table is supposed to be unique on. Catches accidental row duplication from joins.
+- **Value ranges.** Non-negative where it should be, within plausible bounds where you know them, no NaN where you don't expect any. Catches unit mistakes and parser drift.
+- **Cross-table / cross-source agreement.** If two source tables both report the same key, their overlap should agree to the dollar (or within a documented tolerance). Catches misaligned extractions.
+- **Sum reconciles with published total.** If the source publishes both the components and the total, assert that summing the components equals the total within tolerance. See `etl/steps/data/garden/emissions/2026-02-11/emissions_by_custom_sector.py:172` for an example. Catches row-shift extraction bugs and unit-mismatches.
+- **No silent drops.** If you filter, dedupe, or aggregate, assert that the row count or aggregate matches what you'd expect. (`assert len(tb) == n_expected`.) Catches transforms that quietly lose data.
+- **Coverage didn't shrink.** When updating a dataset version, check that you still have at least as many countries / quarters / categories as the previous version — a sudden drop is usually a parsing regression, not a real change.
+- **Magnitude matches the previous version.** When rewriting or updating a step, compare output values against the previous live version — a silent unit regression (e.g. a dropped ×1e6 conversion) passes every schema check and ships wrong-by-a-million values. Source columns whose headers carry unit markers (`(mils)`, `(000)`, `%`) demand an explicit conversion in garden **plus** a magnitude assert (`assert 1e12 < tb[col].max() < 1e14`), so the conversion can't be lost in a future rewrite.
+
+### When checks fail
+
+Don't suppress the assertion to get the step to pass. Treat the failure as the signal it is: investigate, then either fix the upstream logic or — if the source genuinely changed — update the assertion (and document why in a `# NOTE:` comment near the check).


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Every line of the root `CLAUDE.md` is in context for every session in this repo, whether or not it's relevant to the task. This trims it from **34.0k to 25.7k characters** (~8.5k → ~6.4k est. tokens) by cutting content a session can reconstruct on its own, and by moving guidance that only matters in specific contexts to files that load on demand.

The framing follows the [advice Anthropic's Claude Code team gave on writing agent instruction files](https://simonwillison.net/2026/Jul/21/cat-and-thariq/): favour lean prompts, prefer more context and fewer instructions, and don't spend always-loaded budget on extensive examples.

### Cut as derivable from the codebase

- **Catalog System** overview (Dataset/Table/Variable) — its load-bearing fact, that Tables are DataFrame subclasses, is already stated in Code Patterns where the `pr.concat` / `pd.DataFrame(tb)` rules depend on it.
- **Ad-hoc Data Exploration** snippet — repeats the `snap.read_csv/json/excel` bullet a few lines above.
- **Fast File Searching** ("use `rg` instead of `find -exec grep`") and "Get `--help` for details on any command".
- The `uv add` / `uv remove` snippet. The **`Never run bare uv sync`** gotcha stays — that one isn't guessable.

### Moved to lazy loading

- **Sanity checks** (49 lines) → new `.claude/rules/sanity-checks.md`, path-scoped to `etl/steps/**/*.py` and `snapshots/**/*.py`, so it loads on its own whenever a step or snapshot script is opened. A rule rather than a skill, so the requirement can't be missed by failing to invoke something. A one-sentence pointer stays in the root file to keep the requirement itself resident.

  This started as a nested `etl/steps/CLAUDE.md`, which turned out to be the wrong mechanism: nested memory files load only when a file *under that directory* is read, so a session working on a snapshot parser would never have seen it — even though the guidance explicitly covers snapshots that parse non-trivially. A path-scoped rule spans both trees.
- **Querying MySQL** + **Verifying charts on staging** (33 lines) → new `query-grapher-db` skill. Only its one-line description stays resident.
- **VSCode Extensions** (13 lines) → deleted. The existing `vscode-extension-dev` skill already covers the same four commands *and* the "just compiling is NOT enough" warning; this was a duplicate that outlived the skill being written.

One mechanical fix was needed by the move: the two markdown links in the sanity-checks section would have resolved incorrectly from outside the repo root, so they're now plain repo-root paths. Everything else moved verbatim.

Kept deliberately, for the record: the **Standard Garden Step** template (12 lines, and the only place showing the current `paths.*` API — most existing steps in the repo would teach the deprecated one), the metadata/origins rules, the glossary, and the archiving procedure.

### How to test it

Nothing to run against the staging server — this is documentation only. To check it does what it claims:

1. **Read the diff.** The four cuts are listed above; every other removed line reappears verbatim in `.claude/rules/sanity-checks.md` or `.claude/skills/query-grapher-db/SKILL.md`.
2. **Confirm the rule loads on demand.** From the repo root, ask a session to read any garden step, then run `/context` — `.claude/rules/sanity-checks.md` should be absent at startup and listed after the read. Repeat with a file under `snapshots/`.
3. **Confirm the skill is reachable.** Ask a session "how do I query the staging DB for this branch?" — it should route to `query-grapher-db` and surface the `OWIDEnv.from_staging(...)` gotcha, which used to be always-loaded.

Already verified: `make check` passes (lint, format, typecheck), the new skill loads and appears in the skill listing, and the path-scoped rule was confirmed to fire in fresh sessions launched from the repo root — once by reading `etl/steps/data/garden/rff/2026-06-10/emissions_weighted_carbon_price.py` and once by reading `snapshots/who/latest/fluid.py`, each quoting the rule's first sentence back.

One behaviour worth knowing either way: lazily-loaded instructions are not re-injected after `/compact`, unlike the project-root `CLAUDE.md`. They reload the next time a matching file is read. If we later decide sanity checks are too important to be conditional, the fix is to move that section back into the root file and accept the ~1.4k tokens.

### Worth a follow-up

`Critical Rules` is a list of bare absolutes ("Never mask problems", "Always use `.venv/bin/`"), which is the shape the post above argues degrades output — whereas other rules in the same file already give the mechanism *and* name the exception (`Avoid --force` is the good example). Reframing those is a judgement call about shared team guidance, so it's left out of this PR.
