### PR TITLE
✨ References audit: group gdoc tables by ArchieML component

### DIFF
--- a/.claude/skills/find-chart-references/scripts/find_references.py
+++ b/.claude/skills/find-chart-references/scripts/find_references.py
@@ -1019,14 +1019,33 @@ def doc_url(f: dict) -> str:
     return f"https://docs.google.com/document/d/{f['surface_id']}/edit" if f["surface_id"] else ""
 
 
-def deep_link(f: dict, host: str) -> str:
+def admin_url(where_path: str, host: str, admin: str = "") -> str:
+    """Absolute URL for a `where_path`, routing admin routes to the admin origin.
+
+    `admin` is an admin ROOT (".../admin"), while an admin `where_path` already starts
+    with `/admin/`, so the root's own suffix has to come off before joining or the result
+    carries `/admin/admin/`.
+    """
+    if not where_path:
+        return ""
+    if where_path.startswith("/admin/"):
+        origin = (admin or host).removesuffix("/").removesuffix("/admin")
+        return f"{origin}{where_path}"
+    return f"{host}{where_path}"
+
+
+def deep_link(f: dict, host: str, admin: str = "") -> str:
     """Published-article URL with a scroll-to-text fragment on the link's anchor text.
 
     Opens the article scrolled to (and highlighting) the reference, which is the
     fastest way to find it. Falls back to the plain article URL when the reference
     is a block embed with no anchor text.
+
+    Some `where_path`s are admin routes, not public ones (a narrative chart's editor).
+    Those must resolve against the admin origin — the public site does not serve
+    `/admin/...`, so prefixing them with `host` yields a link that 404s.
     """
-    base = f"{host}{f['where_path']}"
+    base = admin_url(f["where_path"], host, admin)
     anchor = (f.get("text") or "").strip()
     if not anchor:
         return base
@@ -1199,7 +1218,7 @@ def write_markdown(findings: list[dict], path: str, host: str, admin: str, cavea
                     ptype = f["context"].split("(")[-1].rstrip(")") if "(" in f["context"] else ""
                     page_type = f" _{ptype}_" if ptype else ""
                     preview = f" · [👁 preview]({gdoc_preview_url(f, admin)})" if f["surface_id"] else ""
-                    links = f"[📄 doc]({doc_url(f)}){preview} · [🔗 page]({deep_link(f, host)})"
+                    links = f"[📄 doc]({doc_url(f)}){preview} · [🔗 page]({deep_link(f, host, admin)})"
                     if f["admin_url"]:
                         links += f" · [✎ chart admin]({f['admin_url']})"
                     subject = (
@@ -1213,7 +1232,7 @@ def write_markdown(findings: list[dict], path: str, host: str, admin: str, cavea
                 lines += ["| Subject | Where | Context | Open |", "|---|---|---|---|"]
                 for f in rows:
                     draft = "" if f["published"] else " ⚠️draft"
-                    link = f"[🔗 open]({host}{f['where_path']})" if f["where_path"] else "—"
+                    link = f"[🔗 open]({admin_url(f['where_path'], host, admin)})" if f["where_path"] else "—"
                     lines.append(
                         f"| {cell(f['subject_label'], 44)} | {cell(f['where'], 72)}{draft} | "
                         f"{cell(f['context'], 44)} | "

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -247,9 +247,13 @@ charts", "Text links", "Front-matter chart URLs") rather than raw ArchieML
 tokens (those live in the CSV's `component` column). **Topic-page All charts
 entries collapse to a per-page summary and need NO action**: the block lists
 only published charts (`GdocPost.loadRelatedCharts` filters on `isPublished` —
-verified in grapher), so entries drop out on their own at the next bake; tag
-the MDIM with the topic only to provide a replacement entry. **ℹ️**
-unpublished/draft pages close the report.
+verified in grapher), so entries drop out on their own at the next bake — and
+no replacement is possible either, because the block is built from `charts` ×
+`chart_tags` only and cannot list MDIMs; featuring the MDIM on a topic page is
+a separate gdoc-authoring change. **Narrative charts get their own section
+(before the All charts summary)** with the explicit recreate → repoint → delete
+steps and the deep-linked admin create URL. **ℹ️** unpublished/draft pages
+close the report.
 
 Pure SQL, so read-only credentials are enough. It sweeps both the current slug
 and every old slug that reaches the chart — references written before a rename

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -280,13 +280,18 @@ groups per chart, in the order they get applied in the editor:
 
 1. **view dimensions** — the target view's own dimension values (from the
    proposal), because the new chart opens on the MDIM's default view;
-2. **controls** — entity selection, tab, time, timeline/map toggles, taken from
-   the narrative chart's `chart_configs.patch` (the delta its author typed on
-   top of the parent) plus its stored `queryParamsForParentChart`. The two
-   encode the same state, so a URL param is dropped when the patch already
-   carries the equivalent config key (`country` ↔ `selectedEntityNames`,
-   `focus` ↔ `focusedSeriesNames`, `time` ↔ `minTime`/`maxTime`) — otherwise the
-   cell asks for one setting twice in two spellings;
+2. **controls** — taken from the narrative chart's `chart_configs.patch` (the
+   delta its author typed on top of the parent) plus its stored
+   `queryParamsForParentChart`, and listed **chart type first** (it decides
+   which other controls exist), **then the entity selection** (the most visible
+   thing to get wrong), then the rest alphabetically. Entities are always shown
+   by **name**, never as codes: a URL param spells them `ZWE~MDG`, so those are
+   resolved against `entities` before display (unknown codes pass through). The
+   patch and the params encode the same state, so a URL param is dropped when
+   the patch already carries the equivalent config key (`country` ↔
+   `selectedEntityNames`, `focus` ↔ `focusedSeriesNames`, `time` ↔
+   `minTime`/`maxTime`) — otherwise the cell asks for one setting twice in two
+   spellings, and the config form is what the editor's fields expose;
 3. **FAUST text** — `title`, `subtitle`, `note`, `sourceDesc`,
    `hideAnnotationFieldsInTitle` from the patch. Miss these and the replacement
    silently renders the *view's* wording instead of the text the article was

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -251,19 +251,39 @@ verified in grapher), so entries drop out on their own at the next bake — and
 no replacement is possible either, because the block is built from `charts` ×
 `chart_tags` only and cannot list MDIMs; featuring the MDIM on a topic page is
 a separate gdoc-authoring change. **Narrative charts get their own table
-(before the All charts summary)**, one row per chart: the admin editor link, the
-parent chart, a **"replicate this rendering"** link — the target view carrying
-that narrative chart's own stored controls, since the admin create page accepts
-only `type` + `chartConfigId` and cannot preset them, so the row also names the
-params to set by hand — **the pages that actually embed it**, resolved by a
-second hop the sweep doesn't make (`posts_gdocs_links` on
-`linkType='narrative-chart'`, both `narrative-chart` and `key-insights`
-components), each with its doc link and the name to search for, and the ordered
-steps. Each row carries only the order that applies to it, on the rule above: a
-**published** page among the users makes create → repoint → delete mandatory;
-with none, the row emits the delete → create shortcut that reuses the same name
-(a draft reference then keeps resolving, since pages reference the name).
-**ℹ️** unpublished/draft pages close the report.
+(before the All charts summary)**, one row per chart: the admin editor link and
+parent chart; **"create from this view"** — the target view carrying that
+narrative chart's stored controls, which is both the rendering to match and the
+place to create from; **"text to re-apply"** (see below); **the pages that
+actually embed it**, resolved by a second hop the sweep doesn't make
+(`posts_gdocs_links` on `linkType='narrative-chart'`, both `narrative-chart` and
+`key-insights` components), each with its doc link and the name to search for;
+and the ordered steps. Each row carries only the order that applies to it, on
+the rule above: a **published** page among the users makes create → repoint →
+delete mandatory; with none, the row emits the delete → create shortcut that
+reuses the same name (a draft reference then keeps resolving, since pages
+reference the name). **ℹ️** unpublished/draft pages close the report.
+
+**Create from the view, not from a create link.** Tell the operator to open the
+target view and use the chart's own **"Create narrative chart"** admin control:
+the MDIM page builds that control's target from whichever view is on screen
+(`site/multiDim/MultiDim.tsx`), so the new chart is parented to the right view
+and inherits the controls set on it. A bare
+`/admin/narrative-charts/create?type=multiDim&chartConfigId=<viewConfigId>` link
+looks equivalent but opens a copy of the MDIM's **default** view — verified in
+practice — so never hand that out as the create step.
+
+**Re-apply the original's FAUST.** A narrative chart's `chart_configs.patch` is
+the delta its author typed on top of the parent, and text overrides in it
+(`title`, `subtitle`, `note`, `sourceDesc`, `hideAnnotationFieldsInTitle`) do
+**not** carry over to a replacement built from an MDIM view — the replacement
+would silently render the view's own wording instead of the text the article was
+written around. The report diffs each patch against the target view's config and
+lists only what genuinely differs, splitting FAUST text (retype verbatim) from
+view controls (entity selection, tab, time, timeline/map toggles). `dimensions`
+and `$schema` are excluded on purpose: the new parent view supplies them, and
+re-applying the old ones would repoint the chart at the retired chart's
+indicators.
 
 **Admin routes need the admin origin.** A narrative chart's `where_path` is
 `/admin/narrative-charts/<id>/edit`, and the public site does not serve

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -302,6 +302,16 @@ differences are asked for. `dimensions` and `$schema` are excluded from the patc
 on purpose: the new parent view supplies them, and re-applying the old ones would
 repoint the chart at the retired chart's indicators.
 
+**Suggest the replacement's name, and check it is free.** When a published page
+holds the original name the replacement needs a different one — and that name is
+**permanent**, since `create` rejects an existing name and there is no rename, so
+it is not a staging name to tidy up after the delete. The report suggests
+`<original>-mdim` (falling back to `-mdim-2`, `-mdim-3`, …), validated against
+every name in `narrative_charts` so the suggestion cannot be the one thing
+`create` refuses; suggestions handed out within a run are reserved as they go. In
+the delete-first case there is nothing to suggest — the row names the original,
+which the delete frees for reuse.
+
 **Admin routes need the admin origin.** A narrative chart's `where_path` is
 `/admin/narrative-charts/<id>/edit`, and the public site does not serve
 `/admin` — prefixing it with the site host yields a link that 404s. Both the

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -273,17 +273,29 @@ and inherits the controls set on it. A bare
 looks equivalent but opens a copy of the MDIM's **default** view — verified in
 practice — so never hand that out as the create step.
 
-**Re-apply the original's FAUST.** A narrative chart's `chart_configs.patch` is
-the delta its author typed on top of the parent, and text overrides in it
-(`title`, `subtitle`, `note`, `sourceDesc`, `hideAnnotationFieldsInTitle`) do
-**not** carry over to a replacement built from an MDIM view — the replacement
-would silently render the view's own wording instead of the text the article was
-written around. The report diffs each patch against the target view's config and
-lists only what genuinely differs, splitting FAUST text (retype verbatim) from
-view controls (entity selection, tab, time, timeline/map toggles). `dimensions`
-and `$schema` are excluded on purpose: the new parent view supplies them, and
-re-applying the old ones would repoint the chart at the retired chart's
-indicators.
+**Creating from an MDIM starts at its DEFAULT view — nothing carries over.**
+Not the dimension selection, not the entity selection, not tab/time, not the
+text. So the report's **"Set by hand after creating"** column lists all three
+groups per chart, in the order they get applied in the editor:
+
+1. **view dimensions** — the target view's own dimension values (from the
+   proposal), because the new chart opens on the MDIM's default view;
+2. **controls** — entity selection, tab, time, timeline/map toggles, taken from
+   the narrative chart's `chart_configs.patch` (the delta its author typed on
+   top of the parent) plus its stored `queryParamsForParentChart`. The two
+   encode the same state, so a URL param is dropped when the patch already
+   carries the equivalent config key (`country` ↔ `selectedEntityNames`,
+   `focus` ↔ `focusedSeriesNames`, `time` ↔ `minTime`/`maxTime`) — otherwise the
+   cell asks for one setting twice in two spellings;
+3. **FAUST text** — `title`, `subtitle`, `note`, `sourceDesc`,
+   `hideAnnotationFieldsInTitle` from the patch. Miss these and the replacement
+   silently renders the *view's* wording instead of the text the article was
+   written around.
+
+Every group is diffed against the target view's config, so only genuine
+differences are asked for. `dimensions` and `$schema` are excluded from the patch
+on purpose: the new parent view supplies them, and re-applying the old ones would
+repoint the chart at the retired chart's indicators.
 
 **Admin routes need the admin origin.** A narrative chart's `where_path` is
 `/admin/narrative-charts/<id>/edit`, and the public site does not serve

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -251,8 +251,15 @@ verified in grapher), so entries drop out on their own at the next bake — and
 no replacement is possible either, because the block is built from `charts` ×
 `chart_tags` only and cannot list MDIMs; featuring the MDIM on a topic page is
 a separate gdoc-authoring change. **Narrative charts get their own section
-(before the All charts summary)** with the explicit recreate → repoint → delete
-steps and the deep-linked admin create URL. **ℹ️** unpublished/draft pages
+(before the All charts summary)**, one block per chart, with the explicit
+recreate → repoint → delete steps, the deep-linked admin create URL, and — the
+part that decides the order — **the pages that actually embed it**, resolved by
+a second hop the sweep doesn't make (`posts_gdocs_links` on
+`linkType='narrative-chart'`, both `narrative-chart` and `key-insights`
+components), each with its doc link and the name to search for. A published page
+among them makes create-then-repoint-then-delete mandatory; when nothing
+references it at all, the report says so and offers the delete-first shortcut
+that reuses the same name. **ℹ️** unpublished/draft pages
 close the report.
 
 Pure SQL, so read-only credentials are enough. It sweeps both the current slug

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -250,18 +250,27 @@ only published charts (`GdocPost.loadRelatedCharts` filters on `isPublished` —
 verified in grapher), so entries drop out on their own at the next bake — and
 no replacement is possible either, because the block is built from `charts` ×
 `chart_tags` only and cannot list MDIMs; featuring the MDIM on a topic page is
-a separate gdoc-authoring change. **Narrative charts get their own section
-(before the All charts summary)**, one block per chart, with the explicit
-numbered steps, the deep-linked admin create URL, and — the part that decides
-the order — **the pages that actually embed it**, resolved by
-a second hop the sweep doesn't make (`posts_gdocs_links` on
+a separate gdoc-authoring change. **Narrative charts get their own table
+(before the All charts summary)**, one row per chart: the admin editor link, the
+parent chart, a **"replicate this rendering"** link — the target view carrying
+that narrative chart's own stored controls, since the admin create page accepts
+only `type` + `chartConfigId` and cannot preset them, so the row also names the
+params to set by hand — **the pages that actually embed it**, resolved by a
+second hop the sweep doesn't make (`posts_gdocs_links` on
 `linkType='narrative-chart'`, both `narrative-chart` and `key-insights`
-components), each with its doc link and the name to search for. Each block
-carries only the order that applies to it, on the rule above: a **published**
-page among the users makes create → repoint → delete mandatory; with none, the
-block emits the delete → create shortcut that reuses the same name (a draft
-reference then keeps resolving, since pages reference the name). **ℹ️**
-unpublished/draft pages close the report.
+components), each with its doc link and the name to search for, and the ordered
+steps. Each row carries only the order that applies to it, on the rule above: a
+**published** page among the users makes create → repoint → delete mandatory;
+with none, the row emits the delete → create shortcut that reuses the same name
+(a draft reference then keeps resolving, since pages reference the name).
+**ℹ️** unpublished/draft pages close the report.
+
+**Admin routes need the admin origin.** A narrative chart's `where_path` is
+`/admin/narrative-charts/<id>/edit`, and the public site does not serve
+`/admin` — prefixing it with the site host yields a link that 404s. Both the
+sweep and this consumer route such paths through a helper
+(`admin_url` / `absolute_url`) that strips the admin root's own `/admin` suffix
+before joining, or the result carries `/admin/admin/`.
 
 Pure SQL, so read-only credentials are enough. It sweeps both the current slug
 and every old slug that reaches the chart — references written before a rename

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -252,15 +252,16 @@ no replacement is possible either, because the block is built from `charts` ×
 `chart_tags` only and cannot list MDIMs; featuring the MDIM on a topic page is
 a separate gdoc-authoring change. **Narrative charts get their own section
 (before the All charts summary)**, one block per chart, with the explicit
-recreate → repoint → delete steps, the deep-linked admin create URL, and — the
-part that decides the order — **the pages that actually embed it**, resolved by
+numbered steps, the deep-linked admin create URL, and — the part that decides
+the order — **the pages that actually embed it**, resolved by
 a second hop the sweep doesn't make (`posts_gdocs_links` on
 `linkType='narrative-chart'`, both `narrative-chart` and `key-insights`
-components), each with its doc link and the name to search for. A published page
-among them makes create-then-repoint-then-delete mandatory; when nothing
-references it at all, the report says so and offers the delete-first shortcut
-that reuses the same name. **ℹ️** unpublished/draft pages
-close the report.
+components), each with its doc link and the name to search for. Each block
+carries only the order that applies to it, on the rule above: a **published**
+page among the users makes create → repoint → delete mandatory; with none, the
+block emits the delete → create shortcut that reuses the same name (a draft
+reference then keeps resolving, since pages reference the name). **ℹ️**
+unpublished/draft pages close the report.
 
 Pure SQL, so read-only credentials are enough. It sweeps both the current slug
 and every old slug that reaches the chart — references written before a rename

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -241,7 +241,8 @@ redirect-specific consumer that adds the replacement URLs. It writes
 `references.csv` + `references.md`, one row per reference. Severity: **🔴**
 embed — the surface renders the chart's own config, so the redirect does not fix
 it and it breaks on unpublish; migrate before applying · **🟡** hyperlink (the
-301 covers it, update the href anyway) or key-chart slot (re-tag the MDIM) ·
+301 covers it, update the href anyway) or all-charts-block slot on a topic page
+(a `chart_tags` row with a keyChartLevel — tag the MDIM in its place) ·
 **ℹ️** unpublished/draft.
 
 Pure SQL, so read-only credentials are enough. It sweeps both the current slug

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -238,12 +238,18 @@ ENV_FILE=<prod creds> DATA_API_ENV=production .venv/bin/python \
 
 The sweep itself is the shared `find-chart-references` skill; this script is the
 redirect-specific consumer that adds the replacement URLs. It writes
-`references.csv` + `references.md`, one row per reference. Severity: **🔴**
-embed — the surface renders the chart's own config, so the redirect does not fix
-it and it breaks on unpublish; migrate before applying · **🟡** hyperlink (the
-301 covers it, update the href anyway) or all-charts-block slot on a topic page
-(a `chart_tags` row with a keyChartLevel — tag the MDIM in its place) ·
-**ℹ️** unpublished/draft.
+`references.csv` + `references.md`, one row per reference. The report is
+organized by what the reader does, not by severity tier: **embedded charts and
+text links sit adjacent in one "Google Doc edits" section** (one editing pass
+per doc covers both — 🔴 embeds break on unpublish and gate the CLI, 🟡 links
+stay functional behind the 301), with reader-facing section names ("Embedded
+charts", "Text links", "Front-matter chart URLs") rather than raw ArchieML
+tokens (those live in the CSV's `component` column). **Topic-page All charts
+entries collapse to a per-page summary and need NO action**: the block lists
+only published charts (`GdocPost.loadRelatedCharts` filters on `isPublished` —
+verified in grapher), so entries drop out on their own at the next bake; tag
+the MDIM with the topic only to provide a replacement entry. **ℹ️**
+unpublished/draft pages close the report.
 
 Pure SQL, so read-only credentials are enough. It sweeps both the current slug
 and every old slug that reaches the chart — references written before a rename

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -340,6 +340,29 @@ def narrative_overrides(findings: list[dict]) -> dict[str, dict]:
     return out
 
 
+def suggest_name(original: str, taken: set[str]) -> str:
+    """A free kebab-case name for a replacement narrative chart.
+
+    Only needed when a published page still holds the original name: `create` rejects an
+    existing name and there is no rename, so the name picked here is PERMANENT — it is not a
+    temporary staging name that can be tidied up after the old chart is deleted. Hence a
+    suffix that stays recognisable to whoever finds it in a doc (`-mdim`, the MDIM-parented
+    version) rather than a bare counter, with counters only as a fallback.
+
+    Every candidate is checked against the names already in use, so the suggestion cannot be
+    the one thing `create` refuses.
+    """
+    for candidate in (f"{original}-mdim", *(f"{original}-mdim-{n}" for n in range(2, 10))):
+        if candidate not in taken:
+            return candidate
+    return ""
+
+
+def taken_narrative_names() -> set[str]:
+    """Every narrative chart name in use — `create` rejects a duplicate."""
+    return set(OWID_ENV.read_sql("SELECT name FROM narrative_charts")["name"])
+
+
 def entity_names(codes: set[str]) -> dict[str, str]:
     """{entity code -> name}, so a `country=ZWE~MDG` param can be shown the way the editor's
     entity picker shows it. Unknown codes are simply left as-is by the caller."""
@@ -378,6 +401,10 @@ def narrative_section(
         "| Narrative chart | Target rendering | Set by hand after creating | Used in (what to repoint) | Steps |",
         "|---|---|---|---|---|",
     ]
+    # Names already in use, so a suggested replacement name is one `create` will accept. The
+    # names suggested in this run are added as they are handed out: two narrative charts on
+    # the same parent would otherwise both be told to use the same free name.
+    taken = taken_narrative_names()
     for f in group:
         name = f["where"]
         used_in = usages.get(name, [])
@@ -464,8 +491,18 @@ def narrative_section(
             "not carry over; compare against the original in the admin editor"
         )
         if published_uses:
+            # The name is permanent — there is no rename — so suggest one that survives, and
+            # one that `create` will actually accept.
+            suggestion = suggest_name(name, taken)
+            taken.add(suggestion)
+            name_hint = (
+                f", under a NEW name (`create` rejects an existing one) — suggested: **`{suggestion}`** "
+                "(checked: not in use)"
+                if suggestion
+                else ", under a NEW name (`create` rejects an existing one)"
+            )
             steps = (
-                f"1. **create**: {create_step}, under a NEW name (`create` rejects an existing one)"
+                f"1. **create**: {create_step}{name_hint}"
                 f"<br>2. {set_step}"
                 "<br>3. **repoint** the page(s) to the new name"
                 "<br>4. **delete** the old one — succeeds once no published page references it"
@@ -473,7 +510,7 @@ def narrative_section(
         else:
             steps = (
                 "1. **delete** the old one — nothing published references it, so this frees the name"
-                f"<br>2. **create**: {create_step}, reusing the SAME name"
+                f"<br>2. **create**: {create_step}, reusing the SAME name — **`{name}`**"
                 f"<br>3. {set_step}"
             )
         lines.append(f"| {chart_cell} | {render_cell} | {faust_cell} | {used_cell} | {steps} |")

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -41,9 +41,19 @@ from collections import defaultdict
 from pathlib import Path
 from urllib.parse import parse_qsl, quote, urlencode
 
+from etl.analytics.config import OWID_BASE_URL, POST_TYPE_TO_URL
 from etl.config import OWID_ENV
 
 FIND_REFERENCES = Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts" / "find_references.py"
+
+# Public path prefix per gdoc type, derived from the repo's own routing map rather than
+# restated, so the two cannot drift: a data insight lives under /data-insights/, an author
+# under /team/, everything else at the root — and `None` means the type has no public URL
+# at all (fragment, homepage), so no link should be offered for it.
+POST_TYPE_PATH = {
+    post_type: None if base is None else base.removeprefix(OWID_BASE_URL)
+    for post_type, base in POST_TYPE_TO_URL.items()
+}
 
 RED, YELLOW, INFO = "RED", "YELLOW", "INFO"
 # Staging admin hosts carry a tailscale suffix that is noise in a link handed to a human.
@@ -167,6 +177,22 @@ def absolute_url(where_path: str, host: str, admin: str = "") -> str:
         origin = (admin or host).removesuffix("/").removesuffix("/admin")
         return f"{origin}{where_path}"
     return f"{host}{where_path}"
+
+
+def public_page_url(post_type: str, slug: str, host: str) -> str:
+    """Public URL of a gdoc, or "" when its type has no public route.
+
+    A gdoc's slug does NOT sit at the root for every type — a data insight is served under
+    /data-insights/ and an author page under /team/ — so building `host/<slug>` for all of
+    them points the reader at a 404. An unknown type falls back to the root, which is where
+    every currently routable type other than those two lives.
+    """
+    if not slug:
+        return ""
+    prefix = POST_TYPE_PATH.get(post_type, "")
+    if prefix is None:
+        return ""
+    return f"{host}/{prefix}{slug}"
 
 
 def deep_link(where_path: str, anchor: str, host: str, admin: str = "") -> str:
@@ -362,11 +388,8 @@ def narrative_section(
         if used_in:
             uses = []
             for u in sorted(used_in, key=lambda u: (not u["published"], u["slug"] or "")):
-                page = (
-                    f"[{cell(u['slug'], 34)}]({host}/{u['slug']})"
-                    if u["published"] and u["slug"]
-                    else f"`{cell(u['slug'] or '(no slug)', 34)}`"
-                )
+                page_url = public_page_url(u["type"], u["slug"], host) if u["published"] else ""
+                page = f"[{cell(u['slug'], 34)}]({page_url})" if page_url else f"`{cell(u['slug'] or '(no slug)', 34)}`"
                 draft = " ⚠️ **draft**" if not u["published"] else ""
                 uses.append(
                     f"{page} _{u['type']}_{draft}<br>`{u['componentType']}` block · "
@@ -565,8 +588,8 @@ def write_markdown(
             "→ delete** when a published page holds it, and the shorter **delete → create under the "
             "same name** when none does (any draft reference then keeps resolving untouched).",
             "",
-            'Create the replacement from the target view itself, using the chart\'s **"Create narrative '
-            'chart"** admin control — the MDIM page builds that control\'s target from whichever view '
+            "Create the replacement from the target view itself, using the chart's **\"Create narrative "
+            "chart\"** admin control — the MDIM page builds that control's target from whichever view "
             "is on screen, so the new chart is parented to the right view and inherits the controls "
             "you set. Do **not** use a bare `/admin/narrative-charts/create?chartConfigId=…` link: it "
             "opens a copy of the MDIM's default view instead of this one.",

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -230,7 +230,13 @@ def narrative_chart_usages(names: set[str]) -> dict[str, list[dict]]:
 
 
 def narrative_section(group: list[dict], usages: dict[str, list[dict]], host: str, admin: str) -> list[str]:
-    """One block per narrative chart: what it is, where it is used, and the ordered steps."""
+    """One block per narrative chart: what it is, where it is used, and the ordered steps.
+
+    Which of the two orders applies is decided by whether a PUBLISHED page references it
+    (the rule SKILL.md states): the delete only refuses for published references, and
+    `create` rejects an existing name, so the name can be reused — leaving any draft
+    reference resolving untouched — exactly when nothing published holds it.
+    """
     lines: list[str] = []
     for f in group:
         name = f["where"]
@@ -240,7 +246,7 @@ def narrative_section(group: list[dict], usages: dict[str, list[dict]], host: st
             f"### `{name}`",
             "",
             f"- parent chart: [`{f['source_chart_slug']}`]({f['old_url']}) · "
-            f"[✎ open the narrative chart]({host}/admin/narrative-charts/{f['narrative_id']}/edit)",
+            f"[✎ open the narrative chart]({admin}/narrative-charts/{f['narrative_id']}/edit)",
             f"- replacement should render: {f['replacement_url']}",
         ]
         if f["param_collisions"]:
@@ -249,7 +255,14 @@ def narrative_section(group: list[dict], usages: dict[str, list[dict]], host: st
                 "dimensions and would override them"
             )
         if used_in:
-            lines.append(f"- **used in {len(used_in)} page(s)** — these are what step 2 repoints:")
+            lines.append(
+                f"- **used in {len(used_in)} page(s)** — "
+                + (
+                    "these are what the repoint step updates:"
+                    if published_uses
+                    else "none of them published, so reusing the name below keeps them resolving as they are:"
+                )
+            )
             for u in sorted(used_in, key=lambda u: (not u["published"], u["slug"] or "")):
                 draft = "" if u["published"] else " ⚠️ **draft**"
                 page = (
@@ -261,19 +274,22 @@ def narrative_section(group: list[dict], usages: dict[str, list[dict]], host: st
                     f"[👁 preview]({admin}/gdocs/{u['gdoc_id']}/preview) · search the doc for `{name}`"
                 )
         else:
-            lines.append(
-                "- **not referenced by any page** — so the shortcut applies: delete it first, then "
-                "recreate the replacement under the SAME name (nothing blocks the delete)"
-            )
-        lines += [
-            f"- **step 1 — create:** {admin}/narrative-charts/create?type=multiDim&chartConfigId={f['target_view_config_id']}",
-            "- **step 2 — repoint:** change the page(s) above to the new narrative chart's name"
-            if used_in
-            else "- **step 2 — repoint:** nothing to repoint",
-            "- **step 3 — delete:** remove the old narrative chart"
-            + (" (only possible once the published page(s) above no longer reference it)" if published_uses else ""),
-            "",
-        ]
+            lines.append("- **not referenced by any page**")
+        create = f"{admin}/narrative-charts/create?type=multiDim&chartConfigId={f['target_view_config_id']}"
+        if published_uses:
+            lines += [
+                f"- **step 1 — create** the replacement under a NEW name (`create` rejects an existing one): {create}",
+                "- **step 2 — repoint:** change the page(s) above to the new narrative chart's name",
+                "- **step 3 — delete:** remove the old narrative chart — the delete succeeds once no "
+                "published page references it, which is why it comes last",
+            ]
+        else:
+            lines += [
+                "- **step 1 — delete** the old narrative chart: nothing published references it, so the "
+                "delete succeeds and frees the name",
+                f"- **step 2 — create** the replacement, reusing the SAME name (`{name}`): {create}",
+            ]
+        lines.append("")
     return lines
 
 
@@ -433,11 +449,12 @@ def write_markdown(
             "",
             "A narrative chart renders its own saved config, so nothing breaks when its parent chart "
             'is unpublished — only its generated "Explore the data" link follows the redirect. The '
-            "plan for each one: **recreate it manually from the target MDIM view and point the pages "
-            "that use it back at the new one** — **create** the replacement, **repoint** the pages, "
-            "then **delete** the old one. That order is forced by the API: the delete is refused while "
-            "a published page still references it, and there is no rename, so the name can only be "
-            "reused when nothing references the old one.",
+            "plan for each one: **recreate it manually from the target MDIM view**. There is no "
+            "repointing API and no rename, and the API forces which order applies — the delete is "
+            "refused while a **published** page references it, and `create` rejects a name that "
+            "already exists. So each block below carries the order that fits it: **create → repoint "
+            "→ delete** when a published page holds it, and the shorter **delete → create under the "
+            "same name** when none does (any draft reference then keeps resolving untouched).",
             "",
         ]
         lines += narrative_section(narrative, narrative_chart_usages({f["where"] for f in narrative}), host, admin)

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -9,8 +9,8 @@ Severity, derived from the sweep's `kind`:
          slug and renders its config directly, so it breaks when the source chart is
          unpublished (which the apply CLI always does). Migrate before applying.
   YELLOW link (the 301 covers it, but the href should be updated so readers don't
-         take an extra hop) or render (a key-chart slot: the topic page loses the
-         chart, so re-tag the MDIM — a follow-up, not a breakage).
+         take an extra hop) or render (an all-charts-block slot: the topic page loses
+         the chart, so tag the MDIM in its place — a follow-up, not a breakage).
   INFO   the referencing page is unpublished or a draft.
 
 Replacement URLs merge each reference's own query string over the view's dimensions,
@@ -44,7 +44,7 @@ RED, YELLOW, INFO = "RED", "YELLOW", "INFO"
 TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
 
 REFERENCE_COLUMNS = [
-    "severity", "surface", "kind", "source_chart_slug", "where", "where_url",
+    "severity", "surface", "component", "kind", "source_chart_slug", "where", "where_url",
     "doc_edit_url", "doc_preview_url", "find_in_doc", "context",
     "old_url", "replacement_url", "param_collisions", "fix",
 ]  # fmt: skip
@@ -52,18 +52,33 @@ REFERENCE_COLUMNS = [
 # Surfaces whose fix is a Google Doc edit. For these the report renders a table with the
 # doc link and a copy-paste search hint (the find-chart-references convention) — handing
 # someone a page URL without saying where in the doc the reference sits makes them
-# re-derive exactly what the sweep already knew.
+# re-derive exactly what the sweep already knew. In the report they are NOT grouped by
+# these sweep surfaces — a data insight IS a gdoc; what matters to the person editing the
+# doc is the ArchieML component they are touching, so the tables group by that instead
+# (see archie_component).
 GDOC_SURFACES = ("gdoc", "gdoc (url link)", "data insight")
 
+# The sweep's `key chart` surface is a chart_tags row with a keyChartLevel — what it feeds
+# on the site is the topic page's "All charts" block ordering, so name it by what the
+# reader loses, not by the DB mechanism.
+SURFACE_LABELS = {"key chart": "all-charts block (topic page)"}
+
 FIXES = {
-    "gdoc": "edit the article block to embed the MDIM view",
-    "gdoc (url link)": "update the href in the article",
     "explorer": "repoint the explorer at the MDIM indicators, or retire the explorer",
     "narrative chart": "replace it: create a new one from the MDIM view (parentChartConfigId = "
     "that view's config_id), move the article references, then delete the old — see SKILL.md",
-    "data insight": "update the data insight's grapher-url",
     "static viz": "regenerate the static visualization against the MDIM view",
-    "key chart": "re-tag the MDIM so the topic page keeps a key chart",
+    "key chart": "tag the MDIM with the same topic (and key-chart level) so it takes the "
+    "chart's place in the topic page's All charts block",
+}
+# Gdoc-backed references: the fix depends on the ArchieML component being edited (and for
+# chart blocks, on whether the block embeds the chart or merely stores its URL).
+COMPONENT_FIXES = {
+    ("chart", "embed"): "edit the chart block to embed the MDIM view",
+    ("chart", "link"): "update the chart block's grapher URL",
+    ("span-link", "link"): "update the href",
+    ("front-matter", "embed"): "update the grapher-url in the front matter",
+    ("front-matter", "link"): "update the grapher-url in the front matter",
 }
 LINK_FIX = "update the href"
 # Link-kind references whose href is generated rather than authored — there is nothing to
@@ -133,6 +148,27 @@ def deep_link(where_path: str, anchor: str, host: str) -> str:
         return base
     encoded = quote(anchor[:200], safe="()").replace("-", "%2D")
     return f"{base}#:~:text={encoded}"
+
+
+def archie_component(ref: dict) -> str:
+    """The ArchieML component this reference lives in: chart, span-link, front-matter, …
+
+    The sweep encodes it as the head of `context` ("chart (article)", "span-link
+    (data-insight)"); the data-insight surface spells its front-matter reference out in
+    prose instead, so normalize that to the same token. This is what the gdoc tables
+    group by — the person editing the doc cares which construct they are touching, not
+    whether the page is an article or a data insight (both are gdocs).
+    """
+    head = ref["context"].split(" — ")[0]
+    if head.startswith("grapher-url"):
+        return "front-matter"
+    return head.split(" (")[0].strip()
+
+
+def page_type(ref: dict) -> str:
+    """article / data-insight / topic-page / fragment — the parenthesized tail of context."""
+    m = re.search(r"\(([^)]+)\)", ref["context"].split(" — ")[0])
+    return m.group(1) if m else ""
 
 
 def find_in_doc(ref: dict) -> str:
@@ -214,7 +250,10 @@ def gdoc_table(group: list[dict]) -> list[str]:
             replace = f"[`{target_label}`]({f['replacement_url']})"
             if f["param_collisions"]:
                 replace += f" ⚠️ params `{f['param_collisions']}` override view dimensions"
-            lines.append(f"| {source} | {cell(f['where'], 44)} | {opens} | {find} | {replace} |")
+            # The page type moved into this cell when the sections stopped separating
+            # gdocs from data insights — it changes who owns the fix.
+            where = cell(f["where"], 44) + (f" _{f['page_type']}_" if f.get("page_type") else "")
+            lines.append(f"| {source} | {where} | {opens} | {find} | {replace} |")
     return lines
 
 
@@ -245,13 +284,17 @@ def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host:
         if not group:
             continue
         lines += [f"## {label} ({len(group)})", "", blurb, ""]
-        by_surface = defaultdict(list)
+        # Gdoc-backed references group by ArchieML component (chart / span-link /
+        # front-matter): a data insight IS a gdoc, and the editor cares which construct
+        # they are touching, not which page type holds it (that is the Where column).
+        # Everything else groups by its (relabeled) surface.
+        by_group = defaultdict(list)
         for f in group:
-            by_surface[f["surface"]].append(f)
-        for surface in sorted(by_surface):
-            lines += [f"### {surface} ({len(by_surface[surface])})", ""]
-            group = by_surface[surface]
-            # Google-Doc-backed surfaces get the table treatment: doc link, previewer,
+            by_group[f["component"] or SURFACE_LABELS.get(f["surface"], f["surface"])].append(f)
+        for group_name in sorted(by_group):
+            lines += [f"### {group_name} ({len(by_group[group_name])})", ""]
+            group = by_group[group_name]
+            # Google-Doc-backed references get the table treatment: doc link, previewer,
             # scrolled page link, and the search string that lands on the reference.
             if all(f["doc_edit_url"] for f in group):
                 lines += gdoc_table(group)
@@ -295,9 +338,12 @@ def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host:
     lines += [
         "---",
         "",
-        "In the tables, the **source chart links to the reference's own URL** (its params applied) and "
-        "**Replace with links to the target MDIM view** the same reference should become. "
-        "📄 opens the Google Doc to edit · 👁 opens the article in the admin previewer (works for "
+        "Google-Doc-backed references are grouped by the **ArchieML component** holding them "
+        "(`chart` block, `span-link`, `front-matter`) — the page type (article, data insight, …) is "
+        "italicized in the Where column. In the tables, the **source chart links to the reference's "
+        "own URL** (its params applied) and **Replace with links to the target MDIM view** the same "
+        "reference should become. "
+        "📄 opens the Google Doc to edit · 👁 opens the page in the admin previewer (works for "
         "unpublished drafts too) · 🔗 opens the published page scrolled to the reference. "
         "**Find in doc** is a copy-paste search string for the Google Doc's find box: the link text for "
         "a prose hyperlink, or the chart slug for a block embed (the doc holds a bare grapher URL "
@@ -347,7 +393,12 @@ def main() -> int:
         new_url, collisions = replacement_url(r, qs, host)
         # Only an embed is broken by the redirect: it renders the chart's own config.
         severity = INFO if not ref["published"] else (RED if ref["kind"] == "embed" else YELLOW)
-        if ref["kind"] == "link":
+        is_gdoc = ref["surface"] in GDOC_SURFACES and ref.get("surface_id")
+        component = archie_component(ref) if is_gdoc else ""
+        if is_gdoc:
+            fallback = LINK_FIX if ref["kind"] == "link" else "migrate this reference by hand"
+            fix = COMPONENT_FIXES.get((component, ref["kind"]), fallback)
+        elif ref["kind"] == "link":
             fix = GENERATED_LINK_FIXES.get(ref["surface"], LINK_FIX)
         else:
             fix = FIXES.get(ref["surface"], "migrate this reference by hand")
@@ -356,11 +407,12 @@ def main() -> int:
             # the one this chart is being redirected to — so hand over the ready-made URL
             # rather than the id to look up.
             fix += f" — create the replacement at {admin}/narrative-charts/create?type=multiDim&chartConfigId={r['target']['viewConfigId']}"
-        is_gdoc = ref["surface"] in GDOC_SURFACES and ref.get("surface_id")
         findings.append(
             {
                 "severity": severity,
                 "surface": ref["surface"],
+                "component": component,
+                "page_type": page_type(ref) if is_gdoc else "",
                 "kind": ref["kind"],
                 "source_chart_slug": ref["subject"],
                 "where": ref["where"],

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -288,6 +288,13 @@ PARAM_CONFIG_EQUIVALENT = {
     "time": ("minTime", "maxTime"),
     "region": ("map",),
 }
+# The order someone rebuilds a chart in: the chart type first, because it decides which other
+# controls exist at all; then the entity selection, the most visible thing to get wrong; then
+# whatever else was overridden, alphabetically.
+CONTROL_ORDER = ("chartTypes", "selectedEntityNames", "country")
+# Params whose values are entity CODES. Codes are what a URL carries, but names are what the
+# editor's entity picker shows, so they are resolved before being handed to a human.
+ENTITY_CODE_PARAMS = ("country", "focus")
 
 
 def narrative_overrides(findings: list[dict]) -> dict[str, dict]:
@@ -331,6 +338,21 @@ def narrative_overrides(findings: list[dict]) -> dict[str, dict]:
             (faust if key in FAUST_KEYS else controls)[key] = value
         out[nid] = {"faust": faust, "controls": controls}
     return out
+
+
+def entity_names(codes: set[str]) -> dict[str, str]:
+    """{entity code -> name}, so a `country=ZWE~MDG` param can be shown the way the editor's
+    entity picker shows it. Unknown codes are simply left as-is by the caller."""
+    codes = {c for c in codes if c}
+    if not codes:
+        return {}
+    df = OWID_ENV.read_sql("SELECT code, name FROM entities WHERE code IN %(c)s", params={"c": tuple(sorted(codes))})
+    return dict(zip(df["code"], df["name"]))
+
+
+def control_sort_key(key: str) -> tuple:
+    """Chart type, then the entity selection, then everything else alphabetically."""
+    return (CONTROL_ORDER.index(key), "") if key in CONTROL_ORDER else (len(CONTROL_ORDER), key)
 
 
 def render_override(value) -> str:
@@ -389,11 +411,19 @@ def narrative_section(
         for key, value in parse_qsl(f["stored_params"], keep_blank_values=True):
             if any(equiv in config_controls for equiv in PARAM_CONFIG_EQUIVALENT.get(key, (key,))):
                 continue
+            # A URL param spells entities as codes; the editor's picker speaks names.
+            if key in ENTITY_CODE_PARAMS and value:
+                codes = value.split("~")
+                names = entity_names(set(codes))
+                value = [names.get(c, c) for c in codes]
             controls[key] = value
         if controls:
             parts.append(
-                "**controls** (entity selection, tab, time — not inherited):<br>"
-                + ", ".join(f"`{k}` = {render_override(v) or '(empty)'}" for k, v in sorted(controls.items()))
+                "**controls** (chart type, entity selection, tab, time — not inherited):<br>"
+                + ", ".join(
+                    f"`{k}` = {render_override(v) or '(empty)'}"
+                    for k, v in sorted(controls.items(), key=lambda kv: control_sort_key(kv[0]))
+                )
             )
         faust = ovr.get("faust") or {}
         if faust:

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -202,6 +202,81 @@ def find_in_doc(ref: dict) -> str:
     return anchor or ref["subject"]
 
 
+def narrative_chart_usages(names: set[str]) -> dict[str, list[dict]]:
+    """{narrative chart name -> the pages embedding it}, for the repoint step.
+
+    A second hop past the sweep, which answers "what references the CHART"; this answers
+    "what references the NARRATIVE CHART hanging off it" — and that is what decides the
+    recreate ORDER, so the report cannot tell someone to "update the article(s)" without
+    it. The delete endpoint refuses while a PUBLISHED post references the narrative chart,
+    which makes create-then-repoint-then-delete mandatory in that case; when nothing
+    references it, the simpler delete-then-recreate-under-the-same-name is available.
+
+    Both component types that can hold one are matched (`narrative-chart` blocks and
+    `key-insights` slides).
+    """
+    if not names:
+        return {}
+    df = OWID_ENV.read_sql(
+        "SELECT l.target AS name, l.componentType, g.id AS gdoc_id, g.slug, g.published, g.type "
+        "FROM posts_gdocs_links l JOIN posts_gdocs g ON g.id = l.sourceId "
+        "WHERE l.linkType = 'narrative-chart' AND l.target IN %(names)s",
+        params={"names": tuple(sorted(names))},
+    )
+    usages: dict[str, list[dict]] = defaultdict(list)
+    for r in df.to_dict("records"):
+        usages[r["name"]].append(r)
+    return usages
+
+
+def narrative_section(group: list[dict], usages: dict[str, list[dict]], host: str, admin: str) -> list[str]:
+    """One block per narrative chart: what it is, where it is used, and the ordered steps."""
+    lines: list[str] = []
+    for f in group:
+        name = f["where"]
+        used_in = usages.get(name, [])
+        published_uses = [u for u in used_in if u["published"]]
+        lines += [
+            f"### `{name}`",
+            "",
+            f"- parent chart: [`{f['source_chart_slug']}`]({f['old_url']}) · "
+            f"[✎ open the narrative chart]({host}/admin/narrative-charts/{f['narrative_id']}/edit)",
+            f"- replacement should render: {f['replacement_url']}",
+        ]
+        if f["param_collisions"]:
+            lines.append(
+                f"- ⚠️ its stored query params `{f['param_collisions']}` collide with the target view's "
+                "dimensions and would override them"
+            )
+        if used_in:
+            lines.append(f"- **used in {len(used_in)} page(s)** — these are what step 2 repoints:")
+            for u in sorted(used_in, key=lambda u: (not u["published"], u["slug"] or "")):
+                draft = "" if u["published"] else " ⚠️ **draft**"
+                page = (
+                    f"[{u['slug']}]({host}/{u['slug']})" if u["published"] and u["slug"] else f"`{u['slug'] or '(no slug)'}`"
+                )  # fmt: skip
+                lines.append(
+                    f"    - {page} _{u['type']}_{draft} — in a `{u['componentType']}` block · "
+                    f"[📄 doc](https://docs.google.com/document/d/{u['gdoc_id']}/edit) · "
+                    f"[👁 preview]({admin}/gdocs/{u['gdoc_id']}/preview) · search the doc for `{name}`"
+                )
+        else:
+            lines.append(
+                "- **not referenced by any page** — so the shortcut applies: delete it first, then "
+                "recreate the replacement under the SAME name (nothing blocks the delete)"
+            )
+        lines += [
+            f"- **step 1 — create:** {admin}/narrative-charts/create?type=multiDim&chartConfigId={f['target_view_config_id']}",
+            "- **step 2 — repoint:** change the page(s) above to the new narrative chart's name"
+            if used_in
+            else "- **step 2 — repoint:** nothing to repoint",
+            "- **step 3 — delete:** remove the old narrative chart"
+            + (" (only possible once the published page(s) above no longer reference it)" if published_uses else ""),
+            "",
+        ]
+    return lines
+
+
 def replacement_url(r: dict, query_string: str, host: str) -> tuple[str, list[str]]:
     """Target URL for a reference, plus any params that would clobber a view dimension."""
     dims = dict(r["target"]["dimensions"])
@@ -296,7 +371,9 @@ def bullet_list(group: list[dict]) -> list[str]:
     return lines
 
 
-def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host: str, gaps: list[str]) -> Path:
+def write_markdown(
+    out: Path, findings: list[dict], redirects: list[dict], host: str, gaps: list[str], admin: str = ""
+) -> Path:
     path = out / "references.md"
     # The reader's partition is by what they DO, not by severity tiers: one editing pass
     # per Google Doc covers embeds and links alike, so those sit adjacent in one section;
@@ -356,18 +433,14 @@ def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host:
             "",
             "A narrative chart renders its own saved config, so nothing breaks when its parent chart "
             'is unpublished — only its generated "Explore the data" link follows the redirect. The '
-            "plan for each one: **recreate it manually from the target MDIM view and point the "
-            "referencing article(s) back at the new one**, in this order —",
-            "",
-            "1. **Create** the replacement parented to the MDIM view (each item below carries the "
-            "ready-made admin create link — it opens the editor already parented to the right view).",
-            "2. **Repoint** the article(s) that reference the old narrative chart to the new name.",
-            "3. **Delete** the old narrative chart. The delete is refused while a published post "
-            "still references it, which is why it comes last.",
+            "plan for each one: **recreate it manually from the target MDIM view and point the pages "
+            "that use it back at the new one** — **create** the replacement, **repoint** the pages, "
+            "then **delete** the old one. That order is forced by the API: the delete is refused while "
+            "a published page still references it, and there is no rename, so the name can only be "
+            "reused when nothing references the old one.",
             "",
         ]
-        lines += bullet_list(narrative)
-        lines.append("")
+        lines += narrative_section(narrative, narrative_chart_usages({f["where"] for f in narrative}), host, admin)
 
     if allcharts:
         by_page = defaultdict(list)
@@ -541,6 +614,10 @@ def main() -> int:
                 "doc_edit_url": f"https://docs.google.com/document/d/{ref['surface_id']}/edit" if is_gdoc else "",
                 "doc_preview_url": f"{admin}/gdocs/{ref['surface_id']}/preview" if is_gdoc else "",
                 "find_in_doc": find_in_doc(ref) if is_gdoc else "",
+                # Narrative rows carry the ids their own section needs: the narrative chart
+                # to open/delete, and the target view to parent the replacement to.
+                "narrative_id": ref["surface_id"] if ref["surface"] == "narrative chart" else "",
+                "target_view_config_id": r["target"]["viewConfigId"],
                 "context": ref["context"] + (f' — "{ref["text"][:60]}"' if ref["text"] else ""),
                 "old_url": f"{host}/grapher/{ref['subject']}" + (f"?{qs.lstrip('?')}" if qs else ""),
                 "replacement_url": new_url,
@@ -552,7 +629,7 @@ def main() -> int:
     findings.sort(key=lambda f: ({RED: 0, YELLOW: 1, INFO: 2}[f["severity"]], f["surface"], f["source_chart_slug"]))
 
     csv_path = write_csv(mapping_dir, findings)
-    md_path = write_markdown(mapping_dir, findings, redirects, host, gaps)
+    md_path = write_markdown(mapping_dir, findings, redirects, host, gaps, admin)
 
     counts: dict[str, int] = defaultdict(int)
     for f in findings:

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -9,9 +9,15 @@ Severity, derived from the sweep's `kind`:
          slug and renders its config directly, so it breaks when the source chart is
          unpublished (which the apply CLI always does). Migrate before applying.
   YELLOW link (the 301 covers it, but the href should be updated so readers don't
-         take an extra hop) or render (an all-charts-block slot: the topic page loses
-         the chart, so tag the MDIM in its place — a follow-up, not a breakage).
-  INFO   the referencing page is unpublished or a draft.
+         take an extra hop).
+  INFO   no action required: the referencing page is unpublished/draft, or the row is
+         a topic page's All charts entry — that block lists only published charts
+         (GdocPost.loadRelatedCharts filters on isPublished), so the entry drops out
+         on its own at the next bake.
+
+The report is organized by what the reader does, not by severity tier: embedded charts
+and text links sit adjacent in one "Google Doc edits" section (one editing pass per doc
+covers both), and All charts entries collapse to a per-topic-page summary.
 
 Replacement URLs merge each reference's own query string over the view's dimensions,
 which is what grapher's redirect handler does (functions/_common/redirectTools.ts).
@@ -63,13 +69,28 @@ GDOC_SURFACES = ("gdoc", "gdoc (url link)", "data insight")
 # reader loses, not by the DB mechanism.
 SURFACE_LABELS = {"key chart": "all-charts block (topic page)"}
 
+# Reader-facing section names for the ArchieML component tokens — "chart" and "span-link"
+# mean nothing to someone who doesn't write ArchieML. The raw token stays in the CSV's
+# `component` column.
+COMPONENT_LABELS = {
+    "chart": "Embedded charts",
+    "span-link": "Text links",
+    "front-matter": "Front-matter chart URLs",
+}
+# Blocking edits first: embedded charts and front-matter URLs break on unpublish, text
+# links merely go through an extra 301 hop.
+COMPONENT_ORDER = ("chart", "front-matter", "span-link")
+
 FIXES = {
     "explorer": "repoint the explorer at the MDIM indicators, or retire the explorer",
     "narrative chart": "replace it: create a new one from the MDIM view (parentChartConfigId = "
     "that view's config_id), move the article references, then delete the old — see SKILL.md",
     "static viz": "regenerate the static visualization against the MDIM view",
-    "key chart": "tag the MDIM with the same topic (and key-chart level) so it takes the "
-    "chart's place in the topic page's All charts block",
+    # No action: the All charts block lists only published charts (GdocPost.loadRelatedCharts
+    # filters on isPublished), so entries drop out at the next bake — nothing breaks or goes
+    # stale. Tagging the MDIM is optional curation, not repair.
+    "key chart": "no action needed — the entry drops out of the All charts block automatically; "
+    "tag the MDIM with the topic only if you want a replacement entry",
 }
 # Gdoc-backed references: the fix depends on the ArchieML component being edited (and for
 # chart blocks, on whether the block embeds the chart or merely stores its URL).
@@ -257,92 +278,141 @@ def gdoc_table(group: list[dict]) -> list[str]:
     return lines
 
 
+def bullet_list(group: list[dict]) -> list[str]:
+    """Fallback rendering for references without a Google Doc behind them."""
+    lines: list[str] = []
+    for f in group:
+        where = f"[{f['where']}]({f['where_url']})" if f["where_url"] else f["where"]
+        lines.append(f"- **{f['source_chart_slug']}** in {where} — {f['context']}")
+        lines.append(f"    - now: {f['old_url']}")
+        lines.append(f"    - should be: {f['replacement_url']}")
+        if f["param_collisions"]:
+            lines.append(
+                f"    - ⚠️ query params `{f['param_collisions']}` collide with the view's dimensions "
+                "and will override them — set the dimension explicitly or drop the param"
+            )
+        lines.append(f"    - fix: {f['fix']}")
+    return lines
+
+
 def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host: str, gaps: list[str]) -> Path:
     path = out / "references.md"
-    red = [f for f in findings if f["severity"] == RED]
-    yellow = [f for f in findings if f["severity"] == YELLOW]
-    info = [f for f in findings if f["severity"] == INFO]
+    # The reader's partition is by what they DO, not by severity tiers: one editing pass
+    # per Google Doc covers embeds and links alike, so those sit adjacent in one section;
+    # the topic-page All charts blocks need no action at all (verified: the block lists
+    # only published charts) and collapse to a per-page summary.
+    allcharts = [f for f in findings if f["surface"] == "key chart"]
+    drafts = [f for f in findings if f["severity"] == INFO and f["surface"] != "key chart"]
+    doc_edits = [f for f in findings if f["severity"] in (RED, YELLOW) and f["doc_edit_url"]]
+    other = [f for f in findings if f["severity"] in (RED, YELLOW) and not f["doc_edit_url"]]
+    embeds = [f for f in doc_edits if f["severity"] == RED]
+    links = [f for f in doc_edits if f["severity"] == YELLOW]
 
     lines = [
         "# What references the charts being redirected",
         "",
         f"{len(redirects)} chart(s) heading for unpublishing — proposed redirects, plus charts already "
-        f"redirected whose source chart is still published. **{len(red)} reference(s) need manual work** "
-        f"— a redirect does not fix them. {len(yellow)} more are hyperlinks the 301 covers but that "
-        "should be updated.",
+        f"redirected whose source chart is still published. **{len(embeds)} embedded reference(s) break "
+        f"when the charts are unpublished** and must be migrated before the CLI runs; {len(links)} text "
+        "link(s) keep working via the 301 but belong in the same editing pass. Topic-page All charts "
+        "blocks update themselves — summarized below, no action needed.",
         "",
         "Replacement URLs merge each reference's own query string over the MDIM view's dimensions, "
         "the same way grapher's redirect handler does.",
         "",
     ]
-    sections = [
-        ("🔴 Needs manual migration", red, "These embed or resolve the chart directly and break when it is unpublished."),
-        ("🟡 Hyperlinks worth updating", yellow, "The 301 handles these; updating the href avoids an extra hop."),
-        ("ℹ️ Unpublished / draft", info, "No reader impact — listed for completeness."),
-    ]  # fmt: skip
-    for label, group, blurb in sections:
-        if not group:
-            continue
-        lines += [f"## {label} ({len(group)})", "", blurb, ""]
-        # Gdoc-backed references group by ArchieML component (chart / span-link /
-        # front-matter): a data insight IS a gdoc, and the editor cares which construct
-        # they are touching, not which page type holds it (that is the Where column).
-        # Everything else groups by its (relabeled) surface.
-        by_group = defaultdict(list)
-        for f in group:
-            by_group[f["component"] or SURFACE_LABELS.get(f["surface"], f["surface"])].append(f)
-        for group_name in sorted(by_group):
-            lines += [f"### {group_name} ({len(by_group[group_name])})", ""]
-            group = by_group[group_name]
-            # Google-Doc-backed references get the table treatment: doc link, previewer,
-            # scrolled page link, and the search string that lands on the reference.
-            if all(f["doc_edit_url"] for f in group):
-                lines += gdoc_table(group)
-            else:
-                for f in group:
-                    where = f"[{f['where']}]({f['where_url']})" if f["where_url"] else f["where"]
-                    lines.append(f"- **{f['source_chart_slug']}** in {where} — {f['context']}")
-                    lines.append(f"    - now: {f['old_url']}")
-                    lines.append(f"    - should be: {f['replacement_url']}")
-                    if f["param_collisions"]:
-                        lines.append(
-                            f"    - ⚠️ query params `{f['param_collisions']}` collide with the view's dimensions "
-                            "and will override them — set the dimension explicitly or drop the param"
-                        )
-                    lines.append(f"    - fix: {f['fix']}")
+
+    if doc_edits:
+        lines += [
+            f"## 📝 Google Doc edits ({len(doc_edits)})",
+            "",
+            "Embedded charts and text links are listed together — one editing pass per doc covers "
+            "both. 🔴 sections break on unpublish (do these before the CLI runs); 🟡 sections stay "
+            "functional behind the 301.",
+            "",
+        ]
+        by_comp = defaultdict(list)
+        for f in doc_edits:
+            by_comp[f["component"]].append(f)
+        ordered = [c for c in COMPONENT_ORDER if c in by_comp] + sorted(set(by_comp) - set(COMPONENT_ORDER))
+        for comp in ordered:
+            group = by_comp[comp]
+            emoji = "🔴" if any(g["severity"] == RED for g in group) else "🟡"
+            lines += [f"### {emoji} {COMPONENT_LABELS.get(comp, comp)} ({len(group)})", ""]
+            lines += gdoc_table(group)
+            lines.append("")
+
+    if allcharts:
+        by_page = defaultdict(list)
+        for f in allcharts:
+            by_page[f["where"]].append(f)
+        lines += [
+            f"## 📊 All charts blocks on topic pages ({len(allcharts)} entries — no action needed)",
+            "",
+            "These blocks list only published charts (grapher's `GdocPost.loadRelatedCharts` filters "
+            "on `isPublished`), so the entries drop out on their own at the next bake — nothing breaks "
+            "or goes stale. Tag the MDIMs with these topics only if you want replacement entries.",
+            "",
+            "| Topic page | Charts affected |",
+            "|---|---|",
+        ]
+        for page in sorted(by_page):
+            lines.append(f"| {page} | {len(by_page[page])} |")
+        lines.append("")
+
+    if other:
+        by_surface = defaultdict(list)
+        for f in other:
+            by_surface[SURFACE_LABELS.get(f["surface"], f["surface"])].append(f)
+        lines += [f"## Other surfaces ({len(other)})", ""]
+        for surface in sorted(by_surface):
+            lines += [f"### {surface} ({len(by_surface[surface])})", ""]
+            lines += bullet_list(by_surface[surface])
+            lines.append("")
+
+    if drafts:
+        lines += [f"## ℹ️ Unpublished / draft ({len(drafts)})", "", "No reader impact — listed for completeness.", ""]
+        by_comp = defaultdict(list)
+        for f in drafts:
+            by_comp[f["component"] or SURFACE_LABELS.get(f["surface"], f["surface"])].append(f)
+        for comp in sorted(by_comp):
+            group = by_comp[comp]
+            lines += [f"### {COMPONENT_LABELS.get(comp, comp)} ({len(group)})", ""]
+            lines += gdoc_table(group) if all(f["doc_edit_url"] for f in group) else bullet_list(group)
             lines.append("")
 
     # Nothing in this audit is applied by running it, and its coverage is not total — so it
     # closes by separating what someone must act on from what nobody has checked, rather
     # than leaving a reader to infer either from the sections above.
     handed_off = (
-        f"**Handed off** — {len(red)} reference(s) under *Needs manual migration* above. Each names the "
-        "page or surface that holds it and the replacement URL to put there; whoever owns that page has "
-        "to make the edit, because unpublishing the chart breaks it and the redirect does not cover it."
-        if red
+        f"**Handed off** — {len(embeds)} embedded reference(s) in the 🔴 sections above. Each names the "
+        "doc that holds it and the replacement URL to put there; whoever owns that page has to make the "
+        "edit, because unpublishing the chart breaks it and the redirect does not cover it."
+        if embeds
         else "**Handed off** — nothing. No reference needs manual migration before the charts are unpublished."
     )
     proposed = (
-        f"**Proposed** — {len(yellow)} hyperlink(s) under *worth updating* above. The 301 keeps them working, "
-        "so updating each href is a call someone still has to make, not a blocker."
-        if yellow
-        else "**Proposed** — nothing. No hyperlink updates are pending a decision."
+        f"**Proposed** — {len(links)} text link(s) in the 🟡 sections above"
+        + (f" and {len(other)} reference(s) under *Other surfaces*" if other else "")
+        + ". The 301 keeps them working, so updating each is a call someone still has to make, not a blocker."
+        if links or other
+        else "**Proposed** — nothing. No link updates are pending a decision."
     )
     unverified = (
         "**Unverified** — this audit does not cover non-ETL explorer TSVs, data insights that store the "
         "reference somewhere other than the surfaces swept here, or charts nested inside layout containers; "
         "see the `find-chart-references` skill for the full surface catalog and its known gaps. "
-        f"{len(info)} unpublished or draft reference(s) were found and listed but not graded for reader impact. "
+        f"{len(drafts)} unpublished or draft reference(s) were found and listed but not graded for reader impact. "
         "Whether the redirects themselves apply cleanly is checked by `preflight.py`, not here."
     )
     lines += [
         "---",
         "",
-        "Google-Doc-backed references are grouped by the **ArchieML component** holding them "
-        "(`chart` block, `span-link`, `front-matter`) — the page type (article, data insight, …) is "
-        "italicized in the Where column. In the tables, the **source chart links to the reference's "
-        "own URL** (its params applied) and **Replace with links to the target MDIM view** the same "
-        "reference should become. "
+        "**Embedded charts** are chart blocks rendered on the page; **text links** are hyperlinks in "
+        "prose; **front-matter chart URLs** are the `grapher-url` field in a data insight's header. "
+        "The page type (article, data insight, …) is italicized in the Where column. In the tables, "
+        "the **source chart links to the reference's own URL** (its params applied) and **Replace "
+        "with links to the target MDIM view** the same reference should become. "
         "📄 opens the Google Doc to edit · 👁 opens the page in the admin previewer (works for "
         "unpublished drafts too) · 🔗 opens the published page scrolled to the reference. "
         "**Find in doc** is a copy-paste search string for the Google Doc's find box: the link text for "
@@ -393,6 +463,10 @@ def main() -> int:
         new_url, collisions = replacement_url(r, qs, host)
         # Only an embed is broken by the redirect: it renders the chart's own config.
         severity = INFO if not ref["published"] else (RED if ref["kind"] == "embed" else YELLOW)
+        if ref["surface"] == "key chart":
+            # Verified no-action: the All charts block only lists published charts, so the
+            # entry disappears on its own when the CLI unpublishes the source.
+            severity = INFO
         is_gdoc = ref["surface"] in GDOC_SURFACES and ref.get("surface_id")
         component = archie_component(ref) if is_gdoc else ""
         if is_gdoc:
@@ -439,8 +513,10 @@ def main() -> int:
     counts: dict[str, int] = defaultdict(int)
     for f in findings:
         counts[f["severity"]] += 1
+    n_allcharts = sum(1 for f in findings if f["surface"] == "key chart")
     print(f"\nreferences: {len(findings)}  (needs manual work: {counts[RED]} | "
-          f"hyperlinks to update: {counts[YELLOW]} | unpublished: {counts[INFO]})")  # fmt: skip
+          f"links to update: {counts[YELLOW]} | no action (all-charts blocks): {n_allcharts} | "
+          f"drafts: {counts[INFO] - n_allcharts})")  # fmt: skip
     if gaps:
         print(f"  {len(gaps)} surface(s)/subject(s) were NOT swept — see 'What's still open' in the report.")
     collisions = [f for f in findings if f["param_collisions"]]

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -748,16 +748,18 @@ def main() -> int:
             # articles, not a repoint of the old one (the parent columns are INSERT-only —
             # see SKILL.md). Nothing breaks meanwhile: the chart renders its own saved
             # config, and only its generated "Explore the data" link follows the redirect.
-            # The admin's create page is deep-linkable to the target view, so hand over the
-            # ready-made URL rather than an id to look up.
-            # The order (create-first vs delete-first) depends on whether a PUBLISHED page
-            # references it, which only the report's own section resolves — so this cell
-            # states the goal and points there rather than asserting one order for every row.
+            # No create URL here: the admin's create route parents the new chart to the
+            # MDIM's DEFAULT view, not the target view, so handing one over in a cell that
+            # cannot show the surrounding caveats is how someone ends up with a replacement
+            # on the wrong view. The route that does work is the view's own control.
+            # The order (create-first vs delete-first) likewise depends on whether a
+            # PUBLISHED page references it, which only the report's own section resolves —
+            # so this cell states the goal and points there.
             fix = (
-                "recreate it manually from the target MDIM view and repoint the pages that use it — "
-                f"create the replacement at {admin}/narrative-charts/create?type=multiDim&chartConfigId={r['target']['viewConfigId']} ; "
-                "see the Narrative charts section of references.md for the pages involved and the "
-                "order the API forces"
+                f"recreate it manually: open the target view ({new_url}), set its controls, and use that "
+                "view's \"Create narrative chart\" admin control — the create route parents to the MDIM's "
+                "default view instead. Then repoint the pages that use it; see the Narrative charts "
+                "section of references.md for those pages, the text to re-apply, and the order the API forces"
             )
         elif is_gdoc:
             fallback = LINK_FIX if ref["kind"] == "link" else "migrate this reference by hand"

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -420,9 +420,24 @@ def narrative_section(
         # MDIM's DEFAULT view with default entities, so nothing below carries over on its own.
         render_cell = f"**[open the target view]({f['replacement_url']})** — the rendering to match"
 
+        # Resolved before the cells are built because both the "set by hand" list and the
+        # steps need it: the name is typed at creation time, and which name applies depends on
+        # whether a published page still holds the original.
+        if published_uses:
+            new_name = suggest_name(name, taken)
+            taken.add(new_name)
+            name_note = (
+                f"**`{new_name}`** — new (a published page still holds `{cell(name, 44)}`); checked: not in use"
+                if new_name
+                else f"a NEW name — a published page still holds `{cell(name, 44)}`"
+            )
+        else:
+            new_name = name
+            name_note = f"**`{name}`** — reuse the original, freed by the delete in step 1"
+
         # Everything the create does not carry over, in the order it gets done in the editor:
-        # pick the view, then its controls, then retype the authored text.
-        parts = []
+        # the name, then the view, then its controls, then the authored text.
+        parts = [f"**name**:<br>{name_note}"]
         dims = f.get("target_dimensions") or {}
         if dims:
             parts.append(
@@ -491,26 +506,17 @@ def narrative_section(
             "not carry over; compare against the original in the admin editor"
         )
         if published_uses:
-            # The name is permanent — there is no rename — so suggest one that survives, and
-            # one that `create` will actually accept.
-            suggestion = suggest_name(name, taken)
-            taken.add(suggestion)
-            name_hint = (
-                f", under a NEW name (`create` rejects an existing one) — suggested: **`{suggestion}`** "
-                "(checked: not in use)"
-                if suggestion
-                else ", under a NEW name (`create` rejects an existing one)"
-            )
             steps = (
-                f"1. **create**: {create_step}{name_hint}"
+                f"1. **create**: {create_step}, naming it as the third column says "
+                "(`create` rejects an existing name)"
                 f"<br>2. {set_step}"
-                "<br>3. **repoint** the page(s) to the new name"
+                f"<br>3. **repoint** the page(s) to `{cell(new_name or 'the new name', 44)}`"
                 "<br>4. **delete** the old one — succeeds once no published page references it"
             )
         else:
             steps = (
                 "1. **delete** the old one — nothing published references it, so this frees the name"
-                f"<br>2. **create**: {create_step}, reusing the SAME name — **`{name}`**"
+                f"<br>2. **create**: {create_step}, naming it as the third column says"
                 f"<br>3. {set_step}"
             )
         lines.append(f"| {chart_cell} | {render_cell} | {faust_cell} | {used_cell} | {steps} |")

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -280,6 +280,14 @@ FAUST_KEYS = ("title", "subtitle", "note", "sourceDesc", "hideAnnotationFieldsIn
 # the new parent view supplies them, and re-applying the old ones would repoint the chart
 # at the source chart's indicators, undoing the migration.
 SKIP_OVERRIDE_KEYS = ("dimensions", "$schema", "id", "slug", "isPublished", "version")
+# Grapher URL params and the config keys holding the same state. Used to keep the "set by
+# hand" list from naming one setting twice in two spellings.
+PARAM_CONFIG_EQUIVALENT = {
+    "country": ("selectedEntityNames",),
+    "focus": ("focusedSeriesNames",),
+    "time": ("minTime", "maxTime"),
+    "region": ("map",),
+}
 
 
 def narrative_overrides(findings: list[dict]) -> dict[str, dict]:
@@ -345,7 +353,7 @@ def narrative_section(
     reference resolving untouched — exactly when nothing published holds it.
     """
     lines = [
-        "| Narrative chart | Create from this view | Text to re-apply | Used in (what to repoint) | Steps |",
+        "| Narrative chart | Target rendering | Set by hand after creating | Used in (what to repoint) | Steps |",
         "|---|---|---|---|---|",
     ]
     for f in group:
@@ -358,32 +366,46 @@ def narrative_section(
             f"[`{cell(name, 40)}`]({admin}/narrative-charts/{f['narrative_id']}/edit) _✎ admin editor_"
             f"<br>parent: [`{cell(f['source_chart_slug'], 32)}`]({f['old_url']})"
         )
-        # This link is the create entry point, not just a preview: the MDIM page's own
-        # "Create narrative chart" control builds its create path from whichever view is on
-        # screen (site/multiDim/MultiDim.tsx), so opening the target view with these params
-        # and using that control parents the new chart to the right view AND carries the
-        # controls over — which the standalone create?chartConfigId= deep link does not do.
-        params = f"<br>controls: `{cell(f['stored_params'].replace('&', '`, `'), 90)}`" if f["stored_params"] else ""
-        collide = (
-            f"<br>⚠️ `{f['param_collisions']}` overrides a view dimension — choose it deliberately"
-            if f["param_collisions"]
-            else ""
-        )
-        controls_left = {k: v for k, v in (ovr.get("controls") or {}).items() if k not in ("tab",)}
-        extra_controls = (
-            "<br>also set: " + ", ".join(f"`{k}` = {render_override(v)}" for k, v in sorted(controls_left.items()))
-            if controls_left
-            else ""
-        )
-        render_cell = f"**[open the target view]({f['replacement_url']})**{params}{collide}{extra_controls}"
+        # The link is the reference rendering to reproduce, and the page the create control
+        # lives on. It is NOT a shortcut: creating from an MDIM starts the new chart at the
+        # MDIM's DEFAULT view with default entities, so nothing below carries over on its own.
+        render_cell = f"**[open the target view]({f['replacement_url']})** — the rendering to match"
 
+        # Everything the create does not carry over, in the order it gets done in the editor:
+        # pick the view, then its controls, then retype the authored text.
+        parts = []
+        dims = f.get("target_dimensions") or {}
+        if dims:
+            parts.append(
+                "**view dimensions** (the create starts on the MDIM's default view):<br>"
+                + ", ".join(f"`{k}` = {v}" for k, v in sorted(dims.items()))
+            )
+        # The stored URL params and the config patch describe the same state in two
+        # encodings, so a param is listed only when the patch has no equivalent config key —
+        # otherwise the cell asks for the entity selection twice, as `country` and again as
+        # `selectedEntityNames`. The config form wins: that is what the editor's fields are.
+        config_controls = ovr.get("controls") or {}
+        controls = dict(config_controls)
+        for key, value in parse_qsl(f["stored_params"], keep_blank_values=True):
+            if any(equiv in config_controls for equiv in PARAM_CONFIG_EQUIVALENT.get(key, (key,))):
+                continue
+            controls[key] = value
+        if controls:
+            parts.append(
+                "**controls** (entity selection, tab, time — not inherited):<br>"
+                + ", ".join(f"`{k}` = {render_override(v) or '(empty)'}" for k, v in sorted(controls.items()))
+            )
         faust = ovr.get("faust") or {}
         if faust:
-            faust_cell = "the original overrides these — the view will NOT supply them:<br>" + "<br>".join(
-                f"`{k}`: {cell(render_override(v), 110)}" for k, v in sorted(faust.items())
+            parts.append(
+                "**text the original overrides** — the view will NOT supply it:<br>"
+                + "<br>".join(f"`{k}`: {cell(render_override(v), 110)}" for k, v in sorted(faust.items()))
             )
         else:
-            faust_cell = "_no text overrides — it inherits FAUST from its parent, so the view's own text applies_"
+            parts.append("_no text overrides — FAUST is inherited, so the view's own text applies_")
+        if f["param_collisions"]:
+            parts.append(f"⚠️ `{f['param_collisions']}` collides with a view dimension — choose it deliberately")
+        faust_cell = "<br><br>".join(parts)
 
         if used_in:
             uses = []
@@ -403,14 +425,18 @@ def narrative_section(
             used_cell = "_not referenced by any page_"
 
         create_step = (
-            'open the target view, set its controls, then use the chart\'s **"Create narrative chart"** '
-            "admin control (visible when logged in) — it parents the new chart to the view on screen"
+            'open the target view and use the chart\'s **"Create narrative chart"** admin control '
+            "(visible when logged in)"
+        )
+        set_step = (
+            "**set everything in the third column by hand** — the new chart opens on the MDIM's "
+            "default view with default entities, so the dimensions, controls and authored text do "
+            "not carry over; compare against the original in the admin editor"
         )
         if published_uses:
             steps = (
                 f"1. **create**: {create_step}, under a NEW name (`create` rejects an existing one)"
-                "<br>2. **re-apply** the text overrides in the middle column, and check the title/subtitle/"
-                "footnote against the original"
+                f"<br>2. {set_step}"
                 "<br>3. **repoint** the page(s) to the new name"
                 "<br>4. **delete** the old one — succeeds once no published page references it"
             )
@@ -418,7 +444,7 @@ def narrative_section(
             steps = (
                 "1. **delete** the old one — nothing published references it, so this frees the name"
                 f"<br>2. **create**: {create_step}, reusing the SAME name"
-                "<br>3. **re-apply** the text overrides in the middle column"
+                f"<br>3. {set_step}"
             )
         lines.append(f"| {chart_cell} | {render_cell} | {faust_cell} | {used_cell} | {steps} |")
     lines.append("")
@@ -589,15 +615,16 @@ def write_markdown(
             "same name** when none does (any draft reference then keeps resolving untouched).",
             "",
             "Create the replacement from the target view itself, using the chart's **\"Create narrative "
-            "chart\"** admin control — the MDIM page builds that control's target from whichever view "
-            "is on screen, so the new chart is parented to the right view and inherits the controls "
-            "you set. Do **not** use a bare `/admin/narrative-charts/create?chartConfigId=…` link: it "
-            "opens a copy of the MDIM's default view instead of this one.",
+            'chart"** admin control — not a bare `/admin/narrative-charts/create?chartConfigId=…` '
+            "link, which opens a copy of the MDIM's default view.",
             "",
-            "Then re-apply the text overrides in the **Text to re-apply** column. FAUST (title, "
-            "subtitle, footnote) that the original authored on top of its parent does not come from "
-            "the new view — miss it and the replacement silently renders the view's own wording "
-            "instead of the text the article was written around.",
+            "**Then expect to rebuild the view by hand.** Creating a narrative chart from an MDIM "
+            "starts it on the MDIM's **default view with default entities** — the dimension selection, "
+            "the entity selection, the tab and time settings, and any text the original authored on "
+            "top of its parent all fail to carry over. The **Set by hand after creating** column lists "
+            "exactly those groups per chart, in the order to apply them. Miss the text and the "
+            "replacement silently renders the view's own wording instead of the wording the article "
+            "was written around; miss the controls and it renders the wrong countries.",
             "",
         ]
         lines += narrative_section(
@@ -790,6 +817,9 @@ def main() -> int:
                 # The narrative chart's own stored controls (entities, tab, time). The admin
                 # create page cannot preset them, so the report names them for hand-copying.
                 "stored_params": qs if ref["surface"] == "narrative chart" else "",
+                # Creating from an MDIM starts at its DEFAULT view, so the dimension
+                # selection has to be re-made by hand too — the report has to name it.
+                "target_dimensions": dict(r["target"]["dimensions"]) if ref["surface"] == "narrative chart" else {},
                 "target_view_config_id": r["target"]["viewConfigId"],
                 "context": ref["context"] + (f' — "{ref["text"][:60]}"' if ref["text"] else ""),
                 "old_url": f"{host}/grapher/{ref['subject']}" + (f"?{qs.lstrip('?')}" if qs else ""),

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -180,9 +180,17 @@ def archie_component(ref: dict) -> str:
 
 
 def page_type(ref: dict) -> str:
-    """article / data-insight / topic-page / fragment — the parenthesized tail of context."""
+    """article / data insight / topic-page / fragment — the parenthesized tail of context.
+
+    The data-insight surface spells its front-matter reference out in prose with no
+    parenthesized suffix, so fall back to the surface name. Without that fallback those
+    rows lose the page-type marker exactly where it now matters most: articles and data
+    insights share one table, and the Where column is the only thing distinguishing them.
+    """
     m = re.search(r"\(([^)]+)\)", ref["context"].split(" — ")[0])
-    return m.group(1) if m else ""
+    if m:
+        return m.group(1)
+    return ref["surface"] if ref["surface"] == "data insight" else ""
 
 
 def find_in_doc(ref: dict) -> str:
@@ -296,24 +304,26 @@ def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host:
     # only published charts) and collapse to a per-page summary.
     allcharts = [f for f in findings if f["surface"] == "key chart"]
     drafts = [f for f in findings if f["severity"] == INFO and f["surface"] != "key chart"]
-    doc_edits = [f for f in findings if f["severity"] in (RED, YELLOW) and f["doc_edit_url"]]
-    narrative = [f for f in findings if f["severity"] in (RED, YELLOW) and f["surface"] == "narrative chart"]
-    other = [
-        f
-        for f in findings
-        if f["severity"] in (RED, YELLOW) and not f["doc_edit_url"] and f["surface"] != "narrative chart"
-    ]
-    embeds = [f for f in doc_edits if f["severity"] == RED]
-    links = [f for f in doc_edits if f["severity"] == YELLOW]
+    actionable = [f for f in findings if f["severity"] in (RED, YELLOW)]
+    doc_edits = [f for f in actionable if f["doc_edit_url"]]
+    narrative = [f for f in actionable if f["surface"] == "narrative chart"]
+    other = [f for f in actionable if not f["doc_edit_url"] and f["surface"] != "narrative chart"]
+    # Every RED finding blocks, wherever it lives: an explorer or static viz that embeds the
+    # chart has no Google Doc behind it, but it renders the chart's own config and breaks on
+    # unpublish exactly like an article embed does — and preflight gates on all of them.
+    # Scoping this to doc-backed rows would have the report announce "no embeds to migrate"
+    # while a blocking surface sat under Proposed being described as 301-covered.
+    embeds = [f for f in actionable if f["severity"] == RED]
+    links = [f for f in actionable if f["severity"] == YELLOW]
 
     lines = [
         "# What references the charts being redirected",
         "",
         f"{len(redirects)} chart(s) heading for unpublishing — proposed redirects, plus charts already "
         f"redirected whose source chart is still published. **{len(embeds)} embedded reference(s) break "
-        f"when the charts are unpublished** and must be migrated before the CLI runs; {len(links)} text "
-        "link(s) keep working via the 301 but belong in the same editing pass. Topic-page All charts "
-        "blocks update themselves — summarized below, no action needed.",
+        f"when the charts are unpublished** and must be migrated before the CLI runs (every 🔴 section "
+        f"below, doc-backed or not); {len(links)} link(s) keep working via the 301 but belong in the same "
+        "editing pass. Topic-page All charts blocks update themselves — summarized below, no action needed.",
         "",
         "Replacement URLs merge each reference's own query string over the MDIM view's dimensions, "
         "the same way grapher's redirect handler does.",
@@ -385,8 +395,12 @@ def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host:
             by_surface[SURFACE_LABELS.get(f["surface"], f["surface"])].append(f)
         lines += [f"## Other surfaces ({len(other)})", ""]
         for surface in sorted(by_surface):
-            lines += [f"### {surface} ({len(by_surface[surface])})", ""]
-            lines += bullet_list(by_surface[surface])
+            group = by_surface[surface]
+            # Same 🔴/🟡 marking as the doc sections: a RED row here blocks the CLI just as
+            # hard, so it must not read as a lower tier merely for lacking a doc link.
+            emoji = "🔴" if any(g["severity"] == RED for g in group) else "🟡"
+            lines += [f"### {emoji} {surface} ({len(group)})", ""]
+            lines += bullet_list(group)
             lines.append("")
 
     if drafts:
@@ -404,17 +418,19 @@ def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host:
     # closes by separating what someone must act on from what nobody has checked, rather
     # than leaving a reader to infer either from the sections above.
     handed_off = (
-        f"**Handed off** — {len(embeds)} embedded reference(s) in the 🔴 sections above. Each names the "
-        "doc that holds it and the replacement URL to put there; whoever owns that page has to make the "
-        "edit, because unpublishing the chart breaks it and the redirect does not cover it."
+        f"**Handed off** — {len(embeds)} embedded reference(s), in every 🔴 section above. Each names the "
+        "surface that holds it and the replacement URL to put there; whoever owns it has to make the edit, "
+        "because unpublishing the chart breaks it and the redirect does not cover it. `preflight.py` gates "
+        "on this same set."
         if embeds
         else "**Handed off** — nothing. No reference needs manual migration before the charts are unpublished."
     )
     proposed = (
-        f"**Proposed** — {len(links)} text link(s) in the 🟡 sections above"
-        + (f" and {len(other)} reference(s) under *Other surfaces*" if other else "")
-        + ". The 301 keeps them working, so updating each is a call someone still has to make, not a blocker."
-        if links or other
+        f"**Proposed** — {len(links)} link-kind reference(s) in the 🟡 sections above"
+        + (f", including {len(narrative)} narrative chart(s) to recreate" if narrative else "")
+        + ". The 301 keeps every one of them working, so acting on each is a call someone still has to "
+        "make, not a blocker."
+        if links
         else "**Proposed** — nothing. No link updates are pending a decision."
     )
     unverified = (

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -245,7 +245,72 @@ def narrative_chart_usages(names: set[str]) -> dict[str, list[dict]]:
     return usages
 
 
-def narrative_section(group: list[dict], usages: dict[str, list[dict]], host: str, admin: str) -> list[str]:
+# A narrative chart's authored patch, split by what a human has to redo in the new editor.
+# FAUST text is copied verbatim and is the easiest thing to lose: it does not come from the
+# parent, so a replacement built only from the view silently renders the VIEW's title and
+# subtitle instead of the ones the article was written around.
+FAUST_KEYS = ("title", "subtitle", "note", "sourceDesc", "hideAnnotationFieldsInTitle")
+# Controls: everything else worth reproducing. `dimensions` and `$schema` are excluded —
+# the new parent view supplies them, and re-applying the old ones would repoint the chart
+# at the source chart's indicators, undoing the migration.
+SKIP_OVERRIDE_KEYS = ("dimensions", "$schema", "id", "slug", "isPublished", "version")
+
+
+def narrative_overrides(findings: list[dict]) -> dict[str, dict]:
+    """{narrative chart id -> its authored overrides, minus what the target view already has}.
+
+    Read from `chart_configs.patch` (the authored delta), not `full`: the patch is exactly
+    what a human typed on top of the parent, which is exactly what has to be retyped on top
+    of the new one. Each override is compared against the TARGET view's config so the report
+    only asks for what actually differs — a title the view already carries needs no work.
+    """
+    ids = {str(f["narrative_id"]) for f in findings if f.get("narrative_id")}
+    view_ids = {f["target_view_config_id"] for f in findings if f.get("target_view_config_id")}
+    if not ids:
+        return {}
+    patches = OWID_ENV.read_sql(
+        "SELECT nc.id, cc.patch FROM narrative_charts nc JOIN chart_configs cc ON cc.id = nc.chartConfigId "
+        "WHERE nc.id IN %(ids)s",
+        params={"ids": tuple(sorted(ids))},
+    )
+    views = (
+        OWID_ENV.read_sql(
+            "SELECT id, full FROM chart_configs WHERE id IN %(ids)s", params={"ids": tuple(sorted(view_ids))}
+        )
+        if view_ids
+        else None
+    )
+    view_cfg = {r["id"]: json.loads(r["full"] or "{}") for r in views.to_dict("records")} if views is not None else {}
+    by_narrative = {str(r["id"]): json.loads(r["patch"] or "{}") for r in patches.to_dict("records")}
+
+    out: dict[str, dict] = {}
+    for f in findings:
+        nid = str(f.get("narrative_id") or "")
+        patch = by_narrative.get(nid)
+        if patch is None:
+            continue
+        target = view_cfg.get(f.get("target_view_config_id"), {})
+        faust, controls = {}, {}
+        for key, value in patch.items():
+            if key in SKIP_OVERRIDE_KEYS or target.get(key) == value:
+                continue
+            (faust if key in FAUST_KEYS else controls)[key] = value
+        out[nid] = {"faust": faust, "controls": controls}
+    return out
+
+
+def render_override(value) -> str:
+    """Compact one-line rendering of an override value for a table cell."""
+    if isinstance(value, list):
+        return ", ".join(str(v) for v in value) or "(empty)"
+    if isinstance(value, dict):
+        return ", ".join(f"{k}={v}" for k, v in value.items())
+    return str(value)
+
+
+def narrative_section(
+    group: list[dict], usages: dict[str, list[dict]], overrides: dict[str, dict], host: str, admin: str
+) -> list[str]:
     """One block per narrative chart: what it is, where it is used, and the ordered steps.
 
     Which of the two orders applies is decided by whether a PUBLISHED page references it
@@ -254,26 +319,45 @@ def narrative_section(group: list[dict], usages: dict[str, list[dict]], host: st
     reference resolving untouched — exactly when nothing published holds it.
     """
     lines = [
-        "| Narrative chart | Parent chart | Replicate this rendering | Used in (what to repoint) | Steps |",
+        "| Narrative chart | Create from this view | Text to re-apply | Used in (what to repoint) | Steps |",
         "|---|---|---|---|---|",
     ]
     for f in group:
         name = f["where"]
         used_in = usages.get(name, [])
         published_uses = [u for u in used_in if u["published"]]
-        create = f"{admin}/narrative-charts/create?type=multiDim&chartConfigId={f['target_view_config_id']}"
+        ovr = overrides.get(str(f.get("narrative_id") or ""), {})
 
-        chart_cell = f"[`{cell(name, 40)}`]({admin}/narrative-charts/{f['narrative_id']}/edit)<br>_✎ admin editor_"
-        parent_cell = f"[`{cell(f['source_chart_slug'], 32)}`]({f['old_url']})"
-        # The create page takes only the parent view, so the reader has to reproduce the
-        # controls by hand — naming them beats making them diff two URLs.
-        params = f"<br>set: `{cell(f['stored_params'].replace('&', '`, `'), 90)}`" if f["stored_params"] else ""
+        chart_cell = (
+            f"[`{cell(name, 40)}`]({admin}/narrative-charts/{f['narrative_id']}/edit) _✎ admin editor_"
+            f"<br>parent: [`{cell(f['source_chart_slug'], 32)}`]({f['old_url']})"
+        )
+        # This link is the create entry point, not just a preview: the MDIM page's own
+        # "Create narrative chart" control builds its create path from whichever view is on
+        # screen (site/multiDim/MultiDim.tsx), so opening the target view with these params
+        # and using that control parents the new chart to the right view AND carries the
+        # controls over — which the standalone create?chartConfigId= deep link does not do.
+        params = f"<br>controls: `{cell(f['stored_params'].replace('&', '`, `'), 90)}`" if f["stored_params"] else ""
         collide = (
             f"<br>⚠️ `{f['param_collisions']}` overrides a view dimension — choose it deliberately"
             if f["param_collisions"]
             else ""
         )
-        render_cell = f"[open the target view]({f['replacement_url']}){params}{collide}"
+        controls_left = {k: v for k, v in (ovr.get("controls") or {}).items() if k not in ("tab",)}
+        extra_controls = (
+            "<br>also set: " + ", ".join(f"`{k}` = {render_override(v)}" for k, v in sorted(controls_left.items()))
+            if controls_left
+            else ""
+        )
+        render_cell = f"**[open the target view]({f['replacement_url']})**{params}{collide}{extra_controls}"
+
+        faust = ovr.get("faust") or {}
+        if faust:
+            faust_cell = "the original overrides these — the view will NOT supply them:<br>" + "<br>".join(
+                f"`{k}`: {cell(render_override(v), 110)}" for k, v in sorted(faust.items())
+            )
+        else:
+            faust_cell = "_no text overrides — it inherits FAUST from its parent, so the view's own text applies_"
 
         if used_in:
             uses = []
@@ -295,18 +379,25 @@ def narrative_section(group: list[dict], usages: dict[str, list[dict]], host: st
         else:
             used_cell = "_not referenced by any page_"
 
+        create_step = (
+            'open the target view, set its controls, then use the chart\'s **"Create narrative chart"** '
+            "admin control (visible when logged in) — it parents the new chart to the view on screen"
+        )
         if published_uses:
             steps = (
-                f"1. [**create**]({create}) under a NEW name (`create` rejects an existing one)"
-                "<br>2. **repoint** the page(s) to the new name"
-                "<br>3. **delete** the old one — succeeds once no published page references it"
+                f"1. **create**: {create_step}, under a NEW name (`create` rejects an existing one)"
+                "<br>2. **re-apply** the text overrides in the middle column, and check the title/subtitle/"
+                "footnote against the original"
+                "<br>3. **repoint** the page(s) to the new name"
+                "<br>4. **delete** the old one — succeeds once no published page references it"
             )
         else:
             steps = (
                 "1. **delete** the old one — nothing published references it, so this frees the name"
-                f"<br>2. [**create**]({create}) the replacement, reusing the SAME name"
+                f"<br>2. **create**: {create_step}, reusing the SAME name"
+                "<br>3. **re-apply** the text overrides in the middle column"
             )
-        lines.append(f"| {chart_cell} | {parent_cell} | {render_cell} | {used_cell} | {steps} |")
+        lines.append(f"| {chart_cell} | {render_cell} | {faust_cell} | {used_cell} | {steps} |")
     lines.append("")
     return lines
 
@@ -470,12 +561,29 @@ def write_markdown(
             "plan for each one: **recreate it manually from the target MDIM view**. There is no "
             "repointing API and no rename, and the API forces which order applies — the delete is "
             "refused while a **published** page references it, and `create` rejects a name that "
-            "already exists. So each block below carries the order that fits it: **create → repoint "
+            "already exists. So each row below carries the order that fits it: **create → repoint "
             "→ delete** when a published page holds it, and the shorter **delete → create under the "
             "same name** when none does (any draft reference then keeps resolving untouched).",
             "",
+            'Create the replacement from the target view itself, using the chart\'s **"Create narrative '
+            'chart"** admin control — the MDIM page builds that control\'s target from whichever view '
+            "is on screen, so the new chart is parented to the right view and inherits the controls "
+            "you set. Do **not** use a bare `/admin/narrative-charts/create?chartConfigId=…` link: it "
+            "opens a copy of the MDIM's default view instead of this one.",
+            "",
+            "Then re-apply the text overrides in the **Text to re-apply** column. FAUST (title, "
+            "subtitle, footnote) that the original authored on top of its parent does not come from "
+            "the new view — miss it and the replacement silently renders the view's own wording "
+            "instead of the text the article was written around.",
+            "",
         ]
-        lines += narrative_section(narrative, narrative_chart_usages({f["where"] for f in narrative}), host, admin)
+        lines += narrative_section(
+            narrative,
+            narrative_chart_usages({f["where"] for f in narrative}),
+            narrative_overrides(narrative),
+            host,
+            admin,
+        )
 
     if allcharts:
         by_page = defaultdict(list)

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -153,11 +153,27 @@ def run_find_references(redirects: list[dict]) -> tuple[list[dict], list[str]]:
         Path(gaps_path).unlink(missing_ok=True)
 
 
-def deep_link(where_path: str, anchor: str, host: str) -> str:
+def absolute_url(where_path: str, host: str, admin: str = "") -> str:
+    """Absolute URL for a `where_path`, routing admin routes to the admin origin.
+
+    A narrative chart's `where_path` is its admin editor (`/admin/narrative-charts/…`),
+    which the public site does not serve — prefixing it with `host` produces a link that
+    404s. `admin` is an admin ROOT (".../admin") and the path already starts with
+    `/admin/`, so the root's suffix comes off before joining.
+    """
+    if not where_path:
+        return ""
+    if where_path.startswith("/admin/"):
+        origin = (admin or host).removesuffix("/").removesuffix("/admin")
+        return f"{origin}{where_path}"
+    return f"{host}{where_path}"
+
+
+def deep_link(where_path: str, anchor: str, host: str, admin: str = "") -> str:
     """Published-page URL scrolled to the reference via a text fragment (block embeds
     have no anchor text, so those fall back to the plain URL). Same encoding as
     find-chart-references / chart_diff citations: parentheses literal, hyphens escaped."""
-    base = f"{host}{where_path}" if where_path else ""
+    base = absolute_url(where_path, host, admin)
     if not base or not anchor:
         return base
     encoded = quote(anchor[:200], safe="()").replace("-", "%2D")
@@ -237,59 +253,61 @@ def narrative_section(group: list[dict], usages: dict[str, list[dict]], host: st
     `create` rejects an existing name, so the name can be reused — leaving any draft
     reference resolving untouched — exactly when nothing published holds it.
     """
-    lines: list[str] = []
+    lines = [
+        "| Narrative chart | Parent chart | Replicate this rendering | Used in (what to repoint) | Steps |",
+        "|---|---|---|---|---|",
+    ]
     for f in group:
         name = f["where"]
         used_in = usages.get(name, [])
         published_uses = [u for u in used_in if u["published"]]
-        lines += [
-            f"### `{name}`",
-            "",
-            f"- parent chart: [`{f['source_chart_slug']}`]({f['old_url']}) · "
-            f"[✎ open the narrative chart]({admin}/narrative-charts/{f['narrative_id']}/edit)",
-            f"- replacement should render: {f['replacement_url']}",
-        ]
-        if f["param_collisions"]:
-            lines.append(
-                f"- ⚠️ its stored query params `{f['param_collisions']}` collide with the target view's "
-                "dimensions and would override them"
-            )
-        if used_in:
-            lines.append(
-                f"- **used in {len(used_in)} page(s)** — "
-                + (
-                    "these are what the repoint step updates:"
-                    if published_uses
-                    else "none of them published, so reusing the name below keeps them resolving as they are:"
-                )
-            )
-            for u in sorted(used_in, key=lambda u: (not u["published"], u["slug"] or "")):
-                draft = "" if u["published"] else " ⚠️ **draft**"
-                page = (
-                    f"[{u['slug']}]({host}/{u['slug']})" if u["published"] and u["slug"] else f"`{u['slug'] or '(no slug)'}`"
-                )  # fmt: skip
-                lines.append(
-                    f"    - {page} _{u['type']}_{draft} — in a `{u['componentType']}` block · "
-                    f"[📄 doc](https://docs.google.com/document/d/{u['gdoc_id']}/edit) · "
-                    f"[👁 preview]({admin}/gdocs/{u['gdoc_id']}/preview) · search the doc for `{name}`"
-                )
-        else:
-            lines.append("- **not referenced by any page**")
         create = f"{admin}/narrative-charts/create?type=multiDim&chartConfigId={f['target_view_config_id']}"
-        if published_uses:
-            lines += [
-                f"- **step 1 — create** the replacement under a NEW name (`create` rejects an existing one): {create}",
-                "- **step 2 — repoint:** change the page(s) above to the new narrative chart's name",
-                "- **step 3 — delete:** remove the old narrative chart — the delete succeeds once no "
-                "published page references it, which is why it comes last",
-            ]
+
+        chart_cell = f"[`{cell(name, 40)}`]({admin}/narrative-charts/{f['narrative_id']}/edit)<br>_✎ admin editor_"
+        parent_cell = f"[`{cell(f['source_chart_slug'], 32)}`]({f['old_url']})"
+        # The create page takes only the parent view, so the reader has to reproduce the
+        # controls by hand — naming them beats making them diff two URLs.
+        params = f"<br>set: `{cell(f['stored_params'].replace('&', '`, `'), 90)}`" if f["stored_params"] else ""
+        collide = (
+            f"<br>⚠️ `{f['param_collisions']}` overrides a view dimension — choose it deliberately"
+            if f["param_collisions"]
+            else ""
+        )
+        render_cell = f"[open the target view]({f['replacement_url']}){params}{collide}"
+
+        if used_in:
+            uses = []
+            for u in sorted(used_in, key=lambda u: (not u["published"], u["slug"] or "")):
+                page = (
+                    f"[{cell(u['slug'], 34)}]({host}/{u['slug']})"
+                    if u["published"] and u["slug"]
+                    else f"`{cell(u['slug'] or '(no slug)', 34)}`"
+                )
+                draft = " ⚠️ **draft**" if not u["published"] else ""
+                uses.append(
+                    f"{page} _{u['type']}_{draft}<br>`{u['componentType']}` block · "
+                    f"[📄 doc](https://docs.google.com/document/d/{u['gdoc_id']}/edit) · "
+                    f"[👁 preview]({admin}/gdocs/{u['gdoc_id']}/preview) · find `{cell(name, 44)}`"
+                )
+            used_cell = "<br><br>".join(uses)
+            if not published_uses:
+                used_cell += "<br>_none published — reusing the name keeps these resolving_"
         else:
-            lines += [
-                "- **step 1 — delete** the old narrative chart: nothing published references it, so the "
-                "delete succeeds and frees the name",
-                f"- **step 2 — create** the replacement, reusing the SAME name (`{name}`): {create}",
-            ]
-        lines.append("")
+            used_cell = "_not referenced by any page_"
+
+        if published_uses:
+            steps = (
+                f"1. [**create**]({create}) under a NEW name (`create` rejects an existing one)"
+                "<br>2. **repoint** the page(s) to the new name"
+                "<br>3. **delete** the old one — succeeds once no published page references it"
+            )
+        else:
+            steps = (
+                "1. **delete** the old one — nothing published references it, so this frees the name"
+                f"<br>2. [**create**]({create}) the replacement, reusing the SAME name"
+            )
+        lines.append(f"| {chart_cell} | {parent_cell} | {render_cell} | {used_cell} | {steps} |")
+    lines.append("")
     return lines
 
 
@@ -601,12 +619,14 @@ def main() -> int:
             # config, and only its generated "Explore the data" link follows the redirect.
             # The admin's create page is deep-linkable to the target view, so hand over the
             # ready-made URL rather than an id to look up.
+            # The order (create-first vs delete-first) depends on whether a PUBLISHED page
+            # references it, which only the report's own section resolves — so this cell
+            # states the goal and points there rather than asserting one order for every row.
             fix = (
-                "recreate it manually and point references back at the new one: "
-                f"(1) create the replacement parented to the target MDIM view — {admin}/narrative-charts/create?type=multiDim&chartConfigId={r['target']['viewConfigId']} ; "
-                "(2) update the article(s) that reference it to the new name; "
-                "(3) delete the old one — the delete is refused while a published post still "
-                "references it, which is why the order matters (see SKILL.md)"
+                "recreate it manually from the target MDIM view and repoint the pages that use it — "
+                f"create the replacement at {admin}/narrative-charts/create?type=multiDim&chartConfigId={r['target']['viewConfigId']} ; "
+                "see the Narrative charts section of references.md for the pages involved and the "
+                "order the API forces"
             )
         elif is_gdoc:
             fallback = LINK_FIX if ref["kind"] == "link" else "migrate this reference by hand"
@@ -625,7 +645,7 @@ def main() -> int:
                 "source_chart_slug": ref["subject"],
                 "where": ref["where"],
                 # Scrolled to the reference when the anchor text allows it.
-                "where_url": deep_link(ref["where_path"], ref.get("text") or "", host),
+                "where_url": deep_link(ref["where_path"], ref.get("text") or "", host, admin),
                 # posts_gdocs.id IS the Google Doc id, so the edit link is direct; the
                 # admin previewer renders unpublished drafts the public URL 404s on.
                 "doc_edit_url": f"https://docs.google.com/document/d/{ref['surface_id']}/edit" if is_gdoc else "",
@@ -634,6 +654,9 @@ def main() -> int:
                 # Narrative rows carry the ids their own section needs: the narrative chart
                 # to open/delete, and the target view to parent the replacement to.
                 "narrative_id": ref["surface_id"] if ref["surface"] == "narrative chart" else "",
+                # The narrative chart's own stored controls (entities, tab, time). The admin
+                # create page cannot preset them, so the report names them for hand-copying.
+                "stored_params": qs if ref["surface"] == "narrative chart" else "",
                 "target_view_config_id": r["target"]["viewConfigId"],
                 "context": ref["context"] + (f' — "{ref["text"][:60]}"' if ref["text"] else ""),
                 "old_url": f"{host}/grapher/{ref['subject']}" + (f"?{qs.lstrip('?')}" if qs else ""),

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -83,14 +83,14 @@ COMPONENT_ORDER = ("chart", "front-matter", "span-link")
 
 FIXES = {
     "explorer": "repoint the explorer at the MDIM indicators, or retire the explorer",
-    "narrative chart": "replace it: create a new one from the MDIM view (parentChartConfigId = "
-    "that view's config_id), move the article references, then delete the old — see SKILL.md",
     "static viz": "regenerate the static visualization against the MDIM view",
-    # No action: the All charts block lists only published charts (GdocPost.loadRelatedCharts
-    # filters on isPublished), so entries drop out at the next bake — nothing breaks or goes
-    # stale. Tagging the MDIM is optional curation, not repair.
-    "key chart": "no action needed — the entry drops out of the All charts block automatically; "
-    "tag the MDIM with the topic only if you want a replacement entry",
+    # No action possible or needed: the All charts block lists only published charts
+    # (GdocPost.loadRelatedCharts filters on isPublished), so entries drop out at the next
+    # bake — and the block is built from charts × chart_tags only, so an MDIM cannot be
+    # tagged into it as a replacement. Featuring the MDIM on the topic page is a separate
+    # gdoc-authoring change, not part of this migration.
+    "key chart": "no action — the entry drops out of the All charts block automatically, and the "
+    "block cannot list MDIMs (it is built from charts only), so there is no replacement to add",
 }
 # Gdoc-backed references: the fix depends on the ArchieML component being edited (and for
 # chart blocks, on whether the block embeds the chart or merely stores its URL).
@@ -102,13 +102,6 @@ COMPONENT_FIXES = {
     ("front-matter", "link"): "update the grapher-url in the front matter",
 }
 LINK_FIX = "update the href"
-# Link-kind references whose href is generated rather than authored — there is nothing to
-# hand-edit, so the generic "update the href" would send the operator looking for a field
-# that doesn't exist.
-GENERATED_LINK_FIXES = {
-    "narrative chart": 'nothing to edit — the generated "Explore the data" link follows the redirect; '
-    "check the param collisions column",
-}
 
 
 def load_redirects(path_arg: str) -> list[dict]:
@@ -304,7 +297,12 @@ def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host:
     allcharts = [f for f in findings if f["surface"] == "key chart"]
     drafts = [f for f in findings if f["severity"] == INFO and f["surface"] != "key chart"]
     doc_edits = [f for f in findings if f["severity"] in (RED, YELLOW) and f["doc_edit_url"]]
-    other = [f for f in findings if f["severity"] in (RED, YELLOW) and not f["doc_edit_url"]]
+    narrative = [f for f in findings if f["severity"] in (RED, YELLOW) and f["surface"] == "narrative chart"]
+    other = [
+        f
+        for f in findings
+        if f["severity"] in (RED, YELLOW) and not f["doc_edit_url"] and f["surface"] != "narrative chart"
+    ]
     embeds = [f for f in doc_edits if f["severity"] == RED]
     links = [f for f in doc_edits if f["severity"] == YELLOW]
 
@@ -342,6 +340,25 @@ def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host:
             lines += gdoc_table(group)
             lines.append("")
 
+    if narrative:
+        lines += [
+            f"## 🎨 Narrative charts ({len(narrative)})",
+            "",
+            "A narrative chart renders its own saved config, so nothing breaks when its parent chart "
+            'is unpublished — only its generated "Explore the data" link follows the redirect. The '
+            "plan for each one: **recreate it manually from the target MDIM view and point the "
+            "referencing article(s) back at the new one**, in this order —",
+            "",
+            "1. **Create** the replacement parented to the MDIM view (each item below carries the "
+            "ready-made admin create link — it opens the editor already parented to the right view).",
+            "2. **Repoint** the article(s) that reference the old narrative chart to the new name.",
+            "3. **Delete** the old narrative chart. The delete is refused while a published post "
+            "still references it, which is why it comes last.",
+            "",
+        ]
+        lines += bullet_list(narrative)
+        lines.append("")
+
     if allcharts:
         by_page = defaultdict(list)
         for f in allcharts:
@@ -351,7 +368,9 @@ def write_markdown(out: Path, findings: list[dict], redirects: list[dict], host:
             "",
             "These blocks list only published charts (grapher's `GdocPost.loadRelatedCharts` filters "
             "on `isPublished`), so the entries drop out on their own at the next bake — nothing breaks "
-            "or goes stale. Tag the MDIMs with these topics only if you want replacement entries.",
+            "or goes stale. There is also **no replacement to add**: the block is built from "
+            "`charts` × `chart_tags` only, so an MDIM cannot appear in it. If a topic page should "
+            "feature the MDIM, that is a separate gdoc-authoring change, not part of this migration.",
             "",
             "| Topic page | Charts affected |",
             "|---|---|",
@@ -469,18 +488,27 @@ def main() -> int:
             severity = INFO
         is_gdoc = ref["surface"] in GDOC_SURFACES and ref.get("surface_id")
         component = archie_component(ref) if is_gdoc else ""
-        if is_gdoc:
+        if ref["surface"] == "narrative chart":
+            # The intended end-state is a manual replacement pointed back at by the same
+            # articles, not a repoint of the old one (the parent columns are INSERT-only —
+            # see SKILL.md). Nothing breaks meanwhile: the chart renders its own saved
+            # config, and only its generated "Explore the data" link follows the redirect.
+            # The admin's create page is deep-linkable to the target view, so hand over the
+            # ready-made URL rather than an id to look up.
+            fix = (
+                "recreate it manually and point references back at the new one: "
+                f"(1) create the replacement parented to the target MDIM view — {admin}/narrative-charts/create?type=multiDim&chartConfigId={r['target']['viewConfigId']} ; "
+                "(2) update the article(s) that reference it to the new name; "
+                "(3) delete the old one — the delete is refused while a published post still "
+                "references it, which is why the order matters (see SKILL.md)"
+            )
+        elif is_gdoc:
             fallback = LINK_FIX if ref["kind"] == "link" else "migrate this reference by hand"
             fix = COMPONENT_FIXES.get((component, ref["kind"]), fallback)
         elif ref["kind"] == "link":
-            fix = GENERATED_LINK_FIXES.get(ref["surface"], LINK_FIX)
+            fix = LINK_FIX
         else:
             fix = FIXES.get(ref["surface"], "migrate this reference by hand")
-        if ref["surface"] == "narrative chart":
-            # The admin's create page is deep-linkable to the parent view, and the view is
-            # the one this chart is being redirected to — so hand over the ready-made URL
-            # rather than the id to look up.
-            fix += f" — create the replacement at {admin}/narrative-charts/create?type=multiDim&chartConfigId={r['target']['viewConfigId']}"
         findings.append(
             {
                 "severity": severity,


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

Re-lands a commit stranded by timing: #6591 was merged while this change was still in its review round, so it never made the squash. One cherry-picked commit on fresh master.

## Change

**Group gdoc-backed reference tables by ArchieML component.** A data insight is itself a gdoc, so grouping `references.md` tables by the sweep's surface taxonomy (`gdoc` / `gdoc (url link)` / `data insight`) split identical work while hiding what the doc editor actually touches. Tables now group by the component holding the reference — `chart` block, `span-link`, `front-matter` — with the page type (article, data insight, fragment) italicized in the Where column, and fix instructions keyed by (component, kind): "edit the chart block…", "update the href", "update the grapher-url in the front matter". `references.csv` gains a `component` column (the raw sweep surface stays).

**Rename `key chart` → `all-charts block (topic page)`.** Those rows are `chart_tags` entries with a `keyChartLevel`, which feed the topic page's All charts block ordering — the section now names what the reader loses rather than the DB mechanism, and the fix text says to tag the MDim in the chart's place.

The component is parsed from the sweep's `context` head (the data-insight surface's prose "grapher-url in the insight's front matter" normalizes to `front-matter`) — deliberately without extending the shared `find-chart-references` export in this PR.

## Validation

Regenerated the Economic Inequality references report against production: 51 references, sections now `chart (5)` / `all-charts block (topic page) (25)` / `span-link (14)` / `front-matter (1)` / `narrative chart (1)` + drafts; ruff + `make check` clean.

## Follow-up commit (e254cdbba)

Reader-driven restructure of `references.md`: embedded charts and text links now sit adjacent inside one **Google Doc edits** section (🔴 embeds gate the CLI, 🟡 links are 301-covered — one editing pass per doc covers both); topic-page **All charts** entries collapse to a per-page summary marked *no action needed* (verified: `GdocPost.loadRelatedCharts` filters on `isPublished`, so entries drop out at the next bake); section names are reader-facing ("Embedded charts", "Text links", "Front-matter chart URLs") with raw ArchieML tokens kept in the CSV's `component` column.