### PR TITLE
🔨 Stop hardcoding catalog paths in collection configs

### DIFF
--- a/etl/steps/export/explorers/un/latest/un_wpp.manual.config.yml
+++ b/etl/steps/export/explorers/un/latest/un_wpp.manual.config.yml
@@ -481,7 +481,7 @@ views:
       variant: estimates
     indicators:
       y:
-        - catalogPath: grapher/un/2024-07-12/un_wpp/deaths#deaths__sex_all__age_0__variant_estimates
+        - catalogPath: un_wpp/deaths#deaths__sex_all__age_0__variant_estimates
   - dimensions:
       indicator: infant_deaths
       age: "0"
@@ -489,7 +489,7 @@ views:
       variant: estimates
     indicators:
       y:
-        - catalogPath: grapher/un/2024-07-12/un_wpp/deaths#deaths__sex_female__age_0__variant_estimates
+        - catalogPath: un_wpp/deaths#deaths__sex_female__age_0__variant_estimates
   - dimensions:
       indicator: infant_deaths
       age: "0"
@@ -497,7 +497,7 @@ views:
       variant: estimates
     indicators:
       y:
-        - catalogPath: grapher/un/2024-07-12/un_wpp/deaths#deaths__sex_male__age_0__variant_estimates
+        - catalogPath: un_wpp/deaths#deaths__sex_male__age_0__variant_estimates
   # Projection views combine projection + estimates as two y-indicators so
   # grapher renders a solid→dashed transition on the line chart AND the map tab
   # auto-combines them into the full 1950–2100 series (see
@@ -606,7 +606,7 @@ views:
       variant: estimates
     indicators:
       y:
-        - catalogPath: grapher/un/2024-07-12/un_wpp/mortality_rate#mortality_rate__sex_all__age_0__variant_estimates
+        - catalogPath: un_wpp/mortality_rate#mortality_rate__sex_all__age_0__variant_estimates
           <<: *display_mortality_rate
   - dimensions:
       indicator: child_mortality_rate
@@ -615,7 +615,7 @@ views:
       variant: estimates
     indicators:
       y:
-        - catalogPath: grapher/un/2024-07-12/un_wpp/mortality_rate#mortality_rate__sex_all__age_0_4__variant_estimates
+        - catalogPath: un_wpp/mortality_rate#mortality_rate__sex_all__age_0_4__variant_estimates
           <<: *display_mortality_rate
 
   # Projection views combine projection + estimates as two y-indicators (projection

--- a/etl/steps/export/multidim/ihme_gbd/latest/air_pollution.config.yml
+++ b/etl/steps/export/multidim/ihme_gbd/latest/air_pollution.config.yml
@@ -86,7 +86,7 @@ views:
       metric: number
     indicators:
       y:
-        - catalogPath: grapher/ihme_gbd/2026-02-07/gbd_risk_deaths/gbd_risk_deaths#value__metric_number__measure_deaths__rei_air_pollution__age_all_ages__cause_all_causes
+        - catalogPath: gbd_risk_deaths#value__metric_number__measure_deaths__rei_air_pollution__age_all_ages__cause_all_causes
     config:
       title: Deaths from air pollution
       subtitle: Estimated premature deaths attributed to air pollution. This means people died earlier than they would have in the absence of air pollution. This includes indoor household pollution, outdoor particulate matter and ozone pollution.
@@ -96,7 +96,7 @@ views:
       metric: rate
     indicators:
       y:
-        - catalogPath: grapher/ihme_gbd/2026-02-07/gbd_risk_deaths/gbd_risk_deaths#value__metric_rate__measure_deaths__rei_air_pollution__age_age_standardized__cause_all_causes
+        - catalogPath: gbd_risk_deaths#value__metric_rate__measure_deaths__rei_air_pollution__age_age_standardized__cause_all_causes
     config:
       title: Death rate from air pollution
       subtitle: Estimated premature deaths attributed to air pollution per 100,000 people. This means people died earlier than they would have in the absence of pollution.
@@ -107,7 +107,7 @@ views:
       metric: share
     indicators:
       y:
-        - catalogPath: grapher/ihme_gbd/2026-02-07/gbd_risk_deaths/gbd_risk_deaths#value__metric_percent__measure_deaths__rei_air_pollution__age_age_standardized__cause_all_causes
+        - catalogPath: gbd_risk_deaths#value__metric_percent__measure_deaths__rei_air_pollution__age_age_standardized__cause_all_causes
     config:
       title: Share of deaths attributed to air pollution
       subtitle: Share of deaths, from any cause, which are attributed to air pollution – from outdoor and indoor sources – as a risk factor.
@@ -118,7 +118,7 @@ views:
       metric: number
     indicators:
       y:
-        - catalogPath: grapher/ihme_gbd/2026-02-07/gbd_risk_deaths/gbd_risk_deaths#value__metric_number__measure_deaths__rei_ambient_particulate_matter_pollution__age_all_ages__cause_all_causes
+        - catalogPath: gbd_risk_deaths#value__metric_number__measure_deaths__rei_ambient_particulate_matter_pollution__age_all_ages__cause_all_causes
     config:
       title: Deaths from outdoor air pollution
       subtitle: Estimated premature deaths attributed to outdoor air pollution. This means people died earlier than they would have in the absence of outdoor particulate matter pollution.
@@ -128,7 +128,7 @@ views:
       metric: rate
     indicators:
       y:
-        - catalogPath: grapher/ihme_gbd/2026-02-07/gbd_risk_deaths/gbd_risk_deaths#value__metric_rate__measure_deaths__rei_ambient_particulate_matter_pollution__age_age_standardized__cause_all_causes
+        - catalogPath: gbd_risk_deaths#value__metric_rate__measure_deaths__rei_ambient_particulate_matter_pollution__age_age_standardized__cause_all_causes
     config:
       title: Outdoor air pollution death rate
       subtitle: Estimated premature deaths attributed to outdoor air pollution per 100,000 people. This means people died earlier than they would have in the absence of pollution.
@@ -139,7 +139,7 @@ views:
       metric: share
     indicators:
       y:
-        - catalogPath: grapher/ihme_gbd/2026-02-07/gbd_risk_deaths/gbd_risk_deaths#value__metric_percent__measure_deaths__rei_ambient_particulate_matter_pollution__age_all_ages__cause_all_causes
+        - catalogPath: gbd_risk_deaths#value__metric_percent__measure_deaths__rei_ambient_particulate_matter_pollution__age_all_ages__cause_all_causes
     config:
       title: Share of deaths attributed to outdoor air pollution
       subtitle: Share of deaths, from any cause, where ambient particulate matter air pollution is a risk factor.
@@ -150,7 +150,7 @@ views:
       metric: number
     indicators:
       y:
-        - catalogPath: grapher/ihme_gbd/2026-02-07/gbd_risk_deaths/gbd_risk_deaths#value__metric_number__measure_deaths__rei_household_air_pollution_from_solid_fuels__age_all_ages__cause_all_causes
+        - catalogPath: gbd_risk_deaths#value__metric_number__measure_deaths__rei_household_air_pollution_from_solid_fuels__age_all_ages__cause_all_causes
     config:
       title: Deaths from indoor air pollution
       subtitle: Estimated premature deaths attributed to indoor air pollution. This means people died earlier than they would have in the absence of indoor air pollution from solid fuels used for cooking and heating.
@@ -160,7 +160,7 @@ views:
       metric: rate
     indicators:
       y:
-        - catalogPath: grapher/ihme_gbd/2026-02-07/gbd_risk_deaths/gbd_risk_deaths#value__metric_rate__measure_deaths__rei_household_air_pollution_from_solid_fuels__age_age_standardized__cause_all_causes
+        - catalogPath: gbd_risk_deaths#value__metric_rate__measure_deaths__rei_household_air_pollution_from_solid_fuels__age_age_standardized__cause_all_causes
     config:
       title: Death rate from indoor air pollution
       subtitle: Estimated premature deaths attributed to indoor air pollution per 100,000 people. This means people died earlier than they would have in the absence of pollution.
@@ -171,7 +171,7 @@ views:
       metric: share
     indicators:
       y:
-        - catalogPath: grapher/ihme_gbd/2026-02-07/gbd_risk_deaths/gbd_risk_deaths#value__metric_percent__measure_deaths__rei_household_air_pollution_from_solid_fuels__age_age_standardized__cause_all_causes
+        - catalogPath: gbd_risk_deaths#value__metric_percent__measure_deaths__rei_household_air_pollution_from_solid_fuels__age_age_standardized__cause_all_causes
     config:
       title: Share of deaths from indoor air pollution
       subtitle: Share of deaths, from any cause, which are attributed to indoor air pollution – from burning solid fuels – as a risk factor.

--- a/etl/steps/export/multidim/un/latest/un_wpp.manual.config.yml
+++ b/etl/steps/export/multidim/un/latest/un_wpp.manual.config.yml
@@ -512,7 +512,7 @@ views:
       variant: estimates
     indicators:
       y:
-        - catalogPath: grapher/un/2024-07-12/un_wpp/deaths#deaths__sex_all__age_0__variant_estimates
+        - catalogPath: un_wpp/deaths#deaths__sex_all__age_0__variant_estimates
   - dimensions:
       indicator: infant_deaths
       age: "0"
@@ -520,7 +520,7 @@ views:
       variant: estimates
     indicators:
       y:
-        - catalogPath: grapher/un/2024-07-12/un_wpp/deaths#deaths__sex_female__age_0__variant_estimates
+        - catalogPath: un_wpp/deaths#deaths__sex_female__age_0__variant_estimates
   - dimensions:
       indicator: infant_deaths
       age: "0"
@@ -528,7 +528,7 @@ views:
       variant: estimates
     indicators:
       y:
-        - catalogPath: grapher/un/2024-07-12/un_wpp/deaths#deaths__sex_male__age_0__variant_estimates
+        - catalogPath: un_wpp/deaths#deaths__sex_male__age_0__variant_estimates
   # Projection views combine projection + estimates as two y-indicators so
   # grapher renders a solid→dashed transition on the line chart AND the map tab
   # auto-combines them into the full 1950–2100 series (see
@@ -637,7 +637,7 @@ views:
       variant: estimates
     indicators:
       y:
-        - catalogPath: grapher/un/2024-07-12/un_wpp/mortality_rate#mortality_rate__sex_all__age_0__variant_estimates
+        - catalogPath: un_wpp/mortality_rate#mortality_rate__sex_all__age_0__variant_estimates
   - dimensions:
       indicator: child_mortality_rate
       age: 0-4
@@ -645,7 +645,7 @@ views:
       variant: estimates
     indicators:
       y:
-        - catalogPath: grapher/un/2024-07-12/un_wpp/mortality_rate#mortality_rate__sex_all__age_0_4__variant_estimates
+        - catalogPath: un_wpp/mortality_rate#mortality_rate__sex_all__age_0_4__variant_estimates
 
   # Projection views combine projection + estimates as two y-indicators (projection
   # first; see note on infant_deaths above) so grapher renders a solid→dashed

--- a/etl/steps/export/multidim/wb/latest/incomes_pip.py
+++ b/etl/steps/export/multidim/wb/latest/incomes_pip.py
@@ -22,8 +22,10 @@ DIMENSIONS_CONFIG = {
 PPP_ADJUSTMENT_SUBTITLE = "This data is adjusted for inflation and differences in living costs between countries."
 
 # Set x (population) and color (region) indicators needed by the Marimekko tab.
-POPULATION_PATH = "grapher/demography/2024-07-15/population/historical#population_historical"
-REGION_PATH = "grapher/regions/2023-01-01/regions/regions#owid_region"
+# Given in short form (`table#column`); `Collection.save` resolves them against the step's
+# dependencies, so the dataset versions are not hardcoded here.
+POPULATION_PATH = "historical#population_historical"
+REGION_PATH = "regions#owid_region"
 
 # Grouped views (all deciles, P10/P50/P90, richer/poorer groups) exist only in the "No spells"
 # variant — they expose no "show breaks in the data" toggle. So the two breaks-dependent garden

--- a/tests/collections/test_model_dimension_view.py
+++ b/tests/collections/test_model_dimension_view.py
@@ -216,6 +216,39 @@ def test_view_expand_paths_and_indicators_used():
     }
 
 
+def test_view_expand_paths_covers_non_y_dimensions_set_after_creation():
+    """
+    Test that expand_paths resolves short-form paths on every chart dimension, not just y.
+
+    Steps set x/color/size after the collection is built (e.g. to add a Marimekko tab, which
+    needs population on x and region on color). Those indicators miss the create-time
+    expansion, so `Collection.save` calls `expand_paths` again to catch them. This test pins
+    that behavior: short paths assigned via `set_indicator` must end up as full catalog paths.
+    """
+    # Start from a y-only view, as a collection would produce it.
+    view = View(dimensions={"d": "a"}, indicators=ViewIndicators.from_dict({"y": "table#ind1"}))
+
+    # Assign the remaining dimensions afterwards, in short form.
+    view.indicators.set_indicator(x="population#population", color="regions#region", size="table#ind2")
+
+    mapping = {
+        "table": ["grapher/ns/latest/ds/table"],
+        "population": ["grapher/demography/latest/population/population"],
+        "regions": ["grapher/regions/latest/regions/regions"],
+    }
+    view.expand_paths(mapping)
+
+    # Every dimension is now a full catalog path, y included.
+    assert view.indicators.y is not None
+    assert view.indicators.y[0].catalogPath == "grapher/ns/latest/ds/table#ind1"
+    assert view.indicators.x is not None
+    assert view.indicators.x.catalogPath == "grapher/demography/latest/population/population#population"
+    assert view.indicators.color is not None
+    assert view.indicators.color.catalogPath == "grapher/regions/latest/regions/regions#region"
+    assert view.indicators.size is not None
+    assert view.indicators.size.catalogPath == "grapher/ns/latest/ds/table#ind2"
+
+
 def test_view_matches_single_dimension_exact():
     """
     Test View.matches with single dimension exact matching.


### PR DESCRIPTION
> _Written by Claude Opus 5 and Claude Fable 5 — @pabloarosado at the wheel._

## Human summary

Not urgent: this PR simply removes a couple of hardcoded paths in a collection config, which is (as far as I can tell) no longer needed.

---

`incomes_pip.py` spelled out the full catalog paths of the population and regions indicators that the Marimekko tab needs on `x` and `color`:

```python
POPULATION_PATH = "grapher/demography/2024-07-15/population/historical#population_historical"
REGION_PATH = "grapher/regions/2023-01-01/regions/regions#owid_region"
```

These are the last hardcoded full paths of this kind in the repo. They are not needed: `Collection.save()` resolves short-form paths (`table#column`) against the step's dependencies, for every chart dimension and also for indicators set after the collection is created. So the constants become:

```python
POPULATION_PATH = "historical#population_historical"
REGION_PATH = "regions#owid_region"
```

Both dataset versions now come from the DAG, so bumping either dependency no longer requires editing this file.

## Verification

Ran the export step before and after the change and compared the generated collection config (`export/multidim/wb/latest/incomes_pip/incomes_pip.config.json`):

- 57 views before and after, 23 of them carrying `x` and `color`.
- Every one of those 23 expands to exactly the two previously hardcoded full paths.
- The configs are identical once the y-indicator ordering is normalized (see below).

## Pre-existing non-determinism (not addressed here)

While comparing configs I found that two runs of the **unchanged** step produce different configs: the 23 grouped "Spells" views list their 17 y indicators in a different order each time. The cause is [incomes_pip.py:71-76](https://github.com/owid/etl/blob/master/etl/steps/export/multidim/wb/latest/incomes_pip.py#L71-L76), which collects `survey_comparability` values into a `set()` and iterates it, so Python's per-process string hash seed decides the series order. It means this mdim's config churns on every rebuild.

Left out of this PR so the comparison above stays a clean no-op. The fix is to sort the values, which also settles the series order in those views.

## Follow-up folded in: the remaining pinned paths in collection configs

A review pass found 19 more full-form pinned paths, in three collection config YAMLs. They are now shortened to the same short form, so all three collections follow their DAG dependency on the next version bump:

| File | Paths |
|---|---|
| `etl/steps/export/multidim/ihme_gbd/latest/air_pollution.config.yml` | 9 |
| `etl/steps/export/multidim/un/latest/un_wpp.manual.config.yml` | 5 |
| `etl/steps/export/explorers/un/latest/un_wpp.manual.config.yml` | 5 |

All pinned versions matched the current DAG dependencies, so this is again a no-op today.

### Verification

Ran each export step before and after the change and compared the generated outputs:

- Air pollution mdim (`air_pollution.config.json`): byte-identical.
- UN WPP explorer (`population-and-demography.config.json` and the generated `.tsv`): byte-identical.
- UN WPP mdim (`population-and-demography.config.json`): identical except for the order of the two entries in its `dependencies` list, which is pre-existing run-to-run churn (the list is serialized from a Python set). All 941 distinct `catalogPath` values in the output are identical and fully expanded.

The only full-form paths left under `etl/steps/export/` are two in the dummy issue-reporting config (`multidim/dummy/latest/issue_reporting.config.yml`), pinned to `covid/latest` so there is no version to drift, and one commented-out line in the democracy explorer config.