### PR TITLE
🐛🤖 Include dataset-level fields in the indicator metadata checksum

### DIFF
--- a/etl/grapher/to_db.py
+++ b/etl/grapher/to_db.py
@@ -45,6 +45,30 @@ CURRENT_DIR = os.path.dirname(__file__)
 @dataclass
 class DatasetUpsertResult:
     dataset_id: int
+    # Dataset-level fields that end up in every indicator's metadata JSON (see
+    # `_dataset_metadata_fields`). They take part in the metadata checksum, so that editing one
+    # of them re-uploads the affected files.
+    metadata_fields: dict[str, Any]
+
+
+def _dataset_metadata_fields(ds: gm.Dataset) -> dict[str, Any]:
+    """Dataset-level fields that `_load_variable` joins into every indicator's metadata JSON.
+
+    Kept in sync with the SELECT in `apps/backport/datasync/data_metadata.py`. `sourceName` and
+    `sourceDescription` are deliberately left out: ETL upserts variables with `sourceId=None`, so
+    the legacy `sources` join only ever contributes to backported datasets.
+
+    None values are dropped, mirroring `_omit_nullable_values` before upload - a field that is
+    null (and therefore absent from the JSON) must not take part in the hash, otherwise adding a
+    field here would flip the checksum of every variable that doesn't set it.
+    """
+    fields = {
+        "datasetName": ds.name,
+        "datasetVersion": ds.version,
+        "updatePeriodDays": ds.updatePeriodDays,
+        "nonRedistributable": bool(ds.nonRedistributable),
+    }
+    return {k: v for k, v in fields.items() if v is not None}
 
 
 def upsert_dataset(engine: Engine, dataset: catalog.Dataset, namespace: str) -> DatasetUpsertResult:
@@ -97,7 +121,7 @@ def upsert_dataset(engine: Engine, dataset: catalog.Dataset, namespace: str) -> 
 
         session.commit()
 
-        return DatasetUpsertResult(ds.id)
+        return DatasetUpsertResult(ds.id, _dataset_metadata_fields(ds))
 
 
 def check_table(table: Table) -> None:
@@ -183,7 +207,7 @@ def upsert_table(
     df["value"] = df["value"].astype("string")
 
     checksum_data = calculate_checksum_data(df)
-    checksum_metadata = calculate_checksum_metadata(variable_meta, df)
+    checksum_metadata = calculate_checksum_metadata(variable_meta, df, dataset_upsert_result.metadata_fields)
 
     if config.FORCE_UPLOAD:
         checksums["dataChecksum"] = None
@@ -318,7 +342,7 @@ def upsert_metadata(
     return db_variable
 
 
-def calculate_checksum_metadata(variable_meta: VariableMeta, df: pd.DataFrame) -> str:
+def calculate_checksum_metadata(variable_meta: VariableMeta, df: pd.DataFrame, dataset_metadata: dict[str, Any]) -> str:
     # Hash the canonical (pruned) dict representation, not the dataclass itself.
     # Dataclass-shape changes (a field renamed, added, or removed — even when the
     # default is None / [] and the JSON output is unchanged) used to spuriously
@@ -334,12 +358,18 @@ def calculate_checksum_metadata(variable_meta: VariableMeta, df: pd.DataFrame) -
     # that prunes inline, same trick `dataclass_from_dict` uses in core/utils.py.
     #
     # entities and years are also part of the metadata checksum.
+    #
+    # So are the dataset-level fields the JSON embeds (`_dataset_metadata_fields`): they live on
+    # the dataset, not on the variable, so without them clearing e.g. `update_period_days` left
+    # every variable's checksum untouched, every upload was skipped, and the file in R2 stayed
+    # stale forever while MySQL was correct.
     return str(
         hash_any(
             (
                 hash_any(sorted(df.entityId.unique())),
                 hash_any(sorted(df.year.unique())),
                 hash_any(variable_meta.to_dict()),
+                hash_any(dataset_metadata),
             )
         )
     )

--- a/tests/test_grapher_import.py
+++ b/tests/test_grapher_import.py
@@ -24,20 +24,44 @@ def test_calculate_checksum_data():
     assert db.calculate_checksum_data(df.iloc[::-1]) == "3523058000783533578"
 
 
+def _get_dataset_metadata():
+    return {"datasetName": "Dataset", "datasetVersion": "2024-12-31", "updatePeriodDays": 365}
+
+
 def test_calculate_checksum_metadata():
     meta = _get_metadata()
     df = _get_data()
+    ds_meta = _get_dataset_metadata()
 
     # Checksum should be deterministic
-    checksum = db.calculate_checksum_metadata(meta, df)
-    assert checksum == db.calculate_checksum_metadata(meta, df)
+    checksum = db.calculate_checksum_metadata(meta, df, ds_meta)
+    assert checksum == db.calculate_checksum_metadata(meta, df, ds_meta)
 
     # Different metadata should produce different checksums
     meta2 = VariableMeta(
         origins=[Origin(title="Different", producer="Producer")],
         presentation=VariablePresentationMeta(title_public="Title public"),
     )
-    assert checksum != db.calculate_checksum_metadata(meta2, df)
+    assert checksum != db.calculate_checksum_metadata(meta2, df, ds_meta)
+
+
+def test_calculate_checksum_metadata_depends_on_dataset_fields():
+    """Dataset-level fields are embedded in the indicator JSON, so they must flip the checksum.
+
+    Regression: they used to be invisible to the checksum, so clearing e.g. `update_period_days`
+    updated MySQL but never re-uploaded the JSON files in R2, which stayed stale indefinitely.
+    """
+    meta = _get_metadata()
+    df = _get_data()
+    checksum = db.calculate_checksum_metadata(meta, df, _get_dataset_metadata())
+
+    # Clearing update_period_days drops it from the JSON (and from the hashed dict).
+    cleared = {k: v for k, v in _get_dataset_metadata().items() if k != "updatePeriodDays"}
+    assert checksum != db.calculate_checksum_metadata(meta, df, cleared)
+
+    # Same for the other fields the JSON embeds.
+    for field, value in [("datasetName", "Renamed"), ("datasetVersion", "2025-01-01"), ("nonRedistributable", True)]:
+        assert checksum != db.calculate_checksum_metadata(meta, df, {**_get_dataset_metadata(), field: value})
 
 
 def test_calculate_checksum_metadata_invariant_to_empty_field_shapes():
@@ -57,8 +81,9 @@ def test_calculate_checksum_metadata_invariant_to_empty_field_shapes():
         sort=[],
     )
     meta_without_empties = VariableMeta(origins=[Origin(title="T", producer="P")])
-    assert db.calculate_checksum_metadata(meta_with_empties, df) == db.calculate_checksum_metadata(
-        meta_without_empties, df
+    ds_meta = _get_dataset_metadata()
+    assert db.calculate_checksum_metadata(meta_with_empties, df, ds_meta) == db.calculate_checksum_metadata(
+        meta_without_empties, df, ds_meta
     )
 
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @Marigold at the wheel._

Dataset-level fields (`updatePeriodDays`, `datasetName`, `datasetVersion`, `nonRedistributable`) are embedded in the per-indicator metadata JSON we serve from R2, but they were not part of `metadataChecksum`. Editing one updated MySQL and left every variable's checksum untouched, so `upsert_table` skipped the upload and the JSON stayed stale indefinitely — nothing downstream ever compensates. This adds those fields to the checksum, so a dataset-level edit re-uploads on the next ordinary run instead of needing `--force-upload`.

_Deep review on the checksum semantics; the rest is mechanical._ Closes #6573.

## How it works

`DatasetUpsertResult` now carries `metadata_fields`, built by `_dataset_metadata_fields(ds)` from the **DB row after upsert** rather than from `DatasetMeta` — that is exactly what `_load_variable` will read when it builds the JSON, so the two can't drift on fields the upsert doesn't write (`version`, notably, is only set on insert).

`None` values are dropped, mirroring `_omit_nullable_values` on the upload path. Two reasons: clearing `update_period_days` should change the hash by *removing* a key (which is the `height` case), and a field added to this dict later won't flip the checksum for the datasets that leave it null.

**`sourceName` / `sourceDescription` are deliberately excluded.** They come from the legacy `sources` join, and ETL upserts every variable with `sourceId=None` — unconditionally, so an existing non-null `sourceId` gets nulled too. The join only ever contributes to backported datasets, which this path doesn't upload:

```
rg -n "source_id=None" etl/grapher/to_db.py       # upsert_metadata
rg -n "ds.sourceId = self.sourceId" etl/grapher/model.py   # Variable.upsert, no guard
```

**The `type` TODO at `to_db.py:292` is left alone.** Same class of bug, different trigger (values change type while metadata doesn't), and hashing it means running `_infer_variable_type` — a per-row Python `map` over every value — on every upsert, including the path that currently returns before touching anything. Worth its own issue, not a rider here.

## Verified

`test_calculate_checksum_metadata_depends_on_dataset_fields` asserts the checksum moves for each of the four fields, including the drop-a-key case that `height` actually is (`update_period_days` cleared, not changed).

Not verified: no end-to-end run against a real MySQL + R2. The dataset-edit → re-upload behaviour is read off `upsert_table`, not observed. A staging run of any dataset with a tweaked `update_period_days` would confirm it.

## Decisions worth a second look

**Chart-diff noise, bounded but real.** `chart_diff.py:878` compares staging vs production `metadataChecksum`, so once this merges, a PR that re-runs a grapher step will flag `METADATA CHANGE` with an empty visible diff until production has re-run that same dataset. It self-clears per dataset, and `chart_diff.py:833` already restricts the comparison to datasets whose files changed on the branch — so the blast radius is "data-only PRs also show a metadata flag, for a few weeks". I did not add a suppression; the alternative is to land it at a quiet moment.

The one-time cost is smaller than #6573 estimates: `to_db.py` is not part of a step's input checksum, so nothing re-runs on merge. Each dataset's metadata files re-upload the next time its grapher step runs for any other reason.

**This does not repair anything already stale.** `grapher/health/2024-12-31/height` still needs one `etlr grapher/health/2024-12-31/height --grapher --force --force-upload` with production credentials, or any future run of that step.
