### PR TITLE
🐛 pr-clean: skip dirty worktrees before mutating anything

### DIFF
--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -87,7 +87,7 @@ from typing import cast
 import click
 import questionary
 import requests
-from git import GitCommandError, InvalidGitRepositoryError, Repo
+from git import GitCommandError, InvalidGitRepositoryError, NoSuchPathError, Repo
 from rich_click.rich_command import RichCommand
 from structlog import get_logger
 
@@ -918,7 +918,16 @@ def worktree_blocking_changes(worktree_path: Path) -> list[str]:
     clean_branch unlinks them itself right before removal, since their real content lives in the
     main repo.
     """
-    lines = Repo(worktree_path).git.status("--porcelain").splitlines()
+    if not worktree_path.exists():
+        # Registered but manually deleted (git lists it as prunable): nothing can block —
+        # `git worktree remove` on it simply prunes the stale registration.
+        return []
+    try:
+        lines = Repo(worktree_path).git.status("--porcelain").splitlines()
+    except (InvalidGitRepositoryError, NoSuchPathError, GitCommandError) as e:
+        # The directory exists but git can't read it as a worktree. Its state is unknowable, so
+        # report it as blocking: clean_branch then skips it untouched instead of half-mutating it.
+        return [f"(unreadable worktree: {e})"]
     share_data_links = {name for name in ("data", *SHARED_SCRATCH_DIRS) if (worktree_path / name).is_symlink()}
     return [line for line in lines if line[3:] not in share_data_links]
 

--- a/apps/pr/cli.py
+++ b/apps/pr/cli.py
@@ -762,17 +762,23 @@ Lists every local branch whose latest GitHub PR is **merged** or **closed** (usi
 state, not `git branch --merged`, so squash-merges are detected). Branches that have a git worktree
 are flagged with `<- worktree`. Pick a single branch, or `all`, and the tool will:
 
-1. (Worktree branches only) Copy that worktree's Claude sessions — the `<uuid>.jsonl` transcripts and
+1. (Worktree branches only) Check the worktree for uncommitted changes that would block
+   `git worktree remove` — modified tracked files or untracked files, not counting `--share-data`'s
+   symlinks, which are handled in step 4. A dirty worktree is skipped with a warning *before
+   anything is copied or modified*, so the worktree stays fully intact; commit/discard the changes
+   (or `git worktree remove --force` it) and re-run. Dirty worktrees are flagged `(dirty)` in the
+   selection list.
+2. (Worktree branches only) Copy that worktree's Claude sessions — the `<uuid>.jsonl` transcripts and
    their `<uuid>/` subfolders under `~/.claude/projects/<encoded-worktree-path>/` — into the main
    repo's project dir, so they stay resumable with `claude --resume` after the worktree is gone.
-2. (Worktree branches only) Copy the worktree's gitignored `workbench/` and `ai/` scratch dirs into
+3. (Worktree branches only) Copy the worktree's gitignored `workbench/` and `ai/` scratch dirs into
    `workbench/<branch>/` and `ai/<branch>/` in the main repo (suffixed `-1`, `-2`... on the rare name
    clash), so the working notes/outputs survive the worktree removal without overwriting anything.
    Skipped for a dir created by `--share-data` (it's a symlink to the main repo already — nothing to
    salvage).
-3. Remove the git worktree (skipped with a warning if it has uncommitted changes). `--share-data`'s
-   symlinks are unlinked first so they don't themselves block the removal.
-4. Delete the local branch.
+4. Remove the git worktree. `--share-data`'s symlinks are unlinked first so they don't themselves
+   block the removal.
+5. Delete the local branch.
 
 Each branch is tagged `[merged]` or `[closed]` so you can see its PR outcome before selecting.
 
@@ -837,10 +843,20 @@ def clean_cli() -> None:
         print("Nothing to clean: no local branch has a merged or closed PR.")
         return
 
+    # Flag worktrees with blocking uncommitted changes in the selection list, so the user knows
+    # before picking that those branches will be skipped (clean_branch re-checks before mutating).
+    dirty = {
+        b: bool(worktree_blocking_changes(worktrees[b]))
+        for b in cleanable
+        if b in worktrees and worktrees[b] != main_worktree_path
+    }
+
     # Build the selection list ('all' first, then one entry per branch).
     choices = [questionary.Choice(title="all", value="__all__")]
     for branch in sorted(cleanable):
-        choices.append(questionary.Choice(title=_branch_label(branch, cleanable[branch], worktrees), value=branch))
+        choices.append(
+            questionary.Choice(title=_branch_label(branch, cleanable[branch], worktrees, dirty), value=branch)
+        )
 
     selected = questionary.select(
         message="Select a branch to clean (or 'all')",
@@ -891,6 +907,22 @@ def list_worktrees(repo) -> dict[str, Path]:
     return result
 
 
+def worktree_blocking_changes(worktree_path: Path) -> list[str]:
+    """Return the `git status --porcelain` lines that would make `git worktree remove` refuse.
+
+    `git worktree remove` refuses when the worktree has modified tracked files or untracked files
+    (ignored files don't count — they're deleted along with the worktree, which is why clean_branch
+    salvages workbench/ and ai/ first). The `--share-data` symlinks (data/ and the scratch dirs) are
+    excluded defensively: today's .gitignore patterns happen to match them, so they don't show up as
+    untracked, but if the ignore rules ever stop covering them they still must not count as blocking —
+    clean_branch unlinks them itself right before removal, since their real content lives in the
+    main repo.
+    """
+    lines = Repo(worktree_path).git.status("--porcelain").splitlines()
+    share_data_links = {name for name in ("data", *SHARED_SCRATCH_DIRS) if (worktree_path / name).is_symlink()}
+    return [line for line in lines if line[3:] not in share_data_links]
+
+
 def fetch_pr_state(branch: str) -> str | None:
     """Return the GitHub PR state for a branch: 'open', 'merged', 'closed', or None.
 
@@ -920,11 +952,13 @@ def fetch_pr_state(branch: str) -> str | None:
     return "closed"
 
 
-def _branch_label(branch: str, state: str, worktrees: dict[str, Path]) -> str:
-    """Build the questionary label for a branch, e.g. 'data-foo  [merged]  <- worktree'."""
+def _branch_label(branch: str, state: str, worktrees: dict[str, Path], dirty: dict[str, bool]) -> str:
+    """Build the questionary label for a branch, e.g. 'data-foo  [merged]  <- worktree (dirty)'."""
     label = f"{branch}  [{state}]"
     if branch in worktrees:
         label += "  <- worktree"
+        if dirty.get(branch):
+            label += " (dirty)"
     return label
 
 
@@ -1006,6 +1040,22 @@ def clean_branch(
         return
 
     if worktree_path is not None:
+        # A dirty worktree must be skipped BEFORE any mutation. Otherwise the salvage copies below
+        # would land in the main repo (the workbench/ai copy is not idempotent — a re-run after the
+        # user cleans up would create suffixed '-1' duplicates) and the --share-data symlinks would
+        # be unlinked, leaving a worktree that still exists but is missing its data/ dir.
+        blocking = worktree_blocking_changes(worktree_path)
+        if blocking:
+            details = "\n".join(f"    {line}" for line in blocking)
+            log.warning(
+                f"Skipping '{branch}': worktree '{worktree_path}' has uncommitted changes that would "
+                f"block `git worktree remove`:\n{details}\n"
+                f"  Nothing was copied or modified. Commit or discard the changes and re-run, or if "
+                f"they're disposable: git worktree remove --force '{worktree_path}'"
+            )
+            return
+
+    if worktree_path is not None:
         # Salvage anything the worktree holds but that's gitignored (so `git worktree remove` would
         # destroy it for good): the Claude sessions, plus the workbench/ and ai/ scratch dirs.
         # The session dir lives outside the worktree, but copy everything before removal on principle.
@@ -1018,23 +1068,23 @@ def clean_branch(
                 continue
             copy_dir_namespaced(src, main_worktree_path / name, branch)
 
-        # `git worktree remove` refuses a worktree with untracked files, and --share-data's
-        # symlinks (data/, workbench/, ai/) count as untracked. Unlink them ourselves first — safe,
-        # since their real content lives in the main repo, untouched — so only genuine leftover
-        # uncommitted/untracked work still blocks the plain removal below.
+        # Unlink --share-data's symlinks (data/, workbench/, ai/) before removal — safe, since
+        # their real content lives in the main repo, untouched. Defensive on two fronts: they must
+        # never block `git worktree remove` as untracked files (today's .gitignore happens to cover
+        # them, but that's incidental), and `git worktree remove` must never get a chance to
+        # traverse into the shared dirs they point to.
         for name in ("data", *SHARED_SCRATCH_DIRS):
             link = worktree_path / name
             if link.is_symlink():
                 link.unlink()
 
+        # Backstop only: dirty worktrees were already skipped above, but the removal can still fail
+        # (e.g. changes made between the check and now, or a submodule in the worktree).
         try:
             repo.git.worktree("remove", str(worktree_path))
             log.info(f"Removed worktree '{worktree_path}'.")
         except GitCommandError as e:
-            log.warning(
-                f"Could not remove worktree '{worktree_path}' (uncommitted changes?). "
-                f"Leaving branch '{branch}' in place.\n{e}"
-            )
+            log.warning(f"Could not remove worktree '{worktree_path}'. Leaving branch '{branch}' in place.\n{e}")
             return
 
     try:

--- a/tests/apps/test_pr_clean.py
+++ b/tests/apps/test_pr_clean.py
@@ -6,6 +6,7 @@ A dirty worktree must be skipped before anything is copied or modified: a failed
 under suffixed names.
 """
 
+import shutil
 from pathlib import Path
 
 import pytest
@@ -86,6 +87,39 @@ def test_blocking_changes_excludes_share_data_symlinks(repo_with_worktree, tmp_p
     blocking = worktree_blocking_changes(worktree_path)
     assert len(blocking) == 1
     assert "untracked.txt" in blocking[0]
+
+
+def test_blocking_changes_missing_worktree_dir(repo_with_worktree):
+    """A registered worktree whose directory was manually deleted must not crash the pre-scan."""
+    _, worktree_path = repo_with_worktree
+    shutil.rmtree(worktree_path)
+    assert worktree_blocking_changes(worktree_path) == []
+
+
+def test_blocking_changes_unreadable_worktree_counts_as_blocking(repo_with_worktree):
+    _, worktree_path = repo_with_worktree
+    (worktree_path / ".git").write_text("gitdir: /nonexistent/gitdir")
+    blocking = worktree_blocking_changes(worktree_path)
+    assert len(blocking) == 1
+    assert "unreadable worktree" in blocking[0]
+
+
+def test_clean_branch_cleans_manually_deleted_worktree(repo_with_worktree, tmp_path):
+    """`git worktree remove` on a prunable (deleted) worktree succeeds, so cleaning completes."""
+    repo, worktree_path = repo_with_worktree
+    main_path = Path(repo.working_tree_dir).resolve()  # ty: ignore
+    shutil.rmtree(worktree_path)
+
+    clean_branch(
+        repo=repo,
+        branch="feature",
+        worktree_path=worktree_path,
+        main_project_dir=tmp_path / "claude_projects",
+        main_worktree_path=main_path,
+    )
+
+    assert "feature" not in [b.name for b in repo.branches]
+    assert str(worktree_path) not in repo.git.worktree("list", "--porcelain")
 
 
 def test_clean_branch_skips_dirty_worktree_without_mutating(repo_with_worktree, tmp_path):

--- a/tests/apps/test_pr_clean.py
+++ b/tests/apps/test_pr_clean.py
@@ -1,0 +1,132 @@
+"""Tests for the worktree-cleaning logic of `etl pr-clean`.
+
+A dirty worktree must be skipped before anything is copied or modified: a failed
+`git worktree remove` after the salvage copies would leave the worktree stripped of its
+--share-data symlinks, and a later re-run would duplicate the salvaged workbench/ai dirs
+under suffixed names.
+"""
+
+from pathlib import Path
+
+import pytest
+from git import Repo
+
+from apps.pr.cli import clean_branch, worktree_blocking_changes
+
+
+def _commit_file(repo: Repo, name: str, content: str, message: str):
+    path = Path(repo.working_tree_dir) / name  # ty: ignore
+    path.write_text(content)
+    repo.index.add([str(path)])
+    return repo.index.commit(message)
+
+
+def _set_identity(repo: Repo) -> None:
+    with repo.config_writer() as config:
+        config.set_value("user", "name", "Test User")
+        config.set_value("user", "email", "test@example.com")
+
+
+@pytest.fixture
+def repo_with_worktree(tmp_path):
+    """A main repo plus a worktree checked out on branch 'feature'.
+
+    The .gitignore uses directory patterns (trailing slash), which match real dirs but NOT
+    symlinks — so a real workbench/ dir is ignored (and never blocks `git worktree remove`),
+    while a --share-data style symlink shows up as untracked, exercising the filter in
+    worktree_blocking_changes.
+    """
+    repo = Repo.init(tmp_path / "main", initial_branch="master")
+    _set_identity(repo)
+    gitignore = Path(repo.working_tree_dir) / ".gitignore"  # ty: ignore
+    gitignore.write_text("data/\nworkbench/\nai/\n")
+    repo.index.add([str(gitignore)])
+    _commit_file(repo, "a.txt", "1", "initial commit")
+    repo.git.branch("feature")
+    worktree_path = tmp_path / "wt"
+    repo.git.worktree("add", str(worktree_path), "feature")
+    return repo, worktree_path
+
+
+def _add_share_data_symlinks(worktree_path: Path, target: Path) -> None:
+    target.mkdir(exist_ok=True)
+    for name in ("data", "workbench", "ai"):
+        (worktree_path / name).symlink_to(target)
+
+
+def test_blocking_changes_clean_worktree(repo_with_worktree):
+    _, worktree_path = repo_with_worktree
+    assert worktree_blocking_changes(worktree_path) == []
+
+
+def test_blocking_changes_modified_tracked_file(repo_with_worktree):
+    _, worktree_path = repo_with_worktree
+    (worktree_path / "a.txt").write_text("edited")
+    blocking = worktree_blocking_changes(worktree_path)
+    assert len(blocking) == 1
+    assert "a.txt" in blocking[0]
+
+
+def test_blocking_changes_untracked_file(repo_with_worktree):
+    _, worktree_path = repo_with_worktree
+    (worktree_path / "untracked.txt").write_text("new")
+    blocking = worktree_blocking_changes(worktree_path)
+    assert len(blocking) == 1
+    assert "untracked.txt" in blocking[0]
+
+
+def test_blocking_changes_excludes_share_data_symlinks(repo_with_worktree, tmp_path):
+    _, worktree_path = repo_with_worktree
+    _add_share_data_symlinks(worktree_path, tmp_path / "shared")
+    # The symlinks are untracked (the dir-only ignore patterns don't match them), yet excluded.
+    assert "?? data" in Repo(worktree_path).git.status("--porcelain")
+    assert worktree_blocking_changes(worktree_path) == []
+    # A real untracked file alongside them still counts.
+    (worktree_path / "untracked.txt").write_text("new")
+    blocking = worktree_blocking_changes(worktree_path)
+    assert len(blocking) == 1
+    assert "untracked.txt" in blocking[0]
+
+
+def test_clean_branch_skips_dirty_worktree_without_mutating(repo_with_worktree, tmp_path):
+    repo, worktree_path = repo_with_worktree
+    main_path = Path(repo.working_tree_dir).resolve()  # ty: ignore
+    _add_share_data_symlinks(worktree_path, tmp_path / "shared")
+    workbench = worktree_path / "workbench_real"
+    (worktree_path / "a.txt").write_text("uncommitted edit")
+
+    clean_branch(
+        repo=repo,
+        branch="feature",
+        worktree_path=worktree_path,
+        main_project_dir=tmp_path / "claude_projects",
+        main_worktree_path=main_path,
+    )
+
+    # Nothing was touched: worktree and branch still exist, symlinks intact, nothing salvaged.
+    assert worktree_path.exists()
+    assert "feature" in [b.name for b in repo.branches]
+    assert (worktree_path / "data").is_symlink()
+    assert not (main_path / "workbench" / "feature").exists()
+    assert not workbench.exists()  # sanity: the dirty test never created a real workbench
+
+
+def test_clean_branch_removes_clean_worktree_and_salvages_scratch_dirs(repo_with_worktree, tmp_path):
+    repo, worktree_path = repo_with_worktree
+    main_path = Path(repo.working_tree_dir).resolve()  # ty: ignore
+    (worktree_path / "data").symlink_to(tmp_path / "shared")
+    workbench = worktree_path / "workbench"
+    workbench.mkdir()
+    (workbench / "notes.txt").write_text("keep me")
+
+    clean_branch(
+        repo=repo,
+        branch="feature",
+        worktree_path=worktree_path,
+        main_project_dir=tmp_path / "claude_projects",
+        main_worktree_path=main_path,
+    )
+
+    assert not worktree_path.exists()
+    assert "feature" not in [b.name for b in repo.branches]
+    assert (main_path / "workbench" / "feature" / "notes.txt").read_text() == "keep me"


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

## Problem

When `etl pr-clean` hit a worktree with uncommitted changes, it only found out at the very end, when `git worktree remove` refused. By then it had already mutated things:

1. It had copied the worktree's `workbench/` and `ai/` dirs into the main repo. That copy is not idempotent: a re-run after cleaning up the worktree creates suffixed duplicates (`workbench/<branch>-1`).
2. It had unlinked the `--share-data` symlinks (`data/`, `workbench/`, `ai/`) inside the worktree, so the worktree that was left behind was missing its data dir and no longer fully functional.

## Fix

`clean_branch` now checks the worktree for blocking changes **before doing anything**. A new helper, `worktree_blocking_changes`, returns the `git status --porcelain` lines that would make `git worktree remove` refuse, excluding the `--share-data` symlinks (they are unlinked by `clean_branch` itself right before removal, so they must never count as blocking). If anything remains, the branch is skipped with a warning listing the offending files and how to proceed, and the worktree is left fully intact.

Dirty worktrees are also flagged as `<- worktree (dirty)` in the selection list, so you know before picking that they will be skipped.

While testing this I found that the existing comment claiming the `--share-data` symlinks "count as untracked and block removal" is not true today (the `.gitignore` patterns match symlinks too), so the unlink step is defensive rather than load-bearing. I verified this empirically and updated the comments accordingly; the exclusion in the new helper keeps that same defensive posture in case the ignore rules ever change.

## Tests

New `tests/apps/test_pr_clean.py` with temp git repos and real worktrees, covering: clean worktree, modified tracked file, untracked file, symlink exclusion, the skip-without-mutation path (worktree, symlinks, and branch all left untouched), and the happy path (worktree removed, branch deleted, scratch dirs salvaged).

## Open items

- **Unverified**: the interactive flow (questionary selection with the new `(dirty)` tag) was not exercised end to end, only the underlying functions are unit-tested.
