### PR TITLE
📊 Add Europe excluding Russia to weekly wildfires

### DIFF
--- a/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
+++ b/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
@@ -2,7 +2,7 @@
 
 import owid.catalog.processing as pr
 import pandas as pd
-from owid.catalog import Dataset, Table
+from owid.catalog import Table
 
 from etl.catalog_helpers import last_date_accessed
 from etl.data_helpers import geo
@@ -35,40 +35,6 @@ REGIONS = {
 
 # The six continents that "World" is defined as the sum of, used to check that "World" stays complete.
 CONTINENTS = ["Africa", "Asia", "Europe", "North America", "Oceania", "South America"]
-
-# Members of "Europe" that the source does not report, and which the aggregates therefore cannot include.
-# "Serbia excluding Kosovo" is an alternative to "Serbia", which the source does report, and the source folds
-# Transnistria into Moldova.
-EUROPE_MEMBERS_NOT_REPORTED = ["Serbia excluding Kosovo", "Transnistria"]
-
-
-def sanity_check_member_coverage(tb: Table, ds_regions: Dataset, summed_columns: list[str]) -> None:
-    """Check that every European country the source covers is present, and reports on every informed date.
-
-    Regions are aggregated with min_num_values_per_year=1, which is what this dataset needs: no country reports in
-    the off-season, and the burnt-area series only starts in 2012, so requiring every member would empty the
-    aggregates. The cost of that tolerance is that a country dropping out of a future weekly snapshot, or missing a
-    single week, would quietly shrink "Europe" and "Europe (excl. Russia)" by the same amount, leaving the
-    reconciliation between the two intact. These asserts make it loud instead.
-    """
-    expected_members = set(
-        geo.list_members_of_region("Europe", ds_regions, excluded_members=["Russia"], exclude_historical_countries=True)
-    ) - set(EUROPE_MEMBERS_NOT_REPORTED)
-
-    missing = sorted(expected_members - set(tb["country"]))
-    assert not missing, f"The source no longer reports {missing}, which would silently shrink the European aggregates."
-
-    members = tb[tb["country"].isin(expected_members)]
-    for column in summed_columns:
-        reporting = members.groupby("date", observed=True)[column].apply(lambda values: values.notna().sum())
-        # NOTE: The source reports either every European country or none of them on a given date. If this ever
-        # fails, check whether the source really has a gap before relaxing it, because a partially covered date
-        # understates a published aggregate.
-        partial = reporting[(reporting > 0) & (reporting < len(expected_members))]
-        assert partial.empty, (
-            f"'{column}' is reported by only some European countries on "
-            f"{[str(date.date()) for date in partial.index[:5]]}, so the European aggregates are understated."
-        )
 
 
 def sanity_check_outputs(tb: Table, summed_columns: list[str]) -> None:
@@ -199,7 +165,6 @@ def run(dest_dir: str) -> None:
     tb = tb.drop(columns=["total_area_ha"])
     tb = tb.set_index(["country", "date"], verify_integrity=True)
 
-    sanity_check_member_coverage(tb.reset_index(), ds_regions=ds_regions, summed_columns=cols_to_keep)
     sanity_check_outputs(tb, summed_columns=cols_to_keep)
 
     #

--- a/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
+++ b/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
@@ -2,6 +2,7 @@
 
 import owid.catalog.processing as pr
 import pandas as pd
+from owid.catalog import Table
 
 from etl.catalog_helpers import last_date_accessed
 from etl.data_helpers import geo
@@ -10,7 +11,72 @@ from etl.helpers import PathFinder, create_dataset
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
 
-REGIONS = ["North America", "South America", "Europe", "Africa", "Asia", "Oceania", "European Union (27)", "World"]
+# Name of the aggregate added alongside "Europe".
+EUROPE_EXCL_RUSSIA = "Europe (excl. Russia)"
+
+# Regions to aggregate.
+# "Europe" includes all of Russia, which accounts for around 90% of the region's burnt area in every year, so the
+# continental total mostly follows the Russian fire season and can move in the opposite direction to the rest of
+# the continent. EUROPE_EXCL_RUSSIA is aggregated alongside it, so readers can choose between "European Union
+# (27)", "Europe" and "Europe (excl. Russia)".
+# NOTE: The order matters. "World" is defined in the regions dataset as the sum of the six continents, so "Europe"
+# has to be aggregated before it. "Europe (excl. Russia)" is not one of those six, so it is not double counted.
+REGIONS = {
+    "North America": {},
+    "South America": {},
+    "Europe": {},
+    EUROPE_EXCL_RUSSIA: {"additional_regions": ["Europe"], "excluded_members": ["Russia"]},
+    "Africa": {},
+    "Asia": {},
+    "Oceania": {},
+    "European Union (27)": {},
+    "World": {},
+}
+
+# The six continents that "World" is defined as the sum of, used to check that "World" stays complete.
+CONTINENTS = ["Africa", "Asia", "Europe", "North America", "Oceania", "South America"]
+
+
+def sanity_check_outputs(tb: Table, summed_columns: list[str]) -> None:
+    """Check the new "Europe (excl. Russia)" aggregate, and that adding it left the other regions untouched."""
+    tb = tb.reset_index()
+    countries = set(tb["country"])
+    assert {"Europe", EUROPE_EXCL_RUSSIA, "Russia", "World"} <= countries, "A required region is missing."
+    assert set(CONTINENTS) <= countries, "A continent is missing, which would make 'World' incomplete."
+
+    europe = tb[tb["country"] == "Europe"].set_index("date").sort_index()
+    excl = tb[tb["country"] == EUROPE_EXCL_RUSSIA].set_index("date").sort_index()
+    russia = tb[tb["country"] == "Russia"].set_index("date").sort_index()
+    assert europe.index.equals(excl.index), "'Europe' and 'Europe (excl. Russia)' cover different dates."
+    assert europe.index.equals(russia.index), "Russia and the European aggregates cover different dates."
+
+    # No indicator should be entirely empty for the new aggregate. FAOSTAT publishes no land area for it, so the
+    # share indicators come out null unless their denominator is derived explicitly.
+    for column in [c for c in tb.columns if c not in ("country", "date")]:
+        if russia[column].notna().any():
+            assert excl[column].notna().any(), f"'{column}' is entirely empty for '{EUROPE_EXCL_RUSSIA}'."
+
+    for column in summed_columns:
+        # Excluding Russia can only lower the total.
+        assert (excl[column] <= europe[column]).all(), f"'{column}' is larger excluding Russia than including it."
+        # Europe minus Europe excluding Russia must be Russia.
+        # NOTE: Values are stored as float32, so compare relative to the magnitude of the total. An exact
+        # comparison fails on rounding alone (the largest totals are of the order of 1e7, where one float32 step
+        # is about 2).
+        informed = europe[column].notna() & excl[column].notna() & russia[column].notna()
+        assert informed.sum() > 0.5 * len(europe), f"'{column}' is informed on too few dates to be checked."
+        error = (europe[column] - excl[column] - russia[column]).abs() / europe[column].abs().clip(lower=1)
+        assert (error[informed] < 1e-5).all(), f"'{column}' for Europe minus Europe excluding Russia is not Russia."
+
+        # "World" is the sum of the six continents. Adding a region must not change it.
+        world = tb[tb["country"] == "World"].set_index("date").sort_index()[column]
+        continents = sum(tb[tb["country"] == c].set_index("date").sort_index()[column].fillna(0) for c in CONTINENTS)
+        informed = world.notna()
+        error = (world - continents).abs() / world.abs().clip(lower=1)
+        assert (error[informed] < 1e-5).all(), f"'World' is not the sum of the six continents for '{column}'."
+
+    for column in [c for c in tb.columns if c.startswith("share_")]:
+        assert excl[column].dropna().between(0, 100).all(), f"'{column}' is outside 0-100% for {EUROPE_EXCL_RUSSIA}."
 
 
 def run(dest_dir: str) -> None:
@@ -83,11 +149,23 @@ def run(dest_dir: str) -> None:
     # Merge land area data with the wildfire data
     tb = pr.merge(tb_pivot, area_most_recent_year, on=["country"], how="left")
 
+    # FAOSTAT publishes a land area for "Europe", but not for aggregates derived from it, so the merge above leaves
+    # the new aggregate without a denominator and its shares would silently come out null. Derive it here.
+    faostat_area_ha = area_most_recent_year.set_index("country")["total_area_ha"]
+    assert {"Europe", "Russia"} <= set(faostat_area_ha.index), (
+        "FAOSTAT is missing a land area for 'Europe' or 'Russia'."
+    )
+    tb.loc[tb["country"] == EUROPE_EXCL_RUSSIA, "total_area_ha"] = (
+        faostat_area_ha.loc["Europe"] - faostat_area_ha.loc["Russia"]
+    )
+
     tb["share_area_ha"] = (tb["area_ha"] / tb["total_area_ha"]) * 100
     tb["share_area_ha_cumulative"] = (tb["area_ha_cumulative"] / tb["total_area_ha"]) * 100
 
     tb = tb.drop(columns=["total_area_ha"])
     tb = tb.set_index(["country", "date"], verify_integrity=True)
+
+    sanity_check_outputs(tb, summed_columns=cols_to_keep)
 
     #
     # Save outputs.

--- a/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
+++ b/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
@@ -2,7 +2,7 @@
 
 import owid.catalog.processing as pr
 import pandas as pd
-from owid.catalog import Table
+from owid.catalog import Dataset, Table
 
 from etl.catalog_helpers import last_date_accessed
 from etl.data_helpers import geo
@@ -35,6 +35,40 @@ REGIONS = {
 
 # The six continents that "World" is defined as the sum of, used to check that "World" stays complete.
 CONTINENTS = ["Africa", "Asia", "Europe", "North America", "Oceania", "South America"]
+
+# Members of "Europe" that the source does not report, and which the aggregates therefore cannot include.
+# "Serbia excluding Kosovo" is an alternative to "Serbia", which the source does report, and the source folds
+# Transnistria into Moldova.
+EUROPE_MEMBERS_NOT_REPORTED = ["Serbia excluding Kosovo", "Transnistria"]
+
+
+def sanity_check_member_coverage(tb: Table, ds_regions: Dataset, summed_columns: list[str]) -> None:
+    """Check that every European country the source covers is present, and reports on every informed date.
+
+    Regions are aggregated with min_num_values_per_year=1, which is what this dataset needs: no country reports in
+    the off-season, and the burnt-area series only starts in 2012, so requiring every member would empty the
+    aggregates. The cost of that tolerance is that a country dropping out of a future weekly snapshot, or missing a
+    single week, would quietly shrink "Europe" and "Europe (excl. Russia)" by the same amount, leaving the
+    reconciliation between the two intact. These asserts make it loud instead.
+    """
+    expected_members = set(
+        geo.list_members_of_region("Europe", ds_regions, excluded_members=["Russia"], exclude_historical_countries=True)
+    ) - set(EUROPE_MEMBERS_NOT_REPORTED)
+
+    missing = sorted(expected_members - set(tb["country"]))
+    assert not missing, f"The source no longer reports {missing}, which would silently shrink the European aggregates."
+
+    members = tb[tb["country"].isin(expected_members)]
+    for column in summed_columns:
+        reporting = members.groupby("date", observed=True)[column].apply(lambda values: values.notna().sum())
+        # NOTE: The source reports either every European country or none of them on a given date. If this ever
+        # fails, check whether the source really has a gap before relaxing it, because a partially covered date
+        # understates a published aggregate.
+        partial = reporting[(reporting > 0) & (reporting < len(expected_members))]
+        assert partial.empty, (
+            f"'{column}' is reported by only some European countries on "
+            f"{[str(date.date()) for date in partial.index[:5]]}, so the European aggregates are understated."
+        )
 
 
 def sanity_check_outputs(tb: Table, summed_columns: list[str]) -> None:
@@ -165,6 +199,7 @@ def run(dest_dir: str) -> None:
     tb = tb.drop(columns=["total_area_ha"])
     tb = tb.set_index(["country", "date"], verify_integrity=True)
 
+    sanity_check_member_coverage(tb.reset_index(), ds_regions=ds_regions, summed_columns=cols_to_keep)
     sanity_check_outputs(tb, summed_columns=cols_to_keep)
 
     #

--- a/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
+++ b/etl/steps/data/garden/climate/2026-07-27/weekly_wildfires.py
@@ -36,6 +36,40 @@ REGIONS = {
 # The six continents that "World" is defined as the sum of, used to check that "World" stays complete.
 CONTINENTS = ["Africa", "Asia", "Europe", "North America", "Oceania", "South America"]
 
+# Number of countries the source reports.
+# NOTE: The comparison below is ">=", so the source covering more countries does not fail the build. Raise this
+# number when that happens, so that a later drop is still caught.
+EXPECTED_NUM_COUNTRIES = 251
+
+
+def sanity_check_inputs(tb: Table, indicators: list[str]) -> None:
+    """Check that the source still reports a complete country-by-date grid.
+
+    Regions are aggregated with min_num_values_per_year=1, which is what this dataset needs: no country reports in
+    the off-season, and the burnt-area series only starts in 2012, so requiring every member would empty the
+    aggregates. The cost of that tolerance is that a country dropping out of the source, or missing a single week,
+    would quietly shrink every aggregate containing it, and no downstream check would notice. These asserts make it
+    loud instead.
+    """
+    num_countries = tb["country"].nunique()
+    assert num_countries >= EXPECTED_NUM_COUNTRIES, (
+        f"The source reports {num_countries} countries, down from {EXPECTED_NUM_COUNTRIES}, so every aggregate "
+        "containing a dropped country is understated."
+    )
+    assert len(tb) == num_countries * tb["date"].nunique(), "The source no longer reports a complete country-date grid."
+
+    for column in indicators:
+        # For a given indicator, every country is informed on exactly the same dates, so a date is reported either
+        # by all countries or by none, and no aggregate is ever built from a subset of its members.
+        # NOTE: If this ever fails, check whether the source really has a gap before relaxing it, because a
+        # partially reported date understates every aggregate on that date.
+        num_countries_per_date = tb.groupby("date", observed=True)[column].apply(lambda values: values.notna().sum())
+        partial = num_countries_per_date[(num_countries_per_date > 0) & (num_countries_per_date < num_countries)]
+        assert partial.empty, (
+            f"'{column}' is reported for only some countries on "
+            f"{[str(date.date()) for date in partial.index[:5]]}, so the aggregates on those dates are understated."
+        )
+
 
 def sanity_check_outputs(tb: Table, summed_columns: list[str]) -> None:
     """Check the new "Europe (excl. Russia)" aggregate, and that adding it left the other regions untouched."""
@@ -136,6 +170,9 @@ def run(dest_dir: str) -> None:
     # Create a date column
     tb_pivot["date"] = pd.to_datetime(tb_pivot["year"].astype(str) + "-" + tb_pivot["month_day"].astype(str))
     tb_pivot = tb_pivot.drop(columns=["year", "month_day"])
+    # Check the source's coverage while the table still holds only countries.
+    sanity_check_inputs(tb_pivot, indicators=cols_to_keep)
+
     aggregations = {agg: "sum" for agg in cols_to_keep}
     # Add region aggregates.
     tb_pivot = geo.add_regions_to_table(


### PR DESCRIPTION
> _Written by Claude Opus 5 — @edomt at the wheel._

## Why

A reader compared our wildfire charts with the EFFIS seasonal trend tool and found they disagreed about the 2026 European fire season.

Our `Europe` aggregate includes all of Russia, which accounts for 85–93% of the region's burnt area in every year of the record. So the `Europe` line mostly follows the Russian fire season, and it can move in the opposite direction to the rest of the continent. Cumulative area burnt at week 29 of 2026, against the 2012–2024 average for the same week:

| Entity | 2026 | 2012–24 average | vs average |
|---|---|---|---|
| `European Union (27)` | 330k ha | 348k ha | 0.95× |
| `Europe (excl. Russia)` *(new)* | 539k ha | 900k ha | 0.60× |
| `Europe` | 3,546k ha | 11,736k ha | 0.30× |
| Russia | 3,007k ha | 10,836k ha | 0.28× |

2026 is Russia's quietest season in the record, which pulls `Europe` down with it. There was previously no way to see the rest of the continent on its own: `European Union (27)` was the only alternative, and it leaves out the UK, Norway, Switzerland, the Balkans, Ukraine and Turkey.

A footnote explaining that `Europe` includes Russia was considered and rejected — it would show on every view of the chart, including views where Europe isn't selected.

## What changed

One aggregate added to the weekly wildfires garden step: `Europe (excl. Russia)`, alongside the existing `Europe` and `European Union (27)`. Nothing is renamed or removed, so all existing entity selections and `?country=~OWID_EUR` links keep working, and no chart configs need touching. The new aggregate appears in the entity selector on every wildfire chart.

The name follows the convention already used in `hyde/2026-06-08/all_indicators.py` and `emissions/2025-12-04/national_contributions.py`, and `Europe (excl. Russia)` already exists as a grapher entity, so it is reused rather than duplicated.

`REGIONS` becomes a dict so the aggregate can be expressed as `Europe` minus Russia. Two things about it are load-bearing and commented in place:

- **The new aggregate needs an explicit land-area denominator.** FAOSTAT publishes a land area for `Europe` but not for anything derived from it, so the `pr.merge` on `country` leaves `total_area_ha` null and both share indicators come out empty — while the step still succeeds. It is derived as Europe's published area minus Russia's, giving 6.39 M km².
- **`Europe` has to be aggregated before `World`.** `World` is defined in the regions dataset as the sum of the six continents (`OWID_AFR`, `OWID_ASI`, `OWID_EUR`, `OWID_NAM`, `OWID_OCE`, `OWID_SAM`), not of individual countries. `Europe (excl. Russia)` is not one of the six, so it is not double counted.

## Sanity checks

`sanity_check_outputs` runs immediately before `create_dataset` and asserts:

- every continent and required region is present;
- `Europe`, `Europe (excl. Russia)` and Russia cover the same dates;
- no indicator is entirely empty for the new aggregate — this is the check that fails loudly on a null denominator;
- excluding Russia can only lower the total;
- `Europe` minus `Europe (excl. Russia)` equals Russia;
- `World` still equals the sum of the six continents;
- the share indicators stay within 0–100%.

The reconciliation comparisons use a relative tolerance of 1e-5. Values are stored as float32, where one step at the largest totals (~1e7 ha) is about 2 hectares, so an exact comparison fails on rounding alone.

## Verification

`etl diff REMOTE data/ --include climate/2026-07-27 --verbose` across all five affected datasets (`garden/weekly_wildfires` plus the four grapher datasets):

- 226 "new values" markers, **no changed and no removed values**;
- `Europe (excl. Russia)` is the only entity appearing anywhere in the diff, so `Europe`, `World`, `European Union (27)` and every country are untouched;
- 1,248 new rows, covering the full 2003-01-07 to 2026-12-30 range;
- no all-null column for the new entity in the garden table or in any of the four grapher datasets;
- implied denominators are correct: 23.51 M km² for `Europe` (with all of Russia), 6.39 M km² excluding it, 4.31 M km² for the EU-27.

## Note

We read the GWIS endpoint (MODIS/VIIRS, baseline from 2012); the EFFIS seasonal trend tool uses EFFIS rapid damage assessment (Sentinel-2, baseline from 2006). For Spain at week 29 of 2026, EFFIS reports 176k ha against a 2006–25 average of 36k, while GWIS reports 153k against an average of 75k. So the two tools also differ in product and baseline period, not only in which countries they cover. Out of scope here.
