### PR TITLE
🐛 References audit: region survives unrelated map overrides

### DIFF
--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -366,16 +366,16 @@ same name. The name is preserved and nothing else changes.
 Never delete first. The delete will fail, and unpublishing the article to force it
 through breaks the page for readers.
 
-**Do the create in the admin UI — it is deep-linkable to the right view:**
-
-```
-{admin_site}/narrative-charts/create?type=multiDim&chartConfigId=<target.viewConfigId>
-```
-
-That opens the narrative-chart editor already parented to the MDIM view, so you
-set the name and the view's controls and save. Prefer this over the API: `AdminAPI`
+**Do the create from the target view in the site UI**, using the chart's own
+**"Create narrative chart"** admin control (see the rule above). Do **not** hand
+out `{admin_site}/narrative-charts/create?type=multiDim&chartConfigId=…`: that
+route opens a copy of the MDIM's *default* view, so the replacement ends up
+parented to the wrong view. Prefer the UI over the API either way: `AdminAPI`
 has `get_narrative_chart` and `update_narrative_chart` but **no create or delete**,
-so the API route means hand-rolled HTTP for both ends of the swap.
+so the API route means hand-rolled HTTP for both ends of the swap. Whichever route
+you take, the new chart starts at the MDIM's default view with default entities —
+the dimension selection, the controls and the authored text all have to be set by
+hand afterwards.
 
 If you do script it, the endpoints are `POST {admin_api}/narrative-charts` and
 `DELETE {admin_api}/narrative-charts/<id>`:

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -273,10 +273,12 @@ and inherits the controls set on it. A bare
 looks equivalent but opens a copy of the MDIM's **default** view — verified in
 practice — so never hand that out as the create step.
 
-**Creating from an MDIM starts at its DEFAULT view — nothing carries over.**
-Not the dimension selection, not the entity selection, not tab/time, not the
-text. So the report's **"Set by hand after creating"** column lists all three
-groups per chart, in the order they get applied in the editor:
+**The new chart opens at the parent view's defaults — the state does not carry
+over.** The control gets the *parent* right, but not the state on top of it: the
+dimension selection, the entity selection and tab/time all come up at defaults,
+and authored text never transfers at all. So the report's **"Set by hand after
+creating"** column lists all three groups per chart, in the order they get
+applied in the editor:
 
 1. **view dimensions** — the target view's own dimension values (from the
    proposal), because the new chart opens on the MDIM's default view;
@@ -367,15 +369,20 @@ Never delete first. The delete will fail, and unpublishing the article to force 
 through breaks the page for readers.
 
 **Do the create from the target view in the site UI**, using the chart's own
-**"Create narrative chart"** admin control (see the rule above). Do **not** hand
-out `{admin_site}/narrative-charts/create?type=multiDim&chartConfigId=…`: that
-route opens a copy of the MDIM's *default* view, so the replacement ends up
-parented to the wrong view. Prefer the UI over the API either way: `AdminAPI`
-has `get_narrative_chart` and `update_narrative_chart` but **no create or delete**,
-so the API route means hand-rolled HTTP for both ends of the swap. Whichever route
-you take, the new chart starts at the MDIM's default view with default entities —
-the dimension selection, the controls and the authored text all have to be set by
-hand afterwards.
+**"Create narrative chart"** admin control (see the rule above). The three routes
+do NOT behave alike, so don't describe them interchangeably:
+
+| route | parent view | state to redo by hand |
+|---|---|---|
+| the view's **"Create narrative chart"** control | the view on screen — correct | the entity selection and other controls open at that view's defaults, and authored FAUST never transfers |
+| a bare `{admin_site}/narrative-charts/create?type=multiDim&chartConfigId=…` link | the MDIM's **default** view — wrong | everything, on top of a parent you then cannot change |
+| scripted `POST {admin_api}/narrative-charts` | whatever `parentChartConfigId` you send | nothing you include in the `config` you post |
+
+So: use the control, then set what the report's **Set by hand after creating**
+column lists. Never hand out the bare create link. Prefer the UI over the API
+anyway — `AdminAPI` has `get_narrative_chart` and `update_narrative_chart` but
+**no create or delete**, so scripting means hand-rolled HTTP for both ends of the
+swap.
 
 If you do script it, the endpoints are `POST {admin_api}/narrative-charts` and
 `DELETE {admin_api}/narrative-charts/<id>`:

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -458,7 +458,7 @@ def narrative_section(
         dims = f.get("target_dimensions") or {}
         if dims:
             parts.append(
-                "**view dimensions** (the create starts on the MDIM's default view):<br>"
+                "**view dimensions** (the new chart opens at the view's defaults):<br>"
                 + ", ".join(f"`{k}` = {v}" for k, v in sorted(dims.items()))
             )
         # The stored URL params and the config patch describe the same state in two
@@ -518,9 +518,9 @@ def narrative_section(
             "(visible when logged in)"
         )
         set_step = (
-            "**set everything in the third column by hand** — the new chart opens on the MDIM's "
-            "default view with default entities, so the dimensions, controls and authored text do "
-            "not carry over; compare against the original in the admin editor"
+            "**set everything in the third column by hand** — the control parents the new chart to the "
+            "right view, but its state opens at that view's defaults, so the dimensions, controls and "
+            "authored text do not carry over; compare against the original in the admin editor"
         )
         if published_uses:
             steps = (
@@ -708,10 +708,11 @@ def write_markdown(
             'chart"** admin control — not a bare `/admin/narrative-charts/create?chartConfigId=…` '
             "link, which opens a copy of the MDIM's default view.",
             "",
-            "**Then expect to rebuild the view by hand.** Creating a narrative chart from an MDIM "
-            "starts it on the MDIM's **default view with default entities** — the dimension selection, "
-            "the entity selection, the tab and time settings, and any text the original authored on "
-            "top of its parent all fail to carry over. The **Set by hand after creating** column lists "
+            "**Then expect to rebuild the state by hand.** The control gets the parent view right, "
+            "but the new chart opens at **that view's defaults** — the dimension selection, the entity "
+            "selection and the tab and time settings all come up at defaults, and any text the "
+            "original authored on top of its parent never transfers at all. (A bare create link is "
+            "worse: it also parents to the wrong view.) The **Set by hand after creating** column lists "
             "exactly those groups per chart, in the order to apply them. Miss the text and the "
             "replacement silently renders the view's own wording instead of the wording the article "
             "was written around; miss the controls and it renders the wrong countries.",

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -282,11 +282,15 @@ FAUST_KEYS = ("title", "subtitle", "note", "sourceDesc", "hideAnnotationFieldsIn
 SKIP_OVERRIDE_KEYS = ("dimensions", "$schema", "id", "slug", "isPublished", "version")
 # Grapher URL params and the config keys holding the same state. Used to keep the "set by
 # hand" list from naming one setting twice in two spellings.
+# Dotted entries are NESTED config keys: `region` lives at `map.region`, and only that
+# subkey represents it. Matching the whole `map` object instead would drop `region` from the
+# checklist whenever the patch overrode any unrelated map setting (`map.colorScale`,
+# `map.hideTimeline`), leaving the replacement focused on the wrong area with nothing said.
 PARAM_CONFIG_EQUIVALENT = {
     "country": ("selectedEntityNames",),
     "focus": ("focusedSeriesNames",),
     "time": ("minTime", "maxTime"),
-    "region": ("map",),
+    "region": ("map.region",),
 }
 # The order someone rebuilds a chart in: the chart type first, because it decides which other
 # controls exist at all; then the entity selection, the most visible thing to get wrong; then
@@ -373,6 +377,19 @@ def entity_names(codes: set[str]) -> dict[str, str]:
     return dict(zip(df["code"], df["name"]))
 
 
+def has_config_key(config: dict, key: str) -> bool:
+    """Whether `config` carries `key`, where a dotted key means a nested subkey.
+
+    `map.region` must match only an actual region override, not the presence of any `map`
+    object: a patch that set `map.colorScale` and nothing else would otherwise be read as
+    already carrying the region.
+    """
+    head, _, rest = key.partition(".")
+    if head not in config:
+        return False
+    return not rest or (isinstance(config[head], dict) and has_config_key(config[head], rest))
+
+
 def control_sort_key(key: str) -> tuple:
     """Chart type, then the entity selection, then everything else alphabetically."""
     return (CONTROL_ORDER.index(key), "") if key in CONTROL_ORDER else (len(CONTROL_ORDER), key)
@@ -451,7 +468,7 @@ def narrative_section(
         config_controls = ovr.get("controls") or {}
         controls = dict(config_controls)
         for key, value in parse_qsl(f["stored_params"], keep_blank_values=True):
-            if any(equiv in config_controls for equiv in PARAM_CONFIG_EQUIVALENT.get(key, (key,))):
+            if any(has_config_key(config_controls, equiv) for equiv in PARAM_CONFIG_EQUIVALENT.get(key, (key,))):
                 continue
             # A URL param spells entities as codes; the editor's picker speaks names.
             if key in ENTITY_CODE_PARAMS and value:


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

Follow-up to #6592, which merged eleven seconds before Codex's review of it landed — so both findings below are currently live on master. This re-lands the fix.

## 1. `region` was dropped from the recreate checklist (P2, real bug)

`PARAM_CONFIG_EQUIVALENT` mapped the `region` URL param to the whole `map` config object, and the suppression check asked only whether `map` was present. So a narrative chart whose patch overrode *any* unrelated map setting — `map.colorScale`, `map.hideTimeline` — had its `region` silently dropped from the "set by hand after creating" list, leaving whoever rebuilt it with a map focused on the wrong area and nothing in the report to say so.

Entries may now be dotted nested keys; `region` maps to `map.region`, and a new `has_config_key()` walks the path so only an actual region override counts as equivalent. Non-dict and missing values are handled (a `map` that is a bare string does not match `map.region`).

## 2. The skill contradicted its own create rule (P2)

#6592 added the rule that the replacement must be created from the target view's own **"Create narrative chart"** control, because `/admin/narrative-charts/create?type=multiDim&chartConfigId=…` opens a copy of the MDIM's *default* view. But the older "To actually fix one" section further down still instructed operators to use exactly that link and claimed it opened the correct view. An operator following that section would have parented the replacement to the wrong view.

That section now routes through the view's control, states why the link must not be handed out, and notes that nothing (dimensions, controls, text) carries over either way. Both remaining mentions of the route in the file are do-not-use warnings.

## Validation

Unit checks: an unrelated map override no longer suppresses `region`; a real `map.region` still does; non-dict/missing/flat keys behave. `make check` and ruff clean.
