### PR TITLE
🔨🤖 (owidbot) read the SVG tester's results file instead of counting log lines

### DIFF
--- a/apps/owidbot/grapher.py
+++ b/apps/owidbot/grapher.py
@@ -1,21 +1,35 @@
+import json
 from pathlib import Path
+
+from git import GitCommandError, InvalidGitRepositoryError, NoSuchPathError, Repo
+from structlog import get_logger
 
 from etl.config import get_container_name
 from etl.paths import BASE_DIR
+
+log = get_logger()
+
+SVG_TESTER_SUITES = ("graphers", "grapher-views", "mdims", "thumbnails")
+
+# Written by devTools/svgTester/verify-graphs.ts, one per suite
+VERIFY_RESULTS_FILENAME = "verify-results.json"
 
 
 def run(branch: str) -> str:
     container_name = get_container_name(branch)
 
-    svg_tester_dirs = ("graphers", "grapher-views", "mdims", "thumbnails")
-    svg_tester_has_run = any(
-        (BASE_DIR.parent / "owid-grapher-svgs" / dir_name / "verify-graphs.log").exists()
-        for dir_name in svg_tester_dirs
-    )
-    svg_tester_graphers = make_differences_line("graphers") if svg_tester_has_run else ""
-    svg_tester_grapher_views = make_differences_line("grapher-views") if svg_tester_has_run else ""
-    svg_tester_mdims = make_differences_line("mdims") if svg_tester_has_run else ""
-    svg_tester_thumbnails = make_differences_line("thumbnails") if svg_tester_has_run else ""
+    svgs_repo = BASE_DIR.parent / "owid-grapher-svgs"
+    grapher_repo = BASE_DIR.parent / "owid-grapher"
+
+    results_by_suite = {
+        suite: load_suite_results(svgs_repo / suite, grapher_repo=grapher_repo) for suite in SVG_TESTER_SUITES
+    }
+
+    # The first owidbot run of a build happens before the SVG tester step,
+    # so no suite has results yet and the whole block is left out.
+    svg_tester_has_run = any(has_results(results) for results in results_by_suite.values())
+
+    lines = {suite: make_differences_line(results, svgs_repo / suite) for suite, results in results_by_suite.items()}
 
     svg_tester_line = (
         f"- **SVG tester:** https://github.com/owid/owid-grapher-svgs/compare/{branch}" if svg_tester_has_run else ""
@@ -25,10 +39,10 @@ def run(branch: str) -> str:
 <details open>
 <summary><b>SVG tester:</b> </summary>
 
-Number of differences (graphers): {svg_tester_graphers}
-Number of differences (grapher views): {svg_tester_grapher_views}
-Number of differences (mdims): {svg_tester_mdims}
-Number of differences (thumbnails): {svg_tester_thumbnails}
+Number of differences (graphers): {lines["graphers"]}
+Number of differences (grapher views): {lines["grapher-views"]}
+Number of differences (mdims): {lines["mdims"]}
+Number of differences (thumbnails): {lines["thumbnails"]}
 
 </details>
 """.strip()
@@ -60,50 +74,114 @@ Number of differences (thumbnails): {svg_tester_thumbnails}
     return body
 
 
-def make_differences_line(dir: str) -> str:
-    log_file = BASE_DIR.parent / "owid-grapher-svgs" / dir / "verify-graphs.log"
-    commit_file = BASE_DIR.parent / "owid-grapher-svgs" / dir / "commit.log"
-    report_filename = f"{dir}/differences.html"
+def load_suite_results(suite_dir: Path, grapher_repo: Path) -> dict | None:
+    """Results for one suite. None when the suite produced no file at all."""
+    results = read_verify_results(suite_dir)
+    if results is None:
+        return None
 
-    # Handle missing log files based on the test suite type:
-    # - 'graphers' is the core test suite that always runs: missing file indicates an error
-    # - Other test suites are optional: missing file likely means skipped
+    if is_stale(results, grapher_repo=grapher_repo):
+        log.warning(
+            "owidbot.svg_tester.stale_results",
+            suite_dir=str(suite_dir),
+            results_commit=results.get("grapherCommit"),
+        )
+        return {"status": "stale"}
+
+    return results
+
+
+def has_results(results: dict | None) -> bool:
+    """True when the suite actually reported on the commit under test."""
+    return results is not None and results.get("status") != "stale"
+
+
+def read_verify_results(suite_dir: Path) -> dict | None:
+    """Parsed verify-results.json, None when the file does not exist."""
+    path = suite_dir / VERIFY_RESULTS_FILENAME
+    if not path.exists():
+        return None
+
     try:
-        num_differences = get_num_differences(log_file)
-        status_icon = get_status_icon(num_differences)
-    except FileNotFoundError:
-        num_differences = "error" if dir == "graphers" else "_skipped_"
-        status_icon = "❓" if dir == "graphers" else ""
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        # Reported as its own state rather than as absent: absence means "this suite
+        # was never run". A truncated file is plausible - the process can be killed mid-write.
+        log.warning("owidbot.svg_tester.unreadable_results", path=str(path), error=str(e))
+        return {"status": "unreadable"}
 
-    commit_id = get_commit_id(commit_file)
+
+def is_stale(results: dict, grapher_repo: Path) -> bool:
+    """True when the results describe a run against a different commit."""
+    results_commit = results.get("grapherCommit")
+    if not results_commit:
+        return False
+
+    head = get_head_commit(grapher_repo)
+    if head is None:
+        return False
+
+    return results_commit != head
+
+
+def get_head_commit(repo_path: Path) -> str | None:
+    """HEAD of the grapher checkout the SVG tester ran against, or None if unavailable."""
+    try:
+        return Repo(repo_path).head.commit.hexsha
+    except (InvalidGitRepositoryError, NoSuchPathError, ValueError) as e:
+        log.warning("owidbot.svg_tester.no_grapher_checkout", repo_path=str(repo_path), error=str(e))
+        return None
+
+
+def make_differences_line(results: dict | None, suite_dir: Path) -> str:
+    """One suite's line in the PR comment."""
+    if results is None:
+        return "_not run_"
+
+    status = results.get("status")
+
+    if status == "stale":
+        return "_not run_ (ignored a leftover results file)"
+
+    if status == "unreadable":
+        return "⚠️ no result (results file unreadable)"
+
+    if status == "running":
+        # verify-graphs.ts writes this before rendering and overwrites it when it
+        # finishes, so it's either still running or was killed mid-run.
+        return "⚠️ no result (killed or still running)"
+
+    counts = results.get("counts", {})
+    num_differences = counts.get("differences", 0)
+    num_errors = counts.get("errors", 0)
+
+    commit_id = get_report_commit(suite_dir.parent, suite_dir.name)
     commit_link = f"({make_commit_link(commit_id=commit_id)})" if commit_id else ""
+
+    status_icon = "❌" if num_differences > 0 else "✅"
     report_link = (
-        f"[Report]({make_report_url(commit_id=commit_id, report_filename=report_filename)})"
-        if status_icon == "❌" and commit_id
+        f"[Report]({make_report_url(commit_id=commit_id, report_filename=f'{suite_dir.name}/differences.html')})"
+        if num_differences > 0 and commit_id
         else ""
     )
 
-    return f"{num_differences} {commit_link} {status_icon} {report_link}".strip()
+    error_note = f"⚠️ {num_errors} error{'s' if num_errors != 1 else ''}" if num_errors else ""
+
+    parts = [str(num_differences), commit_link, status_icon, report_link, error_note]
+    return " ".join(part for part in parts if part)
 
 
-def get_num_differences(path: Path) -> int:
-    with open(path) as f:
-        return len(f.readlines())
-
-
-def get_status_icon(num_differences: int) -> str:
-    if num_differences > 0:
-        return "❌"
-    else:
-        return "✅"
-
-
-def get_commit_id(path: Path) -> str:
+def get_report_commit(svgs_repo: Path, suite: str) -> str | None:
+    """The svgs-repo commit that last changed this suite's report, None if there is none."""
     try:
-        with open(path) as f:
-            return f.readline().strip()
-    except FileNotFoundError:
-        return ""
+        repo = Repo(svgs_repo)
+        # The most recent commit to touch this suite's report
+        sha = repo.git.log("-1", "--format=%H", "--", f"{suite}/differences.html")
+    except (InvalidGitRepositoryError, NoSuchPathError, GitCommandError) as e:
+        log.warning("owidbot.svg_tester.no_svgs_checkout", svgs_repo=str(svgs_repo), error=str(e))
+        return None
+
+    return sha.strip() or None
 
 
 def make_commit_link(commit_id: str) -> str:


### PR DESCRIPTION
🔨🤖 (owidbot) read the SVG tester's results file instead of counting log lines

> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

The SVG tester now writes a machine-readable summary per suite (owid-grapher#6911), so owidbot can stop reconstructing the outcome from a log file.

**Requires owid-grapher#6911 to merge first** — until it does, no suite writes `verify-results.json` and every row reads `_not run_`.

## Why

What owidbot was reconstructing was unreliable in three ways:

- the difference count came from `wc -l` on `verify-graphs.log`, which prints one line per difference **and** whole stack traces for failures — so the count was only right when nothing errored
- a suite that crashed reported as a difference count rather than as an error
- a missing log file meant "skipped", except for `graphers` where it meant "error" — a guess either way

## What it does now

Each suite reports one of five states, in **two classes**: "not run" means nothing was ever supposed to be there; "no result" means we expected one and didn't get it. Only the latter is flagged.

| State | Renders as |
| --- | --- |
| file absent | `_not run_` |
| leftover from another commit | `_not run_ (ignored a leftover results file)` |
| `running` | `⚠️ no result (killed or still running)` |
| `unreadable` | `⚠️ no result (results file unreadable)` |
| ran | `0 ✅` / `141 ([abc123]) ❌ [Report]` / `1 ❌ ⚠️ 2 errors` |

`running` deliberately doesn't claim "killed": the second owidbot run is gated on the tester step so by then it really is dead, but a run that *overlaps* a live tester sees it too — which is exactly what happened while testing on a staging container.

## Two design points worth a look

**Staleness.** Every reset is supposed to clear these files (`git clean -fdx`), but that makes correctness depend on an external step behaving in every environment. So results are checked against the commit under test — `Repo(BASE_DIR.parent / "owid-grapher").head.commit.hexsha` — and a mismatch is treated as a leftover. When either side is unknown the file is trusted: wrongly branding a current run stale is worse than the leftover it guards against.

Rejected alternatives: `BUILDKITE_COMMIT` isn't available (owidbot runs over SSH via `as_owid`, which doesn't forward Buildkite's env), and the PR head sha from the GitHub API is the wrong value (a push during the build would brand a legitimately one-commit-behind file as stale).

**`commit.log` → git.** The report link no longer reads `commit.log`. That file records the commit made *after* the report — `create_report` commits the report, then `commit_differences` commits `references/` and writes the log — and both steps end in `|| :`. So a failed report with a successful `commit_differences` leaves a `commit.log` pointing at a report that was never committed, and the comment links to a 404. Asking git which commit last touched `<suite>/differences.html` can't do that.

Seen live on the test branch: `commit.log` said `c25fe5dc` (the "svg differences" commit) while the report actually lives in `fa197d58` (the "html report" commit). Both serve today, because the file is unchanged in the later tree — which is why nobody has noticed.

## Verified

On `staging-site-svg-tester-debug`, a branch with a deliberate chart-title change, running this module against the real CI artifacts:

```
Number of differences (graphers): 1 ([fa197d](…)) ❌ [Report](…/fa197d58…/graphers/differences.html)
Number of differences (grapher views): 32 ([1faace](…)) ❌ [Report](…)
Number of differences (mdims): 0 ✅
Number of differences (thumbnails): 0 ✅
```

Both report URLs return HTTP 200. The mid-build state renders correctly too — differences with no link yet, because `create_report` only runs once every suite has finished — as does the `running` placeholder for a suite still in flight.

## Open items

**Handed off**
- owid-grapher#6911 must merge before this does anything; ping me if it changes shape.
- Only containers created *after* this merges will run it: owidbot runs from `~/etl` as cloned at container creation, and the grapher pipeline never pulls it. Existing staging sites keep the old comment until they're recreated.

**Proposed**
- The `-` compare link at the top of the comment (`owid-grapher-svgs/compare/<branch>`) is now a weaker duplicate of the per-suite report links. Happy to drop it in a follow-up.

**Unverified**
- The `stale` and `unreadable` states have only been exercised against synthetic fixtures — a container won't produce either on demand.
- `get_report_commit` returning None on a suite with no differences is likewise synthetic-only; the branch tested had differences in both suites that reported.
- This PR ships without unit tests, at the author's request; the states above are the ones tests were covering.
