### PR TITLE
📊 Align UN M49 level-3 region order with the frontend

### DIFF
--- a/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
+++ b/etl/steps/data/grapher/regions/2023-01-01/regions.meta.override.yml
@@ -99,6 +99,16 @@ tables:
         origins:
           - producer: Our World in Data
             title: Regions
+        presentation:
+          grapher_config:
+            map:
+              colorScale:
+                baseColorScheme: OwidCategoricalMap
+                customHiddenCategories:
+                  "No data": true
+                # No customCategoryLabels/tooltipUseCustomLabels here, unlike every other
+                # region indicator: OWID's own region names carry no "(Provider)" suffix,
+                # so there is nothing to strip from the legend or the tooltip.
 
       # UN
       un_region:
@@ -222,16 +232,15 @@ tables:
           Level-3 (most granular) regions defined by the United Nations.
         type: ordinal
         sort:
-          - Central America (UN M49)
+          # Same order as customRegionDisplayOrder.un_m49_3 in the grapher repo, so the
+          # published map's legend and the region hover's mini-map legend agree.
           - Caribbean (UN M49)
+          - Central America (UN M49)
           - South America (UN M49)
-          - Western Africa (UN M49)
+          - Eastern Africa (UN M49)
           - Middle Africa (UN M49)
           - Southern Africa (UN M49)
-          - Eastern Africa (UN M49)
-          # NOTE: not aligned to customRegionDisplayOrder yet. These seven regions have no
-          # entry in MapContinentColors, so their colors come from palette *position* —
-          # reordering would silently recolor them. Reorder together with pinning them.
+          - Western Africa (UN M49)
         origins:
           - *origins_un_m49
         presentation:


### PR DESCRIPTION
> _Written by Claude Opus 5 — @paarriagadap at the wheel._

Two small metadata changes to the region indicators, both follow-ups to [owid-grapher#6907](https://github.com/owid/owid-grapher/pull/6907).

## `un_m49_3_region`: legend order

A provider's region order is defined twice — `sort` here drives the published map's legend, and `customRegionDisplayOrder` in the grapher repo drives the legend of the mini-map in the region hover. For UN M49 level 3 the two disagreed, so the same provider listed its regions two different ways on one page:

| | order |
|---|---|
| was (`sort`) | Central America, Caribbean, South America, **Western** Africa, Middle Africa, Southern Africa, **Eastern** Africa |
| now (= `customRegionDisplayOrder.un_m49_3`) | Caribbean, Central America, South America, **Eastern** Africa, Middle Africa, Southern Africa, **Western** Africa |

The frontend order is also the house left-to-right sweep (Americas west→east, then Africa north→south), and it matches how `fao_2` — the same seven splits under a different provider — is already ordered.

**This reorder was previously unsafe, which is why it hadn't been done.** None of those seven regions had an entry in `MapContinentColors`, so `OwidCategoricalMap` handed out colors by legend *position*: moving an entry silently recolored the map. A `# NOTE:` in this file said as much. #6907 pins all seven by name, so order and color are now independent — and that NOTE is removed here.

## `owid_region`: the map palette

Every other region indicator sets `baseColorScheme: OwidCategoricalMap`; this one didn't. Without it a categorical map falls back to `BuGn`, a sequential green ramp.

The blast radius is smaller than the indicator's usage suggests. Variable 900801 is on **679 charts, but as the `color` dimension in 678 of them** (scatter plots and Marimekkos coloring points by continent), and grapher inherits indicator config from the first **`y`** dimension. Exactly one chart uses it as `y` — `continents-according-to-our-world-in-data` — and that chart already patches `OwidCategoricalMap` itself. So:

- nothing changes on any published chart today;
- the indicator, not the chart, becomes the source of truth, so a future chart built on it gets the right palette by default.

All six OWID region names are pinned by name in both color dictionaries, so the palette resolves correctly. No `customCategoryLabels` / `tooltipUseCustomLabels` were added — those strip a `(Provider)` suffix from the legend and tooltip, and OWID's own region names don't have one. A comment in the file records why this block is shorter than its siblings.

## Verification

- Step rebuilt (`data://grapher/regions/2023-01-01/regions`) and the built metadata read back: `un_m49_3_region.sort` now matches `customRegionDisplayOrder.un_m49_3` element for element, and for both indicators the `sort` list is set-equal to the categories actually present in the data (7 and 6) — so no category is left unsorted and none is sorted but absent.
- `owid_region` carries `baseColorScheme: OwidCategoricalMap`; an audit of all 19 region indicators shows every one now has the palette.
- `make check` clean.

## Still open

- **Sequencing:** the `un_m49_3` colors are pinned in #6907, which is **not merged yet**. If this merges first there is no visible regression — `un_m49_3_region` has no published chart at all — but the two belong together, so #6907 should go first.
- **Unverified:** `un_m49_3_region` still has no chart, so its legend order and its seven colors have never been rendered anywhere. Both are verified as values only.
