### PR TITLE
📊 Drop city values the JRC flags as low plausibility

### DIFF
--- a/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
+++ b/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
@@ -32,7 +32,7 @@ definitions:
   # compose aliases. The density anchor below is the one unavoidable exception, because its own
   # sentence is genuinely part of the same processing description.
   desc_processing_low_plausibility: &desc_processing_low_plausibility |-
-    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the historical figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave those years blank rather than estimate them. Projected values are kept as published, because for future years a low rating usually reflects ordinary forecast uncertainty rather than a misplaced population.
+    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the historical figures it rates as "low", leaving those years blank rather than estimating them. Projected values are kept as published, because for future years a low rating usually reflects ordinary forecast uncertainty.
 
   # Used by the projected density indicators, where nothing is filtered.
   desc_processing_density: &desc_processing_density |-
@@ -41,22 +41,13 @@ definitions:
   desc_processing_density_low_plausibility: &desc_processing_density_low_plausibility |-
     Population density was calculated by dividing the population of the urban center by its total land area.
 
-    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the historical figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave those years blank rather than estimate them. Projected values are kept as published, because for future years a low rating usually reflects ordinary forecast uncertainty rather than a misplaced population.
+    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the historical figures it rates as "low", leaving those years blank rather than estimating them. Projected values are kept as published, because for future years a low rating usually reflects ordinary forecast uncertainty.
 
   desc_key_low_plausibility: &desc_key_low_plausibility |-
-    Historical figures that the producer rates as low plausibility are not shown, and appear as gaps. This affects a small number of cities and years, most visibly Luanda before 2010.
+    Historical figures that the producer rates as low plausibility are not shown, and appear as gaps.
 
   desc_key_largest_city_no_rerank: &desc_key_largest_city_no_rerank |-
     The largest city is found by ranking a country's cities by population. Where the top city's figure is one we do not show, the value is left blank for that year rather than falling back to the second-largest city, which would otherwise be presented as the largest.
-
-  # Two versions, because the capital indicators come in two shapes: a population, which really is a
-  # sum across countries, and a share, which divides that sum by the whole region's population and so
-  # is not additive at all.
-  desc_key_capital_regional_keeps_all: &desc_key_capital_regional_keeps_all |-
-    Figures for regions and income groups are the sum of their countries' capital cities, and include every capital the producer reports — including the few whose figures we do not show for individual countries. So a regional total can be higher than the sum of the countries shown on a chart.
-
-  desc_key_capital_share_regional_keeps_all: &desc_key_capital_share_regional_keeps_all |-
-    For regions and income groups, the capital city population used here is the combined population of their countries' capital cities, and includes every capital the producer reports — including the few whose figures we do not show for individual countries. Because the result is then expressed as a percentage of the whole region's population, the percentages shown for individual countries do not add up to it.
 
   # Degurba descriptions to use for towns and suburbs variables.
   text_degurba_overview: &text_degurba_overview |-
@@ -384,7 +375,6 @@ tables:
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_key_low_plausibility
-          - *desc_key_capital_regional_keeps_all
         description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 0
@@ -402,7 +392,6 @@ tables:
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
-          - *desc_key_capital_regional_keeps_all
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -543,7 +532,6 @@ tables:
           - *desc_capital_threshold_caveat
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-          - *desc_key_capital_share_regional_keeps_all
         description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
@@ -562,7 +550,6 @@ tables:
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_capital_threshold_caveat
           - *desc_crossborder_exclusion
-          - *desc_key_capital_share_regional_keeps_all
         display:
           numDecimalPlaces: 1
           isProjection: true
@@ -583,7 +570,6 @@ tables:
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-          - *desc_key_capital_share_regional_keeps_all
         description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
@@ -601,7 +587,6 @@ tables:
           - The total population includes both urban and rural populations.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_crossborder_exclusion
-          - *desc_key_capital_share_regional_keeps_all
         display:
           numDecimalPlaces: 1
           isProjection: true

--- a/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
+++ b/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
@@ -27,6 +27,26 @@ definitions:
   desc_capital_threshold_caveat: &desc_capital_threshold_caveat |-
     Capital cities are only included if they meet the threshold of at least 50,000 people in a contiguous urban area with a density of at least 1,500 people per km². Some capital cities (e.g., Canberra) do not appear in historical estimates because they did not meet this threshold, though they may appear in projections as they grow.
 
+  # The producer flags the plausibility of every city's population figure. We drop the values it rates
+  # "low" from the indicators that describe a single named city, but not from the city-size aggregates,
+  # which sum every city in a country. YAML cannot combine two anchors into one string, so the variants
+  # below repeat the shared wording.
+  desc_processing_low_plausibility: &desc_processing_low_plausibility |-
+    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave these years blank rather than estimate them.
+
+  desc_processing_density_low_plausibility: &desc_processing_density_low_plausibility |-
+    Population density was calculated by dividing the population of the urban centre by its total land area.
+
+    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave these years blank rather than estimate them.
+
+  desc_processing_largest_city_low_plausibility: &desc_processing_largest_city_low_plausibility |-
+    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995.
+
+    The largest city is found by ranking a country's cities by population. Where the top city's figure is rated "low", we leave the value blank for that country and year. We do not fall back to the second-largest city, which would otherwise be shown as the largest.
+
+  desc_key_low_plausibility: &desc_key_low_plausibility |-
+    Figures that the producer rates as low plausibility are not shown, and appear as gaps. This affects a small number of cities and years, most visibly Luanda before 2010.
+
   # Degurba descriptions to use for towns and suburbs variables.
   text_degurba_overview: &text_degurba_overview |-
     The [Degree of Urbanization](https://human-settlement.emergency.copernicus.eu/degurba.php) classifies areas as [cities](#dod:cities-degurba), [towns and suburbs](#dod:towns-degurba), or [rural areas](#dod:rural-areas-degurba) based on population density and settlement size rather than administrative boundaries. Developed by six international organizations and endorsed by the UN Statistical Commission in 2020, it provides consistent definitions for comparing urbanization across countries.
@@ -352,6 +372,8 @@ tables:
           - *desc_key_common
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -368,6 +390,8 @@ tables:
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -390,7 +414,8 @@ tables:
           - *desc_key_common
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
           - Where a country has multiple capital cities, the density shown is for the administrative capital.
-        description_processing: *desc_processing_density
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_density_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -408,7 +433,8 @@ tables:
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - Where a country has multiple capital cities, the density shown is for the administrative capital.
-        description_processing: *desc_processing_density
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_density_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -430,6 +456,8 @@ tables:
           - *desc_key_common
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
           - The ranking of the top 100 cities is fixed based on their population in 2020. Historical values show the population of those same cities across time.
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapTop100
@@ -443,6 +471,8 @@ tables:
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - The ranking of the top 100 cities is fixed based on their population in 2020. Projected values show the population of those same cities in future years.
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapTop100
@@ -463,7 +493,8 @@ tables:
           - *desc_key_common
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
           - The ranking of the top 100 cities is fixed based on their population in 2020. Historical values show the density of those same cities across time.
-        description_processing: *desc_processing_density
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_density_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapTop100
@@ -478,7 +509,8 @@ tables:
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - The ranking of the top 100 cities is fixed based on their population in 2020. Projected values show the density of those same cities in future years.
-        description_processing: *desc_processing_density
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_density_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapTop100
@@ -503,6 +535,8 @@ tables:
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_capital_threshold_caveat
           - *desc_crossborder_exclusion
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -520,6 +554,8 @@ tables:
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_capital_threshold_caveat
           - *desc_crossborder_exclusion
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
           isProjection: true
@@ -539,6 +575,8 @@ tables:
           - The total population includes both urban and rural populations.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_crossborder_exclusion
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -555,6 +593,8 @@ tables:
           - The total population includes both urban and rural populations.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_crossborder_exclusion
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
           isProjection: true
@@ -577,6 +617,8 @@ tables:
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
           - The largest city is determined by 2020 population and may differ from the capital city. The urban population total used as the denominator covers all cities (urban centres with at least 50,000 people) within the country.
           - *desc_crossborder_exclusion
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_largest_city_low_plausibility
         display:
           numDecimalPlaces: 1
 
@@ -591,6 +633,8 @@ tables:
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - The largest city is determined by 2020 population and may differ from the capital city. The urban population total used as the denominator covers all cities (urban centres with at least 50,000 people) within the country.
           - *desc_crossborder_exclusion
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_largest_city_low_plausibility
         display:
           numDecimalPlaces: 1
           isProjection: true
@@ -608,6 +652,8 @@ tables:
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
           - The largest city is determined by 2020 population and may differ from the capital city. The total population includes both urban and rural populations.
           - *desc_crossborder_exclusion
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_largest_city_low_plausibility
         display:
           numDecimalPlaces: 1
 
@@ -622,6 +668,8 @@ tables:
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - The largest city is determined by 2020 population and may differ from the capital city. The total population includes both urban and rural populations.
           - *desc_crossborder_exclusion
+          - *desc_key_low_plausibility
+        description_processing: *desc_processing_largest_city_low_plausibility
         display:
           numDecimalPlaces: 1
           isProjection: true

--- a/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
+++ b/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
@@ -13,9 +13,6 @@ definitions:
     - City boundaries are model-derived and may not match official administrative limits. Data quality varies by region and tends to be lower where census data is sparse or outdated.
     - The underlying population figures have been rescaled to match UN World Population Prospects 2022 national totals, so country-level numbers are consistent with UN estimates.
 
-  desc_processing_density: &desc_processing_density |-
-    Population density was calculated by dividing the population of the urban centre by its total land area.
-
   desc_processing_cagr: &desc_processing_cagr |-
     The annualized exponential growth rate was calculated as: 100 × ln(P_t / P_prev) / (year_t - year_prev), where P_t is the population at time t and P_prev is the population at the previous observation. For five-year intervals, year_t - year_prev = 5. This assumes constant exponential growth between observations.
 
@@ -34,8 +31,16 @@ definitions:
   desc_processing_low_plausibility: &desc_processing_low_plausibility |-
     The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave these years blank rather than estimate them.
 
+  # Used for the capital-city indicators, which are the only ones in this dataset that also carry
+  # regional and income-group values. Those are sums across countries, so a dropped capital makes the
+  # regional total lower rather than blank, and the text has to say so.
+  desc_processing_capital_low_plausibility: &desc_processing_capital_low_plausibility |-
+    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave these years blank rather than estimate them.
+
+    Figures for regions and income groups are the sum of the countries that have a capital city figure for that year. Countries without one — including those whose figure we do not show — are left out of the sum, so these totals are lower than the true value. Africa's total, for example, does not include Angola for 1995 to 2005.
+
   desc_processing_density_low_plausibility: &desc_processing_density_low_plausibility |-
-    Population density was calculated by dividing the population of the urban centre by its total land area.
+    Population density was calculated by dividing the population of the urban center by its total land area.
 
     The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave these years blank rather than estimate them.
 
@@ -373,7 +378,7 @@ tables:
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_low_plausibility
+        description_processing: *desc_processing_capital_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -391,7 +396,7 @@ tables:
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_low_plausibility
+        description_processing: *desc_processing_capital_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -531,12 +536,12 @@ tables:
           - Estimated share of a country's urban population living in its capital city, based on satellite imagery and census data.
           - *desc_key_common
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
-          - The urban population total used as the denominator covers all cities (urban centres with at least 50,000 people) within the country.
+          - The urban population total used as the denominator covers all cities (urban centers with at least 50,000 people) within the country.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_capital_threshold_caveat
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_low_plausibility
+        description_processing: *desc_processing_capital_low_plausibility
         display:
           numDecimalPlaces: 1
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -550,12 +555,12 @@ tables:
           - Projected share of a country's urban population living in its capital city, based on the GHSL modelling framework anchored to UN World Population Prospects 2022.
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
-          - The urban population total used as the denominator covers all cities (urban centres with at least 50,000 people) within the country.
+          - The urban population total used as the denominator covers all cities (urban centers with at least 50,000 people) within the country.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_capital_threshold_caveat
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_low_plausibility
+        description_processing: *desc_processing_capital_low_plausibility
         display:
           numDecimalPlaces: 1
           isProjection: true
@@ -576,7 +581,7 @@ tables:
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_low_plausibility
+        description_processing: *desc_processing_capital_low_plausibility
         display:
           numDecimalPlaces: 1
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -594,7 +599,7 @@ tables:
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_low_plausibility
+        description_processing: *desc_processing_capital_low_plausibility
         display:
           numDecimalPlaces: 1
           isProjection: true
@@ -615,7 +620,7 @@ tables:
           - Estimated share of a country's urban population living in its largest city (determined by 2020 population), based on satellite imagery and census data.
           - *desc_key_common
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
-          - The largest city is determined by 2020 population and may differ from the capital city. The urban population total used as the denominator covers all cities (urban centres with at least 50,000 people) within the country.
+          - The largest city is determined by 2020 population and may differ from the capital city. The urban population total used as the denominator covers all cities (urban centers with at least 50,000 people) within the country.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
         description_processing: *desc_processing_largest_city_low_plausibility
@@ -631,7 +636,7 @@ tables:
           - Projected share of a country's urban population living in its largest city (determined by 2020 population), based on the GHSL modelling framework anchored to UN World Population Prospects 2022.
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
-          - The largest city is determined by 2020 population and may differ from the capital city. The urban population total used as the denominator covers all cities (urban centres with at least 50,000 people) within the country.
+          - The largest city is determined by 2020 population and may differ from the capital city. The urban population total used as the denominator covers all cities (urban centers with at least 50,000 people) within the country.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
         description_processing: *desc_processing_largest_city_low_plausibility

--- a/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
+++ b/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
@@ -47,7 +47,7 @@ definitions:
     Historical figures that the producer rates as low plausibility are not shown, and appear as gaps.
 
   desc_key_largest_city_no_rerank: &desc_key_largest_city_no_rerank |-
-    The largest city is found by ranking a country's cities by population. Where the top city's figure is one we do not show, the value is left blank for that year rather than falling back to the second-largest city, which would otherwise be presented as the largest.
+    The largest city is found by ranking a country's cities by population. Where the top city's figure is one we do not show due to a "low" plausibility flag, the value is left blank for that year rather than falling back to the second-largest city, which would otherwise be presented as the largest.
 
   # Degurba descriptions to use for towns and suburbs variables.
   text_degurba_overview: &text_degurba_overview |-

--- a/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
+++ b/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
@@ -49,8 +49,14 @@ definitions:
   desc_key_largest_city_no_rerank: &desc_key_largest_city_no_rerank |-
     The largest city is found by ranking a country's cities by population. Where the top city's figure is one we do not show, the value is left blank for that year rather than falling back to the second-largest city, which would otherwise be presented as the largest.
 
+  # Two versions, because the capital indicators come in two shapes: a population, which really is a
+  # sum across countries, and a share, which divides that sum by the whole region's population and so
+  # is not additive at all.
   desc_key_capital_regional_keeps_all: &desc_key_capital_regional_keeps_all |-
     Figures for regions and income groups are the sum of their countries' capital cities, and include every capital the producer reports — including the few whose figures we do not show for individual countries. So a regional total can be higher than the sum of the countries shown on a chart.
+
+  desc_key_capital_share_regional_keeps_all: &desc_key_capital_share_regional_keeps_all |-
+    For regions and income groups, the capital city population used here is the combined population of their countries' capital cities, and includes every capital the producer reports — including the few whose figures we do not show for individual countries. Because the result is then expressed as a percentage of the whole region's population, the percentages shown for individual countries do not add up to it.
 
   # Degurba descriptions to use for towns and suburbs variables.
   text_degurba_overview: &text_degurba_overview |-
@@ -537,7 +543,7 @@ tables:
           - *desc_capital_threshold_caveat
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-          - *desc_key_capital_regional_keeps_all
+          - *desc_key_capital_share_regional_keeps_all
         description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
@@ -556,7 +562,7 @@ tables:
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_capital_threshold_caveat
           - *desc_crossborder_exclusion
-          - *desc_key_capital_regional_keeps_all
+          - *desc_key_capital_share_regional_keeps_all
         display:
           numDecimalPlaces: 1
           isProjection: true
@@ -577,7 +583,7 @@ tables:
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-          - *desc_key_capital_regional_keeps_all
+          - *desc_key_capital_share_regional_keeps_all
         description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
@@ -595,7 +601,7 @@ tables:
           - The total population includes both urban and rural populations.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_crossborder_exclusion
-          - *desc_key_capital_regional_keeps_all
+          - *desc_key_capital_share_regional_keeps_all
         display:
           numDecimalPlaces: 1
           isProjection: true

--- a/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
+++ b/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.meta.yml
@@ -24,33 +24,33 @@ definitions:
   desc_capital_threshold_caveat: &desc_capital_threshold_caveat |-
     Capital cities are only included if they meet the threshold of at least 50,000 people in a contiguous urban area with a density of at least 1,500 people per km². Some capital cities (e.g., Canberra) do not appear in historical estimates because they did not meet this threshold, though they may appear in projections as they grow.
 
-  # The producer flags the plausibility of every city's population figure. We drop the values it rates
-  # "low" from the indicators that describe a single named city, but not from the city-size aggregates,
-  # which sum every city in a country. YAML cannot combine two anchors into one string, so the variants
-  # below repeat the shared wording.
+  # The producer flags the plausibility of every city's population figure. We don't show the values it
+  # rates "low" in indicators built from a single named city, but we keep them in every aggregate.
+  #
+  # This wording is deliberately kept to ONE anchor. YAML cannot join two anchors into one string, so
+  # anything that has to appear alongside it goes in `description_key` instead, which is a list and can
+  # compose aliases. The density anchor below is the one unavoidable exception, because its own
+  # sentence is genuinely part of the same processing description.
   desc_processing_low_plausibility: &desc_processing_low_plausibility |-
-    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave these years blank rather than estimate them.
+    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the historical figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave those years blank rather than estimate them. Projected values are kept as published, because for future years a low rating usually reflects ordinary forecast uncertainty rather than a misplaced population.
 
-  # Used for the capital-city indicators, which are the only ones in this dataset that also carry
-  # regional and income-group values. Those are sums across countries, so a dropped capital makes the
-  # regional total lower rather than blank, and the text has to say so.
-  desc_processing_capital_low_plausibility: &desc_processing_capital_low_plausibility |-
-    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave these years blank rather than estimate them.
-
-    Figures for regions and income groups are the sum of the countries that have a capital city figure for that year. Countries without one — including those whose figure we do not show — are left out of the sum, so these totals are lower than the true value. Africa's total, for example, does not include Angola for 1995 to 2005.
+  # Used by the projected density indicators, where nothing is filtered.
+  desc_processing_density: &desc_processing_density |-
+    Population density was calculated by dividing the population of the urban center by its total land area.
 
   desc_processing_density_low_plausibility: &desc_processing_density_low_plausibility |-
     Population density was calculated by dividing the population of the urban center by its total land area.
 
-    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave these years blank rather than estimate them.
-
-  desc_processing_largest_city_low_plausibility: &desc_processing_largest_city_low_plausibility |-
-    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995.
-
-    The largest city is found by ranking a country's cities by population. Where the top city's figure is rated "low", we leave the value blank for that country and year. We do not fall back to the second-largest city, which would otherwise be shown as the largest.
+    The producer rates how plausible each city's population figure is, on a four-point scale from low to very high. We do not show the historical figures it rates as "low". In those cases the population is sometimes placed in the wrong settlement: in Angola, for example, around one million people are assigned to the small town of Uíge, while Luanda is missing from the data before 1995. We leave those years blank rather than estimate them. Projected values are kept as published, because for future years a low rating usually reflects ordinary forecast uncertainty rather than a misplaced population.
 
   desc_key_low_plausibility: &desc_key_low_plausibility |-
-    Figures that the producer rates as low plausibility are not shown, and appear as gaps. This affects a small number of cities and years, most visibly Luanda before 2010.
+    Historical figures that the producer rates as low plausibility are not shown, and appear as gaps. This affects a small number of cities and years, most visibly Luanda before 2010.
+
+  desc_key_largest_city_no_rerank: &desc_key_largest_city_no_rerank |-
+    The largest city is found by ranking a country's cities by population. Where the top city's figure is one we do not show, the value is left blank for that year rather than falling back to the second-largest city, which would otherwise be presented as the largest.
+
+  desc_key_capital_regional_keeps_all: &desc_key_capital_regional_keeps_all |-
+    Figures for regions and income groups are the sum of their countries' capital cities, and include every capital the producer reports — including the few whose figures we do not show for individual countries. So a regional total can be higher than the sum of the countries shown on a chart.
 
   # Degurba descriptions to use for towns and suburbs variables.
   text_degurba_overview: &text_degurba_overview |-
@@ -378,7 +378,8 @@ tables:
           - For 1950–1975, estimates use UN national statistics. From 1975 onwards, population is mapped to 1 km² grid cells using the [Global Human Settlement Layer (GHSL)](https://human-settlement.emergency.copernicus.eu/).
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_capital_low_plausibility
+          - *desc_key_capital_regional_keeps_all
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -395,8 +396,7 @@ tables:
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
-          - *desc_key_low_plausibility
-        description_processing: *desc_processing_capital_low_plausibility
+          - *desc_key_capital_regional_keeps_all
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -438,8 +438,7 @@ tables:
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - Where a country has multiple capital cities, the density shown is for the administrative capital.
-          - *desc_key_low_plausibility
-        description_processing: *desc_processing_density_low_plausibility
+        description_processing: *desc_processing_density
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -476,8 +475,6 @@ tables:
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - The ranking of the top 100 cities is fixed based on their population in 2020. Projected values show the population of those same cities in future years.
-          - *desc_key_low_plausibility
-        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapTop100
@@ -514,8 +511,7 @@ tables:
           - *desc_key_common
           - Projections use the [CRISP spatial model](https://www.researchgate.net/publication/384062691_Calibration_of_the_CRISP_model_A_global_assessment_of_local_built-up_area_presence) at 1 km² resolution, following the UN World Population Prospects 2024 medium scenario.
           - The ranking of the top 100 cities is fixed based on their population in 2020. Projected values show the density of those same cities in future years.
-          - *desc_key_low_plausibility
-        description_processing: *desc_processing_density_low_plausibility
+        description_processing: *desc_processing_density
         display:
           numDecimalPlaces: 0
           entityAnnotationsMap: *entityAnnotationsMapTop100
@@ -541,7 +537,8 @@ tables:
           - *desc_capital_threshold_caveat
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_capital_low_plausibility
+          - *desc_key_capital_regional_keeps_all
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -559,8 +556,7 @@ tables:
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_capital_threshold_caveat
           - *desc_crossborder_exclusion
-          - *desc_key_low_plausibility
-        description_processing: *desc_processing_capital_low_plausibility
+          - *desc_key_capital_regional_keeps_all
         display:
           numDecimalPlaces: 1
           isProjection: true
@@ -581,7 +577,8 @@ tables:
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_capital_low_plausibility
+          - *desc_key_capital_regional_keeps_all
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
           entityAnnotationsMap: *entityAnnotationsMapCapitals
@@ -598,8 +595,7 @@ tables:
           - The total population includes both urban and rural populations.
           - Where a country has multiple capital cities, the population shown is for the administrative capital.
           - *desc_crossborder_exclusion
-          - *desc_key_low_plausibility
-        description_processing: *desc_processing_capital_low_plausibility
+          - *desc_key_capital_regional_keeps_all
         display:
           numDecimalPlaces: 1
           isProjection: true
@@ -623,7 +619,8 @@ tables:
           - The largest city is determined by 2020 population and may differ from the capital city. The urban population total used as the denominator covers all cities (urban centers with at least 50,000 people) within the country.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_largest_city_low_plausibility
+          - *desc_key_largest_city_no_rerank
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
 
@@ -639,7 +636,8 @@ tables:
           - The largest city is determined by 2020 population and may differ from the capital city. The urban population total used as the denominator covers all cities (urban centers with at least 50,000 people) within the country.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_largest_city_low_plausibility
+          - *desc_key_largest_city_no_rerank
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
           isProjection: true
@@ -658,7 +656,8 @@ tables:
           - The largest city is determined by 2020 population and may differ from the capital city. The total population includes both urban and rural populations.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_largest_city_low_plausibility
+          - *desc_key_largest_city_no_rerank
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
 
@@ -674,7 +673,8 @@ tables:
           - The largest city is determined by 2020 population and may differ from the capital city. The total population includes both urban and rural populations.
           - *desc_crossborder_exclusion
           - *desc_key_low_plausibility
-        description_processing: *desc_processing_largest_city_low_plausibility
+          - *desc_key_largest_city_no_rerank
+        description_processing: *desc_processing_low_plausibility
         display:
           numDecimalPlaces: 1
           isProjection: true

--- a/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.py
+++ b/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.py
@@ -11,6 +11,26 @@ paths = PathFinder(__file__)
 
 START_OF_PROJECTIONS = 2025
 
+# The source rates the plausibility of every city's population figure (0 = low, 1 = moderate,
+# 2 = high, 3 = very high) and the meadow step carries that rating through. We do not publish the
+# figures it rates "low", because in those cases the population is sometimes placed in the wrong
+# settlement: in Angola the source puts ~1 million people in the small town of Uíge (1.01M in 29 km²)
+# while Luanda's urban centre is absent until 1995, and it flags exactly those figures as low. The
+# same pattern shows up in Eritrea, South Sudan, Comoros and Cabo Verde.
+#
+# Two limits on that, both deliberate:
+#
+# 1. Only indicators built from ONE named city are filtered (capital, largest city, top 100). Every
+#    aggregate is left alone -- the city-size buckets, and the regional sums of capital population.
+#    An aggregate sums many cities, so dropping a misplaced one would delete people who really do
+#    live in that country. Filtering the city-size aggregates would also be far more destructive than
+#    it looks: 38 country-years would lose every one of their cities, and Bangladesh, Yemen, Sudan and
+#    Iran would each lose a fifth to two-thirds of their urban population.
+# 2. Only the historical estimates are filtered, never the projections. From 2025 on the rating mostly
+#    marks ordinary forecast uncertainty for small capitals rather than misplacement -- Vientiane is
+#    rated low from 2025, but it really is the largest city in Laos.
+LOW_PLAUSIBILITY = 0
+
 # Regions for which aggregates will be created.
 REGIONS = [
     "North America",
@@ -34,6 +54,20 @@ CITY_SIZE_CUTOFFS = {
     "5m_10m": (5000000, 10000000),
     "above_10m": (10000000, float("inf")),
 }
+
+
+def blank_low_plausibility(tb, value_columns, flag_column):
+    """Blank the values the source rates as low plausibility, in the historical estimates only.
+
+    Blanks rather than drops, and never re-ranks: for the largest-city indicator the meadow step has
+    already picked the winning city, so removing the row here would let a later step fall through to
+    the second-biggest city and publish that as the largest.
+
+    Rows without a flag (regional and income-group aggregates, which carry NaN) are always left alone.
+    """
+    unreliable = (tb[flag_column] == LOW_PLAUSIBILITY) & (tb["year"] < START_OF_PROJECTIONS)
+    tb.loc[unreliable.fillna(False).astype(bool), value_columns] = float("nan")
+    return tb.drop(columns=[flag_column])
 
 
 def calculate_population_shares(tb_data, tb_total_pop, pop_column, share_prefix):
@@ -180,9 +214,13 @@ def run() -> None:
     ####################################################################################################################
     # Extract capital data (exclude top 100 city rows which have different country names like "Paris (France)").
     tb_capitals = tb[has_capital_data & ~has_top_100_data].copy()
-    tb_capitals = tb_capitals[["country", "year", "urban_pop", "urban_density"]]
+    tb_capitals = tb_capitals[["country", "year", "urban_pop", "urban_density", "urban_pop_plausibility"]]
 
     # Add regional aggregates (sum of capital populations across countries in each region).
+    # Deliberately done BEFORE blanking the low-plausibility capitals below, so that regional and
+    # income-group totals still count every capital the source reports. Those sums are aggregates, and
+    # aggregates keep the people throughout this step. Blanking first would silently lower Africa's
+    # total for 1995-2005 by up to 1.6%.
     tb_capitals = geo.add_regions_to_table(
         tb_capitals,
         aggregations={"urban_pop": "sum"},
@@ -191,6 +229,10 @@ def run() -> None:
         ds_income_groups=ds_income_groups,
         min_num_values_per_year=1,
     )
+
+    # Now blank the individual capitals rated low plausibility. Region rows carry no flag, so they and
+    # their totals are untouched.
+    tb_capitals = blank_low_plausibility(tb_capitals, ["urban_pop", "urban_density"], "urban_pop_plausibility")
 
     # Calculate capital city shares (% of urban/total population living in capital cities).
     # This works for both individual countries and regional aggregates.
@@ -203,7 +245,15 @@ def run() -> None:
     # Extract largest city data (individual countries only, no regional aggregates).
     # Note: "Largest city" is determined purely by population, which may differ from the capital.
     tb_largest_city = tb[has_largest_city_data & ~has_top_100_data].copy()
-    tb_largest_city = tb_largest_city[["country", "year", "largest_city_pop", "largest_city_density"]]
+    tb_largest_city = tb_largest_city[
+        ["country", "year", "largest_city_pop", "largest_city_density", "largest_city_plausibility"]
+    ]
+
+    # Blank the largest cities rated low plausibility, before the shares are derived from them, so the
+    # shares go blank with their numerator instead of being computed from a figure we won't publish.
+    tb_largest_city = blank_low_plausibility(
+        tb_largest_city, ["largest_city_pop", "largest_city_density"], "largest_city_plausibility"
+    )
 
     # Calculate largest city shares (% of urban/total population living in the largest city).
     # No regional aggregates - can't meaningfully sum "largest city" across countries.
@@ -215,7 +265,16 @@ def run() -> None:
     ####################################################################################################################
     # Extract top 100 cities (these have country names like "Paris (France)").
     tb_top_100 = tb[has_top_100_data].copy()
-    tb_top_100 = tb_top_100[["country", "year", "urban_pop_top_100", "urban_density_top_100"]]
+    tb_top_100 = tb_top_100[
+        ["country", "year", "urban_pop_top_100", "urban_density_top_100", "urban_pop_top_100_plausibility"]
+    ]
+
+    # Blank the city-years rated low plausibility. Each row is one named city in one year, so this
+    # touches nothing else; the city itself stays in the top 100, since membership is fixed by 2020
+    # population and should not depend on the rating of a single year's figure.
+    tb_top_100 = blank_low_plausibility(
+        tb_top_100, ["urban_pop_top_100", "urban_density_top_100"], "urban_pop_top_100_plausibility"
+    )
 
     ####################################################################################################################
     # SECTION 4: Process city size aggregates

--- a/etl/steps/data/meadow/urbanization/2025-12-10/ghsl_urban_centers.py
+++ b/etl/steps/data/meadow/urbanization/2025-12-10/ghsl_urban_centers.py
@@ -17,6 +17,21 @@ CITY_SIZE_CUTOFFS = {
     "above_10m": (10000000, float("inf")),
 }
 
+# The source rates the plausibility of every urban centre's population figure:
+# 0 = low, 1 = moderate, 2 = high, 3 = very high.
+#
+# We drop the values it rates "low", but only for the indicators that describe ONE named city
+# (capital, largest city, top 100). There, a low-plausibility figure is a false claim about a
+# specific place: in Angola, for instance, the source puts ~1 million people in the small town of
+# Uíge while Luanda's urban centre is absent until 1995, and it flags exactly those figures as low.
+#
+# The city-size aggregates below are deliberately NOT filtered. They sum every city in a country, so
+# dropping a misplaced city would remove people who really do live in that country and make the
+# totals too low. Filtering them would also be far more destructive than it looks: 38 country-years
+# would lose every one of their cities, and several countries would lose a fifth to two-thirds of
+# their urban population.
+LOW_PLAUSIBILITY = 0
+
 
 def run() -> None:
     #
@@ -41,6 +56,7 @@ def run() -> None:
             "BU_km2": "built_up_area",
             "CapitalFlag": "capital",
             "ID_UC_G0": "ID_MTUC_G0",
+            "Plausibility": "plausibility",
         }
     )
 
@@ -53,8 +69,16 @@ def run() -> None:
     tb_raw = tb_raw.dropna(subset=["urban_center_name"])
     tb_raw = tb_raw[tb_raw["urban_center_name"] != "N/A"]
 
+    # Sanity check: the plausibility flag must be present and use the documented 0-3 scale, since we
+    # rely on it below to decide which per-city figures to publish.
+    assert "plausibility" in tb_raw.columns, "Source is missing the Plausibility column."
+    unexpected_flags = set(tb_raw["plausibility"].dropna().unique()) - {0, 1, 2, 3}
+    assert not unexpected_flags, f"Unexpected plausibility flags: {sorted(unexpected_flags)}"
+
     # Create working table with selected columns for capitals/top 100.
-    tb = tb_raw[["ID_MTUC_G0", "country", "urban_center_name", "capital", "year", "urban_pop", "urban_area"]].copy()
+    tb = tb_raw[
+        ["ID_MTUC_G0", "country", "urban_center_name", "capital", "year", "urban_pop", "urban_area", "plausibility"]
+    ].copy()
 
     # Calculate urban density.
     tb["urban_density"] = tb["urban_pop"] / tb["urban_area"]
@@ -90,24 +114,52 @@ def run() -> None:
     tb_capitals = tb_capitals[~multi_capital_mask | preferred_mask].copy()
     tb_capitals = tb_capitals.drop(columns=["ID_MTUC_G0", "capital", "preferred_capital"])
 
+    # Drop the capital-city figures the source rates as low plausibility.
+    # A single-step drop is safe here: the capital is identified by the source's own capital flag (and
+    # our preference list above), never by ranking cities on population, so removing a capital's row
+    # cannot promote another city into its place. It just leaves a gap.
+    tb_capitals = tb_capitals[tb_capitals["plausibility"] != LOW_PLAUSIBILITY].drop(columns=["plausibility"])
+
     # Population and density of the largest city by country and year (by population).
+    # Take whole rows rather than a column-wise groupby().first(), so that the plausibility flag we
+    # check next belongs to the same city as the population figure it is rating.
     tb_largest_city = (
-        tb.sort_values("urban_pop", ascending=False)
-        .groupby(["country", "year"], as_index=False)
-        .first()[["country", "year", "urban_pop", "urban_density"]]
+        tb.dropna(subset=["urban_pop"])
+        .sort_values(["country", "year", "urban_pop"], ascending=[True, True, False])
+        .drop_duplicates(subset=["country", "year"], keep="first")[
+            ["country", "year", "urban_pop", "urban_density", "plausibility"]
+        ]
         .copy()
     )
+
+    # Blank the largest-city figures the source rates as low plausibility -- and do NOT re-rank.
+    # This indicator is derived by sorting a country's cities and taking the top one, so simply
+    # dropping the flagged city would let the sort fall through and publish the SECOND-biggest city as
+    # the largest. That is a worse error than the one we are fixing: Laos would be credited with Pakse
+    # (142k) instead of Vientiane (237k) for 2050-2100. So we blank the country-year instead.
+    implausible_largest = tb_largest_city["plausibility"] == LOW_PLAUSIBILITY
+    tb_largest_city.loc[implausible_largest, ["urban_pop", "urban_density"]] = float("nan")
+    tb_largest_city = tb_largest_city.drop(columns=["plausibility"])
+
     tb_largest_city = tb_largest_city.rename(
         columns={"urban_pop": "largest_city_pop", "urban_density": "largest_city_density"}
     )
 
     # Select the top 100 most populous cities in 2020.
+    # The ranking is deliberately taken from the unfiltered data: it defines which cities the indicator
+    # covers, and that membership should not depend on the quality flag of a single year's figure.
     tb_2020 = tb[tb["year"] == 2020]
     top_100_pop_2020 = tb_2020.nlargest(100, "urban_pop").drop_duplicates(subset=["ID_MTUC_G0"])
 
     # Filter the original Table to select the top urban centers.
     tb_top = tb[tb["ID_MTUC_G0"].isin(top_100_pop_2020["ID_MTUC_G0"])].copy()
-    tb_top = tb_top.drop(columns=["urban_area", "ID_MTUC_G0", "capital"])
+
+    # Drop the individual city-year figures the source rates as low plausibility. Each row here is one
+    # named city in one year, so a flagged figure can be removed on its own without affecting any other
+    # city or year, and the city stays in the top 100.
+    tb_top = tb_top[tb_top["plausibility"] != LOW_PLAUSIBILITY]
+
+    tb_top = tb_top.drop(columns=["urban_area", "ID_MTUC_G0", "capital", "plausibility"])
     tb_top = tb_top.rename(columns={"urban_density": "urban_density_top_100", "urban_pop": "urban_pop_top_100"})
 
     # Format the country column for top 100.
@@ -176,14 +228,18 @@ def run() -> None:
 
     #
     # Create a raw city-level table for matching purposes.
+    # This one keeps the plausibility flag, unfiltered, so the producer's quality rating stays
+    # inspectable downstream -- it is what lets us screen for cases like Uíge in the first place.
     #
-    tb_cities_raw = tb_raw[["country", "urban_center_name", "year", "urban_pop"]].copy()
+    tb_cities_raw = tb_raw[["country", "urban_center_name", "year", "urban_pop", "plausibility"]].copy()
     tb_cities_raw = tb_cities_raw.dropna(subset=["urban_center_name", "urban_pop"])
     tb_cities_raw = tb_cities_raw[tb_cities_raw["urban_pop"] > 0]
 
     # Handle duplicate city names by keeping the first occurrence
     # (some cities appear multiple times with same name in different regions)
     tb_cities_raw = tb_cities_raw.drop_duplicates(subset=["country", "urban_center_name", "year"], keep="first")
+    for col in ["urban_pop", "plausibility"]:
+        tb_cities_raw[col].metadata.origins = tb_cities_raw["country"].metadata.origins
 
     tb_cities_raw = tb_cities_raw.format(["country", "urban_center_name", "year"], short_name="ghsl_urban_centers_raw")
 

--- a/etl/steps/data/meadow/urbanization/2025-12-10/ghsl_urban_centers.py
+++ b/etl/steps/data/meadow/urbanization/2025-12-10/ghsl_urban_centers.py
@@ -20,17 +20,8 @@ CITY_SIZE_CUTOFFS = {
 # The source rates the plausibility of every urban centre's population figure:
 # 0 = low, 1 = moderate, 2 = high, 3 = very high.
 #
-# We drop the values it rates "low", but only for the indicators that describe ONE named city
-# (capital, largest city, top 100). There, a low-plausibility figure is a false claim about a
-# specific place: in Angola, for instance, the source puts ~1 million people in the small town of
-# Uíge while Luanda's urban centre is absent until 1995, and it flags exactly those figures as low.
-#
-# The city-size aggregates below are deliberately NOT filtered. They sum every city in a country, so
-# dropping a misplaced city would remove people who really do live in that country and make the
-# totals too low. Filtering them would also be far more destructive than it looks: 38 country-years
-# would lose every one of their cities, and several countries would lose a fifth to two-thirds of
-# their urban population.
-LOW_PLAUSIBILITY = 0
+# This step only carries the rating through, alongside the figure it applies to. Deciding which
+# figures to publish on the strength of it is business logic, so it lives in the garden step.
 
 
 def run() -> None:
@@ -114,11 +105,9 @@ def run() -> None:
     tb_capitals = tb_capitals[~multi_capital_mask | preferred_mask].copy()
     tb_capitals = tb_capitals.drop(columns=["ID_MTUC_G0", "capital", "preferred_capital"])
 
-    # Drop the capital-city figures the source rates as low plausibility.
-    # A single-step drop is safe here: the capital is identified by the source's own capital flag (and
-    # our preference list above), never by ranking cities on population, so removing a capital's row
-    # cannot promote another city into its place. It just leaves a gap.
-    tb_capitals = tb_capitals[tb_capitals["plausibility"] != LOW_PLAUSIBILITY].drop(columns=["plausibility"])
+    # Carry the source's rating of this capital's population through under a distinct name, so it
+    # survives the merge below and garden can decide what to publish.
+    tb_capitals = tb_capitals.rename(columns={"plausibility": "urban_pop_plausibility"})
 
     # Population and density of the largest city by country and year (by population).
     # Take whole rows rather than a column-wise groupby().first(), so that the plausibility flag we
@@ -132,17 +121,15 @@ def run() -> None:
         .copy()
     )
 
-    # Blank the largest-city figures the source rates as low plausibility -- and do NOT re-rank.
-    # This indicator is derived by sorting a country's cities and taking the top one, so simply
-    # dropping the flagged city would let the sort fall through and publish the SECOND-biggest city as
-    # the largest. That is a worse error than the one we are fixing: Laos would be credited with Pakse
-    # (142k) instead of Vientiane (237k) for 2050-2100. So we blank the country-year instead.
-    implausible_largest = tb_largest_city["plausibility"] == LOW_PLAUSIBILITY
-    tb_largest_city.loc[implausible_largest, ["urban_pop", "urban_density"]] = float("nan")
-    tb_largest_city = tb_largest_city.drop(columns=["plausibility"])
-
+    # Keep the winning city's rating alongside its population. Garden uses it to blank the value where
+    # the source rates it unreliable; note the ranking must stay here, with the rating attached to the
+    # row it came from, so that garden never has to re-rank and accidentally promote the runner-up.
     tb_largest_city = tb_largest_city.rename(
-        columns={"urban_pop": "largest_city_pop", "urban_density": "largest_city_density"}
+        columns={
+            "urban_pop": "largest_city_pop",
+            "urban_density": "largest_city_density",
+            "plausibility": "largest_city_plausibility",
+        }
     )
 
     # Select the top 100 most populous cities in 2020.
@@ -154,13 +141,14 @@ def run() -> None:
     # Filter the original Table to select the top urban centers.
     tb_top = tb[tb["ID_MTUC_G0"].isin(top_100_pop_2020["ID_MTUC_G0"])].copy()
 
-    # Drop the individual city-year figures the source rates as low plausibility. Each row here is one
-    # named city in one year, so a flagged figure can be removed on its own without affecting any other
-    # city or year, and the city stays in the top 100.
-    tb_top = tb_top[tb_top["plausibility"] != LOW_PLAUSIBILITY]
-
-    tb_top = tb_top.drop(columns=["urban_area", "ID_MTUC_G0", "capital", "plausibility"])
-    tb_top = tb_top.rename(columns={"urban_density": "urban_density_top_100", "urban_pop": "urban_pop_top_100"})
+    tb_top = tb_top.drop(columns=["urban_area", "ID_MTUC_G0", "capital"])
+    tb_top = tb_top.rename(
+        columns={
+            "urban_density": "urban_density_top_100",
+            "urban_pop": "urban_pop_top_100",
+            "plausibility": "urban_pop_top_100_plausibility",
+        }
+    )
 
     # Format the country column for top 100.
     tb_top["country"] = tb_top["urban_center_name"] + " (" + tb_top["country"] + ")"
@@ -209,6 +197,9 @@ def run() -> None:
     metadata_cols = [
         "urban_pop",
         "urban_density",
+        "urban_pop_plausibility",
+        "largest_city_plausibility",
+        "urban_pop_top_100_plausibility",
         "largest_city_pop",
         "largest_city_density",
         "urban_density_top_100",

--- a/etl/steps/data/meadow/urbanization/2025-12-10/ghsl_urban_centers.py
+++ b/etl/steps/data/meadow/urbanization/2025-12-10/ghsl_urban_centers.py
@@ -238,8 +238,9 @@ def run() -> None:
     # Handle duplicate city names by keeping the first occurrence
     # (some cities appear multiple times with same name in different regions)
     tb_cities_raw = tb_cities_raw.drop_duplicates(subset=["country", "urban_center_name", "year"], keep="first")
+    # Copy the list per column, so the three columns don't share one mutable origins list.
     for col in ["urban_pop", "plausibility"]:
-        tb_cities_raw[col].metadata.origins = tb_cities_raw["country"].metadata.origins
+        tb_cities_raw[col].metadata.origins = list(tb_cities_raw["country"].metadata.origins)
 
     tb_cities_raw = tb_cities_raw.format(["country", "urban_center_name", "year"], short_name="ghsl_urban_centers_raw")
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @edomt at the wheel._

A reader pointed out that Luanda looked far too small in the early years of our megacities chart. They were right. The cause is in the JRC source data rather than in our processing, but we were publishing it without any warning, because we were discarding the very column the producer ships to warn us.

## The problem

The JRC's urban-centre file rates how plausible each city's population figure is, on a four-point scale: 0 = low, 1 = moderate, 2 = high, 3 = very high. Our meadow step read seven columns from that file and this was not one of them.

For Angola, the file places about **one million people in the small town of Uíge** — 1,011,989 people in 29 km², a density of 34,900 per km², more than three times Luanda's density today in the same dataset. Meanwhile **Luanda's urban centre is absent entirely before 1995**, and when it appears it starts at 306,451 against a UN estimate of 2,066,306 for that year.

The producer rates exactly those figures "low". Luanda is the only city in the top 100 that is ever rated that way.

| Year | UN estimate | JRC value | JRC as % of UN | JRC rating |
|---|---|---|---|---|
| 1975 | 598,504 | no data | | — |
| 1995 | 2,066,306 | 306,451 | 15% | 0 · low |
| 2000 | 2,828,820 | 714,643 | 25% | 0 · low |
| 2005 | 3,872,050 | 1,246,115 | 32% | 0 · low |
| 2010 | 5,300,466 | 3,544,235 | 67% | 1 · moderate |
| 2020 | 8,329,798 | 9,775,496 | 117% | 3 · very high |

This is neither specific to Angola nor new. The previous release, from December 2024, has the same defect. The same pattern — a minor town holding a primate city's population in an implausibly small area — appears in Eritrea (Keren ranked above Asmara), South Sudan (Nimule above Juba), Comoros (Fomboni above Moroni) and Cabo Verde, where Praia is missing from the file altogether.

## What this changes

The meadow step now carries the producer's rating through alongside the figure it applies to, and the garden step decides what to publish. Deciding which figures to trust is business logic, so it belongs in garden; this also means the year cutoff reuses garden's existing `START_OF_PROJECTIONS` constant instead of duplicating it.

We do not publish the figures rated "low", subject to two deliberate limits.

### Limit 1: only indicators built from a single named city

| Treatment | Indicators |
|---|---|
| Values blanked | capital city population and density; top-100 population and density |
| Blanked, and never re-ranked | both "share of population in the largest city" variants |
| Blank automatically, following their numerator | both "share of population in the capital city" variants |
| Left exactly as published | all 36 city-size aggregates, **and** the regional and income-group sums of capital population |

Every aggregate is left alone. An aggregate sums many cities, so deleting a misplaced one would remove people who genuinely do live in that country and make the total too low. The misplaced million in Uíge is a real million Angolans; the source has simply put them in the wrong city.

This applies to the regional sums as well, and getting that right required care. Capital-city populations are summed into continents and income groups. Blanking a capital before aggregating silently lowered those totals — Africa's capital-population total for 1995 to 2005 dropped by up to 1.6%. The garden step therefore aggregates first and blanks the individual country rows afterwards, so no regional or income-group figure moves at all.

Filtering the city-size aggregates would also have been far more destructive than it looks. It would leave 38 country-years with no cities whatsoever, and would cut between a fifth and two-thirds of urban population from Bangladesh, Yemen, Sudan and Iran.

### Limit 2: historical estimates only, never projections

From 2025 onwards a low rating usually reflects ordinary forecast uncertainty about a small capital, not the misplacement we are correcting. Vientiane is rated low from 2025 on, but it really is the largest city in Laos. Projected values are published exactly as the producer supplies them.

### The largest-city indicator needs a two-step rule

That indicator is derived by sorting a country's cities and taking the top one. Simply deleting the flagged city lets the sort fall through and publishes the **second**-biggest city as the largest. That would credit Laos with Pakse (142,362) instead of Vientiane (236,525) for 2050 to 2100, which is a worse error than the one being fixed. So the value is blanked for that country and year, and we never re-rank.

The capital indicator needs no such rule, because capitals come from the source's own capital flag plus our fixed preference list for multi-capital countries, not from a population ranking. Nothing can be promoted into a dropped capital's place.

## Verification against the published catalog

Compared cell by cell against the published version of the table:

- **10 columns differ.** Every one is a per-city indicator.
- **Every single difference is a value becoming blank.** Zero values are recomputed into a different number.
- **No regional or income-group value is touched.**
- **Nothing after 2020 is touched.** The two `_projections` columns that appear in the diff change only at 2020, which is the overlap year the garden step deliberately includes in both the estimates and the projections series. The three affected entities are Cape Verde, Comoros and South Sudan.
- **None of the 36 city-size aggregates moved.**
- **The row count is unchanged**, at 9,020.

What gets blanked: three country-years for each capital indicator and three points for each top-100 indicator, all of them Luanda between 1995 and 2005; and 53 country-years across 8 countries for the largest-city shares.

`make check` passes. All CI checks pass. The one downstream consumer, `garden/urbanization/2026-03-02/sdg_11_2_1`, rebuilds with no differences — it reads the unfiltered `ghsl_urban_centers_raw` table, which this PR extends with the rating column rather than filtering.

## Known limitations we are choosing to accept

These are deliberate decisions, not oversights. Each one is a number we know is imperfect and are publishing anyway.

**Angola's largest-city share stays wrong from 1985 to 2000.** In those four years the JRC rates Uíge "moderate" rather than "low", so our filter leaves it in place. Angola's share of urban population in its largest city will read 16.4% for 1985, 13.6% for 1990, 11.0% for 1995 and 8.7% for 2000, and all four of those numbers describe Uíge rather than Luanda. We are deferring to the producer's own rating rather than substituting our own judgment about which figures are trustworthy. Fixing it would require either a hand-maintained list of country-year exceptions or a rule of our own invention, and we have decided against both for now.

**Angola appears to cross the one-million-person-city threshold about twenty years early.** This affects `pop_citysize_above_1m`, `popshare_citysize_above_1m` and `totalshare_citysize_above_1m`. It follows directly from leaving aggregates alone: the phantom Uíge is over a million people from 1975, so Angola enters that bucket in 1975 rather than in the mid-1990s. About 0.4% of the 1975 world total for that bucket is this phantom.

**`popshare_citysize_above_300k_growth` shows a spurious swing for Angola.** Taking a difference between years amplifies the point where Uíge hands over to Luanda into a growth spike that never happened.

No caveat text has been added to those four indicators, and none is planned. Their descriptions already explain that the figures are sums over every city in a country and that data quality varies where census data is sparse.

## Still open

**Handed off — waiting on a person**

- **Reporting this defect to the JRC**, at `JRC-GHSL-DATA@EC.EUROPA.EU`. It has survived two releases and affects at least six countries. Nobody has written to them yet, and no draft has been prepared.

**Unverified — nobody has checked**

- **No charts have been looked at on staging.** `staging-site-data-drop-city-values` is built and green, so this is available to anyone who wants to do it.
- **Audit coverage is partial.** Only the top 100 cities, and the countries that affect the largest-city indicator, were examined systematically. 1,134 settlements carry a low rating somewhere in the file, and most of them have not been looked at beyond a handful spotted in Iran, Sudan and China.
- **Other capitals may be missing from the source file.** Praia is absent entirely. Nobody has checked whether others are too.
- **The companion `ghsl_countries` file has never been checked** for the same Angola distortion. It is a separate JRC file and may or may not carry it.

