### PR TITLE
🐛 Score numeric-with-sentinel columns in data-diff instead of defaulting to maximal

### DIFF
--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -864,6 +864,31 @@ def _df_to_records(df: pd.DataFrame, limit: int = SAMPLE_LIMIT) -> list[dict[str
     return [{str(k): _fmt(v) for k, v in row.items()} for row in df_samp.to_dict("records")]
 
 
+def _as_comparable_floats(s: pd.Series) -> pd.Series | None:
+    """``s`` as float64 for BARD scoring, or None if it isn't a numeric quantity.
+
+    A numeric indicator can carry a non-numeric **sentinel** in some rows — e.g.
+    `imf/trade`'s `china_imports_share_of_gdp` stores the literal string "China" on China's own
+    rows, since "China's imports as a share of China's GDP" is meaningless. That single string
+    makes the whole column `category`/`object` dtype, and a plain `is_numeric_dtype` gate would
+    hand the column to the unscoreable path, where it defaults to *maximal* severity — ranking
+    the column as the report's worst anomaly on the strength of its dtype alone.
+
+    So coerce instead: sentinels become NaN (they're then treated as coverage events rather than
+    revisions, which is what a value-to-sentinel flip is), and the genuinely numeric rows get
+    scored normally. Columns that are actually categorical — where coercion leaves nothing
+    numeric to compare — still return None and keep the unscoreable path.
+    """
+    if pd.api.types.is_numeric_dtype(s):
+        return s.astype("float64")
+    if isinstance(s.dtype, pd.CategoricalDtype) or pd.api.types.is_object_dtype(s) or pd.api.types.is_string_dtype(s):
+        coerced = pd.to_numeric(s.astype("object"), errors="coerce")
+        # Genuinely categorical when coercion salvages nothing.
+        if coerced.notna().any():
+            return coerced.astype("float64")
+    return None
+
+
 def _changed_records(
     both: pd.DataFrame, col: str, limit: int = SAMPLE_LIMIT
 ) -> tuple[list[dict[str, str]], bool, float | None, int, int]:
@@ -890,11 +915,9 @@ def _changed_records(
     None only for non-numeric columns, where old/new can't be told apart from a category flip.
     """
     old_col, new_col = f"{col} -", f"{col} +"
-    if not (pd.api.types.is_numeric_dtype(both[old_col]) and pd.api.types.is_numeric_dtype(both[new_col])):
+    old, new = _as_comparable_floats(both[old_col]), _as_comparable_floats(both[new_col])
+    if old is None or new is None:
         return _df_to_records(both, limit=limit), False, None, 0, 0
-
-    old = both[old_col].astype("float64")
-    new = both[new_col].astype("float64")
     old_isna = old.isna().to_numpy()
     new_isna = new.isna().to_numpy()
     appeared = old_isna & ~new_isna

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -864,6 +864,11 @@ def _df_to_records(df: pd.DataFrame, limit: int = SAMPLE_LIMIT) -> list[dict[str
     return [{str(k): _fmt(v) for k, v in row.items()} for row in df_samp.to_dict("records")]
 
 
+# A zero-padded string ("004", "007") is an identifier, not a quantity — nothing measured is
+# written that way. Matches a leading zero followed by a digit, so "0.5" and "0" stay numeric.
+ZERO_PADDED_RE = re.compile(r"^-?0\d")
+
+
 def _as_comparable_floats(s: pd.Series) -> pd.Series | None:
     """``s`` as float64 for BARD scoring, or None if its dtype can't carry a number at all.
 
@@ -879,11 +884,22 @@ def _as_comparable_floats(s: pd.Series) -> pd.Series | None:
     scored normally. Whether anything numeric actually survived the coercion is up to the caller,
     which weighs both sides of the diff together — see `_changed_records`. Dtypes that can't hold
     a number at all (datetimes, for one) return None and keep the unscoreable path.
+
+    Codes that merely *look* numeric are the risk in parsing strings, and zero-padding is the one
+    unambiguous tell: a column holding "004" is a set of identifiers (ISO numeric country codes,
+    area codes) whose flips have no measurable size, so it stays unscored rather than reporting
+    "004" -> "008" as a BARD anomaly. Unpadded codes are indistinguishable from small quantities
+    and are still scored — see `_changed_records` on why that beats the unscoreable path.
     """
     if pd.api.types.is_numeric_dtype(s):
         return s.astype("float64")
     if isinstance(s.dtype, pd.CategoricalDtype) or pd.api.types.is_object_dtype(s) or pd.api.types.is_string_dtype(s):
-        return pd.to_numeric(s.astype("object"), errors="coerce").astype("float64")
+        values = s.astype("object")
+        # Checked over distinct values only — cheap even on a wide diff. One padded value is
+        # enough: a code column is a code column even where individual codes need no padding.
+        if any(isinstance(v, str) and ZERO_PADDED_RE.match(v) for v in pd.unique(values)):
+            return None
+        return pd.to_numeric(values, errors="coerce").astype("float64")
     return None
 
 

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -7,7 +7,7 @@ import urllib.error
 from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 import numpy as np
 import pandas as pd
@@ -926,14 +926,39 @@ def _finite(s: pd.Series) -> pd.Series:
     return s.where(np.isfinite(s))
 
 
+def _has_numeric_content(s: pd.Series) -> bool:
+    """Whether ``s`` holds any value that can be compared as a number."""
+    coerced = _as_comparable_floats(s)
+    return coerced is not None and bool(coerced.notna().any())
+
+
+class ChangedRecords(NamedTuple):
+    """Sampled rows of a changed-values diff, plus how the rows behind them broke down."""
+
+    records: list[dict[str, str]]
+    sorted_by_score: bool
+    median_bard: float | None
+    appeared_count: int
+    disappeared_count: int
+    not_scored_count: int
+
+
 def _changed_records(
-    both: pd.DataFrame, col: str, limit: int = SAMPLE_LIMIT, is_code_column: bool = False
-) -> tuple[list[dict[str, str]], bool, float | None, int, int]:
+    both: pd.DataFrame,
+    col: str,
+    limit: int = SAMPLE_LIMIT,
+    is_code_column: bool = False,
+    is_numeric_column: bool = False,
+) -> ChangedRecords:
     """Sample records for a changed-values diff.
 
     `both` holds only the rows that changed, which is all the scoring needs but not always enough
-    to classify the column: pass `is_code_column` when the *full* column shows it holds identifiers
-    (see `_is_code_column`), since its padded values may all sit on rows that didn't change.
+    to classify the column, since the evidence may sit entirely on rows that didn't change. Two
+    verdicts are therefore taken from the *full* columns and passed in: `is_code_column` when they
+    hold identifiers (see `_is_code_column`), whose padded values may all be unchanged, and
+    `is_numeric_column` when they hold numbers, which a sentinel-only edit leaves out of `both`
+    altogether — without it, editing the one sentinel in a numeric column would call the whole
+    column categorical and rank it maximal.
 
     A value appearing or disappearing (NaN on one side) is a *coverage* event, not a value
     *revision* — e.g. the newest year in a new dataset version, or a slow-cadence indicator whose
@@ -964,18 +989,23 @@ def _changed_records(
     old_col, new_col = f"{col} -", f"{col} +"
     old, new = _as_comparable_floats(both[old_col]), _as_comparable_floats(both[new_col])
     # Being a numeric quantity is a property of the column, so decide it across both sides at
-    # once: numeric content on *either* side is enough. `both` holds only the rows that changed,
-    # so one side can legitimately be all sentinels — a version that drops the sentinel convention
-    # changes exactly those rows, and old is then entirely non-numeric. Judging that side alone
-    # would call the indicator categorical and hand it maximal severity, the very failure this
-    # coercion exists to remove; judged jointly, it reads as the coverage event it is.
-    if is_code_column or old is None or new is None or not (old.notna().any() or new.notna().any()):
-        return _df_to_records(both, limit=limit), False, None, 0, 0
+    # once, and accept the full-column verdict over the changed rows. A version that drops the
+    # sentinel convention changes exactly the sentinel rows, leaving one side of `both` entirely
+    # non-numeric; an edit to the sentinel itself leaves both sides so. Judging those on `both`
+    # alone would call the indicator categorical and hand it maximal severity, the very failure
+    # this coercion exists to remove.
+    if is_code_column or old is None or new is None:
+        return ChangedRecords(_df_to_records(both, limit=limit), False, None, 0, 0, 0)
+    if not (is_numeric_column or old.notna().any() or new.notna().any()):
+        return ChangedRecords(_df_to_records(both, limit=limit), False, None, 0, 0, 0)
     old_isna = old.isna().to_numpy()
     new_isna = new.isna().to_numpy()
     appeared = old_isna & ~new_isna
     disappeared = ~old_isna & new_isna
     revised = ~old_isna & ~new_isna
+    # Non-numeric on both sides: neither a revision nor a coverage event, but still a changed row,
+    # so it is counted here rather than left to be inferred away from the other two tallies.
+    not_scored = old_isna & new_isna
 
     score = np.full(len(both), np.nan)
     score[revised] = bard(old.to_numpy()[revised], new.to_numpy()[revised])
@@ -998,7 +1028,14 @@ def _changed_records(
         return "not scored"
 
     top["anomaly score"] = [_label(i) for i in order]
-    return _df_to_records(top, limit=limit), True, median_bard, int(appeared.sum()), int(disappeared.sum())
+    return ChangedRecords(
+        _df_to_records(top, limit=limit),
+        True,
+        median_bard,
+        int(appeared.sum()),
+        int(disappeared.sum()),
+        int(not_scored.sum()),
+    )
 
 
 def _data_diff(
@@ -1063,22 +1100,25 @@ def _data_diff(
             both = samp_a.join(samp_b, lsuffix=" -", rsuffix=" +")
         lines += _df_to_str(both)
 
-        # Classified on the full columns, not on `both`: a code column's padded values may all sit
-        # on rows that didn't change, leaving the changed-rows frame with no sign that it is coded.
-        is_code_column = _is_code_column(table_a[col]) or _is_code_column(table_b[col])
-        records, sorted_by_score, median_bard, appeared_count, disappeared_count = _changed_records(
-            both, col, is_code_column=is_code_column
+        # Classified on the full columns, not on `both`: the rows that prove a column is coded, or
+        # that it is numeric at all, may all be rows that didn't change.
+        changed = _changed_records(
+            both,
+            col,
+            is_code_column=_is_code_column(table_a[col]) or _is_code_column(table_b[col]),
+            is_numeric_column=_has_numeric_content(table_a[col]) or _has_numeric_content(table_b[col]),
         )
         value_diffs.append(
             ValueDiff(
                 kind="changed",
                 count=int(neq.sum()),
                 total=int(n),
-                sample=records,
-                sorted_by_score=sorted_by_score,
-                median_bard=median_bard,
-                appeared_count=appeared_count,
-                disappeared_count=disappeared_count,
+                sample=changed.records,
+                sorted_by_score=changed.sorted_by_score,
+                median_bard=changed.median_bard,
+                appeared_count=changed.appeared_count,
+                disappeared_count=changed.disappeared_count,
+                not_scored_count=changed.not_scored_count,
             )
         )
 

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -907,6 +907,12 @@ def _changed_records(
     resistant to blow-ups on tiny values), with appeared/disappeared rows sorted after them and
     labeled as such instead of given a score. Other dtypes keep the plain random sample.
 
+    A sentinel-carrying column (see `_as_comparable_floats`) can also change from one non-numeric
+    value to another — a sentinel whose text was edited, or a gap filled with a sentinel. Both
+    sides coerce to NaN, so nothing numeric appeared, disappeared or moved: those rows are labeled
+    "not scored" rather than given a number or miscounted as a coverage event. They still show up
+    in the diff's changed-row count and in the sample, so the change stays visible.
+
     Returns (records, sorted_by_score, median_bard, appeared_count, disappeared_count).
     median_bard is the median BARD across all *revised* rows (not just the sample) — the report
     uses it to sort columns, tables and datasets by how big their genuine revisions typically are.
@@ -933,9 +939,18 @@ def _changed_records(
     rank_key = np.where(revised, -score, np.inf)
     order = np.argsort(rank_key, kind="stable")[:limit]
     top = both.iloc[order].copy()
-    top["anomaly score"] = [
-        format_score(score[i]) if revised[i] else ("appeared" if appeared[i] else "disappeared") for i in order
-    ]
+
+    def _label(i: int) -> str:
+        if revised[i]:
+            return format_score(score[i])
+        if appeared[i]:
+            return "appeared"
+        if disappeared[i]:
+            return "disappeared"
+        # Non-numeric on both sides (sentinel to sentinel): not a coverage event either.
+        return "not scored"
+
+    top["anomaly score"] = [_label(i) for i in order]
     return _df_to_records(top, limit=limit), True, median_bard, int(appeared.sum()), int(disappeared.sum())
 
 

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -869,6 +869,26 @@ def _df_to_records(df: pd.DataFrame, limit: int = SAMPLE_LIMIT) -> list[dict[str
 ZERO_PADDED_RE = re.compile(r"^-?0\d")
 
 
+def _is_code_column(s: pd.Series) -> bool:
+    """Whether ``s`` holds identifiers that merely look numeric, rather than quantities.
+
+    Zero-padding is the tell — ISO numeric country codes, area codes — and one padded value is
+    enough, since a code column stays a code column at the values that need no padding. Judge it
+    on the *whole* column: the padded codes may all sit on rows that didn't change, in which case
+    the changed-rows frame alone carries no evidence that the column is coded at all.
+    """
+    if pd.api.types.is_numeric_dtype(s):
+        return False
+    if isinstance(s.dtype, pd.CategoricalDtype):
+        # Categories are already deduplicated, so this costs nothing on a long column.
+        values = s.dtype.categories
+    elif pd.api.types.is_object_dtype(s) or pd.api.types.is_string_dtype(s):
+        values = pd.unique(s.astype("object"))
+    else:
+        return False
+    return any(isinstance(v, str) and ZERO_PADDED_RE.match(v) for v in values)
+
+
 def _as_comparable_floats(s: pd.Series) -> pd.Series | None:
     """``s`` as float64 for BARD scoring, or None if its dtype can't carry a number at all.
 
@@ -885,28 +905,35 @@ def _as_comparable_floats(s: pd.Series) -> pd.Series | None:
     which weighs both sides of the diff together — see `_changed_records`. Dtypes that can't hold
     a number at all (datetimes, for one) return None and keep the unscoreable path.
 
-    Codes that merely *look* numeric are the risk in parsing strings, and zero-padding is the one
-    unambiguous tell: a column holding "004" is a set of identifiers (ISO numeric country codes,
-    area codes) whose flips have no measurable size, so it stays unscored rather than reporting
-    "004" -> "008" as a BARD anomaly. Unpadded codes are indistinguishable from small quantities
-    and are still scored — see `_changed_records` on why that beats the unscoreable path.
+    Codes that merely *look* numeric are the risk in parsing strings, so a column `_is_code_column`
+    recognizes is rejected here too. Infinities are rejected differently — as missing rather than as
+    a whole unscoreable column: `pd.to_numeric` happily parses "Inf" (and a float column can hold
+    one outright), but BARD returns NaN for it, which would poison the column's median and, since
+    `_tier` reads NaN as no tier at all, drop the column out of the report's chips and watch list
+    without a word. An unmeasurable value is exactly what a sentinel is, so it's treated as one.
     """
     if pd.api.types.is_numeric_dtype(s):
-        return s.astype("float64")
+        return _finite(s.astype("float64"))
     if isinstance(s.dtype, pd.CategoricalDtype) or pd.api.types.is_object_dtype(s) or pd.api.types.is_string_dtype(s):
-        values = s.astype("object")
-        # Checked over distinct values only — cheap even on a wide diff. One padded value is
-        # enough: a code column is a code column even where individual codes need no padding.
-        if any(isinstance(v, str) and ZERO_PADDED_RE.match(v) for v in pd.unique(values)):
+        if _is_code_column(s):
             return None
-        return pd.to_numeric(values, errors="coerce").astype("float64")
+        return _finite(pd.to_numeric(s.astype("object"), errors="coerce").astype("float64"))
     return None
 
 
+def _finite(s: pd.Series) -> pd.Series:
+    """``s`` with infinities blanked to NaN, so they're handled as sentinels rather than scored."""
+    return s.where(np.isfinite(s))
+
+
 def _changed_records(
-    both: pd.DataFrame, col: str, limit: int = SAMPLE_LIMIT
+    both: pd.DataFrame, col: str, limit: int = SAMPLE_LIMIT, is_code_column: bool = False
 ) -> tuple[list[dict[str, str]], bool, float | None, int, int]:
     """Sample records for a changed-values diff.
+
+    `both` holds only the rows that changed, which is all the scoring needs but not always enough
+    to classify the column: pass `is_code_column` when the *full* column shows it holds identifiers
+    (see `_is_code_column`), since its padded values may all sit on rows that didn't change.
 
     A value appearing or disappearing (NaN on one side) is a *coverage* event, not a value
     *revision* — e.g. the newest year in a new dataset version, or a slow-cadence indicator whose
@@ -942,7 +969,7 @@ def _changed_records(
     # changes exactly those rows, and old is then entirely non-numeric. Judging that side alone
     # would call the indicator categorical and hand it maximal severity, the very failure this
     # coercion exists to remove; judged jointly, it reads as the coverage event it is.
-    if old is None or new is None or not (old.notna().any() or new.notna().any()):
+    if is_code_column or old is None or new is None or not (old.notna().any() or new.notna().any()):
         return _df_to_records(both, limit=limit), False, None, 0, 0
     old_isna = old.isna().to_numpy()
     new_isna = new.isna().to_numpy()
@@ -1036,7 +1063,12 @@ def _data_diff(
             both = samp_a.join(samp_b, lsuffix=" -", rsuffix=" +")
         lines += _df_to_str(both)
 
-        records, sorted_by_score, median_bard, appeared_count, disappeared_count = _changed_records(both, col)
+        # Classified on the full columns, not on `both`: a code column's padded values may all sit
+        # on rows that didn't change, leaving the changed-rows frame with no sign that it is coded.
+        is_code_column = _is_code_column(table_a[col]) or _is_code_column(table_b[col])
+        records, sorted_by_score, median_bard, appeared_count, disappeared_count = _changed_records(
+            both, col, is_code_column=is_code_column
+        )
         value_diffs.append(
             ValueDiff(
                 kind="changed",

--- a/etl/datadiff.py
+++ b/etl/datadiff.py
@@ -865,7 +865,7 @@ def _df_to_records(df: pd.DataFrame, limit: int = SAMPLE_LIMIT) -> list[dict[str
 
 
 def _as_comparable_floats(s: pd.Series) -> pd.Series | None:
-    """``s`` as float64 for BARD scoring, or None if it isn't a numeric quantity.
+    """``s`` as float64 for BARD scoring, or None if its dtype can't carry a number at all.
 
     A numeric indicator can carry a non-numeric **sentinel** in some rows — e.g.
     `imf/trade`'s `china_imports_share_of_gdp` stores the literal string "China" on China's own
@@ -876,16 +876,14 @@ def _as_comparable_floats(s: pd.Series) -> pd.Series | None:
 
     So coerce instead: sentinels become NaN (they're then treated as coverage events rather than
     revisions, which is what a value-to-sentinel flip is), and the genuinely numeric rows get
-    scored normally. Columns that are actually categorical — where coercion leaves nothing
-    numeric to compare — still return None and keep the unscoreable path.
+    scored normally. Whether anything numeric actually survived the coercion is up to the caller,
+    which weighs both sides of the diff together — see `_changed_records`. Dtypes that can't hold
+    a number at all (datetimes, for one) return None and keep the unscoreable path.
     """
     if pd.api.types.is_numeric_dtype(s):
         return s.astype("float64")
     if isinstance(s.dtype, pd.CategoricalDtype) or pd.api.types.is_object_dtype(s) or pd.api.types.is_string_dtype(s):
-        coerced = pd.to_numeric(s.astype("object"), errors="coerce")
-        # Genuinely categorical when coercion salvages nothing.
-        if coerced.notna().any():
-            return coerced.astype("float64")
+        return pd.to_numeric(s.astype("object"), errors="coerce").astype("float64")
     return None
 
 
@@ -922,7 +920,13 @@ def _changed_records(
     """
     old_col, new_col = f"{col} -", f"{col} +"
     old, new = _as_comparable_floats(both[old_col]), _as_comparable_floats(both[new_col])
-    if old is None or new is None:
+    # Being a numeric quantity is a property of the column, so decide it across both sides at
+    # once: numeric content on *either* side is enough. `both` holds only the rows that changed,
+    # so one side can legitimately be all sentinels — a version that drops the sentinel convention
+    # changes exactly those rows, and old is then entirely non-numeric. Judging that side alone
+    # would call the indicator categorical and hand it maximal severity, the very failure this
+    # coercion exists to remove; judged jointly, it reads as the coverage event it is.
+    if old is None or new is None or not (old.notna().any() or new.notna().any()):
         return _df_to_records(both, limit=limit), False, None, 0, 0
     old_isna = old.isna().to_numpy()
     new_isna = new.isna().to_numpy()

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -181,10 +181,15 @@ class ColumnDiffResult:
         False only for a genuinely categorical changed column, whose `severity` is the 1.0
         "a category flip has no meaningful size" default. The report labels those "not scored"
         instead of quoting a 100% median it never computed.
+
+        A column with no in-place revisions at all — only rows added or removed — is still scored:
+        its severity comes from the share of rows lost, which is measured, not a fallback. Only a
+        `changed` diff can be unscoreable, so the absence of one is never evidence of one.
         """
-        if self.kind != "changed" or not self.value_diffs:
+        changed = [v for v in self.value_diffs if v.kind == "changed"]
+        if self.kind != "changed" or not changed:
             return True
-        return any(v.median_bard is not None for v in self.value_diffs if v.kind == "changed")
+        return any(v.median_bard is not None for v in changed)
 
 
 @dataclass

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -174,6 +174,18 @@ class ColumnDiffResult:
         """A changed column whose diff carries no value changes at all — only metadata edits."""
         return self.kind == "changed" and not self.value_diffs
 
+    @property
+    def is_scored(self) -> bool:
+        """Whether this column's severity is a measured median BARD rather than the fallback.
+
+        False only for a genuinely categorical changed column, whose `severity` is the 1.0
+        "a category flip has no meaningful size" default. The report labels those "not scored"
+        instead of quoting a 100% median it never computed.
+        """
+        if self.kind != "changed" or not self.value_diffs:
+            return True
+        return any(v.median_bard is not None for v in self.value_diffs if v.kind == "changed")
+
 
 @dataclass
 class TableDiffResult:
@@ -458,7 +470,7 @@ def dataset_watch_key(ds: DatasetDiffResult) -> tuple:
     return (tier_rank[ds.tier], lossy_first, -ds.severity, ds.path)
 
 
-def _tier_chip(severity: float, kind: ChangeKind = "changed", tier: Tier | None = None) -> str:
+def _tier_chip(severity: float, kind: ChangeKind = "changed", tier: Tier | None = None, scored: bool = True) -> str:
     """Colored triage chip for a single column: tier icon + its own median BARD score.
 
     Pass `tier` to override the severity-derived tier — a removed column is forced 🔴 regardless
@@ -467,11 +479,19 @@ def _tier_chip(severity: float, kind: ChangeKind = "changed", tier: Tier | None 
     dataset level — see `_rollup_tier_chip`, which a max-of-columns would make say "median" while
     actually showing the single worst column, and which saturates to 100% on any dataset wide
     enough that some column always has a genuine full anomaly (WDI-sized: ~1500 columns).
+
+    Pass `scored=False` for a column whose severity is the non-numeric 1.0 fallback rather than a
+    measured median: the chip then says "not scored" instead of claiming a 100% median that was
+    never computed.
     """
     tier = tier or _tier(severity)
     if tier == "none":
         return ""
-    label = {"removed": "removed", "new": "new"}.get(kind) or f"median anomaly score {format_score(severity)}"
+    if scored is False and kind == "changed":
+        # Unscoreable (categorical) column: severity is the 1.0 fallback, not a measurement.
+        label = "not scored (non-numeric)"
+    else:
+        label = {"removed": "removed", "new": "new"}.get(kind) or f"median anomaly score {format_score(severity)}"
     return f'<span class="chip tier {tier}">{TIER_ICONS[tier]} {_e(label)}</span>'
 
 
@@ -573,7 +593,8 @@ def _top_changes(
                     continue
                 if c.severity > 0:
                     pct = max((v.pct for v in c.value_diffs if v.kind != "new"), default=0.0)
-                    changes.append((c.severity, pct, ds.path, t.name, c.name, "anomaly"))
+                    axis = "anomaly" if c.is_scored else "unscored"
+                    changes.append((c.severity, pct, ds.path, t.name, c.name, axis))
                 elif c.coverage_severity > 0:
                     changes.append((c.coverage_severity, 0.0, ds.path, t.name, c.name, "coverage"))
     losses.sort(key=lambda r: (-r[0], r[2]))
@@ -662,7 +683,7 @@ def _render_value_diff(v: ValueDiff, sample_cap: int = SAMPLE_LIMIT) -> str:
 def _render_column(table_name: str, c: ColumnDiffResult, ds_path: str = "", sample_cap: int = SAMPLE_LIMIT) -> str:
     chips = "".join(f'<span class="chip">{_e(ch)}</span>' for ch in c.changes)
     dim = '<span class="chip dim">dim</span>' if c.is_dim else ""
-    tier = _tier_chip(c.severity, c.kind) if not c.is_dim else ""
+    tier = _tier_chip(c.severity, c.kind, scored=c.is_scored) if not c.is_dim else ""
     anchor = f' id="{_anchor(ds_path, table_name, c.name)}"' if ds_path else ""
     # Dims are navigation context, not indicators — the indicator tier filter skips them.
     # Metadata-only columns get their own filterable category ("meta") instead of a tier.
@@ -902,6 +923,11 @@ def render_html(report: DiffReport) -> str:
         if axis == "coverage":
             icon = "↕"
             meta = f"coverage churn {_e(format_score(severity))} (values appeared/disappeared)"
+        elif axis == "unscored":
+            # Categorical column: severity is the 1.0 fallback, not a measured median. Say so
+            # rather than quoting a 100% score that was never computed.
+            icon = TIER_ICONS.get(_tier(severity), "")
+            meta = f"not scored (non-numeric) · {pct:.0f}% of rows"
         else:
             icon = TIER_ICONS.get(_tier(severity), "")
             meta = f"median anomaly score {_e(format_score(severity))} · {pct:.0f}% of rows"

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -95,6 +95,11 @@ class ValueDiff:
     # for numeric "changed" diffs.
     appeared_count: int = 0
     disappeared_count: int = 0
+    # Rows that changed but hold no comparable number on either side — a sentinel whose text was
+    # edited, say. Neither revisions nor coverage events, so they are tallied on their own rather
+    # than left to be inferred from `count` minus the other two, which would report them as
+    # revisions in the HTML breakdown.
+    not_scored_count: int = 0
 
     @property
     def pct(self) -> float:
@@ -653,13 +658,15 @@ def _render_value_diff(v: ValueDiff, sample_cap: int = SAMPLE_LIMIT) -> str:
         )
         head_note = f' <span class="head-note">— showing {what}{capped}</span>'
     breakdown = ""
-    if v.kind == "changed" and (v.appeared_count or v.disappeared_count):
-        revised = v.count - v.appeared_count - v.disappeared_count
-        bits = [f"{revised:,} revised"]
+    if v.kind == "changed" and (v.appeared_count or v.disappeared_count or v.not_scored_count):
+        revised = v.count - v.appeared_count - v.disappeared_count - v.not_scored_count
+        bits = [f"{revised:,} revised"] if revised else []
         if v.appeared_count:
             bits.append(f"{v.appeared_count:,} appeared")
         if v.disappeared_count:
             bits.append(f"{v.disappeared_count:,} disappeared")
+        if v.not_scored_count:
+            bits.append(f"{v.not_scored_count:,} not scored")
         breakdown = f' <span class="head-note">({", ".join(bits)})</span>'
     head = (
         f'<div class="vd-head {v.kind}">{_e(v.symbol)} {label}: '

--- a/etl/datadiff_report.py
+++ b/etl/datadiff_report.py
@@ -289,6 +289,16 @@ class DatasetDiffResult:
         return sum(t.removed_row_count for t in self.tables)
 
     @property
+    def not_scored_count(self) -> int:
+        """Changed rows carrying no comparable number on either side — an edited sentinel, say.
+
+        They score zero on both the anomaly and the coverage axis, since nothing moved and nothing
+        appeared or disappeared, so a dataset whose only change is one of these would otherwise be
+        summarized as having added data.
+        """
+        return sum(v.not_scored_count for t in self.tables for c in t.columns for v in c.value_diffs)
+
+    @property
     def removed_labels(self) -> list[str]:
         seen: list[str] = []
         for t in self.tables:
@@ -867,12 +877,18 @@ def render_html(report: DiffReport) -> str:
     n_meta_only = sum(1 for ds in report.datasets if ds.is_metadata_only)
     if n_meta_only:
         strip_bits.append(f"📝 {n_meta_only} metadata-only")
-    n_new_only = sum(
-        1 for ds in report.datasets if ds.change_kind == "changed" and ds.tier == "none" and not ds.is_metadata_only
-    )
+    untiered = [
+        ds for ds in report.datasets if ds.change_kind == "changed" and ds.tier == "none" and not ds.is_metadata_only
+    ]
+    # An edited sentinel scores zero on both axes without anything having been added, so it needs
+    # its own bucket rather than being swept in with the datasets that only gained data.
+    n_new_only = sum(1 for ds in untiered if not ds.not_scored_count)
     if n_new_only:
         strip_bits.append(f"➕ {n_new_only} new-data-only")
-    n_diff = sum(tier_counts.values()) + n_meta_only + n_new_only
+    n_unscored_only = sum(1 for ds in untiered if ds.not_scored_count)
+    if n_unscored_only:
+        strip_bits.append(f"🔤 {n_unscored_only} non-numeric-only")
+    n_diff = sum(tier_counts.values()) + n_meta_only + n_new_only + n_unscored_only
     if strip_bits and n_diff >= 2:
         tier_strip = (
             f'<div class="tier-strip">Of the {n_diff:,} dataset{"s" if n_diff != 1 else ""} with '
@@ -898,11 +914,12 @@ def render_html(report: DiffReport) -> str:
             cov_label = _tier_counts_label(
                 _col_tier_counts([c for t in d.tables for c in t.columns], score=lambda c: c.coverage_severity)
             )
-            meta_html = (
-                f'<span class="top-meta">{_e(cov_label)} column(s) w/ shifted coverage</span>'
-                if cov_label
-                else '<span class="top-meta">new data only</span>'
-            )
+            if cov_label:
+                meta_html = f'<span class="top-meta">{_e(cov_label)} column(s) w/ shifted coverage</span>'
+            elif d.not_scored_count:
+                meta_html = '<span class="top-meta">non-numeric value changes only</span>'
+            else:
+                meta_html = '<span class="top-meta">new data only</span>'
         else:
             n_cols = sum(len(t.changed_columns) for t in d.tables)
             n_tables = sum(1 for t in d.tables if t.any_change)

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -1053,3 +1053,57 @@ def test_breakdown_counts_not_scored_rows_separately():
     only_sentinels = ValueDiff(kind="changed", count=2, total=10, median_bard=0.0, not_scored_count=2)
     breakdown = re.search(r"\((\d[^)]*)\)</span>", _render_value_diff(only_sentinels))
     assert breakdown and breakdown.group(1) == "2 not scored"
+
+
+def test_sentinel_only_dataset_is_not_summarized_as_new_data():
+    """A dataset whose only change is an edited sentinel added nothing, so don't say it did.
+
+    Such a change scores zero on both the anomaly and the coverage axis, which used to drop it
+    into the "new data only" bucket in the summary strip and the dataset watch list.
+    """
+    ds = DatasetDiffResult(
+        path="garden/n/v/ds",
+        kind="identical",
+        tables=[
+            TableDiffResult(
+                name="tab",
+                kind="identical",
+                columns=[
+                    ColumnDiffResult(
+                        name="a",
+                        kind="changed",
+                        changes=["changed data"],
+                        value_diffs=[ValueDiff(kind="changed", count=1, total=10, median_bard=0.0, not_scored_count=1)],
+                    )
+                ],
+            )
+        ],
+    )
+    assert ds.not_scored_count == 1
+    assert ds.severity == 0.0
+
+    # A second dataset, so the summary strip and the watch list have enough entries to render.
+    other = DatasetDiffResult(
+        path="garden/n/v/other",
+        kind="identical",
+        tables=[
+            TableDiffResult(
+                name="tab",
+                kind="identical",
+                columns=[
+                    ColumnDiffResult(
+                        name="a",
+                        kind="changed",
+                        changes=["changed data"],
+                        value_diffs=[ValueDiff(kind="changed", count=1, total=10, median_bard=0.5)],
+                    )
+                ],
+            )
+        ],
+    )
+
+    html = render_html(DiffReport(datasets=[ds, other]))
+    assert "new data only" not in html
+    assert "non-numeric value changes only" in html
+    assert "1 non-numeric-only" in html
+    assert "new-data-only" not in html

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -27,6 +27,7 @@ from etl.datadiff_report import (
     DiffReport,
     TableDiffResult,
     ValueDiff,
+    _render_value_diff,
     _tier,
     _tier_chip,
     render_html,
@@ -162,7 +163,7 @@ def test_changed_records_sorts_numeric_by_change_size():
             "a +": [101.0, 250.0, 5.0],  # BARD ≈ 0.005, 0.43, 1.0
         }
     )
-    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    records, sorted_by_score, median_bard, appeared, disappeared, not_scored = _changed_records(both, "a")
     assert sorted_by_score
     # Biggest changes (by anomaly score = BARD) first; growth from zero is maximal (score 1).
     assert [r["country"] for r in records] == ["from_zero", "big", "small"]
@@ -172,13 +173,13 @@ def test_changed_records_sorts_numeric_by_change_size():
     assert (appeared, disappeared) == (0, 0)
 
     # A sample larger than the limit keeps only the biggest movers.
-    top, _, _, _, _ = _changed_records(both, "a", limit=2)
+    top, _, _, _, _, _ = _changed_records(both, "a", limit=2)
     assert [r["country"] for r in top] == ["from_zero", "big"]
 
 
 def test_changed_records_non_numeric_falls_back_to_random_sample():
     both = pd.DataFrame({"country": ["UK", "US"], "a -": ["x", "y"], "a +": ["y", "z"]})
-    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    records, sorted_by_score, median_bard, appeared, disappeared, not_scored = _changed_records(both, "a")
     assert not sorted_by_score
     assert median_bard is None
     assert (appeared, disappeared) == (0, 0)
@@ -198,7 +199,7 @@ def test_changed_records_appeared_and_disappeared_excluded_from_score():
             "a +": [5.0, float("nan"), 20.0],  # 2022: revised (BARD 1/3); 2023: disappeared; 2024: appeared
         }
     )
-    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    records, sorted_by_score, median_bard, appeared, disappeared, not_scored = _changed_records(both, "a")
     assert sorted_by_score
     labels = {r["year"]: r["anomaly score"] for r in records}
     assert labels["2022"] == "33%"
@@ -216,7 +217,7 @@ def test_changed_records_all_appeared_disappeared_score_zero_median():
     non-numeric fallback of 1 -- otherwise a WDI-style "add a new year" update would still pin
     every such column's severity to maximal."""
     both = pd.DataFrame({"year": [2024, 2024], "a -": [float("nan"), float("nan")], "a +": [20.0, 30.0]})
-    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    records, sorted_by_score, median_bard, appeared, disappeared, not_scored = _changed_records(both, "a")
     assert median_bard == 0.0
     assert (appeared, disappeared) == (2, 0)
     assert all(r["anomaly score"] == "appeared" for r in records)
@@ -808,7 +809,7 @@ def test_numeric_column_with_sentinel_is_scored():
             "a +": pd.Categorical(["0.7627", "0.8027", "China", "2.4305"]),
         }
     )
-    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    records, sorted_by_score, median_bard, appeared, disappeared, not_scored = _changed_records(both, "a")
 
     assert sorted_by_score, "a sentinel-carrying numeric column should be score-sorted like any numeric one"
     assert median_bard is not None, "severity must be measured, not the non-numeric 1.0 fallback"
@@ -828,7 +829,7 @@ def test_genuinely_categorical_column_stays_unscored():
             "a +": pd.Categorical(["projection", "projection"]),
         }
     )
-    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    records, sorted_by_score, median_bard, appeared, disappeared, not_scored = _changed_records(both, "a")
 
     assert not sorted_by_score
     assert median_bard is None
@@ -874,7 +875,7 @@ def test_sentinel_to_sentinel_row_is_not_counted_as_coverage():
             "a +": pd.Categorical(["0.7627", "n/a", "China", "China"]),
         }
     )
-    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    records, sorted_by_score, median_bard, appeared, disappeared, not_scored = _changed_records(both, "a")
 
     assert sorted_by_score
     assert median_bard is not None and median_bard < 0.01
@@ -899,7 +900,7 @@ def test_column_scored_when_only_one_side_is_numeric():
             "a +": pd.Categorical(["0.7529", "0.8127", "2.4390"]),
         }
     )
-    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(dropped_sentinel, "a")
+    records, sorted_by_score, median_bard, appeared, disappeared, not_scored = _changed_records(dropped_sentinel, "a")
     assert sorted_by_score
     assert median_bard == 0.0, "no revisions to score, but that is a measured zero, not the 1.0 fallback"
     assert (appeared, disappeared) == (3, 0)
@@ -913,7 +914,7 @@ def test_column_scored_when_only_one_side_is_numeric():
             "a +": pd.Categorical(["China", "China"]),
         }
     )
-    _, sorted_by_score, median_bard, appeared, disappeared = _changed_records(added_sentinel, "a")
+    _, sorted_by_score, median_bard, appeared, disappeared, _ = _changed_records(added_sentinel, "a")
     assert sorted_by_score and median_bard == 0.0
     assert (appeared, disappeared) == (0, 2)
 
@@ -932,7 +933,7 @@ def test_zero_padded_codes_stay_unscored():
             "a +": pd.Categorical(["008", "112"]),
         }
     )
-    _, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    _, sorted_by_score, median_bard, appeared, disappeared, _ = _changed_records(both, "a")
     assert not sorted_by_score
     assert median_bard is None
     assert (appeared, disappeared) == (0, 0)
@@ -945,7 +946,7 @@ def test_zero_padded_codes_stay_unscored():
             "a +": pd.Categorical(["0.8000", "0.1"]),
         }
     )
-    _, sorted_by_score, median_bard, _, _ = _changed_records(decimals, "a")
+    _, sorted_by_score, median_bard, _, _, _ = _changed_records(decimals, "a")
     assert sorted_by_score and median_bard is not None
 
 
@@ -963,8 +964,8 @@ def test_code_column_classified_on_full_column_not_changed_rows():
 
     both = pd.DataFrame({"year": [2001], "a -": pd.Categorical(["100"]), "a +": pd.Categorical(["112"])})
     # Without the full-column verdict the changed rows look like a plain quantity.
-    assert _changed_records(both, "a")[1:] == (True, pytest.approx(0.0566, abs=1e-3), 0, 0)
-    assert _changed_records(both, "a", is_code_column=True)[1:] == (False, None, 0, 0)
+    assert _changed_records(both, "a")[1:] == (True, pytest.approx(0.0566, abs=1e-3), 0, 0, 0)
+    assert _changed_records(both, "a", is_code_column=True)[1:] == (False, None, 0, 0, 0)
 
 
 def test_infinities_are_treated_as_sentinels_not_scored():
@@ -977,7 +978,7 @@ def test_infinities_are_treated_as_sentinels_not_scored():
     """
     for side in (pd.Categorical(["Inf", "2.0"]), [float("inf"), 2.0]):
         both = pd.DataFrame({"year": [2000, 2001], "a -": side, "a +": [1.0, 2.5]})
-        records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+        records, sorted_by_score, median_bard, appeared, disappeared, not_scored = _changed_records(both, "a")
         assert sorted_by_score
         assert median_bard == pytest.approx(0.1111, abs=1e-3), "the median must come from the finite revision only"
         assert (appeared, disappeared) == (1, 0)
@@ -994,7 +995,7 @@ def test_non_numeric_dtypes_stay_unscored():
             "a +": pd.to_datetime(["2000-02-01", "2001-02-01"]),
         }
     )
-    _, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    _, sorted_by_score, median_bard, appeared, disappeared, _ = _changed_records(both, "a")
     assert not sorted_by_score
     assert median_bard is None
     assert (appeared, disappeared) == (0, 0)
@@ -1016,3 +1017,39 @@ def test_coverage_only_numeric_column_is_still_scored():
     assert coverage_only.is_scored
     chip = _tier_chip(coverage_only.severity, coverage_only.kind, scored=coverage_only.is_scored)
     assert "not scored" not in chip
+
+
+def test_sentinel_only_edit_keeps_the_column_numeric():
+    """Editing the sentinel of a numeric column must not reclassify the column as categorical.
+
+    If the numeric rows are unchanged, the only changed row is `"China" -> "N/A"` and `both` holds
+    no number on either side — yet the full columns prove the indicator is numeric-with-sentinels.
+    Without that verdict the column takes the 1.0 fallback and tops the report.
+    """
+    both = pd.DataFrame({"year": [2000], "a -": pd.Categorical(["China"]), "a +": pd.Categorical(["N/A"])})
+
+    assert _changed_records(both, "a")[1:] == (False, None, 0, 0, 0)
+
+    _, sorted_by_score, median_bard, appeared, disappeared, not_scored = _changed_records(
+        both, "a", is_numeric_column=True
+    )
+    assert sorted_by_score
+    assert median_bard == 0.0, "no revision to score, but not the maximal fallback either"
+    assert (appeared, disappeared, not_scored) == (0, 0, 1)
+
+
+def test_breakdown_counts_not_scored_rows_separately():
+    """The HTML breakdown must agree with the row labels rather than inferring revisions.
+
+    Deriving revised as `count - appeared - disappeared` counted the not-scored rows as revisions.
+    """
+    v = ValueDiff(
+        kind="changed", count=4, total=10, median_bard=0.05, appeared_count=0, disappeared_count=1, not_scored_count=2
+    )
+    breakdown = re.search(r"\((\d[^)]*)\)</span>", _render_value_diff(v))
+    assert breakdown and breakdown.group(1) == "1 revised, 1 disappeared, 2 not scored"
+
+    # Nothing left to revise: the "0 revised" bit is dropped rather than printed.
+    only_sentinels = ValueDiff(kind="changed", count=2, total=10, median_bard=0.0, not_scored_count=2)
+    breakdown = re.search(r"\((\d[^)]*)\)</span>", _render_value_diff(only_sentinels))
+    assert breakdown and breakdown.group(1) == "2 not scored"

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -26,6 +26,7 @@ from etl.datadiff_report import (
     DiffReport,
     TableDiffResult,
     ValueDiff,
+    _tier_chip,
     render_html,
 )
 
@@ -835,8 +836,6 @@ def test_genuinely_categorical_column_stays_unscored():
 
 def test_unscored_column_reports_not_scored_instead_of_100_percent():
     """The 1.0 severity fallback must not be rendered as a measured "median anomaly score 100%"."""
-    from etl.datadiff_report import ColumnDiffResult, ValueDiff, _tier_chip
-
     categorical = ColumnDiffResult(
         name="status",
         kind="changed",
@@ -857,3 +856,45 @@ def test_unscored_column_reports_not_scored_instead_of_100_percent():
     assert "not scored" in chip and "100%" not in chip
     # A genuine, measured 100% still says so.
     assert "median anomaly score 100%" in _tier_chip(numeric.severity, numeric.kind, scored=numeric.is_scored)
+
+
+def test_sentinel_to_sentinel_row_is_not_counted_as_coverage():
+    """A row that is non-numeric on both sides is neither a revision nor a coverage event.
+
+    A sentinel whose text changes ("China" -> "n/a"), or a gap filled with a sentinel, coerces to
+    NaN on both sides. Nothing numeric appeared, disappeared or moved, so the row must not be
+    labeled "disappeared" in the sample while `disappeared_count` stays zero.
+    """
+    both = pd.DataFrame(
+        {
+            "year": [2000, 2001, 2002, 2003],
+            "a -": pd.Categorical(["0.7529", "China", "1.5000", None]),
+            "a +": pd.Categorical(["0.7627", "n/a", "China", "China"]),
+        }
+    )
+    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+
+    assert sorted_by_score
+    assert median_bard is not None and median_bard < 0.01
+    # Only the numeric-to-sentinel row (1.5 -> "China") is a genuine coverage loss.
+    assert (appeared, disappeared) == (0, 1)
+    labels = sorted(r["anomaly score"] for r in records)
+    assert labels == ["0.65%", "disappeared", "not scored", "not scored"], labels
+
+
+def test_coverage_only_numeric_column_is_still_scored():
+    """A numeric column with only removed rows has a measured severity, so it is not "not scored".
+
+    Its `value_diffs` hold no `changed` entry at all; the absence of one is not evidence that the
+    column is categorical, and its severity (the share of rows lost) was measured, not defaulted.
+    """
+    coverage_only = ColumnDiffResult(
+        name="gdp",
+        kind="changed",
+        changes=["changed data"],
+        value_diffs=[ValueDiff(kind="removed", count=1, total=4)],
+    )
+
+    assert coverage_only.is_scored
+    chip = _tier_chip(coverage_only.severity, coverage_only.kind, scored=coverage_only.is_scored)
+    assert "not scored" not in chip

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -916,6 +916,37 @@ def test_column_scored_when_only_one_side_is_numeric():
     assert (appeared, disappeared) == (0, 2)
 
 
+def test_zero_padded_codes_stay_unscored():
+    """Identifiers that only look numeric must not be parsed into quantities.
+
+    Meadow tables carry ISO numeric country codes and the like as strings. Coercing them would
+    report "004" -> "008" as a BARD anomaly, so a column holding any zero-padded value is treated
+    as a code column — including the values in it that happen to need no padding.
+    """
+    both = pd.DataFrame(
+        {
+            "year": [2000, 2001],
+            "a -": pd.Categorical(["004", "100"]),
+            "a +": pd.Categorical(["008", "112"]),
+        }
+    )
+    _, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    assert not sorted_by_score
+    assert median_bard is None
+    assert (appeared, disappeared) == (0, 0)
+
+    # Decimals below one are not zero-padding: a real quantity keeps its score.
+    decimals = pd.DataFrame(
+        {
+            "year": [2000, 2001],
+            "a -": pd.Categorical(["0.7500", "0"]),
+            "a +": pd.Categorical(["0.8000", "0.1"]),
+        }
+    )
+    _, sorted_by_score, median_bard, _, _ = _changed_records(decimals, "a")
+    assert sorted_by_score and median_bard is not None
+
+
 def test_non_numeric_dtypes_stay_unscored():
     """A dtype that can't hold a number at all keeps the unscoreable path."""
     both = pd.DataFrame(

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -16,6 +16,7 @@ from etl.datadiff import (
     _changed_records,
     _dataset_files_match,
     _diff_lines,
+    _is_code_column,
     _is_superseded_remote_predecessor,
     _table_metadata_dict,
 )
@@ -26,6 +27,7 @@ from etl.datadiff_report import (
     DiffReport,
     TableDiffResult,
     ValueDiff,
+    _tier,
     _tier_chip,
     render_html,
 )
@@ -945,6 +947,42 @@ def test_zero_padded_codes_stay_unscored():
     )
     _, sorted_by_score, median_bard, _, _ = _changed_records(decimals, "a")
     assert sorted_by_score and median_bard is not None
+
+
+def test_code_column_classified_on_full_column_not_changed_rows():
+    """The padded codes proving a column is coded may all sit on rows that didn't change.
+
+    `both` holds only changed rows, so if "004" stays "004" and only "100" -> "112" moves, the
+    frame carries no evidence of coding at all. `_is_code_column` therefore reads the full column
+    and the verdict is passed in.
+    """
+    full_column = pd.Series(pd.Categorical(["004", "100"]))
+    assert _is_code_column(full_column)
+    assert not _is_code_column(pd.Series(pd.Categorical(["0.75", "China"])))
+    assert not _is_code_column(pd.Series([0.75, 1.25]))
+
+    both = pd.DataFrame({"year": [2001], "a -": pd.Categorical(["100"]), "a +": pd.Categorical(["112"])})
+    # Without the full-column verdict the changed rows look like a plain quantity.
+    assert _changed_records(both, "a")[1:] == (True, pytest.approx(0.0566, abs=1e-3), 0, 0)
+    assert _changed_records(both, "a", is_code_column=True)[1:] == (False, None, 0, 0)
+
+
+def test_infinities_are_treated_as_sentinels_not_scored():
+    """An infinity must not poison the column's median and drop it out of the report.
+
+    `pd.to_numeric` parses "Inf", and a float column can hold one outright. BARD returns NaN for
+    it, `median_bard` becomes NaN, and `_tier` reads NaN as no tier — so the column silently loses
+    its chip and its place in the watch list. Infinities are blanked to NaN and handled like any
+    other unmeasurable value instead.
+    """
+    for side in (pd.Categorical(["Inf", "2.0"]), [float("inf"), 2.0]):
+        both = pd.DataFrame({"year": [2000, 2001], "a -": side, "a +": [1.0, 2.5]})
+        records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+        assert sorted_by_score
+        assert median_bard == pytest.approx(0.1111, abs=1e-3), "the median must come from the finite revision only"
+        assert (appeared, disappeared) == (1, 0)
+        assert not any("nan" in r["anomaly score"] for r in records)
+        assert _tier(median_bard) != "none"
 
 
 def test_non_numeric_dtypes_stay_unscored():

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -787,3 +787,73 @@ def test_is_superseded_remote_predecessor():
     assert not _is_superseded_remote_predecessor(
         "garden/worldbank_wdi/2026-02-27/wdi", {"garden/other/2024-01-01/other": object()}
     )
+
+
+def test_numeric_column_with_sentinel_is_scored():
+    """A numeric column carrying a non-numeric sentinel must still be scored on its numeric rows.
+
+    Real case: `imf/trade.china_imports_share_of_gdp` stores the literal string "China" on
+    China's own rows (the ratio is meaningless there), which makes the whole column `category`
+    dtype. A dtype-only gate sent it to the unscoreable path, where severity defaults to 1.0 —
+    so a column whose genuine revisions were ~0.3% was reported as the worst anomaly (100%) in
+    the whole diff, above real 1.6% changes.
+    """
+    both = pd.DataFrame(
+        {
+            "year": [2000, 2001, 2002, 2003],
+            "a -": pd.Categorical(["0.7529", "0.8127", "China", "2.4390"]),
+            "a +": pd.Categorical(["0.7627", "0.8027", "China", "2.4305"]),
+        }
+    )
+    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+
+    assert sorted_by_score, "a sentinel-carrying numeric column should be score-sorted like any numeric one"
+    assert median_bard is not None, "severity must be measured, not the non-numeric 1.0 fallback"
+    assert median_bard < 0.01, f"tiny revisions should score near zero, got {median_bard}"
+    # The sentinel rows coerce to NaN on both sides, so they are neither revisions nor coverage events.
+    assert (appeared, disappeared) == (0, 0)
+    assert len(records) == 4
+
+
+def test_genuinely_categorical_column_stays_unscored():
+    """A column with no numeric content at all keeps the unscoreable path (median_bard None),
+    so the report labels it "not scored" rather than inventing a number."""
+    both = pd.DataFrame(
+        {
+            "year": [2000, 2001],
+            "a -": pd.Categorical(["estimate", "estimate"]),
+            "a +": pd.Categorical(["projection", "projection"]),
+        }
+    )
+    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+
+    assert not sorted_by_score
+    assert median_bard is None
+    assert (appeared, disappeared) == (0, 0)
+    assert len(records) == 2
+
+
+def test_unscored_column_reports_not_scored_instead_of_100_percent():
+    """The 1.0 severity fallback must not be rendered as a measured "median anomaly score 100%"."""
+    from etl.datadiff_report import ColumnDiffResult, ValueDiff, _tier_chip
+
+    categorical = ColumnDiffResult(
+        name="status",
+        kind="changed",
+        changes=["changed data"],
+        value_diffs=[ValueDiff(kind="changed", count=2, total=2, median_bard=None)],
+    )
+    numeric = ColumnDiffResult(
+        name="gdp",
+        kind="changed",
+        changes=["changed data"],
+        value_diffs=[ValueDiff(kind="changed", count=2, total=2, median_bard=1.0)],
+    )
+
+    assert not categorical.is_scored
+    assert numeric.is_scored
+
+    chip = _tier_chip(categorical.severity, categorical.kind, scored=categorical.is_scored)
+    assert "not scored" in chip and "100%" not in chip
+    # A genuine, measured 100% still says so.
+    assert "median anomaly score 100%" in _tier_chip(numeric.severity, numeric.kind, scored=numeric.is_scored)

--- a/tests/test_datadiff.py
+++ b/tests/test_datadiff.py
@@ -882,6 +882,55 @@ def test_sentinel_to_sentinel_row_is_not_counted_as_coverage():
     assert labels == ["0.65%", "disappeared", "not scored", "not scored"], labels
 
 
+def test_column_scored_when_only_one_side_is_numeric():
+    """Numeric content on either side is enough — a whole side can legitimately be sentinels.
+
+    `both` holds only the rows that changed, so a version that drops (or introduces) a sentinel
+    convention changes exactly the sentinel rows: one side is then entirely non-numeric. Judging
+    that side on its own would call the indicator categorical and give it maximal severity — the
+    failure the coercion exists to remove. It is a pure coverage event and scores as one.
+    """
+    dropped_sentinel = pd.DataFrame(
+        {
+            "year": [2000, 2001, 2002],
+            "a -": pd.Categorical(["China", "China", "China"]),
+            "a +": pd.Categorical(["0.7529", "0.8127", "2.4390"]),
+        }
+    )
+    records, sorted_by_score, median_bard, appeared, disappeared = _changed_records(dropped_sentinel, "a")
+    assert sorted_by_score
+    assert median_bard == 0.0, "no revisions to score, but that is a measured zero, not the 1.0 fallback"
+    assert (appeared, disappeared) == (3, 0)
+    assert all(r["anomaly score"] == "appeared" for r in records)
+
+    # And the mirror image: numbers replaced by a sentinel is a coverage loss.
+    added_sentinel = pd.DataFrame(
+        {
+            "year": [2000, 2001],
+            "a -": pd.Categorical(["1.5000", "2.5000"]),
+            "a +": pd.Categorical(["China", "China"]),
+        }
+    )
+    _, sorted_by_score, median_bard, appeared, disappeared = _changed_records(added_sentinel, "a")
+    assert sorted_by_score and median_bard == 0.0
+    assert (appeared, disappeared) == (0, 2)
+
+
+def test_non_numeric_dtypes_stay_unscored():
+    """A dtype that can't hold a number at all keeps the unscoreable path."""
+    both = pd.DataFrame(
+        {
+            "year": [2000, 2001],
+            "a -": pd.to_datetime(["2000-01-01", "2001-01-01"]),
+            "a +": pd.to_datetime(["2000-02-01", "2001-02-01"]),
+        }
+    )
+    _, sorted_by_score, median_bard, appeared, disappeared = _changed_records(both, "a")
+    assert not sorted_by_score
+    assert median_bard is None
+    assert (appeared, disappeared) == (0, 0)
+
+
 def test_coverage_only_numeric_column_is_still_scored():
     """A numeric column with only removed rows has a measured severity, so it is not "not scored".
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

Two related fixes to how `etl diff`'s HTML report scores columns. Found while reviewing #6561, where `garden/imf/2025-07-08/trade` · `trade.china_imports_share_of_gdp` was reported as the **worst anomaly in the whole diff — 🔴 median anomaly score 100%** — while its sample rows showed changes of roughly 1%.

## 1. Score numeric columns that carry a sentinel

A numeric indicator can legitimately store a non-numeric **sentinel** in some rows. `china_imports_share_of_gdp` sets China's own rows to the literal string `"China"`, because "China's imports as a share of China's GDP" is meaningless. That one string makes the whole column `category` dtype.

`_changed_records` gated on `is_numeric_dtype`, so the column fell to the unscoreable path, which returns `median_bard = None`; `ValueDiff.severity` then falls back to `1.0` ("a category flip has no meaningful size"). The result: a column whose genuine revisions have a **median BARD of 0.35%** (max 10%) was ranked maximal, above real 1.6% changes, in a list sorted by severity. It would have done so on every future diff of that dataset.

New `_as_comparable_floats` coerces instead of rejecting: sentinels become NaN (correctly treated as coverage events, not revisions), the numeric rows score normally, and columns with no numeric content at all still return None and keep the unscoreable path.

Verified against the real column: severity goes from `1.0` → `0.0035`, and the sample is now score-sorted (Tuvalu 2023 at 10% first) instead of appearing in year order.

## 2. Don't quote a score that was never computed

For genuinely categorical columns the `1.0` fallback is a sort key, not a measurement — but the report rendered it as `median anomaly score 100%`, which asserts a median it never calculated. Those columns now read **`not scored (non-numeric)`** in both the column chip and the top-changes list, via a new `ColumnDiffResult.is_scored`. A genuine measured 100% still says `median anomaly score 100%`.

## Edge cases closed in review

Three follow-ups, each a case where the coercion or the new label reached a row it shouldn't:

- **Both sides non-numeric** (5c837d1fb). A sentinel whose text changes, or a gap filled with a sentinel, coerces to NaN twice — neither a revision nor a coverage event. The sample formatter's `else` branch called it `disappeared` while `disappeared_count` stayed zero; it now reads `not scored`. It stays out of both axes deliberately: nothing appeared or disappeared, and giving it the `1.0` default would let one edited sentinel string drag a column's median to maximal.
- **Coverage-only numeric columns** (5c837d1fb). `is_scored` filtered `value_diffs` to `changed` entries and called `any()` on the result — vacuously false for a column whose rows were only removed, so a plain numeric column got chipped `not scored (non-numeric)`. Absence of a `changed` diff is not evidence of a categorical one, and a removed diff's severity (share of rows lost) is measured, not defaulted.
- **Infinities** (f3e10bc29). `pd.to_numeric` parses `"Inf"`, and a float column can hold one outright, but BARD returns NaN for it — so the column's median went NaN, the sample rendered `nan%`, and since `_tier` reads NaN as no tier, the changed column dropped out of the severity chips and the watch list without a word. That silent disappearance was reachable before this PR too. An infinity is an unmeasurable value, which is what a sentinel is, so it's blanked to NaN and handled as one.
- **Sentinel-only edits** (b8b9aebcb). If the numeric rows don't move, the only changed row is the sentinel itself (`"China" → "N/A"`) and `both` holds no number on either side — so a column whose data didn't change took the `1.0` fallback and topped the report. The full columns are now consulted for numeric content too, not just for coding, and the edit reads as the zero-severity change it is.
- **Not-scored rows had no tally** (b8b9aebcb). The HTML breakdown derived revisions as `count - appeared - disappeared`, counting sentinel edits as revisions: one revision, two sentinel edits and one disappearance rendered as `3 revised, 1 disappeared`. `ValueDiff.not_scored_count` carries them now, so the breakdown agrees with the row labels and a sentinel-only edit stays visible without inflating severity.
- **Sentinel-only datasets summarized as additions** (133e49740). Scoring zero on both axes put a dataset whose only change was an edited sentinel into the "new data only" bucket, in the tier strip and the watch list, despite nothing having been added. It has its own `🔤 non-numeric-only` bucket and label now.
- **One side entirely sentinels** (4a4410db6). `both` holds only the rows that changed, so a version that drops or introduces a sentinel convention changes precisely the sentinel rows, leaving one side all non-numeric. Judged per side, the indicator was called categorical and handed maximal severity with no coverage recorded — the original defect again. Comparability is now decided across both sides at once, and those rows read as the coverage event they are (median `0.0`, coverage churn 100%).

## Codes that only look numeric

Parsing strings risks the reverse error: treating identifiers as quantities. Zero-padding is the one unambiguous tell — nothing measured is written `"004"` — so a column holding any zero-padded value is treated as codes and stays unscored (68117e158), rather than reporting an ISO-numeric country code flip `"004" → "008"` as a 19% anomaly. `"0.5"` and `"0"` are unaffected.

The evidence is read from the *full* column, not the changed-row frame (f3e10bc29): a code column's padded values may all sit on rows that didn't change, which left `"100" → "112"` scoring as a 5.7% anomaly.

Unpadded codes like `"1"`/`"2"` remain indistinguishable from small quantities at this layer and are still scored. That is the better of two imperfect answers: the unscoreable path is not neutral, it assigns `1.0` and sends the column to the *top* of the report, above every genuine anomaly.

## Tests

Thirteen in `tests/test_datadiff.py` covering: the sentinel column is scored and score-sorted; a genuinely categorical column stays unscored; the unscored label never renders as `100%` while a real 100% still does; sentinel-to-sentinel rows are not counted as coverage; a coverage-only numeric column stays scored; one numeric side is enough, in both directions; zero-padded codes stay unscored while decimals do not; the code verdict comes from the full column; infinities keep the column tiered instead of NaN-ing its median; a sentinel-only edit stays numeric; the breakdown counts not-scored rows separately; a sentinel-only dataset isn't summarized as new data; and non-numeric dtypes (datetime) stay unscored. Full suite green (47 passed), `make check` clean.

## Not changed

The `"China"` sentinel itself is deliberate ([trade.py](https://github.com/owid/etl/blob/master/etl/steps/data/garden/imf/2025-07-08/trade.py)) and is left alone — the report should handle the pattern, not the other way round. (The comment above it says `= -1` while the code writes `"China"`; stale comment, untouched here to keep this PR scoped.)
