### PR TITLE
✨ Guard Expert agent SQL to read-only single statements

### DIFF
--- a/apps/wizard/app_pages/expert_agent/agent.py
+++ b/apps/wizard/app_pages/expert_agent/agent.py
@@ -18,7 +18,13 @@ from pydantic_ai.tools import RunContext
 # from RestrictedPython import compile_restricted, safe_globals
 from apps.wizard.app_pages.expert_agent.media import save_code_file, save_plot_file
 from apps.wizard.app_pages.expert_agent.utils import CURRENT_DIR, MODEL_DEFAULT, QueryResult, log, serialize_df
-from etl.analytics.metabase import _generate_question_url, create_question, get_question_info, read_semantic_layer
+from etl.analytics.metabase import (
+    _generate_question_url,
+    assert_question_is_read_only,
+    create_question,
+    get_question_info,
+    read_semantic_layer,
+)
 from etl.analytics.metabase import get_question_data as _get_question_data
 from etl.config import GOOGLE_API_KEY, OWID_MCP_SERVER_URL
 from etl.docs import (
@@ -31,6 +37,7 @@ from etl.docs import (
 )
 from etl.files import ruamel_dump
 from etl.paths import BASE_DIR, DOCS_DIR
+from etl.sql_guard import SqlNotReadOnlyError
 
 #######################################################
 # LOAD KNOWLEDGE BASE
@@ -445,6 +452,13 @@ async def execute_query(query: str, title: str, description: str, num_rows: int 
             url_metabase=url_metabase,
             card_id_metabase=card_id,
         )
+    except SqlNotReadOnlyError as e:
+        # Rejected before it ever reached BigQuery: tell the model what the actual rule is,
+        # rather than sending it off to debug GoogleSQL syntax that is not the problem.
+        return QueryResult(
+            message=f"ERROR. This tool only runs a single read-only SELECT statement. {e}",
+            valid=False,
+        )
     except Exception as e:
         return QueryResult(
             message=f"ERROR. Query is invalid! Check for correctness, it must be BigQuery (GoogleSQL) compatible!\nError: {e}",
@@ -542,6 +556,18 @@ async def get_question_data(card_id: int, num_rows: int = 20) -> QueryResult:
             data (list[list]): Small slice of the data (first `num_rows` rows).
             total_rows (int): Total number of rows in the dataframe.
     """
+    # Running a saved question executes whatever SQL it stores, under our Metabase API key, so
+    # the card's own query gets the same read-only check as `execute_query`. The card ids the
+    # agent sees come from questions outside the Expert collection, i.e. ones it did not write.
+    question = get_question_info(card_id)
+    try:
+        assert_question_is_read_only(question)
+    except SqlNotReadOnlyError as e:
+        return QueryResult(
+            message=f"ERROR. Metabase question {card_id} is not read-only, so it was not run. {e}",
+            valid=False,
+        )
+
     # Getting data
     data = _get_question_data(card_id)
 
@@ -557,8 +583,8 @@ async def get_question_data(card_id: int, num_rows: int = 20) -> QueryResult:
     #     text=f"**:material/construction: Tool use**: Getting data from a Metabase question, via `get_question_data`, using id `{card_id}` for question named '{q_name}'",
     # )
 
-    # Generate URL
-    url = await get_question_url(card_id)
+    # Generate URL (reusing the question we already fetched above)
+    url = _generate_question_url(question)
 
     # Serialize
     data = serialize_df(data, num_rows=num_rows)
@@ -601,7 +627,9 @@ async def generate_plot(
     model_name = ctx.model.model_name
     question_id = ctx.deps.get("question_id", f"plot_{card_id}")
 
-    # Get data from Metabase
+    # Get data from Metabase. Same sink as `get_question_data`: running a card executes its
+    # stored SQL, so check it is read-only first.
+    assert_question_is_read_only(get_question_info(card_id))
     df = _get_question_data(card_id)
     if df.empty:
         raise ValueError(f"DataFrame is empty for question with ID {card_id}")

--- a/apps/wizard/app_pages/expert_agent/context.yml
+++ b/apps/wizard/app_pages/expert_agent/context.yml
@@ -70,7 +70,8 @@ context:
     You will typically call `generate_plot` after running `execute_query` to create a new Metabase question, or after using `list_available_questions_metabase` / `get_question_data` to get data from an existing Metabase question.
 
     ## Important SQL Guidelines
-    - The dialect is **BigQuery (GoogleSQL)**. Reference tables with their dataset, e.g. `prod_semantic.views_detailed` — not a bare table name.
+    - The dialect is **BigQuery (GoogleSQL)**. Reference tables with their dataset, e.g. `prod_semantic.views_detailed` — not a bare table name. Beyond `prod_semantic`, the raw analytics datasets `prod_ga4` and `prod_google_analytics4` are in regular use; prefer the curated `prod_semantic` tables when they can answer the question, and only drop down to the raw GA4 datasets when they can't.
+    - **Read-only, one statement.** Only a single `SELECT` (optionally starting with a `WITH` clause) will run; the tools reject anything else before it reaches BigQuery. Never write, and never chain statements with `;`. Query only the analytics datasets you need for the user's question — the connection can see other datasets, including operational ones that are none of your business.
     - For relative dates use `DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)` — BigQuery has no `date - interval` operator, and the unit is an unquoted keyword (`DAY`, `MONTH`, `YEAR`, …). Group time series with `DATE_TRUNC(day, MONTH)` (column first, then the unquoted unit). Don't hardcode dates unless the user asks.
     - **Cost matters**: queries run on BigQuery, billed by bytes scanned. ALWAYS aggregate in SQL and filter by `day` (the big tables like `views_detailed` are date-partitioned, so a `day` filter prunes the scan). Never `SELECT *` from a large table.
 

--- a/etl/analytics/metabase.py
+++ b/etl/analytics/metabase.py
@@ -20,6 +20,7 @@ from etl.config import (
     METABASE_URL_LOCAL,
     OWID_ENV,
 )
+from etl.sql_guard import SqlNotReadOnlyError, validate_read_only_sql
 
 log = get_logger()
 
@@ -55,6 +56,11 @@ def read_semantic_layer(sql: str) -> pd.DataFrame:
 
     To query another database via Metabase, use `read_metabase` instead.
 
+    The query must be a single read-only SELECT: this is the entry point the Expert agent uses
+    for model-written SQL, and the connection behind it is a BigQuery service account with
+    write access to more than the semantic layer. See `etl.sql_guard` for what the check is and
+    is not worth.
+
     Parameters
     ----------
     sql : str
@@ -65,7 +71,13 @@ def read_semantic_layer(sql: str) -> pd.DataFrame:
     pd.DataFrame
         DataFrame containing the results of the query.
 
+    Raises
+    ------
+    SqlNotReadOnlyError
+        If `sql` is not a single read-only SELECT statement.
+
     """
+    validate_read_only_sql(sql)
     return read_metabase(
         sql,
         METABASE_SEMANTIC_LAYER_DATABASE_ID,
@@ -283,6 +295,57 @@ def get_question_info(question_id: int, prod: bool = False) -> dict:
     assert question.get("type") == "question", f"Card with id {question_id} is not a question"
 
     return question
+
+
+def _native_sql_of_question(dataset_query: dict) -> list[str]:
+    """Return every raw-SQL fragment a saved question would run.
+
+    Metabase exposes two shapes for `dataset_query`: the legacy
+    `{"type": "native", "native": {"query": ...}}`, and the MBQL-lib one currently returned by
+    our instance, `{"lib/type": "mbql/query", "stages": [{"lib/type": "mbql.stage/native",
+    "native": "..."}]}`. Query-builder stages carry no SQL and can only read, so they
+    contribute nothing. An unrecognised shape raises rather than being waved through — if this
+    starts firing, Metabase changed its API and the guard needs updating.
+    """
+    if "stages" in dataset_query:
+        sql_fragments = []
+        for stage in dataset_query["stages"]:
+            stage_type = stage.get("lib/type")
+            if stage_type == "mbql.stage/native":
+                native = stage.get("native") or ""
+                # `native` is a plain string in this format, but tolerate the nested form.
+                sql_fragments.append(native.get("query", "") if isinstance(native, dict) else native)
+            elif stage_type != "mbql.stage/mbql":
+                raise SqlNotReadOnlyError(f"Unrecognised Metabase query stage {stage_type!r}; refusing to run it.")
+        return sql_fragments
+
+    query_type = dataset_query.get("type")
+    if query_type == "native":
+        return [(dataset_query.get("native") or {}).get("query") or ""]
+    if query_type == "query":
+        return []
+    raise SqlNotReadOnlyError(f"Unrecognised Metabase query type {query_type!r}; refusing to run it.")
+
+
+def assert_question_is_read_only(question: dict) -> None:
+    """Raise unless running this saved question would only read.
+
+    A card id is worth exactly as much as the SQL stored in it: Metabase runs the card
+    server-side under our own API key, so "execute card N" is a way to execute arbitrary
+    native SQL without ever passing a query string. Callers that take a card id from a
+    language model should run this first.
+
+    Raises
+    ------
+    SqlNotReadOnlyError
+        If the question stores anything other than read-only SELECTs.
+
+    """
+    dataset_query = question.get("dataset_query")
+    if not isinstance(dataset_query, dict) or not dataset_query:
+        raise SqlNotReadOnlyError(f"Metabase question {question.get('id')} has no query definition to check.")
+    for sql in _native_sql_of_question(dataset_query):
+        validate_read_only_sql(sql)
 
 
 def get_question_data(card_id: int, data_format: str = "csv", prod: bool = False) -> pd.DataFrame:

--- a/etl/sql_guard.py
+++ b/etl/sql_guard.py
@@ -1,0 +1,154 @@
+"""Guard for SQL that we did not write ourselves.
+
+Some code paths hand a SQL string composed by an LLM (the Expert agent, the MCP server)
+straight to a database connection. Those connections are shared credentials, not read-only
+ones, so the only thing keeping such a query from writing is the prompt asking it not to.
+
+`validate_read_only_sql` is a cheap structural check that the string is *one* statement and
+that the statement is a `SELECT` (optionally with a leading `WITH` clause). It is defence in
+depth, not a trust boundary: the credential the query travels on is what actually bounds the
+damage, and anyone holding that credential can bypass this function entirely by calling the
+underlying API. Its job is to stop a confused model — or a prompt-injected one — from turning
+a read tool into a write tool.
+
+Two properties matter more than the keyword list:
+
+* **It never rewrites the query.** The sanitized copy is used for analysis only; the caller
+  executes the original string. A validator that strips comments and executes the result will
+  silently truncate a query whose string literal contains `--`.
+* **It only looks at code, never at data.** String literals, quoted identifiers, comments and
+  Metabase template tags are blanked before analysis, so a `;` or the word `delete` inside
+  `WHERE url LIKE '%delete%'` cannot change the verdict.
+"""
+
+import re
+
+__all__ = ["SqlNotReadOnlyError", "validate_read_only_sql"]
+
+
+class SqlNotReadOnlyError(ValueError):
+    """The SQL string is not a single read-only SELECT statement."""
+
+
+# Comments, string literals and quoted identifiers. Everything matched here is blanked out
+# before the query is inspected, so its contents can never influence the verdict.
+_LITERALS_AND_COMMENTS_RE = re.compile(
+    r"""
+      \{\{[^{}]*\}\}           # {{template_tag}} — must come before the # comment rule, because
+                               # Metabase card references look like {{#141-some-card}}
+    | --[^\n]*                 # -- line comment
+    | \#[^\n]*                 # # line comment (BigQuery accepts both)
+    | /\*.*?(?:\*/|$)          # /* block comment */, unterminated included
+    | '(?:\\.|[^'\\])*'        # 'single-quoted string'
+    | "(?:\\.|[^"\\])*"        # "double-quoted string"
+    | `[^`]*`                  # `backtick-quoted identifier` (BigQuery table references)
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
+_WITH_RE = re.compile(r"\s*with\b", re.IGNORECASE)
+_RECURSIVE_RE = re.compile(r"\s*recursive\b", re.IGNORECASE)
+# One CTE definition up to (and including) the opening parenthesis of its body:
+# `name [(col, ...)] AS [NOT MATERIALIZED] (`. The name may be empty here, because a
+# backtick-quoted name has already been blanked out by the sanitizer.
+_CTE_HEAD_RE = re.compile(
+    r"\s*\w*\s*(?:\([^()]*\)\s*)?as\s*(?:(?:not\s+)?materialized\s*)?\(",
+    re.IGNORECASE,
+)
+_SELECT_RE = re.compile(r"\s*select\b", re.IGNORECASE)
+
+
+def _blank_literals_and_comments(sql: str) -> str:
+    """Replace every comment, string literal and quoted identifier with a space.
+
+    Length is not preserved and nothing is unbalanced: each match becomes a single space, which
+    keeps neighbouring tokens apart (`a'x'b` -> `a b`) without leaving any of the original
+    content behind.
+    """
+    return _LITERALS_AND_COMMENTS_RE.sub(" ", sql)
+
+
+def _skip_parenthesized(sql: str, start: int) -> int | None:
+    """Return the index just past the `)` matching the `(` at `start`, or None if unbalanced."""
+    assert sql[start] == "("
+    depth = 0
+    for i in range(start, len(sql)):
+        if sql[i] == "(":
+            depth += 1
+        elif sql[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    return None
+
+
+def _body_after_with_clause(sql: str) -> str | None:
+    """Given a sanitized query starting with `WITH`, return the main query that follows.
+
+    Returns None if the CTE list cannot be parsed, in which case the query is rejected: we
+    would otherwise be guessing about what the statement actually does.
+    """
+    match = _WITH_RE.match(sql)
+    assert match is not None
+    position = match.end()
+
+    recursive = _RECURSIVE_RE.match(sql, position)
+    if recursive:
+        position = recursive.end()
+
+    while True:
+        head = _CTE_HEAD_RE.match(sql, position)
+        if head is None:
+            return None
+        # head.end() - 1 is the opening parenthesis of the CTE body.
+        after_body = _skip_parenthesized(sql, head.end() - 1)
+        if after_body is None:
+            return None
+        position = after_body
+
+        next_comma = re.match(r"\s*,", sql[position:])
+        if next_comma is None:
+            return sql[position:]
+        position += next_comma.end()
+
+
+def validate_read_only_sql(sql: str) -> None:
+    """Raise `SqlNotReadOnlyError` unless `sql` is a single read-only SELECT statement.
+
+    The query is *not* modified — callers execute the string they passed in.
+
+    Accepted: a single `SELECT`, optionally preceded by a `WITH` clause and optionally
+    wrapped in parentheses (`(SELECT ...) UNION ALL (SELECT ...)`), with or without a
+    trailing semicolon.
+
+    Rejected: anything else — DDL/DML, multi-statement scripts, BigQuery scripting
+    (`DECLARE`, `EXPORT DATA`, …), and queries whose structure cannot be parsed.
+    """
+    query = _blank_literals_and_comments(sql)
+
+    if not query.strip():
+        raise SqlNotReadOnlyError("Empty query.")
+
+    # A trailing semicolon is fine; anything after it means more than one statement.
+    if ";" in re.sub(r"[\s;]+$", "", query):
+        raise SqlNotReadOnlyError("Only a single statement can be executed (found `;` mid-query).")
+    query = re.sub(r"[\s;]+$", "", query)
+
+    if _WITH_RE.match(query):
+        body = _body_after_with_clause(query)
+        if body is None:
+            raise SqlNotReadOnlyError(
+                "Could not verify that this is a read-only SELECT: the WITH clause could not be parsed."
+            )
+    else:
+        body = query
+
+    # `(SELECT ...) UNION ALL (SELECT ...)` and other parenthesized set operations.
+    body = body.lstrip()
+    while body.startswith("("):
+        body = body[1:].lstrip()
+
+    if not _SELECT_RE.match(body):
+        first_word = re.match(r"\s*(\w+)", body)
+        found = first_word.group(1).upper() if first_word else "nothing"
+        raise SqlNotReadOnlyError(f"Only SELECT queries can be executed (query starts with `{found}`).")

--- a/owid_mcp/data_utils.py
+++ b/owid_mcp/data_utils.py
@@ -18,6 +18,7 @@ import yaml
 from owid.catalog.core import CatalogPath
 
 from etl.http import HEADERS
+from etl.sql_guard import validate_read_only_sql
 from owid_mcp.config import (
     ALGOLIA_API_KEY,
     ALGOLIA_APP_ID,
@@ -33,9 +34,6 @@ log = structlog.get_logger()
 
 # Global mapping cache
 _NAME_TO_CODE_MAPPING: dict[str, str] | None = None
-
-# SQL validation pattern
-SQL_SELECT_RE = re.compile(r"^\s*select\b", re.IGNORECASE | re.DOTALL)
 
 # DuckDB (Datasette's current query backend) reports a missing column as a
 # "Binder Error", e.g.:
@@ -218,7 +216,8 @@ async def run_sql(query: str, max_rows: int = MAX_ROWS_DEFAULT) -> dict[str, Any
     Parameters
     ----------
     query : str
-        A SQL statement starting with `SELECT`. Anything else is rejected.
+        A single `SELECT` statement (a leading `WITH` clause is fine). Anything else is
+        rejected — see `etl.sql_guard`.
     max_rows : int
         Safety cap (1‑5000). The query is rewritten with `LIMIT` if absent.
 
@@ -227,8 +226,7 @@ async def run_sql(query: str, max_rows: int = MAX_ROWS_DEFAULT) -> dict[str, Any
     dict
         {"csv": "actual csv content", "source": datasette_csv_url}
     """
-    if not SQL_SELECT_RE.match(query):
-        raise ValueError("Only SELECT statements are allowed.")
+    validate_read_only_sql(query)
     if max_rows < 1 or max_rows > MAX_ROWS_HARD:
         raise ValueError(f"max_rows must be 1‑{MAX_ROWS_HARD}.")
 

--- a/tests/test_sql_guard.py
+++ b/tests/test_sql_guard.py
@@ -1,0 +1,133 @@
+"""Tests for the read-only SQL guard."""
+
+import pytest
+
+from etl.analytics.metabase import assert_question_is_read_only
+from etl.sql_guard import SqlNotReadOnlyError, validate_read_only_sql
+
+ACCEPTED = [
+    # Plain SELECT, with and without a trailing semicolon.
+    "SELECT 1",
+    "  select 1  ",
+    "SELECT * FROM `prod_semantic.views_detailed` LIMIT 10;",
+    # Multi-CTE query, the shape most Expert queries have.
+    """
+    WITH sessions AS (
+        SELECT user_pseudo_id, day FROM `prod_ga4.session_metrics` WHERE day >= '2026-01-01'
+    ),
+    ranked AS (
+        SELECT user_pseudo_id, COUNT(*) AS n FROM sessions GROUP BY 1
+    )
+    SELECT * FROM ranked ORDER BY n DESC
+    """,
+    # A `--` inside a string literal must not be read as a comment.
+    "SELECT COUNT(*) FROM t WHERE url LIKE '%--%'",
+    # Words that a keyword blacklist would trip over, inside literals and identifiers.
+    "SELECT last_updated FROM t WHERE action IN ('insert', 'update', 'delete', 'drop table')",
+    "SELECT COUNT(*) FROM t WHERE title = 'How we update our data; and why'",
+    # Real comments.
+    "-- count the rows\nSELECT COUNT(*) FROM t",
+    "/* block\n comment */ SELECT COUNT(*) FROM t",
+    "SELECT COUNT(*) FROM t # trailing BigQuery comment",
+    # Parenthesized set operations.
+    "(SELECT 1) UNION ALL (SELECT 2)",
+    "WITH a AS (SELECT 1 AS x) (SELECT x FROM a) UNION ALL (SELECT 2)",
+    # Backtick-quoted CTE name (blanked by the sanitizer, so the parser must cope).
+    "WITH `my cte` AS (SELECT 1 AS x) SELECT * FROM `my cte`",
+    # Nested parentheses and a subquery inside the CTE body.
+    "WITH a AS (SELECT (SELECT MAX(y) FROM u) AS m FROM t) SELECT * FROM a",
+    # Metabase template tags, including a card reference — the `#` in `{{#141-...}}` is not the
+    # start of a BigQuery comment, and treating it as one used to swallow the closing paren.
+    "with t as (select source_url from `prod_semantic.media_mentions`"
+    " join (select source_url from {{#141-media-sources-metadata}}) using(source_url)"
+    " where {{date_range}}) select * from t",
+]
+
+REJECTED = [
+    "",
+    "   ",
+    "-- nothing but a comment",
+    "DROP TABLE x",
+    "drop table `prod_mysql.users`",
+    "DELETE FROM prod_mysql.sessions WHERE 1=1",
+    "INSERT INTO t VALUES (1)",
+    "CREATE OR REPLACE TABLE t AS SELECT 1",
+    "SELECT 1; DELETE FROM y",
+    "SELECT 1;\nDROP TABLE y;",
+    "SELECT 1; SELECT 2;",
+    # BigQuery scripting.
+    "DECLARE x INT64; SET x = 1;",
+    "EXPORT DATA OPTIONS(uri='gs://bucket/*.csv') AS SELECT * FROM t",
+    "CALL my_procedure()",
+    # A statement smuggled after what looks like a comment: the comment ends at the newline.
+    "SELECT 1 -- harmless\n; DROP TABLE y",
+    # WITH clause that does not lead into a SELECT.
+    "WITH a AS (SELECT 1) DELETE FROM t",
+    "WITH a AS (SELECT 1) INSERT INTO t SELECT * FROM a",
+    # Unparseable WITH clause: reject rather than guess.
+    "WITH a AS (SELECT 1",
+]
+
+
+@pytest.mark.parametrize("sql", ACCEPTED)
+def test_accepts_read_only_queries(sql: str) -> None:
+    validate_read_only_sql(sql)
+
+
+@pytest.mark.parametrize("sql", REJECTED)
+def test_rejects_everything_else(sql: str) -> None:
+    with pytest.raises(SqlNotReadOnlyError):
+        validate_read_only_sql(sql)
+
+
+def _mbql_lib_card(sql: str) -> dict:
+    """A saved question in the shape our Metabase instance currently returns."""
+    return {
+        "id": 1782,
+        "dataset_query": {
+            "lib/type": "mbql/query",
+            "database": 3,
+            "stages": [{"lib/type": "mbql.stage/native", "native": sql}],
+        },
+    }
+
+
+def _legacy_card(sql: str) -> dict:
+    """A saved question in Metabase's older `dataset_query` shape."""
+    return {"id": 812, "dataset_query": {"type": "native", "database": 3, "native": {"query": sql}}}
+
+
+@pytest.mark.parametrize("card", [_mbql_lib_card, _legacy_card])
+def test_accepts_read_only_saved_questions(card) -> None:
+    assert_question_is_read_only(card("WITH a AS (SELECT 1 AS x) SELECT * FROM a"))
+
+
+@pytest.mark.parametrize("card", [_mbql_lib_card, _legacy_card])
+def test_rejects_saved_questions_that_write(card) -> None:
+    with pytest.raises(SqlNotReadOnlyError):
+        assert_question_is_read_only(card("DELETE FROM `prod_mysql.sessions`"))
+
+
+def test_accepts_query_builder_questions() -> None:
+    """Query-builder ("MBQL") questions hold no SQL and can only read."""
+    assert_question_is_read_only(
+        {"id": 5, "dataset_query": {"lib/type": "mbql/query", "stages": [{"lib/type": "mbql.stage/mbql"}]}}
+    )
+    assert_question_is_read_only({"id": 5, "dataset_query": {"type": "query", "query": {"source-table": 1}}})
+
+
+def test_rejects_unrecognised_question_shapes() -> None:
+    """Fail closed: an unknown shape means we cannot tell what the card would run."""
+    with pytest.raises(SqlNotReadOnlyError):
+        assert_question_is_read_only({"id": 5, "dataset_query": {}})
+    with pytest.raises(SqlNotReadOnlyError):
+        assert_question_is_read_only({"id": 5, "dataset_query": {"type": "something-new"}})
+    with pytest.raises(SqlNotReadOnlyError):
+        assert_question_is_read_only({"id": 5, "dataset_query": {"stages": [{"lib/type": "mbql.stage/new"}]}})
+
+
+def test_does_not_modify_the_query() -> None:
+    """The guard inspects a sanitized copy; the caller executes the original string."""
+    sql = "SELECT '--' AS dashes FROM t"
+    validate_read_only_sql(sql)
+    assert sql == "SELECT '--' AS dashes FROM t"


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

The Expert agent passes model-written SQL straight through `read_semantic_layer` to Metabase database 3. That connection is not the old read-only DuckDB semantic layer it replaced: it is a BigQuery service account that currently sees 268 tables across 7 datasets, including a mirror of the grapher database. Nothing but the prompt asked the model to stay inside `prod_semantic`. This adds a structural check — one statement, and that statement a `SELECT` — on every path that runs model-supplied SQL. No behaviour change for any query the agent actually writes.

**This is defence in depth, not a boundary.** `METABASE_API_KEY` is fleet-shared: it sits in several deployed env files and in every developer's local `.env`, so anyone who can reach the Wizard already holds the key and can run the same SQL from a REPL. The real fix is a narrowed BigQuery service account behind its own Metabase connection, plus a per-SA bytes-billed quota. That is infrastructure, it needs a human decision, and it is deliberately not here.

_Review depth: deep on `etl/sql_guard.py` — the only thing that matters is whether it false-rejects real queries. The rest is wiring._

Automated security review finding: https://chatgpt.com/codex/cloud/security/findings/bcfd31fef0048191a4d4d3b1790c8f29

## How it works

`validate_read_only_sql` accepts a single `SELECT`, optionally preceded by a `WITH` clause and optionally parenthesised (`(SELECT …) UNION ALL (SELECT …)`), with or without a trailing semicolon. Two properties do the work:

- **It never rewrites the query.** The analysis runs on a sanitized copy; the caller executes the string it passed in. A validator that strips comments and executes the *result* silently truncates any query whose string literal contains `--`.
- **It only reads code, never data.** Comments, string literals, quoted identifiers and Metabase template tags are blanked before analysis, so a `;` or the word `delete` inside `WHERE url LIKE '%delete%'` cannot change the verdict. This is why there is no keyword blacklist: with literals blanked, "starts with SELECT and contains no statement separator" is already sufficient, and a blacklist only adds false rejects.

`WITH` needs real parsing rather than a prefix match, because `WITH a AS (…) DELETE FROM t` also starts with `WITH`. The CTE list is walked with balanced-paren matching and the main query must then begin with `SELECT`. If the clause can't be parsed, the query is rejected rather than guessed at.

**Three sinks, not one.** Besides `read_semantic_layer`, the agent can execute a saved Metabase card by numeric id (`get_question_data`, and `generate_plot`, which nobody flagged). Metabase runs a card server-side under our API key, so a card id is worth exactly as much as the SQL stored in it — and `list_available_questions_metabase` enumerates cards *outside* the Expert collection, i.e. ones the agent didn't write. `assert_question_is_read_only` fetches the card and applies the same guard to its stored SQL. Restricting to collection 61 instead would have broken the intended workflow, which is precisely to reuse human-authored questions. Unrecognised card shapes fail closed; the comment on `_native_sql_of_question` says what to update if Metabase changes its API again.

`owid_mcp.run_sql` now uses the shared guard in place of its narrower `SQL_SELECT_RE`. Two behaviour changes there, both on a read-only public Datasette: it now rejects multi-statement input, and it now accepts a leading `WITH` (CTEs), which it previously refused outright.

**Rejected: the scanner's dataset allowlist.** The proposed patch restricted queries to tables in `prod_semantic`. Run against the SQL of the 59 most recent bot-generated Expert cards, it rejects 57 — every rejection a legitimate `prod_ga4.*` / `prod_google_analytics4.*` query. The premise is just wrong: the semantic layer is not the only dataset in use. The prompt (`context.yml`) implied it was, and is corrected here.

## Verified

Nothing in this PR was tested by executing a query against BigQuery or Metabase; only card definitions were read.

- **1125 / 1125 saved Metabase questions accepted**, including all 410 bot-generated (🤖) ones, 1003 with real newlines and 99 containing `--` or `/*` comments. This is the check that matters: the scanner's patch scored 2 / 59 on the same kind of corpus. It also caught a real bug in a first draft — `{{#141-media-sources-metadata}}`, a Metabase card-reference tag, was being read as a BigQuery `#` comment, which swallowed a closing paren and false-rejected 3 human cards. Reproduction script below.
- **40 unit cases** in `tests/test_sql_guard.py`: multi-CTE queries, `--` inside string literals, `insert`/`update`/`delete` as literal values, template tags, parenthesised set operations — all accepted; `DROP TABLE x`, `SELECT 1; DELETE FROM y`, trailing-semicolon multi-statement, `DECLARE`/`EXPORT DATA`, `WITH a AS (…) DELETE FROM t`, and unparseable input — all rejected.
- Both saved-card shapes covered by fixtures (the current MBQL-lib one and the legacy `{"type": "native"}`), plus query-builder cards, which carry no SQL.

**Not verified:** the Expert agent end to end in the Wizard — the guard sits behind an LLM tool call and needs Metabase credentials, so it was exercised at the function level instead.

**Still open after this PR:** `etl.analytics.metabase.read_metabase` takes any `database_id` and is unguarded by design — it is the low-level helper for other databases. Anything holding `METABASE_API_KEY` can call it, or call the Metabase API directly. Only the service account scoping closes that.

## How to test it

```bash
# 1. The guard itself
uv run pytest tests/test_sql_guard.py -q

# 2. Real queries still pass, DML still doesn't (needs METABASE_API_KEY in .env; reads card
#    definitions only, runs nothing)
uv run python -c "
from etl.analytics.metabase import mb_cli, _native_sql_of_question
from etl.sql_guard import validate_read_only_sql, SqlNotReadOnlyError
sql = _native_sql_of_question(mb_cli().get('/api/card/1782')['dataset_query'])[0]
validate_read_only_sql(sql); print('real card: accepted')
try: validate_read_only_sql(sql + '; DROP TABLE x')
except SqlNotReadOnlyError as e: print('appended DROP:', e)
"
```

Then open the Expert page in the Wizard and ask it something that needs a new query (e.g. "most viewed charts last week") — it should behave exactly as before.

<details>
<summary>Regression script: run the guard over every saved Metabase question</summary>

```python
from collections import Counter

from etl.analytics.metabase import _native_sql_of_question, assert_question_is_read_only, mb_cli
from etl.sql_guard import SqlNotReadOnlyError

questions = [c for c in mb_cli().get("/api/card/") if c.get("type") == "question"]
accepted, rejected, bot = 0, [], Counter()
for c in questions:
    is_bot = c.get("name", "").startswith("🤖")
    bot["total"] += is_bot
    try:
        assert_question_is_read_only(c)
        accepted += 1
        bot["accepted"] += is_bot
    except SqlNotReadOnlyError as e:
        rejected.append((c["id"], c.get("name"), str(e)))

print(f"questions={len(questions)} accepted={accepted} rejected={len(rejected)}")
print(f"bot-generated: {bot['accepted']}/{bot['total']} accepted")
for row in rejected:
    print("  REJECTED", row)
```

Result at the time of writing: `questions=1125 accepted=1125 rejected=0`, `bot-generated: 410/410 accepted`.
</details>
