### PR TITLE
🐛 Branch out from latest origin master instead of stale local master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,8 +166,6 @@ gh pr edit <number> --body "..."
 
 **Cleaning up after merge**: `etl pr-clean` lists local branches whose PR was merged or closed (it checks the GitHub PR state, so squash-merges are detected), then deletes the selected branch(es). For branches created in a worktree (`etl pr "..." --worktree`), it also removes the worktree and copies that worktree's Claude sessions back into the main repo's `~/.claude/projects/` dir so they stay resumable.
 
-**After `etl pr --worktree`, verify the branch is current AND actually pushed.** Worktree creation can branch off a stale local `master` (missing recent merges → `_check_dag_completeness` "not in the DAG" errors on steps that should already exist) — fix with `git fetch origin master && git rebase origin/master`. That rebase then needs its own push: check `gh pr view --json additions,deletions` isn't `0`/`0` before assuming the PR reflects your commits.
-
 **Post `@codex review` as a separate PR comment** (not in the PR description) when the PR is ready for a review pass. Do not repost it after every push/update unless the user asks or the changes are substantial enough to warrant a fresh review.
 
 To run the full **review → wait → fix → re-review** loop hands-off (and watch CI) in the background while you keep working, use the `pr-babysitter` skill — it spawns a background agent that triggers Codex, judges and fixes the valid findings, and loops to a cap (never merges). Fire it proactively after pushing a substantial chunk to a PR branch.

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -12,6 +12,8 @@ Arguments:
 
 **Main use case**: Branch out from `master` to a temporary `work_branch`, and create a PR to merge `work_branch` -> `master`. You will be asked to choose a category. The value of `work_branch` will be auto-generated based on the title and the category.
 
+The work branch is always created from the latest `origin/<base_branch>`, not from your (possibly stale) local base branch: when branching in place, the local base branch is first fast-forwarded to its remote counterpart (the command fails if the two have diverged); with `--worktree`, the new branch starts directly from `origin/<base_branch>`. Pass `--no-update-base` to branch off your local base branch as-is.
+
 ```shell
 # Without specifying a category (you will be prompted for a category)
 etl pr "some title for the PR"
@@ -197,6 +199,12 @@ MODEL_DEFAULT = "gpt-5-mini"
     is_flag=True,
     help="Automatically assign the PR to the GitHub user the token belongs to.",
 )
+@click.option(
+    "--no-update-base",
+    "no_update_base",
+    is_flag=True,
+    help="Branch off your local base branch as-is, even if it is behind its remote counterpart. By default, the work branch is created from the latest 'origin/<base-branch>'.",
+)
 def cli(
     title: str,
     category: str | None,
@@ -210,6 +218,7 @@ def cli(
     worktree_path: str | None,
     share_data: bool,
     auto_assign: bool,
+    no_update_base: bool,
     # base_branch: Optional[str] = None,
 ) -> None:
     # Check that the user has set up a GitHub token.
@@ -230,6 +239,8 @@ def cli(
         raise click.ClickException("--worktree-path requires --worktree.")
     if share_data and not worktree:
         raise click.ClickException("--share-data requires --worktree.")
+    if no_update_base and direct:
+        raise click.ClickException("--no-update-base has no effect with --direct (no new branch is created).")
 
     # Get category
     category = ensure_category(category)
@@ -266,13 +277,13 @@ def cli(
                 work_branch = f"{work_branch}-private"
         if worktree:
             resolved_worktree_path = resolve_worktree_path(work_branch, worktree_path)
-            branch_out_worktree(repo, base_branch, work_branch, resolved_worktree_path)
+            branch_out_worktree(repo, base_branch, work_branch, resolved_worktree_path, update_base=not no_update_base)
             if share_data:
                 symlink_shared_dirs(resolved_worktree_path)
             # Subsequent git operations (commit, push) must run inside the worktree.
             repo = Repo(resolved_worktree_path)
         else:
-            branch_out(repo, base_branch, work_branch)
+            branch_out(repo, base_branch, work_branch, update_base=not no_update_base)
 
     # Create PR
     create_pr(repo, work_branch, base_branch, pr_title, auto_assign=auto_assign)
@@ -395,13 +406,26 @@ def check_branches_valid(base_branch, work_branch, remote_branches):
         )
 
 
-def branch_out(repo, base_branch, work_branch):
+def branch_out(repo, base_branch, work_branch, update_base: bool = True):
     """Branch out from base_branch and create branch 'work_branch'."""
     try:
         log.info(
             f"Switching to base branch '{base_branch}', creating new branch '{work_branch}' from there, and switching to it."
         )
         repo.git.checkout(base_branch)
+        if update_base:
+            # Fast-forward the local base branch to its remote counterpart (already fetched by
+            # init_repo), so the work branch doesn't start from a stale base. A stale start point
+            # pollutes `etl diff` with every dataset that changed on the base branch since.
+            log.info(f"Fast-forwarding '{base_branch}' to 'origin/{base_branch}'.")
+            try:
+                repo.git.merge("--ff-only", f"origin/{base_branch}")
+            except GitCommandError as e:
+                raise click.ClickException(
+                    f"Local branch '{base_branch}' has diverged from 'origin/{base_branch}', so it cannot be fast-forwarded. "
+                    f"Reconcile them first (e.g. 'git rebase origin/{base_branch}'), or re-run with --no-update-base "
+                    f"to branch off your local '{base_branch}' as-is.\n{e}"
+                )
         repo.git.checkout("-b", work_branch)
     except GitCommandError as e:
         raise click.ClickException(f"Failed to create a new branch from '{base_branch}':\n{e}")
@@ -414,16 +438,24 @@ def resolve_worktree_path(work_branch: str, override: str | None) -> Path:
     return (BASE_DIR.parent / f"etl-{work_branch}").resolve()
 
 
-def branch_out_worktree(repo, base_branch: str, work_branch: str, worktree_path: Path) -> None:
+def branch_out_worktree(
+    repo, base_branch: str, work_branch: str, worktree_path: Path, update_base: bool = True
+) -> None:
     """Create branch 'work_branch' from 'base_branch' inside a new git worktree at 'worktree_path'."""
     if worktree_path.exists():
         raise click.ClickException(
             f"Worktree path '{worktree_path}' already exists. "
             "Choose a different --worktree-path or remove the existing directory."
         )
+    # Branch from the remote's latest base branch (already fetched by init_repo), not from the
+    # possibly stale local one. The local base branch may be checked out in another worktree, so
+    # unlike branch_out it cannot be fast-forwarded here; it is simply left untouched.
+    # --no-track: without it, git would set 'origin/<base_branch>' as the new branch's upstream,
+    # which breaks a plain `git push` on the work branch later.
+    start_point = f"origin/{base_branch}" if update_base else base_branch
     try:
-        log.info(f"Creating worktree at '{worktree_path}' with new branch '{work_branch}' from '{base_branch}'.")
-        repo.git.worktree("add", "-b", work_branch, str(worktree_path), base_branch)
+        log.info(f"Creating worktree at '{worktree_path}' with new branch '{work_branch}' from '{start_point}'.")
+        repo.git.worktree("add", "--no-track", "-b", work_branch, str(worktree_path), start_point)
     except GitCommandError as e:
         raise click.ClickException(f"Failed to create worktree at '{worktree_path}':\n{e}")
 

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -12,7 +12,7 @@ Arguments:
 
 **Main use case**: Branch out from `master` to a temporary `work_branch`, and create a PR to merge `work_branch` -> `master`. You will be asked to choose a category. The value of `work_branch` will be auto-generated based on the title and the category.
 
-The work branch is always created from the latest `origin/<base_branch>`, not from your (possibly stale) local base branch: when branching in place, the local base branch is first fast-forwarded to its remote counterpart (the command fails if the two have diverged); with `--worktree`, the new branch starts directly from `origin/<base_branch>`. Pass `--no-update-base` to branch off your local base branch as-is.
+The work branch is always created from the latest `origin/<base_branch>`, never from your (possibly stale) local base branch, so unpushed commits sitting on the local base branch are not included. When branching in place, the local base branch is also fast-forwarded to its remote counterpart along the way (the command fails if the two have diverged). Pass `--no-update-base` to branch off your local base branch as-is instead.
 
 ```shell
 # Without specifying a category (you will be prompted for a category)
@@ -426,7 +426,19 @@ def branch_out(repo, base_branch, work_branch, update_base: bool = True):
                     f"Reconcile them first (e.g. 'git rebase origin/{base_branch}'), or re-run with --no-update-base "
                     f"to branch off your local '{base_branch}' as-is.\n{e}"
                 )
-        repo.git.checkout("-b", work_branch)
+            # The local base branch may still be ahead of the remote (unpushed commits); the
+            # fast-forward above is a no-op then. The work branch must start exactly at the
+            # remote tip, so those commits don't silently end up in the PR.
+            if repo.commit(base_branch) != repo.commit(f"origin/{base_branch}"):
+                log.warning(
+                    f"Local '{base_branch}' has commits not pushed to 'origin/{base_branch}'; they will NOT be "
+                    f"included in '{work_branch}'. Re-run with --no-update-base to include them."
+                )
+            # --no-track: without it, git would set 'origin/<base_branch>' as the new branch's
+            # upstream, which breaks a plain `git push` on the work branch later.
+            repo.git.checkout("--no-track", "-b", work_branch, f"origin/{base_branch}")
+        else:
+            repo.git.checkout("-b", work_branch)
     except GitCommandError as e:
         raise click.ClickException(f"Failed to create a new branch from '{base_branch}':\n{e}")
 

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -12,7 +12,7 @@ Arguments:
 
 **Main use case**: Branch out from `master` to a temporary `work_branch`, and create a PR to merge `work_branch` -> `master`. You will be asked to choose a category. The value of `work_branch` will be auto-generated based on the title and the category.
 
-The work branch is always created from the latest `origin/<base_branch>`, never from your (possibly stale) local base branch, so unpushed commits sitting on the local base branch are not included. When branching in place, the local base branch is also fast-forwarded to its remote counterpart along the way (the command fails if the two have diverged). Pass `--no-update-base` to branch off your local base branch as-is instead.
+The work branch is always created from the latest `origin/<base_branch>`, never from your (possibly stale) local base branch, so unpushed commits sitting on the local base branch are not included. When branching in place, the local base branch is also fast-forwarded to its remote counterpart when possible (when it carries unpushed or diverged commits, it is left untouched and a warning is logged). Pass `--no-update-base` to branch off your local base branch as-is instead.
 
 ```shell
 # Without specifying a category (you will be prompted for a category)
@@ -203,7 +203,7 @@ MODEL_DEFAULT = "gpt-5-mini"
     "--no-update-base",
     "no_update_base",
     is_flag=True,
-    help="Branch off your local base branch as-is, even if it is behind its remote counterpart. By default, the work branch is created from the latest 'origin/<base-branch>'.",
+    help="Branch off your local base branch as-is, even if it is behind its remote counterpart. By default, the work branch is created from the latest 'origin/<base_branch>'.",
 )
 def cli(
     title: str,
@@ -408,39 +408,52 @@ def check_branches_valid(base_branch, work_branch, remote_branches):
 
 def branch_out(repo, base_branch, work_branch, update_base: bool = True):
     """Branch out from base_branch and create branch 'work_branch'."""
-    try:
-        log.info(
-            f"Switching to base branch '{base_branch}', creating new branch '{work_branch}' from there, and switching to it."
-        )
-        repo.git.checkout(base_branch)
-        if update_base:
-            # Fast-forward the local base branch to its remote counterpart (already fetched by
-            # init_repo), so the work branch doesn't start from a stale base. A stale start point
-            # pollutes `etl diff` with every dataset that changed on the base branch since.
-            log.info(f"Fast-forwarding '{base_branch}' to 'origin/{base_branch}'.")
-            try:
-                repo.git.merge("--ff-only", f"origin/{base_branch}")
-            except GitCommandError as e:
-                raise click.ClickException(
-                    f"Local branch '{base_branch}' has diverged from 'origin/{base_branch}', so it cannot be fast-forwarded. "
-                    f"Reconcile them first (e.g. 'git rebase origin/{base_branch}'), or re-run with --no-update-base "
-                    f"to branch off your local '{base_branch}' as-is.\n{e}"
-                )
-            # The local base branch may still be ahead of the remote (unpushed commits); the
-            # fast-forward above is a no-op then. The work branch must start exactly at the
-            # remote tip, so those commits don't silently end up in the PR.
-            if repo.commit(base_branch) != repo.commit(f"origin/{base_branch}"):
-                log.warning(
-                    f"Local '{base_branch}' has commits not pushed to 'origin/{base_branch}'; they will NOT be "
-                    f"included in '{work_branch}'. Re-run with --no-update-base to include them."
-                )
-            # --no-track: without it, git would set 'origin/<base_branch>' as the new branch's
-            # upstream, which breaks a plain `git push` on the work branch later.
-            repo.git.checkout("--no-track", "-b", work_branch, f"origin/{base_branch}")
-        else:
+    if not update_base:
+        try:
+            log.info(
+                f"Switching to base branch '{base_branch}', creating new branch '{work_branch}' from there, and switching to it."
+            )
+            repo.git.checkout(base_branch)
             repo.git.checkout("-b", work_branch)
+        except GitCommandError as e:
+            raise click.ClickException(f"Failed to create a new branch from '{base_branch}':\n{e}")
+        return
+
+    # Create the work branch directly from the remote's latest base branch (already fetched by
+    # init_repo), never from the possibly stale local one: a stale start point pollutes `etl diff`
+    # with every dataset that changed on the base branch since, and raises "not in the DAG" errors
+    # for steps that already exist. Uncommitted changes carry over, as with any plain checkout.
+    # --no-track: without it, git would set 'origin/<base_branch>' as the new branch's upstream,
+    # which breaks a plain `git push` on the work branch later.
+    try:
+        log.info(f"Creating new branch '{work_branch}' from 'origin/{base_branch}', and switching to it.")
+        repo.git.checkout("--no-track", "-b", work_branch, f"origin/{base_branch}")
     except GitCommandError as e:
-        raise click.ClickException(f"Failed to create a new branch from '{base_branch}':\n{e}")
+        raise click.ClickException(f"Failed to create a new branch from 'origin/{base_branch}':\n{e}")
+
+    # Keep the local base branch from going stale: fast-forward it to the remote when possible.
+    # The work branch is already checked out, so this moves only the ref; it can never touch the
+    # working tree, and never blocks the PR.
+    if base_branch not in {head.name for head in repo.heads}:
+        return
+    local_commit = repo.commit(base_branch)
+    remote_commit = repo.commit(f"origin/{base_branch}")
+    if local_commit == remote_commit:
+        return
+    if repo.is_ancestor(local_commit, remote_commit):
+        try:
+            repo.git.branch("-f", base_branch, f"origin/{base_branch}")
+            log.info(f"Fast-forwarded local '{base_branch}' to 'origin/{base_branch}'.")
+        except GitCommandError as e:
+            # E.g. the base branch is checked out in another worktree.
+            log.warning(f"Could not fast-forward local '{base_branch}' to 'origin/{base_branch}':\n{e}")
+    else:
+        # The local base branch is ahead of the remote or has diverged from it.
+        log.warning(
+            f"Local '{base_branch}' has commits not pushed to 'origin/{base_branch}'; they are NOT included in "
+            f"'{work_branch}', and local '{base_branch}' is left untouched. Re-run with --no-update-base to "
+            f"branch off your local '{base_branch}' as-is."
+        )
 
 
 def resolve_worktree_path(work_branch: str, override: str | None) -> Path:

--- a/tests/apps/test_pr_cli.py
+++ b/tests/apps/test_pr_cli.py
@@ -6,7 +6,6 @@ branch (https://github.com/owid/etl/issues/6552).
 
 from pathlib import Path
 
-import click
 import pytest
 from git import Repo
 
@@ -82,10 +81,25 @@ def test_branch_out_no_update_base_keeps_stale_start_point(stale_local):
     assert stale_local.head.commit == stale_tip
 
 
-def test_branch_out_fails_on_diverged_base(stale_local):
-    _commit_file(stale_local, "local.txt", "3", "local-only commit")
-    with pytest.raises(click.ClickException, match="diverged"):
-        branch_out(stale_local, "master", "work-branch")
+def test_branch_out_diverged_base_starts_from_remote_and_keeps_local_untouched(stale_local):
+    local_tip = _commit_file(stale_local, "local.txt", "3", "local-only commit")
+    remote_tip = stale_local.commit("origin/master")
+    branch_out(stale_local, "master", "work-branch")
+    # The work branch starts at the remote tip; the diverged local base branch is left untouched.
+    assert stale_local.head.commit == remote_tip
+    assert stale_local.commit("master") == local_tip
+
+
+def test_branch_out_carries_uncommitted_changes(stale_local):
+    # Typical workflow: start editing while on a stale 'master', then wrap the work in a PR branch.
+    dirty_file = Path(stale_local.working_tree_dir) / "a.txt"  # ty: ignore
+    dirty_file.write_text("uncommitted edit")
+    remote_tip = stale_local.commit("origin/master")
+    branch_out(stale_local, "master", "work-branch")
+    assert stale_local.head.commit == remote_tip
+    assert dirty_file.read_text() == "uncommitted edit"
+    # The local base branch was still fast-forwarded (only its ref moves, never the working tree).
+    assert stale_local.commit("master") == remote_tip
 
 
 def test_branch_out_worktree_starts_from_remote(stale_local, tmp_path):

--- a/tests/apps/test_pr_cli.py
+++ b/tests/apps/test_pr_cli.py
@@ -1,0 +1,95 @@
+"""Tests for the branching logic of `etl pr`.
+
+The work branch must start from the latest `origin/<base_branch>`, not from a stale local base
+branch (https://github.com/owid/etl/issues/6552).
+"""
+
+from pathlib import Path
+
+import click
+import pytest
+from git import Repo
+
+from apps.pr.cli import branch_out, branch_out_worktree
+
+
+def _commit_file(repo: Repo, name: str, content: str, message: str):
+    path = Path(repo.working_tree_dir) / name  # ty: ignore
+    path.write_text(content)
+    repo.index.add([str(path)])
+    return repo.index.commit(message)
+
+
+def _set_identity(repo: Repo) -> None:
+    with repo.config_writer() as config:
+        config.set_value("user", "name", "Test User")
+        config.set_value("user", "email", "test@example.com")
+
+
+@pytest.fixture
+def stale_local(tmp_path):
+    """A clone whose local 'master' is one commit behind 'origin/master' (already fetched)."""
+    remote_path = tmp_path / "remote.git"
+    Repo.init(remote_path, bare=True, initial_branch="master")
+
+    # Seed the remote with an initial commit on master.
+    seed = Repo.init(tmp_path / "seed", initial_branch="master")
+    _set_identity(seed)
+    _commit_file(seed, "a.txt", "1", "initial commit")
+    seed.create_remote("origin", str(remote_path))
+    seed.remotes.origin.push("master")
+
+    # The local clone whose master will become stale.
+    local = Repo.clone_from(str(remote_path), tmp_path / "local", branch="master")
+    _set_identity(local)
+
+    # Advance the remote's master by one commit, and fetch (branch_out assumes init_repo fetched).
+    _commit_file(seed, "b.txt", "2", "remote-only commit")
+    seed.remotes.origin.push("master")
+    local.remotes.origin.fetch()
+
+    assert local.commit("master") != local.commit("origin/master")
+    return local
+
+
+def test_branch_out_starts_from_remote_and_fast_forwards_base(stale_local):
+    remote_tip = stale_local.commit("origin/master")
+    branch_out(stale_local, "master", "work-branch")
+    assert stale_local.active_branch.name == "work-branch"
+    assert stale_local.head.commit == remote_tip
+    # The local base branch was fast-forwarded along the way.
+    assert stale_local.commit("master") == remote_tip
+
+
+def test_branch_out_no_update_base_keeps_stale_start_point(stale_local):
+    stale_tip = stale_local.commit("master")
+    branch_out(stale_local, "master", "work-branch", update_base=False)
+    assert stale_local.active_branch.name == "work-branch"
+    assert stale_local.head.commit == stale_tip
+
+
+def test_branch_out_fails_on_diverged_base(stale_local):
+    _commit_file(stale_local, "local.txt", "3", "local-only commit")
+    with pytest.raises(click.ClickException, match="diverged"):
+        branch_out(stale_local, "master", "work-branch")
+
+
+def test_branch_out_worktree_starts_from_remote(stale_local, tmp_path):
+    remote_tip = stale_local.commit("origin/master")
+    stale_tip = stale_local.commit("master")
+    worktree_path = tmp_path / "worktree"
+    branch_out_worktree(stale_local, "master", "work-branch", worktree_path)
+    worktree = Repo(worktree_path)
+    assert worktree.active_branch.name == "work-branch"
+    assert worktree.head.commit == remote_tip
+    # The local base branch is left untouched (it may be checked out in another worktree).
+    assert stale_local.commit("master") == stale_tip
+    # No upstream tracking: a plain `git push` on the work branch must not target origin/master.
+    assert worktree.active_branch.tracking_branch() is None
+
+
+def test_branch_out_worktree_no_update_base_keeps_stale_start_point(stale_local, tmp_path):
+    stale_tip = stale_local.commit("master")
+    worktree_path = tmp_path / "worktree"
+    branch_out_worktree(stale_local, "master", "work-branch", worktree_path, update_base=False)
+    assert Repo(worktree_path).head.commit == stale_tip

--- a/tests/apps/test_pr_cli.py
+++ b/tests/apps/test_pr_cli.py
@@ -59,6 +59,20 @@ def test_branch_out_starts_from_remote_and_fast_forwards_base(stale_local):
     assert stale_local.head.commit == remote_tip
     # The local base branch was fast-forwarded along the way.
     assert stale_local.commit("master") == remote_tip
+    # No upstream tracking: a plain `git push` on the work branch must not target origin/master.
+    assert stale_local.active_branch.tracking_branch() is None
+
+
+def test_branch_out_excludes_unpushed_local_commits(stale_local):
+    # Make the local base branch strictly ahead of the remote (unpushed commit on top of its tip).
+    stale_local.git.merge("--ff-only", "origin/master")
+    local_tip = _commit_file(stale_local, "local.txt", "3", "unpushed local commit")
+    remote_tip = stale_local.commit("origin/master")
+    branch_out(stale_local, "master", "work-branch")
+    # The work branch starts exactly at the remote tip, without the unpushed commit.
+    assert stale_local.head.commit == remote_tip
+    # The unpushed commit stays on the local base branch, untouched.
+    assert stale_local.commit("master") == local_tip
 
 
 def test_branch_out_no_update_base_keeps_stale_start_point(stale_local):


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

Fixes #6552.

`etl pr` created the work branch from the local base branch (usually `master`) without syncing it with the remote first. A stale local `master` meant every new branch started behind: `etl diff` then reported every dataset that changed on master since as if the PR had changed it, and `_check_dag_completeness` raised "not in the DAG" errors for steps that already exist.

Changes:
- **In-place mode** (`branch_out`): the work branch is created directly from `origin/<base_branch>` (already fetched by `init_repo`) in a single checkout, so it starts exactly at the remote tip; uncommitted changes carry over, exactly as before. Afterwards, the local base branch is fast-forwarded to the remote as a **ref-only move** (the work branch is already checked out), so the sync can never touch the working tree or block the PR. If the local base carries unpushed or diverged commits, it is left untouched and a warning explains that those commits are not included.
- **Worktree mode** (`branch_out_worktree`): the work branch is likewise created directly from `origin/<base_branch>`; the local base branch may be checked out in another worktree, so it is left untouched.
- Both modes use `--no-track`, preventing git from setting `origin/<base_branch>` as the new branch's upstream, which would break a plain `git push` on the work branch.
- New `--no-update-base` flag restores the old behavior (branch off the local base branch as-is, including any unpushed commits). Rejected together with `--direct`, which creates no branch.
- Dropped the now-obsolete CLAUDE.md note about rebasing after `etl pr --worktree`.
- Added tests covering both branching paths (fresh start point, unpushed-commits exclusion, diverged base, uncommitted changes carried over, opt-out, no upstream tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)