### PR TITLE
📊 Add wealth inequality in France, 1800-2014 (Garbinti, Goupille-Lebret and Piketty)

### DIFF
--- a/dag/economics.yml
+++ b/dag/economics.yml
@@ -11,6 +11,12 @@ steps:
       - data://meadow/economics/2026-07-28/saez_zucman_wealth_shares:
         - snapshot://economics/2026-07-28/saez_zucman_wealth_shares.xlsx
 
+  # Wealth inequality in France, 1800-2014 (Garbinti, Goupille-Lebret and Piketty, 2021)
+  data://grapher/economics/2026-07-28/wealth_france:
+    - data://garden/economics/2026-07-28/wealth_france:
+      - data://meadow/economics/2026-07-28/wealth_france:
+        - snapshot://economics/2026-07-28/wealth_france.xlsx
+
   # OWID - OWID Deflator.
   data://garden/economics/2025-08-29/owid_deflator:
     # World Bank - WDI (specifically indicators used for inflation adjustments).

--- a/etl/steps/data/garden/economics/2026-07-28/wealth_france.countries.json
+++ b/etl/steps/data/garden/economics/2026-07-28/wealth_france.countries.json
@@ -1,0 +1,3 @@
+{
+  "France": "France"
+}

--- a/etl/steps/data/garden/economics/2026-07-28/wealth_france.meta.yml
+++ b/etl/steps/data/garden/economics/2026-07-28/wealth_france.meta.yml
@@ -7,10 +7,9 @@ definitions:
         - Economic Inequality
       attribution_short: Garbinti, Goupille-Lebret and Piketty
     description_key:
-      - Wealth refers to net personal wealth: the market value of all the financial and non-financial assets adults own, minus their debts.
-      - The estimates cover all adults, with each adult counted individually, and wealth is expressed among the adult population.
-      - The series combine income-tax, inheritance and wealth-survey data with national accounts to build homogeneous estimates stretching back to 1800.
-      - Definitions of wealth and the underlying data sources change over such a long period; the source paper documents these breaks in detail.
+      - Wealth refers to net personal wealth.
+      - The estimates cover all adults, with each adult counted individually.
+      - The series combines income-tax, inheritance, and wealth-survey data with national accounts to build estimates stretching back to 1800. Definitions of wealth and the underlying data sources change over such a long period; the source paper documents these changes in detail.
     description_processing: |-
       The source workbook reports the summary statistics behind the paper's wealth series — wealth shares, wealth thresholds and inverted Pareto coefficients by year, plus a separate sheet on wealth growth by group. We use only the wealth-share series.
 
@@ -47,18 +46,6 @@ tables:
         description_short: The share of total personal wealth held by the wealthiest 1% of adults.
         display:
           name: Top 1%
-          numDecimalPlaces: 1
-          tolerance: 5
-
-      share_middle_40:
-        title: Wealth share of the middle 40%
-        presentation:
-          title_public: Wealth share of the middle 40%
-        unit: "%"
-        short_unit: "%"
-        description_short: The share of total personal wealth held by the middle 40% of adults — those wealthier than the poorest 50% but less wealthy than the richest 10%.
-        display:
-          name: Middle 40%
           numDecimalPlaces: 1
           tolerance: 5
 

--- a/etl/steps/data/garden/economics/2026-07-28/wealth_france.meta.yml
+++ b/etl/steps/data/garden/economics/2026-07-28/wealth_france.meta.yml
@@ -1,0 +1,75 @@
+# NOTE: To learn more about the fields, hover over their names.
+definitions:
+  common:
+    processing_level: minor
+    presentation:
+      topic_tags:
+        - Economic Inequality
+      attribution_short: Garbinti, Goupille-Lebret and Piketty
+    description_key:
+      - Wealth refers to net personal wealth: the market value of all the financial and non-financial assets adults own, minus their debts.
+      - The estimates cover all adults, with each adult counted individually, and wealth is expressed among the adult population.
+      - The series combine income-tax, inheritance and wealth-survey data with national accounts to build homogeneous estimates stretching back to 1800.
+      - Definitions of wealth and the underlying data sources change over such a long period; the source paper documents these breaks in detail.
+    description_processing: |-
+      The source workbook reports the summary statistics behind the paper's wealth series — wealth shares, wealth thresholds and inverted Pareto coefficients by year, plus a separate sheet on wealth growth by group. We use only the wealth-share series.
+
+      The wealth shares are reported by the source as fractions of total wealth and have been converted to percentages.
+
+# Learn more about the available fields:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+dataset:
+  update_period_days: 0
+  owners:
+    - Bertha Rohenkohl
+
+tables:
+  wealth_france:
+    variables:
+      share_top_10:
+        title: Wealth share of the richest 10%
+        presentation:
+          title_public: Wealth share of the richest 10%
+        unit: "%"
+        short_unit: "%"
+        description_short: The share of total personal wealth held by the wealthiest 10% of adults.
+        display:
+          name: Top 10%
+          numDecimalPlaces: 1
+          tolerance: 5
+
+      share_top_1:
+        title: Wealth share of the richest 1%
+        presentation:
+          title_public: Wealth share of the richest 1%
+        unit: "%"
+        short_unit: "%"
+        description_short: The share of total personal wealth held by the wealthiest 1% of adults.
+        display:
+          name: Top 1%
+          numDecimalPlaces: 1
+          tolerance: 5
+
+      share_middle_40:
+        title: Wealth share of the middle 40%
+        presentation:
+          title_public: Wealth share of the middle 40%
+        unit: "%"
+        short_unit: "%"
+        description_short: The share of total personal wealth held by the middle 40% of adults — those wealthier than the poorest 50% but less wealthy than the richest 10%.
+        display:
+          name: Middle 40%
+          numDecimalPlaces: 1
+          tolerance: 5
+
+      share_bottom_50:
+        title: Wealth share of the poorest 50%
+        presentation:
+          title_public: Wealth share of the poorest 50%
+        unit: "%"
+        short_unit: "%"
+        description_short: The share of total personal wealth held by the least wealthy 50% of adults.
+        display:
+          name: Bottom 50%
+          numDecimalPlaces: 1
+          tolerance: 5

--- a/etl/steps/data/garden/economics/2026-07-28/wealth_france.py
+++ b/etl/steps/data/garden/economics/2026-07-28/wealth_france.py
@@ -15,6 +15,9 @@ paths = PathFinder(__file__)
 PARTITION_COLUMNS = ["share_bottom_50", "share_middle_40", "share_top_10"]
 SHARE_COLUMNS = PARTITION_COLUMNS + ["share_top_1"]
 
+# The middle 40% is used to verify the partition identity but is not surfaced as an indicator.
+COLUMNS_NOT_SURFACED = ["share_middle_40"]
+
 
 def sanity_check_inputs(tb: Table) -> None:
     assert set(tb["country"].unique()) == {"France"}, "Expected France as the only entity."
@@ -60,6 +63,9 @@ def run() -> None:
     tb = paths.regions.harmonize_names(tb, country_col="country", countries_file=paths.country_mapping_path)
 
     sanity_check_outputs(tb)
+
+    # Drop the middle 40% (kept above only to check the partition identity).
+    tb = tb.drop(columns=COLUMNS_NOT_SURFACED)
 
     tb = tb.format(["country", "year"], short_name=paths.short_name)
 

--- a/etl/steps/data/garden/economics/2026-07-28/wealth_france.py
+++ b/etl/steps/data/garden/economics/2026-07-28/wealth_france.py
@@ -1,0 +1,70 @@
+"""Load a meadow dataset and create a garden dataset.
+
+The source reports wealth shares as fractions (0-1); we convert them to percentages.
+"""
+
+from owid.catalog import Table
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+# Wealth-share columns. bottom 50% + middle 40% + top 10% partition the population and
+# sum to 100%; top 1% is a subset of the top 10%.
+PARTITION_COLUMNS = ["share_bottom_50", "share_middle_40", "share_top_10"]
+SHARE_COLUMNS = PARTITION_COLUMNS + ["share_top_1"]
+
+
+def sanity_check_inputs(tb: Table) -> None:
+    assert set(tb["country"].unique()) == {"France"}, "Expected France as the only entity."
+    assert not tb.duplicated(subset=["country", "year"]).any(), "Duplicate (country, year) rows."
+    assert tb["year"].between(1800, 2020).all(), "Year outside the plausible range."
+    # Source values are fractions of total wealth, so they must lie in (0, 1].
+    for col in SHARE_COLUMNS:
+        vals = tb[col].dropna()
+        assert vals.between(0, 1).all(), f"{col} has values outside 0-1 before conversion to %."
+
+
+def sanity_check_outputs(tb: Table) -> None:
+    assert tb.columns[tb.isna().all()].empty, "Output has a fully-NaN column."
+    for col in SHARE_COLUMNS:
+        vals = tb[col].dropna()
+        assert vals.between(0, 100).all(), f"{col} has values outside 0-100%."
+    # Guard the fraction->% conversion: the top 10% share should be tens of percent, not a fraction.
+    assert 50 < tb["share_top_10"].max() < 100, "Top 10% share not on a percentage scale — conversion lost?"
+    # The three partition shares must add up to 100% (they cover the whole population).
+    partition_sum = tb[PARTITION_COLUMNS].sum(axis=1)
+    assert partition_sum.between(99.5, 100.5).all(), "Bottom 50% + middle 40% + top 10% does not sum to ~100%."
+    # The top 1% is nested inside the top 10%.
+    pair = tb[["share_top_10", "share_top_1"]].dropna()
+    assert (pair["share_top_10"] >= pair["share_top_1"] - 0.05).all(), "Top 10% share below top 1% for some year."
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_meadow = paths.load_dataset("wealth_france")
+    tb = ds_meadow["wealth_france"].reset_index()
+
+    #
+    # Process data.
+    #
+    sanity_check_inputs(tb)
+
+    # Convert wealth shares from fractions (0-1) to percentages.
+    for col in SHARE_COLUMNS:
+        tb[col] = tb[col] * 100
+
+    tb = paths.regions.harmonize_names(tb, country_col="country", countries_file=paths.country_mapping_path)
+
+    sanity_check_outputs(tb)
+
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
+    #
+    # Save outputs.
+    #
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden.save()

--- a/etl/steps/data/grapher/economics/2026-07-28/wealth_france.py
+++ b/etl/steps/data/grapher/economics/2026-07-28/wealth_france.py
@@ -1,0 +1,26 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset and read its table.
+    ds_garden = paths.load_dataset("wealth_france")
+    tb = ds_garden.read("wealth_france")
+
+    #
+    # Process data.
+    #
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
+    #
+    # Save outputs.
+    #
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/economics/2026-07-28/wealth_france.py
+++ b/etl/steps/data/meadow/economics/2026-07-28/wealth_france.py
@@ -1,0 +1,68 @@
+"""Load a snapshot and create a meadow dataset.
+
+The source is the authors' replication workbook. We read only the wealth-distribution
+summary sheet ("sum_stat_w"), whose header spans several rows (percentile labels, a
+units sub-header and machine codes) with yearly data from row 9 onwards. We keep the
+year and the wealth-share columns: bottom 50% (P0-50), middle 40% (P50-90),
+top 10% (P90-100) and top 1% (P99-100).
+"""
+
+from owid.catalog import processing as pr
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+SHEET = "sum_stat_w"
+
+# Column index in the raw sheet -> descriptive indicator name.
+COLUMNS = {
+    0: "year",
+    3: "share_bottom_50",  # P0-50
+    4: "share_middle_40",  # P50-90
+    5: "share_top_10",  # P90-100
+    6: "share_top_1",  # P99-100
+}
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    snap = paths.load_snapshot("wealth_france.xlsx")
+
+    # Read the sheet without a header; the real headers span rows 6-8 and data starts at row 9.
+    tb = snap.read_excel(sheet_name=SHEET, header=None)
+
+    #
+    # Process data.
+    #
+    # Keep only the year column and the wealth-share columns.
+    tb = tb[list(COLUMNS)].rename(columns=COLUMNS, errors="raise")
+
+    # Keep only the yearly data region (rows where the first column is a numeric year).
+    tb = tb[pr.to_numeric(tb["year"], errors="coerce").notna()].copy()
+    tb["year"] = tb["year"].astype(int)
+
+    # Drop years with no wealth data at all.
+    value_cols = [c for c in COLUMNS.values() if c != "year"]
+    tb = tb.dropna(subset=value_cols, how="all")
+
+    # Reshaping a header-less sheet can drop a column's origin; every value column comes from
+    # this snapshot, so restore the origin explicitly.
+    for col in value_cols:
+        tb[col].metadata.origins = [snap.metadata.origin]
+
+    # This is a France-only source; add the country column explicitly.
+    tb["country"] = "France"
+    tb["country"] = tb["country"].astype("category")
+
+    # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
+    #
+    # Save outputs.
+    #
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
+    ds_meadow.save()

--- a/snapshots/economics/2026-07-28/wealth_france.py
+++ b/snapshots/economics/2026-07-28/wealth_france.py
@@ -1,0 +1,14 @@
+"""Script to create a snapshot of dataset.
+
+The data file (the authors' replication workbook) is provided manually. Run with:
+  etls economics/2026-07-28/wealth_france --path-to-file <path>
+"""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run(upload: bool = True, path_to_file: str | None = None) -> None:
+    snap = paths.init_snapshot()
+    snap.create_snapshot(filename=path_to_file, upload=upload)

--- a/snapshots/economics/2026-07-28/wealth_france.xlsx.dvc
+++ b/snapshots/economics/2026-07-28/wealth_france.xlsx.dvc
@@ -1,0 +1,33 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Accounting for Wealth Inequality Dynamics - Methods, Estimates and Simulations for France (1800-2014)
+    description: |-
+      This dataset presents long-run homogeneous series on the distribution of personal wealth in France over the 1800-2014 period. Combining income tax, inheritance and wealth-survey data with national accounts, the authors estimate the share of total net personal wealth held by different groups of the adult population, together with average wealth levels and the wealth thresholds that define each group.
+
+      Wealth is measured as net individual wealth among adults: the market value of all the financial and non-financial assets individuals own, minus their debts, distributed across the adult population.
+    # NOTE: The workbook has two sheets: "sum_stat_w" (summary statistics for the wealth
+    # distribution — wealth shares, thresholds and inverted Pareto coefficients by year) and
+    # "growth" (wealth growth by group across historical sub-periods). We ingest only the
+    # "sum_stat_w" sheet, and within it only the wealth-share columns. The thresholds, Pareto
+    # coefficients and the growth sheet are available in the same file for a future extension.
+    date_published: "2021-02-01"
+
+    # Citation
+    producer: Garbinti, Goupille-Lebret and Piketty
+    citation_full: |-
+      Garbinti, B., Goupille-Lebret, J., & Piketty, T. (2021). Accounting for Wealth-Inequality Dynamics: Methods, Estimates, and Simulations for France. Journal of the European Economic Association, 19(1), 620-663. https://doi.org/10.1093/jeea/jvaa025
+
+    # Files
+    url_main: https://doi.org/10.1093/jeea/jvaa025
+    date_accessed: '2026-07-28'
+
+    # License
+    license:
+      name: © Garbinti, Goupille-Lebret and Piketty (2021)
+outs:
+  - md5: bf3c2bb6b93c727accef4fbddaabc779
+    size: 48235
+    path: wealth_france.xlsx


### PR DESCRIPTION
> _Written by Claude Opus 4.8 — @bertharc at the wheel._

Adds a new dataset on the long-run distribution of personal wealth in France, completing the wealth-shares family alongside the UK (Alvaredo, Atkinson and Morelli) and US (Saez and Zucman) datasets.

## What this adds

- **Dataset:** Wealth inequality in France, 1800–2014 — `economics/2026-07-28/wealth_france`, full snapshot → meadow → garden → grapher chain (co-located with the UK and US wealth datasets).
- **Source:** Garbinti, B., Goupille-Lebret, J., & Piketty, T. (2021). *Accounting for Wealth-Inequality Dynamics: Methods, Estimates, and Simulations for France.* Journal of the European Economic Association, 19(1), 620–663.
- **Coverage:** France, 1807–2014, 116 yearly observations, no gaps.
- **Indicators (3):** wealth shares of the **Top 10%** (P90-100), **Top 1%** (P99-100) and **Bottom 50%** (P0-50) of adults. Top-group names are harmonized with the sibling datasets.

## Processing notes

- The source workbook has two sheets (`sum_stat_w` summary statistics, and `growth`). We ingest only the wealth-share columns of `sum_stat_w`; thresholds, inverted Pareto coefficients and the growth sheet are left for a future extension (recorded in the snapshot `.dvc` NOTE).
- Wealth shares are reported by the source as fractions (0–1) and converted to percentages in garden.
- The Middle 40% (P50-90) share is carried through the garden step only to verify the accounting identity (Bottom 50% + Middle 40% + Top 10% = 100%) and is then dropped; the Top 1% is asserted to nest inside the Top 10%.
- The Bottom 10% (P0-10) column in the file was left out as a tiny, non-standard sub-slice of the Bottom 50%.

An adversarial fact-check against the producers' documentation and independent summaries found no errors; anchor values (Top 10% ≈ 85% pre-WWI, ≈ 51% in 1984, ≈ 58% in 2014) fall within the ranges the authors publish.
