### PR TITLE
📊 Add US top wealth shares (Saez and Zucman, 2020)

### DIFF
--- a/dag/economics.yml
+++ b/dag/economics.yml
@@ -5,6 +5,12 @@ steps:
       - data://meadow/economics/2026-07-28/wealth_uk:
         - snapshot://economics/2026-07-28/wealth_uk.csv
 
+  # US top wealth shares (Saez and Zucman, 2020 - Journal of Economic Perspectives)
+  data://grapher/economics/2026-07-28/saez_zucman_wealth_shares:
+    - data://garden/economics/2026-07-28/saez_zucman_wealth_shares:
+      - data://meadow/economics/2026-07-28/saez_zucman_wealth_shares:
+        - snapshot://economics/2026-07-28/saez_zucman_wealth_shares.xlsx
+
   # OWID - OWID Deflator.
   data://garden/economics/2025-08-29/owid_deflator:
     # World Bank - WDI (specifically indicators used for inflation adjustments).

--- a/etl/steps/data/garden/economics/2026-07-28/saez_zucman_wealth_shares.countries.json
+++ b/etl/steps/data/garden/economics/2026-07-28/saez_zucman_wealth_shares.countries.json
@@ -1,0 +1,3 @@
+{
+  "United States": "United States"
+}

--- a/etl/steps/data/garden/economics/2026-07-28/saez_zucman_wealth_shares.meta.yml
+++ b/etl/steps/data/garden/economics/2026-07-28/saez_zucman_wealth_shares.meta.yml
@@ -6,15 +6,28 @@ definitions:
       topic_tags:
         - Economic Inequality
       attribution_short: Saez and Zucman
-    description_key:
-      - Wealth is measured as marketable (net) wealth: the value of all assets a household owns, minus its debts. It is estimated from capitalized income flows, combining tax, survey and national accounts data.
-      - These are the revised Saez and Zucman estimates from their September 2020 update, which incorporate information from the Federal Reserve's Distributional Financial Accounts.
-      - "\"Tax units\" treat a married couple filing jointly as a single unit, while \"equal-split adults\" divide each household's wealth equally between its adults. Equal-split shares are typically slightly lower, because splitting wealth within couples spreads it across more units."
-      - The authors also publish several alternative estimates of US wealth concentration (from the Survey of Consumer Finances, estate multiplier methods, and other researchers); those are not included here.
     description_processing: |-
       The source workbook contains many series behind the paper's figures (income shares, growth by income group, effective tax rates and transfers), as well as several alternative estimates of wealth concentration. We use only the top wealth-share series, and within those only the revised Saez and Zucman September 2020 estimates, for both the "tax units" and "equal-split adults" population concepts.
 
       The wealth shares are reported by the source as fractions of total wealth and have been converted to percentages.
+
+  # =============================================================================
+  # REUSABLE "WHAT YOU SHOULD KNOW" BULLETS
+  # =============================================================================
+  wysk_marketable_wealth: &wysk_marketable_wealth |-
+    Wealth is measured as marketable (net) wealth.
+  wysk_revised_series: &wysk_revised_series |-
+    These are the revised Saez and Zucman estimates from their 2020 update, which build on the estimates by Saez and Zucman (2016) and incorporate information from the Federal Reserve's Distributional Financial Accounts.
+
+  desc_key_equal_split: &desc_key_equal_split
+    - *wysk_marketable_wealth
+    - These shares are based on the "equal-split adults" series, which divides each household's wealth equally among its adults.
+    - *wysk_revised_series
+
+  desc_key_tax_units: &desc_key_tax_units
+    - *wysk_marketable_wealth
+    - These shares are based on the "tax units" series, which treats a married couple filing jointly as a single unit.
+    - *wysk_revised_series
 
 # Learn more about the available fields:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/
@@ -33,6 +46,7 @@ tables:
         unit: "%"
         short_unit: "%"
         description_short: The share of total wealth held by the richest 10% of tax units (a married couple counts as one unit).
+        description_key: *desc_key_tax_units
         display:
           name: Top 10% (tax units)
           numDecimalPlaces: 1
@@ -45,6 +59,7 @@ tables:
         unit: "%"
         short_unit: "%"
         description_short: The share of total wealth held by the richest 1% of tax units (a married couple counts as one unit).
+        description_key: *desc_key_tax_units
         display:
           name: Top 1% (tax units)
           numDecimalPlaces: 1
@@ -57,6 +72,7 @@ tables:
         unit: "%"
         short_unit: "%"
         description_short: The share of total wealth held by the richest 0.1% of tax units (a married couple counts as one unit).
+        description_key: *desc_key_tax_units
         display:
           name: Top 0.1% (tax units)
           numDecimalPlaces: 1
@@ -69,6 +85,7 @@ tables:
         unit: "%"
         short_unit: "%"
         description_short: The share of total wealth held by the richest 10% of adults, with each household's wealth split equally between its adults.
+        description_key: *desc_key_equal_split
         display:
           name: Top 10% (equal-split adults)
           numDecimalPlaces: 1
@@ -81,6 +98,7 @@ tables:
         unit: "%"
         short_unit: "%"
         description_short: The share of total wealth held by the richest 1% of adults, with each household's wealth split equally between its adults.
+        description_key: *desc_key_equal_split
         display:
           name: Top 1% (equal-split adults)
           numDecimalPlaces: 1
@@ -93,6 +111,7 @@ tables:
         unit: "%"
         short_unit: "%"
         description_short: The share of total wealth held by the richest 0.1% of adults, with each household's wealth split equally between its adults.
+        description_key: *desc_key_equal_split
         display:
           name: Top 0.1% (equal-split adults)
           numDecimalPlaces: 1

--- a/etl/steps/data/garden/economics/2026-07-28/saez_zucman_wealth_shares.meta.yml
+++ b/etl/steps/data/garden/economics/2026-07-28/saez_zucman_wealth_shares.meta.yml
@@ -1,0 +1,97 @@
+# NOTE: To learn more about the fields, hover over their names.
+definitions:
+  common:
+    processing_level: minor
+    presentation:
+      topic_tags:
+        - Economic Inequality
+      attribution_short: Saez and Zucman
+    description_key:
+      - Wealth is measured as marketable (net) wealth: the value of all assets a household owns, minus its debts. It is estimated from capitalized income flows, combining tax, survey and national accounts data.
+      - These are the revised Saez and Zucman estimates from their September 2020 update, which incorporate information from the Federal Reserve's Distributional Financial Accounts.
+      - "\"Tax units\" treat a married couple filing jointly as a single unit, while \"equal-split adults\" divide each household's wealth equally between its adults. Equal-split shares are typically slightly lower, because splitting wealth within couples spreads it across more units."
+      - The authors also publish several alternative estimates of US wealth concentration (from the Survey of Consumer Finances, estate multiplier methods, and other researchers); those are not included here.
+    description_processing: |-
+      The wealth shares are reported by the source as fractions of total wealth and have been converted to percentages. Of the many series in the source workbook, only the revised Saez and Zucman September 2020 estimates are used here, for both the "tax units" and "equal-split adults" population concepts.
+
+# Learn more about the available fields:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+dataset:
+  update_period_days: 0
+  owners:
+    - Bertha Rohenkohl
+
+tables:
+  saez_zucman_wealth_shares:
+    variables:
+      share_top_10_tax_units:
+        title: Wealth share of the richest 10% (tax units)
+        presentation:
+          title_public: Wealth share of the richest 10%
+        unit: "%"
+        short_unit: "%"
+        description_short: The share of total wealth held by the richest 10% of tax units (a married couple counts as one unit).
+        display:
+          name: Top 10% (tax units)
+          numDecimalPlaces: 1
+          tolerance: 5
+
+      share_top_1_tax_units:
+        title: Wealth share of the richest 1% (tax units)
+        presentation:
+          title_public: Wealth share of the richest 1%
+        unit: "%"
+        short_unit: "%"
+        description_short: The share of total wealth held by the richest 1% of tax units (a married couple counts as one unit).
+        display:
+          name: Top 1% (tax units)
+          numDecimalPlaces: 1
+          tolerance: 5
+
+      share_top_0p1_tax_units:
+        title: Wealth share of the richest 0.1% (tax units)
+        presentation:
+          title_public: Wealth share of the richest 0.1%
+        unit: "%"
+        short_unit: "%"
+        description_short: The share of total wealth held by the richest 0.1% of tax units (a married couple counts as one unit).
+        display:
+          name: Top 0.1% (tax units)
+          numDecimalPlaces: 1
+          tolerance: 5
+
+      share_top_10_equal_split:
+        title: Wealth share of the richest 10% (equal-split adults)
+        presentation:
+          title_public: Wealth share of the richest 10%
+        unit: "%"
+        short_unit: "%"
+        description_short: The share of total wealth held by the richest 10% of adults, with each household's wealth split equally between its adults.
+        display:
+          name: Top 10% (equal-split adults)
+          numDecimalPlaces: 1
+          tolerance: 5
+
+      share_top_1_equal_split:
+        title: Wealth share of the richest 1% (equal-split adults)
+        presentation:
+          title_public: Wealth share of the richest 1%
+        unit: "%"
+        short_unit: "%"
+        description_short: The share of total wealth held by the richest 1% of adults, with each household's wealth split equally between its adults.
+        display:
+          name: Top 1% (equal-split adults)
+          numDecimalPlaces: 1
+          tolerance: 5
+
+      share_top_0p1_equal_split:
+        title: Wealth share of the richest 0.1% (equal-split adults)
+        presentation:
+          title_public: Wealth share of the richest 0.1%
+        unit: "%"
+        short_unit: "%"
+        description_short: The share of total wealth held by the richest 0.1% of adults, with each household's wealth split equally between its adults.
+        display:
+          name: Top 0.1% (equal-split adults)
+          numDecimalPlaces: 1
+          tolerance: 5

--- a/etl/steps/data/garden/economics/2026-07-28/saez_zucman_wealth_shares.meta.yml
+++ b/etl/steps/data/garden/economics/2026-07-28/saez_zucman_wealth_shares.meta.yml
@@ -12,7 +12,9 @@ definitions:
       - "\"Tax units\" treat a married couple filing jointly as a single unit, while \"equal-split adults\" divide each household's wealth equally between its adults. Equal-split shares are typically slightly lower, because splitting wealth within couples spreads it across more units."
       - The authors also publish several alternative estimates of US wealth concentration (from the Survey of Consumer Finances, estate multiplier methods, and other researchers); those are not included here.
     description_processing: |-
-      The wealth shares are reported by the source as fractions of total wealth and have been converted to percentages. Of the many series in the source workbook, only the revised Saez and Zucman September 2020 estimates are used here, for both the "tax units" and "equal-split adults" population concepts.
+      The source workbook contains many series behind the paper's figures (income shares, growth by income group, effective tax rates and transfers), as well as several alternative estimates of wealth concentration. We use only the top wealth-share series, and within those only the revised Saez and Zucman September 2020 estimates, for both the "tax units" and "equal-split adults" population concepts.
+
+      The wealth shares are reported by the source as fractions of total wealth and have been converted to percentages.
 
 # Learn more about the available fields:
 # http://docs.owid.io/projects/etl/architecture/metadata/reference/

--- a/etl/steps/data/garden/economics/2026-07-28/saez_zucman_wealth_shares.py
+++ b/etl/steps/data/garden/economics/2026-07-28/saez_zucman_wealth_shares.py
@@ -1,0 +1,72 @@
+"""Load a meadow dataset and create a garden dataset.
+
+The source reports wealth shares as fractions (0-1); we convert them to percentages.
+Each share exists for two population concepts: "tax units" and "equal-split adults".
+"""
+
+from owid.catalog import Table
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+# Cumulative top-share columns per population concept, ordered broadest -> narrowest.
+CONCEPTS = {
+    "tax_units": ["share_top_10_tax_units", "share_top_1_tax_units", "share_top_0p1_tax_units"],
+    "equal_split": ["share_top_10_equal_split", "share_top_1_equal_split", "share_top_0p1_equal_split"],
+}
+SHARE_COLUMNS = [c for cols in CONCEPTS.values() for c in cols]
+
+
+def sanity_check_inputs(tb: Table) -> None:
+    assert set(tb["country"].unique()) == {"United States"}, "Expected United States as the only entity."
+    assert not tb.duplicated(subset=["country", "year"]).any(), "Duplicate (country, year) rows."
+    assert tb["year"].between(1910, 2025).all(), "Year outside the plausible range."
+    # Source values are fractions of total wealth, so they must lie in (0, 1].
+    for col in SHARE_COLUMNS:
+        vals = tb[col].dropna()
+        assert vals.between(0, 1).all(), f"{col} has values outside 0-1 before conversion to %."
+
+
+def sanity_check_outputs(tb: Table) -> None:
+    assert tb.columns[tb.isna().all()].empty, "Output has a fully-NaN column."
+    for col in SHARE_COLUMNS:
+        vals = tb[col].dropna()
+        assert vals.between(0, 100).all(), f"{col} has values outside 0-100%."
+    # Guard the fraction->% conversion: the top 10% share should be tens of percent, not a fraction.
+    assert 50 < tb["share_top_10_tax_units"].max() < 100, "Top 10% share not on a percentage scale — conversion lost?"
+    # Cumulative shares must be non-increasing as the group narrows (top 10% >= top 1% >= top 0.1%).
+    for cols in CONCEPTS.values():
+        for broader, narrower in zip(cols, cols[1:]):
+            pair = tb[[broader, narrower]].dropna()
+            assert (pair[broader] >= pair[narrower] - 0.05).all(), f"{broader} < {narrower} for some year."
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_meadow = paths.load_dataset("saez_zucman_wealth_shares")
+    tb = ds_meadow["saez_zucman_wealth_shares"].reset_index()
+
+    #
+    # Process data.
+    #
+    sanity_check_inputs(tb)
+
+    # Convert wealth shares from fractions (0-1) to percentages.
+    for col in SHARE_COLUMNS:
+        tb[col] = tb[col] * 100
+
+    tb = paths.regions.harmonize_names(tb, country_col="country", countries_file=paths.country_mapping_path)
+
+    sanity_check_outputs(tb)
+
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
+    #
+    # Save outputs.
+    #
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden.save()

--- a/etl/steps/data/grapher/economics/2026-07-28/saez_zucman_wealth_shares.py
+++ b/etl/steps/data/grapher/economics/2026-07-28/saez_zucman_wealth_shares.py
@@ -1,0 +1,26 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset and read its table.
+    ds_garden = paths.load_dataset("saez_zucman_wealth_shares")
+    tb = ds_garden.read("saez_zucman_wealth_shares")
+
+    #
+    # Process data.
+    #
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
+    #
+    # Save outputs.
+    #
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/economics/2026-07-28/saez_zucman_wealth_shares.py
+++ b/etl/steps/data/meadow/economics/2026-07-28/saez_zucman_wealth_shares.py
@@ -1,0 +1,71 @@
+"""Load a snapshot and create a meadow dataset.
+
+The source is a multi-sheet replication workbook. We read only the wealth-shares sheet
+("DataF1-F2(Wealth)"), which has a three-row header (source method, population concept,
+wealth bracket) and yearly data from row 9 onwards. We keep the revised Saez-Zucman
+September 2020 series (columns 7-12): top 10% / 1% / 0.1% shares for two population
+concepts, tax units and equal-split adults.
+"""
+
+from owid.catalog import processing as pr
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+SHEET = "DataF1-F2(Wealth)"
+
+# Column index in the raw sheet -> descriptive indicator name.
+# "share_top_0p1" == top 0.1%; suffix marks the population concept.
+COLUMNS = {
+    0: "year",
+    7: "share_top_10_tax_units",
+    8: "share_top_1_tax_units",
+    9: "share_top_0p1_tax_units",
+    10: "share_top_10_equal_split",
+    11: "share_top_1_equal_split",
+    12: "share_top_0p1_equal_split",
+}
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    snap = paths.load_snapshot("saez_zucman_wealth_shares.xlsx")
+
+    # Read the wealth sheet without a header; the real headers span rows 6-8 and data starts at row 9.
+    tb = snap.read_excel(sheet_name=SHEET, header=None)
+
+    #
+    # Process data.
+    #
+    # Keep only the year column and the revised Saez-Zucman September 2020 series.
+    tb = tb[list(COLUMNS)].rename(columns=COLUMNS, errors="raise")
+
+    # Keep only the yearly data region (rows where the first column is a numeric year).
+    tb = tb[pr.to_numeric(tb["year"], errors="coerce").notna()].copy()
+    tb["year"] = tb["year"].astype(int)
+
+    # Drop years with no wealth data at all (the sheet pads a few empty years at the ends).
+    value_cols = [c for c in COLUMNS.values() if c != "year"]
+    tb = tb.dropna(subset=value_cols, how="all")
+
+    # Reshaping a header-less sheet can drop a column's origin; every value column comes from
+    # this snapshot, so restore the origin explicitly.
+    for col in value_cols:
+        tb[col].metadata.origins = [snap.metadata.origin]
+
+    # This is a US-only source; add the country column explicitly.
+    tb["country"] = "United States"
+    tb["country"] = tb["country"].astype("category")
+
+    # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
+    #
+    # Save outputs.
+    #
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
+    ds_meadow.save()

--- a/snapshots/economics/2026-07-28/saez_zucman_wealth_shares.py
+++ b/snapshots/economics/2026-07-28/saez_zucman_wealth_shares.py
@@ -1,0 +1,18 @@
+"""Script to create a snapshot of dataset.
+
+The data file is the replication workbook for the paper "The Rise of Income and Wealth
+Inequality in America: Evidence from Distributional Macroeconomic Accounts" (Saez and
+Zucman, 2020), available at https://www.aeaweb.org/articles?id=10.1257/jep.34.4.3.
+
+Run with:
+  etls economics/2026-07-28/saez_zucman_wealth_shares --path-to-file <path>
+"""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run(upload: bool = True, path_to_file: str | None = None) -> None:
+    snap = paths.init_snapshot()
+    snap.create_snapshot(filename=path_to_file, upload=upload)

--- a/snapshots/economics/2026-07-28/saez_zucman_wealth_shares.xlsx.dvc
+++ b/snapshots/economics/2026-07-28/saez_zucman_wealth_shares.xlsx.dvc
@@ -1,0 +1,30 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: The Rise of Income and Wealth Inequality in America - Distributional Macroeconomic Accounts
+    description: |-
+      This dataset accompanies the paper "The Rise of Income and Wealth Inequality in America: Evidence from Distributional Macroeconomic Accounts", which uses distributional national accounts to study the long-run concentration of income and wealth in the United States.
+
+      The authors combine tax, survey and national accounts data to estimate the shares of income and wealth held by top groups (such as the top 10%, top 1% and top 0.1%) and by the bottom 50%, along with related series on economic growth by income group, effective tax rates and government transfers.
+
+      OWID uses the top wealth-share series from this workbook (the revised Saez and Zucman September 2020 estimates); the workbook also contains the income-share, growth, tax and transfer series behind the paper's other figures, which are not ingested here.
+    date_published: "2020-11-01"
+
+    # Citation
+    producer: Saez and Zucman
+    citation_full: |-
+      Saez, E., & Zucman, G. (2020). The Rise of Income and Wealth Inequality in America: Evidence from Distributional Macroeconomic Accounts. Journal of Economic Perspectives, 34(4), 3-26. https://doi.org/10.1257/jep.34.4.3
+
+    # Files
+    url_main: https://www.aeaweb.org/articles?id=10.1257/jep.34.4.3
+    date_accessed: '2026-07-28'
+
+    # License
+    license:
+      name: © American Economic Association (2020)
+outs:
+  - md5: a022745f19e95a519672d1e25e192dbf
+    size: 1003341
+    path: saez_zucman_wealth_shares.xlsx

--- a/snapshots/economics/2026-07-28/saez_zucman_wealth_shares.xlsx.dvc
+++ b/snapshots/economics/2026-07-28/saez_zucman_wealth_shares.xlsx.dvc
@@ -8,8 +8,10 @@ meta:
       This dataset accompanies the paper "The Rise of Income and Wealth Inequality in America: Evidence from Distributional Macroeconomic Accounts", which uses distributional national accounts to study the long-run concentration of income and wealth in the United States.
 
       The authors combine tax, survey and national accounts data to estimate the shares of income and wealth held by top groups (such as the top 10%, top 1% and top 0.1%) and by the bottom 50%, along with related series on economic growth by income group, effective tax rates and government transfers.
-
-      OWID uses the top wealth-share series from this workbook (the revised Saez and Zucman September 2020 estimates); the workbook also contains the income-share, growth, tax and transfer series behind the paper's other figures, which are not ingested here.
+    # NOTE: The workbook has ~10 data sheets (Figures 1-6 + appendix). We ingest only the wealth-shares
+    # sheet "DataF1-F2(Wealth)", and within it only the revised Saez-Zucman September 2020 series. The
+    # income-share, growth, tax and transfer sheets, and the alternative wealth-estimate methods, are
+    # available in the same file for a future extension.
     date_published: "2020-11-01"
 
     # Citation


### PR DESCRIPTION
> _Written by Claude Opus 4.8 — @bertharc at the wheel._

## What

Adds a dataset of long-run **US top wealth shares**, extracted from the replication workbook of Saez & Zucman (2020), *"The Rise of Income and Wealth Inequality in America: Evidence from Distributional Macroeconomic Accounts"* (Journal of Economic Perspectives 34(4): 3–26, https://doi.org/10.1257/jep.34.4.3).

New chain in the `economics` namespace (snapshot → meadow → garden → grapher):

- `snapshot://economics/2026-07-28/saez_zucman_wealth_shares.xlsx` (the full workbook is stored as the raw snapshot)
- `data://meadow|garden|grapher/economics/2026-07-28/saez_zucman_wealth_shares`

## Scope

The workbook backs Figures 1–6 + appendix (wealth, income, tax rates, growth, transfers…). Per review, this dataset ingests **only the headline wealth-shares sheet** (`DataF1-F2(Wealth)`), and within it **only the revised Saez–Zucman September 2020 series** — the other ~12 methodological variants (2016 capitalized income, Fed DFA, Smith-Zidar-Zwick, SCF, estates) and the non-wealth sheets are left out (noted in the snapshot for a future extension).

## Coverage

- **Entity:** United States. **Years:** 1917–2019 (103 points/series).
- **6 indicators**, shares of total household wealth (%), for two population concepts:
  - Top 10% / 1% / 0.1% — **tax units**
  - Top 10% / 1% / 0.1% — **equal-split adults**

## Processing notes

- Source values are fractions (0–1); converted to percentages in garden (with a magnitude assert guarding the conversion).
- The wealth sheet has a three-row header (method / population concept / bracket) and padded empty years; meadow parses it header-less, selects the revised-SZ columns, and drops all-empty years.
- Sanity checks assert US-only, no duplicate years, 0–100% range, and that cumulative shares are non-increasing (top 10% ≥ top 1% ≥ top 0.1%).

## Notes for review

- **License:** JEP is an AEA journal with no open data license stated for the replication file; recorded as `© American Economic Association (2020)`, `license.url` left empty. Worth a second look.
- **`attribution_short`:** `Saez and Zucman`.
- **`update_period_days: 0`** — a fixed extract from the 2020 paper (the authors update the online series periodically, but this snapshot is that paper's workbook).
- **Naming:** `saez_zucman_wealth_shares` in the `economics` namespace — happy to rename if you'd prefer a content-based name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UupxZyHHyS4CepaLJ5sNmB)_