### PR TITLE
📜 Make the AI attribution line model-agnostic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ It applies to **every** surface, **every** time you post:
 
 Use the handle of the human directing the work (usually the current git user; ask if ambiguous).
 
-**The only exception** is a comment that is a bare mechanical token with *no prose* — a lone `@codex review` ping or a 👍. The moment your comment contains a sentence of explanation, it needs the line. When in doubt, include it.
+Besides the bot-account case above, **the only exception** is a comment that is a bare mechanical token with *no prose* — a lone `@codex review` ping or a 👍. The moment your comment contains a sentence of explanation, it needs the line. When in doubt, include it.
 
 2. **Use exact handles** from the list below when tagging colleagues. Don't guess — a wrong tag pings a real person. If a name isn't on this list, write the plain name (e.g. "Bastian") instead of `@`-tagging, and ask the user for the handle.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,15 +27,15 @@ Re-state the whole block every time the work is revisited — carry open items f
 
 ## Team
 
-Everything you post to GitHub or Slack goes out under a **human's identity**. Any text you author and post that a reader could take for the human's own words **must** carry the attribution line below. This is mandatory — not a judgment call about whether the comment is "worth it."
+Everything you post to GitHub or Slack goes out under a **human's identity**. Any text you author and post that a reader could take for the human's own words **must** carry the attribution line below. This is mandatory — not a judgment call about whether the comment is "worth it." (An agent posting under its own bot account, e.g. `chatgpt-codex-connector[bot]`, skips the line: the platform already attributes the content.)
 
 1. **Attribute the work.** Put this blockquote as the *first line* of the content:
 
 ```
-> _Written by Claude <model name> — @<handle> at the wheel._
+> _Written by <assistant> <model name> — @<handle> at the wheel._
 ```
 
-Replace `<model name>` with the human-readable name of the model actually generating the content (e.g. "Sonnet 5", "Opus 4.8", "Fable 5", "Haiku 4.5") — not the literal string "Code". Keeping the "Claude" prefix makes the attribution recognizable even to readers unfamiliar with individual model names.
+Replace `<assistant>` with the product actually generating the content ("Claude", "Codex", "Copilot", ...) and `<model name>` with the human-readable name of its underlying model (e.g. "Fable 5", "Opus 4.8", "GPT-5.6"). For Claude, always use a model name, never the literal string "Code". Keeping the product prefix makes the attribution recognizable even to readers unfamiliar with individual model names.
 
 It applies to **every** surface, **every** time you post:
 - PR descriptions / bodies


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

Our `AGENTS.md` is a symlink to `CLAUDE.md`, so non-Claude agents (e.g. Codex reviewing PRs) also read the attribution rule. The template hardcoded the "Claude" prefix, which led Codex to sign a review comment as "Written by Claude GPT-5.6 Sol" (see #6511).

This PR makes the template model-agnostic: `Written by <assistant> <model name>`, where the assistant is the product actually generating the content (Claude, Codex, Copilot, ...). It also clarifies that agents posting under their own bot account can skip the line, since the platform already attributes the content.
