### PR TITLE
🔨🤖 Drop the SVG tester staleness check

### DIFF
--- a/apps/owidbot/grapher.py
+++ b/apps/owidbot/grapher.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-from git import InvalidGitRepositoryError, NoSuchPathError, Repo
 from structlog import get_logger
 
 from etl.config import get_container_name
@@ -19,15 +18,12 @@ def run(branch: str) -> str:
     container_name = get_container_name(branch)
 
     svgs_repo = BASE_DIR.parent / "owid-grapher-svgs"
-    grapher_repo = BASE_DIR.parent / "owid-grapher"
 
-    results_by_suite = {
-        suite: load_suite_results(svgs_repo / suite, grapher_repo=grapher_repo) for suite in SVG_TESTER_SUITES
-    }
+    results_by_suite = {suite: read_verify_results(svgs_repo / suite) for suite in SVG_TESTER_SUITES}
 
     # The first owidbot run of a build happens before the SVG tester step,
     # so no suite has results yet and the whole block is left out.
-    svg_tester_has_run = any(has_results(results) for results in results_by_suite.values())
+    svg_tester_has_run = any(results is not None for results in results_by_suite.values())
 
     rows = "\n".join(
         f"- {suite.replace('-', ' ')}: {make_suite_line(results, container_name=container_name, suite=suite)}"
@@ -72,28 +68,6 @@ def run(branch: str) -> str:
     return body
 
 
-def load_suite_results(suite_dir: Path, grapher_repo: Path) -> dict | None:
-    """Results for one suite. None when the suite produced no file at all."""
-    results = read_verify_results(suite_dir)
-    if results is None:
-        return None
-
-    if is_stale(results, grapher_repo=grapher_repo):
-        log.warning(
-            "owidbot.svg_tester.stale_results",
-            suite_dir=str(suite_dir),
-            results_commit=results.get("grapherCommit"),
-        )
-        return {"status": "stale"}
-
-    return results
-
-
-def has_results(results: dict | None) -> bool:
-    """True when the suite actually reported on the commit under test."""
-    return results is not None and results.get("status") != "stale"
-
-
 def read_verify_results(suite_dir: Path) -> dict | None:
     """Parsed verify-results.json, None when the file does not exist."""
     path = suite_dir / VERIFY_RESULTS_FILENAME
@@ -109,37 +83,12 @@ def read_verify_results(suite_dir: Path) -> dict | None:
         return {"status": "unreadable"}
 
 
-def is_stale(results: dict, grapher_repo: Path) -> bool:
-    """True when the results describe a run against a different commit."""
-    results_commit = results.get("grapherCommit")
-    if not results_commit:
-        return False
-
-    head = get_head_commit(grapher_repo)
-    if head is None:
-        return False
-
-    return results_commit != head
-
-
-def get_head_commit(repo_path: Path) -> str | None:
-    """HEAD of the grapher checkout the SVG tester ran against, or None if unavailable."""
-    try:
-        return Repo(repo_path).head.commit.hexsha
-    except (InvalidGitRepositoryError, NoSuchPathError, ValueError) as e:
-        log.warning("owidbot.svg_tester.no_grapher_checkout", repo_path=str(repo_path), error=str(e))
-        return None
-
-
 def make_suite_line(results: dict | None, container_name: str, suite: str) -> str:
     """One suite's line in the PR comment."""
     if results is None:
         return "_skipped_"
 
     status = results.get("status")
-
-    if status == "stale":
-        return "_skipped_ (ignored a leftover results file)"
 
     if status == "unreadable":
         return "⚠️ no result (results file unreadable)"


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

`is_stale` asked the wrong thing which commit is under test. It compared the results file's `grapherCommit` against the HEAD of `~/owid-grapher`, but that checkout is only moved to the new commit by the Grapher build step, which races the first owidbot run of the same build — and owidbot, a two-second step, normally wins. At that moment both sides still name the *previous* commit, so leftover results read as fresh. The case the check was written for, the same branch with a new commit, is precisely the one it was blind to; what it could catch instead was a suite whose good results it then dropped on the floor.

Rather than fix the comparison now, this removes it:

- `is_stale` and `get_head_commit` are gone, along with the `git` import that only they used.
- `load_suite_results` collapses into `read_verify_results` — no `{"status": "stale"}` sentinel — and `run` no longer needs the grapher checkout path.
- `has_results` is gone; `svg_tester_has_run` is now just "any suite produced a file".
- `make_suite_line` loses its `stale` branch (`_skipped_ (ignored a leftover results file)`).

A results file is now reported with its counts and report link whatever commit it was written for. The `unreadable` and `running` states are untouched.

The trade-off is that during a re-run the comment can show the previous commit's numbers without saying so — the same behaviour as before the check existed. Labelling those rows with the commit they came from, which is the fix that actually works, is described in `docs/svg-tester-comment-freshness.md` in `owid-grapher` and is deliberately not attempted here.

## Testing

`make check` passes. No tests referenced the removed helpers; the only caller of this module is `apps/owidbot/cli.py:95`, whose `grapher.run(branch)` call is unchanged.

## Open items

- The staleness problem itself is unfixed and stays unfixed until the labelling work happens.
