### PR TITLE
📊 Add long-run Ireland migration data

### DIFF
--- a/dag/migration.yml
+++ b/dag/migration.yml
@@ -89,6 +89,14 @@ steps:
         - data://garden/demography/2024-07-15/population
 
 
+  # Long-run net migration for Ireland (CSO)
+  data://grapher/migration/2026-08-05/ireland_net_migration:
+    - data://garden/migration/2026-08-05/ireland_net_migration:
+      - data://meadow/migration/2026-08-05/ireland_net_migration:
+        - snapshot://migration/2026-08-05/ireland_population_change.json
+        - snapshot://migration/2026-08-05/ireland_components_of_population_change.json
+        - snapshot://migration/2026-08-05/ireland_net_emigration_1871_1926.csv
+
   # UN DESA migration flows S3 JSON export (2024)
   export://s3/un_migration/latest/migration_stock_flows_json:
     - data://garden/demography/2024-07-15/population

--- a/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
+++ b/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
@@ -21,23 +21,16 @@ definitions:
   ireland_sources: |-
     Our World in Data maintains this long-run series on Irish migration by combining three sources from the Central Statistics Office and its predecessors:
 
-    - **1871–1926 — averages for the periods between censuses.** The 1926 census report estimated net emigration for each period between censuses as a residual: the change in population, minus registered births, plus registered deaths. Civil registration of births and deaths began in 1864, so 1871 is the first census this method can start from. Each year shows the average for its period.
-    - **1926–1951 — averages for the periods between censuses.** The same residual method, as published with the 2022 census results. Each year shows the average for its period.
-    - **From 1951 — annual estimates.** The Central Statistics Office's annual net migration estimates, which it revises after each census. Each figure refers to the year ending in April.
+    - **1871–1951 — averages for the periods between censuses.** The census reports of 1926 and 2022 estimated net emigration for each period between censuses as a residual: the change in population, minus registered births, plus registered deaths. Civil registration of births and deaths began in 1864, so 1871 is the first census this method can start from. Each year shows the average for its period.
+    - **From 1951 — annual estimates.** The Central Statistics Office's annual net migration estimates, which it revises after each census.
 
     All figures cover the same area — the 26 counties of today's Republic of Ireland. The census reports restate the pre-independence results for this area, so independence in 1922 does not create a break in the series.
 
   ireland_periods: |-
-    Before 1951, the data shows one average value per period between censuses, not what happened in each individual year. The periods are 1871–81, 1881–91, 1891–1901, 1901–11, 1911–26, 1926–36, 1936–46, and 1946–51.
+    Before 1951, the data shows one average value per period between censuses, not what happened in each individual year.
 
   ireland_war_caveat: |-
-    The 1911–1926 value is the hardest to interpret. The residual method counts any unregistered population loss as emigration, so the Irish soldiers who died abroad in the First World War — deaths never registered in Ireland — are counted as emigrants. The period also includes the departure of the British Army and administration after independence.
-
-  ireland_sign: |-
-    Positive values mean more people arrived than left; negative values mean more people left than arrived. Ireland lost people to migration in every year of this series until the 1960s, and in most years until the 1990s.
-
-  ireland_share_denominator: |-
-    This indicator divides net migration in a year by the population in the same year. Before 1951, we interpolate the population between censuses; from 1951, we use the Central Statistics Office's annual population estimates.
+    The 1911–1926 value is the hardest to interpret. The residual method counts any unregistered population loss as emigration, so the Irish soldiers who died abroad in the First World War — deaths never registered in Ireland — are counted as emigrants. The period also includes the departure of the British Army and the disbanded police force after independence.
 
   ireland_processing: |-
     We combined three sources into one series:
@@ -62,8 +55,6 @@ tables:
         short_unit: ""
         description_short: Number of people moving to Ireland each year, minus the number leaving. Negative values mean more people left than arrived.
         description_key: |-
-          {definitions.ireland_sign}
-
           {definitions.ireland_sources}
 
           {definitions.ireland_periods}
@@ -79,10 +70,6 @@ tables:
         short_unit: "%"
         description_short: Number of people moving to Ireland each year, minus the number leaving, as a share of the population. Negative values mean more people left than arrived.
         description_key: |-
-          {definitions.ireland_sign}
-
-          {definitions.ireland_share_denominator}
-
           {definitions.ireland_sources}
 
           {definitions.ireland_periods}

--- a/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
+++ b/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
@@ -4,6 +4,7 @@ definitions:
   common:
     processing_level: major
     presentation:
+      attribution: Central Statistics Office, Ireland (1934, 2023, 2025)
       topic_tags:
         - Migration
       grapher_config:

--- a/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
+++ b/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
@@ -1,0 +1,98 @@
+# Learn more about the available fields:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+definitions:
+  common:
+    processing_level: major
+    presentation:
+      topic_tags:
+        - Migration
+      grapher_config:
+        chartTypes:
+          - LineChart
+        hasMapTab: false
+        selectedEntityNames:
+          - Ireland
+        addCountryMode: disabled
+        hideAnnotationFieldsInTitle:
+          entity: true
+        hideSeriesLabels: true
+        originUrl: https://ourworldindata.org/migration
+
+  ireland_sources: |-
+    Our World in Data maintains this long-run series on Irish migration by combining three sources from the Central Statistics Office and its predecessors:
+
+    - **1871–1926 — averages for the periods between censuses.** The 1926 census report estimated net emigration for each period between censuses as a residual: the change in population, minus registered births, plus registered deaths. Civil registration of births and deaths began in 1864, so 1871 is the first census this method can start from. Each year shows the average for its period.
+    - **1926–1951 — averages for the periods between censuses.** The same residual method, as published with the 2022 census results. Each year shows the average for its period.
+    - **From 1951 — annual estimates.** The Central Statistics Office's annual net migration estimates, which it revises after each census. Each figure refers to the year ending in April.
+
+    All figures cover the same area — the 26 counties of today's Republic of Ireland. The census reports restate the pre-independence results for this area, so independence in 1922 does not create a break in the series.
+
+  ireland_periods: |-
+    Before 1951, the data shows one average value per period between censuses, not what happened in each individual year. The periods are 1871–81, 1881–91, 1891–1901, 1901–11, 1911–26, 1926–36, 1936–46, and 1946–51.
+
+  ireland_war_caveat: |-
+    The 1911–1926 value is the hardest to interpret. The residual method counts any unregistered population loss as emigration, so the Irish soldiers who died abroad in the First World War — deaths never registered in Ireland — are counted as emigrants. The period also includes the departure of the British Army and administration after independence.
+
+  ireland_sign: |-
+    Positive values mean more people arrived than left; negative values mean more people left than arrived. Ireland lost people to migration in every year of this series until the 1960s, and in most years until the 1990s.
+
+  ireland_share_denominator: |-
+    This indicator divides net migration in a year by the population in the same year. Before 1951, we interpolate the population between censuses; from 1951, we use the Central Statistics Office's annual population estimates.
+
+  ireland_processing: |-
+    We combined three sources into one series:
+
+    - For 1871–1926, we hand-entered the average yearly net emigration for each period between censuses from the 1926 census report (Volume X, page 19), and flipped the sign to show net migration. Each year in a period carries the period's average.
+    - For 1926–1951, we divided the net migration total for each period between censuses (2022 census results, table F1005) by the length of the period. Each year in a period carries the period's average.
+    - From 1951 onward, the data comes from the Central Statistics Office's annual estimates (table PEA15), converted from thousands of people to people.
+
+dataset:
+  title: Long-run net migration to Ireland
+  update_period_days: 365
+  owners:
+    - Edouard Mathieu
+
+tables:
+  ireland_net_migration:
+    title: Net migration, Ireland
+    variables:
+      net_migration:
+        title: Net migration to Ireland
+        unit: people
+        short_unit: ""
+        description_short: Number of people moving to Ireland each year, minus the number leaving. Negative values mean more people left than arrived.
+        description_key: |-
+          {definitions.ireland_sign}
+
+          {definitions.ireland_sources}
+
+          {definitions.ireland_periods}
+
+          {definitions.ireland_war_caveat}
+        description_processing: "{definitions.ireland_processing}"
+        display:
+          numDecimalPlaces: 0
+
+      net_migration_share_of_population:
+        title: Net migration to Ireland as a share of the population
+        unit: "%"
+        short_unit: "%"
+        description_short: Number of people moving to Ireland each year, minus the number leaving, as a share of the population. Negative values mean more people left than arrived.
+        description_key: |-
+          {definitions.ireland_sign}
+
+          {definitions.ireland_share_denominator}
+
+          {definitions.ireland_sources}
+
+          {definitions.ireland_periods}
+
+          {definitions.ireland_war_caveat}
+        description_processing: |-
+          {definitions.ireland_processing}
+
+          To calculate the share, we divided each year's net migration by the population: interpolated between census counts before 1951, and the Central Statistics Office's annual estimates from 1951.
+        display:
+          roundingMode: significantFigures
+          numSignificantFigures: 2
+          numDecimalPlaces: 2

--- a/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
+++ b/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
@@ -30,7 +30,7 @@ definitions:
     Before 1951, the data shows one average value per period between censuses, not what happened in each individual year.
 
   ireland_war_caveat: |-
-    The 1911–1926 value is the hardest to interpret. The residual method counts any unregistered population loss as emigration, so the Irish soldiers who died abroad in the First World War — deaths never registered in Ireland — are counted as emigrants. The period also includes the departure of the British Army and the disbanded police force after independence.
+    The 1911–1926 value is the hardest to interpret. The residual method counts any unregistered population loss as emigration, so the Irish soldiers who died abroad in the First World War — deaths never registered in Ireland — are counted as emigrants. The period also includes people who left when British rule ended, such as the British Army garrison and many former policemen.
 
   ireland_processing: |-
     We combined three sources into one series:

--- a/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
+++ b/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
@@ -20,10 +20,13 @@ definitions:
         originUrl: https://ourworldindata.org/migration
 
   ireland_sources: |-
-    Our World in Data maintains this long-run series on Irish migration by combining three sources from the Central Statistics Office and its predecessors:
+    Our World in Data maintains this long-run series on Irish migration by combining various datasets from the Central Statistics Office and its predecessors.
 
-    - **1871–1951 — averages for the periods between censuses.** The census reports of 1926 and 2022 estimated net emigration for each period between censuses as a residual: the change in population, minus registered births, plus registered deaths. Civil registration of births and deaths began in 1864, so 1871 is the first census this method can start from. Each year shows the average for its period.
-    - **From 1951 — annual estimates.** The Central Statistics Office's annual net migration estimates, which it revises after each census.
+    The series rests almost entirely on the same method: net migration is estimated as a "census residual" — the change in population between two censuses, minus registered births, plus registered deaths.
+
+    - Between 1871 and 1951, net migration is estimated as the residual between two censuses, divided by the number of years between censuses. Civil registration of births and deaths began in 1864, so 1871 is the first census from which the method can start.
+    - Since 1951, net migration has been estimated annually. The Central Statistics Office still distributes the residual between two censuses over the years between them, but it tries to estimate the best value for each year, using sources such as labor force surveys and administrative records.
+    - Recent years after the most recent census are provisional, and entirely based on labor force surveys and administrative records.
 
     All figures cover the same area — the 26 counties of today's Republic of Ireland. The census reports restate the pre-independence results for this area, so independence in 1922 does not create a break in the series.
 

--- a/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
+++ b/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
@@ -28,7 +28,7 @@ definitions:
     All figures cover the same area — the 26 counties of today's Republic of Ireland. The census reports restate the pre-independence results for this area, so independence in 1922 does not create a break in the series.
 
   ireland_war_caveat: |-
-    The 1911–1926 value is the hardest to interpret. The residual method counts any unregistered population loss as emigration, so the Irish soldiers who died abroad in the First World War — deaths never registered in Ireland — are counted as emigrants. The period also includes people who left when British rule ended, such as the British Army garrison and many former policemen.
+    The 1911–1926 period is the hardest to interpret. The residual method counts any unregistered population loss as emigration, so the Irish soldiers who died abroad in the First World War — deaths never registered in Ireland — are counted as emigrants. The period also includes people who left when British rule ended, such as the British Army garrison and many former policemen.
 
   ireland_processing: |-
     We combined three sources into one series:

--- a/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
+++ b/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.meta.yml
@@ -27,9 +27,6 @@ definitions:
 
     All figures cover the same area — the 26 counties of today's Republic of Ireland. The census reports restate the pre-independence results for this area, so independence in 1922 does not create a break in the series.
 
-  ireland_periods: |-
-    Before 1951, the data shows one average value per period between censuses, not what happened in each individual year.
-
   ireland_war_caveat: |-
     The 1911–1926 value is the hardest to interpret. The residual method counts any unregistered population loss as emigration, so the Irish soldiers who died abroad in the First World War — deaths never registered in Ireland — are counted as emigrants. The period also includes people who left when British rule ended, such as the British Army garrison and many former policemen.
 
@@ -58,8 +55,6 @@ tables:
         description_key: |-
           {definitions.ireland_sources}
 
-          {definitions.ireland_periods}
-
           {definitions.ireland_war_caveat}
         description_processing: "{definitions.ireland_processing}"
         display:
@@ -72,8 +67,6 @@ tables:
         description_short: Number of people moving to Ireland each year, minus the number leaving, as a share of the population. Negative values mean more people left than arrived.
         description_key: |-
           {definitions.ireland_sources}
-
-          {definitions.ireland_periods}
 
           {definitions.ireland_war_caveat}
         description_processing: |-

--- a/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.py
+++ b/etl/steps/data/garden/migration/2026-08-05/ireland_net_migration.py
@@ -1,0 +1,106 @@
+"""Long-run net migration for Ireland, 1871-2025, on the constant area of today's Republic.
+
+This step builds an annual series from three CSO sources:
+
+- 1871-1926: average yearly net emigration per intercensal period, hand-entered from the 1926
+  Census General Report. Every year in a period carries the period's average.
+- 1926-1951: net migration totals per intercensal period from the 2022 census (table F1005),
+  divided by the period length. Every year in a period carries the period's average.
+- From 1951: the CSO's annual estimates (table PEA15, years ending in April), in thousands.
+
+The share of population divides each year's net migration by the population: interpolated census
+populations before 1951, and the CSO's annual population estimates from 1951.
+"""
+
+import numpy as np
+import pandas as pd
+from owid.catalog import Table
+from owid.catalog import processing as pr
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+# The year from which the annual estimates replace the intercensal period averages.
+ANNUAL_FROM = 1951
+
+
+def spread_periods(tb: Table, value_col: str) -> Table:
+    """Assign each period's average yearly net migration to every year of the period."""
+    rows = []
+    for _, r in tb.iterrows():
+        for year in range(int(r["period_start"]), int(r["period_end"])):
+            rows.append({"year": year, "net_migration": r[value_col]})
+    out = Table(pd.DataFrame(rows))
+    out["net_migration"] = out["net_migration"].copy_metadata(tb[value_col])
+    return out
+
+
+def sanity_check_outputs(tb: Table) -> None:
+    assert not tb["year"].duplicated().any(), "Duplicate years."
+    years = set(tb["year"])
+    assert years == set(range(1871, max(years) + 1)), "The series has gaps."
+    t = tb.set_index("year")
+    # The 1880s were the worst pre-independence decade; the series turns positive only after 1961.
+    assert t.loc[1885, "net_migration"] == -59_733
+    assert (t.loc[:1960, "net_migration"] < 0).all(), "Unexpected net inflow before 1961."
+    assert t["net_migration_share_of_population"].abs().max() < 3, "Share outside the plausible range."
+    assert t["net_migration_share_of_population"].notna().all(), "Missing share values."
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_meadow = paths.load_dataset("ireland_net_migration")
+    tb_annual = ds_meadow.read("annual_estimates")
+    tb_intercensal = ds_meadow.read("intercensal_1926_2022")
+    tb_1926 = ds_meadow.read("intercensal_1871_1926")
+
+    #
+    # Process data.
+    #
+    # 1871-1926: flip hand-entered net emigration (males + females, yearly averages) to net migration.
+    tb_1926["net_migration_yearly"] = -(tb_1926["net_emigration_males"] + tb_1926["net_emigration_females"])
+    early = spread_periods(tb_1926, "net_migration_yearly")
+
+    # 1926-1951: period totals divided by period length.
+    tb_mid = tb_intercensal[tb_intercensal["period_end"] <= ANNUAL_FROM].copy()
+    assert len(tb_mid) == 3, "Expected the periods 1926-1936, 1936-1946 and 1946-1951."
+    tb_mid["net_migration_yearly"] = tb_mid["net_migration"] / (tb_mid["period_end"] - tb_mid["period_start"])
+    mid = spread_periods(tb_mid, "net_migration_yearly")
+
+    # From 1951: annual estimates, converted from thousands to people.
+    late = tb_annual[["year", "net_migration"]].copy()
+    late["net_migration"] = late["net_migration"] * 1000
+
+    tb = pr.concat([early, mid, late], ignore_index=True).sort_values("year")
+
+    # Denominator: census populations (1871-1926 hand-entered, in thousands; 1936-1951 from the
+    # 2022 census table), linearly interpolated between census years; the CSO's annual population
+    # estimates from 1951 (in thousands).
+    census_years = list(tb_1926["period_start"]) + [1926] + list(tb_mid["period_end"])
+    census_pops = (
+        list(tb_1926["population_start_thousands"] * 1000)
+        + [tb_1926["population_end_thousands"].iloc[-1] * 1000]
+        + list(tb_mid["population_end"])
+    )
+    pre = tb["year"] < ANNUAL_FROM
+    tb.loc[pre, "population"] = np.interp(tb.loc[pre, "year"], census_years, census_pops)
+    late_pop = tb_annual.set_index("year")["population"] * 1000
+    tb.loc[~pre, "population"] = tb.loc[~pre, "year"].map(late_pop)
+
+    tb["net_migration_share_of_population"] = tb["net_migration"] / tb["population"] * 100
+    tb["net_migration_share_of_population"] = tb["net_migration_share_of_population"].copy_metadata(tb["net_migration"])
+    tb = tb.drop(columns=["population"])
+    tb["country"] = "Ireland"
+
+    sanity_check_outputs(tb)
+
+    tb = tb.format(["country", "year"], short_name="ireland_net_migration")
+
+    #
+    # Save outputs.
+    #
+    ds_garden = paths.create_dataset(tables=[tb], default_metadata=ds_meadow.metadata)
+    ds_garden.save()

--- a/etl/steps/data/grapher/migration/2026-08-05/ireland_net_migration.py
+++ b/etl/steps/data/grapher/migration/2026-08-05/ireland_net_migration.py
@@ -1,0 +1,19 @@
+"""Load the garden dataset and create a grapher dataset."""
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    ds_garden = paths.load_dataset("ireland_net_migration")
+    tb = ds_garden.read("ireland_net_migration", reset_index=False)
+
+    #
+    # Save outputs.
+    #
+    ds_grapher = paths.create_dataset(tables=[tb], default_metadata=ds_garden.metadata)
+    ds_grapher.save()

--- a/etl/steps/data/meadow/migration/2026-08-05/ireland_net_migration.py
+++ b/etl/steps/data/meadow/migration/2026-08-05/ireland_net_migration.py
@@ -1,0 +1,117 @@
+"""Load the three CSO sources of long-run Irish net migration and create a meadow dataset.
+
+- Census 1926 General Report (hand-entered): average yearly net emigration by sex for each
+  intercensal period 1871-1926, plus census populations, for the 26-county area.
+- Census 2022, table F1005: net migration and population for each intercensal period 1926-2022,
+  estimated as the census residual.
+- Population and Migration Estimates, table PEA15: annual net migration and population from 1951
+  (years ending in April), in thousands.
+"""
+
+import json
+
+import numpy as np
+import pandas as pd
+from owid.catalog import Table
+
+from etl.helpers import PathFinder
+from etl.snapshot import Snapshot
+
+paths = PathFinder(__file__)
+
+
+def read_jsonstat(snap: Snapshot) -> tuple[dict, pd.DataFrame]:
+    """Read a PxStat JSON-stat 2.0 file into a long dataframe with one column per dimension."""
+    with open(snap.path) as f:
+        data = json.load(f)
+    dims = data["dimension"]
+    order = data["id"]
+    labels = {k: list(dims[k]["category"]["label"].values()) for k in order}
+    shape = [len(labels[k]) for k in order]
+    values = np.array(data["value"], dtype=object).reshape(shape)
+    index = pd.MultiIndex.from_product([labels[k] for k in order], names=order)
+    df = pd.DataFrame({"value": values.ravel()}, index=index).reset_index()
+    return data, df
+
+
+def parse_pea15(snap: Snapshot) -> Table:
+    """Annual net migration and population, 1951-2025, in thousands."""
+    _, df = read_jsonstat(snap)
+    df = df.rename(columns={"TLIST(A1)": "year", "C02541V03076": "component"})
+    df = df[df["component"].isin(["Net migration", "Population"])]
+    df = df.pivot(index="year", columns="component", values="value").reset_index()
+    df.columns.name = None
+    df = df.rename(columns={"Net migration": "net_migration", "Population": "population"})
+    df["year"] = df["year"].astype(int)
+    for col in ["net_migration", "population"]:
+        df[col] = pd.to_numeric(df[col], errors="raise")
+
+    tb = snap.read_from_df(df)
+    assert tb["year"].min() == 1951, "PEA15 no longer starts in 1951."
+    assert tb["year"].max() >= 2025, "PEA15 should reach at least 2025."
+    assert tb["net_migration"].notna().all() and tb["population"].notna().all(), "Missing values in PEA15."
+    # Spot-check (thousands): net migration in 1958, the deepest year of the 1950s emigration wave.
+    assert tb.loc[tb["year"] == 1958, "net_migration"].item() == -58.0
+    return tb
+
+
+def parse_f1005(snap: Snapshot) -> Table:
+    """Net migration (period total, persons) and end-of-period population per intercensal period."""
+    _, df = read_jsonstat(snap)
+    df = df.rename(columns={"C02691V03258": "period", "C03853V04603": "region"})
+    df = df[(df["region"] == "State") & (df["STATISTIC"].isin(["Net migration", "Population"]))]
+    df = df.pivot(index="period", columns="STATISTIC", values="value").reset_index()
+    df.columns.name = None
+    df = df.rename(columns={"Net migration": "net_migration", "Population": "population_end"})
+    df["period_start"] = df["period"].str.split(" - ").str[0].astype(int)
+    df["period_end"] = df["period"].str.split(" - ").str[1].astype(int)
+    df = df.sort_values("period_start")[["period_start", "period_end", "net_migration", "population_end"]]
+    for col in ["net_migration", "population_end"]:
+        df[col] = pd.to_numeric(df[col], errors="raise")
+
+    tb = snap.read_from_df(df)
+    assert tb["period_start"].min() == 1926 and tb["period_end"].max() >= 2022, "Expected coverage 1926-2022."
+    # Periods must chain without gaps: each period starts where the previous one ended.
+    assert (tb["period_start"].iloc[1:].values == tb["period_end"].iloc[:-1].values).all(), "Gap between periods."
+    # Spot-checks: the 1926-1936 residual, and the 2022 census population as the last period's end.
+    assert tb.loc[tb["period_start"] == 1926, "net_migration"].item() == -166_751
+    assert tb.loc[tb["period_end"] == 2022, "population_end"].item() == 5_149_139
+    return tb
+
+
+def parse_census_1926(snap: Snapshot) -> Table:
+    """Hand-entered 1871-1926 intercensal net emigration and census populations."""
+    tb = snap.read_csv()
+    assert tb["period_start"].min() == 1871 and tb["period_end"].max() == 1926, "Expected coverage 1871-1926."
+    assert (tb["period_start"].iloc[1:].values == tb["period_end"].iloc[:-1].values).all(), "Gap between periods."
+    assert (tb[["net_emigration_males", "net_emigration_females"]] > 0).all().all()
+    return tb
+
+
+def run() -> None:
+    #
+    # Load inputs.
+    #
+    snap_pea15 = paths.load_snapshot("ireland_population_change.json")
+    snap_f1005 = paths.load_snapshot("ireland_components_of_population_change.json")
+    snap_1926 = paths.load_snapshot("ireland_net_emigration_1871_1926.csv")
+
+    #
+    # Process data.
+    #
+    tb_annual = parse_pea15(snap_pea15)
+    tb_intercensal = parse_f1005(snap_f1005)
+    tb_1926 = parse_census_1926(snap_1926)
+
+    #
+    # Save outputs.
+    #
+    ds_meadow = paths.create_dataset(
+        tables=[
+            tb_annual.format(["year"], short_name="annual_estimates"),
+            tb_intercensal.format(["period_start"], short_name="intercensal_1926_2022"),
+            tb_1926.format(["period_start"], short_name="intercensal_1871_1926"),
+        ],
+        default_metadata=snap_pea15.metadata,
+    )
+    ds_meadow.save()

--- a/snapshots/migration/2026-08-05/ireland_components_of_population_change.json.dvc
+++ b/snapshots/migration/2026-08-05/ireland_components_of_population_change.json.dvc
@@ -1,0 +1,30 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Census of Population 2022 — Components of Population Change
+    description: |-
+      Population, natural increase, actual change, and estimated net migration for each period between Irish censuses from 1926 to 2022, published by the Central Statistics Office as part of the 2022 census results.
+
+      The Central Statistics Office estimates net migration for each intercensal period as a residual: the change in population between two censuses, minus the natural increase (registered births minus registered deaths) over the same period.
+    date_published: "2023-06-29"
+
+    # Citation
+    producer: Central Statistics Office, Ireland
+    citation_full: |-
+      Central Statistics Office, Ireland (2023). Census of Population 2022. Table F1005: Components of Population Change.
+
+    # Files
+    url_main: https://data.cso.ie/table/F1005
+    url_download: https://ws.cso.ie/public/api.restful/PxStat.Data.Cube_API.ReadDataset/F1005/JSON-stat/2.0/en
+    date_accessed: "2026-08-05"
+
+    # License
+    license:
+      name: CC BY 4.0
+      url: https://www.cso.ie/en/aboutus/whoweare/copyrightpolicy/
+outs:
+  - md5: 7c92e90c0cb285b2b37ce7ef51b1b93b
+    size: 6296
+    path: ireland_components_of_population_change.json

--- a/snapshots/migration/2026-08-05/ireland_net_emigration_1871_1926.csv.dvc
+++ b/snapshots/migration/2026-08-05/ireland_net_emigration_1871_1926.csv.dvc
@@ -1,0 +1,29 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Census of Population 1926, Volume X — General Report
+    description: |-
+      The general report on the 1926 Census of the Irish Free State, the first census taken after independence. Its chapter on population changes restates results from the pre-independence censuses for the 26-county area that became the state, so that changes can be compared on constant boundaries.
+
+      We hand-entered two small tables from the report: average yearly net emigration by sex for each period between censuses from 1871 to 1926 (page 19), and the population at each census from 1871 to 1926 (page 11). The report estimates net emigration as a residual: the change in population between two censuses, minus registered births plus registered deaths. Civil registration of births and deaths began in 1864, so 1871-1881 is the first period this method can cover.
+    date_published: "1934"
+
+    # Citation
+    producer: Central Statistics Office, Ireland
+    citation_full: |-
+      Census of Population 1926, Volume X — General Report. Statistics Branch, Department of Industry and Commerce, Dublin, 1934. Published online by the Central Statistics Office, Ireland. Available at: https://www.cso.ie/en/media/csoie/census/census1926results/volume10/C_1926_V10.pdf
+
+    # Files
+    url_main: https://www.cso.ie/en/census/censusvolumes1926to1991/historicalreports/census1926reports/census1926volume10-generalreports/
+    date_accessed: "2026-08-05"
+
+    # License
+    license:
+      name: CC BY 4.0
+      url: https://www.cso.ie/en/aboutus/whoweare/copyrightpolicy/
+outs:
+  - md5: 90f92597a1cc9d55d4cc223286707eb1
+    size: 280
+    path: ireland_net_emigration_1871_1926.csv

--- a/snapshots/migration/2026-08-05/ireland_net_emigration_1871_1926.py
+++ b/snapshots/migration/2026-08-05/ireland_net_emigration_1871_1926.py
@@ -1,0 +1,51 @@
+"""Hand-entered data from the 1926 Census of Ireland, Volume X — General Report (1934).
+
+Two small tables, both restated for the 26-county area that became the Republic of Ireland:
+
+- Average yearly net emigration by sex for each intercensal period, 1871-1926, from the section
+  "Natural Increase and Emigration" on page 19.
+- Census populations in thousands, 1871-1926, from the table "Population (in thousands)" on
+  page 11 (Saorstat Eireann column). Used as the denominator for rates.
+
+Source PDF: https://www.cso.ie/en/media/csoie/census/census1926results/volume10/C_1926_V10.pdf
+(page 19 of the report is page 29 of the PDF; page 11 is page 20).
+"""
+
+import click
+import pandas as pd
+
+from etl.helpers import PathFinder
+
+paths = PathFinder(__file__)
+
+# Page 19: average yearly net emigration (persons per year), by sex, per intercensal period.
+NET_EMIGRATION = [
+    # (period_start, period_end, males, females)
+    (1871, 1881, 24_958, 25_214),
+    (1881, 1891, 29_257, 30_476),
+    (1891, 1901, 20_315, 19_327),
+    (1901, 1911, 11_764, 14_390),
+    (1911, 1926, 13_934, 13_068),
+]
+
+# Page 11: population of Saorstat Eireann at each census, in thousands.
+POPULATION = {1871: 4_053, 1881: 3_870, 1891: 3_469, 1901: 3_222, 1911: 3_140, 1926: 2_972}
+
+
+@click.command()
+@click.option("--upload/--skip-upload", default=True, type=bool, help="Upload dataset to Snapshot")
+def run(upload: bool) -> None:
+    df = pd.DataFrame(
+        NET_EMIGRATION, columns=["period_start", "period_end", "net_emigration_males", "net_emigration_females"]
+    )
+    df["population_start_thousands"] = df["period_start"].map(POPULATION)
+    df["population_end_thousands"] = df["period_end"].map(POPULATION)
+
+    # The report's own text (p. 19): 1911-1926 net emigration totalled 405,029, an average of
+    # 27,002 per year. Check the entered values reproduce this within the report's rounding.
+    total = df[["net_emigration_males", "net_emigration_females"]].sum(axis=1)
+    assert total.iloc[-1] == 27_002, "1911-1926 yearly average does not match the report."
+    assert abs(total.iloc[-1] * 15 - 405_029) <= 15, "1911-1926 total does not match the report."
+
+    snap = paths.init_snapshot()
+    snap.create_snapshot(data=df, upload=upload)

--- a/snapshots/migration/2026-08-05/ireland_population_change.json.dvc
+++ b/snapshots/migration/2026-08-05/ireland_population_change.json.dvc
@@ -1,0 +1,31 @@
+# Learn more at:
+# http://docs.owid.io/projects/etl/architecture/metadata/reference/
+meta:
+  origin:
+    # Data product / Snapshot
+    title: Population and Migration Estimates
+    description: |-
+      Annual estimates of the population and the components of population change — births, deaths, immigration, emigration, and net migration — for Ireland, published by the Central Statistics Office. Each figure refers to the year ending in April.
+
+      This table (PEA15, "Annual Population Change") gives net migration for every year from 1951, and immigration and emigration from 1987. The Central Statistics Office estimates the years between censuses from the census results and annual data on births, deaths, and migration, and revises them after each new census.
+    date_published: "2025-08-26"
+    version_producer: April 2025
+
+    # Citation
+    producer: Central Statistics Office, Ireland
+    citation_full: |-
+      Central Statistics Office, Ireland (2025). Population and Migration Estimates, April 2025. Table PEA15: Annual Population Change.
+
+    # Files
+    url_main: https://data.cso.ie/table/PEA15
+    url_download: https://ws.cso.ie/public/api.restful/PxStat.Data.Cube_API.ReadDataset/PEA15/JSON-stat/2.0/en
+    date_accessed: "2026-08-05"
+
+    # License
+    license:
+      name: CC BY 4.0
+      url: https://www.cso.ie/en/aboutus/whoweare/copyrightpolicy/
+outs:
+  - md5: 49386ad4b1ab1adbd0563ffd06a4f5bf
+    size: 7321
+    path: ireland_population_change.json


### PR DESCRIPTION
> _Written by Claude Fable 5 — @edomt at the wheel._

Part of https://github.com/owid/owid-issues/issues/2470 (child of https://github.com/owid/owid-issues/issues/2464).

## What this adds

A new dataset `migration/2026-08-05/ireland_net_migration` with two indicators for Ireland, 1871–2025: **net migration**, in people and as a share of the population. The whole series covers the same area — the 26 counties of today's Republic — so independence in 1922 does not create a break.

The series is OWID-maintained (`processing_level: major`), combining three sources from the Central Statistics Office and its predecessors:

- **1871–1926** — average yearly net emigration for each period between censuses, from the [1926 Census General Report](https://www.cso.ie/en/media/csoie/census/census1926results/volume10/C_1926_V10.pdf) (Volume X, p. 19), hand-entered with asserts tying the values to the report's own printed totals. The report estimates net emigration as a census residual; civil registration of births and deaths began in 1864, so 1871 is the earliest possible start.
- **1926–1951** — net migration totals per intercensal period from the 2022 census results ([table F1005](https://data.cso.ie/table/F1005)), divided by period length.
- **From 1951** — the CSO's annual estimates ([table PEA15](https://data.cso.ie/table/PEA15), years ending in April).

Before 1951, each year carries its intercensal period's average, so the series is stepped. Shares divide by interpolated census populations before 1951 and the CSO's annual population estimates after — all denominators come from the dataset's own snapshots.

## Notes

- The metadata explains the construction period by period, the sign convention, and the 1911–1926 caveat (the residual method counts First World War deaths abroad as emigration, and the period includes the post-independence departures).
- No gross immigration/emigration indicators — deliberately net-only, per the scoping discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)