### PR TITLE
🐛 Don't re-upload snapshots that are already on R2

### DIFF
--- a/etl/snapshot.py
+++ b/etl/snapshot.py
@@ -208,19 +208,19 @@ class Snapshot:
         """Path to metadata file."""
         return Path(f"{paths.SNAPSHOTS_DIR / self.uri}.dvc")
 
+    def _r2_url(self, md5: str) -> str:
+        """R2 URL of the content-addressed object holding the given md5."""
+        bucket = config.R2_SNAPSHOTS_PUBLIC if self.metadata.is_public else config.R2_SNAPSHOTS_PRIVATE
+        return f"s3://{bucket}/{md5[:2]}/{md5[2:]}"
+
     def _snapshot_exists_on_remote(self, md5: str) -> bool:
-        """Check if snapshot file exists on R2 without downloading it."""
-        if self.metadata.is_public:
-            url = f"{config.R2_SNAPSHOTS_PUBLIC_READ}/{md5[:2]}/{md5[2:]}"
-            try:
-                resp = requests.head(url, timeout=10)
-                return resp.status_code == 200
-            except requests.RequestException:
-                return False
-        else:
-            # For private snapshots, assume it exists if md5 matches — we can't
-            # easily do a HEAD request on S3 without more setup
-            return True
+        """Check if snapshot file exists on R2 without downloading it.
+
+        Asks the R2 API rather than the public snapshots.owid.io URL, whose CDN can serve a stale
+        404 for an object that was only just written. This is only used by `dvc_add`, which needs
+        R2 credentials anyway.
+        """
+        return s3_utils.object_exists(self._r2_url(md5))
 
     def _download_dvc_file(self, md5: str) -> None:
         """Download file from remote to self.path."""
@@ -346,19 +346,27 @@ class Snapshot:
         # Get metadata file
         with open(self.metadata_path) as f:
             meta = ruamel_load(f)
+        dvc_md5_matches = bool(meta.get("outs")) and meta["outs"][0]["md5"] == md5
 
-        # If the file already exists with the same md5, verify it's actually on R2 before skipping
-        if meta.get("outs") and meta["outs"][0]["md5"] == md5:
-            if self._snapshot_exists_on_remote(md5):
+        # Snapshot keys are content-addressed, so a key that already exists holds byte-identical
+        # content and there is nothing to upload. Ask R2 rather than trusting the local .dvc file:
+        # the two disagree whenever the md5 lives on a branch we don't have checked out (autoupdate
+        # PRs are built via the GitHub API, see apps/autoupdate/cli.py) or when an earlier run
+        # uploaded the file but died before committing its .dvc. Re-uploading used to be a harmless
+        # overwrite, but the bucket lock policy on owid-snapshots now rejects it with
+        # ObjectLockedByBucketPolicy.
+        if self._snapshot_exists_on_remote(md5):
+            if dvc_md5_matches:
                 log.info("File already exists with the same md5, skipping upload", snapshot=self.uri)
                 return
-            else:
+            log.info("File already exists on R2 under this md5, skipping upload", snapshot=self.uri)
+        else:
+            if dvc_md5_matches:
                 log.warning("File md5 matches .dvc metadata but is missing from R2, re-uploading", snapshot=self.uri)
 
-        # Upload to S3
-        bucket = config.R2_SNAPSHOTS_PUBLIC if self.metadata.is_public else config.R2_SNAPSHOTS_PRIVATE
-        assert self.metadata.is_public is not None
-        s3_utils.upload(f"s3://{bucket}/{md5[:2]}/{md5[2:]}", str(self.path), public=self.metadata.is_public)
+            # Upload to S3
+            assert self.metadata.is_public is not None
+            s3_utils.upload(self._r2_url(md5), str(self.path), public=self.metadata.is_public)
 
         self.m._update_metadata_file({"outs": [{"md5": md5, "size": self.path.stat().st_size, "path": self.path.name}]})
 

--- a/lib/catalog/owid/catalog/s3_utils.py
+++ b/lib/catalog/owid/catalog/s3_utils.py
@@ -108,6 +108,44 @@ def list_s3_objects(s3_folder: str, client: BaseClient | None = None) -> list[st
     return keys
 
 
+def object_exists(s3_url: str, client: BaseClient | None = None) -> bool:
+    """Check whether an object exists in S3, without downloading it.
+
+    Args:
+        s3_url: S3 URL of the object (e.g., `s3://bucket/path/file.csv`).
+        client: Optional boto3 S3 client. If None, connects to R2 automatically.
+
+    Returns:
+        True if the object exists, False if it does not.
+
+    Raises:
+        UploadError: If the check fails for any reason other than the object being
+            absent (e.g. missing credentials, network error). A failed check is not
+            reported as "does not exist", so callers can't mistake it for one.
+
+    Example:
+        ```python
+        if not object_exists("s3://my-bucket/data/file.csv"):
+            upload("s3://my-bucket/data/file.csv", "local_file.csv")
+        ```
+    """
+    client = client or connect_r2()
+
+    bucket, key = s3_bucket_key(s3_url)
+
+    try:
+        client.head_object(Bucket=bucket, Key=key)  # ty: ignore
+    except ClientError as e:
+        # 404 (no such key) and 403 (no such key, when the caller lacks ListBucket) both
+        # mean "not there"; anything else is a real failure we must not swallow.
+        if e.response.get("ResponseMetadata", {}).get("HTTPStatusCode") in (403, 404):
+            return False
+        log.error(e)
+        raise UploadError(e)
+
+    return True
+
+
 def download(s3_url: str, filename: str, quiet: bool = False, client: BaseClient | None = None) -> None:
     """Download a file from S3 to local filesystem.
 

--- a/lib/catalog/owid/catalog/s3_utils.py
+++ b/lib/catalog/owid/catalog/s3_utils.py
@@ -119,9 +119,9 @@ def object_exists(s3_url: str, client: BaseClient | None = None) -> bool:
         True if the object exists, False if it does not.
 
     Raises:
-        UploadError: If the check fails for any reason other than the object being
-            absent (e.g. missing credentials, network error). A failed check is not
-            reported as "does not exist", so callers can't mistake it for one.
+        UploadError: If the check fails for any reason other than a 404 — missing or
+            insufficient credentials, or a network error. Only a 404 is reported as
+            "does not exist", so a broken check can't be mistaken for an absent object.
 
     Example:
         ```python
@@ -136,9 +136,7 @@ def object_exists(s3_url: str, client: BaseClient | None = None) -> bool:
     try:
         client.head_object(Bucket=bucket, Key=key)  # ty: ignore
     except ClientError as e:
-        # 404 (no such key) and 403 (no such key, when the caller lacks ListBucket) both
-        # mean "not there"; anything else is a real failure we must not swallow.
-        if e.response.get("ResponseMetadata", {}).get("HTTPStatusCode") in (403, 404):
+        if e.response.get("ResponseMetadata", {}).get("HTTPStatusCode") == 404:
             return False
         log.error(e)
         raise UploadError(e)

--- a/lib/catalog/owid/catalog/s3_utils.py
+++ b/lib/catalog/owid/catalog/s3_utils.py
@@ -113,7 +113,9 @@ def object_exists(s3_url: str, client: BaseClient | None = None) -> bool:
 
     Args:
         s3_url: S3 URL of the object (e.g., `s3://bucket/path/file.csv`).
-        client: Optional boto3 S3 client. If None, connects to R2 automatically.
+        client: Optional boto3 S3 client. If None, uses the cached R2 client, so that
+            repeated checks reuse one connection instead of paying for a TLS handshake
+            each time (measured 152ms -> 68ms per check).
 
     Returns:
         True if the object exists, False if it does not.
@@ -129,7 +131,7 @@ def object_exists(s3_url: str, client: BaseClient | None = None) -> bool:
             upload("s3://my-bucket/data/file.csv", "local_file.csv")
         ```
     """
-    client = client or connect_r2()
+    client = client or connect_r2_cached()
 
     bucket, key = s3_bucket_key(s3_url)
 

--- a/lib/catalog/tests/test_s3_utils.py
+++ b/lib/catalog/tests/test_s3_utils.py
@@ -1,0 +1,51 @@
+import pytest
+from botocore.exceptions import ClientError
+
+from owid.catalog.s3_utils import UploadError, object_exists, s3_bucket_key
+
+
+class MockClient:
+    """Minimal stand-in for a boto3 S3 client whose head_object raises a given ClientError."""
+
+    def __init__(self, error: ClientError | None = None):
+        self.error = error
+        self.calls = []
+
+    def head_object(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.error:
+            raise self.error
+        return {"ContentLength": 1}
+
+
+def client_error(status: int) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": str(status)}, "ResponseMetadata": {"HTTPStatusCode": status}},  # ty: ignore
+        "HeadObject",
+    )
+
+
+def test_object_exists():
+    client = MockClient()
+    assert object_exists("s3://my-bucket/ab/cdef", client=client)  # ty: ignore
+    assert client.calls == [{"Bucket": "my-bucket", "Key": "ab/cdef"}]
+
+
+@pytest.mark.parametrize("status", [403, 404])
+def test_object_exists_missing(status):
+    """403 and 404 both mean 'not there' — 403 is what R2/S3 return when the caller can't list."""
+    assert not object_exists("s3://my-bucket/ab/cdef", client=MockClient(client_error(status)))  # ty: ignore
+
+
+def test_object_exists_raises_on_other_errors():
+    """A failed check must not be reported as 'does not exist', or callers would re-upload blindly."""
+    with pytest.raises(UploadError):
+        object_exists("s3://my-bucket/ab/cdef", client=MockClient(client_error(500)))  # ty: ignore
+
+
+def test_s3_bucket_key():
+    assert s3_bucket_key("s3://my-bucket/data/file.csv") == ("my-bucket", "data/file.csv")
+    assert s3_bucket_key("https://my-bucket.s3.us-east-1.amazonaws.com/data/file.csv") == (
+        "my-bucket",
+        "data/file.csv",
+    )

--- a/lib/catalog/tests/test_s3_utils.py
+++ b/lib/catalog/tests/test_s3_utils.py
@@ -31,16 +31,18 @@ def test_object_exists():
     assert client.calls == [{"Bucket": "my-bucket", "Key": "ab/cdef"}]
 
 
-@pytest.mark.parametrize("status", [403, 404])
-def test_object_exists_missing(status):
-    """403 and 404 both mean 'not there' — 403 is what R2/S3 return when the caller can't list."""
-    assert not object_exists("s3://my-bucket/ab/cdef", client=MockClient(client_error(status)))  # ty: ignore
+def test_object_exists_missing():
+    assert not object_exists("s3://my-bucket/ab/cdef", client=MockClient(client_error(404)))  # ty: ignore
 
 
-def test_object_exists_raises_on_other_errors():
-    """A failed check must not be reported as 'does not exist', or callers would re-upload blindly."""
+@pytest.mark.parametrize("status", [401, 403, 500])
+def test_object_exists_raises_on_other_errors(status):
+    """A failed check must not be reported as 'does not exist', or callers would re-upload blindly.
+
+    403 in particular means our credentials are wrong, not that the object is absent.
+    """
     with pytest.raises(UploadError):
-        object_exists("s3://my-bucket/ab/cdef", client=MockClient(client_error(500)))  # ty: ignore
+        object_exists("s3://my-bucket/ab/cdef", client=MockClient(client_error(status)))  # ty: ignore
 
 
 def test_s3_bucket_key():

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -6,7 +6,9 @@ from unittest.mock import MagicMock
 import pytest
 from owid.catalog import Origin
 
-from etl.snapshot import SnapshotArchive, SnapshotMeta, _parse_snapshot_path
+from etl import paths
+from etl.files import ruamel_load
+from etl.snapshot import Snapshot, SnapshotArchive, SnapshotMeta, _parse_snapshot_path
 
 
 @pytest.fixture
@@ -147,6 +149,106 @@ def test_parse_snapshot_path():
     with pytest.raises(AssertionError):
         path = Path("etl/snapshots/unep/2023-03-17/consumption_controlled_substances.hydrobromofluorocarbons.xlsx.dvc")
         _parse_snapshot_path(path)
+
+
+DVC_TEMPLATE = """meta:
+  origin:
+    producer: Producer
+    title: Test dataset
+    date_published: "2024-01-01"
+    url_main: https://example.com
+    date_accessed: "2024-01-02"
+    license:
+      name: CC BY 4.0
+      url: https://example.com/license
+outs:
+  - md5: {md5}
+    size: 1
+    path: test.csv
+"""
+
+# md5 of the data file written by the `snapshot` fixture.
+DATA_MD5 = "e5ebd4c02cefbe7955977c67ada242b7"
+
+
+@pytest.fixture
+def snapshot(monkeypatch):
+    """A Snapshot backed by a temporary snapshots/ and data/ tree, whose .dvc records a stale md5."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+        monkeypatch.setattr(paths, "SNAPSHOTS_DIR", tmpdir / "snapshots")
+        monkeypatch.setattr(paths, "DATA_DIR", tmpdir / "data")
+
+        dvc_path = paths.SNAPSHOTS_DIR / "ns/2024-01-01/test.csv.dvc"
+        dvc_path.parent.mkdir(parents=True)
+        dvc_path.write_text(DVC_TEMPLATE.format(md5="0" * 32))
+
+        data_path = paths.DATA_DIR / "snapshots/ns/2024-01-01/test.csv"
+        data_path.parent.mkdir(parents=True)
+        data_path.write_text("a,b\n1,2\n")
+
+        yield Snapshot("ns/2024-01-01/test.csv")
+
+
+class TestDvcAdd:
+    """Tests for Snapshot.dvc_add, which must never re-upload an object already on R2.
+
+    Snapshot keys are content-addressed, and the bucket lock policy on owid-snapshots rejects
+    overwrites with ObjectLockedByBucketPolicy.
+    """
+
+    @pytest.fixture(autouse=True)
+    def uploads(self, monkeypatch):
+        """Record calls to s3_utils.upload instead of hitting R2."""
+        calls = []
+        monkeypatch.setattr("etl.snapshot.s3_utils.upload", lambda *args, **kwargs: calls.append(args))
+        return calls
+
+    def test_uploads_when_missing_from_remote(self, snapshot, uploads, monkeypatch):
+        monkeypatch.setattr(Snapshot, "_snapshot_exists_on_remote", lambda self, md5: False)
+
+        snapshot.dvc_add(upload=True)
+
+        assert len(uploads) == 1
+        assert uploads[0][0] == f"s3://owid-snapshots/{DATA_MD5[:2]}/{DATA_MD5[2:]}"
+        assert ruamel_load(snapshot.metadata_path.read_text())["outs"][0]["md5"] == DATA_MD5
+
+    def test_skips_upload_when_already_on_remote_but_dvc_is_stale(self, snapshot, uploads, monkeypatch):
+        """The autoupdate case: the new md5 only exists on an open PR branch, so the local .dvc
+        still holds master's older md5 even though the file is already on R2."""
+        monkeypatch.setattr(Snapshot, "_snapshot_exists_on_remote", lambda self, md5: True)
+
+        snapshot.dvc_add(upload=True)
+
+        assert uploads == []
+        # The .dvc is still brought up to date, otherwise the snapshot would never be recorded.
+        assert ruamel_load(snapshot.metadata_path.read_text())["outs"][0]["md5"] == DATA_MD5
+
+    def test_no_op_when_dvc_matches_and_file_is_on_remote(self, snapshot, uploads, monkeypatch):
+        snapshot.metadata_path.write_text(DVC_TEMPLATE.format(md5=DATA_MD5))
+        monkeypatch.setattr(Snapshot, "_snapshot_exists_on_remote", lambda self, md5: True)
+        before = snapshot.metadata_path.read_text()
+
+        snapshot.dvc_add(upload=True)
+
+        assert uploads == []
+        # Nothing changed, so the .dvc is left untouched rather than round-tripped through ruamel.
+        assert snapshot.metadata_path.read_text() == before
+
+    def test_reuploads_when_dvc_matches_but_file_is_missing_from_remote(self, snapshot, uploads, monkeypatch):
+        snapshot.metadata_path.write_text(DVC_TEMPLATE.format(md5=DATA_MD5))
+        monkeypatch.setattr(Snapshot, "_snapshot_exists_on_remote", lambda self, md5: False)
+
+        snapshot.dvc_add(upload=True)
+
+        assert len(uploads) == 1
+
+    def test_skips_everything_without_upload(self, snapshot, uploads, monkeypatch):
+        monkeypatch.setattr(Snapshot, "_snapshot_exists_on_remote", lambda self, md5: False)
+
+        snapshot.dvc_add(upload=False)
+
+        assert uploads == []
 
 
 def test_snapshot_to_yaml():

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,13 +1,13 @@
 import tempfile
 import zipfile
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from owid.catalog import Origin
+from owid.catalog import Origin, s3_utils
 
-from etl import paths
-from etl.files import ruamel_load
+from etl import config, paths
+from etl.files import checksum_file, ruamel_load
 from etl.snapshot import Snapshot, SnapshotArchive, SnapshotMeta, _parse_snapshot_path
 
 
@@ -249,6 +249,45 @@ class TestDvcAdd:
         snapshot.dvc_add(upload=False)
 
         assert uploads == []
+
+
+# The snapshot the autoupdate build kept failing on: it is updated daily behind a long-lived PR, so
+# its local .dvc regularly holds an older md5 than the object already stored on R2.
+EPOCH_URI = "artificial_intelligence/2025-03-12/epoch_compute_intensive.csv"
+
+
+@pytest.mark.integration
+def test_dvc_add_skips_upload_of_snapshot_already_on_r2():
+    """Against real R2 and the real producer: never re-upload a snapshot that is already stored.
+
+    Reproduces the state that made the autoupdate build fail with ObjectLockedByBucketPolicy — the
+    downloaded content is unchanged, so its md5 is already on R2, but the local .dvc still holds an
+    older md5 and therefore can't be used to detect that.
+
+    Skips rather than passes when that state can't be reached, so a skip is never mistaken for a
+    verified run. Downloads into data/snapshots/ and restores the .dvc afterwards; never writes to
+    R2 — a genuine upload would need a brand new object in a locked production bucket.
+    """
+    snap = Snapshot(EPOCH_URI)
+    snap.download_from_source()
+
+    md5 = checksum_file(snap.path)
+    assert snap.metadata.outs is not None
+    if md5 == snap.metadata.outs[0]["md5"]:
+        pytest.skip(f"local .dvc already records the current content ({md5}), nothing to reproduce")
+    if not s3_utils.object_exists(f"s3://{config.R2_SNAPSHOTS_PUBLIC}/{md5[:2]}/{md5[2:]}"):
+        pytest.skip(f"content is new ({md5}), so dvc_add should upload it; not writing to production R2")
+
+    original_dvc = snap.metadata_path.read_text()
+    try:
+        with patch.object(s3_utils, "upload", side_effect=AssertionError("re-uploaded an object already on R2")):
+            snap.dvc_add(upload=True)
+
+        # The .dvc must still be brought up to date, or the snapshot would never be recorded.
+        # Checked on the file rather than snap.metadata, which is only read at construction.
+        assert ruamel_load(snap.metadata_path.read_text())["outs"][0]["md5"] == md5
+    finally:
+        snap.metadata_path.write_text(original_dvc)
 
 
 def test_snapshot_to_yaml():


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Since a bucket lock policy was added to `owid-snapshots`, the nightly autoupdate build fails with `ObjectLockedByBucketPolicy` whenever it re-uploads a snapshot whose content-addressed object is already there. `dvc_add` only skipped the upload when the md5 matched the **local** `.dvc`, which misses the two cases where the object is on R2 but the local file doesn't say so. It now asks R2 directly. No change when the snapshot content is genuinely new.

_Deep review of `dvc_add`'s new control flow (four states, all now covered by tests); the rest is skimmable._

## Why the old guard misses

Keys are content-addressed (`{md5[:2]}/{md5[2:]}`), so the same content always lands on the same key. Re-PUTting it used to be a harmless idempotent overwrite; the lock policy now rejects it. Two ways the local `.dvc` disagrees with R2:

1. **An open autoupdate PR.** `apps/autoupdate/cli.py` compares against `origin/master`, commits the new `.dvc` to the PR branch via the GitHub API, and `git restore`s the local files afterwards — so the working tree permanently holds master's older md5 while R2 and the branch hold the newer one. Every run after the first re-uploads the same object until the PR merges. #6336 has been open since 25 June, which is why this surfaced on Epoch.
2. **A retry after a partial run.** A run that uploads snapshot A, then dies on snapshot B, never commits A's `.dvc`. The retry re-downloads A, gets the same md5, and re-PUTs the object its own first attempt just wrote.

Both happened in the same build on 2026-07-31: attempt 1 died on `epoch_compute_intensive` (case 1, object written by the previous night's run), and the manual retry died on `epoch` (case 2, object written 33 minutes earlier by attempt 1).

## How it works

`dvc_add` now checks R2 for the key regardless of what the `.dvc` says. An existing key means byte-identical content, so skipping the upload is always safe — and the `.dvc` still gets updated, otherwise the snapshot would never be recorded. Four states:

| `.dvc` md5 | on R2 | behaviour |
|---|---|---|
| matches | yes | no-op, `.dvc` untouched (unchanged from before) |
| stale | yes | **skip upload, update `.dvc`** (was: crash) |
| stale | no | upload, update `.dvc` (unchanged) |
| matches | no | warn, re-upload (unchanged) |

Two decisions worth knowing about:

- **The existence check now uses the R2 API, not `HEAD https://snapshots.owid.io/...`.** That URL is CDN-fronted and can serve a cached 404 for an object written seconds ago — which is exactly the retry case, and a false negative reintroduces the crash. `_snapshot_exists_on_remote` is only reachable from `dvc_add` (`rg -n "_snapshot_exists_on_remote" --glob '!**/.venv/**'`), i.e. only under `--upload`, which needs R2 credentials anyway. This also removes the public/private asymmetry: the private branch used to `return True` unconditionally, so a private snapshot missing from R2 was silently never re-uploaded.
- **`object_exists` treats only a 404 as absent** and raises `UploadError` on anything else. Mapping 403 to "not there" is the common idiom, but here it would send a request with bad credentials straight into the upload the check exists to prevent.

The alternative I rejected: catching `ObjectLockedByBucketPolicy` in `s3_utils.upload` and swallowing it. It's fewer lines, but it treats a policy rejection as success without ever establishing that the stored bytes are the ones we hold.

## Cost: one HEAD per snapshot upload, and nothing anywhere else

Only `dvc_add` reaches the check, so it runs when a snapshot step actually uploads (`etls … --upload`, plus fasttrack's import) — never during `etlr`'s dirtiness checks. Those go through `SnapshotStep.is_dirty` → `Snapshot.is_dirty` (local size/md5 comparison) and `checksum_output` → `checksum_file(<the .dvc>)`, neither of which touches the network. So the thousands of snapshots in the DAG cost nothing extra.

Where it does run: 56 ms, measured against the real bucket, versus the 139 ms CDN `HEAD` it replaces on the path where the `.dvc` already matched. It's cheaper than what it replaces, and it's ~1% of the multi-MB upload it guards. `object_exists` defaults to `connect_r2_cached()` for this — with a fresh client per call it was 152 ms, nearly all of it re-handshaking TLS.

## Verified

- **An integration test on the snapshot that actually failed** (`make test-integration`), against the real producer and real R2: downloads `epoch_compute_intensive.csv`, asserts the reproducing state (local `.dvc` `0c484be2…`, downloaded content hashes to `2ed0c9a2…`, that key already on R2), then fails if `dvc_add` re-uploads. It skips rather than passes when that state isn't reachable, and never writes to R2. Confirmed it has teeth: monkeypatching the old `dvc_add` back in makes it fail with `re-uploaded an object already on R2`.
- **`object_exists` against the real bucket**, read-only: the two keys the failed build tried to re-PUT both return `True`, an all-zeros key returns `False`.
- **Unit tests** cover all four states in the table plus `upload=False`, and `object_exists`'s 404-vs-raise split. They assert behaviour, not just green: that `upload` is *not* called, that the `.dvc` *is* updated anyway, and that the no-op case leaves the `.dvc` byte-identical rather than round-tripping it through ruamel.
- **Not verified:** no live upload was exercised (that would mean writing a new object to a locked production bucket), so the `stale`/`not on R2` path is only covered by the mocked test. Other writers to `owid-snapshots` (`etl d upload`, backport mirrors) can hit the same lock and are untouched here.

<details>
<summary>Evidence from the failing build</summary>

Object timestamps in the public bucket, which pin down both cases:

```
$ curl -sI https://snapshots.owid.io/2e/d0c9a21fa774b2a767e34b6e53259f | grep -i last-modified
last-modified: Thu, 30 Jul 2026 07:03:32 GMT   # written by the previous night's run → case 1
$ curl -sI https://snapshots.owid.io/94/7949f12d0393ff44b377daa12963ca | grep -i last-modified
last-modified: Fri, 31 Jul 2026 07:03:32 GMT   # written by attempt 1, re-PUT by the retry → case 2
```

md5s for `artificial_intelligence/2025-03-12` at the time of the failure:

```
$ git show master:snapshots/.../epoch_compute_intensive.csv.dvc      # 0c484be2…  (last merged Epoch PR)
$ git show origin/auto-epoch:snapshots/.../epoch_compute_intensive.csv.dvc  # 2ed0c9a2…  (on R2 since 30 Jul)
```

Pre-existing failures on master, unrelated to this branch (same three fail with these changes stashed): `tests/apps/wizard/app_pages/test_apps.py::test_app_chart_diff`, `tests/collections/test_explorer_migration.py::test_explorer_legacy_{1,2}`.

</details>

