### PR TITLE
🐛 Chart diff: only treat a slug as taken if a chart owns it

### DIFF
--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -573,7 +573,10 @@ class ChartDiff:
 
     @staticmethod
     def _get_chart_slugs(target_session: Session, slugs: set[str] | None = None) -> set[str]:
-        """Get all chart slugs. Use `slugs` to filter slugs as this can be slow otherwise."""
+        """Get every slug already taken in the /grapher/<slug> namespace.
+
+        Use `slugs` to filter slugs as this can be slow otherwise.
+        """
         if slugs is not None:
             where = "WHERE slug IN %(slugs)s"
             where_charts = "AND cc.slug IN %(slugs)s"
@@ -595,7 +598,25 @@ class ChartDiff:
                 params=params,
             )["slug"]
         )
-        return slugs | slugs_redirects
+        # Multi-dim pages are served from the same /grapher/<slug> route as charts, so a slug a
+        # published multi-dim answers on is taken too — the same reason `chart_slug_redirects` is
+        # included above. `multi_dim_redirects.source` stores a full path rather than a bare slug,
+        # and only its /grapher/ entries share the chart namespace (the rest are /explorers/ ones),
+        # hence the prefix test and strip. LEFT() rather than LIKE, to keep a literal `%` out of a
+        # query that also carries `%(slugs)s` placeholders.
+        slugs_mdim = set(
+            read_sql(
+                "SELECT slug FROM ("
+                "  SELECT slug FROM multi_dim_data_pages WHERE published = 1 AND slug IS NOT NULL"
+                "  UNION"
+                "  SELECT SUBSTRING(source, CHAR_LENGTH('/grapher/') + 1) FROM multi_dim_redirects"
+                "  WHERE LEFT(source, CHAR_LENGTH('/grapher/')) = '/grapher/'"
+                f") t {where}",
+                target_session,
+                params=params,
+            )["slug"]
+        )
+        return slugs | slugs_redirects | slugs_mdim
 
     @staticmethod
     def _get_target_charts(target_session, source_charts):

--- a/apps/wizard/app_pages/chart_diff/chart_diff.py
+++ b/apps/wizard/app_pages/chart_diff/chart_diff.py
@@ -576,15 +576,25 @@ class ChartDiff:
         """Get all chart slugs. Use `slugs` to filter slugs as this can be slow otherwise."""
         if slugs is not None:
             where = "WHERE slug IN %(slugs)s"
+            where_charts = "AND cc.slug IN %(slugs)s"
             params = {"slugs": tuple(slugs)}
         else:
             where = ""
+            where_charts = ""
             params = {}
 
         slugs_redirects = set(
             read_sql(f"SELECT slug FROM chart_slug_redirects {where}", target_session, params=params)["slug"]
         )
-        slugs = set(read_sql(f"SELECT slug FROM chart_configs {where}", target_session, params=params)["slug"])
+        # A slug is only taken if a *chart* owns the config row, hence the join through `charts`
+        slugs = set(
+            read_sql(
+                "SELECT cc.slug FROM chart_configs cc JOIN charts c ON c.configId = cc.id "
+                f"WHERE cc.slug IS NOT NULL {where_charts}",
+                target_session,
+                params=params,
+            )["slug"]
+        )
         return slugs | slugs_redirects
 
     @staticmethod


### PR DESCRIPTION
> _Written by Claude Opus 5 — @sophiamersmann at the wheel._

`ChartDiff._get_chart_slugs` read `chart_configs.slug` without joining an owner table, so it also collected slugs from config rows that no chart points at — on production, 15 leftover `mdd-*` slugs from republished multi-dim pages. Those slugs feed chart diff's "slug already exists in target environment" check, which then blocks a new chart from syncing over a slug that no chart actually holds. Joining through `charts` fixes it, and verifying against a production clone shows exactly those 15 slugs dropping out and nothing else changing. This also matters for the upcoming `chart_configs` refactor: once each config's authored layer becomes its own row, most slug-bearing rows in that table will not be charts, so reading slugs without an owner join stops being safe by default. One follow-up from the same scan is left for its own PR (details below).

<details>
<summary>Full description</summary>

## What

The query was:

```sql
SELECT slug FROM chart_configs WHERE slug IN %(slugs)s
```

A `chart_configs` row is only a *chart's* slug if a chart points at it. Without the join the query also returns slugs from config rows nothing owns — on production, 15 leftover `mdd-*` slugs from republished multi-dim pages.

Those slugs feed the conflict check in `ChartDiff.from_charts_df`:

```python
if not target_chart and source_chart.slug in slugs_in_target:
    error = f"Slug '{source_chart.slug}' already exists in target environment."
```

So a new chart claiming one of those slugs is reported as a conflict and blocked from syncing, even though no chart holds the slug — the multi-dim page owns it via `multi_dim_data_pages.slug`.

## Verification

Both code paths, against a production clone:

| branch | before | after | removed | added |
| --- | --- | --- | --- | --- |
| unfiltered (`slugs=None`) | 5,083 | 5,068 | 15 | 0 |
| filtered (215-slug probe, orphans included) | 215 | 200 | 15 | 0 |

The removed set is identical in both and is exactly the 15 `mdd-*` slugs. Nothing was added, so no real chart slug lost its conflict protection.

## Also

Added `cc.slug IS NOT NULL`. `None` was previously in the set, so a new draft chart (which has no slug) could match itself and be told its slug was taken. Only reachable through the unfiltered branch, which the sole caller never uses — latent rather than live.

The `where` / `where_charts` split is needed because the qualified `cc.slug` can't share the redirects query's unqualified clause.

## Context: the planned `chart_configs` refactor

Found while scanning the ETL for `chart_configs` reads that assume a single owner, ahead of a planned grapher schema change. Today every grapher config is stored twice in that table, as `patch` (the authored delta) and `full` (the merged result). The refactor replaces both with a single `config` column and moves the authored layer into **separate `chart_configs` rows**, reached through new FK columns (`charts.patchConfigId`, `multi_dim_x_chart_configs.patchConfigId`, `narrative_charts.patchConfigId`). The invariant becomes:

> A `chart_configs` row is a config. The FK that names it says which kind. Always reach a config through its owner.

That is what makes this small fix worth landing on its own:

- **A slug-bearing row stops meaning "a chart".** The refactor adds roughly 14.7k authored-layer rows, and a published chart's authored row carries **both `slug` and `isPublished`** (both are force-kept when the patch is computed). So all ~4.3k published charts will have their slug present twice in this table. `idx_chart_configs_slug` is non-unique, so MySQL will not complain about any of it.
- **The join is what makes correctness guaranteed rather than incidental.** Being honest about the blast radius for *this* call site: because the result is collapsed into a `set()`, the duplicate rows carry the same slug values and `slugs_in_target` would come out unchanged — so the conflict check would not newly misfire. But that is the `set()` accidentally doing the job the join should do, and it stops holding the moment anyone counts rows, returns ids, joins onward, or drops the dedup.
- **The refactor would otherwise quietly mask today's bug.** Its cleanup deletes the ~7.3k orphaned config rows, which includes the 15 `mdd-*` slugs this PR removes. Fixing the query now means the live bug is fixed on its own merits, and the reason the query is correct is visible in the code rather than a side effect of someone else's migration.

This was the only by-slug read of `chart_configs` in the repo without an owner join; every other one, SQL and ORM alike, already reaches the table through `charts.configId`.

## Still open

- Not covered here: a separate finding from the same scan, that `chart_revisions.config` stores a chart's *authored patch*, while `chart_diff_show` renders and diffs it as if it were a fully resolved config. Selecting "Last approved on staging" in the chart-revision dropdown therefore renders the approved version with every inherited field missing — untitled for 198 charts on production, no subtitle for 243, no map tab for 172 — and the config diff beside it reports each of those inherited keys as though the pending edit had added it. 392 charts have inheritance enabled with a thinner patch than full, 354 of them inheriting title, subtitle or note. Narrow in practice: it needs a re-review after a prior approval, and the reviewer has to switch the dropdown off its "production" default. Left for its own PR — the fix belongs upstream, where the merge logic lives.
- Nobody has eyeballed this in the Wizard UI. The change is verified at the SQL level only; a reviewer with a pending chart diff could confirm the conflict warning behaves.

</details>
