### PR TITLE
🐛 🐛 covid: Fix income-group entity names in vaccination breakdowns multidim

### DIFF
--- a/etl/steps/export/multidim/covid/latest/covid.vax_breakdowns.yml
+++ b/etl/steps/export/multidim/covid/latest/covid.vax_breakdowns.yml
@@ -37,9 +37,9 @@ views:
       addCountryMode: "disabled"
       selectedEntityNames:
         - High-income countries
-        - Upper-middle-countriesincome countries
+        - Upper-middle-income countries
         - Lower-middle-income countries
-        - Low-income
+        - Low-income countries
       selectedEntityColors:
         High-income countries: "#0D8553"
         Upper-middle-income countries: "#A1CB81"


### PR DESCRIPTION
> _Written by Claude Fable 5 — @pabloarosado at the wheel._

Two entity names in the income-group view of the covid vaccination-breakdowns collection are misspelled: "Upper-middle-countriesincome countries" and "Low-income". The intended spellings are shown by the `selectedEntityColors` block directly below and by the collection's own `default_selection`.

The typos never mattered because view-level `selectedEntityNames` is currently erased at upsert (the collection `default_selection` is merged over it). Once [Let a multi-dim view define its own default entity selection (owid-grapher#6922)](https://github.com/owid/owid-grapher/pull/6922) merges, view-level selections are honored, and these names would fail to resolve, leaving two of the four income groups unselected.

Note the collection is currently commented out of the covid export step (`covid.py`), so this fix takes effect only if it is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
