### PR TITLE
✨ Explorer to MDim: references audit, payloads, site-redirect gate, ETL retirement

### DIFF
--- a/.claude/skills/find-chart-references/scripts/find_references.py
+++ b/.claude/skills/find-chart-references/scripts/find_references.py
@@ -890,12 +890,18 @@ def sweep_mdim_subject(mdim: str) -> list[dict]:
 
 
 def sweep_explorer_subject(explorer: str) -> list[dict]:
-    # An unknown slug matches nothing in every query below, so the run would end with
-    # `references: 0` — the same output as an explorer nothing points at. Resolve it first,
-    # as the chart, indicator and MDIM subjects do.
+    # An unknown slug matches nothing in every query below, so a run would end with
+    # `references: 0` — the same output as an explorer nothing points at. But unlike a chart,
+    # an explorer that is GONE is the normal end state of a migration, and pages can still
+    # link to it: every query here keys on the slug, not on a row id, so they all work for a
+    # deleted explorer. So record a gap and keep sweeping instead of returning empty — a
+    # retired explorer's leftover links are exactly what someone needs to find, and
+    # returning [] hid them. A typo now surfaces as a gap rather than a bare print.
     if OWID_ENV.read_sql("SELECT slug FROM explorers WHERE slug = %(s)s", params={"s": explorer}).empty:
-        print(f"  (explorer not found: {explorer})")
-        return []
+        gap(
+            f"explorer '{explorer}' is not in the `explorers` table — swept its references anyway "
+            "(already retired?). If the slug is simply wrong, every count for it is a false zero."
+        )
 
     df = OWID_ENV.read_sql(
         "SELECT pg.id AS gdoc_id, pg.slug AS post_slug, pg.type AS post_type, pg.published, "
@@ -962,6 +968,46 @@ def sweep_explorer_subject(explorer: str) -> list[dict]:
                 query_string=url_query(target),
                 text=r["text"],
                 published=r["published"],
+            )  # fmt: skip
+        )
+
+    out += sweep_explorer_inbound_redirects(explorer)
+    return out
+
+
+def sweep_explorer_inbound_redirects(explorer: str) -> list[dict]:
+    """Site redirects pointing AT this explorer.
+
+    Symmetric with the `redirect` surface the MDIM subject already reports, and load-bearing
+    rather than informational: an explorer path that is the target of a site redirect cannot
+    be given an MDIM redirect at all — the admin endpoint rejects it as a chain, and because
+    it caches its per-source checks, that one row fails every entry for the explorer. So this
+    is a blocker a consumer needs to surface before it tries to apply anything.
+
+    The `LIKE` prefilter is re-checked in Python for the same reason the URL passes are: a
+    prefix match would let `/explorers/inequality-wb` answer for `inequality`.
+    """
+    df = OWID_ENV.read_sql(
+        "SELECT id, source, target FROM redirects WHERE target LIKE %(like)s",
+        params={"like": f"%/explorers/{explorer}%"},
+    )
+    pattern = re.compile(rf"/explorers/{re.escape(explorer)}(?:[?#/]|$)")
+    out = []
+    for r in df.to_dict("records"):
+        if not pattern.search(r["target"] or ""):
+            continue
+        out.append(
+            rec(
+                "explorer",
+                explorer,
+                None,
+                "site redirect",
+                LINK,
+                r["source"],
+                r["source"],
+                surface_id=int(r["id"]),
+                context=f"site redirect id={r['id']} points here — blocks creating an MDIM redirect (chain)",
+                query_string=url_query(r["target"]),
             )  # fmt: skip
         )
     return out

--- a/.claude/skills/find-chart-references/scripts/find_references.py
+++ b/.claude/skills/find-chart-references/scripts/find_references.py
@@ -44,6 +44,8 @@ from collections import defaultdict
 from pathlib import Path
 from urllib.parse import parse_qs, quote, urlencode, urlsplit
 
+from reference_report import redirect_target_path
+
 from etl.config import OWID_ENV
 
 RENDER, EMBED, LINK = "render", "embed", "link"
@@ -991,10 +993,11 @@ def sweep_explorer_inbound_redirects(explorer: str) -> list[dict]:
         "SELECT id, source, target FROM redirects WHERE target LIKE %(like)s",
         params={"like": f"%/explorers/{explorer}%"},
     )
-    pattern = re.compile(rf"/explorers/{re.escape(explorer)}(?:[?#/]|$)")
     out = []
     for r in df.to_dict("records"):
-        if not pattern.search(r["target"] or ""):
+        # Pathname equality, via the same helper the preflight blocks on: a redirect to another
+        # page that merely names this explorer in its query or fragment is not an inbound chain.
+        if redirect_target_path(r["target"]) != f"/explorers/{explorer}":
             continue
         out.append(
             rec(

--- a/.claude/skills/find-chart-references/scripts/find_references.py
+++ b/.claude/skills/find-chart-references/scripts/find_references.py
@@ -44,13 +44,30 @@ from collections import defaultdict
 from pathlib import Path
 from urllib.parse import parse_qs, quote, urlencode, urlsplit
 
-from reference_report import redirect_target_path
-
 from etl.config import OWID_ENV
 
 RENDER, EMBED, LINK = "render", "embed", "link"
 TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
 GOOGLE_REDIRECT_RE = re.compile(r"^https?://(?:www\.)?google\.[a-z.]+/url\?", re.IGNORECASE)
+
+
+def redirect_target_path(target: str | None) -> str:
+    """Pathname of a site-redirect target, with a trailing slash normalized away.
+
+    A target may be a bare path, a path carrying a query and/or fragment, or an absolute URL,
+    and only its PATHNAME says which page it points at. A target that merely mentions another
+    page inside its query — `/article?next=/explorers/foo` — does not point at that page, so
+    substring-matching the raw string reports an unrelated redirect as an inbound chain.
+
+    It lives in this module, which imports no siblings by design (it is loaded by path, not as a
+    package), because the sweep and the redirect preflights must apply this rule IDENTICALLY:
+    the sweep decides whether to raise the finding and a preflight decides whether to block on
+    it. Two copies drifted once already, so consumers import this one.
+    """
+    path = urlsplit((target or "").strip()).path
+    return path.rstrip("/") or path
+
+
 # Every raw-URL sweep adds this to its SQL prefilter. A wrapper can percent-encode the
 # nested URL's slashes, in which case a `LIKE '%/grapher/<slug>%'` prefilter drops the row
 # before `unwrap_redirect` ever sees it — so wrapper rows are always candidates and the

--- a/.claude/skills/find-chart-references/scripts/find_references.py
+++ b/.claude/skills/find-chart-references/scripts/find_references.py
@@ -51,13 +51,16 @@ TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
 GOOGLE_REDIRECT_RE = re.compile(r"^https?://(?:www\.)?google\.[a-z.]+/url\?", re.IGNORECASE)
 
 
-def redirect_target_path(target: str | None) -> str:
-    """Pathname of a site-redirect target, with a trailing slash normalized away.
+def url_pathname(target: str | None) -> str:
+    """Pathname of a URL, with a trailing slash normalized away.
 
-    A target may be a bare path, a path carrying a query and/or fragment, or an absolute URL,
-    and only its PATHNAME says which page it points at. A target that merely mentions another
-    page inside its query — `/article?next=/explorers/foo` — does not point at that page, so
-    substring-matching the raw string reports an unrelated redirect as an inbound chain.
+    A URL may be a bare path, a path carrying a query and/or fragment, or absolute, and only its
+    PATHNAME says which page it points at. One that merely mentions another page inside its query
+    — `/article?next=/explorers/foo` — does not navigate there, so substring-matching the raw
+    string reports an unrelated page as a reference to that page.
+
+    Used for BOTH a site redirect's target and a gdoc's raw link target, because the consequence
+    is the same in both: a spurious match becomes a RED row, and a RED row blocks a preflight.
 
     It lives in this module, which imports no siblings by design (it is loaded by path, not as a
     package), because the sweep and the redirect preflights must apply this rule IDENTICALLY:
@@ -848,10 +851,11 @@ def sweep_mdim_subject(mdim: str) -> list[dict]:
         "WHERE pgl.linkType = 'url' AND (pgl.target LIKE %(t)s OR pgl.target LIKE %(wrap)s)",
         params={"t": f"%/grapher/{slug}%", "wrap": WRAPPER_LIKE},
     )
-    exact = re.compile(rf"/grapher/{re.escape(slug)}(?:[?#/]|$)")
     for r in raw.to_dict("records"):
         target = unwrap_redirect(r["target"])
-        if not exact.search(target):
+        # As in the explorer pass: compare the unwrapped url's pathname, so a link that merely
+        # names this slug inside another page's query is not counted as a reference to it.
+        if url_pathname(target) != f"/grapher/{slug}":
             continue
         if ARCHIVE_HOST in target:
             continue  # archived snapshots are frozen by design
@@ -963,10 +967,12 @@ def sweep_explorer_subject(explorer: str) -> list[dict]:
         "WHERE pgl.linkType = 'url' AND (pgl.target LIKE %(t)s OR pgl.target LIKE %(wrap)s)",
         params={"t": f"%/explorers/{explorer}%", "wrap": WRAPPER_LIKE},
     )
-    exact = re.compile(rf"/explorers/{re.escape(explorer)}(?:[?#/]|$)")
     for r in raw.to_dict("records"):
         target = unwrap_redirect(r["target"])
-        if not exact.search(target):
+        # Pathname of the UNWRAPPED url: a gdoc link to another page that merely carries this
+        # explorer's URL in its query or fragment does not navigate here, and a non-span
+        # component would be emitted as a RED row, which blocks the redirect preflight.
+        if url_pathname(target) != f"/explorers/{explorer}":
             continue
         if ARCHIVE_HOST in target:
             continue  # archived snapshots are frozen by design
@@ -1014,7 +1020,7 @@ def sweep_explorer_inbound_redirects(explorer: str) -> list[dict]:
     for r in df.to_dict("records"):
         # Pathname equality, via the same helper the preflight blocks on: a redirect to another
         # page that merely names this explorer in its query or fragment is not an inbound chain.
-        if redirect_target_path(r["target"]) != f"/explorers/{explorer}":
+        if url_pathname(r["target"]) != f"/explorers/{explorer}":
             continue
         out.append(
             rec(

--- a/.claude/skills/find-chart-references/scripts/reference_report.py
+++ b/.claude/skills/find-chart-references/scripts/reference_report.py
@@ -26,7 +26,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from urllib.parse import quote, urlsplit
+from urllib.parse import quote
 
 from etl.analytics.config import OWID_BASE_URL, POST_TYPE_TO_URL
 
@@ -118,24 +118,6 @@ def reference_digest(raw: list[dict], subject: str) -> str:
         if str(r.get("subject")) == str(subject)
     )
     return hashlib.sha256("\n".join(items).encode()).hexdigest()[:16]
-
-
-def redirect_target_path(target: str | None) -> str:
-    """Pathname of a site-redirect target, with a trailing slash normalized away.
-
-    A target may be a bare path, a path carrying a query and/or fragment, or an absolute URL,
-    and only its PATHNAME says which page it points at. A target that merely mentions another
-    page inside its query — `/article?next=/explorers/foo` — does not point at that page, so
-    substring-matching the raw string reports an unrelated redirect as an inbound chain. That
-    is a blocker on both sides, and acting on it means repointing or deleting a redirect that
-    had nothing to do with the migration.
-
-    It lives here, alongside the presentation helpers, because the sweep and the preflight must
-    apply this rule *identically*: the sweep decides whether to emit the finding and the
-    preflight decides whether to block on it, and two copies of the rule already drifted once.
-    """
-    path = urlsplit((target or "").strip()).path
-    return path.rstrip("/") or path
 
 
 def absolute_url(where_path: str, host: str, admin: str = "") -> str:

--- a/.claude/skills/find-chart-references/scripts/reference_report.py
+++ b/.claude/skills/find-chart-references/scripts/reference_report.py
@@ -26,7 +26,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 from etl.analytics.config import OWID_BASE_URL, POST_TYPE_TO_URL
 
@@ -118,6 +118,24 @@ def reference_digest(raw: list[dict], subject: str) -> str:
         if str(r.get("subject")) == str(subject)
     )
     return hashlib.sha256("\n".join(items).encode()).hexdigest()[:16]
+
+
+def redirect_target_path(target: str | None) -> str:
+    """Pathname of a site-redirect target, with a trailing slash normalized away.
+
+    A target may be a bare path, a path carrying a query and/or fragment, or an absolute URL,
+    and only its PATHNAME says which page it points at. A target that merely mentions another
+    page inside its query — `/article?next=/explorers/foo` — does not point at that page, so
+    substring-matching the raw string reports an unrelated redirect as an inbound chain. That
+    is a blocker on both sides, and acting on it means repointing or deleting a redirect that
+    had nothing to do with the migration.
+
+    It lives here, alongside the presentation helpers, because the sweep and the preflight must
+    apply this rule *identically*: the sweep decides whether to emit the finding and the
+    preflight decides whether to block on it, and two copies of the rule already drifted once.
+    """
+    path = urlsplit((target or "").strip()).path
+    return path.rstrip("/") or path
 
 
 def absolute_url(where_path: str, host: str, admin: str = "") -> str:

--- a/.claude/skills/find-chart-references/scripts/reference_report.py
+++ b/.claude/skills/find-chart-references/scripts/reference_report.py
@@ -1,0 +1,171 @@
+"""Presentation helpers shared by the consumers of the reference sweep.
+
+The sweep in `find_references.py` answers *what references this subject*. Every consumer
+then has to turn a finding into something a human can click and act on, and that work is
+identical whichever subject was swept: resolve a `where_path` to an absolute URL (routing
+admin routes to the admin origin), build a scroll-to-the-reference deep link, name the
+ArchieML component and the page type, produce a copy-paste search string for the Google
+Doc, and shell out to the sweep itself.
+
+It lives in this skill rather than in either consumer because this skill *is* the shared
+producer — both `map-charts-to-mdim/scripts/audit_references.py` and
+`map-explorer-to-mdim/scripts/audit_references.py` import from here, so a fix to the
+`/admin/` routing or the text-fragment encoding lands in both at once. That has already
+been a real bug in one consumer while the other was correct.
+
+Deliberately NOT here: `replacement_url()` and the markdown table builders. A chart
+reference's params merge over the target view's, reference-wins; an explorer reference's do
+the opposite (the redirect *deletes* matched source params and lets view params win), and
+the table columns differ. Sharing either would make one consumer subtly wrong.
+"""
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import quote
+
+from etl.analytics.config import OWID_BASE_URL, POST_TYPE_TO_URL
+
+FIND_REFERENCES = Path(__file__).resolve().parent / "find_references.py"
+
+# Public path prefix per gdoc type, derived from the repo's own routing map rather than
+# restated, so the two cannot drift: a data insight lives under /data-insights/, an author
+# under /team/, everything else at the root — and `None` means the type has no public URL
+# at all (fragment, homepage), so no link should be offered for it.
+POST_TYPE_PATH = {
+    post_type: None if base is None else base.removeprefix(OWID_BASE_URL)
+    for post_type, base in POST_TYPE_TO_URL.items()
+}
+
+RED, YELLOW, INFO = "RED", "YELLOW", "INFO"
+# Staging admin hosts carry a tailscale suffix that is noise in a link handed to a human.
+TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
+
+
+def run_sweep(subject_args: list[str]) -> tuple[list[dict], list[str]]:
+    """Run the sweep for any subject and return (findings, gaps).
+
+    `subject_args` is the subject selection verbatim, e.g. `["--chart-slugs", "a,b"]` or
+    `["--explorer", "x", "--explorer", "y"]`.
+
+    Returning the gaps alongside the findings is the whole point of going through here: the
+    sweep fails open on optional surfaces (a legacy table that is absent, a subject that
+    does not resolve), so a run that skipped one returns fewer references and no error —
+    indistinguishable from a clean result unless the gaps travel with the findings into the
+    consumer's own report.
+    """
+    if not FIND_REFERENCES.exists():
+        raise SystemExit(f"Missing {FIND_REFERENCES} — this skill provides the surface sweep.")
+    with tempfile.NamedTemporaryFile("r", suffix=".json", delete=False) as tmp:
+        out_path = tmp.name
+    with tempfile.NamedTemporaryFile("r", suffix=".json", delete=False) as tmp:
+        gaps_path = tmp.name
+    try:
+        cmd = [sys.executable, str(FIND_REFERENCES), *subject_args, "--json", out_path, "--gaps-json", gaps_path]
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        if proc.returncode != 0:
+            raise SystemExit(f"find_references.py failed:\n{proc.stdout}\n{proc.stderr}")
+        print(proc.stdout.rstrip())
+        gaps_raw = Path(gaps_path).read_text().strip()
+        return json.loads(Path(out_path).read_text()), (json.loads(gaps_raw) if gaps_raw else [])
+    finally:
+        Path(out_path).unlink(missing_ok=True)
+        Path(gaps_path).unlink(missing_ok=True)
+
+
+def absolute_url(where_path: str, host: str, admin: str = "") -> str:
+    """Absolute URL for a `where_path`, routing admin routes to the admin origin.
+
+    A narrative chart's `where_path` is its admin editor (`/admin/narrative-charts/…`),
+    which the public site does not serve — prefixing it with `host` produces a link that
+    404s. `admin` is an admin ROOT (".../admin") and the path already starts with
+    `/admin/`, so the root's suffix comes off before joining.
+    """
+    if not where_path:
+        return ""
+    if where_path.startswith("/admin/"):
+        origin = (admin or host).removesuffix("/").removesuffix("/admin")
+        return f"{origin}{where_path}"
+    return f"{host}{where_path}"
+
+
+def public_page_url(post_type: str, slug: str, host: str) -> str:
+    """Public URL of a gdoc, or "" when its type has no public route.
+
+    A gdoc's slug does NOT sit at the root for every type — a data insight is served under
+    /data-insights/ and an author page under /team/ — so building `host/<slug>` for all of
+    them points the reader at a 404. An unknown type falls back to the root, which is where
+    every currently routable type other than those two lives.
+    """
+    if not slug:
+        return ""
+    prefix = POST_TYPE_PATH.get(post_type, "")
+    if prefix is None:
+        return ""
+    return f"{host}/{prefix}{slug}"
+
+
+def deep_link(where_path: str, anchor: str, host: str, admin: str = "") -> str:
+    """Published-page URL scrolled to the reference via a text fragment (block embeds
+    have no anchor text, so those fall back to the plain URL). Same encoding as
+    find-chart-references / chart_diff citations: parentheses literal, hyphens escaped."""
+    base = absolute_url(where_path, host, admin)
+    if not base or not anchor:
+        return base
+    encoded = quote(anchor[:200], safe="()").replace("-", "%2D")
+    return f"{base}#:~:text={encoded}"
+
+
+def archie_component(ref: dict) -> str:
+    """The ArchieML component this reference lives in: chart, span-link, front-matter, …
+
+    The sweep encodes it as the head of `context` ("chart (article)", "span-link
+    (data-insight)"); the data-insight surface spells its front-matter reference out in
+    prose instead, so normalize that to the same token. This is what the gdoc tables
+    group by — the person editing the doc cares which construct they are touching, not
+    whether the page is an article or a data insight (both are gdocs).
+    """
+    head = ref["context"].split(" — ")[0]
+    if head.startswith("grapher-url"):
+        return "front-matter"
+    return head.split(" (")[0].strip()
+
+
+def page_type(ref: dict) -> str:
+    """article / data insight / topic-page / fragment — the parenthesized tail of context.
+
+    The data-insight surface spells its front-matter reference out in prose with no
+    parenthesized suffix, so fall back to the surface name. Without that fallback those
+    rows lose the page-type marker exactly where it matters most: articles and data
+    insights share one table, and the Where column is the only thing distinguishing them.
+    """
+    m = re.search(r"\(([^)]+)\)", ref["context"].split(" — ")[0])
+    if m:
+        return m.group(1)
+    return ref["surface"] if ref["surface"] == "data insight" else ""
+
+
+def find_in_doc(ref: dict) -> str:
+    """Copy-paste search string for the Google Doc's find box: the visible anchor text for
+    a prose hyperlink; for a block embed the doc holds a bare URL, so the subject — exactly
+    as the author typed it, which is what `posts_gdocs_links.target` stores and may be an
+    old slug."""
+    anchor = " ".join((ref.get("text") or "").split())
+    return anchor or ref["subject"]
+
+
+def cell(value: str, limit: int = 70, marker: str = "…") -> str:
+    """Table-safe cell: escape pipes and newlines, truncate runaway text.
+
+    Pass marker="" for copy-paste search strings: an appended ellipsis is a character
+    that does not exist in the doc, so the copied text would match nothing — a bare
+    literal prefix still finds the spot. Pipes are escaped after truncating so the cut
+    can never leave half an escape sequence behind.
+    """
+    text = " ".join(str(value or "").split())
+    if len(text) > limit:
+        text = text[: limit - 1] + marker
+    return text.replace("|", "\\|")

--- a/.claude/skills/find-chart-references/scripts/reference_report.py
+++ b/.claude/skills/find-chart-references/scripts/reference_report.py
@@ -19,6 +19,7 @@ the opposite (the redirect *deletes* matched source params and lets view params 
 the table columns differ. Sharing either would make one consumer subtly wrong.
 """
 
+import hashlib
 import json
 import re
 import subprocess
@@ -74,6 +75,40 @@ def run_sweep(subject_args: list[str]) -> tuple[list[dict], list[str]]:
     finally:
         Path(out_path).unlink(missing_ok=True)
         Path(gaps_path).unlink(missing_ok=True)
+
+
+# The identity of a reference, for freshness purposes: which surface, of what kind, on which
+# page, pointing where. Presentation-only fields (`context`, `text`, the resolved URLs) are
+# excluded on purpose — prose changing next to a link is not a new reference, and treating it
+# as one trains people to re-run an audit to clear noise, which is how a real change gets
+# waved through.
+REFERENCE_DIGEST_FIELDS = (
+    "surface",
+    "kind",
+    "where",
+    "where_path",
+    "surface_id",
+    "config_id",
+    "query_string",
+    "published",
+)
+
+
+def reference_digest(raw: list[dict], subject: str) -> str:
+    """Stable digest of the live references the sweep just found for one subject.
+
+    An audit records this; a preflight recomputes it and compares. Without that binding, a gate
+    reading the audit's CSV cannot tell whether the CSV still describes the site: a page that
+    added an embed after the audit ran, or an audit folder carried over from an earlier
+    migration, both leave the gate reporting a clean audit while the change is about to break
+    something live. Order-insensitive, because SQL row order is not a fact about the site.
+    """
+    items = sorted(
+        json.dumps([r.get(f) for f in REFERENCE_DIGEST_FIELDS], sort_keys=True, ensure_ascii=False)
+        for r in raw
+        if str(r.get("subject")) == str(subject)
+    )
+    return hashlib.sha256("\n".join(items).encode()).hexdigest()[:16]
 
 
 def absolute_url(where_path: str, host: str, admin: str = "") -> str:

--- a/.claude/skills/find-chart-references/scripts/reference_report.py
+++ b/.claude/skills/find-chart-references/scripts/reference_report.py
@@ -78,10 +78,9 @@ def run_sweep(subject_args: list[str]) -> tuple[list[dict], list[str]]:
 
 
 # The identity of a reference, for freshness purposes: which surface, of what kind, on which
-# page, pointing where. Presentation-only fields (`context`, `text`, the resolved URLs) are
-# excluded on purpose — prose changing next to a link is not a new reference, and treating it
-# as one trains people to re-run an audit to clear noise, which is how a real change gets
-# waved through.
+# page, pointing where. Presentation-only fields (`text`, the resolved URLs) are excluded on
+# purpose — prose changing next to a link is not a new reference, and treating it as one trains
+# people to re-run an audit to clear noise, which is how a real change gets waved through.
 REFERENCE_DIGEST_FIELDS = (
     "surface",
     "kind",
@@ -102,9 +101,19 @@ def reference_digest(raw: list[dict], subject: str) -> str:
     added an embed after the audit ran, or an audit folder carried over from an earlier
     migration, both leave the gate reporting a clean audit while the change is about to break
     something live. Order-insensitive, because SQL row order is not a fact about the site.
+
+    The ArchieML component joins the fields above because consumers derive SEVERITY from it, not
+    from `kind` alone: an `explorer-tiles` reference survives a redirect while a `chart` embed
+    breaks, and both are `kind == "embed"` on the same page with the same ids. Swapping one for
+    the other turns a harmless row into a blocker without moving any other field, so the
+    component is digested — normalized, so the prose it is parsed out of still is not.
     """
     items = sorted(
-        json.dumps([r.get(f) for f in REFERENCE_DIGEST_FIELDS], sort_keys=True, ensure_ascii=False)
+        json.dumps(
+            [archie_component(r)] + [r.get(f) for f in REFERENCE_DIGEST_FIELDS],
+            sort_keys=True,
+            ensure_ascii=False,
+        )
         for r in raw
         if str(r.get("subject")) == str(subject)
     )
@@ -149,6 +158,35 @@ def deep_link(where_path: str, anchor: str, host: str, admin: str = "") -> str:
     find-chart-references / chart_diff citations: parentheses literal, hyphens escaped."""
     base = absolute_url(where_path, host, admin)
     if not base or not anchor:
+        return base
+    encoded = quote(anchor[:200], safe="()").replace("-", "%2D")
+    return f"{base}#:~:text={encoded}"
+
+
+def page_deep_link(ref: dict, host: str, admin: str = "") -> str:
+    """Public URL of the page holding this reference, scrolled to it — "" when it has none.
+
+    The base cannot be taken from `where_path` alone. The gdoc-link sweep builds it as
+    `/<slug>` for every gdoc type, but a data insight is served under `/data-insights/` and an
+    author page under `/team/`, so those links 404 — and a prose link has anchor text, so the
+    text fragment attaches successfully and makes the wrong base look like a working link. The
+    page TYPE therefore decides the base whenever it is one the site routes, and `where_path`
+    is used where it is the authority instead: admin routes, and surfaces whose type is not a
+    routed gdoc type (a narrative chart's editor URL, or the data-insight front-matter surface,
+    whose `where_path` already carries the right prefix).
+    """
+    ptype = page_type(ref)
+    if ptype and POST_TYPE_PATH.get(ptype, "") is None:
+        return ""  # fragment / homepage: no reader-facing URL exists
+    base = ""
+    if ptype in POST_TYPE_PATH and ref.get("where"):
+        base = public_page_url(ptype, ref["where"], host)
+    if not base:
+        base = absolute_url(ref.get("where_path") or "", host, admin)
+    if not base:
+        return ""
+    anchor = ref.get("text") or ""
+    if not anchor:
         return base
     encoded = quote(anchor[:200], safe="()").replace("-", "%2D")
     return f"{base}#:~:text={encoded}"

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -52,8 +52,8 @@ from reference_report import (  # noqa: E402
     YELLOW,
     archie_component,
     cell,
-    deep_link,
     find_in_doc,
+    page_deep_link,
     page_type,
     public_page_url,
     run_sweep,
@@ -777,7 +777,7 @@ def main() -> int:
                 "source_chart_slug": ref["subject"],
                 "where": ref["where"],
                 # Scrolled to the reference when the anchor text allows it.
-                "where_url": deep_link(ref["where_path"], ref.get("text") or "", host, admin),
+                "where_url": page_deep_link(ref, host, admin),
                 # posts_gdocs.id IS the Google Doc id, so the edit link is direct; the
                 # admin previewer renders unpublished drafts the public URL 404s on.
                 "doc_edit_url": f"https://docs.google.com/document/d/{ref['surface_id']}/edit" if is_gdoc else "",

--- a/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/audit_references.py
@@ -33,31 +33,31 @@ Usage:
 import argparse
 import csv
 import json
-import re
-import subprocess
 import sys
-import tempfile
 from collections import defaultdict
 from pathlib import Path
-from urllib.parse import parse_qsl, quote, urlencode
+from urllib.parse import parse_qsl, urlencode
 
-from etl.analytics.config import OWID_BASE_URL, POST_TYPE_TO_URL
 from etl.config import OWID_ENV
 
-FIND_REFERENCES = Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts" / "find_references.py"
-
-# Public path prefix per gdoc type, derived from the repo's own routing map rather than
-# restated, so the two cannot drift: a data insight lives under /data-insights/, an author
-# under /team/, everything else at the root — and `None` means the type has no public URL
-# at all (fragment, homepage), so no link should be offered for it.
-POST_TYPE_PATH = {
-    post_type: None if base is None else base.removeprefix(OWID_BASE_URL)
-    for post_type, base in POST_TYPE_TO_URL.items()
-}
-
-RED, YELLOW, INFO = "RED", "YELLOW", "INFO"
-# Staging admin hosts carry a tailscale suffix that is noise in a link handed to a human.
-TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
+# The sweep's own skill owns the helpers every consumer of it needs (URL resolution, deep
+# links, component/page-type parsing, the doc search string) so a fix lands in every
+# consumer at once. `replacement_url()` below is deliberately NOT among them: its merge
+# semantics are chart-specific.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts"))
+from reference_report import (  # noqa: E402
+    INFO,
+    RED,
+    TAILSCALE_SUFFIX_RE,
+    YELLOW,
+    archie_component,
+    cell,
+    deep_link,
+    find_in_doc,
+    page_type,
+    public_page_url,
+    run_sweep,
+)
 
 REFERENCE_COLUMNS = [
     "severity", "surface", "component", "kind", "source_chart_slug", "where", "where_url",
@@ -135,113 +135,8 @@ def load_redirects(path_arg: str) -> list[dict]:
 
 
 def run_find_references(redirects: list[dict]) -> tuple[list[dict], list[str]]:
-    """Delegate the surface sweep to the find-chart-references skill.
-
-    Returns its findings and the surfaces it could not sweep. The sweep fails open on
-    optional surfaces (a legacy table that is absent, a subject that does not resolve), so
-    a run that skipped one returns fewer references and no error — indistinguishable from a
-    clean result unless the gaps travel with the findings into this audit's own report.
-    """
-    if not FIND_REFERENCES.exists():
-        raise SystemExit(f"Missing {FIND_REFERENCES} — the find-chart-references skill provides the surface sweep.")
-    slugs = ",".join(r["chart"]["slug"] for r in redirects)
-    with tempfile.NamedTemporaryFile("r", suffix=".json", delete=False) as tmp:
-        out_path = tmp.name
-    with tempfile.NamedTemporaryFile("r", suffix=".json", delete=False) as tmp:
-        gaps_path = tmp.name
-    try:
-        cmd = [sys.executable, str(FIND_REFERENCES), "--chart-slugs", slugs]
-        cmd += ["--json", out_path, "--gaps-json", gaps_path]
-        proc = subprocess.run(cmd, capture_output=True, text=True)
-        if proc.returncode != 0:
-            raise SystemExit(f"find_references.py failed:\n{proc.stdout}\n{proc.stderr}")
-        print(proc.stdout.rstrip())
-        gaps_raw = Path(gaps_path).read_text().strip()
-        return json.loads(Path(out_path).read_text()), (json.loads(gaps_raw) if gaps_raw else [])
-    finally:
-        Path(out_path).unlink(missing_ok=True)
-        Path(gaps_path).unlink(missing_ok=True)
-
-
-def absolute_url(where_path: str, host: str, admin: str = "") -> str:
-    """Absolute URL for a `where_path`, routing admin routes to the admin origin.
-
-    A narrative chart's `where_path` is its admin editor (`/admin/narrative-charts/…`),
-    which the public site does not serve — prefixing it with `host` produces a link that
-    404s. `admin` is an admin ROOT (".../admin") and the path already starts with
-    `/admin/`, so the root's suffix comes off before joining.
-    """
-    if not where_path:
-        return ""
-    if where_path.startswith("/admin/"):
-        origin = (admin or host).removesuffix("/").removesuffix("/admin")
-        return f"{origin}{where_path}"
-    return f"{host}{where_path}"
-
-
-def public_page_url(post_type: str, slug: str, host: str) -> str:
-    """Public URL of a gdoc, or "" when its type has no public route.
-
-    A gdoc's slug does NOT sit at the root for every type — a data insight is served under
-    /data-insights/ and an author page under /team/ — so building `host/<slug>` for all of
-    them points the reader at a 404. An unknown type falls back to the root, which is where
-    every currently routable type other than those two lives.
-    """
-    if not slug:
-        return ""
-    prefix = POST_TYPE_PATH.get(post_type, "")
-    if prefix is None:
-        return ""
-    return f"{host}/{prefix}{slug}"
-
-
-def deep_link(where_path: str, anchor: str, host: str, admin: str = "") -> str:
-    """Published-page URL scrolled to the reference via a text fragment (block embeds
-    have no anchor text, so those fall back to the plain URL). Same encoding as
-    find-chart-references / chart_diff citations: parentheses literal, hyphens escaped."""
-    base = absolute_url(where_path, host, admin)
-    if not base or not anchor:
-        return base
-    encoded = quote(anchor[:200], safe="()").replace("-", "%2D")
-    return f"{base}#:~:text={encoded}"
-
-
-def archie_component(ref: dict) -> str:
-    """The ArchieML component this reference lives in: chart, span-link, front-matter, …
-
-    The sweep encodes it as the head of `context` ("chart (article)", "span-link
-    (data-insight)"); the data-insight surface spells its front-matter reference out in
-    prose instead, so normalize that to the same token. This is what the gdoc tables
-    group by — the person editing the doc cares which construct they are touching, not
-    whether the page is an article or a data insight (both are gdocs).
-    """
-    head = ref["context"].split(" — ")[0]
-    if head.startswith("grapher-url"):
-        return "front-matter"
-    return head.split(" (")[0].strip()
-
-
-def page_type(ref: dict) -> str:
-    """article / data insight / topic-page / fragment — the parenthesized tail of context.
-
-    The data-insight surface spells its front-matter reference out in prose with no
-    parenthesized suffix, so fall back to the surface name. Without that fallback those
-    rows lose the page-type marker exactly where it now matters most: articles and data
-    insights share one table, and the Where column is the only thing distinguishing them.
-    """
-    m = re.search(r"\(([^)]+)\)", ref["context"].split(" — ")[0])
-    if m:
-        return m.group(1)
-    return ref["surface"] if ref["surface"] == "data insight" else ""
-
-
-def find_in_doc(ref: dict) -> str:
-    """Copy-paste search string for the Google Doc's find box (find-chart-references
-    convention): the visible anchor text for a prose hyperlink; for a block embed the doc
-    holds a bare grapher URL, so the slug — exactly as the author typed it, which is what
-    `posts_gdocs_links.target` stores and may be an old slug."""
-    anchor = " ".join((ref.get("text") or "").split())
-    return anchor or ref["subject"]
+    """Sweep every source chart, current slug only (the sweep resolves old slugs itself)."""
+    return run_sweep(["--chart-slugs", ",".join(r["chart"]["slug"] for r in redirects)])
 
 
 def narrative_chart_usages(names: set[str]) -> dict[str, list[dict]]:
@@ -558,20 +453,6 @@ def write_csv(out: Path, findings: list[dict]) -> Path:
         for row in findings:
             w.writerow({k: row.get(k, "") for k in REFERENCE_COLUMNS})
     return path
-
-
-def cell(value: str, limit: int = 70, marker: str = "…") -> str:
-    """Table-safe cell: escape pipes and newlines, truncate runaway text.
-
-    Pass marker="" for copy-paste search strings: an appended ellipsis is a character
-    that does not exist in the doc, so the copied text would match nothing — a bare
-    literal prefix still finds the spot. Pipes are escaped after truncating so the cut
-    can never leave half an escape sequence behind.
-    """
-    text = " ".join(str(value or "").split())
-    if len(text) > limit:
-        text = text[: limit - 1] + marker
-    return text.replace("|", "\\|")
 
 
 def gdoc_table(group: list[dict]) -> list[str]:

--- a/.claude/skills/map-charts-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-charts-to-mdim/scripts/preflight.py
@@ -321,11 +321,24 @@ def cli_blockers(redirects: list[dict]) -> dict[str, list[str]]:
     sources = tuple(r["source"] for r in redirects)
     slugs = tuple(r["chart"]["slug"] for r in redirects)
 
-    site_sources = dict(
-        OWID_ENV.read_sql(
-            "SELECT source, target FROM redirects WHERE source IN %(s)s", params={"s": sources}
-        ).itertuples(index=False, name=None)
-    )
+    # Both directions, and both the current and the old slugs. `extract_and_match.py` reads
+    # both at proposal time; reading only `source` here meant a site redirect created AFTER
+    # extraction was never re-detected, leaving `cli_required` frozen at proposal time — and
+    # the CLI's guarantee to repoint such a row is the reason `cli_required` exists.
+    old_slug_paths = tuple(f"/grapher/{s}" for r in redirects for s in r.get("oldSlugs", []))
+    all_paths = tuple({*sources, *old_slug_paths})
+    site_rows = OWID_ENV.read_sql(
+        "SELECT source, target FROM redirects WHERE source IN %(s)s OR target IN %(s)s",
+        params={"s": all_paths},
+    ).to_dict("records")
+    site_sources = {r["source"]: r["target"] for r in site_rows if r["source"] in sources}
+    site_targets: dict[str, list[str]] = defaultdict(list)
+    old_slug_targets: dict[str, list[str]] = defaultdict(list)
+    for r in site_rows:
+        if r["target"] in sources:
+            site_targets[r["target"]].append(r["source"])
+        elif r["target"] in old_slug_paths:
+            old_slug_targets[r["target"]].append(r["source"])
     own_old_slugs = set(
         OWID_ENV.read_sql("SELECT slug FROM chart_slug_redirects WHERE slug IN %(s)s", params={"s": slugs})["slug"]
     )
@@ -369,7 +382,12 @@ def cli_blockers(redirects: list[dict]) -> dict[str, list[str]]:
     for r in redirects:
         source, slug, t = r["source"], r["chart"]["slug"], r["target"]
         if source in site_sources:
-            reasons[source].append(f"already a site redirect source -> {site_sources[source]}")
+            reasons[source].append(
+                f"already a site redirect source -> {site_sources[source]}. This is not a retryable CLI "
+                "error: a site redirect is served by the asset layer BEFORE the 404 handler that consults "
+                "MDIM redirects, so this URL can never reach the MDIM view. Delete or repoint that "
+                "`redirects` row, or accept that the chart URL keeps going where it points."
+            )
         if slug in own_old_slugs:
             reasons[source].append("chart slug is itself an old slug in chart_slug_redirects")
         if slug == t["mdimSlug"]:
@@ -382,6 +400,45 @@ def cli_blockers(redirects: list[dict]) -> dict[str, list[str]]:
         if clashing:
             reasons[source].append(f"old slug(s) already a redirect source elsewhere: {clashing}")
     return reasons
+
+
+def site_redirect_notes(redirects: list[dict]) -> dict[str, list[str]]:
+    """Non-blocking site-redirect facts the CLI operator should still know.
+
+    Two kinds, both re-read here rather than trusted from proposal time:
+
+    - a site redirect pointing AT a source chart. The CLI repoints it (`replaceSiteRedirects`),
+      so it is not a blocker — but the admin API rejects exactly this shape, which is why the
+      CLI is mandatory. Detecting it only at extraction meant one created afterwards silently
+      weakened that warning.
+    - a site redirect pointing at one of the chart's OLD slugs. The CLI repoints only the
+      source, so this becomes a 2-hop chain after the run: X -> /grapher/<old> -> MDIM view.
+      It still resolves, so it is a note, not a blocker — but it is invisible otherwise.
+    """
+    notes: dict[str, list[str]] = defaultdict(list)
+    if not redirects:
+        return notes
+    sources = tuple(r["source"] for r in redirects)
+    old_by_source = {r["source"]: [f"/grapher/{s}" for s in r.get("oldSlugs", [])] for r in redirects}
+    all_paths = tuple({*sources, *(p for paths in old_by_source.values() for p in paths)})
+    rows = OWID_ENV.read_sql(
+        "SELECT source, target FROM redirects WHERE target IN %(s)s", params={"s": all_paths}
+    ).to_dict("records")
+    for r in redirects:
+        pointing_here = [x["source"] for x in rows if x["target"] == r["source"]]
+        if pointing_here:
+            notes[r["source"]].append(
+                f"site redirect(s) point AT this chart: {pointing_here} — the CLI repoints them; the admin "
+                "API would reject this shape, so the CLI is mandatory"
+            )
+        for old in old_by_source[r["source"]]:
+            via = [x["source"] for x in rows if x["target"] == old]
+            if via:
+                notes[r["source"]].append(
+                    f"site redirect(s) {via} point at the OLD slug {old}, which the CLI does not repoint — "
+                    "after the run they resolve via a 2-hop chain. Repoint them at the MDIM view to avoid it."
+                )
+    return notes
 
 
 def existing_mdim_redirects(sources: tuple[str, ...]) -> dict[str, dict]:
@@ -627,6 +684,7 @@ def main() -> int:
     sources = tuple(r["source"] for r in redirects + already_done)
     existing = existing_mdim_redirects(sources)
     blockers = cli_blockers(redirects)
+    notes = site_redirect_notes(redirects)
     stale = stale_charts(redirects + already_done)
     for source, reason in stale_targets(redirects + already_done).items():
         stale.setdefault(source, reason)
@@ -711,6 +769,15 @@ def main() -> int:
     # without holding the batch back from `Ready` for a step nobody can now undo.
     done_ids = {r["chart"]["id"] for r in already_done if r["source"] in unpublished}
     blocking_embeds = {cid: n for cid, n in embeds.items() if cid not in done_ids}
+    if notes:
+        print(
+            "\nSite redirects touching these charts (NOT blockers — listed so the CLI's repointing is not a "
+            "surprise, and so the 2-hop case can be avoided):"
+        )
+        for note_source, messages in sorted(notes.items()):
+            for message in messages:
+                print(f"  {note_source.removeprefix('/grapher/')}: {message}")
+
     if embeds:
         print("\nSurfaces a redirect will NOT fix (these embed the chart and break when it is unpublished):")
         for r in redirects + already_done:

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -310,7 +310,10 @@ Then remove the explorer's ETL footprint — and **never delete a step without a
 exist on disk today), remove the `dag/*.yml` entry, `make check`, **commit**; then run
 `.venv/bin/etl archive-dag` and commit `dag/archive/*.yml` separately, since it reads *committed*
 history. `git checkout` anything unrelated it sweeps in. Archive anything now orphaned
-upstream — a garden step that existed only to feed this explorer — in a second round.
+upstream — a garden step that existed only to feed this explorer — in a second round. If any of
+those is a **migrated/backport dataset**, delete its now-orphaned
+`snapshots/backport/latest/dataset_<id>_*` mirror files too: archiving the DAG entry leaves them
+on disk, and nothing will point at them again.
 
 > **Grep before deleting a shared explorer data step.** Some are consumed **off-DAG**, by
 > scripts fetching their published catalog CSVs by URL. Those consumers are invisible to

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -192,6 +192,17 @@ best-fitting MDIM with **no query params**, which grapher renders as that MDIM's
 (hence `viewId: null`, `dimensions: {}`). The best-fitting MDIM is the one most views resolve
 to, or whatever `DEFAULT_MDIM` in `mapping_rules.py` overrides it to.
 
+> **The catch-all's destination is the only one nothing pins.** Its row stores
+> `viewConfigId = NULL`, so it resolves at request time to whichever view the MDIM renders for
+> an empty selection — the **first view in config order** (grapher's `filterToAvailableChoices`
+> takes the first available view's choice at every dimension). Rebuilding the MDIM can reorder
+> its views, or edit that view's config in place, and the bare explorer URL then lands somewhere
+> nobody reviewed. Extraction records that view in `_sources.json` (not in the payload, which
+> must stay byte-reproducible) and preflight **warns** when it moves. A warning, not a blocker:
+> the destination is a moving reference by construction, so blocking would flip an approved
+> catch-all to NOT READY on any unrelated MDIM rebuild. To pin it, give the catch-all an
+> explicit target view instead.
+
 The script prints a validation report: how many explorer views resolved, distinct MDIM
 views hit per MDIM, how many rows share a target, and **FLAGS** for any explorer view that
 didn't resolve to a real MDIM view (fix the rules and re-run until there are no flags).

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -43,26 +43,26 @@ applies before running, and don't assume `.env.prod` exists:**
 
 1. **Staging branch** (often easiest): if you're on a `staging-site-<branch>` branch,
    `OWID_ENV` already points at that prod-clone DB — run the commands as-is, no prefix.
-2. **Production, read-only, via `.env.prod`**: prefix commands with
-   `ENV_FILE=.env.prod DATA_API_ENV=production`. **Only if `.env.prod` is present.**
+2. **Production, read-only, via an env file**: prefix commands with
+   `ENV_FILE=<prod creds> DATA_API_ENV=production`. Don't assume the file name — check
+   what exists (`ls -la .env*`); on some machines it is `.env.prod`, on others `.env.live`.
 3. **Some other credentials file**: the user may keep prod (or other) DB creds in a
    different env file — run with `ENV_FILE=<their file> [DATA_API_ENV=production]`.
 
 **Preflight — check, then ask if needed:**
 
 ```bash
-# Is .env.prod available?
-ls -la .env.prod 2>/dev/null && echo "found .env.prod" || echo "NO .env.prod"
+ls -la .env* 2>/dev/null          # which credentials files exist?
 
 # Connectivity test (swap the ENV_FILE prefix for whatever applies; drop it on a staging branch):
-ENV_FILE=.env.prod DATA_API_ENV=production .venv/bin/python -c \
+ENV_FILE=<prod creds> DATA_API_ENV=production .venv/bin/python -c \
   "from etl.config import OWID_ENV; print('DB OK:', OWID_ENV.read_sql('SELECT 1 AS x').iloc[0,0])"
 ```
 
-If `.env.prod` is missing **and** you're not on a staging branch with the data, **stop
-and ask the user which credentials / env file to use** (e.g. "I don't see `.env.prod` —
-which env file holds DB credentials that can reach the explorer + MDIMs? Or should I run
-this from a staging branch?"). Then use that file as the `ENV_FILE=` prefix for both
+If no prod credentials file exists **and** you're not on a staging branch with the data,
+**stop and ask the user which credentials / env file to use** (e.g. "which env file holds DB
+credentials that can reach the explorer + MDIMs? Or should I run this from a staging
+branch?"). Then use that file as the `ENV_FILE=` prefix for both
 script invocations below. Don't hardcode credentials.
 
 If the connection works but a query returns nothing, the scripts stop with a clear
@@ -262,11 +262,15 @@ curl -sI "https://ourworldindata.org/explorers/<slug>?<one view's params>" | gre
 # expect 302 + location: /grapher/<mdim>?<view dims>
 ```
 
-### 8. Retire the explorer's ETL step
+### 8. Retire the explorer, then its ETL step
 
-Once the redirect is verified, remove the explorer's ETL footprint — and **never delete a step
-without archiving it** (see `CLAUDE.md`). Delete the step's `.py` **and its sibling
-`.config.yml`** (the periodic archive sweep only knows `.py`, which is why orphaned configs
+**The explorer is unpublished or deleted BY HAND in the admin.** Removing the ETL step does
+not unpublish it — the `explorers` row survives, so it keeps showing up in listings and
+search. Do not flip `isPublished` in the step's `.config.yml` and re-run hoping to achieve it;
+that is not the route (and no explorer config in the repo carries `isPublished: false`).
+
+Then remove the explorer's ETL footprint — and **never delete a step without archiving it**
+(see `CLAUDE.md`). Delete the step's `.py` **and its sibling `.config.yml`** (the periodic archive sweep only knows `.py`, which is why orphaned configs
 exist on disk today), remove the `dag/*.yml` entry, `make check`, **commit**; then run
 `etl archive-dag` and commit `dag/archive/*.yml` separately, since it reads *committed*
 history. `git checkout` anything unrelated it sweeps in. Archive anything now orphaned

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: map-explorer-to-mdim
 description: >-
-  Suggest a redirect mapping from a (soon-to-sunset) OWID explorer's views to the
-  views of one or more replacement MDIMs. Pulls explorer views and MDIM views from
-  the grapher DB, writes a CSV per source/target plus a wide joint proposal that
-  routes each explorer view to a target MDIM view, and flags when several explorer
-  views land on the same MDIM view. Trigger when the user says "map explorer <slug>
-  to mdim(s) <...>", "suggest explorer->MDIM redirects", "we're sunsetting the
-  <slug> explorer, map its views to the new multidims", or similar.
+  Take (soon-to-sunset) OWID explorers to redirected MDIMs, end to end. Maps each
+  explorer's views to the views of one or more replacement MDIMs, writes ONE
+  apply-ready JSON payload per explorer for the admin bulk-redirect endpoint, audits
+  every article that links or embeds each explorer (with the view each link will land
+  on), preflights every validation the endpoint performs — including site redirects
+  that would block it — and covers retiring the explorer's ETL step afterwards.
+  Trigger when the user says "map explorer <slug> to mdim(s) <...>", "suggest
+  explorer->MDIM redirects", "we're sunsetting the <slug> explorer, map its views to
+  the new multidims", "redirect these explorers to MDIMs", or similar.
 metadata:
   internal: true
 ---
@@ -128,9 +130,23 @@ Writes `mapping_proposal.csv`, one row per explorer view:
 | `<mdim>_<dimslug>` … | wide block; only the **target** MDIM's columns are filled with the translated slugs |
 | `shared_target_explorer_ids` | when >1 explorer view lands on the same MDIM view, the comma-joined list of all those explorer ids (e.g. `1,12`); empty when the target is unique |
 
-It also writes **`mapping.json`** — the same mapping as a redirect payload for an
-owid-grapher API (yet to be built) to consume. Unlike the CSV (positional `dimension_N`
-columns, meant for a spreadsheet), the JSON carries every identifier a redirect needs:
+It also writes **`mapping.json`** — the machine record — and
+**`admin_bulk_payload.json`**, which is what you actually apply. The API exists:
+`POST {admin}/api/multi-dim-redirects/bulk` (`handleBulkCreateMultiDimRedirects`), also
+reachable from the *Bulk-create redirects from JSON* button on `/admin/multi-dim-redirects`.
+Its Zod schema deliberately mirrors this file's `catchAll` + `redirects` shape, ignores keys
+it doesn't know (`sourceViewId`, `viewId`, `mdim`, `stats`, `targets`), and reports
+`target: null` entries as `skipped`.
+
+> **Post `admin_bulk_payload.json`, never `mapping.json`.** The payload has empty-valued
+> source dimensions stripped out. That is mandatory, not cosmetic: a condition is matched
+> against the incoming URL's params, and an absent param is not an empty string — so a
+> condition of `{"Period": ""}` can never match, and every view carrying one silently falls
+> through to the catch-all instead of its intended target. `mapping.json` keeps them because
+> it is the faithful record of the view grid.
+
+Unlike the CSV (positional `dimension_N` columns, meant for a spreadsheet), the JSON carries
+every identifier a redirect needs:
 
 ```jsonc
 {
@@ -176,8 +192,109 @@ didn't resolve to a real MDIM view (fix the rules and re-run until there are no 
 ### 4. Review
 
 Sanity-check the flagged rows and the judgment calls (approximate type matches, aggregate
-collapses, MDIM choices with no explorer source). The CSVs are typically pasted into a
-spreadsheet for a human reviewer / topic owner to confirm before redirects are created.
+collapses, MDIM choices with no explorer source). `/review-explorer-mdim-mapping` renders the
+pairs side by side with approve/flag controls for a topic owner; corrections go through
+`mapping_rules.py` and a rebuild, not the HTML.
+
+### 5. Audit what references the explorers (ALWAYS offer; run when the user says yes)
+
+```bash
+ENV_FILE=<prod creds> DATA_API_ENV=production .venv/bin/python \
+  .claude/skills/map-explorer-to-mdim/scripts/audit_references.py \
+  --mapping ai/<a>-mdim-mapping --mapping ai/<b>-mdim-mapping \
+  --out ai/<combined>-redirects
+```
+
+Writes `references.csv` + `references.md` across all the explorers in one pass. It resolves
+each referencing URL through the rules the payload would create, so every row says which view
+the reader lands on — and separates *the link had no params* from *the link names a choice the
+explorer has since dropped*, which lands on the MDIM's default view and needs authoring
+attention rather than a URL swap.
+
+**The timeline differs from the chart skill's, and this is the thing to say out loud:** an
+embedded explorer breaks the moment the redirect is **created**, not later at unpublish,
+because the embed renders by fetching the explorer page and parsing it. So the 🔴 rows are
+migrated *before* step 7, not after.
+
+### 6. Preflight (read-only, gated)
+
+```bash
+ENV_FILE=<prod creds> DATA_API_ENV=production .venv/bin/python \
+  .claude/skills/map-explorer-to-mdim/scripts/preflight.py \
+  --mapping ai/<a>-mdim-mapping --mapping ai/<b>-mdim-mapping \
+  --out ai/<combined>-redirects [--record ai/<combined>-redirects/bulk_redirects.json]
+```
+
+Mirrors every validation the endpoint performs, per explorer — because it memoizes its
+source-side checks and re-throws the cached rejection, so **one source-level problem fails
+every entry for that explorer**. Blockers: the explorer path is already a site-redirect
+source, or the *target* of one (the chain case); the slug collides with a chart's old slug; a
+target MDIM is missing or unpublished; the target `/grapher/<slug>` is itself a redirect
+source; two views share a source condition; the view fingerprint no longer matches the live
+explorer; redirects already exist that differ from the payload; or embedded references are
+outstanding. A **missing** `references.csv` is a blocker too — "never looked" must not read
+like "looked and found nothing".
+
+A retired explorer whose redirects are all live reports `DONE` and exits 0. That is the
+finished state, not an error.
+
+Non-zero exit means **do not post anything**.
+
+### 7. Apply — the admin bulk endpoint (GATED, production)
+
+> [!WARNING]
+> **Creating the redirect darkens the explorer immediately.** It is checked on *every*
+> `/explorers/*` request, ahead of `env.ASSETS.fetch`, so it beats the baked explorer page and
+> any `_redirects` entry, and fires while the explorer is still published. There is no staged
+> rollout and no bulk undo — removal is one row at a time.
+
+Paste each `admin_bulk_payload.json` into *Bulk-create redirects from JSON* at
+`{admin}/multi-dim-redirects`, **one explorer at a time**. Read the response
+**positionally**: every `results[i].source` is the same `/explorers/<slug>` string, so index 0
+is the catch-all when present and index `i` is `redirects[i-1]`. Expect
+`created + skipped + errors == entries`.
+
+Then wait for the bake **plus ~2 minutes** (the redirect map is fetched with a 2-minute edge
+TTL) and verify:
+
+```bash
+curl -sI "https://ourworldindata.org/explorers/<slug>?<one view's params>" | grep -i "^HTTP/\|^location:"
+# expect 302 + location: /grapher/<mdim>?<view dims>
+```
+
+### 8. Retire the explorer's ETL step
+
+Once the redirect is verified, remove the explorer's ETL footprint — and **never delete a step
+without archiving it** (see `CLAUDE.md`). Delete the step's `.py` **and its sibling
+`.config.yml`** (the periodic archive sweep only knows `.py`, which is why orphaned configs
+exist on disk today), remove the `dag/*.yml` entry, `make check`, **commit**; then run
+`etl archive-dag` and commit `dag/archive/*.yml` separately, since it reads *committed*
+history. `git checkout` anything unrelated it sweeps in. Archive anything now orphaned
+upstream — a garden step that existed only to feed this explorer — in a second round.
+
+> **Grep before deleting a shared explorer data step.** Some are consumed **off-DAG**, by
+> scripts fetching their published catalog CSVs by URL. Those consumers are invisible to
+> `etl archive-dag`, so the step looks like a safe leaf when it is not. Search for its catalog
+> URL first and keep it until every consumer is retired.
+
+Track these steps with `TodoWrite` in the chat. **Do not generate a checklist file**, and
+there is no `HANDOFF.md` for this skill — unlike the chart path there is no cross-team
+handoff, since the same operator pastes the payload.
+
+## What each run writes
+
+| file | written by | contents |
+|---|---|---|
+| `explorer_views.csv` | extract | `id` 1..N + `dimension_1..M` (display values) |
+| `multidim_<short>_views.csv` | extract | one per MDIM, ids `A1…`/`B1…` |
+| `_scaffold.md` | extract | dimension legend, distinct values, auto-matches, `mapping_rules.py` template |
+| `_sources.json` | extract | slugs, catalogPaths, MDIM ids/slugs/published, **`viewsFingerprint`**, `configMd5` — don't hand-edit |
+| `mapping_rules.py` | **you** | routing + value translation |
+| `mapping_proposal.csv` | build | one row per explorer view, wide target block |
+| `mapping.json` | build | faithful machine record (empty source dims **kept**) |
+| **`admin_bulk_payload.json`** | build | **the apply unit** — one per explorer, paste into the admin modal |
+| `references.csv` / `references.md` | audit | combined across explorers, in `--out` |
+| `bulk_redirects.json` | preflight `--record` | combined record; **not postable** |
 
 ## Notes & gotchas
 
@@ -195,3 +312,23 @@ spreadsheet for a human reviewer / topic owner to confirm before redirects are c
 - Re-running `extract_views.py` overwrites the CSVs and `_sources.json` but **not** your `mapping_rules.py`.
 - `mapping.json` needs `_sources.json`; if you extracted before this output existed, just
   re-run `extract_views.py` once (it preserves `mapping_rules.py`), then `build_mapping.py`.
+- **One payload per explorer is a correctness requirement**, not a convention: the endpoint's
+  schema has a single `catchAll`, so a merged file would silently drop all but one.
+- **There is no bulk delete** — only `DELETE /api/multi-dims/:id/redirects/:redirectId`, one
+  row at a time. A 460-row batch posted wrongly is expensive to undo, which is why the
+  preflight exists.
+- **Explorer redirects never reach `_redirects`** (`getRecentMultiDimRedirects` excludes
+  non-`/grapher/` sources), so there is no static-redirect fallback and no one-week window —
+  they live only in the baked redirect map.
+- **Matched source params are deleted from the outgoing URL and unmatched ones leak through.**
+  The target view's params win; `country=`, `time=`, `tab=` ride through untouched, which is
+  what a reader following an old link wants.
+- **An explorer view's id is positional row order** — a re-saved TSV renumbers every id that
+  `mapping_proposal.csv`, the review HTML and `sourceViewId` key on. That is what
+  `viewsFingerprint` detects; `configMd5` is only a secondary signal, since it flips on any
+  FAUST edit and gating on it would force a needless re-review.
+- **Algolia keeps indexing the explorer** until the next index build, so it can still appear
+  in site search after the redirect exists.
+- **Retiring the explorer row itself is separate** from the redirect: deleting it makes
+  `linkedChart` unresolvable, so `Chart` blocks render nothing and tiles vanish. The five
+  WB/WID inequality explorers migrated in July are the worked example.

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -262,6 +262,13 @@ and compares. Without that, the gate reads a CSV from an earlier run and cannot 
 added an embed since, or an audit folder carried over from another migration — both of which
 would read as a clean audit while the redirect is about to break something live.
 
+It also records `mappingDigests`, binding the audit to the mapping its **advice** came from.
+Every replacement URL in `references.md` is derived from the mapping, so rebuilding the mapping
+with different targets invalidates that advice while the explorer's own references — and so the
+reference digest — stay identical. This is the one staleness with no second chance: an operator
+who repoints an embed at the wrong view leaves it no longer naming the explorer, so no later
+sweep can ever surface the mistake. Preflight blocks on it before the reference gate reports.
+
 **Unverifiable is a blocker, not a warning**, in all three cases — no extraction pair, no
 `mapping.json`, no reference digest. A warning does not reach the exit code, so `Ready` would
 print over a report stating in plain words that the payload's provenance is unknown. Re-running

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -243,11 +243,25 @@ exist that differ from the payload; or embedded references are outstanding. A **
 `references.csv` is a blocker too — "never looked" must not read like "looked and found
 nothing".
 
-That payload-vs-extraction check earns its place: the payload and `_sources.json` are separate
-files, so re-running `extract_views.py` without a successful rebuild — or with a rebuild that
-aborted on duplicate conditions, which happens *after* `mapping.json` is written but *before*
-the payload is — leaves the OLD payload beside the NEW extraction. The fingerprint check passes
-in that state, because it validates the extraction, not the rules about to be posted.
+Two of those checks exist because **nothing else ties the payload to the run that produced it**,
+and an aborted or skipped rebuild leaves a stale one in place. `build_mapping.py` writes
+`mapping_proposal.csv` and `mapping.json` *before* `admin_bulk_payload.json`, and aborts between
+them on duplicate conditions — so the artifacts a human reviews can describe one build while the
+payload about to be posted comes from another, with the fingerprint check none the wiser (it
+validates the extraction, not the rules). Preflight therefore checks both ends:
+
+- the payload's **source conditions** against `explorer_views.csv` + `_sources.json`, which
+  catches an extraction re-run with no rebuild at all;
+- the payload **as a whole** against the transform of the `mapping.json` beside it, which is
+  what catches a rebuild that aborted in between — including one where only the *targets*
+  changed, invisible to any source-side check.
+
+The reference gate is bound to live state the same way. `audit_references.py` records a
+`referenceDigests` entry per explorer in `references_manifest.json`; preflight re-runs the sweep
+and compares. Without that, the gate reads a CSV from an earlier run and cannot see a page that
+added an embed since, or an audit folder carried over from another migration — both of which
+would read as a clean audit while the redirect is about to break something live. An audit
+predating the digests reports as unverifiable rather than clean.
 
 A retired explorer whose redirects are all live reports `DONE` and exits 0. That is the
 finished state, not an error. But retirement does not retire the **target** side: an MDIM that

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -308,13 +308,13 @@ that is not the route (and no explorer config in the repo carries `isPublished: 
 Then remove the explorer's ETL footprint — and **never delete a step without archiving it**
 (see `CLAUDE.md`). Delete the step's `.py` **and its sibling `.config.yml`** (the periodic archive sweep only knows `.py`, which is why orphaned configs
 exist on disk today), remove the `dag/*.yml` entry, `make check`, **commit**; then run
-`etl archive-dag` and commit `dag/archive/*.yml` separately, since it reads *committed*
+`.venv/bin/etl archive-dag` and commit `dag/archive/*.yml` separately, since it reads *committed*
 history. `git checkout` anything unrelated it sweeps in. Archive anything now orphaned
 upstream — a garden step that existed only to feed this explorer — in a second round.
 
 > **Grep before deleting a shared explorer data step.** Some are consumed **off-DAG**, by
 > scripts fetching their published catalog CSVs by URL. Those consumers are invisible to
-> `etl archive-dag`, so the step looks like a safe leaf when it is not. Search for its catalog
+> `.venv/bin/etl archive-dag`, so the step looks like a safe leaf when it is not. Search for its catalog
 > URL first and keep it until every consumer is retired.
 
 Track these steps with `TodoWrite` in the chat. **Do not generate a checklist file**, and

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -260,8 +260,13 @@ The reference gate is bound to live state the same way. `audit_references.py` re
 `referenceDigests` entry per explorer in `references_manifest.json`; preflight re-runs the sweep
 and compares. Without that, the gate reads a CSV from an earlier run and cannot see a page that
 added an embed since, or an audit folder carried over from another migration — both of which
-would read as a clean audit while the redirect is about to break something live. An audit
-predating the digests reports as unverifiable rather than clean.
+would read as a clean audit while the redirect is about to break something live.
+
+**Unverifiable is a blocker, not a warning**, in all three cases — no extraction pair, no
+`mapping.json`, no reference digest. A warning does not reach the exit code, so `Ready` would
+print over a report stating in plain words that the payload's provenance is unknown. Re-running
+`extract_views.py` / `build_mapping.py` / `audit_references.py` is the cheap way to clear any of
+them; posting an artifact nothing backs is not.
 
 A retired explorer whose redirects are all live reports `DONE` and exits 0. That is the
 finished state, not an error. But retirement does not retire the **target** side: an MDIM that

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -179,6 +179,13 @@ The **source** view is identified by the explorer slug + dimension **name→disp
 **slug→choice-slug** (the MDIM URL query params). Unresolved views are kept with
 `target: null` so the API can see the full picture; a consumer typically skips them.
 
+> **An unresolved view is not a view left alone.** The endpoint reports `target: null` entries
+> as `skipped`, so they get no rule of their own — and the catch-all constrains no params, so
+> it matches them instead. Those URLs land on the target MDIM's **default** view, carrying the
+> explorer's own params into the grapher URL, rather than on anything equivalent to the view
+> that was asked for. Leaving views unresolved is a deliberate call (they may genuinely have no
+> MDIM counterpart), never a no-op; preflight reports the count so it gets made on purpose.
+
 **`catchAll` is always present**: it redirects the bare explorer URL (no query params) — and
 serves as the sensible fallback for any view a consumer doesn't route individually — to the
 best-fitting MDIM with **no query params**, which grapher renders as that MDIM's default view
@@ -231,12 +238,22 @@ every entry for that explorer**. Blockers: the explorer path is already a site-r
 source, or the *target* of one (the chain case); the slug collides with a chart's old slug; a
 target MDIM is missing or unpublished; the target `/grapher/<slug>` is itself a redirect
 source; two views share a source condition; the view fingerprint no longer matches the live
-explorer; redirects already exist that differ from the payload; or embedded references are
-outstanding. A **missing** `references.csv` is a blocker too — "never looked" must not read
-like "looked and found nothing".
+explorer; the payload was not built from the extraction sitting beside it; redirects already
+exist that differ from the payload; or embedded references are outstanding. A **missing**
+`references.csv` is a blocker too — "never looked" must not read like "looked and found
+nothing".
+
+That payload-vs-extraction check earns its place: the payload and `_sources.json` are separate
+files, so re-running `extract_views.py` without a successful rebuild — or with a rebuild that
+aborted on duplicate conditions, which happens *after* `mapping.json` is written but *before*
+the payload is — leaves the OLD payload beside the NEW extraction. The fingerprint check passes
+in that state, because it validates the extraction, not the rules about to be posted.
 
 A retired explorer whose redirects are all live reports `DONE` and exits 0. That is the
-finished state, not an error.
+finished state, not an error. But retirement does not retire the **target** side: an MDIM that
+has since been unpublished, rebuilt, re-slugged or edited in place breaks redirects that are
+already in the DB, and no explorer row is left to notice it. So every target check runs for a
+retired explorer too, and a slug carrying any blocker is never reported `DONE`.
 
 Non-zero exit means **do not post anything**.
 

--- a/.claude/skills/map-explorer-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/audit_references.py
@@ -44,16 +44,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "find-chart-referen
 from redirect_rules import build_source_rules, choice_values, resolve_explorer_url  # noqa: E402
 from reference_report import (  # noqa: E402
     INFO,
-    POST_TYPE_PATH,
     RED,
     TAILSCALE_SUFFIX_RE,
     YELLOW,
     archie_component,
     cell,
-    deep_link,
     find_in_doc,
+    page_deep_link,
     page_type,
-    public_page_url,
     reference_digest,
     run_sweep,
 )
@@ -151,13 +149,12 @@ def resolve_missing_slugs(runs: dict[str, dict]) -> None:
 
 
 def _where_url(ref: dict, host: str, admin: str) -> str:
-    """Public URL of the referencing page, scrolled to the reference — "" when it has none."""
-    ptype = page_type(ref)
-    if ptype and POST_TYPE_PATH.get(ptype, "") is None:
-        return ""  # fragment / homepage: no reader-facing URL exists
-    return deep_link(ref["where_path"], ref.get("text") or "", host, admin) or public_page_url(
-        ptype, ref["where"], host
-    )
+    """Public URL of the referencing page, scrolled to the reference — "" when it has none.
+
+    Shared, because resolving the base from the page TYPE rather than from `where_path` is what
+    keeps a data-insight or author page from being linked at the site root, where it 404s.
+    """
+    return page_deep_link(ref, host, admin)
 
 
 def severity_of(ref: dict, component: str) -> str:

--- a/.claude/skills/map-explorer-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/audit_references.py
@@ -1,0 +1,493 @@
+"""Show where each explorer being redirected is linked or embedded, and where it will land.
+
+READ-ONLY. The surface sweep lives in the `find-chart-references` skill — this script is the
+redirect-specific consumer: it runs that sweep for N explorers, then resolves each
+referencing URL through the redirect rules the mapping would create, so the report says not
+just *what* points at the explorer but *which view the reader ends up on*.
+
+Severity is derived from what actually breaks, not from the sweep's `kind`, because the
+explorer timeline differs from the chart one in a way that matters:
+
+  RED   an embedded explorer. The renderer fetches the explorer page and parses its HTML, so
+        once the URL 302s to a grapher page the block renders nothing. It breaks the moment
+        the redirect is CREATED — not later at unpublish, as with charts — because the
+        explorer redirect is checked on every request, ahead of the page itself.
+  RED   a site redirect pointing at the explorer: a blocker. The admin endpoint refuses such
+        a source as a chain, and it caches per-source checks, so one row fails every entry.
+  YELLOW a prose link (the 302 carries it, but the href should skip the hop) or a homepage
+        explorer tile (a plain link with bake-time text: keeps working, but advertises a
+        retired explorer).
+  INFO  the referencing page is unpublished or a draft.
+
+Any row can additionally be flagged ⚠️ when its params no longer resolve to the view the
+author meant — see `redirect_rules.resolve_explorer_url`.
+
+Usage:
+    ENV_FILE=<prod creds> DATA_API_ENV=production .venv/bin/python \
+        .claude/skills/map-explorer-to-mdim/scripts/audit_references.py \
+        --mapping ai/<a>-mdim-mapping --mapping ai/<b>-mdim-mapping \
+        --out ai/<combined>-redirects
+"""
+
+import argparse
+import csv
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from urllib.parse import parse_qsl
+
+from etl.config import OWID_ENV
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts"))
+from redirect_rules import build_source_rules, choice_values, resolve_explorer_url  # noqa: E402
+from reference_report import (  # noqa: E402
+    INFO,
+    POST_TYPE_PATH,
+    RED,
+    TAILSCALE_SUFFIX_RE,
+    YELLOW,
+    archie_component,
+    cell,
+    deep_link,
+    find_in_doc,
+    page_type,
+    public_page_url,
+    run_sweep,
+)
+
+REFERENCE_COLUMNS = [
+    "severity", "explorer", "surface", "component", "page_type", "kind", "where", "where_url",
+    "doc_edit_url", "doc_preview_url", "find_in_doc", "context", "old_url",
+    "match", "matched_view_id", "matched_target_mdim", "stale_params", "leftover_params",
+    "replacement_url", "fix",
+]  # fmt: skip
+
+GDOC_SURFACES = ("gdoc", "gdoc (url link)", "data insight")
+
+# What each ArchieML component does with the explorer decides whether the redirect breaks it.
+# `chart`, `key-insights` and `front-matter` all resolve the explorer by fetching its page and
+# parsing the HTML, so they render nothing once the URL redirects. `explorer-tiles` is the one
+# EMBED-kind component that only builds an <a href>, so it survives — hence a component-level
+# override rather than trusting `kind` alone.
+COMPONENT_LABELS = {
+    "chart": "Embedded explorers",
+    "key-insights": "Embedded explorers (key insights)",
+    "front-matter": "Front-matter explorer URLs",
+    "span-link": "Text links",
+    "explorer-tiles": "Homepage explorer tiles",
+}
+COMPONENT_ORDER = ("chart", "key-insights", "front-matter", "span-link", "explorer-tiles")
+SURVIVES_REDIRECT = ("explorer-tiles",)
+
+BREAKS_FIX = (
+    "replace the block with the MDIM view **before** the redirect is created — the embed "
+    "breaks the same instant, because it renders by fetching the explorer page"
+)
+COMPONENT_FIXES = {
+    "chart": BREAKS_FIX,
+    "key-insights": BREAKS_FIX,
+    "front-matter": "update the grapher-url in the front matter before the redirect is created",
+    "span-link": "update the href (the 302 covers it meanwhile)",
+    "explorer-tiles": "re-point the tile at the MDIM: it keeps working, but advertises a retired explorer",
+}
+REDIRECT_FIX = (
+    "BLOCKER — repoint or delete this site redirect first. Repoint unless it is a vanity path "
+    "nothing links to: deleting a row whose source is a real URL turns that URL into a 404. "
+    "Admin: /admin/site-redirects (delete) then POST /api/site-redirects/new with the MDIM target"
+)
+
+
+def load_mappings(paths: list[str]) -> dict[str, dict]:
+    """{explorer slug -> {mapping, dir, rules, dim_names, choices}} for each --mapping dir."""
+    out: dict[str, dict] = {}
+    for raw in paths:
+        d = Path(raw)
+        if not d.is_dir():
+            d = d.parent
+        mapping_path = d / "mapping.json"
+        if not mapping_path.exists():
+            raise SystemExit(f"Not found: {mapping_path}. Run extract_views.py + build_mapping.py first.")
+        mapping = json.loads(mapping_path.read_text())
+        slug = mapping["explorer"]["slug"]
+        if slug in out:
+            raise SystemExit(f"Two --mapping dirs both describe explorer {slug!r}: {out[slug]['dir']} and {d}")
+        dim_names, choices = choice_values(d)
+        out[slug] = {
+            "mapping": mapping,
+            "dir": d,
+            "rules": build_source_rules(mapping),
+            "dim_names": dim_names,
+            "choices": choices,
+        }
+    return out
+
+
+def resolve_missing_slugs(runs: dict[str, dict]) -> None:
+    """Fill in target MDIM slugs for runs extracted before they were recorded.
+
+    A mapping built by an older extraction carries no `mdimSlug`, and without it every
+    replacement URL would be `/grapher/`. Resolve by catalogPath rather than refusing to run,
+    so an old proposal can still be audited.
+    """
+    missing = {r.catalog_path for run in runs.values() for r in run["rules"] if not r.mdim_slug and r.catalog_path}
+    if not missing:
+        return
+    df = OWID_ENV.read_sql(
+        "SELECT catalogPath, slug FROM multi_dim_data_pages WHERE catalogPath IN %(cps)s",
+        params={"cps": tuple(sorted(missing))},
+    )
+    by_path = dict(zip(df["catalogPath"], df["slug"]))
+    unknown = sorted(missing - set(by_path))
+    if unknown:
+        print(f"warning: no MDIM row for {unknown} — their replacement URLs will be incomplete")
+    for run in runs.values():
+        run["rules"] = [
+            r if r.mdim_slug else type(r)(**{**r.__dict__, "mdim_slug": by_path.get(r.catalog_path, "")})
+            for r in run["rules"]
+        ]
+
+
+def _where_url(ref: dict, host: str, admin: str) -> str:
+    """Public URL of the referencing page, scrolled to the reference — "" when it has none."""
+    ptype = page_type(ref)
+    if ptype and POST_TYPE_PATH.get(ptype, "") is None:
+        return ""  # fragment / homepage: no reader-facing URL exists
+    return deep_link(ref["where_path"], ref.get("text") or "", host, admin) or public_page_url(
+        ptype, ref["where"], host
+    )
+
+
+def severity_of(ref: dict, component: str) -> str:
+    """RED / YELLOW / INFO from what the redirect actually does to this surface."""
+    if ref["surface"] == "site redirect":
+        return RED  # a blocker regardless of the referencing page's state
+    if not ref["published"]:
+        return INFO
+    if component in SURVIVES_REDIRECT:
+        return YELLOW
+    return RED if ref["kind"] == "embed" else YELLOW
+
+
+def build_rows(runs: dict[str, dict], raw: list[dict], host: str, admin: str) -> list[dict]:
+    rows = []
+    for ref in raw:
+        run = runs.get(ref["subject"])
+        if run is None:
+            continue
+        component = archie_component(ref) if ref["surface"] in GDOC_SURFACES else ref["surface"]
+        query = dict(parse_qsl((ref["query_string"] or "").lstrip("?"), keep_blank_values=True))
+        resolved = resolve_explorer_url(run["rules"], query, host, run["choices"], run["dim_names"])
+        is_gdoc = ref["surface"] in GDOC_SURFACES and ref.get("surface_id")
+        severity = severity_of(ref, component)
+
+        if ref["surface"] == "site redirect":
+            fix = REDIRECT_FIX
+        else:
+            fix = COMPONENT_FIXES.get(component, "migrate this reference by hand")
+        if resolved.match.startswith("catch-all (stale") or resolved.match.startswith("catch-all (partial"):
+            fix += " — ⚠️ and pick the view deliberately: its current params no longer select one"
+
+        old_url = f"{host}/explorers/{ref['subject']}" + (
+            f"?{(ref['query_string'] or '').lstrip('?')}" if ref["query_string"] else ""
+        )
+        rows.append(
+            {
+                "severity": severity,
+                "explorer": ref["subject"],
+                "surface": ref["surface"],
+                "component": component,
+                "page_type": page_type(ref) if is_gdoc else "",
+                "kind": ref["kind"],
+                "where": ref["where"],
+                # No link at all for a page type with no public route (a fragment, the
+                # homepage): `where_path` for those is "/" or empty, so a deep link would
+                # point at the site root, which reads as a real destination and is not one.
+                "where_url": _where_url(ref, host, admin),
+                "doc_edit_url": f"https://docs.google.com/document/d/{ref['surface_id']}/edit" if is_gdoc else "",
+                "doc_preview_url": f"{admin}/gdocs/{ref['surface_id']}/preview" if is_gdoc else "",
+                "find_in_doc": find_in_doc(ref) if is_gdoc else "",
+                "context": ref["context"],
+                "old_url": old_url,
+                "match": resolved.match,
+                "matched_view_id": (resolved.rule.view_id if resolved.rule else "") or "",
+                "matched_target_mdim": resolved.rule.mdim if resolved.rule else "",
+                "stale_params": ", ".join(f"{k}={v}" for k, v in sorted(resolved.stale_params.items())),
+                "leftover_params": ", ".join(sorted(resolved.leftover_params)),
+                "replacement_url": resolved.url,
+                "fix": fix,
+            }
+        )
+    order = {RED: 0, YELLOW: 1, INFO: 2}
+    rows.sort(key=lambda r: (order[r["severity"]], r["component"], r["explorer"], r["where"]))
+    return rows
+
+
+def write_csv(out: Path, rows: list[dict]) -> Path:
+    path = out / "references.csv"
+    with open(path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=REFERENCE_COLUMNS)
+        w.writeheader()
+        for row in rows:
+            w.writerow({k: row.get(k, "") for k in REFERENCE_COLUMNS})
+    return path
+
+
+def gdoc_table(group: list[dict]) -> list[str]:
+    """One table per fix: doc links, the search string, and where the reference lands."""
+    by_fix: dict[str, list[dict]] = defaultdict(list)
+    for row in group:
+        by_fix[row["fix"]].append(row)
+    lines: list[str] = []
+    for fix in sorted(by_fix):
+        if lines:
+            lines.append("")
+        lines += [f"Fix: {fix}", ""]
+        lines += ["| Explorer | Where | Open | Find in doc | Lands on |", "|---|---|---|---|---|"]
+        for row in by_fix[fix]:
+            opens = " · ".join(
+                part
+                for part in (
+                    f"[📄 doc]({row['doc_edit_url']})" if row["doc_edit_url"] else "",
+                    f"[👁 preview]({row['doc_preview_url']})" if row["doc_preview_url"] else "",
+                    f"[🔗 page]({row['where_url']})" if row["where_url"] else "",
+                )
+                if part
+            )
+            find = f"`{cell(row['find_in_doc'], 55, marker='')}`" if row["find_in_doc"] else "—"
+            lands = row["match"]
+            if row["replacement_url"]:
+                label = cell(row["replacement_url"].split("/grapher/", 1)[-1], 52)
+                lands = f"[`{label}`]({row['replacement_url']})<br>_{row['match']}_"
+            if row["stale_params"]:
+                lands += f"<br>⚠️ dead choice: `{cell(row['stale_params'], 60)}`"
+            where = cell(row["where"] or "(no slug)", 40) + (f" _{row['page_type']}_" if row["page_type"] else "")
+            lines.append(f"| `{cell(row['explorer'], 34)}` | {where} | {opens} | {find} | {lands} |")
+    return lines
+
+
+def rollup(runs: dict[str, dict], rows: list[dict]) -> list[str]:
+    """Per-explorer go/no-go: is this one safe to redirect yet?"""
+    lines = [
+        "| Explorer | refs | 🔴 breaks | 🟡 links | → view | → catch-all | ⚠️ wrong view | inbound redirects | verdict |",
+        "|---|---|---|---|---|---|---|---|---|",
+    ]
+    for slug in sorted(runs):
+        mine = [r for r in rows if r["explorer"] == slug]
+        breaks = [r for r in mine if r["severity"] == RED and r["surface"] != "site redirect"]
+        inbound = [r for r in mine if r["surface"] == "site redirect"]
+        links = [r for r in mine if r["severity"] == YELLOW]
+        to_view = [r for r in mine if r["match"] == "view"]
+        to_catch = [r for r in mine if r["match"].startswith("catch-all")]
+        wrong = [r for r in mine if r["stale_params"] or "partial" in r["match"]]
+        if inbound:
+            verdict = "⛔ blocked (inbound redirect)"
+        elif breaks:
+            verdict = f"migrate {len(breaks)} embed(s) first"
+        elif wrong:
+            verdict = "review the ⚠️ rows, then go"
+        else:
+            verdict = "✅ no blockers"
+        lines.append(
+            f"| `{slug}` | {len(mine)} | {len(breaks)} | {len(links)} | {len(to_view)} | "
+            f"{len(to_catch)} | {len(wrong)} | {len(inbound)} | {verdict} |"
+        )
+    return lines
+
+
+def write_markdown(out: Path, runs: dict[str, dict], rows: list[dict], gaps: list[str]) -> Path:
+    path = out / "references.md"
+    blockers = [r for r in rows if r["surface"] == "site redirect"]
+    breaks = [r for r in rows if r["severity"] == RED and r["surface"] != "site redirect"]
+    links = [r for r in rows if r["severity"] == YELLOW]
+    drafts = [r for r in rows if r["severity"] == INFO]
+    wrong = [r for r in rows if r["stale_params"] or "partial" in r["match"]]
+
+    lines = [
+        "# What references the explorers being redirected",
+        "",
+        f"{len(runs)} explorer(s) · {len(rows)} reference(s). **{len(breaks)} break the moment the "
+        f"redirect exists**, {len(links)} are links the 302 covers, {len(wrong)} would land on the "
+        "wrong view.",
+        "",
+        "> [!WARNING]",
+        "> **Creating the redirect darkens a live explorer immediately.** An explorer redirect is "
+        "checked on *every* request to `/explorers/*`, before the explorer page is served — so it "
+        "beats the baked explorer and any site redirect, and fires while the explorer is still "
+        "published. Everything that *embeds* the explorer breaks in that same instant, because "
+        "those embeds render by fetching the explorer page and parsing it. There is no staged "
+        "rollout, and removing redirects afterwards is one row at a time.",
+        "",
+    ]
+
+    if blockers:
+        lines += [
+            f"## ⛔ Blockers to clear before applying ({len(blockers)})",
+            "",
+            "A site redirect pointing at the explorer makes the bulk endpoint reject the redirect as "
+            "a chain — and it caches its per-source checks, so one row fails **every** entry for that "
+            "explorer, not one row.",
+            "",
+        ]
+        lines += gdoc_table(blockers) if all(r["doc_edit_url"] for r in blockers) else _bullets(blockers)
+        lines.append("")
+
+    doc_rows = [r for r in rows if r["severity"] in (RED, YELLOW) and r["surface"] != "site redirect"]
+    if doc_rows:
+        lines += [
+            f"## 📝 Google Doc edits ({len(doc_rows)})",
+            "",
+            "Embedded explorers and text links are listed together — one editing pass per doc covers "
+            "both. 🔴 sections break when the redirect is created; 🟡 sections keep working behind the "
+            "302.",
+            "",
+        ]
+        by_comp: dict[str, list[dict]] = defaultdict(list)
+        for row in doc_rows:
+            by_comp[row["component"]].append(row)
+        ordered = [c for c in COMPONENT_ORDER if c in by_comp] + sorted(set(by_comp) - set(COMPONENT_ORDER))
+        for comp in ordered:
+            group = by_comp[comp]
+            emoji = "🔴" if any(r["severity"] == RED for r in group) else "🟡"
+            lines += [f"### {emoji} {COMPONENT_LABELS.get(comp, comp)} ({len(group)})", ""]
+            lines += gdoc_table(group) if all(r["doc_edit_url"] for r in group) else _bullets(group)
+            lines.append("")
+
+    if wrong:
+        lines += [
+            f"## ⚠️ References that will land on the wrong view ({len(wrong)})",
+            "",
+            "These carry parameters that no longer select a view — either naming a choice the explorer "
+            "has dropped, or only some of its dimensions. Today the explorer quietly falls back to a "
+            "default; after the redirect they land on the MDIM's default view. So the fix is to author "
+            "the intended MDIM view URL, not to swap the URL mechanically.",
+            "",
+            "| Explorer | Where | Why | Currently lands on |",
+            "|---|---|---|---|",
+        ]
+        for row in wrong:
+            why = (
+                f"dead choice `{cell(row['stale_params'], 55)}`" if row["stale_params"] else "only some dimensions set"
+            )
+            target = f"[`{cell(row['replacement_url'].split('/grapher/', 1)[-1], 46)}`]({row['replacement_url']})"
+            lines.append(f"| `{cell(row['explorer'], 30)}` | {cell(row['where'], 40)} | {why} | {target} |")
+        lines.append("")
+
+    lines += [f"## 📊 Coverage per explorer ({len(runs)})", ""]
+    lines += rollup(runs, rows)
+    lines.append("")
+
+    if drafts:
+        lines += [f"## ℹ️ Unpublished / draft ({len(drafts)})", "", "No reader impact — listed for completeness.", ""]
+        lines += _bullets(drafts)
+        lines.append("")
+
+    lines += [
+        "---",
+        "",
+        "**Embedded explorers** render the explorer page inside the article; **text links** are "
+        "hyperlinks in prose; **front-matter explorer URLs** are the `explorer-url`/`grapher-url` "
+        "field in a data insight's header; **homepage explorer tiles** are links with bake-time "
+        "titles. 📄 opens the Google Doc · 👁 the admin previewer (works for drafts) · 🔗 the "
+        "published page, scrolled to the reference. **Find in doc** is a copy-paste search string. "
+        "**Lands on** is computed with grapher's own matching rules, so it is where the reader "
+        "actually ends up once the redirect exists.",
+        "",
+        "## What's still open",
+        "",
+        (
+            f"**Handed off** — {len(blockers)} site redirect(s) to repoint and {len(breaks)} embed(s) to "
+            "migrate, both before anything is applied. Each names the surface and the replacement URL."
+            if blockers or breaks
+            else "**Handed off** — nothing. No blocker and no embed needs migrating before applying."
+        ),
+        "",
+        (
+            f"**Proposed** — {len(links)} link(s) the 302 already covers, worth updating to skip the hop"
+            + (f", and {len(wrong)} reference(s) whose target view needs a decision" if wrong else "")
+            + "."
+            if links or wrong
+            else "**Proposed** — nothing pending a decision."
+        ),
+        "",
+        "**Unverified** — for an explorer subject the sweep covers article links and embeds only: it "
+        "does **not** cover data insights that store the reference elsewhere, static visualizations, "
+        "key-chart slots, or narrative charts, and it cannot enumerate a legacy CSV/TSV-backed "
+        "explorer's own views. Whether the redirects themselves would be accepted is checked by "
+        "`preflight.py`, not here.",
+        "",
+    ]
+    if gaps:
+        lines += [
+            f"This run also skipped {len(gaps)} surface(s) or subject(s) — an empty result for these "
+            "means UNKNOWN, not that nothing references them:",
+            "",
+            *[f"- {g}" for g in gaps],
+            "",
+        ]
+    path.write_text("\n".join(lines))
+    return path
+
+
+def _bullets(group: list[dict]) -> list[str]:
+    lines = []
+    for row in group:
+        where = f"[{row['where']}]({row['where_url']})" if row["where_url"] else row["where"]
+        lines.append(f"- **{row['explorer']}** in {where} — {row['context']}")
+        lines.append(f"    - now: {row['old_url']}")
+        if row["replacement_url"]:
+            lines.append(f"    - lands on: {row['replacement_url']} _({row['match']})_")
+        lines.append(f"    - fix: {row['fix']}")
+    return lines
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Audit what links or embeds the explorers in a redirect proposal.")
+    ap.add_argument("--mapping", action="append", required=True, help="A mapping dir (repeatable)")
+    ap.add_argument("--out", default=None, help="Output folder (required with >1 --mapping)")
+    ap.add_argument("--host", default=None, help="Base URL for links (default: the DB environment's site)")
+    args = ap.parse_args()
+
+    runs = load_mappings(args.mapping)
+    if args.out:
+        out = Path(args.out)
+        out.mkdir(parents=True, exist_ok=True)
+    elif len(args.mapping) == 1:
+        out = next(iter(runs.values()))["dir"]
+    else:
+        raise SystemExit("--out is required when more than one --mapping is given")
+
+    host = (args.host or OWID_ENV.site or "https://ourworldindata.org").rstrip("/")
+    admin = TAILSCALE_SUFFIX_RE.sub("", (OWID_ENV.admin_site or "https://admin.owid.io/admin").rstrip("/"))
+    print(f"grapher DB: {OWID_ENV.name}")
+    print(f"explorers: {', '.join(sorted(runs))}")
+
+    resolve_missing_slugs(runs)
+    subject_args = [arg for slug in sorted(runs) for arg in ("--explorer", slug)]
+    raw, gaps = run_sweep(subject_args)
+
+    rows = build_rows(runs, raw, host, admin)
+    csv_path = write_csv(out, rows)
+    md_path = write_markdown(out, runs, rows, gaps)
+
+    counts: dict[str, int] = defaultdict(int)
+    for row in rows:
+        counts[row["severity"]] += 1
+    blockers = sum(1 for r in rows if r["surface"] == "site redirect")
+    print(
+        f"\nreferences: {len(rows)}  (blockers: {blockers} | break on redirect: {counts[RED] - blockers} | "
+        f"links: {counts[YELLOW]} | drafts: {counts[INFO]})"
+    )
+    wrong = [r for r in rows if r["stale_params"] or "partial" in r["match"]]
+    if wrong:
+        print(f"⚠️  {len(wrong)} reference(s) would land on the MDIM's default view rather than an intended one:")
+        for row in wrong[:10]:
+            print(f"  {row['explorer']} in {row['where']}: {row['stale_params'] or row['match']}")
+    print(f"\n-> {csv_path}")
+    print(f"-> {md_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/map-explorer-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/audit_references.py
@@ -41,7 +41,7 @@ from etl.config import OWID_ENV
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts"))
-from redirect_rules import build_source_rules, choice_values, resolve_explorer_url  # noqa: E402
+from redirect_rules import build_source_rules, choice_values, payload_digest, resolve_explorer_url  # noqa: E402
 from reference_report import (  # noqa: E402
     INFO,
     RED,
@@ -115,6 +115,9 @@ def load_mappings(paths: list[str]) -> dict[str, dict]:
         dim_names, choices = choice_values(d)
         out[slug] = {
             "mapping": mapping,
+            # Digested BEFORE resolve_missing_slugs mutates the mapping in memory, so it is a
+            # digest of the file on disk — which is what preflight can recompute.
+            "mappingDigest": payload_digest(mapping),
             "dir": d,
             "rules": build_source_rules(mapping),
             "dim_names": dim_names,
@@ -234,6 +237,13 @@ def write_manifest(out: Path, runs: dict[str, dict], rows: list[dict], gaps: lis
     re-runs the sweep and recomputes them, so an audit that no longer describes the live site —
     a page that added an embed since, or a folder reused from another migration — is rejected
     instead of being read as clean.
+
+    `mappingDigests` binds the audit to the mapping its ADVICE came from, which the reference
+    digest cannot: every replacement URL in `references.md` is derived from the mapping, so
+    rebuilding the mapping with different targets invalidates that advice while the explorer's
+    own references stay identical. Nothing live reveals the difference. Following stale advice
+    migrates an embed to the wrong MDIM view, and once the embed no longer names the explorer no
+    later sweep can find it — so this is the one staleness that cannot be caught after the fact.
     """
     per: dict[str, int] = {slug: 0 for slug in runs}
     for row in rows:
@@ -242,6 +252,7 @@ def write_manifest(out: Path, runs: dict[str, dict], rows: list[dict], gaps: lis
         "explorers": sorted(runs),
         "referenceCounts": per,
         "referenceDigests": {slug: reference_digest(raw, slug) for slug in sorted(runs)},
+        "mappingDigests": {slug: runs[slug]["mappingDigest"] for slug in sorted(runs)},
         "total": len(rows),
         "gaps": gaps,
     }

--- a/.claude/skills/map-explorer-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/audit_references.py
@@ -224,6 +224,28 @@ def build_rows(runs: dict[str, dict], raw: list[dict], host: str, admin: str) ->
     return rows
 
 
+def write_manifest(out: Path, runs: dict[str, dict], rows: list[dict], gaps: list[str]) -> Path:
+    """Record WHICH explorers were audited, and with what result.
+
+    Necessary because a clean audit produces no rows: an explorer nothing references
+    contributes nothing to references.csv, so a consumer deriving coverage from the rows alone
+    cannot tell "audited, found nothing" from "never audited" — and would gate on it forever.
+    The manifest is the positive record of the run.
+    """
+    per: dict[str, int] = {slug: 0 for slug in runs}
+    for row in rows:
+        per[row["explorer"]] = per.get(row["explorer"], 0) + 1
+    manifest = {
+        "explorers": sorted(runs),
+        "referenceCounts": per,
+        "total": len(rows),
+        "gaps": gaps,
+    }
+    path = out / "references_manifest.json"
+    path.write_text(json.dumps(manifest, indent=2) + "\n")
+    return path
+
+
 def write_csv(out: Path, rows: list[dict]) -> Path:
     path = out / "references.csv"
     with open(path, "w", newline="") as f:
@@ -470,6 +492,7 @@ def main() -> int:
     rows = build_rows(runs, raw, host, admin)
     csv_path = write_csv(out, rows)
     md_path = write_markdown(out, runs, rows, gaps)
+    manifest_path = write_manifest(out, runs, rows, gaps)
 
     counts: dict[str, int] = defaultdict(int)
     for row in rows:
@@ -486,6 +509,7 @@ def main() -> int:
             print(f"  {row['explorer']} in {row['where']}: {row['stale_params'] or row['match']}")
     print(f"\n-> {csv_path}")
     print(f"-> {md_path}")
+    print(f"-> {manifest_path}  (which explorers were audited — preflight reads this)")
     return 0
 
 

--- a/.claude/skills/map-explorer-to-mdim/scripts/audit_references.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/audit_references.py
@@ -54,6 +54,7 @@ from reference_report import (  # noqa: E402
     find_in_doc,
     page_type,
     public_page_url,
+    reference_digest,
     run_sweep,
 )
 
@@ -224,13 +225,18 @@ def build_rows(runs: dict[str, dict], raw: list[dict], host: str, admin: str) ->
     return rows
 
 
-def write_manifest(out: Path, runs: dict[str, dict], rows: list[dict], gaps: list[str]) -> Path:
-    """Record WHICH explorers were audited, and with what result.
+def write_manifest(out: Path, runs: dict[str, dict], rows: list[dict], gaps: list[str], raw: list[dict]) -> Path:
+    """Record WHICH explorers were audited, with what result, and against what live state.
 
     Necessary because a clean audit produces no rows: an explorer nothing references
     contributes nothing to references.csv, so a consumer deriving coverage from the rows alone
     cannot tell "audited, found nothing" from "never audited" — and would gate on it forever.
     The manifest is the positive record of the run.
+
+    `referenceDigests` makes that record *verifiable* rather than merely present: preflight
+    re-runs the sweep and recomputes them, so an audit that no longer describes the live site —
+    a page that added an embed since, or a folder reused from another migration — is rejected
+    instead of being read as clean.
     """
     per: dict[str, int] = {slug: 0 for slug in runs}
     for row in rows:
@@ -238,6 +244,7 @@ def write_manifest(out: Path, runs: dict[str, dict], rows: list[dict], gaps: lis
     manifest = {
         "explorers": sorted(runs),
         "referenceCounts": per,
+        "referenceDigests": {slug: reference_digest(raw, slug) for slug in sorted(runs)},
         "total": len(rows),
         "gaps": gaps,
     }
@@ -492,7 +499,7 @@ def main() -> int:
     rows = build_rows(runs, raw, host, admin)
     csv_path = write_csv(out, rows)
     md_path = write_markdown(out, runs, rows, gaps)
-    manifest_path = write_manifest(out, runs, rows, gaps)
+    manifest_path = write_manifest(out, runs, rows, gaps, raw)
 
     counts: dict[str, int] = defaultdict(int)
     for row in rows:

--- a/.claude/skills/map-explorer-to-mdim/scripts/build_mapping.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/build_mapping.py
@@ -253,8 +253,11 @@ def write_admin_payload(out: Path, mapping: dict, allow_duplicates: bool) -> tup
             "--allow-duplicate-conditions to drop the later duplicates and report them."
         )
     if errors:
-        drop = {id(b) for _, b in clashes}
-        payload["redirects"] = [r for r in payload.get("redirects") or [] if id(r) not in drop]
+        # Match on sourceViewId: `clashes` holds SourceRule objects built from the payload, so
+        # comparing object identity against the payload's own dicts could never match and the
+        # rows the report claimed to drop would still be posted — and then rejected.
+        drop = {b.source_view_id for _, b in clashes if b.source_view_id is not None}
+        payload["redirects"] = [r for r in payload.get("redirects") or [] if r.get("sourceViewId") not in drop]
 
     path = out / "admin_bulk_payload.json"
     path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")

--- a/.claude/skills/map-explorer-to-mdim/scripts/build_mapping.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/build_mapping.py
@@ -146,10 +146,18 @@ def write_mapping_json(
     # because an empty string reads like a real empty slug — the consumers resolve a missing
     # one from the DB instead.
     slug_of = {m["short"]: m.get("slug") for m in mdims_meta if m.get("slug")}
+    # {mdim short -> {view id -> {configId, md5}}}: the rendering each target was reviewed
+    # against. Carried so preflight can detect a view whose config was edited in place, which
+    # changes neither its id nor its dimensions.
+    views_of = {m["short"]: (m.get("views") or {}) for m in mdims_meta}
 
-    def with_slug(mdim: str, target: dict) -> dict:
+    def with_slug(mdim: str, target: dict, view_id: str = "") -> dict:
         if slug_of.get(mdim):
             target["mdimSlug"] = slug_of[mdim]
+        reviewed = views_of.get(mdim, {}).get(view_id) if view_id else None
+        if reviewed:
+            target["viewConfigId"] = reviewed.get("configId", "")
+            target["viewConfigMd5"] = reviewed.get("md5", "")
         return target
 
     catch_all = {
@@ -179,6 +187,7 @@ def write_mapping_json(
                     "viewId": m.view_id,
                     "dimensions": m.target,
                 },
+                m.view_id,
             )
             sharers = ids_by_target[(m.mdim, m.view_id)]
             if len(sharers) > 1:

--- a/.claude/skills/map-explorer-to-mdim/scripts/build_mapping.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/build_mapping.py
@@ -32,9 +32,18 @@ import argparse
 import csv
 import importlib.util
 import json
+import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from redirect_rules import (  # noqa: E402
+    build_source_rules,
+    duplicate_conditions,
+    strip_empty,
+    views_fingerprint,
+)
 
 
 @dataclass
@@ -130,14 +139,30 @@ def write_mapping_json(
     params, which grapher renders as that MDIM's default view.
     """
     catalog_path_of = {m["short"]: m["catalogPath"] for m in mdims_meta}
+    # `mdimSlug` is what a /grapher/<slug> URL needs. Carrying it here means the audit and
+    # preflight can build target URLs from the mapping alone; the bulk endpoint's Zod schema
+    # strips unknown keys, so adding it does not affect what can be posted. It is OMITTED
+    # rather than emitted empty when unknown (a run extracted before slugs were recorded),
+    # because an empty string reads like a real empty slug — the consumers resolve a missing
+    # one from the DB instead.
+    slug_of = {m["short"]: m.get("slug") for m in mdims_meta if m.get("slug")}
+
+    def with_slug(mdim: str, target: dict) -> dict:
+        if slug_of.get(mdim):
+            target["mdimSlug"] = slug_of[mdim]
+        return target
+
     catch_all = {
         "source": {"explorerSlug": explorer_slug},
-        "target": {
-            "mdim": default_mdim,
-            "catalogPath": catalog_path_of.get(default_mdim),
-            "viewId": None,
-            "dimensions": {},
-        },
+        "target": with_slug(
+            default_mdim,
+            {
+                "mdim": default_mdim,
+                "catalogPath": catalog_path_of.get(default_mdim),
+                "viewId": None,
+                "dimensions": {},
+            },
+        ),
     }
     redirects = []
     for m in mappings:
@@ -146,12 +171,15 @@ def write_mapping_json(
             "source": {"explorerSlug": explorer_slug, "dimensions": m.dims},
         }
         if m.resolved:
-            record["target"] = {
-                "mdim": m.mdim,
-                "catalogPath": catalog_path_of.get(m.mdim),
-                "viewId": m.view_id,
-                "dimensions": m.target,
-            }
+            record["target"] = with_slug(
+                m.mdim,
+                {
+                    "mdim": m.mdim,
+                    "catalogPath": catalog_path_of.get(m.mdim),
+                    "viewId": m.view_id,
+                    "dimensions": m.target,
+                },
+            )
             sharers = ids_by_target[(m.mdim, m.view_id)]
             if len(sharers) > 1:
                 record["sharedTargetSourceIds"] = [int(s) for s in sharers]
@@ -164,7 +192,15 @@ def write_mapping_json(
     payload = {
         "explorer": {"slug": explorer_slug, "dimensions": explorer_dims},
         "targets": [
-            {"mdim": m["short"], "catalogPath": m["catalogPath"], "dimensions": m["dimensions"]} for m in mdims_meta
+            {
+                "mdim": m["short"],
+                "catalogPath": m["catalogPath"],
+                "dimensions": m["dimensions"],
+                # Only present for runs extracted after these were recorded.
+                **({"mdimSlug": m["slug"]} if m.get("slug") else {}),
+                **({"published": m["published"]} if m.get("published") is not None else {}),
+            }
+            for m in mdims_meta
         ],
         "stats": {"total": len(mappings), "resolved": resolved, "unresolved": len(mappings) - resolved},
         "catchAll": catch_all,
@@ -175,10 +211,83 @@ def write_mapping_json(
     return path
 
 
+def write_admin_payload(out: Path, mapping: dict, allow_duplicates: bool) -> tuple[Path, int, list[str]]:
+    """Write the apply-ready `admin_bulk_payload.json` — one explorer per file.
+
+    Two differences from `mapping.json`, both load-bearing:
+
+    1. **Empty-valued source dimensions are deleted.** The request-time matcher compares a
+       condition against the incoming URL's params, and an absent param is not an empty
+       string — so a condition of `{"Period": ""}` can never match, and every view carrying
+       one silently falls through to the catch-all instead of its intended target. This is
+       the one mistake that yields a payload the endpoint accepts and then serves wrongly.
+    2. **Duplicate conditions abort.** Once stripped, two views can collapse to the same
+       condition; the endpoint rejects the second, so the row would be unreachable. Failing
+       here beats discovering it at apply time, when there is no bulk undo.
+
+    `mapping.json` keeps the empties: it is the faithful record of the explorer's view grid.
+    One file per explorer is a correctness requirement, not a convention — the endpoint's
+    schema has a single `catchAll`, so a merged file would silently drop all but one.
+    """
+    payload = json.loads(json.dumps(mapping))  # deep copy; mapping.json must stay unstripped
+    stripped = 0
+    for holder in [payload.get("catchAll") or {}, *(payload.get("redirects") or [])]:
+        dims = (holder.get("source") or {}).get("dimensions")
+        if not dims:
+            continue
+        kept = strip_empty(dims)
+        stripped += len(dims) - len(kept)
+        holder["source"]["dimensions"] = kept
+
+    clashes = duplicate_conditions(build_source_rules(payload))
+    errors = [
+        f"views {a.source_view_id or 'catchAll'} and {b.source_view_id or 'catchAll'} both reduce to "
+        f"condition {a.condition or '{}'} — the endpoint rejects the second, so it would never serve"
+        for a, b in clashes
+    ]
+    if errors and not allow_duplicates:
+        raise SystemExit(
+            "Duplicate source conditions — refusing to write a payload with unreachable rows:\n  "
+            + "\n  ".join(errors)
+            + "\nFix the mapping so each view has a distinct condition, or pass "
+            "--allow-duplicate-conditions to drop the later duplicates and report them."
+        )
+    if errors:
+        drop = {id(b) for _, b in clashes}
+        payload["redirects"] = [r for r in payload.get("redirects") or [] if id(r) not in drop]
+
+    path = out / "admin_bulk_payload.json"
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+    return path, stripped, errors
+
+
+def check_fingerprint(out: Path, sources: dict, dim_names: list[str], rows: list[list[str]]) -> None:
+    """Abort when `explorer_views.csv` no longer matches what extraction recorded.
+
+    Catches a hand-edited CSV, which would silently renumber the positional view ids that
+    every downstream artifact keys on. The live-vs-recorded check is preflight's job.
+    """
+    recorded = (sources.get("explorer") or {}).get("viewsFingerprint")
+    if not recorded:
+        return  # extracted before fingerprints existed; preflight still checks against live
+    actual = views_fingerprint(dim_names, rows)
+    if actual != recorded:
+        raise SystemExit(
+            f"explorer_views.csv does not match _sources.json ({actual} != {recorded}).\n"
+            "The view grid changed since extraction, so the positional ids in every artifact "
+            "are no longer trustworthy. Re-run extract_views.py, re-review, and rebuild."
+        )
+
+
 def main():
     ap = argparse.ArgumentParser(description="Build the explorer->MDIM mapping proposal.")
     ap.add_argument(
         "--out", required=True, help="Folder with explorer_views.csv, multidim_*_views.csv, mapping_rules.py"
+    )
+    ap.add_argument(
+        "--allow-duplicate-conditions",
+        action="store_true",
+        help="Drop later duplicate source conditions instead of aborting (they can never serve).",
     )
     args = ap.parse_args()
     out = Path(args.out)
@@ -203,6 +312,8 @@ def main():
             f"EXPLORER_DIMENSIONS has {len(rules.EXPLORER_DIMENSIONS)} names but "
             f"explorer_views.csv has {n_dims} dimension columns."
         )
+
+    check_fingerprint(out, sources, rules.EXPLORER_DIMENSIONS, [r[1:] for r in exp_rows])
 
     # MDIM views: short -> (dim_slugs, {tuple(values): view_id})
     mdim_dims = {}
@@ -279,10 +390,21 @@ def main():
         out, explorer_slug, rules.EXPLORER_DIMENSIONS, sources["mdims"], ids_by_target, mappings, default_mdim
     )
 
+    mapping = json.loads(json_path.read_text())
+    payload_path, stripped, dup_errors = write_admin_payload(out, mapping, args.allow_duplicate_conditions)
+
     # Report
     resolved = sum(1 for m in mappings if m.resolved)
     print(f"-> {path}")
-    print(f"-> {json_path}")
+    print(f"-> {json_path}  (record: empty source dimensions kept)")
+    print(f"-> {payload_path}  (APPLY THIS: paste into the admin bulk-redirect modal)")
+    n_entries = len(mapping.get("redirects") or []) + (1 if (mapping.get("catchAll") or {}).get("target") else 0)
+    print(
+        f"   payload entries: {n_entries} (of which skipped at apply: {len(mappings) - resolved})"
+        f" | empty source-dim values stripped: {stripped}"
+    )
+    for err in dup_errors:
+        print(f"   DROPPED duplicate: {err}")
     print(f"explorer views: {len(mappings)}  |  resolved: {resolved}  |  unresolved: {len(mappings) - resolved}")
     n_views = defaultdict(int)
     view_ids = defaultdict(set)

--- a/.claude/skills/map-explorer-to-mdim/scripts/build_mapping.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/build_mapping.py
@@ -39,9 +39,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from redirect_rules import (  # noqa: E402
-    build_source_rules,
-    duplicate_conditions,
-    strip_empty,
+    drop_duplicate_entries,
+    strip_payload,
     views_fingerprint,
 )
 
@@ -238,17 +237,9 @@ def write_admin_payload(out: Path, mapping: dict, allow_duplicates: bool) -> tup
     One file per explorer is a correctness requirement, not a convention — the endpoint's
     schema has a single `catchAll`, so a merged file would silently drop all but one.
     """
-    payload = json.loads(json.dumps(mapping))  # deep copy; mapping.json must stay unstripped
-    stripped = 0
-    for holder in [payload.get("catchAll") or {}, *(payload.get("redirects") or [])]:
-        dims = (holder.get("source") or {}).get("dimensions")
-        if not dims:
-            continue
-        kept = strip_empty(dims)
-        stripped += len(dims) - len(kept)
-        holder["source"]["dimensions"] = kept
-
-    clashes = duplicate_conditions(build_source_rules(payload))
+    # Via the shared transform, so preflight can re-derive this byte-for-byte and prove the
+    # payload on disk was built from the mapping.json beside it.
+    payload, stripped, clashes = strip_payload(mapping)
     errors = [
         f"views {a.source_view_id or 'catchAll'} and {b.source_view_id or 'catchAll'} both reduce to "
         f"condition {a.condition or '{}'} — the endpoint rejects the second, so it would never serve"
@@ -262,11 +253,7 @@ def write_admin_payload(out: Path, mapping: dict, allow_duplicates: bool) -> tup
             "--allow-duplicate-conditions to drop the later duplicates and report them."
         )
     if errors:
-        # Match on sourceViewId: `clashes` holds SourceRule objects built from the payload, so
-        # comparing object identity against the payload's own dicts could never match and the
-        # rows the report claimed to drop would still be posted — and then rejected.
-        drop = {b.source_view_id for _, b in clashes if b.source_view_id is not None}
-        payload["redirects"] = [r for r in payload.get("redirects") or [] if r.get("sourceViewId") not in drop]
+        payload = drop_duplicate_entries(payload, clashes)
 
     path = out / "admin_bulk_payload.json"
     path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")

--- a/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
@@ -31,48 +31,23 @@ import argparse
 import csv
 import json
 import re
+import sys
 from pathlib import Path
 
 from sqlalchemy import text
 
 from etl.config import OWID_ENV
 
-WIDGET_SUFFIXES = ("Dropdown", "Radio", "Checkbox")
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from redirect_rules import (  # noqa: E402
+    parse_explorer_views,
+    views_fingerprint,
+)
 
 
 def slugify(value: str) -> str:
     """Lowercase + underscores; only used to *suggest* value->slug matches."""
     return re.sub(r"_+", "_", re.sub(r"[^a-z0-9]+", "_", value.strip().lower())).strip("_")
-
-
-def dim_name(col: str) -> str:
-    """'Disaster Type Dropdown' -> 'Disaster Type'."""
-    parts = col.split(" ")
-    return " ".join(parts[:-1]) if parts and parts[-1] in WIDGET_SUFFIXES else col
-
-
-# ----- Explorer -----------------------------------------------------------------
-
-
-def parse_explorer_views(tsv: str):
-    """Return (dim_names, rows) from the graphers block of an explorer TSV."""
-    lines = tsv.split("\n")
-    try:
-        gi = next(i for i, ln in enumerate(lines) if ln.rstrip("\r") == "graphers")
-    except StopIteration:
-        raise SystemExit("No 'graphers' block found in explorer TSV.")
-
-    header = lines[gi + 1].split("\t")
-    dim_cols = [(j, dim_name(name)) for j, name in enumerate(header) if name.split(" ")[-1] in WIDGET_SUFFIXES]
-    dim_names = [name for _, name in dim_cols]
-
-    rows = []
-    for ln in lines[gi + 2 :]:
-        if not ln.startswith("\t"):  # blank line or next top-level key ends the block
-            break
-        fields = ln.split("\t")
-        rows.append([fields[j] if j < len(fields) else "" for j, _ in dim_cols])
-    return dim_names, rows
 
 
 def write_explorer_csv(out: Path, dim_names, rows) -> Path:
@@ -94,9 +69,15 @@ def short_name_of(catalog_path: str) -> str:
 
 
 def get_mdim_views(catalog_path: str):
-    """Return (dim_slugs, rows) for a published MDIM from multi_dim_data_pages.config."""
+    """Return (mdim_id, slug, published, dim_slugs, rows) for an MDIM.
+
+    The id/slug/published triple travels into `_sources.json` so the payload can carry
+    `mdimSlug` without a second DB round-trip, and so preflight can gate on publication:
+    the bulk endpoint refuses a redirect to an unpublished MDIM at create time, and the
+    baker filters on `published` again, so an unpublished target silently produces nothing.
+    """
     df = OWID_ENV.read_sql(
-        text("SELECT config FROM multi_dim_data_pages WHERE catalogPath = :cp"),
+        text("SELECT id, slug, published, config FROM multi_dim_data_pages WHERE catalogPath = :cp"),
         params={"cp": catalog_path},
     )
     if df.empty:
@@ -110,7 +91,7 @@ def get_mdim_views(catalog_path: str):
     used = set().union(*(v["dimensions"].keys() for v in views)) if views else set()
     dim_slugs = [s for s in order if s in used]  # config order, only dims that vary in views
     rows = [[v["dimensions"].get(s, "") for s in dim_slugs] for v in views]
-    return dim_slugs, rows
+    return int(df["id"].iloc[0]), df["slug"].iloc[0] or "", bool(df["published"].iloc[0]), dim_slugs, rows
 
 
 def write_mdim_csv(out: Path, short: str, prefix: str, dim_slugs, rows) -> Path:
@@ -204,18 +185,34 @@ def build_scaffold(out: Path, explorer_slug, dim_names, exp_rows, mdims) -> Path
     return path
 
 
-def write_sources_json(out: Path, explorer_slug, dim_names, mdims) -> Path:
+def write_sources_json(out: Path, explorer_slug, dim_names, exp_rows, mdims, is_published, config_md5) -> Path:
     """Persist the identifiers build_mapping.py needs to emit the redirect mapping.json.
 
-    mdims: list of dicts {short, prefix, catalog_path, dim_slugs, rows}.
+    mdims: list of dicts {short, prefix, catalog_path, mdim_id, slug, published, dim_slugs, rows}.
+
+    `viewsFingerprint` is the staleness signal an explorer view has never had — its id is
+    positional row order, so a re-saved TSV renumbers every id that `mapping_proposal.csv`,
+    the review HTML and `sourceViewId` key on, with nothing to detect it. `configMd5` is
+    kept only as a secondary signal: it flips on any FAUST edit, so gating on it would force
+    a needless re-review (see preflight's EDITED warning).
     """
     data = {
-        "explorer": {"slug": explorer_slug, "dimensions": dim_names},
+        "explorer": {
+            "slug": explorer_slug,
+            "dimensions": dim_names,
+            "isPublished": is_published,
+            "viewCount": len(exp_rows),
+            "viewsFingerprint": views_fingerprint(dim_names, exp_rows),
+            "configMd5": config_md5,
+        },
         "mdims": [
             {
                 "short": m["short"],
                 "prefix": m["prefix"],
                 "catalogPath": m["catalog_path"],
+                "multiDimId": m["mdim_id"],
+                "slug": m["slug"],
+                "published": m["published"],
                 "dimensions": m["dim_slugs"],
             }
             for m in mdims
@@ -258,24 +255,49 @@ def main():
     check_db_connection()
 
     # Explorer
-    df = OWID_ENV.read_sql(text("SELECT tsv FROM explorers WHERE slug = :slug"), params={"slug": args.explorer})
+    df = OWID_ENV.read_sql(
+        text("SELECT tsv, isPublished, configMd5 FROM explorers WHERE slug = :slug"),
+        params={"slug": args.explorer},
+    )
     if df.empty:
         raise SystemExit(f"Explorer not found: {args.explorer!r}")
+    is_published = bool(df["isPublished"].iloc[0])
+    config_md5 = df["configMd5"].iloc[0] or ""
     dim_names, exp_rows = parse_explorer_views(df["tsv"].iloc[0])
     p = write_explorer_csv(out, dim_names, exp_rows)
     print(f"explorer: {len(exp_rows)} views, dims={dim_names} -> {p.name}")
+    print(f"  fingerprint {views_fingerprint(dim_names, exp_rows)} | isPublished={is_published}")
 
     # MDIMs
     mdims = []
     for i, cp in enumerate(args.mdim):
         prefix = chr(ord("A") + i)
         short = short_name_of(cp)
-        dim_slugs, rows = get_mdim_views(cp)
+        mdim_id, mdim_slug, published, dim_slugs, rows = get_mdim_views(cp)
         p = write_mdim_csv(out, short, prefix, dim_slugs, rows)
         print(f"{prefix} {short}: {len(rows)} views, dims={dim_slugs} -> {p.name}")
-        mdims.append({"short": short, "prefix": prefix, "catalog_path": cp, "dim_slugs": dim_slugs, "rows": rows})
+        if not published:
+            # Early signal only — preflight is the gate. Worth saying here because every
+            # later step looks healthy while the redirect would produce nothing at all.
+            print(
+                f"  WARNING: {cp} is NOT published. The bulk endpoint refuses a redirect to an "
+                "unpublished MDIM, and the baker filters on published again — so this target "
+                "would silently serve no redirect. Publish it before applying."
+            )
+        mdims.append(
+            {
+                "short": short,
+                "prefix": prefix,
+                "catalog_path": cp,
+                "mdim_id": mdim_id,
+                "slug": mdim_slug,
+                "published": published,
+                "dim_slugs": dim_slugs,
+                "rows": rows,
+            }
+        )
 
-    p = write_sources_json(out, args.explorer, dim_names, mdims)
+    p = write_sources_json(out, args.explorer, dim_names, exp_rows, mdims, is_published, config_md5)
     print(f"sources -> {p.name}")
 
     p = build_scaffold(out, args.explorer, dim_names, exp_rows, mdims)

--- a/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
@@ -69,7 +69,7 @@ def short_name_of(catalog_path: str) -> str:
 
 
 def get_mdim_views(catalog_path: str):
-    """Return (mdim_id, slug, published, dim_slugs, rows) for an MDIM.
+    """Return (mdim_id, slug, published, dim_slugs, rows, view_configs, default_view) for an MDIM.
 
     The id/slug/published triple travels into `_sources.json` so the payload can carry
     `mdimSlug` without a second DB round-trip, and so preflight can gate on publication:
@@ -105,7 +105,28 @@ def get_mdim_views(catalog_path: str):
         dim_slugs,
         rows,
         view_configs,
+        default_view(views, view_configs),
     )
+
+
+def default_view(views: list[dict], view_configs: list[dict]) -> dict:
+    """The view a bare `/grapher/<mdim-slug>` renders — the catch-all's real destination.
+
+    A catch-all redirect stores `viewConfigId = NULL`, so its target is whichever view the MDIM
+    resolves to for an empty selection; nothing in the payload pins it. Grapher's
+    `filterToAvailableChoices` walks the dimensions left to right and, with no choice selected,
+    takes `availableViewsBeforeSelection[0]`'s choice at every step — and the first view is in
+    every one of those filtered sets, since each step only keeps views matching choices already
+    taken from it. So an empty selection resolves to `views[0]`, and recording it needs no port
+    of the wider algorithm.
+
+    Kept in `_sources.json` and deliberately NOT in the payload: the endpoint has no field for
+    it, and adding one would change payload bytes that the byte-identical rebuild gate relies on.
+    """
+    if not views:
+        return {}
+    first, cfg = views[0], (view_configs[0] if view_configs else {})
+    return {"dimensions": dict(first.get("dimensions") or {}), **{k: cfg.get(k, "") for k in ("configId", "md5")}}
 
 
 def view_config_md5s(config_ids: list[str]) -> dict[str, str]:
@@ -243,6 +264,9 @@ def write_sources_json(out: Path, explorer_slug, dim_names, exp_rows, mdims, is_
                 "views": {
                     f"{m['prefix']}{i + 1}": vc for i, vc in enumerate(m.get("view_configs") or []) if vc["configId"]
                 },
+                # What a catch-all actually lands on. Recorded here rather than in the payload,
+                # which has no field for it and must stay byte-reproducible.
+                "defaultView": m.get("default_view") or {},
             }
             for m in mdims
         ],
@@ -302,7 +326,7 @@ def main():
     for i, cp in enumerate(args.mdim):
         prefix = chr(ord("A") + i)
         short = short_name_of(cp)
-        mdim_id, mdim_slug, published, dim_slugs, rows, view_configs = get_mdim_views(cp)
+        mdim_id, mdim_slug, published, dim_slugs, rows, view_configs, default = get_mdim_views(cp)
         p = write_mdim_csv(out, short, prefix, dim_slugs, rows)
         print(f"{prefix} {short}: {len(rows)} views, dims={dim_slugs} -> {p.name}")
         if not published:
@@ -324,6 +348,7 @@ def main():
                 "dim_slugs": dim_slugs,
                 "rows": rows,
                 "view_configs": view_configs,
+                "default_view": default,
             }
         )
 

--- a/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
@@ -91,7 +91,31 @@ def get_mdim_views(catalog_path: str):
     used = set().union(*(v["dimensions"].keys() for v in views)) if views else set()
     dim_slugs = [s for s in order if s in used]  # config order, only dims that vary in views
     rows = [[v["dimensions"].get(s, "") for s in dim_slugs] for v in views]
-    return int(df["id"].iloc[0]), df["slug"].iloc[0] or "", bool(df["published"].iloc[0]), dim_slugs, rows
+    # Each view's rendered config id, and its md5. The md5 is the only thing that changes when
+    # grapher edits a view's config IN PLACE — the id and the dimensions both survive that — so
+    # without it a mapping reviewed against the old rendering passes every check while pointing
+    # at materially different content. The chart-side workflow tracks the same field.
+    config_ids = [v.get("fullConfigId") for v in views]
+    md5s = view_config_md5s([c for c in config_ids if c])
+    view_configs = [{"configId": c, "md5": md5s.get(c, "")} for c in config_ids]
+    return (
+        int(df["id"].iloc[0]),
+        df["slug"].iloc[0] or "",
+        bool(df["published"].iloc[0]),
+        dim_slugs,
+        rows,
+        view_configs,
+    )
+
+
+def view_config_md5s(config_ids: list[str]) -> dict[str, str]:
+    """{chart_configs.id -> fullMd5} for a set of MDIM view configs."""
+    if not config_ids:
+        return {}
+    df = OWID_ENV.read_sql(
+        "SELECT id, fullMd5 FROM chart_configs WHERE id IN %(ids)s", params={"ids": tuple(sorted(set(config_ids)))}
+    )
+    return dict(zip(df["id"], df["fullMd5"]))
 
 
 def write_mdim_csv(out: Path, short: str, prefix: str, dim_slugs, rows) -> Path:
@@ -214,6 +238,11 @@ def write_sources_json(out: Path, explorer_slug, dim_names, exp_rows, mdims, is_
                 "slug": m["slug"],
                 "published": m["published"],
                 "dimensions": m["dim_slugs"],
+                # Keyed by the same A1/B2… ids as multidim_<short>_views.csv, so build_mapping
+                # can attach the reviewed rendering to each target without re-reading the DB.
+                "views": {
+                    f"{m['prefix']}{i + 1}": vc for i, vc in enumerate(m.get("view_configs") or []) if vc["configId"]
+                },
             }
             for m in mdims
         ],
@@ -273,7 +302,7 @@ def main():
     for i, cp in enumerate(args.mdim):
         prefix = chr(ord("A") + i)
         short = short_name_of(cp)
-        mdim_id, mdim_slug, published, dim_slugs, rows = get_mdim_views(cp)
+        mdim_id, mdim_slug, published, dim_slugs, rows, view_configs = get_mdim_views(cp)
         p = write_mdim_csv(out, short, prefix, dim_slugs, rows)
         print(f"{prefix} {short}: {len(rows)} views, dims={dim_slugs} -> {p.name}")
         if not published:
@@ -294,6 +323,7 @@ def main():
                 "published": published,
                 "dim_slugs": dim_slugs,
                 "rows": rows,
+                "view_configs": view_configs,
             }
         )
 

--- a/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/extract_views.py
@@ -68,6 +68,43 @@ def short_name_of(catalog_path: str) -> str:
     return catalog_path.split("#", 1)[1] if "#" in catalog_path else catalog_path.rstrip("/").split("/")[-1]
 
 
+def unique_short_names(catalog_paths: list[str]) -> list[str]:
+    """One short name per MDIM, disambiguated when two paths would derive the same one.
+
+    That name is load-bearing well beyond a filename: it names `multidim_<short>_views.csv`, it
+    keys every per-MDIM dict in `build_mapping.py` (catalogPath, slug, view metadata, the view
+    lookup table), and it is what `mapping_rules.py` returns from `route()`. So two MDIMs
+    deriving the same name would overwrite one another's views and silently send every rule that
+    named it to whichever MDIM was extracted last — a wrong target that validates cleanly all
+    the way through preflight, because every artifact agrees on it.
+
+    Collisions are easy to hit: `.../pip/gini#gini` and `.../wid/gini#gini` both reduce to
+    `gini`. A colliding name is qualified with its catalogPath's namespace, which is what
+    distinguishes them in practice and stays readable in `route()`. A name that does not collide
+    is returned untouched, so existing runs are completely unaffected.
+    """
+    base = [short_name_of(cp) for cp in catalog_paths]
+    out: list[str] = []
+    for cp, short in zip(catalog_paths, base):
+        if base.count(short) == 1:
+            out.append(short)
+            continue
+        parts = cp.split("#", 1)[0].strip("/").split("/")
+        namespace = parts[1] if len(parts) > 1 else parts[0]
+        out.append(f"{namespace}_{short}")
+    # Qualifying can still collide (same namespace and table, different version). Fail loudly
+    # rather than overwrite, since there is no further qualifier that would stay readable.
+    if len(set(out)) != len(out):
+        clashing = sorted({s for s in out if out.count(s) > 1})
+        raise SystemExit(
+            f"Two --mdim paths still derive the same short name after qualifying by namespace: {clashing}.\n  "
+            + "\n  ".join(f"{s} <- {cp}" for s, cp in zip(out, catalog_paths) if s in clashing)
+            + "\nEvery artifact and every mapping rule keys on that name, so one MDIM's views would "
+            "overwrite the other's. Map these MDIMs in separate runs."
+        )
+    return out
+
+
 def get_mdim_views(catalog_path: str):
     """Return (mdim_id, slug, published, dim_slugs, rows, view_configs, default_view) for an MDIM.
 
@@ -323,9 +360,11 @@ def main():
 
     # MDIMs
     mdims = []
-    for i, cp in enumerate(args.mdim):
+    # Resolved up front, and for all paths together, because disambiguation is only possible with
+    # every path in view — and because nothing should be written until the names are known unique.
+    shorts = unique_short_names(list(args.mdim))
+    for i, (cp, short) in enumerate(zip(args.mdim, shorts)):
         prefix = chr(ord("A") + i)
-        short = short_name_of(cp)
         mdim_id, mdim_slug, published, dim_slugs, rows, view_configs, default = get_mdim_views(cp)
         p = write_mdim_csv(out, short, prefix, dim_slugs, rows)
         print(f"{prefix} {short}: {len(rows)} views, dims={dim_slugs} -> {p.name}")

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -289,6 +289,9 @@ def target_state(catalog_paths: set[str]) -> dict[str, dict]:
             "slug": r["slug"] or "",
             "published": bool(r["published"]),
             "views": views,
+            # (signature, configId) of the view an empty selection resolves to — the catch-all's
+            # unpinned destination. First in config order; `views` preserves that order.
+            "default": next(iter(views.items()), ()),
         }
     live_md5 = view_config_md5s(config_ids)
     for t in out.values():
@@ -354,6 +357,46 @@ def revalidate_targets(rules, targets: dict[str, dict]) -> tuple[list, list, lis
             if live and live != rule.view_config_md5:
                 retargeted_views.append((rule.source_view_id, rule.view_id))
     return missing_views, reslugged, retargeted_views
+
+
+def catch_all_default(run: dict, targets: dict[str, dict]) -> tuple[str, str]:
+    """(status, message): does the catch-all still land where it did at extraction?
+
+    The catch-all row stores `viewConfigId = NULL`, so unlike every mapped rule its destination
+    is not pinned by anything in the payload — it is whichever view the MDIM resolves for an
+    empty selection, which is `views[0]` (see `extract_views.default_view`). Rebuilding the MDIM
+    can reorder its views, or edit that view's config in place, and the bare explorer URL then
+    lands somewhere nobody reviewed while every other check stays green.
+
+    A WARNING, not a blocker, and deliberately so: the destination is a moving reference by
+    construction, so any unrelated MDIM rebuild would otherwise flip an approved catch-all to
+    NOT READY with re-extraction the only way to clear it. Silent when nothing was recorded —
+    a run from before this was tracked has nothing to compare, which is not evidence of drift.
+    """
+    target = (run["payload"].get("catchAll") or {}).get("target") or {}
+    path = target.get("catalogPath")
+    recorded = next(
+        (m.get("defaultView") or {} for m in run["sources"].get("mdims") or [] if m.get("catalogPath") == path),
+        {},
+    )
+    t = targets.get(path)
+    if not recorded or t is None or not t["published"] or not t["default"]:
+        return OK, ""
+    live_dims, live_config = t["default"]
+    if dict(live_dims) != (recorded.get("dimensions") or {}):
+        return (
+            WARN,
+            f"the catch-all's DEFAULT view moved since extraction: {recorded.get('dimensions')} -> {dict(live_dims)}. "
+            "The bare explorer URL, and every unresolved view, now land on a view nobody reviewed. Re-extract to "
+            "review the new default, or set an explicit target for the catch-all.",
+        )
+    if recorded.get("md5") and live_config and live_config in t["md5"] and t["md5"][live_config] != recorded["md5"]:
+        return (
+            WARN,
+            "the catch-all's default view is the same view but its config was EDITED since extraction, so the bare "
+            "explorer URL renders something other than what was reviewed. Re-extract and re-check that view.",
+        )
+    return OK, ""
 
 
 def target_is_redirect_source(mdim_slugs: set[str]) -> set[str]:
@@ -750,6 +793,10 @@ def main() -> int:
             findings.append((WARN, slug, note))
         if not (run["payload"].get("catchAll") or {}).get("target"):
             findings.append((WARN, slug, "no catch-all — the bare explorer URL keeps serving the explorer"))
+        else:
+            status, message = catch_all_default(run, targets)
+            if status != OK:
+                findings.append((status, slug, message))
 
     if not args.no_references:
         status, message = reference_gate(out, slugs)

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -85,7 +85,14 @@ def extraction_conditions(d: Path) -> dict[int, dict[str, str]] | None:
         return None
     grid: dict[int, dict[str, str]] = {}
     with open(views_path, newline="") as f:
-        for row in csv.DictReader(f):
+        reader = csv.DictReader(f)
+        # `_sources.json` names dimension_1..N and the CSV carries those columns; extraction
+        # writes both from one list, so they can only disagree if the two files come from
+        # different runs. That is precisely what this check exists to catch, so refuse to
+        # compare rather than silently read a short row as a set of empty values.
+        if [f"dimension_{i}" for i in range(1, len(names) + 1)] != [c for c in (reader.fieldnames or []) if c != "id"]:
+            return None
+        for row in reader:
             values = [(row.get(f"dimension_{i}") or "").strip() for i in range(1, len(names) + 1)]
             grid[int(row["id"])] = strip_empty(dict(zip(names, values)))
     return grid
@@ -107,8 +114,9 @@ def payload_binding(run: dict) -> tuple[str, str]:
     if grid is None:
         return (
             WARN,
-            "no explorer_views.csv/_sources.json pair beside the payload — cannot confirm it was built from "
-            "this extraction, so a stale payload would go unnoticed",
+            "no usable explorer_views.csv/_sources.json pair beside the payload (missing, or the two disagree "
+            "on the dimension columns) — cannot confirm the payload was built from this extraction, so a "
+            "stale payload would go unnoticed here",
         )
     entries = run["payload"].get("redirects") or []
     mismatched, unknown = [], []

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -116,11 +116,16 @@ def payload_binding(run: dict) -> tuple[str, str]:
     """
     grid = extraction_conditions(run["dir"])
     if grid is None:
+        # A blocker, not a warning: warnings do not reach the exit code, so `Ready` would print
+        # over a report that says the payload's provenance is unknown. Same rule the reference
+        # gate already applies to a missing references.csv — "we could not check" must not land
+        # in the same bucket as "we checked and it is fine".
         return (
-            WARN,
-            "no usable explorer_views.csv/_sources.json pair beside the payload (missing, or the two disagree "
-            "on the dimension columns) — cannot confirm the payload was built from this extraction, so a "
-            "stale payload would go unnoticed here",
+            BLOCKER,
+            "UNVERIFIABLE PAYLOAD — no usable explorer_views.csv/_sources.json pair beside it (missing, or the "
+            "two disagree on the dimension columns), so nothing confirms this payload was built from this "
+            "extraction. Re-run extract_views.py and build_mapping.py, and re-review, rather than posting "
+            "source conditions no artifact backs.",
         )
     entries = run["payload"].get("redirects") or []
     mismatched, unknown = [], []
@@ -169,7 +174,12 @@ def payload_matches_build(run: dict) -> tuple[str, str]:
     """
     mapping_path = run["dir"] / "mapping.json"
     if not mapping_path.exists():
-        return WARN, "no mapping.json beside the payload — cannot confirm the two came from the same build"
+        return (
+            BLOCKER,
+            "UNVERIFIABLE PAYLOAD — no mapping.json beside it, so nothing confirms the payload and the reviewed "
+            "proposal came from the same build. Re-run build_mapping.py; a warning here would let `Ready` print "
+            "over a payload whose targets no artifact backs.",
+        )
     mapping = json.loads(mapping_path.read_text())
     strict, _, clashes = strip_payload(mapping)
     # Either duplicate-handling outcome is legitimate: the builder aborts on clashes unless
@@ -444,10 +454,15 @@ def audit_freshness(out: Path, slugs: list[str]) -> tuple[str, str]:
         recorded = json.loads(manifest_path.read_text()).get("referenceDigests") or {}
     stale_record = sorted(set(slugs) - set(recorded))
     if stale_record:
+        # A blocker, for the same reason a missing references.csv is one: this branch does not
+        # run the sweep, so nothing at all has looked at the live site. Warning would let
+        # `Ready` print while an embed added since that audit stays invisible — and creating the
+        # redirect breaks it on the next request.
         return (
-            WARN,
-            f"the audit recorded no verifiable reference digest for {stale_record} (it predates them), so a "
-            "reference added since cannot be detected here — re-run audit_references.py to make it checkable",
+            BLOCKER,
+            f"UNVERIFIABLE AUDIT — no reference digest recorded for {stale_record}, so references.csv cannot be "
+            "checked against the live site and anything added since it ran is invisible. Re-run "
+            "audit_references.py (it records the digest) before applying.",
         )
     raw, gaps = run_sweep([arg for slug in slugs for arg in ("--explorer", slug)])
     drifted = sorted(slug for slug in slugs if reference_digest(raw, slug) != recorded[slug])

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -486,7 +486,13 @@ def reference_gate(out: Path, slugs: list[str]) -> tuple[str, str]:
     else:
         audited = {r["explorer"] for r in rows}  # pre-manifest run: best effort
     unaudited = sorted(set(slugs) - audited)
-    breaks = [r for r in rows if r["severity"] == "RED" and r["surface"] != "site redirect"]
+    # Restricted to the explorers being preflighted, as the coverage check above already is.
+    # A combined audit covers several explorers, so counting every RED row would fail a ready
+    # payload over an embed belonging to one that is not in this run — and re-running the same
+    # combined audit could never clear it.
+    breaks = [
+        r for r in rows if r["severity"] == "RED" and r["surface"] != "site redirect" and r["explorer"] in set(slugs)
+    ]
     if unaudited:
         return BLOCKER, f"the audit did not cover {unaudited} — re-run audit_references.py for every explorer"
     if breaks:

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -1,0 +1,379 @@
+"""Validate explorer→MDIM redirect payloads against the live DB before anything is posted.
+
+READ-ONLY (nothing is written unless --record). Exits non-zero while any BLOCKER remains.
+
+Every check here mirrors a validation the admin bulk endpoint performs, or a fact about how
+the redirect is served. That matters more than on the chart side for two reasons:
+
+- **There is no bulk delete.** Redirects are removed one row at a time, so a 460-row batch
+  posted wrongly costs 460 clicks. This script is the whole safety net.
+- **The endpoint memoizes its source-side checks and re-throws the cached rejection**, so a
+  single source-level problem fails EVERY entry for that explorer, not one row. Checks are
+  therefore grouped per explorer, and their messages say so.
+
+Usage:
+    ENV_FILE=<prod creds> DATA_API_ENV=production .venv/bin/python \
+        .claude/skills/map-explorer-to-mdim/scripts/preflight.py \
+        --mapping ai/<a>-mdim-mapping --mapping ai/<b>-mdim-mapping \
+        --out ai/<combined>-redirects [--no-references] [--record <path>]
+"""
+
+import argparse
+import csv
+import json
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from etl.config import OWID_ENV
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from redirect_rules import (  # noqa: E402
+    build_source_rules,
+    duplicate_conditions,
+    parse_explorer_views,
+    views_fingerprint,
+)
+
+TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
+BLOCKER, WARN, OK = "BLOCKER", "WARN", "ok"
+
+
+def load_runs(paths: list[str]) -> dict[str, dict]:
+    """{explorer slug -> {payload, mapping, sources, dir, rules}} from each --mapping dir.
+
+    The PAYLOAD is what gets posted, so it is what gets validated — `mapping.json` keeps the
+    empty source dimensions that the payload strips, and validating the record instead of the
+    artifact would check something nobody applies.
+    """
+    runs: dict[str, dict] = {}
+    for raw in paths:
+        d = Path(raw)
+        if not d.is_dir():
+            d = d.parent
+        payload_path = d / "admin_bulk_payload.json"
+        if not payload_path.exists():
+            raise SystemExit(
+                f"Not found: {payload_path}. Run build_mapping.py — it writes the apply-ready payload "
+                "next to mapping.json."
+            )
+        payload = json.loads(payload_path.read_text())
+        slug = payload["explorer"]["slug"]
+        sources_path = d / "_sources.json"
+        runs[slug] = {
+            "dir": d,
+            "payload": payload,
+            "rules": build_source_rules(payload),
+            "sources": json.loads(sources_path.read_text()) if sources_path.exists() else {},
+        }
+    return runs
+
+
+def live_explorer_state(slugs: list[str]) -> dict[str, dict]:
+    df = OWID_ENV.read_sql(
+        "SELECT slug, tsv, isPublished, configMd5 FROM explorers WHERE slug IN %(s)s",
+        params={"s": tuple(slugs)},
+    )
+    return {r["slug"]: r for r in df.to_dict("records")}
+
+
+def existing_redirects(slugs: list[str]) -> dict[str, list[dict]]:
+    df = OWID_ENV.read_sql(
+        "SELECT source, sourceQueryParams, multiDimId, viewConfigId FROM multi_dim_redirects WHERE source IN %(s)s",
+        params={"s": tuple(f"/explorers/{s}" for s in slugs)},
+    )
+    out: dict[str, list[dict]] = defaultdict(list)
+    for r in df.to_dict("records"):
+        out[r["source"].removeprefix("/explorers/")].append(r)
+    return out
+
+
+def site_redirect_rows(slugs: list[str]) -> tuple[dict[str, list], dict[str, list]]:
+    """({slug -> rows where the explorer path is the SOURCE}, {slug -> rows where it is the TARGET}).
+
+    Both are blockers, for different reasons: a source collision is
+    `checkSourceNotSiteRedirectSource`, a target one is `checkSourceNotRedirectTarget` — the
+    chain check. The `LIKE` is re-checked in Python so `/explorers/inequality-wb` cannot
+    answer for `inequality`.
+    """
+    paths = [f"/explorers/{s}" for s in slugs]
+    df = OWID_ENV.read_sql(
+        "SELECT id, source, target FROM redirects WHERE source IN %(p)s OR target LIKE %(like)s",
+        params={"p": tuple(paths), "like": "%/explorers/%"},
+    )
+    as_source: dict[str, list] = defaultdict(list)
+    as_target: dict[str, list] = defaultdict(list)
+    for r in df.to_dict("records"):
+        for slug in slugs:
+            if r["source"] == f"/explorers/{slug}":
+                as_source[slug].append(r)
+            if re.search(rf"/explorers/{re.escape(slug)}(?:[?#/]|$)", r["target"] or ""):
+                as_target[slug].append(r)
+    return as_source, as_target
+
+
+def chart_slug_collisions(slugs: list[str]) -> set[str]:
+    """Explorer slugs that are also a chart's OLD slug (`checkSourceNotChartSlugRedirectSource`)."""
+    df = OWID_ENV.read_sql("SELECT slug FROM chart_slug_redirects WHERE slug IN %(s)s", params={"s": tuple(slugs)})
+    return set(df["slug"])
+
+
+def target_state(catalog_paths: set[str]) -> dict[str, dict]:
+    if not catalog_paths:
+        return {}
+    df = OWID_ENV.read_sql(
+        "SELECT catalogPath, id, slug, published FROM multi_dim_data_pages WHERE catalogPath IN %(c)s",
+        params={"c": tuple(sorted(catalog_paths))},
+    )
+    return {r["catalogPath"]: r for r in df.to_dict("records")}
+
+
+def target_is_redirect_source(mdim_slugs: set[str]) -> set[str]:
+    """MDIM slugs whose `/grapher/<slug>` is already a redirect source (`checkTargetNotRedirectSource`)."""
+    if not mdim_slugs:
+        return set()
+    paths = tuple(f"/grapher/{s}" for s in sorted(mdim_slugs))
+    taken: set[str] = set()
+    for sql, params in (
+        ("SELECT source FROM redirects WHERE source IN %(p)s", {"p": paths}),
+        ("SELECT source FROM multi_dim_redirects WHERE source IN %(p)s", {"p": paths}),
+    ):
+        taken |= {r.removeprefix("/grapher/") for r in OWID_ENV.read_sql(sql, params=params)["source"]}
+    df = OWID_ENV.read_sql(
+        "SELECT slug FROM chart_slug_redirects WHERE slug IN %(s)s", params={"s": tuple(sorted(mdim_slugs))}
+    )
+    return taken | set(df["slug"])
+
+
+def reference_gate(out: Path, slugs: list[str]) -> tuple[str, str]:
+    """(status, message) from the audit's own report — the surfaces the redirect breaks.
+
+    A missing `references.csv` is a BLOCKER, not a pass: 'we never looked' and 'we looked and
+    found nothing' must not produce the same verdict.
+    """
+    path = out / "references.csv"
+    if not path.exists():
+        return BLOCKER, f"no references.csv in {out} — run audit_references.py first (or pass --no-references)"
+    with open(path, newline="") as f:
+        rows = list(csv.DictReader(f))
+    audited = {r["explorer"] for r in rows}
+    unaudited = sorted(set(slugs) - audited)
+    breaks = [r for r in rows if r["severity"] == "RED" and r["surface"] != "site redirect"]
+    if unaudited and not breaks:
+        return BLOCKER, f"references.csv does not cover {unaudited} — re-run audit_references.py for every explorer"
+    if breaks:
+        per = defaultdict(int)
+        for r in breaks:
+            per[r["explorer"]] += 1
+        detail = ", ".join(f"{k}: {v}" for k, v in sorted(per.items()))
+        return BLOCKER, f"{len(breaks)} embedded reference(s) still to migrate ({detail}) — see references.md"
+    return OK, f"{len(rows)} reference(s) audited, none embedded"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Validate explorer redirect payloads before applying.")
+    ap.add_argument("--mapping", action="append", required=True, help="A mapping dir (repeatable)")
+    ap.add_argument("--out", default=None, help="Folder holding references.csv (default: the sole mapping dir)")
+    ap.add_argument("--no-references", action="store_true", help="Skip the embedded-reference gate")
+    ap.add_argument("--record", default=None, help="Also write a combined machine record to this path")
+    args = ap.parse_args()
+
+    runs = load_runs(args.mapping)
+    slugs = sorted(runs)
+    if args.out:
+        out = Path(args.out)
+    elif len(args.mapping) == 1:
+        out = next(iter(runs.values()))["dir"]
+    else:
+        raise SystemExit("--out is required when more than one --mapping is given")
+
+    admin = TAILSCALE_SUFFIX_RE.sub("", (OWID_ENV.admin_site or "https://admin.owid.io/admin").rstrip("/"))
+    print(f"Environment: {OWID_ENV.site}   READ-ONLY preflight — nothing is created here.")
+    print(f"explorers: {', '.join(slugs)}\n")
+
+    live = live_explorer_state(slugs)
+    existing = existing_redirects(slugs)
+    as_source, as_target = site_redirect_rows(slugs)
+    colliding = chart_slug_collisions(slugs)
+    all_paths = {r.catalog_path for run in runs.values() for r in run["rules"] if r.catalog_path}
+    targets = target_state(all_paths)
+    taken_targets = target_is_redirect_source({t["slug"] for t in targets.values() if t["slug"]})
+
+    findings: list[tuple[str, str, str]] = []  # (status, explorer, message)
+    for slug in slugs:
+        run = runs[slug]
+        rules = run["rules"]
+        row = live.get(slug)
+        applied = existing.get(slug, [])
+
+        if row is None:
+            if applied:
+                findings.append(
+                    (
+                        OK,
+                        slug,
+                        f"DONE — explorer retired and {len(applied)} redirect(s) already live. Nothing to apply.",
+                    )
+                )
+                continue
+            findings.append(
+                (BLOCKER, slug, "explorer is not in the `explorers` table and has no redirects — wrong slug?")
+            )
+            continue
+
+        if row["isPublished"]:
+            findings.append(
+                (
+                    WARN,
+                    slug,
+                    "explorer is still PUBLISHED — creating the redirect darkens it immediately (the redirect "
+                    "is checked on every /explorers/* request, ahead of the page itself)",
+                )
+            )
+
+        recorded = (run["sources"].get("explorer") or {}).get("viewsFingerprint")
+        if recorded:
+            dim_names, live_rows = parse_explorer_views(row["tsv"])
+            actual = views_fingerprint(dim_names, live_rows)
+            if actual != recorded:
+                findings.append(
+                    (
+                        BLOCKER,
+                        slug,
+                        f"STALE — the explorer's views changed since extraction ({recorded} -> {actual}, "
+                        f"{(run['sources']['explorer'].get('viewCount'))} -> {len(live_rows)} views). Every "
+                        "positional view id in the payload is now untrustworthy: re-run extract_views.py, "
+                        "re-review, rebuild.",
+                    )
+                )
+            elif (run["sources"].get("explorer") or {}).get("configMd5") not in (None, "", row["configMd5"]):
+                findings.append(
+                    (
+                        WARN,
+                        slug,
+                        "EDITED — the explorer's config changed but its view grid did not; mapping still valid",
+                    )
+                )
+        else:
+            findings.append(
+                (WARN, slug, "no viewsFingerprint recorded (extracted before they existed) — staleness unchecked")
+            )
+
+        for r in as_source.get(slug, []):
+            findings.append(
+                (
+                    BLOCKER,
+                    slug,
+                    f"/explorers/{slug} is already a site redirect source (id={r['id']} -> {r['target']}). The "
+                    "endpoint refuses it, and the site redirect would win anyway. Delete or repoint that row.",
+                )
+            )
+        for r in as_target.get(slug, []):
+            findings.append(
+                (
+                    BLOCKER,
+                    slug,
+                    f"CHAIN — site redirect id={r['id']} ({r['source']} -> {r['target']}) points AT this explorer. "
+                    f"The endpoint rejects it as a chain, and because it caches per-source checks this fails ALL "
+                    f"{len(rules)} entries for this explorer, not one row.\n"
+                    f"      Fix: repoint, do not just delete — a row whose source is a real URL becomes a 404. "
+                    f"Delete at {admin}/site-redirects, then POST {admin}/api/site-redirects/new with the MDIM "
+                    f"target (references.md computes it). A vanity launch path nothing links to can simply go.",
+                )
+            )
+        if slug in colliding:
+            findings.append(
+                (
+                    BLOCKER,
+                    slug,
+                    f"'{slug}' is also a chart's old slug in chart_slug_redirects — the endpoint refuses it",
+                )
+            )
+
+        for path in sorted({r.catalog_path for r in rules if r.catalog_path}):
+            t = targets.get(path)
+            if t is None:
+                findings.append((BLOCKER, slug, f"target MDIM not in multi_dim_data_pages: {path}"))
+            elif not t["published"]:
+                findings.append(
+                    (
+                        BLOCKER,
+                        slug,
+                        f"target MDIM is NOT published: {path}. The endpoint refuses it at create time and the "
+                        "baker filters on published again, so the redirect would silently serve nothing.",
+                    )
+                )
+            elif t["slug"] in taken_targets:
+                findings.append((BLOCKER, slug, f"target /grapher/{t['slug']} is itself a redirect source"))
+
+        for a, b in duplicate_conditions(rules):
+            findings.append(
+                (
+                    BLOCKER,
+                    slug,
+                    f"views {a.source_view_id or 'catchAll'} and {b.source_view_id or 'catchAll'} share the "
+                    f"condition {a.condition or '{}'} — the endpoint rejects the second, so it could never serve",
+                )
+            )
+
+        if applied:
+            have = {tuple(sorted((json.loads(r["sourceQueryParams"]) or {}).items())) for r in applied}
+            want = {tuple(sorted(r.condition.items())) for r in rules}
+            if have != want:
+                findings.append(
+                    (
+                        BLOCKER,
+                        slug,
+                        f"{len(applied)} redirect(s) already exist for this explorer and differ from the payload "
+                        f"({len(want - have)} to add, {len(have - want)} unexpected). There is NO bulk delete: "
+                        f"remove them one at a time at {admin}/multi-dim-redirects before re-applying.",
+                    )
+                )
+
+        n_skipped = sum(1 for e in run["payload"].get("redirects") or [] if not e.get("target"))
+        if n_skipped:
+            findings.append(
+                (
+                    WARN,
+                    slug,
+                    f"{n_skipped} view(s) unresolved — the endpoint reports them `skipped`; those URLs keep "
+                    "serving the explorer until the catch-all takes them",
+                )
+            )
+        if not (run["payload"].get("catchAll") or {}).get("target"):
+            findings.append((WARN, slug, "no catch-all — the bare explorer URL keeps serving the explorer"))
+
+    if not args.no_references:
+        status, message = reference_gate(out, slugs)
+        findings.append((status, "(all)", message))
+
+    print(f"{'status':8} {'explorer':38} note")
+    print("-" * 150)
+    for status, slug, message in sorted(findings, key=lambda f: ({BLOCKER: 0, WARN: 1, OK: 2}[f[0]], f[1])):
+        print(f"{status:8} {slug:38} {message}")
+
+    blockers = [f for f in findings if f[0] == BLOCKER]
+    print()
+    print(
+        "> Creating an explorer redirect takes effect on the NEXT REQUEST, while the explorer is still "
+        "published, and everything embedding it breaks at that moment. There is no bulk undo."
+    )
+    if args.record:
+        record = {"explorers": [{"slug": s, "payload": runs[s]["payload"]} for s in slugs]}
+        Path(args.record).write_text(json.dumps(record, indent=2, ensure_ascii=False) + "\n")
+        print(
+            f"\n-> {args.record}  (a RECORD, not a payload: the endpoint's schema has a single catchAll, so a "
+            "combined file would drop all but one. Post the per-explorer admin_bulk_payload.json files.)"
+        )
+    if blockers:
+        print(f"\nNOT READY: {len(blockers)} blocker(s). Nothing should be posted until each is cleared.")
+        return 1
+    print(f"\nReady: {sum(len(runs[s]['rules']) for s in slugs)} redirect rule(s) across {len(slugs)} explorer(s).")
+    for slug in slugs:
+        print(f"  paste {runs[slug]['dir']}/admin_bulk_payload.json at {admin}/multi-dim-redirects")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -35,12 +35,11 @@ from redirect_rules import (  # noqa: E402
     drop_duplicate_entries,
     duplicate_conditions,
     parse_explorer_views,
-    redirect_target_path,
     strip_empty,
     strip_payload,
     views_fingerprint,
 )
-from reference_report import reference_digest, run_sweep  # noqa: E402
+from reference_report import redirect_target_path, reference_digest, run_sweep  # noqa: E402
 
 TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
 BLOCKER, WARN, OK = "BLOCKER", "WARN", "ok"

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -29,13 +29,17 @@ from pathlib import Path
 from etl.config import OWID_ENV
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts"))
 from redirect_rules import (  # noqa: E402
     build_source_rules,
+    drop_duplicate_entries,
     duplicate_conditions,
     parse_explorer_views,
     strip_empty,
+    strip_payload,
     views_fingerprint,
 )
+from reference_report import reference_digest, run_sweep  # noqa: E402
 
 TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
 BLOCKER, WARN, OK = "BLOCKER", "WARN", "ok"
@@ -148,6 +152,38 @@ def payload_binding(run: dict) -> tuple[str, str]:
         + "; ".join(parts)
         + ". Re-run build_mapping.py and re-review; an aborted build leaves the previous payload in place, "
         "and the fingerprint check alone cannot see that."
+    )
+
+
+def payload_matches_build(run: dict) -> tuple[str, str]:
+    """(status, message): is the payload the one this run's `mapping.json` produces?
+
+    `payload_binding` only ties the payload's SOURCE side to the extraction, which leaves the
+    target side loose — and the targets are what a reviewer signs off on. `mapping.json` is
+    written from the current build immediately BEFORE the payload, and the payload is a pure
+    function of it, so re-deriving that transform proves the two came from the same build. This
+    is what catches a build that aborted between them (duplicate conditions do exactly that,
+    after mapping.json is written): `mapping_proposal.csv` and `mapping.json` then describe the
+    targets a human reviewed, while the payload still carries the previous run's, with no
+    source-side difference to give it away.
+    """
+    mapping_path = run["dir"] / "mapping.json"
+    if not mapping_path.exists():
+        return WARN, "no mapping.json beside the payload — cannot confirm the two came from the same build"
+    mapping = json.loads(mapping_path.read_text())
+    strict, _, clashes = strip_payload(mapping)
+    # Either duplicate-handling outcome is legitimate: the builder aborts on clashes unless
+    # --allow-duplicate-conditions was passed, in which case it drops the later ones.
+    candidates = [strict]
+    if clashes:
+        candidates.append(drop_duplicate_entries(json.loads(json.dumps(strict)), clashes))
+    if any(run["payload"] == candidate for candidate in candidates):
+        return OK, "payload is exactly what mapping.json builds — same build"
+    return BLOCKER, (
+        "STALE PAYLOAD — admin_bulk_payload.json is not what mapping.json next to it builds, so the two are "
+        "from different runs. mapping.json and mapping_proposal.csv are written BEFORE the payload, so a build "
+        "that aborted in between leaves a reviewed proposal beside an unreviewed payload — including different "
+        "targets. Re-run build_mapping.py and re-review before applying."
     )
 
 
@@ -393,6 +429,40 @@ def reference_gate(out: Path, slugs: list[str]) -> tuple[str, str]:
     return OK, f"{len(rows)} reference(s) audited, none embedded"
 
 
+def audit_freshness(out: Path, slugs: list[str]) -> tuple[str, str]:
+    """(status, message): does the audit on disk still describe the live site?
+
+    `reference_gate` reads a CSV an earlier run produced, so by itself it cannot see anything
+    that changed since — a page that added an explorer embed after the audit, or an audit folder
+    carried over from another migration. In both cases it reports a clean audit while the
+    redirect is about to break something live, which is the exact failure the gate exists to
+    prevent. So the sweep is re-run here and compared against the digest the audit recorded.
+    """
+    manifest_path = out / "references_manifest.json"
+    recorded = {}
+    if manifest_path.exists():
+        recorded = json.loads(manifest_path.read_text()).get("referenceDigests") or {}
+    stale_record = sorted(set(slugs) - set(recorded))
+    if stale_record:
+        return (
+            WARN,
+            f"the audit recorded no verifiable reference digest for {stale_record} (it predates them), so a "
+            "reference added since cannot be detected here — re-run audit_references.py to make it checkable",
+        )
+    raw, gaps = run_sweep([arg for slug in slugs for arg in ("--explorer", slug)])
+    drifted = sorted(slug for slug in slugs if reference_digest(raw, slug) != recorded[slug])
+    if drifted:
+        return (
+            BLOCKER,
+            f"the live references for {drifted} no longer match the audit — something links or embeds those "
+            "explorers that references.csv does not list (or this folder's audit is from another run). Re-run "
+            "audit_references.py and re-read references.md before applying.",
+        )
+    if gaps:
+        return WARN, f"live references still match the audit, but the sweep reported {len(gaps)} gap(s): {gaps[:3]}"
+    return OK, f"live references still match the audit for {len(slugs)} explorer(s)"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Validate explorer redirect payloads before applying.")
     ap.add_argument("--mapping", action="append", required=True, help="A mapping dir (repeatable)")
@@ -437,8 +507,9 @@ def main() -> int:
             )
             continue
 
-        status, message = payload_binding(run)
-        findings.append((status, slug, message))
+        for check in (payload_binding, payload_matches_build):
+            status, message = check(run)
+            findings.append((status, slug, message))
 
         if retired:
             # No explorer row means no TSV to re-fingerprint, so the source side cannot be
@@ -633,8 +704,9 @@ def main() -> int:
             findings.append((WARN, slug, "no catch-all — the bare explorer URL keeps serving the explorer"))
 
     if not args.no_references:
-        status, message = reference_gate(out, slugs)
-        findings.append((status, "(all)", message))
+        for gate in (reference_gate, audit_freshness):
+            status, message = gate(out, slugs)
+            findings.append((status, "(all)", message))
 
     print(f"{'status':8} {'explorer':38} note")
     print("-" * 150)

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -183,6 +183,48 @@ def target_is_redirect_source(mdim_slugs: set[str]) -> set[str]:
     return taken | set(df["slug"])
 
 
+def compare_applied(rules, applied: list[dict], targets: dict[str, dict], admin: str) -> tuple[str, str]:
+    """(status, message) comparing the redirects already in the DB with the payload.
+
+    Called for BOTH a live and an already-retired explorer. Presence of *some* rows is not
+    completion: a partial or wrong bulk run leaves a subset behind — often just the catch-all —
+    and if the explorer has since been deleted there is nothing else left to notice it. So the
+    conditions AND their targets are compared before anything is called done.
+    """
+
+    # A catch-all row stores sourceQueryParams as SQL NULL, so this cannot assume a JSON
+    # string — json.loads(None) raises, and every explorer that already has a catch-all
+    # applied would crash here rather than being compared.
+    def condition_of(row: dict) -> tuple:
+        raw = row["sourceQueryParams"]
+        params = json.loads(raw) if isinstance(raw, str) else (raw or {})
+        return tuple(sorted((params or {}).items()))
+
+    have = {condition_of(r): (r["multiDimId"], r["viewConfigId"]) for r in applied}
+    want = {tuple(sorted(r.condition.items())): expected_row(r, targets) for r in rules}
+    if set(have) != set(want):
+        missing, extra = len(set(want) - set(have)), len(set(have) - set(want))
+        return (
+            BLOCKER,
+            f"{len(applied)} redirect(s) exist but the set differs from the payload ({missing} missing, "
+            f"{extra} unexpected) — a partial or superseded run. There is NO bulk delete: remove the "
+            f"unexpected rows one at a time at {admin}/multi-dim-redirects, then apply the payload.",
+        )
+    retargeted = {c for c in want if have[c] != want[c]}
+    if retargeted:
+        return (
+            BLOCKER,
+            f"all {len(want)} source condition(s) exist but {len(retargeted)} point at a DIFFERENT target than "
+            f"the payload. Remove those rows at {admin}/multi-dim-redirects before re-applying — the endpoint "
+            "would reject them as duplicate sources.",
+        )
+    return (
+        OK,
+        f"DONE — all {len(want)} redirect(s) already applied and pointing at the payload's targets. Do not "
+        "paste it again; the endpoint rejects duplicate source conditions.",
+    )
+
+
 def reference_gate(out: Path, slugs: list[str]) -> tuple[str, str]:
     """(status, message) from the audit's own report — the surfaces the redirect breaks.
 
@@ -254,14 +296,19 @@ def main() -> int:
 
         if row is None:
             if applied:
-                done.add(slug)
-                findings.append(
-                    (
-                        OK,
-                        slug,
-                        f"DONE — explorer retired and {len(applied)} redirect(s) already live. Nothing to apply.",
+                status, message = compare_applied(rules, applied, targets, admin)
+                if status == OK:
+                    done.add(slug)
+                    findings.append((OK, slug, f"DONE — explorer retired; {message.removeprefix('DONE — ')}"))
+                else:
+                    findings.append(
+                        (
+                            status,
+                            slug,
+                            f"explorer is already retired, but its redirects are INCOMPLETE: {message} "
+                            "(the explorer row is gone, so nothing else would surface this)",
+                        )
                     )
-                )
                 continue
             findings.append(
                 (BLOCKER, slug, "explorer is not in the `explorers` table and has no redirects — wrong slug?")
@@ -364,8 +411,13 @@ def main() -> int:
                 continue  # already reported above
             if rule.mdim_slug and rule.mdim_slug != t["slug"]:
                 reslugged.append((rule.mdim_slug, t["slug"]))
-            if rule.target_dims and tuple(sorted(rule.target_dims.items())) not in t["views"]:
-                missing_views.append((rule.source_view_id, rule.view_id, rule.target_dims))
+            # Resolve through expected_row rather than testing signature membership: a view can
+            # be present but carry no `fullConfigId`, in which case it cannot be stored as a
+            # viewConfigId at all — the chart-side extractor drops such views from its target
+            # pool for the same reason. Membership alone would let that reach `Ready`.
+            if rule.target_dims and expected_row(rule, targets)[1] is None:
+                unstorable = tuple(sorted(rule.target_dims.items())) in t["views"]
+                missing_views.append((rule.source_view_id, rule.view_id, rule.target_dims, unstorable))
         for was, now in sorted(set(reslugged)):
             findings.append(
                 (
@@ -376,13 +428,20 @@ def main() -> int:
                 )
             )
         if missing_views:
-            sample = "; ".join(f"view {sid} ({vid}) -> {dims}" for sid, vid, dims in missing_views[:3])
+            sample = "; ".join(f"view {sid} ({vid}) -> {dims}" for sid, vid, dims, _ in missing_views[:3])
+            no_config = sum(1 for *_, unstorable in missing_views if unstorable)
+            detail = (
+                f" {no_config} of them still exist but carry no fullConfigId, so they cannot be stored as a "
+                "redirect target at all."
+                if no_config
+                else ""
+            )
             findings.append(
                 (
                     BLOCKER,
                     slug,
-                    f"{len(missing_views)} target view(s) no longer exist in the live MDIM config — the MDIM was "
-                    f"rebuilt or re-sliced since extraction. e.g. {sample}. Re-extract, re-review, rebuild.",
+                    f"{len(missing_views)} target view(s) are not usable in the live MDIM config — rebuilt or "
+                    f"re-sliced since extraction.{detail} e.g. {sample}. Re-extract, re-review, rebuild.",
                 )
             )
 
@@ -397,47 +456,10 @@ def main() -> int:
             )
 
         if applied:
-            have = {
-                tuple(sorted((json.loads(r["sourceQueryParams"]) or {}).items())): (r["multiDimId"], r["viewConfigId"])
-                for r in applied
-            }
-            want = {tuple(sorted(r.condition.items())): expected_row(r, targets) for r in rules}
-            if set(have) != set(want):
-                findings.append(
-                    (
-                        BLOCKER,
-                        slug,
-                        f"{len(applied)} redirect(s) already exist for this explorer and differ from the payload "
-                        f"({len(set(want) - set(have))} to add, {len(set(have) - set(want))} unexpected). There is "
-                        f"NO bulk delete: remove them one at a time at {admin}/multi-dim-redirects before "
-                        "re-applying.",
-                    )
-                )
-            else:
-                # Every condition is present. Whether that is DONE or a conflict depends on the
-                # TARGETS: re-posting an identical payload is rejected as duplicate sources, and
-                # a set pointing somewhere else must never read as ready.
-                retargeted = {c for c in want if have[c] != want[c]}
-                if retargeted:
-                    findings.append(
-                        (
-                            BLOCKER,
-                            slug,
-                            f"all {len(want)} source condition(s) already exist but {len(retargeted)} point at a "
-                            f"DIFFERENT target than the payload. Remove those rows at {admin}/multi-dim-redirects "
-                            "before re-applying — the endpoint would reject them as duplicate sources.",
-                        )
-                    )
-                else:
-                    done.add(slug)
-                    findings.append(
-                        (
-                            OK,
-                            slug,
-                            f"DONE — all {len(want)} redirect(s) already applied and pointing at the payload's "
-                            "targets. Do not paste it again; the endpoint rejects duplicate source conditions.",
-                        )
-                    )
+            status, message = compare_applied(rules, applied, targets, admin)
+            if status == OK:
+                done.add(slug)
+            findings.append((status, slug, message))
 
         n_skipped = sum(1 for e in run["payload"].get("redirects") or [] if not e.get("target"))
         if n_skipped:

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -67,6 +67,15 @@ def load_runs(paths: list[str]) -> dict[str, dict]:
             )
         payload = json.loads(payload_path.read_text())
         slug = payload["explorer"]["slug"]
+        # Keying by slug means a second dir for the same explorer would REPLACE the first, so one
+        # of the payloads the operator explicitly passed would never be validated while still
+        # looking like part of the ready batch. audit_references.py already refuses this; refuse
+        # it here too rather than silently validating whichever came last.
+        if slug in runs:
+            raise SystemExit(
+                f"Two --mapping dirs both describe explorer {slug!r}: {runs[slug]['dir']} and {d}. "
+                "Pass one dir per explorer — otherwise only one of those payloads gets validated."
+            )
         sources_path = d / "_sources.json"
         runs[slug] = {
             "dir": d,
@@ -666,8 +675,22 @@ def main() -> int:
                         )
                     )
             else:
+                # A blocker, like the other unverifiable states: this is the ONLY check that
+                # compares the payload's source side against the LIVE explorer, so without a
+                # recorded fingerprint nothing would notice views reordered, added or relabelled
+                # since extraction — and every positional view id in the payload would be
+                # pointing at whatever now sits in that row. `payload_binding` cannot substitute
+                # for it: it compares the payload against `explorer_views.csv`, and a legacy run
+                # has both equally stale. Unlike the retired case below, this one is clearable —
+                # re-run extract_views.py and rebuild.
                 findings.append(
-                    (WARN, slug, "no viewsFingerprint recorded (extracted before they existed) — staleness unchecked")
+                    (
+                        BLOCKER,
+                        slug,
+                        "UNVERIFIABLE SOURCE — no viewsFingerprint recorded (extracted before they existed), so "
+                        "the payload's source conditions were never compared against the live explorer. Re-run "
+                        "extract_views.py, re-review and rebuild before applying.",
+                    )
                 )
 
         for r in as_source.get(slug, []):

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -33,6 +33,7 @@ from redirect_rules import (  # noqa: E402
     build_source_rules,
     duplicate_conditions,
     parse_explorer_views,
+    strip_empty,
     views_fingerprint,
 )
 
@@ -68,6 +69,78 @@ def load_runs(paths: list[str]) -> dict[str, dict]:
             "sources": json.loads(sources_path.read_text()) if sources_path.exists() else {},
         }
     return runs
+
+
+def extraction_conditions(d: Path) -> dict[int, dict[str, str]] | None:
+    """{sourceViewId -> source condition} implied by the extraction sitting in this run's folder.
+
+    None when the pair of files needed to derive it is not there, which is the only honest
+    answer for a run predating them — the caller reports that as unchecked rather than clean.
+    """
+    sources_path, views_path = d / "_sources.json", d / "explorer_views.csv"
+    if not (sources_path.exists() and views_path.exists()):
+        return None
+    names = list((json.loads(sources_path.read_text()).get("explorer") or {}).get("dimensions") or [])
+    if not names:
+        return None
+    grid: dict[int, dict[str, str]] = {}
+    with open(views_path, newline="") as f:
+        for row in csv.DictReader(f):
+            values = [(row.get(f"dimension_{i}") or "").strip() for i in range(1, len(names) + 1)]
+            grid[int(row["id"])] = strip_empty(dict(zip(names, values)))
+    return grid
+
+
+def payload_binding(run: dict) -> tuple[str, str]:
+    """(status, message): was `admin_bulk_payload.json` built from the extraction beside it?
+
+    The payload and `_sources.json` are separate files loaded independently, so nothing ties one
+    to the other. Re-running extract_views.py refreshes `_sources.json`; if the rebuild that
+    should follow never happens — or aborts partway, which it does on duplicate conditions,
+    AFTER mapping.json is written but BEFORE the payload is — the OLD payload is left beside the
+    NEW extraction. The live-vs-recorded fingerprint check then passes (it validates the fresh
+    extraction) while every rule about to be posted still comes from the stale payload, and
+    preflight reports Ready for source conditions the explorer no longer has. So the payload's
+    own conditions are compared against the view grid on disk, not just its fingerprint.
+    """
+    grid = extraction_conditions(run["dir"])
+    if grid is None:
+        return (
+            WARN,
+            "no explorer_views.csv/_sources.json pair beside the payload — cannot confirm it was built from "
+            "this extraction, so a stale payload would go unnoticed",
+        )
+    entries = run["payload"].get("redirects") or []
+    mismatched, unknown = [], []
+    for entry in entries:
+        vid = entry.get("sourceViewId")
+        if vid not in grid:
+            unknown.append(vid)
+        elif grid[vid] != strip_empty((entry.get("source") or {}).get("dimensions") or {}):
+            mismatched.append(vid)
+    # A view missing from the payload is expected in exactly one case: its condition collapsed
+    # onto an earlier rule's and --allow-duplicate-conditions dropped it, in which case that
+    # condition is still represented by the rule that kept it. Anything else is a view the
+    # payload never mapped — an extraction that gained rows since it was built.
+    represented = {tuple(sorted(strip_empty((e.get("source") or {}).get("dimensions") or {}).items())) for e in entries}
+    represented.add(())  # the catch-all constrains nothing, so it stands in for an all-empty row
+    covered = {e.get("sourceViewId") for e in entries}
+    absent = [i for i in sorted(grid) if i not in covered and tuple(sorted(grid[i].items())) not in represented]
+    if not (mismatched or unknown or absent):
+        return OK, f"payload matches the {len(grid)}-view extraction beside it"
+    parts = []
+    if mismatched:
+        parts.append(f"{len(mismatched)} entry(ies) carry dimensions the extraction does not (e.g. {mismatched[:5]})")
+    if unknown:
+        parts.append(f"{len(unknown)} entry(ies) name view ids the extraction no longer has (e.g. {unknown[:5]})")
+    if absent:
+        parts.append(f"{len(absent)} extracted view(s) have no entry in the payload (e.g. {absent[:5]})")
+    return BLOCKER, (
+        "STALE PAYLOAD — admin_bulk_payload.json was not built from the extraction beside it: "
+        + "; ".join(parts)
+        + ". Re-run build_mapping.py and re-review; an aborted build leaves the previous payload in place, "
+        "and the fingerprint check alone cannot see that."
+    )
 
 
 def live_explorer_state(slugs: list[str]) -> dict[str, dict]:
@@ -348,65 +421,70 @@ def main() -> int:
         rules = run["rules"]
         row = live.get(slug)
         applied = existing.get(slug, [])
+        retired = row is None
 
-        if row is None:
-            if applied:
-                status, message = compare_applied(rules, applied, targets, admin)
-                if status == OK:
-                    done.add(slug)
-                    findings.append((OK, slug, f"DONE — explorer retired; {message.removeprefix('DONE — ')}"))
-                else:
-                    findings.append(
-                        (
-                            status,
-                            slug,
-                            f"explorer is already retired, but its redirects are INCOMPLETE: {message} "
-                            "(the explorer row is gone, so nothing else would surface this)",
-                        )
-                    )
-                continue
+        if retired and not applied:
             findings.append(
                 (BLOCKER, slug, "explorer is not in the `explorers` table and has no redirects — wrong slug?")
             )
             continue
 
-        if row["isPublished"]:
+        status, message = payload_binding(run)
+        findings.append((status, slug, message))
+
+        if retired:
+            # No explorer row means no TSV to re-fingerprint, so the source side cannot be
+            # rechecked against anything live. Everything on the TARGET side still decides
+            # whether the stored redirects serve what was reviewed, so the checks below run for a
+            # retired explorer too — an MDIM that has since been unpublished, rebuilt, re-slugged
+            # or edited in place breaks redirects that are already in the DB, and matching stored
+            # ids alone would report that as done.
             findings.append(
                 (
                     WARN,
                     slug,
-                    "explorer is still PUBLISHED — creating the redirect darkens it immediately (the redirect "
-                    "is checked on every /explorers/* request, ahead of the page itself)",
+                    "explorer row is gone, so its view grid cannot be re-fingerprinted against the live TSV — "
+                    "only the extraction on disk backs the payload's source conditions",
                 )
             )
-
-        recorded = (run["sources"].get("explorer") or {}).get("viewsFingerprint")
-        if recorded:
-            dim_names, live_rows = parse_explorer_views(row["tsv"])
-            actual = views_fingerprint(dim_names, live_rows)
-            if actual != recorded:
-                findings.append(
-                    (
-                        BLOCKER,
-                        slug,
-                        f"STALE — the explorer's views changed since extraction ({recorded} -> {actual}, "
-                        f"{(run['sources']['explorer'].get('viewCount'))} -> {len(live_rows)} views). Every "
-                        "positional view id in the payload is now untrustworthy: re-run extract_views.py, "
-                        "re-review, rebuild.",
-                    )
-                )
-            elif (run["sources"].get("explorer") or {}).get("configMd5") not in (None, "", row["configMd5"]):
+        else:
+            if row["isPublished"]:
                 findings.append(
                     (
                         WARN,
                         slug,
-                        "EDITED — the explorer's config changed but its view grid did not; mapping still valid",
+                        "explorer is still PUBLISHED — creating the redirect darkens it immediately (the redirect "
+                        "is checked on every /explorers/* request, ahead of the page itself)",
                     )
                 )
-        else:
-            findings.append(
-                (WARN, slug, "no viewsFingerprint recorded (extracted before they existed) — staleness unchecked")
-            )
+
+            recorded = (run["sources"].get("explorer") or {}).get("viewsFingerprint")
+            if recorded:
+                dim_names, live_rows = parse_explorer_views(row["tsv"])
+                actual = views_fingerprint(dim_names, live_rows)
+                if actual != recorded:
+                    findings.append(
+                        (
+                            BLOCKER,
+                            slug,
+                            f"STALE — the explorer's views changed since extraction ({recorded} -> {actual}, "
+                            f"{(run['sources']['explorer'].get('viewCount'))} -> {len(live_rows)} views). Every "
+                            "positional view id in the payload is now untrustworthy: re-run extract_views.py, "
+                            "re-review, rebuild.",
+                        )
+                    )
+                elif (run["sources"].get("explorer") or {}).get("configMd5") not in (None, "", row["configMd5"]):
+                    findings.append(
+                        (
+                            WARN,
+                            slug,
+                            "EDITED — the explorer's config changed but its view grid did not; mapping still valid",
+                        )
+                    )
+            else:
+                findings.append(
+                    (WARN, slug, "no viewsFingerprint recorded (extracted before they existed) — staleness unchecked")
+                )
 
         for r in as_source.get(slug, []):
             findings.append(
@@ -507,20 +585,42 @@ def main() -> int:
 
         if applied:
             status, message = compare_applied(rules, applied, targets, admin)
-            if status == OK:
+            # `compare_applied` only compares stored ids against the payload, so on its own it
+            # would call a migration done while the checks above say the target side no longer
+            # renders what was reviewed. A slug carrying a blocker is never done.
+            if status == OK and any(f[0] == BLOCKER and f[1] == slug for f in findings):
+                status, message = (
+                    WARN,
+                    f"the {len(rules)} stored redirect(s) do match the payload's targets, but the blocker(s) above "
+                    "mean the target side no longer serves what was reviewed — NOT done",
+                )
+            elif status == OK:
                 done.add(slug)
+                if retired:
+                    message = f"DONE — explorer retired; {message.removeprefix('DONE — ')}"
+            elif retired:
+                message = (
+                    f"explorer is already retired, but its redirects are INCOMPLETE: {message} "
+                    "(the explorer row is gone, so nothing else would surface this)"
+                )
             findings.append((status, slug, message))
 
         n_skipped = sum(1 for e in run["payload"].get("redirects") or [] if not e.get("target"))
         if n_skipped:
-            findings.append(
-                (
-                    WARN,
-                    slug,
-                    f"{n_skipped} view(s) unresolved — the endpoint reports them `skipped`; those URLs keep "
-                    "serving the explorer until the catch-all takes them",
+            if (run["payload"].get("catchAll") or {}).get("target"):
+                note = (
+                    f"{n_skipped} view(s) unresolved — the endpoint reports them `skipped`, so they get no rule of "
+                    "their own and the catch-all (which constrains no params) matches them instead: those URLs do "
+                    "NOT keep serving the explorer, they land on the target MDIM's DEFAULT view with the "
+                    "explorer's own params still on the URL. Fine only if those views have no MDIM equivalent — "
+                    "otherwise resolve them and rebuild before applying."
                 )
-            )
+            else:
+                note = (
+                    f"{n_skipped} view(s) unresolved — the endpoint reports them `skipped` and there is no "
+                    "catch-all, so those URLs keep serving the explorer"
+                )
+            findings.append((WARN, slug, note))
         if not (run["payload"].get("catchAll") or {}).get("target"):
             findings.append((WARN, slug, "no catch-all — the bare explorer URL keeps serving the explorer"))
 

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -30,6 +30,7 @@ from etl.config import OWID_ENV
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts"))
+from find_references import redirect_target_path  # noqa: E402
 from redirect_rules import (  # noqa: E402
     build_source_rules,
     drop_duplicate_entries,
@@ -39,7 +40,7 @@ from redirect_rules import (  # noqa: E402
     strip_payload,
     views_fingerprint,
 )
-from reference_report import redirect_target_path, reference_digest, run_sweep  # noqa: E402
+from reference_report import reference_digest, run_sweep  # noqa: E402
 
 TAILSCALE_SUFFIX_RE = re.compile(r"\.tail[0-9a-z]+\.ts\.net")
 BLOCKER, WARN, OK = "BLOCKER", "WARN", "ok"

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -30,7 +30,7 @@ from etl.config import OWID_ENV
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "find-chart-references" / "scripts"))
-from find_references import redirect_target_path  # noqa: E402
+from find_references import url_pathname  # noqa: E402
 from redirect_rules import (  # noqa: E402
     build_source_rules,
     drop_duplicate_entries,
@@ -239,7 +239,7 @@ def site_redirect_rows(slugs: list[str]) -> tuple[dict[str, list], dict[str, lis
     as_source: dict[str, list] = defaultdict(list)
     as_target: dict[str, list] = defaultdict(list)
     for r in df.to_dict("records"):
-        target_path = redirect_target_path(r["target"])
+        target_path = url_pathname(r["target"])
         for slug in slugs:
             if r["source"] == f"/explorers/{slug}":
                 as_source[slug].append(r)
@@ -324,15 +324,15 @@ def expected_row(rule, targets: dict[str, dict]) -> tuple[int | None, str | None
     return t["id"], t["views"].get(tuple(sorted(rule.target_dims.items())))
 
 
-def revalidate_targets(rules, targets: dict[str, dict]) -> tuple[list, list, list]:
-    """Per-rule target staleness: (missing_views, reslugged, retargeted_views).
+def revalidate_targets(rules, targets: dict[str, dict]) -> tuple[list, list, list, list]:
+    """Per-rule target staleness: (missing_views, reslugged, retargeted_views, broken_configs).
 
     An MDIM can be rebuilt, re-sliced or re-slugged while its catalogPath stays present and
     published, in which case the reviewed view no longer exists — and applying would reject
     those entries after creating others. It can also keep every view in place and only change
     what one of them renders, which nothing above notices.
     """
-    missing_views, reslugged, retargeted_views = [], [], []
+    missing_views, reslugged, retargeted_views, broken_configs = [], [], [], []
     for rule in rules:
         t = targets.get(rule.catalog_path)
         if t is None or not t["published"]:
@@ -348,15 +348,23 @@ def revalidate_targets(rules, targets: dict[str, dict]) -> tuple[list, list, lis
             unstorable = tuple(sorted(rule.target_dims.items())) in t["views"]
             missing_views.append((rule.source_view_id, rule.view_id, rule.target_dims, unstorable))
             continue
+        # A view naming a `fullConfigId` with no live row in `chart_configs` (or a row carrying
+        # no `fullMd5`) is a BROKEN target, not an unchanged one. Checked before the drift
+        # comparison and independently of whether a rendering was recorded, because the two
+        # absences mean opposite things: nothing recorded on our side is merely unknown, while
+        # nothing live is a target that cannot serve — and the endpoint would reject that row
+        # after creating the ones before it.
+        if config_id and not t["md5"].get(config_id):
+            broken_configs.append((rule.source_view_id, rule.view_id, config_id))
+            continue
         # Same view id, same dimensions, different rendering: grapher edits a view's chart
         # config in place. Skipped when no md5 was recorded (a run from before this was
         # tracked, or a catch-all, which points at whatever the default view happens to be) —
         # absence of a recorded rendering is not evidence of drift.
-        if rule.view_config_md5:
-            live = t["md5"].get(config_id or "", "")
-            if live and live != rule.view_config_md5:
+        if rule.view_config_md5 and config_id:
+            if t["md5"][config_id] != rule.view_config_md5:
                 retargeted_views.append((rule.source_view_id, rule.view_id))
-    return missing_views, reslugged, retargeted_views
+    return missing_views, reslugged, retargeted_views, broken_configs
 
 
 def catch_all_default(run: dict, targets: dict[str, dict]) -> tuple[str, str]:
@@ -703,7 +711,19 @@ def main() -> int:
             elif t["slug"] in taken_targets:
                 findings.append((BLOCKER, slug, f"target /grapher/{t['slug']} is itself a redirect source"))
 
-        missing_views, reslugged, retargeted_views = revalidate_targets(rules, targets)
+        missing_views, reslugged, retargeted_views, broken_configs = revalidate_targets(rules, targets)
+        if broken_configs:
+            sample = ", ".join(f"view {sid} -> {vid} (config {cid})" for sid, vid, cid in broken_configs[:4])
+            findings.append(
+                (
+                    BLOCKER,
+                    slug,
+                    f"{len(broken_configs)} target view(s) name a chart config that is missing from "
+                    f"`chart_configs`, or that carries no fullMd5 — the view cannot be stored as a redirect "
+                    f"target, so the endpoint would reject those rows AFTER creating the ones before them, with "
+                    f"no bulk undo. e.g. {sample}. Rebuild the MDIM, then re-extract and re-review.",
+                )
+            )
         if retargeted_views:
             sample = ", ".join(f"view {sid} -> {vid}" for sid, vid in retargeted_views[:4])
             findings.append(

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -157,11 +157,18 @@ def reference_gate(out: Path, slugs: list[str]) -> tuple[str, str]:
         return BLOCKER, f"no references.csv in {out} — run audit_references.py first (or pass --no-references)"
     with open(path, newline="") as f:
         rows = list(csv.DictReader(f))
-    audited = {r["explorer"] for r in rows}
+    # Coverage comes from the audit's manifest, never from the rows: an explorer nothing
+    # references contributes no rows, so deriving it from the CSV alone would report a
+    # perfectly clean audit as "not audited" and gate on it forever, unclearable by re-running.
+    manifest_path = out / "references_manifest.json"
+    if manifest_path.exists():
+        audited = set(json.loads(manifest_path.read_text()).get("explorers") or [])
+    else:
+        audited = {r["explorer"] for r in rows}  # pre-manifest run: best effort
     unaudited = sorted(set(slugs) - audited)
     breaks = [r for r in rows if r["severity"] == "RED" and r["surface"] != "site redirect"]
-    if unaudited and not breaks:
-        return BLOCKER, f"references.csv does not cover {unaudited} — re-run audit_references.py for every explorer"
+    if unaudited:
+        return BLOCKER, f"the audit did not cover {unaudited} — re-run audit_references.py for every explorer"
     if breaks:
         per = defaultdict(int)
         for r in breaks:

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -35,6 +35,7 @@ from redirect_rules import (  # noqa: E402
     drop_duplicate_entries,
     duplicate_conditions,
     parse_explorer_views,
+    redirect_target_path,
     strip_empty,
     strip_payload,
     views_fingerprint,
@@ -221,8 +222,13 @@ def site_redirect_rows(slugs: list[str]) -> tuple[dict[str, list], dict[str, lis
 
     Both are blockers, for different reasons: a source collision is
     `checkSourceNotSiteRedirectSource`, a target one is `checkSourceNotRedirectTarget` — the
-    chain check. The `LIKE` is re-checked in Python so `/explorers/inequality-wb` cannot
-    answer for `inequality`.
+    chain check. The `LIKE` is only a prefilter and is re-checked in Python, so
+    `/explorers/inequality-wb` cannot answer for `inequality`.
+
+    The target side compares the PATHNAME, not the raw string: a redirect to some other page
+    that merely mentions the explorer URL in a query or fragment (`/article?next=/explorers/foo`)
+    is not a chain, and matching it would block every entry for that explorer and send the
+    operator off to delete or repoint an unrelated redirect.
     """
     paths = [f"/explorers/{s}" for s in slugs]
     df = OWID_ENV.read_sql(
@@ -232,10 +238,11 @@ def site_redirect_rows(slugs: list[str]) -> tuple[dict[str, list], dict[str, lis
     as_source: dict[str, list] = defaultdict(list)
     as_target: dict[str, list] = defaultdict(list)
     for r in df.to_dict("records"):
+        target_path = redirect_target_path(r["target"])
         for slug in slugs:
             if r["source"] == f"/explorers/{slug}":
                 as_source[slug].append(r)
-            if re.search(rf"/explorers/{re.escape(slug)}(?:[?#/]|$)", r["target"] or ""):
+            if target_path == f"/explorers/{slug}":
                 as_target[slug].append(r)
     return as_source, as_target
 

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -36,6 +36,7 @@ from redirect_rules import (  # noqa: E402
     drop_duplicate_entries,
     duplicate_conditions,
     parse_explorer_views,
+    payload_digest,
     strip_empty,
     strip_payload,
     views_fingerprint,
@@ -446,7 +447,7 @@ def reference_gate(out: Path, slugs: list[str]) -> tuple[str, str]:
     return OK, f"{len(rows)} reference(s) audited, none embedded"
 
 
-def audit_freshness(out: Path, slugs: list[str]) -> tuple[str, str]:
+def audit_freshness(out: Path, slugs: list[str], runs: dict[str, dict]) -> tuple[str, str]:
     """(status, message): does the audit on disk still describe the live site?
 
     `reference_gate` reads a CSV an earlier run produced, so by itself it cannot see anything
@@ -456,10 +457,35 @@ def audit_freshness(out: Path, slugs: list[str]) -> tuple[str, str]:
     prevent. So the sweep is re-run here and compared against the digest the audit recorded.
     """
     manifest_path = out / "references_manifest.json"
-    recorded = {}
+    recorded, recorded_mappings = {}, {}
     if manifest_path.exists():
-        recorded = json.loads(manifest_path.read_text()).get("referenceDigests") or {}
-    stale_record = sorted(set(slugs) - set(recorded))
+        manifest = json.loads(manifest_path.read_text())
+        recorded = manifest.get("referenceDigests") or {}
+        recorded_mappings = manifest.get("mappingDigests") or {}
+
+    # The audit's ADVICE — every replacement URL in references.md — comes from the mapping, not
+    # from the live site, so a mapping rebuilt with different targets since the audit leaves the
+    # reference digest matching while the advice is wrong. Checked first, because this is the
+    # staleness that cannot be recovered from: once an operator has repointed an embed at the
+    # wrong view, it no longer names the explorer and no later sweep will ever surface it.
+    drifted_mappings = []
+    for slug in slugs:
+        run = runs.get(slug)
+        mapping_path = (run["dir"] / "mapping.json") if run else None
+        if slug not in recorded_mappings or mapping_path is None or not mapping_path.exists():
+            continue  # covered by the unverifiable-audit blocker below
+        if payload_digest(json.loads(mapping_path.read_text())) != recorded_mappings[slug]:
+            drifted_mappings.append(slug)
+    if drifted_mappings:
+        return (
+            BLOCKER,
+            f"STALE AUDIT ADVICE — the mapping changed since the audit for {drifted_mappings}, so every "
+            "replacement URL in references.md was computed from different target views. Migrating an embed to "
+            "one of those sends it to the wrong view, and it then stops naming the explorer, so no later sweep "
+            "can find the mistake. Re-run audit_references.py before touching any reference.",
+        )
+
+    stale_record = sorted(set(slugs) - (set(recorded) & set(recorded_mappings)))
     if stale_record:
         # A blocker, for the same reason a missing references.csv is one: this branch does not
         # run the sweep, so nothing at all has looked at the live site. Warning would let
@@ -467,9 +493,9 @@ def audit_freshness(out: Path, slugs: list[str]) -> tuple[str, str]:
         # redirect breaks it on the next request.
         return (
             BLOCKER,
-            f"UNVERIFIABLE AUDIT — no reference digest recorded for {stale_record}, so references.csv cannot be "
-            "checked against the live site and anything added since it ran is invisible. Re-run "
-            "audit_references.py (it records the digest) before applying.",
+            f"UNVERIFIABLE AUDIT — no reference and mapping digest recorded for {stale_record}, so "
+            "references.csv cannot be checked against the live site, nor its replacement URLs against the "
+            "mapping they came from. Re-run audit_references.py (it records both) before applying.",
         )
     raw, gaps = run_sweep([arg for slug in slugs for arg in ("--explorer", slug)])
     drifted = sorted(slug for slug in slugs if reference_digest(raw, slug) != recorded[slug])
@@ -726,9 +752,10 @@ def main() -> int:
             findings.append((WARN, slug, "no catch-all — the bare explorer URL keeps serving the explorer"))
 
     if not args.no_references:
-        for gate in (reference_gate, audit_freshness):
-            status, message = gate(out, slugs)
-            findings.append((status, "(all)", message))
+        status, message = reference_gate(out, slugs)
+        findings.append((status, "(all)", message))
+        status, message = audit_freshness(out, slugs, runs)
+        findings.append((status, "(all)", message))
 
     print(f"{'status':8} {'explorer':38} note")
     print("-" * 150)

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -120,13 +120,50 @@ def chart_slug_collisions(slugs: list[str]) -> set[str]:
 
 
 def target_state(catalog_paths: set[str]) -> dict[str, dict]:
+    """{catalogPath -> {id, slug, published, views}} where `views` maps a view's dimension
+    signature to its `fullConfigId`.
+
+    The view map is what makes target-side staleness detectable. Checking only that the MDIM
+    row exists and is published passes an MDIM that was rebuilt, re-sliced or re-slugged after
+    extraction — so preflight would report Ready for a payload whose reviewed target views no
+    longer exist, and applying it would reject some entries AFTER creating others (there is no
+    transaction, and no bulk undo). It also yields the expected `viewConfigId` per rule, which
+    is what distinguishes "already applied" from "applied differently".
+    """
     if not catalog_paths:
         return {}
     df = OWID_ENV.read_sql(
-        "SELECT catalogPath, id, slug, published FROM multi_dim_data_pages WHERE catalogPath IN %(c)s",
+        "SELECT catalogPath, id, slug, published, config FROM multi_dim_data_pages WHERE catalogPath IN %(c)s",
         params={"c": tuple(sorted(catalog_paths))},
     )
-    return {r["catalogPath"]: r for r in df.to_dict("records")}
+    out: dict[str, dict] = {}
+    for r in df.to_dict("records"):
+        cfg = json.loads(r["config"]) if isinstance(r["config"], str) else (r["config"] or {})
+        views = {
+            tuple(sorted((v.get("dimensions") or {}).items())): v.get("fullConfigId") for v in cfg.get("views") or []
+        }
+        out[r["catalogPath"]] = {
+            "id": int(r["id"]),
+            "slug": r["slug"] or "",
+            "published": bool(r["published"]),
+            "views": views,
+        }
+    return out
+
+
+def expected_row(rule, targets: dict[str, dict]) -> tuple[int | None, str | None]:
+    """The (multiDimId, viewConfigId) the endpoint would store for this rule.
+
+    A catch-all constrains no dimensions, so it is stored with `viewConfigId = NULL` (verified
+    against production) — which is why an empty target signature maps to None rather than to
+    whichever view happens to have no dimensions.
+    """
+    t = targets.get(rule.catalog_path)
+    if t is None:
+        return None, None
+    if not rule.target_dims:
+        return t["id"], None
+    return t["id"], t["views"].get(tuple(sorted(rule.target_dims.items())))
 
 
 def target_is_redirect_source(mdim_slugs: set[str]) -> set[str]:
@@ -208,6 +245,7 @@ def main() -> int:
     taken_targets = target_is_redirect_source({t["slug"] for t in targets.values() if t["slug"]})
 
     findings: list[tuple[str, str, str]] = []  # (status, explorer, message)
+    done: set[str] = set()  # explorers already fully applied — nothing to paste
     for slug in slugs:
         run = runs[slug]
         rules = run["rules"]
@@ -216,6 +254,7 @@ def main() -> int:
 
         if row is None:
             if applied:
+                done.add(slug)
                 findings.append(
                     (
                         OK,
@@ -314,6 +353,39 @@ def main() -> int:
             elif t["slug"] in taken_targets:
                 findings.append((BLOCKER, slug, f"target /grapher/{t['slug']} is itself a redirect source"))
 
+        # Per-RULE target revalidation. An MDIM can be rebuilt, re-sliced or re-slugged while
+        # its catalogPath stays present and published, in which case the reviewed view no
+        # longer exists — and applying would reject those entries after creating others.
+        missing_views = []
+        reslugged = []
+        for rule in rules:
+            t = targets.get(rule.catalog_path)
+            if t is None or not t["published"]:
+                continue  # already reported above
+            if rule.mdim_slug and rule.mdim_slug != t["slug"]:
+                reslugged.append((rule.mdim_slug, t["slug"]))
+            if rule.target_dims and tuple(sorted(rule.target_dims.items())) not in t["views"]:
+                missing_views.append((rule.source_view_id, rule.view_id, rule.target_dims))
+        for was, now in sorted(set(reslugged)):
+            findings.append(
+                (
+                    BLOCKER,
+                    slug,
+                    f"target MDIM was re-slugged since extraction ({was} -> {now}) — every replacement URL in "
+                    "the payload points at the old slug. Re-run extract_views.py and rebuild.",
+                )
+            )
+        if missing_views:
+            sample = "; ".join(f"view {sid} ({vid}) -> {dims}" for sid, vid, dims in missing_views[:3])
+            findings.append(
+                (
+                    BLOCKER,
+                    slug,
+                    f"{len(missing_views)} target view(s) no longer exist in the live MDIM config — the MDIM was "
+                    f"rebuilt or re-sliced since extraction. e.g. {sample}. Re-extract, re-review, rebuild.",
+                )
+            )
+
         for a, b in duplicate_conditions(rules):
             findings.append(
                 (
@@ -325,18 +397,47 @@ def main() -> int:
             )
 
         if applied:
-            have = {tuple(sorted((json.loads(r["sourceQueryParams"]) or {}).items())) for r in applied}
-            want = {tuple(sorted(r.condition.items())) for r in rules}
-            if have != want:
+            have = {
+                tuple(sorted((json.loads(r["sourceQueryParams"]) or {}).items())): (r["multiDimId"], r["viewConfigId"])
+                for r in applied
+            }
+            want = {tuple(sorted(r.condition.items())): expected_row(r, targets) for r in rules}
+            if set(have) != set(want):
                 findings.append(
                     (
                         BLOCKER,
                         slug,
                         f"{len(applied)} redirect(s) already exist for this explorer and differ from the payload "
-                        f"({len(want - have)} to add, {len(have - want)} unexpected). There is NO bulk delete: "
-                        f"remove them one at a time at {admin}/multi-dim-redirects before re-applying.",
+                        f"({len(set(want) - set(have))} to add, {len(set(have) - set(want))} unexpected). There is "
+                        f"NO bulk delete: remove them one at a time at {admin}/multi-dim-redirects before "
+                        "re-applying.",
                     )
                 )
+            else:
+                # Every condition is present. Whether that is DONE or a conflict depends on the
+                # TARGETS: re-posting an identical payload is rejected as duplicate sources, and
+                # a set pointing somewhere else must never read as ready.
+                retargeted = {c for c in want if have[c] != want[c]}
+                if retargeted:
+                    findings.append(
+                        (
+                            BLOCKER,
+                            slug,
+                            f"all {len(want)} source condition(s) already exist but {len(retargeted)} point at a "
+                            f"DIFFERENT target than the payload. Remove those rows at {admin}/multi-dim-redirects "
+                            "before re-applying — the endpoint would reject them as duplicate sources.",
+                        )
+                    )
+                else:
+                    done.add(slug)
+                    findings.append(
+                        (
+                            OK,
+                            slug,
+                            f"DONE — all {len(want)} redirect(s) already applied and pointing at the payload's "
+                            "targets. Do not paste it again; the endpoint rejects duplicate source conditions.",
+                        )
+                    )
 
         n_skipped = sum(1 for e in run["payload"].get("redirects") or [] if not e.get("target"))
         if n_skipped:
@@ -376,9 +477,17 @@ def main() -> int:
     if blockers:
         print(f"\nNOT READY: {len(blockers)} blocker(s). Nothing should be posted until each is cleared.")
         return 1
-    print(f"\nReady: {sum(len(runs[s]['rules']) for s in slugs)} redirect rule(s) across {len(slugs)} explorer(s).")
-    for slug in slugs:
+    to_apply = [s for s in slugs if s not in done]
+    if not to_apply:
+        print(f"\nNothing to apply: all {len(slugs)} explorer(s) are already fully redirected.")
+        return 0
+    print(
+        f"\nReady: {sum(len(runs[s]['rules']) for s in to_apply)} redirect rule(s) across {len(to_apply)} explorer(s)."
+    )
+    for slug in to_apply:
         print(f"  paste {runs[slug]['dir']}/admin_bulk_payload.json at {admin}/multi-dim-redirects")
+    if done:
+        print(f"  (skipping {sorted(done)} — already applied)")
     return 0
 
 

--- a/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/preflight.py
@@ -120,8 +120,8 @@ def chart_slug_collisions(slugs: list[str]) -> set[str]:
 
 
 def target_state(catalog_paths: set[str]) -> dict[str, dict]:
-    """{catalogPath -> {id, slug, published, views}} where `views` maps a view's dimension
-    signature to its `fullConfigId`.
+    """{catalogPath -> {id, slug, published, views, md5}} where `views` maps a view's dimension
+    signature to its `fullConfigId`, and `md5` that config id to the config's current `fullMd5`.
 
     The view map is what makes target-side staleness detectable. Checking only that the MDIM
     row exists and is published passes an MDIM that was rebuilt, re-sliced or re-slugged after
@@ -129,6 +129,11 @@ def target_state(catalog_paths: set[str]) -> dict[str, dict]:
     longer exist, and applying it would reject some entries AFTER creating others (there is no
     transaction, and no bulk undo). It also yields the expected `viewConfigId` per rule, which
     is what distinguishes "already applied" from "applied differently".
+
+    The md5 map covers the case none of that catches: grapher edits a view's chart config IN
+    PLACE, so swapping its indicators or changing its rendering leaves both the dimension
+    signature and the `fullConfigId` untouched. Without the md5 a mapping reviewed against the
+    old rendering reaches Ready and sends readers somewhere materially different.
     """
     if not catalog_paths:
         return {}
@@ -137,18 +142,33 @@ def target_state(catalog_paths: set[str]) -> dict[str, dict]:
         params={"c": tuple(sorted(catalog_paths))},
     )
     out: dict[str, dict] = {}
+    config_ids: set[str] = set()
     for r in df.to_dict("records"):
         cfg = json.loads(r["config"]) if isinstance(r["config"], str) else (r["config"] or {})
         views = {
             tuple(sorted((v.get("dimensions") or {}).items())): v.get("fullConfigId") for v in cfg.get("views") or []
         }
+        config_ids |= {c for c in views.values() if c}
         out[r["catalogPath"]] = {
             "id": int(r["id"]),
             "slug": r["slug"] or "",
             "published": bool(r["published"]),
             "views": views,
         }
+    live_md5 = view_config_md5s(config_ids)
+    for t in out.values():
+        t["md5"] = {cid: live_md5.get(cid, "") for cid in t["views"].values() if cid}
     return out
+
+
+def view_config_md5s(config_ids: set[str]) -> dict[str, str]:
+    """{chart_configs.id -> fullMd5} for a set of MDIM view configs."""
+    if not config_ids:
+        return {}
+    df = OWID_ENV.read_sql(
+        "SELECT id, fullMd5 FROM chart_configs WHERE id IN %(ids)s", params={"ids": tuple(sorted(config_ids))}
+    )
+    return dict(zip(df["id"], df["fullMd5"]))
 
 
 def expected_row(rule, targets: dict[str, dict]) -> tuple[int | None, str | None]:
@@ -164,6 +184,41 @@ def expected_row(rule, targets: dict[str, dict]) -> tuple[int | None, str | None
     if not rule.target_dims:
         return t["id"], None
     return t["id"], t["views"].get(tuple(sorted(rule.target_dims.items())))
+
+
+def revalidate_targets(rules, targets: dict[str, dict]) -> tuple[list, list, list]:
+    """Per-rule target staleness: (missing_views, reslugged, retargeted_views).
+
+    An MDIM can be rebuilt, re-sliced or re-slugged while its catalogPath stays present and
+    published, in which case the reviewed view no longer exists — and applying would reject
+    those entries after creating others. It can also keep every view in place and only change
+    what one of them renders, which nothing above notices.
+    """
+    missing_views, reslugged, retargeted_views = [], [], []
+    for rule in rules:
+        t = targets.get(rule.catalog_path)
+        if t is None or not t["published"]:
+            continue  # reported separately, per catalogPath
+        if rule.mdim_slug and rule.mdim_slug != t["slug"]:
+            reslugged.append((rule.mdim_slug, t["slug"]))
+        # Resolve through expected_row rather than testing signature membership: a view can be
+        # present but carry no `fullConfigId`, in which case it cannot be stored as a
+        # viewConfigId at all — the chart-side extractor drops such views from its target pool
+        # for the same reason. Membership alone would let that reach `Ready`.
+        _, config_id = expected_row(rule, targets)
+        if rule.target_dims and config_id is None:
+            unstorable = tuple(sorted(rule.target_dims.items())) in t["views"]
+            missing_views.append((rule.source_view_id, rule.view_id, rule.target_dims, unstorable))
+            continue
+        # Same view id, same dimensions, different rendering: grapher edits a view's chart
+        # config in place. Skipped when no md5 was recorded (a run from before this was
+        # tracked, or a catch-all, which points at whatever the default view happens to be) —
+        # absence of a recorded rendering is not evidence of drift.
+        if rule.view_config_md5:
+            live = t["md5"].get(config_id or "", "")
+            if live and live != rule.view_config_md5:
+                retargeted_views.append((rule.source_view_id, rule.view_id))
+    return missing_views, reslugged, retargeted_views
 
 
 def target_is_redirect_source(mdim_slugs: set[str]) -> set[str]:
@@ -400,24 +455,19 @@ def main() -> int:
             elif t["slug"] in taken_targets:
                 findings.append((BLOCKER, slug, f"target /grapher/{t['slug']} is itself a redirect source"))
 
-        # Per-RULE target revalidation. An MDIM can be rebuilt, re-sliced or re-slugged while
-        # its catalogPath stays present and published, in which case the reviewed view no
-        # longer exists — and applying would reject those entries after creating others.
-        missing_views = []
-        reslugged = []
-        for rule in rules:
-            t = targets.get(rule.catalog_path)
-            if t is None or not t["published"]:
-                continue  # already reported above
-            if rule.mdim_slug and rule.mdim_slug != t["slug"]:
-                reslugged.append((rule.mdim_slug, t["slug"]))
-            # Resolve through expected_row rather than testing signature membership: a view can
-            # be present but carry no `fullConfigId`, in which case it cannot be stored as a
-            # viewConfigId at all — the chart-side extractor drops such views from its target
-            # pool for the same reason. Membership alone would let that reach `Ready`.
-            if rule.target_dims and expected_row(rule, targets)[1] is None:
-                unstorable = tuple(sorted(rule.target_dims.items())) in t["views"]
-                missing_views.append((rule.source_view_id, rule.view_id, rule.target_dims, unstorable))
+        missing_views, reslugged, retargeted_views = revalidate_targets(rules, targets)
+        if retargeted_views:
+            sample = ", ".join(f"view {sid} -> {vid}" for sid, vid in retargeted_views[:4])
+            findings.append(
+                (
+                    BLOCKER,
+                    slug,
+                    f"{len(retargeted_views)} target view(s) have been EDITED since extraction — same view id and "
+                    f"same dimensions, but a different rendered config, so the redirect would send readers to "
+                    f"materially different content than was reviewed. e.g. {sample}. Re-extract and re-review.",
+                )
+            )
+
         for was, now in sorted(set(reslugged)):
             findings.append(
                 (

--- a/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
@@ -20,6 +20,7 @@ Ported from owid-grapher (read `origin/master`, not a stale checkout):
 
 import csv
 import hashlib
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from urllib.parse import urlencode
@@ -304,14 +305,44 @@ def resolve_explorer_url(
     return ResolvedUrl(url=url, rule=rule, match=match, stale_params=stale, leftover_params=leftover)
 
 
+def strip_payload(mapping: dict) -> tuple[dict, int, list[tuple[SourceRule, SourceRule]]]:
+    """(apply-ready payload, empties removed, colliding rule pairs) for a mapping. Pure.
+
+    The single definition of how `mapping.json` becomes `admin_bulk_payload.json`, so the
+    builder that writes the payload and the preflight that re-derives it to check the payload
+    was actually built from the mapping beside it cannot drift apart. Whoever writes a payload
+    with `--allow-duplicate-conditions` finishes the job with `drop_duplicate_entries`.
+    """
+    payload = json.loads(json.dumps(mapping))  # deep copy; mapping.json must stay unstripped
+    stripped = 0
+    for holder in [payload.get("catchAll") or {}, *(payload.get("redirects") or [])]:
+        dims = (holder.get("source") or {}).get("dimensions")
+        if not dims:
+            continue
+        kept = strip_empty(dims)
+        stripped += len(dims) - len(kept)
+        holder["source"]["dimensions"] = kept
+    return payload, stripped, duplicate_conditions(build_source_rules(payload))
+
+
+def drop_duplicate_entries(payload: dict, clashes: list[tuple[SourceRule, SourceRule]]) -> dict:
+    """Remove the later entry of each colliding pair — the one the endpoint would reject.
+
+    Matches on `sourceViewId`: `clashes` holds SourceRule objects built from the payload, so
+    comparing object identity against the payload's own dicts could never match, and the rows
+    a report claimed to drop would still be posted and then rejected.
+    """
+    drop = {b.source_view_id for _, b in clashes if b.source_view_id is not None}
+    payload["redirects"] = [r for r in payload.get("redirects") or [] if r.get("sourceViewId") not in drop]
+    return payload
+
+
 def choice_values(mapping_dir: Path) -> tuple[list[str], dict[str, set[str]]]:
     """(dimension names, value set per dimension) from a run's `explorer_views.csv`.
 
     The CSV stores dimensions positionally (`dimension_1…`), so the names come from
     `_sources.json`; this reads the pair together so callers cannot mismatch them.
     """
-    import json
-
     sources = json.loads((mapping_dir / "_sources.json").read_text())
     names = list(sources["explorer"]["dimensions"])
     values: dict[str, set[str]] = {name: set() for name in names}

--- a/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
@@ -1,0 +1,299 @@
+"""Pure functions mirroring how grapher stores, matches and applies explorer redirects.
+
+Every function here is a port of a specific grapher symbol, named in its docstring. Nothing
+in this module touches the DB or the filesystem, so it is the one piece of this skill that
+can be exercised without credentials — and it is where the semantics that are easy to get
+subtly wrong live:
+
+- an explorer redirect's source condition is matched against the incoming URL's query
+  params, so a condition on an EMPTY value can never match (an absent param is not an empty
+  one). `strip_empty` exists for that reason and is mandatory, not cosmetic;
+- the target view's params WIN over the incoming ones, and every matched source param the
+  view does not constrain is DELETED. This is the opposite of how the chart-side audit
+  merges a reference's params, which is why that helper is deliberately not shared.
+
+Ported from owid-grapher (read `origin/master`, not a stale checkout):
+  packages/@ourworldindata/utils/src/QueryParamDecisionTree.ts
+  db/model/MultiDimRedirects.ts
+  functions/_common/redirectTools.ts
+"""
+
+import csv
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import urlencode
+
+# Explorer TSV columns whose header ends in one of these are the dimension (widget) columns.
+WIDGET_SUFFIXES = ("Dropdown", "Radio", "Checkbox")
+
+
+def dim_name(col: str) -> str:
+    """Human dimension name from an explorer TSV column header (drops the widget suffix)."""
+    for suffix in WIDGET_SUFFIXES:
+        if col.endswith(suffix):
+            return col[: -len(suffix)].strip()
+    return col.strip()
+
+
+def parse_explorer_views(tsv: str) -> tuple[list[str], list[list[str]]]:
+    """(dimension names, one row of display values per view) from an explorer TSV.
+
+    Reads the `graphers` block; a view row's dimension columns are those whose header ends
+    in a widget suffix. Row ORDER is significant: it is the only identity an explorer view
+    has, and `views_fingerprint` hashes it for exactly that reason.
+    """
+    lines = tsv.split("\n")
+    dim_cols: list[int] = []
+    names: list[str] = []
+    rows: list[list[str]] = []
+    in_block = False
+    for line in lines:
+        if not line.startswith("\t"):
+            in_block = line.strip() == "graphers"
+            if in_block:
+                dim_cols, names = [], []
+            continue
+        if not in_block:
+            continue
+        cells = line[1:].split("\t")
+        if not names and not dim_cols:
+            for i, col in enumerate(cells):
+                if col.strip().endswith(WIDGET_SUFFIXES):
+                    dim_cols.append(i)
+                    names.append(dim_name(col))
+            continue
+        rows.append([(cells[i].strip() if i < len(cells) else "") for i in dim_cols])
+    return names, rows
+
+
+def views_fingerprint(dim_names: list[str], rows: list[list[str]]) -> str:
+    """Stable digest of an explorer's view grid, as the redirects see it.
+
+    Order-sensitive on purpose: a re-saved TSV that renumbers rows, and a relabelled choice,
+    both invalidate the positional view ids that `mapping_proposal.csv`, the review HTML and
+    `sourceViewId` all key on — and there is no other fingerprint to catch that (an explorer
+    view has no config id or md5 of its own). Empty values are stripped first so the hash
+    covers exactly what the redirect conditions key on: a change to a column the redirects
+    ignore raises no false alarm.
+    """
+    payload = "\n".join(
+        "\t".join(f"{name}={value}" for name, value in zip(dim_names, row) if value != "") for row in rows
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def strip_empty(dims: dict) -> dict:
+    """Drop empty-valued keys from a source condition.
+
+    MANDATORY before posting a payload. The request-time matcher compares a condition value
+    against the incoming URL's param, and an absent param is not an empty string — so a
+    condition of `{"Period": ""}` can never match, and every view carrying one silently
+    falls through to the catch-all instead of its intended target. Keeping them is the one
+    mistake that produces a payload the endpoint accepts and then serves wrongly.
+    """
+    return {k: v for k, v in dims.items() if v != "" and v is not None}
+
+
+@dataclass(frozen=True)
+class SourceRule:
+    """One `multi_dim_redirects` row, as the request-time matcher sees it."""
+
+    condition: dict[str, str]  # == the row's sourceQueryParams (already empty-stripped)
+    insert_index: int  # 0 = catch-all, then payload order; ties in specificity break on it
+    source_view_id: int | None  # None for the catch-all
+    mdim: str
+    mdim_slug: str
+    catalog_path: str
+    view_id: str  # "A2"; "" for the catch-all's default view
+    target_dims: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def specificity(self) -> int:
+        return len(self.condition)
+
+
+def build_source_rules(mapping: dict) -> list[SourceRule]:
+    """Every rule a payload built from this mapping would create, in insertion order.
+
+    The catch-all goes first because it is inserted first and therefore carries the lowest
+    row id; `target: None` entries are skipped because the endpoint reports them `skipped`
+    and creates no row.
+    """
+    rules: list[SourceRule] = []
+    catch_all = mapping.get("catchAll") or {}
+    if catch_all.get("target"):
+        t = catch_all["target"]
+        rules.append(
+            SourceRule(
+                condition=strip_empty((catch_all.get("source") or {}).get("dimensions") or {}),
+                insert_index=0,
+                source_view_id=None,
+                mdim=t.get("mdim", ""),
+                mdim_slug=t.get("mdimSlug", ""),
+                catalog_path=t.get("catalogPath", ""),
+                view_id=t.get("viewId") or "",
+                target_dims=dict(t.get("dimensions") or {}),
+            )
+        )
+    for entry in mapping.get("redirects") or []:
+        t = entry.get("target")
+        if not t:
+            continue
+        rules.append(
+            SourceRule(
+                condition=strip_empty((entry.get("source") or {}).get("dimensions") or {}),
+                insert_index=len(rules),
+                source_view_id=entry.get("sourceViewId"),
+                mdim=t.get("mdim", ""),
+                mdim_slug=t.get("mdimSlug", ""),
+                catalog_path=t.get("catalogPath", ""),
+                view_id=t.get("viewId") or "",
+                target_dims=dict(t.get("dimensions") or {}),
+            )
+        )
+    return rules
+
+
+def duplicate_conditions(rules: list[SourceRule]) -> list[tuple[SourceRule, SourceRule]]:
+    """Pairs of rules that collapse to the same condition once empties are stripped.
+
+    The endpoint rejects the second of each pair (its duplicate `(source, sourceQueryParams)`
+    check), so the row is unreachable. Distinct from many-views-to-one-MDIM-view, which is
+    normal and fine — that is `sharedTargetSourceIds`.
+    """
+    seen: dict[tuple, SourceRule] = {}
+    clashes = []
+    for rule in rules:
+        key = tuple(sorted(rule.condition.items()))
+        if key in seen:
+            clashes.append((seen[key], rule))
+        else:
+            seen[key] = rule
+    return clashes
+
+
+def match_query_params(rules: list[SourceRule], query: dict[str, str]) -> SourceRule | None:
+    """The rule grapher would pick for these incoming query params.
+
+    Mirrors `buildQueryParamDecisionTree` + `matchQueryParamDecisionTree`. Those build a
+    greedy decision tree, but the result they compute is exactly: **the first rule in
+    (specificity DESC, insertion order ASC) order whose every condition key equals the
+    incoming value.** Following any path down that tree leaves only the rules consistent
+    with the branches taken, and a leaf returns the highest-priority such rule — priority
+    being the index after a stable sort by descending specificity, i.e. this ordering.
+
+    An absent incoming param matches no condition (the tree sends it to the `default`
+    branch, where only rules that don't constrain that key survive). We never emit `null`
+    condition values, so the wildcard case cannot arise here.
+    """
+    for rule in sorted(rules, key=lambda r: (-r.specificity, r.insert_index)):
+        if all(query.get(key) == value for key, value in rule.condition.items()):
+            return rule
+    return None
+
+
+def build_target_query_params(rule: SourceRule) -> dict[str, str | None]:
+    """Params to apply to the redirect target: mirrors `buildTargetQueryParams`.
+
+    Every param the target view sets is applied, so the redirect always lands on that view.
+    Every source param that was matched on but that the view does not constrain maps to
+    `None` — a signal to REMOVE it from the outgoing URL, since it is explorer-specific and
+    has no business in a grapher URL.
+    """
+    target: dict[str, str | None] = {key: rule.target_dims[key] for key in sorted(rule.target_dims)}
+    for key in sorted(rule.condition):
+        if key not in rule.target_dims:
+            target[key] = None
+    return target
+
+
+def apply_target_query_params(query: dict[str, str], target: dict[str, str | None]) -> dict[str, str]:
+    """Outgoing query params: mirrors `getRedirectForExplorerUrl`.
+
+    Starts from the INCOMING params, then applies the target's: a string sets or overrides,
+    `None` deletes. So target params win, and params the redirect says nothing about
+    (`country`, `time`, `tab`, `facet`) ride through untouched — which is what a reader
+    following an old link wants.
+    """
+    out = dict(query)
+    for key, value in target.items():
+        if value is None:
+            out.pop(key, None)
+        else:
+            out[key] = value
+    return out
+
+
+@dataclass
+class ResolvedUrl:
+    """Where a URL pointing at the explorer ends up once the redirects exist."""
+
+    url: str
+    rule: SourceRule | None
+    match: str  # view | catch-all (no params) | catch-all (stale params) | …
+    stale_params: dict[str, str] = field(default_factory=dict)
+    leftover_params: dict[str, str] = field(default_factory=dict)
+
+
+def resolve_explorer_url(
+    rules: list[SourceRule],
+    query: dict[str, str],
+    host: str,
+    choice_values: dict[str, set[str]],
+    dim_names: list[str] | None = None,
+) -> ResolvedUrl:
+    """Resolve one referencing URL's params to the view it will land on, and why.
+
+    `choice_values` maps each dimension name to the values the explorer still offers; a
+    param naming a dimension but carrying a value that is no longer offered is `stale` —
+    the reference is already semi-broken today (the explorer snaps to a default) and after
+    the redirect it lands on the MDIM's default view, so it needs authoring attention
+    rather than a mechanical URL swap. Distinguishing that from "the link simply had no
+    params" is the difference between a real finding and noise.
+    """
+    dims = set(dim_names or choice_values.keys())
+    stale = {k: v for k, v in query.items() if k in choice_values and v not in choice_values[k]}
+    rule = match_query_params(rules, query)
+    if rule is None:
+        return ResolvedUrl(url="", rule=None, match="unmatched (no catch-all)", stale_params=stale)
+
+    target = build_target_query_params(rule)
+    merged = apply_target_query_params(query, target)
+    url = f"{host}/grapher/{rule.mdim_slug}"
+    if merged:
+        url += "?" + urlencode(sorted(merged.items()))
+
+    if rule.source_view_id is not None:
+        match = "view"
+    elif not any(k in dims for k in query):
+        match = "catch-all (no params)"
+    elif stale:
+        match = "catch-all (stale params)"
+    else:
+        match = "catch-all (partial params)"
+    # Explorer-dimension params that survive into the grapher URL because the matched rule
+    # did not condition on them. Harmless noise unless the name collides with an
+    # unconstrained MDIM dimension slug, which would silently pick a view.
+    leftover = {k: v for k, v in merged.items() if k in dims and k not in rule.target_dims}
+    return ResolvedUrl(url=url, rule=rule, match=match, stale_params=stale, leftover_params=leftover)
+
+
+def choice_values(mapping_dir: Path) -> tuple[list[str], dict[str, set[str]]]:
+    """(dimension names, value set per dimension) from a run's `explorer_views.csv`.
+
+    The CSV stores dimensions positionally (`dimension_1…`), so the names come from
+    `_sources.json`; this reads the pair together so callers cannot mismatch them.
+    """
+    import json
+
+    sources = json.loads((mapping_dir / "_sources.json").read_text())
+    names = list(sources["explorer"]["dimensions"])
+    values: dict[str, set[str]] = {name: set() for name in names}
+    with open(mapping_dir / "explorer_views.csv", newline="") as f:
+        for row in csv.DictReader(f):
+            for i, name in enumerate(names, start=1):
+                value = (row.get(f"dimension_{i}") or "").strip()
+                if value:
+                    values[name].add(value)
+    return names, values

--- a/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
@@ -104,6 +104,18 @@ def views_fingerprint(dim_names: list[str], rows: list[list[str]]) -> str:
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 
+def payload_digest(payload: dict) -> str:
+    """Stable digest of a mapping or payload — what a consumer's advice was computed from.
+
+    An audit's replacement URLs are derived from the mapping, so rebuilding the mapping with
+    different targets silently invalidates `references.md` while the explorer's own references
+    are unchanged. Nothing about the live site reveals that, which is why the artifact is
+    digested and not merely dated: an operator following stale advice migrates an embed to the
+    wrong MDIM view, and once the embed no longer names the explorer, no later sweep can find it.
+    """
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, ensure_ascii=False).encode()).hexdigest()[:16]
+
+
 def strip_empty(dims: dict) -> dict:
     """Drop empty-valued keys from a source condition.
 

--- a/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
@@ -23,7 +23,7 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from urllib.parse import urlencode, urlsplit
+from urllib.parse import urlencode
 
 # Explorer TSV columns whose header ends in one of these are the dimension (widget) columns.
 WIDGET_SUFFIXES = ("Dropdown", "Radio", "Checkbox")
@@ -102,19 +102,6 @@ def views_fingerprint(dim_names: list[str], rows: list[list[str]]) -> str:
         "\t".join(f"{name}={value}" for name, value in zip(dim_names, row) if value != "") for row in rows
     )
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
-
-
-def redirect_target_path(target: str | None) -> str:
-    """Pathname of a site-redirect target, with a trailing slash normalized away.
-
-    A target may be a bare path, a path carrying a query and/or fragment, or an absolute URL,
-    and only its PATHNAME says which page it points at. A target that merely mentions another
-    page inside its query — `/article?next=/explorers/foo` — does not point at that page, so
-    substring-matching the raw string reports an unrelated redirect as a chain and blocks every
-    entry for that explorer.
-    """
-    path = urlsplit((target or "").strip()).path
-    return path.rstrip("/") or path
 
 
 def strip_empty(dims: dict) -> dict:

--- a/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
@@ -48,10 +48,12 @@ def parse_explorer_views(tsv: str) -> tuple[list[str], list[list[str]]]:
     names: list[str] = []
     rows: list[list[str]] = []
     in_block = False
+    seen_block = False
     for line in lines:
         if not line.startswith("\t"):
             in_block = line.strip() == "graphers"
             if in_block:
+                seen_block = True
                 dim_cols, names = [], []
             continue
         if not in_block:
@@ -64,6 +66,18 @@ def parse_explorer_views(tsv: str) -> tuple[list[str], list[list[str]]]:
                     names.append(dim_name(col))
             continue
         rows.append([(cells[i].strip() if i < len(cells) else "") for i in dim_cols])
+    # Fail loudly rather than returning an empty grid. An empty grid extracts cleanly,
+    # fingerprints cleanly, and builds a catch-all-only payload that silently discards every
+    # per-view redirect — so it has to be an error, not a quiet zero.
+    if not seen_block:
+        raise SystemExit("No 'graphers' block found in the explorer TSV — cannot read its views.")
+    if not names:
+        raise SystemExit(
+            "The explorer's `graphers` block has no dimension columns (no header ending in "
+            f"{'/'.join(WIDGET_SUFFIXES)}) — cannot map views without dimensions."
+        )
+    if not rows:
+        raise SystemExit("The explorer's `graphers` block declares dimensions but contains no view rows.")
     return names, rows
 
 

--- a/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
@@ -23,7 +23,7 @@ import hashlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 
 # Explorer TSV columns whose header ends in one of these are the dimension (widget) columns.
 WIDGET_SUFFIXES = ("Dropdown", "Radio", "Checkbox")
@@ -102,6 +102,19 @@ def views_fingerprint(dim_names: list[str], rows: list[list[str]]) -> str:
         "\t".join(f"{name}={value}" for name, value in zip(dim_names, row) if value != "") for row in rows
     )
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def redirect_target_path(target: str | None) -> str:
+    """Pathname of a site-redirect target, with a trailing slash normalized away.
+
+    A target may be a bare path, a path carrying a query and/or fragment, or an absolute URL,
+    and only its PATHNAME says which page it points at. A target that merely mentions another
+    page inside its query — `/article?next=/explorers/foo` — does not point at that page, so
+    substring-matching the raw string reports an unrelated redirect as a chain and blocks every
+    entry for that explorer.
+    """
+    path = urlsplit((target or "").strip()).path
+    return path.rstrip("/") or path
 
 
 def strip_empty(dims: dict) -> dict:

--- a/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
+++ b/.claude/skills/map-explorer-to-mdim/scripts/redirect_rules.py
@@ -61,7 +61,13 @@ def parse_explorer_views(tsv: str) -> tuple[list[str], list[list[str]]]:
         cells = line[1:].split("\t")
         if not names and not dim_cols:
             for i, col in enumerate(cells):
-                if col.strip().endswith(WIDGET_SUFFIXES):
+                # Strip BEFORE both the suffix test and dim_name: a CRLF file leaves "\r" on the
+                # last header, which the test tolerates but dim_name does not — so the suffix
+                # survived and the dimension was named "Foo Dropdown" instead of "Foo". That
+                # name becomes the redirect's condition key, so every URL for those views would
+                # miss its rule and fall through to the catch-all, silently.
+                col = col.strip()
+                if col.endswith(WIDGET_SUFFIXES):
                     dim_cols.append(i)
                     names.append(dim_name(col))
             continue
@@ -121,6 +127,9 @@ class SourceRule:
     catalog_path: str
     view_id: str  # "A2"; "" for the catch-all's default view
     target_dims: dict[str, str] = field(default_factory=dict)
+    # The rendering this target was reviewed against. Empty for runs extracted before it was
+    # recorded, and for a catch-all (which points at whatever the MDIM's default view is).
+    view_config_md5: str = ""
 
     @property
     def specificity(self) -> int:
@@ -148,6 +157,7 @@ def build_source_rules(mapping: dict) -> list[SourceRule]:
                 catalog_path=t.get("catalogPath", ""),
                 view_id=t.get("viewId") or "",
                 target_dims=dict(t.get("dimensions") or {}),
+                view_config_md5=t.get("viewConfigMd5") or "",
             )
         )
     for entry in mapping.get("redirects") or []:
@@ -164,6 +174,7 @@ def build_source_rules(mapping: dict) -> list[SourceRule]:
                 catalog_path=t.get("catalogPath", ""),
                 view_id=t.get("viewId") or "",
                 target_dims=dict(t.get("dimensions") or {}),
+                view_config_md5=t.get("viewConfigMd5") or "",
             )
         )
     return rules

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -51,9 +51,7 @@ payload has them removed.
 
 **Review the matches before applying.** `/review-explorer-mdim-mapping` builds an HTML page
 showing each explorer view beside the MDIM view it would redirect to, with approve/flag
-controls; decisions persist in the browser and export to JSON. Correct a wrong match by
-editing `mapping_rules.py` and re-running the build — the HTML is a review surface, not an
-editor.
+controls; decisions persist in the browser and export to JSON. You can let Claude know about this corrections in the matches.
 
 ### 3. Clear site redirects involving the explorer
 
@@ -61,10 +59,18 @@ A `/explorers/<slug>` that is already a site redirect's **source**, or its **tar
 the bulk endpoint reject the redirect — and it caches per-source checks, so one row fails
 *every* entry for that explorer. Fix at `/admin/site-redirects`:
 
-- **source** `/explorers/<slug>` → delete the row.
-- **target** `/explorers/<slug>` → **repoint**, don't delete: many are real URLs and
-  deleting one creates a 404. Delete then re-create with the MDIM as target. Only a vanity
-  path nothing links to should just go.
+- **source** `/explorers/<slug>` → delete the row. The explorer URL is being redirected to
+  the MDIM instead, and a site redirect on the same path would win anyway.
+- **target** `/explorers/<slug>` → **repoint it rather than deleting it.** Delete the row,
+  then re-create it with the MDIM URL as the target.
+
+  The reason to repoint: that row's *source* is usually a URL readers still follow — an old
+  chart slug, or a renamed explorer. Deleting it without re-creating turns that URL into a
+  404. `references.md` gives you the MDIM URL to use for each one.
+
+  Deleting outright is fine only when nothing links to the source. The live example is
+  `/poverty-explorer-launch`, a one-off announcement URL from when the explorer shipped:
+  nothing points at it, so it can simply go.
 
 Either action re-bakes automatically.
 

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -41,6 +41,12 @@ You write the routing rules; it emits **one `admin_bulk_payload.json` per explor
 that file, not `mapping.json` — the payload has empty-valued source dimensions stripped, and
 keeping them routes those views to the catch-all instead of their targets.
 
+**Review the matches before applying.** `/review-explorer-mdim-mapping` builds an HTML page
+showing each explorer view beside the MDIM view it would redirect to, with approve/flag
+controls; decisions persist in the browser and export to JSON. Correct a wrong match by
+editing `mapping_rules.py` and re-running the build — the HTML is a review surface, not an
+editor.
+
 ### 3. Clear site redirects involving the explorer
 
 A `/explorers/<slug>` that is already a site redirect's **source**, or its **target**, makes

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -63,8 +63,8 @@ Each row gives you:
 - a per-explorer summary: how many references break, how many are just links, and whether
   anything blocks the redirect.
 
-Start with the 🔴 sections — those are the embeds. It also flags links whose parameters no
-longer match any view: those land on the MDIM's default view, so they need a deliberate
+Start with the 🔴 sections — those are the embeds. The report also flags links whose parameters
+no longer match any view: those land on the MDIM's default view, so they need a deliberate
 choice rather than a straight swap.
 
 ### 3. Clear site redirects involving the explorer

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -101,6 +101,13 @@ It matches charts to MDIM views by indicator ID and reports **every place each c
 linked or embedded** with the replacement URL. Embedded references break at unpublish and no
 redirect repairs them, so migrate those first.
 
+**Review the matches before applying.** The skill also builds an HTML page showing each
+chart beside the MDIM view it would redirect to, with approve/flag controls; decisions
+persist in the browser and export to JSON, which the preflight then reads so flagged charts
+are excluded. To force or suppress a match, put the chart id in `overrides.csv` and re-run —
+only matches it is confident about are proposed, and the rest are reported rather than
+guessed.
+
 ### 2. Re-create any narrative charts
 
 There is no way to repoint one, so each is re-created from the MDIM view and the article

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -25,21 +25,18 @@ An unpublished MDIM is refused as a redirect target, and even if a row existed t
 
 Steps 1–3 are reversible; step 4 is not.
 
-### 1. Replace the references in articles
-
-Anything that **embeds** an explorer breaks the moment the redirect exists — the embed
-renders by fetching the explorer page and parsing it, so a redirect leaves it blank. Prose links
-survive on the redirect but should be updated anyway.
-
-`/map-explorer-to-mdim` lists every reference with its replacement URL and where to edit in the Google Doc.
-
-### 2. Run `/map-explorer-to-mdim`
+### 1. Run `/map-explorer-to-mdim`
 
 The skill reads the explorer's views and the target MDIM's views, then asks you to write the
 routing rules: which explorer view corresponds to which MDIM view. That is the only manual
 part, and it is per explorer.
 
-It then writes two JSON files per explorer, and only one of them is for posting:
+**Review the matches before applying.** `/review-explorer-mdim-mapping` builds an HTML page
+showing each explorer view beside the MDIM view it would redirect to, with approve/flag
+controls; decisions persist in the browser and export to JSON. You can let Claude know about
+these corrections in the matches.
+
+It writes two JSON files per explorer, and only one of them is for posting:
 
 - **`admin_bulk_payload.json`** — this is the file you paste in step 4.
 - `mapping.json` — the record of the mapping, useful for reference and diffing.
@@ -49,9 +46,26 @@ blank dimension values that a view leaves unset, and a blank never matches a rea
 views would quietly land on the MDIM's default view instead of the one you mapped them to. The
 payload has them removed.
 
-**Review the matches before applying.** `/review-explorer-mdim-mapping` builds an HTML page
-showing each explorer view beside the MDIM view it would redirect to, with approve/flag
-controls; decisions persist in the browser and export to JSON. You can let Claude know about this corrections in the matches.
+It also sweeps the site for everything pointing at the explorer, which is step 2.
+
+### 2. Replace the references in articles
+
+Anything that **embeds** an explorer breaks the moment the redirect exists — the embed
+renders by fetching the explorer page and parsing it, so a redirect leaves it blank. Prose
+links survive on the redirect but should be updated anyway.
+
+Work from **`references.md`** (and `references.csv`, the same rows for sorting and filtering).
+Each row gives you:
+
+- the page holding the reference, and a link straight into its **Google Doc**;
+- the **text to search for** in that doc, so you land on the right block;
+- the **replacement URL**, and which MDIM view that link will actually resolve to;
+- a per-explorer summary: how many references break, how many are just links, and whether
+  anything blocks the redirect.
+
+Start with the 🔴 sections — those are the embeds. It also flags links whose parameters no
+longer match any view: those land on the MDIM's default view, so they need a deliberate
+choice rather than a straight swap.
 
 ### 3. Clear site redirects involving the explorer
 
@@ -115,9 +129,15 @@ Then remove the ETL footprint. **Never delete a step without archiving it** (see
 
 ### 1. Run `/map-charts-to-mdim`
 
-It matches charts to MDIM views by indicator ID and reports **every place each chart is
-linked or embedded** with the replacement URL. Embedded references break at unpublish and no
-redirect repairs them, so migrate those first.
+It matches charts to MDIM views by indicator ID, and writes **`references.md`** — the file you
+work from before anything is applied (plus `references.csv` for sorting and filtering). Same
+shape as the explorer one: the page holding each reference, a link into its Google Doc, the
+text to search for, and the replacement URL.
+
+Work the 🔴 sections first: those are embeds, they break when the chart is unpublished, and no
+redirect repairs them. 🟡 rows keep working through the redirect but are worth updating. It
+also lists the topic-page *All charts* entries, which need nothing — they drop out on their
+own — and any narrative charts, which are step 2.
 
 **Review the matches before applying.** The skill also builds an HTML page showing each
 chart beside the MDIM view it would redirect to, with approve/flag controls; decisions

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -1,0 +1,164 @@
+---
+tags:
+  - Data Workflow
+icon: lucide/signpost
+---
+
+# Redirecting explorers and charts to MDIMs
+
+When an MDIM replaces an explorer or a set of charts, the old URLs have to keep working:
+readers follow links from articles, from Google, and from other sites. This page is the
+end-to-end order of operations for that cutover.
+
+!!! warning "Redirects are created in production, and there is no bulk undo"
+    Explorer redirects are removed one row at a time, and chart redirects unpublish the
+    source charts in the same transaction. Everything below is arranged so that the
+    irreversible step comes last, after the checks have passed.
+
+## Before you start: the MDIM has to be ready
+
+Publish the MDIM first, and **add the MDIM views you want as featured metrics by hand**.
+Nothing propagates them for you — a retired chart's spot in a topic page's *All charts*
+block cannot be inherited by an MDIM (that block is built from charts only), and an
+explorer's featured position disappears with the explorer. Decide which views deserve to
+be surfaced, and add them, before the old surface goes dark.
+
+An unpublished MDIM is worse than a missing one here: the redirect is refused at creation,
+and even if a row existed the baker filters on publication, so the redirect would silently
+serve nothing.
+
+## Explorers
+
+Run these in order. Steps 1–3 are reversible; step 4 is not.
+
+### 1. Replace the references in articles and other pages
+
+Anything that **embeds** an explorer breaks the moment the redirect exists — not later,
+when the explorer is retired. An embedded explorer is rendered by fetching the explorer
+page and parsing it, so once that URL 302s to a grapher page the block renders nothing.
+Prose links are fine (the 302 carries them), but they should be updated anyway so readers
+don't take an extra hop.
+
+`/map-explorer-to-mdim` produces this list for you, with the replacement URL for each
+reference and the specific view it will land on. Do the edits before step 4.
+
+### 2. Run `/map-explorer-to-mdim` to get one JSON per explorer
+
+The skill reads the explorer's views and the target MDIM's views, you write the routing
+rules, and it emits **one `admin_bulk_payload.json` per explorer** — that is the unit you
+apply. It also reports which views it could not route, which land on the catch-all, and
+which referencing URLs carry parameters the explorer no longer offers (those land on the
+MDIM's default view rather than the intended one).
+
+Post the payload, not `mapping.json`: the payload has empty-valued source dimensions
+stripped out, and keeping them would route those views to the catch-all instead of their
+intended targets.
+
+### 3. Remove site redirects that involve the explorer
+
+A `/explorers/<slug>` path that is already the **source** of a site redirect, or the
+**target** of one, makes the bulk endpoint reject the redirect — and because it caches its
+per-source checks, one such row fails *every* entry for that explorer, not one row.
+
+Check and clear these at `/admin/site-redirects` before applying:
+
+- **Source** `/explorers/<slug>` → delete the row.
+- **Target** `/explorers/<slug>` → do **not** just delete it. Many of these are real URLs
+  (an old chart slug, a renamed explorer) and deleting one turns a working URL into a 404.
+  Repoint it: delete the row, then re-create it with the MDIM URL as the target. Only a
+  vanity path that nothing links to should simply be deleted.
+
+Deleting or adding a site redirect triggers a re-bake automatically.
+
+### 4. Apply: paste each JSON into the admin
+
+Go to `/admin/multi-dim-redirects` and use the **Bulk-create redirects from JSON** button,
+once per explorer. You can rehearse the whole thing on a staging server, but the redirect
+that readers follow has to be created **in production**.
+
+Then verify, per explorer:
+
+```bash
+# expect a 302 and a /grapher/... Location
+curl -sI "https://ourworldindata.org/explorers/<slug>?<one view's params>" \
+  | grep -i "^HTTP/\|^location:"
+```
+
+Allow for the bake plus a couple of minutes — the redirect map is cached at the edge.
+
+!!! note "The redirect takes effect immediately, even while the explorer is still published"
+    An explorer redirect is checked on *every* request to `/explorers/*`, before the
+    explorer page itself is served. So creating it is what darkens the explorer — you do
+    not need to unpublish first, and you cannot stage the two separately.
+
+### 5. Retire the explorer's ETL step
+
+Once the redirect is verified, remove the explorer's footprint in this repo. **Never delete
+a step without archiving it** (see the archiving rules in `CLAUDE.md`):
+
+1. Delete the step files — the `.py` **and** its sibling `.config.yml`. Removing only the
+   `.py` leaves an orphaned config behind, which has happened before.
+2. Remove the step's `dag/*.yml` entry, run `make check`, and **commit**.
+3. Run `etl archive-dag` and commit the regenerated `dag/archive/*.yml` separately. It reads
+   *committed* history, so the removal has to land first. If it sweeps in unrelated steps
+   somebody else left un-archived, `git checkout` those files to keep the PR scoped.
+4. Check whether anything upstream is now orphaned — a garden step that existed only to feed
+   the retired explorer has to be archived in a second round, the same way.
+
+!!! danger "Grep before you delete a shared step"
+    Some explorer data steps are consumed **off-DAG**, by scripts that read their published
+    CSVs by URL. Those consumers are invisible to `etl archive-dag`, so the step looks like a
+    safe leaf when it is not. Search the repo for the step's catalog URL before removing it,
+    and keep it until every consumer is retired.
+
+## Charts
+
+### 1. Run `/map-charts-to-mdim`
+
+It matches each chart to an equivalent MDIM view by indicator IDs, and — the part you act on
+first — reports **every place a chart is linked or embedded**, with the replacement URL:
+article chart blocks, prose links, data insights, static visualizations, and the
+*All charts* blocks on topic pages. Embedded references break when the chart is
+unpublished, and no redirect repairs them, so they are migrated before the cutover.
+
+### 2. Re-create any narrative charts
+
+If a chart being retired has narrative charts hanging off it, the skill tells you so and
+hands you the steps. There is no way to repoint an existing one, so each is **re-created**
+from the equivalent MDIM view and the referencing article is pointed at the new one. Two
+things do not carry over and have to be set by hand: the entity selection and other
+controls, and any title/subtitle/footnote the original overrode.
+
+### 3. Hand the CSV to a Grapher developer
+
+The skill produces a `;`-delimited CSV plus a handoff note. **Give both to a Grapher
+developer and let them run the migration** — this step is not run from ETL.
+
+### 4. They run the CLI
+
+A Grapher developer runs `createMultiDimRedirectsFromCsv`, which creates the redirects,
+unpublishes the source charts, and migrates the charts' old slugs, all in one transaction.
+
+!!! warning "This cannot be done from the admin UI"
+    The *Multi-dim redirects* admin page rejects exactly these cases: it refuses any source
+    that already has an old slug pointing at it, and its bulk endpoint accepts explorer
+    sources only. Charts with old slugs — which is most of them — can only be migrated by
+    the CLI. The CLI is also what repoints the old slugs, so hand-unpublishing a chart first
+    would turn its old URLs into 404s.
+
+### 5. Log the cutover date
+
+Ask the developer to confirm when the run happened, and record it. Analytics cannot
+reconstruct it afterwards: once a chart stops being published its view history resolves to
+a null chart id, retroactively, so a continuous series has to be stitched from the old slug
+before the cutover and the MDIM slug after it.
+
+## Why the two paths differ
+
+| | Explorers | Charts |
+|---|---|---|
+| Applied with | admin **Bulk-create redirects from JSON**, one payload per explorer | `createMultiDimRedirectsFromCsv`, run by a Grapher developer |
+| Redirect fires | on every request, so the source goes dark immediately | only when the URL 404s, so the source must be unpublished — which the CLI does |
+| Embeds break | when the redirect is created | when the chart is unpublished |
+| Old slugs | not applicable | migrated by the CLI; the admin API refuses them |
+| Undo | one row at a time | none — unpublishing is part of the transaction |

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -141,10 +141,7 @@ own — and any narrative charts, which are step 2.
 
 **Review the matches before applying.** The skill also builds an HTML page showing each
 chart beside the MDIM view it would redirect to, with approve/flag controls; decisions
-persist in the browser and export to JSON, which the preflight then reads so flagged charts
-are excluded. To force or suppress a match, put the chart id in `overrides.csv` and re-run —
-only matches it is confident about are proposed, and the rest are reported rather than
-guessed.
+persist in the browser and export to JSON, so the skill can read and adjust the matches.
 
 ### 2. Re-create any narrative charts
 

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -76,9 +76,13 @@ Allow the bake plus a couple of minutes for the edge cache.
     It is checked on *every* `/explorers/*` request, before the explorer page is served. So
     creating it is what retires the explorer — you cannot stage the two separately.
 
-### 5. Retire the ETL step
+### 5. Retire the explorer and its ETL step
 
-**Never delete a step without archiving it** (see `CLAUDE.md`):
+**Unpublish or delete the explorer in the admin first — by hand.** Removing the ETL step does
+not unpublish anything: the explorer row stays in the DB, so it keeps appearing in listings
+and search. Flipping `isPublished` in the step's config and re-running is *not* the route.
+
+Then remove the ETL footprint. **Never delete a step without archiving it** (see `CLAUDE.md`):
 
 1. Delete the step's `.py` **and** its `.config.yml` — leaving an orphaned config has
    happened before.

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -118,7 +118,9 @@ Then remove the ETL footprint. **Never delete a step without archiving it** (see
 3. Run `.venv/bin/etl archive-dag` and commit `dag/archive/*.yml` separately — it reads *committed*
    history. `git checkout` anything unrelated it sweeps in.
 4. Archive anything now orphaned upstream (a garden step that only fed this explorer) in a
-   second round.
+   second round. If one of those steps is a **migrated/backport dataset**, also delete its
+   now-orphaned `snapshots/backport/latest/dataset_<id>_*` mirror files — archiving the DAG
+   entry leaves them behind, and nothing else will ever point at them again.
 
 !!! danger "Grep before deleting a shared step"
     Some explorer data steps are read **off-DAG**, by scripts fetching their published CSVs

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -15,12 +15,11 @@ is the order of operations.
 
 ## First: the MDIM has to be ready
 
-Publish it, and **add the MDIM views you want as featured metrics by hand**. Nothing
-propagates them — a topic page's *All charts* block is built from charts only, so it cannot
-list an MDIM, and an explorer's featured position disappears with the explorer.
+Publish it, and **add the MDIM views you want as featured metrics by hand**. Nothing propagates charts and explorers here.
 
-An unpublished MDIM is refused as a redirect target, and even if a row existed the baker
-filters on publication, so the redirect would serve nothing.
+Note that a topic page's *All charts* won't show a redirected MDim, because the block is built from charts only. Have that in mind if you are redirecting charts touching multiple topic pages.
+
+An unpublished MDIM is refused as a redirect target, and even if a row existed the baker filters on publication, so the redirect would serve nothing.
 
 ## Explorers
 
@@ -29,17 +28,26 @@ Steps 1–3 are reversible; step 4 is not.
 ### 1. Replace the references in articles
 
 Anything that **embeds** an explorer breaks the moment the redirect exists — the embed
-renders by fetching the explorer page and parsing it, so a 302 leaves it blank. Prose links
-survive on the 302 but should be updated anyway.
+renders by fetching the explorer page and parsing it, so a redirect leaves it blank. Prose links
+survive on the redirect but should be updated anyway.
 
-`/map-explorer-to-mdim` lists every reference with its replacement URL and the view it will
-land on. Do the edits now.
+`/map-explorer-to-mdim` lists every reference with its replacement URL and where to edit in the Google Doc.
 
 ### 2. Run `/map-explorer-to-mdim`
 
-You write the routing rules; it emits **one `admin_bulk_payload.json` per explorer**. Post
-that file, not `mapping.json` — the payload has empty-valued source dimensions stripped, and
-keeping them routes those views to the catch-all instead of their targets.
+The skill reads the explorer's views and the target MDIM's views, then asks you to write the
+routing rules: which explorer view corresponds to which MDIM view. That is the only manual
+part, and it is per explorer.
+
+It then writes two JSON files per explorer, and only one of them is for posting:
+
+- **`admin_bulk_payload.json`** — this is the file you paste in step 4.
+- `mapping.json` — the record of the mapping, useful for reference and diffing.
+
+Posting `mapping.json` by mistake is not obvious, so it is worth knowing why: it keeps the
+blank dimension values that a view leaves unset, and a blank never matches a real URL. Those
+views would quietly land on the MDIM's default view instead of the one you mapped them to. The
+payload has them removed.
 
 **Review the matches before applying.** `/review-explorer-mdim-mapping` builds an HTML page
 showing each explorer view beside the MDIM view it would redirect to, with approve/flag

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -6,159 +6,129 @@ icon: lucide/signpost
 
 # Redirecting explorers and charts to MDIMs
 
-When an MDIM replaces an explorer or a set of charts, the old URLs have to keep working:
-readers follow links from articles, from Google, and from other sites. This page is the
-end-to-end order of operations for that cutover.
+When an MDIM replaces an explorer or a set of charts, the old URLs must keep working. This
+is the order of operations.
 
 !!! warning "Redirects are created in production, and there is no bulk undo"
-    Explorer redirects are removed one row at a time, and chart redirects unpublish the
-    source charts in the same transaction. Everything below is arranged so that the
-    irreversible step comes last, after the checks have passed.
+    Explorer redirects are removed one row at a time; the chart CLI unpublishes the source
+    charts in the same transaction. The irreversible step comes last, on purpose.
 
-## Before you start: the MDIM has to be ready
+## First: the MDIM has to be ready
 
-Publish the MDIM first, and **add the MDIM views you want as featured metrics by hand**.
-Nothing propagates them for you — a retired chart's spot in a topic page's *All charts*
-block cannot be inherited by an MDIM (that block is built from charts only), and an
-explorer's featured position disappears with the explorer. Decide which views deserve to
-be surfaced, and add them, before the old surface goes dark.
+Publish it, and **add the MDIM views you want as featured metrics by hand**. Nothing
+propagates them — a topic page's *All charts* block is built from charts only, so it cannot
+list an MDIM, and an explorer's featured position disappears with the explorer.
 
-An unpublished MDIM is worse than a missing one here: the redirect is refused at creation,
-and even if a row existed the baker filters on publication, so the redirect would silently
-serve nothing.
+An unpublished MDIM is refused as a redirect target, and even if a row existed the baker
+filters on publication, so the redirect would serve nothing.
 
 ## Explorers
 
-Run these in order. Steps 1–3 are reversible; step 4 is not.
+Steps 1–3 are reversible; step 4 is not.
 
-### 1. Replace the references in articles and other pages
+### 1. Replace the references in articles
 
-Anything that **embeds** an explorer breaks the moment the redirect exists — not later,
-when the explorer is retired. An embedded explorer is rendered by fetching the explorer
-page and parsing it, so once that URL 302s to a grapher page the block renders nothing.
-Prose links are fine (the 302 carries them), but they should be updated anyway so readers
-don't take an extra hop.
+Anything that **embeds** an explorer breaks the moment the redirect exists — the embed
+renders by fetching the explorer page and parsing it, so a 302 leaves it blank. Prose links
+survive on the 302 but should be updated anyway.
 
-`/map-explorer-to-mdim` produces this list for you, with the replacement URL for each
-reference and the specific view it will land on. Do the edits before step 4.
+`/map-explorer-to-mdim` lists every reference with its replacement URL and the view it will
+land on. Do the edits now.
 
-### 2. Run `/map-explorer-to-mdim` to get one JSON per explorer
+### 2. Run `/map-explorer-to-mdim`
 
-The skill reads the explorer's views and the target MDIM's views, you write the routing
-rules, and it emits **one `admin_bulk_payload.json` per explorer** — that is the unit you
-apply. It also reports which views it could not route, which land on the catch-all, and
-which referencing URLs carry parameters the explorer no longer offers (those land on the
-MDIM's default view rather than the intended one).
+You write the routing rules; it emits **one `admin_bulk_payload.json` per explorer**. Post
+that file, not `mapping.json` — the payload has empty-valued source dimensions stripped, and
+keeping them routes those views to the catch-all instead of their targets.
 
-Post the payload, not `mapping.json`: the payload has empty-valued source dimensions
-stripped out, and keeping them would route those views to the catch-all instead of their
-intended targets.
+### 3. Clear site redirects involving the explorer
 
-### 3. Remove site redirects that involve the explorer
+A `/explorers/<slug>` that is already a site redirect's **source**, or its **target**, makes
+the bulk endpoint reject the redirect — and it caches per-source checks, so one row fails
+*every* entry for that explorer. Fix at `/admin/site-redirects`:
 
-A `/explorers/<slug>` path that is already the **source** of a site redirect, or the
-**target** of one, makes the bulk endpoint reject the redirect — and because it caches its
-per-source checks, one such row fails *every* entry for that explorer, not one row.
+- **source** `/explorers/<slug>` → delete the row.
+- **target** `/explorers/<slug>` → **repoint**, don't delete: many are real URLs and
+  deleting one creates a 404. Delete then re-create with the MDIM as target. Only a vanity
+  path nothing links to should just go.
 
-Check and clear these at `/admin/site-redirects` before applying:
+Either action re-bakes automatically.
 
-- **Source** `/explorers/<slug>` → delete the row.
-- **Target** `/explorers/<slug>` → do **not** just delete it. Many of these are real URLs
-  (an old chart slug, a renamed explorer) and deleting one turns a working URL into a 404.
-  Repoint it: delete the row, then re-create it with the MDIM URL as the target. Only a
-  vanity path that nothing links to should simply be deleted.
+### 4. Apply
 
-Deleting or adding a site redirect triggers a re-bake automatically.
-
-### 4. Apply: paste each JSON into the admin
-
-Go to `/admin/multi-dim-redirects` and use the **Bulk-create redirects from JSON** button,
-once per explorer. You can rehearse the whole thing on a staging server, but the redirect
-that readers follow has to be created **in production**.
-
-Then verify, per explorer:
+At `/admin/multi-dim-redirects`, use **Bulk-create redirects from JSON**, once per explorer.
+Rehearse on staging if you like, but the real redirect is created **in production**. Verify:
 
 ```bash
-# expect a 302 and a /grapher/... Location
 curl -sI "https://ourworldindata.org/explorers/<slug>?<one view's params>" \
-  | grep -i "^HTTP/\|^location:"
+  | grep -i "^HTTP/\|^location:"   # expect 302 + a /grapher/... Location
 ```
 
-Allow for the bake plus a couple of minutes — the redirect map is cached at the edge.
+Allow the bake plus a couple of minutes for the edge cache.
 
-!!! note "The redirect takes effect immediately, even while the explorer is still published"
-    An explorer redirect is checked on *every* request to `/explorers/*`, before the
-    explorer page itself is served. So creating it is what darkens the explorer — you do
-    not need to unpublish first, and you cannot stage the two separately.
+!!! note "The redirect darkens the explorer immediately"
+    It is checked on *every* `/explorers/*` request, before the explorer page is served. So
+    creating it is what retires the explorer — you cannot stage the two separately.
 
-### 5. Retire the explorer's ETL step
+### 5. Retire the ETL step
 
-Once the redirect is verified, remove the explorer's footprint in this repo. **Never delete
-a step without archiving it** (see the archiving rules in `CLAUDE.md`):
+**Never delete a step without archiving it** (see `CLAUDE.md`):
 
-1. Delete the step files — the `.py` **and** its sibling `.config.yml`. Removing only the
-   `.py` leaves an orphaned config behind, which has happened before.
-2. Remove the step's `dag/*.yml` entry, run `make check`, and **commit**.
-3. Run `etl archive-dag` and commit the regenerated `dag/archive/*.yml` separately. It reads
-   *committed* history, so the removal has to land first. If it sweeps in unrelated steps
-   somebody else left un-archived, `git checkout` those files to keep the PR scoped.
-4. Check whether anything upstream is now orphaned — a garden step that existed only to feed
-   the retired explorer has to be archived in a second round, the same way.
+1. Delete the step's `.py` **and** its `.config.yml` — leaving an orphaned config has
+   happened before.
+2. Remove the `dag/*.yml` entry, `make check`, **commit**.
+3. Run `etl archive-dag` and commit `dag/archive/*.yml` separately — it reads *committed*
+   history. `git checkout` anything unrelated it sweeps in.
+4. Archive anything now orphaned upstream (a garden step that only fed this explorer) in a
+   second round.
 
-!!! danger "Grep before you delete a shared step"
-    Some explorer data steps are consumed **off-DAG**, by scripts that read their published
-    CSVs by URL. Those consumers are invisible to `etl archive-dag`, so the step looks like a
-    safe leaf when it is not. Search the repo for the step's catalog URL before removing it,
-    and keep it until every consumer is retired.
+!!! danger "Grep before deleting a shared step"
+    Some explorer data steps are read **off-DAG**, by scripts fetching their published CSVs
+    by URL. `etl archive-dag` cannot see those, so the step looks like a safe leaf when it
+    is not. Search for its catalog URL first, and keep it until every consumer is retired.
 
 ## Charts
 
 ### 1. Run `/map-charts-to-mdim`
 
-It matches each chart to an equivalent MDIM view by indicator IDs, and — the part you act on
-first — reports **every place a chart is linked or embedded**, with the replacement URL:
-article chart blocks, prose links, data insights, static visualizations, and the
-*All charts* blocks on topic pages. Embedded references break when the chart is
-unpublished, and no redirect repairs them, so they are migrated before the cutover.
+It matches charts to MDIM views by indicator ID and reports **every place each chart is
+linked or embedded** with the replacement URL. Embedded references break at unpublish and no
+redirect repairs them, so migrate those first.
 
 ### 2. Re-create any narrative charts
 
-If a chart being retired has narrative charts hanging off it, the skill tells you so and
-hands you the steps. There is no way to repoint an existing one, so each is **re-created**
-from the equivalent MDIM view and the referencing article is pointed at the new one. Two
-things do not carry over and have to be set by hand: the entity selection and other
-controls, and any title/subtitle/footnote the original overrode.
+There is no way to repoint one, so each is re-created from the MDIM view and the article
+pointed at the new name. The entity selection, other controls, and any overridden
+title/subtitle/footnote do **not** carry over.
 
 ### 3. Hand the CSV to a Grapher developer
 
-The skill produces a `;`-delimited CSV plus a handoff note. **Give both to a Grapher
-developer and let them run the migration** — this step is not run from ETL.
+You get a `;`-delimited CSV plus a handoff note. **They run the migration, not us.** Ask
+Martin first — he wrote the CLI; any Grapher developer can run it otherwise.
 
 ### 4. They run the CLI
 
-A Grapher developer runs `createMultiDimRedirectsFromCsv`, which creates the redirects,
-unpublishes the source charts, and migrates the charts' old slugs, all in one transaction.
+`createMultiDimRedirectsFromCsv` creates the redirects, unpublishes the source charts, and
+migrates their old slugs in one transaction.
 
 !!! warning "This cannot be done from the admin UI"
-    The *Multi-dim redirects* admin page rejects exactly these cases: it refuses any source
-    that already has an old slug pointing at it, and its bulk endpoint accepts explorer
-    sources only. Charts with old slugs — which is most of them — can only be migrated by
-    the CLI. The CLI is also what repoints the old slugs, so hand-unpublishing a chart first
-    would turn its old URLs into 404s.
+    *Multi-dim redirects* refuses any source that already has an old slug pointing at it,
+    and its bulk endpoint takes explorer sources only. Most charts have old slugs, so the
+    CLI is the only route — and it is what repoints them, so hand-unpublishing a chart first
+    turns its old URLs into 404s.
 
 ### 5. Log the cutover date
 
-Ask the developer to confirm when the run happened, and record it. Analytics cannot
-reconstruct it afterwards: once a chart stops being published its view history resolves to
-a null chart id, retroactively, so a continuous series has to be stitched from the old slug
-before the cutover and the MDIM slug after it.
+Ask for confirmation of when the run happened and record it. Once a chart stops being
+published its view history resolves to a null chart id, retroactively, so a continuous
+series needs the old slug before the cutover and the MDIM slug after.
 
-## Why the two paths differ
+## Why the two differ
 
 | | Explorers | Charts |
 |---|---|---|
 | Applied with | admin **Bulk-create redirects from JSON**, one payload per explorer | `createMultiDimRedirectsFromCsv`, run by a Grapher developer |
-| Redirect fires | on every request, so the source goes dark immediately | only when the URL 404s, so the source must be unpublished — which the CLI does |
+| Redirect fires | every request — the source goes dark at once | only on a 404, so the source must be unpublished |
 | Embeds break | when the redirect is created | when the chart is unpublished |
-| Old slugs | not applicable | migrated by the CLI; the admin API refuses them |
-| Undo | one row at a time | none — unpublishing is part of the transaction |
+| Old slugs | n/a | migrated by the CLI; the admin API refuses them |
+| Undo | one row at a time | none |

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -115,14 +115,14 @@ Then remove the ETL footprint. **Never delete a step without archiving it** (see
 1. Delete the step's `.py` **and** its `.config.yml` — leaving an orphaned config has
    happened before.
 2. Remove the `dag/*.yml` entry, `make check`, **commit**.
-3. Run `etl archive-dag` and commit `dag/archive/*.yml` separately — it reads *committed*
+3. Run `.venv/bin/etl archive-dag` and commit `dag/archive/*.yml` separately — it reads *committed*
    history. `git checkout` anything unrelated it sweeps in.
 4. Archive anything now orphaned upstream (a garden step that only fed this explorer) in a
    second round.
 
 !!! danger "Grep before deleting a shared step"
     Some explorer data steps are read **off-DAG**, by scripts fetching their published CSVs
-    by URL. `etl archive-dag` cannot see those, so the step looks like a safe leaf when it
+    by URL. `.venv/bin/etl archive-dag` cannot see those, so the step looks like a safe leaf when it
     is not. Search for its catalog URL first, and keep it until every consumer is retired.
 
 ## Charts

--- a/zensical.toml
+++ b/zensical.toml
@@ -30,6 +30,7 @@ nav = [
             { "Updating data" = "guides/data-work/update-data.md" },
             { "Update charts" = "guides/data-work/update-charts.md" },
             { "MDIMs and Explorers" = "guides/data-work/mdims.md" },
+            { "Redirect to MDIMs" = "guides/data-work/redirect-to-mdims.md" },
             { "Export data" = "guides/data-work/export-data.md" },
             { "Publish indicator metadata" = "guides/data-work/create-gsheet.md" },
             { "Wizard" = "guides/wizard.md" },


### PR DESCRIPTION
> _Written by Claude Fable 5 — @paarriagadap at the wheel._

`map-charts-to-mdim` grew a full pre-apply safety chain over the last few days — a references audit, a preflight mirroring every apply-time validation, one payload per source page, an embed gate. `map-explorer-to-mdim` had none of it: it stopped at "paste the CSVs into a spreadsheet", and the real July explorer migration was finished with two throwaway scripts in `ai/` that were never folded back. This brings the explorer path up to the same standard, adds the ETL-side retirement step, and fixes three site-redirect gaps on the chart side.

## What was missing, and what it cost

**No references audit.** Nobody knew what breaks when an explorer goes dark — and the explorer timeline is worse than the chart one: since owid-grapher #6860 the redirect is checked as a `before` middleware on *every* `/explorers/*` request, ahead of `env.ASSETS.fetch`, so an **embedded explorer breaks the instant the redirect is created**, not later at unpublish. Embeds render by fetching the explorer page and parsing its HTML, so a 302 leaves them blank.

**No site-redirect gate.** The bulk endpoint rejects a source that is already a site-redirect source *or* the target of one. Site redirect **id 353** (`/poverty-explorer-launch → /explorers/poverty-explorer`) exists today, and because the endpoint memoizes its source checks and re-throws the cached rejection, it would fail **every** entry for that explorer, not one row.

**No payload in the skill.** `ai/explorer-mdim-redirects/build_admin_payloads.py` stripped empty-valued source dimensions by hand. That is mandatory, not cosmetic: a condition is matched against the incoming URL's params, and an absent param is not an empty string — so `{"Period": ""}` can never match, and every view carrying one silently falls through to the catch-all. On `poverty-explorer` that is **24 values**.

**No ETL retirement.** After the redirect lands, the step, its DAG entry and any orphaned upstream remain, and `CLAUDE.md` forbids deleting a step without archiving it.

## What's here

**`redirect_rules.py`** — grapher's redirect semantics as pure functions, read from `origin/master` (the local grapher checkout predates #6708/#6860). `QueryParamDecisionTree` provably reduces to *"first rule in (specificity desc, insertion order) whose every condition matches"* — argued in the docstring, not asserted. Plus `buildTargetQueryParams` and `getRedirectForExplorerUrl`: **target params win, and matched source params the view doesn't constrain are deleted** — the opposite of the chart-side merge, which is why that helper is deliberately not shared.

**`audit_references.py`** (new) — N mappings, one combined report. Resolves every referencing URL through the rules the payload would create, so each row says which view the reader lands on, and separates four outcomes that look identical in the DB: a specific view, the catch-all with no params, the catch-all because a param names a **dropped choice**, and the catch-all because only some dimensions are set. Severity comes from what breaks, not from `kind` — `explorer-tiles` is the one embed-kind component that survives, hence a component-level override. Sections group by component, not explorer, because the unit of work is one editing pass per doc; a per-explorer rollup answers "is this one safe to darken".

**`preflight.py`** (new) — read-only, mirrors every endpoint validation, grouped per explorer with the failure count spelled out. A **missing** `references.csv` is a blocker, not a pass. A retired explorer whose redirects are live reports `DONE` and exits 0.

**Shared helpers** moved to `find-chart-references/scripts/reference_report.py`, where the sweep lives — the `/admin/` routing bug was real in one consumer while the other was correct. Verified by regenerating the charts report and requiring byte-identical output.

**Chart-side gaps:** preflight now re-reads site redirects in *both* directions (it only read `source`, so a redirect created after extraction went undetected); site redirects pointing at a chart's **old** slugs are reported as a 2-hop-chain note; and the conflict message now says a site redirect means the URL can **never** reach the MDIM view, since it is served before the 404 handler.

**New docs page** — [Redirect to MDIMs](docs/guides/data-work/redirect-to-mdims.md): publish the MDIM and add featured views by hand, then the explorer path (replace references → one JSON per explorer → clear site redirects, repointing rather than deleting → paste in the admin → retire the ETL step) and the chart path (migrate references → re-create narrative charts → hand the CSV to a Grapher developer for the CLI, the only route that migrates old slugs).

## Verification (all against production, read-only)

- **Ported semantics** unit-tested, including that an empty condition value can never match and that target params win.
- **All three July payloads rebuild byte-identically** — the strongest evidence the folded-in transformation is faithful.
- **Charts `references.md` and `references.csv` byte-identical** after the helper extraction.
- `poverty-explorer`: 162 views, 24 empty values stripped; audit finds 38 references, the id=353 blocker, 5 embeds, and exactly the five references still naming the `$2.15 per day` poverty line the 2025 PIP update renamed; preflight exits 1 with the chain blocker (naming all 61 entries), the unpublished `poverty_pip` target and the embed gate.
- Retired `inequality`: the sweep now surfaces **2 live published links that were invisible before**; preflight reports `DONE`.
- Corrupting a recorded fingerprint produces `STALE`.
- The 22-chart proposal still reports `Ready: 22`, with the new checks finding nothing.
- **A target view edited in place is now caught.** Grapher edits a view's chart config in
  place, so swapping its indicators leaves both the dimension signature and the `fullConfigId`
  unchanged — a mapping reviewed against the old rendering passed every check. Each target
  view's `fullMd5` is now recorded at extraction and compared against the live one, as the
  chart workflow already does; the five already-migrated July payloads still rebuild
  byte-identically (an unrecorded md5 is not treated as drift), and all three retired July
  explorers still report `DONE`.
- **The catch-all's destination is pinned too.** Its row stores `viewConfigId = NULL`, so
  unlike every mapped rule nothing in the payload fixes where it lands — it resolves at request
  time to the MDIM's first view. Extraction records that view (signature, config id, md5) in
  `_sources.json`, not in the payload, and preflight **warns** when it moves. A warning by
  design: the destination is a moving reference by construction, so a blocker would flip an
  approved catch-all to NOT READY on any unrelated MDIM rebuild.
- `make check` clean throughout, and 660 unit tests pass.

## What's still open

- **Cleared** — the open question about whether deleting an `export://explorers/...` step
  leaves the explorer *published* is answered: it does. Unpublishing or deleting happens **by
  hand in the admin**, before the ETL step is removed; flipping `isPublished` in the config and
  re-running is not the route. Step 8 of the skill and the docs page both say so now.
- **Handed off** — nothing outstanding.
- **Proposed** — don't migrate `poverty-explorer` until its only target (`wb/latest/poverty_pip`) is published, id 353 is repointed, and the five `$2.15` references are rewritten. Also in scope but unexamined: `poverty-lis`, `poverty-wb`.
- **Unverified** — no payload has been posted, by design. Whether Cloudflare evaluates `_redirects` ahead of the Pages Function is not settled in the repo; it only matters for a row inserted directly in SQL, bypassing the API guard, and should be checked on a preview rather than reasoned about. For an explorer subject the sweep covers article links and embeds only — not data insights storing the reference elsewhere, static viz, key-chart slots or narrative charts — and a legacy CSV/TSV-backed explorer's own views are outside grapher's tables entirely. `etl archive-dag`'s current sweep breadth is unmeasured.


