### PR TITLE
🐛 Select steps with dag-only dependency changes in modified builds

### DIFF
--- a/etl/dag_helpers.py
+++ b/etl/dag_helpers.py
@@ -630,6 +630,19 @@ def load_single_dag_file(filename: str | Path) -> Graph:
     return _parse_dag_yaml(_load_dag_yaml(str(filename)))
 
 
+def parse_dag_yaml_text(text: str) -> Graph:
+    """Flatten the ``steps:`` of a DAG YAML document given as text.
+
+    Same output shape as :func:`load_single_dag_file`, for callers that hold the
+    document's content rather than a file on disk (e.g. a historical version of a
+    DAG file read from git).
+    """
+    dag_yml = yaml.safe_load(text) or {}
+    if not dag_yml.get("steps"):
+        return {}
+    return _parse_dag_yaml(dag_yml)
+
+
 def _load_dag(filename: str | Path, prev_dag: dict[str, Any]):
     """
     Recursive helper to 1) load a dag itself, and 2) load any sub-dags

--- a/etl/git_helpers.py
+++ b/etl/git_helpers.py
@@ -15,7 +15,7 @@ from typing import Any, cast
 
 import requests
 import sh
-from git import Repo
+from git import GitCommandError, Repo
 from structlog import get_logger
 
 from etl.config import TLS_VERIFY
@@ -152,6 +152,20 @@ def log_time(func):
 
 
 # @log_time
+def get_file_at_merge_base(file_path: str, base_branch: str = "master", repo_path: Path | str = BASE_DIR) -> str | None:
+    """Content of ``file_path`` at the merge base of ``origin/<base_branch>`` and HEAD.
+
+    Returns None when the file does not exist at the merge base, or when the merge base cannot
+    be resolved at all (e.g. no ``origin`` remote) — callers treat both as "no previous version".
+    """
+    repo = Repo(repo_path)
+    try:
+        merge_base = repo.git.merge_base(f"origin/{base_branch}", "HEAD").strip()
+        return repo.git.show(f"{merge_base}:{file_path}")
+    except GitCommandError:
+        return None
+
+
 def get_changed_files(
     current_branch: str | None = None,
     base_branch: str | None = None,

--- a/etl/io.py
+++ b/etl/io.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 from structlog import get_logger
 
-from etl.dag_helpers import load_dag
+from etl.dag_helpers import load_dag, load_single_dag_file, parse_dag_yaml_text
+from etl.git_helpers import get_file_at_merge_base
 from etl.paths import BASE_DIR, SNAPSHOTS_DIR, STEP_DIR
 from etl.steps import filter_to_subgraph
 
@@ -30,6 +31,38 @@ def get_changed_steps(files_changed: dict[str, dict[str, str]]) -> list[str]:
         else:
             continue
 
+    return changed_steps
+
+
+def get_dag_dependency_changed_steps(files_changed: dict[str, dict[str, str]]) -> set[str]:
+    """Steps whose dependency lists changed in edited ``dag/*.yml`` files.
+
+    A dependency-only edit — e.g. repointing a consumer step from one input version to another —
+    touches no file under ``etl/steps/`` or ``snapshots/``, so :func:`get_changed_steps` cannot
+    see it; yet the step rebuilds to different content. Without this, ``--modified`` builds (and
+    the chart-diff / datadiff selections built on the same machinery) silently skip repointed
+    steps, and their value changes ship with the next full build unreviewed (WDI 2026-07: six
+    repointed consumers changed data that neither diff surfaced).
+
+    Diff each changed DAG file against its merge-base version and select every step whose
+    dependency set differs, including steps newly declared in the file. ``dag/archive/*`` is a
+    generated record of retired steps and is ignored.
+    """
+    changed_steps: set[str] = set()
+    for file_path, file_status in files_changed.items():
+        # files_changed values are {"status": ..., "diff": ...} dicts from get_changed_files,
+        # but plain status strings are also accepted (mirrors get_changed_steps' inputs in tests).
+        status = file_status.get("status") if isinstance(file_status, dict) else file_status
+        if status == "D":
+            continue
+        if not file_path.startswith("dag/") or file_path.startswith("dag/archive/") or not file_path.endswith(".yml"):
+            continue
+        current = load_single_dag_file(BASE_DIR / file_path)
+        base_text = get_file_at_merge_base(file_path)
+        base = parse_dag_yaml_text(base_text) if base_text else {}
+        for step, deps in current.items():
+            if set(deps or set()) != set(base.get(step) or set()):
+                changed_steps.add(step)
     return changed_steps
 
 
@@ -73,6 +106,16 @@ def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]], incl
             else:
                 export_path = rel_export.with_suffix("").with_suffix("").as_posix()
             changed_export_uris.append(f"export://{export_path}")
+
+    # Dependency-only DAG edits (repoints) change a step's content without touching its files —
+    # select those steps too, so they enter the subgraph expansion below like any changed step.
+    for step_uri in sorted(get_dag_dependency_changed_steps(files_changed)):
+        if step_uri.startswith(("data://", "data-private://")):
+            ds_path = step_uri.split("://", 1)[1]
+            if ds_path not in dataset_catalog_paths:
+                dataset_catalog_paths.append(ds_path)
+        elif step_uri.startswith("export://") and step_uri not in changed_export_uris:
+            changed_export_uris.append(step_uri)
 
     if not dataset_catalog_paths:
         # No data steps changed. We can still have directly-changed export steps; return those when

--- a/etl/io.py
+++ b/etl/io.py
@@ -143,7 +143,7 @@ def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]], incl
     # rather than superseding one in place; matching all of them would sweep unrelated, untouched
     # datasets into the comparison. Since those aren't part of `dataset_catalog_paths` and usually
     # aren't built locally either, `etl diff` would report each one as falsely "removed".
-    all_data_steps = {s.split("://", 1)[1] for s in DAG if s.startswith("data://")}
+    all_data_steps = {s.split("://", 1)[1] for s in DAG if s.startswith(("data://", "data-private://"))}
     sibling_versions = []
     for ds_path in dataset_catalog_paths:
         parts = ds_path.split("/")
@@ -167,9 +167,11 @@ def get_all_changed_catalog_paths(files_changed: dict[str, dict[str, str]], incl
     # swept into the result too, even though only the new version is actually changing.
     dag_steps = list(filter_to_subgraph(DAG, dataset_catalog_paths, downstream=True).keys())
 
-    # From data://... extract catalogPath
+    # From data://... extract catalogPath. Keep data-private:// steps too: dropping them here would
+    # return an empty list for a private-only change, so `etl run --modified --private` (and
+    # chart-diff/datadiff) would silently skip the affected private steps.
     # TODO: use StepPath from https://github.com/owid/etl/pull/3165 to refactor this
-    catalog_paths = [step.split("://")[1] for step in dag_steps if step.startswith("data://")]
+    catalog_paths = [step.split("://", 1)[1] for step in dag_steps if step.startswith(("data://", "data-private://"))]
     for sibling in sibling_versions:
         if sibling not in catalog_paths:
             catalog_paths.append(sibling)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -192,3 +192,43 @@ steps:
     assert "grapher/malnutrition/2024-12-16/malnutrition" in result
     # (The repoint target also appears, as upstream deps always do in the subgraph expansion —
     # harmless, since an unchanged dataset diffs as identical.)
+
+
+@patch("etl.io.get_file_at_merge_base")
+@patch("etl.io.load_single_dag_file")
+@patch("etl.io.load_dag")
+def test_get_all_changed_catalog_paths_private_dag_only_dependency_change(
+    mock_load_dag, mock_load_single, mock_merge_base
+):
+    """A repoint of a data-private:// consumer must survive into the returned catalog paths.
+
+    The final projection kept only data:// nodes, so a private-only repoint returned an empty
+    list — `etl run --modified --private` then reported no modified steps and skipped the
+    rebuild, and chart-diff/datadiff filtered the private steps out as spurious.
+    """
+    mock_load_dag.return_value = {
+        "data-private://garden/worldbank_wdi/2026-07-27/wdi": set(),
+        "data-private://garden/malnutrition/2024-12-16/malnutrition": {
+            "data-private://garden/worldbank_wdi/2026-07-27/wdi"
+        },
+        "data-private://grapher/malnutrition/2024-12-16/malnutrition": {
+            "data-private://garden/malnutrition/2024-12-16/malnutrition"
+        },
+    }
+    mock_load_single.return_value = {
+        "data-private://garden/malnutrition/2024-12-16/malnutrition": {
+            "data-private://garden/worldbank_wdi/2026-07-27/wdi"
+        },
+    }
+    mock_merge_base.return_value = """
+steps:
+  data-private://garden/malnutrition/2024-12-16/malnutrition:
+    - data-private://garden/worldbank_wdi/2026-07-14/wdi
+"""
+
+    result = get_all_changed_catalog_paths({"dag/main.yml": {"status": "M", "diff": ""}})
+
+    # The repointed private consumer and its private downstream step are both returned, URI-less
+    # like their public counterparts.
+    assert "garden/malnutrition/2024-12-16/malnutrition" in result
+    assert "grapher/malnutrition/2024-12-16/malnutrition" in result

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -128,3 +128,67 @@ def test_get_all_changed_catalog_paths_only_pulls_in_closest_preceding_sibling(m
     assert "garden/worldbank_wdi/2025-01-24/wdi" not in result
     assert "garden/worldbank_wdi/2025-09-08/wdi" not in result
     assert "garden/worldbank_wdi/2026-01-29/wdi" not in result
+
+
+@patch("etl.io.get_file_at_merge_base")
+@patch("etl.io.load_single_dag_file")
+def test_get_dag_dependency_changed_steps_repoint(mock_load_single, mock_merge_base):
+    """A dag-only dependency edit (repoint) must select the repointed step — and only it.
+
+    This is the WDI 2026-07 follow-up shape: consumers were repointed from one WDI version to
+    another with no change to any file under etl/steps/, so file-based selection saw nothing,
+    staging skipped the rebuilds, and six consumers' value changes reached neither chart-diff
+    nor datadiff.
+    """
+    from etl.io import get_dag_dependency_changed_steps
+
+    # Current branch state: consumer repointed to 2026-07-27; bystander untouched.
+    mock_load_single.return_value = {
+        "data://garden/malnutrition/2024-12-16/malnutrition": {"data://garden/worldbank_wdi/2026-07-27/wdi"},
+        "data://garden/technology/2024-12-23/internet": {"data://garden/demography/2024-07-15/population"},
+    }
+    # Merge-base state of the same dag file, in the nested form dag files actually use.
+    mock_merge_base.return_value = """
+steps:
+  data://garden/malnutrition/2024-12-16/malnutrition:
+    - data://garden/worldbank_wdi/2026-07-14/wdi
+  data://garden/technology/2024-12-23/internet:
+    - data://garden/demography/2024-07-15/population
+"""
+
+    changed = get_dag_dependency_changed_steps({"dag/main.yml": {"status": "M", "diff": ""}})
+    assert changed == {"data://garden/malnutrition/2024-12-16/malnutrition"}
+
+    # dag/archive is a generated record — never a selection source.
+    assert get_dag_dependency_changed_steps({"dag/archive/main.yml": "M"}) == set()
+    # Deleted dag files select nothing.
+    assert get_dag_dependency_changed_steps({"dag/main.yml": "D"}) == set()
+
+
+@patch("etl.io.get_file_at_merge_base")
+@patch("etl.io.load_single_dag_file")
+@patch("etl.io.load_dag")
+def test_get_all_changed_catalog_paths_dag_only_dependency_change(mock_load_dag, mock_load_single, mock_merge_base):
+    """A repoint-only branch must select the repointed consumer and its downstream steps,
+    even though no file under etl/steps/ changed."""
+    mock_load_dag.return_value = {
+        "data://garden/worldbank_wdi/2026-07-27/wdi": set(),
+        "data://garden/malnutrition/2024-12-16/malnutrition": {"data://garden/worldbank_wdi/2026-07-27/wdi"},
+        "data://grapher/malnutrition/2024-12-16/malnutrition": {"data://garden/malnutrition/2024-12-16/malnutrition"},
+    }
+    mock_load_single.return_value = {
+        "data://garden/malnutrition/2024-12-16/malnutrition": {"data://garden/worldbank_wdi/2026-07-27/wdi"},
+    }
+    mock_merge_base.return_value = """
+steps:
+  data://garden/malnutrition/2024-12-16/malnutrition:
+    - data://garden/worldbank_wdi/2026-07-14/wdi
+"""
+
+    result = get_all_changed_catalog_paths({"dag/main.yml": {"status": "M", "diff": ""}})
+
+    assert "garden/malnutrition/2024-12-16/malnutrition" in result
+    # Downstream grapher step is swept in via the subgraph expansion.
+    assert "grapher/malnutrition/2024-12-16/malnutrition" in result
+    # (The repoint target also appears, as upstream deps always do in the subgraph expansion —
+    # harmless, since an unchanged dataset diffs as identical.)


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

## The bug

Staging builds run `etl run … --modified` to rebuild only steps changed vs master (a deliberate speed optimization — `staging-site-master` still does full builds). The changed-step detection behind it, `get_changed_steps` in `etl/io.py`, only looks at files under `etl/steps/` and `snapshots/` — **changed `dag/*.yml` files are ignored entirely**.

A dependency-only edit (repointing a consumer step from one input version to another) therefore selects nothing: the staging server never rebuilds the repointed steps, their grapher variables keep production's checksums, and both **chart-diff** and the server-side **data-diff** (which reuse the same selection machinery) are structurally blind to the resulting value changes. The changes then ship with the next full master build, unreviewed.

Observed on #6561 (WDI repoint follow-up): six repointed consumers changed data — including three published charts — while chart-diff reported "Data changes: 0" and data-diff reported only "1 new". On the staging server itself, `etl run --dry-run data://garden/imf/2025-07-08/trade` said "Would run 1 steps" — etlr's checksum-based detection knew; the `--modified` file filter never asked it.

## The fix

`get_dag_dependency_changed_steps` (new, `etl/io.py`): for every changed `dag/*.yml` (excluding the generated `dag/archive/`), flatten the branch version and the merge-base version of the file and select every step whose dependency set differs — including steps newly declared. `get_all_changed_catalog_paths` feeds those steps into the same downstream-subgraph expansion as file-changed steps, so `--modified` builds, chart-diff and datadiff all see them. The speed optimization is preserved: the build is still a subset, just a correct one.

Supporting helpers: `parse_dag_yaml_text` (`dag_helpers.py` — flatten a DAG document from text, nested or flat form) and `get_file_at_merge_base` (`git_helpers.py`).

## Second bug, found in review: `data-private://` steps were dropped entirely

The final projection in `get_all_changed_catalog_paths` kept only `data://` nodes, so **every** `data-private://` step was filtered out of the returned paths — not just dag-repointed ones, but file-edited private steps too. A private-only change returned an empty list, and `etl run --modified --private`, chart-diff and datadiff all silently skipped the affected steps. This predates the present PR (it dates to the commit that created `etl/io.py`) and affects **580 private steps** currently in the active DAG. Both the projection and the sibling-version lookup now accept `data-private://`.

## Verification

- Two new tests in `tests/test_io.py`: the pure repoint shape (nested dag form, bystander steps unselected, `dag/archive/` and deleted files ignored) and the end-to-end selection including downstream subgraph expansion.
- A third test covers the private-step case (`test_get_all_changed_catalog_paths_private_dag_only_dependency_change`).
- Live validation against the real #6561 branch: the selector returns exactly the repointed consumers plus the newly-declared `gdp_historical` step; on a branch with no dag edits it returns an empty set.
