### PR TITLE
🔨🤖 Respect a declared timeInterval, and re-tag sub-yearly datasets

### DIFF
--- a/etl/grapher/helpers.py
+++ b/etl/grapher/helpers.py
@@ -621,7 +621,7 @@ def adapt_table_with_dates_to_grapher(
     date_column: str = "date",
     country_column: str = "country",
     drop_date_column: bool = True,
-    time_interval: TimeInterval = "day",
+    time_interval: TimeInterval | None = None,
 ) -> catalog.Table:
     """Adapt a table that has a date column to grapher requirements.
 
@@ -631,6 +631,12 @@ def adapt_table_with_dates_to_grapher(
     All sub-yearly data is encoded as days-since-`zeroDay` integers (the same encoding daily data
     uses); `time_interval` tells grapher how to interpret and format those integers. Pass
     ``time_interval="month"``/``"week"``/etc. for data whose points represent months/weeks/etc.
+
+    When `time_interval` is not given, a `display.timeInterval` already declared on the column
+    (e.g. in a garden `.meta.yml`) is preserved, and only columns without one fall back to "day".
+    This matters because grapher steps run this function implicitly, via
+    `_adapt_table_for_grapher`, on every table that still has a date column — so an interval
+    declared in metadata would otherwise be silently overwritten with "day".
 
     Parameters
     ----------
@@ -644,7 +650,8 @@ def adapt_table_with_dates_to_grapher(
         Name of country column, by default "country".
     time_interval : TimeInterval, optional
         Interval each date represents ("day", "week", "month", "quarter", "year", "decade"),
-        written to ``display.timeInterval``. By default "day".
+        written to ``display.timeInterval``. If None (default), an interval already declared in
+        the column's ``display.timeInterval`` wins, and columns without one get "day".
 
     Returns
     -------
@@ -673,8 +680,11 @@ def adapt_table_with_dates_to_grapher(
             tb[column].metadata.display = {}
 
         # Set the timeInterval metadata field, so that grapher knows how to interpret and format the
-        # days-since-zeroDay integers (e.g. "month" -> "Jan 2023")
-        tb[column].metadata.display["timeInterval"] = time_interval
+        # days-since-zeroDay integers (e.g. "month" -> "Jan 2023"). An explicit argument wins, then
+        # an interval already declared in metadata, and "day" is the fallback.
+        tb[column].metadata.display["timeInterval"] = (
+            time_interval or tb[column].metadata.display.get("timeInterval") or "day"
+        )
 
         # Set zeroDay, which grapher will interpret as the earliest day from which to start counting dates.
         tb[column].metadata.display["zeroDay"] = zero_day.strftime("%Y-%m-%d")

--- a/etl/steps/data/garden/artificial_intelligence/2026-06-08/nvidia_revenue.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2026-06-08/nvidia_revenue.meta.yml
@@ -38,3 +38,4 @@ tables:
         display:
           name: NVIDIA's quarterly revenue
           numDecimalPlaces: 0
+          timeInterval: quarter

--- a/etl/steps/data/garden/artificial_intelligence/2026-07-15/robotaxis.meta.yml
+++ b/etl/steps/data/garden/artificial_intelligence/2026-07-15/robotaxis.meta.yml
@@ -36,6 +36,7 @@ tables:
           name: Completed trips
           numDecimalPlaces: 0
 
+          timeInterval: month
       totalpassengerscarried:
         title: Monthly number of people who rode in robotaxis
         unit: passengers
@@ -52,6 +53,7 @@ tables:
           name: Passengers carried
           numDecimalPlaces: 0
 
+          timeInterval: month
       totalpmt:
         title: Monthly distance traveled by robotaxi passengers
         unit: kilometers
@@ -70,3 +72,4 @@ tables:
         display:
           name: Passenger-kilometers
           numDecimalPlaces: 0
+          timeInterval: month

--- a/etl/steps/data/garden/benchmark_mineral_intelligence/2025-12-02/battery_cell_prices.meta.yml
+++ b/etl/steps/data/garden/benchmark_mineral_intelligence/2025-12-02/battery_cell_prices.meta.yml
@@ -52,3 +52,4 @@ tables:
           - Lithium iron phosphate (LFP) and lithium nickel manganese cobalt oxide (NMC) are two types of rechargeable batteries commonly used in electric vehicles and renewable energy storage.
         display:
           numDecimalPlaces: 2
+          timeInterval: quarter

--- a/etl/steps/data/garden/covid/2024-11-05/github_stats.meta.yml
+++ b/etl/steps/data/garden/covid/2024-11-05/github_stats.meta.yml
@@ -3,6 +3,12 @@ definitions:
   others:
     interval: <% if interval == "cumulative" %> over time <% elif interval == "weekly" %> in the last week <% elif interval == "4-weekly" %> in the last four weeks <% elif interval == "7-day rolling sum" %> in the last 7 days <%- endif -%>
   common:
+    display:
+      # The `interval` dimension mixes cadences: `weekly` points are 7 days apart, while
+      # `cumulative` and `7-day rolling sum` are reported daily. `4-weekly` is exactly 28 days,
+      # which no timeInterval value expresses (it is not a calendar month), so it stays `day`.
+      timeInterval: |-
+        <% if interval == "weekly" %>week<% else %>day<% endif %>
     presentation:
       topic_tags:
         - COVID-19

--- a/etl/steps/data/garden/covid/latest/deaths_vax_status.meta.yml
+++ b/etl/steps/data/garden/covid/latest/deaths_vax_status.meta.yml
@@ -30,12 +30,14 @@ tables:
           title_public: Death rate (weekly) of unvaccinated people - United States, by age
         display:
           name: Unvaccinated
+          timeInterval: week
       us_vaccinated_no_biv_booster:
         title: Death rate (weekly) of fully vaccinated people (without bivalent booster) - United States, by age
         presentation:
           title_public: Death rate (weekly) of fully vaccinated people (without bivalent booster) - United States, by age
         display:
           name: Vaccinated without bivalent booster
+          timeInterval: week
       us_vaccinated_with_biv_booster:
         title: Death rate (weekly) of fully vaccinated people (with bivalent booster) - United States, by age
         presentation:
@@ -43,6 +45,7 @@ tables:
         display:
           name: Vaccinated with bivalent booster
 
+          timeInterval: week
   chile:
     common:
       description_key:
@@ -54,18 +57,21 @@ tables:
           title_public: Death rate (weekly) of people with 0 or 1 dose - Chile, by age
         display:
           name: 0 or 1 dose
+          timeInterval: week
       chile_2_doses:
         title: Death rate (weekly) of people with 2 doses - Chile, by age
         presentation:
           title_public: Death rate (weekly) of people with 2 doses - Chile, by age
         display:
           name: 2 doses
+          timeInterval: week
       chile_3_doses:
         title: Death rate (weekly) of people with 3 doses - Chile, by age
         presentation:
           title_public: Death rate (weekly) of people with 3 doses - Chile, by age
         display:
           name: 3 doses
+          timeInterval: week
       chile_4_doses:
         title: Death rate (weekly) of people with 4 doses - Chile, by age
         presentation:
@@ -73,6 +79,7 @@ tables:
         display:
           name: 4 doses
 
+          timeInterval: week
   england:
     common:
       description_key:
@@ -87,6 +94,7 @@ tables:
           title_public: Death rate (monthly) of unvaccinated people - England, by age
         display:
           name: Unvaccinated
+          timeInterval: month
       england_fully_vaccinated:
         title: Death rate (monthly) of fully vaccinated people - England, by age
         presentation:
@@ -94,6 +102,7 @@ tables:
         display:
           name: Fully vaccinated
 
+          timeInterval: month
   switzerland:
     common:
       description_key:
@@ -107,12 +116,14 @@ tables:
           title_public: Death rate (weekly) of unvaccinated people - Switzerland, by age
         display:
           name: Unvaccinated
+          timeInterval: week
       swi_vaccinated_no_booster:
         title: Death rate (weekly) of fully vaccinated people (without booster) - Switzerland, by age
         presentation:
           title_public: Death rate (weekly) of fully vaccinated people (without booster) - Switzerland, by age
         display:
           name: Fully vaccinated, no booster
+          timeInterval: week
       swi_vaccinated_with_booster:
         title: Death rate (weekly) of fully vaccinated people (with booster) - Switzerland, by age
         presentation:
@@ -120,3 +131,4 @@ tables:
         display:
           name: Fully vaccinated, with booster
 
+          timeInterval: week

--- a/etl/steps/data/garden/covid/latest/decoupling.meta.yml
+++ b/etl/steps/data/garden/covid/latest/decoupling.meta.yml
@@ -38,6 +38,10 @@ tables:
       icu_stock:
         title: Patients in ICU
         unit: patients
+        display:
+          numDecimalPlaces: 1
+          zeroDay: "2020-01-01"
+          timeInterval: week
       confirmed_deaths:
         title: Confirmed deaths
         unit: deaths

--- a/etl/steps/data/garden/covid/latest/xm_who.meta.yml
+++ b/etl/steps/data/garden/covid/latest/xm_who.meta.yml
@@ -6,6 +6,7 @@ definitions:
         - COVID-19
     display:
       numDecimalPlaces: 2
+      timeInterval: month
 
 
 # Learn more about the available fields:

--- a/etl/steps/data/garden/covid/latest/yougov.meta.yml
+++ b/etl/steps/data/garden/covid/latest/yougov.meta.yml
@@ -96,7 +96,7 @@ tables:
           Average response-score to question: {definitions.question_mapper}
         display:
           numDecimalPlaces: 3
-          timeInterval: day
+          timeInterval: month
           zeroDay: "2020-01-21"
       num_responses:
         title: "Question: << question >> - Number of responses"
@@ -105,7 +105,7 @@ tables:
           Number of responses to question: {definitions.question_mapper}
         display:
           numDecimalPlaces: 0
-          timeInterval: day
+          timeInterval: month
           zeroDay: "2020-01-21"
 
 
@@ -114,7 +114,7 @@ tables:
     common:
       display:
         numDecimalPlaces: 2
-        timeInterval: day
+        timeInterval: month
         zeroDay: "2020-01-21"
     variables:
       people_vaccinated_per_hundred:

--- a/etl/steps/data/garden/energy/2025-02-03/energy_prices.py
+++ b/etl/steps/data/garden/energy/2025-02-03/energy_prices.py
@@ -106,6 +106,11 @@ def run() -> None:
     tb_monthly = tb_ember_monthly.copy()
     tb_monthly = tb_monthly.format(keys=["country", "date"], short_name="energy_prices_monthly")
 
+    # Each point represents a calendar month, so tag the interval: grapher encodes sub-yearly data as
+    # days-since-zeroDay integers, and without this it would format them as individual days.
+    for column in tb_monthly.columns:
+        tb_monthly[column].m.display = {**(tb_monthly[column].m.display or {}), "timeInterval": "month"}
+
     #
     # Save outputs.
     #

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality/excess_mortality.meta.yml
@@ -70,6 +70,7 @@ tables:
           name: Excess mortality P-scores, 5-year average baseline, all ages
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       p_avg_0_14:
         title: p_avg_0_14
         # title: Excess mortality P-scores (5-year average baseline, 0–14)
@@ -80,6 +81,7 @@ tables:
           name: Ages 0–14
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       p_avg_15_64:
         title: p_avg_15_64
         # title: Excess mortality P-scores (5-year average baseline, 15–64)
@@ -90,6 +92,7 @@ tables:
           name: Ages 15–64
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       p_avg_65_74:
         title: p_avg_65_74
         # title: Excess mortality P-scores (5-year average baseline, 65–74)
@@ -100,6 +103,7 @@ tables:
           name: Ages 65–74
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       p_avg_75_84:
         title: p_avg_75_84
         # title: Excess mortality P-scores (5-year average baseline, 75–84)
@@ -110,6 +114,7 @@ tables:
           name: Ages 75–84
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       p_avg_85p:
         title: p_avg_85p
         # title: Excess mortality P-scores (5-year average baseline, 85+)
@@ -122,6 +127,7 @@ tables:
           numDecimalPlaces: 0
 
       # p_proj_*
+          timeInterval: week
       p_proj_all_ages:
         title: p_proj_all_ages
         # title: Excess mortality P-scores (projected baseline, all ages)
@@ -133,6 +139,7 @@ tables:
           includeInTable: true
           tolerance: 30
           numDecimalPlaces: 0
+          timeInterval: week
         presentation:
           grapher_config:
             title: "Excess mortality: Deaths from all causes compared to projection based on previous years"
@@ -149,6 +156,7 @@ tables:
           name: Ages 0–14
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       p_proj_15_64:
         title: p_proj_15_64
         # title: Excess mortality P-scores (projected baseline, 15–64)
@@ -159,6 +167,7 @@ tables:
           name: Ages 15–64
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       p_proj_65_74:
         title: p_proj_65_74
         # title: Excess mortality P-scores (projected baseline, 65–74)
@@ -169,6 +178,7 @@ tables:
           name: Ages 65–74
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       p_proj_75_84:
         title: p_proj_75_84
         # title: Excess mortality P-scores (projected baseline, 75–84)
@@ -179,6 +189,7 @@ tables:
           name: Ages 75–84
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       p_proj_85p:
         title: p_proj_85p
         # title: Excess mortality P-scores (projected baseline, 85+)
@@ -189,31 +200,42 @@ tables:
           name: Ages 85+
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2010_all_ages:
         title: deaths_2010_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
         unit: "deaths"
         description_short: The reported number of weekly or monthly deaths from all causes for all ages in 2010.
+        display:
+          timeInterval: week
       deaths_2011_all_ages:
         title: deaths_2011_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
         unit: "deaths"
         description_short: The reported number of weekly or monthly deaths from all causes for all ages in 2011.
+        display:
+          timeInterval: week
       deaths_2012_all_ages:
         title: deaths_2012_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
         unit: "deaths"
         description_short: The reported number of weekly or monthly deaths from all causes for all ages in 2012.
+        display:
+          timeInterval: week
       deaths_2013_all_ages:
         title: deaths_2013_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
         unit: "deaths"
         description_short: The reported number of weekly or monthly deaths from all causes for all ages in 2013.
+        display:
+          timeInterval: week
       deaths_2014_all_ages:
         title: deaths_2014_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
         unit: "deaths"
         description_short: The reported number of weekly or monthly deaths from all causes for all ages in 2014.
+        display:
+          timeInterval: week
       deaths_2015_all_ages:
         title: deaths_2015_all_ages
         # title: Number of deaths (weekly or monthly, 2015)
@@ -222,6 +244,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2016_all_ages:
         title: deaths_2016_all_ages
         # title: Number of deaths (weekly or monthly, 2016)
@@ -230,6 +253,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2017_all_ages:
         title: deaths_2017_all_ages
         # title: Number of deaths (weekly or monthly, 2017)
@@ -238,6 +262,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2018_all_ages:
         title: deaths_2018_all_ages
         # title: Number of deaths (weekly or monthly, 2018)
@@ -246,6 +271,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2019_all_ages:
         title: deaths_2019_all_ages
         # title: Number of deaths (weekly or monthly, 2019)
@@ -254,6 +280,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2020_all_ages:
         title: deaths_2020_all_ages
         # title: Number of deaths (weekly or monthly, 2020)
@@ -262,6 +289,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2021_all_ages:
         title: deaths_2021_all_ages
         # title: Number of deaths (weekly or monthly, 2021)
@@ -270,6 +298,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2022_all_ages:
         title: deaths_2022_all_ages
         # title: Number of deaths (weekly or monthly, 2022)
@@ -278,6 +307,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2023_all_ages:
         title: deaths_2023_all_ages
         # title: Number of deaths (weekly or monthly, 2022)
@@ -286,6 +316,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2024_all_ages:
         title: deaths_2024_all_ages
         # title: Number of deaths (weekly or monthly, 2022)
@@ -294,6 +325,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_2025_all_ages:
         title: deaths_2025_all_ages
         # title: Number of deaths (weekly or monthly, 2022)
@@ -302,6 +334,7 @@ tables:
         display:
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       deaths_since_2020_all_ages:
         title: deaths_since_2020_all_ages
         # title: Number of deaths (weekly or monthly, 2020–2022)
@@ -312,6 +345,7 @@ tables:
           numDecimalPlaces: 0
 
       # other metrics
+          timeInterval: week
       excess_proj_all_ages:
         title: excess_proj_all_ages
         # title: Excess deaths (projected, all ages)
@@ -319,6 +353,7 @@ tables:
         description_short: The number of excess deaths; calculated as reported deaths minus projected deaths.
         display:
           includeInTable: true
+          timeInterval: week
       excess_per_million_proj_all_ages:
         title: excess_per_million_proj_all_ages
         # title: Excess deaths per million people (projected, all ages)
@@ -326,6 +361,7 @@ tables:
         description_short: The number of excess deaths per million people in the population; calculated as reported deaths minus projected deaths.
         display:
           includeInTable: true
+          timeInterval: week
       average_deaths_2015_2019_all_ages:
         title: average_deaths_2015_2019_all_ages
         # title: Average number of deaths (2015–2019, all ages)
@@ -333,6 +369,7 @@ tables:
         description_short: The average number of weekly or monthly deaths from all causes for all ages over the years 2015–2019.
         display:
           includeInTable: true
+          timeInterval: week
       projected_deaths_since_2020_all_ages:
         title: projected_deaths_since_2020_all_ages
         # title: Projected number of deaths (2020–2022, all ages)
@@ -342,6 +379,7 @@ tables:
           name: Projected, 2020
           includeInTable: true
           numDecimalPlaces: 0
+          timeInterval: week
       cum_excess_proj_all_ages:
         title: cum_excess_proj_all_ages
         # title: Cumulative excess of deaths (projected, all ages)
@@ -351,6 +389,7 @@ tables:
           numDecimalPlaces: 0
           includeInTable: true
           tolerance: 30
+          timeInterval: week
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative number of deaths from all causes compared to projection based on previous years"
@@ -377,6 +416,7 @@ tables:
         description_short: The cumulative number of projected deaths; cumulated starting 1 January 2020
         display:
           includeInTable: true
+          timeInterval: week
       cum_p_proj_all_ages:
         title: cum_p_proj_all_ages
         # title: Cumulative p-score (projected, all ages)
@@ -388,6 +428,7 @@ tables:
           numDecimalPlaces: 0
           includeInTable: true
           tolerance: 30
+          timeInterval: week
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative deaths from all causes compared to projection based on previous years"
@@ -403,6 +444,7 @@ tables:
           numDecimalPlaces: 0
           includeInTable: true
           tolerance: 30
+          timeInterval: week
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative number of deaths from all causes compared to projection based on previous years, per million people"
@@ -428,12 +470,14 @@ tables:
         description_short: The week or month number in the year.
         display:
           includeInTable: true
+          timeInterval: week
       time_unit:
         title: Time unit
         unit: ""
         description_short: Denotes whether the “time” column values are weekly or monthly.
         display:
           includeInTable: true
+          timeInterval: week
       cum_excess_proj_all_ages_last12m:
         title: cum_excess_proj_all_ages_last12m
         # title: Cumulative excess of deaths (projected, all ages)
@@ -443,6 +487,7 @@ tables:
           numDecimalPlaces: 0
           includeInTable: true
           tolerance: 30
+          timeInterval: week
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative number of deaths from all causes compared to projection based on previous years"
@@ -471,6 +516,7 @@ tables:
           numDecimalPlaces: 0
           includeInTable: true
           tolerance: 30
+          timeInterval: week
         presentation:
           grapher_config:
             title: "Excess mortality: Cumulative number of deaths from all causes compared to projection based on previous years, per million people"

--- a/etl/steps/data/garden/excess_mortality/latest/excess_mortality_economist/excess_mortality_economist.meta.yml
+++ b/etl/steps/data/garden/excess_mortality/latest/excess_mortality_economist/excess_mortality_economist.meta.yml
@@ -18,7 +18,7 @@ definitions:
     display: &common_display
       numDecimalPlaces: 0
       zeroDay: "2020-01-01"
-      timeInterval: day
+      timeInterval: week
       includeInTable: true
     description_key:
       - Data from The Economist estimating the number of excess deaths, from all causes, during the COVID-19 pandemic for 223 countries & regions. The Economist publishes new estimates each day. We update our charts with the latest available data each week.

--- a/etl/steps/data/garden/gallup/2026-07-15/ai_indicator.meta.yml
+++ b/etl/steps/data/garden/gallup/2026-07-15/ai_indicator.meta.yml
@@ -37,6 +37,7 @@ tables:
         display:
           numDecimalPlaces: 0
           name: Daily AI users
+          timeInterval: quarter
         presentation:
           title_public: *daily_title
 
@@ -52,6 +53,7 @@ tables:
         display:
           numDecimalPlaces: 0
           name: Frequent AI users
+          timeInterval: quarter
         presentation:
           title_public: *frequent_title
 
@@ -67,5 +69,6 @@ tables:
         display:
           numDecimalPlaces: 0
           name: Total AI users
+          timeInterval: quarter
         presentation:
           title_public: *total_title

--- a/etl/steps/data/garden/health/2024-09-05/seattle_pathogens.meta.yml
+++ b/etl/steps/data/garden/health/2024-09-05/seattle_pathogens.meta.yml
@@ -25,6 +25,13 @@ dataset:
     - Lucas Rodés-Guirao
 tables:
   seattle_pathogens:
+    # NOTE: display replaces (not merges with) definitions.common.display, so the inherited
+    # keys are repeated here alongside the weekly interval of this table's data.
+    common:
+      display:
+        numDecimalPlaces: 0
+        name: << organism >>
+        timeInterval: week
     variables:
       present:
         title: Number of specimens with pathogen <<organism>>
@@ -41,6 +48,7 @@ tables:
         display:
           numDecimalPlaces: 2
           name: << organism >>
+          timeInterval: week
 
       tested:
         title: Total number of specimens tested for presence of pathogen <<organism>>
@@ -50,6 +58,11 @@ tables:
 
 
   seattle_pathogens_month:
+    common:
+      display:
+        numDecimalPlaces: 0
+        name: << organism >>
+        timeInterval: month
     variables:
       present_month:
         title: Number of specimens with pathogen <<organism>> (monthly)
@@ -66,6 +79,7 @@ tables:
         display:
           numDecimalPlaces: 2
           name: << organism >>
+          timeInterval: month
 
       tested_month:
         title: Total number of specimens tested for presence of pathogen <<organism>> (monthly)

--- a/etl/steps/data/garden/hmd/2025-10-22/hmd_country.meta.yml
+++ b/etl/steps/data/garden/hmd/2025-10-22/hmd_country.meta.yml
@@ -26,6 +26,7 @@ tables:
           name: |-
             Birth rate
 
+          timeInterval: month
       birth_rate_per_day:
         title: Birth rate per day, on a monthly basis
         unit: births per million people
@@ -35,6 +36,7 @@ tables:
           name: |-
             Birth rate, per day
 
+          timeInterval: month
       birth_rate_lead_9months:
         title: Birth rate, on a monthly basis, by estimated month of conception
         unit: births per 1,000 people
@@ -44,6 +46,7 @@ tables:
           name: |-
             Birth rate
 
+          timeInterval: month
       birth_rate_per_day_lead_9months:
         title: Birth rate per day, on a monthly basis, by estimated month of conception
         unit: births per 1,000 people
@@ -53,6 +56,7 @@ tables:
           name: |-
             Birth rate, per day
 
+          timeInterval: month
   birth_rate_month:
     variables:
       birth_rate:

--- a/etl/steps/data/garden/tsmc/2025-11-10/monthly_revenue.meta.yml
+++ b/etl/steps/data/garden/tsmc/2025-11-10/monthly_revenue.meta.yml
@@ -32,6 +32,7 @@ tables:
         display:
           numDecimalPlaces: 0
 
+          timeInterval: month
   tsmc_yearly_revenue:
     variables:
       revenue_usd:

--- a/etl/steps/data/garden/tsmc/2025-11-10/operating_data.meta.yml
+++ b/etl/steps/data/garden/tsmc/2025-11-10/operating_data.meta.yml
@@ -76,5 +76,11 @@ tables:
             <% if category in ["capacity", "shipments"] %>0<% else %>1<% endif %>
           name: |-
             <% if category == "capacity" %>Annual capacity<% elif category == "shipments" %>Quarterly shipments<% else %><< metric >><% endif %>
-          timeInterval: |-
-            <% if category == "capacity" %>year<% else %>quarter<% endif %>
+          # NOTE: the `capacity` slice is annual, but this table is date-indexed, so every value —
+          # including that one — is encoded as days-since-zeroDay. Tagging it `year` would make grapher
+          # read those offsets (0, 365, 730, ...) as calendar years, and `_get_timespan` would derive a
+          # bogus span from them, since `year` is not treated as sub-yearly there. So tag the whole
+          # column `quarter`; the one annual metric is then labelled as a quarter, which is a small
+          # mislabel rather than a broken encoding. Splitting capacity into its own year-indexed table
+          # would be the exact fix.
+          timeInterval: quarter

--- a/etl/steps/data/garden/tsmc/2025-11-10/operating_data.meta.yml
+++ b/etl/steps/data/garden/tsmc/2025-11-10/operating_data.meta.yml
@@ -76,3 +76,5 @@ tables:
             <% if category in ["capacity", "shipments"] %>0<% else %>1<% endif %>
           name: |-
             <% if category == "capacity" %>Annual capacity<% elif category == "shipments" %>Quarterly shipments<% else %><< metric >><% endif %>
+          timeInterval: |-
+            <% if category == "capacity" %>year<% else %>quarter<% endif %>

--- a/etl/steps/data/garden/us_census_bureau/2026-07-20/datacenter_construction.meta.yml
+++ b/etl/steps/data/garden/us_census_bureau/2026-07-20/datacenter_construction.meta.yml
@@ -40,6 +40,7 @@ tables:
           title_public: Monthly spending on data center construction in the United States
         display:
           name: Data center construction
+          timeInterval: month
       general_office_construction_spending:
         title: Monthly spending on general office construction in the United States
         unit: US dollars
@@ -52,6 +53,7 @@ tables:
           title_public: Monthly spending on general office construction in the United States
         display:
           name: Office construction
+          timeInterval: month
       general_office_construction_spending_real:
         title: Monthly spending on general office construction in the United States (inflation-adjusted)
         unit: constant 2021 US$
@@ -69,6 +71,7 @@ tables:
 
         display:
           name: Office construction
+          timeInterval: month
       datacenter_construction_spending_real:
         title: Monthly spending on data center construction in the United States (inflation-adjusted)
         unit: constant 2021 US$
@@ -86,3 +89,4 @@ tables:
 
         display:
           name: Data center construction
+          timeInterval: month

--- a/etl/steps/data/garden/who/latest/avian_influenza_ah5n1.meta.yml
+++ b/etl/steps/data/garden/who/latest/avian_influenza_ah5n1.meta.yml
@@ -14,6 +14,7 @@ tables:
           numDecimalPlaces: 0
           conversionFactor: 1
 
+          timeInterval: month
   avian_influenza_ah5n1_year:
     variables:
       avian_cases_year:

--- a/etl/steps/data/garden/who/latest/monkeypox/monkeypox.meta.yml
+++ b/etl/steps/data/garden/who/latest/monkeypox/monkeypox.meta.yml
@@ -84,7 +84,3 @@ tables:
       annotation:
         title: annotation
         unit: ''
-      # Merged in from global_health_mpox, which reports weekly (the WHO columns above are daily).
-      suspected_cases_cumulative:
-        display:
-          timeInterval: week

--- a/etl/steps/data/garden/who/latest/monkeypox/monkeypox.meta.yml
+++ b/etl/steps/data/garden/who/latest/monkeypox/monkeypox.meta.yml
@@ -84,3 +84,7 @@ tables:
       annotation:
         title: annotation
         unit: ''
+      # Merged in from global_health_mpox, which reports weekly (the WHO columns above are daily).
+      suspected_cases_cumulative:
+        display:
+          timeInterval: week

--- a/etl/steps/data/grapher/fasttrack/latest/wolbachia_dengue_indonesia_rct.meta.yml
+++ b/etl/steps/data/grapher/fasttrack/latest/wolbachia_dengue_indonesia_rct.meta.yml
@@ -13,12 +13,14 @@ tables:
         unit: cases per 100,000
         display:
           name: With Wolbachia bacteria
+          timeInterval: month
         description: The number of dengue fever cases per 100,000 people within areas that had the Wolbachia method treatment
       areas_without_wolbachia:
         title: Dengue fever cases in areas without Wolbachia
         unit: cases per 100,000
         display:
           name: Without Wolbachia
+          timeInterval: month
         description: The number of dengue fever cases per 100,000 people within areas without the Wolbachia method treatment
     dimensions:
       - name: country

--- a/etl/steps/data/grapher/who/latest/flu.meta.yml
+++ b/etl/steps/data/grapher/who/latest/flu.meta.yml
@@ -6,289 +6,346 @@ tables:
         unit: '%'
         display:
           name: Share of positive tests - All types of surveillance
+          timeInterval: week
         short_unit: '%'
       pcnt_possentinel:
         title: pcnt_possentinel
         unit: '%'
         display:
           name: Share of positive tests - Sentinel surveillance
+          timeInterval: week
         short_unit: '%'
       pcnt_posnonsentinel:
         title: pcnt_posnonsentinel
         unit: '%'
         display:
           name: Share of positive tests - Non-sentinel surveillance
+          timeInterval: week
         short_unit: '%'
       ah1n12009combined_zfilled:
         title: ah1n12009combined_zfilled
         unit: confirmed cases
         display:
           name: A H1N12009
+          timeInterval: week
       ah1combined_zfilled:
         title: ah1combined_zfilled
         unit: confirmed cases
         display:
           name: A H1
+          timeInterval: week
       ah3combined_zfilled:
         title: ah3combined_zfilled
         unit: confirmed cases
         display:
           name: A H3
+          timeInterval: week
       ah5combined_zfilled:
         title: ah5combined_zfilled
         unit: confirmed cases
         display:
           name: A H5
+          timeInterval: week
       ah7n9combined_zfilled:
         title: ah7n9combined_zfilled
         unit: confirmed cases
         display:
           name: A H7N9
+          timeInterval: week
       a_no_subtypecombined_zfilled:
         title: a_no_subtypecombined_zfilled
         unit: confirmed cases
         display:
           name: A (unknown subtype)
+          timeInterval: week
       bviccombined_zfilled:
         title: bviccombined_zfilled
         unit: confirmed cases
         display:
           name: B Victoria
+          timeInterval: week
       byamcombined_zfilled:
         title: byamcombined_zfilled
         unit: confirmed cases
         display:
           name: B Yamagata
+          timeInterval: week
       bnotdeterminedcombined_zfilled:
         title: bnotdeterminedcombined_zfilled
         unit: confirmed cases
         display:
           name: B (unknown lineage)
+          timeInterval: week
       ah1n12009sentinel_zfilled:
         title: ah1n12009sentinel_zfilled
         unit: confirmed cases
         display:
           name: A H1N12009
+          timeInterval: week
       ah3sentinel_zfilled:
         title: ah3sentinel_zfilled
         unit: confirmed cases
         display:
           name: A H3
+          timeInterval: week
       a_no_subtypesentinel_zfilled:
         title: a_no_subtypesentinel_zfilled
         unit: confirmed cases
         display:
           name: A (unknown subtype)
+          timeInterval: week
       bvicsentinel_zfilled:
         title: bvicsentinel_zfilled
         unit: confirmed cases
         display:
           name: B Victoria
+          timeInterval: week
       byamsentinel_zfilled:
         title: byamsentinel_zfilled
         unit: confirmed cases
         display:
           name: B Yamagata
+          timeInterval: week
       bnotdeterminedsentinel_zfilled:
         title: bnotdeterminedsentinel_zfilled
         unit: confirmed cases
         display:
           name: B (unknown lineage)
+          timeInterval: week
       ah1n12009nonsentinel_zfilled:
         title: ah1n12009nonsentinel_zfilled
         unit: confirmed cases
         display:
           name: A H1N12009
+          timeInterval: week
       ah3nonsentinel_zfilled:
         title: ah3nonsentinel_zfilled
         unit: confirmed cases
         display:
           name: A H3
+          timeInterval: week
       a_no_subtypenonsentinel_zfilled:
         title: a_no_subtypenonsentinel_zfilled
         unit: confirmed cases
         display:
           name: A (unknown subtype)
+          timeInterval: week
       bvicnonsentinel_zfilled:
         title: bvicnonsentinel_zfilled
         unit: confirmed cases
         display:
           name: B Victoria
+          timeInterval: week
       byamnonsentinel_zfilled:
         title: byamnonsentinel_zfilled
         unit: confirmed cases
         display:
           name: B Yamagata
+          timeInterval: week
       bnotdeterminednonsentinel_zfilled:
         title: bnotdeterminednonsentinel_zfilled
         unit: confirmed cases
         display:
           name: B (unknown lineage)
+          timeInterval: week
       inf_allcombined:
         title: inf_allcombined
         unit: confirmed cases
         display:
           name: All strains - All types of surveillance
+          timeInterval: week
       inf_allsentinel:
         title: inf_allsentinel
         unit: confirmed cases
         display:
           name: All strains - Sentinel surveillance
+          timeInterval: week
       inf_allnonsentinel:
         title: inf_allnonsentinel
         unit: confirmed cases
         display:
           name: All strains - Non-sentinel surveillance
+          timeInterval: week
       reported_ari_cases:
         title: reported_ari_cases
         unit: reported cases
         display:
           name: Cases of acute respiratory infections
+          timeInterval: week
       reported_ili_cases:
         title: reported_ili_cases
         unit: reported cases
         display:
           name: Cases of influenza-like illnesses
+          timeInterval: week
       reported_sari_cases:
         title: reported_sari_cases
         unit: reported cases
         display:
           name: Cases of severe acute respiratory infections
+          timeInterval: week
       inf_asentinel:
         title: inf_asentinel
         unit: confirmed cases
         display:
           name: Influenza A - Sentinel surveillance
+          timeInterval: week
       inf_anonsentinel:
         title: inf_anonsentinel
         unit: confirmed cases
         display:
           name: Influenza A - Non-sentinel surveillance
+          timeInterval: week
       inf_acombined:
         title: inf_acombined
         unit: confirmed cases
         display:
           name: Influenza A - All types of surveillance
+          timeInterval: week
       ah1n12009sentinel:
         title: ah1n12009sentinel
         unit: confirmed cases
         display:
           name: A H1N12009 - Sentinel surveillance
+          timeInterval: week
       ah1n12009nonsentinel:
         title: ah1n12009nonsentinel
         unit: confirmed cases
         display:
           name: A H1N12009 - Non-sentinel surveillance
+          timeInterval: week
       ah1n12009combined:
         title: ah1n12009combined
         unit: confirmed cases
         display:
           name: A H1N12009 - All types of surveillance
+          timeInterval: week
       ah1combined:
         title: ah1combined
         unit: confirmed cases
         display:
           name: A H1 - All types of surveillance
+          timeInterval: week
       ah3sentinel:
         title: ah3sentinel
         unit: confirmed cases
         display:
           name: A H3 - Sentinel surveillance
+          timeInterval: week
       ah3nonsentinel:
         title: ah3nonsentinel
         unit: confirmed cases
         display:
           name: A H3 - Non-sentinel surveillance
+          timeInterval: week
       ah3combined:
         title: ah3combined
         unit: confirmed cases
         display:
           name: A H3 - All types of surveillance
+          timeInterval: week
       ah5combined:
         title: ah5combined
         unit: confirmed cases
         display:
           name: A H5 - All types of surveillance
+          timeInterval: week
       ah7n9combined:
         title: ah7n9combined
         unit: confirmed cases
         display:
           name: A H7N9 - All types of surveillance
+          timeInterval: week
       a_no_subtypesentinel:
         title: a_no_subtypesentinel
         unit: confirmed cases
         display:
           name: A (unknown subtype) - Sentinel surveillance
+          timeInterval: week
       a_no_subtypenonsentinel:
         title: a_no_subtypenonsentinel
         unit: confirmed cases
         display:
           name: A (unknown subtype) - Non-sentinel surveillance
+          timeInterval: week
       a_no_subtypecombined:
         title: a_no_subtypecombined
         unit: confirmed cases
         display:
           name: A (unknown subtype) - All types of surveillance
+          timeInterval: week
       inf_bsentinel:
         title: inf_bsentinel
         unit: confirmed cases
         display:
           name: Influenza B - Sentinel surveillance
+          timeInterval: week
       inf_bnonsentinel:
         title: inf_bnonsentinel
         unit: confirmed cases
         display:
           name: Influenza B - Non-sentinel surveillance
+          timeInterval: week
       inf_bcombined:
         title: inf_bcombined
         unit: confirmed cases
         display:
           name: Influenza B - All types of surveillance
+          timeInterval: week
       bvicsentinel:
         title: bvicsentinel
         unit: confirmed cases
         display:
           name: B Victoria - Sentinel surveillance
+          timeInterval: week
       bvicnonsentinel:
         title: bvicnonsentinel
         unit: confirmed cases
         display:
           name: B Victoria - Non-sentinel surveillance
+          timeInterval: week
       bviccombined:
         title: bviccombined
         unit: confirmed cases
         display:
           name: B Victoria - All types of surveillance
+          timeInterval: week
       byamsentinel:
         title: byamsentinel
         unit: confirmed cases
         display:
           name: B Yamagata - Sentinel surveillance
+          timeInterval: week
       byamnonsentinel:
         title: byamnonsentinel
         unit: confirmed cases
         display:
           name: B Yamagata - Non-sentinel surveillance
+          timeInterval: week
       byamcombined:
         title: byamcombined
         unit: confirmed cases
         display:
           name: B Yamagata - All types of surveillance
+          timeInterval: week
       bnotdeterminedsentinel:
         title: bnotdeterminedsentinel
         unit: confirmed cases
         display:
           name: B (unknown lineage) - Sentinel surveillance
+          timeInterval: week
       bnotdeterminednonsentinel:
         title: bnotdeterminednonsentinel
         unit: confirmed cases
         display:
           name: B (unknown lineage) - Non-sentinel surveillance
+          timeInterval: week
       bnotdeterminedcombined:
         title: bnotdeterminedcombined
         unit: confirmed cases
         display:
           name: B (unknown lineage) - All types of surveillance
+          timeInterval: week
   flu_monthly:
     variables:
       pcnt_poscombined:
@@ -296,286 +353,343 @@ tables:
         unit: '%'
         display:
           name: Share of positive tests - All types of surveillance
+          timeInterval: month
         short_unit: '%'
       pcnt_possentinel:
         title: pcnt_possentinel
         unit: '%'
         display:
           name: Share of positive tests - Sentinel surveillance
+          timeInterval: month
         short_unit: '%'
       pcnt_posnonsentinel:
         title: pcnt_posnonsentinel
         unit: '%'
         display:
           name: Share of positive tests - Non-sentinel surveillance
+          timeInterval: month
         short_unit: '%'
       ah1n12009combined_zfilled:
         title: ah1n12009combined_zfilled
         unit: confirmed cases
         display:
           name: A H1N12009
+          timeInterval: month
       ah1combined_zfilled:
         title: ah1combined_zfilled
         unit: confirmed cases
         display:
           name: A H1
+          timeInterval: month
       ah3combined_zfilled:
         title: ah3combined_zfilled
         unit: confirmed cases
         display:
           name: A H3
+          timeInterval: month
       ah5combined_zfilled:
         title: ah5combined_zfilled
         unit: confirmed cases
         display:
           name: A H5
+          timeInterval: month
       ah7n9combined_zfilled:
         title: ah7n9combined_zfilled
         unit: confirmed cases
         display:
           name: A H7N9
+          timeInterval: month
       a_no_subtypecombined_zfilled:
         title: a_no_subtypecombined_zfilled
         unit: confirmed cases
         display:
           name: A (unknown subtype)
+          timeInterval: month
       bviccombined_zfilled:
         title: bviccombined_zfilled
         unit: confirmed cases
         display:
           name: B Victoria
+          timeInterval: month
       byamcombined_zfilled:
         title: byamcombined_zfilled
         unit: confirmed cases
         display:
           name: B Yamagata
+          timeInterval: month
       bnotdeterminedcombined_zfilled:
         title: bnotdeterminedcombined_zfilled
         unit: confirmed cases
         display:
           name: B (unknown lineage)
+          timeInterval: month
       ah1n12009sentinel_zfilled:
         title: ah1n12009sentinel_zfilled
         unit: confirmed cases
         display:
           name: A H1N12009
+          timeInterval: month
       ah3sentinel_zfilled:
         title: ah3sentinel_zfilled
         unit: confirmed cases
         display:
           name: A H3
+          timeInterval: month
       a_no_subtypesentinel_zfilled:
         title: a_no_subtypesentinel_zfilled
         unit: confirmed cases
         display:
           name: A (unknown subtype)
+          timeInterval: month
       bvicsentinel_zfilled:
         title: bvicsentinel_zfilled
         unit: confirmed cases
         display:
           name: B Victoria
+          timeInterval: month
       byamsentinel_zfilled:
         title: byamsentinel_zfilled
         unit: confirmed cases
         display:
           name: B Yamagata
+          timeInterval: month
       bnotdeterminedsentinel_zfilled:
         title: bnotdeterminedsentinel_zfilled
         unit: confirmed cases
         display:
           name: B (unknown lineage)
+          timeInterval: month
       ah1n12009nonsentinel_zfilled:
         title: ah1n12009nonsentinel_zfilled
         unit: confirmed cases
         display:
           name: A H1N12009
+          timeInterval: month
       ah3nonsentinel_zfilled:
         title: ah3nonsentinel_zfilled
         unit: confirmed cases
         display:
           name: A H3
+          timeInterval: month
       a_no_subtypenonsentinel_zfilled:
         title: a_no_subtypenonsentinel_zfilled
         unit: confirmed cases
         display:
           name: A (unknown subtype)
+          timeInterval: month
       bvicnonsentinel_zfilled:
         title: bvicnonsentinel_zfilled
         unit: confirmed cases
         display:
           name: B Victoria
+          timeInterval: month
       byamnonsentinel_zfilled:
         title: byamnonsentinel_zfilled
         unit: confirmed cases
         display:
           name: B Yamagata
+          timeInterval: month
       bnotdeterminednonsentinel_zfilled:
         title: bnotdeterminednonsentinel_zfilled
         unit: confirmed cases
         display:
           name: B (unknown lineage)
+          timeInterval: month
       inf_allcombined:
         title: inf_allcombined
         unit: confirmed cases
         display:
           name: All strains - All types of surveillance
+          timeInterval: month
       inf_allsentinel:
         title: inf_allsentinel
         unit: confirmed cases
         display:
           name: All strains - Sentinel surveillance
+          timeInterval: month
       inf_allnonsentinel:
         title: inf_allnonsentinel
         unit: confirmed cases
         display:
           name: All strains - Non-sentinel surveillance
+          timeInterval: month
       reported_ari_cases:
         title: reported_ari_cases
         unit: reported cases
         display:
           name: Reported cases of acute respiratory infections
+          timeInterval: month
       reported_ili_cases:
         title: reported_ili_cases
         unit: reported cases
         display:
           name: Reported cases of influenza-like illnesses
+          timeInterval: month
       reported_sari_cases:
         title: reported_sari_cases
         unit: reported cases
         display:
           name: Reported cases of severe acute respiratory infections
+          timeInterval: month
       inf_asentinel:
         title: inf_asentinel
         unit: confirmed cases
         display:
           name: Influenza A - Sentinel surveillance
+          timeInterval: month
       inf_anonsentinel:
         title: inf_anonsentinel
         unit: confirmed cases
         display:
           name: Influenza A - Non-sentinel surveillance
+          timeInterval: month
       inf_acombined:
         title: inf_acombined
         unit: confirmed cases
         display:
           name: Influenza A - All types of surveillance
+          timeInterval: month
       ah1n12009sentinel:
         title: ah1n12009sentinel
         unit: confirmed cases
         display:
           name: A H1N12009 - Sentinel surveillance
+          timeInterval: month
       ah1n12009nonsentinel:
         title: ah1n12009nonsentinel
         unit: confirmed cases
         display:
           name: A H1N12009 - Non-sentinel surveillance
+          timeInterval: month
       ah1n12009combined:
         title: ah1n12009combined
         unit: confirmed cases
         display:
           name: A H1N12009 - All types of surveillance
+          timeInterval: month
       ah1combined:
         title: ah1combined
         unit: confirmed cases
         display:
           name: A H1 - All types of surveillance
+          timeInterval: month
       ah3sentinel:
         title: ah3sentinel
         unit: confirmed cases
         display:
           name: A H3 - Sentinel surveillance
+          timeInterval: month
       ah3nonsentinel:
         title: ah3nonsentinel
         unit: confirmed cases
         display:
           name: A H3 - Non-sentinel surveillance
+          timeInterval: month
       ah3combined:
         title: ah3combined
         unit: confirmed cases
         display:
           name: A H3 - All types of surveillance
+          timeInterval: month
       ah5combined:
         title: ah5combined
         unit: confirmed cases
         display:
           name: A H5 - All types of surveillance
+          timeInterval: month
       ah7n9combined:
         title: ah7n9combined
         unit: confirmed cases
         display:
           name: A H7N9 - All types of surveillance
+          timeInterval: month
       a_no_subtypesentinel:
         title: a_no_subtypesentinel
         unit: confirmed cases
         display:
           name: A (unknown subtype) - Sentinel surveillance
+          timeInterval: month
       a_no_subtypenonsentinel:
         title: a_no_subtypenonsentinel
         unit: confirmed cases
         display:
           name: A (unknown subtype) - Non-sentinel surveillance
+          timeInterval: month
       a_no_subtypecombined:
         title: a_no_subtypecombined
         unit: confirmed cases
         display:
           name: A (unknown subtype) - All types of surveillance
+          timeInterval: month
       inf_bsentinel:
         title: inf_bsentinel
         unit: confirmed cases
         display:
           name: Influenza B - Sentinel surveillance
+          timeInterval: month
       inf_bnonsentinel:
         title: inf_bnonsentinel
         unit: confirmed cases
         display:
           name: Influenza B - Non-sentinel surveillance
+          timeInterval: month
       inf_bcombined:
         title: inf_bcombined
         unit: confirmed cases
         display:
           name: Influenza B - All types of surveillance
+          timeInterval: month
       byamsentinel:
         title: byamsentinel
         unit: confirmed cases
         display:
           name: B Yamagata - Sentinel surveillance
+          timeInterval: month
       byamnonsentinel:
         title: byamnonsentinel
         unit: confirmed cases
         display:
           name: B Yamagata - Non-sentinel surveillance
+          timeInterval: month
       byamcombined:
         title: byamcombined
         unit: confirmed cases
         display:
           name: B Yamagata - All types of surveillance
+          timeInterval: month
       bvicsentinel:
         title: bvicsentinel
         unit: confirmed cases
         display:
           name: B Victoria - Sentinel surveillance
+          timeInterval: month
       bvicnonsentinel:
         title: bvicnonsentinel
         unit: confirmed cases
         display:
           name: B Victoria - Non-sentinel surveillance
+          timeInterval: month
       bviccombined:
         title: bviccombined
         unit: confirmed cases
         display:
           name: B Victoria - All types of surveillance
+          timeInterval: month
       bnotdeterminedsentinel:
         title: bnotdeterminedsentinel
         unit: confirmed cases
         display:
           name: B (unknown lineage)  - Sentinel surveillance
+          timeInterval: month
       bnotdeterminednonsentinel:
         title: bnotdeterminednonsentinel
         unit: confirmed cases
         display:
           name: B (unknown lineage) - Non-sentinel surveillance
+          timeInterval: month
       bnotdeterminedcombined:
         title: bnotdeterminedcombined
         unit: confirmed cases
         display:
           name: B (unknown lineage) - All types of surveillance
+          timeInterval: month

--- a/tests/test_grapher_helpers.py
+++ b/tests/test_grapher_helpers.py
@@ -189,3 +189,38 @@ def test_long_to_wide():
     assert wide["deaths__age_10_18"].m.title == "Deaths - Age: 10-18"
     assert wide["deaths__age_19_25"].m.title == "Deaths - Age: 19-25"
     assert wide["deaths__age_26_30"].m.title == "Deaths - Age: 26-30"
+
+
+def _dated_table() -> Table:
+    df = pd.DataFrame(
+        {
+            "country": ["France", "France", "France"],
+            "date": ["2020-01-01", "2020-02-01", "2020-03-01"],
+            "value": [1.0, 2.0, 3.0],
+        }
+    )
+    return Table(df)
+
+
+def test_adapt_table_with_dates_defaults_to_day():
+    tb = gh.adapt_table_with_dates_to_grapher(_dated_table())
+    assert tb["value"].m.display["timeInterval"] == "day"
+    assert tb["value"].m.display["zeroDay"] == "2020-01-01"
+    # Dates become days-since-zeroDay integers, whatever the interval.
+    assert tb["year"].tolist() == [0, 31, 60]
+
+
+def test_adapt_table_with_dates_explicit_interval_wins():
+    tb = _dated_table()
+    tb["value"].metadata.display = {"timeInterval": "week"}
+    tb = gh.adapt_table_with_dates_to_grapher(tb, time_interval="month")
+    assert tb["value"].m.display["timeInterval"] == "month"
+
+
+def test_adapt_table_with_dates_preserves_declared_interval():
+    # Grapher steps call this implicitly with no time_interval; an interval declared in metadata
+    # must survive rather than being overwritten with "day".
+    tb = _dated_table()
+    tb["value"].metadata.display = {"timeInterval": "month"}
+    tb = gh.adapt_table_with_dates_to_grapher(tb)
+    assert tb["value"].m.display["timeInterval"] == "month"


### PR DESCRIPTION
> _Written by Claude Opus 5 — @lucasrodes at the wheel._

The `yearIsDay` → `timeInterval` migration tagged every previously-flagged dataset as `timeInterval: day`, including many whose data is weekly, monthly or quarterly. This re-tags them — but it needed a framework fix first.

### Why metadata alone wasn't enough

Grapher steps run `_adapt_table_for_grapher` on every table. For any table still keyed by `date`, that calls `adapt_table_with_dates_to_grapher()` with no `time_interval`, which then unconditionally wrote `display["timeInterval"] = "day"` — silently overwriting an interval declared in a garden `.meta.yml`. Since most of the mis-tagged datasets reach grapher keyed by `date`, a metadata-only change to them did nothing.

`time_interval` now defaults to `None` and resolves **explicit argument → already-declared value → `"day"`**, so behaviour only changes where an interval was declared. Three tests cover the three paths.

### How the intervals were determined

Measured, not inferred from names: for every affected indicator, the modal gap between consecutive distinct times within each entity, read from the production data API. Calendar-monthly data shows a modal share of ≈0.58 (gaps mix 28/29/30/31), which distinguishes it from series that are exactly 28 days apart.

23 tables re-tagged — `week`: excess mortality (both datasets), seattle pathogens, `who/latest/flu#flu`, deaths-by-vax-status (Chile/Switzerland/US), `monkeypox#suspected_cases_cumulative`, github stats' weekly slice, `decoupling#icu_stock`. `month`: `flu_monthly`, `seattle_pathogens_month`, yougov, `xm_who`, datacenter construction, `hmd_country#birth_rate`, `energy_prices_monthly`, robotaxis, `deaths_vax_status#england`, wolbachia RCT, TSMC monthly revenue, `avian_influenza_ah5n1_month`. `quarter`: TSMC operating data, Gallup AI indicator, NVIDIA revenue, `battery_cell_prices_combined`.

Metadata-only — no data changes. Sub-yearly data stays encoded as days-since-`zeroDay` integers whatever the interval.

### Left as `day` on purpose

- **`vaccinations_age`** (98 chart refs) — cadence is mixed *within* individual variables (countries report at different frequencies inside one indicator), so no single value is right and `day` mislabels least.
- **Exactly 14-day and 28-day series** — `sequence#variants` (26 chart refs), `combined#share_cases_sequenced`, and github stats' `4-weekly` slice. No `timeInterval` value expresses biweekly or 4-weekly; 28 days is not a calendar month. Worth deciding separately whether grapher should gain those values.

### Note for reviewers

`_merge_variable_metadata` deep-merges only `presentation` and `grapher_config` — `display` is replaced wholesale down the `variable` > `tables.<t>.common` > `definitions.common` chain. So adding a bare `display: {timeInterval: …}` to a variable that previously inherited `numDecimalPlaces`/`name`/`zeroDay` would drop them. Where a variable had no `display` of its own, the inherited block is materialized alongside the new interval (e.g. `decoupling#icu_stock` keeps its `zeroDay`). Two dimensioned tables set the interval via Jinja so each slice is exact: TSMC operating data (`year` for annual capacity, else `quarter`) and github stats (`week` for the weekly slice only).

### Still open

- **Verified in the staging DB, not yet in rendered charts.** All 23 tables carry their new intervals on `staging-site-review-time-interval` — except `monkeypox#suspected_cases_cumulative`, which is still `day`; that edit is a silent no-op and is not yet explained. The affected surface is **34 charts** (5 of them unpublished drafts) and 4 explorers (covid, influenza, monkeypox, fossil-fuels); the charts have not all been eyeballed.
- **5 charts now combine indicators at different sub-yearly intervals** and don't render sensibly: `excess-deaths-cumulative-economist-single-entity`, `excess-deaths-daily-economist-single-entity`, `excess-deaths-cumulative-who`, `excess-deaths-cumulative-economist-who`, and unpublished #8023 `covid-deaths-reported-estimated`. In each, daily confirmed deaths sit alongside weekly and/or monthly excess-mortality estimates. This needs grapher-side support for per-indicator frequencies before merging.
- Rebased on master after #6393 version-bumped `fossil_fuels` 2026-05-05 → 2026-06-30 and dropped the `fossil_fuels_monthly` table entirely; that dataset's edit was therefore removed rather than ported, since the monthly table no longer exists anywhere.
- **Superseded versions not measured.** 862 variables on older step versions were excluded as not live; if any still feeds a chart, it isn't covered.
- **`vaccinations_age` not reviewed chart-by-chart** — a specific chart covering only weekly-reporting countries might still justify `week`.
- Earlier corrections in b1e487194 have not reached production either, so those datasets keep reading `day` on the live site until their steps re-run — independent of this PR.

