### PR TITLE
📊 Add incidence of child work in Italy, 1881-1961 (Toniolo and Vecchi)

### DIFF
--- a/dag/labor.yml
+++ b/dag/labor.yml
@@ -58,6 +58,12 @@ steps:
   #
   # Child labor in the long run (multiple sources)
   #
+  # Incidence of child work in Italy, 1881-1961, by sex (Toniolo and Vecchi, 2007)
+  data://grapher/child_labor/2026-08-03/child_work_incidence_italy:
+    - data://garden/child_labor/2026-08-03/child_work_incidence_italy:
+      - data://meadow/child_labor/2026-08-03/child_work_incidence_italy:
+        - snapshot://child_labor/2026-08-03/child_work_incidence_italy.csv
+
   data://grapher/child_labor/2026-05-08/child_labor_long_run:
     - data://garden/child_labor/2026-05-08/child_labor_long_run:
       - data://meadow/child_labor/2026-05-08/child_labor_long_run:

--- a/etl/steps/data/garden/child_labor/2026-08-03/child_work_incidence_italy.countries.json
+++ b/etl/steps/data/garden/child_labor/2026-08-03/child_work_incidence_italy.countries.json
@@ -1,0 +1,3 @@
+{
+  "Italy": "Italy"
+}

--- a/etl/steps/data/garden/child_labor/2026-08-03/child_work_incidence_italy.meta.yml
+++ b/etl/steps/data/garden/child_labor/2026-08-03/child_work_incidence_italy.meta.yml
@@ -1,0 +1,58 @@
+# NOTE: To learn more about the fields, hover over their names.
+definitions:
+  common:
+    processing_level: minor
+    presentation:
+      topic_tags:
+        - Child Labor
+      attribution_short: Toniolo and Vecchi
+    description_key:
+      - "\"Child work\" here means the economic activity of children, as recorded in Italian population censuses. The authors use it as a broader concept than \"child labor\", which the International Labour Organization reserves for work that is damaging to the child."
+      - Incidence is the share of all children aged 10-14 who are economically active, estimated from published census data using corrections to keep the figures comparable across censuses.
+      - The initially large gap between boys and girls narrows over time, with the two rates converging by the early 1930s.
+
+# Learn more about the available fields:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+dataset:
+  update_period_days: 0
+  owners:
+    - Bertha Rohenkohl
+
+tables:
+  child_work_incidence_italy:
+    variables:
+      incidence_both_sexes:
+        title: Incidence of child work among children aged 10-14
+        presentation:
+          title_public: Incidence of child work among children aged 10-14
+        unit: "%"
+        short_unit: "%"
+        description_short: Share of all children aged 10-14 in Italy who were economically active.
+        display:
+          name: Both sexes
+          numDecimalPlaces: 1
+          tolerance: 5
+
+      incidence_boys:
+        title: Incidence of child work among boys aged 10-14
+        presentation:
+          title_public: Incidence of child work among boys aged 10-14
+        unit: "%"
+        short_unit: "%"
+        description_short: Share of boys aged 10-14 in Italy who were economically active.
+        display:
+          name: Boys
+          numDecimalPlaces: 1
+          tolerance: 5
+
+      incidence_girls:
+        title: Incidence of child work among girls aged 10-14
+        presentation:
+          title_public: Incidence of child work among girls aged 10-14
+        unit: "%"
+        short_unit: "%"
+        description_short: Share of girls aged 10-14 in Italy who were economically active.
+        display:
+          name: Girls
+          numDecimalPlaces: 1
+          tolerance: 5

--- a/etl/steps/data/garden/child_labor/2026-08-03/child_work_incidence_italy.py
+++ b/etl/steps/data/garden/child_labor/2026-08-03/child_work_incidence_italy.py
@@ -1,0 +1,67 @@
+"""Load a meadow dataset and create a garden dataset.
+
+The source reports the incidence of child work (share of children aged 10-14 who are
+economically active) in Italy by sex. Values are already percentages.
+"""
+
+from owid.catalog import Table
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+# Source column -> descriptive indicator name.
+COLUMNS = {
+    "incidence_both_sexes_pct": "incidence_both_sexes",
+    "incidence_boys_pct": "incidence_boys",
+    "incidence_girls_pct": "incidence_girls",
+}
+SHARE_COLUMNS = list(COLUMNS.values())
+
+
+def sanity_check_inputs(tb: Table) -> None:
+    assert set(tb["country"].unique()) == {"Italy"}, "Expected Italy as the only entity."
+    assert not tb.duplicated(subset=["country", "year"]).any(), "Duplicate (country, year) rows."
+    assert tb["year"].between(1881, 1961).all(), "Year outside the plausible census range."
+    for col in COLUMNS:
+        vals = tb[col].dropna()
+        assert vals.between(0, 100).all(), f"{col} has values outside 0-100%."
+
+
+def sanity_check_outputs(tb: Table) -> None:
+    assert tb.columns[tb.isna().all()].empty, "Output has a fully-NaN column."
+    for col in SHARE_COLUMNS:
+        assert tb[col].dropna().between(0, 100).all(), f"{col} outside 0-100%."
+    # The both-sexes incidence is a population-weighted average of boys and girls, so it must
+    # lie between the two (with a small tolerance for rounding in the transcribed source).
+    lo = tb[["incidence_boys", "incidence_girls"]].min(axis=1) - 0.05
+    hi = tb[["incidence_boys", "incidence_girls"]].max(axis=1) + 0.05
+    assert (tb["incidence_both_sexes"].between(lo, hi)).all(), "Both-sexes incidence not bracketed by boys/girls."
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_meadow = paths.load_dataset("child_work_incidence_italy")
+    tb = ds_meadow["child_work_incidence_italy"].reset_index()
+
+    #
+    # Process data.
+    #
+    sanity_check_inputs(tb)
+
+    tb = tb.rename(columns=COLUMNS, errors="raise")
+
+    tb = paths.regions.harmonize_names(tb, country_col="country", countries_file=paths.country_mapping_path)
+
+    sanity_check_outputs(tb)
+
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
+    #
+    # Save outputs.
+    #
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden.save()

--- a/etl/steps/data/grapher/child_labor/2026-08-03/child_work_incidence_italy.py
+++ b/etl/steps/data/grapher/child_labor/2026-08-03/child_work_incidence_italy.py
@@ -1,0 +1,26 @@
+"""Load a garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    # Load garden dataset and read its table.
+    ds_garden = paths.load_dataset("child_work_incidence_italy")
+    tb = ds_garden.read("child_work_incidence_italy")
+
+    #
+    # Process data.
+    #
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
+    #
+    # Save outputs.
+    #
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/child_labor/2026-08-03/child_work_incidence_italy.py
+++ b/etl/steps/data/meadow/child_labor/2026-08-03/child_work_incidence_italy.py
@@ -1,0 +1,30 @@
+"""Load a snapshot and create a meadow dataset."""
+
+from etl.helpers import PathFinder
+
+# Get paths and naming conventions for current step.
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    snap = paths.load_snapshot("child_work_incidence_italy.csv")
+    tb = snap.read_csv()
+
+    #
+    # Process data.
+    #
+    # The source is Italy-only; add the country column explicitly.
+    tb["country"] = "Italy"
+    tb["country"] = tb["country"].astype("category")
+
+    # Ensure all columns are snake-case, set an appropriate index, and sort conveniently.
+    tb = tb.format(["country", "year"], short_name=paths.short_name)
+
+    #
+    # Save outputs.
+    #
+    ds_meadow = paths.create_dataset(tables=[tb], default_metadata=snap.metadata)
+    ds_meadow.save()

--- a/snapshots/child_labor/2026-08-03/child_work_incidence_italy.csv.dvc
+++ b/snapshots/child_labor/2026-08-03/child_work_incidence_italy.csv.dvc
@@ -1,0 +1,34 @@
+# NOTE: Manually transcribed by OWID from an appendix table of the paper reporting the
+# headline child-work incidence series (overall economic-activity rate of children aged
+# 10-14, by sex). The paper also
+# reports child work by economic sector and by region, and companion series for other
+# countries — none of which are included here. In case of updating, upload manually.
+
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Italian children at work, 1881-1961
+    description: |-
+      This paper quantifies the extent and main characteristics of child work in Italy during 1881-1961. Drawing on Italian population censuses, the authors build a database of the economically active population aged 10-14 by gender, region and economic sector, and use it to measure the incidence of child work — the share of children aged 10-14 who are economically active.
+
+      The authors use "child work" to mean the economic activity of children, a broader concept than "child labor", which the International Labour Organization defines as activities damaging to the child. They find that child work incidence declined sharply over the period, from 64.3% in 1881 to 3.6% in 1961, with the initially large gap between boys and girls closing by the early 1930s.
+    date_published: "2007-11-01"
+
+    # Citation
+    producer: Toniolo and Vecchi
+    citation_full: |-
+      Toniolo, G., & Vecchi, G. (2007). Italian Children at Work, 1881-1961. Giornale degli Economisti e Annali di Economia, 66(3), 401-427. https://www.jstor.org/stable/23248256
+
+    # Files
+    url_main: https://www.jstor.org/stable/23248256
+    date_accessed: '2026-08-03'
+
+    # License
+    license:
+      name: © Toniolo and Vecchi (2007)
+outs:
+  - md5: d915e7f41b60ee0e8d89ee091f396923
+    size: 225
+    path: child_work_incidence_italy.csv

--- a/snapshots/child_labor/2026-08-03/child_work_incidence_italy.py
+++ b/snapshots/child_labor/2026-08-03/child_work_incidence_italy.py
@@ -1,0 +1,14 @@
+"""Script to create a snapshot of dataset.
+
+The data file (manually transcribed from the paper) is provided manually. Run with:
+  etls child_labor/2026-08-03/child_work_incidence_italy --path-to-file <path>
+"""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run(upload: bool = True, path_to_file: str | None = None) -> None:
+    snap = paths.init_snapshot()
+    snap.create_snapshot(filename=path_to_file, upload=upload)


### PR DESCRIPTION
> _Written by Claude Opus 4.8 — @bertharc at the wheel._

Adds a small standalone dataset: the long-run **incidence of child work** in Italy (share of children aged 10–14 who were economically active), by sex, from Toniolo & Vecchi (2007).

## What this adds

- **Dataset:** `child_labor/2026-08-03/child_work_incidence_italy` — full snapshot → meadow → garden → grapher chain.
- **Source:** Toniolo, G., & Vecchi, G. (2007). *Italian Children at Work, 1881–1961.* Giornale degli Economisti e Annali di Economia, 66(3), 401–427 ([JSTOR](https://www.jstor.org/stable/23248256)). Data manually transcribed from an appendix table.
- **Coverage:** Italy, census years 1881–1961 (8 observations).
- **Indicators (3):** incidence of child work among children aged 10–14 — **both sexes**, **boys**, **girls** (percent).

## Why a new dataset (not the existing one)

This paper is already partly ingested in the active **`child_labor_long_run`** dataset — but that uses the paper's **Table 4 (child work by economic sector × sex)**. This PR adds the paper's **headline overall-incidence series** (64.3% in 1881 → 3.6% in 1961), a different and complementary cut that is not currently in the modern data.

## Notes

- **"Child work"**, not "child labor": the authors deliberately use the broader "economically active" concept from censuses, distinct from the ILO's harm-based definition. Metadata is worded accordingly.
- Sanity checks assert Italy-only, census-year range, 0–100% values, and that the both-sexes rate is bracketed by the boys/girls rates each year.
- The published journal version is © EGEA SpA and paywalled; an openly-licensed World Bank working-paper version of the same paper also exists (used by the existing snapshot).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UupxZyHHyS4CepaLJ5sNmB)_