### PR TITLE
📊 Correct why the JRC rates some city figures low

### DIFF
--- a/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.py
+++ b/etl/steps/data/garden/urbanization/2025-12-10/ghsl_urban_centers.py
@@ -13,22 +13,31 @@ START_OF_PROJECTIONS = 2025
 
 # The source rates the plausibility of every city's population figure (0 = low, 1 = moderate,
 # 2 = high, 3 = very high) and the meadow step carries that rating through. We do not publish the
-# figures it rates "low", because in those cases the population is sometimes placed in the wrong
-# settlement: in Angola the source puts ~1 million people in the small town of Uíge (1.01M in 29 km²)
-# while Luanda's urban centre is absent until 1995, and it flags exactly those figures as low. The
-# same pattern shows up in Eritrea, South Sudan, Comoros and Cabo Verde.
+# figures it rates "low".
+#
+# Why those figures go wrong, per the JRC (July 2026): the underlying population grid is built from
+# only two census epochs per country -- 2006 and 2014 for Angola, 2001 and 2012 for Eritrea -- and the
+# rate of change between them is extrapolated across the whole 1975-2030 series. Where a city was
+# shrinking between its two census years, running that decline backwards inflates its early figures:
+# Angola's Uíge reaches 1.01M in 1975 in 29 km². Where a city was growing fast, the same procedure
+# extrapolates it back to almost nothing, which is why Luanda has no urban centre before 1995. The
+# rating flags precisely these thin-input cases, which is what makes it a good filter for us.
+#
+# Note this is a back-extrapolation artifact, not a spatial one: the population is not assigned to the
+# wrong place, so Uíge's early figures are its own and not Luanda's. A JRC update adding 1995 data for
+# Angola and 1984 data for Eritrea is expected to improve these cases.
 #
 # Two limits on that, both deliberate:
 #
 # 1. Only indicators built from ONE named city are filtered (capital, largest city, top 100). Every
 #    aggregate is left alone -- the city-size buckets, and the regional sums of capital population.
-#    An aggregate sums many cities, so dropping a misplaced one would delete people who really do
-#    live in that country. Filtering the city-size aggregates would also be far more destructive than
-#    it looks: 38 country-years would lose every one of their cities, and Bangladesh, Yemen, Sudan and
-#    Iran would each lose a fifth to two-thirds of their urban population.
+#    An aggregate sums many cities, so dropping a badly estimated one would delete people who really
+#    do live in that country. Filtering the city-size aggregates would also be far more destructive
+#    than it looks: 38 country-years would lose every one of their cities, and Bangladesh, Yemen, Sudan
+#    and Iran would each lose a fifth to two-thirds of their urban population.
 # 2. Only the historical estimates are filtered, never the projections. From 2025 on the rating mostly
-#    marks ordinary forecast uncertainty for small capitals rather than misplacement -- Vientiane is
-#    rated low from 2025, but it really is the largest city in Laos.
+#    marks ordinary forecast uncertainty for small capitals rather than a bad historical extrapolation
+#    -- Vientiane is rated low from 2025, but it really is the largest city in Laos.
 LOW_PLAUSIBILITY = 0
 
 # Regions for which aggregates will be created.


### PR DESCRIPTION
> _Written by Claude Opus 5 — @edomt at the wheel._

Follow-up to #6567. Comments only — no behaviour change, no values changed, no reader-facing text changed.

## What was wrong

#6567 added a filter that drops city population figures the JRC rates as low plausibility. The code comments explained *why* those figures are wrong by saying the population had been placed in the wrong settlement — that Angola's Uíge was holding roughly a million of Luanda's residents.

We asked the JRC about it, and that explanation is not what happens.

## What actually happens

Their population grid is built from only **two census epochs per country** — 2006 and 2014 for Angola, 2001 and 2012 for Eritrea. The rate of change measured between those two years is extrapolated across the entire 1975–2030 series.

- A city that was **shrinking** between its two census years has that decline extrapolated backwards, which inflates its early figures. That is why Uíge reaches 1.01 million in 1975 in 29 km².
- A city that was **growing fast** extrapolates backwards to almost nothing. That is why Luanda has no urban centre at all before 1995.

So it is a back-extrapolation artifact, not a spatial one. Uíge's early population is its own, not Luanda's, and the mirror image between the two series is a coincidence of one declining and one growing trend rather than a transfer between them.

This is a better justification for the filter than the one we had: the rating marks precisely the cases where the model is extrapolating from thin input data.

## What changed here

Three comment blocks in `garden/urbanization/2025-12-10/ghsl_urban_centers.py` — the main policy comment, and two uses of the word "misplaced" that carried the wrong model. Verified that no value moved: every cell is bit-identical to the published catalog.

`etl diff` reports "changed data" on some columns, which is a red herring — the published catalog stores them as `Float32` while a local build produces `Float64`. Exact cell comparison shows zero differences.

## Two things the JRC also corrected

Neither needs a code change, but both are worth recording:

- **Praia is not missing from the source.** DEGURBA classifies it as a Semi-Dense Urban Cluster rather than an Urban Centre, so it is outside the collection we use. Cabo Verde legitimately has no capital city in this dataset, which is consistent with our own published definition of a city.
- **Comparing their city figures against UN World Urbanization Prospects is not apples-to-apples.** They correct population dynamics at the census-unit level, not the city level, and DEGURBA draws different boundaries. The comparison table in #6567's description should be read with that in mind.

They also confirmed that **South Sudan and Comoros** are not explained by the mechanism above and warrant investigation on their side, and that an upcoming release adds 1995 data for Angola and 1984 data for Eritrea, which should improve these cases.

## Still open

- **Nothing handed off.** The JRC has replied; no further response is required from us, though offering South Sudan and Comoros as test cases would be welcome to them.
- **Unverified:** the six charts affected by #6567 have still not been looked at visually. Their underlying values were verified against the staging API before that PR merged, but nobody has viewed the rendered charts.