### PR TITLE
✨ (owidbot) link the SVG tester report to the admin page

### DIFF
--- a/apps/owidbot/grapher.py
+++ b/apps/owidbot/grapher.py
@@ -1,7 +1,7 @@
 import json
 from pathlib import Path
 
-from git import GitCommandError, InvalidGitRepositoryError, NoSuchPathError, Repo
+from git import InvalidGitRepositoryError, NoSuchPathError, Repo
 from structlog import get_logger
 
 from etl.config import get_container_name
@@ -29,20 +29,18 @@ def run(branch: str) -> str:
     # so no suite has results yet and the whole block is left out.
     svg_tester_has_run = any(has_results(results) for results in results_by_suite.values())
 
-    lines = {suite: make_differences_line(results, svgs_repo / suite) for suite, results in results_by_suite.items()}
-
-    svg_tester_line = (
-        f"- **SVG tester:** https://github.com/owid/owid-grapher-svgs/compare/{branch}" if svg_tester_has_run else ""
+    rows = "\n".join(
+        f"- {suite.replace('-', ' ')}: {make_suite_line(results, container_name=container_name, suite=suite)}"
+        for suite, results in results_by_suite.items()
     )
+
+    svg_tester_line = f"- **SVG tester:** {make_report_url(container_name)}" if svg_tester_has_run else ""
     svg_tester_block = (
         f"""
 <details open>
 <summary><b>SVG tester:</b> </summary>
 
-Number of differences (graphers): {lines["graphers"]}
-Number of differences (grapher views): {lines["grapher-views"]}
-Number of differences (mdims): {lines["mdims"]}
-Number of differences (thumbnails): {lines["thumbnails"]}
+{rows}
 
 </details>
 """.strip()
@@ -133,63 +131,40 @@ def get_head_commit(repo_path: Path) -> str | None:
         return None
 
 
-def make_differences_line(results: dict | None, suite_dir: Path) -> str:
+def make_suite_line(results: dict | None, container_name: str, suite: str) -> str:
     """One suite's line in the PR comment."""
     if results is None:
-        return "_not run_"
+        return "_skipped_"
 
     status = results.get("status")
 
     if status == "stale":
-        return "_not run_ (ignored a leftover results file)"
+        return "_skipped_ (ignored a leftover results file)"
 
     if status == "unreadable":
         return "⚠️ no result (results file unreadable)"
 
     if status == "running":
-        # verify-graphs.ts writes this before rendering and overwrites it when it
-        # finishes, so it's either still running or was killed mid-run.
-        return "⚠️ no result (killed or still running)"
+        # verify-graphs.ts writes this before its first render and overwrites it at the end
+        return "_running_ (or killed mid-run)"
 
     counts = results.get("counts", {})
     num_differences = counts.get("differences", 0)
     num_errors = counts.get("errors", 0)
 
-    commit_id = get_report_commit(suite_dir.parent, suite_dir.name)
-    commit_link = f"({make_commit_link(commit_id=commit_id)})" if commit_id else ""
+    if not num_differences and not num_errors:
+        return "✅ no differences"
 
-    status_icon = "❌" if num_differences > 0 else "✅"
-    report_link = (
-        f"[Report]({make_report_url(commit_id=commit_id, report_filename=f'{suite_dir.name}/differences.html')})"
-        if num_differences > 0 and commit_id
-        else ""
-    )
+    notes = []
+    if num_differences:
+        notes.append(f"❌ {num_differences} difference{'s' if num_differences != 1 else ''}")
+    if num_errors:
+        notes.append(f"⚠️ {num_errors} error{'s' if num_errors != 1 else ''}")
 
-    error_note = f"⚠️ {num_errors} error{'s' if num_errors != 1 else ''}" if num_errors else ""
-
-    parts = [str(num_differences), commit_link, status_icon, report_link, error_note]
-    return " ".join(part for part in parts if part)
+    return f"{', '.join(notes)} ([report]({make_report_url(container_name, suite=suite)}))"
 
 
-def get_report_commit(svgs_repo: Path, suite: str) -> str | None:
-    """The svgs-repo commit that last changed this suite's report, None if there is none."""
-    try:
-        repo = Repo(svgs_repo)
-        # The most recent commit to touch this suite's report
-        sha = repo.git.log("-1", "--format=%H", "--", f"{suite}/differences.html")
-    except (InvalidGitRepositoryError, NoSuchPathError, GitCommandError) as e:
-        log.warning("owidbot.svg_tester.no_svgs_checkout", svgs_repo=str(svgs_repo), error=str(e))
-        return None
-
-    return sha.strip() or None
-
-
-def make_commit_link(commit_id: str) -> str:
-    commit_hash = commit_id[:6]
-    commit_url = f"https://github.com/owid/owid-grapher-svgs/commit/{commit_id}"
-    return f"[{commit_hash}]({commit_url})"
-
-
-def make_report_url(commit_id: str, report_filename: str) -> str:
-    # raw.githack.com serves raw files from GitHub with proper HTML content type
-    return f"https://rawcdn.githack.com/owid/owid-grapher-svgs/{commit_id}/{report_filename}"
+def make_report_url(container_name: str, suite: str | None = None) -> str:
+    """The SVG tester page on the staging container, for one suite or the index"""
+    url = f"http://{container_name}/admin/svgtester"
+    return f"{url}/{suite}" if suite else url


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

The SVG tester's report is now served by the staging container's own admin server, so owidbot's PR comment links to `/admin/svgtester` instead of a `rawcdn.githack.com` URL built from a commit in `owid-grapher-svgs`.

**Both links move.** The block header goes to the index, replacing the `owid-grapher-svgs/compare/<branch>` link that only resolved while that branch was pushed; each suite links to `/admin/svgtester/<suite>`. Nothing in the comment references the svgs remote any more, which is what lets a follow-up stop pushing per-run branches to it. `get_report_commit`, `make_commit_link` and the githack `make_report_url` go with them.

**The rows are restructured too**, because `Number of differences (<suite>)` stopped being an accurate label once the line grew a status, an error count and a link:

> - graphers: ❌ 142 differences, ⚠️ 2 errors ([report](#))
> - grapher views: ✅ no differences
> - mdims: ⚠️ 3 errors ([report](#))
> - thumbnails: _skipped_

Each row names its suite and each icon labels its own fact — ✅ clean, ❌ differences, ⚠️ a render failure — mirroring the exit codes the tester itself reports. A suite with errors but no differences used to read as a green tick with no link; it now reports the errors and links to the report, which lists render failures above the differences. The four hard-coded template lines are gone, so the block iterates the suite list.

Two accepted trade-offs of serving the report from the machine that produced it: it needs the tailnet and an admin login where githack was public, and it dies with its container.

Part of the SVG tester redesign — item 19b of `docs/svg-tester-redesign-plan.md` in `owid-grapher`. Depends on the viewer being on grapher `master`, so a container built from a branch that predates it will 404 until that branch rebases.

## Testing

`make check` passes. Rendering was exercised by calling `run()` with `BASE_DIR` pointed at a temporary fixture, covering every state the comment can show: differences, differences with errors, errors only, clean, skipped, stale, unreadable, and killed mid-run.
