### PR TITLE
🐛 Layer-aware chart diff and sync for ETL-authored charts

### DIFF
--- a/apps/chart_config_id/cli.py
+++ b/apps/chart_config_id/cli.py
@@ -134,8 +134,8 @@ def lookup(config_file: Path, slug: str | None, chart_id: int | None, env_name: 
     console.print(f"Looking up {target} in [bold]{owid_env.conf.DB_NAME}[/bold] on {owid_env.conf.DB_HOST}")
 
     # Deliberately a plain SELECT of the columns we need rather than loading the ORM `Chart`: some
-    # environments (production, until the grapher release lands) lack the `catalogPath` /
-    # `configIdETL` columns the model declares, and selecting those would fail with "Unknown column".
+    # environments (production, until the grapher release lands) lack the `etlConfigCatalogPath` /
+    # `patchConfigIdETL` columns the model declares, and selecting those would fail with "Unknown column".
     if chart_id is not None:
         # `charts.id` is the primary key, so this matches at most one row — no ambiguity to resolve.
         query = (

--- a/apps/chart_sync/cli.py
+++ b/apps/chart_sync/cli.py
@@ -17,6 +17,7 @@ from apps.wizard.app_pages.chart_diff.chart_diff import (
     ChartDiffsLoader,
     configs_are_equal,
     get_deleted_charts,
+    patch_is_pristine,
     same_config_uuid,
     tags_are_equal,
 )
@@ -244,6 +245,15 @@ def cli(
                     migrated_config = diff.source_chart.migrate_config(source_session, target_session)
                     migrated_etl_config = diff.source_chart.migrate_etl_config(source_session, target_session)
 
+                    # For ETL-managed charts, the admin patch is written to the target
+                    # only when someone deliberately edited it on staging. A pristine
+                    # patch must never overwrite the target's patch — production admin
+                    # edits (hotfixes) live there and belong to production.
+                    source_patch = (
+                        diff.source_chart.load_patch_config(source_session) if migrated_etl_config is not None else None
+                    )
+                    push_admin_patch = migrated_etl_config is None or not patch_is_pristine(source_patch)
+
                     # Get user who edited the chart
                     user_id = diff.source_chart.lastEditedByUserId
 
@@ -307,7 +317,8 @@ def cli(
                                         catalog_path=diff.source_chart.catalogPath,
                                         user_id=user_id,
                                     )
-                                target_api.update_chart(target_chart_id, migrated_config, user_id=user_id)
+                                if push_admin_patch:
+                                    target_api.update_chart(target_chart_id, migrated_config, user_id=user_id)
                                 target_api.set_tags(target_chart_id, source_tags, user_id=user_id)
 
                         # Rejected chart diff
@@ -349,7 +360,8 @@ def cli(
                                         catalog_path=diff.source_chart.catalogPath,
                                         user_id=user_id,
                                     )
-                                    target_api.update_chart(resp["chartId"], migrated_config, user_id=user_id)
+                                    if push_admin_patch:
+                                        target_api.update_chart(resp["chartId"], migrated_config, user_id=user_id)
                                 else:
                                     resp = target_api.create_chart(
                                         migrated_config, user_id=user_id, config_id=source_config_id

--- a/apps/chart_sync/cli.py
+++ b/apps/chart_sync/cli.py
@@ -268,8 +268,8 @@ def cli(
                         cross_env_twin = diff.source_chart.id != diff.target_chart.id and (
                             same_config_uuid(diff.source_chart.configId, diff.target_chart.configId)
                             or (
-                                diff.source_chart.catalogPath
-                                and diff.source_chart.catalogPath == diff.target_chart.catalogPath
+                                diff.source_chart.etlConfigCatalogPath
+                                and diff.source_chart.etlConfigCatalogPath == diff.target_chart.etlConfigCatalogPath
                             )
                         )
 
@@ -314,7 +314,7 @@ def cli(
                                     target_api.upsert_chart_etl_config(
                                         chart_config_id=diff.target_chart.configId,
                                         grapher_config=migrated_etl_config,
-                                        catalog_path=diff.source_chart.catalogPath,
+                                        catalog_path=diff.source_chart.etlConfigCatalogPath,
                                         user_id=user_id,
                                     )
                                 if push_admin_patch:
@@ -357,7 +357,7 @@ def cli(
                                     resp = target_api.upsert_chart_etl_config(
                                         chart_config_id=source_config_id,
                                         grapher_config=migrated_etl_config,
-                                        catalog_path=diff.source_chart.catalogPath,
+                                        catalog_path=diff.source_chart.etlConfigCatalogPath,
                                         user_id=user_id,
                                     )
                                     if push_admin_patch:

--- a/apps/chart_sync/cli.py
+++ b/apps/chart_sync/cli.py
@@ -17,6 +17,7 @@ from apps.wizard.app_pages.chart_diff.chart_diff import (
     ChartDiffsLoader,
     configs_are_equal,
     get_deleted_charts,
+    patch_is_pristine,
     tags_are_equal,
 )
 from apps.wizard.utils import get_staging_creation_time
@@ -243,6 +244,15 @@ def cli(
                     migrated_config = diff.source_chart.migrate_config(source_session, target_session)
                     migrated_etl_config = diff.source_chart.migrate_etl_config(source_session, target_session)
 
+                    # For ETL-managed charts, the admin patch is written to the target
+                    # only when someone deliberately edited it on staging. A pristine
+                    # patch must never overwrite the target's patch — production admin
+                    # edits (hotfixes) live there and belong to production.
+                    source_patch = (
+                        diff.source_chart.load_patch_config(source_session) if migrated_etl_config is not None else None
+                    )
+                    push_admin_patch = migrated_etl_config is None or not patch_is_pristine(source_patch)
+
                     # Get user who edited the chart
                     user_id = diff.source_chart.lastEditedByUserId
 
@@ -306,7 +316,8 @@ def cli(
                                         catalog_path=diff.source_chart.catalogPath,
                                         user_id=user_id,
                                     )
-                                target_api.update_chart(target_chart_id, migrated_config, user_id=user_id)
+                                if push_admin_patch:
+                                    target_api.update_chart(target_chart_id, migrated_config, user_id=user_id)
                                 target_api.set_tags(target_chart_id, source_tags, user_id=user_id)
 
                         # Rejected chart diff
@@ -348,7 +359,8 @@ def cli(
                                         catalog_path=diff.source_chart.catalogPath,
                                         user_id=user_id,
                                     )
-                                    target_api.update_chart(resp["chartId"], migrated_config, user_id=user_id)
+                                    if push_admin_patch:
+                                        target_api.update_chart(resp["chartId"], migrated_config, user_id=user_id)
                                 else:
                                     resp = target_api.create_chart(
                                         migrated_config, user_id=user_id, config_id=source_config_id

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -219,13 +219,78 @@ def _is_cross_env_twin(source_chart: gm.Chart, target_chart: gm.Chart | None) ->
     return bool(source_chart.catalogPath and source_chart.catalogPath == target_chart.catalogPath)
 
 
+# Keys the ETL bootstrap (and the server-side rediff) leaves in a chart's admin
+# patch without any human having touched the chart in the admin.
+_PRISTINE_PATCH_KEYS = {"$schema", "id", "version", "slug", "isPublished"}
+
+# Keys that are environment- or bookkeeping-noise when comparing single config layers.
+_LAYER_NOISE_KEYS = ("id", "version", "$schema", "bakedGrapherURL", "adminBaseUrl", "dataApiUrl")
+
+
+def patch_is_pristine(patch: dict[str, Any] | None) -> bool:
+    """True when a chart's admin patch carries no human edits.
+
+    A freshly ETL-created chart's patch holds only bootstrap keys (slug, schema,
+    version, id) and is unpublished. Anything beyond that — an extra key, or a
+    publication — is a deliberate admin action that chart-sync must carry.
+
+    Known limitation: a slug rename made in the staging admin is indistinguishable
+    from the bootstrap slug and reads as pristine.
+    """
+    if not patch:
+        return True
+    if patch.get("isPublished"):
+        return False
+    return set(patch.keys()) <= _PRISTINE_PATCH_KEYS
+
+
+def _layer_configs_equal(config_1: dict[str, Any] | None, config_2: dict[str, Any] | None) -> bool:
+    """Compare two single config layers (an etlConfig or a patch), ignoring noise keys.
+
+    Unlike `configs_are_equal`, layers have no `isInheritanceEnabled`, and their
+    `$schema` may differ across environments purely because one side was migrated
+    more recently — the production ETL run rewrites the layer anyway.
+    """
+    c1 = {k: v for k, v in (config_1 or {}).items() if k not in _LAYER_NOISE_KEYS}
+    c2 = {k: v for k, v in (config_2 or {}).items() if k not in _LAYER_NOISE_KEYS}
+    return pprint.pformat(c1, sort_dicts=True) == pprint.pformat(c2, sort_dicts=True)
+
+
+def etl_chart_has_branch_changes(
+    source_etl: dict[str, Any] | None,
+    target_etl: dict[str, Any] | None,
+    source_patch: dict[str, Any] | None,
+    target_patch: dict[str, Any] | None,
+) -> bool:
+    """Layer-aware replacement of the full-config comparison for ETL-managed charts.
+
+    A chart belongs in chart-diff only if the *branch* changed one of its layers:
+
+    - the ETL (code) layer differs between staging and production, or
+    - the staging admin patch was deliberately edited (non-pristine) and differs
+      from production's patch.
+
+    Production-only patch edits (e.g. a hotfix made in the production admin after
+    the staging server was created) are invisible to the branch: they are not the
+    branch's change, chart-sync must not overwrite them, so the chart is excluded.
+    """
+    if not _layer_configs_equal(source_etl, target_etl):
+        return True
+    if patch_is_pristine(source_patch):
+        return False
+    return not _layer_configs_equal(source_patch, target_patch)
+
+
 def _target_updated_at_for_review(source_chart: gm.Chart, target_chart: gm.Chart | None) -> dt.datetime | None:
     """Timestamp key used for approvals/conflicts.
 
-    Cross-environment twins did not exist in production when the staging chart
-    was reviewed, so their approvals were recorded with targetUpdatedAt=NULL.
+    Approvals bind to the production state that was on screen when the reviewer
+    approved. If production is edited afterwards, the approval must go stale —
+    for cross-environment twins too, otherwise a sync can overwrite the newer
+    production edit under a pre-existing approval. Only a chart with no
+    production counterpart at review time records NULL.
     """
-    if target_chart is None or _is_cross_env_twin(source_chart, target_chart):
+    if target_chart is None:
         return None
     return target_chart.updatedAt
 
@@ -257,6 +322,7 @@ class ChartDiff:
         score_indicators_anomalies: float | None = None,
         article_refs: list[ArticleRef] | None = None,
         staging_created_at: dt.datetime | None = None,
+        source_patch_config: dict[str, Any] | None = None,
     ):
         """Constructor of ChartDiff.
 
@@ -277,6 +343,9 @@ class ChartDiff:
         self.tags_edited = tags_edited
         # Creation time of the staging server (used to detect edits in production)
         self._staging_created_at = staging_created_at
+        # The source chart's admin patch layer (None when not loaded). Used to decide
+        # whether production edits on a cross-env twin can conflict with this diff.
+        self.source_patch_config = source_patch_config
 
         # Analytics, anomalies and other scores
         self.article_refs = article_refs if article_refs else []
@@ -396,7 +465,15 @@ class ChartDiff:
                 with Session(OWID_ENV.engine) as session:
                     staging_created_at = get_staging_creation_time(session)
             chart_edited_in_prod = self.target_chart.updatedAt > staging_created_at
-            if _is_cross_env_twin(self.source_chart, self.target_chart):
+            if _is_cross_env_twin(self.source_chart, self.target_chart) and (
+                self.source_patch_config is None or patch_is_pristine(self.source_patch_config)
+            ):
+                # A twin's production row is created/updated after the staging server
+                # exists, so its updatedAt alone signals nothing. While the staging
+                # patch is pristine, sync never writes the patch, so production admin
+                # edits are safe by construction. Once the staging patch carries
+                # deliberate edits, sync will write it — a production edit is then a
+                # real conflict again.
                 chart_edited_in_prod = False
 
             # If edited, check if conflict was resolved
@@ -548,6 +625,13 @@ class ChartDiff:
             # Article refs
             article_refs = article_refs_all.get(chart_id, [])
 
+            # Load the staging chart's admin patch for cross-env twins: `in_conflict`
+            # needs it to tell whether a production edit can actually conflict with
+            # anything this branch would sync.
+            source_patch_config = None
+            if target_chart is not None and _is_cross_env_twin(source_chart, target_chart):
+                source_patch_config = source_chart.load_patch_config(source_session)
+
             # Build Chart Diff object
             chart_diff: ChartDiff = cls(
                 source_chart=source_chart,
@@ -562,6 +646,7 @@ class ChartDiff:
                 score_indicators_anomalies=chart_anomalies_score,
                 article_refs=article_refs,
                 staging_created_at=staging_created_at,
+                source_patch_config=source_patch_config,
             )
 
             chart_diffs.append(chart_diff)
@@ -1057,23 +1142,38 @@ def _modified_chart_configs_on_staging(
 
     # get modified charts
     # NOTE: isInheritanceEnabled change needs to be detected too
-    base_q = """
+    def base_q(session: Session) -> str:
+        # A chart's rendered config (`configId`) and admin patch (`patchConfigId`) are each
+        # their own chart_configs row. The ETL layer (`patchConfigIdETL`) only exists once
+        # the grapher migration adding it has run — production may lag the staging server.
+        if _charts_table_has_etl_columns(session.get_bind()):
+            etl_select = "ccE.config as etlLayer,"
+            etl_join = "left join chart_configs as ccE on c.patchConfigIdETL = ccE.id"
+        else:
+            etl_select = "NULL as etlLayer,"
+            etl_join = ""
+        return f"""
     select
         c.id as chartId,
         MD5(CONCAT(cc.config, IFNULL(isInheritanceEnabled, 0))) as chartChecksum,
         cc.config as chartConfig,
+        ccP.config as chartPatch,
+        {etl_select}
         isInheritanceEnabled
     from charts as c
     join chart_configs as cc on c.configId = cc.id
+    join chart_configs as ccP on c.patchConfigId = ccP.id
+    {etl_join}
     where
     """
+
     where = """
         -- only compare charts that have been updated on staging server
         (
             c.lastEditedAt >= %(timestamp_staging_creation)s
         )
     """
-    query_source = base_q + where
+    query_source = base_q(source_session) + where
     params = {"timestamp_staging_creation": TIMESTAMP_STAGING_CREATION}
     # Add filter for chart IDs
     if chart_ids is not None:
@@ -1093,7 +1193,9 @@ def _modified_chart_configs_on_staging(
     where = """
         c.id in %(chart_ids)s
     """
-    target_df = read_sql(base_q + where, target_session, params={"chart_ids": tuple(source_df.chartId.unique())})
+    target_df = read_sql(
+        base_q(target_session) + where, target_session, params={"chart_ids": tuple(source_df.chartId.unique())}
+    )
 
     source_df = source_df.set_index("chartId")
     target_df = target_df.set_index("chartId")
@@ -1110,6 +1212,22 @@ def _modified_chart_configs_on_staging(
     ix = diff["configEdited"] & target_df["chartChecksum"].notnull()
     equal_configs = []
     for chart_id, row in diff.loc[ix].iterrows():
+        # ETL-managed charts (an etlConfig layer on both sides) are compared layer by
+        # layer: the chart is a branch change only if the branch changed a layer. A
+        # production-only patch edit (e.g. an admin hotfix after this staging server
+        # was created) must neither list the chart nor be overwritten by sync.
+        source_etl_raw = row.get("etlLayer")
+        target_etl_raw = target_df.loc[chart_id, "etlLayer"] if "etlLayer" in target_df.columns else None
+        if pd.notnull(source_etl_raw) and pd.notnull(target_etl_raw):
+            source_patch = json.loads(row["chartPatch"]) if pd.notnull(row.get("chartPatch")) else {}
+            target_patch_raw = target_df.loc[chart_id, "chartPatch"]
+            target_patch = json.loads(target_patch_raw) if pd.notnull(target_patch_raw) else {}
+            if not etl_chart_has_branch_changes(
+                json.loads(source_etl_raw), json.loads(target_etl_raw), source_patch, target_patch
+            ):
+                equal_configs.append(chart_id)
+            continue
+
         source_config = json.loads(row["chartConfig"])
         target_config = json.loads(target_df.loc[chart_id, "chartConfig"])
 

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -143,7 +143,7 @@ class ArticleRef:
 
 
 # TODO: Remove this guard (and the defer() in _get_target_charts) once
-# owid-grapher #6553 — which adds charts.catalogPath and charts.configIdETL — is
+# owid-grapher #6826 — which adds charts.etlConfigCatalogPath and charts.patchConfigIdETL — is
 # merged to master and deployed. Until then PRODUCTION's charts table lacks those
 # columns, so chart-diff (which queries prod) must not select or match on them.
 # We detect their presence at runtime instead of using a manual flag, so the
@@ -159,7 +159,7 @@ def _charts_table_has_etl_columns(engine) -> bool:
             text(
                 "SELECT COUNT(*) FROM information_schema.COLUMNS "
                 "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'charts' "
-                "AND COLUMN_NAME IN ('catalogPath', 'configIdETL')"
+                "AND COLUMN_NAME IN ('etlConfigCatalogPath', 'patchConfigIdETL')"
             )
         ).scalar()
     return n == 2
@@ -198,8 +198,8 @@ def _same_chart_across_envs(source_chart: gm.Chart, target_chart: gm.Chart) -> b
         return True
     if (
         _target_has_etl_columns(target_chart)
-        and source_chart.catalogPath
-        and source_chart.catalogPath == target_chart.catalogPath
+        and source_chart.etlConfigCatalogPath
+        and source_chart.etlConfigCatalogPath == target_chart.etlConfigCatalogPath
     ):
         return True
     # Legacy fallback for charts synced before config UUIDs were carried
@@ -216,7 +216,9 @@ def _is_cross_env_twin(source_chart: gm.Chart, target_chart: gm.Chart | None) ->
         return True
     if not _target_has_etl_columns(target_chart):
         return False
-    return bool(source_chart.catalogPath and source_chart.catalogPath == target_chart.catalogPath)
+    return bool(
+        source_chart.etlConfigCatalogPath and source_chart.etlConfigCatalogPath == target_chart.etlConfigCatalogPath
+    )
 
 
 # Keys the ETL bootstrap (and the server-side rediff) leaves in a chart's admin
@@ -647,7 +649,7 @@ class ChartDiff:
             # both patches to flag deliberate staging admin edits in the UI.
             source_patch_config = None
             target_patch_config = None
-            is_etl_managed = getattr(source_chart, "configIdETL", None) is not None
+            is_etl_managed = getattr(source_chart, "patchConfigIdETL", None) is not None
             if is_etl_managed or (target_chart is not None and _is_cross_env_twin(source_chart, target_chart)):
                 source_patch_config = source_chart.load_patch_config(source_session)
                 if target_chart is not None:
@@ -837,14 +839,14 @@ class ChartDiff:
                 if target_has_cols:
                     target_charts_list = gm.Chart.load_charts(target_session, chart_ids=chart_ids)
                 else:
-                    # prod doesn't have charts.catalogPath/configIdETL yet, so don't
+                    # prod doesn't have charts.etlConfigCatalogPath/patchConfigIdETL yet, so don't
                     # SELECT them (it would raise "Unknown column"). See
                     # _charts_table_has_etl_columns.
                     target_charts_list = list(
                         target_session.scalars(
                             select(gm.Chart)
                             .where(gm.Chart.id.in_(list(chart_ids)))
-                            .options(defer(gm.Chart.catalogPath), defer(gm.Chart.configIdETL))
+                            .options(defer(gm.Chart.etlConfigCatalogPath), defer(gm.Chart.patchConfigIdETL))
                         ).all()
                     )
                     if not target_charts_list:
@@ -868,16 +870,16 @@ class ChartDiff:
 
                 stmt = select(gm.Chart).where(gm.Chart.configId == source_chart.configId)
                 if not target_has_cols:
-                    stmt = stmt.options(defer(gm.Chart.catalogPath), defer(gm.Chart.configIdETL))
+                    stmt = stmt.options(defer(gm.Chart.etlConfigCatalogPath), defer(gm.Chart.patchConfigIdETL))
                 twin = target_session.scalars(stmt).one_or_none()
                 if twin is not None:
                     target_charts[source_chart_id] = twin
                     continue
 
-                if target_has_cols and source_chart.catalogPath:
+                if target_has_cols and source_chart.etlConfigCatalogPath:
                     try:
                         target_charts[source_chart_id] = gm.Chart.load_chart(
-                            target_session, catalog_path=source_chart.catalogPath
+                            target_session, catalog_path=source_chart.etlConfigCatalogPath
                         )
                     except NoResultFound:
                         pass

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -323,6 +323,7 @@ class ChartDiff:
         article_refs: list[ArticleRef] | None = None,
         staging_created_at: dt.datetime | None = None,
         source_patch_config: dict[str, Any] | None = None,
+        target_patch_config: dict[str, Any] | None = None,
     ):
         """Constructor of ChartDiff.
 
@@ -343,9 +344,11 @@ class ChartDiff:
         self.tags_edited = tags_edited
         # Creation time of the staging server (used to detect edits in production)
         self._staging_created_at = staging_created_at
-        # The source chart's admin patch layer (None when not loaded). Used to decide
-        # whether production edits on a cross-env twin can conflict with this diff.
+        # The two admin patch layers (None when not loaded). Used to decide whether
+        # production edits on a cross-env twin can conflict with this diff, and to
+        # flag deliberate staging admin edits on ETL-managed charts.
         self.source_patch_config = source_patch_config
+        self.target_patch_config = target_patch_config
 
         # Analytics, anomalies and other scores
         self.article_refs = article_refs if article_refs else []
@@ -388,6 +391,19 @@ class ChartDiff:
     def is_rejected(self) -> bool:
         """Check if the chart has been rejected."""
         return self.approval_status == gm.ChartStatus.REJECTED.value
+
+    @property
+    def has_staging_admin_edits(self) -> bool:
+        """True when this ETL-managed chart carries deliberate admin edits made on staging.
+
+        Such edits will be synced to production as an admin override; the UI warns the
+        reviewer and suggests moving them into the chart's ETL config instead. A patch
+        identical to production's (e.g. a long-standing override on an adopted chart)
+        does not count — nothing new would be written.
+        """
+        if self.source_patch_config is None or patch_is_pristine(self.source_patch_config):
+            return False
+        return not _layer_configs_equal(self.source_patch_config, self.target_patch_config)
 
     @property
     def is_pending(self) -> bool:
@@ -625,12 +641,17 @@ class ChartDiff:
             # Article refs
             article_refs = article_refs_all.get(chart_id, [])
 
-            # Load the staging chart's admin patch for cross-env twins: `in_conflict`
-            # needs it to tell whether a production edit can actually conflict with
-            # anything this branch would sync.
+            # Load the admin patch layers for ETL-managed charts: `in_conflict` needs
+            # the source patch to tell whether a production edit can conflict with
+            # anything this branch would sync, and `has_staging_admin_edits` compares
+            # both patches to flag deliberate staging admin edits in the UI.
             source_patch_config = None
-            if target_chart is not None and _is_cross_env_twin(source_chart, target_chart):
+            target_patch_config = None
+            is_etl_managed = getattr(source_chart, "configIdETL", None) is not None
+            if is_etl_managed or (target_chart is not None and _is_cross_env_twin(source_chart, target_chart)):
                 source_patch_config = source_chart.load_patch_config(source_session)
+                if target_chart is not None:
+                    target_patch_config = target_chart.load_patch_config(target_session)
 
             # Build Chart Diff object
             chart_diff: ChartDiff = cls(
@@ -647,6 +668,7 @@ class ChartDiff:
                 article_refs=article_refs,
                 staging_created_at=staging_created_at,
                 source_patch_config=source_patch_config,
+                target_patch_config=target_patch_config,
             )
 
             chart_diffs.append(chart_diff)

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -301,6 +301,7 @@ class ChartDiff:
         article_refs: list[ArticleRef] | None = None,
         staging_created_at: dt.datetime | None = None,
         source_patch_config: dict[str, Any] | None = None,
+        target_patch_config: dict[str, Any] | None = None,
     ):
         """Constructor of ChartDiff.
 
@@ -321,9 +322,11 @@ class ChartDiff:
         self.tags_edited = tags_edited
         # Creation time of the staging server (used to detect edits in production)
         self._staging_created_at = staging_created_at
-        # The source chart's admin patch layer (None when not loaded). Used to decide
-        # whether production edits on a cross-env twin can conflict with this diff.
+        # The two admin patch layers (None when not loaded). Used to decide whether
+        # production edits on a cross-env twin can conflict with this diff, and to
+        # flag deliberate staging admin edits on ETL-managed charts.
         self.source_patch_config = source_patch_config
+        self.target_patch_config = target_patch_config
 
         # Analytics, anomalies and other scores
         self.article_refs = article_refs if article_refs else []
@@ -366,6 +369,19 @@ class ChartDiff:
     def is_rejected(self) -> bool:
         """Check if the chart has been rejected."""
         return self.approval_status == gm.ChartStatus.REJECTED.value
+
+    @property
+    def has_staging_admin_edits(self) -> bool:
+        """True when this ETL-managed chart carries deliberate admin edits made on staging.
+
+        Such edits will be synced to production as an admin override; the UI warns the
+        reviewer and suggests moving them into the chart's ETL config instead. A patch
+        identical to production's (e.g. a long-standing override on an adopted chart)
+        does not count — nothing new would be written.
+        """
+        if self.source_patch_config is None or patch_is_pristine(self.source_patch_config):
+            return False
+        return not _layer_configs_equal(self.source_patch_config, self.target_patch_config)
 
     @property
     def is_pending(self) -> bool:
@@ -603,12 +619,17 @@ class ChartDiff:
             # Article refs
             article_refs = article_refs_all.get(chart_id, [])
 
-            # Load the staging chart's admin patch for cross-env twins: `in_conflict`
-            # needs it to tell whether a production edit can actually conflict with
-            # anything this branch would sync.
+            # Load the admin patch layers for ETL-managed charts: `in_conflict` needs
+            # the source patch to tell whether a production edit can conflict with
+            # anything this branch would sync, and `has_staging_admin_edits` compares
+            # both patches to flag deliberate staging admin edits in the UI.
             source_patch_config = None
-            if target_chart is not None and _is_cross_env_twin(source_chart, target_chart):
+            target_patch_config = None
+            is_etl_managed = getattr(source_chart, "configIdETL", None) is not None
+            if is_etl_managed or (target_chart is not None and _is_cross_env_twin(source_chart, target_chart)):
                 source_patch_config = source_chart.load_patch_config(source_session)
+                if target_chart is not None:
+                    target_patch_config = target_chart.load_patch_config(target_session)
 
             # Build Chart Diff object
             chart_diff: ChartDiff = cls(
@@ -625,6 +646,7 @@ class ChartDiff:
                 article_refs=article_refs,
                 staging_created_at=staging_created_at,
                 source_patch_config=source_patch_config,
+                target_patch_config=target_patch_config,
             )
 
             chart_diffs.append(chart_diff)

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -197,13 +197,78 @@ def _is_cross_env_twin(source_chart: gm.Chart, target_chart: gm.Chart | None) ->
     return bool(source_chart.catalogPath and source_chart.catalogPath == target_chart.catalogPath)
 
 
+# Keys the ETL bootstrap (and the server-side rediff) leaves in a chart's admin
+# patch without any human having touched the chart in the admin.
+_PRISTINE_PATCH_KEYS = {"$schema", "id", "version", "slug", "isPublished"}
+
+# Keys that are environment- or bookkeeping-noise when comparing single config layers.
+_LAYER_NOISE_KEYS = ("id", "version", "$schema", "bakedGrapherURL", "adminBaseUrl", "dataApiUrl")
+
+
+def patch_is_pristine(patch: dict[str, Any] | None) -> bool:
+    """True when a chart's admin patch carries no human edits.
+
+    A freshly ETL-created chart's patch holds only bootstrap keys (slug, schema,
+    version, id) and is unpublished. Anything beyond that — an extra key, or a
+    publication — is a deliberate admin action that chart-sync must carry.
+
+    Known limitation: a slug rename made in the staging admin is indistinguishable
+    from the bootstrap slug and reads as pristine.
+    """
+    if not patch:
+        return True
+    if patch.get("isPublished"):
+        return False
+    return set(patch.keys()) <= _PRISTINE_PATCH_KEYS
+
+
+def _layer_configs_equal(config_1: dict[str, Any] | None, config_2: dict[str, Any] | None) -> bool:
+    """Compare two single config layers (an etlConfig or a patch), ignoring noise keys.
+
+    Unlike `configs_are_equal`, layers have no `isInheritanceEnabled`, and their
+    `$schema` may differ across environments purely because one side was migrated
+    more recently — the production ETL run rewrites the layer anyway.
+    """
+    c1 = {k: v for k, v in (config_1 or {}).items() if k not in _LAYER_NOISE_KEYS}
+    c2 = {k: v for k, v in (config_2 or {}).items() if k not in _LAYER_NOISE_KEYS}
+    return pprint.pformat(c1, sort_dicts=True) == pprint.pformat(c2, sort_dicts=True)
+
+
+def etl_chart_has_branch_changes(
+    source_etl: dict[str, Any] | None,
+    target_etl: dict[str, Any] | None,
+    source_patch: dict[str, Any] | None,
+    target_patch: dict[str, Any] | None,
+) -> bool:
+    """Layer-aware replacement of the full-config comparison for ETL-managed charts.
+
+    A chart belongs in chart-diff only if the *branch* changed one of its layers:
+
+    - the ETL (code) layer differs between staging and production, or
+    - the staging admin patch was deliberately edited (non-pristine) and differs
+      from production's patch.
+
+    Production-only patch edits (e.g. a hotfix made in the production admin after
+    the staging server was created) are invisible to the branch: they are not the
+    branch's change, chart-sync must not overwrite them, so the chart is excluded.
+    """
+    if not _layer_configs_equal(source_etl, target_etl):
+        return True
+    if patch_is_pristine(source_patch):
+        return False
+    return not _layer_configs_equal(source_patch, target_patch)
+
+
 def _target_updated_at_for_review(source_chart: gm.Chart, target_chart: gm.Chart | None) -> dt.datetime | None:
     """Timestamp key used for approvals/conflicts.
 
-    Cross-environment twins did not exist in production when the staging chart
-    was reviewed, so their approvals were recorded with targetUpdatedAt=NULL.
+    Approvals bind to the production state that was on screen when the reviewer
+    approved. If production is edited afterwards, the approval must go stale —
+    for cross-environment twins too, otherwise a sync can overwrite the newer
+    production edit under a pre-existing approval. Only a chart with no
+    production counterpart at review time records NULL.
     """
-    if target_chart is None or _is_cross_env_twin(source_chart, target_chart):
+    if target_chart is None:
         return None
     return target_chart.updatedAt
 
@@ -235,6 +300,7 @@ class ChartDiff:
         score_indicators_anomalies: float | None = None,
         article_refs: list[ArticleRef] | None = None,
         staging_created_at: dt.datetime | None = None,
+        source_patch_config: dict[str, Any] | None = None,
     ):
         """Constructor of ChartDiff.
 
@@ -255,6 +321,9 @@ class ChartDiff:
         self.tags_edited = tags_edited
         # Creation time of the staging server (used to detect edits in production)
         self._staging_created_at = staging_created_at
+        # The source chart's admin patch layer (None when not loaded). Used to decide
+        # whether production edits on a cross-env twin can conflict with this diff.
+        self.source_patch_config = source_patch_config
 
         # Analytics, anomalies and other scores
         self.article_refs = article_refs if article_refs else []
@@ -374,7 +443,15 @@ class ChartDiff:
                 with Session(OWID_ENV.engine) as session:
                     staging_created_at = get_staging_creation_time(session)
             chart_edited_in_prod = self.target_chart.updatedAt > staging_created_at
-            if _is_cross_env_twin(self.source_chart, self.target_chart):
+            if _is_cross_env_twin(self.source_chart, self.target_chart) and (
+                self.source_patch_config is None or patch_is_pristine(self.source_patch_config)
+            ):
+                # A twin's production row is created/updated after the staging server
+                # exists, so its updatedAt alone signals nothing. While the staging
+                # patch is pristine, sync never writes the patch, so production admin
+                # edits are safe by construction. Once the staging patch carries
+                # deliberate edits, sync will write it — a production edit is then a
+                # real conflict again.
                 chart_edited_in_prod = False
 
             # If edited, check if conflict was resolved
@@ -526,6 +603,13 @@ class ChartDiff:
             # Article refs
             article_refs = article_refs_all.get(chart_id, [])
 
+            # Load the staging chart's admin patch for cross-env twins: `in_conflict`
+            # needs it to tell whether a production edit can actually conflict with
+            # anything this branch would sync.
+            source_patch_config = None
+            if target_chart is not None and _is_cross_env_twin(source_chart, target_chart):
+                source_patch_config = source_chart.load_patch_config(source_session)
+
             # Build Chart Diff object
             chart_diff: ChartDiff = cls(
                 source_chart=source_chart,
@@ -540,6 +624,7 @@ class ChartDiff:
                 score_indicators_anomalies=chart_anomalies_score,
                 article_refs=article_refs,
                 staging_created_at=staging_created_at,
+                source_patch_config=source_patch_config,
             )
 
             chart_diffs.append(chart_diff)
@@ -1016,6 +1101,15 @@ def _modified_data_metadata_on_staging(
     return diff
 
 
+def _etl_columns_available(session: Session) -> bool:
+    """True when the grapher DB behind `session` has the charts.configIdETL column."""
+    try:
+        read_sql("select configIdETL from charts limit 1", session)
+        return True
+    except Exception:
+        return False
+
+
 # @log_time
 def _modified_chart_configs_on_staging(
     source_session: Session, target_session: Session, chart_ids: list[int] | None = None
@@ -1024,23 +1118,36 @@ def _modified_chart_configs_on_staging(
 
     # get modified charts
     # NOTE: isInheritanceEnabled change needs to be detected too
-    base_q = """
+    def base_q(session: Session) -> str:
+        # The ETL config layer only exists once the grapher migration adding
+        # charts.configIdETL has run — production may lag the staging server.
+        if _etl_columns_available(session):
+            etl_select = "ccE.full as etlLayer,"
+            etl_join = "left join chart_configs as ccE on c.configIdETL = ccE.id"
+        else:
+            etl_select = "NULL as etlLayer,"
+            etl_join = ""
+        return f"""
     select
         c.id as chartId,
         MD5(CONCAT(cc.full, IFNULL(isInheritanceEnabled, 0))) as chartChecksum,
         cc.full as chartConfig,
+        cc.patch as chartPatch,
+        {etl_select}
         isInheritanceEnabled
     from charts as c
     join chart_configs as cc on c.configId = cc.id
+    {etl_join}
     where
     """
+
     where = """
         -- only compare charts that have been updated on staging server
         (
             c.lastEditedAt >= %(timestamp_staging_creation)s
         )
     """
-    query_source = base_q + where
+    query_source = base_q(source_session) + where
     params = {"timestamp_staging_creation": TIMESTAMP_STAGING_CREATION}
     # Add filter for chart IDs
     if chart_ids is not None:
@@ -1060,7 +1167,9 @@ def _modified_chart_configs_on_staging(
     where = """
         c.id in %(chart_ids)s
     """
-    target_df = read_sql(base_q + where, target_session, params={"chart_ids": tuple(source_df.chartId.unique())})
+    target_df = read_sql(
+        base_q(target_session) + where, target_session, params={"chart_ids": tuple(source_df.chartId.unique())}
+    )
 
     source_df = source_df.set_index("chartId")
     target_df = target_df.set_index("chartId")
@@ -1077,6 +1186,22 @@ def _modified_chart_configs_on_staging(
     ix = diff["configEdited"] & target_df["chartChecksum"].notnull()
     equal_configs = []
     for chart_id, row in diff.loc[ix].iterrows():
+        # ETL-managed charts (an etlConfig layer on both sides) are compared layer by
+        # layer: the chart is a branch change only if the branch changed a layer. A
+        # production-only patch edit (e.g. an admin hotfix after this staging server
+        # was created) must neither list the chart nor be overwritten by sync.
+        source_etl_raw = row.get("etlLayer")
+        target_etl_raw = target_df.loc[chart_id, "etlLayer"] if "etlLayer" in target_df.columns else None
+        if pd.notnull(source_etl_raw) and pd.notnull(target_etl_raw):
+            source_patch = json.loads(row["chartPatch"]) if pd.notnull(row.get("chartPatch")) else {}
+            target_patch_raw = target_df.loc[chart_id, "chartPatch"]
+            target_patch = json.loads(target_patch_raw) if pd.notnull(target_patch_raw) else {}
+            if not etl_chart_has_branch_changes(
+                json.loads(source_etl_raw), json.loads(target_etl_raw), source_patch, target_patch
+            ):
+                equal_configs.append(chart_id)
+            continue
+
         source_config = json.loads(row["chartConfig"])
         target_config = json.loads(target_df.loc[chart_id, "chartConfig"])
 

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -338,6 +338,17 @@ class ChartDiffShow:
             )
 
     def _show_chart_diff_header(self):
+        # ETL-authored charts are edited in their ETL YAML; deliberate edits made in
+        # the staging admin are legal but should be a conscious choice.
+        if getattr(self.diff, "has_staging_admin_edits", False):
+            st.warning(
+                "This ETL-authored chart carries edits made in the **staging admin**. "
+                "Approving will sync them to production as an admin override on top of the ETL config. "
+                "Consider moving them into the chart's `.config.yml` in ETL instead, so they are versioned "
+                "and reviewed with the code — otherwise the ETL YAML and the chart will permanently disagree "
+                "on these fields."
+            )
+
         # Three columns: status, refresh, link
         col1, col2, col3 = st.columns([2, 3, 1], vertical_alignment="bottom")
 

--- a/apps/wizard/app_pages/chart_diff/chart_diff_show.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff_show.py
@@ -292,6 +292,17 @@ class ChartDiffShow:
             )
 
     def _show_chart_diff_header(self):
+        # ETL-authored charts are edited in their ETL YAML; deliberate edits made in
+        # the staging admin are legal but should be a conscious choice.
+        if getattr(self.diff, "has_staging_admin_edits", False):
+            st.warning(
+                "This ETL-authored chart carries edits made in the **staging admin**. "
+                "Approving will sync them to production as an admin override on top of the ETL config. "
+                "Consider moving them into the chart's `.config.yml` in ETL instead, so they are versioned "
+                "and reviewed with the code — otherwise the ETL YAML and the chart will permanently disagree "
+                "on these fields."
+            )
+
         # Three columns: status, refresh, link
         col1, col2, col3 = st.columns([2, 3, 1], vertical_alignment="bottom")
 

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -392,9 +392,11 @@ class Chart(Base):
     configId: Mapped[str] = mapped_column(CHAR(36))
     # The authored layer, as its own chart_configs row. `configId` is what renders.
     patchConfigId: Mapped[bytes] = mapped_column(CHAR(36))
-    configIdETL: Mapped[bytes | None] = mapped_column(CHAR(36), init=False)
-    # ETL step that authored this chart (mirrors multi_dim_data_pages.catalogPath); NULL for hand-authored charts.
-    catalogPath: Mapped[str | None] = mapped_column(VARCHAR(767), init=False)
+    # The ETL-authored layer, as its own chart_configs row (mirrors variables.patchConfigIdETL, per chart).
+    patchConfigIdETL: Mapped[bytes | None] = mapped_column(CHAR(36), init=False)
+    # ETL step that authored this chart's ETL layer (mirrors multi_dim_data_pages.catalogPath); NULL for
+    # hand-authored charts. Not an identifier: it records the current owner and may change on a step rename.
+    etlConfigCatalogPath: Mapped[str | None] = mapped_column(VARCHAR(767), init=False)
     isInheritanceEnabled: Mapped[int] = mapped_column(TINYINT(1), server_default=text("'1'"))
     forceDatapage: Mapped[int] = mapped_column(TINYINT(1), server_default=text("'0'"))
     createdAt: Mapped[datetime] = mapped_column(DateTime, server_default=text("CURRENT_TIMESTAMP"), init=False)
@@ -464,7 +466,7 @@ class Chart(Base):
         elif slug:
             cond = cls.slug == slug
         elif catalog_path:
-            cond = cls.catalogPath == catalog_path
+            cond = cls.etlConfigCatalogPath == catalog_path
         elif config_id:
             cond = cls.configId == config_id
         else:
@@ -532,7 +534,7 @@ class Chart(Base):
         """Load the chart's ETL-authored config layer, if it has one."""
         assert self.id, "Chart must come from a database"
         etl_config = session.scalar(
-            select(ChartConfig.config).join(Chart, ChartConfig.id == Chart.configIdETL).where(Chart.id == self.id)
+            select(ChartConfig.config).join(Chart, ChartConfig.id == Chart.patchConfigIdETL).where(Chart.id == self.id)
         )
         return copy.deepcopy(etl_config) if etl_config else None
 

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -536,6 +536,14 @@ class Chart(Base):
         )
         return copy.deepcopy(etl_config) if etl_config else None
 
+    def load_patch_config(self, session: Session) -> dict[str, Any]:
+        """Load the chart's admin patch layer (the config admins edit on top of the ETL layer)."""
+        assert self.id, "Chart must come from a database"
+        patch = session.scalar(
+            select(ChartConfig.config).join(Chart, ChartConfig.id == Chart.patchConfigId).where(Chart.id == self.id)
+        )
+        return copy.deepcopy(patch) if patch else {}
+
     @classmethod
     def load_variables_checksums(cls, session: Session, chart_ids: list[int]) -> pd.DataFrame:
         """Load checksums for all variables from the chart and return them as a list of dicts."""

--- a/etl/grapher/model.py
+++ b/etl/grapher/model.py
@@ -516,6 +516,14 @@ class Chart(Base):
         )
         return copy.deepcopy(etl_config) if etl_config else None
 
+    def load_patch_config(self, session: Session) -> dict[str, Any]:
+        """Load the chart's admin patch layer (the config admins edit on top of the ETL layer)."""
+        assert self.id, "Chart must come from a database"
+        patch = session.scalar(
+            select(ChartConfig.patch).join(Chart, ChartConfig.id == Chart.configId).where(Chart.id == self.id)
+        )
+        return copy.deepcopy(patch) if patch else {}
+
     @classmethod
     def load_variables_checksums(cls, session: Session, chart_ids: list[int]) -> pd.DataFrame:
         """Load checksums for all variables from the chart and return them as a list of dicts."""

--- a/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
@@ -36,7 +36,9 @@ def test_config_uuid_identifies_chart_twins():
 
     assert _same_chart_across_envs(source, target)
     assert _is_cross_env_twin(source, target)
-    assert _target_updated_at_for_review(source, target) is None
+    # Approvals bind to the production state that was reviewed — twins included —
+    # so a later production edit invalidates a stale approval.
+    assert _target_updated_at_for_review(source, target) == target.updatedAt
 
     diff = ChartDiff(source_chart=source, target_chart=target, approval=None, conflict=None)
     assert diff.chart_id == source.id
@@ -62,7 +64,7 @@ def test_catalog_path_identifies_etl_chart_twins(monkeypatch):
 
     assert _same_chart_across_envs(source, target)
     assert _is_cross_env_twin(source, target)
-    assert _target_updated_at_for_review(source, target) is None
+    assert _target_updated_at_for_review(source, target) == target.updatedAt
 
     diff = ChartDiff(source_chart=source, target_chart=target, approval=None, conflict=None)
     assert diff.chart_id == source.id
@@ -85,3 +87,120 @@ def test_regular_charts_still_match_by_id_and_created_at():
     assert _same_chart_across_envs(source, target)
     assert not _is_cross_env_twin(source, target)
     assert _target_updated_at_for_review(source, target) == target.updatedAt
+
+
+# --- Layer-aware behavior for ETL-authored charts -----------------------------
+#
+# Scenario names refer to the situations that motivated the change:
+# an ETL-authored chart exists in production, an admin hotfixes it there, and
+# other branches' staging servers rebuild the same chart from the YAML.
+
+_SCHEMA_10 = "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
+_SCHEMA_11 = "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
+
+
+def _etl_layer(schema=_SCHEMA_10, variable_id=111):
+    return {
+        "$schema": schema,
+        "title": "Number of whales caught per year",
+        "subtitle": "Annual number of whales killed worldwide.",
+        "dimensions": [{"property": "y", "variableId": variable_id}],
+    }
+
+
+def _bootstrap_patch(published=False):
+    # What a chart's admin patch looks like straight after the ETL created it.
+    return {"$schema": _SCHEMA_10, "id": 9220, "version": 3, "slug": "whales-caught", "isPublished": published}
+
+
+def test_patch_is_pristine():
+    from apps.wizard.app_pages.chart_diff.chart_diff import patch_is_pristine
+
+    assert patch_is_pristine(None)
+    assert patch_is_pristine({})
+    assert patch_is_pristine(_bootstrap_patch())
+    # Publishing is a deliberate admin action.
+    assert not patch_is_pristine(_bootstrap_patch(published=True))
+    # So is any config override.
+    assert not patch_is_pristine({**_bootstrap_patch(), "subtitle": "Hotfixed subtitle."})
+
+
+def test_unrelated_branch_does_not_see_production_hotfix():
+    """An admin hotfix in production must not surface as a change on an unrelated branch."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import etl_chart_has_branch_changes
+
+    assert not etl_chart_has_branch_changes(
+        source_etl=_etl_layer(schema=_SCHEMA_11),  # staging migrated further — still no branch change
+        target_etl=_etl_layer(schema=_SCHEMA_10),
+        source_patch=_bootstrap_patch(),  # untouched on staging
+        target_patch={**_bootstrap_patch(published=True), "subtitle": "Hotfixed subtitle."},
+    )
+
+
+def test_branch_changing_the_code_layer_shows_the_chart():
+    """A data update (or YAML edit) on the branch changes the ETL layer — chart is listed."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import etl_chart_has_branch_changes
+
+    assert etl_chart_has_branch_changes(
+        source_etl=_etl_layer(variable_id=222),  # re-versioned indicator
+        target_etl=_etl_layer(variable_id=111),
+        source_patch=_bootstrap_patch(),
+        target_patch=_bootstrap_patch(published=True),
+    )
+
+
+def test_staging_admin_edit_shows_the_chart():
+    """A deliberate edit in the staging admin is the one thing sync must carry."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import etl_chart_has_branch_changes
+
+    assert etl_chart_has_branch_changes(
+        source_etl=_etl_layer(),
+        target_etl=_etl_layer(),
+        source_patch={**_bootstrap_patch(), "yAxis": {"min": 0}},
+        target_patch=_bootstrap_patch(published=True),
+    )
+
+
+def test_adopted_chart_with_identical_patches_is_hidden():
+    """An adopted chart whose (non-pristine) patch matches production has no branch changes."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import etl_chart_has_branch_changes
+
+    patch = {**_bootstrap_patch(published=True), "note": "Long-standing admin note."}
+    assert not etl_chart_has_branch_changes(
+        source_etl=_etl_layer(),
+        target_etl=_etl_layer(),
+        source_patch=patch,
+        target_patch=patch,
+    )
+
+
+def test_twin_conflict_depends_on_staging_patch():
+    """Production edits conflict with a twin only once the staging patch carries edits."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiff
+
+    config_id = "0198c0e8-0000-7000-8000-000000000000"
+    staging_created_at = datetime(2026, 1, 1)
+    source = _chart(100, datetime(2026, 1, 1), config_id=config_id)
+    target = _chart(200, datetime(2026, 1, 2), config_id=config_id)  # edited after staging creation
+
+    # Pristine staging patch: sync will not write the patch, production edits are safe.
+    diff = ChartDiff(
+        source_chart=source,
+        target_chart=target,
+        approval=None,
+        conflict=None,
+        staging_created_at=staging_created_at,
+        source_patch_config=_bootstrap_patch(),
+    )
+    assert not diff.in_conflict
+
+    # Deliberate staging edit: a production edit is a real conflict again.
+    diff = ChartDiff(
+        source_chart=source,
+        target_chart=target,
+        approval=None,
+        conflict=None,
+        staging_created_at=staging_created_at,
+        source_patch_config={**_bootstrap_patch(), "subtitle": "Staging override."},
+    )
+    assert diff.in_conflict

--- a/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
@@ -224,3 +224,36 @@ def test_twin_conflict_depends_on_staging_patch():
         source_patch_config={**_bootstrap_patch(), "subtitle": "Staging override."},
     )
     assert diff.in_conflict
+
+
+def test_has_staging_admin_edits():
+    """The UI warning fires only for deliberate, new staging admin edits."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiff
+
+    config_id = "0198c0e8-0000-7000-8000-000000000000"
+    source = _chart(100, datetime(2026, 1, 1), config_id=config_id)
+    target = _chart(200, datetime(2026, 1, 2), config_id=config_id)
+
+    def _diff(source_patch, target_patch):
+        return ChartDiff(
+            source_chart=source,
+            target_chart=target,
+            approval=None,
+            conflict=None,
+            source_patch_config=source_patch,
+            target_patch_config=target_patch,
+        )
+
+    # Pristine staging patch: nothing to warn about.
+    assert not _diff(_bootstrap_patch(), None).has_staging_admin_edits
+    # Long-standing override on an adopted chart, identical on both sides: no new edit.
+    patch = {**_bootstrap_patch(published=True), "note": "Old note."}
+    assert not _diff(patch, patch).has_staging_admin_edits
+    # Deliberate staging edit that differs from production: warn.
+    assert _diff(
+        {**_bootstrap_patch(), "subtitle": "Staging override."}, _bootstrap_patch(published=True)
+    ).has_staging_admin_edits
+    # New chart (no production counterpart) with deliberate edits: warn too.
+    assert _diff({**_bootstrap_patch(), "subtitle": "Staging override."}, None).has_staging_admin_edits
+    # Patch never loaded (non-ETL chart): never warn.
+    assert not _diff(None, None).has_staging_admin_edits

--- a/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
@@ -204,3 +204,36 @@ def test_twin_conflict_depends_on_staging_patch():
         source_patch_config={**_bootstrap_patch(), "subtitle": "Staging override."},
     )
     assert diff.in_conflict
+
+
+def test_has_staging_admin_edits():
+    """The UI warning fires only for deliberate, new staging admin edits."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiff
+
+    config_id = "0198c0e8-0000-7000-8000-000000000000"
+    source = _chart(100, datetime(2026, 1, 1), config_id=config_id)
+    target = _chart(200, datetime(2026, 1, 2), config_id=config_id)
+
+    def _diff(source_patch, target_patch):
+        return ChartDiff(
+            source_chart=source,
+            target_chart=target,
+            approval=None,
+            conflict=None,
+            source_patch_config=source_patch,
+            target_patch_config=target_patch,
+        )
+
+    # Pristine staging patch: nothing to warn about.
+    assert not _diff(_bootstrap_patch(), None).has_staging_admin_edits
+    # Long-standing override on an adopted chart, identical on both sides: no new edit.
+    patch = {**_bootstrap_patch(published=True), "note": "Old note."}
+    assert not _diff(patch, patch).has_staging_admin_edits
+    # Deliberate staging edit that differs from production: warn.
+    assert _diff(
+        {**_bootstrap_patch(), "subtitle": "Staging override."}, _bootstrap_patch(published=True)
+    ).has_staging_admin_edits
+    # New chart (no production counterpart) with deliberate edits: warn too.
+    assert _diff({**_bootstrap_patch(), "subtitle": "Staging override."}, None).has_staging_admin_edits
+    # Patch never loaded (non-ETL chart): never warn.
+    assert not _diff(None, None).has_staging_admin_edits

--- a/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
@@ -15,7 +15,7 @@ def _chart(chart_id: int, created_at: datetime, catalog_path: str | None = None,
         id=chart_id,
         createdAt=created_at,
         updatedAt=created_at + timedelta(hours=1),
-        catalogPath=catalog_path,
+        etlConfigCatalogPath=catalog_path,
         configId=config_id or f"config-uuid-{chart_id}",
     )
 

--- a/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
+++ b/tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py
@@ -36,7 +36,9 @@ def test_config_uuid_identifies_chart_twins():
 
     assert _same_chart_across_envs(source, target)
     assert _is_cross_env_twin(source, target)
-    assert _target_updated_at_for_review(source, target) is None
+    # Approvals bind to the production state that was reviewed — twins included —
+    # so a later production edit invalidates a stale approval.
+    assert _target_updated_at_for_review(source, target) == target.updatedAt
 
     diff = ChartDiff(source_chart=source, target_chart=target, approval=None, conflict=None)
     assert diff.chart_id == source.id
@@ -82,7 +84,7 @@ def test_catalog_path_identifies_etl_chart_twins(monkeypatch):
 
     assert _same_chart_across_envs(source, target)
     assert _is_cross_env_twin(source, target)
-    assert _target_updated_at_for_review(source, target) is None
+    assert _target_updated_at_for_review(source, target) == target.updatedAt
 
     diff = ChartDiff(source_chart=source, target_chart=target, approval=None, conflict=None)
     assert diff.chart_id == source.id
@@ -105,3 +107,120 @@ def test_regular_charts_still_match_by_id_and_created_at():
     assert _same_chart_across_envs(source, target)
     assert not _is_cross_env_twin(source, target)
     assert _target_updated_at_for_review(source, target) == target.updatedAt
+
+
+# --- Layer-aware behavior for ETL-authored charts -----------------------------
+#
+# Scenario names refer to the situations that motivated the change:
+# an ETL-authored chart exists in production, an admin hotfixes it there, and
+# other branches' staging servers rebuild the same chart from the YAML.
+
+_SCHEMA_10 = "https://files.ourworldindata.org/schemas/grapher-schema.010.json"
+_SCHEMA_11 = "https://files.ourworldindata.org/schemas/grapher-schema.011.json"
+
+
+def _etl_layer(schema=_SCHEMA_10, variable_id=111):
+    return {
+        "$schema": schema,
+        "title": "Number of whales caught per year",
+        "subtitle": "Annual number of whales killed worldwide.",
+        "dimensions": [{"property": "y", "variableId": variable_id}],
+    }
+
+
+def _bootstrap_patch(published=False):
+    # What a chart's admin patch looks like straight after the ETL created it.
+    return {"$schema": _SCHEMA_10, "id": 9220, "version": 3, "slug": "whales-caught", "isPublished": published}
+
+
+def test_patch_is_pristine():
+    from apps.wizard.app_pages.chart_diff.chart_diff import patch_is_pristine
+
+    assert patch_is_pristine(None)
+    assert patch_is_pristine({})
+    assert patch_is_pristine(_bootstrap_patch())
+    # Publishing is a deliberate admin action.
+    assert not patch_is_pristine(_bootstrap_patch(published=True))
+    # So is any config override.
+    assert not patch_is_pristine({**_bootstrap_patch(), "subtitle": "Hotfixed subtitle."})
+
+
+def test_unrelated_branch_does_not_see_production_hotfix():
+    """An admin hotfix in production must not surface as a change on an unrelated branch."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import etl_chart_has_branch_changes
+
+    assert not etl_chart_has_branch_changes(
+        source_etl=_etl_layer(schema=_SCHEMA_11),  # staging migrated further — still no branch change
+        target_etl=_etl_layer(schema=_SCHEMA_10),
+        source_patch=_bootstrap_patch(),  # untouched on staging
+        target_patch={**_bootstrap_patch(published=True), "subtitle": "Hotfixed subtitle."},
+    )
+
+
+def test_branch_changing_the_code_layer_shows_the_chart():
+    """A data update (or YAML edit) on the branch changes the ETL layer — chart is listed."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import etl_chart_has_branch_changes
+
+    assert etl_chart_has_branch_changes(
+        source_etl=_etl_layer(variable_id=222),  # re-versioned indicator
+        target_etl=_etl_layer(variable_id=111),
+        source_patch=_bootstrap_patch(),
+        target_patch=_bootstrap_patch(published=True),
+    )
+
+
+def test_staging_admin_edit_shows_the_chart():
+    """A deliberate edit in the staging admin is the one thing sync must carry."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import etl_chart_has_branch_changes
+
+    assert etl_chart_has_branch_changes(
+        source_etl=_etl_layer(),
+        target_etl=_etl_layer(),
+        source_patch={**_bootstrap_patch(), "yAxis": {"min": 0}},
+        target_patch=_bootstrap_patch(published=True),
+    )
+
+
+def test_adopted_chart_with_identical_patches_is_hidden():
+    """An adopted chart whose (non-pristine) patch matches production has no branch changes."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import etl_chart_has_branch_changes
+
+    patch = {**_bootstrap_patch(published=True), "note": "Long-standing admin note."}
+    assert not etl_chart_has_branch_changes(
+        source_etl=_etl_layer(),
+        target_etl=_etl_layer(),
+        source_patch=patch,
+        target_patch=patch,
+    )
+
+
+def test_twin_conflict_depends_on_staging_patch():
+    """Production edits conflict with a twin only once the staging patch carries edits."""
+    from apps.wizard.app_pages.chart_diff.chart_diff import ChartDiff
+
+    config_id = "0198c0e8-0000-7000-8000-000000000000"
+    staging_created_at = datetime(2026, 1, 1)
+    source = _chart(100, datetime(2026, 1, 1), config_id=config_id)
+    target = _chart(200, datetime(2026, 1, 2), config_id=config_id)  # edited after staging creation
+
+    # Pristine staging patch: sync will not write the patch, production edits are safe.
+    diff = ChartDiff(
+        source_chart=source,
+        target_chart=target,
+        approval=None,
+        conflict=None,
+        staging_created_at=staging_created_at,
+        source_patch_config=_bootstrap_patch(),
+    )
+    assert not diff.in_conflict
+
+    # Deliberate staging edit: a production edit is a real conflict again.
+    diff = ChartDiff(
+        source_chart=source,
+        target_chart=target,
+        approval=None,
+        conflict=None,
+        staging_created_at=staging_created_at,
+        source_patch_config={**_bootstrap_patch(), "subtitle": "Staging override."},
+    )
+    assert diff.in_conflict


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

Stacked on [#6511 "Charts as first-class citizens in ETL, addressed by chart config UUID"](https://github.com/owid/etl/pull/6511). Fixes how chart-diff and chart-sync treat ETL-authored charts, so that production admin edits can never be silently overwritten and unrelated branches stop seeing phantom chart changes. ETL-only changes; no owid-grapher changes required.

## The problem (two scenarios)

**Phantom diffs on unrelated branches.** An ETL-authored chart is rebuilt from its YAML by every staging server whose branch contains it. That rebuild carries no production admin edits, so the moment an admin hotfixes the chart in production, every staging server's copy differs from production and the chart shows up in every branch's chart-diff — as if the branch had changed it. The "diff" it shows is literally the hotfix being undone.

**Silent overwrite of production hotfixes.** For cross-environment twins (same config UUID, different numeric ids — the normal state of an ETL-authored chart), the edited-in-production conflict check was disabled unconditionally, and approvals were recorded with a NULL target timestamp that later production edits couldn't invalidate. Approving such a phantom diff and merging made chart-sync push the staging config over production, deleting the hotfix with no warning (flagged by Codex on [#6511 "Charts as first-class citizens in ETL, addressed by chart config UUID"](https://github.com/owid/etl/pull/6511) as P1).

## The model

An ETL-authored chart is two layers with two owners and two delivery routes:

| Layer | Owner | Reaches production via |
|---|---|---|
| `etlConfig` (code layer) | git | production's ETL run after merge |
| admin patch | admins | chart-diff approval + chart-sync |

Chart-diff should list a chart only when **the branch changed a layer**; chart-sync should write only layers the branch changed.

## What changed

- **chart-diff selection** (`_modified_chart_configs_on_staging`): ETL-managed charts are compared layer by layer instead of full-vs-full. A chart is listed only if the code layers differ, or the staging patch is non-pristine and differs from production's. Production-only patch edits no longer surface on unrelated branches.
- **Pristine patch**: a patch holding only the ETL bootstrap keys (`slug`, `$schema`, `version`, `id`) and unpublished counts as untouched. Publishing, or any config override, marks it as a deliberate admin edit.
- **chart-sync**: for ETL-managed charts, `update_chart` (which the server re-diffs into the target's patch) runs only when the staging patch is non-pristine — in both the update and the create paths. A pristine patch can never clobber production's.
- **Conflicts**: the twin override now applies only while the staging patch is pristine (when sync can't touch production's patch anyway). Once the staging patch carries edits, a production edit is flagged as a conflict again.
- **Approvals**: `_target_updated_at_for_review` binds approvals to the production timestamp that was reviewed, twins included, so a later production edit invalidates a stale approval.
- `Chart.load_patch_config()` added to the grapher model (mirrors `load_etl_config`). After the `chart_configs` refactor a chart's rendered config, admin patch and ETL layer are three `chart_configs` rows (`configId`, `patchConfigId`, `patchConfigIdETL`); the layer comparison reads each from its own row.
- Follows the column renames from [owid/owid-grapher#6826 "ETL-authored chart configs, addressed by chart config UUID"](https://github.com/owid/owid-grapher/pull/6826) (`charts.configIdETL` → `patchConfigIdETL`, `charts.catalogPath` → `etlConfigCatalogPath`) in the ORM, chart-diff, chart-sync and `etl chart-config-id`. These touch [#6511 "Charts as first-class citizens in ETL, addressed by chart config UUID"](https://github.com/owid/etl/pull/6511)'s code and can be moved down to that branch.

## The staging-admin warning

For ETL-authored charts, the branch's medium is the YAML; edits made in the staging admin are legal but should be a conscious choice. When chart-diff finds an ETL chart with deliberate staging-admin edits that differ from production, it now shows a warning: the edits will sync as an admin override, and the reviewer is nudged to move them into the chart's `.config.yml` (versioned, reviewed with the code). Long-standing overrides on adopted charts that are identical on both sides don't trigger it.

## Known limitations

- A slug rename made in the staging admin is indistinguishable from the ETL bootstrap slug and reads as pristine (won't sync). Renames should be made in the YAML.
- When the target DB doesn't yet have `charts.patchConfigIdETL` (production before [owid/owid-grapher#6826 "ETL-authored chart configs, addressed by chart config UUID"](https://github.com/owid/owid-grapher/pull/6826) deploys), the comparison falls back to today's full-config behavior.
- The UI still shows code-layer changes as ordinary approvable diffs. Approving them is now harmless (sync writes nothing for them), but reclassifying them as review-only — like data changes — is a possible follow-up.

## Test plan

- New scenario tests in `tests/apps/wizard/app_pages/chart_diff/test_chart_diff.py`: pristine-patch detection, phantom hidden on unrelated branches, code-layer change listed, staging-admin edit listed, adopted chart with identical patches hidden, twin conflict gated on staging patch.
- Two existing twin tests updated for the new approval binding.
- Full non-integration suite passes (839 tests), `make check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


