### PR TITLE
🐛 Surface tracebacks when a step fails

### DIFF
--- a/etl/command.py
+++ b/etl/command.py
@@ -808,8 +808,11 @@ def _print_step_failure(e: BaseException) -> None:
     from etl.steps import StepFailedError
 
     if isinstance(e, StepFailedError):
-        # The step ran in a child process that already printed the real traceback. Everything this
-        # exception would add is executor plumbing (_RemoteTraceback, future.result frames).
+        # The step ran in a child process, which handed its traceback back through the exception.
+        # Printing the exception itself would only add executor plumbing (_RemoteTraceback,
+        # future.result frames).
+        if e.child_traceback:
+            print(e.child_traceback, file=sys.stderr)
         print(e, file=sys.stderr)
     else:
         traceback.print_exception(type(e), e, e.__traceback__)

--- a/etl/command.py
+++ b/etl/command.py
@@ -9,6 +9,7 @@ import re
 import resource
 import sys
 import time
+import traceback
 from collections.abc import Callable, Iterator, MutableMapping
 from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, ThreadPoolExecutor, wait
 from contextlib import contextmanager
@@ -607,6 +608,9 @@ def exec_steps(steps: "list[Step]", strict_after: Any, continue_on_failure: bool
                     exceptions.append(e)
                     skipped_steps.append(step)
                     click.echo(click.style(f"--- FAILED {step}", fg="red"))
+                    # Only the first exception gets raised at the end of the run, so report this
+                    # one now or it is lost.
+                    _print_step_failure(e)
                     continue
                 else:
                     raise e
@@ -753,7 +757,18 @@ def exec_graph_parallel(
                     try:
                         future.result()
                         topological_sorter.done(task)
-                    except Exception as e:
+                    except KeyboardInterrupt:
+                        raise
+                    # Catch BaseException, not Exception: a step that somehow raises SystemExit would
+                    # otherwise end the run without ever naming the step or printing its traceback.
+                    except BaseException as e:
+                        # Report the failure right away. Re-raising is not enough: the pool only
+                        # exits once every already-submitted step has finished, which on a full
+                        # build is hours after the failure, and in CONTINUE_ON_FAILURE mode all but
+                        # the first exception are never raised at all.
+                        print(f"--- Failed {task} - {click.style('FAILED', fg='red')}")
+                        _print_step_failure(e)
+
                         if continue_on_failure:
                             failed_tasks.add(task)
                             skipped_tasks.add(
@@ -761,14 +776,14 @@ def exec_graph_parallel(
                             )  # Failed tasks should also be considered skipped for dependency checking
                             exceptions.append(e)
                             topological_sorter.done(task)  # Mark as done so execution can continue
-                            print(f"--- Failed {task} - {click.style('FAILED', fg='red')}")
                         else:
                             raise e
 
         # If we collected exceptions during CONTINUE_ON_FAILURE mode, raise the first one
         if continue_on_failure and exceptions:
-            for exception in exceptions:
-                log.error("step_exception", exception=str(exception))
+            # Tracebacks were printed as each step failed; recap the step names, since by now they
+            # are thousands of lines up in the log.
+            log.error("steps_failed", steps=sorted(failed_tasks))
             raise exceptions[0]
 
 
@@ -785,6 +800,19 @@ def _create_expected_time_message(
         return ""
     else:
         return prepend_message + partial_message + append_message
+
+
+def _print_step_failure(e: BaseException) -> None:
+    """Print what a failed step's exception says, on stderr, right when the failure happens."""
+    from etl.steps import StepFailedError
+
+    if isinstance(e, StepFailedError):
+        # The step ran in a child process that already printed the real traceback. Everything this
+        # exception would add is executor plumbing (_RemoteTraceback, future.result frames).
+        print(e, file=sys.stderr)
+    else:
+        traceback.print_exception(type(e), e, e.__traceback__)
+    sys.stderr.flush()
 
 
 def _exec_step_job(

--- a/etl/command.py
+++ b/etl/command.py
@@ -623,8 +623,9 @@ def exec_steps(steps: "list[Step]", strict_after: Any, continue_on_failure: bool
         _write_execution_times(execution_times)
 
     if continue_on_failure and exceptions:
-        for step, exception in zip(failing_steps, exceptions):
-            log.error("step_exception", step=str(step), exception=str(exception))
+        # Tracebacks were printed as each step failed; recap the step names, since by now they are
+        # thousands of lines up in the log.
+        log.error("steps_failed", steps=sorted(str(step) for step in failing_steps))
         # Raise the first exception
         raise exceptions[0]
 

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -56,13 +56,18 @@ INSTANT_METADATA_DIFF = {}
 
 
 class StepFailedError(Exception):
-    """A step's code raised, and the child process (fork or subprocess) that ran it already printed
-    the traceback.
+    """A step's code raised in the child process (fork or subprocess) that ran it.
 
     This must be a regular Exception rather than a `sys.exit(exit_code)`: the runners catch
     `Exception` to log which step failed and to honour `--continue-on-failure`, and a `SystemExit`
     would sail past those handlers and end the run without naming the step or printing anything.
     """
+
+    def __init__(self, message: str, child_traceback: str = "") -> None:
+        super().__init__(message)
+        # Traceback from the child, if it managed to hand one back. Kept out of the message so that
+        # re-raising this at the end of a run repeats the summary line, not the whole traceback.
+        self.child_traceback = child_traceback
 
 
 def compile_steps(
@@ -692,9 +697,17 @@ class DataStep(Step):
         else:
             self._run_py_subprocess()
 
+    def _read_child_traceback(self, traceback_path: Path) -> str:
+        """Read back the traceback a failed child left behind, if it got that far."""
+        try:
+            return traceback_path.read_text().rstrip()
+        except OSError:
+            return ""
+
     def _run_py_fork(self) -> None:
         """Run the step in a forked child process (Linux only)."""
         import resource
+        import tempfile
         import traceback
 
         # Apply the same virtual-memory limit that prlimit would enforce
@@ -705,6 +718,12 @@ class DataStep(Step):
                 )
             except ValueError:
                 pass  # not all systems support RLIMIT_AS
+
+        # Somewhere for the child to leave its traceback; see the child branch below. Created here
+        # so the name is unique per run and both processes know it.
+        traceback_fd, traceback_file = tempfile.mkstemp(prefix="etl-step-traceback-", suffix=".txt")
+        os.close(traceback_fd)
+        traceback_path = Path(traceback_file)
 
         # Flush before forking to prevent the child from inheriting (and
         # potentially re-flushing) buffered output from the parent, which
@@ -740,21 +759,33 @@ class DataStep(Step):
                 run_module_run(step_module, self._dest_dir.as_posix())
                 os._exit(0)
             except BaseException:
-                # Write the traceback in one call, prefixed with the step it belongs to. Sibling
-                # children of a parallel build share this stderr, and line-by-line writes from
-                # several of them interleave into an unreadable mix.
-                os.write(2, f"--- Traceback for {self}\n{traceback.format_exc()}".encode())
+                # Hand the traceback to the parent through a file rather than writing it to the
+                # stderr this child shares with its siblings. A traceback easily exceeds PIPE_BUF,
+                # above which a write is neither atomic nor guaranteed to complete in one call, so
+                # concurrent children would interleave into an unreadable mix. The parent attaches
+                # it to StepFailedError, which the runners print one failure at a time.
+                try:
+                    traceback_path.write_text(f"--- Traceback for {self}\n{traceback.format_exc()}")
+                except OSError:
+                    # Last resort, interleaved or not: never lose the traceback.
+                    traceback.print_exc()
                 os._exit(1)
         else:
             # ---------- parent process ----------
-            _, status = os.waitpid(pid, 0)
-            if os.WIFEXITED(status):
-                exit_code = os.WEXITSTATUS(status)
-                if exit_code != 0:
-                    raise StepFailedError(f"Step {self} failed with exit code {exit_code} (traceback above)")
-            elif os.WIFSIGNALED(status):
-                sig = os.WTERMSIG(status)
-                raise Exception(f"Step {self} was killed by signal {sig}")
+            try:
+                _, status = os.waitpid(pid, 0)
+                if os.WIFEXITED(status):
+                    exit_code = os.WEXITSTATUS(status)
+                    if exit_code != 0:
+                        raise StepFailedError(
+                            f"Step {self} failed with exit code {exit_code}",
+                            child_traceback=self._read_child_traceback(traceback_path),
+                        )
+                elif os.WIFSIGNALED(status):
+                    sig = os.WTERMSIG(status)
+                    raise Exception(f"Step {self} was killed by signal {sig}")
+            finally:
+                traceback_path.unlink(missing_ok=True)
 
     def _run_py_subprocess(self) -> None:
         """Run the step in a new subprocess (fallback for non-Linux or debug mode)."""

--- a/etl/steps/__init__.py
+++ b/etl/steps/__init__.py
@@ -55,6 +55,16 @@ DAG = dict[str, set[str]]
 INSTANT_METADATA_DIFF = {}
 
 
+class StepFailedError(Exception):
+    """A step's code raised, and the child process (fork or subprocess) that ran it already printed
+    the traceback.
+
+    This must be a regular Exception rather than a `sys.exit(exit_code)`: the runners catch
+    `Exception` to log which step failed and to honour `--continue-on-failure`, and a `SystemExit`
+    would sail past those handlers and end the run without naming the step or printing anything.
+    """
+
+
 def compile_steps(
     dag: DAG,
     subdag: DAG,
@@ -730,7 +740,10 @@ class DataStep(Step):
                 run_module_run(step_module, self._dest_dir.as_posix())
                 os._exit(0)
             except BaseException:
-                traceback.print_exc()
+                # Write the traceback in one call, prefixed with the step it belongs to. Sibling
+                # children of a parallel build share this stderr, and line-by-line writes from
+                # several of them interleave into an unreadable mix.
+                os.write(2, f"--- Traceback for {self}\n{traceback.format_exc()}".encode())
                 os._exit(1)
         else:
             # ---------- parent process ----------
@@ -738,7 +751,7 @@ class DataStep(Step):
             if os.WIFEXITED(status):
                 exit_code = os.WEXITSTATUS(status)
                 if exit_code != 0:
-                    sys.exit(exit_code)
+                    raise StepFailedError(f"Step {self} failed with exit code {exit_code} (traceback above)")
             elif os.WIFSIGNALED(status):
                 sig = os.WTERMSIG(status)
                 raise Exception(f"Step {self} was killed by signal {sig}")
@@ -769,7 +782,7 @@ class DataStep(Step):
         try:
             subprocess.check_call(args, env=env)
         except subprocess.CalledProcessError as e:
-            sys.exit(e.returncode)
+            raise StepFailedError(f"Step {self} failed with exit code {e.returncode} (traceback above)") from e
 
     def _download_dataset_from_catalog(self) -> bool:
         """Download the dataset from the catalog if the checksums match. Return True if successful."""

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -63,6 +63,50 @@ def test_exec_graph_parallel():
     assert all(task in done for task in exec_graph.keys())
 
 
+def test_exec_graph_parallel_prints_traceback(capsys):
+    def failing_func(task: str, **kwargs):
+        raise ValueError(f"boom in {task}")
+
+    # Without continue_on_failure the exception propagates, but only once the pool has drained
+    # every already-submitted step, so the traceback has to be printed as soon as the step fails.
+    with pytest.raises(ValueError):
+        cmd.exec_graph_parallel({"task1": set()}, failing_func, continue_on_failure=False, workers=1, use_threads=True)
+
+    captured = capsys.readouterr()
+    assert "--- Failed task1" in captured.out
+    assert "ValueError: boom in task1" in captured.err
+
+
+def test_exec_graph_parallel_reports_every_failure(capsys):
+    def failing_func(task: str, **kwargs):
+        raise ValueError(f"boom in {task}")
+
+    # In continue_on_failure mode only the first exception is ever raised, so each failure needs
+    # its own traceback in the log.
+    with pytest.raises(ValueError):
+        cmd.exec_graph_parallel(
+            {"task1": set(), "task2": set()}, failing_func, continue_on_failure=True, workers=2, use_threads=True
+        )
+
+    captured = capsys.readouterr()
+    assert "ValueError: boom in task1" in captured.err
+    assert "ValueError: boom in task2" in captured.err
+
+
+def test_exec_graph_parallel_does_not_exit_silently_on_system_exit(capsys):
+    # A step that raises SystemExit (as the forked step runner used to on failure) must not end the
+    # run in silence: `except Exception` would not catch it and nothing would be printed.
+    def exiting_func(task: str, **kwargs):
+        raise SystemExit(1)
+
+    with pytest.raises(SystemExit):
+        cmd.exec_graph_parallel({"task1": set()}, exiting_func, continue_on_failure=False, workers=1, use_threads=True)
+
+    captured = capsys.readouterr()
+    assert "--- Failed task1" in captured.out
+    assert "SystemExit" in captured.err
+
+
 def test_construct_full_dag():
     """Test construct_full_dag function covers grapher step generation and export step handling."""
     # Test DAG with data://grapher step and export step

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -80,18 +80,29 @@ def test_data_step_recovers_from_partial_output():
 
 
 def test_data_step_failure_raises_step_failed_error():
-    # A step whose run() raises must surface as a regular Exception naming the step. It used to
-    # exit via sys.exit(1), and that SystemExit sailed past the `except Exception` handlers in the
-    # runners, ending the whole run without logging the step or printing anything.
-    # NOTE: the child's traceback goes to stderr, but pytest's capture does not survive the fork,
-    # so that half is covered by test_command.py::test_exec_graph_parallel_prints_traceback.
+    # A step whose run() raises must surface as a regular Exception carrying the step name and the
+    # traceback from the child that ran it. It used to exit via sys.exit(1), and that SystemExit
+    # sailed past the `except Exception` handlers in the runners, ending the whole run without
+    # logging the step or printing anything.
     with temporary_step() as step_name:
         py_file = paths.STEP_DIR / "data" / f"{step_name}.py"
         py_file.write_text("def run() -> None:\n    raise ValueError('boom in step code')\n")
 
+        leftovers_before = set(Path(tempfile.gettempdir()).glob("etl-step-traceback-*"))
+
         # DEBUG runs steps in-process; the runners use a forked child in a real run.
-        with patch("etl.config.DEBUG", False), pytest.raises(StepFailedError, match=step_name):
+        with patch("etl.config.DEBUG", False), pytest.raises(StepFailedError) as exc_info:
             DataStep(step_name, []).run()
+
+    assert step_name in str(exc_info.value)
+    # The traceback rides along on the exception (not in its message, which gets re-raised at the
+    # end of a run), so whoever handles the failure can print it.
+    child_traceback = exc_info.value.child_traceback
+    assert f"--- Traceback for data://{step_name}" in child_traceback
+    assert "ValueError: boom in step code" in child_traceback
+    assert "Traceback (most recent call last)" in child_traceback
+    # The file the child passes its traceback through is the parent's to clean up.
+    assert set(Path(tempfile.gettempdir()).glob("etl-step-traceback-*")) == leftovers_before
 
 
 def test_data_step_becomes_dirty_when_pandas_version_changes():

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -28,6 +28,7 @@ from etl.steps import (
     DataStepPrivate,
     SnapshotStep,
     Step,
+    StepFailedError,
     filter_to_subgraph,
     get_etag,
     isolated_env,
@@ -76,6 +77,21 @@ def test_data_step_recovers_from_partial_output():
         assert (dest_dir / "index.json").exists()
         assert not (dest_dir / "leftover.parquet").exists()
         Dataset(dest_dir.as_posix())
+
+
+def test_data_step_failure_raises_step_failed_error():
+    # A step whose run() raises must surface as a regular Exception naming the step. It used to
+    # exit via sys.exit(1), and that SystemExit sailed past the `except Exception` handlers in the
+    # runners, ending the whole run without logging the step or printing anything.
+    # NOTE: the child's traceback goes to stderr, but pytest's capture does not survive the fork,
+    # so that half is covered by test_command.py::test_exec_graph_parallel_prints_traceback.
+    with temporary_step() as step_name:
+        py_file = paths.STEP_DIR / "data" / f"{step_name}.py"
+        py_file.write_text("def run() -> None:\n    raise ValueError('boom in step code')\n")
+
+        # DEBUG runs steps in-process; the runners use a forked child in a real run.
+        with patch("etl.config.DEBUG", False), pytest.raises(StepFailedError, match=step_name):
+            DataStep(step_name, []).run()
 
 
 def test_data_step_becomes_dirty_when_pandas_version_changes():


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

A failing step could end an ETL run without printing anything about it.

`DataStep._run_py_fork` turned a child's non-zero exit into `sys.exit(exit_code)`. `SystemExit` is not an `Exception`, so it sailed past the `except Exception` handlers in `_exec_step_job` and `exec_graph_parallel`:

- no `step_failed` log, no `--- Failed <step>` line
- it short-circuited the end-of-run handling, so in `--continue-on-failure` mode **every other step's exception was dropped** — only the first one is ever re-raised, and that code never ran
- the run exited 1 with no explanation, and only after the pool had drained every already-submitted step (hours, on a full build)

This is what hid a grapher step's `AttributeError` in a recent staging build: the log showed `[error] step_failed step=grapher://...energy_institute...` and nothing else, and diagnosing it needed an ssh to the staging box to re-run the step by hand.

## Changes

- the fork and subprocess runners raise `StepFailedError` (a normal `Exception`) instead of calling `sys.exit`, so the runners log and handle it like any other failure
- `exec_graph_parallel` reports each failure as it happens instead of only re-raising the first one after the pool drains, and catches `BaseException` so a stray `SystemExit` can never again end a run in silence
- same immediate reporting in the sequential path, where all but the first traceback were lost too
- both runners end with the same `steps_failed` recap naming every failed step — by then the individual failures are thousands of lines up the log, and the list is what you feed back into `etl run`. This replaces the sequential path's per-exception `step_exception` loop (whose parallel counterpart did not even log the step name, only `str(exception)`)
- the forked child writes its traceback in a single call, prefixed with the step it belongs to; siblings in a parallel build were interleaving line-by-line into unreadable soup

For `StepFailedError` only the message is printed: the child already printed the real traceback, and everything the wrapper adds is executor plumbing (`_RemoteTraceback`, `future.result` frames — ~25 lines per failed step).

## How to test it

Already verified: `make check`, `pytest tests` (the two `test_explorer_migration.py::test_explorer_legacy_*` failures are pre-existing on master), 4 new unit tests, plus the end-to-end before/after below.

To see it yourself, drop a step that raises into the DAG and run it on the forked path (`DEBUG=0`; locally `ENV=dev` implies `DEBUG=1`, which runs steps in-process and never had this problem — it only bites on staging/production):

```bash
mkdir -p etl/steps/data/garden/dummy_failing/2026-07-28
cat > etl/steps/data/garden/dummy_failing/2026-07-28/boom.py <<'PY'
def run() -> None:
    values = {"a": 1}
    raise ValueError(f"deliberate failure: {values['missing_key']}")
PY
cat > etl/steps/data/garden/dummy_failing/2026-07-28/boom2.py <<'PY'
def run() -> None:
    raise RuntimeError("second deliberate failure, in a different step")
PY
# add both to dag/main.yml under `steps:` with no dependencies, then:
DEBUG=0 .venv/bin/etl run garden/dummy_failing --workers 2 --continue-on-failure
```

Before, with two steps failing (exit code 1, and `grep -c "step_failed\|--- Failed\|steps_failed"` → **0**):

```
--- Running 2 steps with 2 processes (20 threads each):
--- Starting data://garden/dummy_failing/2026-07-28/boom2
--- Starting data://garden/dummy_failing/2026-07-28/boom
Traceback (most recent call last):
Traceback (most recent call last):
  File ".../etl/steps/__init__.py", line 730, in _run_py_fork
    run_module_run(step_module, self._dest_dir.as_posix())
  ...
    raise RuntimeError("second deliberate failure, in a different step")
  File ".../etl/steps/__init__.py", line 730, in _run_py_fork      <-- two children, one stderr
  ...
RuntimeError: second deliberate failure, in a different step
    raise ValueError(f"deliberate failure: {values['missing_key']}")
KeyError: 'missing_key'
```

Neither step is named anywhere, and a step failing in the parent process (any `grapher://` step) would leave no trace at all.

After:

```
--- Traceback for data://garden/dummy_failing/2026-07-28/boom2
Traceback (most recent call last):
  ...
    raise RuntimeError("second deliberate failure, in a different step")
RuntimeError: second deliberate failure, in a different step
--- Traceback for data://garden/dummy_failing/2026-07-28/boom
Traceback (most recent call last):
  ...
    raise ValueError(f"deliberate failure: {values['missing_key']}")
KeyError: 'missing_key'
[error    ] step_failed   step=data://garden/dummy_failing/2026-07-28/boom2
[error    ] step_failed   step=data://garden/dummy_failing/2026-07-28/boom
Step data://garden/dummy_failing/2026-07-28/boom2 failed with exit code 1 (traceback above)
Step data://garden/dummy_failing/2026-07-28/boom failed with exit code 1 (traceback above)
--- Failed data://garden/dummy_failing/2026-07-28/boom2 - FAILED
--- Failed data://garden/dummy_failing/2026-07-28/boom - FAILED
[error    ] steps_failed  steps=['data://garden/dummy_failing/2026-07-28/boom', 'data://garden/dummy_failing/2026-07-28/boom2']
```

Exit code is 1 in both cases, and the same holds without `--continue-on-failure`.

