### PR TITLE
🐛🤖 Fix wrong time intervals in climate_change_impacts_monthly

### DIFF
--- a/etl/steps/data/grapher/climate/2026-07-10/climate_change_impacts_monthly.py
+++ b/etl/steps/data/grapher/climate/2026-07-10/climate_change_impacts_monthly.py
@@ -1,8 +1,5 @@
 """Load a garden dataset and create a grapher dataset."""
 
-from owid.catalog import Table
-from owid.catalog import processing as pr
-
 from etl.grapher.helpers import adapt_table_with_dates_to_grapher
 from etl.helpers import PathFinder
 
@@ -29,30 +26,6 @@ TIME_INTERVAL_OVERRIDES = {
     "sea_level_average": "quarter",
 }
 
-# Pandas period alias for each interval whose points must be unique within a period.
-PERIOD_ALIAS_BY_INTERVAL = {"month": "M", "quarter": "Q"}
-
-
-def sanity_check_time_intervals(tb: Table) -> None:
-    """Check that no column holds two points within one period of its declared time interval.
-
-    Such a pair would be indistinguishable to grapher, which would plot only the first of the two.
-    A new or updated indicator whose dates are irregular needs an entry in TIME_INTERVAL_OVERRIDES.
-    """
-    dates = pr.to_datetime(tb["date"].astype(str))
-    for column in tb.drop(columns=["country", "date"]).columns:
-        alias = PERIOD_ALIAS_BY_INTERVAL.get(TIME_INTERVAL_OVERRIDES.get(column, "month"))
-        if alias is None:
-            # The column is tagged "day"; its dates are already as precise as grapher can plot.
-            continue
-        periods = tb.loc[tb[column].notna(), ["country"]].assign(period=dates.dt.to_period(alias))
-        collisions = len(periods) - len(periods.drop_duplicates())
-        assert collisions == 0, (
-            f"Column `{column}` has {collisions} points sharing a period with another point, which "
-            f"grapher would drop. Add it to TIME_INTERVAL_OVERRIDES with the interval its dates "
-            f"actually represent."
-        )
-
 
 def run() -> None:
     #
@@ -67,9 +40,6 @@ def run() -> None:
     #
     # Create a country column (required by grapher).
     tb = tb.rename(columns={"location": "country"}, errors="raise")
-
-    # Check that every column's declared time interval matches the precision of its dates.
-    sanity_check_time_intervals(tb)
 
     # Adapt table with dates to grapher requirements.
     tb = adapt_table_with_dates_to_grapher(tb, time_interval="month")

--- a/etl/steps/data/grapher/climate/2026-07-10/climate_change_impacts_monthly.py
+++ b/etl/steps/data/grapher/climate/2026-07-10/climate_change_impacts_monthly.py
@@ -1,10 +1,57 @@
 """Load a garden dataset and create a grapher dataset."""
 
+from owid.catalog import Table
+from owid.catalog import processing as pr
+
 from etl.grapher.helpers import adapt_table_with_dates_to_grapher
 from etl.helpers import PathFinder
 
 # Get paths and naming conventions for current step.
 paths = PathFinder(__file__)
+
+# Most columns in this table are monthly, reported on the 15th of each month, so the whole table is
+# adapted with time_interval="month". These columns are not, and need their own interval: grapher
+# snaps sub-yearly times to the start of their period, so a column tagged with a coarser interval
+# than its dates actually have collapses several points onto one time key and silently keeps only
+# the first of them.
+TIME_INTERVAL_OVERRIDES = {
+    # Ocean pH is measured on Aloha-station cruise dates, with 17-31 day gaps.
+    "ocean_ph": "day",
+    "ocean_ph_yearly_average": "day",
+    # IMBIE reports drifting fractional-year stamps (1992-01-01, 1992-01-31, 1992-03-01, ...), so
+    # some months hold two measurements and others none.
+    "cumulative_ice_mass_change_imbie": "day",
+    # NASA's ice mass follows GRACE satellite overpasses, on varying days of the month.
+    "land_ice_mass_nasa": "day",
+    # Sea level is quarterly, reported on the 15th of the quarter's first month.
+    "sea_level_church_and_white_2011": "quarter",
+    "sea_level_uhslc": "quarter",
+    "sea_level_average": "quarter",
+}
+
+# Pandas period alias for each interval whose points must be unique within a period.
+PERIOD_ALIAS_BY_INTERVAL = {"month": "M", "quarter": "Q"}
+
+
+def sanity_check_time_intervals(tb: Table) -> None:
+    """Check that no column holds two points within one period of its declared time interval.
+
+    Such a pair would be indistinguishable to grapher, which would plot only the first of the two.
+    A new or updated indicator whose dates are irregular needs an entry in TIME_INTERVAL_OVERRIDES.
+    """
+    dates = pr.to_datetime(tb["date"].astype(str))
+    for column in tb.drop(columns=["country", "date"]).columns:
+        alias = PERIOD_ALIAS_BY_INTERVAL.get(TIME_INTERVAL_OVERRIDES.get(column, "month"))
+        if alias is None:
+            # The column is tagged "day"; its dates are already as precise as grapher can plot.
+            continue
+        periods = tb.loc[tb[column].notna(), ["country"]].assign(period=dates.dt.to_period(alias))
+        collisions = len(periods) - len(periods.drop_duplicates())
+        assert collisions == 0, (
+            f"Column `{column}` has {collisions} points sharing a period with another point, which "
+            f"grapher would drop. Add it to TIME_INTERVAL_OVERRIDES with the interval its dates "
+            f"actually represent."
+        )
 
 
 def run() -> None:
@@ -21,14 +68,15 @@ def run() -> None:
     # Create a country column (required by grapher).
     tb = tb.rename(columns={"location": "country"}, errors="raise")
 
+    # Check that every column's declared time interval matches the precision of its dates.
+    sanity_check_time_intervals(tb)
+
     # Adapt table with dates to grapher requirements.
     tb = adapt_table_with_dates_to_grapher(tb, time_interval="month")
 
-    # Ocean pH measurements are irregular Aloha-station cruise dates (17-31 day gaps), not monthly
-    # aggregates. With timeInterval "month", grapher snaps them to the 1st of the month, and the
-    # ~15 months holding two cruises collapse onto one time key (values silently dropped).
-    for column in ["ocean_ph", "ocean_ph_yearly_average"]:
-        tb[column].metadata.display["timeInterval"] = "day"
+    # Give the columns whose dates are not monthly their own time interval.
+    for column, time_interval in TIME_INTERVAL_OVERRIDES.items():
+        tb[column].metadata.display["timeInterval"] = time_interval
 
     # Set an appropriate index and sort conveniently.
     tb = tb.format(["country", "year"])

--- a/etl/steps/data/grapher/climate/2026-07-10/climate_change_impacts_monthly.py
+++ b/etl/steps/data/grapher/climate/2026-07-10/climate_change_impacts_monthly.py
@@ -24,6 +24,12 @@ def run() -> None:
     # Adapt table with dates to grapher requirements.
     tb = adapt_table_with_dates_to_grapher(tb, time_interval="month")
 
+    # Ocean pH measurements are irregular Aloha-station cruise dates (17-31 day gaps), not monthly
+    # aggregates. With timeInterval "month", grapher snaps them to the 1st of the month, and the
+    # ~15 months holding two cruises collapse onto one time key (values silently dropped).
+    for column in ["ocean_ph", "ocean_ph_yearly_average"]:
+        tb[column].metadata.display["timeInterval"] = "day"
+
     # Set an appropriate index and sort conveniently.
     tb = tb.format(["country", "year"])
 


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

## Problem

`grapher/climate/2026-07-10/climate_change_impacts_monthly` adapts its whole table with `adapt_table_with_dates_to_grapher(tb, time_interval="month")`. That's right for most of its columns — 16 of 22 are reported on the 15th of each month, exactly one point per month — but six columns have dates that aren't monthly, and grapher snaps sub-yearly times to the start of their period. Any column whose dates put two points in one month therefore collapses them onto a single time key, and only the first survives.

Introduced in b1e4871 (2026-07-22), which set the table-wide `"month"` interval. Every version of this table from 2024-01-31 through 2026-06-19 carried `"day"` on all columns, so the loss is scoped to the 2026-07-10 version.

## What the audit found

I checked the date regularity of all 22 columns in the garden table.

**Points silently dropped (3 columns):**

| indicator | points | collapsed | why the dates aren't monthly |
|---|---|---|---|
| `cumulative_ice_mass_change_imbie` | 630 | **157** (76 Antarctica + 81 Greenland) | drifting fractional-year stamps — `1992-01-01`, `1992-01-31`, `1992-03-01`, … so some months hold two points and others none |
| `ocean_ph` / `ocean_ph_yearly_average` | 346 / 335 | 15 each | Aloha-station cruise dates, 17–31 day gaps |
| `land_ice_mass_nasa` | 384 | 8 (4 per entity) | GRACE satellite overpasses, on 20 different days of the month |

**Wrong interval, no data lost (3 columns):** `sea_level_church_and_white_2011`, `sea_level_uhslc`, `sea_level_average` are **quarterly** — every date is the 15th of Jan/Apr/Jul/Oct, 90–92 day gaps. No collisions, so nothing was ever dropped, but the label was wrong: they rendered as "Oct 2020" instead of "Q4 2020".

**Correct as-is (16 columns):** sea ice extent, SST anomalies (+ bounds), ocean heat content, snow cover, and all the GHG concentration series — all one point per month on the 15th.

## Fix

Replace the single-column override with a `TIME_INTERVAL_OVERRIDES` map applied after the table-wide monthly call: `"day"` for the three irregular columns, `"quarter"` for the three sea level ones. Resampling upstream so `"month"` becomes honest was rejected — it invents points the producers never published.

## Verification

Real browser, production vs `staging-site-bug-ocean-ph-use`. Vertex counts are per line series; "console" counts `Found more than one matching row in table undefined`.

| surface | production | staging | console (prod → staging) |
|---|---|---|---|
| `seawater-ph` | 331 / 320 | **346 / 335** | 30 → 0 |
| `ice-sheet-mass-balance` | 188 | **192** | 0 → 0 |
| climate-change explorer, *Mass balance of ice sheets* (Antarctica) | 230 (imbie) / 188 (nasa) | **306 / 192** | 165 → 0 |
| `sea-level` | 563 / 204 / 519 | 563 / 204 / 519 (unchanged) | 0 → 0 |

Every count on staging now matches the point count in the indicator's `data.json`, i.e. nothing is dropped anymore. The explorer's ice view is the worst-hit surface — 80 of Antarctica's points were missing there, and its 165 warnings are exactly the 157 + 8 collisions across both entities.

The sea level relabel shows up as expected: the time label reads **"Q4 2020"** on staging where production reads "Oct 2020".

Two things worth knowing:

- **`ice-sheet-mass-balance` logged nothing on production** despite dropping 4 points per entity — it plots a single variable, so it never reaches the `fullJoinTables` warning. The console noise is a symptom of multi-variable charts only; single-variable charts lose data silently.
- **Don't verify these charts through the `.svg` endpoint.** `http://staging-site-bug-ocean-ph-use/grapher/seawater-ph.svg` still renders the old 331/320, byte-identical to production's, and a query-string cache-bust doesn't clear it. Use a browser.

## Sweep for the same bug elsewhere

b1e4871 re-tagged five other datasets. I audited every indicator in each against the interval it declares, using production data:

| dataset | interval | result |
|---|---|---|
| `climate/2026-07-10/surface_temperature` | month | 202 vars, 0 collisions (all on the 15th) |
| `climate/2026-08-01/weekly_wildfires` | week | 10 vars, 0 collisions |
| `climate/2026-07-10/sst_by_month` | month | 3 vars, 0 collisions |
| `oecd/2025-03-11/co2_air_transport` | month | 5 monthly vars, 0 collisions |
| `who/2025-03-19/flu_yamagata` | week | 1 var, 0 collisions |

No other step in the repo declares a coarser-than-day interval, so `climate_change_impacts_monthly` was the only casualty.

## Also done on staging (no file diff)

Dropped the stale dimension override `display.timeInterval: "day"` on variable 1290415 in the `seawater-ph` chart config — a leftover from the `yearIsDay` migration, and a no-op either way since `LegacyToOwidTable` reads variable metadata rather than the merged dimension display. DB-only edit; it rides to production via chart-diff approval.

## Still open

- **Chart-diff approval** is pending for that dimension-override removal — it reaches production only once someone approves it in the Wizard and this merges.
- **The rest of the `seawater-ph` dimension override wasn't touched**: it still duplicates `unit`, `shortUnit` and `zeroDay` from the variable metadata, and labels the series "Monthly average" — arguably wrong now that we're treating these as irregular measurements rather than monthly aggregates. Renaming it is an editorial call, so I left it.
- **Nobody reviewed whether `"quarter"` is the labelling the topic owner wants** for sea level. It's the honest interval, but it changes user-facing time strings on a published chart.
