### PR TITLE
📜 Fold ODA-update session lessons into update-dataset and related skills

### DIFF
--- a/.claude/skills/update-dataset/data-update-template.md
+++ b/.claude/skills/update-dataset/data-update-template.md
@@ -104,6 +104,8 @@ The OWID GDocs Add-on colors and indents these docs. You can reproduce that styl
 
 Per-line HTML shape: `<p style="margin-left:10pt"><span style="color:#666666">…</span></p>`; links `<a href="…" style="color:#1155cc;text-decoration:underline">…</a>`; encode all non-ASCII as HTML entities. Verify afterward with `download_file_content(exportMimeType="text/html")` and check the `color:` / `margin-left:` survived. (If OWID changes the scheme, re-extract it from a recent correctly-formatted doc rather than trusting these hex values.)
 
+**Dod links do not survive the HTML import.** A fragment href like `#dod:oda` gets rewritten by Google's importer into an internal bookmark id (`#id.xxxxxxxx`), silently breaking the dod. External `https://` links come through fine (wrapped in Google's redirector, which is normal). After creating the doc, list every dod the body uses in the handoff and ask the user to re-add each one by hand (select the anchor text → edit link → paste the literal `#dod:…`).
+
 ---
 
 ## Field-by-field guidance


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

Lessons from the OECD ODA 2026-07 update (#6524), folded into the skills that will run the next cycle. All phrased as general patterns; the ODA incident appears only as a trailing example.

**`update-dataset`**
- §5b-bis sanity-check table: composite sums over optionally-reported components — a bare `.sum()` fabricates zeros, but `min_count=len(components)` can wipe most of a series when category coverage widens over time; the robust rule is `min_count=1` + a withdrawn-component detector for partially-published years.
- Step 7 narrative charts: the upgrader's stale-FAUST warnings only cover narrative charts visited in the same run — sweep **all** of them afterwards, plus a plain base-year grep (pinned notes can be several releases stale, and the similarity check misses reworded ones). Parent FAUST edits reach narrative children lazily (materialized `full`) — re-save the child's patch unchanged to force re-derivation.
- Guardrails: pinned deflator sentences get **literal substring** swaps, never year-regexes; partial-year preliminary releases need a per-series max-year sweep — stacked time-series self-protect, single-time discrete views render the partial year with `tolerance` backfilling prior-year values (mixed vintages), and the right guard is `timelineMaxTime` (a `maxTime` pin leaves the year reachable by slider/URL).

**`review-data-pr`** (§8e mirror): when a release added a partial year, unguarded single-time views on partially-published indicators are a finding.

**`check-empty-entities`**: pre-existing chart/narrative selection gaps are one-line fixes that ride Chart Diff — offer them in-session; mapping nuances (live twin already selected → drop; twin has no data on that chart's indicators → drop); gdoc Find & Replace can't edit hyperlink targets; token deletions in `country=` URLs must anchor on the leading `~` (entity-name prefix overlap); keep deferred findings on a tracked list.

**`check-hardcoded-years`**: chart-level variant of the incomplete-latest-year exception; `timelineMaxTime` vs `maxTime` as guards; don't judge a year's completeness from a render — tolerance backfill makes partial years look whole.

**`data-updates-comms` + template**: a checksum change ≠ "gained the new year" (rebases mark everything changed) — verify picked views actually reach the new year, and prefer the release's headline-measure chart; basis discipline for every number and ranking (attribute or round producer-basis figures; enumerate measure × price-basis combinations before echoing "X overtook Y").

**Template (dod follow-up to the first commit)**: a manual dod re-add through the Docs UI stores the bare `#dod:…` fragment and works (CMS matches `startsWith("#dod:")`); verify via the HTML export — `read_file_content` absolutizes fragments and makes a correct link look broken.