### PR TITLE
📊 Add IHME GBD regions to regions dataset

### DIFF
--- a/etl/steps/data/garden/demography/2026-02-05/ihme_2020.countries.json
+++ b/etl/steps/data/garden/demography/2026-02-05/ihme_2020.countries.json
@@ -207,7 +207,7 @@
   "Eastern Europe": "Eastern Europe (IHME GBD)",
   "Eastern Sub-Saharan Africa": "Eastern Sub-Saharan Africa (IHME GBD)",
   "High-income": "High-income (IHME GBD)",
-  "High-income Asia Pacific": "High-Income Asia Pacific (IHME GBD)",
+  "High-income Asia Pacific": "High-income Asia Pacific (IHME GBD)",
   "High-income North America": "High-income North America (IHME GBD)",
   "Latin America and Caribbean": "Latin America and Caribbean (IHME GBD)",
   "North Africa and Middle East": "North Africa and Middle East (IHME GBD)",

--- a/etl/steps/data/garden/regions/2023-01-01/regions.yml
+++ b/etl/steps/data/garden/regions/2023-01-01/regions.yml
@@ -5358,13 +5358,16 @@
 
 ##########
 # Institute for Health Metrics and Evaluation (IHME), Global Burden of Disease (GBD)
-# https://ghdx.healthdata.org/record/global-burden-disease-study-2021-gbd-2021-cause-rei-and-location-hierarchies
+# https://ghdx.healthdata.org/record/gbd-2023-cause-rei-and-location-hierarchies
 # The GBD location hierarchy partitions the 204 countries and territories GBD reports on into two
 # nested levels: 7 super-regions (ihme_gbd_1) and 21 regions (ihme_gbd_2). Regions are grouped by
 # epidemiological similarity and geographic proximity, so they do not follow the UN M49 classification
 # (only High-income North America happens to coincide with another provider's region, by chance).
-# Membership is taken from IHME's published GBD location hierarchy file (levels 1-3 of the
-# 'GBD 2021 Locations Hierarchy' sheet); subnational levels 4-6 are ignored.
+# Membership is taken from IHME's published GBD location hierarchy (the Global-rooted location set of
+# the 'All Location Hierarchies' sheet, levels 1-3); subnational levels 4+ are ignored, as are the SDI
+# quintile groups that also sit at level 1 but aggregate by development level rather than geography.
+# GBD 2023 and GBD 2021 define these regions identically: same 7 super-regions, same 21 regions, same
+# 204 countries, verified member for member (ai/ihme_regions/compare_gbd_round.py).
 # NOTE: North Africa and Middle East, and South Asia, are super-regions with no finer breakdown, so
 # each is a single region present at both levels. They are tagged ihme_gbd_1 and back-filled into the
 # ihme_gbd_2 map in the grapher step (as done for ILO's Arab States).

--- a/etl/steps/data/garden/regions/2023-01-01/regions.yml
+++ b/etl/steps/data/garden/regions/2023-01-01/regions.yml
@@ -5355,3 +5355,384 @@
     - TON
     - VUT
     - WSM
+
+##########
+# Institute for Health Metrics and Evaluation (IHME), Global Burden of Disease (GBD)
+# https://ghdx.healthdata.org/record/global-burden-disease-study-2021-gbd-2021-cause-rei-and-location-hierarchies
+# The GBD location hierarchy partitions the 204 countries and territories GBD reports on into two
+# nested levels: 7 super-regions (ihme_gbd_1) and 21 regions (ihme_gbd_2). Regions are grouped by
+# epidemiological similarity and geographic proximity, so they do not follow the UN M49 classification
+# (only High-income North America happens to coincide with another provider's region, by chance).
+# Membership is taken from IHME's published GBD location hierarchy file (levels 1-3 of the
+# 'GBD 2021 Locations Hierarchy' sheet); subnational levels 4-6 are ignored.
+# NOTE: North Africa and Middle East, and South Asia, are super-regions with no finer breakdown, so
+# each is a single region present at both levels. They are tagged ihme_gbd_1 and back-filled into the
+# ihme_gbd_2 map in the grapher step (as done for ILO's Arab States).
+##########
+
+### Central Europe, Eastern Europe, and Central Asia
+- code: IHME_CEECA
+  name: "Central Europe, Eastern Europe, and Central Asia (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_1
+  members:
+    - IHME_CAS
+    - IHME_CEU
+    - IHME_EEU
+- code: IHME_CAS
+  name: "Central Asia (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - ARM
+    - AZE
+    - GEO
+    - KAZ
+    - KGZ
+    - MNG
+    - TJK
+    - TKM
+    - UZB
+- code: IHME_CEU
+  name: "Central Europe (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - ALB
+    - BGR
+    - BIH
+    - CZE
+    - HRV
+    - HUN
+    - MKD
+    - MNE
+    - POL
+    - ROU
+    - SRB
+    - SVK
+    - SVN
+- code: IHME_EEU
+  name: "Eastern Europe (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - BLR
+    - EST
+    - LTU
+    - LVA
+    - MDA
+    - RUS
+    - UKR
+
+### High-income
+- code: IHME_HI
+  name: "High-income (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_1
+  members:
+    - IHME_ANZ
+    - IHME_HIAP
+    - IHME_HINA
+    - IHME_SLA
+    - IHME_WEU
+- code: IHME_ANZ
+  name: "Australasia (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - AUS
+    - NZL
+- code: IHME_HIAP
+  name: "High-income Asia Pacific (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - BRN
+    - JPN
+    - KOR
+    - SGP
+- code: IHME_HINA
+  name: "High-income North America (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - CAN
+    - GRL
+    - USA
+- code: IHME_SLA
+  name: "Southern Latin America (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - ARG
+    - CHL
+    - URY
+- code: IHME_WEU
+  name: "Western Europe (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - AND
+    - AUT
+    - BEL
+    - CHE
+    - CYP
+    - DEU
+    - DNK
+    - ESP
+    - FIN
+    - FRA
+    - GBR
+    - GRC
+    - IRL
+    - ISL
+    - ISR
+    - ITA
+    - LUX
+    - MCO
+    - MLT
+    - NLD
+    - NOR
+    - PRT
+    - SMR
+    - SWE
+
+### Latin America and Caribbean
+- code: IHME_LAC
+  name: "Latin America and Caribbean (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_1
+  members:
+    - IHME_ALA
+    - IHME_CAR
+    - IHME_CLA
+    - IHME_TLA
+- code: IHME_ALA
+  name: "Andean Latin America (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - BOL
+    - ECU
+    - PER
+- code: IHME_CAR
+  name: "Caribbean (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - ATG
+    - BHS
+    - BLZ
+    - BMU
+    - BRB
+    - CUB
+    - DMA
+    - DOM
+    - GRD
+    - GUY
+    - HTI
+    - JAM
+    - KNA
+    - LCA
+    - PRI
+    - SUR
+    - TTO
+    - VCT
+    - VIR
+- code: IHME_CLA
+  name: "Central Latin America (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - COL
+    - CRI
+    - GTM
+    - HND
+    - MEX
+    - NIC
+    - PAN
+    - SLV
+    - VEN
+- code: IHME_TLA
+  name: "Tropical Latin America (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - BRA
+    - PRY
+
+### North Africa and Middle East
+- code: IHME_NAFME
+  name: "North Africa and Middle East (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_1
+  members:
+    - AFG
+    - ARE
+    - BHR
+    - DZA
+    - EGY
+    - IRN
+    - IRQ
+    - JOR
+    - KWT
+    - LBN
+    - LBY
+    - MAR
+    - OMN
+    - PSE
+    - QAT
+    - SAU
+    - SDN
+    - SYR
+    - TUN
+    - TUR
+    - YEM
+
+### South Asia
+- code: IHME_SAS
+  name: "South Asia (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_1
+  members:
+    - BGD
+    - BTN
+    - IND
+    - NPL
+    - PAK
+
+### Southeast Asia, East Asia, and Oceania
+- code: IHME_SEAEAO
+  name: "Southeast Asia, East Asia, and Oceania (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_1
+  members:
+    - IHME_EAS
+    - IHME_OCE
+    - IHME_SEA
+- code: IHME_EAS
+  name: "East Asia (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - CHN
+    - PRK
+    - TWN
+- code: IHME_OCE
+  name: "Oceania (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - ASM
+    - COK
+    - FJI
+    - FSM
+    - GUM
+    - KIR
+    - MHL
+    - MNP
+    - NIU
+    - NRU
+    - PLW
+    - PNG
+    - SLB
+    - TKL
+    - TON
+    - TUV
+    - VUT
+    - WSM
+- code: IHME_SEA
+  name: "Southeast Asia (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - IDN
+    - KHM
+    - LAO
+    - LKA
+    - MDV
+    - MMR
+    - MUS
+    - MYS
+    - PHL
+    - SYC
+    - THA
+    - TLS
+    - VNM
+
+### Sub-Saharan Africa
+- code: IHME_SSA
+  name: "Sub-Saharan Africa (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_1
+  members:
+    - IHME_CSSA
+    - IHME_ESSA
+    - IHME_SSSA
+    - IHME_WSSA
+- code: IHME_CSSA
+  name: "Central Sub-Saharan Africa (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - AGO
+    - CAF
+    - COD
+    - COG
+    - GAB
+    - GNQ
+- code: IHME_ESSA
+  name: "Eastern Sub-Saharan Africa (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - BDI
+    - COM
+    - DJI
+    - ERI
+    - ETH
+    - KEN
+    - MDG
+    - MOZ
+    - MWI
+    - RWA
+    - SOM
+    - SSD
+    - TZA
+    - UGA
+    - ZMB
+- code: IHME_SSSA
+  name: "Southern Sub-Saharan Africa (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - BWA
+    - LSO
+    - NAM
+    - SWZ
+    - ZAF
+    - ZWE
+- code: IHME_WSSA
+  name: "Western Sub-Saharan Africa (IHME GBD)"
+  region_type: "aggregate"
+  defined_by: ihme_gbd_2
+  members:
+    - BEN
+    - BFA
+    - CIV
+    - CMR
+    - CPV
+    - GHA
+    - GIN
+    - GMB
+    - GNB
+    - LBR
+    - MLI
+    - MRT
+    - NER
+    - NGA
+    - SEN
+    - SLE
+    - STP
+    - TCD
+    - TGO

--- a/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
+++ b/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
@@ -780,11 +780,14 @@ tables:
           Super-regions as defined by the Institute for Health Metrics and Evaluation (IHME) in its Global Burden of Disease (GBD) study.
         type: ordinal
         sort:
+          # NOTE: High-income is not a geographic band; it leads because High-income North America is
+          # its westernmost part. Sub-Saharan Africa is alone in the Africa slot because IHME folds
+          # North Africa into its Middle East bucket, which takes the Middle East slot.
           - "High-income (IHME GBD)"
           - "Latin America and Caribbean (IHME GBD)"
-          - "Central Europe, Eastern Europe, and Central Asia (IHME GBD)"
           - "Sub-Saharan Africa (IHME GBD)"
           - "North Africa and Middle East (IHME GBD)"
+          - "Central Europe, Eastern Europe, and Central Asia (IHME GBD)"
           - "South Asia (IHME GBD)"
           - "Southeast Asia, East Asia, and Oceania (IHME GBD)"
         origins:
@@ -794,7 +797,9 @@ tables:
             hideAnnotationFieldsInTitle:
               time: true
             map:
+              tooltipUseCustomLabels: true   # tooltip shows the stripped label, not "<Region> (IHME GBD)"
               colorScale:
+                baseColorScheme: OwidCategoricalMap
                 customCategoryLabels:
                   "High-income (IHME GBD)": "High-income"
                   "Latin America and Caribbean (IHME GBD)": "Latin America and Caribbean"
@@ -813,20 +818,22 @@ tables:
           Regions as defined by the Institute for Health Metrics and Evaluation (IHME) in its Global Burden of Disease (GBD) study.
         type: ordinal
         sort:
+          # NOTE: the four Sub-Saharan regions are alone in the Africa slot because IHME folds North
+          # Africa into its Middle East bucket, which takes the Middle East slot after them.
           - "High-income North America (IHME GBD)"
           - "Caribbean (IHME GBD)"
           - "Central Latin America (IHME GBD)"
           - "Andean Latin America (IHME GBD)"
           - "Tropical Latin America (IHME GBD)"
           - "Southern Latin America (IHME GBD)"
-          - "Western Europe (IHME GBD)"
-          - "Central Europe (IHME GBD)"
-          - "Eastern Europe (IHME GBD)"
           - "Western Sub-Saharan Africa (IHME GBD)"
           - "Central Sub-Saharan Africa (IHME GBD)"
           - "Eastern Sub-Saharan Africa (IHME GBD)"
           - "Southern Sub-Saharan Africa (IHME GBD)"
           - "North Africa and Middle East (IHME GBD)"
+          - "Western Europe (IHME GBD)"
+          - "Central Europe (IHME GBD)"
+          - "Eastern Europe (IHME GBD)"
           - "Central Asia (IHME GBD)"
           - "South Asia (IHME GBD)"
           - "East Asia (IHME GBD)"
@@ -841,7 +848,9 @@ tables:
             hideAnnotationFieldsInTitle:
               time: true
             map:
+              tooltipUseCustomLabels: true   # tooltip shows the stripped label, not "<Region> (IHME GBD)"
               colorScale:
+                baseColorScheme: OwidCategoricalMap
                 customCategoryLabels:
                   "High-income North America (IHME GBD)": "High-income North America"
                   "Caribbean (IHME GBD)": "Caribbean"

--- a/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
+++ b/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
@@ -82,8 +82,8 @@ definitions:
   origins_ihme_gbd: &origins_ihme_gbd
     producer: IHME, Global Burden of Disease
     title: Global Burden of Disease, Location Hierarchy
-    url_main: https://ghdx.healthdata.org/record/global-burden-disease-study-2021-gbd-2021-cause-rei-and-location-hierarchies
-    date_accessed: "2026-08-04"
+    url_main: https://ghdx.healthdata.org/record/gbd-2023-cause-rei-and-location-hierarchies
+    date_accessed: "2026-08-05"
     attribution_short: IHME-GBD
 
 tables:

--- a/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
+++ b/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
@@ -775,7 +775,7 @@ tables:
 
       # IHME GBD (super-regions)
       ihme_gbd_1_region:
-        title: World super-regions according to IHME
+        title: World super-regions according to IHME GBD
         description_short: |-
           Super-regions as defined by the Institute for Health Metrics and Evaluation (IHME) in its Global Burden of Disease (GBD) study.
         type: ordinal
@@ -813,7 +813,7 @@ tables:
 
       # IHME GBD (regions)
       ihme_gbd_2_region:
-        title: World regions according to IHME
+        title: World regions according to IHME GBD
         description_short: |-
           Regions as defined by the Institute for Health Metrics and Evaluation (IHME) in its Global Burden of Disease (GBD) study.
         type: ordinal

--- a/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
+++ b/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
@@ -79,6 +79,12 @@ definitions:
     date_accessed: "2026-04-24"
     citation_full: Ember - Yearly Electricity Data (2026).
     attribution_short: Ember
+  origins_ihme_gbd: &origins_ihme_gbd
+    producer: IHME, Global Burden of Disease
+    title: Global Burden of Disease, Location Hierarchy
+    url_main: https://ghdx.healthdata.org/record/global-burden-disease-study-2021-gbd-2021-cause-rei-and-location-hierarchies
+    date_accessed: "2026-08-04"
+    attribution_short: IHME-GBD
 
 tables:
   regions:
@@ -764,5 +770,99 @@ tables:
                   "Eastern Asia and South-eastern Asia (FAO)": "Eastern Asia and South-eastern Asia"
                   "Australia and New Zealand (FAO)": "Australia and New Zealand"
                   "Oceania excluding Australia and New Zealand (FAO)": "Oceania excluding Australia and New Zealand"
+                customHiddenCategories:
+                  "No data": true
+
+      # IHME GBD (super-regions)
+      ihme_gbd_1_region:
+        title: World super-regions according to IHME
+        description_short: |-
+          Super-regions as defined by the Institute for Health Metrics and Evaluation (IHME) in its Global Burden of Disease (GBD) study.
+        type: ordinal
+        sort:
+          - "High-income (IHME GBD)"
+          - "Latin America and Caribbean (IHME GBD)"
+          - "Central Europe, Eastern Europe, and Central Asia (IHME GBD)"
+          - "Sub-Saharan Africa (IHME GBD)"
+          - "North Africa and Middle East (IHME GBD)"
+          - "South Asia (IHME GBD)"
+          - "Southeast Asia, East Asia, and Oceania (IHME GBD)"
+        origins:
+          - *origins_ihme_gbd
+        presentation:
+          grapher_config:
+            hideAnnotationFieldsInTitle:
+              time: true
+            map:
+              colorScale:
+                customCategoryLabels:
+                  "High-income (IHME GBD)": "High-income"
+                  "Latin America and Caribbean (IHME GBD)": "Latin America and Caribbean"
+                  "Central Europe, Eastern Europe, and Central Asia (IHME GBD)": "Central Europe, Eastern Europe, and Central Asia"
+                  "Sub-Saharan Africa (IHME GBD)": "Sub-Saharan Africa"
+                  "North Africa and Middle East (IHME GBD)": "North Africa and Middle East"
+                  "South Asia (IHME GBD)": "South Asia"
+                  "Southeast Asia, East Asia, and Oceania (IHME GBD)": "Southeast Asia, East Asia, and Oceania"
+                customHiddenCategories:
+                  "No data": true
+
+      # IHME GBD (regions)
+      ihme_gbd_2_region:
+        title: World regions according to IHME
+        description_short: |-
+          Regions as defined by the Institute for Health Metrics and Evaluation (IHME) in its Global Burden of Disease (GBD) study.
+        type: ordinal
+        sort:
+          - "High-income North America (IHME GBD)"
+          - "Caribbean (IHME GBD)"
+          - "Central Latin America (IHME GBD)"
+          - "Andean Latin America (IHME GBD)"
+          - "Tropical Latin America (IHME GBD)"
+          - "Southern Latin America (IHME GBD)"
+          - "Western Europe (IHME GBD)"
+          - "Central Europe (IHME GBD)"
+          - "Eastern Europe (IHME GBD)"
+          - "Western Sub-Saharan Africa (IHME GBD)"
+          - "Central Sub-Saharan Africa (IHME GBD)"
+          - "Eastern Sub-Saharan Africa (IHME GBD)"
+          - "Southern Sub-Saharan Africa (IHME GBD)"
+          - "North Africa and Middle East (IHME GBD)"
+          - "Central Asia (IHME GBD)"
+          - "South Asia (IHME GBD)"
+          - "East Asia (IHME GBD)"
+          - "Southeast Asia (IHME GBD)"
+          - "High-income Asia Pacific (IHME GBD)"
+          - "Australasia (IHME GBD)"
+          - "Oceania (IHME GBD)"
+        origins:
+          - *origins_ihme_gbd
+        presentation:
+          grapher_config:
+            hideAnnotationFieldsInTitle:
+              time: true
+            map:
+              colorScale:
+                customCategoryLabels:
+                  "High-income North America (IHME GBD)": "High-income North America"
+                  "Caribbean (IHME GBD)": "Caribbean"
+                  "Central Latin America (IHME GBD)": "Central Latin America"
+                  "Andean Latin America (IHME GBD)": "Andean Latin America"
+                  "Tropical Latin America (IHME GBD)": "Tropical Latin America"
+                  "Southern Latin America (IHME GBD)": "Southern Latin America"
+                  "Western Europe (IHME GBD)": "Western Europe"
+                  "Central Europe (IHME GBD)": "Central Europe"
+                  "Eastern Europe (IHME GBD)": "Eastern Europe"
+                  "Western Sub-Saharan Africa (IHME GBD)": "Western Sub-Saharan Africa"
+                  "Central Sub-Saharan Africa (IHME GBD)": "Central Sub-Saharan Africa"
+                  "Eastern Sub-Saharan Africa (IHME GBD)": "Eastern Sub-Saharan Africa"
+                  "Southern Sub-Saharan Africa (IHME GBD)": "Southern Sub-Saharan Africa"
+                  "North Africa and Middle East (IHME GBD)": "North Africa and Middle East"
+                  "Central Asia (IHME GBD)": "Central Asia"
+                  "South Asia (IHME GBD)": "South Asia"
+                  "East Asia (IHME GBD)": "East Asia"
+                  "Southeast Asia (IHME GBD)": "Southeast Asia"
+                  "High-income Asia Pacific (IHME GBD)": "High-income Asia Pacific"
+                  "Australasia (IHME GBD)": "Australasia"
+                  "Oceania (IHME GBD)": "Oceania"
                 customHiddenCategories:
                   "No data": true

--- a/etl/steps/data/grapher/regions/2023-01-01/regions.py
+++ b/etl/steps/data/grapher/regions/2023-01-01/regions.py
@@ -85,6 +85,14 @@ def run() -> None:
         mask = tb_regions["ilo_2_region"].isna() & (tb_regions["ilo_1_region"] == "Arab States (ILO)")
         tb_regions.loc[mask, "ilo_2_region"] = tb_regions.loc[mask, "ilo_1_region"]
 
+    # North Africa and Middle East, and South Asia, are IHME GBD super-regions with no finer breakdown, so
+    # each is tagged ihme_gbd_1 only. Backfill them into the region map (ihme_gbd_2) so that partition is
+    # complete; IHME itself reports both as a super-region and as a region (mirrors the ILO case above).
+    if {"ihme_gbd_1_region", "ihme_gbd_2_region"} <= set(tb_regions.columns):
+        shared = ["North Africa and Middle East (IHME GBD)", "South Asia (IHME GBD)"]
+        mask = tb_regions["ihme_gbd_2_region"].isna() & tb_regions["ihme_gbd_1_region"].isin(shared)
+        tb_regions.loc[mask, "ihme_gbd_2_region"] = tb_regions.loc[mask, "ihme_gbd_1_region"]
+
     # Australia and New Zealand is one of FAO's 8 SDG regions, but it is also a fao_2 subregion, so it is
     # tagged fao_2. Backfill it into the fao_sdg map so that partition is complete (mirrors the ILO case above).
     if {"fao_2_region", "fao_sdg_region"} <= set(tb_regions.columns):


### PR DESCRIPTION
> _Written by Claude Opus 5 — @lucasrodes at the wheel._

Closes #5626. Adds the IHME Global Burden of Disease location hierarchy to the shared regions dataset as two categorical map indicators, for the [world-region-map-definitions](https://ourworldindata.org/world-region-map-definitions) page.

## Two tiers (`ihme_gbd_1_region`, `ihme_gbd_2_region`)

IHME's hierarchy has two nested levels over the 204 countries and territories GBD reports on: **7 super-regions** (`defined_by: ihme_gbd_1`) and **21 regions** (`ihme_gbd_2`). Both are complete, pairwise-disjoint partitions of the same 204 countries, so each level is a clean map indicator.

Membership is taken from IHME's published **GBD 2023** location hierarchy (the Global-rooted location set, levels 1–3; subnational levels ignored) and verified by set-equality for all 28 aggregates. **Cross-checked against GBD 2021: the two rounds define these regions identically** — same 7 super-regions, same 21 regions, same 204 countries, member for member. All 204 GBD location names resolved to existing OWID codes with no manual mapping, and every member is a plain country — no historical entities, no nested OWID aggregates.

These are specifically the **GBD** hierarchy, not "IHME's regions" generally. IHME's hierarchy file carries **16 location sets**; only the one rooted at `Global` is theirs by construction. The other 15 are groupings it ships so GBD results can be re-sliced — WHO regions, World Bank regions and income levels, `Four World Regions`, OECD, G20, EU, African Union, ASEAN, League of Arab States, GCC, Commonwealth, Nordic Region, Sahel, OIC. IHME's own glossary calls these "GBD region" and contrasts them with those groupings, so `defined_by`, the entity suffix and both indicator titles all name GBD explicitly.

Names carry the `(IHME GBD)` suffix, matching the region entities already published by `demography/2026-02-05/ihme_2020`: 25 of the 26 line up exactly. The 26th is a spelling fix — that step harmonized to `High-Income Asia Pacific`, while IHME writes `High-income Asia Pacific`. Left unaligned, that one entity would match no defined region in the frontend. No chart config referenced it, so the correction is free.

Four assignments read as errors but are IHME's own, and are worth knowing before reviewing the map: **Israel** is in `Western Europe`; **Afghanistan** and **Türkiye** are in `North Africa and Middle East`, not South Asia or Europe; **Belize**, **Guyana** and **Suriname** are in `Caribbean`; and **Mongolia**, **Armenia**, **Azerbaijan** and **Georgia** are in `Central Asia`. All follow from grouping by epidemiological similarity, and all are identical in GBD 2021 and 2023.

## Members are listed explicitly, not composed

IHME groups locations by epidemiological similarity, so its boundaries cut across every other classification we already define — `Central Europe` mixes M49's Eastern and Southern Europe, `Caribbean` includes Belize, Guyana and Suriname, `Central Asia` picks up Armenia, Azerbaijan, Georgia and Mongolia.

Checked against all 156 existing aggregates: **17 of the 21 regions have no existing aggregate that fits inside them at all.** The four that do are coincidental rather than definitional (`High-income North America` happens to equal Ember's `North America`; `Western Europe` is Maddison's plus five). Referencing those would let a future Maddison or Ember revision silently change what IHME's regions mean, so members are listed explicitly — as ILO, WID, Maddison, IEA and Ember all do. Unlike FAO, which references `UNM49_*` because FAO declares it follows M49, IHME declares no such link.

Reuse that *is* definitional is applied: super-regions reference their child regions rather than re-listing countries, so each of the 204 country codes appears exactly once in the section.

## Regions present at both levels

`North Africa and Middle East` and `South Asia` are super-regions with no finer breakdown, so each is a single region appearing at both levels. Since a region carries one `defined_by`, they are tagged `ihme_gbd_1` and back-filled into the `ihme_gbd_2` map in the grapher step — the same treatment as ILO's `Arab States`.

## Map presentation

Rebased onto #6603, so both indicators follow the shared conventions rather than the older template:

- **`baseColorScheme: OwidCategoricalMap`** on the indicator, so colors are looked up by region name and every chart built on it inherits the palette. Without it a categorical map falls back to `BuGn`, a sequential green ramp.
- **`map.tooltipUseCustomLabels: true`**, so hovering a country shows `Western Europe` rather than `Western Europe (IHME GBD)` — `customCategoryLabels` alone only renames the legend.
- **No `customCategoryColors`.** Colors belong in `MapContinentColors`, keyed by region name; a block here would fork the source of truth.
- **Legend order follows the house sweep** — Americas → Latin America/Caribbean → Africa → Middle East/North Africa → Europe → Central Asia → South Asia → East and South-East Asia → Australia and New Zealand → Oceania. Because IHME folds North Africa into its Middle East bucket, the Sub-Saharan regions are alone in the Africa slot and lead it. Both `sort` lists are to be copied verbatim into `customRegionDisplayOrder` on the frontend PR so the published legend and the hover mini-map agree.

## Two traps in the 2023 hierarchy file

Both are handled, and both would have produced wrong regions silently:

- It ships **only** a combined `All Location Hierarchies` sheet, which stacks 14 location sets together. The GBD hierarchy has to be selected as the Global-rooted set — reading the sheet whole would fold the World Bank, OECD, African Union and other groupings in as GBD regions.
- Its **level 1 holds 11 entries, not 7**: the 7 super-regions plus 4 SDI quintile groups, which aggregate by development level rather than geography. Deriving super-regions as the parents of the 21 regions excludes them by construction.

The file also renames two countries (`Turkey` → `Türkiye`, `Cote d'Ivoire` → `Côte d'Ivoire`) and ships both double-encoded; they resolve through existing OWID aliases once the encoding is repaired.

## Files

- `etl/steps/data/garden/regions/2023-01-01/regions.yml`: the 26 `IHME_*` definitions.
- `etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml`: origin anchor plus both indicators' metadata.
- `etl/steps/data/grapher/regions/2023-01-01/regions.py`: the cross-tier back-fill.
- `etl/steps/data/garden/demography/2026-02-05/ihme_2020.countries.json`: the `High-income` spelling alignment.

## Still open

**Handed off**
- **Region-definition map charts** are not created yet — they need the indicators on this branch's staging server first. Two charts to follow, matching `world-regions-according-to-fao` / `-ilo` / `-wid`: one per tier.
- **The [world-region-map-definitions](https://ourworldindata.org/world-region-map-definitions) article** needs a section headed `Institute for Health Metrics and Evaluation (IHME GBD)`. It's a gdoc, editable only in admin. Both tiers' tooltips will point at anchor `#institute-for-health-metrics-and-evaluation-ihme-gbd`, so the heading must match.
- **Frontend counterpart** (registers `ihme_gbd_1` / `ihme_gbd_2` as full region providers, and carries the color proposal below). It can be opened against this branch's staging catalog, but must be regenerated from prod before merging. Three wrinkles: the bare suffix slug is `ihmegbd` (≠ the per-level keys) and must be registered separately or grouping and hovers silently break; the tier-2 hover map needs a frontend back-fill for the two shared regions, or their member countries render grey; and `customRegionDisplayOrder` must match the `sort` lists here.
- **Region colors need a design sign-off**, on the frontend PR rather than this one. Nothing in ETL sets a color. All 26 regions need entries in **both** `ContinentColors` (strong, for charts) and `MapContinentColors` (muted, for maps) in `CustomSchemes.ts`, checked side by side on `/admin/test-region-maps`. Two constraints specific to IHME: no two regions of a tier may share a color, and the tiers must be checked independently since each is its own legend — with 21 regions in tier 2 that is the tightest palette fit of any provider so far.

**Unverified**
- **The colors on this branch's staging are not the proposal.** Until the names are pinned in `MapContinentColors`, `OwidCategoricalMap` hands out palette colors by legend *position*, so tier-2's 21 categories will repeat colors there. That staging render is good for checking membership, legend order and labels — not colors. It also means reordering `sort` later would silently recolor the map until the pinning lands, so the two changes should move together.
- **Four orphaned entities** — `Africa / America / Asia / Europe (IHME GBD)` exist in production and are **IHME's `Four World Regions` set, not the GBD hierarchy**, imported under the same `(IHME GBD)` suffix by a step that no longer maps to them. So they resolve to the IHME provider and match no defined region. No chart references them and no step produces them; left untouched, but they are the concrete reason the naming here is GBD-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
