### PR TITLE
🐛 Fix MDim chart matcher: ignore decoration indicators

### DIFF
--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -123,7 +123,12 @@ tab, an editor adds continent colors to a line chart — and requiring them to a
 literally drops same-y pairs into `none` with no report at all (equal y sets means
 they aren't even a near miss). A match made across such a difference says so in
 the proposal's `note` column. Content indicators (a scatter's GDP-per-capita x, a
-"political regime" coloring) are never stripped. Several matching views → tiebreak
+"political regime" coloring) are never stripped. Two guardrails keep the rule from
+overreaching: a **scatter's x slot is never stripped** — on a `ScatterPlot`,
+`x=population` is the plotted relationship, not decoration (size/color there still
+are) — and the population pattern is **end-anchored** to the raw head-count columns
+(`#population`, `#population_historical`, `#population_projection`), because the
+same dataset also carries population *density* columns that are content. Several matching views → tiebreak
 on chart type; still ambiguous → reported, never guessed. **Any** partial indicator overlap
 that is not an exact match → `near_miss`, reported only — not just subset/superset:
 a chart plotting `{A, B}` against a view plotting `{A, C}` shares `A`, so calling

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -114,8 +114,17 @@ charts that means one file per chart, in `payloads/`. The combined
 `audit_references.py` read — don't hand that one over as a copy-paste payload.
 
 **Matching**: a chart matches a view when the y-variable-ID sets are equal AND
-x/size/color agree (absent == absent). Several matching views → tiebreak on chart
-type; still ambiguous → reported, never guessed. **Any** partial indicator overlap
+x/size/color agree (absent == absent) — after **decoration indicators** are
+stripped from x/size/color on both sides: population as Marimekko width / bubble
+size, and `regions#owid_region` as continent coloring (matched by catalogPath, so
+version bumps don't matter). Charts and views carry these inconsistently without
+changing what data is plotted — an MDIM view adds `x=population` for its Marimekko
+tab, an editor adds continent colors to a line chart — and requiring them to agree
+literally drops same-y pairs into `none` with no report at all (equal y sets means
+they aren't even a near miss). A match made across such a difference says so in
+the proposal's `note` column. Content indicators (a scatter's GDP-per-capita x, a
+"political regime" coloring) are never stripped. Several matching views → tiebreak
+on chart type; still ambiguous → reported, never guessed. **Any** partial indicator overlap
 that is not an exact match → `near_miss`, reported only — not just subset/superset:
 a chart plotting `{A, B}` against a view plotting `{A, C}` shares `A`, so calling
 it `none` would assert an overlap check that came out the other way. Quality labels:
@@ -451,3 +460,20 @@ them:
 After a real run, fold anything the matcher or these docs got wrong back into
 this SKILL.md (and check whether the sibling `map-explorer-to-mdim` /
 `review-explorer-mdim-mapping` skills need the same fix).
+
+- **Same-y charts vanishing into `none` is the matcher's blind spot** — when a
+  reviewer reports a "clear equivalent" the run missed, diff the two sides'
+  x/size/color slots first (charts.csv vs multidim_views.csv): the y sets being
+  equal means the miss can only be a slot disagreement, and if it's a decoration
+  indicator the fix belongs in `DECORATION_PATTERN`, not in `overrides.csv`.
+  (2026-08: population + owid_region cost 5 of 19 Economic Inequality matches.)
+- **Preflight's embed gate must classify exactly like `find-chart-references`.**
+  It re-implements the embed count in SQL for read-only use, so any component
+  the sweep exempts (e.g. `all-charts` — a topic page's auto-generated index
+  where a retired chart just drops out) must be exempted there too, or preflight
+  blocks on a reference the audit rightly never lists.
+- **Re-runs that add targets invalidate those rows' review decisions** — the
+  review HTML fingerprints each decision on (target, both config md5s), so a row
+  that gains or changes a target gets its saved approval/note pruned on next
+  load. Before re-running the extractor mid-review, have the reviewer export
+  (⬇ JSON); unchanged rows re-import cleanly.

--- a/.claude/skills/map-charts-to-mdim/scripts/extract_and_match.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/extract_and_match.py
@@ -18,8 +18,9 @@ every slot: same set of y variables, same x/size/color (absent == absent) —
 after stripping *decoration* indicators (population as Marimekko width / bubble
 size, owid_region as continent coloring) from x/size/color on both sides, since
 charts and views carry those inconsistently without changing what data is
-plotted. Ties between several matching views are broken by chart type; anything
-still ambiguous is reported, not proposed.
+plotted. A scatter's x axis is exempt — there population is the plotted
+relationship, not decoration. Ties between several matching views are broken by
+chart type; anything still ambiguous is reported, not proposed.
 
 Outputs into ``--out``:
 - ``charts.csv``                 — the selected source charts and their indicator slots
@@ -62,14 +63,21 @@ EXTRA_SLOTS = ("x", "size", "color")
 # continent. Requiring these slots to agree exactly silently dropped
 # same-y-different-decoration pairs into `none` — with equal y sets they are not even a
 # near miss, so nothing reported the gap. They are stripped from x/size/color (never
-# from y) on BOTH sides before matching; the raw slots stay in charts.csv /
+# from y) on BOTH sides before matching — except a scatter's x slot, which is the plotted
+# relationship itself (see `effective()`); the raw slots stay in charts.csv /
 # multidim_views.csv, and an exact match made across a decoration difference says so in
 # the proposal's `note` column. Only these two families qualify — a color like
 # "political regime" or a scatter x like GDP per capita is content and stays in the
 # match key. (Matched against catalogPath, so version bumps keep matching; legacy
 # variables with a NULL catalogPath are conservatively treated as content.)
+# Both alternatives are end-anchored: the demography `population` dataset also carries
+# population *density* columns (`population_density#population_density`,
+# `historical#population_density_historical`, `projections#population_density_projection`)
+# which an unanchored `#population` prefix would swallow — density is content, not
+# decoration. The anchored family is exactly the raw head-counts: `#population`,
+# `#population_historical`, `#population_projection`.
 DECORATION_PATTERN = re.compile(
-    r"/population/[^/#]+#population"  # demography population + population_historical
+    r"/population/[^/#]+#population(_historical|_projection)?$"  # demography population head-counts
     r"|/regions/regions#\w+_region$"  # owid_region & friends (continent coloring)
 )
 QUALITIES = ("exact", "forced", "ambiguous", "near_miss", "none", "skipped")
@@ -407,10 +415,20 @@ def match_charts(charts: list[dict], views: list[dict], id_to_path: dict[int, st
     """Set match_quality / target / candidates / near-miss info on each chart dict."""
 
     def effective(rec) -> tuple:
-        """x/size/color with decoration indicators treated as absent."""
-        return tuple(
-            None if rec[s] and DECORATION_PATTERN.search(id_to_path.get(rec[s]) or "") else rec[s] for s in EXTRA_SLOTS
-        )
+        """x/size/color with decoration indicators treated as absent.
+
+        On a scatter the x axis IS the content — population there is the plotted
+        relationship (e.g. "GDP per capita vs. population"), not Marimekko bar-width
+        decoration — so ScatterPlot records keep their x slot literal on both sides.
+        A scatter's size=population (bubble size) and color=owid_region stay decoration.
+        """
+        slots = []
+        for s in EXTRA_SLOTS:
+            vid = rec[s]
+            content_slot = s == "x" and rec["chart_type"] == "ScatterPlot"
+            strip = vid and not content_slot and DECORATION_PATTERN.search(id_to_path.get(vid) or "")
+            slots.append(None if strip else vid)
+        return tuple(slots)
 
     def slot_label(vid) -> str:
         return f"{vid} ({path_tail(id_to_path.get(vid))})" if vid else "absent"

--- a/.claude/skills/map-charts-to-mdim/scripts/extract_and_match.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/extract_and_match.py
@@ -14,9 +14,12 @@ redirect is created here, or anywhere in this skill — applying is
 Charts are selected by exactly one of ``--tag`` / ``--slugs`` / ``--dataset-id``
 and matched against the views of every published MDIM (or only those passed via
 repeatable ``--mdim``). A chart matches a view when their indicator IDs agree on
-every slot: same set of y variables, same x/size/color (absent == absent). Ties
-between several matching views are broken by chart type; anything still
-ambiguous is reported, not proposed.
+every slot: same set of y variables, same x/size/color (absent == absent) —
+after stripping *decoration* indicators (population as Marimekko width / bubble
+size, owid_region as continent coloring) from x/size/color on both sides, since
+charts and views carry those inconsistently without changing what data is
+plotted. Ties between several matching views are broken by chart type; anything
+still ambiguous is reported, not proposed.
 
 Outputs into ``--out``:
 - ``charts.csv``                 — the selected source charts and their indicator slots
@@ -43,6 +46,7 @@ Usage:
 import argparse
 import csv
 import json
+import re
 from collections import Counter, defaultdict
 from pathlib import Path
 from urllib.parse import urlencode
@@ -51,6 +55,23 @@ from etl.config import OWID_ENV
 
 PUBLIC_HOST = "https://ourworldindata.org"
 EXTRA_SLOTS = ("x", "size", "color")
+
+# Decoration indicators style a chart without changing what data it plots, and charts vs
+# MDIM views carry them inconsistently: an MDIM view adds x=population so its Marimekko
+# tab has bar widths, a chart editor adds color=owid_region to color countries by
+# continent. Requiring these slots to agree exactly silently dropped
+# same-y-different-decoration pairs into `none` — with equal y sets they are not even a
+# near miss, so nothing reported the gap. They are stripped from x/size/color (never
+# from y) on BOTH sides before matching; the raw slots stay in charts.csv /
+# multidim_views.csv, and an exact match made across a decoration difference says so in
+# the proposal's `note` column. Only these two families qualify — a color like
+# "political regime" or a scatter x like GDP per capita is content and stays in the
+# match key. (Matched against catalogPath, so version bumps keep matching; legacy
+# variables with a NULL catalogPath are conservatively treated as content.)
+DECORATION_PATTERN = re.compile(
+    r"/population/[^/#]+#population"  # demography population + population_historical
+    r"|/regions/regions#\w+_region$"  # owid_region & friends (continent coloring)
+)
 QUALITIES = ("exact", "forced", "ambiguous", "near_miss", "none", "skipped")
 
 PROPOSAL_COLUMNS = [
@@ -384,9 +405,19 @@ def attach_view_config_facts(views: list[dict], mdim_ids: list[int]) -> None:
 
 def match_charts(charts: list[dict], views: list[dict], id_to_path: dict[int, str]) -> None:
     """Set match_quality / target / candidates / near-miss info on each chart dict."""
+
+    def effective(rec) -> tuple:
+        """x/size/color with decoration indicators treated as absent."""
+        return tuple(
+            None if rec[s] and DECORATION_PATTERN.search(id_to_path.get(rec[s]) or "") else rec[s] for s in EXTRA_SLOTS
+        )
+
+    def slot_label(vid) -> str:
+        return f"{vid} ({path_tail(id_to_path.get(vid))})" if vid else "absent"
+
     by_key: dict[tuple, list[dict]] = defaultdict(list)
     for v in views:
-        by_key[(v["y"], v["x"], v["size"], v["color"])].append(v)
+        by_key[(v["y"], *effective(v))].append(v)
 
     for c in charts:
         c.update({"quality": "none", "tiebreak": "", "target": None, "candidates": [], "near_misses": [], "note": ""})
@@ -397,7 +428,8 @@ def match_charts(charts: list[dict], views: list[dict], id_to_path: dict[int, st
         if not c["y"]:
             c["note"] = "chart has no y indicators"
             continue
-        candidates = by_key.get((c["y"], c["x"], c["size"], c["color"]), [])
+        c_eff = effective(c)
+        candidates = by_key.get((c["y"], *c_eff), [])
         if len(candidates) == 1:
             c["quality"], c["target"] = "exact", candidates[0]
         elif len(candidates) > 1:
@@ -414,12 +446,21 @@ def match_charts(charts: list[dict], views: list[dict], id_to_path: dict[int, st
             # suggestions report assert that no view carries any of the chart's indicators,
             # which is exactly what it is not. That broader reading is what the CSV legend
             # has always documented ("indicator sets overlap but differ").
-            near = [
-                v for v in views if all(v[s] == c[s] for s in EXTRA_SLOTS) and (v["y"] & c["y"]) and v["y"] != c["y"]
-            ]
+            near = [v for v in views if effective(v) == c_eff and (v["y"] & c["y"]) and v["y"] != c["y"]]
             near.sort(key=lambda v: (-len(v["y"] & c["y"]), len(v["y"] ^ c["y"])))
             if near:
                 c["quality"], c["near_misses"] = "near_miss", near[:3]
+
+        # A match made across a decoration difference is still a match, but the reviewer
+        # should see that the two sides did not agree literally.
+        if c["target"] is not None:
+            diffs = [
+                f"{s}: chart {slot_label(c[s])} vs view {slot_label(c['target'][s])}"
+                for s in EXTRA_SLOTS
+                if c[s] != c["target"][s]
+            ]
+            if diffs:
+                c["note"] = "decoration difference ignored — " + "; ".join(diffs)
 
 
 def describe_near_miss(c: dict, id_to_path: dict[int, str]) -> str:

--- a/.claude/skills/map-charts-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/preflight.py
@@ -499,15 +499,20 @@ def embed_references(redirects: list[dict]) -> dict[int, str]:
         ),
     )
     # Block-level components render the chart; `span-*` is a hyperlink in prose, which the
-    # 301 covers. LEFT() rather than LIKE: a literal '%' in the SQL string would collide
-    # with pymysql's own parameter formatting.
+    # 301 covers, and `all-charts` is a topic page's auto-generated chart index — the block
+    # lists every chart carrying the page's tag, so an unpublished chart simply drops out
+    # and nothing breaks (find-chart-references excludes these rows for the same reason —
+    # the gate must agree with the audit, or preflight blocks on a reference the audit
+    # rightly never lists). LEFT() rather than LIKE: a literal '%' in the SQL string would
+    # collide with pymysql's own parameter formatting.
     add_by_slug(
         "articleEmbeds",
         OWID_ENV.read_sql(
             "SELECT pgl.target AS slug, COUNT(*) AS n FROM posts_gdocs_links pgl "
             "JOIN posts_gdocs pg ON pg.id = pgl.sourceId "
             "WHERE pgl.target IN %(slugs)s AND pgl.linkType IN ('grapher', 'guided-chart') "
-            "AND pg.published = 1 AND (pgl.componentType IS NULL OR LEFT(pgl.componentType, 5) <> 'span-') "
+            "AND pg.published = 1 AND (pgl.componentType IS NULL "
+            "OR (LEFT(pgl.componentType, 5) <> 'span-' AND pgl.componentType <> 'all-charts')) "
             "GROUP BY pgl.target",
             params={"slugs": slugs},
         ),


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

## Problem

The `map-charts-to-mdim` matcher required a chart and an MDim view to agree **literally** on all four indicator slots (y, x, size, color). But charts and views carry *decoration* indicators inconsistently, without changing what data is plotted:

- MDim views add `x = population` so their Marimekko tab has bar widths;
- chart editors add `color = regions#owid_region` to color countries by continent.

A same-y pair differing only in decoration fell into `none` — and because the y sets were *equal*, it didn't even qualify as a `near_miss` (that requires unequal y), so nothing reported the gap. On the Economic Inequality sweep this silently hid 5 of what are now 19 exact matches, including [economic-inequality-gini-index](https://ourworldindata.org/grapher/economic-inequality-gini-index) → `gini-coefficient-wb`, whose only difference was continent coloring on the chart side.

A second, related mismatch: `preflight.py`'s embed gate counted `componentType='all-charts'` rows (a topic page's auto-generated chart index) as blocking article embeds, while the `find-chart-references` sweep deliberately exempts them — a retired chart simply drops out of that block, nothing breaks. The gate blocked on a reference the audit rightly never lists.

## Fix

- **`extract_and_match.py`**: strip decoration indicators from the x/size/color slots on **both** sides before matching, via a new `DECORATION_PATTERN` matched against catalogPath (version-proof): demography `population`/`population_historical`, and `regions#…_region`. y is never stripped; content indicators (a scatter's GDP-per-capita x, a "political regime" coloring) stay in the match key. Any match made across a decoration difference is spelled out in the proposal's `note` column so the reviewer sees it.
- **`preflight.py`**: exempt `all-charts` rows from the embed gate, matching `find-chart-references`' classification.
- **`SKILL.md`**: documented the rule and added three lessons (same-y misses are always a slot disagreement; the gate must classify exactly like the audit; re-runs that change targets prune those rows' saved review decisions — export first).

## Validation

Re-ran the Economic Inequality extraction against production (read-only): 14 → 19 exact matches, 0 ambiguous, 0 conflicts; the 14 pre-fix rows are byte-identical, so existing review decisions survive. All 19 rows pass preflight. Both scripts pass ruff check + format; `make check` clean.

## Open items

- **Proposed** — the 19 redirect proposals themselves live in gitignored `ai/` and ship separately via the usual `redirects_for_cli.csv` + `HANDOFF.md` handoff after human review; this PR only changes the tooling.
- **Unverified** — the decoration list is deliberately minimal (population + `…_region`); other cosmetic families (e.g. income-group coloring) stay content until a real case shows they should not.
