### PR TITLE
📜 skills: Note the CSV redirect CLI's limits on query params and explorers

### DIFF
--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -36,6 +36,32 @@ at it, and its bulk endpoint accepts explorer sources only. The CLI
 (`owid-grapher/devTools/createMultiDimRedirectsFromCsv.ts`) exists precisely for
 the chart case.
 
+**And only for that case: one bare chart path per row.** Two things the CSV
+pipeline cannot express — if a migration needs either, the CLI itself has to
+change first, so raise it with a Grapher developer instead of bending the CSV
+around it:
+
+- **Source query params.** The source column is a path. Anything after `?`
+  survives into `multi_dim_redirects.source` verbatim, and chart sources are baked
+  as a flat slug → path map that strips only the `/grapher/` prefix
+  (`getGrapherToMultiDimRedirects` → `getMultiDimRedirectTargets`), so the row
+  matches no request and the redirect never fires. Conditioning on the incoming
+  params is what the `sourceQueryParams` column does, and the CLI never writes it —
+  grapher honors it for `/explorers/` sources only (they bake to a query-param
+  decision tree resolved at the edge), and the admin route rejects it outright on a
+  `/grapher/` source. A per-params chart redirect therefore needs changes on both
+  sides, CLI and serving. `preflight.py` rejects a source carrying a query string
+  for this reason.
+- **Explorer sources.** `/explorers/...` passes the CLI's source regex, and the row
+  it writes is worse than inert: with `sourceQueryParams` NULL it bakes as an
+  *unconditional* rule, and explorer redirects are consulted on **every** request
+  (unlike chart redirects, which fire only on a 404), so the entire explorer —
+  every view, whatever the params — starts 302-ing to the single target view. The
+  chart handling it also skips, silently: the source is never unpublished
+  (`getChartSlugsToUnpublish` skips non-`/grapher/` sources), and the chained
+  old-slug migration early-returns. Explorers go through the admin bulk endpoint,
+  which is `map-explorer-to-mdim`'s job, not this skill's.
+
 ## Inputs
 
 Exactly one chart selection:
@@ -508,9 +534,9 @@ them:
   tolerated **only** on line 1, no comment lines anywhere, no duplicate sources,
   both fields must start with `/`. Any violation aborts the CLI's whole run. The
   extractor validates its own output and `preflight.py` re-validates it.
-- **Never put query params on the source.** They pass the CLI's regex and get
-  stored verbatim, but serving matches the bare path — so the redirect would
-  simply never fire.
+- **Never put query params on the source, and never an `/explorers/` source.**
+  Both pass the CLI's regex and neither works — see "one bare chart path per row"
+  above for the mechanism and for what would have to change in grapher.
 - **Targets carry every dimension or none.** The CLI resolves the target query
   string to exactly one view; a partial dimension spec matches several and
   throws. Our targets always carry the full dict, so don't hand-trim them.

--- a/.claude/skills/map-charts-to-mdim/SKILL.md
+++ b/.claude/skills/map-charts-to-mdim/SKILL.md
@@ -36,10 +36,9 @@ at it, and its bulk endpoint accepts explorer sources only. The CLI
 (`owid-grapher/devTools/createMultiDimRedirectsFromCsv.ts`) exists precisely for
 the chart case.
 
-**And only for that case: one bare chart path per row.** Two things the CSV
-pipeline cannot express — if a migration needs either, the CLI itself has to
-change first, so raise it with a Grapher developer instead of bending the CSV
-around it:
+**And only for that case: one bare chart path per row.** Two shapes the CSV
+pipeline cannot express. Neither is worked around by editing the CSV — one has
+another route, the other needs the CLI changed:
 
 - **Source query params.** The source column is a path. Anything after `?`
   survives into `multi_dim_redirects.source` verbatim, and chart sources are baked

--- a/.claude/skills/map-explorer-to-mdim/SKILL.md
+++ b/.claude/skills/map-explorer-to-mdim/SKILL.md
@@ -134,6 +134,11 @@ It also writes **`mapping.json`** — the machine record — and
 **`admin_bulk_payload.json`**, which is what you actually apply. The API exists:
 `POST {admin}/api/multi-dim-redirects/bulk` (`handleBulkCreateMultiDimRedirects`), also
 reachable from the *Bulk-create redirects from JSON* button on `/admin/multi-dim-redirects`.
+This endpoint is the **only** way to apply an explorer redirect: the CSV CLI that
+`map-charts-to-mdim` hands over (`createMultiDimRedirectsFromCsv`) accepts an
+`/explorers/` source, but it writes no `sourceQueryParams` — so the row bakes as one
+unconditional rule and every view of the explorer 302s to a single MDIM view,
+per-view routing gone.
 Its Zod schema deliberately mirrors this file's `catchAll` + `redirects` shape, ignores keys
 it doesn't know (`sourceViewId`, `viewId`, `mdim`, `stats`, `targets`), and reports
 `target: null` entries as `skipped`.

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -170,13 +170,9 @@ migrates their old slugs in one transaction.
     turns its old URLs into 404s.
 
 !!! note "The CSV takes one bare chart path per row"
-    No query string on the source, and no `/explorers/` source. Both pass the CLI's
-    validation and then misbehave: a source carrying `?…` is stored as given but never
-    matched, so the redirect silently never fires; an explorer source becomes an
-    *unconditional* rule, sending every view of that explorer to one MDIM view. Neither is
-    something to fix by editing the CSV — the script itself would need changing (and for
-    query params, so would the way chart redirects are served), so raise it with a Grapher
-    developer.
+    No query string on the source, no `/explorers/` source. Both pass validation and then
+    misbehave — a `?…` source never matches; an explorer source sends *every* view to one
+    MDIM view. The fix is in the script, not the CSV: ask a Grapher developer.
 
 ## Why the two differ
 

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -170,9 +170,12 @@ migrates their old slugs in one transaction.
     turns its old URLs into 404s.
 
 !!! note "The CSV takes one bare chart path per row"
-    Anything else validates and then fails silently. An `/explorers/` source sends *every*
-    view to one MDIM view — use the explorer route above instead. A `?…` source never
-    matches, and covering that needs a change to the script (ask a Grapher developer).
+    A source is `/grapher/<slug>` and stops there — no query string, meaning nothing from the
+    `?` onward, which on a chart URL is what picks the view (`?tab=map`, `?country=~FRA`).
+    A source carrying one validates and then never matches an incoming URL, so the redirect
+    silently never fires; sending different parameters to different views would need a change
+    to the script (ask a Grapher developer). An `/explorers/` source also validates, then
+    sends *every* view of the explorer to one MDIM view — use the explorer route above.
 
 ## Why the two differ
 

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -172,7 +172,8 @@ migrates their old slugs in one transaction.
 !!! note "The CSV takes one bare chart path per row"
     No query string on the source, no `/explorers/` source. Both pass validation and then
     misbehave — a `?…` source never matches; an explorer source sends *every* view to one
-    MDIM view. The fix is in the script, not the CSV: ask a Grapher developer.
+    MDIM view. The fix is in the script, not the CSV — ask a Grapher developer if you need
+    to cover either case.
 
 ## Why the two differ
 

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -169,6 +169,15 @@ migrates their old slugs in one transaction.
     CLI is the only route — and it is what repoints them, so hand-unpublishing a chart first
     turns its old URLs into 404s.
 
+!!! note "The CSV takes one bare chart path per row"
+    No query string on the source, and no `/explorers/` source. Both pass the CLI's
+    validation and then misbehave: a source carrying `?…` is stored as given but never
+    matched, so the redirect silently never fires; an explorer source becomes an
+    *unconditional* rule, sending every view of that explorer to one MDIM view. Neither is
+    something to fix by editing the CSV — the script itself would need changing (and for
+    query params, so would the way chart redirects are served), so raise it with a Grapher
+    developer.
+
 ## Why the two differ
 
 | | Explorers | Charts |

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -170,9 +170,9 @@ migrates their old slugs in one transaction.
     turns its old URLs into 404s.
 
 !!! note "The CSV takes one bare chart path per row"
-    Both other shapes validate and then fail silently: an `/explorers/` source sends *every*
-    view to one MDIM view — use the explorer route above instead — and a `?…` source never
-    matches, which needs a change to the script (ask a Grapher developer).
+    Anything else validates and then fails silently. An `/explorers/` source sends *every*
+    view to one MDIM view — use the explorer route above instead. A `?…` source never
+    matches, and covering that needs a change to the script (ask a Grapher developer).
 
 ## Why the two differ
 

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -170,10 +170,9 @@ migrates their old slugs in one transaction.
     turns its old URLs into 404s.
 
 !!! note "The CSV takes one bare chart path per row"
-    No query string on the source, no `/explorers/` source. Both pass validation and then
-    misbehave — a `?…` source never matches; an explorer source sends *every* view to one
-    MDIM view. The fix is in the script, not the CSV — ask a Grapher developer if you need
-    to cover either case.
+    Both other shapes validate and then fail silently: an `/explorers/` source sends *every*
+    view to one MDIM view — use the explorer route above instead — and a `?…` source never
+    matches, which needs a change to the script (ask a Grapher developer).
 
 ## Why the two differ
 

--- a/docs/guides/data-work/redirect-to-mdims.md
+++ b/docs/guides/data-work/redirect-to-mdims.md
@@ -169,11 +169,11 @@ migrates their old slugs in one transaction.
     CLI is the only route — and it is what repoints them, so hand-unpublishing a chart first
     turns its old URLs into 404s.
 
-!!! note "The CSV takes one bare chart path per row"
-    A source is `/grapher/<slug>` and stops there — no query string, meaning nothing from the
-    `?` onward, which on a chart URL is what picks the view (`?tab=map`, `?country=~FRA`).
-    A source carrying one validates and then never matches an incoming URL, so the redirect
-    silently never fires; sending different parameters to different views would need a change
+!!! note "The CSV takes bare chart paths only — no query strings, no explorer sources"
+    A source is `/grapher/<slug>` and stops there. A query string is everything from the `?`
+    onward, which on a chart URL is what picks the view (`?tab=map`, `?country=~FRA`); a
+    source carrying one validates and then never matches an incoming URL, so the redirect
+    silently never fires. Sending different parameters to different views would need a change
     to the script (ask a Grapher developer). An `/explorers/` source also validates, then
     sends *every* view of the explorer to one MDIM view — use the explorer route above.
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

Feedback on the chart→MDim redirect handover: the CSV script would need changes if source query params or explorer sources were involved. Neither case is reachable from `map-charts-to-mdim`'s own output (sources are always bare `/grapher/<slug>` paths), so this documents the boundary before someone hand-edits a CSV into it.

## What the note records

Traced through `createMultiDimRedirectsFromCsv.ts` and grapher's serving path:

- **Source query params.** They pass the CLI's source regex and land inside `multi_dim_redirects.source`. Chart sources bake to a flat *slug* → path map (`SiteBaker.bakeRedirects` calls `getGrapherToChartAndMultiDimRedirects` with an empty prefix), consulted only when the URL 404s — so `/grapher/foo?tab=map` bakes as the key `foo?tab=map` and matches no request. Param-conditional routing is the `sourceQueryParams` column, which the CLI never writes **and** which the admin route rejects outright on a `/grapher/` source. So it is a change on both sides, CLI and serving — not only the script. `preflight.py` already rejects a source carrying a query string.
- **Explorer sources.** Worse than inert. `/explorers/...` passes the regex, and with `sourceQueryParams` NULL the row bakes as an *unconditional* rule — and explorer redirects are checked on **every** request, not just 404s (`functions/explorers/[slug].ts`). The whole explorer would 302 to one MDim view. The CLI also never unpublishes the source (`getChartSlugsToUnpublish` skips non-`/grapher/` sources) and its chained old-slug migration early-returns. Explorers go through the admin bulk endpoint, i.e. `map-explorer-to-mdim`.

## Changes

- `map-charts-to-mdim/SKILL.md` — new "one bare chart path per row" block after the CLI-vs-admin-API paragraph; the old *"Never put query params on the source"* gotcha collapses into a pointer to it (it now duplicated the section, and its "serving matches the bare path" wording was vaguer than the actual mechanism).
- `map-explorer-to-mdim/SKILL.md` — one paragraph stating the admin bulk endpoint is the only way to apply an explorer redirect, and why the CSV CLI is not a substitute.
- `docs/guides/data-work/redirect-to-mdims.md` — a reader-facing note in the *Charts → They run the CLI* section: one bare chart path per row, and why neither case is fixable by editing the CSV.

Docs only; no script or behavior change. `make check` passes.

## Open items

- **Unverified** — every runtime claim is read from code on `origin/master` in both repos, not executed. Nobody has fed a query-param'd or `/explorers/` source to the CLI; the failure modes are derived. The explorer one (a live catch-all 302 on a still-published explorer) would only be proven by a staging run.
- **Not addressed** — the CLI itself is unchanged. If a migration ever genuinely needs either case, that is a Grapher-side ticket; none is filed.
- **Correction made while writing** — the first draft claimed an explorer-sourced redirect "would never fire", by analogy with chart redirects. The explorer edge handler contradicts that; the note now says it fires on every request.
