### PR TITLE
🐛 MDim chart matcher: twin-variable suspects + stale-decision fix

### DIFF
--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -142,6 +142,17 @@ it `none` would assert an overlap check that came out the other way. Quality lab
 - `none` — no view shares the chart's indicators. **An accepted outcome** — only
   matched charts get redirects; don't force the rest.
 
+**Twin suspects.** ID matching is blind to one real equivalence: a dataset that
+publishes the same series in two tables (WID/LIS do — `inequality#share_top_10__…`
+for the standalone charts vs `incomes#share__…quantile_10…` for the MDIM; verified
+value-identical). The extractor flags these — unmatched charts whose y comes from
+the same dataset as a slot-compatible view with a similar column name — in the run
+report and in `mdim_suggestions.md` as **twin suspects**, with the exact
+`overrides.csv` line to use. A suspect is NOT a match: verify first that the two
+indicators' values are identical (fetch both
+`api.ourworldindata.org/v1/indicators/<id>.data.json` and compare every
+entity-year), then force it, citing the verification in the override note.
+
 Either side carrying several indicators in one `x`/`size`/`color` slot has no
 chart-shaped signature, so it is **excluded from matching** rather than truncated
 to the first: a truncated signature can spuriously exact-match a counterpart that
@@ -482,3 +493,11 @@ this SKILL.md (and check whether the sibling `map-explorer-to-mdim` /
   that gains or changes a target gets its saved approval/note pruned on next
   load. Before re-running the extractor mid-review, have the reviewer export
   (⬇ JSON); unchanged rows re-import cleanly.
+- **A reviewer flagging an unmatched row with "the target should be X" is the
+  twin-variable signal** (2026-08: 3 of 3 such flags were twins — same dataset,
+  two tables, identical values). The workflow is: verify values via the
+  indicators API, force via `overrides.csv`, re-run. The old flag then reads as
+  stale in `preflight.py --decisions` (a decision exported with an empty target
+  no longer matches the now-targeted row — deliberate, or the flag would silently
+  drop the freshly forced redirect from the CSV); the forced rows just need a
+  quick re-approve + re-export.

--- a/.claude/skills/map-charts-to-mdim/scripts/extract_and_match.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/extract_and_match.py
@@ -480,6 +480,65 @@ def match_charts(charts: list[dict], views: list[dict], id_to_path: dict[int, st
             if diffs:
                 c["note"] = "decoration difference ignored — " + "; ".join(diffs)
 
+    find_twin_suspects(charts, views, id_to_path, effective)
+
+
+def find_twin_suspects(charts: list[dict], views: list[dict], id_to_path: dict[int, str], effective) -> None:
+    """Flag unmatched charts whose equivalent view may exist under DIFFERENT variable ids.
+
+    ID-based matching is blind to one real shape: a dataset publishing the same series in
+    two tables (e.g. WID/LIS `inequality#share_top_10__…` for standalone charts vs
+    `incomes#share__…quantile_10…` for the MDIM — verified value-identical). The chart and
+    the view then share no variable id, so the pair lands in `none`/`near_miss` with
+    nothing pointing at the equivalence, and only a human staring at both panes catches it.
+
+    This is a SUSPECT list, not a match: same dataset + similar column name does not prove
+    the values agree, so the suggestion report tells the reviewer to compare the two
+    indicators' data (api.ourworldindata.org) and force via overrides.csv only if
+    identical. Heuristic: y variables from the same dataset, overlapping head tokens (the
+    indicator stem before the first `__` — keeps `gini` from pairing with `mean` just
+    because both carry the same long dimension suffix), Jaccard ≥ 0.5 on full column
+    tokens, and slot-compatible (a scatter's content x still has to agree).
+    """
+
+    def col(vid: int) -> str:
+        cp = id_to_path.get(vid) or ""
+        return cp.split("#", 1)[1] if "#" in cp else ""
+
+    def norm(t: str) -> str:
+        # '1pct'/'10pct' and '1'/'10' are the same quantile spelled two ways (share_top_1
+        # vs quantile_richest_1pct) — without this the real twin loses to a wrong-quantile
+        # view whose tokens happen to align better.
+        return t.removesuffix("pct")
+
+    def tokens(ids) -> set[str]:
+        return {norm(t) for i in ids for t in col(i).replace("__", "_").split("_") if t}
+
+    def heads(ids) -> set[str]:
+        return {norm(t) for i in ids for t in col(i).split("__", 1)[0].split("_") if t}
+
+    def datasets(ids) -> set[str]:
+        # 'grapher/ns/version/dataset/table#col' -> 'grapher/ns/version/dataset'
+        return {"/".join(p[:4]) for i in ids if len(p := (id_to_path.get(i) or "").split("/")) >= 4}
+
+    for c in charts:
+        c["twin_suspects"] = []
+        if c["quality"] not in ("near_miss", "none") or c["note"] or not c["y"]:
+            continue
+        c_ds, c_heads, c_tok, c_eff = datasets(c["y"]), heads(c["y"]), tokens(c["y"]), effective(c)
+        suspects = []
+        for v in views:
+            if v["y"] & c["y"] or effective(v) != c_eff:
+                continue  # shared ids are already near-miss territory; slot mismatch can't redirect
+            if not (datasets(v["y"]) & c_ds) or not (heads(v["y"]) & c_heads):
+                continue
+            v_tok = tokens(v["y"])
+            jaccard = len(c_tok & v_tok) / len(c_tok | v_tok)
+            if jaccard >= 0.5:
+                suspects.append((jaccard, v))
+        suspects.sort(key=lambda t: (-t[0], t[1]["row_id"]))
+        c["twin_suspects"] = suspects[:2]
+
 
 def describe_near_miss(c: dict, id_to_path: dict[int, str]) -> str:
     """Both sides of the gap, per candidate view.
@@ -926,10 +985,29 @@ def write_mdim_suggestions(out: Path, charts: list[dict], id_to_path: dict[int, 
         wanted |= set(c["y"])
         for v in c["near_misses"]:
             wanted |= set(v["y"])
+        for _, v in c.get("twin_suspects", []):
+            wanted |= set(v["y"])
     names = indicator_names(wanted)
 
     def label(i: int) -> str:
         return names.get(i) or path_tail(id_to_path.get(i)) or str(i)
+
+    def twin_lines(c: dict) -> list[str]:
+        """Twin-variable suspects: possibly the same series under different variable ids."""
+        out = []
+        for jaccard, v in c.get("twin_suspects", []):
+            chart_ids = ", ".join(str(i) for i in sorted(c["y"]))
+            view_ids = ", ".join(str(i) for i in sorted(v["y"]))
+            out += [
+                f"    - ⚠️ **twin suspect** ({jaccard:.0%} column-name overlap): **{v['mdim_slug']}** view "
+                f"`{v['view_id']}` ([open]({v['url']})) plots the same dataset's "
+                + ", ".join(f"`{label(i)}`" for i in sorted(v["y"]))
+                + f" — possibly the same series under different variable ids (chart {chart_ids} vs view {view_ids}). "
+                f"Compare their values (api.ourworldindata.org/v1/indicators/<id>.data.json); "
+                f"if identical, force via overrides.csv: "
+                f"`{c['chart_id']},{v['mdim_catalog_path']}|{v['view_id']},<why>`",
+            ]
+        return out
 
     lines = [
         "# Suggested MDIM changes",
@@ -964,6 +1042,7 @@ def write_mdim_suggestions(out: Path, charts: list[dict], id_to_path: dict[int, 
                     lines.append(f"    - the chart also plots {names_s} — the view does not")
                 lines.append(f"    - to redirect: add a view plotting exactly {len(c['y'])} indicator(s) — "
                              + ", ".join(f"`{label(i)}`" for i in sorted(c["y"])))  # fmt: skip
+            lines += twin_lines(c)
             lines.append("")
 
     if none:
@@ -979,6 +1058,7 @@ def write_mdim_suggestions(out: Path, charts: list[dict], id_to_path: dict[int, 
             inds = ", ".join(f"`{label(i)}`" for i in sorted(c["y"])[:4])
             more = "" if len(c["y"]) <= 4 else f" (+{len(c['y']) - 4} more)"
             lines.append(f"- **{c['chart_slug']}** — plots {inds}{more}")
+            lines += twin_lines(c)
         lines.append("")
 
     if unchecked:
@@ -1225,6 +1305,18 @@ def report(charts: list[dict], mdims: list[dict], views: list[dict], stats: dict
     for slug in sorted(per_mdim):
         n_charts = sum(1 for c in proposed if c["target"]["mdim_slug"] == slug)
         print(f"  {slug}: {n_charts} chart(s) -> {len(per_mdim[slug])} distinct view(s)")
+    # An override may since have forced the chart (that's the twin workflow completing) —
+    # only still-unmatched charts belong in this nudge.
+    twins = [c for c in charts if c.get("twin_suspects") and c["quality"] in ("near_miss", "none")]
+    if twins:
+        print(
+            f"\ntwin suspects: {len(twins)} unmatched chart(s) may equal a view under DIFFERENT variable ids\n"
+            "  (same dataset, similar column names — e.g. the series published in two tables).\n"
+            "  See mdim_suggestions.md: verify the values are identical, then force via overrides.csv."
+        )
+        for c in twins:
+            for jaccard, v in c["twin_suspects"]:
+                print(f"  {c['chart_slug']} ~ {v['mdim_slug']}?{v['query_str']}  ({jaccard:.0%})")
     cli_required = [c for c in proposed if c["cli_required"]]
     if cli_required:
         n_aliases = sum(len(c["old_slugs"]) for c in cli_required)

--- a/.claude/skills/map-charts-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/preflight.py
@@ -80,12 +80,19 @@ def apply_decisions(
 ) -> tuple[list[dict], list[tuple[dict, str]], list[dict], int]:
     """Drop entries whose chart the reviewer flagged; count kept entries that carry no decision.
 
-    A decision is bound to the proposal it was made on, on BOTH sides: if the export carries
-    the reviewed target (target_mdim/view_id), the reviewed source version (config_md5) or the
-    reviewed target rendering (view_config_md5) and any of them differs from the entry, the
-    decision is stale and treated as no decision at all. The md5 halves matter because a re-run
-    after either end was edited rewrites mapping.json with the new md5s, so `stale_charts` and
-    `stale_targets` compare new-against-new and see nothing.
+    A decision is bound to the proposal it was made on, on BOTH sides: if the reviewed target
+    (target_mdim/view_id), the reviewed source version (config_md5) or the reviewed target
+    rendering (view_config_md5) differs from the entry, the decision is stale and treated as
+    no decision at all. The md5 halves matter because a re-run after either end was edited
+    rewrites mapping.json with the new md5s, so `stale_charts` and `stale_targets` compare
+    new-against-new and see nothing.
+
+    An EMPTY reviewed target is itself a mismatch, not missing data: every entry here has a
+    target, so a decision exported with no target was made while the chart had no proposed
+    redirect (near_miss/none) — typically a flag saying "the target should be X" that a later
+    `overrides.csv` force resolved. Honoring that flag would silently drop the freshly forced
+    redirect. (Cost: exports from before the target columns existed all read as stale, which
+    only raises the undecided count — conservative, never excluding.)
     """
     kept, flagged, stale, undecided = [], [], [], 0
     for e in entries:
@@ -94,7 +101,7 @@ def apply_decisions(
         reviewed_target = (d.get("target_mdim", ""), d.get("view_id", ""))
         reviewed_md5 = d.get("config_md5", "")
         reviewed_view_md5 = d.get("view_config_md5", "")
-        drifted = any(reviewed_target) and reviewed_target != (e["target"]["mdimSlug"], e["target"]["viewId"])
+        drifted = bool(status) and reviewed_target != (e["target"]["mdimSlug"], e["target"]["viewId"])
         edited = bool(reviewed_md5) and bool(e["chart"].get("configMd5")) and reviewed_md5 != e["chart"]["configMd5"]
         retargeted = (
             bool(reviewed_view_md5)


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

Follow-up to #6588, from the human review round of the Economic Inequality chart→MDim mapping. The reviewer flagged 3 unmatched charts with "the equivalent view is X" — all three turned out to be the same failure shape, plus the fix path exposed a preflight bug.

## 1. Twin-variable suspects (extract_and_match.py)

ID-based matching is structurally blind to a dataset that publishes the **same series in two tables**: WID and LIS both carry e.g. `inequality#share_top_10__…` (used by the standalone charts) and `incomes#share__…quantile_10…` (used by the MDim) — different variable ids, values verified identical on every entity-year (3765/3765 and 1060/1060 points). Such pairs land in `none`/`near_miss` with nothing pointing at the equivalence.

The extractor now reports **twin suspects**: an unmatched chart whose y variables come from the same dataset as a slot-compatible view with a similar column name (overlapping head tokens + ≥50% token overlap, quantile spellings normalized so `share_top_1` finds `quantile_richest_1pct`). Reported in the run summary and in `mdim_suggestions.md` with the ready-to-paste `overrides.csv` line — explicitly as *suspects to verify by comparing the two indicators' data via the public API*, never as automatic matches. On the Economic Inequality run this catches all 3 reviewer-found twins, ranked first.

## 2. Stale-decision fix (preflight.py)

`--decisions` treated an exported decision with an **empty target** as carrying no target info, so its status still applied. But a decision exported while the chart had *no proposed redirect* (flagged as "should point at X") then survived onto the same chart after an `overrides.csv` force — and, being `flagged`, silently dropped the freshly forced redirect from the CLI CSV. An empty reviewed target on a targeted row is now a mismatch like any other: the decision reads as stale and the row is kept, counted as undecided. Cost: exports predating the target columns read entirely as stale, which only raises the undecided warning — conservative, never excluding.

## Validation

- Economic Inequality run: 19 exact + 3 forced = 22 proposed redirects, 0 ambiguous/conflicts; the 19 pre-existing rows byte-identical.
- Twin detector control run (overrides removed): all 3 known twins surfaced with the correct view ranked first; 3 remaining suspects are genuine non-twins (multi-indicator or extrapolated variants) for a human to reject.
- Preflight with the reviewer's original export: 3 old flags → `STALE DECISION … treated as undecided`, rows kept; 0 excluded.
- `make check` + ruff clean.

## Open items

- **Unverified** — the twin heuristic's thresholds (head-token overlap, 50% Jaccard, top-2) are tuned on this one migration; the next migration run will tell whether they generalize.
